### PR TITLE
validation: Warm coins cache during prevalidation to connect blocks faster

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2546,6 +2546,7 @@ bool CChainState::DisconnectTip(BlockValidationState& state, const CChainParams&
     return true;
 }
 
+static int64_t nTimeWarmingBlock = 0;
 static int64_t nTimeReadFromDisk = 0;
 static int64_t nTimeConnectTotal = 0;
 static int64_t nTimeFlush = 0;
@@ -3892,6 +3893,9 @@ void BlockWarmer::WarmCoinsCacheThread()
             }
         }
 
+        const int64_t start_time = GetTimeMicros();
+        bool did_finish = false;
+
         {
             LOCK(m_cs_warm_block);
 
@@ -3910,8 +3914,14 @@ void BlockWarmer::WarmCoinsCacheThread()
             }
 
             m_warm_block = nullptr;
+            if (!m_stop_warming_block) {
+                did_finish = true;
+            }
             m_stop_warming_block = true;
         }
+
+        const int64_t end_time = GetTimeMicros(); nTimeWarmingBlock += end_time - start_time;
+        LogPrint(BCLog::BENCH, "- Warmed coins cache for: %.2fms [%.2fs], finished %d\n", MILLI * (end_time - start_time), nTimeWarmingBlock * MICRO, did_finish);
     }
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1263,7 +1263,7 @@ CoinsViews::CoinsViews(
 
 void CoinsViews::InitCache()
 {
-    m_cacheview = MakeUnique<CCoinsViewCache>(&m_catcherview);
+    m_cacheview = std::make_shared<CCoinsViewCache>(&m_catcherview);
 }
 
 CChainState::CChainState(BlockManager& blockman, uint256 from_snapshot_blockhash)

--- a/src/validation.h
+++ b/src/validation.h
@@ -430,7 +430,7 @@ public:
 
     //! This is the top layer of the cache hierarchy - it keeps as many coins in memory as
     //! can fit per the dbcache setting.
-    std::unique_ptr<CCoinsViewCache> m_cacheview GUARDED_BY(cs_main);
+    std::shared_ptr<CCoinsViewCache> m_cacheview GUARDED_BY(cs_main);
 
     //! This constructor initializes CCoinsViewDB and CCoinsViewErrorCatcher instances, but it
     //! *does not* create a CCoinsViewCache instance by default. This is done separately because the


### PR DESCRIPTION
[Retrieving coins from disk is a significant source of `ConnectBlock` latency](https://github.com/bitcoin/bitcoin/pull/18941#issuecomment-633684774). This PR increases `ConnectBlock` speed by retrieving coins from disk on a separate thread before `ConnectBlock` is reached. When a block is passed into `ProcessNewBlock` it is immediately warmed before prevalidation checks are begun.

Benchmarking IBD with `-prune=10000` and default `-dbcache` from blocks `600000-633000` gives a 7.1% increase in speed. Since this is only really useful when blocks take a long time to prevalidate, benchmarks from genesis only give a 2.3% increase. However, this should keep increasing as more large blocks get mined, so it will be even more useful in the future. Of course this will be less useful with high `-dbcache` values.