### PR TITLE
Remove checks for nullptr from BlockAssembler::CreateNewBlock

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -107,8 +107,6 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     pblocktemplate.reset(new CBlockTemplate());
 
-    if(!pblocktemplate.get())
-        return nullptr;
     pblock = &pblocktemplate->block; // pointer for convenience
 
     // Add dummy coinbase tx as first transaction

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -148,8 +148,6 @@ static UniValue generateBlocks(ChainstateManager& chainman, const CTxMemPool& me
     while (nHeight < nHeightEnd && !ShutdownRequested())
     {
         std::unique_ptr<CBlockTemplate> pblocktemplate(BlockAssembler(mempool, Params()).CreateNewBlock(coinbase_script));
-        if (!pblocktemplate.get())
-            throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         CBlock *pblock = &pblocktemplate->block;
 
         uint256 block_hash;
@@ -349,9 +347,6 @@ static UniValue generateblock(const JSONRPCRequest& request)
 
         CTxMemPool empty_mempool;
         std::unique_ptr<CBlockTemplate> blocktemplate(BlockAssembler(empty_mempool, chainparams).CreateNewBlock(coinbase_script));
-        if (!blocktemplate) {
-            throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
-        }
         block = blocktemplate->block;
     }
 
@@ -722,8 +717,6 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
         // Create new block
         CScript scriptDummy = CScript() << OP_TRUE;
         pblocktemplate = BlockAssembler(mempool, Params()).CreateNewBlock(scriptDummy);
-        if (!pblocktemplate)
-            throw JSONRPCError(RPC_OUT_OF_MEMORY, "Out of memory");
 
         // Need to update only after we know CreateNewBlock succeeded
         pindexPrev = pindexPrevNew;


### PR DESCRIPTION
Motivation/rationale: Minor nit.

Background:

See: https://en.cppreference.com/w/cpp/memory/new/operator_new

`operator new()` does not normally ever return `nullptr` unless one
explicitly uses the `std::nothrow` version or unless one redefines it.  Neither
is the case in this entire codebase, hence the check for `nullptr` for the
return value from `BlockAssembler::CreateNewBlock` was entirely
superfluous and all branches that test it would always evaluate to
`false`. So, it can be safely removed in the interests of code quality.

tl;dr: `operator new()` either succeeds or throws `std::bad_alloc`, it can
never return `nullptr`.

