### PR TITLE
Verify the block filter hash when reading from disk.

### DIFF
--- a/src/bench/gcs_filter.cpp
+++ b/src/bench/gcs_filter.cpp
@@ -17,7 +17,7 @@ static void ConstructGCSFilter(benchmark::State& state)
 
     uint64_t siphash_k0 = 0;
     while (state.KeepRunning()) {
-        GCSFilter filter({siphash_k0, 0, 20, 1 << 20}, elements);
+        GCSFilter filter({siphash_k0, 0, BASIC_FILTER_P, BASIC_FILTER_M}, elements);
 
         siphash_k0++;
     }
@@ -32,12 +32,48 @@ static void MatchGCSFilter(benchmark::State& state)
         element[1] = static_cast<unsigned char>(i >> 8);
         elements.insert(std::move(element));
     }
-    GCSFilter filter({0, 0, 20, 1 << 20}, elements);
+    GCSFilter filter({0, 0, BASIC_FILTER_P, BASIC_FILTER_M}, elements);
 
     while (state.KeepRunning()) {
         filter.Match(GCSFilter::Element());
     }
 }
 
+static void DecodeGCSFilter(benchmark::State& state)
+{
+    GCSFilter::ElementSet elements;
+    for (int i = 0; i < 10000; ++i) {
+        GCSFilter::Element element(32);
+        element[0] = static_cast<unsigned char>(i);
+        element[1] = static_cast<unsigned char>(i >> 8);
+        elements.insert(std::move(element));
+    }
+    GCSFilter filter({0, 0, BASIC_FILTER_P, BASIC_FILTER_M}, elements);
+    auto encoded = filter.GetEncoded();
+
+    while (state.KeepRunning()) {
+        GCSFilter filter({0, 0, BASIC_FILTER_P, BASIC_FILTER_M}, encoded);
+    }
+}
+
+static void BlockFilterGetHash(benchmark::State& state)
+{
+    GCSFilter::ElementSet elements;
+    for (int i = 0; i < 10000; ++i) {
+        GCSFilter::Element element(32);
+        element[0] = static_cast<unsigned char>(i);
+        element[1] = static_cast<unsigned char>(i >> 8);
+        elements.insert(std::move(element));
+    }
+    GCSFilter filter({0, 0, BASIC_FILTER_P, BASIC_FILTER_M}, elements);
+    BlockFilter block_filter(BlockFilterType::BASIC, {}, filter.GetEncoded());
+
+    while (state.KeepRunning()) {
+        block_filter.GetHash();
+    }
+}
+
+BENCHMARK(BlockFilterGetHash, 10000);
 BENCHMARK(ConstructGCSFilter, 1000);
+BENCHMARK(DecodeGCSFilter, 5000);
 BENCHMARK(MatchGCSFilter, 50 * 1000);

--- a/src/bench/gcs_filter.cpp
+++ b/src/bench/gcs_filter.cpp
@@ -73,7 +73,24 @@ static void BlockFilterGetHash(benchmark::State& state)
     }
 }
 
+static void DecodeCheckedGCSFilter(benchmark::State& state)
+{
+    GCSFilter::ElementSet elements;
+    for (int i = 0; i < 10000; ++i) {
+        GCSFilter::Element element(32);
+        element[0] = static_cast<unsigned char>(i);
+        element[1] = static_cast<unsigned char>(i >> 8);
+        elements.insert(std::move(element));
+    }
+    GCSFilter filter({0, 0, BASIC_FILTER_P, BASIC_FILTER_M}, elements);
+    auto encoded = filter.GetEncoded();
+
+    while (state.KeepRunning()) {
+        GCSFilter filter({0, 0, BASIC_FILTER_P, BASIC_FILTER_M}, encoded, true);
+    }
+}
 BENCHMARK(BlockFilterGetHash, 10000);
 BENCHMARK(ConstructGCSFilter, 1000);
 BENCHMARK(DecodeGCSFilter, 5000);
+BENCHMARK(DecodeCheckedGCSFilter, 50000);
 BENCHMARK(MatchGCSFilter, 50 * 1000);

--- a/src/blockfilter.h
+++ b/src/blockfilter.h
@@ -59,7 +59,7 @@ public:
     explicit GCSFilter(const Params& params = Params());
 
     /** Reconstructs an already-created filter from an encoding. */
-    GCSFilter(const Params& params, std::vector<unsigned char> encoded_filter);
+    GCSFilter(const Params& params, std::vector<unsigned char> encoded_filter, const bool filter_checked=false);
 
     /** Builds a new filter from the params and set of elements. */
     GCSFilter(const Params& params, const ElementSet& elements);
@@ -122,7 +122,7 @@ public:
 
     //! Reconstruct a BlockFilter from parts.
     BlockFilter(BlockFilterType filter_type, const uint256& block_hash,
-                std::vector<unsigned char> filter);
+                std::vector<unsigned char> filter, const bool filter_checked=false);
 
     //! Construct a new BlockFilter of the specified type from a block.
     BlockFilter(BlockFilterType filter_type, const CBlock& block, const CBlockUndo& block_undo);

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -5,6 +5,7 @@
 #include <map>
 
 #include <dbwrapper.h>
+#include <hash.h>
 #include <index/blockfilterindex.h>
 #include <util/system.h>
 #include <validation.h>
@@ -142,7 +143,7 @@ bool BlockFilterIndex::CommitInternal(CDBBatch& batch)
     return BaseIndex::CommitInternal(batch);
 }
 
-bool BlockFilterIndex::ReadFilterFromDisk(const FlatFilePos& pos, BlockFilter& filter) const
+bool BlockFilterIndex::ReadFilterFromDisk(const FlatFilePos& pos, BlockFilter& filter, const uint256& hash) const
 {
     CAutoFile filein(m_filter_fileseq->Open(pos, true), SER_DISK, CLIENT_VERSION);
     if (filein.IsNull()) {
@@ -153,7 +154,10 @@ bool BlockFilterIndex::ReadFilterFromDisk(const FlatFilePos& pos, BlockFilter& f
     std::vector<unsigned char> encoded_filter;
     try {
         filein >> block_hash >> encoded_filter;
-        filter = BlockFilter(GetFilterType(), block_hash, std::move(encoded_filter));
+        uint256 result;
+        CHash256().Write(encoded_filter.data(), encoded_filter.size()).Finalize(result.begin());
+        if (result != hash) return error("Checksum mismatch in filter decode.");
+        filter = BlockFilter(GetFilterType(), block_hash, std::move(encoded_filter), true);
     }
     catch (const std::exception& e) {
         return error("%s: Failed to deserialize block filter from disk: %s", __func__, e.what());
@@ -380,7 +384,7 @@ bool BlockFilterIndex::LookupFilter(const CBlockIndex* block_index, BlockFilter&
         return false;
     }
 
-    return ReadFilterFromDisk(entry.pos, filter_out);
+    return ReadFilterFromDisk(entry.pos, filter_out, entry.hash);
 }
 
 bool BlockFilterIndex::LookupFilterHeader(const CBlockIndex* block_index, uint256& header_out)
@@ -424,7 +428,7 @@ bool BlockFilterIndex::LookupFilterRange(int start_height, const CBlockIndex* st
     filters_out.resize(entries.size());
     auto filter_pos_it = filters_out.begin();
     for (const auto& entry : entries) {
-        if (!ReadFilterFromDisk(entry.pos, *filter_pos_it)) {
+        if (!ReadFilterFromDisk(entry.pos, *filter_pos_it, entry.hash)) {
             return false;
         }
         ++filter_pos_it;

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -35,7 +35,7 @@ private:
     FlatFilePos m_next_filter_pos;
     std::unique_ptr<FlatFileSeq> m_filter_fileseq;
 
-    bool ReadFilterFromDisk(const FlatFilePos& pos, BlockFilter& filter) const;
+    bool ReadFilterFromDisk(const FlatFilePos& pos, BlockFilter& filter, const uint256& hash) const;
     size_t WriteFilterToDisk(FlatFilePos& pos, const BlockFilter& filter);
 
     Mutex m_cs_headers_cache;


### PR DESCRIPTION
What's stored in the block filter index data files is the block_hash and the encoded gcs filter.

If there's a disk error that corrupts the encoded filter there's no way for the node to know.

Clients that use the "header" chain will notice the error though.

It takes 1ms to verify the hash on a filter with 10000 elements.