### PR TITLE
fuzz: Add fuzzing harness for TorController

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -291,6 +291,7 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/strprintf.cpp \
  test/fuzz/system.cpp \
  test/fuzz/timedata.cpp \
+ test/fuzz/torcontrol.cpp \
  test/fuzz/transaction.cpp \
  test/fuzz/tx_in.cpp \
  test/fuzz/tx_out.cpp \

--- a/src/test/fuzz/torcontrol.cpp
+++ b/src/test/fuzz/torcontrol.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <torcontrol.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+class DummyTorControlConnection : public TorControlConnection
+{
+public:
+    DummyTorControlConnection() : TorControlConnection{nullptr}
+    {
+    }
+
+    bool Connect(const std::string&, const ConnectionCB&, const ConnectionCB&)
+    {
+        return true;
+    }
+
+    void Disconnect()
+    {
+    }
+
+    bool Command(const std::string&, const ReplyHandlerCB&)
+    {
+        return true;
+    }
+};
+
+void initialize_torcontrol()
+{
+    static const auto testing_setup = MakeNoLogFileContext<>();
+}
+
+FUZZ_TARGET_INIT(torcontrol, initialize_torcontrol)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+
+    TorController tor_controller;
+    while (fuzzed_data_provider.ConsumeBool()) {
+        TorControlReply tor_control_reply;
+        CallOneOf(
+            fuzzed_data_provider,
+            [&] {
+                tor_control_reply.code = 250;
+            },
+            [&] {
+                tor_control_reply.code = 510;
+            },
+            [&] {
+                tor_control_reply.code = fuzzed_data_provider.ConsumeIntegral<int>();
+            });
+        tor_control_reply.lines = ConsumeRandomLengthStringVector(fuzzed_data_provider);
+        if (tor_control_reply.lines.empty()) {
+            break;
+        }
+        DummyTorControlConnection dummy_tor_control_connection;
+        CallOneOf(
+            fuzzed_data_provider,
+            [&] {
+                tor_controller.add_onion_cb(dummy_tor_control_connection, tor_control_reply);
+            },
+            [&] {
+                tor_controller.auth_cb(dummy_tor_control_connection, tor_control_reply);
+            },
+            [&] {
+                tor_controller.authchallenge_cb(dummy_tor_control_connection, tor_control_reply);
+            },
+            [&] {
+                tor_controller.protocolinfo_cb(dummy_tor_control_connection, tor_control_reply);
+            });
+    }
+}

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -56,77 +56,6 @@ static const int MAX_LINE_LENGTH = 100000;
 
 /****** Low-level TorControlConnection ********/
 
-/** Reply from Tor, can be single or multi-line */
-class TorControlReply
-{
-public:
-    TorControlReply() { Clear(); }
-
-    int code;
-    std::vector<std::string> lines;
-
-    void Clear()
-    {
-        code = 0;
-        lines.clear();
-    }
-};
-
-/** Low-level handling for Tor control connection.
- * Speaks the SMTP-like protocol as defined in torspec/control-spec.txt
- */
-class TorControlConnection
-{
-public:
-    typedef std::function<void(TorControlConnection&)> ConnectionCB;
-    typedef std::function<void(TorControlConnection &,const TorControlReply &)> ReplyHandlerCB;
-
-    /** Create a new TorControlConnection.
-     */
-    explicit TorControlConnection(struct event_base *base);
-    ~TorControlConnection();
-
-    /**
-     * Connect to a Tor control port.
-     * tor_control_center is address of the form host:port.
-     * connected is the handler that is called when connection is successfully established.
-     * disconnected is a handler that is called when the connection is broken.
-     * Return true on success.
-     */
-    bool Connect(const std::string& tor_control_center, const ConnectionCB& connected, const ConnectionCB& disconnected);
-
-    /**
-     * Disconnect from Tor control port.
-     */
-    void Disconnect();
-
-    /** Send a command, register a handler for the reply.
-     * A trailing CRLF is automatically added.
-     * Return true on success.
-     */
-    bool Command(const std::string &cmd, const ReplyHandlerCB& reply_handler);
-
-    /** Response handlers for async replies */
-    boost::signals2::signal<void(TorControlConnection &,const TorControlReply &)> async_handler;
-private:
-    /** Callback when ready for use */
-    std::function<void(TorControlConnection&)> connected;
-    /** Callback when connection lost */
-    std::function<void(TorControlConnection&)> disconnected;
-    /** Libevent event base */
-    struct event_base *base;
-    /** Connection to control socket */
-    struct bufferevent *b_conn;
-    /** Message being received */
-    TorControlReply message;
-    /** Response handlers */
-    std::deque<ReplyHandlerCB> reply_handlers;
-
-    /** Libevent handlers: internal */
-    static void readcb(struct bufferevent *bev, void *ctx);
-    static void eventcb(struct bufferevent *bev, short what, void *ctx);
-};
-
 TorControlConnection::TorControlConnection(struct event_base *_base):
     base(_base), b_conn(nullptr)
 {
@@ -362,55 +291,6 @@ std::map<std::string,std::string> ParseTorReplyMapping(const std::string &s)
     }
     return mapping;
 }
-
-/****** Bitcoin specific TorController implementation ********/
-
-/** Controller that connects to Tor control socket, authenticate, then create
- * and maintain an ephemeral onion service.
- */
-class TorController
-{
-public:
-    TorController(struct event_base* base, const std::string& tor_control_center, const CService& target);
-    ~TorController();
-
-    /** Get name of file to store private key in */
-    fs::path GetPrivateKeyFile();
-
-    /** Reconnect, after getting disconnected */
-    void Reconnect();
-private:
-    struct event_base* base;
-    const std::string m_tor_control_center;
-    TorControlConnection conn;
-    std::string private_key;
-    std::string service_id;
-    bool reconnect;
-    struct event *reconnect_ev;
-    float reconnect_timeout;
-    CService service;
-    const CService m_target;
-    /** Cookie for SAFECOOKIE auth */
-    std::vector<uint8_t> cookie;
-    /** ClientNonce for SAFECOOKIE auth */
-    std::vector<uint8_t> clientNonce;
-
-    /** Callback for ADD_ONION result */
-    void add_onion_cb(TorControlConnection& conn, const TorControlReply& reply);
-    /** Callback for AUTHENTICATE result */
-    void auth_cb(TorControlConnection& conn, const TorControlReply& reply);
-    /** Callback for AUTHCHALLENGE result */
-    void authchallenge_cb(TorControlConnection& conn, const TorControlReply& reply);
-    /** Callback for PROTOCOLINFO result */
-    void protocolinfo_cb(TorControlConnection& conn, const TorControlReply& reply);
-    /** Callback after successful connection */
-    void connected_cb(TorControlConnection& conn);
-    /** Callback after connection lost or failed connection attempt */
-    void disconnected_cb(TorControlConnection& conn);
-
-    /** Callback for reconnect timer */
-    static void reconnect_cb(evutil_socket_t fd, short what, void *arg);
-};
 
 TorController::TorController(struct event_base* _base, const std::string& tor_control_center, const CService& target):
     base(_base),

--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -8,7 +8,19 @@
 #ifndef BITCOIN_TORCONTROL_H
 #define BITCOIN_TORCONTROL_H
 
+#include <fs.h>
+#include <netaddress.h>
+
+#include <boost/signals2/signal.hpp>
+
+#include <event2/bufferevent.h>
+#include <event2/event.h>
+
+#include <cstdlib>
+#include <deque>
+#include <functional>
 #include <string>
+#include <vector>
 
 class CService;
 
@@ -20,5 +32,125 @@ void InterruptTorControl();
 void StopTorControl();
 
 CService DefaultOnionServiceTarget();
+
+/** Reply from Tor, can be single or multi-line */
+class TorControlReply
+{
+public:
+    TorControlReply() { Clear(); }
+
+    int code;
+    std::vector<std::string> lines;
+
+    void Clear()
+    {
+        code = 0;
+        lines.clear();
+    }
+};
+
+/** Low-level handling for Tor control connection.
+ * Speaks the SMTP-like protocol as defined in torspec/control-spec.txt
+ */
+class TorControlConnection
+{
+public:
+    typedef std::function<void(TorControlConnection&)> ConnectionCB;
+    typedef std::function<void(TorControlConnection &,const TorControlReply &)> ReplyHandlerCB;
+
+    /** Create a new TorControlConnection.
+     */
+    explicit TorControlConnection(struct event_base *base);
+    ~TorControlConnection();
+
+    /**
+     * Connect to a Tor control port.
+     * tor_control_center is address of the form host:port.
+     * connected is the handler that is called when connection is successfully established.
+     * disconnected is a handler that is called when the connection is broken.
+     * Return true on success.
+     */
+    bool Connect(const std::string& tor_control_center, const ConnectionCB& connected, const ConnectionCB& disconnected);
+
+    /**
+     * Disconnect from Tor control port.
+     */
+    void Disconnect();
+
+    /** Send a command, register a handler for the reply.
+     * A trailing CRLF is automatically added.
+     * Return true on success.
+     */
+    bool Command(const std::string &cmd, const ReplyHandlerCB& reply_handler);
+
+    /** Response handlers for async replies */
+    boost::signals2::signal<void(TorControlConnection &,const TorControlReply &)> async_handler;
+private:
+    /** Callback when ready for use */
+    std::function<void(TorControlConnection&)> connected;
+    /** Callback when connection lost */
+    std::function<void(TorControlConnection&)> disconnected;
+    /** Libevent event base */
+    struct event_base *base;
+    /** Connection to control socket */
+    struct bufferevent *b_conn;
+    /** Message being received */
+    TorControlReply message;
+    /** Response handlers */
+    std::deque<ReplyHandlerCB> reply_handlers;
+
+    /** Libevent handlers: internal */
+    static void readcb(struct bufferevent *bev, void *ctx);
+    static void eventcb(struct bufferevent *bev, short what, void *ctx);
+};
+
+/****** Bitcoin specific TorController implementation ********/
+
+/** Controller that connects to Tor control socket, authenticate, then create
+ * and maintain an ephemeral onion service.
+ */
+class TorController
+{
+public:
+    TorController(struct event_base* base, const std::string& tor_control_center, const CService& target);
+    ~TorController();
+
+    /** Get name of file to store private key in */
+    fs::path GetPrivateKeyFile();
+
+    /** Reconnect, after getting disconnected */
+    void Reconnect();
+private:
+    struct event_base* base;
+    const std::string m_tor_control_center;
+    TorControlConnection conn;
+    std::string private_key;
+    std::string service_id;
+    bool reconnect;
+    struct event *reconnect_ev;
+    float reconnect_timeout;
+    CService service;
+    const CService m_target;
+    /** Cookie for SAFECOOKIE auth */
+    std::vector<uint8_t> cookie;
+    /** ClientNonce for SAFECOOKIE auth */
+    std::vector<uint8_t> clientNonce;
+
+    /** Callback for ADD_ONION result */
+    void add_onion_cb(TorControlConnection& conn, const TorControlReply& reply);
+    /** Callback for AUTHENTICATE result */
+    void auth_cb(TorControlConnection& conn, const TorControlReply& reply);
+    /** Callback for AUTHCHALLENGE result */
+    void authchallenge_cb(TorControlConnection& conn, const TorControlReply& reply);
+    /** Callback for PROTOCOLINFO result */
+    void protocolinfo_cb(TorControlConnection& conn, const TorControlReply& reply);
+    /** Callback after successful connection */
+    void connected_cb(TorControlConnection& conn);
+    /** Callback after connection lost or failed connection attempt */
+    void disconnected_cb(TorControlConnection& conn);
+
+    /** Callback for reconnect timer */
+    static void reconnect_cb(evutil_socket_t fd, short what, void *arg);
+};
 
 #endif /* BITCOIN_TORCONTROL_H */

--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -113,6 +113,9 @@ class TorController
 {
 public:
     TorController(struct event_base* base, const std::string& tor_control_center, const CService& target);
+    TorController() : conn{nullptr} {
+        // Used for testing only.
+    }
     ~TorController();
 
     /** Get name of file to store private key in */
@@ -127,7 +130,7 @@ private:
     std::string private_key;
     std::string service_id;
     bool reconnect;
-    struct event *reconnect_ev;
+    struct event *reconnect_ev = nullptr;
     float reconnect_timeout;
     CService service;
     const CService m_target;
@@ -136,6 +139,7 @@ private:
     /** ClientNonce for SAFECOOKIE auth */
     std::vector<uint8_t> clientNonce;
 
+public:
     /** Callback for ADD_ONION result */
     void add_onion_cb(TorControlConnection& conn, const TorControlReply& reply);
     /** Callback for AUTHENTICATE result */


### PR DESCRIPTION
Add fuzzing harness for `TorController`.

See [`doc/fuzzing.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md) for information on how to fuzz Bitcoin Core. Don't forget to contribute any coverage increasing inputs you find to the [Bitcoin Core fuzzing corpus repo](https://github.com/bitcoin-core/qa-assets).

Happy fuzzing :)