### PR TITLE
refactor: Use AbortError in FatalError

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -17,15 +17,13 @@ constexpr char DB_BEST_BLOCK = 'B';
 constexpr int64_t SYNC_LOG_INTERVAL = 30; // seconds
 constexpr int64_t SYNC_LOCATOR_WRITE_INTERVAL = 30; // seconds
 
-template<typename... Args>
+template <typename... Args>
 static void FatalError(const char* fmt, const Args&... args)
 {
     std::string strMessage = tfm::format(fmt, args...);
     SetMiscWarning(Untranslated(strMessage));
     LogPrintf("*** %s\n", strMessage);
-    uiInterface.ThreadSafeMessageBox(
-        Untranslated("Error: A fatal internal error occurred, see debug.log for details"),
-        "", CClientUIInterface::MSG_ERROR);
+    AbortError(_("A fatal internal error occurred, see debug.log for details"));
     StartShutdown();
 }
 

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -122,6 +122,7 @@ void InitWarning(const bilingual_str& str);
 
 /** Show error message **/
 bool InitError(const bilingual_str& str);
+constexpr auto AbortError = InitError;
 
 extern CClientUIInterface uiInterface;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1662,8 +1662,6 @@ bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex)
     return true;
 }
 
-constexpr auto AbortError = InitError;
-
 /** Abort with a message */
 static bool AbortNode(const std::string& strMessage, bilingual_str user_message = bilingual_str())
 {


### PR DESCRIPTION
`FatalError` has been copied from `AbortNode`, so the two should use the same style to avoid confusion.

Follow-up to #18927 