### PR TITLE
tests: Add fuzzing harness for AES{CBC,}256{Encrypt,Decrypt}, poly1305_auth, CHKDF_HMAC_SHA256_L32, ChaCha20 and ChaCha20Poly1305AEAD

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -36,6 +36,7 @@ FUZZ_TARGETS = \
   test/fuzz/crypto_aes256 \
   test/fuzz/crypto_aes256cbc \
   test/fuzz/crypto_chacha20 \
+  test/fuzz/crypto_chacha20_poly1305_aead \
   test/fuzz/crypto_common \
   test/fuzz/crypto_hkdf_hmac_sha256_l32 \
   test/fuzz/crypto_poly1305 \
@@ -508,6 +509,12 @@ test_fuzz_crypto_chacha20_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_crypto_chacha20_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_crypto_chacha20_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_crypto_chacha20_SOURCES = test/fuzz/crypto_chacha20.cpp
+
+test_fuzz_crypto_chacha20_poly1305_aead_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_crypto_chacha20_poly1305_aead_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_crypto_chacha20_poly1305_aead_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_crypto_chacha20_poly1305_aead_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_crypto_chacha20_poly1305_aead_SOURCES = test/fuzz/crypto_chacha20_poly1305_aead.cpp
 
 test_fuzz_crypto_common_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_crypto_common_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -34,6 +34,7 @@ FUZZ_TARGETS = \
   test/fuzz/coins_view \
   test/fuzz/crypto \
   test/fuzz/crypto_aes256 \
+  test/fuzz/crypto_aes256cbc \
   test/fuzz/crypto_common \
   test/fuzz/cuckoocache \
   test/fuzz/decode_tx \
@@ -492,6 +493,12 @@ test_fuzz_crypto_aes256_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_crypto_aes256_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_crypto_aes256_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_crypto_aes256_SOURCES = test/fuzz/crypto_aes256.cpp
+
+test_fuzz_crypto_aes256cbc_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_crypto_aes256cbc_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_crypto_aes256cbc_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_crypto_aes256cbc_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_crypto_aes256cbc_SOURCES = test/fuzz/crypto_aes256cbc.cpp
 
 test_fuzz_crypto_common_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_crypto_common_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -35,6 +35,7 @@ FUZZ_TARGETS = \
   test/fuzz/crypto \
   test/fuzz/crypto_aes256 \
   test/fuzz/crypto_aes256cbc \
+  test/fuzz/crypto_chacha20 \
   test/fuzz/crypto_common \
   test/fuzz/crypto_hkdf_hmac_sha256_l32 \
   test/fuzz/crypto_poly1305 \
@@ -501,6 +502,12 @@ test_fuzz_crypto_aes256cbc_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_crypto_aes256cbc_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_crypto_aes256cbc_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_crypto_aes256cbc_SOURCES = test/fuzz/crypto_aes256cbc.cpp
+
+test_fuzz_crypto_chacha20_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_crypto_chacha20_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_crypto_chacha20_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_crypto_chacha20_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_crypto_chacha20_SOURCES = test/fuzz/crypto_chacha20.cpp
 
 test_fuzz_crypto_common_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_crypto_common_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -33,6 +33,7 @@ FUZZ_TARGETS = \
   test/fuzz/coins_deserialize \
   test/fuzz/coins_view \
   test/fuzz/crypto \
+  test/fuzz/crypto_aes256 \
   test/fuzz/crypto_common \
   test/fuzz/cuckoocache \
   test/fuzz/decode_tx \
@@ -485,6 +486,12 @@ test_fuzz_crypto_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_crypto_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_crypto_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_crypto_SOURCES = test/fuzz/crypto.cpp
+
+test_fuzz_crypto_aes256_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_crypto_aes256_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_crypto_aes256_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_crypto_aes256_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_crypto_aes256_SOURCES = test/fuzz/crypto_aes256.cpp
 
 test_fuzz_crypto_common_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_crypto_common_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -36,6 +36,7 @@ FUZZ_TARGETS = \
   test/fuzz/crypto_aes256 \
   test/fuzz/crypto_aes256cbc \
   test/fuzz/crypto_common \
+  test/fuzz/crypto_hkdf_hmac_sha256_l32 \
   test/fuzz/crypto_poly1305 \
   test/fuzz/cuckoocache \
   test/fuzz/decode_tx \
@@ -506,6 +507,12 @@ test_fuzz_crypto_common_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_crypto_common_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_crypto_common_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_crypto_common_SOURCES = test/fuzz/crypto_common.cpp
+
+test_fuzz_crypto_hkdf_hmac_sha256_l32_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_crypto_hkdf_hmac_sha256_l32_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_crypto_hkdf_hmac_sha256_l32_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_crypto_hkdf_hmac_sha256_l32_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_crypto_hkdf_hmac_sha256_l32_SOURCES = test/fuzz/crypto_hkdf_hmac_sha256_l32.cpp
 
 test_fuzz_crypto_poly1305_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_crypto_poly1305_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -36,6 +36,7 @@ FUZZ_TARGETS = \
   test/fuzz/crypto_aes256 \
   test/fuzz/crypto_aes256cbc \
   test/fuzz/crypto_common \
+  test/fuzz/crypto_poly1305 \
   test/fuzz/cuckoocache \
   test/fuzz/decode_tx \
   test/fuzz/descriptor_parse \
@@ -505,6 +506,12 @@ test_fuzz_crypto_common_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_crypto_common_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_crypto_common_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_crypto_common_SOURCES = test/fuzz/crypto_common.cpp
+
+test_fuzz_crypto_poly1305_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_crypto_poly1305_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_crypto_poly1305_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_crypto_poly1305_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_crypto_poly1305_SOURCES = test/fuzz/crypto_poly1305.cpp
 
 test_fuzz_cuckoocache_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_cuckoocache_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/test/fuzz/crypto_aes256.cpp
+++ b/src/test/fuzz/crypto_aes256.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <crypto/aes.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cassert>
+#include <cstdint>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    const std::vector<uint8_t> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, AES256_KEYSIZE);
+
+    AES256Encrypt encrypt{key.data()};
+    AES256Decrypt decrypt{key.data()};
+
+    while (fuzzed_data_provider.ConsumeBool()) {
+        const std::vector<uint8_t> plaintext = ConsumeFixedLengthByteVector(fuzzed_data_provider, AES_BLOCKSIZE);
+        std::vector<uint8_t> ciphertext(AES_BLOCKSIZE);
+        encrypt.Encrypt(ciphertext.data(), plaintext.data());
+        std::vector<uint8_t> decrypted_plaintext(AES_BLOCKSIZE);
+        decrypt.Decrypt(decrypted_plaintext.data(), ciphertext.data());
+        assert(decrypted_plaintext == plaintext);
+    }
+}

--- a/src/test/fuzz/crypto_aes256cbc.cpp
+++ b/src/test/fuzz/crypto_aes256cbc.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <crypto/aes.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cassert>
+#include <cstdint>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    const std::vector<uint8_t> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, AES256_KEYSIZE);
+    const std::vector<uint8_t> iv = ConsumeFixedLengthByteVector(fuzzed_data_provider, AES_BLOCKSIZE);
+    const bool pad = fuzzed_data_provider.ConsumeBool();
+
+    AES256CBCEncrypt encrypt{key.data(), iv.data(), pad};
+    AES256CBCDecrypt decrypt{key.data(), iv.data(), pad};
+
+    while (fuzzed_data_provider.ConsumeBool()) {
+        const std::vector<uint8_t> plaintext = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+        std::vector<uint8_t> ciphertext(plaintext.size() + AES_BLOCKSIZE);
+        const int encrypt_ret = encrypt.Encrypt(plaintext.data(), plaintext.size(), ciphertext.data());
+        ciphertext.resize(encrypt_ret);
+        std::vector<uint8_t> decrypted_plaintext(ciphertext.size());
+        const int decrypt_ret = decrypt.Decrypt(ciphertext.data(), ciphertext.size(), decrypted_plaintext.data());
+        decrypted_plaintext.resize(decrypt_ret);
+        assert(decrypted_plaintext == plaintext || (!pad && plaintext.size() % AES_BLOCKSIZE != 0 && encrypt_ret == 0 && decrypt_ret == 0));
+    }
+}

--- a/src/test/fuzz/crypto_chacha20.cpp
+++ b/src/test/fuzz/crypto_chacha20.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <crypto/chacha20.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cstdint>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+
+    ChaCha20 chacha20;
+    if (fuzzed_data_provider.ConsumeBool()) {
+        const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(16, 32));
+        chacha20 = ChaCha20{key.data(), key.size()};
+    }
+    while (fuzzed_data_provider.ConsumeBool()) {
+        switch (fuzzed_data_provider.ConsumeIntegralInRange(0, 4)) {
+        case 0: {
+            const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(16, 32));
+            chacha20.SetKey(key.data(), key.size());
+            break;
+        }
+        case 1: {
+            chacha20.SetIV(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+            break;
+        }
+        case 2: {
+            chacha20.Seek(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+            break;
+        }
+        case 3: {
+            std::vector<uint8_t> output(fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
+            chacha20.Keystream(output.data(), output.size());
+            break;
+        }
+        case 4: {
+            std::vector<uint8_t> output(fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
+            const std::vector<uint8_t> input = ConsumeFixedLengthByteVector(fuzzed_data_provider, output.size());
+            chacha20.Crypt(input.data(), output.data(), input.size());
+            break;
+        }
+        }
+    }
+}

--- a/src/test/fuzz/crypto_chacha20_poly1305_aead.cpp
+++ b/src/test/fuzz/crypto_chacha20_poly1305_aead.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <crypto/chacha_poly_aead.h>
+#include <crypto/poly1305.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+
+    const std::vector<uint8_t> k1 = ConsumeFixedLengthByteVector(fuzzed_data_provider, CHACHA20_POLY1305_AEAD_KEY_LEN);
+    const std::vector<uint8_t> k2 = ConsumeFixedLengthByteVector(fuzzed_data_provider, CHACHA20_POLY1305_AEAD_KEY_LEN);
+
+    ChaCha20Poly1305AEAD aead(k1.data(), k1.size(), k2.data(), k2.size());
+    uint64_t seqnr_payload = 0;
+    uint64_t seqnr_aad = 0;
+    int aad_pos = 0;
+    size_t buffer_size = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096);
+    std::vector<uint8_t> in(buffer_size + CHACHA20_POLY1305_AEAD_AAD_LEN + POLY1305_TAGLEN, 0);
+    std::vector<uint8_t> out(buffer_size + CHACHA20_POLY1305_AEAD_AAD_LEN + POLY1305_TAGLEN, 0);
+    bool is_encrypt = fuzzed_data_provider.ConsumeBool();
+    while (fuzzed_data_provider.ConsumeBool()) {
+        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 6)) {
+        case 0: {
+            buffer_size = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(64, 4096);
+            in = std::vector<uint8_t>(buffer_size + CHACHA20_POLY1305_AEAD_AAD_LEN + POLY1305_TAGLEN, 0);
+            out = std::vector<uint8_t>(buffer_size + CHACHA20_POLY1305_AEAD_AAD_LEN + POLY1305_TAGLEN, 0);
+            break;
+        }
+        case 1: {
+            (void)aead.Crypt(seqnr_payload, seqnr_aad, aad_pos, out.data(), out.size(), in.data(), buffer_size, is_encrypt);
+            break;
+        }
+        case 2: {
+            uint32_t len = 0;
+            const bool ok = aead.GetLength(&len, seqnr_aad, aad_pos, in.data());
+            assert(ok);
+            break;
+        }
+        case 3: {
+            seqnr_payload += 1;
+            aad_pos += CHACHA20_POLY1305_AEAD_AAD_LEN;
+            if (aad_pos + CHACHA20_POLY1305_AEAD_AAD_LEN > CHACHA20_ROUND_OUTPUT) {
+                aad_pos = 0;
+                seqnr_aad += 1;
+            }
+            break;
+        }
+        case 4: {
+            seqnr_payload = fuzzed_data_provider.ConsumeIntegral<int>();
+            break;
+        }
+        case 5: {
+            seqnr_aad = fuzzed_data_provider.ConsumeIntegral<int>();
+            break;
+        }
+        case 6: {
+            is_encrypt = fuzzed_data_provider.ConsumeBool();
+            break;
+        }
+        }
+    }
+}

--- a/src/test/fuzz/crypto_hkdf_hmac_sha256_l32.cpp
+++ b/src/test/fuzz/crypto_hkdf_hmac_sha256_l32.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <crypto/hkdf_sha256_32.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+
+    const std::vector<uint8_t> initial_key_material = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+
+    CHKDF_HMAC_SHA256_L32 hkdf_hmac_sha256_l32(initial_key_material.data(), initial_key_material.size(), fuzzed_data_provider.ConsumeRandomLengthString(1024));
+    while (fuzzed_data_provider.ConsumeBool()) {
+        std::vector<uint8_t> out(32);
+        hkdf_hmac_sha256_l32.Expand32(fuzzed_data_provider.ConsumeRandomLengthString(128), out.data());
+    }
+}

--- a/src/test/fuzz/crypto_poly1305.cpp
+++ b/src/test/fuzz/crypto_poly1305.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <crypto/poly1305.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cstdint>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+
+    const std::vector<uint8_t> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, POLY1305_KEYLEN);
+    const std::vector<uint8_t> in = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+
+    std::vector<uint8_t> tag_out(POLY1305_TAGLEN);
+    poly1305_auth(tag_out.data(), in.data(), in.size(), key.data());
+}


### PR DESCRIPTION
Add fuzzing harness for `AES{CBC,}256{Encrypt,Decrypt}`, `poly1305_auth`, `CHKDF_HMAC_SHA256_L32`, `ChaCha20` and `ChaCha20Poly1305AEAD`.

See [`doc/fuzzing.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md) for information on how to fuzz Bitcoin Core. Don't forget to contribute any coverage increasing inputs you find to the [Bitcoin Core fuzzing corpus repo](https://github.com/bitcoin-core/qa-assets).

Happy fuzzing :)