### PR TITLE
[test] WIP: rewrite generate() in test_node to gain determinism in test data

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -379,6 +379,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
                 wallet_name = w.split('=', 1)[1]
                 n.createwallet(wallet_name=wallet_name, descriptors=self.options.descriptors)
         self.import_deterministic_coinbase_privkeys()
+        self.import_hd_seed()
         if not self.setup_clean_chain:
             for n in self.nodes:
                 assert_equal(n.getblockchaininfo()["blocks"], 199)
@@ -402,6 +403,16 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
                 continue
 
             n.importprivkey(privkey=n.get_deterministic_priv_key().key, label='coinbase')
+
+    # Preset an HD seed for nodes, if the nodes have wallet compiled
+    def import_hd_seed(self):
+        for n in self.nodes:
+            try:
+                n.getwalletinfo()
+            except JSONRPCException as e:
+                assert str(e).startswith('Method not found')
+                continue
+            n.sethdseed()
 
     def run_test(self):
         """Tests must override this method to define test logic"""

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -134,7 +134,7 @@ class TestNode():
         self.hdkeypathnonce =0
 
     AddressKeyPair = collections.namedtuple('AddressKeyPair', ['address', 'key'])
-    PRIV_KEYS = [
+    PRIV_KEYS = [ #seed and xpub, regtest node, call sethdseed, make upseed using random strings => 
             # address , privkey
             AddressKeyPair('mjTkW3DjgyZck4KbiRusZsqTgaYTxdSz6z', 'cVpF924EspNh8KjYsfhgY96mmxvT6DgdWiTYMtMjuM74hJaU5psW'),
             AddressKeyPair('msX6jQXvxiNhx3Q62PKeLPrhrqZQdSimTg', 'cUxsWyKyZ9MAQTaAhUQWJmBbSvHMwSmuv59KgxQV7oZQU3PXN3KE'),
@@ -149,9 +149,21 @@ class TestNode():
             AddressKeyPair('mpFAHDjX7KregM3rVotdXzQmkbwtbQEnZ6', 'cT7qK7g1wkYEMvKowd2ZrX1E5f6JQ7TM246UfqbCiyF7kZhorpX3'),
             AddressKeyPair('mzRe8QZMfGi58KyWCse2exxEFry2sfF2Y7', 'cPiRWE8KMjTRxH1MWkPerhfoHFn5iHPWVK5aPqjW8NxmdwenFinJ'),
     ]
-
+    SeedXpubPair = collections.namedtuple('SeedXPubPair', ['seed', 'xpub'])
+    XPUBS = [
+        # how to go from hdseed to xpub, by calling getnewaddress?
+        # run cli?
+        # can you make up your ownhd seed
+        # if not, how to pregenerate key
+        # maybe checkout DeriveNewSeed
+    ]
     def get_deterministic_priv_key(self):
         """Return a deterministic priv key in base58, that only depends on the node's index"""
+        assert len(self.PRIV_KEYS) == MAX_NODES
+        return self.PRIV_KEYS[self.index]
+
+    def get_deterministic_hd_seed(self):
+        """Return a deterministic hd seed, that only depends on the node's index"""
         assert len(self.PRIV_KEYS) == MAX_NODES
         return self.PRIV_KEYS[self.index]
 
@@ -296,17 +308,26 @@ class TestNode():
         self._raise_assertion_error("Unable to retrieve cookie credentials after {}s".format(self.rpc_timeout))
 
     def generate(self, nblocks, maxtries=1000000):
-        # if wallet is not compiled, blocks are generated to an address or descriptor using an HD seed
-        if '-disablewallet' in self.extra_args:
-            xpub = "tpubDAXcJ7s7ZwicqjprRaEWdPoHKrCS215qxGYxpusRLLmJuT69ZSicuGdSfyvyKpvUNYBW1s2U3NSrT6vrCYB9e6nZUEvrqnwXPF8ArTCRXMY"
-            finger_print = "d34db33f"
-            keypath = "/44'/0'/0'/0/" + str(self.hdkeypathnonce)
-            desc = "pkh([" + finger_print + keypath + "]" + xpub+ "/1)" 
-            self.hdkeypathnonce += 1
-            return self.generatetodescriptor(nblocks, desc, maxtries)
-        else:
-            hd_address = self.getnewaddress()
-            return self.generatetoaddress(nblocks, hd_address, maxtries)
+        # # if wallet is not compiled, blocks are generated to an address or descriptor using an HD seed
+        # # the seeds and corresponding xpubs have been pregenerated
+        # if '-disablewallet' in self.extra_args:
+        #     print('############')
+        #     xpub = "tpubDAXcJ7s7ZwicqjprRaEWdPoHKrCS215qxGYxpusRLLmJuT69ZSicuGdSfyvyKpvUNYBW1s2U3NSrT6vrCYB9e6nZUEvrqnwXPF8ArTCRXMY"
+        #     finger_print = "d34db33f"
+        #     keypath = "/44'/0'/0'/0/" + str(self.hdkeypathnonce)
+        #     desc = "pkh([" + finger_print + keypath + "]" + xpub+ "/1)" 
+        #     self.hdkeypathnonce += 1
+        #     return self.generatetodescriptor(nblocks, desc, maxtries)
+        # # if wallet has been compiled, the hd seed has been preset in the test_framework
+        # else:
+        #     print('*************')
+        #     finger_print = self.hdinfo
+        #     hd_address = self.getnewaddress()
+        #     return self.generatetoaddress(nblocks, hd_address, maxtries)
+        #     #wallet, hd seed = descriptor'
+        self.log.debug("TestNode.generate() dispatches `generate` call to `generatetoaddress`")
+        return self.generatetoaddress(nblocks=nblocks, address=self.get_deterministic_priv_key().address, maxtries=maxtries)
+            
           
     def get_wallet_rpc(self, wallet_name):
         if self.use_cli:

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -297,18 +297,17 @@ class TestNode():
 
     def generate(self, nblocks, maxtries=1000000):
         # if wallet is not compiled, blocks are generated to an address or descriptor using an HD seed
-        hd_address = self.getnewaddress()
-        hd_info = self.getaddressinfo(hd_address)
-        if self.getwalletinfo()["descriptors"]:
-            #TODO: figure out how to make sure the keypath does increase & is unique
-            assert_equal(hd_info["hdkeypath"], "m/84'/1'/0'/0/" + str(self.hdkeypathnonce))
-            self.hdkeypathnonce += 1 
-            self.generatetodescriptor(nblocks, hd_address, maxtries)
-        else:
-            assert_equal(hd_info["hdkeypath"], "m/0'/0'/"+str(self.hdkeypathnonce)+"'")          
+        if '-disablewallet' in self.extra_args:
+            xpub = "tpubDAXcJ7s7ZwicqjprRaEWdPoHKrCS215qxGYxpusRLLmJuT69ZSicuGdSfyvyKpvUNYBW1s2U3NSrT6vrCYB9e6nZUEvrqnwXPF8ArTCRXMY"
+            finger_print = "d34db33f"
+            keypath = "/44'/0'/0'/0/" + str(self.hdkeypathnonce)
+            desc = "pkh([" + finger_print + keypath + "]" + xpub+ "/1)" 
             self.hdkeypathnonce += 1
-            self.generatetoaddress(nblocks, hd_address, maxtries)
-
+            return self.generatetodescriptor(nblocks, desc, maxtries)
+        else:
+            hd_address = self.getnewaddress()
+            return self.generatetoaddress(nblocks, hd_address, maxtries)
+          
     def get_wallet_rpc(self, wallet_name):
         if self.use_cli:
             return RPCOverloadWrapper(self.cli("-rpcwallet={}".format(wallet_name)), True, self.descriptors)


### PR DESCRIPTION
This improvement was proposed by jnewbery in #19022 

We want to rewrite generate() function by using an hd seed to create addresses. This allows the test to have unique but deterministic addresses to which blocks can be generated. 

**TODO:** 
Investigate why certain created keypaths do not increase incrementally/consistently:

currently, I am using a counter `keypathnonce` to assert every key path generated from my HD seed is _unique_ and _increment by one_ (maybe this was the wrong assumption to start with?). 
Interestingly, when I ran tests, it seems that one particular key path,`m/0'/0'/105` and `m/0'/0'/106` , are always skipped. Whereas the rest of my hdkeypath increase consistently by one:

```
"m/0'/0'/0'
...
"m/0'/0'/101'
"m/0'/0'/102'
"m/0'/0'/103'
"m/0'/0'/104'
(skipping 105 and 106)
"m/0'/0'/107'

```



My assertion error

```
2020-06-16T15:29:57.583000Z TestFramework (ERROR): Assertion failed
Traceback (most recent call last):
  File "/Users/gwang/Documents/bitcoin/test/functional/test_framework/test_framework.py", line 116, in main
    self.run_test()
  File "test/functional/feature_dbcrash.py", line 223, in run_test
    utxo_list = create_confirmed_utxos(self.nodes[3].getnetworkinfo()['relayfee'], self.nodes[3], 5000)
  File "/Users/gwang/Documents/bitcoin/test/functional/test_framework/util.py", line 547, in create_confirmed_utxos
    node.generate(1)
  File "/Users/gwang/Documents/bitcoin/test/functional/test_framework/test_node.py", line 307, in generate
    assert_equal(hd_info["hdkeypath"], "m/0'/0'/"+str(self.hdkeypathnonce)+"'")
  File "/Users/gwang/Documents/bitcoin/test/functional/test_framework/util.py", line 46, in assert_equal
    raise AssertionError("not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args))
AssertionError: not(m/0'/0'/107' == m/0'/0'/105')
```
