### PR TITLE
test: Add missing sync_blocks

### DIFF
--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -93,6 +93,7 @@ class NotificationsTest(BitcoinTestFramework):
             self.nodes[0].sethdseed(seed=self.nodes[1].dumpprivkey(keyhash_to_p2pkh(hex_str_to_bytes(self.nodes[1].getwalletinfo()['hdseedid'])[::-1])))
             self.nodes[0].rescanblockchain()
             self.nodes[0].generatetoaddress(100, ADDRESS_BCRT1_UNSPENDABLE)
+            self.sync_blocks()
 
             # Generate transaction on node 0, sync mempools, and check for
             # notification on node 1.


### PR DESCRIPTION
Bitcoin Core does not sort block and tx announcements for other peers, so generating 100 blocks and then sending out a transaction might reject it if it arrives too early. (non-final)

Fix that by syncing the blocks first.

Fix #19265
Fix #19311 