### PR TITLE
wallet: Handle concurrent wallet loading

### DIFF
--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -7,18 +7,35 @@
 Verify that a bitcoind node can load multiple wallet files
 """
 from decimal import Decimal
+from threading import Thread
 import os
 import shutil
 import time
 
+from test_framework.authproxy import JSONRPCException
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.test_node import ErrorMatch
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
+    get_rpc_proxy,
 )
 
 FEATURE_LATEST = 169900
+
+got_loading_error = False
+def test_load_unload(node, name):
+    global got_loading_error
+    for i in range(10):
+        if got_loading_error:
+            return
+        try:
+            node.loadwallet(name)
+            node.unloadwallet(name)
+        except JSONRPCException as e:
+            if e.error['code'] == -4 and 'Wallet already being loading' in e.error['message']:
+                got_loading_error = True
+                return
 
 
 class MultiWalletTest(BitcoinTestFramework):
@@ -211,6 +228,18 @@ class MultiWalletTest(BitcoinTestFramework):
         assert_raises_rpc_error(-19, "Wallet file not specified", node.getwalletinfo)
         w2 = node.get_wallet_rpc(wallet_names[1])
         w2.getwalletinfo()
+
+        self.log.info("Concurrent wallet loading")
+        threads = []
+        for _ in range(3):
+            n = node.cli if self.options.usecli else get_rpc_proxy(node.url, 1, timeout=600, coveragedir=node.coverage_dir)
+            t = Thread(target=test_load_unload, args=(n, wallet_names[2], ))
+            t.start()
+            threads.append(t)
+        for t in threads:
+            t.join()
+        global got_loading_error
+        assert_equal(got_loading_error, True)
 
         self.log.info("Load remaining wallets")
         for wallet_name in wallet_names[2:]:


### PR DESCRIPTION
This PR handles concurrent wallet loading.

This can be tested by running in parallel the following script a couple of times:
```sh
for i in {1..10}
do
  src/bitcoin-cli -regtest loadwallet foo
  src/bitcoin-cli -regtest unloadwallet foo
done
```

Eventually the error occurs:
```
error code: -4
error message:
Wallet already being loading.
```

For reference, loading and already loaded wallet gives:
```
error code: -4
error message:
Wallet file verification failed. Error loading wallet w1. Duplicate -wallet filename specified.
```

Fixes #19232.