### PR TITLE
build: don't warn when doxygen isn't found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -111,9 +111,6 @@ AC_PATH_TOOL(READELF, readelf)
 AC_PATH_TOOL(CPPFILT, c++filt)
 AC_PATH_TOOL(OBJCOPY, objcopy)
 AC_PATH_PROG(DOXYGEN, doxygen)
-if test -z "$DOXYGEN"; then
-   AC_MSG_WARN([Doxygen not found])
-fi
 AM_CONDITIONAL([HAVE_DOXYGEN], [test -n "$DOXYGEN"])
 
 AC_ARG_VAR(PYTHONPATH, Augments the default search path for python module files)


### PR DESCRIPTION
Doxygen isn't so important that we need to warn when it is missing. I'd
assume it might even be missing more often than not for most builds.