### PR TITLE
refactor: Replace RecursiveMutex with Mutex in CTxMemPool

### DIFF
--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -5,12 +5,12 @@
 #include <bench/bench.h>
 #include <consensus/validation.h>
 #include <crypto/sha256.h>
+#include <sync.h>
 #include <test/util/mining.h>
 #include <test/util/setup_common.h>
 #include <test/util/wallet.h>
 #include <txmempool.h>
 #include <validation.h>
-
 
 #include <vector>
 
@@ -46,6 +46,7 @@ static void AssembleBlock(benchmark::Bench& bench)
     }
     {
         LOCK(::cs_main); // Required for ::AcceptToMemoryPool.
+        AssertLockNotHeld(test_setup.m_node.mempool->cs);
 
         for (const auto& txr : txs) {
             TxValidationState state;

--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -50,7 +50,7 @@ static void AssembleBlock(benchmark::Bench& bench)
 
         for (const auto& txr : txs) {
             TxValidationState state;
-            bool ret{::AcceptToMemoryPool(*test_setup.m_node.mempool, state, txr, nullptr /* plTxnReplaced */, false /* bypass_limits */, /* nAbsurdFee */ 0)};
+            bool ret{::AcceptToMemoryPoolWithUnlockedMempool(*test_setup.m_node.mempool, state, txr, nullptr /* plTxnReplaced */, false /* bypass_limits */, /* nAbsurdFee */ 0)};
             assert(ret);
         }
     }

--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -133,7 +133,7 @@ static void MempoolEviction(benchmark::Bench& bench)
         AddTx(tx5_r, 1000LL, pool);
         AddTx(tx6_r, 1100LL, pool);
         AddTx(tx7_r, 9000LL, pool);
-        pool.TrimToSize(pool.DynamicMemoryUsage() * 3 / 4);
+        pool.TrimToSize(pool.DynamicMemoryUsageNonLockHelper() * 3 / 4);
         pool.TrimToSize(GetVirtualTransactionSize(*tx1_r));
     });
 }

--- a/src/bench/mempool_stress.cpp
+++ b/src/bench/mempool_stress.cpp
@@ -86,7 +86,7 @@ static void ComplexMemPool(benchmark::Bench& bench)
         for (auto& tx : ordered_coins) {
             AddTx(tx, pool);
         }
-        pool.TrimToSize(pool.DynamicMemoryUsage() * 3 / 4);
+        pool.TrimToSize(pool.DynamicMemoryUsageNonLockHelper() * 3 / 4);
         pool.TrimToSize(GetVirtualTransactionSize(*ordered_coins.front()));
     });
 }

--- a/src/bench/rpc_mempool.cpp
+++ b/src/bench/rpc_mempool.cpp
@@ -18,21 +18,23 @@ static void AddTx(const CTransactionRef& tx, const CAmount& fee, CTxMemPool& poo
 static void RpcMempool(benchmark::Bench& bench)
 {
     CTxMemPool pool;
-    LOCK2(cs_main, pool.cs);
-
-    for (int i = 0; i < 1000; ++i) {
-        CMutableTransaction tx = CMutableTransaction();
-        tx.vin.resize(1);
-        tx.vin[0].scriptSig = CScript() << OP_1;
-        tx.vin[0].scriptWitness.stack.push_back({1});
-        tx.vout.resize(1);
-        tx.vout[0].scriptPubKey = CScript() << OP_1 << OP_EQUAL;
-        tx.vout[0].nValue = i;
-        const CTransactionRef tx_r{MakeTransactionRef(tx)};
-        AddTx(tx_r, /* fee */ i, pool);
+    {
+        LOCK2(cs_main, pool.cs);
+        for (int i = 0; i < 1000; ++i) {
+            CMutableTransaction tx = CMutableTransaction();
+            tx.vin.resize(1);
+            tx.vin[0].scriptSig = CScript() << OP_1;
+            tx.vin[0].scriptWitness.stack.push_back({1});
+            tx.vout.resize(1);
+            tx.vout[0].scriptPubKey = CScript() << OP_1 << OP_EQUAL;
+            tx.vout[0].nValue = i;
+            const CTransactionRef tx_r{MakeTransactionRef(tx)};
+            AddTx(tx_r, /* fee */ i, pool);
+        }
     }
 
     bench.run([&] {
+        LOCK(pool.cs);
         (void)MempoolToJSON(pool, /*verbose*/ true);
     });
 }

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -132,7 +132,7 @@ public:
     explicit PartiallyDownloadedBlock(CTxMemPool* poolIn) : pool(poolIn) {}
 
     // extra_txn is a list of extra transactions to look at, in <witness hash, reference> form
-    ReadStatus InitData(const CBlockHeaderAndShortTxIDs& cmpctblock, const std::vector<std::pair<uint256, CTransactionRef>>& extra_txn);
+    ReadStatus InitData(const CBlockHeaderAndShortTxIDs& cmpctblock, const std::vector<std::pair<uint256, CTransactionRef>>& extra_txn, bool mempool_locked = false);
     bool IsTxAvailable(size_t index) const;
     ReadStatus FillBlock(CBlock& block, const std::vector<CTransactionRef>& vtx_missing);
 };

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -333,9 +333,10 @@ public:
     {
         return ::feeEstimator.HighestTargetTracked(FeeEstimateHorizon::LONG_HALFLIFE);
     }
-    CFeeRate mempoolMinFee() override
+    CFeeRate mempoolMinFee() override EXCLUSIVE_LOCKS_REQUIRED(!::mempool.cs)
     {
         if (!m_node.mempool) return {};
+        AssertLockNotHeld(m_node.mempool->cs);
         return m_node.mempool->GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000);
     }
     CFeeRate relayMinFee() override { return ::minRelayTxFee; }

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -290,7 +290,7 @@ public:
     bool broadcastTransaction(const CTransactionRef& tx,
         const CAmount& max_tx_fee,
         bool relay,
-        std::string& err_string) override
+        std::string& err_string) override EXCLUSIVE_LOCKS_REQUIRED(!m_node.mempool->cs)
     {
         const TransactionError err = BroadcastTransaction(m_node, tx, err_string, max_tx_fee, relay, /*wait_callback*/ false);
         // Chain clients only care about failures to accept the tx to the mempool. Disregard non-mempool related failures.

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -298,10 +298,12 @@ public:
         // that Chain clients do not need to know about.
         return TransactionError::OK == err;
     }
-    void getTransactionAncestry(const uint256& txid, size_t& ancestors, size_t& descendants) override
+    void getTransactionAncestry(const uint256& txid, size_t& ancestors, size_t& descendants) override EXCLUSIVE_LOCKS_REQUIRED(!::mempool.cs)
     {
         ancestors = descendants = 0;
         if (!m_node.mempool) return;
+        AssertLockNotHeld(m_node.mempool->cs);
+        LOCK(m_node.mempool->cs);
         m_node.mempool->GetTransactionAncestry(txid, ancestors, descendants);
     }
     void getPackageLimits(unsigned int& limit_ancestor_count, unsigned int& limit_descendant_count) override

--- a/src/miner.h
+++ b/src/miner.h
@@ -158,7 +158,7 @@ public:
     explicit BlockAssembler(const CTxMemPool& mempool, const CChainParams& params, const Options& options);
 
     /** Construct a new block template with coinbase to scriptPubKeyIn */
-    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn);
+    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn, bool mempool_locked = false);
 
     static Optional<int64_t> m_last_block_num_txs;
     static Optional<int64_t> m_last_block_weight;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4392,7 +4392,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
 
                 // Respond to BIP35 mempool requests
                 if (fSendTrickle && pto->m_tx_relay->fSendMempool) {
-                    auto vtxinfo = m_mempool.infoAll();
+                    auto vtxinfo = WITH_LOCK(m_mempool.cs, return m_mempool.infoAll());
                     pto->m_tx_relay->fSendMempool = false;
                     CFeeRate filterrate;
                     {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -889,7 +889,7 @@ void PeerLogicValidation::InitializeNode(CNode *pnode) {
 
 void PeerLogicValidation::ReattemptInitialBroadcast(CScheduler& scheduler) const
 {
-    std::map<uint256, uint256> unbroadcast_txids = m_mempool.GetUnbroadcastTxs();
+    std::map<uint256, uint256> unbroadcast_txids = WITH_LOCK(m_mempool.cs, return m_mempool.GetUnbroadcastTxs());
 
     for (const auto& elem : unbroadcast_txids) {
         // Sanity check: all unbroadcast txns should exist in the mempool

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2065,7 +2065,7 @@ void static ProcessOrphanTx(
         TxValidationState orphan_state;
 
         if (setMisbehaving.count(fromPeer)) continue;
-        if (::AcceptToMemoryPool(mempool, orphan_state, porphanTx, &removed_txn, false /* bypass_limits */, 0 /* nAbsurdFee */)) {
+        if (::AcceptToMemoryPoolWithUnlockedMempool(mempool, orphan_state, porphanTx, &removed_txn, false /* bypass_limits */, 0 /* nAbsurdFee */)) {
             LogPrint(BCLog::MEMPOOL, "   accepted orphan tx %s\n", orphanHash.ToString());
             RelayTransaction(orphanHash, porphanTx->GetWitnessHash(), connman);
             for (unsigned int i = 0; i < orphanTx.vout.size(); i++) {
@@ -3025,7 +3025,7 @@ void PeerLogicValidation::ProcessMessage(CNode& pfrom, const std::string& msg_ty
         // (older than our recency filter) if trying to DoS us, without any need
         // for witness malleation.
         if (!AlreadyHaveTx(GenTxid(/* is_wtxid=*/true, wtxid), m_mempool) &&
-            ::AcceptToMemoryPool(m_mempool, state, ptx, &lRemovedTxn, false /* bypass_limits */, 0 /* nAbsurdFee */)) {
+            ::AcceptToMemoryPoolWithUnlockedMempool(m_mempool, state, ptx, &lRemovedTxn, false /* bypass_limits */, 0 /* nAbsurdFee */)) {
             m_mempool.check(&::ChainstateActive().CoinsTip());
             RelayTransaction(tx.GetHash(), tx.GetWitnessHash(), m_connman);
             for (unsigned int i = 0; i < tx.vout.size(); i++) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4676,6 +4676,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
         if (pto->m_tx_relay != nullptr && pto->nVersion >= FEEFILTER_VERSION && gArgs.GetBoolArg("-feefilter", DEFAULT_FEEFILTER) &&
             !pto->HasPermission(PF_FORCERELAY) // peers with the forcerelay permission should not filter txs to us
         ) {
+            AssertLockNotHeld(m_mempool.cs);
             CAmount currentFilter = m_mempool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK();
             int64_t timeNow = GetTimeMicros();
             static FeeFilterRounder g_filter_rounder{CFeeRate{DEFAULT_MIN_RELAY_TX_FEE}};

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -9,14 +9,15 @@
 #include <consensus/params.h>
 #include <net.h>
 #include <sync.h>
+#include <txmempool.h>
 #include <validationinterface.h>
 
 class CChainParams;
-class CTxMemPool;
 class ChainstateManager;
 
 extern RecursiveMutex cs_main;
 extern RecursiveMutex g_cs_orphans;
+extern CTxMemPool mempool;
 
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
 static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
@@ -68,7 +69,7 @@ public:
     * @param[in]   pfrom           The node which we have received messages from.
     * @param[in]   interrupt       Interrupt condition for processing threads
     */
-    bool ProcessMessages(CNode* pfrom, std::atomic<bool>& interrupt) override;
+    bool ProcessMessages(CNode* pfrom, std::atomic<bool>& interrupt) override EXCLUSIVE_LOCKS_REQUIRED(!::mempool.cs);
     /**
     * Send queued protocol messages to be sent to a give node.
     *
@@ -89,7 +90,7 @@ public:
     /** Process a single message from a peer. Public for fuzz testing */
     void ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStream& vRecv,
                         const std::chrono::microseconds time_received, const CChainParams& chainparams,
-                        const std::atomic<bool>& interruptMsgProc);
+                        const std::atomic<bool>& interruptMsgProc) EXCLUSIVE_LOCKS_REQUIRED(!m_mempool.cs);
 
 private:
     int64_t m_stale_tip_check_time; //!< Next time to check for stale tip

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -42,7 +42,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
     if (!node.mempool->exists(hashTx)) {
         // Transaction is not already in the mempool. Submit it.
         TxValidationState state;
-        if (!::AcceptToMemoryPool(*node.mempool, state, std::move(tx),
+        if (!::AcceptToMemoryPoolWithUnlockedMempool(*node.mempool, state, std::move(tx),
                 nullptr /* plTxnReplaced */, false /* bypass_limits */, max_tx_fee)) {
             err_string = state.ToString();
             if (state.IsInvalid()) {

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -6,11 +6,11 @@
 #define BITCOIN_NODE_TRANSACTION_H
 
 #include <attributes.h>
+#include <node/context.h>
 #include <policy/feerate.h>
 #include <primitives/transaction.h>
+#include <txmempool.h>
 #include <util/error.h>
-
-struct NodeContext;
 
 /** Maximum fee rate for sendrawtransaction and testmempoolaccept RPC calls.
  * Also used by the GUI when broadcasting a completed PSBT.
@@ -36,6 +36,12 @@ static const CFeeRate DEFAULT_MAX_RAW_TX_FEE_RATE{COIN / 10};
  * @param[in]  wait_callback wait until callbacks have been processed to avoid stale result due to a sequentially RPC.
  * return error
  */
-NODISCARD TransactionError BroadcastTransaction(NodeContext& node, CTransactionRef tx, std::string& err_string, const CAmount& max_tx_fee, bool relay, bool wait_callback);
+NODISCARD TransactionError BroadcastTransaction(
+    NodeContext& node,
+    CTransactionRef tx,
+    std::string& err_string,
+    const CAmount& max_tx_fee,
+    bool relay,
+    bool wait_callback) EXCLUSIVE_LOCKS_REQUIRED(!node.mempool->cs);
 
 #endif // BITCOIN_NODE_TRANSACTION_H

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -18,7 +18,7 @@ RBFTransactionState IsRBFOptIn(const CTransaction& tx, const CTxMemPool& pool)
 
     // If this transaction is not in our mempool, then we can't be sure
     // we will know about all its inputs.
-    if (!pool.exists(tx.GetHash())) {
+    if (!pool.existsNonLockHelper(tx.GetHash())) {
         return RBFTransactionState::UNKNOWN;
     }
 

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -101,6 +101,7 @@ void PSBTOperationsDialog::broadcastTransaction()
 
     CTransactionRef tx = MakeTransactionRef(mtx);
     std::string err_string;
+    AssertLockNotHeld(m_client_model->node().context()->mempool->cs);
     TransactionError error = BroadcastTransaction(
         *m_client_model->node().context(), tx, err_string, DEFAULT_MAX_RAW_TX_FEE_RATE.GetFeePerK(), /* relay */ true, /* await_callback */ false);
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -22,6 +22,7 @@
 #include <interfaces/node.h>
 #include <node/ui_interface.h>
 #include <psbt.h>
+#include <sync.h>
 #include <util/strencodings.h>
 
 #include <QAction>

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -362,7 +362,7 @@ static bool rest_mempool_contents(const util::Ref& context, HTTPRequest* req, co
 
     switch (rf) {
     case RetFormat::JSON: {
-        UniValue mempoolObject = MempoolToJSON(*mempool, true);
+        UniValue mempoolObject = WITH_LOCK(mempool->cs, return MempoolToJSON(*mempool, true));
 
         std::string strJSON = mempoolObject.write() + "\n";
         req->WriteHeader("Content-Type", "application/json");

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1411,7 +1411,7 @@ UniValue MempoolInfoToJSON(const CTxMemPool& pool)
     LOCK(pool.cs);
     UniValue ret(UniValue::VOBJ);
     ret.pushKV("loaded", pool.IsLoadedNonLockHelper());
-    ret.pushKV("size", (int64_t)pool.size());
+    ret.pushKV("size", (int64_t)pool.sizeNonLockHelper());
     ret.pushKV("bytes", (int64_t)pool.GetTotalTxSize());
     ret.pushKV("usage", (int64_t)pool.DynamicMemoryUsage());
     size_t maxmempool = gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1410,7 +1410,7 @@ UniValue MempoolInfoToJSON(const CTxMemPool& pool)
     // Make sure this call is atomic in the pool.
     LOCK(pool.cs);
     UniValue ret(UniValue::VOBJ);
-    ret.pushKV("loaded", pool.IsLoaded());
+    ret.pushKV("loaded", pool.IsLoadedNonLockHelper());
     ret.pushKV("size", (int64_t)pool.size());
     ret.pushKV("bytes", (int64_t)pool.GetTotalTxSize());
     ret.pushKV("usage", (int64_t)pool.DynamicMemoryUsage());

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -485,8 +485,8 @@ static void entryToJSON(const CTxMemPool& pool, UniValue& info, const CTxMemPool
 
 UniValue MempoolToJSON(const CTxMemPool& pool, bool verbose)
 {
+    AssertLockHeld(pool.cs);
     if (verbose) {
-        LOCK(pool.cs);
         UniValue o(UniValue::VOBJ);
         for (const CTxMemPoolEntry& e : pool.mapTx) {
             const uint256& hash = e.GetTx().GetHash();
@@ -540,7 +540,9 @@ static UniValue getrawmempool(const JSONRPCRequest& request)
     if (!request.params[0].isNull())
         fVerbose = request.params[0].get_bool();
 
-    return MempoolToJSON(EnsureMemPool(request.context), fVerbose);
+    CTxMemPool& mempool = EnsureMemPool(request.context);
+    LOCK(mempool.cs);
+    return MempoolToJSON(mempool, fVerbose);
 }
 
 static UniValue getmempoolancestors(const JSONRPCRequest& request)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1413,7 +1413,7 @@ UniValue MempoolInfoToJSON(const CTxMemPool& pool)
     ret.pushKV("loaded", pool.IsLoadedNonLockHelper());
     ret.pushKV("size", (int64_t)pool.sizeNonLockHelper());
     ret.pushKV("bytes", (int64_t)pool.GetTotalTxSize());
-    ret.pushKV("usage", (int64_t)pool.DynamicMemoryUsage());
+    ret.pushKV("usage", (int64_t)pool.DynamicMemoryUsageNonLockHelper());
     size_t maxmempool = gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
     ret.pushKV("maxmempool", (int64_t) maxmempool);
     ret.pushKV("mempoolminfee", ValueFromAmount(std::max(pool.GetMinFeeNonLockHelper(maxmempool), ::minRelayTxFee).GetFeePerK()));

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1416,7 +1416,7 @@ UniValue MempoolInfoToJSON(const CTxMemPool& pool)
     ret.pushKV("usage", (int64_t)pool.DynamicMemoryUsage());
     size_t maxmempool = gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
     ret.pushKV("maxmempool", (int64_t) maxmempool);
-    ret.pushKV("mempoolminfee", ValueFromAmount(std::max(pool.GetMinFee(maxmempool), ::minRelayTxFee).GetFeePerK()));
+    ret.pushKV("mempoolminfee", ValueFromAmount(std::max(pool.GetMinFeeNonLockHelper(maxmempool), ::minRelayTxFee).GetFeePerK()));
     ret.pushKV("minrelaytxfee", ValueFromAmount(::minRelayTxFee.GetFeePerK()));
     ret.pushKV("unbroadcastcount", uint64_t{pool.GetUnbroadcastTxs().size()});
     return ret;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -449,7 +449,7 @@ static void entryToJSON(const CTxMemPool& pool, UniValue& info, const CTxMemPool
     std::set<std::string> setDepends;
     for (const CTxIn& txin : tx.vin)
     {
-        if (pool.exists(txin.prevout.hash))
+        if (pool.existsNonLockHelper(txin.prevout.hash))
             setDepends.insert(txin.prevout.hash.ToString());
     }
 

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -7,6 +7,7 @@
 
 #include <amount.h>
 #include <sync.h>
+#include <txmempool.h>
 
 #include <stdint.h>
 #include <vector>
@@ -15,7 +16,6 @@ extern RecursiveMutex cs_main;
 
 class CBlock;
 class CBlockIndex;
-class CTxMemPool;
 class ChainstateManager;
 class UniValue;
 struct NodeContext;
@@ -43,7 +43,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
 UniValue MempoolInfoToJSON(const CTxMemPool& pool);
 
 /** Mempool to JSON */
-UniValue MempoolToJSON(const CTxMemPool& pool, bool verbose = false);
+UniValue MempoolToJSON(const CTxMemPool& pool, bool verbose = false) EXCLUSIVE_LOCKS_REQUIRED(pool.cs);
 
 /** Block header to JSON */
 UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex) LOCKS_EXCLUDED(cs_main);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -929,7 +929,7 @@ static UniValue testmempoolaccept(const JSONRPCRequest& request)
     {
         LOCK(cs_main);
         AssertLockNotHeld(mempool.cs);
-        test_accept_res = ::AcceptToMemoryPool(mempool, state, std::move(tx),
+        test_accept_res = ::AcceptToMemoryPoolWithUnlockedMempool(mempool, state, std::move(tx),
             nullptr /* plTxnReplaced */, false /* bypass_limits */, max_raw_tx_fee, /* test_accept */ true);
     }
     result_0.pushKV("allowed", test_accept_res);

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -80,9 +80,9 @@ BOOST_AUTO_TEST_CASE(SimpleRoundTripTest)
 
         BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2]->GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
 
-        size_t poolSize = pool.size();
+        size_t poolSize = pool.sizeNonLockHelper();
         pool.removeRecursive(*block.vtx[2], MemPoolRemovalReason::REPLACED);
-        BOOST_CHECK_EQUAL(pool.size(), poolSize - 1);
+        BOOST_CHECK_EQUAL(pool.sizeNonLockHelper(), poolSize - 1);
 
         CBlock block2;
         {

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(SimpleRoundTripTest)
         stream >> shortIDs2;
 
         PartiallyDownloadedBlock partialBlock(&pool);
-        BOOST_CHECK(partialBlock.InitData(shortIDs2, extra_txn) == READ_STATUS_OK);
+        BOOST_CHECK(partialBlock.InitData(shortIDs2, extra_txn, true) == READ_STATUS_OK);
         BOOST_CHECK( partialBlock.IsTxAvailable(0));
         BOOST_CHECK(!partialBlock.IsTxAvailable(1));
         BOOST_CHECK( partialBlock.IsTxAvailable(2));
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(NonCoinbasePreforwardRTTest)
         stream >> shortIDs2;
 
         PartiallyDownloadedBlock partialBlock(&pool);
-        BOOST_CHECK(partialBlock.InitData(shortIDs2, extra_txn) == READ_STATUS_OK);
+        BOOST_CHECK(partialBlock.InitData(shortIDs2, extra_txn, true) == READ_STATUS_OK);
         BOOST_CHECK(!partialBlock.IsTxAvailable(0));
         BOOST_CHECK( partialBlock.IsTxAvailable(1));
         BOOST_CHECK( partialBlock.IsTxAvailable(2));
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(SufficientPreforwardRTTest)
         stream >> shortIDs2;
 
         PartiallyDownloadedBlock partialBlock(&pool);
-        BOOST_CHECK(partialBlock.InitData(shortIDs2, extra_txn) == READ_STATUS_OK);
+        BOOST_CHECK(partialBlock.InitData(shortIDs2, extra_txn, true) == READ_STATUS_OK);
         BOOST_CHECK( partialBlock.IsTxAvailable(0));
         BOOST_CHECK( partialBlock.IsTxAvailable(1));
         BOOST_CHECK( partialBlock.IsTxAvailable(2));

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -472,7 +472,7 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     BOOST_CHECK(!pool.exists(tx3.GetHash()));
 
     CFeeRate maxFeeRateRemoved(25000, GetVirtualTransactionSize(CTransaction(tx3)) + GetVirtualTransactionSize(CTransaction(tx2)));
-    BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);
+    BOOST_CHECK_EQUAL(pool.GetMinFeeNonLockHelper(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);
 
     CMutableTransaction tx4 = CMutableTransaction();
     tx4.vin.resize(2);
@@ -549,27 +549,27 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     std::vector<CTransactionRef> vtx;
     SetMockTime(42);
     SetMockTime(42 + CTxMemPool::ROLLING_FEE_HALFLIFE);
-    BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);
+    BOOST_CHECK_EQUAL(pool.GetMinFeeNonLockHelper(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);
     // ... we should keep the same min fee until we get a block
     pool.removeForBlock(vtx, 1);
     SetMockTime(42 + 2*CTxMemPool::ROLLING_FEE_HALFLIFE);
-    BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), llround((maxFeeRateRemoved.GetFeePerK() + 1000)/2.0));
+    BOOST_CHECK_EQUAL(pool.GetMinFeeNonLockHelper(1).GetFeePerK(), llround((maxFeeRateRemoved.GetFeePerK() + 1000)/2.0));
     // ... then feerate should drop 1/2 each halflife
 
     SetMockTime(42 + 2*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2);
-    BOOST_CHECK_EQUAL(pool.GetMinFee(pool.DynamicMemoryUsage() * 5 / 2).GetFeePerK(), llround((maxFeeRateRemoved.GetFeePerK() + 1000)/4.0));
+    BOOST_CHECK_EQUAL(pool.GetMinFeeNonLockHelper(pool.DynamicMemoryUsage() * 5 / 2).GetFeePerK(), llround((maxFeeRateRemoved.GetFeePerK() + 1000)/4.0));
     // ... with a 1/2 halflife when mempool is < 1/2 its target size
 
     SetMockTime(42 + 2*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2 + CTxMemPool::ROLLING_FEE_HALFLIFE/4);
-    BOOST_CHECK_EQUAL(pool.GetMinFee(pool.DynamicMemoryUsage() * 9 / 2).GetFeePerK(), llround((maxFeeRateRemoved.GetFeePerK() + 1000)/8.0));
+    BOOST_CHECK_EQUAL(pool.GetMinFeeNonLockHelper(pool.DynamicMemoryUsage() * 9 / 2).GetFeePerK(), llround((maxFeeRateRemoved.GetFeePerK() + 1000)/8.0));
     // ... with a 1/4 halflife when mempool is < 1/4 its target size
 
     SetMockTime(42 + 7*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2 + CTxMemPool::ROLLING_FEE_HALFLIFE/4);
-    BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), 1000);
+    BOOST_CHECK_EQUAL(pool.GetMinFeeNonLockHelper(1).GetFeePerK(), 1000);
     // ... but feerate should never drop below 1000
 
     SetMockTime(42 + 8*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2 + CTxMemPool::ROLLING_FEE_HALFLIFE/4);
-    BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), 0);
+    BOOST_CHECK_EQUAL(pool.GetMinFeeNonLockHelper(1).GetFeePerK(), 0);
     // ... unless it has gone all the way to 0 (after getting past 1000/2)
 
     SetMockTime(0);

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -444,12 +444,12 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     pool.addUnchecked(entry.Fee(5000LL).FromTx(tx2));
 
     pool.TrimToSize(pool.DynamicMemoryUsage()); // should do nothing
-    BOOST_CHECK(pool.exists(tx1.GetHash()));
-    BOOST_CHECK(pool.exists(tx2.GetHash()));
+    BOOST_CHECK(pool.existsNonLockHelper(tx1.GetHash()));
+    BOOST_CHECK(pool.existsNonLockHelper(tx2.GetHash()));
 
     pool.TrimToSize(pool.DynamicMemoryUsage() * 3 / 4); // should remove the lower-feerate transaction
-    BOOST_CHECK(pool.exists(tx1.GetHash()));
-    BOOST_CHECK(!pool.exists(tx2.GetHash()));
+    BOOST_CHECK(pool.existsNonLockHelper(tx1.GetHash()));
+    BOOST_CHECK(!pool.existsNonLockHelper(tx2.GetHash()));
 
     pool.addUnchecked(entry.FromTx(tx2));
     CMutableTransaction tx3 = CMutableTransaction();
@@ -462,14 +462,14 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     pool.addUnchecked(entry.Fee(20000LL).FromTx(tx3));
 
     pool.TrimToSize(pool.DynamicMemoryUsage() * 3 / 4); // tx3 should pay for tx2 (CPFP)
-    BOOST_CHECK(!pool.exists(tx1.GetHash()));
-    BOOST_CHECK(pool.exists(tx2.GetHash()));
-    BOOST_CHECK(pool.exists(tx3.GetHash()));
+    BOOST_CHECK(!pool.existsNonLockHelper(tx1.GetHash()));
+    BOOST_CHECK(pool.existsNonLockHelper(tx2.GetHash()));
+    BOOST_CHECK(pool.existsNonLockHelper(tx3.GetHash()));
 
     pool.TrimToSize(GetVirtualTransactionSize(CTransaction(tx1))); // mempool is limited to tx1's size in memory usage, so nothing fits
-    BOOST_CHECK(!pool.exists(tx1.GetHash()));
-    BOOST_CHECK(!pool.exists(tx2.GetHash()));
-    BOOST_CHECK(!pool.exists(tx3.GetHash()));
+    BOOST_CHECK(!pool.existsNonLockHelper(tx1.GetHash()));
+    BOOST_CHECK(!pool.existsNonLockHelper(tx2.GetHash()));
+    BOOST_CHECK(!pool.existsNonLockHelper(tx3.GetHash()));
 
     CFeeRate maxFeeRateRemoved(25000, GetVirtualTransactionSize(CTransaction(tx3)) + GetVirtualTransactionSize(CTransaction(tx2)));
     BOOST_CHECK_EQUAL(pool.GetMinFeeNonLockHelper(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);
@@ -529,19 +529,19 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
 
     // we only require this to remove, at max, 2 txn, because it's not clear what we're really optimizing for aside from that
     pool.TrimToSize(pool.DynamicMemoryUsage() - 1);
-    BOOST_CHECK(pool.exists(tx4.GetHash()));
-    BOOST_CHECK(pool.exists(tx6.GetHash()));
-    BOOST_CHECK(!pool.exists(tx7.GetHash()));
+    BOOST_CHECK(pool.existsNonLockHelper(tx4.GetHash()));
+    BOOST_CHECK(pool.existsNonLockHelper(tx6.GetHash()));
+    BOOST_CHECK(!pool.existsNonLockHelper(tx7.GetHash()));
 
-    if (!pool.exists(tx5.GetHash()))
+    if (!pool.existsNonLockHelper(tx5.GetHash()))
         pool.addUnchecked(entry.Fee(1000LL).FromTx(tx5));
     pool.addUnchecked(entry.Fee(9000LL).FromTx(tx7));
 
     pool.TrimToSize(pool.DynamicMemoryUsage() / 2); // should maximize mempool size by only removing 5/7
-    BOOST_CHECK(pool.exists(tx4.GetHash()));
-    BOOST_CHECK(!pool.exists(tx5.GetHash()));
-    BOOST_CHECK(pool.exists(tx6.GetHash()));
-    BOOST_CHECK(!pool.exists(tx7.GetHash()));
+    BOOST_CHECK(pool.existsNonLockHelper(tx4.GetHash()));
+    BOOST_CHECK(!pool.existsNonLockHelper(tx5.GetHash()));
+    BOOST_CHECK(pool.existsNonLockHelper(tx6.GetHash()));
+    BOOST_CHECK(!pool.existsNonLockHelper(tx7.GetHash()));
 
     pool.addUnchecked(entry.Fee(1000LL).FromTx(tx5));
     pool.addUnchecked(entry.Fee(9000LL).FromTx(tx7));

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -443,11 +443,11 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     tx2.vout[0].nValue = 10 * COIN;
     pool.addUnchecked(entry.Fee(5000LL).FromTx(tx2));
 
-    pool.TrimToSize(pool.DynamicMemoryUsage()); // should do nothing
+    pool.TrimToSize(pool.DynamicMemoryUsageNonLockHelper()); // should do nothing
     BOOST_CHECK(pool.existsNonLockHelper(tx1.GetHash()));
     BOOST_CHECK(pool.existsNonLockHelper(tx2.GetHash()));
 
-    pool.TrimToSize(pool.DynamicMemoryUsage() * 3 / 4); // should remove the lower-feerate transaction
+    pool.TrimToSize(pool.DynamicMemoryUsageNonLockHelper() * 3 / 4); // should remove the lower-feerate transaction
     BOOST_CHECK(pool.existsNonLockHelper(tx1.GetHash()));
     BOOST_CHECK(!pool.existsNonLockHelper(tx2.GetHash()));
 
@@ -461,7 +461,7 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     tx3.vout[0].nValue = 10 * COIN;
     pool.addUnchecked(entry.Fee(20000LL).FromTx(tx3));
 
-    pool.TrimToSize(pool.DynamicMemoryUsage() * 3 / 4); // tx3 should pay for tx2 (CPFP)
+    pool.TrimToSize(pool.DynamicMemoryUsageNonLockHelper() * 3 / 4); // tx3 should pay for tx2 (CPFP)
     BOOST_CHECK(!pool.existsNonLockHelper(tx1.GetHash()));
     BOOST_CHECK(pool.existsNonLockHelper(tx2.GetHash()));
     BOOST_CHECK(pool.existsNonLockHelper(tx3.GetHash()));
@@ -528,7 +528,7 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     pool.addUnchecked(entry.Fee(9000LL).FromTx(tx7));
 
     // we only require this to remove, at max, 2 txn, because it's not clear what we're really optimizing for aside from that
-    pool.TrimToSize(pool.DynamicMemoryUsage() - 1);
+    pool.TrimToSize(pool.DynamicMemoryUsageNonLockHelper() - 1);
     BOOST_CHECK(pool.existsNonLockHelper(tx4.GetHash()));
     BOOST_CHECK(pool.existsNonLockHelper(tx6.GetHash()));
     BOOST_CHECK(!pool.existsNonLockHelper(tx7.GetHash()));
@@ -537,7 +537,7 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
         pool.addUnchecked(entry.Fee(1000LL).FromTx(tx5));
     pool.addUnchecked(entry.Fee(9000LL).FromTx(tx7));
 
-    pool.TrimToSize(pool.DynamicMemoryUsage() / 2); // should maximize mempool size by only removing 5/7
+    pool.TrimToSize(pool.DynamicMemoryUsageNonLockHelper() / 2); // should maximize mempool size by only removing 5/7
     BOOST_CHECK(pool.existsNonLockHelper(tx4.GetHash()));
     BOOST_CHECK(!pool.existsNonLockHelper(tx5.GetHash()));
     BOOST_CHECK(pool.existsNonLockHelper(tx6.GetHash()));
@@ -557,11 +557,11 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     // ... then feerate should drop 1/2 each halflife
 
     SetMockTime(42 + 2*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2);
-    BOOST_CHECK_EQUAL(pool.GetMinFeeNonLockHelper(pool.DynamicMemoryUsage() * 5 / 2).GetFeePerK(), llround((maxFeeRateRemoved.GetFeePerK() + 1000)/4.0));
+    BOOST_CHECK_EQUAL(pool.GetMinFeeNonLockHelper(pool.DynamicMemoryUsageNonLockHelper() * 5 / 2).GetFeePerK(), llround((maxFeeRateRemoved.GetFeePerK() + 1000)/4.0));
     // ... with a 1/2 halflife when mempool is < 1/2 its target size
 
     SetMockTime(42 + 2*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2 + CTxMemPool::ROLLING_FEE_HALFLIFE/4);
-    BOOST_CHECK_EQUAL(pool.GetMinFeeNonLockHelper(pool.DynamicMemoryUsage() * 9 / 2).GetFeePerK(), llround((maxFeeRateRemoved.GetFeePerK() + 1000)/8.0));
+    BOOST_CHECK_EQUAL(pool.GetMinFeeNonLockHelper(pool.DynamicMemoryUsageNonLockHelper() * 9 / 2).GetFeePerK(), llround((maxFeeRateRemoved.GetFeePerK() + 1000)/8.0));
     // ... with a 1/4 halflife when mempool is < 1/4 its target size
 
     SetMockTime(42 + 7*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2 + CTxMemPool::ROLLING_FEE_HALFLIFE/4);

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -761,7 +761,7 @@ BOOST_AUTO_TEST_CASE(MempoolAncestryTests)
     tb = make_tx(/* output_values */ {5 * COIN, 3 * COIN}, /* inputs */  {ta});
     tc = make_tx(/* output_values */ {2 * COIN}, /* inputs */ {tb}, /* input_indices */ {1});
     td = make_tx(/* output_values */ {6 * COIN}, /* inputs */ {tb, tc}, /* input_indices */ {0, 0});
-    pool.clear();
+    pool.clearNonLockHelper();
     pool.addUnchecked(entry.Fee(10000LL).FromTx(ta));
     pool.addUnchecked(entry.Fee(10000LL).FromTx(tb));
     pool.addUnchecked(entry.Fee(10000LL).FromTx(tc));

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -133,7 +133,7 @@ void MinerTestingSetup::TestPackageSelection(const CChainParams& chainparams, co
     uint256 hashHighFeeTx = tx.GetHash();
     m_node.mempool->addUnchecked(entry.Fee(50000).Time(GetTime()).SpendsCoinbase(false).FromTx(tx));
 
-    std::unique_ptr<CBlockTemplate> pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey);
+    std::unique_ptr<CBlockTemplate> pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, true);
     BOOST_CHECK(pblocktemplate->block.vtx[1]->GetHash() == hashParentTx);
     BOOST_CHECK(pblocktemplate->block.vtx[2]->GetHash() == hashHighFeeTx);
     BOOST_CHECK(pblocktemplate->block.vtx[3]->GetHash() == hashMediumFeeTx);
@@ -153,7 +153,7 @@ void MinerTestingSetup::TestPackageSelection(const CChainParams& chainparams, co
     tx.vout[0].nValue = 5000000000LL - 1000 - 50000 - feeToUse;
     uint256 hashLowFeeTx = tx.GetHash();
     m_node.mempool->addUnchecked(entry.Fee(feeToUse).FromTx(tx));
-    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey);
+    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, true);
     // Verify that the free tx and the low fee tx didn't get selected
     for (size_t i=0; i<pblocktemplate->block.vtx.size(); ++i) {
         BOOST_CHECK(pblocktemplate->block.vtx[i]->GetHash() != hashFreeTx);
@@ -167,7 +167,7 @@ void MinerTestingSetup::TestPackageSelection(const CChainParams& chainparams, co
     tx.vout[0].nValue -= 2; // Now we should be just over the min relay fee
     hashLowFeeTx = tx.GetHash();
     m_node.mempool->addUnchecked(entry.Fee(feeToUse+2).FromTx(tx));
-    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey);
+    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, true);
     BOOST_CHECK(pblocktemplate->block.vtx[4]->GetHash() == hashFreeTx);
     BOOST_CHECK(pblocktemplate->block.vtx[5]->GetHash() == hashLowFeeTx);
 
@@ -188,7 +188,7 @@ void MinerTestingSetup::TestPackageSelection(const CChainParams& chainparams, co
     tx.vout[0].nValue = 5000000000LL - 100000000 - feeToUse;
     uint256 hashLowFeeTx2 = tx.GetHash();
     m_node.mempool->addUnchecked(entry.Fee(feeToUse).SpendsCoinbase(false).FromTx(tx));
-    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey);
+    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, true);
 
     // Verify that this tx isn't selected.
     for (size_t i=0; i<pblocktemplate->block.vtx.size(); ++i) {
@@ -201,7 +201,7 @@ void MinerTestingSetup::TestPackageSelection(const CChainParams& chainparams, co
     tx.vin[0].prevout.n = 1;
     tx.vout[0].nValue = 100000000 - 10000; // 10k satoshi fee
     m_node.mempool->addUnchecked(entry.Fee(10000).FromTx(tx));
-    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey);
+    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, true);
     BOOST_CHECK(pblocktemplate->block.vtx[8]->GetHash() == hashLowFeeTx2);
 }
 
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     LOCK(m_node.mempool->cs);
 
     // Just to make sure we can still make simple blocks
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, true));
 
     const CAmount BLOCKSUBSIDY = 50*COIN;
     const CAmount LOWFEE = CENT;
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         tx.vin[0].prevout.hash = hash;
     }
 
-    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error, HasReason("bad-blk-sigops"));
+    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, true), std::runtime_error, HasReason("bad-blk-sigops"));
     m_node.mempool->clearNonLockHelper();
 
     tx.vin[0].prevout.hash = txFirst[0]->GetHash();
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         m_node.mempool->addUnchecked(entry.Fee(LOWFEE).Time(GetTime()).SpendsCoinbase(spendsCoinbase).SigOpsCost(80).FromTx(tx));
         tx.vin[0].prevout.hash = hash;
     }
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, true));
     m_node.mempool->clearNonLockHelper();
 
     // block size > limit
@@ -320,13 +320,13 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         m_node.mempool->addUnchecked(entry.Fee(LOWFEE).Time(GetTime()).SpendsCoinbase(spendsCoinbase).FromTx(tx));
         tx.vin[0].prevout.hash = hash;
     }
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, true));
     m_node.mempool->clearNonLockHelper();
 
     // orphan in *m_node.mempool, template creation fails
     hash = tx.GetHash();
     m_node.mempool->addUnchecked(entry.Fee(LOWFEE).Time(GetTime()).FromTx(tx));
-    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error, HasReason("bad-txns-inputs-missingorspent"));
+    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, true), std::runtime_error, HasReason("bad-txns-inputs-missingorspent"));
     m_node.mempool->clearNonLockHelper();
 
     // child with higher feerate than parent
@@ -343,7 +343,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vout[0].nValue = tx.vout[0].nValue+BLOCKSUBSIDY-HIGHERFEE; //First txn output + fresh coinbase - new txn fee
     hash = tx.GetHash();
     m_node.mempool->addUnchecked(entry.Fee(HIGHERFEE).Time(GetTime()).SpendsCoinbase(true).FromTx(tx));
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, true));
     m_node.mempool->clearNonLockHelper();
 
     // coinbase in *m_node.mempool, template creation fails
@@ -355,7 +355,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     // give it a fee so it'll get mined
     m_node.mempool->addUnchecked(entry.Fee(LOWFEE).Time(GetTime()).SpendsCoinbase(false).FromTx(tx));
     // Should throw bad-cb-multiple
-    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error, HasReason("bad-cb-multiple"));
+    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, true), std::runtime_error, HasReason("bad-cb-multiple"));
     m_node.mempool->clearNonLockHelper();
 
     // double spend txn pair in *m_node.mempool, template creation fails
@@ -368,7 +368,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vout[0].scriptPubKey = CScript() << OP_2;
     hash = tx.GetHash();
     m_node.mempool->addUnchecked(entry.Fee(HIGHFEE).Time(GetTime()).SpendsCoinbase(true).FromTx(tx));
-    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error, HasReason("bad-txns-inputs-missingorspent"));
+    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, true), std::runtime_error, HasReason("bad-txns-inputs-missingorspent"));
     m_node.mempool->clearNonLockHelper();
 
     // subsidy changing
@@ -384,7 +384,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         next->BuildSkip();
         ::ChainActive().SetTip(next);
     }
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, true));
     // Extend to a 210000-long block chain.
     while (::ChainActive().Tip()->nHeight < 210000) {
         CBlockIndex* prev = ::ChainActive().Tip();
@@ -396,7 +396,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         next->BuildSkip();
         ::ChainActive().SetTip(next);
     }
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, true));
 
     // invalid p2sh txn in *m_node.mempool, template creation fails
     tx.vin[0].prevout.hash = txFirst[0]->GetHash();
@@ -413,7 +413,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     hash = tx.GetHash();
     m_node.mempool->addUnchecked(entry.Fee(LOWFEE).Time(GetTime()).SpendsCoinbase(false).FromTx(tx));
     // Should throw block-validation-failed
-    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error, HasReason("block-validation-failed"));
+    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, true), std::runtime_error, HasReason("block-validation-failed"));
     m_node.mempool->clearNonLockHelper();
 
     // Delete the dummy blocks again.
@@ -501,7 +501,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vin[0].nSequence = CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG | 1;
     BOOST_CHECK(!TestSequenceLocks(CTransaction(tx), flags)); // Sequence locks fail
 
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, true));
 
     // None of the of the absolute height/time locked tx should have made
     // it into the template because we still check IsFinalTx in CreateNewBlock,
@@ -514,7 +514,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     ::ChainActive().Tip()->nHeight++;
     SetMockTime(::ChainActive().Tip()->GetMedianTimePast() + 1);
 
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, true));
     BOOST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 5U);
 
     ::ChainActive().Tip()->nHeight--;

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     }
 
     BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error, HasReason("bad-blk-sigops"));
-    m_node.mempool->clear();
+    m_node.mempool->clearNonLockHelper();
 
     tx.vin[0].prevout.hash = txFirst[0]->GetHash();
     tx.vout[0].nValue = BLOCKSUBSIDY;
@@ -301,7 +301,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         tx.vin[0].prevout.hash = hash;
     }
     BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
-    m_node.mempool->clear();
+    m_node.mempool->clearNonLockHelper();
 
     // block size > limit
     tx.vin[0].scriptSig = CScript();
@@ -321,13 +321,13 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         tx.vin[0].prevout.hash = hash;
     }
     BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
-    m_node.mempool->clear();
+    m_node.mempool->clearNonLockHelper();
 
     // orphan in *m_node.mempool, template creation fails
     hash = tx.GetHash();
     m_node.mempool->addUnchecked(entry.Fee(LOWFEE).Time(GetTime()).FromTx(tx));
     BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error, HasReason("bad-txns-inputs-missingorspent"));
-    m_node.mempool->clear();
+    m_node.mempool->clearNonLockHelper();
 
     // child with higher feerate than parent
     tx.vin[0].scriptSig = CScript() << OP_1;
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     hash = tx.GetHash();
     m_node.mempool->addUnchecked(entry.Fee(HIGHERFEE).Time(GetTime()).SpendsCoinbase(true).FromTx(tx));
     BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
-    m_node.mempool->clear();
+    m_node.mempool->clearNonLockHelper();
 
     // coinbase in *m_node.mempool, template creation fails
     tx.vin.resize(1);
@@ -356,7 +356,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     m_node.mempool->addUnchecked(entry.Fee(LOWFEE).Time(GetTime()).SpendsCoinbase(false).FromTx(tx));
     // Should throw bad-cb-multiple
     BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error, HasReason("bad-cb-multiple"));
-    m_node.mempool->clear();
+    m_node.mempool->clearNonLockHelper();
 
     // double spend txn pair in *m_node.mempool, template creation fails
     tx.vin[0].prevout.hash = txFirst[0]->GetHash();
@@ -369,7 +369,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     hash = tx.GetHash();
     m_node.mempool->addUnchecked(entry.Fee(HIGHFEE).Time(GetTime()).SpendsCoinbase(true).FromTx(tx));
     BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error, HasReason("bad-txns-inputs-missingorspent"));
-    m_node.mempool->clear();
+    m_node.mempool->clearNonLockHelper();
 
     // subsidy changing
     int nHeight = ::ChainActive().Height();
@@ -414,7 +414,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     m_node.mempool->addUnchecked(entry.Fee(LOWFEE).Time(GetTime()).SpendsCoinbase(false).FromTx(tx));
     // Should throw block-validation-failed
     BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error, HasReason("block-validation-failed"));
-    m_node.mempool->clear();
+    m_node.mempool->clearNonLockHelper();
 
     // Delete the dummy blocks again.
     while (::ChainActive().Tip()->nHeight > nHeight) {
@@ -519,7 +519,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 
     ::ChainActive().Tip()->nHeight--;
     SetMockTime(0);
-    m_node.mempool->clear();
+    m_node.mempool->clearNonLockHelper();
 
     TestPackageSelection(chainparams, scriptPubKey, txFirst);
 

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
             // 9/10 blocks add 2nd highest and so on until ...
             // 1/10 blocks add lowest fee transactions
             while (txHashes[9-h].size()) {
-                CTransactionRef ptx = mpool.get(txHashes[9-h].back());
+                CTransactionRef ptx = mpool.getNonLockHelper(txHashes[9-h].back());
                 if (ptx)
                     block.push_back(ptx);
                 txHashes[9-h].pop_back();
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     // Estimates should still not be below original
     for (int j = 0; j < 10; j++) {
         while(txHashes[j].size()) {
-            CTransactionRef ptx = mpool.get(txHashes[j].back());
+            CTransactionRef ptx = mpool.getNonLockHelper(txHashes[j].back());
             if (ptx)
                 block.push_back(ptx);
             txHashes[j].pop_back();
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
                 tx.vin[0].prevout.n = 10000*blocknum+100*j+k;
                 uint256 hash = tx.GetHash();
                 mpool.addUnchecked(entry.Fee(feeV[j]).Time(GetTime()).Height(blocknum).FromTx(tx));
-                CTransactionRef ptx = mpool.get(hash);
+                CTransactionRef ptx = mpool.getNonLockHelper(hash);
                 if (ptx)
                     block.push_back(ptx);
 

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -5,7 +5,9 @@
 #include <consensus/validation.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
+#include <sync.h>
 #include <test/util/setup_common.h>
+#include <txmempool.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
@@ -33,12 +35,13 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChain100Setup)
     TxValidationState state;
 
     LOCK(cs_main);
+    AssertLockNotHeld(m_node.mempool->cs);
 
     unsigned int initialPoolSize = m_node.mempool->size();
 
     BOOST_CHECK_EQUAL(
             false,
-            AcceptToMemoryPool(*m_node.mempool, state, MakeTransactionRef(coinbaseTx),
+            ::AcceptToMemoryPool(*m_node.mempool, state, MakeTransactionRef(coinbaseTx),
                 nullptr /* plTxnReplaced */,
                 true /* bypass_limits */,
                 0 /* nAbsurdFee */));

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -41,7 +41,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChain100Setup)
 
     BOOST_CHECK_EQUAL(
             false,
-            ::AcceptToMemoryPool(*m_node.mempool, state, MakeTransactionRef(coinbaseTx),
+            ::AcceptToMemoryPoolWithUnlockedMempool(*m_node.mempool, state, MakeTransactionRef(coinbaseTx),
                 nullptr /* plTxnReplaced */,
                 true /* bypass_limits */,
                 0 /* nAbsurdFee */));

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -31,7 +31,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
         AssertLockNotHeld(m_node.mempool->cs);
 
         TxValidationState state;
-        return ::AcceptToMemoryPool(*m_node.mempool, state, MakeTransactionRef(tx),
+        return ::AcceptToMemoryPoolWithUnlockedMempool(*m_node.mempool, state, MakeTransactionRef(tx),
             nullptr /* plTxnReplaced */, true /* bypass_limits */, 0 /* nAbsurdFee */);
     };
 

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -7,6 +7,7 @@
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <script/standard.h>
+#include <sync.h>
 #include <test/util/setup_common.h>
 #include <txmempool.h>
 #include <validation.h>
@@ -27,9 +28,10 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
 
     const auto ToMemPool = [this](const CMutableTransaction& tx) {
         LOCK(cs_main);
+        AssertLockNotHeld(m_node.mempool->cs);
 
         TxValidationState state;
-        return AcceptToMemoryPool(*m_node.mempool, state, MakeTransactionRef(tx),
+        return ::AcceptToMemoryPool(*m_node.mempool, state, MakeTransactionRef(tx),
             nullptr /* plTxnReplaced */, true /* bypass_limits */, 0 /* nAbsurdFee */);
     };
 

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -290,7 +290,7 @@ BOOST_AUTO_TEST_CASE(mempool_locks_reorg)
             TxValidationState state;
             std::list<CTransactionRef> plTxnReplaced;
             for (const auto& tx : txs) {
-                BOOST_REQUIRE(::AcceptToMemoryPool(
+                BOOST_REQUIRE(::AcceptToMemoryPoolWithUnlockedMempool(
                     *m_node.mempool,
                     state,
                     tx,

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -11,7 +11,9 @@
 #include <pow.h>
 #include <random.h>
 #include <script/standard.h>
+#include <sync.h>
 #include <test/util/setup_common.h>
+#include <txmempool.h>
 #include <util/time.h>
 #include <validation.h>
 #include <validationinterface.h>
@@ -283,10 +285,12 @@ BOOST_AUTO_TEST_CASE(mempool_locks_reorg)
         // Add the txs to the tx pool
         {
             LOCK(cs_main);
+            AssertLockNotHeld(m_node.mempool->cs);
+
             TxValidationState state;
             std::list<CTransactionRef> plTxnReplaced;
             for (const auto& tx : txs) {
-                BOOST_REQUIRE(AcceptToMemoryPool(
+                BOOST_REQUIRE(::AcceptToMemoryPool(
                     *m_node.mempool,
                     state,
                     tx,

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
 
     // Without any coins in the cache, we shouldn't need to flush.
     BOOST_CHECK_EQUAL(
-        chainstate.GetCoinsCacheSizeState(&tx_pool, MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes*/ 0),
+        chainstate.GetCoinsCacheSizeState(tx_pool, MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes*/ 0),
         CoinsCacheSizeState::OK);
 
     // If the initial memory allocations of cacheCoins don't match these common
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
         }
 
         BOOST_CHECK_EQUAL(
-            chainstate.GetCoinsCacheSizeState(&tx_pool, MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes*/ 0),
+            chainstate.GetCoinsCacheSizeState(tx_pool, MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes*/ 0),
             CoinsCacheSizeState::CRITICAL);
 
         BOOST_TEST_MESSAGE("Exiting cache flush tests early due to unsupported arch");
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
         print_view_mem_usage(view);
         BOOST_CHECK_EQUAL(view.AccessCoin(res).DynamicMemoryUsage(), COIN_SIZE);
         BOOST_CHECK_EQUAL(
-            chainstate.GetCoinsCacheSizeState(&tx_pool, MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes*/ 0),
+            chainstate.GetCoinsCacheSizeState(tx_pool, MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes*/ 0),
             CoinsCacheSizeState::OK);
     }
 
@@ -101,26 +101,26 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
     for (int i{0}; i < 4; ++i) {
         add_coin(view);
         print_view_mem_usage(view);
-        if (chainstate.GetCoinsCacheSizeState(&tx_pool, MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes*/ 0) ==
+        if (chainstate.GetCoinsCacheSizeState(tx_pool, MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes*/ 0) ==
             CoinsCacheSizeState::CRITICAL) {
             break;
         }
     }
 
     BOOST_CHECK_EQUAL(
-        chainstate.GetCoinsCacheSizeState(&tx_pool, MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes*/ 0),
+        chainstate.GetCoinsCacheSizeState(tx_pool, MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes*/ 0),
         CoinsCacheSizeState::CRITICAL);
 
     // Passing non-zero max mempool usage should allow us more headroom.
     BOOST_CHECK_EQUAL(
-        chainstate.GetCoinsCacheSizeState(&tx_pool, MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes*/ 1 << 10),
+        chainstate.GetCoinsCacheSizeState(tx_pool, MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes*/ 1 << 10),
         CoinsCacheSizeState::OK);
 
     for (int i{0}; i < 3; ++i) {
         add_coin(view);
         print_view_mem_usage(view);
         BOOST_CHECK_EQUAL(
-            chainstate.GetCoinsCacheSizeState(&tx_pool, MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes*/ 1 << 10),
+            chainstate.GetCoinsCacheSizeState(tx_pool, MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes*/ 1 << 10),
             CoinsCacheSizeState::OK);
     }
 
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
         BOOST_CHECK(usage_percentage >= 0.9);
         BOOST_CHECK(usage_percentage < 1);
         BOOST_CHECK_EQUAL(
-            chainstate.GetCoinsCacheSizeState(&tx_pool, MAX_COINS_CACHE_BYTES, 1 << 10),
+            chainstate.GetCoinsCacheSizeState(tx_pool, MAX_COINS_CACHE_BYTES, 1 << 10),
             CoinsCacheSizeState::LARGE);
     }
 
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
     for (int i{0}; i < 1000; ++i) {
         add_coin(view);
         BOOST_CHECK_EQUAL(
-            chainstate.GetCoinsCacheSizeState(&tx_pool),
+            chainstate.GetCoinsCacheSizeState(tx_pool.DynamicMemoryUsage()),
             CoinsCacheSizeState::OK);
     }
 
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
     // preallocated memory that doesn't get reclaimed even after flush.
 
     BOOST_CHECK_EQUAL(
-        chainstate.GetCoinsCacheSizeState(&tx_pool, MAX_COINS_CACHE_BYTES, 0),
+        chainstate.GetCoinsCacheSizeState(tx_pool, MAX_COINS_CACHE_BYTES, 0),
         CoinsCacheSizeState::CRITICAL);
 
     view.SetBestBlock(InsecureRand256());
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
     print_view_mem_usage(view);
 
     BOOST_CHECK_EQUAL(
-        chainstate.GetCoinsCacheSizeState(&tx_pool, MAX_COINS_CACHE_BYTES, 0),
+        chainstate.GetCoinsCacheSizeState(tx_pool, MAX_COINS_CACHE_BYTES, 0),
         CoinsCacheSizeState::CRITICAL);
 }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -783,7 +783,6 @@ static TxMempoolInfo GetInfo(CTxMemPool::indexed_transaction_set::const_iterator
 
 std::vector<TxMempoolInfo> CTxMemPool::infoAll() const
 {
-    LOCK(cs);
     auto iters = GetSortedDepthAndScore();
 
     std::vector<TxMempoolInfo> ret;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1106,9 +1106,8 @@ void CTxMemPool::GetTransactionAncestry(const uint256& txid, size_t& ancestors, 
     }
 }
 
-bool CTxMemPool::IsLoaded() const
+bool CTxMemPool::IsLoadedNonLockHelper() const
 {
-    LOCK(cs);
     return m_is_loaded;
 }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -728,6 +728,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
 
 bool CTxMemPool::CompareDepthAndScore(const uint256& hasha, const uint256& hashb, bool wtxid)
 {
+    AssertLockNotHeld(cs);
     LOCK(cs);
     indexed_transaction_set::const_iterator i = wtxid ? get_iter_from_wtxid(hasha) : mapTx.find(hasha);
     if (i == mapTx.end()) return false;
@@ -812,6 +813,7 @@ CTransactionRef CTxMemPool::get(const uint256& hash) const
 
 TxMempoolInfo CTxMemPool::info(const GenTxid& gtxid) const
 {
+    AssertLockNotHeld(cs);
     LOCK(cs);
     indexed_transaction_set::const_iterator i = (gtxid.IsWtxid() ? get_iter_from_wtxid(gtxid.GetHash()) : mapTx.find(gtxid.GetHash()));
     if (i == mapTx.end())
@@ -823,6 +825,7 @@ TxMempoolInfo CTxMemPool::info(const uint256& txid) const { return info(GenTxid{
 
 void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeDelta)
 {
+    AssertLockNotHeld(cs);
     {
         LOCK(cs);
         CAmount &delta = mapDeltas[hash];
@@ -1118,6 +1121,7 @@ bool CTxMemPool::IsLoaded() const
 
 void CTxMemPool::SetIsLoaded(bool loaded)
 {
+    AssertLockNotHeld(cs);
     LOCK(cs);
     m_is_loaded = loaded;
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -610,9 +610,8 @@ static void CheckInputsAndUpdateCoins(const CTransaction& tx, CCoinsViewCache& m
     UpdateCoins(tx, mempoolDuplicate, std::numeric_limits<int>::max());
 }
 
-void CTxMemPool::check(const CCoinsViewCache *pcoins) const
+void CTxMemPool::checkNonLockHelper(const CCoinsViewCache* pcoins) const
 {
-    LOCK(cs);
     if (nCheckFrequency == 0)
         return;
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -773,7 +773,6 @@ std::vector<CTxMemPool::indexed_transaction_set::const_iterator> CTxMemPool::Get
 
 void CTxMemPool::queryHashes(std::vector<uint256>& vtxid) const
 {
-    LOCK(cs);
     auto iters = GetSortedDepthAndScore();
 
     vtxid.clear();

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -329,7 +329,7 @@ void CTxMemPoolEntry::UpdateAncestorState(int64_t modifySize, CAmount modifyFee,
 CTxMemPool::CTxMemPool(CBlockPolicyEstimator* estimator)
     : nTransactionsUpdated(0), minerPolicyEstimator(estimator), m_epoch(0), m_has_epoch_guard(false)
 {
-    _clear(); //lock free clear
+    clearInternal();
 
     // Sanity checks off by default for performance, because otherwise
     // accepting transactions becomes O(N^2) where N is the number
@@ -582,7 +582,7 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
     blockSinceLastRollingFeeBump = true;
 }
 
-void CTxMemPool::_clear()
+void CTxMemPool::clearInternal()
 {
     mapLinks.clear();
     mapTx.clear();
@@ -593,12 +593,6 @@ void CTxMemPool::_clear()
     blockSinceLastRollingFeeBump = false;
     rollingMinimumFeeRate = 0;
     ++nTransactionsUpdated;
-}
-
-void CTxMemPool::clear()
-{
-    LOCK(cs);
-    _clear();
 }
 
 static void CheckInputsAndUpdateCoins(const CTransaction& tx, CCoinsViewCache& mempoolDuplicate, const int64_t spendheight)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1096,8 +1096,8 @@ uint64_t CTxMemPool::CalculateDescendantMaximum(txiter entry) const {
     return maximum;
 }
 
-void CTxMemPool::GetTransactionAncestry(const uint256& txid, size_t& ancestors, size_t& descendants) const {
-    LOCK(cs);
+void CTxMemPool::GetTransactionAncestry(const uint256& txid, size_t& ancestors, size_t& descendants) const
+{
     auto it = mapTx.find(txid);
     ancestors = descendants = 0;
     if (it != mapTx.end()) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -999,8 +999,8 @@ const CTxMemPool::setEntries & CTxMemPool::GetMemPoolChildren(txiter entry) cons
     return it->second.children;
 }
 
-CFeeRate CTxMemPool::GetMinFee(size_t sizelimit) const {
-    LOCK(cs);
+CFeeRate CTxMemPool::GetMinFeeNonLockHelper(size_t sizelimit) const
+{
     if (!blockSinceLastRollingFeeBump || rollingMinimumFeeRate == 0)
         return CFeeRate(llround(rollingMinimumFeeRate));
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -337,9 +337,9 @@ CTxMemPool::CTxMemPool(CBlockPolicyEstimator* estimator)
     nCheckFrequency = 0;
 }
 
-bool CTxMemPool::isSpent(const COutPoint& outpoint) const
+bool CTxMemPool::isSpent(const COutPoint& outpoint) const NO_THREAD_SAFETY_ANALYSIS
 {
-    LOCK(cs);
+    AssertLockHeld(cs);
     return mapNextTx.count(outpoint);
 }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -889,7 +889,7 @@ CTxMemPool::setEntries CTxMemPool::GetIterSet(const std::set<uint256>& hashes) c
 bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
 {
     for (unsigned int i = 0; i < tx.vin.size(); i++)
-        if (exists(tx.vin[i].prevout.hash))
+        if (existsNonLockHelper(tx.vin[i].prevout.hash))
             return false;
     return true;
 }
@@ -1062,7 +1062,7 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
         if (pvNoSpendsRemaining) {
             for (const CTransaction& tx : txn) {
                 for (const CTxIn& txin : tx.vin) {
-                    if (exists(txin.prevout.hash)) continue;
+                    if (existsNonLockHelper(txin.prevout.hash)) continue;
                     pvNoSpendsRemaining->push_back(txin.prevout);
                 }
             }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -417,7 +417,7 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
     for (const CTxIn& txin : it->GetTx().vin)
         mapNextTx.erase(txin.prevout);
 
-    RemoveUnbroadcastTx(hash, true /* add logging because unchecked */ );
+    RemoveUnbroadcastTxNonLockHelper(hash, true /* add logging because unchecked */ );
 
     if (vTxHashes.size() > 1) {
         vTxHashes[it->vTxHashesIdx] = std::move(vTxHashes.back());
@@ -917,11 +917,8 @@ size_t CTxMemPool::DynamicMemoryUsageNonLockHelper() const
     return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 15 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(mapLinks) + memusage::DynamicUsage(vTxHashes) + cachedInnerUsage;
 }
 
-void CTxMemPool::RemoveUnbroadcastTx(const uint256& txid, const bool unchecked) {
-    LOCK(cs);
-
-    if (m_unbroadcast_txids.erase(txid))
-    {
+void CTxMemPool::RemoveUnbroadcastTxNonLockHelper(const uint256& txid, const bool unchecked) {
+    if (m_unbroadcast_txids.erase(txid)) {
         LogPrint(BCLog::MEMPOOL, "Removed %i from set of unbroadcast txns%s\n", txid.GetHex(), (unchecked ? " before confirmation that txn was sent out" : ""));
     }
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -801,7 +801,7 @@ public:
 
     TxMempoolInfo info(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(!cs);
     TxMempoolInfo info(const GenTxid& gtxid) const EXCLUSIVE_LOCKS_REQUIRED(!cs);
-    std::vector<TxMempoolInfo> infoAll() const;
+    std::vector<TxMempoolInfo> infoAll() const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     size_t DynamicMemoryUsage() const;
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -727,7 +727,7 @@ public:
      * Calculate the ancestor and descendant count for the given transaction.
      * The counts include the transaction itself.
      */
-    void GetTransactionAncestry(const uint256& txid, size_t& ancestors, size_t& descendants) const;
+    void GetTransactionAncestry(const uint256& txid, size_t& ancestors, size_t& descendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** @returns true if the mempool is fully loaded */
     bool IsLoaded() const;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -823,7 +823,13 @@ public:
     }
 
     /** Removes a transaction from the unbroadcast set */
-    void RemoveUnbroadcastTx(const uint256& txid, const bool unchecked = false);
+    void RemoveUnbroadcastTxNonLockHelper(const uint256& txid, const bool unchecked) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void RemoveUnbroadcastTx(const uint256& txid, const bool unchecked = false) EXCLUSIVE_LOCKS_REQUIRED(!cs)
+    {
+        AssertLockNotHeld(cs);
+        LOCK(cs);
+        RemoveUnbroadcastTxNonLockHelper(txid, unchecked);
+    }
 
     /** Returns transactions in unbroadcast set */
     std::map<uint256, uint256> GetUnbroadcastTxs() const {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -595,7 +595,14 @@ public:
      * all inputs are in the mapNextTx array). If sanity-checking is turned off,
      * check does nothing.
      */
-    void check(const CCoinsViewCache *pcoins) const;
+    void checkNonLockHelper(const CCoinsViewCache* pcoins) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void check(const CCoinsViewCache* pcoins) const EXCLUSIVE_LOCKS_REQUIRED(!cs)
+    {
+        AssertLockNotHeld(cs);
+        LOCK(cs);
+        checkNonLockHelper(pcoins);
+    }
+
     void setSanityCheck(double dFrequency = 1.0) EXCLUSIVE_LOCKS_REQUIRED(!cs)
     {
         AssertLockNotHeld(cs);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -641,7 +641,7 @@ public:
 
     bool CompareDepthAndScore(const uint256& hasha, const uint256& hashb, bool wtxid = false) EXCLUSIVE_LOCKS_REQUIRED(!cs);
     void queryHashes(std::vector<uint256>& vtxid) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-    bool isSpent(const COutPoint& outpoint) const;
+    bool isSpent(const COutPoint& outpoint) const; // EXCLUSIVE_LOCKS_REQUIRED(cs);
     unsigned int GetTransactionsUpdated() const;
     void AddTransactionsUpdated(unsigned int n);
     /**

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -803,7 +803,13 @@ public:
     TxMempoolInfo info(const GenTxid& gtxid) const EXCLUSIVE_LOCKS_REQUIRED(!cs);
     std::vector<TxMempoolInfo> infoAll() const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
-    size_t DynamicMemoryUsage() const;
+    size_t DynamicMemoryUsageNonLockHelper() const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    size_t DynamicMemoryUsage() const EXCLUSIVE_LOCKS_REQUIRED(!cs)
+    {
+        AssertLockNotHeld(cs);
+        LOCK(cs);
+        return DynamicMemoryUsageNonLockHelper();
+    }
 
     /** Adds a transaction to the unbroadcast set */
     void AddUnbroadcastTx(const uint256& txid, const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(!cs)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -730,7 +730,13 @@ public:
     void GetTransactionAncestry(const uint256& txid, size_t& ancestors, size_t& descendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** @returns true if the mempool is fully loaded */
-    bool IsLoaded() const;
+    bool IsLoadedNonLockHelper() const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    bool IsLoaded() const EXCLUSIVE_LOCKS_REQUIRED(!cs)
+    {
+        AssertLockNotHeld(cs);
+        LOCK(cs);
+        return IsLoadedNonLockHelper();
+    }
 
     /** Sets the current loaded state */
     void SetIsLoaded(bool loaded) EXCLUSIVE_LOCKS_REQUIRED(!cs);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -614,7 +614,7 @@ public:
     void clear();
     void _clear() EXCLUSIVE_LOCKS_REQUIRED(cs); //lock free
     bool CompareDepthAndScore(const uint256& hasha, const uint256& hashb, bool wtxid=false);
-    void queryHashes(std::vector<uint256>& vtxid) const;
+    void queryHashes(std::vector<uint256>& vtxid) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     bool isSpent(const COutPoint& outpoint) const;
     unsigned int GetTransactionsUpdated() const;
     void AddTransactionsUpdated(unsigned int n);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -706,7 +706,13 @@ public:
       *  takes the fee rate to go back down all the way to 0. When the feerate
       *  would otherwise be half of this, it is set to 0 instead.
       */
-    CFeeRate GetMinFee(size_t sizelimit) const;
+    CFeeRate GetMinFeeNonLockHelper(size_t sizelimit) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    CFeeRate GetMinFee(size_t sizelimit) const EXCLUSIVE_LOCKS_REQUIRED(!cs)
+    {
+        AssertLockNotHeld(cs);
+        LOCK(cs);
+        return GetMinFeeNonLockHelper(sizelimit);
+    }
 
     /** Remove transactions from the mempool until its dynamic size is <= sizelimit.
       *  pvNoSpendsRemaining, if set, will be populated with the list of outpoints

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -786,12 +786,19 @@ public:
         return existsNonLockHelper(txid);
     }
 
-    CTransactionRef get(const uint256& hash) const;
+    CTransactionRef getNonLockHelper(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    CTransactionRef get(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(!cs)
+    {
+        AssertLockNotHeld(cs);
+        LOCK(cs);
+        return getNonLockHelper(hash);
+    }
     txiter get_iter_from_wtxid(const uint256& wtxid) const EXCLUSIVE_LOCKS_REQUIRED(cs)
     {
         AssertLockHeld(cs);
         return mapTx.project<0>(mapTx.get<index_by_wtxid>().find(wtxid));
     }
+
     TxMempoolInfo info(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(!cs);
     TxMempoolInfo info(const GenTxid& gtxid) const EXCLUSIVE_LOCKS_REQUIRED(!cs);
     std::vector<TxMempoolInfo> infoAll() const;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -579,6 +579,8 @@ private:
      */
     std::map<uint256, uint256> m_unbroadcast_txids GUARDED_BY(cs);
 
+    void ClearPrioritisation(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs);
+
 public:
     indirectmap<COutPoint, const CTransaction*> mapNextTx GUARDED_BY(cs);
     std::map<uint256, CAmount> mapDeltas;
@@ -627,7 +629,6 @@ public:
     /** Affect CreateNewBlock prioritisation of transactions */
     void PrioritiseTransaction(const uint256& hash, const CAmount& nFeeDelta);
     void ApplyDelta(const uint256& hash, CAmount &nFeeDelta) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void ClearPrioritisation(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Get the transaction in the pool that spends the same prevout */
     const CTransaction* GetConflictTx(const COutPoint& prevout) const EXCLUSIVE_LOCKS_REQUIRED(cs);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -741,10 +741,16 @@ public:
     /** Sets the current loaded state */
     void SetIsLoaded(bool loaded) EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
-    unsigned long size() const
+    unsigned long sizeNonLockHelper() const EXCLUSIVE_LOCKS_REQUIRED(cs)
     {
-        LOCK(cs);
         return mapTx.size();
+    }
+
+    unsigned long size() const EXCLUSIVE_LOCKS_REQUIRED(!cs)
+    {
+        AssertLockNotHeld(cs);
+        LOCK(cs);
+        return sizeNonLockHelper();
     }
 
     uint64_t GetTotalTxSize() const EXCLUSIVE_LOCKS_REQUIRED(cs)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -832,8 +832,8 @@ public:
     }
 
     /** Returns transactions in unbroadcast set */
-    std::map<uint256, uint256> GetUnbroadcastTxs() const {
-        LOCK(cs);
+    std::map<uint256, uint256> GetUnbroadcastTxs() const EXCLUSIVE_LOCKS_REQUIRED(cs)
+    {
         return m_unbroadcast_txids;
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -386,7 +386,7 @@ static void UpdateMempoolForReorg(CTxMemPool& mempool, DisconnectedBlockTransact
         // ignore validation errors in resurrected transactions
         TxValidationState stateDummy;
         if (!fAddToMempool || (*it)->IsCoinBase() ||
-            !AcceptToMemoryPool(mempool, stateDummy, *it,
+            !::AcceptToMemoryPool(mempool, stateDummy, *it,
                                 nullptr /* plTxnReplaced */, true /* bypass_limits */, 0 /* nAbsurdFee */)) {
             // If the transaction doesn't make it in to the mempool, remove any
             // transactions that depend on it (which would now be orphans).
@@ -5086,6 +5086,7 @@ bool LoadMempool(CTxMemPool& pool)
             TxValidationState state;
             if (nTime + nExpiryTimeout > nNow) {
                 LOCK(cs_main);
+                AssertLockNotHeld(pool.cs);
                 AcceptToMemoryPoolWithTime(chainparams, pool, state, tx, nTime,
                                            nullptr /* plTxnReplaced */, false /* bypass_limits */, 0 /* nAbsurdFee */,
                                            false /* test_accept */);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -431,7 +431,7 @@ static bool CheckInputsFromMempoolAndCache(const CTransaction& tx, TxValidationS
         if (coin.IsSpent()) return false;
 
         // Check equivalence for available inputs.
-        const CTransactionRef& txFrom = pool.get(txin.prevout.hash);
+        const CTransactionRef& txFrom = pool.getNonLockHelper(txin.prevout.hash);
         if (txFrom) {
             assert(txFrom->GetHash() == txin.prevout.hash);
             assert(txFrom->vout.size() > txin.prevout.n);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2831,7 +2831,7 @@ bool CChainState::ActivateBestChainStep(BlockValidationState& state, const CChai
         // any disconnected transactions back to the mempool.
         UpdateMempoolForReorg(m_mempool, disconnectpool, true);
     }
-    m_mempool.check(&CoinsTip());
+    m_mempool.checkNonLockHelper(&CoinsTip());
 
     // Callbacks/notifications for a new best chain.
     if (fInvalidFound)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2293,9 +2293,9 @@ bool CChainState::FlushStateToDiskHelper(
     const CChainParams& chainparams,
     BlockValidationState &state,
     FlushStateMode mode,
-    int nManualPruneHeight)
+    int nManualPruneHeight,
+    const CoinsCacheSizeState cache_state)
 {
-    LOCK(cs_main);
     assert(this->CanFlushToDisk());
     static std::chrono::microseconds nLastWrite{0};
     static std::chrono::microseconds nLastFlush{0};
@@ -2309,7 +2309,6 @@ bool CChainState::FlushStateToDiskHelper(
     {
         bool fFlushForPrune = false;
         bool fDoFullFlush = false;
-        CoinsCacheSizeState cache_state = GetCoinsCacheSizeState(&m_mempool);
         LOCK(cs_LastBlockFile);
         if (fPruneMode && (fCheckForPruning || nManualPruneHeight > 0) && !fReindex) {
             if (nManualPruneHeight > 0) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -391,7 +391,7 @@ static void UpdateMempoolForReorg(CTxMemPool& mempool, DisconnectedBlockTransact
             // If the transaction doesn't make it in to the mempool, remove any
             // transactions that depend on it (which would now be orphans).
             mempool.removeRecursive(**it, MemPoolRemovalReason::REORG);
-        } else if (mempool.exists((*it)->GetHash())) {
+        } else if (mempool.existsNonLockHelper((*it)->GetHash())) {
             vHashUpdate.push_back((*it)->GetHash());
         }
         ++it;
@@ -600,7 +600,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         return state.Invalid(TxValidationResult::TX_PREMATURE_SPEND, "non-final");
 
     // is it already in the memory pool?
-    if (m_pool.exists(hash)) {
+    if (m_pool.existsNonLockHelper(hash)) {
         return state.Invalid(TxValidationResult::TX_CONFLICT, "txn-already-in-mempool");
     }
 
@@ -889,7 +889,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
                 // Rather than check the UTXO set - potentially expensive -
                 // it's cheaper to just check if the new input refers to a
                 // tx that's in the mempool.
-                if (m_pool.exists(tx.vin[j].prevout.hash)) {
+                if (m_pool.existsNonLockHelper(tx.vin[j].prevout.hash)) {
                     return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "replacement-adds-unconfirmed",
                             strprintf("replacement %s adds unconfirmed input, idx %d",
                                 hash.ToString(), j));
@@ -1022,7 +1022,7 @@ bool MemPoolAccept::Finalize(ATMPArgs& args, Workspace& ws)
     // trim mempool and check if tx was trimmed
     if (!bypass_limits) {
         LimitMempoolSize(m_pool, gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000, std::chrono::hours{gArgs.GetArg("-mempoolexpiry", DEFAULT_MEMPOOL_EXPIRY)});
-        if (!m_pool.exists(hash))
+        if (!m_pool.existsNonLockHelper(hash))
             return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "mempool full");
     }
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -522,9 +522,9 @@ private:
     bool Finalize(ATMPArgs& args, Workspace& ws) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_pool.cs);
 
     // Compare a package's feerate against minimum allowed.
-    bool CheckFeeRate(size_t package_size, CAmount package_fee, TxValidationState& state)
+    bool CheckFeeRate(size_t package_size, CAmount package_fee, TxValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(m_pool.cs)
     {
-        CAmount mempoolRejectFee = m_pool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFee(package_size);
+        CAmount mempoolRejectFee = m_pool.GetMinFeeNonLockHelper(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFee(package_size);
         if (mempoolRejectFee > 0 && package_fee < mempoolRejectFee) {
             return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "mempool min fee not met", strprintf("%d < %d", package_fee, mempoolRejectFee));
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2257,23 +2257,22 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
     return true;
 }
 
-CoinsCacheSizeState CChainState::GetCoinsCacheSizeState(const CTxMemPool* tx_pool)
+CoinsCacheSizeState CChainState::GetCoinsCacheSizeState(int64_t mempool_usage)
 {
     return this->GetCoinsCacheSizeState(
-        tx_pool,
+        mempool_usage,
         m_coinstip_cache_size_bytes,
         gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000);
 }
 
 CoinsCacheSizeState CChainState::GetCoinsCacheSizeState(
-    const CTxMemPool* tx_pool,
+    int64_t mempool_usage,
     size_t max_coins_cache_size_bytes,
     size_t max_mempool_size_bytes)
 {
-    const int64_t nMempoolUsage = tx_pool ? tx_pool->DynamicMemoryUsage() : 0;
     int64_t cacheSize = CoinsTip().DynamicMemoryUsage();
     int64_t nTotalSpace =
-        max_coins_cache_size_bytes + std::max<int64_t>(max_mempool_size_bytes - nMempoolUsage, 0);
+        max_coins_cache_size_bytes + std::max<int64_t>(max_mempool_size_bytes - mempool_usage, 0);
 
     //! No need to periodic flush if at least this much space still available.
     static constexpr int64_t MAX_BLOCK_COINSDB_USAGE_BYTES = 10 * 1024 * 1024;  // 10MB
@@ -2287,6 +2286,17 @@ CoinsCacheSizeState CChainState::GetCoinsCacheSizeState(
         return CoinsCacheSizeState::LARGE;
     }
     return CoinsCacheSizeState::OK;
+}
+
+CoinsCacheSizeState CChainState::GetCoinsCacheSizeState(
+    const CTxMemPool& tx_pool,
+    size_t max_coins_cache_size_bytes,
+    size_t max_mempool_size_bytes)
+{
+    return this->GetCoinsCacheSizeState(
+        tx_pool.DynamicMemoryUsage(),
+        max_coins_cache_size_bytes,
+        max_mempool_size_bytes);
 }
 
 bool CChainState::FlushStateToDiskHelper(

--- a/src/validation.h
+++ b/src/validation.h
@@ -628,7 +628,7 @@ public:
     {
         LOCK(cs_main);
         AssertLockHeld(::mempool.cs);
-        const CoinsCacheSizeState cache_state = GetCoinsCacheSizeState(&::mempool);
+        const CoinsCacheSizeState cache_state = GetCoinsCacheSizeState(::mempool.DynamicMemoryUsageNonLockHelper());
         return FlushStateToDiskHelper(chainparams, state, mode, nManualPruneHeight, cache_state);
     }
 
@@ -640,11 +640,7 @@ public:
     {
         LOCK(cs_main);
         AssertLockNotHeld(::mempool.cs);
-        CoinsCacheSizeState cache_state;
-        {
-            LOCK(::mempool.cs);
-            cache_state = GetCoinsCacheSizeState(&::mempool);
-        }
+        const CoinsCacheSizeState cache_state = GetCoinsCacheSizeState(::mempool.DynamicMemoryUsage());
         return FlushStateToDiskHelper(chainparams, state, mode, nManualPruneHeight, cache_state);
     }
 
@@ -714,13 +710,18 @@ public:
     //! Dictates whether we need to flush the cache to disk or not.
     //!
     //! @return the state of the size of the coins cache.
-    CoinsCacheSizeState GetCoinsCacheSizeState(const CTxMemPool* tx_pool)
+    CoinsCacheSizeState GetCoinsCacheSizeState(int64_t mempool_usage)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     CoinsCacheSizeState GetCoinsCacheSizeState(
-        const CTxMemPool* tx_pool,
+        int64_t mempool_usage,
         size_t max_coins_cache_size_bytes,
         size_t max_mempool_size_bytes) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    CoinsCacheSizeState GetCoinsCacheSizeState(
+        const CTxMemPool& tx_pool,
+        size_t max_coins_cache_size_bytes,
+        size_t max_mempool_size_bytes) EXCLUSIVE_LOCKS_REQUIRED(::cs_main, !tx_pool.cs);
 
     std::string ToString() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -612,11 +612,32 @@ public:
      *
      * @returns true unless a system error occurred
      */
-    bool FlushStateToDisk(
+    bool FlushStateToDiskHelper(
         const CChainParams& chainparams,
         BlockValidationState &state,
         FlushStateMode mode,
-        int nManualPruneHeight = 0);
+        int nManualPruneHeight);
+
+    bool FlushStateToDiskWithLockedMempool(
+        const CChainParams& chainparams,
+        BlockValidationState& state,
+        FlushStateMode mode,
+        int nManualPruneHeight = 0) // EXCLUSIVE_LOCKS_REQUIRED(::mempool.cs)
+        EXCLUSIVE_LOCKS_REQUIRED(::mempool.cs)
+    {
+        AssertLockHeld(::mempool.cs);
+        return FlushStateToDiskHelper(chainparams, state, mode, nManualPruneHeight);
+    }
+
+    bool FlushStateToDiskWithUnlockedMempool(
+        const CChainParams& chainparams,
+        BlockValidationState& state,
+        FlushStateMode mode,
+        int nManualPruneHeight = 0) EXCLUSIVE_LOCKS_REQUIRED(!::mempool.cs)
+    {
+        AssertLockNotHeld(::mempool.cs);
+        return FlushStateToDiskHelper(chainparams, state, mode, nManualPruneHeight);
+    }
 
     //! Unconditionally flush all changes to disk.
     void ForceFlushStateToDisk();

--- a/src/validation.h
+++ b/src/validation.h
@@ -201,9 +201,16 @@ void PruneBlockFilesManual(int nManualPruneHeight);
 
 /** (try to) add transaction to memory pool
  * plTxnReplaced will be appended to with all transactions replaced from mempool **/
-bool AcceptToMemoryPool(CTxMemPool& pool, TxValidationState &state, const CTransactionRef &tx,
-                        std::list<CTransactionRef>* plTxnReplaced,
-                        bool bypass_limits, const CAmount nAbsurdFee, bool test_accept=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+bool AcceptToMemoryPoolWithLockedMempool(
+    CTxMemPool& pool, TxValidationState& state, const CTransactionRef& tx,
+    std::list<CTransactionRef>* plTxnReplaced,
+    bool bypass_limits, const CAmount nAbsurdFee, bool test_accept = false)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs);
+bool AcceptToMemoryPoolWithUnlockedMempool(
+    CTxMemPool& pool, TxValidationState& state, const CTransactionRef& tx,
+    std::list<CTransactionRef>* plTxnReplaced,
+    bool bypass_limits, const CAmount nAbsurdFee, bool test_accept = false)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main, !pool.cs);
 
 /** Get the BIP9 state for a given deployment at the current tip. */
 ThresholdState VersionBitsTipState(const Consensus::Params& params, Consensus::DeploymentPos pos);

--- a/src/validation.h
+++ b/src/validation.h
@@ -616,7 +616,8 @@ public:
         const CChainParams& chainparams,
         BlockValidationState &state,
         FlushStateMode mode,
-        int nManualPruneHeight);
+        int nManualPruneHeight,
+        CoinsCacheSizeState cache_state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     bool FlushStateToDiskWithLockedMempool(
         const CChainParams& chainparams,
@@ -625,8 +626,10 @@ public:
         int nManualPruneHeight = 0) // EXCLUSIVE_LOCKS_REQUIRED(::mempool.cs)
         EXCLUSIVE_LOCKS_REQUIRED(::mempool.cs)
     {
+        LOCK(cs_main);
         AssertLockHeld(::mempool.cs);
-        return FlushStateToDiskHelper(chainparams, state, mode, nManualPruneHeight);
+        const CoinsCacheSizeState cache_state = GetCoinsCacheSizeState(&::mempool);
+        return FlushStateToDiskHelper(chainparams, state, mode, nManualPruneHeight, cache_state);
     }
 
     bool FlushStateToDiskWithUnlockedMempool(
@@ -635,8 +638,14 @@ public:
         FlushStateMode mode,
         int nManualPruneHeight = 0) EXCLUSIVE_LOCKS_REQUIRED(!::mempool.cs)
     {
+        LOCK(cs_main);
         AssertLockNotHeld(::mempool.cs);
-        return FlushStateToDiskHelper(chainparams, state, mode, nManualPruneHeight);
+        CoinsCacheSizeState cache_state;
+        {
+            LOCK(::mempool.cs);
+            cache_state = GetCoinsCacheSizeState(&::mempool);
+        }
+        return FlushStateToDiskHelper(chainparams, state, mode, nManualPruneHeight, cache_state);
     }
 
     //! Unconditionally flush all changes to disk.


### PR DESCRIPTION
This PR replaces `RecursiveMutex CTxMemPool::cs` with `Mutex CTxMemPool:cs`.

All of the related code branches are covered by appropriate lock assertions to insure that the mutex locking policy has not been changed by accident

Related to #19303.