### PR TITLE
wallet: Move BerkeleyBatch static functions to BerkeleyDatabase

### DIFF
--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -614,14 +614,12 @@ void BerkeleyEnvironment::Flush(bool fShutdown)
     }
 }
 
-bool BerkeleyBatch::PeriodicFlush(BerkeleyDatabase& database)
+bool BerkeleyDatabase::PeriodicFlush()
 {
-    if (database.IsDummy()) {
+    if (IsDummy()) {
         return true;
     }
     bool ret = false;
-    BerkeleyEnvironment *env = database.env.get();
-    const std::string& strFile = database.strFile;
     TRY_LOCK(cs_db, lockDb);
     if (lockDb)
     {

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -292,11 +292,10 @@ BerkeleyBatch::SafeDbt::operator Dbt*()
     return &m_dbt;
 }
 
-bool BerkeleyBatch::VerifyEnvironment(const fs::path& file_path, bilingual_str& errorStr)
+bool BerkeleyDatabase::Verify(bilingual_str& errorStr)
 {
-    std::string walletFile;
-    std::shared_ptr<BerkeleyEnvironment> env = GetWalletEnv(file_path, walletFile);
     fs::path walletDir = env->Directory();
+    fs::path file_path = walletDir / strFile;
 
     LogPrintf("Using BerkeleyDB version %s\n", BerkeleyDatabaseVersion());
     LogPrintf("Using wallet %s\n", file_path.string());
@@ -306,19 +305,10 @@ bool BerkeleyBatch::VerifyEnvironment(const fs::path& file_path, bilingual_str& 
         return false;
     }
 
-    return true;
-}
-
-bool BerkeleyBatch::VerifyDatabaseFile(const fs::path& file_path, bilingual_str& errorStr)
-{
-    std::string walletFile;
-    std::shared_ptr<BerkeleyEnvironment> env = GetWalletEnv(file_path, walletFile);
-    fs::path walletDir = env->Directory();
-
-    if (fs::exists(walletDir / walletFile))
+    if (fs::exists(file_path))
     {
-        if (!env->Verify(walletFile)) {
-            errorStr = strprintf(_("%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup."), walletFile);
+        if (!env->Verify(strFile)) {
+            errorStr = strprintf(_("%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup."), file_path);
             return false;
         }
     }

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -131,6 +131,9 @@ public:
     /** Make sure all changes are flushed to disk.
      */
     void Flush(bool shutdown);
+    /* flush the wallet passively (TRY_LOCK)
+       ideal to be called periodically */
+    bool PeriodicFlush();
 
     void IncrementUpdateCounter();
 
@@ -214,10 +217,6 @@ public:
 
     void Flush();
     void Close();
-
-    /* flush the wallet passively (TRY_LOCK)
-       ideal to be called periodically */
-    static bool PeriodicFlush(BerkeleyDatabase& database);
 
     template <typename K, typename T>
     bool Read(const K& key, T& value)

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -141,6 +141,9 @@ public:
     unsigned int nLastFlushed;
     int64_t nLastWalletUpdate;
 
+    /** Verifies the environment and database file */
+    bool Verify(bilingual_str& error);
+
     /**
      * Pointer to shared database environment.
      *
@@ -215,10 +218,6 @@ public:
     /* flush the wallet passively (TRY_LOCK)
        ideal to be called periodically */
     static bool PeriodicFlush(BerkeleyDatabase& database);
-    /* verifies the database environment */
-    static bool VerifyEnvironment(const fs::path& file_path, bilingual_str& errorStr);
-    /* verifies the database file */
-    static bool VerifyDatabaseFile(const fs::path& file_path, bilingual_str& errorStr);
 
     template <typename K, typename T>
     bool Read(const K& key, T& value)

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -287,8 +287,6 @@ public:
     bool TxnBegin();
     bool TxnCommit();
     bool TxnAbort();
-
-    bool static Rewrite(BerkeleyDatabase& database, const char* pszSkip = nullptr);
 };
 
 std::string BerkeleyDatabaseVersion();

--- a/src/wallet/salvage.cpp
+++ b/src/wallet/salvage.cpp
@@ -20,6 +20,11 @@ bool RecoverDatabaseFile(const fs::path& file_path)
     std::string filename;
     std::shared_ptr<BerkeleyEnvironment> env = GetWalletEnv(file_path, filename);
 
+    if (!env->Open(true /* retry */)) {
+        tfm::format(std::cerr, "Error initializing wallet database environment %s!", env->Directory());
+        return false;
+    }
+
     // Recovery procedure:
     // move wallet file to walletfilename.timestamp.bak
     // Call Salvage with fAggressive=true to

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3708,15 +3708,11 @@ bool CWallet::Verify(interfaces::Chain& chain, const WalletLocation& location, b
     std::unique_ptr<WalletDatabase> database = CreateWalletDatabase(wallet_path);
 
     try {
-        if (!WalletBatch::VerifyEnvironment(wallet_path, error_string)) {
-            return false;
-        }
+        return database->Verify(error_string);
     } catch (const fs::filesystem_error& e) {
         error_string = Untranslated(strprintf("Error loading wallet %s. %s", location.GetName(), fsbridge::get_filesystem_error_message(e)));
         return false;
     }
-
-    return WalletBatch::VerifyDatabaseFile(wallet_path, error_string);
 }
 
 std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain, const WalletLocation& location, bilingual_str& error, std::vector<bilingual_str>& warnings, uint64_t wallet_creation_flags)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -964,7 +964,7 @@ void MaybeCompactWalletDB()
         }
 
         if (dbh.nLastFlushed != nUpdateCounter && GetTime() - dbh.nLastWalletUpdate >= 2) {
-            if (BerkeleyBatch::PeriodicFlush(dbh)) {
+            if (dbh.PeriodicFlush()) {
                 dbh.nLastFlushed = nUpdateCounter;
             }
         }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -973,16 +973,6 @@ void MaybeCompactWalletDB()
     fOneThread = false;
 }
 
-bool WalletBatch::VerifyEnvironment(const fs::path& wallet_path, bilingual_str& errorStr)
-{
-    return BerkeleyBatch::VerifyEnvironment(wallet_path, errorStr);
-}
-
-bool WalletBatch::VerifyDatabaseFile(const fs::path& wallet_path, bilingual_str& errorStr)
-{
-    return BerkeleyBatch::VerifyDatabaseFile(wallet_path, errorStr);
-}
-
 bool WalletBatch::WriteDestData(const std::string &address, const std::string &key, const std::string &value)
 {
     return WriteIC(std::make_pair(DBKeys::DESTDATA, std::make_pair(address, key)), value);

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -112,7 +112,7 @@ static bool SalvageWallet(const fs::path& path)
     // Initialize the environment before recovery
     bilingual_str error_string;
     try {
-        WalletBatch::VerifyEnvironment(path, error_string);
+        database->Verify(error_string);
     } catch (const fs::filesystem_error& e) {
         error_string = Untranslated(strprintf("Error loading wallet. %s", fsbridge::get_filesystem_error_message(e)));
     }
@@ -138,11 +138,6 @@ bool ExecuteWalletToolFunc(const std::string& command, const std::string& name)
     } else if (command == "info" || command == "salvage") {
         if (!fs::exists(path)) {
             tfm::format(std::cerr, "Error: no wallet file at %s\n", name);
-            return false;
-        }
-        bilingual_str error;
-        if (!WalletBatch::VerifyEnvironment(path, error)) {
-            tfm::format(std::cerr, "%s\nError loading %s. Is wallet being used by other process?\n", error.original, name);
             return false;
         }
 

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -71,8 +71,7 @@ class ToolWalletTest(BitcoinTestFramework):
         self.assert_raises_tool_error('Error: two methods provided (info and create). Only one method should be provided.', 'info', 'create')
         self.assert_raises_tool_error('Error parsing command line arguments: Invalid parameter -foo', '-foo')
         self.assert_raises_tool_error(
-            'Error initializing wallet database environment "{}"!\nError loading wallet.dat. Is wallet being used by other process?'
-            .format(os.path.join(self.nodes[0].datadir, self.chain, 'wallets')),
+            'Error loading wallet.dat. Is wallet being used by another process?',
             '-wallet=wallet.dat',
             'info',
         )


### PR DESCRIPTION
The `BerkeleyBatch` class has 4 static functions that operate on `BerkeleyDatabase` or `BerkeleyEnvironment`. It doesn't make sense for these to be standalone nor for them to be static functions. So instead, move them from `BerkeleyBatch` into `BerkeleyDatabase` and make them member functions instead of static.

`BerkeleyBatch::VerifyEnvironment` and `BerkeleyBatch::VerifyDatabaseFile` are combined into a single `BerkeleyDatabase::Verify` function that operates on that `BerkeleyDatabase` object.

`BerkeleyBatch::Rewrite` and `BerkeleyBatch::PeriodicFlush` both took a `BerkeleyDatabase` as an argument and did stuff on it. So we just make it a member function so it doesn't need to take a database as an argument.

Part of #18971