### PR TITLE
qt: Allow horizontal slider in debugwindow peers tab to autosize display

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1080,7 +1080,7 @@
               </property>
               <property name="minimumSize">
                <size>
-                <width>300</width>
+                <width>0</width>
                 <height>0</height>
                </size>
               </property>


### PR DESCRIPTION
When fiddling around  with new node flags other than the usual. 
  
Not all possible node flag strings i.e. UNKNOWN where 
visible in peers details tab.
Since v18.2 fixed size was set to 300 and sliding is thereby limited. 

A fix on my old linux cruft and small screen was to set  minimumSize width to -1 or 0.
Qt the will then autosize the slider to the max string length.
 
Thereby i had full display of all flags inclusive sliding without to fullscreen the window.  

Not sure if this is even an issue for those who can afford big screens or high res macs?
Feedback welcome.