### PR TITLE
build: Do not include server symbols in wallet

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -6,6 +6,10 @@
 
 export LC_ALL=C
 
+travis_retry sudo apt update && sudo apt install -y clang-format-9
+sudo update-alternatives --install /usr/bin/clang-format      clang-format      $(which clang-format-9     ) 100
+sudo update-alternatives --install /usr/bin/clang-format-diff clang-format-diff $(which clang-format-diff-9) 100
+
 travis_retry pip3 install codespell==1.17.1
 travis_retry pip3 install flake8==3.8.3
 travis_retry pip3 install yq

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -110,9 +110,9 @@ BITCOIN_CORE_H = \
   banman.h \
   base58.h \
   bech32.h \
-  bloom.h \
   blockencodings.h \
   blockfilter.h \
+  bloom.h \
   chain.h \
   chainparams.h \
   chainparamsbase.h \
@@ -133,6 +133,7 @@ BITCOIN_CORE_H = \
   core_io.h \
   core_memusage.h \
   cuckoocache.h \
+  dbwrapper.h \
   flatfile.h \
   fs.h \
   httprpc.h \
@@ -148,7 +149,6 @@ BITCOIN_CORE_H = \
   interfaces/wallet.h \
   key.h \
   key_io.h \
-  dbwrapper.h \
   limitedmap.h \
   logging.h \
   logging/timer.h \
@@ -167,6 +167,7 @@ BITCOIN_CORE_H = \
   node/context.h \
   node/psbt.h \
   node/transaction.h \
+  node/ui_interface.h \
   node/utxo_snapshot.h \
   noui.h \
   optional.h \
@@ -206,13 +207,12 @@ BITCOIN_CORE_H = \
   support/events.h \
   support/lockedpool.h \
   sync.h \
-  threadsafety.h \
   threadinterrupt.h \
+  threadsafety.h \
   timedata.h \
   torcontrol.h \
   txdb.h \
   txmempool.h \
-  node/ui_interface.h \
   undo.h \
   util/asmap.h \
   util/bip32.h \
@@ -221,8 +221,6 @@ BITCOIN_CORE_H = \
   util/error.h \
   util/fees.h \
   util/golombrice.h \
-  util/spanparsing.h \
-  util/system.h \
   util/macros.h \
   util/memory.h \
   util/message.h \
@@ -230,7 +228,9 @@ BITCOIN_CORE_H = \
   util/rbf.h \
   util/ref.h \
   util/settings.h \
+  util/spanparsing.h \
   util/string.h \
+  util/system.h \
   util/threadnames.h \
   util/time.h \
   util/translation.h \
@@ -241,9 +241,9 @@ BITCOIN_CORE_H = \
   validationinterface.h \
   versionbits.h \
   versionbitsinfo.h \
-  walletinitinterface.h \
   wallet/bdb.h \
   wallet/coincontrol.h \
+  wallet/coinselection.h \
   wallet/context.h \
   wallet/crypter.h \
   wallet/db.h \
@@ -258,7 +258,7 @@ BITCOIN_CORE_H = \
   wallet/walletdb.h \
   wallet/wallettool.h \
   wallet/walletutil.h \
-  wallet/coinselection.h \
+  walletinitinterface.h \
   warnings.h \
   zmq/zmqabstractnotifier.h \
   zmq/zmqconfig.h\
@@ -287,16 +287,16 @@ libbitcoin_server_a_SOURCES = \
   blockfilter.cpp \
   chain.cpp \
   consensus/tx_verify.cpp \
+  dbwrapper.cpp \
   flatfile.cpp \
   httprpc.cpp \
   httpserver.cpp \
   index/base.cpp \
   index/blockfilterindex.cpp \
   index/txindex.cpp \
+  init.cpp \
   interfaces/chain.cpp \
   interfaces/node.cpp \
-  init.cpp \
-  dbwrapper.cpp \
   miner.cpp \
   net.cpp \
   net_processing.cpp \
@@ -305,6 +305,7 @@ libbitcoin_server_a_SOURCES = \
   node/context.cpp \
   node/psbt.cpp \
   node/transaction.cpp \
+  node/ui_interface.cpp \
   noui.cpp \
   policy/fees.cpp \
   policy/rbf.cpp \
@@ -323,7 +324,6 @@ libbitcoin_server_a_SOURCES = \
   torcontrol.cpp \
   txdb.cpp \
   txmempool.cpp \
-  node/ui_interface.cpp \
   validation.cpp \
   validationinterface.cpp \
   versionbits.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -234,6 +234,7 @@ BITCOIN_CORE_H = \
   util/threadnames.h \
   util/time.h \
   util/translation.h \
+  util/ui_change_type.h \
   util/url.h \
   util/vector.h \
   validation.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -212,7 +212,7 @@ BITCOIN_CORE_H = \
   torcontrol.h \
   txdb.h \
   txmempool.h \
-  ui_interface.h \
+  node/ui_interface.h \
   undo.h \
   util/asmap.h \
   util/bip32.h \
@@ -323,7 +323,7 @@ libbitcoin_server_a_SOURCES = \
   torcontrol.cpp \
   txdb.cpp \
   txmempool.cpp \
-  ui_interface.cpp \
+  node/ui_interface.cpp \
   validation.cpp \
   validationinterface.cpp \
   versionbits.cpp \

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -6,7 +6,7 @@
 #include <banman.h>
 
 #include <netaddress.h>
-#include <ui_interface.h>
+#include <node/ui_interface.h>
 #include <util/system.h>
 #include <util/time.h>
 #include <util/translation.h>

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -13,9 +13,9 @@
 #include <init.h>
 #include <interfaces/chain.h>
 #include <node/context.h>
+#include <node/ui_interface.h>
 #include <noui.h>
 #include <shutdown.h>
-#include <ui_interface.h>
 #include <util/ref.h>
 #include <util/strencodings.h>
 #include <util/system.h>

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -7,10 +7,10 @@
 #include <chainparamsbase.h>
 #include <compat.h>
 #include <netbase.h>
+#include <node/ui_interface.h>
 #include <rpc/protocol.h> // For HTTP status codes
 #include <shutdown.h>
 #include <sync.h>
-#include <ui_interface.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <util/threadnames.h>

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -4,9 +4,9 @@
 
 #include <chainparams.h>
 #include <index/base.h>
+#include <node/ui_interface.h>
 #include <shutdown.h>
 #include <tinyformat.h>
-#include <ui_interface.h>
 #include <util/system.h>
 #include <util/translation.h>
 #include <validation.h>

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -3,8 +3,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <index/txindex.h>
+#include <node/ui_interface.h>
 #include <shutdown.h>
-#include <ui_interface.h>
 #include <util/system.h>
 #include <util/translation.h>
 #include <validation.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -31,6 +31,7 @@
 #include <net_processing.h>
 #include <netbase.h>
 #include <node/context.h>
+#include <node/ui_interface.h>
 #include <policy/feerate.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
@@ -48,7 +49,6 @@
 #include <torcontrol.h>
 #include <txdb.h>
 #include <txmempool.h>
-#include <ui_interface.h>
 #include <util/asmap.h>
 #include <util/moneystr.h>
 #include <util/string.h>

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -13,6 +13,7 @@
 #include <node/coin.h>
 #include <node/context.h>
 #include <node/transaction.h>
+#include <node/ui_interface.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
 #include <policy/rbf.h>
@@ -25,7 +26,6 @@
 #include <sync.h>
 #include <timedata.h>
 #include <txmempool.h>
-#include <ui_interface.h>
 #include <uint256.h>
 #include <univalue.h>
 #include <util/system.h>

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -17,6 +17,7 @@
 #include <netaddress.h>
 #include <netbase.h>
 #include <node/context.h>
+#include <node/ui_interface.h>
 #include <policy/feerate.h>
 #include <policy/fees.h>
 #include <policy/settings.h>
@@ -26,7 +27,6 @@
 #include <support/allocators/secure.h>
 #include <sync.h>
 #include <txmempool.h>
-#include <ui_interface.h>
 #include <util/ref.h>
 #include <util/system.h>
 #include <util/translation.h>

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -13,11 +13,11 @@
 #include <script/standard.h>
 #include <support/allocators/secure.h>
 #include <sync.h>
-#include <ui_interface.h>
 #include <uint256.h>
 #include <util/check.h>
 #include <util/ref.h>
 #include <util/system.h>
+#include <util/ui_change_type.h>
 #include <wallet/context.h>
 #include <wallet/feebumper.h>
 #include <wallet/fees.h>

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -9,8 +9,8 @@
 #include <pubkey.h>                    // For CKeyID and CScriptID (definitions needed in CTxDestination instantiation)
 #include <script/standard.h>           // For CTxDestination
 #include <support/allocators/secure.h> // For SecureString
-#include <ui_interface.h>              // For ChangeType
 #include <util/message.h>
+#include <util/ui_change_type.h>
 
 #include <functional>
 #include <map>

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -14,12 +14,12 @@
 #include <clientversion.h>
 #include <consensus/consensus.h>
 #include <crypto/sha256.h>
-#include <netbase.h>
 #include <net_permissions.h>
+#include <netbase.h>
+#include <node/ui_interface.h>
 #include <protocol.h>
 #include <random.h>
 #include <scheduler.h>
-#include <ui_interface.h>
 #include <util/strencodings.h>
 #include <util/translation.h>
 

--- a/src/node/ui_interface.cpp
+++ b/src/node/ui_interface.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <ui_interface.h>
+#include <node/ui_interface.h>
 
 #include <util/translation.h>
 

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UI_INTERFACE_H
-#define BITCOIN_UI_INTERFACE_H
+#ifndef BITCOIN_NODE_UI_INTERFACE_H
+#define BITCOIN_NODE_UI_INTERFACE_H
 
 #include <functional>
 #include <memory>
@@ -118,4 +118,4 @@ constexpr auto AbortError = InitError;
 
 extern CClientUIInterface uiInterface;
 
-#endif // BITCOIN_UI_INTERFACE_H
+#endif // BITCOIN_NODE_UI_INTERFACE_H

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -6,7 +6,7 @@
 #include <noui.h>
 
 #include <logging.h>
-#include <ui_interface.h>
+#include <node/ui_interface.h>
 #include <util/translation.h>
 
 #include <string>

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -30,11 +30,10 @@
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <noui.h>
-#include <ui_interface.h>
 #include <uint256.h>
 #include <util/system.h>
-#include <util/translation.h>
 #include <util/threadnames.h>
+#include <util/translation.h>
 #include <validation.h>
 
 #include <memory>

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -34,7 +34,7 @@
 #include <chainparams.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
-#include <ui_interface.h>
+#include <node/ui_interface.h>
 #include <util/system.h>
 #include <util/translation.h>
 #include <validation.h>

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -14,9 +14,9 @@
 
 #include <chainparams.h>
 #include <interfaces/node.h>
-#include <policy/policy.h>
 #include <key_io.h>
-#include <ui_interface.h>
+#include <node/ui_interface.h>
+#include <policy/policy.h>
 #include <util/system.h>
 #include <wallet/wallet.h>
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -21,9 +21,9 @@
 #include <chainparams.h>
 #include <interfaces/node.h>
 #include <key_io.h>
+#include <node/ui_interface.h>
 #include <policy/fees.h>
 #include <txmempool.h>
-#include <ui_interface.h>
 #include <wallet/coincontrol.h>
 #include <wallet/fees.h>
 #include <wallet/wallet.h>

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -14,7 +14,6 @@
 #include <interfaces/wallet.h>
 #include <qt/guiutil.h>
 #include <qt/networkstyle.h>
-#include <ui_interface.h>
 #include <util/system.h>
 #include <util/translation.h>
 

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -17,7 +17,7 @@
 #include <qt/transactiontablemodel.h>
 #include <qt/walletmodel.h>
 
-#include <ui_interface.h>
+#include <node/ui_interface.h>
 
 #include <QApplication>
 #include <QComboBox>

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -21,8 +21,8 @@
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <key_io.h>
+#include <node/ui_interface.h>
 #include <psbt.h>
-#include <ui_interface.h>
 #include <util/system.h> // for GetBoolArg
 #include <util/translation.h>
 #include <wallet/coincontrol.h>

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -20,8 +20,8 @@
 #include <qt/walletmodel.h>
 
 #include <interfaces/node.h>
+#include <node/ui_interface.h>
 #include <psbt.h>
-#include <ui_interface.h>
 #include <util/strencodings.h>
 
 #include <QAction>

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -9,8 +9,8 @@
 #include <timedata.h>
 
 #include <netaddress.h>
+#include <node/ui_interface.h>
 #include <sync.h>
-#include <ui_interface.h>
 #include <util/system.h>
 #include <util/translation.h>
 #include <warnings.h>

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -5,10 +5,10 @@
 
 #include <txdb.h>
 
+#include <node/ui_interface.h>
 #include <pow.h>
 #include <random.h>
 #include <shutdown.h>
-#include <ui_interface.h>
 #include <uint256.h>
 #include <util/system.h>
 #include <util/translation.h>

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -20,14 +20,6 @@ class connection;
 }
 } // namespace boost
 
-/** General change type (added, updated, removed). */
-enum ChangeType
-{
-    CT_NEW,
-    CT_UPDATED,
-    CT_DELETED
-};
-
 /** Signals for UI communication. */
 class CClientUIInterface
 {

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -122,7 +122,7 @@ void InitWarning(const bilingual_str& str);
 
 /** Show error message **/
 bool InitError(const bilingual_str& str);
-inline bool AbortError(const bilingual_str& str) { return InitError(str); }
+constexpr auto AbortError = InitError;
 
 extern CClientUIInterface uiInterface;
 

--- a/src/util/ui_change_type.h
+++ b/src/util/ui_change_type.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2012-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_UI_CHANGE_TYPE_H
+#define BITCOIN_UTIL_UI_CHANGE_TYPE_H
+
+/** General change type (added, updated, removed). */
+enum ChangeType {
+    CT_NEW,
+    CT_UPDATED,
+    CT_DELETED
+};
+
+#endif // BITCOIN_UTIL_UI_CHANGE_TYPE_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -20,6 +20,7 @@
 #include <index/txindex.h>
 #include <logging.h>
 #include <logging/timer.h>
+#include <node/ui_interface.h>
 #include <optional.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
@@ -36,7 +37,6 @@
 #include <tinyformat.h>
 #include <txdb.h>
 #include <txmempool.h>
-#include <ui_interface.h>
 #include <uint256.h>
 #include <undo.h>
 #include <util/moneystr.h>

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -7,8 +7,8 @@
 #include <interfaces/chain.h>
 #include <net.h>
 #include <node/context.h>
+#include <node/ui_interface.h>
 #include <outputtype.h>
-#include <ui_interface.h>
 #include <util/moneystr.h>
 #include <util/system.h>
 #include <util/translation.h>

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -13,11 +13,11 @@
 #include <policy/feerate.h>
 #include <psbt.h>
 #include <tinyformat.h>
-#include <ui_interface.h>
 #include <util/message.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/system.h>
+#include <util/ui_change_type.h>
 #include <validationinterface.h>
 #include <wallet/coinselection.h>
 #include <wallet/crypter.h>


### PR DESCRIPTION
This reverts a hacky workaround from commit b83cc0f, which only happens to work due to compiler optimizations. Then, it actually fixes the linker error.

The underlying problem is that the wallet includes symbols from the server (ui_interface), which usually results in linker failures. Though, in this specific case the linker failures have not been observed (unless `-O0`) because our compilers were smart enough to strip unused symbols.

Fix the underlying problem by creating a new header-only with the needed symbol and move ui_interface to node to clarify that this is part of libbitcoin_server.