### PR TITLE
refactor: Fix clang compile failure

### DIFF
--- a/ci/test/00_setup_env_native_nowallet.sh
+++ b/ci/test/00_setup_env_native_nowallet.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_nowallet
 export DOCKER_NAME_TAG=ubuntu:16.04  # Use xenial to have one config run the tests in python3.5, see doc/dependencies.md
-export PACKAGES="python3-zmq"
+export PACKAGES="python3-zmq clang-3.8 llvm-3.8"  # Use clang-3.8 to test C++11 compatibility, see doc/dependencies.md
 export DEP_OPTS="NO_WALLET=1"
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
+export BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports CC=clang-3.8 CXX=clang++-3.8"

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -274,14 +274,11 @@ public:
         return CScript() << CScript::EncodeOP_N(id.version) << std::vector<unsigned char>(id.program, id.program + id.length);
     }
 };
-
-const CScriptVisitor g_script_visitor;
-
 } // namespace
 
 CScript GetScriptForDestination(const CTxDestination& dest)
 {
-    return boost::apply_visitor(::g_script_visitor, dest);
+    return boost::apply_visitor(CScriptVisitor{}, dest);
 }
 
 CScript GetScriptForRawPubKey(const CPubKey& pubKey)


### PR DESCRIPTION
Fix

```
script/standard.cpp:278:22: error: default initialization of an object of const type 'const (anonymous namespace)::CScriptVisitor' without a user-provided default constructor
const CScriptVisitor g_script_visitor;
                     ^
                                     {}
1 error generated.