### PR TITLE
doc: add release note for -getinfo displaying multiwallet balances

### DIFF
--- a/doc/release-notes-18594.md
+++ b/doc/release-notes-18594.md
@@ -1,0 +1,5 @@
+## CLI
+
+The `bitcoin-cli -getinfo` command now displays the wallet name and balance for
+each of the loaded wallets when more than one is loaded (e.g. in multiwallet
+mode) and a wallet is not specified with `-rpcwallet`. (#18594)


### PR DESCRIPTION
Release note for #18594. This is one of the commits from #19089, which had one concept ACK and approach ACK since late May. It seems better to submit the changes atomically.
