### PR TITLE
torcontrol : avoid to set wrong outbound proxy and network settings when creating an inbound onion service.

### DIFF
--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -526,16 +526,6 @@ void TorController::auth_cb(TorControlConnection& _conn, const TorControlReply& 
 {
     if (reply.code == 250) {
         LogPrint(BCLog::TOR, "tor: Authentication successful\n");
-
-        // Now that we know Tor is running setup the proxy for onion addresses
-        // if -onion isn't set to something else.
-        if (gArgs.GetArg("-onion", "") == "") {
-            CService resolved(LookupNumeric("127.0.0.1", 9050));
-            proxyType addrOnion = proxyType(resolved, true);
-            SetProxy(NET_ONION, addrOnion);
-            SetReachable(NET_ONION, true);
-        }
-
         // Finally - now create the service
         if (private_key.empty()) // No private key, generate one
             private_key = "NEW:RSA1024"; // Explicitly request RSA1024 - see issue #9214


### PR DESCRIPTION
While fiddling around with torcontrol and other tor proxy settings,
I noticed that the node tried to connect over the default 9050 port and ignored my settings. 

That was the case when the node try's to create a default hidden ephemeral tor service at startup.

So ,when we define our own proxy settings in conf, we don't want this to be skipped
by the default proxy creation that we setup while creating the
ephemeral hidden onion service.
Note; When -torcontrol and -proxy is defined in conf, we should *not*
override this with the default settings 127.0.0.1:9050.
Since the proxy ip and port might for good reasons have been set to other values.

Before this fix default settings could override conf and you could end
up not to be able to connect to .onion nodes or connect over the wrong proxy.

Also fixes #14722 some years ago noticed by qubenix 
EDIT:

While check more options I wondered what PR  #14425 is about?
And indeed the -onlynet flags are clearly disregarded  in respect to onions
since #7553. We could merge #14425 or adapt the tor.md doku to the actual
behavior.  Here my suggestion, with some *British* humor. :woman_shrugging:
My guess the consumption of the Catch22 movie, had influence when parts of
the option logic where implemented in the first place. 
 
edit saibato
The Tor doc change laanwj  mentioned later in review had moved to #20091 
This PR now also fixes #13378 and is replacement for the fix from wodry #14425
