### PR TITLE
net: improve encapsulation of CNetAddr

### DIFF
--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -726,12 +726,10 @@ bool CService::GetSockAddr(struct sockaddr* paddr, socklen_t *addrlen) const
  */
 std::vector<unsigned char> CService::GetKey() const
 {
-     std::vector<unsigned char> vKey;
-     vKey.resize(18);
-     memcpy(vKey.data(), ip, 16);
-     vKey[16] = port / 0x100; // most significant byte of our port
-     vKey[17] = port & 0x0FF; // least significant byte of our port
-     return vKey;
+    auto key = GetAddrBytes();
+    key.push_back(port / 0x100); // most significant byte of our port
+    key.push_back(port & 0x0FF); // least significant byte of our port
+    return key;
 }
 
 std::string CService::ToStringPort() const

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -160,7 +160,11 @@ class CService : public CNetAddr
         CService(const struct in6_addr& ipv6Addr, uint16_t port);
         explicit CService(const struct sockaddr_in6& addr);
 
-        SERIALIZE_METHODS(CService, obj) { READWRITE(obj.ip, Using<BigEndianFormatter<2>>(obj.port)); }
+        SERIALIZE_METHODS(CService, obj)
+        {
+            READWRITEAS(CNetAddr, obj);
+            READWRITE(Using<BigEndianFormatter<2>>(obj.port));
+        }
 };
 
 bool SanityCheckASMap(const std::vector<bool>& asmap);


### PR DESCRIPTION
Do not access `CNetAddr::ip` directly from `CService` methods.

This improvement will help later when we change the type of
`CNetAddr::ip` (in the BIP155 implementation).

(chopped off from https://github.com/bitcoin/bitcoin/pull/19031 to ease review)