### PR TITLE
net processing: Move orphan reprocessing to a global

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2107,6 +2107,8 @@ void CConnman::ThreadMessageHandler()
                 return;
         }
 
+        fMoreWork |= m_msgproc->ProcessGlobalTasks(flagInterruptMsgProc);
+
         {
             LOCK(cs_vNodes);
             for (CNode* pnode : vNodesCopy)
@@ -2120,11 +2122,6 @@ void CConnman::ThreadMessageHandler()
         fMsgProcWake = false;
     }
 }
-
-
-
-
-
 
 bool CConnman::BindListenPort(const CService& addrBind, bilingual_str& strError, NetPermissionFlags permissions)
 {

--- a/src/net.h
+++ b/src/net.h
@@ -855,8 +855,6 @@ public:
     // Whether a ping is requested.
     std::atomic<bool> fPingQueued{false};
 
-    std::set<uint256> orphan_work_set;
-
     CNode(NodeId id, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn, SOCKET hSocketIn, const CAddress &addrIn, uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn, const CAddress &addrBindIn, const std::string &addrNameIn = "", bool fInboundIn = false, bool block_relay_only = false);
     ~CNode();
     CNode(const CNode&) = delete;

--- a/src/net.h
+++ b/src/net.h
@@ -507,6 +507,7 @@ class NetEventsInterface
 public:
     virtual bool ProcessMessages(CNode* pnode, std::atomic<bool>& interrupt) = 0;
     virtual bool SendMessages(CNode* pnode) = 0;
+    virtual bool ProcessGlobalTasks(std::atomic<bool>& interrupt) = 0;
     virtual void InitializeNode(CNode* pnode) = 0;
     virtual void FinalizeNode(NodeId id, bool& update_connection_time) = 0;
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2845,12 +2845,7 @@ void ProcessMessage(
                 tx.GetHash().ToString(),
                 mempool.size(), mempool.DynamicMemoryUsage() / 1000);
 
-            // Recursively process any orphan transactions that depended on this one
-            ProcessOrphanTx(connman, mempool, g_orphan_work_set, lRemovedTxn);
-
-        }
-        else if (state.GetResult() == TxValidationResult::TX_MISSING_INPUTS)
-        {
+        } else if (state.GetResult() == TxValidationResult::TX_MISSING_INPUTS) {
             bool fRejectedParents = false; // It may be the case that the orphans parents have all been rejected
             for (const CTxIn& txin : tx.vin) {
                 if (recentRejects->contains(txin.prevout.hash)) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3687,6 +3687,12 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
     return fMoreWork;
 }
 
+bool PeerLogicValidation::ProcessGlobalTasks(std::atomic<bool>& interruptMsgProc)
+{
+    // No tasks to process!
+    return false;
+}
+
 void PeerLogicValidation::ConsiderEviction(CNode& pto, int64_t time_in_seconds)
 {
     AssertLockHeld(cs_main);

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -73,6 +73,14 @@ public:
     */
     bool SendMessages(CNode* pto) override EXCLUSIVE_LOCKS_REQUIRED(pto->cs_sendProcessing);
 
+    /**
+    * Process global tasks that aren't attached to a specific peer
+    *
+    * @param[in]   interrupt       Interrupt condition for processing threads
+    * @returns     bool            true if there's more work to do
+    */
+    bool ProcessGlobalTasks(std::atomic<bool>& interrupt) override;
+
     /** Consider evicting an outbound peer based on the amount of time they've been behind our tip */
     void ConsiderEviction(CNode& pto, int64_t time_in_seconds) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     /** Evict extra outbound peers. If we think our tip may be stale, connect to an extra outbound */


### PR DESCRIPTION
Currently we keep a per-peer list of orphans to reconsider after one of their parents is accepted. There's no reason this list should be connected to the peer that provided the parent, so instead make it a global. Process that list in a separate call into net processing that does general work rather than in the context of a specific peer.