### PR TITLE
refactor: Drop g_orphan_list global

### DIFF
--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -21,6 +21,7 @@
 #include <test/util/setup_common.h>
 
 #include <stdint.h>
+#include <unordered_map>
 
 #include <boost/test/unit_test.hpp>
 
@@ -52,7 +53,7 @@ struct COrphanTx {
     NodeId fromPeer;
     int64_t nTimeExpire;
 };
-extern std::map<uint256, COrphanTx> mapOrphanTransactions GUARDED_BY(g_cs_orphans);
+extern std::unordered_map<uint256, COrphanTx, SaltedTxidHasher> mapOrphanTransactions GUARDED_BY(g_cs_orphans);
 
 static CService ip(uint32_t i)
 {
@@ -358,12 +359,8 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
 
 static CTransactionRef RandomOrphan()
 {
-    std::map<uint256, COrphanTx>::iterator it;
     LOCK2(cs_main, g_cs_orphans);
-    it = mapOrphanTransactions.lower_bound(InsecureRand256());
-    if (it == mapOrphanTransactions.end())
-        it = mapOrphanTransactions.begin();
-    return it->second.tx;
+    return mapOrphanTransactions.begin()->second.tx;
 }
 
 BOOST_AUTO_TEST_CASE(DoS_mapOrphans)


### PR DESCRIPTION
This PR partially reverts changes from 7257353b93e9f45e67071b0b86a0313e7a70aaaa, but does not change the uniformly eviction behavior introduced in #14626.