### PR TITLE
build: target Windows 7 when building libevent and fix ipv6 usage

### DIFF
--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -3,8 +3,10 @@ $(package)_version=2.1.11-stable
 $(package)_download_path=https://github.com/libevent/libevent/archive/
 $(package)_file_name=release-$($(package)_version).tar.gz
 $(package)_sha256_hash=229393ab2bf0dc94694f21836846b424f3532585bac3468738b7bf752c03901e
+$(package)_patches=0001-fix-windows-getaddrinfo.patch
 
 define $(package)_preprocess_cmds
+   patch -p1 < $($(package)_patch_dir)/0001-fix-windows-getaddrinfo.patch && \
   ./autogen.sh
 endef
 

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -10,12 +10,16 @@ define $(package)_preprocess_cmds
   ./autogen.sh
 endef
 
+# When building for Windows, we set _WIN32_WINNT to target the same Windows
+# version as we do in configure. Due to quirks in libevents build system, this
+# is also required to enable support for ipv6. See #19375.
 define $(package)_set_vars
   $(package)_config_opts=--disable-shared --disable-openssl --disable-libevent-regress --disable-samples
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
   $(package)_config_opts_release=--disable-debug-mode
   $(package)_config_opts_linux=--with-pic
   $(package)_config_opts_android=--with-pic
+  $(package)_cppflags_mingw32=-D_WIN32_WINNT=0x0601
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/libevent/0001-fix-windows-getaddrinfo.patch
+++ b/depends/patches/libevent/0001-fix-windows-getaddrinfo.patch
@@ -1,0 +1,15 @@
+diff -ur libevent-2.1.8-stable.orig/configure.ac libevent-2.1.8-stable/configure.ac
+--- libevent-2.1.8-stable.orig/configure.ac	2017-01-29 17:51:00.000000000 +0000
++++ libevent-2.1.8-stable/configure.ac	2020-03-07 01:11:16.311335005 +0000
+@@ -389,6 +389,10 @@
+ 		#ifdef HAVE_NETDB_H
+ 		#include <netdb.h>
+ 		#endif
++#ifdef _WIN32
++#include <winsock2.h>
++#include <ws2tcpip.h>
++#endif
+ 	    ]],
+ 	    [[
+ 		getaddrinfo;
+Only in libevent-2.1.8-stable: configure.ac~


### PR DESCRIPTION
TLDR: This poaches a commit from #18287 and adds one more to adjust the Windows version targeted when building libevent. These changes combined should fully fix ipv6 usage with the RPC server on Windows.

---

Binding the RPC server to a ipv6 address does not currently work on Windows.
We currently try and bind to `127.0.0.1` and `::1` [by default](https://github.com/bitcoin/bitcoin/blob/master/src/httpserver.cpp#L304).

On Windows you'll see lines like this in debug.log:
```bash
2020-06-24T01:49:04Z libevent: getaddrinfo: nodename nor servname provided, or not known
2020-06-24T01:49:04Z Binding RPC on address ::1 port 8332 failed
```

This issue was bought up in, and supposedly fixed by #18287, however the two people that tested it, both said that it didn't fix the problem. I think I now understand why that change alone is incomplete.

Our call into libevent starts with [evhttp_bind_socket_with_handle()](https://github.com/bitcoin/bitcoin/blob/master/src/httpserver.cpp#L325):
```bash
evhttp_bind_socket_with_handle()
	bind_socket()
		make_addrinfo()
			evutil_getaddrinfo()
				if #USE_NATIVE_GETADDRINFO
					#ifndef AI_ADDRCONFIG
						evutil_adjust_hints_for_addrconfig_()
							evutil_check_interfaces()
								evutil_check_ifaddrs()
									evutil_found_ifaddr()
										// miss identifies ipv6 as ipv4?
					#endif
					evutil_getaddrinfo_common_()
```

The problem is falling into ["#ifndef AI_ADDRCONFIG"](https://github.com/libevent/libevent/blob/master/evutil.c#L1580): 

```cpp
#ifndef AI_ADDRCONFIG
	/* Not every system has AI_ADDRCONFIG, so fake it. */
	if (hints.ai_family == PF_UNSPEC &&
	    (hints.ai_flags & EVUTIL_AI_ADDRCONFIG)) {
		evutil_adjust_hints_for_addrconfig_(&hints);
	}
#endif
```

When this occurs, hints end up being adjusted, and it seems that ipv6 addresses end up being mis-identified as ipv4?

However this shouldn't happen, as these `AI_` definitions are available on Windows.
The issue is that in evutil.c, `_WIN32_WINNT` [is set to `0x501`](https://github.com/libevent/libevent/blob/master/evutil.c#L45) (XP).

This obviously predates Vista (`0x0600`), which is when the `AI_ADDRCONFIG` definition (and others) became [available](https://docs.microsoft.com/en-us/windows/win32/api/ws2def/ns-ws2def-addrinfoa).


The change here will override libevents internal D_WIN32_WINNT defines. This should be ok, because it's only making "more" of the Windows API available. It's also aligned with what we do in our own configure, we pass [`D_WIN32_WINNT=0x0601`](https://github.com/bitcoin/bitcoin/blob/master/configure.ac#L610). We also now use linker flags to restrict our binary from running on a Windows version [earlier than Windows 7](https://github.com/bitcoin/bitcoin/blob/master/configure.ac#L621).

The combined fixes can be tested by running:

`bitcoind -rpcbind=::1 rpcallowip='0.0.0.0/0' -debug=http`

and then querying it using:

`bitcoin-cli -rpcconnect=::1 getblockchaininfo`

TODO:
- [x] Open an issue upstream. https://github.com/libevent/libevent/issues/1041