### PR TITLE
refactor: Use Mutex type for g_cs_recent_confirmed_transactions

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -189,7 +189,7 @@ namespace {
      * We use this to avoid requesting transactions that have already been
      * confirnmed.
      */
-    RecursiveMutex g_cs_recent_confirmed_transactions;
+    Mutex g_cs_recent_confirmed_transactions;
     std::unique_ptr<CRollingBloomFilter> g_recent_confirmed_transactions GUARDED_BY(g_cs_recent_confirmed_transactions);
 
     /** Blocks that are in flight, and that are in the queue to be downloaded. */


### PR DESCRIPTION
No need the `RecursiveMutex` type for the `g_cs_recent_confirmed_transactions`.

Related to #19303.