### PR TITLE
span: Add lifetimebound attribute to guard against temporary lifetime issues

### DIFF
--- a/src/span.h
+++ b/src/span.h
@@ -61,12 +61,6 @@ public:
     template <typename O, typename std::enable_if<std::is_convertible<O (*)[], C (*)[]>::value, int>::type = 0>
     constexpr Span(const Span<O>& other) noexcept : m_data(other.m_data), m_size(other.m_size) {}
 
-    /** Default copy constructor. */
-    constexpr Span(const Span&) noexcept = default;
-
-    /** Default assignment operator. */
-    Span& operator=(const Span& other) noexcept = default;
-
     /** Construct a Span from an array. This matches the corresponding C++20 std::span constructor. */
     template <int N>
     constexpr Span(C (&a)[N]) noexcept : m_data(a), m_size(N) {}

--- a/src/span.h
+++ b/src/span.h
@@ -18,6 +18,12 @@
 #define ASSERT_IF_DEBUG(x)
 #endif
 
+#if defined(__clang__) && __has_attribute(lifetimebound)
+#define SPAN_ATTR_LIFETIMEBOUND [[clang::lifetimebound]]
+#else
+#define SPAN_ATTR_LIFETIMEBOUND
+#endif
+
 /** A Span is an object that can refer to a contiguous sequence of objects.
  *
  * It implements a subset of C++20's std::span.
@@ -73,7 +79,7 @@ public:
      * Note that this restriction does not exist when converting arrays or other Spans (see above).
      */
     template <typename V, typename std::enable_if<(std::is_const<C>::value || std::is_lvalue_reference<V>::value) && std::is_convertible<typename std::remove_pointer<decltype(std::declval<V&>().data())>::type (*)[], C (*)[]>::value && std::is_convertible<decltype(std::declval<V&>().size()), std::size_t>::value, int>::type = 0>
-    constexpr Span(V&& v) noexcept : m_data(v.data()), m_size(v.size()) {}
+    constexpr Span(V&& v SPAN_ATTR_LIFETIMEBOUND) noexcept : m_data(v.data()), m_size(v.size()) {}
 
     constexpr C* data() const noexcept { return m_data; }
     constexpr C* begin() const noexcept { return m_data; }


### PR DESCRIPTION
See [here](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0936r0.pdf) for more detail on lifetimebound.

This is implemented using preprocesor macros rather than configure checks in order to keep span.h self-contained.

The ```[[clang::lifetimebound]]``` syntax was chosen over ```__attribute__((lifetimebound))``` because the former is more flexible and works to guard ```this``` as well as function parameters, and also because at least for now, it's available only in clang.

There are currently no violations in our codebase, but this can easily be tested by inserting one like this somewhere and compiling with a modern clang:
```c++
Span<const int> bad(std::vector<int>{1,2,3});
```

The result:
> warning: temporary whose address is used as value of local variable 'bad' will be destroyed at the end of the full-expression [-Wdangling]
    Span<const int> bad(std::vector<int>{1,2,3});
```