### PR TITLE
test: speed up functional tests

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -259,9 +259,9 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         self.log.debug('Closing down network thread')
         self.network_thread.close()
         if not self.options.noshutdown:
-            self.log.info("Stopping nodes")
-            if self.nodes:
-                self.stop_nodes()
+            self.log.info("Killing nodes")
+            for node in self.nodes:
+                node.kill_node(wait=False)
         else:
             for node in self.nodes:
                 node.cleanup_on_exit = False

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -164,12 +164,12 @@ class TestNode():
     def __del__(self):
         # Ensure that we don't leave any bitcoind processes lying around after
         # the test ends
-        if self.process and self.cleanup_on_exit:
+        if self.cleanup_on_exit:
             # Should only happen on test failure
             # Avoid using logger, as that may have already been shutdown when
             # this destructor is called.
             print(self._node_msg("Cleaning up leftover process"))
-            self.process.kill()
+            self.kill_node()
 
     def __getattr__(self, name):
         """Dispatches any unrecognised messages to the RPC connection or a CLI instance."""
@@ -336,6 +336,13 @@ class TestNode():
         self.stderr.close()
 
         del self.p2ps[:]
+
+    def kill_node(self, wait=True):
+        if self.process:
+            self.process.kill()
+            if wait:
+                self.process.wait()
+        self.process = None
 
     def is_node_stopped(self):
         """Checks whether the node has stopped.


### PR DESCRIPTION
Rationale: faster functional test shutdown

We don't need to wait for clean nodes shutdown during test shutdown,
so just send kill signal and move on with the next test. Because we
already allow to run tests in parallel there is no possible problems
due to resource contention.

I did a simple measurement of shutdown time. Waiting for a clean shutdown takes on average about 0.4-0.6s on my system depending on amount of nodes. Just sending a SIGKILL is <1ms.

For the whole test suite this gives ~80s speed up, which is about 2% improvement. I understand that is not much, but the change is also very small and all future tests will automatically benefit from this change. 

This is how a measured nodes shutdown time:
```diff
diff --git a/test/functional/test_framework/test_framework.py b/test/functional/test_framework/test_framework.py
index 9d9e06515..09721ee34 100755
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -260,8 +260,11 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         self.network_thread.close()
         if not self.options.noshutdown:
             self.log.info("Stopping nodes")
+            start = time.time()
             if self.nodes:
                 self.stop_nodes()
+            end = time.time()
+            print("Stop time: %f" % (end - start))
         else:
             for node in self.nodes:
                 node.cleanup_on_exit = False
```