### PR TITLE
test: Change default test logging directory

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -1168,8 +1168,19 @@ if EMBEDDED_UNIVALUE
 endif
 
 %.cpp.test: %.cpp
-	@echo Running tests: `cat $< | grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1` from $<
-	$(AM_V_at)$(TEST_BINARY) --catch_system_errors=no -l test_suite -t "`cat $< | grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1`" -- DEBUG_LOG_OUT > $<.log 2>&1 || (cat $<.log && false)
+	@echo Running tests: $$(\
+		cat $< | \
+		grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | \
+		cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1) \
+		from $<
+	$(AM_V_at)$(TEST_BINARY) \
+		--catch_system_errors=no -l test_suite -t "$$(\
+			cat $< | \
+			grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | \
+			cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1\
+		)" -- DEBUG_LOG_OUT > $(abs_builddir)/$$(\
+			echo $< | grep -E -o "(wallet/test/.*\.cpp|test/.*\.cpp)" | $(SED) -e s/\.cpp/.log/\
+		) 2>&1 || (cat $<.log && false)
 
 %.json.h: %.json
 	@$(MKDIR_P) $(@D)


### PR DESCRIPTION
This PR changes the default test log location request here: https://github.com/bitcoin/bitcoin/issues/17224.  Instead of using the location of the makefile [automatic variable](https://www.gnu.org/software/make/manual/make.html#Automatic-Variables) `$<` I extract just the basename and then prepend a new location `./test`.  This is done because `$<` represents the variable name AND location of the prerequisite here.