### PR TITLE
QA: Use GBT to get block versions correct

### DIFF
--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -61,14 +61,12 @@ class SegWitTest(BitcoinTestFramework):
             ],
             [
                 "-acceptnonstdtxn=1",
-                "-blockversion=4",
                 "-rpcserialversion=1",
                 "-segwitheight=432",
                 "-addresstype=legacy",
             ],
             [
                 "-acceptnonstdtxn=1",
-                "-blockversion=536870915",
                 "-segwitheight=432",
                 "-addresstype=legacy",
             ],


### PR DESCRIPTION
The goal here is to decouple unrelated tests from the details of block versions.

Currently, these tests are forcing specific versions of blocks for no real reason.