### PR TITLE
rpc, cli: add network in/out connections to `getnetworkinfo` and `-getinfo`

### DIFF
--- a/doc/release-notes-19405.md
+++ b/doc/release-notes-19405.md
@@ -4,3 +4,9 @@
   `connections_out`, that provide the number of inbound and outbound peer
   connections. These new fields are in addition to the existing `connections`
   field, which returns the total number of peer connections. (#19405)
+
+## CLI
+
+- The `connections` field of `bitcoin-cli -getinfo` is expanded to return a JSON
+  object with `in`, `out` and `total` numbers of peer connections. It previously
+  returned a single integer value for the total number of peer connections. (#19405)

--- a/doc/release-notes-19405.md
+++ b/doc/release-notes-19405.md
@@ -1,0 +1,6 @@
+## Updated RPCs
+
+- `getnetworkinfo` now returns two new fields, `connections_in` and
+  `connections_out`, that provide the number of inbound and outbound peer
+  connections. These new fields are in addition to the existing `connections`
+  field, which returns the total number of peer connections. (#19405)

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -271,7 +271,13 @@ public:
         result.pushKV("headers", batch[ID_BLOCKCHAININFO]["result"]["headers"]);
         result.pushKV("verificationprogress", batch[ID_BLOCKCHAININFO]["result"]["verificationprogress"]);
         result.pushKV("timeoffset", batch[ID_NETWORKINFO]["result"]["timeoffset"]);
-        result.pushKV("connections", batch[ID_NETWORKINFO]["result"]["connections"]);
+
+        UniValue connections(UniValue::VOBJ);
+        connections.pushKV("in", batch[ID_NETWORKINFO]["result"]["connections_in"]);
+        connections.pushKV("out", batch[ID_NETWORKINFO]["result"]["connections_out"]);
+        connections.pushKV("total", batch[ID_NETWORKINFO]["result"]["connections"]);
+        result.pushKV("connections", connections);
+
         result.pushKV("proxy", batch[ID_NETWORKINFO]["result"]["networks"][0]["proxy"]);
         result.pushKV("difficulty", batch[ID_BLOCKCHAININFO]["result"]["difficulty"]);
         result.pushKV("chain", UniValue(batch[ID_BLOCKCHAININFO]["result"]["chain"]));

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -490,7 +490,9 @@ static UniValue getnetworkinfo(const JSONRPCRequest& request)
                         }},
                         {RPCResult::Type::BOOL, "localrelay", "true if transaction relay is requested from peers"},
                         {RPCResult::Type::NUM, "timeoffset", "the time offset"},
-                        {RPCResult::Type::NUM, "connections", "the number of connections"},
+                        {RPCResult::Type::NUM, "connections", "the total number of connections"},
+                        {RPCResult::Type::NUM, "connections_in", "the number of inbound connections"},
+                        {RPCResult::Type::NUM, "connections_out", "the number of outbound connections"},
                         {RPCResult::Type::BOOL, "networkactive", "whether p2p networking is enabled"},
                         {RPCResult::Type::ARR, "networks", "information per network",
                         {
@@ -538,7 +540,9 @@ static UniValue getnetworkinfo(const JSONRPCRequest& request)
     obj.pushKV("timeoffset",    GetTimeOffset());
     if (node.connman) {
         obj.pushKV("networkactive", node.connman->GetNetworkActive());
-        obj.pushKV("connections",   (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_ALL));
+        obj.pushKV("connections", (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_ALL));
+        obj.pushKV("connections_in", (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_IN));
+        obj.pushKV("connections_out", (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_OUT));
     }
     obj.pushKV("networks",      GetNetworksInfo());
     obj.pushKV("relayfee",      ValueFromAmount(::minRelayTxFee.GetFeePerK()));

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -414,7 +414,7 @@ static UniValue getnettotals(const JSONRPCRequest& request)
                    {
                        {RPCResult::Type::NUM, "totalbytesrecv", "Total bytes received"},
                        {RPCResult::Type::NUM, "totalbytessent", "Total bytes sent"},
-                       {RPCResult::Type::NUM_TIME, "timemillis", "Current UNIX time in milliseconds"},
+                       {RPCResult::Type::NUM_TIME, "timemillis", "Current " + UNIX_EPOCH_TIME + " in milliseconds"},
                        {RPCResult::Type::OBJ, "uploadtarget", "",
                        {
                            {RPCResult::Type::NUM, "timeframe", "Length of the measuring timeframe in seconds"},

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -71,7 +71,14 @@ class TestBitcoinCli(BitcoinTestFramework):
         assert_equal(cli_get_info['blocks'], blockchain_info['blocks'])
         assert_equal(cli_get_info['headers'], blockchain_info['headers'])
         assert_equal(cli_get_info['timeoffset'], network_info['timeoffset'])
-        assert_equal(cli_get_info['connections'], network_info['connections'])
+        assert_equal(
+            cli_get_info['connections'],
+            {
+                'in': network_info['connections_in'],
+                'out': network_info['connections_out'],
+                'total': network_info['connections']
+            }
+        )
         assert_equal(cli_get_info['proxy'], network_info['networks'][0]['proxy'])
         assert_equal(cli_get_info['difficulty'], blockchain_info['difficulty'])
         assert_equal(cli_get_info['chain'], blockchain_info['chain'])

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -103,8 +103,11 @@ class NetTest(BitcoinTestFramework):
 
     def test_getnetworkinfo(self):
         self.log.info("Test getnetworkinfo")
-        assert_equal(self.nodes[0].getnetworkinfo()['networkactive'], True)
-        assert_equal(self.nodes[0].getnetworkinfo()['connections'], 2)
+        info = self.nodes[0].getnetworkinfo()
+        assert_equal(info['networkactive'], True)
+        assert_equal(info['connections'], 2)
+        assert_equal(info['connections_in'], 1)
+        assert_equal(info['connections_out'], 1)
 
         with self.nodes[0].assert_debug_log(expected_msgs=['SetNetworkActive: false\n']):
             self.nodes[0].setnetworkactive(state=False)
@@ -118,8 +121,11 @@ class NetTest(BitcoinTestFramework):
         connect_nodes(self.nodes[0], 1)
         connect_nodes(self.nodes[1], 0)
 
-        assert_equal(self.nodes[0].getnetworkinfo()['networkactive'], True)
-        assert_equal(self.nodes[0].getnetworkinfo()['connections'], 2)
+        info = self.nodes[0].getnetworkinfo()
+        assert_equal(info['networkactive'], True)
+        assert_equal(info['connections'], 2)
+        assert_equal(info['connections_in'], 1)
+        assert_equal(info['connections_out'], 1)
 
         # check the `servicesnames` field
         network_info = [node.getnetworkinfo() for node in self.nodes]


### PR DESCRIPTION
This is basic info that is present in the GUI that I've been wishing to have exposed via the RPC and CLI without needing a bash workaround or script. For human users it would also be useful to have it in `-getinfo`.

`bitcoin-cli getnetworkinfo`
```
  "connections": 15,
  "connections_in": 6,
  "connections_out": 9,
```

`bitcoin-cli -getinfo`
```
  "connections": {
    "in": 6,
    "out": 9,
    "total": 15
  },
```

Update the tests, RPC help, and release notes for the changes. Also fixup the `getnettotals` timemillis help while touching `rpc/net.cpp`.

-----

Reviewers can manually test this PR by [building from source](https://jonatack.github.io/articles/how-to-compile-bitcoin-core-and-run-the-tests), launching bitcoind, and then running `bitcoin-cli -getinfo`, `bitcoin-cli getnetworkinfo`, `bitcoin-cli help getnetworkinfo`, and `bitcoin-cli help getnettotals` (for the UNIX epoch time change).
