### PR TITLE
net: Make DNS lookup mockable, add fuzzing harness

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -252,6 +252,7 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/net.cpp \
  test/fuzz/net_permissions.cpp \
  test/fuzz/netaddress.cpp \
+ test/fuzz/netbase_dns_lookup.cpp \
  test/fuzz/node_eviction.cpp \
  test/fuzz/p2p_transport_deserializer.cpp \
  test/fuzz/parse_hd_keypath.cpp \

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -64,6 +64,11 @@ struct ProxyCredentials
     std::string password;
 };
 
+/**
+ * Wrapper for getaddrinfo(3). Do not use directly: call Lookup/LookupHost/LookupNumeric/LookupSubNet.
+ */
+std::vector<CNetAddr> WrappedGetAddrInfo(const std::string& name, bool allow_lookup);
+
 enum Network ParseNetwork(const std::string& net);
 std::string GetNetworkName(enum Network net);
 /** Return a vector of publicly routable Network names; optionally append NET_UNROUTABLE. */
@@ -74,12 +79,16 @@ bool IsProxy(const CNetAddr &addr);
 bool SetNameProxy(const proxyType &addrProxy);
 bool HaveNameProxy();
 bool GetNameProxy(proxyType &nameProxyOut);
-bool LookupHost(const std::string& name, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions, bool fAllowLookup);
-bool LookupHost(const std::string& name, CNetAddr& addr, bool fAllowLookup);
-bool Lookup(const std::string& name, CService& addr, int portDefault, bool fAllowLookup);
-bool Lookup(const std::string& name, std::vector<CService>& vAddr, int portDefault, bool fAllowLookup, unsigned int nMaxSolutions);
-CService LookupNumeric(const std::string& name, int portDefault = 0);
-bool LookupSubNet(const std::string& strSubnet, CSubNet& subnet);
+
+using DNSLookupFn = std::function<std::vector<CNetAddr>(const std::string&, bool)>;
+extern DNSLookupFn g_dns_lookup;
+
+bool LookupHost(const std::string& name, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions, bool fAllowLookup, DNSLookupFn dns_lookup_function = g_dns_lookup);
+bool LookupHost(const std::string& name, CNetAddr& addr, bool fAllowLookup, DNSLookupFn dns_lookup_function = g_dns_lookup);
+bool Lookup(const std::string& name, CService& addr, int portDefault, bool fAllowLookup, DNSLookupFn dns_lookup_function = g_dns_lookup);
+bool Lookup(const std::string& name, std::vector<CService>& vAddr, int portDefault, bool fAllowLookup, unsigned int nMaxSolutions, DNSLookupFn dns_lookup_function = g_dns_lookup);
+CService LookupNumeric(const std::string& name, int portDefault = 0, DNSLookupFn dns_lookup_function = g_dns_lookup);
+bool LookupSubNet(const std::string& strSubnet, CSubNet& subnet, DNSLookupFn dns_lookup_function = g_dns_lookup);
 
 /**
  * Create a TCP socket in the given address family.

--- a/src/test/fuzz/netbase_dns_lookup.cpp
+++ b/src/test/fuzz/netbase_dns_lookup.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <netaddress.h>
+#include <netbase.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+FuzzedDataProvider* fuzzed_data_provider_ptr = nullptr;
+
+std::vector<CNetAddr> fuzzed_dns_lookup_function(const std::string& name, bool allow_lookup)
+{
+    std::vector<CNetAddr> resolved_addresses;
+    while (fuzzed_data_provider_ptr->ConsumeBool()) {
+        resolved_addresses.push_back(ConsumeNetAddr(*fuzzed_data_provider_ptr));
+    }
+    return resolved_addresses;
+}
+} // namespace
+
+FUZZ_TARGET(netbase_dns_lookup)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    fuzzed_data_provider_ptr = &fuzzed_data_provider;
+    const std::string name = fuzzed_data_provider.ConsumeRandomLengthString(512);
+    const unsigned int max_results = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+    const bool allow_lookup = fuzzed_data_provider.ConsumeBool();
+    const int default_port = fuzzed_data_provider.ConsumeIntegral<int>();
+    {
+        std::vector<CNetAddr> resolved_addresses;
+        if (LookupHost(name, resolved_addresses, max_results, allow_lookup, fuzzed_dns_lookup_function)) {
+            for (const CNetAddr& resolved_address : resolved_addresses) {
+                assert(!resolved_address.IsInternal());
+            }
+        }
+        assert(resolved_addresses.size() <= max_results || max_results == 0);
+    }
+    {
+        CNetAddr resolved_address;
+        if (LookupHost(name, resolved_address, allow_lookup, fuzzed_dns_lookup_function)) {
+            assert(!resolved_address.IsInternal());
+        }
+    }
+    {
+        std::vector<CService> resolved_services;
+        if (Lookup(name, resolved_services, default_port, allow_lookup, max_results, fuzzed_dns_lookup_function)) {
+            for (const CNetAddr& resolved_service : resolved_services) {
+                assert(!resolved_service.IsInternal());
+            }
+        }
+        assert(resolved_services.size() <= max_results || max_results == 0);
+    }
+    {
+        CService resolved_service;
+        if (Lookup(name, resolved_service, default_port, allow_lookup, fuzzed_dns_lookup_function)) {
+            assert(!resolved_service.IsInternal());
+        }
+    }
+    {
+        CService resolved_service = LookupNumeric(name, default_port, fuzzed_dns_lookup_function);
+        assert(!resolved_service.IsInternal());
+    }
+    {
+        CSubNet resolved_subnet;
+        if (LookupSubNet(name, resolved_subnet, fuzzed_dns_lookup_function)) {
+            assert(resolved_subnet.IsValid());
+        }
+    }
+    fuzzed_data_provider_ptr = nullptr;
+}


### PR DESCRIPTION
Make DNS lookup mockable/testable/fuzzable.

Add fuzzing harness for `Lookup(…)`/`LookupHost(…)`/`LookupNumeric(…)`/`LookupSubNet(…)`.

See [`doc/fuzzing.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md) for information on how to fuzz Bitcoin Core. Don't forget to contribute any coverage increasing inputs you find to the [Bitcoin Core fuzzing corpus repo](https://github.com/bitcoin-core/qa-assets).

Happy fuzzing :)