### PR TITLE
wallet: let Listwalletdir do not iterate through our blocksdata.

### DIFF
--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -57,9 +57,26 @@ bool IsBerkeleyBtree(const fs::path& path)
 std::vector<fs::path> ListWalletDir()
 {
     const fs::path wallet_dir = GetWalletDir();
+    const fs::path data_dir = GetDataDir();
+    const fs::path blocks_dir = GetBlocksDir();
+
     const size_t offset = wallet_dir.string().size() + 1;
     std::vector<fs::path> paths;
     boost::system::error_code ec;
+
+    // Here we place the top level dirs we want to skip in case walletdir is datadir or blocksdir
+    // Those directories are referenced in doc/files.md
+    const std::vector<fs::path> ignore_paths = {
+                                        blocks_dir,
+                                        data_dir / "blktree",
+                                        data_dir / "chainstate",
+                                        data_dir / "coins",
+                                        data_dir / "database",
+                                        data_dir / "indexes",
+                                        data_dir / "regtest",
+                                        data_dir / "signet",
+                                        data_dir / "testnet3"
+                                        };
 
     for (auto it = fs::recursive_directory_iterator(wallet_dir, ec); it != fs::recursive_directory_iterator(); it.increment(ec)) {
         if (ec) {
@@ -67,25 +84,33 @@ std::vector<fs::path> ListWalletDir()
             continue;
         }
 
-        // Get wallet path relative to walletdir by removing walletdir from the wallet path.
-        // This can be replaced by boost::filesystem::lexically_relative once boost is bumped to 1.60.
-        const fs::path path = it->path().string().substr(offset);
+        // We don't want to iterate through those special node dirs
+        if (std::count(ignore_paths.begin(), ignore_paths.end(), it->path())) {
+            it.no_push();
+            continue;
+        }
 
-        if (it->status().type() == fs::directory_file && IsBerkeleyBtree(it->path() / "wallet.dat")) {
-            // Found a directory which contains wallet.dat btree file, add it as a wallet.
-            paths.emplace_back(path);
-        } else if (it.level() == 0 && it->symlink_status().type() == fs::regular_file && IsBerkeleyBtree(it->path())) {
-            if (it->path().filename() == "wallet.dat") {
-                // Found top-level wallet.dat btree file, add top level directory ""
-                // as a wallet.
-                paths.emplace_back();
-            } else {
-                // Found top-level btree file not called wallet.dat. Current bitcoin
-                // software will never create these files but will allow them to be
-                // opened in a shared database environment for backwards compatibility.
-                // Add it to the list of available wallets.
-                paths.emplace_back(path);
+        try {
+            if (it->status().type() == fs::directory_file && IsBerkeleyBtree(it->path() / "wallet.dat")) {
+                // Found a directory which contains wallet.dat btree file, add it as a wallet.
+                // Get wallet path relative to walletdir by removing walletdir from the wallet path.
+                // This can be replaced by boost::filesystem::lexically_relative once boost is bumped to 1.60.
+                paths.emplace_back(it->path().string().substr(offset));
+            } else if (it.level() == 0 && it->symlink_status().type() == fs::regular_file && IsBerkeleyBtree(it->path())) {
+                if (it->path().filename() == "wallet.dat") {
+                    // Found top-level wallet.dat btree file, add top level directory ""
+                    // as a wallet.
+                    paths.emplace_back();
+                } else {
+                    // Found top-level btree file not called wallet.dat. Current bitcoin
+                    // software will never create these files but will allow them to be
+                    // opened in a shared database environment for backwards compatibility.
+                    // Add it to the list of available wallets.
+                    paths.emplace_back(it->path().filename());
+                }
             }
+        } catch (const std::exception& e) {
+            LogPrintf("%s: Error scanning %s: %s\n", __func__, it->path().string(), e.what());
         }
     }
 

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_WALLET_WALLETUTIL_H
 #define BITCOIN_WALLET_WALLETUTIL_H
 
+#include <algorithm>
 #include <fs.h>
 #include <script/descriptor.h>
 


### PR DESCRIPTION
Fix: While fiddling with wallets, I noticed that if datadir == walltetsdir an unsynced node can become quite unresponsive.

if no "wallets" dir is in datadir ( i.e. exiting old node ) 
we would have iterate trough our own node files
to find wallets, that consumes time and could cause an unresponsive node.

