### PR TITLE
http: Track active requests and wait for last to finish

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -146,6 +146,10 @@ static std::unique_ptr<WorkQueue<HTTPClosure>> g_work_queue{nullptr};
 static std::vector<HTTPPathHandler> pathHandlers;
 //! Bound listening sockets
 static std::vector<evhttp_bound_socket *> boundSockets;
+//! Track active requests
+static Mutex g_requests_mutex;
+static std::condition_variable g_requests_cv;
+static std::set<evhttp_request*> g_requests GUARDED_BY(g_requests_mutex);
 
 /** Check if a network address is allowed to access the HTTP server */
 static bool ClientAllowed(const CNetAddr& netaddr)
@@ -210,6 +214,18 @@ std::string RequestMethodString(HTTPRequest::RequestMethod m)
 /** HTTP request callback */
 static void http_request_cb(struct evhttp_request* req, void* arg)
 {
+    // Track requests and notify when last active request is completed.
+    {
+        LOCK(g_requests_mutex);
+        g_requests.insert(req);
+        evhttp_request_set_on_complete_cb(req, [](struct evhttp_request* req, void*) {
+            LOCK(g_requests_mutex);
+            auto n = g_requests.erase(req);
+            assert(n == 1);
+            if (g_requests.empty()) g_requests_cv.notify_all();
+        }, nullptr);
+    }
+
     // Disable reading to work around a libevent bug, fixed in 2.2.0.
     if (event_get_version_number() >= 0x02010600 && event_get_version_number() < 0x02020001) {
         evhttp_connection* conn = evhttp_request_get_connection(req);
@@ -459,6 +475,12 @@ void StopHTTPServer()
         evhttp_del_accept_socket(eventHTTP, socket);
     }
     boundSockets.clear();
+    {
+        WAIT_LOCK(g_requests_mutex, lock);
+        while (!g_requests.empty()) {
+            g_requests_cv.wait(lock);
+        }
+    }
     if (eventBase) {
         LogPrint(BCLog::HTTP, "Waiting for HTTP event thread to exit\n");
         if (g_thread_http.joinable()) g_thread_http.join();

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -481,13 +481,15 @@ void StopHTTPServer()
             g_requests_cv.wait(lock);
         }
     }
+    if (eventHTTP) {
+        event_base_once(eventBase, -1, EV_TIMEOUT, [](evutil_socket_t, short, void*) {
+            evhttp_free(eventHTTP);
+            eventHTTP = nullptr;
+        }, nullptr, nullptr);
+    }
     if (eventBase) {
         LogPrint(BCLog::HTTP, "Waiting for HTTP event thread to exit\n");
         if (g_thread_http.joinable()) g_thread_http.join();
-    }
-    if (eventHTTP) {
-        evhttp_free(eventHTTP);
-        eventHTTP = nullptr;
     }
     if (eventBase) {
         event_base_free(eventBase);


### PR DESCRIPTION
This PR calls `evhttp_free` before releasing event base. But according to `evhttp_free` [docs](https://github.com/libevent/libevent/blob/1cea01d6d5c84337dac663e5464059ccd2d6a8dd/include/event2/http.h#L208-L217):
> Works only if no requests are currently being served.

So this PR also tracks active requests with libevent and waits for last request to finish. This requires libevent 2.1 due to `evhttp_request_set_on_complete_cb` (https://github.com/libevent/libevent/blob/master/whatsnew-2.1.txt).

Finally, the call to `evhttp_free` is done in the event base loop to avoid concurrency issues.

Now test/functional/feature_abortnode.py quits normally, not due to socket timeouts.