### PR TITLE
Fix boost/C++17 compile failures

### DIFF
--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -294,7 +294,7 @@ public:
 
 CScript GetScriptForDestination(const CTxDestination& dest)
 {
-    return boost::apply_visitor(CScriptVisitor{}, dest);
+    return boost::apply_visitor(CScriptVisitor(), dest);
 }
 
 CScript GetScriptForRawPubKey(const CPubKey& pubKey)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -223,7 +223,7 @@ static void SetFeeEstimateMode(const CWallet* pwallet, CCoinControl& cc, const U
         cc.m_feerate = CFeeRate(fee_rate);
 
         // default RBF to true for explicit fee rate modes
-        if (cc.m_signal_bip125_rbf == boost::none) cc.m_signal_bip125_rbf = true;
+        if (cc.m_signal_bip125_rbf == nullopt) cc.m_signal_bip125_rbf = true;
     } else if (!estimate_param.isNull()) {
         cc.m_confirm_target = ParseConfirmTarget(estimate_param, pwallet->chain().estimateMaxBlocks());
     }


### PR DESCRIPTION
Compiling with C++17 enabled, but not the latest version of boost (e.g. 1.69) will result in a compile failure. I know that C++17 is not "officially" supported yet, especially not with all boost versions, since C++17 is meant to replace boost, but some of my systems can no longer compile Bitcoin Core and upstreaming the patches avoids others running into the same issue.