### PR TITLE
test: Fix intermittent failure in wallet_encryption

### DIFF
--- a/test/functional/wallet_encryption.py
+++ b/test/functional/wallet_encryption.py
@@ -13,6 +13,7 @@ from test_framework.util import (
     assert_greater_than_or_equal,
 )
 
+
 class WalletEncryptionTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
@@ -72,20 +73,25 @@ class WalletEncryptionTest(BitcoinTestFramework):
 
         # Test timeout bounds
         assert_raises_rpc_error(-8, "Timeout cannot be negative.", self.nodes[0].walletpassphrase, passphrase2, -10)
-        # Check the timeout
-        # Check a time less than the limit
+
+        self.log.info('Check a timeout less than the limit')
         MAX_VALUE = 100000000
         expected_time = int(time.time()) + MAX_VALUE - 600
         self.nodes[0].walletpassphrase(passphrase2, MAX_VALUE - 600)
+        # give buffer for walletpassphrase, since it iterates over all crypted keys
+        expected_time_with_buffer = time.time() + MAX_VALUE - 600
         actual_time = self.nodes[0].getwalletinfo()['unlocked_until']
         assert_greater_than_or_equal(actual_time, expected_time)
-        assert_greater_than(expected_time + 5, actual_time) # 5 second buffer
-        # Check a time greater than the limit
+        assert_greater_than(expected_time_with_buffer, actual_time)
+
+        self.log.info('Check a timeout greater than the limit')
         expected_time = int(time.time()) + MAX_VALUE - 1
         self.nodes[0].walletpassphrase(passphrase2, MAX_VALUE + 1000)
+        expected_time_with_buffer = time.time() + MAX_VALUE
         actual_time = self.nodes[0].getwalletinfo()['unlocked_until']
         assert_greater_than_or_equal(actual_time, expected_time)
-        assert_greater_than(expected_time + 5, actual_time) # 5 second buffer
+        assert_greater_than(expected_time_with_buffer, actual_time)
+
 
 if __name__ == '__main__':
     WalletEncryptionTest().main()


### PR DESCRIPTION
Iterating all crypted keys might take time.

E.g.

```
 node0 2020-07-01T14:41:19.227367Z [httpworker.0] ThreadRPCServer method=walletpassphrase user=__cookie__ 
 node0 2020-07-01T14:41:24.377142Z [httpworker.0] queue run of timer lockwallet() in 100000000 seconds (using HTTP) 
...
 test  2020-07-01T14:41:24.379000Z TestFramework (ERROR): Assertion failed 
                                   Traceback (most recent call last):
                                     File "/tmp/cirrus-ci-build/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/test/functional/test_framework/test_framework.py", line 117, in main
                                       self.run_test()
                                     File "/tmp/cirrus-ci-build/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/test/functional/wallet_encryption.py", line 88, in run_test
                                       assert_greater_than(expected_time + 5, actual_time) # 5 second buffer
                                     File "/tmp/cirrus-ci-build/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/test/functional/test_framework/util.py", line 54, in assert_greater_than
                                       raise AssertionError("%s <= %s" % (str(thing1), str(thing2)))
                                   AssertionError: 1693614483 <= 1693614484
```

https://cirrus-ci.com/task/5322429885054976?command=ci#L4517