### PR TITLE
build: configure.ac and netbsd-build.md for NetBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1015,11 +1015,18 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdint.h>
 
 dnl LevelDB platform checks
 AC_MSG_CHECKING(for fdatasync)
+case $host in
+  *netbsd*)
+AC_MSG_RESULT(no because NetBSD will not fdatasync on directories and this breaks leveldb); HAVE_FDATASYNC=0
+     ;;
+  *)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]],
  [[ fdatasync(0); ]])],
  [ AC_MSG_RESULT(yes); HAVE_FDATASYNC=1 ],
  [ AC_MSG_RESULT(no); HAVE_FDATASYNC=0 ]
 )
+     ;;
+esac
 
 AC_MSG_CHECKING(for F_FULLFSYNC)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <fcntl.h>]],

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -1,6 +1,6 @@
 NetBSD build guide
 ======================
-(updated for NetBSD 8.0)
+(updated for NetBSD 9.0)
 
 This guide describes how to build bitcoind and command-line utilities on NetBSD.
 
@@ -9,18 +9,18 @@ This guide does not contain instructions for building the GUI.
 Preparation
 -------------
 
-You will need the following modules, which can be installed via pkgsrc or pkgin:
+You will need the following packages, which can be installed via pkgsrc or pkgin:
 
 ```
-autoconf
-automake
-boost
-git
-gmake
-libevent
-libtool
-pkg-config
-python37
+devel/autoconf
+devel/automake
+devel/boost-libs
+devel/git
+devel/gmake
+devel/libevent
+devel/libtool
+devel/pkg-config
+lang/python37
 
 git clone https://github.com/bitcoin/bitcoin.git
 ```
@@ -32,10 +32,8 @@ See [dependencies.md](dependencies.md) for a complete overview.
 BerkeleyDB is only necessary for the wallet functionality. To skip this, pass
 `--disable-wallet` to `./configure` and skip to the next section.
 
-It is recommended to use Berkeley DB 4.8. You cannot use the BerkeleyDB library
-from ports, for the same reason as boost above (g++/libstd++ incompatibility).
-If you have to build it yourself, you can use [the installation script included
-in contrib/](/contrib/install_db4.sh) like so:
+It is recommended to use Berkeley DB 4.8. For maximum compatibility, use the
+bundled [installation script included in contrib/](/contrib/install_db4.sh) like so:
 
 ```bash
 ./contrib/install_db4.sh `pwd`
@@ -54,27 +52,24 @@ export BDB_PREFIX="$PWD/db4"
 With wallet:
 ```bash
 ./autogen.sh
-./configure --with-gui=no CPPFLAGS="-I/usr/pkg/include" \
-    LDFLAGS="-L/usr/pkg/lib" \
-    BOOST_CPPFLAGS="-I/usr/pkg/include" \
-    BOOST_LDFLAGS="-L/usr/pkg/lib" \
-    BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
-    BDB_CFLAGS="-I${BDB_PREFIX}/include" \
-    MAKE=gmake
+
+MAKE="gmake" \
+CPPFLAGS="-I/usr/pkg/include" LDFLAGS="-L/usr/pkg/lib -Wl,-R/usr/pkg/lib" \
+BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include" \
+./configure --with-gui=no --with-boost=/usr/pkg
 ```
 
 Without wallet:
 ```bash
 ./autogen.sh
-./configure --with-gui=no --disable-wallet \
-    CPPFLAGS="-I/usr/pkg/include" \
-    LDFLAGS="-L/usr/pkg/lib" \
-    BOOST_CPPFLAGS="-I/usr/pkg/include" \
-    BOOST_LDFLAGS="-L/usr/pkg/lib" \
-    MAKE=gmake
+
+MAKE="gmake" \
+CPPFLAGS="-I/usr/pkg/include" LDFLAGS="-L/usr/pkg/lib -Wl,-R/usr/pkg/lib" \
+BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include" \
+./configure --with-gui=no --with-boost=/usr/pkg --disable-wallet
 ```
 
-Build and run the tests:
+Build and run the tests (very important!):
 ```bash
 gmake # use -jX here for parallelism
 gmake check


### PR DESCRIPTION
At the moment these changes are not functional on master as of a few minutes ago,
failing with an Abort trap in gmake check, but this can be fixed in another
PR. These particular changes should be otherwise correct and back-portable to
v0.20.0, and will end up with a working gmake check there.

Hopefully these changes will be of some use to the, apparently, other NetBSD
user out there who is by now on an outdated version.
