### PR TITLE
walletdb: don't reinitialize desc cache with multiple cache entries

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -592,9 +592,6 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             ssValue >> ser_xpub;
             CExtPubKey xpub;
             xpub.Decode(ser_xpub.data());
-            if (wss.m_descriptor_caches.count(desc_id)) {
-                wss.m_descriptor_caches[desc_id] = DescriptorCache();
-            }
             if (parent) {
                 wss.m_descriptor_caches[desc_id].CacheParentExtPubKey(key_exp_index, xpub);
             } else {

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -146,6 +146,14 @@ class ImportDescriptorsTest(BitcoinTestFramework):
                      ismine=True,
                      solvable=True)
 
+        # Check persistence of data and that loading works correctly
+        w1.unloadwallet()
+        self.nodes[1].loadwallet('w1')
+        test_address(w1,
+                     key.p2sh_p2wpkh_addr,
+                     ismine=True,
+                     solvable=True)
+
         # # Test importing of a multisig descriptor
         key1 = get_generate_key()
         key2 = get_generate_key()
@@ -369,6 +377,10 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         self.nodes[0].generate(6)
         self.sync_all()
         assert_equal(wmulti_pub.getbalance(), wmulti_priv.getbalance())
+
+        # Make sure that descriptor wallets containing multiple xpubs in a single descriptor load correctly
+        wmulti_pub.unloadwallet()
+        self.nodes[1].loadwallet('wmulti_pub')
 
         self.log.info("Multisig with distributed keys")
         self.nodes[1].createwallet(wallet_name="wmulti_priv1", descriptors=True)


### PR DESCRIPTION
When loading descriptor caches, we would accidentally reinitialize the descriptor cache when seeing that one already exists. This should have only been initializing the cache when one does not exist. However this code itself is unnecessary as the act of looking up the cache to add to it will initialize it if it didn't already exist.

This issue could be hit by trying to load a wallet that had imported a multisig descriptor. The wallet would fail to load.

A test has been added to wallet_importdescriptors.py to catch this case. Another test case has also been added to check that loading a wallet with only single key descriptors works.