### PR TITLE
rpc: Add options argument to listtransactions, with paginatebypointer options

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -61,6 +61,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "waitfornewblock", 0, "timeout" },
     { "listtransactions", 1, "count" },
     { "listtransactions", 2, "skip" },
+    { "listtransactions", 2, "options" },
     { "listtransactions", 3, "include_watchonly" },
     { "walletpassphrase", 1, "timeout" },
     { "getblocktemplate", 0, "template_request" },


### PR DESCRIPTION
This is #14898 rebased against current master, review comments addressed and help text updated with output changes when `pageinatebypointer` option is used.

~Added fifth param to `listtransactions` named `options`,~ Previous `skip` argument is replaced with `options`, with backwards compatibility, where it's treated as a `skip` if it's integer, not an object. `options` may be an object containing `paginatebypointer` (boolean default: false) and `nextpagepointer` (string default: OMITTED).~ 

With `paginatebypointer` output will have the following changes.

1. Return transactions is ordered by most recent transactions. Though the default does reverse the order after transactions are fetched and clipped.
2. `skip` argument has no effect. Instead `nextpagepointer` will be used for pagination.
3. Return value is an object containing, records (array of txs) and nextpagepointer (string)
