### PR TITLE
test: Remove cached directories and associated script blocks from appveyor config

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,8 +5,6 @@ configuration: Release
 platform: x64
 clone_depth: 5
 environment:
-  APPVEYOR_SAVE_CACHE_ON_ERROR: true
-  CLCACHE_SERVER: 1
   PATH: 'C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%'
   PYTHONUTF8: 1
   QT_DOWNLOAD_URL: 'https://github.com/sipsorcery/qt_win_binary/releases/download/v1.6/Qt5.9.8_x64_static_vs2019.zip'
@@ -14,59 +12,41 @@ environment:
   QT_LOCAL_PATH: 'C:\Qt5.9.8_x64_static_vs2019'
   VCPKG_INSTALL_PATH: 'C:\tools\vcpkg\installed'
   VCPKG_COMMIT_ID: 'ed0df8ecc4ed7e755ea03e18aaf285fd9b4b4a74'
-cache:
-- C:\tools\vcpkg\installed -> build_msvc\vcpkg-packages.txt
-- C:\Qt5.9.8_x64_static_vs2019
 install:
 # Disable zmq test for now since python zmq library on Windows would cause Access violation sometimes.
 # - cmd: pip install zmq
 # Powershell block below is to install the c++ dependencies via vcpkg. The pseudo code is:
-# 1. Check whether the vcpkg install directory exists (note that updating the vcpkg-packages.txt file
-#    will cause the appveyor cache rules to invalidate the directory)
-# 2. If the directory is missing:
 #    a. Checkout the vcpkg source (including port files) for the specific checkout and build the vcpkg binary,
 #    b. Install the missing packages.
 - ps: |
       $env:PACKAGES = Get-Content -Path build_msvc\vcpkg-packages.txt
-      Write-Host "vcpkg list: $env:PACKAGES"
-      if(!(Test-Path -Path ($env:VCPKG_INSTALL_PATH))) {
-          cd c:\tools\vcpkg
-          $env:GIT_REDIRECT_STDERR = '2>&1' # git is writing non-errors to STDERR when doing git pull. Send to STDOUT instead.
-          git pull origin master
-          git checkout $env:VCPKG_COMMIT_ID
-          .\bootstrap-vcpkg.bat
-          Add-Content "C:\tools\vcpkg\triplets\$env:PLATFORM-windows-static.cmake" "set(VCPKG_BUILD_TYPE release)"
-          .\vcpkg install --triplet $env:PLATFORM-windows-static $env:PACKAGES.split() > $null
-          cd "$env:APPVEYOR_BUILD_FOLDER"
-      }
-      else {
-        Write-Host "required vcpkg packages already installed."
-      }
-      c:\tools\vcpkg\vcpkg integrate install
+      Write-Host "vcpkg installing packages: $env:PACKAGES"
+      cd c:\tools\vcpkg
+      $env:GIT_REDIRECT_STDERR = '2>&1' # git is writing non-errors to STDERR when doing git pull. Send to STDOUT instead.
+      git pull origin master > $null
+      git -c advice.detachedHead=false checkout $env:VCPKG_COMMIT_ID
+      .\bootstrap-vcpkg.bat > $null
+      Add-Content "C:\tools\vcpkg\triplets\$env:PLATFORM-windows-static.cmake" "set(VCPKG_BUILD_TYPE release)"
+      .\vcpkg install --triplet $env:PLATFORM-windows-static $env:PACKAGES.split() > $null
+      Write-Host "vcpkg packages installed successfully."
+      .\vcpkg integrate install
+      cd "$env:APPVEYOR_BUILD_FOLDER"
 before_build:
 # Powershell block below is to download and extract the Qt static libraries. The pseudo code is:
-# 1. If the Qt destination directory exists assume it is correct and do nothing. To
-#    force a fresh install of the packages delete the job's appveyor cache.
-# 2. Otherwise:
 #    a. Download the zip file with the prebuilt Qt static libraries.
 #    b. Check that the downloaded file matches the expected hash.
 #    c. Extract the zip file to the specific destination path expected by the msbuild projects.
 - ps: |
-      if(!(Test-Path -Path ($env:QT_LOCAL_PATH))) {
-        Write-Host "Downloading Qt binaries.";
-        Invoke-WebRequest -Uri $env:QT_DOWNLOAD_URL -Out qtdownload.zip;
-        Write-Host "Qt binaries successfully downloaded, checking hash against $env:QT_DOWNLOAD_HASH...";
-        if((Get-FileHash qtdownload.zip).Hash -eq $env:QT_DOWNLOAD_HASH) {
-          Expand-Archive qtdownload.zip -DestinationPath $env:QT_LOCAL_PATH;
-          Write-Host "Qt binary download matched the expected hash.";
-        }
-        else {
-          Write-Host "ERROR: Qt binary download did not match the expected hash.";
-          Exit-AppveyorBuild;
-        }
+      Write-Host "Downloading Qt binaries.";
+      Invoke-WebRequest -Uri $env:QT_DOWNLOAD_URL -Out qtdownload.zip;
+      Write-Host "Qt binaries successfully downloaded, checking hash against $env:QT_DOWNLOAD_HASH...";
+      if((Get-FileHash qtdownload.zip).Hash -eq $env:QT_DOWNLOAD_HASH) {
+        Expand-Archive qtdownload.zip -DestinationPath $env:QT_LOCAL_PATH;
+        Write-Host "Qt binary download matched the expected hash.";
       }
       else {
-         Write-Host "Qt binaries already present.";
+        Write-Host "ERROR: Qt binary download did not match the expected hash.";
+        Exit-AppveyorBuild;
       }
 - cmd: python build_msvc\msvc-autogen.py
 build_script:


### PR DESCRIPTION
Appveyor CI jobs have been failing in the last 24 hours due to a seemingly corrupted cache, see #19440.

It's possible that the appveyor cache issue is related to the[ recent update](https://www.appveyor.com/updates/2020/07/03/) of the Visual Studio 2019 image

PR #19431 changes the "save cache or error" to false in an attempt to avoid a failing CI job from potentially corrupting the cache. In theory the only way a PR could affect the cache is if the `vcpkg` install list changed. That happens very rarely and did not happen in the last 24 hours and so was not the cause of the current cache problems.

I have done some testing with appveyor build jobs on my own fork and found that installing the `vcpkg` dependencies from scratch and doing a full build can now be done in just under 60 minutes. This is the first time in over 5 months I have been able to build Bitcoin Core on appveyor. Either the new Visual Studio 2019 image has dramatically reduced the build time or appveyor images have had their CPU increased.

This PR removes all use of dependency caching from the appveyor CI config. The trade-off is the 15 minutes saved on each build from having the dependencies cached versus the hours maintainers need to spend investigating when the CI jobs start failing.

