### PR TITLE
rpc generate: print useful help and error message

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -236,6 +236,17 @@ static UniValue generatetodescriptor(const JSONRPCRequest& request)
     return generateBlocks(chainman, mempool, coinbase_script, num_blocks, max_tries);
 }
 
+static UniValue generate(const JSONRPCRequest& request)
+{
+    const std::string help_str{"generate ( nblocks maxtries ) has been replaced by the -generate cli option. Refer to -help for more information."};
+
+    if (request.fHelp) {
+        throw std::runtime_error(help_str);
+    } else {
+        throw JSONRPCError(RPC_METHOD_NOT_FOUND, help_str);
+    }
+}
+
 static UniValue generatetoaddress(const JSONRPCRequest& request)
 {
             RPCHelpMan{"generatetoaddress",
@@ -1198,6 +1209,7 @@ static const CRPCCommand commands[] =
     { "util",               "estimatesmartfee",       &estimatesmartfee,       {"conf_target", "estimate_mode"} },
 
     { "hidden",             "estimaterawfee",         &estimaterawfee,         {"conf_target", "threshold"} },
+    { "hidden",             "generate",               &generate,               {} },
 };
 // clang-format on
 

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test generate RPC."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+
+
+class RPCGenerateTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def run_test(self):
+        message = (
+            "generate ( nblocks maxtries ) has been replaced by the -generate "
+            "cli option. Refer to -help for more information."
+        )
+
+        self.log.info("Test rpc generate raises with message to use cli option")
+        assert_raises_rpc_error(-32601, message, self.nodes[0].rpc.generate)
+
+        self.log.info("Test rpc generate help prints message to use cli option")
+        assert_equal(message, self.nodes[0].help("generate"))
+
+        self.log.info("Test rpc generate is a hidden command not discoverable in general help")
+        assert message not in self.nodes[0].help()
+
+
+if __name__ == "__main__":
+    RPCGenerateTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -708,14 +708,16 @@ class RPCCoverage():
         Return a set of currently untested RPC commands.
 
         """
-        # This is shared from `test/functional/test-framework/coverage.py`
+        # This is shared from `test/functional/test_framework/coverage.py`
         reference_filename = 'rpc_interface.txt'
         coverage_file_prefix = 'coverage.'
 
         coverage_ref_filename = os.path.join(self.dir, reference_filename)
         coverage_filenames = set()
         all_cmds = set()
-        covered_cmds = set()
+        # Consider RPC generate covered, because it is overloaded in
+        # test_framework/test_node.py and not seen by the coverage check.
+        covered_cmds = set({'generate'})
 
         if not os.path.isfile(coverage_ref_filename):
             raise RuntimeError("No coverage reference found")

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -193,6 +193,7 @@ BASE_SCRIPTS = [
     'p2p_eviction.py',
     'rpc_signmessage.py',
     'rpc_generateblock.py',
+    'rpc_generate.py',
     'wallet_balance.py',
     'feature_nulldummy.py',
     'mempool_accept.py',


### PR DESCRIPTION
This was a requested follow-up to #19133 and #17700 to alleviate confusion and head-scratching by people following tutorials that use `generate`. See https://github.com/bitcoin/bitcoin/pull/19455#issuecomment-668172916 below, https://github.com/bitcoin/bitcoin/pull/19133#issuecomment-636860943 and https://github.com/bitcoin/bitcoin/pull/17700#issuecomment-566159096.

before
```
$ bitcoin-cli help generate
help: unknown command: generate

$ bitcoin-cli generate
error code: -32601
error message:
Method not found
```

after
```
$ bitcoin-cli help generate
generate ( nblocks maxtries ) has been replaced by the -generate cli option. Refer to -help for more information.

$ bitcoin-cli generate
error code: -32601
error message:
generate ( nblocks maxtries ) has been replaced by the -generate cli option. Refer to -help for more information.
```

In the general help it remains hidden, as requested by laanwj.
```
$ bitcoin-cli help

== Generating ==
generateblock "output" ["rawtx/txid",...]
generatetoaddress nblocks "address" ( maxtries )
generatetodescriptor num_blocks "descriptor" ( maxtries )
```
