### PR TITLE
Add zmq notifications for evicted transactions, tests

### DIFF
--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -59,9 +59,11 @@ the command line or in the configuration file.
 Currently, the following notifications are supported:
 
     -zmqpubhashtx=address
+    -zmqpubhashtxevict=address
     -zmqpubhashblock=address
     -zmqpubrawblock=address
     -zmqpubrawtx=address
+    -zmqpubrawtxevict=address
 
 The socket type is PUB and the address must be a valid ZeroMQ socket
 address. The same address can be used in more than one notification.
@@ -70,9 +72,11 @@ The option to set the PUB socket's outbound message high water mark
 (SNDHWM) may be set individually for each notification:
 
     -zmqpubhashtxhwm=n
+    -zmqpubhashtxevicthwm=n
     -zmqpubhashblockhwm=n
     -zmqpubrawblockhwm=n
     -zmqpubrawtxhwm=n
+    -zmqpubrawtxevicthwm=n
 
 The high water mark value must be an integer greater than or equal to 0.
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -481,21 +481,29 @@ void SetupServerArgs(NodeContext& node)
 
 #if ENABLE_ZMQ
     gArgs.AddArg("-zmqpubhashblock=<address>", "Enable publish hash block in <address>", ArgsManager::ALLOW_ANY, OptionsCategory::ZMQ);
-    gArgs.AddArg("-zmqpubhashtx=<address>", "Enable publish hash transaction in <address>", ArgsManager::ALLOW_ANY, OptionsCategory::ZMQ);
+    gArgs.AddArg("-zmqpubhashtx=<address>", "Enable publish hash transaction in <address> on entry into mempool, and appearance in blocks", ArgsManager::ALLOW_ANY, OptionsCategory::ZMQ);
+    gArgs.AddArg("-zmqpubhashtxevict=<address>", "Enable publish hash transaction in <address> upon mempool eviction other than through block inclusion", ArgsManager::ALLOW_ANY, OptionsCategory::ZMQ);
     gArgs.AddArg("-zmqpubrawblock=<address>", "Enable publish raw block in <address>", ArgsManager::ALLOW_ANY, OptionsCategory::ZMQ);
-    gArgs.AddArg("-zmqpubrawtx=<address>", "Enable publish raw transaction in <address>", ArgsManager::ALLOW_ANY, OptionsCategory::ZMQ);
+    gArgs.AddArg("-zmqpubrawtx=<address>", "Enable publish raw transaction in <address> on entry into mempool, and appearance in blocks", ArgsManager::ALLOW_ANY, OptionsCategory::ZMQ);
+    gArgs.AddArg("-zmqpubrawtxevict=<address>", "Enable publish raw transaction in <address> upon mempool eviction other than through block inclusion", ArgsManager::ALLOW_ANY, OptionsCategory::ZMQ);
     gArgs.AddArg("-zmqpubhashblockhwm=<n>", strprintf("Set publish hash block outbound message high water mark (default: %d)", CZMQAbstractNotifier::DEFAULT_ZMQ_SNDHWM), ArgsManager::ALLOW_ANY, OptionsCategory::ZMQ);
     gArgs.AddArg("-zmqpubhashtxhwm=<n>", strprintf("Set publish hash transaction outbound message high water mark (default: %d)", CZMQAbstractNotifier::DEFAULT_ZMQ_SNDHWM), ArgsManager::ALLOW_ANY, OptionsCategory::ZMQ);
+    gArgs.AddArg("-zmqpubhashtxevicthwm=<n>", strprintf("Set publish evicted hash transaction outbound message high water mark (default: %d)", CZMQAbstractNotifier::DEFAULT_ZMQ_SNDHWM), ArgsManager::ALLOW_ANY, OptionsCategory::ZMQ);
     gArgs.AddArg("-zmqpubrawblockhwm=<n>", strprintf("Set publish raw block outbound message high water mark (default: %d)", CZMQAbstractNotifier::DEFAULT_ZMQ_SNDHWM), ArgsManager::ALLOW_ANY, OptionsCategory::ZMQ);
     gArgs.AddArg("-zmqpubrawtxhwm=<n>", strprintf("Set publish raw transaction outbound message high water mark (default: %d)", CZMQAbstractNotifier::DEFAULT_ZMQ_SNDHWM), ArgsManager::ALLOW_ANY, OptionsCategory::ZMQ);
+    gArgs.AddArg("-zmqpubrawtxevicthwm=<n>", strprintf("Set publish evicted raw transaction outbound message high water mark (default: %d)", CZMQAbstractNotifier::DEFAULT_ZMQ_SNDHWM), ArgsManager::ALLOW_ANY, OptionsCategory::ZMQ);
 #else
     hidden_args.emplace_back("-zmqpubhashblock=<address>");
     hidden_args.emplace_back("-zmqpubhashtx=<address>");
+    hidden_args.emplace_back("-zmqpubhashtxevict=<address>");
     hidden_args.emplace_back("-zmqpubrawblock=<address>");
     hidden_args.emplace_back("-zmqpubrawtx=<address>");
+    hidden_args.emplace_back("-zmqpubrawtxevict=<address>");
     hidden_args.emplace_back("-zmqpubhashblockhwm=<n>");
     hidden_args.emplace_back("-zmqpubhashtxhwm=<n>");
+    hidden_args.emplace_back("-zmqpubhashtxevicthwm=<n>");
     hidden_args.emplace_back("-zmqpubrawblockhwm=<n>");
+    hidden_args.emplace_back("-zmqpubrawtxevicthwm=<n>");
     hidden_args.emplace_back("-zmqpubrawtxhwm=<n>");
 #endif
 

--- a/src/zmq/zmqabstractnotifier.cpp
+++ b/src/zmq/zmqabstractnotifier.cpp
@@ -20,3 +20,8 @@ bool CZMQAbstractNotifier::NotifyTransaction(const CTransaction &/*transaction*/
 {
     return true;
 }
+
+bool CZMQAbstractNotifier::NotifyTransactionEviction(const CTransaction &/*transaction*/, MemPoolRemovalReason reason)
+{
+    return true;
+}

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_ZMQ_ZMQABSTRACTNOTIFIER_H
 #define BITCOIN_ZMQ_ZMQABSTRACTNOTIFIER_H
 
+#include <txmempool.h>
 #include <zmq/zmqconfig.h>
 
 class CBlockIndex;
@@ -42,6 +43,7 @@ public:
 
     virtual bool NotifyBlock(const CBlockIndex *pindex);
     virtual bool NotifyTransaction(const CTransaction &transaction);
+    virtual bool NotifyTransactionEviction(const CTransaction &transaction, MemPoolRemovalReason reason);
 
 protected:
     void *psocket;

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -26,6 +26,7 @@ protected:
 
     // CValidationInterface
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
+    void TransactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected) override;
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -40,6 +40,13 @@ public:
     bool NotifyTransaction(const CTransaction &transaction) override;
 };
 
+class CZMQPublishHashTransactionEvictionNotifier : public CZMQAbstractPublishNotifier
+{
+public:
+    bool NotifyTransactionEviction(const CTransaction &transaction, MemPoolRemovalReason reason) override;
+};
+
+
 class CZMQPublishRawBlockNotifier : public CZMQAbstractPublishNotifier
 {
 public:
@@ -50,6 +57,12 @@ class CZMQPublishRawTransactionNotifier : public CZMQAbstractPublishNotifier
 {
 public:
     bool NotifyTransaction(const CTransaction &transaction) override;
+};
+
+class CZMQPublishRawTransactionEvictionNotifier : public CZMQAbstractPublishNotifier
+{
+public:
+    bool NotifyTransactionEviction(const CTransaction &transaction, MemPoolRemovalReason reason) override;
 };
 
 #endif // BITCOIN_ZMQ_ZMQPUBLISHNOTIFIER_H

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -26,6 +26,8 @@ public:
 
     bool Initialize(void *pcontext) override;
     void Shutdown() override;
+
+    bool NotifyTransactionX(const CTransaction&, const char*); // Common code between txn publishers
 };
 
 class CZMQPublishHashBlockNotifier : public CZMQAbstractPublishNotifier

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -142,6 +142,10 @@ class ZMQTest (BitcoinTestFramework):
         assert_equal(self.nodes[1].getzmqnotifications(), [])
 
     def test_reorg(self):
+        if not self.is_wallet_compiled():
+            self.log.info("Skipping reorg test because wallet is disabled")
+            return
+
         import zmq
         address = 'tcp://127.0.0.1:28333'
 
@@ -165,34 +169,40 @@ class ZMQTest (BitcoinTestFramework):
         # Relax so that the subscriber is ready before publishing zmq messages
         sleep(0.2)
 
-        # Generate 1 block in nodes[0] and receive all notifications
+        # Generate 1 block in nodes[0] with 1 mempool tx and receive all notifications
+        payment_txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1.0)
         disconnect_block = self.nodes[0].generatetoaddress(1, ADDRESS_BCRT1_UNSPENDABLE)[0]
         disconnect_cb = self.nodes[0].getblock(disconnect_block)["tx"][0]
         assert_equal(self.nodes[0].getbestblockhash(), hashblock.receive().hex())
-        hashtx.receive() # consume, already tested
+        assert_equal(hashtx.receive().hex(), payment_txid)
+        assert_equal(hashtx.receive().hex(), disconnect_cb)
 
         # Generate 2 blocks in nodes[1]
         connect_blocks = self.nodes[1].generatetoaddress(2, ADDRESS_BCRT1_UNSPENDABLE)
 
         # nodes[0] will reorg chain after connecting back nodes[1]
         connect_nodes(self.nodes[0], 1)
-        self.sync_all()
+        self.sync_blocks() # tx in mempool valid but not advertised
 
         # Should receive nodes[1] tip
         assert_equal(self.nodes[1].getbestblockhash(), hashblock.receive().hex())
 
-        # During reorg, should only receive the last coinbase tx from tip
-        assert_equal(hashtx.receive().hex(), self.nodes[1].getblock(connect_blocks[1])["tx"][0])
+        # During reorg:
+        # Get old payment transaction notification from disconnect and disconnected cb
+        assert_equal(hashtx.receive().hex(), payment_txid)
+        assert_equal(hashtx.receive().hex(), disconnect_cb)
+        # And the payment transaction again due to mempool entry
+        assert_equal(hashtx.receive().hex(), payment_txid)
+        assert_equal(hashtx.receive().hex(), payment_txid)
+        # And the new connected coinbases
+        for i in [0, 1]:
+            assert_equal(hashtx.receive().hex(), self.nodes[1].getblock(connect_blocks[i])["tx"][0])
 
-        # But if we do a simple invalidate we announce the disconnected coinbase
+        # If we do a simple invalidate we announce the disconnected coinbase
         self.nodes[0].invalidateblock(connect_blocks[1])
         assert_equal(hashtx.receive().hex(), self.nodes[1].getblock(connect_blocks[1])["tx"][0])
-        # And not the current tip
-        try:
-            hashtx.receive()
-            raise Exception("Should have failed")
-        except zmq.error.Again:
-            pass
+        # And the current tip
+        assert_equal(hashtx.receive().hex(), self.nodes[1].getblock(connect_blocks[0])["tx"][0])
 
 if __name__ == '__main__':
     ZMQTest().main()

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -123,6 +123,13 @@ class ZMQTest (BitcoinTestFramework):
             hex = rawtx.receive()
             assert_equal(payment_txid, hash256_reversed(hex).hex())
 
+            # Mining the block with this tx should result in second notification
+            # after coinbase tx notification
+            self.nodes[0].generatetoaddress(1, ADDRESS_BCRT1_UNSPENDABLE)
+            hashtx.receive()
+            txid = hashtx.receive()
+            assert_equal(payment_txid, txid.hex())
+
 
         self.log.info("Test the getzmqnotifications RPC")
         assert_equal(self.nodes[0].getzmqnotifications(), [


### PR DESCRIPTION
Currently the only zmq notifications that exist for transactions are for:
1) Entry into mempool
2) Appearance in blocks
3) Disconnect from block

For mempool-tracking purposes, it's useful to know when transactions are being dropped from the local mempool without relying on a tight polling loop. This notification publishes anytime a transaction is removed from the mempool, aside from the case where it is confirmed in the new incoming block(already published in 2 above).

Based on https://github.com/bitcoin/bitcoin/pull/19507

Additional test cases that could be added:
1) block conflict
2) mempool timeout
3) mempool trim to size