### PR TITLE
Use LevelDB paranoid_checks option unconditionally

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -105,11 +105,7 @@ static leveldb::Options GetOptions(size_t nCacheSize)
     options.filter_policy = leveldb::NewBloomFilterPolicy(10);
     options.compression = leveldb::kNoCompression;
     options.info_log = new CBitcoinLevelDBLogger();
-    if (leveldb::kMajorVersion > 1 || (leveldb::kMajorVersion == 1 && leveldb::kMinorVersion >= 16)) {
-        // LevelDB versions before 1.16 consider short writes to be corruption. Only trigger error
-        // on corruption in later versions.
-        options.paranoid_checks = true;
-    }
+    options.paranoid_checks = true;
     SetMaxOpenFiles(&options);
     return options;
 }


### PR DESCRIPTION
It is safe as LevelDB [1.18+](https://github.com/bitcoin/bitcoin/pull/5093) is used since  [v0.10.0](https://github.com/bitcoin/bitcoin/releases/tag/v0.10.0).