### PR TITLE
refactor: Drop unused CDBWrapper methods

### DIFF
--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -292,18 +292,6 @@ public:
     // Get an estimate of LevelDB memory usage (in bytes).
     size_t DynamicMemoryUsage() const;
 
-    // not available for LevelDB; provide for compatibility with BDB
-    bool Flush()
-    {
-        return true;
-    }
-
-    bool Sync()
-    {
-        CDBBatch batch(*this);
-        return WriteBatch(batch, true);
-    }
-
     CDBIterator *NewIterator()
     {
         return new CDBIterator(*this, pdb->NewIterator(iteroptions));


### PR DESCRIPTION
`CDBWrapper::Flush()` and `CDBWrapper::Sync()` are not used in the code.