### PR TITLE
rpc: deprecate banscore field in getpeerinfo

### DIFF
--- a/doc/release-notes-19469.md
+++ b/doc/release-notes-19469.md
@@ -1,0 +1,6 @@
+Updated RPCs
+------------
+
+- `getpeerinfo` no longer returns the `banscore` field unless the configuration
+  option `-deprecatedrpc=banscore` is used. The `banscore` field will be fully
+  removed in the next major release. (#19469)

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -112,7 +112,7 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
                             {RPCResult::Type::BOOL, "inbound", "Inbound (true) or Outbound (false)"},
                             {RPCResult::Type::BOOL, "addnode", "Whether connection was due to addnode/-connect or if it was an automatic/inbound connection"},
                             {RPCResult::Type::NUM, "startingheight", "The starting height (block) of the peer"},
-                            {RPCResult::Type::NUM, "banscore", "The ban score"},
+                            {RPCResult::Type::NUM, "banscore", "The ban score (DEPRECATED, returned only if config option -deprecatedrpc=banscore is passed)"},
                             {RPCResult::Type::NUM, "synced_headers", "The last header we have in common with this peer"},
                             {RPCResult::Type::NUM, "synced_blocks", "The last block we have in common with this peer"},
                             {RPCResult::Type::ARR, "inflight", "",
@@ -191,7 +191,10 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
         obj.pushKV("addnode", stats.m_manual_connection);
         obj.pushKV("startingheight", stats.nStartingHeight);
         if (fStateStats) {
-            obj.pushKV("banscore", statestats.nMisbehavior);
+            if (IsDeprecatedRPCEnabled("banscore")) {
+                // banscore is deprecated in v0.21 for removal in v0.22
+                obj.pushKV("banscore", statestats.nMisbehavior);
+            }
             obj.pushKV("synced_headers", statestats.nSyncHeight);
             obj.pushKV("synced_blocks", statestats.nCommonHeight);
             UniValue heights(UniValue::VARR);

--- a/test/functional/rpc_getpeerinfo_banscore_deprecation.py
+++ b/test/functional/rpc_getpeerinfo_banscore_deprecation.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test deprecation of getpeerinfo RPC banscore field."""
+
+from test_framework.test_framework import BitcoinTestFramework
+
+
+class GetpeerinfoBanscoreDeprecationTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.extra_args = [[], ["-deprecatedrpc=banscore"]]
+
+    def run_test(self):
+        self.log.info("Test getpeerinfo by default no longer returns a banscore field")
+        assert "banscore" not in self.nodes[0].getpeerinfo()[0].keys()
+
+        self.log.info("Test getpeerinfo returns banscore with -deprecatedrpc=banscore")
+        assert "banscore" in self.nodes[1].getpeerinfo()[0].keys()
+
+
+if __name__ == "__main__":
+    GetpeerinfoBanscoreDeprecationTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -243,6 +243,7 @@ BASE_SCRIPTS = [
     'feature_blocksdir.py',
     'feature_config_args.py',
     'rpc_getdescriptorinfo.py',
+    'rpc_getpeerinfo_banscore_deprecation.py',
     'rpc_help.py',
     'feature_help.py',
     'feature_shutdown.py',


### PR DESCRIPTION
Per https://github.com/bitcoin/bitcoin/pull/19219#discussion_r443074487 and https://github.com/bitcoin/bitcoin/pull/19219#issuecomment-652699592, this PR deprecates returning the `banscore` field in the `getpeerinfo` RPC, updates the help, adds a test, and updates the release notes. Related to #19464.