### PR TITLE
banlist: log post-swept banlist size at startup

### DIFF
--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -26,7 +26,7 @@ BanMan::BanMan(fs::path ban_file, CClientUIInterface* client_interface, int64_t 
         SweepBanned();            // sweep out unused entries
 
         LogPrint(BCLog::NET, "Loaded %d banned node ips/subnets from banlist.dat  %dms\n",
-            banmap.size(), GetTimeMillis() - n_start);
+            m_banned.size(), GetTimeMillis() - n_start);
     } else {
         LogPrintf("Invalid or missing banlist.dat; recreating\n");
         SetBannedSetDirty(true); // force write


### PR DESCRIPTION
We are currently logging the size of the banlist from before `SweepBanned()` has been called, meaning the value may be incorrect. 

i.e banlist.dat had `1`ban. That ban is swept on startup. We log "loaded 1 banned node..". Actual banlist size is `0`.