### PR TITLE
util: Make default arg values more specific

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -170,11 +170,10 @@ static bool AppInit(int argc, char* argv[])
             return false;
         }
 
-        args.SoftSetBoolArg("-printtoconsole", SERVER_ARGS_OPTIONS.printtoconsole_default);
         args.SoftSetBoolArg("-server", SERVER_ARGS_OPTIONS.server_default);
 
         // Set this early so that parameter interactions go to console
-        InitLogging(args);
+        InitLogging(args, SERVER_ARGS_OPTIONS);
         InitParameterInteraction(args);
         if (!AppInitBasicSetup(args)) {
             // InitError will have been called with detailed error, which ends up on console

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -28,6 +28,7 @@
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 UrlDecodeFn* const URL_DECODE = urlDecode;
+constexpr ServerArgsOptions SERVER_ARGS_OPTIONS{/*gui*/ false, /*printtoconsole_default*/ true, /*server_default*/ true};
 
 #if HAVE_DECL_FORK
 
@@ -111,7 +112,7 @@ static bool AppInit(int argc, char* argv[])
     util::ThreadSetInternalName("init");
 
     // If Qt is used, parameters/bitcoin.conf are parsed in qt/bitcoin.cpp's main()
-    SetupServerArgs(node);
+    SetupServerArgs(node, SERVER_ARGS_OPTIONS);
     ArgsManager& args = *Assert(node.args);
     std::string error;
     if (!args.ParseParameters(argc, argv, error)) {
@@ -169,8 +170,9 @@ static bool AppInit(int argc, char* argv[])
             return false;
         }
 
-        // -server defaults to true for bitcoind but not for the GUI so do this here
-        args.SoftSetBoolArg("-server", true);
+        args.SoftSetBoolArg("-printtoconsole", SERVER_ARGS_OPTIONS.printtoconsole_default);
+        args.SoftSetBoolArg("-server", SERVER_ARGS_OPTIONS.server_default);
+
         // Set this early so that parameter interactions go to console
         InitLogging(args);
         InitParameterInteraction(args);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -887,11 +887,15 @@ void InitParameterInteraction(ArgsManager& args)
  * Note that this is called very early in the process lifetime, so you should be
  * careful about what global state you rely on here.
  */
-void InitLogging(const ArgsManager& args)
+void InitLogging(const ArgsManager& args, const ServerArgsOptions& options)
 {
     LogInstance().m_print_to_file = !args.IsArgNegated("-debuglogfile");
     LogInstance().m_file_path = AbsPathForConfigVal(args.GetArg("-debuglogfile", DEFAULT_DEBUGLOGFILE));
-    LogInstance().m_print_to_console = args.GetBoolArg("-printtoconsole", !args.GetBoolArg("-daemon", false));
+    if (args.GetBoolArg("-daemon", DEFAULT_DAEMON) || args.GetBoolArg("-daemonwait", DEFAULT_DAEMONWAIT)) {
+        LogInstance().m_print_to_console = false;
+    } else {
+        LogInstance().m_print_to_console = args.GetBoolArg("-printtoconsole", options.printtoconsole_default);
+    }
     LogInstance().m_log_timestamps = args.GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
     LogInstance().m_log_time_micros = args.GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
 #ifdef HAVE_THREAD_LOCAL

--- a/src/init.h
+++ b/src/init.h
@@ -82,7 +82,7 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
 /**
  * Register all arguments with the ArgsManager
  */
-void SetupServerArgs(NodeContext& node);
+void SetupServerArgs(NodeContext& node, ServerArgsOptions options);
 
 /** Returns licensing information (for -version) */
 std::string LicenseInfo();

--- a/src/init.h
+++ b/src/init.h
@@ -26,6 +26,17 @@ namespace util {
 class Ref;
 } // namespace util
 
+struct ServerArgsOptions {
+    constexpr ServerArgsOptions(bool gui_, bool printtoconsole_default_, bool server_default_)
+        : gui{gui_}, printtoconsole_default{printtoconsole_default_}, server_default{server_default_}
+    {
+    }
+
+    const bool gui;
+    const bool printtoconsole_default;
+    const bool server_default;
+};
+
 /** Interrupt threads */
 void Interrupt(NodeContext& node);
 void Shutdown(NodeContext& node);

--- a/src/init.h
+++ b/src/init.h
@@ -41,7 +41,7 @@ struct ServerArgsOptions {
 void Interrupt(NodeContext& node);
 void Shutdown(NodeContext& node);
 //!Initialize the logging infrastructure
-void InitLogging(const ArgsManager& args);
+void InitLogging(const ArgsManager& args, const ServerArgsOptions& options);
 //!Parameter interaction: change current parameters depending on various rules
 void InitParameterInteraction(ArgsManager& args);
 

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -33,6 +33,7 @@ enum class SynchronizationState;
 struct CNodeStateStats;
 struct NodeContext;
 struct bilingual_str;
+struct ServerArgsOptions;
 
 namespace interfaces {
 class Handler;
@@ -56,7 +57,7 @@ public:
     virtual ~Node() {}
 
     //! Init logging.
-    virtual void initLogging() = 0;
+    virtual void initLogging(const ServerArgsOptions& options) = 0;
 
     //! Init parameter interaction.
     virtual void initParameterInteraction() = 0;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -66,7 +66,7 @@ class NodeImpl : public Node
 {
 public:
     explicit NodeImpl(NodeContext* context) { setContext(context); }
-    void initLogging() override { InitLogging(*Assert(m_context->args)); }
+    void initLogging(const ServerArgsOptions& options) override { InitLogging(*Assert(m_context->args), options); }
     void initParameterInteraction() override { InitParameterInteraction(*Assert(m_context->args)); }
     bilingual_str getWarnings() override { return GetWarnings(true); }
     uint32_t getLogCategories() override { return LogInstance().GetCategoryMask(); }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -65,6 +65,8 @@ Q_IMPORT_PLUGIN(QMacStylePlugin);
 #endif
 #endif
 
+constexpr ServerArgsOptions SERVER_ARGS_OPTIONS{/*gui*/ true, /*printtoconsole_default*/ false, /*server_default*/ false};
+
 // Declare meta types used for QMetaObject::invokeMethod
 Q_DECLARE_METATYPE(bool*)
 Q_DECLARE_METATYPE(CAmount)
@@ -309,9 +311,8 @@ void BitcoinApplication::startThread()
 
 void BitcoinApplication::parameterSetup()
 {
-    // Default printtoconsole to false for the GUI. GUI programs should not
-    // print to the console unnecessarily.
-    gArgs.SoftSetBoolArg("-printtoconsole", false);
+    gArgs.SoftSetBoolArg("-printtoconsole", SERVER_ARGS_OPTIONS.printtoconsole_default);
+    gArgs.SoftSetBoolArg("-server", SERVER_ARGS_OPTIONS.server_default);
 
     InitLogging(gArgs);
     InitParameterInteraction(gArgs);
@@ -471,7 +472,7 @@ int GuiMain(int argc, char* argv[])
 
     /// 2. Parse command-line options. We do this after qt in order to show an error if there are problems parsing these
     // Command-line options take precedence:
-    SetupServerArgs(node_context);
+    SetupServerArgs(node_context, SERVER_ARGS_OPTIONS);
     SetupUIArgs(gArgs);
     std::string error;
     if (!gArgs.ParseParameters(argc, argv, error)) {

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -311,10 +311,9 @@ void BitcoinApplication::startThread()
 
 void BitcoinApplication::parameterSetup()
 {
-    gArgs.SoftSetBoolArg("-printtoconsole", SERVER_ARGS_OPTIONS.printtoconsole_default);
     gArgs.SoftSetBoolArg("-server", SERVER_ARGS_OPTIONS.server_default);
 
-    InitLogging(gArgs);
+    InitLogging(gArgs, SERVER_ARGS_OPTIONS);
     InitParameterInteraction(gArgs);
 }
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -39,6 +39,7 @@
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 UrlDecodeFn* const URL_DECODE = nullptr;
+constexpr ServerArgsOptions SERVER_ARGS_OPTIONS{/*gui*/ false, /*printtoconsole_default*/ true, /*server_default*/ true};
 
 FastRandomContext g_insecure_rand_ctx;
 /** Random context to get unique temp data dirs. Separate from g_insecure_rand_ctx, which can be seeded from a const env var */
@@ -89,7 +90,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
     gArgs.ForceSetArg("-datadir", m_path_root.string());
     ClearDatadirCache();
     {
-        SetupServerArgs(m_node);
+        SetupServerArgs(m_node, SERVER_ARGS_OPTIONS);
         std::string error;
         const bool success{m_node.args->ParseParameters(arguments.size(), arguments.data(), error)};
         assert(success);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -99,7 +99,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
     SelectParams(chainName);
     SeedInsecureRand();
     if (G_TEST_LOG_FUN) LogInstance().PushBackCallback(G_TEST_LOG_FUN);
-    InitLogging(*m_node.args);
+    InitLogging(*m_node.args, SERVER_ARGS_OPTIONS);
     AppInitParameterInteraction(*m_node.args);
     LogInstance().StartLogging();
     SHA256AutoDetect();


### PR DESCRIPTION
This PR:
- silents printing of the `-daemon` option for `bitcoin-qt`
- prints the correct default value of the `-printtoconsole` option for `bitcoin-qt`
- prints the default value of the `-server` option

---

On master (abdfd2d0e3ebec7dbead89317ee9192189a35809):
```
$ ./src/bitcoind -help  # `bitcoin-qt -help' prints the same
...
  -daemon
       Run in the background as a daemon and accept commands
...
  -printtoconsole
       Send trace/debug info to console (default: 1 when no -daemon. To disable
       logging to file, set -nodebuglogfile)
...
  -server
       Accept command line and JSON-RPC commands
```

---

With this PR:
```
$ ./src/bitcoind -help
...
  -daemon
       Run in the background as a daemon and accept commands
...
  -printtoconsole
       Send trace/debug info to console (default: 1). Disabled when -daemon=1.
       To disable logging to file, set -nodebuglogfile
...
  -server
       Accept command line and JSON-RPC commands (default: 1)

$ ./src/qt/bitcoin-qt -help
...
  -printtoconsole
       Send trace/debug info to console (default: 0). To disable logging to
       file, set -nodebuglogfile
...
  -server
       Accept command line and JSON-RPC commands (default: 0)
```