### PR TITLE
rpc: Add mempoolchanges

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -139,6 +139,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "pruneblockchain", 0, "height" },
     { "keypoolrefill", 0, "newsize" },
     { "getrawmempool", 0, "verbose" },
+    { "mempoolchanges", 1, "stream" },
+    { "mempoolchanges", 2, "max" },
     { "estimatesmartfee", 0, "conf_target" },
     { "estimaterawfee", 0, "conf_target" },
     { "estimaterawfee", 1, "threshold" },

--- a/test/functional/rpc_mempoolchanges.py
+++ b/test/functional/rpc_mempoolchanges.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test mempoolchanges RPC call"""
+
+from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+class MempoolChangesTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = False
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+        # basic start stop
+        stream = node.mempoolchanges('start')
+        node.mempoolchanges('stop', stream)
+        # start gives a different stream id
+        stream = node.mempoolchanges('start')
+        assert_equal(stream, 2)
+        # mempool is empty
+        changes = node.mempoolchanges('pull', stream, 10)
+        assert_equal(changes, [])
+        # mempool with one transaction
+        txid = node.sendtoaddress(address=ADDRESS_BCRT1_UNSPENDABLE, amount=1)
+        changes = node.mempoolchanges('pull', stream, 10)
+        assert_equal(changes, [{'add': txid}])
+        # pulling again doesn't give the same data
+        changes = node.mempoolchanges('pull', stream, 10)
+        assert_equal(changes, [])
+        node.mempoolchanges('stop', stream)
+
+
+if __name__ == '__main__':
+    MempoolChangesTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -245,6 +245,7 @@ BASE_SCRIPTS = [
     'feature_config_args.py',
     'rpc_getdescriptorinfo.py',
     'rpc_getpeerinfo_banscore_deprecation.py',
+    'rpc_mempoolchanges.py',
     'rpc_help.py',
     'feature_help.py',
     'feature_shutdown.py',


### PR DESCRIPTION
The new RPC `mempoolchanges` allows a client to retrieve mempool changes in a reliable way.

The client needs to start a dedicated stream:
```
bitcoin-cli mempoolchanges start
1
```
This returns the stream ID and at this point it contains the mempool content and it will keep track of all mempool changes.

To retrieve the actual changes the client calls:
```
bitcoin-cli mempoolchanges pull 1 10
[
]
```
This pulls up to 10 changes from the given stream.

Finally the client can stop the stream with
```
bitcoin-cli mempoolchanges stop 1
```
Also, the stream is limited and if that limit is reached then the stream is automatically stopped.

TODO: option to block until changes are available.
