### PR TITLE
Add parameter feature to serialization and use it for CAddress

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -7,6 +7,8 @@ FUZZ_TARGETS = \
   test/fuzz/addr_info_deserialize \
   test/fuzz/addrdb \
   test/fuzz/address_deserialize \
+  test/fuzz/address_withtime_deserialize \
+  test/fuzz/address_disk_deserialize \
   test/fuzz/addrman_deserialize \
   test/fuzz/asmap \
   test/fuzz/asmap_direct \
@@ -337,6 +339,18 @@ test_fuzz_address_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_address_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_address_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_address_deserialize_SOURCES = test/fuzz/deserialize.cpp
+
+test_fuzz_address_withtime_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DADDRESS_DESERIALIZE_WITHTIME=1
+test_fuzz_address_withtime_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_address_withtime_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_address_withtime_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_address_withtime_deserialize_SOURCES = test/fuzz/deserialize.cpp
+
+test_fuzz_address_disk_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DADDRESS_DESERIALIZE_DISK=1
+test_fuzz_address_disk_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_address_disk_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_address_disk_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_address_disk_deserialize_SOURCES = test/fuzz/deserialize.cpp
 
 test_fuzz_addrman_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DADDRMAN_DESERIALIZE=1
 test_fuzz_addrman_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -60,8 +60,7 @@ public:
 
     SERIALIZE_METHODS(CAddrInfo, obj)
     {
-        READWRITEAS(CAddress, obj);
-        READWRITE(obj.source, obj.nLastSuccess, obj.nAttempts);
+        READWRITE(AsBase<CAddress>(obj), obj.source, obj.nLastSuccess, obj.nAttempts);
     }
 
     CAddrInfo(const CAddress &addrIn, const CNetAddr &addrSource) : CAddress(addrIn), source(addrSource)

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -60,7 +60,7 @@ public:
 
     SERIALIZE_METHODS(CAddrInfo, obj)
     {
-        READWRITE(AsBase<CAddress>(obj), obj.source, obj.nLastSuccess, obj.nAttempts);
+        READWRITE(WithParams(CAddress::Format::DISK, AsBase<CAddress>(obj)), obj.source, obj.nLastSuccess, obj.nAttempts);
     }
 
     CAddrInfo(const CAddress &addrIn, const CNetAddr &addrSource) : CAddress(addrIn), source(addrSource)

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -21,8 +21,7 @@ struct CDiskTxPos : public FlatFilePos
 
     SERIALIZE_METHODS(CDiskTxPos, obj)
     {
-        READWRITEAS(FlatFilePos, obj);
-        READWRITE(VARINT(obj.nTxOffset));
+        READWRITE(AsBase<FlatFilePos>(obj), VARINT(obj.nTxOffset));
     }
 
     CDiskTxPos(const FlatFilePos &blockIn, unsigned int nTxOffsetIn) : FlatFilePos(blockIn.nFile, blockIn.nPos), nTxOffset(nTxOffsetIn) {

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -162,8 +162,7 @@ class CService : public CNetAddr
 
         SERIALIZE_METHODS(CService, obj)
         {
-            READWRITEAS(CNetAddr, obj);
-            READWRITE(Using<BigEndianFormatter<2>>(obj.port));
+            READWRITE(AsBase<CNetAddr>(obj), Using<BigEndianFormatter<2>>(obj.port));
         }
 };
 

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -81,8 +81,7 @@ public:
 
     SERIALIZE_METHODS(CBlock, obj)
     {
-        READWRITEAS(CBlockHeader, obj);
-        READWRITE(obj.vtx);
+        READWRITE(AsBase<CBlockHeader>(obj), obj.vtx);
     }
 
     void SetNull()

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -380,8 +380,7 @@ public:
             // nTime.
             READWRITE(obj.nTime);
         }
-        READWRITE(Using<CustomUintFormatter<8>>(obj.nServices));
-        READWRITEAS(CService, obj);
+        READWRITE(Using<CustomUintFormatter<8>>(obj.nServices), AsBase<CService>(obj));
     }
 
     ServiceFlags nServices{NODE_NONE};

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -354,6 +354,7 @@ static inline bool MayHaveUsefulAddressDB(ServiceFlags services)
     return (services & NODE_NETWORK) || (services & NODE_NETWORK_LIMITED);
 }
 
+
 /** A CService with information about it as peer */
 class CAddress : public CService
 {
@@ -368,23 +369,21 @@ public:
     CAddress() : CService{} {};
     explicit CAddress(CService ipIn, ServiceFlags nServicesIn) : CService{ipIn}, nServices{nServicesIn} {};
 
-    SERIALIZE_METHODS(CAddress, obj)
+    enum class Format {
+        DISK,
+        NETWORK_NOTIME,
+        NETWORK_WITHTIME,
+    };
+
+    SERIALIZE_METHODS_PARAMS(CAddress, obj, Format, fmt)
     {
         SER_READ(obj, obj.nTime = TIME_INIT);
-        if (s.GetType() & SER_DISK) {
+        if (fmt == Format::DISK) {
             uint32_t disk_version = DISK_VERSION;
             READWRITE(disk_version);
             READWRITE(obj.nTime);
-        } else if (s.GetType() & SER_NETWORK) {
-            // The only time we serialize a CAddress object without nTime is in
-            // the initial VERSION messages which contain two CAddress records.
-            // At that point, the serialization version is INIT_PROTO_VERSION.
-            // After the version handshake, serialization version is >=
-            // MIN_PEER_PROTO_VERSION and all ADDR messages are serialized with
-            // nTime.
-            if (s.GetVersion() != INIT_PROTO_VERSION) {
-                READWRITE(obj.nTime);
-            }
+        } else if (fmt == Format::NETWORK_WITHTIME) {
+            READWRITE(obj.nTime);
         }
         READWRITE(Using<CustomUintFormatter<8>>(obj.nServices), AsBase<CService>(obj));
     }

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -412,7 +412,7 @@ public:
     CScript(std::vector<unsigned char>::const_iterator pbegin, std::vector<unsigned char>::const_iterator pend) : CScriptBase(pbegin, pend) { }
     CScript(const unsigned char* pbegin, const unsigned char* pend) : CScriptBase(pbegin, pend) { }
 
-    SERIALIZE_METHODS(CScript, obj) { READWRITEAS(CScriptBase, obj); }
+    SERIALIZE_METHODS(CScript, obj) { READWRITE(AsBase<CScriptBase>(obj)); }
 
     explicit CScript(int64_t b) { operator<<(b); }
     explicit CScript(opcodetype b)     { operator<<(b); }

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -164,12 +164,29 @@ enum
     SER_GETHASH         = (1 << 2),
 };
 
-//! Convert the reference base type to X, without changing constness or reference type.
-template<typename X> X& ReadWriteAsHelper(X& x) { return x; }
-template<typename X> const X& ReadWriteAsHelper(const X& x) { return x; }
+/* Convert any argument to a reference to X, maintaining constness.
+ *
+ * This can be used in serialization code to invoke a base class's
+ * serialization routines.
+ *
+ * Example use:
+ *   class Base { ... };
+ *   class Child : public Base {
+ *     int m_data;
+ *   public:
+ *     SERIALIZE_METHODS(Child, obj) {
+ *       READWRITE(AsBase<Base>(obj), obj.m_data);
+ *     }
+ *   };
+ *
+ * static_cast cannot easily be used here, as the type of Obj will be const Child&
+ * during serialization and Child& during deserialization. AsBase will convert to
+ * const Base& and Base& appropriately.
+ */
+template<typename X> X& AsBase(X& x) { return x; }
+template<typename X> const X& AsBase(const X& x) { return x; }
 
 #define READWRITE(...) (::SerReadWriteMany(s, ser_action, __VA_ARGS__))
-#define READWRITEAS(type, obj) (::SerReadWriteMany(s, ser_action, ReadWriteAsHelper<type>(obj)))
 #define SER_READ(obj, code) ::SerRead(s, ser_action, obj, [&](Stream& s, typename std::remove_const<Type>::type& obj) { code; })
 #define SER_WRITE(obj, code) ::SerWrite(s, ser_action, obj, [&](Stream& s, const Type& obj) { code; })
 

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -196,6 +196,12 @@ void test_one_input(const std::vector<uint8_t>& buffer)
 #elif ADDRESS_DESERIALIZE
         CAddress a;
         DeserializeFromFuzzingInput(buffer, WithParams(CAddress::Format::NETWORK_NOTIME, a));
+#elif ADDRESS_DESERIALIZE_WITHTIME
+        CAddress a;
+        DeserializeFromFuzzingInput(buffer, WithParams(CAddress::Format::NETWORK_WITHTIME, a));
+#elif ADDRESS_DESERIALIZE_DISK
+        CAddress a;
+        DeserializeFromFuzzingInput(buffer, WithParams(CAddress::Format::DISK, a));
 #elif INV_DESERIALIZE
         CInv i;
         DeserializeFromFuzzingInput(buffer, i);

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -60,7 +60,7 @@ T Deserialize(CDataStream ds)
 }
 
 template <typename T>
-void DeserializeFromFuzzingInput(const std::vector<uint8_t>& buffer, T& obj)
+void DeserializeFromFuzzingInput(const std::vector<uint8_t>& buffer, T&& obj)
 {
     CDataStream ds(buffer, SER_NETWORK, INIT_PROTO_VERSION);
     try {
@@ -195,7 +195,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         (void)mh.IsValid(pchMessageStart);
 #elif ADDRESS_DESERIALIZE
         CAddress a;
-        DeserializeFromFuzzingInput(buffer, a);
+        DeserializeFromFuzzingInput(buffer, WithParams(CAddress::Format::NETWORK_NOTIME, a));
 #elif INV_DESERIALIZE
         CInv i;
         DeserializeFromFuzzingInput(buffer, i);


### PR DESCRIPTION
This introduces a concept of "serialization parameters". Every serializer can define its own parameter type, and a value of that type must be provided when serializing/deserializing, e.g. using `ss << WithParams(parameter, value)`, causing `value` to be serialized to `ss`, with parameter `parameter`. Note these parameters are automatically passed down the stack, so for example a vector can be serialized with a parameter, which will be available to all the elements' serializers.

In this PR, the feature is only used for `CAddress` serialization, but I plan to also convert `SERIALIZE_TRANSACTION_NO_WITNESS` in a follow-up. Eventually I hope to get rid of all GetVersion/GetType and replace it with this approach, which is type-safe (code won't compile if the correct parameter isn't passed somewhere), and avoids collisions between flags.