### PR TITLE
ProcessHeadersMessage() fix potential bug

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1804,10 +1804,8 @@ static void ProcessHeadersMessage(CNode& pfrom, CConnman* connman, ChainstateMan
 
     BlockValidationState state;
     if (!chainman.ProcessNewBlockHeaders(headers, state, chainparams, &pindexLast)) {
-        if (state.IsInvalid()) {
-            MaybePunishNodeForBlock(pfrom.GetId(), state, via_compact_block, "invalid header received");
-            return;
-        }
+        MaybePunishNodeForBlock(pfrom.GetId(), state, via_compact_block, "invalid header received");
+        return;
     }
 
     {


### PR DESCRIPTION
It seems that this part of code can produce assertion fails
```
assert(pindexLast); // line 1819
```

Because inside function ProcessNewBlockHeaders is invoked AcceptBlockHeader function that potentially can return only 'error' and doesn`t set 'state' variable in the invalid state.

Here is the code of the AcceptBlockHeader 

```
 if (!ContextualCheckBlockHeader(block, state, chainparams, pindexPrev, GetAdjustedTime()))
            return error("%s: Consensus::ContextualCheckBlockHeader: %s, %s", __func__, hash.ToString(), state.ToString());
```

```
if (!CheckBlockHeader(block, state, chainparams.GetConsensus()))
            return error("%s: Consensus::CheckBlockHeader: %s, %s", __func__, hash.ToString(), state.ToString());
```