### PR TITLE
psbt: Increment input value sum only once per UTXO in decodepsbt

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1105,39 +1105,38 @@ UniValue decodepsbt(const JSONRPCRequest& request)
         UniValue in(UniValue::VOBJ);
         // UTXOs
         bool have_a_utxo = false;
+        CTxOut txout;
         if (!input.witness_utxo.IsNull()) {
-            const CTxOut& txout = input.witness_utxo;
+            txout = input.witness_utxo;
+
+            UniValue o(UniValue::VOBJ);
+            ScriptToUniv(txout.scriptPubKey, o, true);
 
             UniValue out(UniValue::VOBJ);
-
             out.pushKV("amount", ValueFromAmount(txout.nValue));
+            out.pushKV("scriptPubKey", o);
+
+            in.pushKV("witness_utxo", out);
+
+            have_a_utxo = true;
+        }
+        if (input.non_witness_utxo) {
+            txout = input.non_witness_utxo->vout[psbtx.tx->vin[i].prevout.n];
+
+            UniValue non_wit(UniValue::VOBJ);
+            TxToUniv(*input.non_witness_utxo, uint256(), non_wit, false);
+            in.pushKV("non_witness_utxo", non_wit);
+
+            have_a_utxo = true;
+        }
+        if (have_a_utxo) {
             if (MoneyRange(txout.nValue) && MoneyRange(total_in + txout.nValue)) {
                 total_in += txout.nValue;
             } else {
                 // Hack to just not show fee later
                 have_all_utxos = false;
             }
-
-            UniValue o(UniValue::VOBJ);
-            ScriptToUniv(txout.scriptPubKey, o, true);
-            out.pushKV("scriptPubKey", o);
-            in.pushKV("witness_utxo", out);
-            have_a_utxo = true;
-        }
-        if (input.non_witness_utxo) {
-            UniValue non_wit(UniValue::VOBJ);
-            TxToUniv(*input.non_witness_utxo, uint256(), non_wit, false);
-            in.pushKV("non_witness_utxo", non_wit);
-            CAmount utxo_val = input.non_witness_utxo->vout[psbtx.tx->vin[i].prevout.n].nValue;
-            if (MoneyRange(utxo_val) && MoneyRange(total_in + utxo_val)) {
-                total_in += utxo_val;
-            } else {
-                // Hack to just not show fee later
-                have_all_utxos = false;
-            }
-            have_a_utxo = true;
-        }
-        if (!have_a_utxo) {
+        } else {
             have_all_utxos = false;
         }
 


### PR DESCRIPTION
Refactors the UTXO processing of `decodepsbt` to extract the relevant `CTxOut` and handle the input amounts from that. This avoids double counting the input value.

Fixes #19516