### PR TITLE
add static_check_equal for easier to read compiler errors

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -18,6 +18,7 @@
 #include <support/allocators/secure.h>
 #include <sync.h>     // for Mutex
 #include <util/time.h> // for GetTimeMicros()
+#include <util/check.h> // for static_check_equal
 
 #include <stdlib.h>
 #include <thread>
@@ -408,7 +409,7 @@ public:
     {
         assert(num <= 32);
         unsigned char buf[64];
-        static_assert(sizeof(buf) == CSHA512::OUTPUT_SIZE, "Buffer needs to have hasher's output size");
+        static_check_equal(sizeof(buf), CSHA512::OUTPUT_SIZE, "Buffer needs to have hasher's output size");
         bool ret;
         {
             LOCK(m_mutex);

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -56,4 +56,26 @@ T get_pure_r_value(T&& val)
 /** Identity function. Abort if the value compares equal to zero */
 #define Assert(val) [&]() -> decltype(get_pure_r_value(val))& { auto& check = (val); assert(#val && check); return check; }()
 
+/** Helper for static_check_equal, no type inference **/
+template <typename T1, typename T2, T1 value_1, T2 value_2, bool b>
+struct static_check_struct {
+    constexpr static_check_struct() {
+        static_assert(b, "Static Check Failed");
+    }
+};
+
+/** Check if the template arguments are (operator) at compile time. Compiler error prints values if
+ * failure. **/
+#define static_check_macro_msg(f, s1, s2, msg) static_check_struct<decltype(s1), decltype(s2), s1, s2, s1 f s2>()
+#define static_check_macro_nomsg(f, s1, s2)  static_check_macro_msg(f, s1, s2, "")
+#define static_check_macro_selector(f, s1, s2, msg, FUNC, ...) FUNC
+#define static_check_macro(...) static_check_macro_selector(__VA_ARGS__, static_check_macro_msg(__VA_ARGS__), static_check_macro_nomsg(__VA_ARGS__),)
+#define static_check_equal(...) static_check_macro(==, __VA_ARGS__)
+#define static_check_not_equal(...) static_check_macro(!=, __VA_ARGS__)
+#define static_check_greater(...) static_check_macro(>, __VA_ARGS__)
+#define static_check_less(...) static_check_macro(<, __VA_ARGS__)
+#define static_check_greater_equal(...) static_check_macro(>=, __VA_ARGS__)
+#define static_check_less_equal(...) static_check_macro(<=, __VA_ARGS__)
+
+
 #endif // BITCOIN_UTIL_CHECK_H


### PR DESCRIPTION
I find myself reaching for this function all the time and re-implementing it. Maybe it makes sense to add to util/check.h and eventually replace uses of static_assert with this to save contributor time when diagnosing failing static_asserts.

The benefit of 
```c++
static_check_equal(1, 2)
```

is that it prints 1 and 2 in the compiler error.
```
./util/check.h: In instantiation of ‘static_check_equal_struct<T1, T2, value_1, value_2>::static_check_equal_struct() [with T1 = int; T2 = int; T1 value_1 = 1; T2 value_2 = 2]’:
txmempool.cpp:29:5:   required from here
./util/check.h:63:31: error: static assertion failed: Equality check failed, value_1 != value_2.
   63 |         static_assert(value_1 == value_2, "Equality check failed, value_1 != value_2.");
```
Compare to:
```c++
static_assert(sizeof(int) == sizeof(size_t))
```

which just gives

```
txmempool.cpp:29:31: error: static assertion failed
   29 |     static_assert(sizeof(int) == sizeof(size_t));
```

is that you don't actually get to see what size T and T2 actually are, which can make it annoying to debug what went wrong, so then you end up guessing and recompiling or having to run the code to print the size out.