### PR TITLE
Add base_blob and BaseHash data() methods

### DIFF
--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -75,6 +75,16 @@ public:
         return m_hash < other.m_hash;
     }
 
+    unsigned char* data()
+    {
+        return m_hash.data();
+    }
+
+    const unsigned char* data() const
+    {
+        return m_hash.data();
+    }
+
     size_t size() const
     {
         return m_hash.size();

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -12,20 +12,20 @@
 template <unsigned int BITS>
 base_blob<BITS>::base_blob(const std::vector<unsigned char>& vch)
 {
-    assert(vch.size() == sizeof(data));
-    memcpy(data, vch.data(), sizeof(data));
+    assert(vch.size() == sizeof(m_data));
+    memcpy(m_data, vch.data(), sizeof(m_data));
 }
 
 template <unsigned int BITS>
 std::string base_blob<BITS>::GetHex() const
 {
-    return HexStr(std::reverse_iterator<const uint8_t*>(data + sizeof(data)), std::reverse_iterator<const uint8_t*>(data));
+    return HexStr(std::reverse_iterator<const uint8_t*>(m_data + sizeof(m_data)), std::reverse_iterator<const uint8_t*>(m_data));
 }
 
 template <unsigned int BITS>
 void base_blob<BITS>::SetHex(const char* psz)
 {
-    memset(data, 0, sizeof(data));
+    memset(m_data, 0, sizeof(m_data));
 
     // skip leading spaces
     while (IsSpace(*psz))
@@ -39,7 +39,7 @@ void base_blob<BITS>::SetHex(const char* psz)
     size_t digits = 0;
     while (::HexDigit(psz[digits]) != -1)
         digits++;
-    unsigned char* p1 = (unsigned char*)data;
+    unsigned char* p1 = (unsigned char*)m_data;
     unsigned char* pend = p1 + WIDTH;
     while (digits > 0 && p1 < pend) {
         *p1 = ::HexDigit(psz[--digits]);

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -18,11 +18,11 @@ class base_blob
 {
 protected:
     static constexpr int WIDTH = BITS / 8;
-    uint8_t data[WIDTH];
+    uint8_t m_data[WIDTH];
 public:
     base_blob()
     {
-        memset(data, 0, sizeof(data));
+        memset(m_data, 0, sizeof(m_data));
     }
 
     explicit base_blob(const std::vector<unsigned char>& vch);
@@ -30,17 +30,17 @@ public:
     bool IsNull() const
     {
         for (int i = 0; i < WIDTH; i++)
-            if (data[i] != 0)
+            if (m_data[i] != 0)
                 return false;
         return true;
     }
 
     void SetNull()
     {
-        memset(data, 0, sizeof(data));
+        memset(m_data, 0, sizeof(m_data));
     }
 
-    inline int Compare(const base_blob& other) const { return memcmp(data, other.data, sizeof(data)); }
+    inline int Compare(const base_blob& other) const { return memcmp(m_data, other.m_data, sizeof(m_data)); }
 
     friend inline bool operator==(const base_blob& a, const base_blob& b) { return a.Compare(b) == 0; }
     friend inline bool operator!=(const base_blob& a, const base_blob& b) { return a.Compare(b) != 0; }
@@ -53,32 +53,42 @@ public:
 
     unsigned char* begin()
     {
-        return &data[0];
+        return &m_data[0];
     }
 
     unsigned char* end()
     {
-        return &data[WIDTH];
+        return &m_data[WIDTH];
     }
 
     const unsigned char* begin() const
     {
-        return &data[0];
+        return &m_data[0];
     }
 
     const unsigned char* end() const
     {
-        return &data[WIDTH];
+        return &m_data[WIDTH];
+    }
+
+    unsigned char* data()
+    {
+        return &m_data[0];
+    }
+
+    const unsigned char* data() const
+    {
+        return &m_data[0];
     }
 
     unsigned int size() const
     {
-        return sizeof(data);
+        return sizeof(m_data);
     }
 
     uint64_t GetUint64(int pos) const
     {
-        const uint8_t* ptr = data + pos * 8;
+        const uint8_t* ptr = m_data + pos * 8;
         return ((uint64_t)ptr[0]) | \
                ((uint64_t)ptr[1]) << 8 | \
                ((uint64_t)ptr[2]) << 16 | \
@@ -92,13 +102,13 @@ public:
     template<typename Stream>
     void Serialize(Stream& s) const
     {
-        s.write((char*)data, sizeof(data));
+        s.write((char*)m_data, sizeof(m_data));
     }
 
     template<typename Stream>
     void Unserialize(Stream& s)
     {
-        s.read((char*)data, sizeof(data));
+        s.read((char*)m_data, sizeof(m_data));
     }
 };
 


### PR DESCRIPTION
Having size() and data() methods makes these work more nicely with spans and multiprocess serialization code

This change was originally pushed as part of #10102