### PR TITLE
qt, build: Fix QFileDialog for static builds

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -80,7 +80,6 @@ $(package)_config_opts += -no-feature-colordialog
 $(package)_config_opts += -no-feature-commandlineparser
 $(package)_config_opts += -no-feature-concurrent
 $(package)_config_opts += -no-feature-dial
-$(package)_config_opts += -no-feature-filesystemwatcher
 $(package)_config_opts += -no-feature-fontcombobox
 $(package)_config_opts += -no-feature-ftp
 $(package)_config_opts += -no-feature-http


### PR DESCRIPTION
This change partially reverts 248e22bbc0d7bc40ae3584d53a18507c46b0e553 (#16386) and makes `QFileDialog`s work again for static builds.

Fixes https://github.com/bitcoin-core/gui/issues/32.