### PR TITLE
qt: Typo fix in bitcoin_pl.ts

### DIFF
--- a/src/qt/locale/bitcoin_pl.ts
+++ b/src/qt/locale/bitcoin_pl.ts
@@ -1023,7 +1023,7 @@
     </message>
     <message>
         <source>Unknown...</source>
-        <translation>Nienznane...</translation>
+        <translation>Nieznany...</translation>
     </message>
     <message>
         <source>Last block time</source>


### PR DESCRIPTION
I noticed this typo while syncing blockchain.