### PR TITLE
ci: Add tsan suppression for race in DatabaseBatch

### DIFF
--- a/ci/test/00_setup_env_native_tsan.sh
+++ b/ci/test/00_setup_env_native_tsan.sh
@@ -12,4 +12,4 @@ export PACKAGES="clang llvm libc++abi-dev libc++-dev python3-zmq"
 export DEP_OPTS="CC=clang CXX='clang++ -stdlib=libc++'"
 export TEST_RUNNER_EXTRA="--exclude feature_block --timeout-factor=4"  # Increase timeout because sanitizers slow down. Low memory on Travis machines, exclude feature_block.
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-zmq --with-gui=no CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER' --with-sanitizers=thread CC=clang CXX='clang++ -stdlib=libc++'"
+export BITCOIN_CONFIG="--enable-zmq --with-gui=no CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER' CXXFLAGS='-g' --with-sanitizers=thread CC=clang CXX='clang++ -stdlib=libc++'"

--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -23,6 +23,7 @@ race:LoadWallet
 race:WalletBatch::WriteHDChain
 race:BerkeleyBatch
 race:BerkeleyDatabase
+race:DatabaseBatch
 race:zmq::*
 race:bitcoin-qt
 # deadlock (TODO fix)


### PR DESCRIPTION
Since #19325 was merged, the corresponding change in TSan suppression file gets required.

This PR is:
- an analogous to #19226 and #19450, and
- a temporary workaround for CI fail like https://cirrus-ci.com/task/5741795508224000?command=ci#L4993