### PR TITLE
refactor: Add ParseBool to rpc/util

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -536,10 +536,7 @@ static UniValue getrawmempool(const JSONRPCRequest& request)
                 },
             }.Check(request);
 
-    bool fVerbose = false;
-    if (!request.params[0].isNull())
-        fVerbose = request.params[0].get_bool();
-
+    const bool fVerbose = ParseBool(request.params[0], false);
     return MempoolToJSON(EnsureMemPool(request.context), fVerbose);
 }
 
@@ -564,10 +561,7 @@ static UniValue getmempoolancestors(const JSONRPCRequest& request)
                 },
             }.Check(request);
 
-    bool fVerbose = false;
-    if (!request.params[1].isNull())
-        fVerbose = request.params[1].get_bool();
-
+    const bool fVerbose = ParseBool(request.params[1], false);
     uint256 hash = ParseHashV(request.params[0], "parameter 1");
 
     const CTxMemPool& mempool = EnsureMemPool(request.context);
@@ -627,10 +621,7 @@ static UniValue getmempooldescendants(const JSONRPCRequest& request)
                 },
             }.Check(request);
 
-    bool fVerbose = false;
-    if (!request.params[1].isNull())
-        fVerbose = request.params[1].get_bool();
-
+    const bool fVerbose = ParseBool(request.params[1], false);
     uint256 hash = ParseHashV(request.params[0], "parameter 1");
 
     const CTxMemPool& mempool = EnsureMemPool(request.context);
@@ -761,10 +752,7 @@ static UniValue getblockheader(const JSONRPCRequest& request)
             }.Check(request);
 
     uint256 hash(ParseHashV(request.params[0], "hash"));
-
-    bool fVerbose = true;
-    if (!request.params[1].isNull())
-        fVerbose = request.params[1].get_bool();
+    const bool fVerbose = ParseBool(request.params[1], true);
 
     const CBlockIndex* pblockindex;
     const CBlockIndex* tip;
@@ -1063,9 +1051,7 @@ UniValue gettxout(const JSONRPCRequest& request)
     uint256 hash(ParseHashV(request.params[0], "txid"));
     int n = request.params[1].get_int();
     COutPoint out(hash, n);
-    bool fMempool = true;
-    if (!request.params[2].isNull())
-        fMempool = request.params[2].get_bool();
+    const bool fMempool = ParseBool(request.params[2], true);
 
     Coin coin;
     CCoinsViewCache* coins_view = &::ChainstateActive().CoinsTip();

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1337,10 +1337,9 @@ UniValue finalizepsbt(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("TX decode failed %s", error));
     }
 
-    bool extract = request.params[1].isNull() || (!request.params[1].isNull() && request.params[1].get_bool());
-
     CMutableTransaction mtx;
     bool complete = FinalizeAndExtractPSBT(psbtx, mtx);
+    const bool extract = ParseBool(request.params[1], true);
 
     UniValue result(UniValue::VOBJ);
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
@@ -1470,9 +1469,9 @@ UniValue converttopsbt(const JSONRPCRequest& request)
 
     // parse hex string from parameter
     CMutableTransaction tx;
-    bool permitsigdata = request.params[1].isNull() ? false : request.params[1].get_bool();
-    bool witness_specified = !request.params[2].isNull();
-    bool iswitness = witness_specified ? request.params[2].get_bool() : false;
+    const bool permitsigdata = ParseBool(request.params[1], false);
+    const bool witness_specified = !request.params[2].isNull();
+    const bool iswitness = ParseBool(request.params[2], false);
     const bool try_witness = witness_specified ? iswitness : true;
     const bool try_no_witness = witness_specified ? !iswitness : true;
     if (!DecodeHexTx(tx, request.params[0].get_str(), try_no_witness, try_witness)) {

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -130,6 +130,11 @@ CoinStatsHashType ParseHashType(const UniValue& param, const CoinStatsHashType d
     }
 }
 
+bool ParseBool(const UniValue& param, const bool default_value)
+{
+    return param.isNull() ? default_value : param.get_bool();
+}
+
 std::string HelpExampleCli(const std::string& methodname, const std::string& args)
 {
     return "> bitcoin-cli " + methodname + " " + args + "\n";

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -80,6 +80,9 @@ extern std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKe
 
 CoinStatsHashType ParseHashType(const UniValue& param, const CoinStatsHashType default_type);
 
+/** Parse bool from UniValue param with default fallback */
+bool ParseBool(const UniValue& param, const bool default_value);
+
 extern CAmount AmountFromValue(const UniValue& value);
 extern std::string HelpExampleCli(const std::string& methodname, const std::string& args);
 extern std::string HelpExampleRpc(const std::string& methodname, const std::string& args);


### PR DESCRIPTION
Mini refactoring for DRYer code and better readability. Replaces several instances of bool parsing in the RPC code with a rpc/util function. Also uses const when appropriate.