### PR TITLE
fuzz: add missing overrides to signature_checker

### DIFF
--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -48,7 +48,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     if (CompressScript(script, compressed)) {
         const unsigned int size = compressed[0];
         compressed.erase(compressed.begin());
-        assert(size >= 0 && size <= 5);
+        assert(size <= 5);
         CScript decompressed_script;
         const bool ok = DecompressScript(decompressed_script, size, compressed);
         assert(ok);

--- a/src/test/fuzz/scriptnum_ops.cpp
+++ b/src/test/fuzz/scriptnum_ops.cpp
@@ -33,7 +33,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         case 0: {
             const int64_t i = fuzzed_data_provider.ConsumeIntegral<int64_t>();
             assert((script_num == i) != (script_num != i));
-            assert((script_num <= i) != script_num > i);
+            assert((script_num <= i) != (script_num > i));
             assert((script_num >= i) != (script_num < i));
             // Avoid signed integer overflow:
             // script/script.h:264:93: runtime error: signed integer overflow: -2261405121394637306 + -9223372036854775802 cannot be represented in type 'long'

--- a/src/test/fuzz/signature_checker.cpp
+++ b/src/test/fuzz/signature_checker.cpp
@@ -28,17 +28,17 @@ public:
     {
     }
 
-    virtual bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const
+    bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const override
     {
         return m_fuzzed_data_provider.ConsumeBool();
     }
 
-    virtual bool CheckLockTime(const CScriptNum& nLockTime) const
+    bool CheckLockTime(const CScriptNum& nLockTime) const override
     {
         return m_fuzzed_data_provider.ConsumeBool();
     }
 
-    virtual bool CheckSequence(const CScriptNum& nSequence) const
+    bool CheckSequence(const CScriptNum& nSequence) const override
     {
         return m_fuzzed_data_provider.ConsumeBool();
     }


### PR DESCRIPTION
These functions in `fuzz/signature_checker.cpp` override virtual member functions and should be marked `override` instead of `virtual`, which is for introducing a new virtual function. The overridden virtual functions are in `script/interpreter.h:151/156/161`.

Also, per MarcoFalke suggestion, add missing parentheses in `fuzz/scriptnum_ops.cpp` and remove useless `unsigned int >= 0` conditional in `fuzz/script.cpp`.

These changes fix 5 compile warnings in gcc 10 and 3 in clang 11/12.