### PR TITLE
rpc: Add getindexinfo RPC

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -115,6 +115,10 @@ Changes to Wallet or GUI related RPCs can be found in the GUI or Wallet section 
 New RPCs
 --------
 
+- The `getindexinfo` RPC returns the actively running indices of the node,
+  including their current sync status and height. It also accepts an `index_name`
+  to specify returning only the status of that index. (#19550)
+
 Build System
 ------------
 

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -319,3 +319,12 @@ void BaseIndex::Stop()
         m_thread_sync.join();
     }
 }
+
+IndexSummary BaseIndex::GetSummary() const
+{
+    IndexSummary summary{};
+    summary.name = GetName();
+    summary.synced = m_synced;
+    summary.best_block_height = m_best_block_index.load()->nHeight;
+    return summary;
+}

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -13,6 +13,12 @@
 
 class CBlockIndex;
 
+struct IndexSummary {
+    std::string name;
+    bool synced{false};
+    int best_block_height{0};
+};
+
 /**
  * Base class for indices of blockchain data. This implements
  * CValidationInterface and ensures blocks are indexed sequentially according
@@ -106,6 +112,9 @@ public:
 
     /// Stops the instance from staying in sync with blockchain updates.
     void Stop();
+
+    /// Get a summary of the index and its state.
+    IndexSummary GetSummary() const;
 };
 
 #endif // BITCOIN_INDEX_BASE_H


### PR DESCRIPTION
As I was playing with indices a I was missing an RPC that gives information about the active indices in the node. I think this can be helpful for many users, especially since there are some new index candidates coming up (#14053, #18000) that can give a quick overview without the user having to parse the logs.

Feature summary:
- Adds new RPC `getindexinfo` (placed in Util section)
- That RPC only lists the actively running indices
- For each index it gives the name, whether it is synced and up to which block height it is synced
