### PR TITLE
test: fix intermittent failure in p2p_ibd_txrelay

### DIFF
--- a/test/functional/p2p_ibd_txrelay.py
+++ b/test/functional/p2p_ibd_txrelay.py
@@ -8,7 +8,6 @@ from decimal import Decimal
 
 from test_framework.messages import COIN
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
 
 MAX_FEE_FILTER = Decimal(9170997) / COIN
 NORMAL_FEE_FILTER = Decimal(100) / COIN
@@ -22,12 +21,12 @@ class P2PIBDTxRelayTest(BitcoinTestFramework):
             ["-minrelaytxfee={}".format(NORMAL_FEE_FILTER)],
             ["-minrelaytxfee={}".format(NORMAL_FEE_FILTER)],
         ]
+
     def run_test(self):
         self.log.info("Check that nodes set minfilter to MAX_MONEY while still in IBD")
         for node in self.nodes:
             assert node.getblockchaininfo()['initialblockdownload']
-            for conn_info in node.getpeerinfo():
-                assert_equal(conn_info['minfeefilter'], MAX_FEE_FILTER)
+            self.wait_until(lambda: all(peer['minfeefilter'] == MAX_FEE_FILTER for peer in node.getpeerinfo()))
 
         # Come out of IBD by generating a block
         self.nodes[0].generate(1)
@@ -36,8 +35,7 @@ class P2PIBDTxRelayTest(BitcoinTestFramework):
         self.log.info("Check that nodes reset minfilter after coming out of IBD")
         for node in self.nodes:
             assert not node.getblockchaininfo()['initialblockdownload']
-            for conn_info in node.getpeerinfo():
-                assert_equal(conn_info['minfeefilter'], NORMAL_FEE_FILTER)
+            self.wait_until(lambda: all(peer['minfeefilter'] == NORMAL_FEE_FILTER for peer in node.getpeerinfo()))
 
 
 if __name__ == '__main__':

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -31,6 +31,7 @@ from .util import (
     disconnect_nodes,
     get_datadir_path,
     initialize_datadir,
+    wait_until,
 )
 
 
@@ -601,6 +602,9 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
     def sync_all(self, nodes=None):
         self.sync_blocks(nodes)
         self.sync_mempools(nodes)
+
+    def wait_until(self, test_function, timeout=60, lock=None):
+        return wait_until(test_function, timeout=timeout, lock=lock, timeout_factor=self.options.timeout_factor)
 
     # Private helper methods. These should not be accessed by the subclass test scripts.
 


### PR DESCRIPTION
To fix these intermittent failures in Travis CI.
```
162/163 - p2p_ibd_txrelay.py failed, Duration: 2 s

stdout:
2020-07-19T05:44:17.213000Z TestFramework (INFO):
    Check that nodes set minfilter to MAX_MONEY while still in IBD
2020-07-19T05:44:17.216000Z TestFramework (ERROR): Assertion failed
Traceback (most recent call last):
  File "/Users/travis/build/bitcoin/bitcoin/ci/scratch/build/bitcoin-x86_64-apple-darwin16/test/functional/test_framework/test_framework.py", line 117, in main
    self.run_test()
  File "/Users/travis/build/bitcoin/bitcoin/ci/scratch/build/bitcoin-x86_64-apple-darwin16/test/functional/p2p_ibd_txrelay.py", line 30, in run_test
    assert_equal(conn_info['minfeefilter'], MAX_FEE_FILTER)
  File "/Users/travis/build/bitcoin/bitcoin/ci/scratch/build/bitcoin-x86_64-apple-darwin16/test/functional/test_framework/util.py", line 49, in assert_equal
    raise AssertionError("not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args))

AssertionError: not(0E-8 == 0.09170997)
2020-07-19T05:44:17.293000Z TestFramework (INFO): Stopping nodes
```

At Marco's suggestion, cherry-picked part of #19134 to nicely simplify using `wait_until`.