### PR TITLE
test: Fix fuzzer compilation on macOS

### DIFF
--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -332,7 +332,7 @@ public:
             return 0;
         }
         std::memcpy(buf, random_bytes.data(), random_bytes.size());
-        if (AdditionOverflow((uint64_t)fuzzed_file->m_offset, random_bytes.size())) {
+        if (AdditionOverflow(fuzzed_file->m_offset, (int64_t)random_bytes.size())) {
             return fuzzed_file->m_fuzzed_data_provider.ConsumeBool() ? 0 : -1;
         }
         fuzzed_file->m_offset += random_bytes.size();
@@ -343,7 +343,7 @@ public:
     {
         FuzzedFileProvider* fuzzed_file = (FuzzedFileProvider*)cookie;
         const ssize_t n = fuzzed_file->m_fuzzed_data_provider.ConsumeIntegralInRange<ssize_t>(0, size);
-        if (AdditionOverflow(fuzzed_file->m_offset, n)) {
+        if (AdditionOverflow(fuzzed_file->m_offset, (int64_t)n)) {
             return fuzzed_file->m_fuzzed_data_provider.ConsumeBool() ? 0 : -1;
         }
         fuzzed_file->m_offset += n;


### PR DESCRIPTION
fixes #19557

Before the fix:
```
➜  bitcoin git:(fix-fuzzer-macos) make
Making all in src
  CXX      test/fuzz/addition_overflow-addition_overflow.o
In file included from test/fuzz/addition_overflow.cpp:7:
./test/fuzz/util.h:335:13: error: no matching function for call to 'AdditionOverflow'
        if (AdditionOverflow((uint64_t)fuzzed_file->m_offset, random_bytes.size())) {
            ^~~~~~~~~~~~~~~~
./test/fuzz/util.h:201:16: note: candidate template ignored: deduced conflicting types for parameter 'T' ('unsigned long long' vs. 'unsigned long')
NODISCARD bool AdditionOverflow(const T i, const T j) noexcept
               ^
./test/fuzz/util.h:346:13: error: no matching function for call to 'AdditionOverflow'
        if (AdditionOverflow(fuzzed_file->m_offset, n)) {
            ^~~~~~~~~~~~~~~~
./test/fuzz/util.h:201:16: note: candidate template ignored: deduced conflicting types for parameter 'T' ('long long' vs. 'long')
NODISCARD bool AdditionOverflow(const T i, const T j) noexcept
               ^
```

After the fix:
```
➜  bitcoin git:(fix-fuzzer-macos) ./configure --enable-fuzz --with-sanitizers=fuzzer,address,undefined CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ --disable-asm && make clean && make -j5
...
...
  CXXLD    test/fuzz/uint256_deserialize
Making all in doc/man
make[1]: Nothing to be done for `all'.
make[1]: Nothing to be done for `all-am'.
```
