### PR TITLE
p2p: clean up Misbehaving()

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1059,23 +1059,22 @@ unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans)
  * Increment peer's misbehavior score. If the new value >= DISCOURAGEMENT_THRESHOLD, mark the node
  * to be discouraged, meaning the peer might be disconnected and added to the discouragement filter.
  */
-void Misbehaving(NodeId pnode, int howmuch, const std::string& message) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+void Misbehaving(const NodeId pnode, const int howmuch, const std::string& message) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
-    if (howmuch == 0)
-        return;
+    assert(howmuch > 0);
 
-    CNodeState *state = State(pnode);
-    if (state == nullptr)
-        return;
+    CNodeState* const state = State(pnode);
+    if (state == nullptr) return;
 
     state->nMisbehavior += howmuch;
-    std::string message_prefixed = message.empty() ? "" : (": " + message);
+    const std::string message_prefixed = message.empty() ? "" : (": " + message);
     if (state->nMisbehavior >= DISCOURAGEMENT_THRESHOLD && state->nMisbehavior - howmuch < DISCOURAGEMENT_THRESHOLD)
     {
-        LogPrint(BCLog::NET, "%s: %s peer=%d (%d -> %d) DISCOURAGE THRESHOLD EXCEEDED%s\n", __func__, state->name, pnode, state->nMisbehavior-howmuch, state->nMisbehavior, message_prefixed);
+        LogPrint(BCLog::NET, "Misbehaving: peer=%d (%d -> %d) DISCOURAGE THRESHOLD EXCEEDED%s\n", pnode, state->nMisbehavior - howmuch, state->nMisbehavior, message_prefixed);
         state->m_should_discourage = true;
-    } else
-        LogPrint(BCLog::NET, "%s: %s peer=%d (%d -> %d)%s\n", __func__, state->name, pnode, state->nMisbehavior-howmuch, state->nMisbehavior, message_prefixed);
+    } else {
+        LogPrint(BCLog::NET, "Misbehaving: peer=%d (%d -> %d)%s\n", pnode, state->nMisbehavior - howmuch, state->nMisbehavior, message_prefixed);
+    }
 }
 
 /**

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3723,32 +3723,32 @@ void ProcessMessage(
  */
 bool PeerLogicValidation::MaybeDiscourageAndDisconnect(CNode& pnode)
 {
-    NodeId peer_id{pnode.GetId()};
+    const NodeId peer_id{pnode.GetId()};
     {
         LOCK(cs_main);
-        CNodeState &state = *State(peer_id);
+        CNodeState& state = *State(peer_id);
 
         // There's nothing to do if the m_should_discourage flag isn't set
         if (!state.m_should_discourage) return false;
 
-        // Reset m_should_discourage
         state.m_should_discourage = false;
     } // cs_main
 
     if (pnode.HasPermission(PF_NOBAN)) {
-        // Peer has the NOBAN permission flag - log but don't disconnect
+        // We never disconnect or discourage peers for bad behavior if they have the NOBAN permission flag
         LogPrintf("Warning: not punishing noban peer %d!\n", peer_id);
         return false;
     }
 
     if (pnode.m_manual_connection) {
-        // Peer is a manual connection - log but don't disconnect
+        // We never disconnect or discourage manual peers for bad behavior
         LogPrintf("Warning: not punishing manually connected peer %d!\n", peer_id);
         return false;
     }
 
     if (pnode.addr.IsLocal()) {
-        // Peer is on a local address. Disconnect this peer, but don't discourage the local address
+        // We disconnect local peers for bad behavior but don't discourage (since that would discourage
+        // all peers on the same local address)
         LogPrintf("Warning: disconnecting but not discouraging local peer %d!\n", peer_id);
         pnode.fDisconnect = true;
         return true;


### PR DESCRIPTION
This PR makes a few minor clean-ups to `Misbehaving()` in preparation to move it out of the cs_main lock.

There are very minor logging changes but otherwise no functional changes.