### PR TITLE
doc: Update obsolete links to online reference #19582

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -63,100 +63,100 @@ namespace NetMsgType {
 /**
  * The version message provides information about the transmitting node to the
  * receiving node at the beginning of a connection.
- * @see https://bitcoin.org/en/developer-reference#version
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#version
  */
 extern const char* VERSION;
 /**
  * The verack message acknowledges a previously-received version message,
  * informing the connecting node that it can begin to send other messages.
- * @see https://bitcoin.org/en/developer-reference#verack
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#verack
  */
 extern const char* VERACK;
 /**
  * The addr (IP address) message relays connection information for peers on the
  * network.
- * @see https://bitcoin.org/en/developer-reference#addr
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#addr
  */
 extern const char* ADDR;
 /**
  * The inv message (inventory message) transmits one or more inventories of
  * objects known to the transmitting peer.
- * @see https://bitcoin.org/en/developer-reference#inv
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#inv
  */
 extern const char* INV;
 /**
  * The getdata message requests one or more data objects from another node.
- * @see https://bitcoin.org/en/developer-reference#getdata
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#getdata
  */
 extern const char* GETDATA;
 /**
  * The merkleblock message is a reply to a getdata message which requested a
  * block using the inventory type MSG_MERKLEBLOCK.
  * @since protocol version 70001 as described by BIP37.
- * @see https://bitcoin.org/en/developer-reference#merkleblock
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#merkleblock
  */
 extern const char* MERKLEBLOCK;
 /**
  * The getblocks message requests an inv message that provides block header
  * hashes starting from a particular point in the block chain.
- * @see https://bitcoin.org/en/developer-reference#getblocks
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#getblocks
  */
 extern const char* GETBLOCKS;
 /**
  * The getheaders message requests a headers message that provides block
  * headers starting from a particular point in the block chain.
  * @since protocol version 31800.
- * @see https://bitcoin.org/en/developer-reference#getheaders
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#getheaders
  */
 extern const char* GETHEADERS;
 /**
  * The tx message transmits a single transaction.
- * @see https://bitcoin.org/en/developer-reference#tx
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#tx
  */
 extern const char* TX;
 /**
  * The headers message sends one or more block headers to a node which
  * previously requested certain headers with a getheaders message.
  * @since protocol version 31800.
- * @see https://bitcoin.org/en/developer-reference#headers
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#headers
  */
 extern const char* HEADERS;
 /**
  * The block message transmits a single serialized block.
- * @see https://bitcoin.org/en/developer-reference#block
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#block
  */
 extern const char* BLOCK;
 /**
  * The getaddr message requests an addr message from the receiving node,
  * preferably one with lots of IP addresses of other receiving nodes.
- * @see https://bitcoin.org/en/developer-reference#getaddr
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#getaddr
  */
 extern const char* GETADDR;
 /**
  * The mempool message requests the TXIDs of transactions that the receiving
  * node has verified as valid but which have not yet appeared in a block.
  * @since protocol version 60002.
- * @see https://bitcoin.org/en/developer-reference#mempool
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#mempool
  */
 extern const char* MEMPOOL;
 /**
  * The ping message is sent periodically to help confirm that the receiving
  * peer is still connected.
- * @see https://bitcoin.org/en/developer-reference#ping
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#ping
  */
 extern const char* PING;
 /**
  * The pong message replies to a ping message, proving to the pinging node that
  * the ponging node is still alive.
  * @since protocol version 60001 as described by BIP31.
- * @see https://bitcoin.org/en/developer-reference#pong
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#pong
  */
 extern const char* PONG;
 /**
  * The notfound message is a reply to a getdata message which requested an
  * object the receiving node does not have available for relay.
  * @since protocol version 70001.
- * @see https://bitcoin.org/en/developer-reference#notfound
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#notfound
  */
 extern const char* NOTFOUND;
 /**
@@ -165,7 +165,7 @@ extern const char* NOTFOUND;
  * @since protocol version 70001 as described by BIP37.
  *   Only available with service bit NODE_BLOOM since protocol version
  *   70011 as described by BIP111.
- * @see https://bitcoin.org/en/developer-reference#filterload
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#filterload
  */
 extern const char* FILTERLOAD;
 /**
@@ -174,7 +174,7 @@ extern const char* FILTERLOAD;
  * @since protocol version 70001 as described by BIP37.
  *   Only available with service bit NODE_BLOOM since protocol version
  *   70011 as described by BIP111.
- * @see https://bitcoin.org/en/developer-reference#filteradd
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#filteradd
  */
 extern const char* FILTERADD;
 /**
@@ -183,14 +183,14 @@ extern const char* FILTERADD;
  * @since protocol version 70001 as described by BIP37.
  *   Only available with service bit NODE_BLOOM since protocol version
  *   70011 as described by BIP111.
- * @see https://bitcoin.org/en/developer-reference#filterclear
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#filterclear
  */
 extern const char* FILTERCLEAR;
 /**
  * Indicates that a node prefers to receive new block announcements via a
  * "headers" message rather than an "inv".
  * @since protocol version 70012 as described by BIP130.
- * @see https://bitcoin.org/en/developer-reference#sendheaders
+ * @see https://developer.bitcoin.org/reference/p2p_networking.html#sendheaders
  */
 extern const char* SENDHEADERS;
 /**


### PR DESCRIPTION
Updated all the obsolete links to valid ones.

Found this issue from https://github.com/bitcoin/bitcoin/issues/19582.
