### PR TITLE
rpc: RPCResult Type of MempoolEntryDescription should be OBJ.

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -525,9 +525,9 @@ static UniValue getrawmempool(const JSONRPCRequest& request)
                             {RPCResult::Type::STR_HEX, "", "The transaction id"},
                         }},
                     RPCResult{"for verbose = true",
-                        RPCResult::Type::OBJ, "", "",
+                        RPCResult::Type::OBJ_DYN, "", "",
                         {
-                            {RPCResult::Type::OBJ_DYN, "transactionid", "", MempoolEntryDescription()},
+                            {RPCResult::Type::OBJ, "transactionid", "", MempoolEntryDescription()},
                         }},
                 },
                 RPCExamples{
@@ -556,7 +556,7 @@ static UniValue getmempoolancestors(const JSONRPCRequest& request)
                         RPCResult::Type::ARR, "", "",
                         {{RPCResult::Type::STR_HEX, "", "The transaction id of an in-mempool ancestor transaction"}}},
                     RPCResult{"for verbose = true",
-                        RPCResult::Type::OBJ_DYN, "transactionid", "", MempoolEntryDescription()},
+                        RPCResult::Type::OBJ, "transactionid", "", MempoolEntryDescription()},
                 },
                 RPCExamples{
                     HelpExampleCli("getmempoolancestors", "\"mytxid\"")
@@ -616,9 +616,9 @@ static UniValue getmempooldescendants(const JSONRPCRequest& request)
                         RPCResult::Type::ARR, "", "",
                         {{RPCResult::Type::STR_HEX, "", "The transaction id of an in-mempool descendant transaction"}}},
                     RPCResult{"for verbose = true",
-                        RPCResult::Type::OBJ, "", "",
+                        RPCResult::Type::OBJ_DYN, "", "",
                         {
-                            {RPCResult::Type::OBJ_DYN, "transactionid", "", MempoolEntryDescription()},
+                            {RPCResult::Type::OBJ, "transactionid", "", MempoolEntryDescription()},
                         }},
                 },
                 RPCExamples{
@@ -674,7 +674,7 @@ static UniValue getmempoolentry(const JSONRPCRequest& request)
                     {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id (must be in mempool)"},
                 },
                 RPCResult{
-                    RPCResult::Type::OBJ_DYN, "", "", MempoolEntryDescription()},
+                    RPCResult::Type::OBJ, "", "", MempoolEntryDescription()},
                 RPCExamples{
                     HelpExampleCli("getmempoolentry", "\"mytxid\"")
             + HelpExampleRpc("getmempoolentry", "\"mytxid\"")


### PR DESCRIPTION
If multiple entries are possible, wrapping Type should be OBJ_DYN.

fixes #19579
