### PR TITLE
test: moved from percent format to proper format for consistency

### DIFF
--- a/test/lint/check-rpc-mappings.py
+++ b/test/lint/check-rpc-mappings.py
@@ -55,7 +55,7 @@ def process_commands(fname):
                     in_rpcs = False
                 elif '{' in line and '"' in line:
                     m = re.search(r'{ *("[^"]*"), *("[^"]*"), *&([^,]*), *{([^}]*)} *},', line)
-                    assert m, 'No match to table expression: %s' % line
+                    assert m, 'No match to table expression: {}'.format(line)
                     name = parse_string(m.group(2))
                     args_str = m.group(4).strip()
                     if args_str:
@@ -81,7 +81,7 @@ def process_mapping(fname):
                     in_rpcs = False
                 elif '{' in line and '"' in line:
                     m = re.search(r'{ *("[^"]*"), *([0-9]+) *, *("[^"]*") *},', line)
-                    assert m, 'No match to table expression: %s' % line
+                    assert m, 'No match to table expression: {}'.format(line)
                     name = parse_string(m.group(1))
                     idx = int(m.group(2))
                     argname = parse_string(m.group(3))
@@ -117,11 +117,11 @@ def main():
         try:
             rargnames = cmds_by_name[cmdname].args[argidx].names
         except IndexError:
-            print('ERROR: %s argument %i (named %s in vRPCConvertParams) is not defined in dispatch table' % (cmdname, argidx, argname))
+            print('ERROR: {} argument {} (named {} in vRPCConvertParams) is not defined in dispatch table'.format(cmdname, argidx, argname))
             errors += 1
             continue
         if argname not in rargnames:
-            print('ERROR: %s argument %i is named %s in vRPCConvertParams but %s in dispatch table' % (cmdname, argidx, argname, rargnames), file=sys.stderr)
+            print('ERROR: {} argument {} is named {} in vRPCConvertParams but {} in dispatch table'.format(cmdname, argidx, argname, rargnames), file=sys.stderr)
             errors += 1
 
     # Check for conflicts in vRPCConvertParams conversion
@@ -132,7 +132,7 @@ def main():
         for arg in cmd.args:
             convert = [((cmd.name, arg.idx, argname) in mapping) for argname in arg.names]
             if any(convert) != all(convert):
-                print('ERROR: %s argument %s has conflicts in vRPCConvertParams conversion specifier %s' % (cmd.name, arg.names, convert))
+                print('ERROR: {} argument {} has conflicts in vRPCConvertParams conversion specifier {}'.format(cmd.name, arg.names, convert))
                 errors += 1
             arg.convert = all(convert)
 
@@ -152,8 +152,7 @@ def main():
             if argname in IGNORE_DUMMY_ARGS:
                 # these are testing or dummy, don't warn for them
                 continue
-            print('WARNING: conversion mismatch for argument named %s (%s)' %
-                  (argname, list(zip(all_methods_by_argname[argname], converts_by_argname[argname]))))
+            print('WARNING: conversion mismatch for argument named {} ({})'.format(argname, list(zip(all_methods_by_argname[argname], converts_by_argname[argname]))))
 
     sys.exit(errors > 0)
 

--- a/test/util/bitcoin-util-test.py
+++ b/test/util/bitcoin-util-test.py
@@ -100,7 +100,7 @@ def bctest(testDir, testObj, buildenv):
             logging.error("Output data missing for " + outputFn)
             raise Exception
         if not outputType:
-            logging.error("Output file %s does not have a file extension" % outputFn)
+            logging.error("Output file {} does not have a file extension".format(outputFn))
             raise Exception
 
     # Run the test
@@ -108,7 +108,7 @@ def bctest(testDir, testObj, buildenv):
     try:
         outs = proc.communicate(input=inputData)
     except OSError:
-        logging.error("OSError, Failed to execute " + execprog)
+        logging.error("OSError, Failed to execute {}".format(execprog))
         raise
 
     if outputData:
@@ -117,20 +117,20 @@ def bctest(testDir, testObj, buildenv):
         try:
             a_parsed = parse_output(outs[0], outputType)
         except Exception as e:
-            logging.error('Error parsing command output as %s: %s' % (outputType, e))
+            logging.error('Error parsing command output as {}: {}'.format(outputType, e))
             raise
         try:
             b_parsed = parse_output(outputData, outputType)
         except Exception as e:
-            logging.error('Error parsing expected output %s as %s: %s' % (outputFn, outputType, e))
+            logging.error('Error parsing expected output {} as {}: {}'.format(outputFn, outputType, e))
             raise
         # Compare data
         if a_parsed != b_parsed:
-            logging.error("Output data mismatch for " + outputFn + " (format " + outputType + ")")
+            logging.error("Output data mismatch for {0} (format {0})".format(outputType))
             data_mismatch = True
         # Compare formatting
         if outs[0] != outputData:
-            error_message = "Output formatting mismatch for " + outputFn + ":\n"
+            error_message = "Output formatting mismatch for {}:\n".format(outputFn)
             error_message += "".join(difflib.context_diff(outputData.splitlines(True),
                                                           outs[0].splitlines(True),
                                                           fromfile=outputFn,
@@ -145,7 +145,7 @@ def bctest(testDir, testObj, buildenv):
     if "return_code" in testObj:
         wantRC = testObj['return_code']
     if proc.returncode != wantRC:
-        logging.error("Return code mismatch for " + outputFn)
+        logging.error("Return code mismatch for {}".format(outputFn))
         raise Exception
 
     if "error_txt" in testObj:
@@ -157,7 +157,8 @@ def bctest(testDir, testObj, buildenv):
         # linux through wine. Just assert that the expected error text appears
         # somewhere in stderr.
         if want_error not in outs[1]:
-            logging.error("Error mismatch:\n" + "Expected: " + want_error + "\nReceived: " + outs[1].rstrip())
+            recv_result = outs[1].rstrip()
+            logging.error("Error mismatch:\n" + "Expected: {}\nReceived: {}".format(want_error, recv_result))
             raise Exception
 
 def parse_output(a, fmt):
@@ -169,7 +170,7 @@ def parse_output(a, fmt):
     elif fmt == 'hex':  # hex: parse and compare binary data
         return binascii.a2b_hex(a.strip())
     else:
-        raise NotImplementedError("Don't know how to compare %s" % fmt)
+        raise NotImplementedError("Don't know how to compare {}".format(fmt))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Simple changes some of the python test related files. 
I converted from the old % format, ex:
"test %s" % "hello"
to the new str.format:
"test {}".format("hello")

This is more modern, as well as more consistent with the rest of the codebase (I have looked around and seen str.format used)
