### PR TITLE
refactor: Make mapBlocksUnknownParent local, and rename it

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -62,6 +62,7 @@
 #include <walletinitinterface.h>
 
 #include <functional>
+#include <map>
 #include <set>
 #include <stdint.h>
 #include <stdio.h>
@@ -693,6 +694,7 @@ static void ThreadImport(ChainstateManager& chainman, std::vector<fs::path> vImp
     // -reindex
     if (fReindex) {
         int nFile = 0;
+        std::multimap<uint256, FlatFilePos> blocks_with_unknown_parent;
         while (true) {
             FlatFilePos pos(nFile, 0);
             if (!fs::exists(GetBlockPosFilename(pos)))
@@ -701,7 +703,7 @@ static void ThreadImport(ChainstateManager& chainman, std::vector<fs::path> vImp
             if (!file)
                 break; // This error is logged in OpenBlockFile
             LogPrintf("Reindexing block file blk%05u.dat...\n", (unsigned int)nFile);
-            LoadExternalBlockFile(chainparams, file, &pos);
+            LoadExternalBlockFile(chainparams, file, &pos, &blocks_with_unknown_parent);
             if (ShutdownRequested()) {
                 LogPrintf("Shutdown requested. Exit %s\n", __func__);
                 return;

--- a/src/test/fuzz/load_external_block_file.cpp
+++ b/src/test/fuzz/load_external_block_file.cpp
@@ -11,6 +11,7 @@
 #include <validation.h>
 
 #include <cstdint>
+#include <map>
 #include <vector>
 
 void initialize()
@@ -26,6 +27,11 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     if (fuzzed_block_file == nullptr) {
         return;
     }
-    FlatFilePos flat_file_pos;
-    LoadExternalBlockFile(Params(), fuzzed_block_file, fuzzed_data_provider.ConsumeBool() ? &flat_file_pos : nullptr);
+    if (fuzzed_data_provider.ConsumeBool()) {
+        FlatFilePos flat_file_pos;
+        std::multimap<uint256, FlatFilePos> blocks_with_unknown_parent;
+        LoadExternalBlockFile(Params(), fuzzed_block_file, &flat_file_pos, &blocks_with_unknown_parent);
+    } else {
+        LoadExternalBlockFile(Params(), fuzzed_block_file);
+    }
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -157,7 +157,11 @@ FILE* OpenBlockFile(const FlatFilePos &pos, bool fReadOnly = false);
 /** Translation to a filesystem path */
 fs::path GetBlockPosFilename(const FlatFilePos &pos);
 /** Import blocks from an external file */
-void LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, FlatFilePos* dbp = nullptr);
+void LoadExternalBlockFile(
+    const CChainParams& chainparams,
+    FILE* fileIn,
+    FlatFilePos* dbp = nullptr,
+    std::multimap<uint256, FlatFilePos>* blocks_with_unknown_parent = nullptr);
 /** Ensures we have a genesis block in the block tree, possibly writing one to disk. */
 bool LoadGenesisBlock(const CChainParams& chainparams);
 /** Unload database information */


### PR DESCRIPTION
**LarryRuane**'s [comment](https://github.com/bitcoin/bitcoin/pull/16981#discussion_r337597803) in #16981:
> Does it bother anyone else that this is `static`? This is global state, which, in general, equals evil. It must be static, given that it's declared here, since its state must persist across calls to this function (very often, a block and its parent are in different `blk` files). We could eliminate this global state by allocating this map in the caller of this function, `src/init.cpp: ThreadImport()`, and passing it by reference to `LoadExternalBlockFile()`.
> 
> Another thing that seems missing from the current design is, what happens if there are leftover entries in this map after reindexing has completed? That means we've read blocks from disk but never found their parent blocks. In my testing, this map is empty at the end of reindexing, as expected. But what if it wasn't? That would mean we're missing one or more `blocks/blk00nnn.dat` files, or some blocks from those files. Isn't that worth at least a `LogPrintf()`? Making this change would also require moving the map out to the caller, because this function doesn't know if it will be called again.