### PR TITLE
Fix .gitignore for src/test/fuzz directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ src/bitcoin-gui
 src/bitcoin-node
 src/bitcoin-tx
 src/bitcoin-wallet
-src/test/fuzz
+src/test/fuzz/*
 !src/test/fuzz/*.*
 src/test/test_bitcoin
 src/qt/test/test_bitcoin-qt


### PR DESCRIPTION
On master (31d2b4098a9e4ee9a694ba1ad42829637cbcf3c6):
```
$ git ls-files --ignored --exclude-standard
contrib/init/org.bitcoin.bitcoind.plist
contrib/macdeploy/fancy.plist
src/qt/Makefile
src/qt/test/Makefile
src/test/Makefile
src/test/fuzz/FuzzedDataProvider.h
src/test/fuzz/addition_overflow.cpp
src/test/fuzz/addrdb.cpp
src/test/fuzz/asmap.cpp
src/test/fuzz/asmap_direct.cpp
src/test/fuzz/autofile.cpp
src/test/fuzz/banman.cpp
src/test/fuzz/base_encode_decode.cpp
src/test/fuzz/bech32.cpp
src/test/fuzz/block.cpp
src/test/fuzz/block_header.cpp
src/test/fuzz/blockfilter.cpp
src/test/fuzz/bloom_filter.cpp
src/test/fuzz/buffered_file.cpp
src/test/fuzz/chain.cpp
src/test/fuzz/checkqueue.cpp
src/test/fuzz/coins_view.cpp
src/test/fuzz/crypto.cpp
src/test/fuzz/crypto_aes256.cpp
src/test/fuzz/crypto_aes256cbc.cpp
src/test/fuzz/crypto_chacha20.cpp
src/test/fuzz/crypto_chacha20_poly1305_aead.cpp
src/test/fuzz/crypto_common.cpp
src/test/fuzz/crypto_hkdf_hmac_sha256_l32.cpp
src/test/fuzz/crypto_poly1305.cpp
src/test/fuzz/cuckoocache.cpp
src/test/fuzz/decode_tx.cpp
src/test/fuzz/descriptor_parse.cpp
src/test/fuzz/deserialize.cpp
src/test/fuzz/eval_script.cpp
src/test/fuzz/fee_rate.cpp
src/test/fuzz/fees.cpp
src/test/fuzz/flatfile.cpp
src/test/fuzz/float.cpp
src/test/fuzz/fuzz.cpp
src/test/fuzz/fuzz.h
src/test/fuzz/golomb_rice.cpp
src/test/fuzz/hex.cpp
src/test/fuzz/http_request.cpp
src/test/fuzz/integer.cpp
src/test/fuzz/key.cpp
src/test/fuzz/key_io.cpp
src/test/fuzz/kitchen_sink.cpp
src/test/fuzz/load_external_block_file.cpp
src/test/fuzz/locale.cpp
src/test/fuzz/merkleblock.cpp
src/test/fuzz/message.cpp
src/test/fuzz/multiplication_overflow.cpp
src/test/fuzz/net_permissions.cpp
src/test/fuzz/netaddress.cpp
src/test/fuzz/p2p_transport_deserializer.cpp
src/test/fuzz/parse_hd_keypath.cpp
src/test/fuzz/parse_iso8601.cpp
src/test/fuzz/parse_numbers.cpp
src/test/fuzz/parse_script.cpp
src/test/fuzz/parse_univalue.cpp
src/test/fuzz/policy_estimator.cpp
src/test/fuzz/policy_estimator_io.cpp
src/test/fuzz/pow.cpp
src/test/fuzz/prevector.cpp
src/test/fuzz/primitives_transaction.cpp
src/test/fuzz/process_message.cpp
src/test/fuzz/process_messages.cpp
src/test/fuzz/protocol.cpp
src/test/fuzz/psbt.cpp
src/test/fuzz/random.cpp
src/test/fuzz/rbf.cpp
src/test/fuzz/rolling_bloom_filter.cpp
src/test/fuzz/script.cpp
src/test/fuzz/script_bitcoin_consensus.cpp
src/test/fuzz/script_descriptor_cache.cpp
src/test/fuzz/script_flags.cpp
src/test/fuzz/script_interpreter.cpp
src/test/fuzz/script_ops.cpp
src/test/fuzz/script_sigcache.cpp
src/test/fuzz/script_sign.cpp
src/test/fuzz/scriptnum_ops.cpp
src/test/fuzz/signature_checker.cpp
src/test/fuzz/span.cpp
src/test/fuzz/spanparsing.cpp
src/test/fuzz/string.cpp
src/test/fuzz/strprintf.cpp
src/test/fuzz/system.cpp
src/test/fuzz/timedata.cpp
src/test/fuzz/transaction.cpp
src/test/fuzz/tx_in.cpp
src/test/fuzz/tx_out.cpp
src/test/fuzz/util.h
src/univalue/gen/gen.cpp
test/functional/data/wallets/high_minversion/db.log
test/functional/data/wallets/high_minversion/wallet.dat
```

With this PR:
```
$ git ls-files --ignored --exclude-standard
contrib/init/org.bitcoin.bitcoind.plist
contrib/macdeploy/fancy.plist
src/qt/Makefile
src/qt/test/Makefile
src/test/Makefile
src/univalue/gen/gen.cpp
test/functional/data/wallets/high_minversion/db.log
test/functional/data/wallets/high_minversion/wallet.dat
```