### PR TITLE
test: clean message_count and last_message

### DIFF
--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -283,9 +283,13 @@ class P2PInterface(P2PConnection):
     def __init__(self):
         super().__init__()
 
-        # Track number of messages of each type received and the most recent
-        # message of each type
+        # Track number of messages of each type received.
+        # Should be read-only in a test.
         self.message_count = defaultdict(int)
+
+        # Track the most recent message of each type.
+        # To wait for a message to be received, pop that message from
+        # this and use wait_until.
         self.last_message = {}
 
         # A count of the number of ping messages we've sent to the node
@@ -472,7 +476,7 @@ class P2PInterface(P2PConnection):
 
     def wait_for_verack(self, timeout=60):
         def test_function():
-            return self.message_count["verack"]
+            return "verack" in self.last_message
 
         self.wait_until(test_function, timeout=timeout)
 


### PR DESCRIPTION
From #19580 

This PR changes comments to clarify the intended usage of `message_count` and `last_message`.  Additionally it changes the only usage of `message_count` to use `last_message` instead, bringing the code into alignment with the intended usage.

Note: Now `message_count` is completely unused.  However, it is ready to be used (i.e. the supporting code works) and likely will be used in some test in the future.