### PR TITLE
doc: Fix log message for -reindex

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4786,7 +4786,7 @@ void LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, FlatFi
     } catch (const std::runtime_error& e) {
         AbortNode(std::string("System error: ") + e.what());
     }
-    LogPrintf("Loaded %i blocks from external file in %dms\n", nLoaded, GetTimeMillis() - nStart);
+    LogPrintf("Processed %s file. Loaded %i blocks in %dms\n", dbp ? "block" : "external", nLoaded, GetTimeMillis() - nStart);
 }
 
 void CChainState::CheckBlockIndex(const Consensus::Params& consensusParams)


### PR DESCRIPTION
During `-reindex` in the following log messages:
```
2020-07-27T15:33:17Z [loadblk] Reindexing block file blk02155.dat...
2020-07-27T15:33:19Z [loadblk] Loaded 0 blocks from external file in 1170ms
2020-07-27T15:33:19Z [loadblk] Reindexing block file blk02156.dat...
2020-07-27T15:33:20Z [loadblk] Loaded 0 blocks from external file in 1221ms
2020-07-27T15:33:20Z [loadblk] Reindexing block file blk02157.dat...
2020-07-27T15:33:27Z [loadblk] Loaded 609 blocks from external file in 7214ms
```

the latest one is clearly wrong as all of the "loaded 609 blocks" are not from the `blk02157.dat` file. Some of them belong to the previously processed `*.dat` files.

With this PR these messages will look like:
```
2020-07-27T15:33:20Z [loadblk] Reindexing block file blk02157.dat...
2020-07-27T15:33:27Z [loadblk] Processed block file. Loaded 609 blocks in 7214ms
```

This was done while reviewing #16981.