### PR TITLE
doc: set CC_FOR_BUILD when building on OpenBSD

### DIFF
--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,6 +1,6 @@
 OpenBSD build guide
 ======================
-(updated for OpenBSD 6.4)
+(updated for OpenBSD 6.7)
 
 This guide describes how to build bitcoind and command-line utilities on OpenBSD.
 
@@ -15,7 +15,7 @@ Run the following as root to install the base dependencies for building:
 pkg_add git gmake libevent libtool boost
 pkg_add autoconf # (select highest version, e.g. 2.69)
 pkg_add automake # (select highest version, e.g. 1.16)
-pkg_add python # (select highest version, e.g. 3.6)
+pkg_add python # (select highest version, e.g. 3.8)
 
 git clone https://github.com/bitcoin/bitcoin.git
 ```
@@ -23,10 +23,10 @@ git clone https://github.com/bitcoin/bitcoin.git
 See [dependencies.md](dependencies.md) for a complete overview.
 
 **Important**: From OpenBSD 6.2 onwards a C++11-supporting clang compiler is
-part of the base image, and while building it is necessary to make sure that this
-compiler is used and not ancient g++ 4.2.1. This is done by appending
-`CC=cc CXX=c++` to configuration commands. Mixing different compilers
-within the same executable will result in linker errors.
+part of the base image, and while building it is necessary to make sure that
+this compiler is used and not ancient g++ 4.2.1. This is done by appending
+`CC=cc CC_FOR_BUILD=cc CXX=c++` to configuration commands. Mixing different
+compilers within the same executable will result in errors.
 
 ### Building BerkeleyDB
 
@@ -77,7 +77,7 @@ To configure with wallet:
 
 To configure without wallet:
 ```bash
-./configure --disable-wallet --with-gui=no CC=cc CXX=c++ MAKE=gmake
+./configure --disable-wallet --with-gui=no CC=cc CC_FOR_BUILD=cc CXX=c++ MAKE=gmake
 ```
 
 Build and run the tests:


### PR DESCRIPTION
Closes: #19559

While #19559 has been fixed upstream, it makes sense to not only
recommend using `CC_FOR_BUILD`here  until the fix is pulled in as
part of our next libsecp update, but after discussing with Cory,
he suggested we should be setting this on OpenBSD (which still has
the an ancient GCC) regardless.