### PR TITLE
p2p: change `CInv::type` from `int` to `uint32_t`, fix UBSan warning

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2972,7 +2972,6 @@ void ProcessMessage(
                 }
             }
             if (!fRejectedParents) {
-                uint32_t nFetchFlags = GetFetchFlags(pfrom);
                 const auto current_time = GetTime<std::chrono::microseconds>();
 
                 for (const CTxIn& txin : tx.vin) {
@@ -2981,7 +2980,7 @@ void ProcessMessage(
                     // wtxidrelay peers.
                     // Eventually we should replace this with an improved
                     // protocol for getting all unconfirmed parents.
-                    CInv _inv(MSG_TX | nFetchFlags, txin.prevout.hash);
+                    CInv _inv(MSG_TX, txin.prevout.hash);
                     pfrom.AddKnownTx(txin.prevout.hash);
                     if (!AlreadyHave(_inv, mempool)) RequestTx(State(pfrom.GetId()), ToGenTxid(_inv), current_time);
                 }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2647,7 +2647,7 @@ void ProcessMessage(
             LogPrint(BCLog::NET, "got inv: %s  %s peer=%d\n", inv.ToString(), fAlreadyHave ? "have" : "new", pfrom.GetId());
 
             if (inv.IsMsgTx()) {
-                inv.type |= nFetchFlags;
+                inv.SetTypeBitwiseOr(nFetchFlags);
             }
 
             if (inv.IsMsgBlk()) {
@@ -2802,10 +2802,9 @@ void ProcessMessage(
             // expensive disk reads, because it will require the peer to
             // actually receive all the data read from disk over the network.
             LogPrint(BCLog::NET, "Peer %d sent us a getblocktxn for a block > %i deep\n", pfrom.GetId(), MAX_BLOCKTXN_DEPTH);
-            CInv inv;
-            inv.type = State(pfrom.GetId())->fWantsCmpctWitness ? MSG_WITNESS_BLOCK : MSG_BLOCK;
-            inv.hash = req.blockhash;
-            pfrom.vRecvGetData.push_back(inv);
+
+            uint32_t inv_type{State(pfrom.GetId())->fWantsCmpctWitness ? MSG_WITNESS_BLOCK : MSG_BLOCK};
+            pfrom.vRecvGetData.emplace_back(inv_type, req.blockhash);
             // The message processing loop will go around again (without pausing) and we'll respond then (without cs_main)
             return;
         }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2625,14 +2625,12 @@ void ProcessMessage(
 
         LOCK(cs_main);
 
-        uint32_t nFetchFlags = GetFetchFlags(pfrom);
         const auto current_time = GetTime<std::chrono::microseconds>();
         uint256* best_block{nullptr};
 
         for (CInv &inv : vInv)
         {
-            if (interruptMsgProc)
-                return;
+            if (interruptMsgProc) return;
 
             // Ignore INVs that don't match wtxidrelay setting.
             // Note that orphan parent fetching always uses MSG_TX GETDATAs regardless of the wtxidrelay setting.
@@ -2645,10 +2643,6 @@ void ProcessMessage(
 
             bool fAlreadyHave = AlreadyHave(inv, mempool);
             LogPrint(BCLog::NET, "got inv: %s  %s peer=%d\n", inv.ToString(), fAlreadyHave ? "have" : "new", pfrom.GetId());
-
-            if (inv.IsMsgTx()) {
-                inv.SetTypeBitwiseOr(nFetchFlags);
-            }
 
             if (inv.IsMsgBlk()) {
                 UpdateBlockAvailability(pfrom.GetId(), inv.hash);

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -163,7 +163,7 @@ CInv::CInv()
     hash.SetNull();
 }
 
-CInv::CInv(int typeIn, const uint256& hashIn) : type(typeIn), hash(hashIn) {}
+CInv::CInv(uint32_t typeIn, const uint256& hashIn) : type(typeIn), hash(hashIn) {}
 
 bool operator<(const CInv& a, const CInv& b)
 {

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -400,6 +400,8 @@ enum GetDataMsg : uint32_t {
 /** inv message data */
 class CInv
 {
+private:
+    uint32_t type;
 public:
     CInv();
     CInv(uint32_t typeIn, const uint256& hashIn);
@@ -427,8 +429,8 @@ public:
     bool IsMsgBlkOrMsgWitnessBlk() const { return type == MSG_BLOCK || type == MSG_WITNESS_BLOCK; }
     bool IsGenBlkMsg() const { return type == MSG_BLOCK || type == MSG_FILTERED_BLOCK || type == MSG_CMPCT_BLOCK || type == MSG_WITNESS_BLOCK; }
 
-    uint32_t type;
     uint256 hash;
+    void SetTypeBitwiseOr(uint32_t flags) { type |= flags; }
 };
 
 /** Convert a TX/WITNESS_TX/WTX CInv to a GenTxid. */

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -247,7 +247,7 @@ extern const char* CFCHECKPT;
  * txid.
  * @since protocol version 70016 as described by BIP 339.
  */
-extern const char *WTXIDRELAY;
+extern const char* WTXIDRELAY;
 }; // namespace NetMsgType
 
 /* Get a vector of all valid message types (see above) */
@@ -402,7 +402,7 @@ class CInv
 {
 public:
     CInv();
-    CInv(int typeIn, const uint256& hashIn);
+    CInv(uint32_t typeIn, const uint256& hashIn);
 
     SERIALIZE_METHODS(CInv, obj) { READWRITE(obj.type, obj.hash); }
 
@@ -427,7 +427,7 @@ public:
     bool IsMsgBlkOrMsgWitnessBlk() const { return type == MSG_BLOCK || type == MSG_WITNESS_BLOCK; }
     bool IsGenBlkMsg() const { return type == MSG_BLOCK || type == MSG_FILTERED_BLOCK || type == MSG_CMPCT_BLOCK || type == MSG_WITNESS_BLOCK; }
 
-    int type;
+    uint32_t type;
     uint256 hash;
 };
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -430,7 +430,6 @@ public:
     bool IsGenBlkMsg() const { return type == MSG_BLOCK || type == MSG_FILTERED_BLOCK || type == MSG_CMPCT_BLOCK || type == MSG_WITNESS_BLOCK; }
 
     uint256 hash;
-    void SetTypeBitwiseOr(uint32_t flags) { type |= flags; }
 };
 
 /** Convert a TX/WITNESS_TX/WTX CInv to a GenTxid. */

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -412,12 +412,20 @@ public:
     std::string ToString() const;
 
     // Single-message helper methods
-    bool IsMsgTx()        const { return type == MSG_TX; }
-    bool IsMsgWtx()       const { return type == MSG_WTX; }
+    bool IsUndefined() const { return type == UNDEFINED; }
+    bool IsMsgTx() const { return type == MSG_TX; }
+    bool IsMsgBlk() const { return type == MSG_BLOCK; }
+    bool IsMsgWtx() const { return type == MSG_WTX; }
+    bool IsMsgFilteredBlk() const { return type == MSG_FILTERED_BLOCK; }
+    bool IsMsgCmpctBlk() const { return type == MSG_CMPCT_BLOCK; }
+    bool IsMsgWitnessBlk() const { return type == MSG_WITNESS_BLOCK; }
     bool IsMsgWitnessTx() const { return type == MSG_WITNESS_TX; }
+    bool IsMsgFilteredWitnessBlk() const { return type == MSG_FILTERED_WITNESS_BLOCK; }
 
     // Combined-message helper methods
-    bool IsGenTxMsg()     const { return type == MSG_TX || type == MSG_WTX || type == MSG_WITNESS_TX; }
+    bool IsGenTxMsg() const { return type == MSG_TX || type == MSG_WTX || type == MSG_WITNESS_TX; }
+    bool IsMsgBlkOrMsgWitnessBlk() const { return type == MSG_BLOCK || type == MSG_WITNESS_BLOCK; }
+    bool IsGenBlkMsg() const { return type == MSG_BLOCK || type == MSG_FILTERED_BLOCK || type == MSG_CMPCT_BLOCK || type == MSG_WITNESS_BLOCK; }
 
     int type;
     uint256 hash;


### PR DESCRIPTION
Credit to Crypt-iQ for finding and reporting the UBSan implicit-integer-sign-change issue and to vasild for the original review suggestion in https://github.com/bitcoin/bitcoin/pull/19590#pullrequestreview-455788826.

Closes #19678.