### PR TITLE
[0.20] lint: fix shellcheck URL in CI install

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -11,5 +11,5 @@ travis_retry pip3 install flake8==3.7.8
 travis_retry pip3 install yq
 
 SHELLCHECK_VERSION=v0.6.0
-curl -s "https://storage.googleapis.com/shellcheck/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar --xz -xf - --directory /tmp/
+curl -sL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar --xz -xf - --directory /tmp/
 export PATH="/tmp/shellcheck-${SHELLCHECK_VERSION}:${PATH}"


### PR DESCRIPTION
This is causing the tests to fail for backports i.e #19606. If you look in the Travis logs there, the output is:
```bash
You are downloading ShellCheck from an outdated URL!
Please update to the new URL:
https://github.com/koalaman/shellcheck/releases/download/v0.6.0/shellcheck-v0.6.0.linux.x86_64.tar.xz
For more information, see:
https://github.com/koalaman/shellcheck/issues/1871
PS: Sorry for breaking your build. The hosting costs were getting out of hand :(
```