### PR TITLE
util: use HAVE_FDATASYNC to determine fdatasync() use

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1021,7 +1021,7 @@ bool FileCommit(FILE *file)
         return false;
     }
 #else
-    #if defined(__linux__) || defined(__NetBSD__)
+    #if defined(HAVE_FDATASYNC)
     if (fdatasync(fileno(file)) != 0 && errno != EINVAL) { // Ignore EINVAL for filesystems that don't support sync
         LogPrintf("%s: fdatasync failed: %d\n", __func__, errno);
         return false;


### PR DESCRIPTION
Rather than just using on Linux and NetBSD, use `fdatasync()` based
on whether it's available. i.e `fdatasync` is available in newer versions of FreeBSD.

This also aligns more closely with what is being done in leveldb.

Was pointed out by Luke in #19430.
