### PR TITLE
doc: Clang 8 or later is required with FORCE_USE_SYSTEM_CLANG

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -110,9 +110,9 @@ The following can be set when running make: `make FOO=bar`
 <dt>BUILD_ID_SALT</dt>
 <dd>Optional salt to use when generating build package ids</dd>
 <dt>FORCE_USE_SYSTEM_CLANG</dt>
-<dd>(EXPERTS ONLY) When cross-compiling for macOS, use clang found in the
-system's <code>$PATH</code> rather than the default prebuilt release of clang
-from llvm.org</dd>
+<dd>(EXPERTS ONLY) When cross-compiling for macOS, use Clang found in the
+system's <code>$PATH</code> rather than the default prebuilt release of Clang
+from llvm.org. Clang 8 or later is required.</dd>
 </dl>
 
 If some packages are not built, for example `make NO_WALLET=1`, the appropriate


### PR DESCRIPTION
The usage of pragmas within the macOS SDK requires LLVM Clang 8. This is
the same version as our prebuilt Clang, however the minimum is worth noting 
here as they may diverge and/or expert users might expect they could use an
earlier version.

If you compile depends using `FORCE_USE_SYSTEM_CLANG=1` and Clang 7 you'll see output like:
```bash
In file included from kernel/qcore_mac_objc.mm:44:
In file included from /bitcoin/depends/SDKs/Xcode-11.3.1-11C505-extracted-SDK-with-libcxx-headers/System/Library/Frameworks/AppKit.framework/Headers/NSText.h:9:
In file included from /bitcoin/depends/SDKs/Xcode-11.3.1-11C505-extracted-SDK-with-libcxx-headers/System/Library/Frameworks/AppKit.framework/Headers/NSView.h:19:
In file included from /bitcoin/depends/SDKs/Xcode-11.3.1-11C505-extracted-SDK-with-libcxx-headers/System/Library/Frameworks/AppKit.framework/Headers/NSResponder.h:10:
/bitcoin/depends/SDKs/Xcode-11.3.1-11C505-extracted-SDK-with-libcxx-headers/System/Library/Frameworks/AppKit.framework/Headers/NSEvent.h:19:1: error:
      expected 'push' or 'pop' after '#pragma clang attribute'
/bitcoin/depends/SDKs/Xcode-11.3.1-11C505-extracted-SDK-with-libcxx-headers/usr/include/os/availability.h:104:273: note: expanded from macro
      'API_UNAVAILABLE_BEGIN'
  ...__API_UNAVAILABLE_BEGIN5, __API_UNAVAILABLE_BEGIN4, __API_UNAVAILABLE_BEGIN3, __API_UNAVAILABLE_BEGIN2, __API_UNAVAILABLE_BEGIN1, 0)(__VA_A...
                                                                                                             ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
```

I've got a [godbolt here](https://godbolt.org/z/j6r987) that contains a demo of the issue (based off the macOS SDK). It will compile with Clang 8 but not with Clang 7.