### PR TITLE
[RFC] Package-relay:  sender-initiated

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -172,6 +172,7 @@ BITCOIN_CORE_H = \
   noui.h \
   optional.h \
   outputtype.h \
+  packagecache.h\
   policy/feerate.h \
   policy/fees.h \
   policy/policy.h \
@@ -307,6 +308,7 @@ libbitcoin_server_a_SOURCES = \
   node/transaction.cpp \
   node/ui_interface.cpp \
   noui.cpp \
+  packagecache.cpp\
   policy/fees.cpp \
   policy/rbf.cpp \
   policy/settings.cpp \

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2511,6 +2511,10 @@ void ProcessMessage(
             connman.PushMessage(&pfrom, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::WTXIDRELAY));
         }
 
+        if (nVersion >= PACKAGE_RELAY_VERSION) {
+            connman.PushMessage(&pfrom, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::SENDPACKAGE));
+        }
+
         connman.PushMessage(&pfrom, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::VERACK));
 
         pfrom.nServices = nServices;
@@ -2662,6 +2666,14 @@ void ProcessMessage(
                 State(pfrom.GetId())->m_wtxid_relay = true;
                 g_wtxid_relay_peers++;
             }
+        }
+        return;
+    }
+
+    if (msg_type == NetMsgType::SENDPACKAGE) {
+        if (pfrom.nVersion >= PACKAGE_RELAY_VERSION) {
+            LOCK(cs_main);
+            State(pfrom.GetId())->m_packagerelay = true;
         }
         return;
     }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -427,6 +427,9 @@ struct CNodeState {
     //! Whether this peer relays txs via wtxid
     bool m_wtxid_relay{false};
 
+    //! Whether this peer supports package relay
+    bool m_packagerelay;
+
     CNodeState(CAddress addrIn, std::string addrNameIn, bool is_inbound, bool is_manual) :
         address(addrIn), name(std::move(addrNameIn)), m_is_inbound(is_inbound),
         m_is_manual_connection (is_manual)
@@ -455,6 +458,7 @@ struct CNodeState {
         m_chain_sync = { 0, nullptr, false, false };
         m_last_block_announcement = 0;
         m_recently_announced_invs.reset();
+        m_packagerelay = false;
     }
 };
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1435,6 +1435,7 @@ bool static AlreadyHave(const CInv& inv, const CTxMemPool& mempool) EXCLUSIVE_LO
     case MSG_TX:
     case MSG_WITNESS_TX:
     case MSG_WTX:
+    case MSG_PACKAGE:
         {
             assert(recentRejects);
             if (::ChainActive().Tip()->GetBlockHash() != hashRecentRejectsChainTip)
@@ -1723,7 +1724,7 @@ void static ProcessGetData(CNode& pfrom, const CChainParams& chainparams, CConnm
     // Process as many TX items from the front of the getdata queue as
     // possible, since they're common and it's efficient to batch process
     // them.
-    while (it != pfrom.vRecvGetData.end() && (it->type == MSG_TX || it->type == MSG_WITNESS_TX || it->type == MSG_WTX)) {
+    while (it != pfrom.vRecvGetData.end() && (it->type == MSG_TX || it->type == MSG_WITNESS_TX || it->type == MSG_WTX || it->type == MSG_PACKAGE)) {
         if (interruptMsgProc) return;
         // The send buffer provides backpressure. If there's no space in
         // the buffer, pause processing until the next call.

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -102,4 +102,7 @@ bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats);
 /** Relay transaction to every node */
 void RelayTransaction(const uint256& txid, const uint256& wtxid, const CConnman& connman) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+/** Schedule package relay globally */
+void RelayPackage(uint64_t downstream_peer, const std::list<CTransactionRef>& package);
+
 #endif // BITCOIN_NET_PROCESSING_H

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -10,6 +10,8 @@
 #include <primitives/transaction.h>
 #include <util/error.h>
 
+#include <list>
+
 struct NodeContext;
 
 /** Maximum fee rate for sendrawtransaction and testmempoolaccept RPC calls.
@@ -37,5 +39,23 @@ static const CFeeRate DEFAULT_MAX_RAW_TX_FEE_RATE{COIN / 10};
  * return error
  */
 NODISCARD TransactionError BroadcastTransaction(NodeContext& node, CTransactionRef tx, std::string& err_string, const CAmount& max_tx_fee, bool relay, bool wait_callback);
+
+/**
+ * Submit a package to the mempool and (optionally) relay it to all P2P peers.
+ *
+ * Mempool submission can be synchronous (will await mempool entry notification
+ * over the CValidationInterface) or asynchronous (will submit and not wait for
+ * notification), depending on the value of wait_callback. wait_callback MUST
+ * NOT be set while cs_main, cs_mempool or cs_wallet are held to avoid
+ * deadlock.
+ *
+ * @param[in]  node reference to node context
+ * @param[in]  package the packaged transaction to broadcast
+ * @param[out] err_string reference to std::string to fill with error string if available
+ * @param[in]  relay flag if both mempool insertion and p2p relay are requested
+ * @param[in]  wait_callback wait until callbacks have been processed to avoid stale result due to a sequentially RPC.
+ * return error
+ */
+NODISCARD TransactionError BroadcastPackage(NodeContext& node, std::list<CTransactionRef>& package, std::string& err_string, bool relay, bool wait_callback);
 
 #endif // BITCOIN_NODE_TRANSACTION_H

--- a/src/packagecache.cpp
+++ b/src/packagecache.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <packagecache.h>
+
+/** Maximum number of package per peer */
+static constexpr int32_t MAX_PEER_PACKAGE = 1000;
+/** How many microseconds to keep this package entry available for announcing/fetching. */
+static constexpr std::chrono::microseconds PACKAGE_CACHE_DELAY{std::chrono::seconds{60}};
+
+PackageCache::PackageCache() :
+    m_cache(boost::make_tuple(
+        boost::make_tuple(
+            boost::multi_index::const_mem_fun<Package, PackageTime, &Package::ExtractTime>(),
+            std::less<PackageTime>()
+        ),
+        boost::make_tuple(
+            boost::multi_index::const_mem_fun<Package, PackageId, &Package::ExtractId>(),
+            std::less<PackageId>()
+        )
+    )) {}
+
+size_t PackageCache::CountPackage(uint64_t upstream_peer) const
+{
+    auto it = m_peerinfo.find(upstream_peer);
+    if (it != m_peerinfo.end()) return it->second.m_total;
+    return 0;
+}
+
+void PackageCache::FlushOldPackages(std::chrono::microseconds timeout)
+{
+    while (!m_cache.empty()) {
+        auto it = m_cache.get<ByTime>().begin();
+        if (it->m_time <= timeout) {
+            Erase<ByTime>(it);
+        } else {
+            break;
+        }
+    }
+}
+
+void PackageCache::ReceivedPackage(uint64_t upstream_peer, const uint256& package_id, std:: vector<uint256> package_wtxids, std::chrono::microseconds recvtime)
+{
+    if (CountPackage(upstream_peer) >= MAX_PEER_PACKAGE) return;
+
+    // If we already know about this package ignore it.
+    auto it = m_cache.get<ById>().find(PackageId{package_id});
+    if (it != m_cache.get<ById>().end()) return;
+
+    auto ret = m_cache.get<ById>().emplace(package_id, package_wtxids, upstream_peer, recvtime + PACKAGE_CACHE_DELAY);
+    if (ret.second) {
+        ++m_peerinfo[upstream_peer].m_total;
+        for (const uint256& wtxid: package_wtxids) {
+            auto it = m_associated_pkgs.find(wtxid);
+            if (it != m_associated_pkgs.end()) {
+                it->second.emplace(package_id);
+            }
+        }
+    }
+}
+
+static const uint256 UINT256_ZERO;
+
+void PackageCache::GetAnnouncable(uint64_t downstream_peer, std::vector<uint256>& package_ids)
+{
+    auto it = m_cache.get<ById>().lower_bound(PackageId{UINT256_ZERO});
+    while (it != m_cache.get<ById>().end()) {
+        // If this downstream peer hasn't heard about it, mark it for announcement.
+        if (it->m_already_announced.count(downstream_peer) == 0) {
+            package_ids.push_back(it->m_package_id);
+            it->m_already_announced.emplace(downstream_peer);
+        }
+        it++;
+    }
+}
+
+void PackageCache::GetPackageWtxids(uint64_t downstream_peer, const uint256& package_id, std::vector<uint256>& package_wtxids)
+{
+    auto it = m_cache.get<ById>().find(PackageId{package_id});
+    if (it != m_cache.get<ById>().end()) {
+        // If downstream peer hasn't be announced package id don't yet walk away
+        if (it->m_already_announced.count(downstream_peer) == 0) return;
+        package_wtxids = it->package_wtxids;
+    }
+}
+
+bool PackageCache::HasPackage(uint256& wtxid) {
+    return m_associated_pkgs.count(wtxid) == 1;
+}
+
+void PackageCache::AddPackageKnown(uint64_t upstream_peer, uint256 package_id) {
+    auto it = m_cache.get<ById>().find(PackageId{package_id});
+    if (it != m_cache.get<ById>().end()) {
+        it->m_already_announced.emplace(upstream_peer);
+    }
+}

--- a/src/packagecache.h
+++ b/src/packagecache.h
@@ -1,0 +1,137 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_PACKAGE_H
+#define BITCOIN_PACKAGE_H
+
+#include <uint256.h>
+
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/mem_fun.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+
+#include <chrono>
+#include <map>
+#include <set>
+#include <unordered_map>
+#include <vector>
+
+#include <stdint.h>
+
+/** Data structure to keep cache and schedule package announcement from/to peers.
+ *
+ * Maintain a cache of package_id -> set of wtxids. As we cache data at the request
+ * of untrusted peers we have to bound them (MAX_PEER_PACKAGE) to avoid risk of memory
+ * DoS. We also expire package entry after PACKAGE_CACHE_DELAY to flush the cache and
+ * avoid any late-stucking entry, which means package round-trip should have been achieved
+ * with ever downstream peers before.
+ *
+ * XXX: round-robin announcements to avoid upstream peers overflowing our
+ * downstream package bandwidth ?
+ */
+class PackageCache {
+
+    //! Tag for the PackageTime-based index.
+    struct ByTime {};
+    //! Tag for the PackageId-based index.
+    struct ById {};
+
+    //! The ByTime index is sorted by (recvtime, id).
+    using PackageTime = std::tuple<std::chrono::microseconds, const uint256&>;
+
+    //! The ById index is sorted by id.
+    using PackageId = const uint256;
+
+    //! A package entry
+    struct Package {
+        //! Package id that was received.
+        const uint256 m_package_id;
+        //! List of wtxids included in this package.
+        const std::vector<uint256> package_wtxids;
+        //! What upstream peer sends this package.
+        const uint64_t m_peer;
+        //! When this package should be pruned for expiration.
+        mutable std::chrono::microseconds m_time;
+        //! List of downstream peers already announced to.
+        mutable std::set<uint64_t> m_already_announced;
+
+        //! Construct a new entry from scratch.
+        Package(const uint256& package_id, std::vector<uint256> wtxids, uint64_t peer, std::chrono::microseconds exptime) :
+            m_package_id(package_id), package_wtxids(wtxids), m_peer(peer), m_time(exptime) {}
+
+        //! Extract the PackageTime from this Package.
+        PackageTime ExtractTime() const { return PackageTime{m_time, m_package_id}; }
+
+        //! Extract the PackageId from this Package.
+        PackageId ExtractId() const { return PackageId{m_package_id}; }
+    };
+
+    //! Data type for the main data structure
+    using Cache = boost::multi_index_container<
+        Package,
+        boost::multi_index::indexed_by<
+            boost::multi_index::ordered_unique<
+                boost::multi_index::tag<ByTime>,
+                boost::multi_index::const_mem_fun<Package, PackageTime, &Package::ExtractTime>
+            >,
+            boost::multi_index::ordered_unique<
+                boost::multi_index::tag<ById>,
+                boost::multi_index::const_mem_fun<Package, PackageId, &Package::ExtractId>
+            >
+        >
+    >;
+
+    Cache m_cache;
+
+    //! Per-peer statistics object.
+    struct PeerInfo {
+        size_t m_total = 0; //!< Total number of entries for this peer
+    };
+
+    std::unordered_map<uint64_t, PeerInfo> m_peerinfo;
+
+    //! Wrapper around Index::...::erase that keeps m_peerinfo and m_associated_pkgs up to date.
+    template<typename Tag>
+    typename Cache::index<Tag>::type::iterator Erase(typename Cache::index<Tag>::type::iterator it)
+    {
+        auto peerit = m_peerinfo.find(it->m_peer);
+        if (--peerit->second.m_total == 0) m_peerinfo.erase(peerit);
+        for (const uint256& wtxid : it->package_wtxids) {
+            auto pkgit = m_associated_pkgs.find(wtxid);
+            pkgit->second.erase(it->m_package_id);
+        }
+        return m_cache.get<Tag>().erase(it);
+    }
+
+    //! Count how many packages are being cached for a peer.
+    size_t CountPackage(uint64_t downstream_peer) const;
+
+    //! Delete entry older than timeout.
+    void FlushOldPackages(std::chrono::microseconds timeout);
+
+    //! Per-wtxid associated packages.
+    std::map<uint256, std::set<uint256>> m_associated_pkgs;
+
+public:
+    //! Construct a PackageCache.
+    PackageCache();
+
+    //! We received a new package, enter it.
+    void ReceivedPackage(uint64_t upstream_peer, const uint256& package_id, std::vector<uint256> package_wtxids, std::chrono::microseconds recvtime);
+
+    //! Select package ids not already announced to this downstream peer.
+    void GetAnnouncable(uint64_t downstream_peer, std::vector<uint256>& package_ids);
+
+    //! Get wtxids included inside a known package id.
+    void GetPackageWtxids(uint64_t downstream_peer, const uint256& package_id, std::vector<uint256>& package_wtxids);
+
+    //! Check if we know a package associated to this txid.
+    bool HasPackage(uint256& wtxid);
+
+    //! Add package known by this peer.
+    void AddPackageKnown(uint64_t upstream_peer, uint256 package_id);
+};
+
+#endif // BITCOIN_PACKAGE_H

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -47,6 +47,7 @@ const char *CFHEADERS="cfheaders";
 const char *GETCFCHECKPT="getcfcheckpt";
 const char *CFCHECKPT="cfcheckpt";
 const char *WTXIDRELAY="wtxidrelay";
+const char *PACKAGE="package";
 } // namespace NetMsgType
 
 /** All known message types. Keep this in the same order as the list of
@@ -85,6 +86,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::GETCFCHECKPT,
     NetMsgType::CFCHECKPT,
     NetMsgType::WTXIDRELAY,
+    NetMsgType::PACKAGE,
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes+ARRAYLEN(allNetMessageTypes));
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -184,6 +184,7 @@ std::string CInv::GetCommand() const
     // WTX is not a message type, just an inv type
     case MSG_WTX:            return cmd.append("wtx");
     case MSG_BLOCK:          return cmd.append(NetMsgType::BLOCK);
+    case MSG_PACKAGE:        return cmd.append(NetMsgType::PACKAGE);
     case MSG_FILTERED_BLOCK: return cmd.append(NetMsgType::MERKLEBLOCK);
     case MSG_CMPCT_BLOCK:    return cmd.append(NetMsgType::CMPCTBLOCK);
     default:

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -48,6 +48,7 @@ const char *GETCFCHECKPT="getcfcheckpt";
 const char *CFCHECKPT="cfcheckpt";
 const char *WTXIDRELAY="wtxidrelay";
 const char *PACKAGE="package";
+const char *SENDPACKAGE="sendpackage";
 } // namespace NetMsgType
 
 /** All known message types. Keep this in the same order as the list of
@@ -87,6 +88,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::CFCHECKPT,
     NetMsgType::WTXIDRELAY,
     NetMsgType::PACKAGE,
+    NetMsgType::SENDPACKAGE,
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes+ARRAYLEN(allNetMessageTypes));
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -418,6 +418,7 @@ enum GetDataMsg : uint32_t {
     MSG_BLOCK = 2,
     MSG_WTX = 5,                                      //!< Defined in BIP 339
     // The following can only occur in getdata. Invs always use TX/WTX or BLOCK.
+    MSG_PACKAGE = 6,                                  //!< Defined in XXX
     MSG_FILTERED_BLOCK = 3,                           //!< Defined in BIP37
     MSG_CMPCT_BLOCK = 4,                              //!< Defined in BIP152
     MSG_WITNESS_BLOCK = MSG_BLOCK | MSG_WITNESS_FLAG, //!< Defined in BIP144

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -11,10 +11,12 @@
 #define BITCOIN_PROTOCOL_H
 
 #include <netaddress.h>
+#include <primitives/transaction.h>
 #include <serialize.h>
 #include <uint256.h>
 #include <version.h>
 
+#include <list>
 #include <stdint.h>
 #include <string>
 
@@ -226,6 +228,13 @@ extern const char* GETBLOCKTXN;
  */
 extern const char* BLOCKTXN;
 /**
+ * The package message transmits a group of transactions with
+ * interdependencies for which the aggregated feerate should be
+ * equal or over to recipient's announced feerate.
+ * @since protocol 80002 as described by BIP XXX
+ */
+extern const char* PACKAGE;
+/**
  * getcfilters requests compact filters for a range of blocks.
  * Only available with service bit NODE_COMPACT_FILTERS as described by
  * BIP 157 & 158.
@@ -432,6 +441,18 @@ public:
 
     int type;
     uint256 hash;
+};
+
+class CPackageRelay
+{
+public:
+    std::vector<CTransactionRef> package_txn;
+
+    CPackageRelay() {}
+    explicit CPackageRelay(const std::vector<CTransactionRef> txn) :
+        package_txn(txn) {}
+
+    SERIALIZE_METHODS(CPackageRelay, obj) { READWRITE(Using<VectorFormatter<DefaultFormatter>>(obj.package_txn)); }
 };
 
 #endif // BITCOIN_PROTOCOL_H

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -276,6 +276,11 @@ extern const char* CFCHECKPT;
  * @since protocol version 70016 as described by BIP 339.
  */
 extern const char *WTXIDRELAY;
+/**
+ * Indicates that a node support package-relay
+ * @since protocol 80002 as described by BIP XXX
+ */
+extern const char* SENDPACKAGE;
 }; // namespace NetMsgType
 
 /* Get a vector of all valid message types (see above) */

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -99,6 +99,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "signrawtransactionwithkey", 2, "prevtxs" },
     { "signrawtransactionwithwallet", 1, "prevtxs" },
     { "sendrawtransaction", 1, "maxfeerate" },
+    { "sendpackage", 1, "rawtxs" },
     { "testmempoolaccept", 0, "rawtxs" },
     { "testmempoolaccept", 1, "maxfeerate" },
     { "combinerawtransaction", 0, "txs" },

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -904,6 +904,12 @@ bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
     // conflict with the underlying cache, and it cannot have pruned entries (as it contains full)
     // transactions. First checking the underlying cache risks returning a pruned entry instead.
     CTransactionRef ptx = mempool.get(outpoint.hash);
+    if (!ptx) {
+        // If a coin is missing from the mempool, check to see if it's part of
+        // a candidate package
+        auto it = package_tx.find(outpoint.hash);
+        if (it != package_tx.end()) ptx = it->second;
+    }
     if (ptx) {
         if (outpoint.n < ptx->vout.size()) {
             coin = Coin(ptx->vout[outpoint.n], MEMPOOL_HEIGHT, false);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -862,8 +862,12 @@ public:
  */
 class CCoinsViewMemPool : public CCoinsViewBacked
 {
+public:
+    void AddPotentialTransaction(const CTransactionRef& ptx) { package_tx.emplace(ptx->GetHash(), ptx); }
+
 protected:
     const CTxMemPool& mempool;
+    std::map<uint256, const CTransactionRef> package_tx;
 
 public:
     CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -257,10 +257,9 @@ bool TestLockPointValidity(const LockPoints* lp)
     return true;
 }
 
-bool CheckSequenceLocks(const CTxMemPool& pool, const CTransaction& tx, int flags, LockPoints* lp, bool useExistingLockPoints)
+static bool CheckSequenceLocks(CCoinsViewCache &view, const CTransaction& tx, int flags, LockPoints* lp, bool useExistingLockPoints=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
-    AssertLockHeld(pool.cs);
 
     CBlockIndex* tip = ::ChainActive().Tip();
     assert(tip != nullptr);
@@ -282,14 +281,12 @@ bool CheckSequenceLocks(const CTxMemPool& pool, const CTransaction& tx, int flag
         lockPair.second = lp->time;
     }
     else {
-        // CoinsTip() contains the UTXO set for ::ChainActive().Tip()
-        CCoinsViewMemPool viewMemPool(&::ChainstateActive().CoinsTip(), pool);
         std::vector<int> prevheights;
         prevheights.resize(tx.vin.size());
         for (size_t txinIndex = 0; txinIndex < tx.vin.size(); txinIndex++) {
             const CTxIn& txin = tx.vin[txinIndex];
             Coin coin;
-            if (!viewMemPool.GetCoin(txin.prevout, coin)) {
+            if (!view.GetCoin(txin.prevout, coin)) {
                 return error("%s: Missing input", __func__);
             }
             if (coin.nHeight == MEMPOOL_HEIGHT) {
@@ -327,6 +324,14 @@ bool CheckSequenceLocks(const CTxMemPool& pool, const CTransaction& tx, int flag
         }
     }
     return EvaluateSequenceLocks(index, lockPair);
+}
+
+bool CheckSequenceLocks(const CTxMemPool& pool, const CTransaction& tx, int flags, LockPoints* lp, bool useExistingLockPoints)
+{
+    AssertLockHeld(cs_main);
+    CCoinsViewMemPool viewMemPool(&::ChainstateActive().CoinsTip(), pool);
+    CCoinsViewCache view(&viewMemPool);
+    return CheckSequenceLocks(view, tx, flags, lp, useExistingLockPoints);
 }
 
 // Returns the script flags which should be checked for a given block
@@ -481,11 +486,14 @@ public:
     // Single transaction acceptance
     bool AcceptSingleTransaction(const CTransactionRef& ptx, ATMPArgs& args) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+    // Multiple transaction acceptance
+    bool AcceptMultipleTransactions(const std::list<CTransactionRef>& tx_list, ATMPArgs& args) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
 private:
     // All the intermediate state that gets passed between the various levels
     // of checking a given transaction.
     struct Workspace {
-        Workspace(const CTransactionRef& ptx) : m_ptx(ptx), m_hash(ptx->GetHash()) {}
+        Workspace(const CTransactionRef& ptx, bool _cpfpable) : m_cpfpable(_cpfpable), m_ptx(ptx), m_hash(ptx->GetHash()) {}
         std::set<uint256> m_conflicts;
         CTxMemPool::setEntries m_all_conflicting;
         CTxMemPool::setEntries m_ancestors;
@@ -495,6 +503,8 @@ private:
         CAmount m_modified_fees;
         CAmount m_conflicting_fees;
         size_t m_conflicting_size;
+
+        const bool m_cpfpable; // whether the fee-checks for this tx can be satisfied by another tx
 
         const CTransactionRef& m_ptx;
         const uint256& m_hash;
@@ -541,7 +551,8 @@ private:
     CCoinsViewMemPool m_viewmempool;
     CCoinsView m_dummy;
 
-    // The package limits in effect at the time of invocation.
+    // Package acceptance uses a heuristic to test against these limits,
+    // separately from what is done in PreChecks().
     const size_t m_limit_ancestors;
     const size_t m_limit_ancestor_size;
     // These may be modified while evaluating a transaction (eg to account for
@@ -559,7 +570,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // Copy/alias what we need out of args
     TxValidationState &state = args.m_state;
     const int64_t nAcceptTime = args.m_accept_time;
-    const bool bypass_limits = args.m_bypass_limits;
+    const bool bypass_limits = args.m_bypass_limits || ws.m_cpfpable;
     const CAmount& nAbsurdFee = args.m_absurd_fee;
     std::vector<COutPoint>& coins_to_uncache = args.m_coins_to_uncache;
 
@@ -678,9 +689,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // Only accept BIP68 sequence locked transactions that can be mined in the next
     // block; we don't want our mempool filled up with transactions that can't
     // be mined yet.
-    // Must keep pool.cs for this unless we change CheckSequenceLocks to take a
-    // CoinsViewCache instead of create its own
-    if (!CheckSequenceLocks(m_pool, tx, STANDARD_LOCKTIME_VERIFY_FLAGS, &lp))
+    if (!CheckSequenceLocks(m_view, tx, STANDARD_LOCKTIME_VERIFY_FLAGS, &lp))
         return state.Invalid(TxValidationResult::TX_PREMATURE_SPEND, "non-BIP68-final");
 
     CAmount nFees = 0;
@@ -721,8 +730,8 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         return state.Invalid(TxValidationResult::TX_NOT_STANDARD, "bad-txns-too-many-sigops",
                 strprintf("%d", nSigOpsCost));
 
-    // No transactions are allowed below minRelayTxFee except from disconnected
-    // blocks
+    // No transactions are allowed below minRelayTxFee/mempool min fee except
+    // from disconnected blocks
     if (!bypass_limits && !CheckFeeRate(nSize, nModifiedFees, state)) return false;
 
     if (nAbsurdFee && nFees > nAbsurdFee)
@@ -985,7 +994,7 @@ bool MemPoolAccept::Finalize(ATMPArgs& args, Workspace& ws)
     const CTransaction& tx = *ws.m_ptx;
     const uint256& hash = ws.m_hash;
     TxValidationState &state = args.m_state;
-    const bool bypass_limits = args.m_bypass_limits;
+    const bool bypass_limits = args.m_bypass_limits || ws.m_cpfpable;
 
     CTxMemPool::setEntries& allConflicting = ws.m_all_conflicting;
     CTxMemPool::setEntries& setAncestors = ws.m_ancestors;
@@ -1032,7 +1041,7 @@ bool MemPoolAccept::AcceptSingleTransaction(const CTransactionRef& ptx, ATMPArgs
     AssertLockHeld(cs_main);
     LOCK(m_pool.cs); // mempool "read lock" (held through GetMainSignals().TransactionAddedToMempool())
 
-    Workspace workspace(ptx);
+    Workspace workspace(ptx, /* m_cpfpable */ false);
 
     if (!PreChecks(args, workspace)) return false;
 
@@ -1053,6 +1062,132 @@ bool MemPoolAccept::AcceptSingleTransaction(const CTransactionRef& ptx, ATMPArgs
 
     GetMainSignals().TransactionAddedToMempool(ptx);
 
+    return true;
+}
+
+
+bool MemPoolAccept::AcceptMultipleTransactions(const std::list<CTransactionRef>& tx_list, ATMPArgs& args)
+{
+    AssertLockHeld(cs_main);
+    LOCK(m_pool.cs);
+
+    std::list<Workspace> tx_workspaces;
+
+    for (const CTransactionRef& ptx : tx_list) {
+        // The last transaction must be validated for making it past the fee
+        // checks on its own, to prevent packages from including low-fee,
+        // unnecessary children that are attached to higher fee parents.
+        tx_workspaces.emplace_back(Workspace(ptx, ptx != tx_list.back()));
+        Workspace &ws = tx_workspaces.back();
+
+        if (!PreChecks(args, ws)) return false;
+
+        // For now, do not allow replacements in package transactions. If we
+        // relax this, we would need to check that no child transaction depends
+        // on any in-mempool transaction that conflicts with any package
+        // transaction.
+        if (!ws.m_conflicts.empty()) {
+            return args.m_state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "rbf-disallowed-in-package", strprintf("mempool conflicts with tx %s", ptx->GetHash().ToString()));
+        }
+        // Add this transaction to our coinsview, so that subsequent
+        // transactions in this package will have their inputs available.
+        m_viewmempool.AddPotentialTransaction(ptx);
+    }
+
+    // Check overall package feerate
+    size_t total_size=0;
+    CAmount total_fee=0;
+    uint64_t total_count = tx_list.size();
+    for (const Workspace& ws : tx_workspaces) {
+        total_size += ws.m_entry->GetTxSize();
+        total_fee += ws.m_modified_fees;
+    }
+    if (!CheckFeeRate(total_size, total_fee, args.m_state)) return false;
+
+    // The ancestor/descendant limit calculations in PreChecks() will be overly
+    // permissive, because not all ancestors will be known as we descend down
+    // the package. Thus the ancestor checks done by
+    // CalculateMemPoolAncestors() will be incomplete. If any ancestor or
+    // descendant limit is violated in one of those checks, however, we know
+    // the package will not be accepted when we include all ancestors, as the
+    // ancestor/descendant size/counts only go up as we add more ancestors to
+    // each transaction.
+    // We will end up needing to recalculate setAncestors for each transaction
+    // prior to calling Finalize, but we should do the correct package-size
+    // calculations before we call ScriptChecks(), to avoid CPU-DoS.
+
+    // For now, do something conservative -- assume that the union of ancestors
+    // of each transaction is an ancestor of every transaction, for package
+    // size purposes.
+    CTxMemPool::setEntries all_ancestors;
+    for (const Workspace& ws : tx_workspaces) {
+        all_ancestors.insert(ws.m_ancestors.begin(), ws.m_ancestors.end());
+    }
+
+    if (total_count + all_ancestors.size() > m_limit_ancestors) {
+        return args.m_state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "too-long-package-mempool-chain", strprintf("exceeds ancestor count limit [package: %u limit: %u]", total_count + all_ancestors.size(), m_limit_ancestors));
+    }
+
+    // Check the package limits for every ancestor, assuming the whole package
+    // descends from each.
+    size_t ancestor_size = total_size;
+    for (auto tx_iter : all_ancestors) {
+        if (tx_iter->GetSizeWithDescendants() + total_size > m_limit_descendant_size) {
+            return args.m_state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "too-long-package-mempool-chain", strprintf("exceeds descendant size limit for tx %s [limit: %u]", tx_iter->GetTx().GetHash().ToString(), m_limit_descendant_size));
+        }
+        if (tx_iter->GetCountWithDescendants() + total_count > m_limit_descendants) {
+            return args.m_state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "too-long-package-mempool-chain", strprintf("exceeds descendant size limit for tx %s [limit: %u]", tx_iter->GetTx().GetHash().ToString(), m_limit_descendants));
+        }
+        ancestor_size += tx_iter->GetTxSize();
+    }
+
+    // In case we have no in-mempool ancestors, we must check the transaction
+    // package itself.
+    if (total_size > m_limit_descendant_size) {
+        return args.m_state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "too-long-package-mempool-chain", strprintf("exceeds descendant size limit for tx %s [limit: %u]", tx_list.front()->GetHash().ToString(), m_limit_descendant_size));
+    }
+    if (ancestor_size > m_limit_ancestor_size) {
+        return args.m_state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "too-long-package-mempool-chain", strprintf("exceeds ancestor size limit for tx %s [limit: %u]", tx_list.back()->GetHash().ToString(), m_limit_ancestor_size));
+    }
+
+    // Do the script checks after all policy checks are done
+    std::vector<PrecomputedTransactionData> txdata;
+    txdata.reserve(tx_list.size());
+    for (auto wit = tx_workspaces.begin(); wit != tx_workspaces.end(); ++wit) {
+        txdata.emplace_back(*wit->m_ptx);
+        if (!PolicyScriptChecks(args, *wit, txdata.back())) return false;
+    }
+
+    // This package should be accepted except possibly for failing in
+    // TrimToSize(), which we can't exercise without actually adding to the
+    // mempool and seeing what would happen. Note that we are not adding
+    // these transactions to the script cache, unlike in the single-tx case.
+    if (args.m_test_accept) return true;
+
+    // Add everything to the mempool, and make sure the last transaction makes
+    // it in.
+    size_t i=0;
+    for (auto wit = tx_workspaces.begin(); wit != tx_workspaces.end(); ++wit, ++i) {
+        // Recheck the scripts with consensus flags and cache script execution
+        // success. We have to wait until all the inputs are in the mempool or
+        // in the utxo set (for now) before we can invoke this. This should
+        // not fail unless there's a logic bug in our script validation, but if
+        // it somehow were to fail on some child tx, we would potentially be
+        // allowing parents into the mempool with this logic.
+        if (!ConsensusScriptChecks(args, *wit, txdata[i])) return false;
+
+        // Recalculate ancestors for every transaction after the first, because
+        // previously the ancestor sets were missing package transactions that
+        // were not yet in the mempool at the time PreChecks() was called.
+        if (wit != tx_workspaces.begin()) {
+            wit->m_ancestors.clear();
+            std::string dummy_string;
+            // Don't worry about the return value here; it must pass based on
+            // the checks above. TODO: assert on passing?
+            m_pool.CalculateMemPoolAncestors(*(wit->m_entry), wit->m_ancestors, m_limit_ancestors, m_limit_ancestor_size, m_limit_descendants, m_limit_descendant_size, dummy_string);
+        }
+        if (!Finalize(args, *wit)) return false;
+    }
     return true;
 }
 
@@ -1078,6 +1213,32 @@ static bool AcceptToMemoryPoolWithTime(const CChainParams& chainparams, CTxMemPo
     // After we've (potentially) uncached entries, ensure our coins cache is still within its size limits
     BlockValidationState state_dummy;
     ::ChainstateActive().FlushStateToDisk(chainparams, state_dummy, FlushStateMode::PERIODIC);
+    return res;
+}
+
+bool AcceptPackageToMemoryPool(CTxMemPool& pool, TxValidationState &state,
+        std::list<CTransactionRef>& tx_list, std::list<CTransactionRef>* replaced_transactions,
+        const CAmount nAbsurdFee, bool test_accept)
+{
+    const CChainParams& chainparams = Params();
+    AssertLockHeld(cs_main);
+
+    std::vector<COutPoint> coins_to_uncache;
+    MemPoolAccept::ATMPArgs args { chainparams, state, GetTime(), replaced_transactions, /* m_bypass_limits */ false, nAbsurdFee, coins_to_uncache, test_accept };
+    bool res = MemPoolAccept(pool).AcceptMultipleTransactions(tx_list, args);
+
+    if (!res) {
+        // Remove coins that were not present in the coins cache beforehand;
+        // this is to prevent memory DoS in case we receive a large number of
+        // invalid transactions that attempt to overrun the in-memory coins cache
+        // (`CCoinsViewCache::cacheCoins`).
+        for (const COutPoint& hashTx : coins_to_uncache) {
+            ::ChainstateActive().CoinsTip().Uncache(hashTx);
+        }
+    }
+    // After we've (potentially) uncached entries, ensure our coins cache is still within its size limits
+    BlockValidationState stateDummy;
+    ::ChainstateActive().FlushStateToDisk(chainparams, stateDummy, FlushStateMode::PERIODIC);
     return res;
 }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -195,6 +195,10 @@ bool AcceptToMemoryPool(CTxMemPool& pool, TxValidationState &state, const CTrans
                         std::list<CTransactionRef>* plTxnReplaced,
                         bool bypass_limits, const CAmount nAbsurdFee, bool test_accept=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+bool AcceptPackageToMemoryPool(CTxMemPool& pool, TxValidationState &state, std::list<CTransactionRef>& tx_list,
+                               std::list<CTransactionRef>* replaced_transactions,
+                               const CAmount nAbsurdFee, bool test_accept) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
 /** Get the BIP9 state for a given deployment at the current tip. */
 ThresholdState VersionBitsTipState(const Consensus::Params& params, Consensus::DeploymentPos pos);
 

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70016;
+static const int PROTOCOL_VERSION = 80002;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -37,5 +37,8 @@ static const int INVALID_CB_NO_BAN_VERSION = 70015;
 
 //! "wtxidrelay" command for wtxid-based relay starts with this version
 static const int WTXID_RELAY_VERSION = 70016;
+
+//! package-relay starts with this version
+static const int PACKAGE_RELAY_VERSION = 80002;
 
 #endif // BITCOIN_VERSION_H

--- a/test/functional/feature_package_relay.py
+++ b/test/functional/feature_package_relay.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test processing of two-transaction packages"""
+
+from io import BytesIO
+from decimal import Decimal
+from test_framework.messages import FromHex, CTransaction, msg_tx
+from test_framework.mininode import P2PInterface
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import hex_str_to_bytes
+
+# P2PInterface is a class containing callbacks to be executed when a P2P
+# message is received from the node-under-test. Subclass P2PInterface and
+# override the on_*() methods if you need custom behaviour.
+class BaseNode(P2PInterface):
+    def __init__(self):
+        """Initialize the P2PInterface
+
+        Used to initialize custom properties for the Node that aren't
+        included by default in the base class. Be aware that the P2PInterface
+        base class already stores a counter for each P2P message type and the
+        last received message of each type, which should be sufficient for the
+        needs of most tests.
+
+        Call super().__init__() first for standard initialization and then
+        initialize custom properties."""
+        super().__init__()
+        # Stores a dictionary of all blocks received
+
+    def on_block(self, message):
+        """Override the standard on_block callback
+
+        Store the hash of a received block in the dictionary."""
+        message.block.calc_sha256()
+        self.block_receive_map[message.block.sha256] += 1
+
+    def on_inv(self, message):
+        """Override the standard on_inv callback"""
+        pass
+
+
+class PackageRelay(BitcoinTestFramework):
+    # Each functional test is a subclass of the BitcoinTestFramework class.
+
+    # Override the set_test_params(), skip_test_if_missing_module(), add_options(), setup_chain(), setup_network()
+    # and setup_nodes() methods to customize the test setup as required.
+
+    def set_test_params(self):
+        """Override test parameters for your individual test.
+
+        This method must be overridden and num_nodes must be explicitly set."""
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        self.extra_args = [[], ["-minrelaytxfee=0", "-mintxfee=0.00000001"]]
+
+
+    # Use skip_test_if_missing_module() to skip the test if your test requires certain modules to be present.
+    # This test uses generate which requires wallet to be compiled
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+
+    def run_test(self):
+        """Main test logic"""
+
+        # Create P2P connections will wait for a verack to make sure the connection is fully up
+        self.nodes[0].add_p2p_connection(BaseNode())
+
+        self.nodes[1].generate(101)
+        self.sync_all(self.nodes[0:2])
+
+        # On node1, generate a 0-fee transaction, and then a 2-satoshi-per-byte
+        # transaction
+        utxos = self.nodes[1].listunspent()
+        assert len(utxos) == 1
+
+
+        self.nodes[1].settxfee(Decimal("0.00000002"))
+        parent_txid = self.nodes[1].sendtoaddress(self.nodes[1].getnewaddress(), 1)
+        raw_parent_tx = self.nodes[1].gettransaction(parent_txid)['hex']
+
+        # Deliver the 0-fee transaction it doesn't get into the mempool of node0.
+        try:
+            self.nodes[0].sendrawtransaction(raw_parent_tx)
+        except:
+            pass
+        assert parent_txid not in self.nodes[0].getrawmempool()
+
+        inputs_child = []
+        inputs_child.append({"txid": parent_txid, "vout": 0 })
+        outputs_child = {}
+        # Child spend parent with a 500 sat-fee
+        outputs_child[self.nodes[1].getnewaddress()] = Decimal("0.99999500")
+        child_tx = self.nodes[1].signrawtransactionwithwallet(self.nodes[1].createrawtransaction(inputs_child, outputs_child))['hex']
+        package_txn = [parent_tx.serialize().hex(), child_tx]
+
+        self.nodes[1].sendpackage(rawtxs=package_txn)
+
+        #XXX: wait for package
+        time.sleep(10)
+
+        assert parent_txid in self.nodes[0].getrawmempool()
+
+
+
+if __name__ == '__main__':
+    PackageRelay().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -160,6 +160,7 @@ BASE_SCRIPTS = [
     'wallet_disable.py',
     'p2p_addr_relay.py',
     'p2p_getdata.py',
+    'feature_package_relay.py',
     'rpc_net.py',
     'wallet_keypool.py',
     'wallet_keypool.py --descriptors',


### PR DESCRIPTION
_This is demo code for a sender-initiated version of package-relay. This is not proposed for merging, only to illustrate package relay design with trade-offs compared to #16401. See my update on #14895 to advance discussions on package-relay._

Few design choices of interest:
* introduce new p2p messages, `sendpackages`, `MSG_PACKAGE`, `package` and new `package_id` identifier incorporated to the INV/GETDATA control logic : https://gist.github.com/ariard/10924249b3b7f6e239d80895372839b8
* add a new `sendpackage` rpc to let a higher-application signals a chain of transactions and such start a propagation on the p2p network
* integrate a `PackageCache` to internally cache the mapping package_id -> txids/wtxids, as they need to be persistent across a round-trip between upstream/downstream peers, it must be DoS resistant
*  build on #16401 `AcceptMultipleTransactions` with a package policy restriction to 2-tx only, make it easier to reason on for replacement
* allow for package replacement based on newer feerate higher that the union of feerate of all transactions conflicted, no dedup for now between conflicted set
* don't redundantly send a transaction via INV(MSG_TX) if we know an associated package and peer signal package relay support
* TODO: integrate package_id with overhaul transaction request/AlreadyHave to save further on bandwidth
