### PR TITLE
Warn on unknown rw_settings

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -426,6 +426,14 @@ bool ArgsManager::ReadSettingsFile(std::vector<std::string>* errors)
         SaveErrors(read_errors, errors);
         return false;
     }
+    for (const auto& setting : m_settings.rw_settings) {
+        std::string section;
+        std::string key = setting.first;
+        (void)InterpretOption(section, key, /* value */ {}); // Split setting key into section and argname
+        if (!GetArgFlags('-' + key)) {
+            LogPrintf("Ignoring unknown rw_settings value %s\n", setting.first);
+        }
+    }
     return true;
 }
 

--- a/test/functional/feature_settings.py
+++ b/test/functional/feature_settings.py
@@ -30,19 +30,25 @@ class SettingsTest(BitcoinTestFramework):
 
         # Assert settings are parsed and logged
         with settings.open("w") as fp:
-            json.dump({"string": "string", "num": 5, "bool": True, "null": None, "list": [6,7]}, fp)
+            json.dump({"string": "string", "num": 5, "bool": True, "null": None, "list": [6, 7]}, fp)
         with node.assert_debug_log(expected_msgs=[
+                'Ignoring unknown rw_settings value bool',
+                'Ignoring unknown rw_settings value list',
+                'Ignoring unknown rw_settings value null',
+                'Ignoring unknown rw_settings value num',
+                'Ignoring unknown rw_settings value string',
                 'Setting file arg: string = "string"',
                 'Setting file arg: num = 5',
                 'Setting file arg: bool = true',
                 'Setting file arg: null = null',
-                'Setting file arg: list = [6,7]']):
+                'Setting file arg: list = [6,7]',
+        ]):
             self.start_node(0)
             self.stop_node(0)
 
         # Assert settings are unchanged after shutdown
         with settings.open() as fp:
-            assert_equal(json.load(fp), {"string": "string", "num": 5, "bool": True, "null": None, "list": [6,7]})
+            assert_equal(json.load(fp), {"string": "string", "num": 5, "bool": True, "null": None, "list": [6, 7]})
 
         # Test invalid json
         with settings.open("w") as fp:


### PR DESCRIPTION
Log a warning to debug log if unknown settings are encountered. This should probably only ever happen when the software is upgraded.

Something similar is already done for the command line and config file. See:

* test: Add test for unknown args #16234 (commit fa7dd88b71a1c6641bd450fae29a4a31849b1afd)