### PR TITLE
refactor: replace sizeof(a)/sizeof(a[0]) by ARRAYLEN(a)

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -52,7 +52,7 @@ bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch, int max_ret_
     int size = strlen(psz) * 733 /1000 + 1; // log(58) / log(256), rounded up.
     std::vector<unsigned char> b256(size);
     // Process the characters.
-    static_assert(sizeof(mapBase58)/sizeof(mapBase58[0]) == 256, "mapBase58.size() should be 256"); // guarantee not out of range
+    static_assert(ARRAYLEN(mapBase58) == 256, "mapBase58.size() should be 256"); // guarantee not out of range
     while (*psz && !IsSpace(*psz)) {
         // Decode base58 character
         int carry = mapBase58[(uint8_t)*psz];

--- a/src/bench/data.cpp
+++ b/src/bench/data.cpp
@@ -3,12 +3,13 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/data.h>
+#include <util/strencodings.h>
 
 namespace benchmark {
 namespace data {
 
 #include <bench/data/block413567.raw.h>
-const std::vector<uint8_t> block413567{block413567_raw, block413567_raw + sizeof(block413567_raw) / sizeof(block413567_raw[0])};
+const std::vector<uint8_t> block413567{block413567_raw, block413567_raw + ARRAYLEN(block413567_raw)};
 
 } // namespace data
 } // namespace benchmark

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -8,6 +8,7 @@
 
 #include <chainparamsbase.h>
 #include <tinyformat.h>
+#include <util/strencodings.h>
 
 #include <QApplication>
 
@@ -21,7 +22,6 @@ static const struct {
     {"test", QAPP_APP_NAME_TESTNET, 70, 30},
     {"regtest", QAPP_APP_NAME_REGTEST, 160, 30}
 };
-static const unsigned network_styles_count = sizeof(network_styles)/sizeof(*network_styles);
 
 // titleAddText needs to be const char* for tr()
 NetworkStyle::NetworkStyle(const QString &_appName, const int iconColorHueShift, const int iconColorSaturationReduction, const char *_titleAddText):
@@ -80,7 +80,7 @@ NetworkStyle::NetworkStyle(const QString &_appName, const int iconColorHueShift,
 const NetworkStyle* NetworkStyle::instantiate(const std::string& networkId)
 {
     std::string titleAddText = networkId == CBaseChainParams::MAIN ? "" : strprintf("[%s]", networkId);
-    for (unsigned x=0; x<network_styles_count; ++x)
+    for (unsigned x=0; x<ARRAYLEN(network_styles); ++x)
     {
         if (networkId == network_styles[x].networkId)
         {

--- a/src/qt/platformstyle.cpp
+++ b/src/qt/platformstyle.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <qt/platformstyle.h>
+#include <util/strencodings.h>
 
 #include <QApplication>
 #include <QColor>
@@ -23,7 +24,6 @@ static const struct {
     /* Other: linux, unix, ... */
     {"other", true, true, false}
 };
-static const unsigned platform_styles_count = sizeof(platform_styles)/sizeof(*platform_styles);
 
 namespace {
 /* Local functions for colorizing single-color images */
@@ -121,7 +121,7 @@ QIcon PlatformStyle::TextColorIcon(const QIcon& icon) const
 
 const PlatformStyle *PlatformStyle::instantiate(const QString &platformId)
 {
-    for (unsigned x=0; x<platform_styles_count; ++x)
+    for (unsigned x=0; x<ARRAYLEN(platform_styles); ++x)
     {
         if (platformId == platform_styles[x].platformId)
         {

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <rpc/client.h>
+#include <util/strencodings.h>
 #include <util/system.h>
 
 #include <set>
@@ -196,10 +197,7 @@ public:
 
 CRPCConvertTable::CRPCConvertTable()
 {
-    const unsigned int n_elem =
-        (sizeof(vRPCConvertParams) / sizeof(vRPCConvertParams[0]));
-
-    for (unsigned int i = 0; i < n_elem; i++) {
+    for (unsigned int i = 0; i < ARRAYLEN(vRPCConvertParams); i++) {
         members.insert(std::make_pair(vRPCConvertParams[i].methodName,
                                       vRPCConvertParams[i].paramIdx));
         membersByName.insert(std::make_pair(vRPCConvertParams[i].methodName,

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -257,7 +257,7 @@ static const CRPCCommand vRPCCommands[] =
 CRPCTable::CRPCTable()
 {
     unsigned int vcidx;
-    for (vcidx = 0; vcidx < (sizeof(vRPCCommands) / sizeof(vRPCCommands[0])); vcidx++)
+    for (vcidx = 0; vcidx < ARRAYLEN(vRPCCommands); vcidx++)
     {
         const CRPCCommand *pcmd;
 

--- a/src/test/base32_tests.cpp
+++ b/src/test/base32_tests.cpp
@@ -13,7 +13,7 @@ BOOST_AUTO_TEST_CASE(base32_testvectors)
 {
     static const std::string vstrIn[]  = {"","f","fo","foo","foob","fooba","foobar"};
     static const std::string vstrOut[] = {"","my======","mzxq====","mzxw6===","mzxw6yq=","mzxw6ytb","mzxw6ytboi======"};
-    for (unsigned int i=0; i<sizeof(vstrIn)/sizeof(vstrIn[0]); i++)
+    for (unsigned int i=0; i<ARRAYLEN(vstrIn); i++)
     {
         std::string strEnc = EncodeBase32(vstrIn[i]);
         BOOST_CHECK_EQUAL(strEnc, vstrOut[i]);

--- a/src/test/base64_tests.cpp
+++ b/src/test/base64_tests.cpp
@@ -13,7 +13,7 @@ BOOST_AUTO_TEST_CASE(base64_testvectors)
 {
     static const std::string vstrIn[]  = {"","f","fo","foo","foob","fooba","foobar"};
     static const std::string vstrOut[] = {"","Zg==","Zm8=","Zm9v","Zm9vYg==","Zm9vYmE=","Zm9vYmFy"};
-    for (unsigned int i=0; i<sizeof(vstrIn)/sizeof(vstrIn[0]); i++)
+    for (unsigned int i=0; i<ARRAYLEN(vstrIn); i++)
     {
         std::string strEnc = EncodeBase64(vstrIn[i]);
         BOOST_CHECK_EQUAL(strEnc, vstrOut[i]);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -227,10 +227,10 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 
     // We can't make transactions until we have inputs
     // Therefore, load 110 blocks :)
-    static_assert(sizeof(blockinfo) / sizeof(*blockinfo) == 110, "Should have 110 blocks to import");
+    static_assert(ARRAYLEN(blockinfo) == 110, "Should have 110 blocks to import");
     int baseheight = 0;
     std::vector<CTransactionRef> txFirst;
-    for (unsigned int i = 0; i < sizeof(blockinfo)/sizeof(*blockinfo); ++i)
+    for (unsigned int i = 0; i < ARRAYLEN(blockinfo); ++i)
     {
         CBlock *pblock = &pblocktemplate->block; // pointer for convenience
         {

--- a/src/test/scriptnum_tests.cpp
+++ b/src/test/scriptnum_tests.cpp
@@ -5,6 +5,7 @@
 #include <script/script.h>
 #include <test/scriptnum10.h>
 #include <test/util/setup_common.h>
+#include <util/strencodings.h>
 
 #include <boost/test/unit_test.hpp>
 #include <limits.h>
@@ -164,9 +165,9 @@ static void RunOperators(const int64_t& num1, const int64_t& num2)
 
 BOOST_AUTO_TEST_CASE(creation)
 {
-    for(size_t i = 0; i < sizeof(values) / sizeof(values[0]); ++i)
+    for(size_t i = 0; i < ARRAYLEN(values); ++i)
     {
-        for(size_t j = 0; j < sizeof(offsets) / sizeof(offsets[0]); ++j)
+        for(size_t j = 0; j < ARRAYLEN(offsets); ++j)
         {
             RunCreate(values[i]);
             RunCreate(values[i] + offsets[j]);
@@ -177,9 +178,9 @@ BOOST_AUTO_TEST_CASE(creation)
 
 BOOST_AUTO_TEST_CASE(operators)
 {
-    for(size_t i = 0; i < sizeof(values) / sizeof(values[0]); ++i)
+    for(size_t i = 0; i < ARRAYLEN(values); ++i)
     {
-        for(size_t j = 0; j < sizeof(offsets) / sizeof(offsets[0]); ++j)
+        for(size_t j = 0; j < ARRAYLEN(offsets); ++j)
         {
             RunOperators(values[i], values[i]);
             RunOperators(values[i], -values[i]);

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -88,7 +88,7 @@ void static RandomScript(CScript &script) {
     script = CScript();
     int ops = (InsecureRandRange(10));
     for (int i=0; i<ops; i++)
-        script << oplist[InsecureRandRange(sizeof(oplist)/sizeof(oplist[0]))];
+        script << oplist[InsecureRandRange(ARRAYLEN(oplist))];
 }
 
 void static RandomTransaction(CMutableTransaction &tx, bool fSingle) {


### PR DESCRIPTION
This tiny refactoring PR replaces all occurences of `sizeof(x)/sizeof(x[0])` (or `sizeof(x)/sizeof(*x)`, respectively) with the macro `ARRAYLEN(x)`. While the pattern to determine the array of a length is a very common one and should be familiar for every C or C++ programmer, I think readability is still improved if it is hidden behind a macro. And since we have already `ARRAYLEN` in the codebase since the beginning (indeed Satoshi already had it in v0.1.0, see https://github.com/trottier/original-bitcoin/blob/master/src/util.h#L27), why not use it consistently?

The instances to replace were discovered via

`$ grep -Ir "sizeof.*/.*sizeof" src/*`

If this gets a Concept ACK, one could probably discuss if the header `strencodings.h` is really the right location for this macro -- it doesn't have anything to do with strings at all. Maybe `util/macro.h` would be a more appropriate place.
