### PR TITLE
param: add bool parameter -ephemeraltoronion to generate ephemeral tor addreses

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -462,6 +462,7 @@ void SetupServerArgs(NodeContext& node)
     argsman.AddArg("-peertimeout=<n>", strprintf("Specify p2p connection timeout in seconds. This option determines the amount of time a peer may be inactive before the connection to it is dropped. (minimum: 1, default: %d)", DEFAULT_PEER_CONNECT_TIMEOUT), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CONNECTION);
     argsman.AddArg("-torcontrol=<ip>:<port>", strprintf("Tor control port to use if onion listening enabled (default: %s)", DEFAULT_TOR_CONTROL), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-torpassword=<pass>", "Tor control port password (default: empty)", ArgsManager::ALLOW_ANY | ArgsManager::SENSITIVE, OptionsCategory::CONNECTION);
+    argsman.AddArg("-ephemeraltoronion", strprintf("generate ephemeral tor onion address at any node restart, default: %u)", DEFAULT_EPHEMERAL_TOR_ONION), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
 #ifdef USE_UPNP
 #if USE_UPNP
     argsman.AddArg("-upnp", "Use UPnP to map the listening port (default: 1 when listening and no -proxy)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);

--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -11,6 +11,8 @@
 
 extern const std::string DEFAULT_TOR_CONTROL;
 static const bool DEFAULT_LISTEN_ONION = true;
+/** Allow onion address to be created ephemeral on every node restart */
+static const bool DEFAULT_EPHEMERAL_TOR_ONION = false;
 
 void StartTorControl();
 void InterruptTorControl();


### PR DESCRIPTION
We have for up till now generated in the torcontroler service call quasi
static onion addresses instead of full ephemeral like we call them in `doc/tor.md`
Those address would not have changed like those in torrc as long as the` onion_private_key`
file we created at first creation of the tor address would not have been deleted or changed.

When we transition to ADDRv2 messages it makes sense to allow from a privacy 
perspective temporary tor address for as long the node is not rebooted or if we
decide to go even further for every wallet to have there own onion address.    
