### PR TITLE
Add -netinfo peer connections dashboard

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -39,6 +39,8 @@ static const char DEFAULT_RPCCONNECT[] = "127.0.0.1";
 static const int DEFAULT_HTTP_CLIENT_TIMEOUT=900;
 static const bool DEFAULT_NAMED=false;
 static const int CONTINUE_EXECUTION=-1;
+static const std::string ONION{".onion"};
+static const size_t ONION_LEN{ONION.size()};
 
 /** Default number of blocks to generate for RPC generatetoaddress. */
 static const std::string DEFAULT_NBLOCKS = "1";
@@ -297,6 +299,21 @@ public:
 class NetinfoRequestHandler : public BaseRequestHandler
 {
 private:
+    bool IsAddrIPv6(const std::string& addr) const
+    {
+        return !addr.empty() && addr.front() == '[';
+    }
+    bool IsInboundOnion(const std::string& addr_local, int mapped_as) const
+    {
+        return mapped_as == 0 && addr_local.find(ONION) != std::string::npos;
+    }
+    bool IsOutboundOnion(const std::string& addr, int mapped_as) const
+    {
+        const size_t addr_len{addr.size()};
+        const size_t onion_pos{addr.rfind(ONION)};
+        return mapped_as == 0 && onion_pos != std::string::npos && addr_len > ONION_LEN &&
+               (onion_pos == addr_len - ONION_LEN || onion_pos == addr.find_last_of(":") - ONION_LEN);
+    }
     bool m_verbose{false}; //!< Whether user requested verbose -netinfo report
 public:
     const int ID_PEERINFO = 0;

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -315,6 +315,12 @@ private:
                (onion_pos == addr_len - ONION_LEN || onion_pos == addr.find_last_of(":") - ONION_LEN);
     }
     bool m_verbose{false}; //!< Whether user requested verbose -netinfo report
+    std::string ChainToString() const
+    {
+        if (gArgs.GetChainName() == CBaseChainParams::TESTNET) return " testnet";
+        if (gArgs.GetChainName() == CBaseChainParams::REGTEST) return " regtest";
+        return "";
+    }
 public:
     const int ID_PEERINFO = 0;
     const int ID_NETWORKINFO = 1;
@@ -369,7 +375,10 @@ public:
             }
         }
 
-        std::string result;
+        // Generate report header.
+        const UniValue& networkinfo{batch[ID_NETWORKINFO]["result"]};
+        std::string result{strprintf("%s %s%s - %i%s\n\n", PACKAGE_NAME, FormatFullVersion(), ChainToString(), networkinfo["protocolversion"].get_int(), networkinfo["subversion"].get_str())};
+
         return JSONRPCReplyObj(UniValue{result}, NullUniValue, 1);
     }
 };

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -387,6 +387,17 @@ public:
         result += strprintf("out    %5i   %5i   %5i   %5i   %5i\n", ipv4_o, ipv6_o, onion_o, total_o, block_relay_o);
         result += strprintf("total  %5i   %5i   %5i   %5i   %5i\n", ipv4_i + ipv4_o, ipv6_i + ipv6_o, onion_i + onion_o, total_i + total_o, block_relay_i + block_relay_o);
 
+        // Report local addresses, ports, and scores.
+        result += "\nLocal addresses";
+        const UniValue& local_addrs{networkinfo["localaddresses"]};
+        if (local_addrs.empty()) {
+            result += ": n/a\n";
+        } else {
+            for (const UniValue& addr : local_addrs.getValues()) {
+                result += strprintf("\n%-40i  port %5i     score %6i", addr["address"].get_str(), addr["port"].get_int(), addr["score"].get_int());
+            }
+        }
+
         return JSONRPCReplyObj(UniValue{result}, NullUniValue, 1);
     }
 };

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -336,6 +336,39 @@ public:
         const std::vector<UniValue> batch{JSONRPCProcessBatchReply(batch_in)};
         if (!batch[ID_PEERINFO]["error"].isNull()) return batch[ID_PEERINFO];
         if (!batch[ID_NETWORKINFO]["error"].isNull()) return batch[ID_NETWORKINFO];
+
+        // Count peer connection totals.
+        int ipv4_i{0}, ipv6_i{0}, onion_i{0}, block_relay_i{0}; // inbound conn counters
+        int ipv4_o{0}, ipv6_o{0}, onion_o{0}, block_relay_o{0}; // outbound conn counters
+        const UniValue& getpeerinfo{batch[ID_PEERINFO]["result"]};
+
+        for (const UniValue& peer : getpeerinfo.getValues()) {
+            const std::string addr{peer["addr"].get_str()};
+            const std::string addr_local{peer["addrlocal"].isNull() ? "" : peer["addrlocal"].get_str()};
+            const int mapped_as{peer["mapped_as"].isNull() ? 0 : peer["mapped_as"].get_int()};
+            const bool is_block_relay{!peer["relaytxes"].get_bool()};
+            const bool is_inbound{peer["inbound"].get_bool()};
+            if (is_inbound) {
+                if (IsAddrIPv6(addr)) {
+                    ++ipv6_i;
+                } else if (IsInboundOnion(addr_local, mapped_as)) {
+                    ++onion_i;
+                } else {
+                    ++ipv4_i;
+                }
+                if (is_block_relay) ++block_relay_i;
+            } else {
+                if (IsAddrIPv6(addr)) {
+                    ++ipv6_o;
+                } else if (IsOutboundOnion(addr, mapped_as)) {
+                    ++onion_o;
+                } else {
+                    ++ipv4_o;
+                }
+                if (is_block_relay) ++block_relay_o;
+            }
+        }
+
         std::string result;
         return JSONRPCReplyObj(UniValue{result}, NullUniValue, 1);
     }

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -344,8 +344,8 @@ public:
         if (!batch[ID_NETWORKINFO]["error"].isNull()) return batch[ID_NETWORKINFO];
 
         // Count peer connection totals.
-        int ipv4_i{0}, ipv6_i{0}, onion_i{0}, block_relay_i{0}; // inbound conn counters
-        int ipv4_o{0}, ipv6_o{0}, onion_o{0}, block_relay_o{0}; // outbound conn counters
+        int ipv4_i{0}, ipv6_i{0}, onion_i{0}, block_relay_i{0}, total_i{0}; // inbound conn counters
+        int ipv4_o{0}, ipv6_o{0}, onion_o{0}, block_relay_o{0}, total_o{0}; // outbound conn counters
         const UniValue& getpeerinfo{batch[ID_PEERINFO]["result"]};
 
         for (const UniValue& peer : getpeerinfo.getValues()) {
@@ -378,6 +378,14 @@ public:
         // Generate report header.
         const UniValue& networkinfo{batch[ID_NETWORKINFO]["result"]};
         std::string result{strprintf("%s %s%s - %i%s\n\n", PACKAGE_NAME, FormatFullVersion(), ChainToString(), networkinfo["protocolversion"].get_int(), networkinfo["subversion"].get_str())};
+
+        // Report peer connection totals by type.
+        total_i = ipv4_i + ipv6_i + onion_i;
+        total_o = ipv4_o + ipv6_o + onion_o;
+        result += "        ipv4    ipv6   onion   total  block-relay\n";
+        result += strprintf("in     %5i   %5i   %5i   %5i   %5i\n", ipv4_i, ipv6_i, onion_i, total_i, block_relay_i);
+        result += strprintf("out    %5i   %5i   %5i   %5i   %5i\n", ipv4_o, ipv6_o, onion_o, total_o, block_relay_o);
+        result += strprintf("total  %5i   %5i   %5i   %5i   %5i\n", ipv4_i + ipv4_o, ipv6_i + ipv6_o, onion_i + onion_o, total_i + total_o, block_relay_i + block_relay_o);
 
         return JSONRPCReplyObj(UniValue{result}, NullUniValue, 1);
     }

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -373,6 +373,11 @@ public:
         if (!batch[ID_PEERINFO]["error"].isNull()) return batch[ID_PEERINFO];
         if (!batch[ID_NETWORKINFO]["error"].isNull()) return batch[ID_NETWORKINFO];
 
+        const UniValue& networkinfo{batch[ID_NETWORKINFO]["result"]};
+        if (networkinfo["version"].get_int() < 209900) {
+            throw std::runtime_error("-netinfo requires bitcoind server to be running v0.21.0 and up");
+        }
+
         // Count peer connection totals, and if m_verbose is true, store peer data in a vector of structs.
         const int64_t time_now{GetSystemTimeInSeconds()};
         int ipv4_i{0}, ipv6_i{0}, onion_i{0}, block_relay_i{0}, total_i{0}; // inbound conn counters
@@ -430,7 +435,6 @@ public:
         }
 
         // Generate report header.
-        const UniValue& networkinfo{batch[ID_NETWORKINFO]["result"]};
         std::string result{strprintf("%s %s%s - %i%s\n\n", PACKAGE_NAME, FormatFullVersion(), ChainToString(), networkinfo["protocolversion"].get_int(), networkinfo["subversion"].get_str())};
 
         // Report detailed peer connections list sorted by direction and minimum ping time.


### PR DESCRIPTION
This PR is inspired by laanwj's python script mentioned in #19405, which it turns out I ended up using every day and extending because I got hooked on using it to monitor Bitcoin peer connections.

For the full experience, run `./src/bitcoin-cli -netinfo 4`

On Linux, try it with watch `watch ./src/bitcoin-cli -netinfo 4`

Help doc
```
$ ./src/bitcoin-cli -help | grep -A3 netinfo
  -netinfo
       Get network peer connection information from the remote server. An
       optional integer argument from 0 to 4 can be passed for different
       peers listings (default: 0).
```
