### PR TITLE
Allow updating mempool-txn with cheaper witnesses

### DIFF
--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -22,6 +22,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
     assert(node.mempool);
     std::promise<void> promise;
     uint256 hashTx = tx->GetHash();
+    GenTxid gtxid(true, tx->GetWitnessHash());
     bool callback_set = false;
 
     { // cs_main scope
@@ -35,7 +36,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
         // So if the output does exist, then this transaction exists in the chain.
         if (!existingCoin.IsSpent()) return TransactionError::ALREADY_IN_CHAIN;
     }
-    if (!node.mempool->exists(hashTx)) {
+    if (!node.mempool->exists(gtxid)) {
         // Transaction is not already in the mempool. Submit it.
         TxValidationState state;
         if (!AcceptToMemoryPool(*node.mempool, state, std::move(tx),

--- a/test/functional/mempool_wtxid.py
+++ b/test/functional/mempool_wtxid.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test mempool wtxid acceptance in case of an already known transaction
+with identical non-witness data but lower feerate witness."""
+
+from codecs import encode
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+
+from test_framework.messages import (
+        CTransaction,
+        CTxIn,
+        CTxInWitness,
+        CTxOut,
+        COutPoint,
+        sha256,
+        COIN,
+        hash256,
+)
+
+from test_framework.util import (
+        assert_equal,
+        assert_not_equal,
+)
+
+from test_framework.script import (
+        CScript,
+        OP_0,
+        OP_TRUE,
+        OP_IF,
+        OP_HASH160,
+        OP_EQUAL,
+        OP_ELSE,
+        OP_ENDIF,
+        hash160,
+)
+
+class MempoolWtxidTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.supports_cli = False
+        self.extra_args = [["-incrementalrelayfee=0"]]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        self.log.info('Start with empty mempool, and 200 blocks')
+        self.mempool_size = 0
+        assert_equal(node.getblockcount(), 200)
+        assert_equal(node.getmempoolinfo()['size'], self.mempool_size)
+
+        txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
+
+        # Create a Segwit output
+        hashlock = hash160(b'Preimage')
+        witness_script = CScript([OP_IF, OP_HASH160, hashlock, OP_EQUAL, OP_ELSE, OP_TRUE, OP_ENDIF])
+        witness_program = sha256(witness_script)
+        script_pubkey = CScript([OP_0, witness_program])
+
+        parent = CTransaction()
+        parent.vin.append(CTxIn(COutPoint(int(txid, 16), 0), b""))
+        parent.vout.append(CTxOut(int(9.99998 * COIN), script_pubkey))
+        parent.rehash()
+
+        # Confirm parent with alternative script branches witnessScript
+        raw_parent = self.nodes[0].signrawtransactionwithwallet(parent.serialize().hex())['hex']
+        parent_txid = self.nodes[0].sendrawtransaction(hexstring=raw_parent, maxfeerate=0)
+        self.nodes[0].generate(1)
+
+        # Create a new segwit transaction with witness solving first branch
+        child_witness_script = CScript([OP_TRUE])
+        child_witness_program = sha256(child_witness_script)
+        child_script_pubkey = CScript([OP_0, child_witness_program])
+
+        child_one = CTransaction()
+        child_one.vin.append(CTxIn(COutPoint(int(parent_txid, 16), 0), b""))
+        child_one.vout.append(CTxOut(int(9.99996 * COIN), child_script_pubkey))
+        child_one.wit.vtxinwit.append(CTxInWitness())
+        child_one.wit.vtxinwit[0].scriptWitness.stack = [b'Preimage', b'\x01', witness_script]
+        child_one_txid = self.nodes[0].sendrawtransaction(hexstring=child_one.serialize().hex())
+        child_one_wtxid = encode(hash256(child_one.serialize_with_witness())[::-1], 'hex_codec').decode('ascii')
+
+        self.log.info('Verify that transaction with lower-feerate witness gets in the mempool')
+        in_mempool_wtxid = self.nodes[0].getrawmempool(True)[child_one_txid]['wtxid']
+        assert_equal(child_one_wtxid, in_mempool_wtxid)
+
+        # Create another identical segwit transaction with witness solving second branch
+        child_two = CTransaction()
+        child_two.vin.append(CTxIn(COutPoint(int(parent_txid, 16), 0), b""))
+        child_two.vout.append(CTxOut(int(9.99996 * COIN), child_script_pubkey))
+        child_two.wit.vtxinwit.append(CTxInWitness())
+        child_two.wit.vtxinwit[0].scriptWitness.stack = [b'', witness_script]
+        child_two_txid = self.nodes[0].sendrawtransaction(hexstring=child_two.serialize().hex())
+        child_two_wtxid = encode(hash256(child_two.serialize_with_witness())[::-1], 'hex_codec').decode('ascii')
+
+        assert_equal(child_one_txid, child_two_txid)
+        assert_not_equal(child_one_wtxid, child_two_wtxid)
+
+        self.log.info('Verify that identical transaction with higher-feerate witness gets in the mempool')
+        in_mempool_wtxid = self.nodes[0].getrawmempool(True)[child_one_txid]['wtxid']
+        assert_equal(child_two_wtxid, in_mempool_wtxid)
+
+if __name__ == '__main__':
+    MempoolWtxidTest().main()

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -49,6 +49,11 @@ def assert_equal(thing1, thing2, *args):
         raise AssertionError("not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args))
 
 
+def assert_not_equal(thing1, thing2, *args):
+    if thing1 == thing2 or any(thing1 == arg for arg in args):
+        raise AssertionError("not(%s)" % " != ".join(str(arg) for arg in (thing1, thing2) + args))
+
+
 def assert_greater_than(thing1, thing2):
     if thing1 <= thing2:
         raise AssertionError("%s <= %s" % (str(thing1), str(thing2)))

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -234,6 +234,7 @@ BASE_SCRIPTS = [
     'feature_asmap.py',
     'mempool_unbroadcast.py',
     'mempool_compatibility.py',
+    'mempool_wtxid.py',
     'rpc_deriveaddresses.py',
     'rpc_deriveaddresses.py --usecli',
     'p2p_ping.py',


### PR DESCRIPTION
Accepting a transaction to the mempool only succeeds if this transaction
isn't already present. This check operating on txid, it prevents new
submissions of the transaction with identical non-witness data but
smaller valid witnesses. Therefore, overall mempool feerate won't improve
even if such higher-feerate mempool candidate is learnt through wtxid-relay.

This commit changes mempool and transaction broadcast already-present checks
from transaction's txid to its wtxid.

A new-wtxid submission may still fail due to replacement rules in
function of local policy settings.


@jnewbery RE: https://github.com/bitcoin/bitcoin/pull/18044#discussion_r460704950 I think we agree on the "same txid, different txids" nonsense, I didn't mean to track multiple witnesses for one txid rather to accept and rebroadcast "the best mempool candidate known for a given txid". A script may have alternatives solvable branches and witnesses to spend them might be different in weight thus creating wtxid with divergent feerates. A best known candidate with regards to a txid is defined as a higher-feerate witness (a smaller one) transaction than our current in mempool one, with identical non-witness data.

You might submit a txidA:wtxid1 to your local node, and schedule it for initial-broadcast reattempt. Few minutes, latter you announce to your node a higher-feerate txidA:wtxid2, which effectively replace wtxid1. At `ReattemptInitialBroadcast`, only wtxid2 will be rebroadcast if needed, as best known candidate for txidA. According to me, that's where unbroadcast semantic is unclear, to which wtxid the user should expect seeing "broadcast-reattempt" property guarantee ?

Given our current relay policy default, I concede this is rather a marginal case, beyond illustrating another limit of our mempool replacement rules. In the future, it's likely to worsen as taproot make it far easier to create witnesses with divergent feerates (e.g a 1-of-1 tapscript compared to a 15-of-15 one). In case of concurrent broadcast, the mempool won't necessary learn the best-feerate candidate. That said, IMO, it's worthy to fix because "txn-already-in-mempool" isn't accurate anymore in a wtxid-relay context.