### PR TITLE
wallet: Replace -zapwallettxes with zapwallettxes RPC

### DIFF
--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -48,7 +48,6 @@ void DummyWalletInit::AddWalletOptions(ArgsManager& argsman) const
         "-walletdir=<dir>",
         "-walletnotify=<cmd>",
         "-walletrbf",
-        "-zapwallettxes=<mode>",
         "-dblogsize=<n>",
         "-flushwallet",
         "-privdb",

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -173,6 +173,11 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "createwallet", 4, "avoid_reuse"},
     { "createwallet", 5, "descriptors"},
     { "getnodeaddresses", 0, "count"},
+    { "zapwallettxes", 0, "keep_metadata"},
+    { "zapwallettxes", 1, "rescan"},
+    { "zapwallettxes", 2, "start_height"},
+    { "zapwallettxes", 3, "stop_height"},
+    { "zapwallettxes", 4, "scan_mempool"},
     { "stop", 0, "wait" },
 };
 // clang-format on

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -64,13 +64,13 @@ void WalletInit::AddWalletOptions(ArgsManager& argsman) const
     argsman.AddArg("-walletnotify=<cmd>", "Execute command when a wallet transaction changes. %s in cmd is replaced by TxID and %w is replaced by wallet name. %w is not currently implemented on windows. On systems where %w is supported, it should NOT be quoted because this would break shell escaping used to invoke the command.", ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
 #endif
     argsman.AddArg("-walletrbf", strprintf("Send transactions with full-RBF opt-in enabled (RPC only, default: %u)", DEFAULT_WALLET_RBF), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
-    argsman.AddArg("-zapwallettxes=<mode>", "Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup"
-                               " (1 = keep tx meta data e.g. payment request information, 2 = drop tx meta data)", ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
 
     argsman.AddArg("-dblogsize=<n>", strprintf("Flush wallet database activity from memory to disk log every <n> megabytes (default: %u)", DEFAULT_WALLET_DBLOGSIZE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
     argsman.AddArg("-flushwallet", strprintf("Run a thread to flush wallet periodically (default: %u)", DEFAULT_FLUSHWALLET), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
     argsman.AddArg("-privdb", strprintf("Sets the DB_PRIVATE flag in the wallet db environment (default: %u)", DEFAULT_WALLET_PRIVDB), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
     argsman.AddArg("-walletrejectlongchains", strprintf("Wallet will not create transactions that violate mempool chain limits (default: %u)", DEFAULT_WALLET_REJECT_LONG_CHAINS), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
+
+    argsman.AddHiddenArgs({"-zapwallettxes"});
 }
 
 bool WalletInit::ParameterInteraction() const
@@ -83,26 +83,12 @@ bool WalletInit::ParameterInteraction() const
         return true;
     }
 
-    const bool is_multiwallet = gArgs.GetArgs("-wallet").size() > 1;
-
     if (gArgs.GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY) && gArgs.SoftSetBoolArg("-walletbroadcast", false)) {
         LogPrintf("%s: parameter interaction: -blocksonly=1 -> setting -walletbroadcast=0\n", __func__);
     }
 
-    bool zapwallettxes = gArgs.GetBoolArg("-zapwallettxes", false);
-    // -zapwallettxes implies dropping the mempool on startup
-    if (zapwallettxes && gArgs.SoftSetBoolArg("-persistmempool", false)) {
-        LogPrintf("%s: parameter interaction: -zapwallettxes enabled -> setting -persistmempool=0\n", __func__);
-    }
-
-    // -zapwallettxes implies a rescan
-    if (zapwallettxes) {
-        if (is_multiwallet) {
-            return InitError(strprintf(Untranslated("%s is only allowed with a single wallet file"), "-zapwallettxes"));
-        }
-        if (gArgs.SoftSetBoolArg("-rescan", true)) {
-            LogPrintf("%s: parameter interaction: -zapwallettxes enabled -> setting -rescan=1\n", __func__);
-        }
+    if (gArgs.IsArgSet("-zapwallettxes")) {
+        return InitError(_("-zapwallettxes has been replaced with the zapwallettxes RPC. Please use that instead."));
     }
 
     if (gArgs.GetBoolArg("-sysperms", false))

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2480,7 +2480,7 @@ static UniValue loadwallet(const JSONRPCRequest& request)
             RPCHelpMan{"loadwallet",
                 "\nLoads a wallet from a wallet file or directory."
                 "\nNote that all wallet command-line options used when starting bitcoind will be"
-                "\napplied to the new wallet (eg -zapwallettxes, rescan, etc).\n",
+                "\napplied to the new wallet (eg -rescan, etc).\n",
                 {
                     {"filename", RPCArg::Type::STR, RPCArg::Optional::NO, "The wallet directory or .dat file."},
                 },

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3177,6 +3177,14 @@ DBErrors CWallet::ZapWalletTx(std::list<CWalletTx>& vWtx)
     if (nZapWalletTxRet != DBErrors::LOAD_OK)
         return nZapWalletTxRet;
 
+    // Clear mapWallet and mapTxSpends
+    {
+        LOCK(cs_wallet);
+        mapWallet.clear();
+        mapTxSpends.clear();
+        wtxOrdered.clear();
+    }
+
     return DBErrors::LOAD_OK;
 }
 

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -527,8 +527,6 @@ class WalletTest(BitcoinTestFramework):
         maintenance = [
             '-rescan',
             '-reindex',
-            '-zapwallettxes=1',
-            '-zapwallettxes=2',
         ]
         chainlimit = 6
         for m in maintenance:

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -134,11 +134,6 @@ class MultiWalletTest(BitcoinTestFramework):
         open(not_a_dir, 'a', encoding="utf8").close()
         self.nodes[0].assert_start_raises_init_error(['-walletdir=' + not_a_dir], 'Error: Specified -walletdir "' + not_a_dir + '" is not a directory')
 
-        self.log.info("Do not allow -zapwallettxes with multiwallet")
-        self.nodes[0].assert_start_raises_init_error(['-zapwallettxes', '-wallet=w1', '-wallet=w2'], "Error: -zapwallettxes is only allowed with a single wallet file")
-        self.nodes[0].assert_start_raises_init_error(['-zapwallettxes=1', '-wallet=w1', '-wallet=w2'], "Error: -zapwallettxes is only allowed with a single wallet file")
-        self.nodes[0].assert_start_raises_init_error(['-zapwallettxes=2', '-wallet=w1', '-wallet=w2'], "Error: -zapwallettxes is only allowed with a single wallet file")
-
         # if wallets/ doesn't exist, datadir should be the default wallet dir
         wallet_dir2 = data_dir('walletdir')
         os.rename(wallet_dir(), wallet_dir2)

--- a/test/functional/wallet_zapwallettxes.py
+++ b/test/functional/wallet_zapwallettxes.py
@@ -82,5 +82,8 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         # This will raise an exception because the unconfirmed transaction has been zapped
         assert_raises_rpc_error(-5, 'Invalid or non-wallet transaction id', zaptx.gettransaction, txid2)
 
+        self.log.info("Make sure -zapwallettxes gives an error")
+        self.nodes[0].assert_start_raises_init_error(["-zapwallettxes"], "Error: -zapwallettxes has been replaced with the zapwallettxes RPC. Please use that instead.")
+
 if __name__ == '__main__':
     ZapWalletTXesTest().main()

--- a/test/functional/wallet_zapwallettxes.py
+++ b/test/functional/wallet_zapwallettxes.py
@@ -18,62 +18,69 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    wait_until,
 )
 
 class ZapWalletTXesTest (BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
-        self.num_nodes = 2
+        self.num_nodes = 1
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
 
     def run_test(self):
         self.log.info("Mining blocks...")
-        self.nodes[0].generate(1)
-        self.sync_all()
-        self.nodes[1].generate(100)
+        self.nodes[0].generate(101)
         self.sync_all()
 
+        # Make a wallet that we will do the zapping on
+        self.nodes[0].createwallet(wallet_name="zaptx")
+        zaptx = self.nodes[0].get_wallet_rpc("zaptx")
+        default = self.nodes[0].get_wallet_rpc("")
+
         # This transaction will be confirmed
-        txid1 = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 10)
+        txid1 = default.sendtoaddress(zaptx.getnewaddress(), 10)
 
         self.nodes[0].generate(1)
         self.sync_all()
 
         # This transaction will not be confirmed
-        txid2 = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 20)
+        txid2 = default.sendtoaddress(zaptx.getnewaddress(), 20)
 
-        # Confirmed and unconfirmed transactions are now in the wallet.
-        assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)
-        assert_equal(self.nodes[0].gettransaction(txid2)['txid'], txid2)
+        # Confirmed and unconfirmed transactions are the only transactions in the wallet.
+        assert_equal(zaptx.gettransaction(txid1)['txid'], txid1)
+        assert_equal(zaptx.gettransaction(txid2)['txid'], txid2)
+        assert_equal(len(zaptx.listtransactions()), 2)
 
-        # Restart node0. Both confirmed and unconfirmed transactions remain in the wallet.
-        self.restart_node(0)
+        # Zap with no scans, wallet should not have any txs
+        zaptx.zapwallettxes(keep_metadata=False, rescan=False, scan_mempool=False)
+        assert_equal(len(zaptx.listtransactions()), 0)
 
-        assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)
-        assert_equal(self.nodes[0].gettransaction(txid2)['txid'], txid2)
+        # Rescanning blockchain should give us the confirmed tx
+        zaptx.rescanblockchain(0)
+        assert_equal(zaptx.gettransaction(txid1)['txid'], txid1)
 
-        # Restart node0 with zapwallettxes and persistmempool. The unconfirmed
-        # transaction is zapped from the wallet, but is re-added when the mempool is reloaded.
-        self.restart_node(0, ["-persistmempool=1", "-zapwallettxes=2"])
+        # Unload and reload wallet to get the mempool rescan
+        zaptx.unloadwallet()
+        self.nodes[0].loadwallet("zaptx")
 
-        wait_until(lambda: self.nodes[0].getmempoolinfo()['size'] == 1, timeout=3)
-        self.nodes[0].syncwithvalidationinterfacequeue()  # Flush mempool to wallet
+        assert_equal(zaptx.gettransaction(txid1)['txid'], txid1)
+        assert_equal(zaptx.gettransaction(txid2)['txid'], txid2)
 
-        assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)
-        assert_equal(self.nodes[0].gettransaction(txid2)['txid'], txid2)
+        # Zap with blockchain and mempool rescan
+        zaptx.zapwallettxes(rescan=True, scan_mempool=True)
 
-        # Restart node0 with zapwallettxes, but not persistmempool.
-        # The unconfirmed transaction is zapped and is no longer in the wallet.
-        self.restart_node(0, ["-zapwallettxes=2"])
+        assert_equal(zaptx.gettransaction(txid1)['txid'], txid1)
+        assert_equal(zaptx.gettransaction(txid2)['txid'], txid2)
+
+        # Zap with no args (just blockchain rescan)
+        zaptx.zapwallettxes()
 
         # tx1 is still be available because it was confirmed
-        assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)
+        assert_equal(zaptx.gettransaction(txid1)['txid'], txid1)
 
         # This will raise an exception because the unconfirmed transaction has been zapped
-        assert_raises_rpc_error(-5, 'Invalid or non-wallet transaction id', self.nodes[0].gettransaction, txid2)
+        assert_raises_rpc_error(-5, 'Invalid or non-wallet transaction id', zaptx.gettransaction, txid2)
 
 if __name__ == '__main__':
     ZapWalletTXesTest().main()

--- a/test/lint/check-doc.py
+++ b/test/lint/check-doc.py
@@ -23,7 +23,7 @@ CMD_GREP_WALLET_ARGS = r"git grep --function-context 'void WalletInit::AddWallet
 CMD_GREP_WALLET_HIDDEN_ARGS = r"git grep --function-context 'void DummyWalletInit::AddWalletOptions' -- {}".format(CMD_ROOT_DIR)
 CMD_GREP_DOCS = r"git grep --perl-regexp '{}' {}".format(REGEX_DOC, CMD_ROOT_DIR)
 # list unsupported, deprecated and duplicate args as they need no documentation
-SET_DOC_OPTIONAL = set(['-h', '-help', '-dbcrashratio', '-forcecompactdb'])
+SET_DOC_OPTIONAL = set(['-h', '-help', '-dbcrashratio', '-forcecompactdb', '-zapwallettxes'])
 
 
 def lint_missing_argument_documentation():


### PR DESCRIPTION
`-zapwallettxes` is known to not work with multiwallet and is currently disabled if multiple wallets are being loaded.

This PR removes the `-zapwallettxes` startup option and replaces its functionality with a `zapwallettxes` RPC command. This RPC does almost the same thing that the startup command did in that it removes all of the transactions from the target wallet. A blockchain rescan can optionally be triggered, as well as a mempool rescan. The default is to rescan the blockchain but not the mempool.

However a large difference is that `-zapwallettxes` would prevent the mempool from being loaded (#10330) but the RPC does not clear the mempool. However this does mean that the usefulness of this is questionable as the unconfirmed transactions that are being removed from the wallet would still appear in the mempool. The original behavior can be replicated by doing `zapwallettxes` and restarting with `-persistmempool=0`.

Also tests are updated to use the new RPC.