### PR TITLE
lint: Don't use TRAVIS_COMMIT_RANGE in commit message linter

### DIFF
--- a/test/lint/lint-git-commit-check.sh
+++ b/test/lint/lint-git-commit-check.sh
@@ -14,21 +14,22 @@ while getopts "?" opt; do
   case $opt in
     ?)
       echo "Usage: $0 [N]"
-      echo "       TRAVIS_COMMIT_RANGE='<commit range>' $0"
+      echo "       COMMIT_RANGE='<commit range>' $0"
       echo "       $0 -?"
       echo "Checks unmerged commits, the previous N commits, or a commit range."
-      echo "TRAVIS_COMMIT_RANGE='47ba2c3...ee50c9e' $0"
+      echo "COMMIT_RANGE='47ba2c3...ee50c9e' $0"
       exit ${EXIT_CODE}
     ;;
   esac
 done
 
-if [ -z "${TRAVIS_COMMIT_RANGE}" ]; then
-  if [ -n "$1" ]; then
-    TRAVIS_COMMIT_RANGE="HEAD~$1...HEAD"
-  else
-    TRAVIS_COMMIT_RANGE="origin/master..HEAD"
-  fi
+if [ -z "${COMMIT_RANGE}" ]; then
+    if [ -n "$1" ]; then
+      COMMIT_RANGE="HEAD~$1...HEAD"
+    else
+      MERGE_BASE=$(git merge-base HEAD master)
+      COMMIT_RANGE="$MERGE_BASE..HEAD"
+    fi
 fi
 
 while IFS= read -r commit_hash  || [[ -n "$commit_hash" ]]; do
@@ -41,6 +42,6 @@ while IFS= read -r commit_hash  || [[ -n "$commit_hash" ]]; do
             EXIT_CODE=1
         fi
     done < <(git log --format=%B -n 1 "$commit_hash")
-done < <(git log "${TRAVIS_COMMIT_RANGE}" --format=%H)
+done < <(git log "${COMMIT_RANGE}" --format=%H)
 
 exit ${EXIT_CODE}


### PR DESCRIPTION
#19439 was recently merged and seemed to work fine but I now noticed strange behavior when it was running in Travis, which I could not reproduce locally. It turns out `TRAVIS_COMMIT_RANGE` which is used in Travis to get the commits for the linter, uses all the commits that were in a push, which includes all rebase commits for example. This means that the linter can fail on a commit that the developer has never even seen before, which can be very confusing. See an example here which caused me to look into this: https://travis-ci.org/github/bitcoin/bitcoin/jobs/714296381 The commit that is reported as failing in my PR is not part of my PR.

I think we rather want to use something like `git merge-base` to get the commit range by default and in Travis. I am leaving the env variable functionality in place with a different name but this is not a variable that can be expected to be present in the CI environments so the `merge-base` range should be used there by default.