### PR TITLE
test: Wait until is_connected in add_p2p_connection

### DIFF
--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -218,11 +218,6 @@ class FilterTest(BitcoinTestFramework):
         # Add peer but do not send version yet
         filter_peer_without_nrelay = self.nodes[0].add_p2p_connection(P2PBloomFilter(), send_version=False, wait_for_verack=False)
         # Send version with fRelay=False
-        filter_peer_without_nrelay.wait_until(
-            lambda: filter_peer_without_nrelay.is_connected,
-            timeout=10,
-            check_connected=False,
-        )
         version_without_fRelay = msg_version()
         version_without_fRelay.nRelay = 0
         filter_peer_without_nrelay.send_message(version_without_fRelay)

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -474,7 +474,7 @@ class P2PInterface(P2PConnection):
         def test_function():
             return "verack" in self.last_message
 
-        self.wait_until(test_function, timeout=timeout, check_connected=False)
+        self.wait_until(test_function, timeout=timeout)
 
     # Message sending helper functions
 

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -524,6 +524,7 @@ class TestNode():
 
         p2p_conn.peer_connect(**kwargs, net=self.chain, timeout_factor=self.timeout_factor)()
         self.p2ps.append(p2p_conn)
+        p2p_conn.wait_until(lambda: p2p_conn.is_connected, check_connected=False)
         if wait_for_verack:
             # Wait for the node to send us the version and verack
             p2p_conn.wait_for_verack()


### PR DESCRIPTION
Moving the wait_until from the individual test scripts to the test framework simplifies two tests