### PR TITLE
Floating-Point Nakamoto Consensus 

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3148,7 +3148,7 @@ void ProcessMessage(
 
         // If this was a new header with more work than our tip, update the
         // peer's last block announcement time
-        if (received_new_header && pindex->nChainWork > ::ChainActive().Tip()->nChainWork) {
+        if (received_new_header && pindex->nChainWork >= ::ChainActive().Tip()->nChainWork) {
             nodestate->m_last_block_announcement = GetTime();
         }
 
@@ -3158,7 +3158,7 @@ void ProcessMessage(
         if (pindex->nStatus & BLOCK_HAVE_DATA) // Nothing to do here
             return;
 
-        if (pindex->nChainWork <= ::ChainActive().Tip()->nChainWork || // We know something better
+        if (pindex->nChainWork < ::ChainActive().Tip()->nChainWork || // We know something better
                 pindex->nTx != 0) { // We had this block at some point, but pruned it
             if (fAlreadyInFlight) {
                 // We requested this block for some reason, but our mempool will probably be useless

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -45,6 +45,20 @@ public:
     friend inline bool operator==(const base_blob& a, const base_blob& b) { return a.Compare(b) == 0; }
     friend inline bool operator!=(const base_blob& a, const base_blob& b) { return a.Compare(b) != 0; }
     friend inline bool operator<(const base_blob& a, const base_blob& b) { return a.Compare(b) < 0; }
+    friend inline bool operator>(const base_blob& a, const base_blob& b) { return a.Compare(b) > 0; }
+    void operator+=(const base_blob& a) {
+        uint64_t cur = 0;
+        uint64_t overflow = 0;
+        const unsigned char * source = a.data();
+        for (int i = WIDTH - 1; i >= 0; i--){
+            cur = m_data[i] + source[i] + overflow;
+            //record the low byte:
+            m_data[i] = cur & 0xff;
+            //keep track of the rest.
+            overflow = (cur >> 8);
+        }
+        //fitness tests will not lead to an int overflow
+    }
 
     std::string GetHex() const;
     void SetHex(const char* psz);


### PR DESCRIPTION
This change is related to a whitepaper I submitted privately to ZmnSCPxj, and this PR is by his request.

Changes in this pr:
- Updated the protocol layer to accept a competing chain of the same height so that it's fitness can be tested.
- Updated the verification layer to incorporate a block fitness test to resolve disagreements.
- Introduced an uint256-bit addition operator to support the block fitness test.
 
---
When forming a Nakamoto Consensus, two competing chains of equal length can presented to the network. Nodes within the network see these two chains authoritative equals, and a disagreement forms on which is the authoritative equal.  Floating-Point Nakamoto Consensus introduces a method of disagreement resolution by setting up a kind of relay-race - where the winning team’s strength is carried forward.   This design is intended to cement the lead of the winner and to greatly incentivize the network to adopt the dominant chain no matter how many valid solutions are advertised, or what order they arrive.

The first step in this new algorithm is that a node in the network should continue to conduct traditional Nakamoto Consensus, but If at any point there are two solution blocks advertised for the same height - then the more-fit block is chosen as the winner which is then propagated to neighbors.  It is in the best interest of all miners to adopt the most-fit block, failing to do so risks wasting resources on a mining a block that would be discarded.

In order to have a decentralized solution, this kind of agreement must be empirically derived from the existing proof-of-work so that it is identically verifiable by all nodes on the network.  Additionally, this fitness evaluation needs to ensure that no two competing solutions can be numerically equivalent.
