### PR TITLE
Move cs_vSend into SocketSendData and resolve RecordBytesSent lock inconsistency

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -747,8 +747,9 @@ void V1TransportSerializer::prepareForTransport(CSerializedNetMsg& msg, std::vec
     CVectorWriter{SER_NETWORK, INIT_PROTO_VERSION, header, 0, hdr};
 }
 
-size_t CConnman::SocketSendData(CNode *pnode) const EXCLUSIVE_LOCKS_REQUIRED(pnode->cs_vSend)
+size_t CConnman::SocketSendData(CNode *pnode) const
 {
+    LOCK(pnode->cs_vSend);
     auto it = pnode->vSendMsg.begin();
     size_t nSentSize = 0;
 
@@ -1445,11 +1446,8 @@ void CConnman::SocketHandler()
         //
         if (sendSet)
         {
-            LOCK(pnode->cs_vSend);
-            size_t nBytes = SocketSendData(pnode);
-            if (nBytes) {
-                RecordBytesSent(nBytes);
-            }
+            const size_t bytes_sent{SocketSendData(pnode)};
+            if (bytes_sent) RecordBytesSent(bytes_sent);
         }
 
         InactivityCheck(pnode);
@@ -2821,10 +2819,10 @@ void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
     pnode->m_serializer->prepareForTransport(msg, serialized_header);
     const size_t total_size{message_size + serialized_header.size()};
 
-    size_t bytes_sent{0};
+    bool optimistic_send{false};
     {
         LOCK(pnode->cs_vSend);
-        bool optimistic_send{pnode->vSendMsg.empty()};
+        optimistic_send = pnode->vSendMsg.empty();
 
         //log total amount of bytes per message type
         pnode->mapSendBytesPerMsgCmd[msg.m_type] += total_size;
@@ -2837,13 +2835,12 @@ void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
         if (message_size) {
             pnode->vSendMsg.push_back(std::move(msg.data));
         }
-
-        // If write queue empty, attempt "optimistic write"
-        if (optimistic_send) {
-            bytes_sent = SocketSendData(pnode);
-        }
     }
-    if (bytes_sent) RecordBytesSent(bytes_sent);
+    // If write queue was empty, attempt "optimistic write"
+    if (optimistic_send) {
+        const size_t bytes_sent{SocketSendData(pnode)};
+        if (bytes_sent) RecordBytesSent(bytes_sent);
+    }
 }
 
 bool CConnman::ForNode(NodeId id, std::function<bool(CNode* pnode)> func)

--- a/src/net.h
+++ b/src/net.h
@@ -759,8 +759,8 @@ public:
     // socket
     std::atomic<ServiceFlags> nServices{NODE_NONE};
     SOCKET hSocket GUARDED_BY(cs_hSocket);
-    size_t nSendSize{0}; // total size of all vSendMsg entries
-    size_t nSendOffset{0}; // offset inside the first vSendMsg already sent
+    size_t nSendSize GUARDED_BY(cs_vSend){0}; // total size of all vSendMsg entries
+    size_t nSendOffset GUARDED_BY(cs_vSend){0}; // offset inside the first vSendMsg already sent
     uint64_t nSendBytes GUARDED_BY(cs_vSend){0};
     std::deque<std::vector<unsigned char>> vSendMsg GUARDED_BY(cs_vSend);
     RecursiveMutex cs_vSend;
@@ -817,7 +817,7 @@ public:
     std::atomic_bool fPauseSend{false};
 
 protected:
-    mapMsgCmdSize mapSendBytesPerMsgCmd;
+    mapMsgCmdSize mapSendBytesPerMsgCmd GUARDED_BY(cs_vSend);
     mapMsgCmdSize mapRecvBytesPerMsgCmd GUARDED_BY(cs_vRecv);
 
 public:


### PR DESCRIPTION
As it stands, `RecordBytesSent` is called twice, once under the `cs_vSend` lock, and once not.  This PR moves both calls out of the lock.

In doing this, I've made a change to SocketSendData.  Before, it required the caller to lock `cs_vSend`, now it locks `cs_vSend` itself.  The only case where this makes a difference is when performing an optimistic write (where MessageHandler is the thread that calls SocketSendData, not SocketHandler).  As justified in the commit message, I don't think this will cause any problems, and subjectively I think this is an improvement to how we're using the locks.  I'm more than happy to be told that I'm wrong :)

Additionally this PR brings PushMessage into line with the style guide, and does verious other cleanups.

This PR was originally related to #18784 but it now stands on its own.