### PR TITLE
depends: CMake invocation cleanup

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -158,9 +158,9 @@ $(1)_autoconf += LDFLAGS="$$($(1)_ldflags)"
 endif
 
 $(1)_cmake=env CC="$$($(1)_cc)" \
-               CFLAGS="$$($(1)_cflags)" \
+               CFLAGS="$$($(1)_cppflags) $$($(1)_cflags)" \
                CXX="$$($(1)_cxx)" \
-               CXXFLAGS="$$($(1)_cxxflags)" \
+               CXXFLAGS="$$($(1)_cppflags) $$($(1)_cxxflags)" \
              cmake -DCMAKE_INSTALL_PREFIX:PATH="$$($($(1)_type)_prefix)"
 ifneq ($($(1)_type),build)
 ifneq ($(host),$(build))

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -161,6 +161,7 @@ $(1)_cmake=env CC="$$($(1)_cc)" \
                CFLAGS="$$($(1)_cppflags) $$($(1)_cflags)" \
                CXX="$$($(1)_cxx)" \
                CXXFLAGS="$$($(1)_cppflags) $$($(1)_cxxflags)" \
+               LDFLAGS="$$($(1)_ldflags)" \
              cmake -DCMAKE_INSTALL_PREFIX:PATH="$$($($(1)_type)_prefix)"
 ifneq ($($(1)_type),build)
 ifneq ($(host),$(build))

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -157,7 +157,11 @@ ifneq ($($(1)_ldflags),)
 $(1)_autoconf += LDFLAGS="$$($(1)_ldflags)"
 endif
 
-$(1)_cmake=env CC="$$($(1)_cc)" CXX="$$($(1)_cxx)" CFLAGS="$$($(1)_cflags)" CXXFLAGS="$$($(1)_cxxflags)" cmake -DCMAKE_INSTALL_PREFIX:PATH=$($($(1)_type)_prefix)
+$(1)_cmake=env CC="$$($(1)_cc)" \
+               CFLAGS="$$($(1)_cflags)" \
+               CXX="$$($(1)_cxx)" \
+               CXXFLAGS="$$($(1)_cxxflags)" \
+             cmake -DCMAKE_INSTALL_PREFIX:PATH="$$($($(1)_type)_prefix)"
 ifneq ($($(1)_type),build)
 ifneq ($(host),$(build))
 $(1)_cmake += -DCMAKE_SYSTEM_NAME=$($(host_os)_cmake_system)

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -157,12 +157,12 @@ ifneq ($($(1)_ldflags),)
 $(1)_autoconf += LDFLAGS="$$($(1)_ldflags)"
 endif
 
-$(1)_cmake=cmake -DCMAKE_INSTALL_PREFIX=$($($(1)_type)_prefix)
+$(1)_cmake=env CC="$$($(1)_cc)" CXX="$$($(1)_cxx)" CFLAGS="$$($(1)_cflags)" CXXFLAGS="$$($(1)_cxxflags)" cmake -DCMAKE_INSTALL_PREFIX:PATH=$($($(1)_type)_prefix)
 ifneq ($($(1)_type),build)
 ifneq ($(host),$(build))
-$(1)_cmake += -DCMAKE_SYSTEM_NAME=$($(host_os)_cmake_system) -DCMAKE_SYSROOT=$(host_prefix)
-$(1)_cmake += -DCMAKE_C_COMPILER_TARGET=$(host) -DCMAKE_C_COMPILER=$(firstword $($($(1)_type)_CC)) -DCMAKE_C_FLAGS="$(wordlist 2,1000,$($($(1)_type)_CC))"
-$(1)_cmake += -DCMAKE_CXX_COMPILER_TARGET=$(host) -DCMAKE_CXX_COMPILER=$(firstword $($($(1)_type)_CXX)) -DCMAKE_CXX_FLAGS="$(wordlist 2,1000,$($($(1)_type)_CXX))"
+$(1)_cmake += -DCMAKE_SYSTEM_NAME=$($(host_os)_cmake_system)
+$(1)_cmake += -DCMAKE_C_COMPILER_TARGET=$(host)
+$(1)_cmake += -DCMAKE_CXX_COMPILER_TARGET=$(host)
 endif
 endif
 endef

--- a/depends/packages/native_cdrkit.mk
+++ b/depends/packages/native_cdrkit.mk
@@ -12,7 +12,7 @@ endef
 # Starting with 10.1, GCC defaults to -fno-common, resulting in linking errors.
 # Pass -fcommon to retain the legacy behaviour.
 define $(package)_config_cmds
-  cmake -DCMAKE_INSTALL_PREFIX=$(build_prefix) -DCMAKE_C_FLAGS="-fcommon"
+  $($(package)_cmake) -DCMAKE_C_FLAGS="$$($(1)_cflags) -fcommon"
 endef
 
 define $(package)_build_cmds

--- a/depends/packages/native_libdmg-hfsplus.mk
+++ b/depends/packages/native_libdmg-hfsplus.mk
@@ -12,7 +12,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_config_cmds
-  cmake -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) -DCMAKE_C_FLAGS="-Wl,--build-id=none" ..
+  $($(package)_cmake) -DCMAKE_C_FLAGS="$$($(1)_cflags) -Wl,--build-id=none" ..
 endef
 
 define $(package)_build_cmds


### PR DESCRIPTION
- Use `$($(package)_cmake)` instead of invoking `cmake` directly
- Use well-known env vars instead of overriding CMake variables