### PR TITLE
rpc: Fix addnode remove command error

### DIFF
--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -276,7 +276,7 @@ static UniValue addnode(const JSONRPCRequest& request)
     else if(strCommand == "remove")
     {
         if(!node.connman->RemoveAddedNode(strNode))
-            throw JSONRPCError(RPC_CLIENT_NODE_NOT_ADDED, "Error: Node has not been added.");
+            throw JSONRPCError(RPC_CLIENT_NODE_NOT_ADDED, "Error: Node could not be removed. It has not been added previously.");
     }
 
     return NullUniValue;

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -131,6 +131,13 @@ class NetTest(BitcoinTestFramework):
         added_nodes = self.nodes[0].getaddednodeinfo(ip_port)
         assert_equal(len(added_nodes), 1)
         assert_equal(added_nodes[0]['addednode'], ip_port)
+        # check that node cannot be added again
+        assert_raises_rpc_error(-23, "Node already added", self.nodes[0].addnode, node=ip_port, command='add')
+        # check that node can be removed
+        self.nodes[0].addnode(node=ip_port, command='remove')
+        assert_equal(self.nodes[0].getaddednodeinfo(), [])
+        # check that trying to remove the node again returns an error
+        assert_raises_rpc_error(-24, "Node could not be removed", self.nodes[0].addnode, node=ip_port, command='remove')
         # check that a non-existent node returns an error
         assert_raises_rpc_error(-24, "Node has not been added", self.nodes[0].getaddednodeinfo, '1.1.1.1')
 


### PR DESCRIPTION
The `addnode` RPC with the `remove` command parameter is used to remove a node from the "added nodes". It did not have test coverage and in case of failure to remove the node it responded with the confusing message "Error: Node has not been added.".

This PR adds test coverage and introduces a new error code as well as changes the error message to something that makes sense.