### PR TITLE
wallet: Replace -zapwallettxes with wallet tool command

### DIFF
--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -28,10 +28,12 @@ static void SetupWalletToolArgs(ArgsManager& argsman)
     argsman.AddArg("-wallet=<wallet-name>", "Specify wallet name", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::OPTIONS);
     argsman.AddArg("-debug=<category>", "Output debugging information (default: 0).", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-printtoconsole", "Send trace/debug info to console (default: 1 when no -debug is true, 0 otherwise).", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
+    argsman.AddArg("-keepmeta", "Keep metadata for zapwallettxes (default: true)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 
     argsman.AddArg("info", "Get wallet info", ArgsManager::ALLOW_ANY, OptionsCategory::COMMANDS);
     argsman.AddArg("create", "Create new wallet file", ArgsManager::ALLOW_ANY, OptionsCategory::COMMANDS);
     argsman.AddArg("salvage", "Attempt to recover private keys from a corrupt wallet", ArgsManager::ALLOW_ANY, OptionsCategory::COMMANDS);
+    argsman.AddArg("zapwallettxes", "Remove all of the transactions from the wallet. A rescan will be required the next time the wallet is loaded.", ArgsManager::ALLOW_ANY, OptionsCategory::COMMANDS);
 }
 
 static bool WalletAppInit(int argc, char* argv[])

--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -48,7 +48,6 @@ void DummyWalletInit::AddWalletOptions(ArgsManager& argsman) const
         "-walletdir=<dir>",
         "-walletnotify=<cmd>",
         "-walletrbf",
-        "-zapwallettxes=<mode>",
         "-dblogsize=<n>",
         "-flushwallet",
         "-privdb",

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -64,13 +64,13 @@ void WalletInit::AddWalletOptions(ArgsManager& argsman) const
     argsman.AddArg("-walletnotify=<cmd>", "Execute command when a wallet transaction changes. %s in cmd is replaced by TxID and %w is replaced by wallet name. %w is not currently implemented on windows. On systems where %w is supported, it should NOT be quoted because this would break shell escaping used to invoke the command.", ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
 #endif
     argsman.AddArg("-walletrbf", strprintf("Send transactions with full-RBF opt-in enabled (RPC only, default: %u)", DEFAULT_WALLET_RBF), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
-    argsman.AddArg("-zapwallettxes=<mode>", "Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup"
-                               " (1 = keep tx meta data e.g. payment request information, 2 = drop tx meta data)", ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
 
     argsman.AddArg("-dblogsize=<n>", strprintf("Flush wallet database activity from memory to disk log every <n> megabytes (default: %u)", DEFAULT_WALLET_DBLOGSIZE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
     argsman.AddArg("-flushwallet", strprintf("Run a thread to flush wallet periodically (default: %u)", DEFAULT_FLUSHWALLET), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
     argsman.AddArg("-privdb", strprintf("Sets the DB_PRIVATE flag in the wallet db environment (default: %u)", DEFAULT_WALLET_PRIVDB), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
     argsman.AddArg("-walletrejectlongchains", strprintf("Wallet will not create transactions that violate mempool chain limits (default: %u)", DEFAULT_WALLET_REJECT_LONG_CHAINS), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
+
+    argsman.AddHiddenArgs({"-zapwallettxes"});
 }
 
 bool WalletInit::ParameterInteraction() const
@@ -83,26 +83,12 @@ bool WalletInit::ParameterInteraction() const
         return true;
     }
 
-    const bool is_multiwallet = gArgs.GetArgs("-wallet").size() > 1;
-
     if (gArgs.GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY) && gArgs.SoftSetBoolArg("-walletbroadcast", false)) {
         LogPrintf("%s: parameter interaction: -blocksonly=1 -> setting -walletbroadcast=0\n", __func__);
     }
 
-    bool zapwallettxes = gArgs.GetBoolArg("-zapwallettxes", false);
-    // -zapwallettxes implies dropping the mempool on startup
-    if (zapwallettxes && gArgs.SoftSetBoolArg("-persistmempool", false)) {
-        LogPrintf("%s: parameter interaction: -zapwallettxes enabled -> setting -persistmempool=0\n", __func__);
-    }
-
-    // -zapwallettxes implies a rescan
-    if (zapwallettxes) {
-        if (is_multiwallet) {
-            return InitError(strprintf(Untranslated("%s is only allowed with a single wallet file"), "-zapwallettxes"));
-        }
-        if (gArgs.SoftSetBoolArg("-rescan", true)) {
-            LogPrintf("%s: parameter interaction: -zapwallettxes enabled -> setting -rescan=1\n", __func__);
-        }
+    if (gArgs.IsArgSet("-zapwallettxes")) {
+        return InitError(_("-zapwallettxes has been replaced with the zapwallettxes command in the bitcoin-wallet tool. Please use that instead."));
     }
 
     if (gArgs.GetBoolArg("-sysperms", false))

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2481,7 +2481,7 @@ static UniValue loadwallet(const JSONRPCRequest& request)
             RPCHelpMan{"loadwallet",
                 "\nLoads a wallet from a wallet file or directory."
                 "\nNote that all wallet command-line options used when starting bitcoind will be"
-                "\napplied to the new wallet (eg -zapwallettxes, rescan, etc).\n",
+                "\napplied to the new wallet (eg -rescan, etc).\n",
                 {
                     {"filename", RPCArg::Type::STR, RPCArg::Optional::NO, "The wallet directory or .dat file."},
                 },

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3742,21 +3742,6 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
 {
     const std::string walletFile = WalletDataFilePath(location.GetPath()).string();
 
-    // needed to restore wallet transaction meta data after -zapwallettxes
-
-    if (gArgs.GetBoolArg("-zapwallettxes", false)) {
-        chain.initMessage(_("Zapping all transactions from wallet...").translated);
-
-        bool keep_meta = gArgs.GetArg("-zapwallettxes", "1") != "2";
-        std::map<uint256, CWalletTx> vWtx;
-        std::unique_ptr<CWallet> tempWallet = MakeUnique<CWallet>(&chain, location, CreateWalletDatabase(location.GetPath()));
-        DBErrors nZapWalletRet = tempWallet->ZapWalletTx(vWtx, keep_meta);
-        if (nZapWalletRet != DBErrors::LOAD_OK) {
-            error = strprintf(_("Error loading %s: Wallet corrupted"), walletFile);
-            return nullptr;
-        }
-    }
-
     chain.initMessage(_("Loading wallet...").translated);
 
     int64_t nStart = GetTimeMillis();
@@ -4018,7 +4003,7 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
         walletInstance->chainStateFlushed(chain.getTipLocator());
         walletInstance->database->IncrementUpdateCounter();
 
-        // Restore wallet transaction metadata after -zapwallettxes=1
+        // Restore wallet transaction metadata after 'bitcoin-wallet -keepmeta zapwallettxes'
         if (walletInstance->m_has_zapped)
         {
             WalletBatch batch(*walletInstance->database);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3144,7 +3144,7 @@ DBErrors CWallet::ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256
     return DBErrors::LOAD_OK;
 }
 
-DBErrors CWallet::ZapWalletTx(std::list<CWalletTx>& vWtx)
+DBErrors CWallet::ZapWalletTx(std::map<uint256, CWalletTx>& vWtx)
 {
     DBErrors nZapWalletTxRet = WalletBatch(*database,"cr+").ZapWalletTx(vWtx);
     if (nZapWalletTxRet == DBErrors::NEED_REWRITE)
@@ -3743,7 +3743,7 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
     const std::string walletFile = WalletDataFilePath(location.GetPath()).string();
 
     // needed to restore wallet transaction meta data after -zapwallettxes
-    std::list<CWalletTx> vWtx;
+    std::map<uint256, CWalletTx> vWtx;
 
     if (gArgs.GetBoolArg("-zapwallettxes", false)) {
         chain.initMessage(_("Zapping all transactions from wallet...").translated);
@@ -4022,8 +4022,9 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
         {
             WalletBatch batch(*walletInstance->database);
 
-            for (const CWalletTx& wtxOld : vWtx)
+            for (const auto& wtx_pair : vWtx)
             {
+                const CWalletTx& wtxOld = wtx_pair.second;
                 uint256 hash = wtxOld.GetHash();
                 std::map<uint256, CWalletTx>::iterator mi = walletInstance->mapWallet.find(hash);
                 if (mi != walletInstance->mapWallet.end())

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1065,6 +1065,9 @@ public:
     DBErrors ZapWalletTx(std::map<uint256, CWalletTx>& vWtx, bool keep_meta);
     DBErrors ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256>& vHashOut) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
+    bool m_has_zapped = false;
+    void SetHasZapped();
+
     bool SetAddressBook(const CTxDestination& address, const std::string& strName, const std::string& purpose);
 
     bool DelAddressBook(const CTxDestination& address);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1062,7 +1062,7 @@ public:
     void chainStateFlushed(const CBlockLocator& loc) override;
 
     DBErrors LoadWallet(bool& fFirstRunRet);
-    DBErrors ZapWalletTx(std::list<CWalletTx>& vWtx);
+    DBErrors ZapWalletTx(std::map<uint256, CWalletTx>& vWtx);
     DBErrors ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256>& vHashOut) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     bool SetAddressBook(const CTxDestination& address, const std::string& strName, const std::string& purpose);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1062,7 +1062,7 @@ public:
     void chainStateFlushed(const CBlockLocator& loc) override;
 
     DBErrors LoadWallet(bool& fFirstRunRet);
-    DBErrors ZapWalletTx(std::map<uint256, CWalletTx>& vWtx);
+    DBErrors ZapWalletTx(std::map<uint256, CWalletTx>& vWtx, bool keep_meta);
     DBErrors ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256>& vHashOut) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     bool SetAddressBook(const CTxDestination& address, const std::string& strName, const std::string& purpose);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -925,7 +925,7 @@ DBErrors WalletBatch::ZapSelectTx(std::vector<uint256>& vTxHashIn, std::vector<u
     return DBErrors::LOAD_OK;
 }
 
-DBErrors WalletBatch::ZapWalletTx(std::map<uint256, CWalletTx>& vWtx)
+DBErrors WalletBatch::ZapWalletTx(std::map<uint256, CWalletTx>& vWtx, bool keep_meta)
 {
     // build list of wallet TXs
     DBErrors err = FindWalletTx(vWtx);
@@ -935,6 +935,7 @@ DBErrors WalletBatch::ZapWalletTx(std::map<uint256, CWalletTx>& vWtx)
     // erase each wallet TX
     for (const auto& wtx_pair : vWtx) {
         const uint256& hash = wtx_pair.first;
+        if (keep_meta && !WriteZapTx(wtx_pair.second)) return DBErrors::CORRUPT;
         if (!EraseTx(hash))
             return DBErrors::CORRUPT;
     }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -48,6 +48,7 @@ const std::string WALLETDESCRIPTORCKEY{"walletdescriptorckey"};
 const std::string WALLETDESCRIPTORKEY{"walletdescriptorkey"};
 const std::string WATCHMETA{"watchmeta"};
 const std::string WATCHS{"watchs"};
+const std::string ZAPTX{"zaptx"};
 } // namespace DBKeys
 
 //
@@ -84,6 +85,16 @@ bool WalletBatch::WriteTx(const CWalletTx& wtx)
 bool WalletBatch::EraseTx(uint256 hash)
 {
     return EraseIC(std::make_pair(DBKeys::TX, hash));
+}
+
+bool WalletBatch::WriteZapTx(const CWalletTx& wtx)
+{
+    return WriteIC(std::make_pair(DBKeys::ZAPTX, wtx.GetHash()), wtx);
+}
+
+bool WalletBatch::EraseZapTx(uint256 hash)
+{
+    return EraseIC(std::make_pair(DBKeys::ZAPTX, hash));
 }
 
 bool WalletBatch::WriteKeyMetadata(const CKeyMetadata& meta, const CPubKey& pubkey, const bool overwrite)

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -80,6 +80,7 @@ extern const std::string WALLETDESCRIPTORCKEY;
 extern const std::string WALLETDESCRIPTORKEY;
 extern const std::string WATCHMETA;
 extern const std::string WATCHS;
+extern const std::string ZAPTX;
 } // namespace DBKeys
 
 /* simple HD chain data model */
@@ -220,6 +221,9 @@ public:
 
     bool WriteTx(const CWalletTx& wtx);
     bool EraseTx(uint256 hash);
+
+    bool WriteZapTx(const CWalletTx& wtx);
+    bool EraseZapTx(uint256 hash);
 
     bool WriteKeyMetadata(const CKeyMetadata& meta, const CPubKey& pubkey, const bool overwrite);
     bool WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata &keyMeta);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -256,8 +256,8 @@ public:
     bool WriteActiveScriptPubKeyMan(uint8_t type, const uint256& id, bool internal);
 
     DBErrors LoadWallet(CWallet* pwallet);
-    DBErrors FindWalletTx(std::vector<uint256>& vTxHash, std::list<CWalletTx>& vWtx);
-    DBErrors ZapWalletTx(std::list<CWalletTx>& vWtx);
+    DBErrors FindWalletTx(std::map<uint256, CWalletTx>& vWtx);
+    DBErrors ZapWalletTx(std::map<uint256, CWalletTx>& vWtx);
     DBErrors ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256>& vHashOut);
     /* Function to determine if a certain KV/key-type is a key (cryptographical key) type */
     static bool IsKeyType(const std::string& strType);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -261,7 +261,7 @@ public:
 
     DBErrors LoadWallet(CWallet* pwallet);
     DBErrors FindWalletTx(std::map<uint256, CWalletTx>& vWtx);
-    DBErrors ZapWalletTx(std::map<uint256, CWalletTx>& vWtx);
+    DBErrors ZapWalletTx(std::map<uint256, CWalletTx>& vWtx, bool keep_meta);
     DBErrors ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256>& vHashOut);
     /* Function to determine if a certain KV/key-type is a key (cryptographical key) type */
     static bool IsKeyType(const std::string& strType);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -260,7 +260,7 @@ public:
     bool WriteActiveScriptPubKeyMan(uint8_t type, const uint256& id, bool internal);
 
     DBErrors LoadWallet(CWallet* pwallet);
-    DBErrors FindWalletTx(std::map<uint256, CWalletTx>& vWtx);
+    DBErrors FindWalletTx(std::map<uint256, CWalletTx>& vWtx, bool find_zapped = false);
     DBErrors ZapWalletTx(std::map<uint256, CWalletTx>& vWtx, bool keep_meta);
     DBErrors ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256>& vHashOut);
     /* Function to determine if a certain KV/key-type is a key (cryptographical key) type */

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -527,8 +527,6 @@ class WalletTest(BitcoinTestFramework):
         maintenance = [
             '-rescan',
             '-reindex',
-            '-zapwallettxes=1',
-            '-zapwallettxes=2',
         ]
         chainlimit = 6
         for m in maintenance:

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -134,11 +134,6 @@ class MultiWalletTest(BitcoinTestFramework):
         open(not_a_dir, 'a', encoding="utf8").close()
         self.nodes[0].assert_start_raises_init_error(['-walletdir=' + not_a_dir], 'Error: Specified -walletdir "' + not_a_dir + '" is not a directory')
 
-        self.log.info("Do not allow -zapwallettxes with multiwallet")
-        self.nodes[0].assert_start_raises_init_error(['-zapwallettxes', '-wallet=w1', '-wallet=w2'], "Error: -zapwallettxes is only allowed with a single wallet file")
-        self.nodes[0].assert_start_raises_init_error(['-zapwallettxes=1', '-wallet=w1', '-wallet=w2'], "Error: -zapwallettxes is only allowed with a single wallet file")
-        self.nodes[0].assert_start_raises_init_error(['-zapwallettxes=2', '-wallet=w1', '-wallet=w2'], "Error: -zapwallettxes is only allowed with a single wallet file")
-
         # if wallets/ doesn't exist, datadir should be the default wallet dir
         wallet_dir2 = data_dir('walletdir')
         os.rename(wallet_dir(), wallet_dir2)

--- a/test/functional/wallet_zapwallettxes.py
+++ b/test/functional/wallet_zapwallettxes.py
@@ -4,76 +4,113 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the zapwallettxes functionality.
 
-- start two bitcoind nodes
-- create two transactions on node 0 - one is confirmed and one is unconfirmed.
-- restart node 0 and verify that both the confirmed and the unconfirmed
-  transactions are still available.
-- restart node 0 with zapwallettxes and persistmempool, and verify that both
-  the confirmed and the unconfirmed transactions are still available.
-- restart node 0 with just zapwallettxes and verify that the confirmed
+- make two wallest
+- create two transactions on zaptx wallet - one is confirmed and one is unconfirmed.
+- run zapwallettxes, reload the wallet, and verify that both transactions are available
+- run zapwallettxes, restart node 0 without persistmempool, and verify that the confirmed
   transactions are still available, but that the unconfirmed transaction has
   been zapped.
 """
+
+import subprocess
+import textwrap
+
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    wait_until,
 )
 
 class ZapWalletTXesTest (BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
-        self.num_nodes = 2
+        self.extra_args = [["-keypool=1"]]
+        self.num_nodes = 1
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
+        self.skip_if_no_wallet_tool()
+
+    def bitcoin_wallet_process(self, *args):
+        binary = self.config["environment"]["BUILDDIR"] + '/src/bitcoin-wallet' + self.config["environment"]["EXEEXT"]
+        args = ['-datadir={}'.format(self.nodes[0].datadir), '-chain=%s' % self.chain] + list(args)
+        return subprocess.Popen([binary] + args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+
+    def assert_tool_output(self, output, *args):
+        p = self.bitcoin_wallet_process(*args)
+        stdout, stderr = p.communicate()
+        assert_equal(stderr, '')
+        assert_equal(stdout, output)
+        assert_equal(p.poll(), 0)
+
+    def assert_zapped(self, wallet):
+        if not self.nodes[0].is_node_stopped():
+            self.nodes[0].unloadwallet(wallet)
+        out = textwrap.dedent('''\
+            Wallet info
+            ===========
+            Encrypted: no
+            HD (hd seed available): yes
+            Keypool Size: 2
+            Transactions: 2
+            Address Book: 2
+        ''')
+        self.assert_tool_output(out, "-wallet={}".format(wallet), "info")
+        self.assert_tool_output("", "-wallet={}".format(wallet), "zapwallettxes")
+        out = textwrap.dedent('''\
+            Wallet info
+            ===========
+            Encrypted: no
+            HD (hd seed available): yes
+            Keypool Size: 2
+            Transactions: 0
+            Address Book: 2
+        ''')
+        self.assert_tool_output(out, '-wallet={}'.format(wallet), 'info')
+        if not self.nodes[0].is_node_stopped():
+            self.nodes[0].loadwallet(wallet)
 
     def run_test(self):
         self.log.info("Mining blocks...")
-        self.nodes[0].generate(1)
-        self.sync_all()
-        self.nodes[1].generate(100)
+        self.nodes[0].generate(101)
         self.sync_all()
 
+        # Make a wallet that we will do the zapping on
+        self.nodes[0].createwallet(wallet_name="zaptx")
+        zaptx = self.nodes[0].get_wallet_rpc("zaptx")
+        default = self.nodes[0].get_wallet_rpc("")
+
         # This transaction will be confirmed
-        txid1 = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 10)
+        txid1 = default.sendtoaddress(zaptx.getnewaddress(), 10)
 
         self.nodes[0].generate(1)
         self.sync_all()
 
         # This transaction will not be confirmed
-        txid2 = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 20)
+        txid2 = default.sendtoaddress(zaptx.getnewaddress(), 20)
+        zaptx.keypoolrefill()
 
-        # Confirmed and unconfirmed transactions are now in the wallet.
-        assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)
-        assert_equal(self.nodes[0].gettransaction(txid2)['txid'], txid2)
+        # Confirmed and unconfirmed transactions are the only transactions in the wallet.
+        assert_equal(zaptx.gettransaction(txid1)['txid'], txid1)
+        assert_equal(zaptx.gettransaction(txid2)['txid'], txid2)
+        assert_equal(len(zaptx.listtransactions()), 2)
 
-        # Restart node0. Both confirmed and unconfirmed transactions remain in the wallet.
-        self.restart_node(0)
+        # Zap normally. The wallet should be rescanned (both blockchain and mempool) on loading
+        self.assert_zapped("zaptx")
+        assert_equal(zaptx.gettransaction(txid1)['txid'], txid1)
+        assert_equal(zaptx.gettransaction(txid2)['txid'], txid2)
 
-        assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)
-        assert_equal(self.nodes[0].gettransaction(txid2)['txid'], txid2)
-
-        # Restart node0 with zapwallettxes and persistmempool. The unconfirmed
-        # transaction is zapped from the wallet, but is re-added when the mempool is reloaded.
-        self.restart_node(0, ["-persistmempool=1", "-zapwallettxes=2"])
-
-        wait_until(lambda: self.nodes[0].getmempoolinfo()['size'] == 1, timeout=3)
-        self.nodes[0].syncwithvalidationinterfacequeue()  # Flush mempool to wallet
-
-        assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)
-        assert_equal(self.nodes[0].gettransaction(txid2)['txid'], txid2)
-
-        # Restart node0 with zapwallettxes, but not persistmempool.
-        # The unconfirmed transaction is zapped and is no longer in the wallet.
-        self.restart_node(0, ["-zapwallettxes=2"])
+        # Zap normally. Restart the node with -persismempool=0
+        self.stop_node(0)
+        self.assert_zapped("zaptx")
+        self.start_node(0, ["-persistmempool=0", "-wallet=zaptx"])
+        zaptx = self.nodes[0].get_wallet_rpc("zaptx")
 
         # tx1 is still be available because it was confirmed
-        assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)
+        assert_equal(zaptx.gettransaction(txid1)['txid'], txid1)
 
         # This will raise an exception because the unconfirmed transaction has been zapped
-        assert_raises_rpc_error(-5, 'Invalid or non-wallet transaction id', self.nodes[0].gettransaction, txid2)
+        assert_raises_rpc_error(-5, 'Invalid or non-wallet transaction id', zaptx.gettransaction, txid2)
 
 if __name__ == '__main__':
     ZapWalletTXesTest().main()

--- a/test/functional/wallet_zapwallettxes.py
+++ b/test/functional/wallet_zapwallettxes.py
@@ -128,5 +128,8 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         # This will raise an exception because the unconfirmed transaction has been zapped
         assert_raises_rpc_error(-5, 'Invalid or non-wallet transaction id', zaptx.gettransaction, txid2)
 
+        self.log.info("Make sure -zapwallettxes gives an error")
+        self.nodes[0].assert_start_raises_init_error(["-zapwallettxes"], "Error: -zapwallettxes has been replaced with the zapwallettxes command in the bitcoin-wallet tool. Please use that instead.")
+
 if __name__ == '__main__':
     ZapWalletTXesTest().main()

--- a/test/lint/check-doc.py
+++ b/test/lint/check-doc.py
@@ -23,7 +23,7 @@ CMD_GREP_WALLET_ARGS = r"git grep --function-context 'void WalletInit::AddWallet
 CMD_GREP_WALLET_HIDDEN_ARGS = r"git grep --function-context 'void DummyWalletInit::AddWalletOptions' -- {}".format(CMD_ROOT_DIR)
 CMD_GREP_DOCS = r"git grep --perl-regexp '{}' {}".format(REGEX_DOC, CMD_ROOT_DIR)
 # list unsupported, deprecated and duplicate args as they need no documentation
-SET_DOC_OPTIONAL = set(['-h', '-help', '-dbcrashratio', '-forcecompactdb'])
+SET_DOC_OPTIONAL = set(['-h', '-help', '-dbcrashratio', '-forcecompactdb', '-zapwallettxes'])
 
 
 def lint_missing_argument_documentation():


### PR DESCRIPTION
Replaces the `-zapwallettxes` startup option with a `zapwallettxes` command in the wallet tool.

To preserve the transaction metadata, using `zapwallettxes` rewrites the transactions as a `zaptx` record and removes the original `tx` record. `bestblock` is also reset to null to trigger a rescan. On loading the wallet, a rescan will be triggered. If any `zaptx` records were found, then the metadata from those records is copied to the new tx. All `zaptx` records are removed after loading. If metadata is not kept (by using `-keepmeta=0` in the wallet tool), then no `zaptx` records will be created.

Lastly `-zapwallettxes` is replaced with an error telling users to use the wallet tool command instead.

Alternative to #19653 and #19671