### PR TITLE
Shrink CAddress from 48 to 40 bytes on x64

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -371,9 +371,10 @@ public:
         READWRITEAS(CService, obj);
     }
 
-    ServiceFlags nServices{NODE_NONE};
     // disk and network only
     uint32_t nTime{TIME_INIT};
+
+    ServiceFlags nServices{NODE_NONE};
 };
 
 /** getdata message type flags */


### PR DESCRIPTION
`CAddress` inherits `CService` which is 28 bytes (on 64 bit machines).
`CAddress` then adds two member variables - one that requires 4 byte
alignment (`nTime`) and one that requires 8 byte alignment
(`nServices`).

Declare the smaller one first so that it fits in bytes 29..32.

On 32 bit machines this change has no effect and `CAddress` remains 40
bytes.