### PR TITLE
test: Fix 'make cov' with clang

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -550,57 +550,52 @@ BOOST_AUTO_TEST_CASE(util_ReadConfigStream)
     BOOST_CHECK(test_args.m_settings.ro_config["sec1"].size() == 3);
     BOOST_CHECK(test_args.m_settings.ro_config["sec2"].size() == 2);
 
-    BOOST_CHECK(test_args.m_settings.ro_config[""].count("a")
-                && test_args.m_settings.ro_config[""].count("b")
-                && test_args.m_settings.ro_config[""].count("ccc")
-                && test_args.m_settings.ro_config[""].count("d")
-                && test_args.m_settings.ro_config[""].count("fff")
-                && test_args.m_settings.ro_config[""].count("ggg")
-                && test_args.m_settings.ro_config[""].count("h")
-                && test_args.m_settings.ro_config[""].count("i")
-               );
-    BOOST_CHECK(test_args.m_settings.ro_config["sec1"].count("ccc")
-                && test_args.m_settings.ro_config["sec1"].count("h")
-                && test_args.m_settings.ro_config["sec2"].count("ccc")
-                && test_args.m_settings.ro_config["sec2"].count("iii")
-               );
+    BOOST_CHECK(test_args.m_settings.ro_config[""].count("a"));
+    BOOST_CHECK(test_args.m_settings.ro_config[""].count("b"));
+    BOOST_CHECK(test_args.m_settings.ro_config[""].count("ccc"));
+    BOOST_CHECK(test_args.m_settings.ro_config[""].count("d"));
+    BOOST_CHECK(test_args.m_settings.ro_config[""].count("fff"));
+    BOOST_CHECK(test_args.m_settings.ro_config[""].count("ggg"));
+    BOOST_CHECK(test_args.m_settings.ro_config[""].count("h"));
+    BOOST_CHECK(test_args.m_settings.ro_config[""].count("i"));
+    BOOST_CHECK(test_args.m_settings.ro_config["sec1"].count("ccc"));
+    BOOST_CHECK(test_args.m_settings.ro_config["sec1"].count("h"));
+    BOOST_CHECK(test_args.m_settings.ro_config["sec2"].count("ccc"));
+    BOOST_CHECK(test_args.m_settings.ro_config["sec2"].count("iii"));
 
-    BOOST_CHECK(test_args.IsArgSet("-a")
-                && test_args.IsArgSet("-b")
-                && test_args.IsArgSet("-ccc")
-                && test_args.IsArgSet("-d")
-                && test_args.IsArgSet("-fff")
-                && test_args.IsArgSet("-ggg")
-                && test_args.IsArgSet("-h")
-                && test_args.IsArgSet("-i")
-                && !test_args.IsArgSet("-zzz")
-                && !test_args.IsArgSet("-iii")
-               );
+    BOOST_CHECK(test_args.IsArgSet("-a"));
+    BOOST_CHECK(test_args.IsArgSet("-b"));
+    BOOST_CHECK(test_args.IsArgSet("-ccc"));
+    BOOST_CHECK(test_args.IsArgSet("-d"));
+    BOOST_CHECK(test_args.IsArgSet("-fff"));
+    BOOST_CHECK(test_args.IsArgSet("-ggg"));
+    BOOST_CHECK(test_args.IsArgSet("-h"));
+    BOOST_CHECK(test_args.IsArgSet("-i"));
+    BOOST_CHECK(!test_args.IsArgSet("-zzz"));
+    BOOST_CHECK(!test_args.IsArgSet("-iii"));
 
-    BOOST_CHECK(test_args.GetArg("-a", "xxx") == ""
-                && test_args.GetArg("-b", "xxx") == "1"
-                && test_args.GetArg("-ccc", "xxx") == "argument"
-                && test_args.GetArg("-d", "xxx") == "e"
-                && test_args.GetArg("-fff", "xxx") == "0"
-                && test_args.GetArg("-ggg", "xxx") == "1"
-                && test_args.GetArg("-h", "xxx") == "0"
-                && test_args.GetArg("-i", "xxx") == "1"
-                && test_args.GetArg("-zzz", "xxx") == "xxx"
-                && test_args.GetArg("-iii", "xxx") == "xxx"
-               );
+    BOOST_CHECK_EQUAL(test_args.GetArg("-a", "xxx"), "");
+    BOOST_CHECK_EQUAL(test_args.GetArg("-b", "xxx"), "1");
+    BOOST_CHECK_EQUAL(test_args.GetArg("-ccc", "xxx"), "argument");
+    BOOST_CHECK_EQUAL(test_args.GetArg("-d", "xxx"), "e");
+    BOOST_CHECK_EQUAL(test_args.GetArg("-fff", "xxx"), "0");
+    BOOST_CHECK_EQUAL(test_args.GetArg("-ggg", "xxx"), "1");
+    BOOST_CHECK_EQUAL(test_args.GetArg("-h", "xxx"), "0");
+    BOOST_CHECK_EQUAL(test_args.GetArg("-i", "xxx"), "1");
+    BOOST_CHECK_EQUAL(test_args.GetArg("-zzz", "xxx"), "xxx");
+    BOOST_CHECK_EQUAL(test_args.GetArg("-iii", "xxx"), "xxx");
 
     for (const bool def : {false, true}) {
-        BOOST_CHECK(test_args.GetBoolArg("-a", def)
-                     && test_args.GetBoolArg("-b", def)
-                     && !test_args.GetBoolArg("-ccc", def)
-                     && !test_args.GetBoolArg("-d", def)
-                     && !test_args.GetBoolArg("-fff", def)
-                     && test_args.GetBoolArg("-ggg", def)
-                     && !test_args.GetBoolArg("-h", def)
-                     && test_args.GetBoolArg("-i", def)
-                     && test_args.GetBoolArg("-zzz", def) == def
-                     && test_args.GetBoolArg("-iii", def) == def
-                   );
+        BOOST_CHECK(test_args.GetBoolArg("-a", def));
+        BOOST_CHECK(test_args.GetBoolArg("-b", def));
+        BOOST_CHECK(!test_args.GetBoolArg("-ccc", def));
+        BOOST_CHECK(!test_args.GetBoolArg("-d", def));
+        BOOST_CHECK(!test_args.GetBoolArg("-fff", def));
+        BOOST_CHECK(test_args.GetBoolArg("-ggg", def));
+        BOOST_CHECK(!test_args.GetBoolArg("-h", def));
+        BOOST_CHECK(test_args.GetBoolArg("-i", def));
+        BOOST_CHECK(test_args.GetBoolArg("-zzz", def) == def);
+        BOOST_CHECK(test_args.GetBoolArg("-iii", def) == def);
     }
 
     BOOST_CHECK(test_args.GetArgs("-a").size() == 1
@@ -636,13 +631,12 @@ BOOST_AUTO_TEST_CASE(util_ReadConfigStream)
     test_args.SelectConfigNetwork("sec1");
 
     // same as original
-    BOOST_CHECK(test_args.GetArg("-a", "xxx") == ""
-                && test_args.GetArg("-b", "xxx") == "1"
-                && test_args.GetArg("-fff", "xxx") == "0"
-                && test_args.GetArg("-ggg", "xxx") == "1"
-                && test_args.GetArg("-zzz", "xxx") == "xxx"
-                && test_args.GetArg("-iii", "xxx") == "xxx"
-               );
+    BOOST_CHECK_EQUAL(test_args.GetArg("-a", "xxx"), "");
+    BOOST_CHECK_EQUAL(test_args.GetArg("-b", "xxx"), "1");
+    BOOST_CHECK_EQUAL(test_args.GetArg("-fff", "xxx"), "0");
+    BOOST_CHECK_EQUAL(test_args.GetArg("-ggg", "xxx"), "1");
+    BOOST_CHECK_EQUAL(test_args.GetArg("-zzz", "xxx"), "xxx");
+    BOOST_CHECK_EQUAL(test_args.GetArg("-iii", "xxx"), "xxx");
     // d is overridden
     BOOST_CHECK(test_args.GetArg("-d", "xxx") == "eee");
     // section-specific setting
@@ -657,14 +651,13 @@ BOOST_AUTO_TEST_CASE(util_ReadConfigStream)
     test_args.SelectConfigNetwork("sec2");
 
     // same as original
-    BOOST_CHECK(test_args.GetArg("-a", "xxx") == ""
-                && test_args.GetArg("-b", "xxx") == "1"
-                && test_args.GetArg("-d", "xxx") == "e"
-                && test_args.GetArg("-fff", "xxx") == "0"
-                && test_args.GetArg("-ggg", "xxx") == "1"
-                && test_args.GetArg("-zzz", "xxx") == "xxx"
-                && test_args.GetArg("-h", "xxx") == "0"
-               );
+    BOOST_CHECK(test_args.GetArg("-a", "xxx") == "");
+    BOOST_CHECK(test_args.GetArg("-b", "xxx") == "1");
+    BOOST_CHECK(test_args.GetArg("-d", "xxx") == "e");
+    BOOST_CHECK(test_args.GetArg("-fff", "xxx") == "0");
+    BOOST_CHECK(test_args.GetArg("-ggg", "xxx") == "1");
+    BOOST_CHECK(test_args.GetArg("-zzz", "xxx") == "xxx");
+    BOOST_CHECK(test_args.GetArg("-h", "xxx") == "0");
     // section-specific setting
     BOOST_CHECK(test_args.GetArg("-iii", "xxx") == "2");
     // section takes priority for multiple values


### PR DESCRIPTION
This is a follow up of #19688.

With this PR it is possible to do the following:
```
$ ./autogen.sh
$ ./configure --enable-lcov CC=clang CXX=clang++
$ make
$ make cov
```

Currently, on master (8a85377cd0b60cb00dae4f595d628d1afbd28bd5), `make cov` fails to `Processing src/test/test_bitcoin-util_tests.gcda`.