### PR TITLE
tests: fix -fsanitize=integer complaints

### DIFF
--- a/src/test/fuzz/crypto_chacha20_poly1305_aead.cpp
+++ b/src/test/fuzz/crypto_chacha20_poly1305_aead.cpp
@@ -47,20 +47,28 @@ void test_one_input(const std::vector<uint8_t>& buffer)
             break;
         }
         case 3: {
-            seqnr_payload += 1;
+            if (AdditionOverflow(seqnr_payload, static_cast<uint64_t>(1))) {
+                seqnr_payload = 0;
+            } else {
+                seqnr_payload += 1;
+            }
             aad_pos += CHACHA20_POLY1305_AEAD_AAD_LEN;
             if (aad_pos + CHACHA20_POLY1305_AEAD_AAD_LEN > CHACHA20_ROUND_OUTPUT) {
                 aad_pos = 0;
-                seqnr_aad += 1;
+                if (AdditionOverflow(seqnr_aad, static_cast<uint64_t>(1))) {
+                    seqnr_aad = 0;
+                } else {
+                    seqnr_aad += 1;
+                }
             }
             break;
         }
         case 4: {
-            seqnr_payload = fuzzed_data_provider.ConsumeIntegral<int>();
+            seqnr_payload = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
             break;
         }
         case 5: {
-            seqnr_aad = fuzzed_data_provider.ConsumeIntegral<int>();
+            seqnr_aad = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
             break;
         }
         case 6: {

--- a/src/test/fuzz/pow.cpp
+++ b/src/test/fuzz/pow.cpp
@@ -43,7 +43,12 @@ void test_one_input(const std::vector<uint8_t>& buffer)
                 current_block.nHeight = current_height;
             }
             if (fuzzed_data_provider.ConsumeBool()) {
-                current_block.nTime = fixed_time + current_height * consensus_params.nPowTargetSpacing;
+                if (!MultiplicationOverflow(current_height, static_cast<int>(consensus_params.nPowTargetSpacing)) && current_height >= 0) {
+                    const uint32_t current_height_time = current_height * consensus_params.nPowTargetSpacing;
+                    if (!AdditionOverflow(fixed_time, current_height_time)) {
+                        current_block.nTime = fixed_time + current_height_time;
+                    }
+                }
             }
             if (fuzzed_data_provider.ConsumeBool()) {
                 current_block.nBits = fixed_bits;

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -140,13 +140,13 @@ void test_one_input(const std::vector<uint8_t>& buffer)
 
     {
         WitnessUnknown witness_unknown_1{};
-        witness_unknown_1.version = fuzzed_data_provider.ConsumeIntegral<int>();
+        witness_unknown_1.version = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
         const std::vector<uint8_t> witness_unknown_program_1 = fuzzed_data_provider.ConsumeBytes<uint8_t>(40);
         witness_unknown_1.length = witness_unknown_program_1.size();
         std::copy(witness_unknown_program_1.begin(), witness_unknown_program_1.end(), witness_unknown_1.program);
 
         WitnessUnknown witness_unknown_2{};
-        witness_unknown_2.version = fuzzed_data_provider.ConsumeIntegral<int>();
+        witness_unknown_2.version = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
         const std::vector<uint8_t> witness_unknown_program_2 = fuzzed_data_provider.ConsumeBytes<uint8_t>(40);
         witness_unknown_2.length = witness_unknown_program_2.size();
         std::copy(witness_unknown_program_2.begin(), witness_unknown_program_2.end(), witness_unknown_2.program);

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -163,7 +163,7 @@ NODISCARD inline CTxDestination ConsumeTxDestination(FuzzedDataProvider& fuzzed_
     }
     case 5: {
         WitnessUnknown witness_unknown{};
-        witness_unknown.version = fuzzed_data_provider.ConsumeIntegral<int>();
+        witness_unknown.version = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
         const std::vector<uint8_t> witness_unknown_program_1 = fuzzed_data_provider.ConsumeBytes<uint8_t>(40);
         witness_unknown.length = witness_unknown_program_1.size();
         std::copy(witness_unknown_program_1.begin(), witness_unknown_program_1.end(), witness_unknown.program);

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -37,11 +37,13 @@ unsigned-integer-overflow:policy/fees.cpp
 unsigned-integer-overflow:prevector.h
 unsigned-integer-overflow:script/interpreter.cpp
 unsigned-integer-overflow:stl_bvector.h
+unsigned-integer-overflow:test/fuzz/FuzzedDataProvider.h
 unsigned-integer-overflow:txmempool.cpp
 unsigned-integer-overflow:util/strencodings.cpp
 unsigned-integer-overflow:validation.cpp
 
 implicit-integer-sign-change:*/include/c++/*/bits/*.h
+implicit-integer-sign-change:*/include/c++/*/memory*
 implicit-integer-sign-change:*/new_allocator.h
 implicit-integer-sign-change:/usr/include/boost/date_time/format_date_parser.hpp
 implicit-integer-sign-change:arith_uint256.cpp
@@ -61,6 +63,7 @@ implicit-integer-sign-change:script/interpreter.cpp
 implicit-integer-sign-change:serialize.h
 implicit-integer-sign-change:test/arith_uint256_tests.cpp
 implicit-integer-sign-change:test/coins_tests.cpp
+implicit-integer-sign-change:test/fuzz/FuzzedDataProvider.h
 implicit-integer-sign-change:test/pow_tests.cpp
 implicit-integer-sign-change:test/prevector_tests.cpp
 implicit-integer-sign-change:test/sighash_tests.cpp


### PR DESCRIPTION
First steps towards running fuzz tests with `-fsanitize=integer` and not having it fail. This PR fixes the complaints in the `src/test/fuzz` directory only. There are other complaints that are not handled because I thought the scope of the PR would sprawl.

c0f40ba767dcbcd89223eb7f7678d8d4263a9f1a fixes 
```
SUMMARY: UndefinedBehaviorSanitizer: implicit-integer-sign-change test/fuzz/FuzzedDataProvider.h:108:27 in
test/fuzz/FuzzedDataProvider.h:87:51

SUMMARY: UndefinedBehaviorSanitizer: unsigned-integer-overflow test/fuzz/FuzzedDataProvider.h:108:31 in
test/fuzz/FuzzedDataProvider.h:108:31

SUMMARY: UndefinedBehaviorSanitizer: implicit-integer-sign-change /usr/local/opt/llvm/bin/../include/c++/v1/memory:1876:35
```

03826e53ba292ae2434acd21424e82adf40804dc fixes
```
SUMMARY: UndefinedBehaviorSanitizer: unsigned-integer-overflow test/fuzz/FuzzedDataProvider.h:108:31 in
test/fuzz/util.h:166:35

SUMMARY: UndefinedBehaviorSanitizer: implicit-integer-sign-change test/fuzz/FuzzedDataProvider.h:108:27 in
test/fuzz/script.cpp:145:37
```

febe0f8a3c3c469a0d65c2d1f35eda1e04f9bcf1 fixes
```
SUMMARY: UndefinedBehaviorSanitizer: implicit-integer-sign-change test/fuzz/FuzzedDataProvider.h:108:27 in
test/fuzz/crypto_chacha20_poly1305_aead.cpp:63:25
```

d698eadfac153d426b10c730b95eed2c06373baf fixes
```
test/fuzz/pow.cpp:46:39: runtime error: implicit conversion from type 'long' of value 4294967712 (64-bit, signed) to type 'uint32_t' (aka 'unsigned int')      changed the value to 416 (32-bit, unsigned)
```

