### PR TITLE
build: Add Werror=range-loop-analysis

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -377,6 +377,7 @@ if test "x$enable_werror" = "xyes"; then
   AX_CHECK_COMPILE_FLAG([-Werror=shadow-field],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=shadow-field"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Werror=switch],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=switch"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Werror=thread-safety],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=thread-safety"],,[[$CXXFLAG_WERROR]])
+  AX_CHECK_COMPILE_FLAG([-Werror=range-loop-analysis],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=range-loop-analysis"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Werror=unused-variable],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=unused-variable"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Werror=date-time],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=date-time"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Werror=return-type],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=return-type"],,[[$CXXFLAG_WERROR]])

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -130,7 +130,7 @@ bool ExecuteWalletToolFunc(const std::string& command, const std::string& name)
             std::vector<bilingual_str> warnings;
             bool ret = RecoverDatabaseFile(path, error, warnings);
             if (!ret) {
-                for (const auto warning : warnings) {
+                for (const auto& warning : warnings) {
                     tfm::format(std::cerr, "%s\n", warning.original);
                 }
                 if (!error.empty()) {


### PR DESCRIPTION
The warning is implicitly enabled for Bitcoin Core. Also explicitly since commit d92204c900d.

To avoid "fix range loop" follow-up refactors, we have two options:

* Disable the warning, so that issues never appear
* Enable it as an error, so that issues are either caught locally or by ci