### PR TITLE
 Move comment about BaseIndex::DB from TxIndex::DB 

### DIFF
--- a/src/index/base.h
+++ b/src/index/base.h
@@ -21,6 +21,13 @@ class CBlockIndex;
 class BaseIndex : public CValidationInterface
 {
 protected:
+    /**
+     * The database stores a block locator of the chain the database is synced to
+     * so that the index can efficiently determine the point it last stopped at.
+     * A locator is used instead of a simple hash of the chain tip because blocks
+     * and block index entries may not be flushed to disk until after this database
+     * is updated.
+    */
     class DB : public CDBWrapper
     {
     public:

--- a/src/index/disktxpos.h
+++ b/src/index/disktxpos.h
@@ -5,10 +5,8 @@
 #ifndef BITCOIN_INDEX_DISKTXPOS_H
 #define BITCOIN_INDEX_DISKTXPOS_H
 
-#include <chain.h>
 #include <flatfile.h>
-#include <primitives/block.h>
-#include <primitives/transaction.h>
+#include <serialize.h>
 
 struct CDiskTxPos : public FlatFilePos
 {

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -16,15 +16,9 @@ constexpr char DB_TXINDEX_BLOCK = 'T';
 
 std::unique_ptr<TxIndex> g_txindex;
 
-/**
- * Access to the txindex database (indexes/txindex/)
- *
- * The database stores a block locator of the chain the database is synced to
- * so that the TxIndex can efficiently determine the point it last stopped at.
- * A locator is used instead of a simple hash of the chain tip because blocks
- * and block index entries may not be flushed to disk until after this database
- * is updated.
- */
+
+
+/** Access to the txindex database (indexes/txindex/) */
 class TxIndex::DB : public BaseIndex::DB
 {
 public:


### PR DESCRIPTION
Moves a comment about the `BaseIndex::DB` from the `TxIndex::DB` into the correct place. Originally part of https://github.com/bitcoin/bitcoin/pull/14053.