### PR TITLE
Fix -Wtautological-constant-out-of-range-compare warnings on 32-bit systems

### DIFF
--- a/src/policy/feerate.cpp
+++ b/src/policy/feerate.cpp
@@ -5,11 +5,14 @@
 
 #include <policy/feerate.h>
 
+#include <amount.h>
 #include <tinyformat.h>
+
+#include <cassert>
 
 CFeeRate::CFeeRate(const CAmount& nFeePaid, size_t nBytes_)
 {
-    assert(nBytes_ <= uint64_t(std::numeric_limits<int64_t>::max()));
+    assert(sizeof(size_t) < 8 || nBytes_ <= uint64_t(std::numeric_limits<int64_t>::max()));
     int64_t nSize = int64_t(nBytes_);
 
     if (nSize > 0)
@@ -20,7 +23,7 @@ CFeeRate::CFeeRate(const CAmount& nFeePaid, size_t nBytes_)
 
 CAmount CFeeRate::GetFee(size_t nBytes_) const
 {
-    assert(nBytes_ <= uint64_t(std::numeric_limits<int64_t>::max()));
+    assert(sizeof(size_t) < 8 || nBytes_ <= uint64_t(std::numeric_limits<int64_t>::max()));
     int64_t nSize = int64_t(nBytes_);
 
     CAmount nFee = nSatoshisPerK * nSize / 1000;

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -74,7 +74,6 @@ int ecdsa_signature_parse_der_lax(const secp256k1_context* ctx, secp256k1_ecdsa_
             pos++;
             lenbyte--;
         }
-        static_assert(sizeof(size_t) >= 4, "size_t too small");
         if (lenbyte >= 4) {
             return 0;
         }
@@ -113,7 +112,6 @@ int ecdsa_signature_parse_der_lax(const secp256k1_context* ctx, secp256k1_ecdsa_
             pos++;
             lenbyte--;
         }
-        static_assert(sizeof(size_t) >= 4, "size_t too small");
         if (lenbyte >= 4) {
             return 0;
         }

--- a/src/test/fuzz/fee_rate.cpp
+++ b/src/test/fuzz/fee_rate.cpp
@@ -21,7 +21,7 @@ FUZZ_TARGET(fee_rate)
 
     (void)fee_rate.GetFeePerK();
     const size_t bytes = fuzzed_data_provider.ConsumeIntegral<size_t>();
-    if (!MultiplicationOverflow(static_cast<int64_t>(bytes), satoshis_per_k) && bytes <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+    if (!MultiplicationOverflow(static_cast<int64_t>(bytes), satoshis_per_k) && (sizeof(size_t) < 8 || bytes <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))) {
         (void)fee_rate.GetFee(bytes);
     }
     (void)fee_rate.ToString();


### PR DESCRIPTION
On 32-bit system
```
$ uname -nrmo
odroid-hc1 4.14.187-odroidxu4 armv7l GNU/Linux
$ lsb_release -ds
Ubuntu 20.04.1 LTS
$ clang --version
clang version 10.0.0-4ubuntu1 
Target: armv7l-unknown-linux-gnueabihf
Thread model: posix
InstalledDir: /usr/bin
```

the clang fires the following warnings:
```
  CXX      policy/libbitcoin_common_a-feerate.o
policy/feerate.cpp:14:20: warning: result of comparison of constant 9223372036854775807 with expression of type 'size_t' (aka 'unsigned int') is always true [-Wtautological-constant-out-of-range-compare]
    assert(nBytes_ <= uint64_t(std::numeric_limits<int64_t>::max()));
           ~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/assert.h:93:27: note: expanded from macro 'assert'
     (static_cast <bool> (expr)                                         \
                          ^~~~
policy/feerate.cpp:25:20: warning: result of comparison of constant 9223372036854775807 with expression of type 'size_t' (aka 'unsigned int') is always true [-Wtautological-constant-out-of-range-compare]
    assert(nBytes_ <= uint64_t(std::numeric_limits<int64_t>::max()));
           ~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/assert.h:93:27: note: expanded from macro 'assert'
     (static_cast <bool> (expr)                                         \
                          ^~~~
2 warnings generated.
```

Fix is safe as https://github.com/bitcoin/bitcoin/blob/a57af897ec16976b28de05aa0b9c3f6a96d73ede/src/compat/assumptions.h#L55-L59