### PR TITLE
build: Drop back compatibility code for 32-bit x86 Linux binaries

### DIFF
--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -76,7 +76,6 @@ ELF_ALLOWED_LIBRARIES = {
 'libdl.so.2' # programming interface to dynamic linker
 }
 ARCH_MIN_GLIBC_VER = {
-'80386':  (2,1),
 'X86-64': (2,2,5),
 'ARM':    (2,4),
 'AArch64':(2,17),

--- a/src/compat/glibc_compat.cpp
+++ b/src/compat/glibc_compat.cpp
@@ -16,7 +16,7 @@ extern "C" void* memcpy(void* a, const void* b, size_t c)
     return memmove(a, b, c);
 }
 
-#if defined(__i386__) || defined(__arm__)
+#if defined(__arm__)
 
 extern "C" int64_t __udivmoddi4(uint64_t u, uint64_t v, uint64_t* rp);
 
@@ -46,9 +46,7 @@ extern "C" int64_t __wrap___divmoddi4(int64_t u, int64_t v, int64_t* rp)
 #endif
 
 extern "C" float log2f_old(float x);
-#ifdef __i386__
-__asm(".symver log2f_old,log2f@GLIBC_2.1");
-#elif defined(__amd64__)
+#if defined(__amd64__)
 __asm(".symver log2f_old,log2f@GLIBC_2.2.5");
 #elif defined(__arm__)
 __asm(".symver log2f_old,log2f@GLIBC_2.4");


### PR DESCRIPTION
We do not ship 32-bit x86 Linux binaries (#17504, #18104), therefore, this PR removes unused code.