### PR TITLE
ci: Move valgrind fuzzer to cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ container:
   # https://cirrus-ci.org/faq/#are-there-any-limits
   # Each project has 16 CPU in total, assign 2 to each container, so that 8 tasks run in parallel
   cpu: 2
-  memory: 6G  # https://cirrus-ci.org/guide/linux/#linux-containers
+  memory: 8G  # Set to 8GB to avoid OOM. https://cirrus-ci.org/guide/linux/#linux-containers
 env:
   PACKAGE_MANAGER_INSTALL : "apt-get update && apt-get install -y"
   MAKEJOBS: "-j4"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -66,3 +66,11 @@ task:
     image: ubuntu:focal
   env:
     FILE_ENV: "./ci/test/00_setup_env_native_asan.sh"
+
+task:
+  name: 'x86_64 Linux  [GOAL: install]  [focal]  [no depends, only system libs, fuzzers under valgrind]'
+  << : *GLOBAL_TASK_TEMPLATE
+  container:
+    image: ubuntu:focal
+  env:
+    FILE_ENV: "./ci/test/00_setup_env_native_fuzz_with_valgrind.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,11 +110,6 @@ jobs:
         FILE_ENV="./ci/test/00_setup_env_native_multiprocess.sh"
 
     - stage: test
-      name: 'x86_64 Linux  [GOAL: install]  [focal]  [no depends, only system libs, fuzzers under valgrind]'
-      env: >-
-        FILE_ENV="./ci/test/00_setup_env_native_fuzz_with_valgrind.sh"
-
-    - stage: test
       name: 'x86_64 Linux  [GOAL: install]  [xenial]  [no wallet]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_native_nowallet.sh"


### PR DESCRIPTION
The first commit should fix the 50min timeout in forked repos. Similar to #19424. E.g. https://travis-ci.org/github/bitcoin-core/gui/builds/718322267

The second commit should fix #19744 