### PR TITLE
refactor: remove unused c-string variant of atoi64()

### DIFF
--- a/src/test/fuzz/locale.cpp
+++ b/src/test/fuzz/locale.cpp
@@ -52,7 +52,6 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     const bool parseint64_without_locale = ParseInt64(random_string, &parseint64_out_without_locale);
     const int64_t atoi64_without_locale = atoi64(random_string);
     const int atoi_without_locale = atoi(random_string);
-    const int64_t atoi64c_without_locale = atoi64(random_string.c_str());
     const int64_t random_int64 = fuzzed_data_provider.ConsumeIntegral<int64_t>();
     const std::string tostring_without_locale = ToString(random_int64);
     // The variable `random_int32` is no longer used, but the harness still needs to
@@ -80,8 +79,6 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     }
     const int64_t atoi64_with_locale = atoi64(random_string);
     assert(atoi64_without_locale == atoi64_with_locale);
-    const int64_t atoi64c_with_locale = atoi64(random_string.c_str());
-    assert(atoi64c_without_locale == atoi64c_with_locale);
     const int atoi_with_locale = atoi(random_string);
     assert(atoi_without_locale == atoi_with_locale);
     const std::string tostring_with_locale = ToString(random_int64);

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -407,15 +407,6 @@ std::string FormatParagraph(const std::string& in, size_t width, size_t indent)
     return out.str();
 }
 
-int64_t atoi64(const char* psz)
-{
-#ifdef _MSC_VER
-    return _atoi64(psz);
-#else
-    return strtoll(psz, nullptr, 10);
-#endif
-}
-
 int64_t atoi64(const std::string& str)
 {
 #ifdef _MSC_VER

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -56,7 +56,6 @@ std::string EncodeBase32(const unsigned char* pch, size_t len);
 std::string EncodeBase32(const std::string& str);
 
 void SplitHostPort(std::string in, int& portOut, std::string& hostOut);
-int64_t atoi64(const char* psz);
 int64_t atoi64(const std::string& str);
 int atoi(const std::string& str);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -227,7 +227,7 @@ static inline void ReadOrderPos(int64_t& nOrderPos, mapValue_t& mapValue)
         nOrderPos = -1; // TODO: calculate elsewhere
         return;
     }
-    nOrderPos = atoi64(mapValue["n"].c_str());
+    nOrderPos = atoi64(mapValue["n"]);
 }
 
 


### PR DESCRIPTION
This is another micro-PR "removing old cruft with potentially sharp edges" (quote by practicalswift, see #19739). Gets rid of the c-string variant of the function `atoi64()`, which is only used in fuzzers and on one place with `wallet/wallet.h` (where it is originally a `std::string` anyways and uses `.c_str()` -- this method call can simply be removed.)