### PR TITLE
tests: add sync_all to fix race condition in wallet groups test

### DIFF
--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -103,6 +103,7 @@ class WalletGroupTest(BitcoinTestFramework):
         self.nodes[0].sendtoaddress(addr_aps, 1.0)
         self.nodes[0].sendtoaddress(addr_aps, 1.0)
         self.nodes[0].generate(1)
+        self.sync_all()
         txid4 = self.nodes[3].sendtoaddress(self.nodes[0].getnewaddress(), 0.1)
         tx4 = self.nodes[3].getrawtransaction(txid4, True)
         # tx4 should have 2 inputs and 2 outputs although one output would


### PR DESCRIPTION
This most likely fixes #19749, the intermittent CI issues with wallet_groups.

This fix is also included in #19743.