### PR TITLE
net/net_processing: Convert net std::list buffers to std::forward_list

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -37,6 +37,7 @@
 #include <optional>
 #include <thread>
 #include <vector>
+#include <forward_list>
 
 class CScheduler;
 class CNode;
@@ -414,7 +415,8 @@ public:
     Mutex cs_vRecv;
 
     RecursiveMutex cs_vProcessMsg;
-    std::list<CNetMessage> vProcessMsg GUARDED_BY(cs_vProcessMsg);
+    std::forward_list<CNetMessage> vProcessMsg GUARDED_BY(cs_vProcessMsg);
+    std::forward_list<CNetMessage>::iterator m_process_msg_most_recent GUARDED_BY(cs_vProcessMsg);
     size_t nProcessQueueSize{0};
 
     RecursiveMutex cs_sendProcessing;
@@ -693,7 +695,8 @@ private:
     //! service advertisements.
     const ServiceFlags nLocalServices;
 
-    std::list<CNetMessage> vRecvMsg;  // Used only by SocketHandler thread
+    std::forward_list<CNetMessage> vRecvMsg;  // Used only by SocketHandler thread
+    std::forward_list<CNetMessage>::iterator m_recv_msg_most_recent;
 
     mutable RecursiveMutex cs_addrName;
     std::string addrName GUARDED_BY(cs_addrName);


### PR DESCRIPTION
Currently we use a std::list for the message queue. This is a doubly-linked list. However, we never insert things in the middle, we only really pull from the front or append to the back. Thus we can replace std::list with std::forward_list, which saves a bit of memory per message (8 bytes, plus having to set the back pointers). 

Not the highest priority PR, but a decent refactor I spotted while looking at this code for an unrelated reason that doesn't add that much code complexity. Shakes fist at STL for not making std::forward_list store a tail pointer, but it's easy enough to implement on your own.