### PR TITLE
[doc] Struct members should have m_ prefix

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -81,7 +81,7 @@ required when doing so would need changes to significant pieces of existing
 code.
   - Variable (including function arguments) and namespace names are all lowercase and may use `_` to
     separate words (snake_case).
-    - Class member variables have a `m_` prefix.
+    - Class and struct member variables have an `m_` prefix.
     - Global variables have a `g_` prefix.
   - Compile-time constant names are all uppercase, and use `_` to separate words.
   - Class names, function names, and method names are UpperCamelCase


### PR DESCRIPTION
For consistency, struct members should have the `m_` prefix (in C++ structs are just classes with default public membership)