### PR TITLE
build, doc: Make explicit dependency of system zlib for building depends

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -20,6 +20,7 @@ packages:
 - "patch"
 - "pkg-config"
 - "python3"
+- "libz-dev"
 # Cross compilation HOSTS:
 #  - arm-linux-gnueabihf
 - "binutils-arm-linux-gnueabihf"

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -22,6 +22,7 @@ packages:
 - "zip"
 - "ca-certificates"
 - "python3"
+- "libz-dev"
 remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
   "dir": "bitcoin"

--- a/depends/README.md
+++ b/depends/README.md
@@ -54,7 +54,7 @@ The paths are automatically configured and no other options are needed unless ta
 
 Common linux dependencies:
 
-    sudo apt-get install make automake cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config python3 patch
+    sudo apt-get install make automake cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config python3 patch libz-dev
 
 For linux ARM cross compilation:
 


### PR DESCRIPTION
Make explicit dependency of the system `zlib` for building depends. See:
  - https://github.com/bitcoin/bitcoin/commit/b5f374fef71ba2ba99e3d9629b66fd1491fd7c90
  - https://github.com/bitcoin/bitcoin/blob/197450f80868fe752c6107955e5da80704212b34/depends/packages/qt.mk#L74
  - https://github.com/bitcoin/bitcoin/issues/18536#issuecomment-654261884
