### PR TITLE
doc: Remove label from good first issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/good_first_issue.md
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.md
@@ -2,10 +2,12 @@
 name: Good first issue
 about: '(Regular devs only): Suggest a new good first issue'
 title: ''
-labels: good first issue
+labels: ''
 assignees: ''
 
 ---
+
+<!-- Needs the label "good first issue" assigned manually before or after opening -->
 
 <!-- A good first issue is an uncontroversial issue, that has a relatively unique and obvious solution -->
 


### PR DESCRIPTION
Good first issues aren't that frequent that manually assigning the label is a problem, but this fixes the spam problem (e.g. https://twitter.com/GoodFirstIssues/status/1295455089491161088 )