### PR TITLE
Flag when blocks have had their scripts checked instead of skipped

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -127,6 +127,7 @@ enum BlockStatus: uint32_t {
     BLOCK_FAILED_MASK        =   BLOCK_FAILED_VALID | BLOCK_FAILED_CHILD,
 
     BLOCK_OPT_WITNESS       =   128, //!< block data in blk*.data was received with a witness-enforcing client
+    BLOCK_OPT_SCRIPTSCHECKED =  256, //!< scripts & signatures were definitely checked
 };
 
 /** The block chain is a tree shaped structure starting with the

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2210,8 +2210,8 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
     if (!WriteUndoDataForBlock(blockundo, state, pindex, chainparams))
         return false;
 
-    if (!pindex->IsValid(BLOCK_VALID_SCRIPTS)) {
-        pindex->RaiseValidity(BLOCK_VALID_SCRIPTS);
+    if (pindex->RaiseValidity(BLOCK_VALID_SCRIPTS) || (fScriptChecks && !(pindex->nStatus | BLOCK_OPT_SCRIPTSCHECKED))) {
+        if (fScriptChecks) pindex->nStatus |= BLOCK_OPT_SCRIPTSCHECKED;
         setDirtyBlockIndex.insert(pindex);
     }
 


### PR DESCRIPTION
We raise blocks to `BLOCK_VALID_SCRIPTS` regardless of whether we validate scripts or skip them.

A more obvious change might be to demote scripts-skipped to `BLOCK_VALID_CHAIN` and allow this status as an ancestor of `BLOCK_VALID_SCRIPTS`, but that would have compatibility issues at least.

Instead, just begin setting an additional flag set when we *don't* skip script checks.

This could be useful for later going back and verifying scripts of skipped blocks post-sync, but it's not clear to me yet if that's useful with assumeutxo around the corner(?). Regardless, it seems like a good idea to save this detail in case it proves useful.