### PR TITLE
rpc: Add dumpcoinstats

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -173,6 +173,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getblockstats", 0, "hash_or_height" },
     { "getblockstats", 1, "stats" },
     { "pruneblockchain", 0, "height" },
+    { "dumpcoinstats", 1, "cumulative"},
     { "keypoolrefill", 0, "newsize" },
     { "getrawmempool", 0, "verbose" },
     { "getrawmempool", 1, "mempool_sequence" },

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -70,6 +70,7 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
     "addconnection",  // avoid DNS lookups
     "addnode",        // avoid DNS lookups
     "addpeeraddress", // avoid DNS lookups
+    "dumpcoinstats",  // avoid writing to disk
     "dumptxoutset",   // avoid writing to disk
     "dumpwallet", // avoid writing to disk
     "echoipc",              // avoid assertion failure (Assertion `"EnsureAnyNodeContext(request.context).init" && check' failed.)

--- a/test/functional/feature_abortnode.py
+++ b/test/functional/feature_abortnode.py
@@ -11,7 +11,6 @@
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import get_datadir_path
 import os
 
 
@@ -26,7 +25,7 @@ class AbortNodeTest(BitcoinTestFramework):
 
     def run_test(self):
         self.generate(self.nodes[0], 3, sync_fun=self.no_op)
-        datadir = get_datadir_path(self.options.tmpdir, 0)
+        datadir = self.nodes[0].datadir_path
 
         # Deleting the undo file will result in reorg failure
         os.unlink(os.path.join(datadir, self.chain, 'blocks', 'rev00000.dat'))

--- a/test/functional/feature_coinstatsindex.py
+++ b/test/functional/feature_coinstatsindex.py
@@ -29,16 +29,14 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    get_datadir_path,
 )
 from test_framework.wallet import (
     MiniWallet,
     getnewdestination,
 )
 
-
-import os
 import re
+
 
 class CoinStatsIndexTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -310,7 +308,7 @@ class CoinStatsIndexTest(BitcoinTestFramework):
             else:
                 file = "test.csv"
 
-            path = os.path.join(get_datadir_path(self.options.tmpdir, 1), file)
+            path = str(self.nodes[1].datadir_path / file)
             self.nodes[1].dumpcoinstats(path, cumulative)
 
             with open(path, 'r', encoding='utf-8') as f:

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -49,7 +49,6 @@ from test_framework.util import (
     assert_raises_rpc_error,
     assert_is_hex_string,
     assert_is_hash_string,
-    get_datadir_path,
 )
 from test_framework.wallet import MiniWallet
 
@@ -573,7 +572,7 @@ class BlockchainTest(BitcoinTestFramework):
         assert_vin_contains_prevout(3)
 
         self.log.info("Test that getblock with verbosity 2 and 3 still works with pruned Undo data")
-        datadir = get_datadir_path(self.options.tmpdir, 0)
+        datadir = self.nodes[0].datadir_path
 
         self.log.info("Test getblock with invalid verbosity type returns proper error message")
         assert_raises_rpc_error(-3, "JSON value of type string is not of expected type number", node.getblock, blockhash, "2")

--- a/test/functional/rpc_users.py
+++ b/test/functional/rpc_users.py
@@ -112,7 +112,7 @@ class HTTPBasicsTest(BitcoinTestFramework):
         self.nodes[0].assert_start_raises_init_error(expected_msg=init_error, extra_args=['-rpcauth=foo$bar$baz'])
 
         self.log.info('Check that failure to write cookie file will abort the node gracefully')
-        cookie_file = os.path.join(get_datadir_path(self.options.tmpdir, 0), self.chain, '.cookie.tmp')
+        cookie_file = str(self.nodes[0].chain_path / '.cookie.tmp')
         os.mkdir(cookie_file)
         self.nodes[0].assert_start_raises_init_error(expected_msg=init_error)
 

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -403,8 +403,12 @@ class TestNode():
             conf.write(conf_data)
 
     @property
+    def datadir_path(self) -> Path:
+        return Path(self.datadir)
+
+    @property
     def chain_path(self) -> Path:
-        return Path(self.datadir) / self.chain
+        return self.datadir_path / self.chain
 
     @property
     def debug_log_path(self) -> Path:


### PR DESCRIPTION
Requires #19521 (this PR only adds the last commit).

The rpc `dumpcoinstats` dumps the content of the coinstats index into a CSV file for auditing purposes.