### PR TITLE
p2p: Remove fGetAddr flag

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -935,7 +935,6 @@ public:
     // flood relay
     std::vector<CAddress> vAddrToSend;
     std::unique_ptr<CRollingBloomFilter> m_addr_known{nullptr};
-    bool fGetAddr{false};
     std::chrono::microseconds m_next_addr_send GUARDED_BY(cs_sendProcessing){0};
     std::chrono::microseconds m_next_local_addr_send GUARDED_BY(cs_sendProcessing){0};
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2493,7 +2493,6 @@ void PeerLogicValidation::ProcessMessage(CNode& pfrom, const std::string& msg_ty
 
             // Get recent addresses
             m_connman.PushMessage(&pfrom, CNetMsgMaker(nSendVersion).Make(NetMsgType::GETADDR));
-            pfrom.fGetAddr = true;
 
             // Moves address from New to Tried table in Addrman, resolves
             // tried-table collisions, etc.
@@ -2634,8 +2633,7 @@ void PeerLogicValidation::ProcessMessage(CNode& pfrom, const std::string& msg_ty
                 continue;
             }
             bool fReachable = IsReachable(addr);
-            if (addr.nTime > nSince && !pfrom.fGetAddr && vAddr.size() <= 10 && addr.IsRoutable())
-            {
+            if (addr.nTime > nSince && vAddr.size() <= 10 && addr.IsRoutable()) {
                 // Relay to a limited number of other nodes
                 RelayAddress(addr, fReachable, m_connman);
             }
@@ -2644,8 +2642,6 @@ void PeerLogicValidation::ProcessMessage(CNode& pfrom, const std::string& msg_ty
                 vAddrOk.push_back(addr);
         }
         m_connman.AddNewAddresses(vAddrOk, pfrom.addr, 2 * 60 * 60);
-        if (vAddr.size() < 1000)
-            pfrom.fGetAddr = false;
         if (pfrom.IsAddrFetchConn())
             pfrom.fDisconnect = true;
         return;


### PR DESCRIPTION
`fGetAddr` is an old flag that indicates an ongoing GETADDR/ADDR interaction. Introduced in https://github.com/bitcoin/bitcoin/commit/dd519206a684c772a4a06ceecc87c665ad09d8be, it prevents further relay of received ADDR answers to other peers via the `RelayAddress()` gossip mechanism while set - probably to prevent ADDR traffic from being dominated by large GETADDR answers. 

It also used to be possible to receive a large GETADDR answer spread over multiple ADDR messages (each bounded to max 1000 addresses), so the condition `if (vAddr.size() < 1000) pfrom.fGetAddr = false;` was meant to ensure that `fGetAddr` would only get cleared once the last ADDR of the package was received (typically with < 1000 addresses).

However, `fGetAddr` currently does not work as originally intended and is no longer useful:
- typically, the first ADDR we receive from a peer after sending the GETADDR is not the GETADDR response but the self-announcement of our peer. If this is the case, `fGetAddr` acts on it (preventing its relay) and is already inactivated once the GETADDR response is received.
-  https://github.com/bitcoin/bitcoin/commit/5cbf75324d1509a1262b65c5073314a4da3f6d77 introduced the condition `vAddr.size() <= 10`, so messages with more than 10 elements won't be relayed further regardless.
- since #5419, we do not get more than one ADDR message in response to GETADDR because `vAddrToSend` cannot have more than 1000 elements. 

Removing the flag will cause initial self-announcement from outbound peers to be gossip-relayed.

Thanks to jnewbery for help with reconstructing the history of `fGetAddr`!

**[Outdated, but left in for context]**
Removing the flag will change behaviour in two special cases:
1.) If the GETADDR response is exactly of size 1000, `fGetAddr` will not not be cleared on current master, so that the next "regular" ADDR message by this peer won't be relayed - this does not seem intentional, changing it arguably fixes a bug.
2.) If the response to GETADDR is small  (<=10 addresses), it will be relayed to peers just as any other ADDR message of that size.