### PR TITLE
net: Remove old check for 3-byte shifted IP addresses from pre-0.2.9 nodes

### DIFF
--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -269,17 +269,6 @@ bool CNetAddr::IsLocal() const
  */
 bool CNetAddr::IsValid() const
 {
-    // Cleanup 3-byte shifted addresses caused by garbage in size field
-    // of addr messages from versions before 0.2.9 checksum.
-    // Two consecutive addr messages look like this:
-    // header20 vectorlen3 addr26 addr26 addr26 header20 vectorlen3 addr26 addr26 addr26...
-    // so if the first length field is garbled, it reads the second batch
-    // of addr misaligned by 3 bytes.
-    if (IsIPv6() && memcmp(m_addr.data(), IPV4_IN_IPV6_PREFIX.data() + 3,
-                           sizeof(IPV4_IN_IPV6_PREFIX) - 3) == 0) {
-        return false;
-    }
-
     // unspecified IPv6 address (::/128)
     unsigned char ipNone6[16] = {};
     if (IsIPv6() && memcmp(m_addr.data(), ipNone6, sizeof(ipNone6)) == 0) {


### PR DESCRIPTION
The change removes an old check for IPv6 addresses in range ::ff:ff00:0:0:0/72 that were created due to a bug in size field of addr messages for 0.2.8 nodes and before.

This check is no longer needed as they are no more pre 0.2.9 nodes on the network (as per bitnodes network snapshot).

Credits for discovering this go to sipa in https://github.com/bitcoin/bitcoin/pull/19628#discussion_r475907453

Thanks for the attention!