### PR TITLE
Bugfix: Define and use HAVE_FDATASYNC correctly outside LevelDB

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1039,13 +1039,13 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdint.h>
  [ AC_MSG_RESULT(no)]
 )
 
-dnl LevelDB platform checks
 AC_MSG_CHECKING(for fdatasync)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]],
  [[ fdatasync(0); ]])],
  [ AC_MSG_RESULT(yes); HAVE_FDATASYNC=1 ],
  [ AC_MSG_RESULT(no); HAVE_FDATASYNC=0 ]
 )
+AC_DEFINE_UNQUOTED([HAVE_FDATASYNC], [$HAVE_FDATASYNC], [Define to 1 if fdatasync is available.])
 
 AC_MSG_CHECKING(for F_FULLFSYNC)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <fcntl.h>]],

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1025,7 +1025,7 @@ bool FileCommit(FILE *file)
         return false;
     }
 #else
-    #if defined(HAVE_FDATASYNC)
+    #if HAVE_FDATASYNC
     if (fdatasync(fileno(file)) != 0 && errno != EINVAL) { // Ignore EINVAL for filesystems that don't support sync
         LogPrintf("%s: fdatasync failed: %d\n", __func__, errno);
         return false;


### PR DESCRIPTION
Fixes a bug introduced in #19614

The LevelDB-specific fdatasync check was only using `AC_SUBST`, which works for Makefiles, but doesn't define anything for C++. Furthermore, the #define is typically 0 or 1, never undefined.

This fixes both issues by defining it and checking its value instead of whether it is merely defined.

Pulled out of #14501 by fanquake's request