### PR TITLE
chain: Fix CChain comparison UB by removing it (it was unused)

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -398,12 +398,6 @@ public:
         return vChain[nHeight];
     }
 
-    /** Compare two chains efficiently. */
-    friend bool operator==(const CChain &a, const CChain &b) {
-        return a.vChain.size() == b.vChain.size() &&
-               a.vChain[a.vChain.size() - 1] == b.vChain[b.vChain.size() - 1];
-    }
-
     /** Efficiently check whether a block is present in this chain. */
     bool Contains(const CBlockIndex *pindex) const {
         return (*this)[pindex->nHeight] == pindex;


### PR DESCRIPTION
Comparing two empty `CChain`s is currently undefined behaviour, and resulted in false assertion failures when comparing identical empty `CChain`s in local testing.

Let's just remove this comparison operator since it doesn't seem to be used anywhere.