### PR TITLE
ci: check if scripted diff is using BSD sed syntax

### DIFF
--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -29,6 +29,28 @@ for commit in $(git rev-list --reverse $1); do
             echo "Failed"
             RET=1
         else
+            for option in $(echo $SCRIPT | grep -w 'sed'); do
+                case $option in
+                    "''")
+                        BSD_SED=1
+                        continue
+                        ;;
+                    -*a*)
+                        BSD_SED=1
+                        continue
+                        ;;
+                    -*I*)
+                        BSD_SED=1
+                        continue
+                        ;;
+                esac
+            done
+            if test $BSD_SED -eq 1; then
+                echo "Error: scripted diff contain sed syntax in BSD extensions"
+                echo "Failed"
+                RET=1
+                continue
+            fi
             echo "Running script for: $commit"
             echo "$SCRIPT"
             (eval "$SCRIPT")


### PR DESCRIPTION
#19815 

Check for the follorwing options/syntax in *BSD extensions that do not exists in GNU sed: `-a -I` and `sed -i ''`