### PR TITLE
rpc: simpler setban and new ban manipulation commands

### DIFF
--- a/doc/release-notes/release-notes-19825.md
+++ b/doc/release-notes/release-notes-19825.md
@@ -1,0 +1,2 @@
+### RPC and other APIs
+- #19825 `setban` behavior changed. Banning a subnet that is a subset of a previous ban is a no-op instead of an rpc error.

--- a/doc/release-notes/release-notes-19825.md
+++ b/doc/release-notes/release-notes-19825.md
@@ -1,2 +1,3 @@
 ### RPC and other APIs
-- #19825 `setban` behavior changed. Banning a subnet that is a subset of a previous ban is a no-op instead of an rpc error.
+- #19825 `setban` behavior changed: Banning a subnet that is a subset of a previous ban is a no-op instead of an rpc error.
+- #19825 `setban` behavior changed: Unbanning a non-banned subnet is a no-op instead of an rpc error.

--- a/doc/release-notes/release-notes-19825.md
+++ b/doc/release-notes/release-notes-19825.md
@@ -2,3 +2,4 @@
 - #19825 `setban` behavior changed: Banning a subnet that is a subset of a previous ban is a no-op instead of an rpc error.
 - #19825 `setban` behavior changed: Unbanning a non-banned subnet is a no-op instead of an rpc error.
 - #19825 `setban` behavior changed: Added `setban ip removeall` to remove all bans that affect an ip address.
+- #19825 `listbanned ip` added: Lists ban entries that include ip.

--- a/doc/release-notes/release-notes-19825.md
+++ b/doc/release-notes/release-notes-19825.md
@@ -1,3 +1,4 @@
 ### RPC and other APIs
 - #19825 `setban` behavior changed: Banning a subnet that is a subset of a previous ban is a no-op instead of an rpc error.
 - #19825 `setban` behavior changed: Unbanning a non-banned subnet is a no-op instead of an rpc error.
+- #19825 `setban` behavior changed: Added `setban ip removeall` to remove all bans that affect an ip address.

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -137,12 +137,6 @@ bool BanMan::Ban(const CSubNet& sub_net, int64_t ban_time_offset, bool since_uni
     return true;
 }
 
-bool BanMan::Unban(const CNetAddr& net_addr)
-{
-    CSubNet sub_net(net_addr);
-    return Unban(sub_net);
-}
-
 bool BanMan::Unban(const CSubNet& sub_net)
 {
     {

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -89,20 +89,6 @@ bool BanMan::IsBanned(const CNetAddr& net_addr)
     return false;
 }
 
-bool BanMan::IsBanned(const CSubNet& sub_net)
-{
-    auto current_time = GetTime();
-    LOCK(m_cs_banned);
-    banmap_t::iterator i = m_banned.find(sub_net);
-    if (i != m_banned.end()) {
-        CBanEntry ban_entry = (*i).second;
-        if (current_time < ban_entry.nBanUntil) {
-            return true;
-        }
-    }
-    return false;
-}
-
 void BanMan::Discourage(const CNetAddr& net_addr)
 {
     LOCK(m_cs_banned);

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -135,6 +135,25 @@ bool BanMan::Unban(const CSubNet& sub_net)
     return true;
 }
 
+void BanMan::UnbanAll(const CNetAddr& net_addr)
+{
+    {
+        LOCK(m_cs_banned);
+        for (auto it = m_banned.begin(); it != m_banned.end();) {
+            CSubNet sub_net = it->first;
+            if (sub_net.Match(net_addr)) {
+                it = m_banned.erase(it);
+                m_is_dirty = true;
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    if (m_client_interface) m_client_interface->BannedListChanged();
+    DumpBanlist(); //store banlist to disk immediately
+}
+
 void BanMan::GetBanned(banmap_t& banmap)
 {
     LOCK(m_cs_banned);

--- a/src/banman.h
+++ b/src/banman.h
@@ -59,8 +59,11 @@ class BanMan
 public:
     ~BanMan();
     BanMan(fs::path ban_file, CClientUIInterface* client_interface, int64_t default_ban_time);
-    void Ban(const CNetAddr& net_addr, int64_t ban_time_offset = 0, bool since_unix_epoch = false);
-    void Ban(const CSubNet& sub_net, int64_t ban_time_offset = 0, bool since_unix_epoch = false);
+
+    //! Returns true if a new ban is added
+    // Updates existing ban entries with longer ones
+    bool Ban(const CSubNet& sub_net, int64_t ban_time_offset = 0, bool since_unix_epoch = false);
+
     void Discourage(const CNetAddr& net_addr);
     void ClearBanned();
 

--- a/src/banman.h
+++ b/src/banman.h
@@ -76,7 +76,6 @@ public:
     //! Return whether net_addr is discouraged.
     bool IsDiscouraged(const CNetAddr& net_addr);
 
-    bool Unban(const CNetAddr& net_addr);
     bool Unban(const CSubNet& sub_net);
     void GetBanned(banmap_t& banmap);
     void DumpBanlist();

--- a/src/banman.h
+++ b/src/banman.h
@@ -74,6 +74,9 @@ public:
     bool IsDiscouraged(const CNetAddr& net_addr);
 
     bool Unban(const CSubNet& sub_net);
+
+    // Removes all ban entries that include net_addr
+    void UnbanAll(const CNetAddr& net_addr);
     void GetBanned(banmap_t& banmap);
     void DumpBanlist();
 

--- a/src/banman.h
+++ b/src/banman.h
@@ -70,9 +70,6 @@ public:
     //! Return whether net_addr is banned
     bool IsBanned(const CNetAddr& net_addr);
 
-    //! Return whether sub_net is exactly banned
-    bool IsBanned(const CSubNet& sub_net);
-
     //! Return whether net_addr is discouraged.
     bool IsDiscouraged(const CNetAddr& net_addr);
 

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -99,7 +99,7 @@ public:
     virtual bool getBanned(banmap_t& banmap) = 0;
 
     //! Ban node.
-    virtual bool ban(const CNetAddr& net_addr, int64_t ban_time_offset) = 0;
+    virtual bool ban(const CSubNet& net_addr, int64_t ban_time_offset) = 0;
 
     //! Unban node.
     virtual bool unban(const CSubNet& ip) = 0;

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -1116,7 +1116,7 @@ CSubNet::CSubNet(const CNetAddr& addr) : CSubNet()
     switch (addr.m_net) {
     case NET_IPV4:
     case NET_IPV6:
-        valid = true;
+        valid = addr.IsValid();
         assert(addr.m_addr.size() <= sizeof(netmask));
         memset(netmask, 0xFF, addr.m_addr.size());
         break;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -140,10 +140,10 @@ public:
         }
         return false;
     }
-    bool ban(const CNetAddr& net_addr, int64_t ban_time_offset) override
+    bool ban(const CSubNet& sub_net, int64_t ban_time_offset) override
     {
         if (m_context->banman) {
-            m_context->banman->Ban(net_addr, ban_time_offset);
+            m_context->banman->Ban(sub_net, ban_time_offset);
             return true;
         }
         return false;

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1209,7 +1209,8 @@ void RPCConsole::banSelectedNode(int bantime)
         // Find possible nodes, ban it and clear the selected node
         const auto stats = peer.data(PeerTableModel::StatsRole).value<CNodeCombinedStats*>();
         if (stats) {
-            m_node.ban(stats->nodeStats.addr, bantime);
+            CSubNet sub_net(stats->nodeStats.addr);
+            m_node.ban(sub_net, bantime);
             m_node.disconnectByAddress(stats->nodeStats.addr);
         }
     }

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -721,9 +721,7 @@ static RPCHelpMan setban()
     }
     else if(strCommand == "remove")
     {
-        if (!node.banman->Unban(subNet)) {
-            throw JSONRPCError(RPC_CLIENT_INVALID_IP_OR_SUBNET, "Error: Unban failed. Requested address/subnet was not previously manually banned.");
-        }
+        node.banman->Unban(subNet);
     }
     return NullUniValue;
 },

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -48,7 +48,6 @@ FUZZ_TARGET_INIT(banman, initialize_banman)
                 [&] {
                     ban_man.ClearBanned();
                 },
-                [] {},
                 [&] {
                     ban_man.IsBanned(ConsumeNetAddr(fuzzed_data_provider));
                 },
@@ -62,7 +61,6 @@ FUZZ_TARGET_INIT(banman, initialize_banman)
                 [&] {
                     ban_man.DumpBanlist();
                 },
-                [] {},
                 [&] {
                     ban_man.Discourage(ConsumeNetAddr(fuzzed_data_provider));
                 });

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -56,9 +56,6 @@ FUZZ_TARGET_INIT(banman, initialize_banman)
                     ban_man.IsBanned(ConsumeSubNet(fuzzed_data_provider));
                 },
                 [&] {
-                    ban_man.Unban(ConsumeNetAddr(fuzzed_data_provider));
-                },
-                [&] {
                     ban_man.Unban(ConsumeSubNet(fuzzed_data_provider));
                 },
                 [&] {

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -42,10 +42,6 @@ FUZZ_TARGET_INIT(banman, initialize_banman)
             CallOneOf(
                 fuzzed_data_provider,
                 [&] {
-                    ban_man.Ban(ConsumeNetAddr(fuzzed_data_provider),
-                                ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
-                },
-                [&] {
                     ban_man.Ban(ConsumeSubNet(fuzzed_data_provider),
                                 ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
                 },

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -53,9 +53,6 @@ FUZZ_TARGET_INIT(banman, initialize_banman)
                     ban_man.IsBanned(ConsumeNetAddr(fuzzed_data_provider));
                 },
                 [&] {
-                    ban_man.IsBanned(ConsumeSubNet(fuzzed_data_provider));
-                },
-                [&] {
                     ban_man.Unban(ConsumeSubNet(fuzzed_data_provider));
                 },
                 [&] {

--- a/test/functional/p2p_disconnect_ban.py
+++ b/test/functional/p2p_disconnect_ban.py
@@ -66,6 +66,32 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.nodes[1].clearbanned()
         assert_equal(len(self.nodes[1].listbanned()), 0)
 
+        self.log.info("setban removeall: ipv4 test")
+        self.nodes[1].setban("127.0.0.1/16", "add")
+        self.nodes[1].setban("127.0.0.1/24", "add")
+        self.nodes[1].setban("127.0.0.1/32", "add")
+        assert_equal(len(self.nodes[1].listbanned()), 3)
+        assert_raises_rpc_error(-8, "Error: setban removeall requires a single IP address",
+            self.nodes[1].setban, "127.0.0.3/32", "removeall")
+        self.nodes[1].setban("127.0.0.3", "removeall")
+        listbanned_response = self.nodes[1].listbanned()
+        assert_equal(len(listbanned_response), 1)
+        assert_equal(listbanned_response[0]["address"], "127.0.0.1/32")
+        self.nodes[1].clearbanned()
+
+        self.log.info("setban removeall: ipv6 test")
+        self.nodes[1].setban("2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/96", "add")
+        self.nodes[1].setban("2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/112", "add")
+        self.nodes[1].setban("2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/128", "add")
+        assert_equal(len(self.nodes[1].listbanned()), 3)
+        assert_raises_rpc_error(-8, "Error: setban removeall requires a single IP address",
+            self.nodes[1].setban, "2001:4d48:ac57:400:cacf:e9ff:fe1d:9c64/128", "removeall")
+        self.nodes[1].setban("2001:4d48:ac57:400:cacf:e9ff:fe1d:9c64", "removeall")
+        listbanned_response = self.nodes[1].listbanned()
+        assert_equal(len(listbanned_response), 1)
+        assert_equal(listbanned_response[0]["address"], "2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/128")
+        self.nodes[1].clearbanned()
+
         self.log.info("setban: test persistence across node restart")
         self.nodes[1].setban("127.0.0.0/32", "add")
         self.nodes[1].setban("127.0.0.0/24", "add")

--- a/test/functional/p2p_disconnect_ban.py
+++ b/test/functional/p2p_disconnect_ban.py
@@ -55,8 +55,9 @@ class DisconnectBanTest(BitcoinTestFramework):
         assert_raises_rpc_error(-30, "Error: Invalid IP/Subnet", self.nodes[1].setban, "127.0.0.1/42", "add")
         assert_equal(len(self.nodes[1].listbanned()), 1)  # still only one banned ip because 127.0.0.1/42 is invalid
 
-        self.log.info("setban remove: fail to unban a non-banned subnet")
-        assert_raises_rpc_error(-30, "Error: Unban failed", self.nodes[1].setban, "127.0.0.1", "remove")
+        # Unbanning a non-banned subnet should succeed as user intent is accomplished
+        self.log.info("setban remove: unban a non-banned subnet")
+        self.nodes[1].setban("127.0.0.1", "remove")
         assert_equal(len(self.nodes[1].listbanned()), 1)
 
         self.log.info("setban remove: successfully unban subnet")

--- a/test/functional/p2p_disconnect_ban.py
+++ b/test/functional/p2p_disconnect_ban.py
@@ -66,11 +66,14 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.nodes[1].clearbanned()
         assert_equal(len(self.nodes[1].listbanned()), 0)
 
-        self.log.info("setban removeall: ipv4 test")
+        self.log.info("setban listbanned and removeall: ipv4 test")
         self.nodes[1].setban("127.0.0.1/16", "add")
         self.nodes[1].setban("127.0.0.1/24", "add")
         self.nodes[1].setban("127.0.0.1/32", "add")
         assert_equal(len(self.nodes[1].listbanned()), 3)
+        assert_raises_rpc_error(-8, "Error: Invalid IP address", self.nodes[1].listbanned, "127.0.0.3/32")
+        relevant_bans = self.nodes[1].listbanned("127.0.0.3")
+        assert_equal({x["address"] for x in relevant_bans}, {"127.0.0.0/16", "127.0.0.0/24"})
         assert_raises_rpc_error(-8, "Error: setban removeall requires a single IP address",
             self.nodes[1].setban, "127.0.0.3/32", "removeall")
         self.nodes[1].setban("127.0.0.3", "removeall")
@@ -79,11 +82,14 @@ class DisconnectBanTest(BitcoinTestFramework):
         assert_equal(listbanned_response[0]["address"], "127.0.0.1/32")
         self.nodes[1].clearbanned()
 
-        self.log.info("setban removeall: ipv6 test")
+        self.log.info("setban listbanned and removeall: ipv6 test")
         self.nodes[1].setban("2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/96", "add")
         self.nodes[1].setban("2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/112", "add")
         self.nodes[1].setban("2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/128", "add")
         assert_equal(len(self.nodes[1].listbanned()), 3)
+        assert_raises_rpc_error(-8, "Error: Invalid IP address",
+            self.nodes[1].listbanned, "2001:4d48:ac57:400:cacf:e9ff:fe1d:9c64/128")
+        relevant_bans = self.nodes[1].listbanned("2001:4d48:ac57:400:cacf:e9ff:fe1d:9c64")
         assert_raises_rpc_error(-8, "Error: setban removeall requires a single IP address",
             self.nodes[1].setban, "2001:4d48:ac57:400:cacf:e9ff:fe1d:9c64/128", "removeall")
         self.nodes[1].setban("2001:4d48:ac57:400:cacf:e9ff:fe1d:9c64", "removeall")


### PR DESCRIPTION
Initially motivated by: https://github.com/bitcoin/bitcoin/pull/19219/files#r442410269

### Objectives:
1. Consolidate `BanMan` functions
2. Throw fewer RPC errors. If user intent is accomplished, the command is successful even if no change was made.

### Changes:
- Remove `BanMan::Ban(CNetAddr&)` and use `BanMan::Ban(CSubNet&)` instead (ips are subnets of one)
  - RPC change: `setban subnet/ip add` now allows adding a ban entry for an ip in an already banned subnet. No error will be thrown so long as the user intent is accomplished.
- Remove `BanMan::Unban(CNetAddr&)` and use `BanMan::Unban(CSubNet&)` instead (ips are subnets of one)
  - RPC change: Unbanning a non-banned subnet will no longer raise an rpc error as user intent is accomplished.
- Remove unused `BanMan::IsBanned(CSubNet&)`
- RPC change: Add `setban ip removeall` to remove all ban entries that include an IP address
- RPC change: Add `listbanned ip` to return all ban entries that include an IP address