### PR TITLE
wallet, refactor: Remove duplicate map lookups in GetAddressBalances

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3372,9 +3372,6 @@ std::map<CTxDestination, CAmount> CWallet::GetAddressBalances() const
                     continue;
 
                 CAmount n = IsSpent(walletEntry.first, i) ? 0 : wtx.tx->vout[i].nValue;
-
-                if (!balances.count(addr))
-                    balances[addr] = 0;
                 balances[addr] += n;
             }
         }


### PR DESCRIPTION
Now just one lookup in `balances` instead of three.