### PR TITLE
Set appveyor VM version to previous Visual Studio 2019 release

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 version: '{branch}.{build}'
 skip_tags: true
-image: Visual Studio 2019
+image: Previous Visual Studio 2019
 configuration: Release
 platform: x64
 clone_depth: 5


### PR DESCRIPTION
The Visual Studio 2019 Appveyor [update](https://www.appveyor.com/updates/2020/08/29/) includes a bump of `cmake` to `3.18.2`.

The `berkeleydb` dependency from the pegged `vcpkg` commit now fails to build with the `cmake` update.

Setting the Appveyor VM back to the previous version should fix the immediate issue while a solution is identified for updating the `berkeleydb` build configuration.


