### PR TITLE
Refactoring and minor improvement for self-advertisements

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -181,11 +181,11 @@ static std::vector<CAddress> convertSeed6(const std::vector<SeedSpec6> &vSeedsIn
 // Otherwise, return the unroutable 0.0.0.0 but filled in with
 // the normal parameters, since the IP may be changed to a useful
 // one by discovery.
-CAddress GetLocalAddress(const CNetAddr *paddrPeer, ServiceFlags nLocalServices)
+CAddress GetLocalAddress(const CNetAddr& paddrPeer, ServiceFlags nLocalServices)
 {
     CAddress ret(CService(CNetAddr(),GetListenPort()), nLocalServices);
     CService addr;
-    if (GetLocal(addr, paddrPeer))
+    if (GetLocal(addr, &paddrPeer))
     {
         ret = CAddress(addr, nLocalServices);
     }
@@ -201,22 +201,22 @@ static int GetnScore(const CService& addr)
 }
 
 // Is our peer's addrLocal potentially useful as an external IP source?
-bool IsPeerAddrLocalGood(CNode *pnode)
+bool IsPeerAddrLocalGood(CNode& pnode)
 {
-    CService addrLocal = pnode->GetAddrLocal();
-    return fDiscover && pnode->addr.IsRoutable() && addrLocal.IsRoutable() &&
+    CService addrLocal = pnode.GetAddrLocal();
+    return fDiscover && pnode.addr.IsRoutable() && addrLocal.IsRoutable() &&
            IsReachable(addrLocal.GetNetwork());
 }
 
 // pushes our own address to a peer
-void AdvertiseLocal(CNode *pnode)
+void AdvertiseLocal(CNode& pnode)
 {
-    if (fListen && pnode->fSuccessfullyConnected)
+    if (fListen && pnode.fSuccessfullyConnected)
     {
-        CAddress addrLocal = GetLocalAddress(&pnode->addr, pnode->GetLocalServices());
+        CAddress addrLocal = GetLocalAddress(pnode.addr, pnode.GetLocalServices());
         if (gArgs.GetBoolArg("-addrmantest", false)) {
             // use IPv4 loopback during addrmantest
-            addrLocal = CAddress(CService(LookupNumeric("127.0.0.1", GetListenPort())), pnode->GetLocalServices());
+            addrLocal = CAddress(CService(LookupNumeric("127.0.0.1", GetListenPort())), pnode.GetLocalServices());
         }
         // If discovery is enabled, sometimes give our peer the address it
         // tells us that it sees us as in case it has a better idea of our
@@ -225,12 +225,12 @@ void AdvertiseLocal(CNode *pnode)
         if (IsPeerAddrLocalGood(pnode) && (!addrLocal.IsRoutable() ||
              rng.randbits((GetnScore(addrLocal) > LOCAL_MANUAL) ? 3 : 1) == 0))
         {
-            addrLocal.SetIP(pnode->GetAddrLocal());
+            addrLocal.SetIP(pnode.GetAddrLocal());
         }
         if (addrLocal.IsRoutable() || gArgs.GetBoolArg("-addrmantest", false))
         {
             LogPrint(BCLog::NET, "AdvertiseLocal: advertising address %s\n", addrLocal.ToString());
-            pnode->PushAddress(addrLocal, rng);
+            pnode.PushAddress(addrLocal, rng);
         }
     }
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -131,8 +131,8 @@ uint16_t GetListenPort()
     return (uint16_t)(gArgs.GetArg("-port", Params().GetDefaultPort()));
 }
 
-// find 'best' local address for a particular peer
-bool GetLocal(CService& addr, const CNetAddr *paddrPeer)
+/** Find the 'best' local address for a particular peer. */
+static bool GetLocal(CService& addr, const CNetAddr* paddrPeer)
 {
     if (!fListen)
         return false;
@@ -262,7 +262,7 @@ bool AddLocal(const CService& addr, int nScore)
     return true;
 }
 
-bool AddLocal(const CNetAddr &addr, int nScore)
+static bool AddLocal(const CNetAddr &addr, int nScore)
 {
     return AddLocal(CService(addr, GetListenPort()), nScore);
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -177,10 +177,6 @@ static std::vector<CAddress> convertSeed6(const std::vector<SeedSpec6> &vSeedsIn
     return vSeedsOut;
 }
 
-// get best local address for a particular peer as a CAddress
-// Otherwise, return the unroutable 0.0.0.0 but filled in with
-// the normal parameters, since the IP may be changed to a useful
-// one by discovery.
 CAddress GetLocalAddress(const CNetAddr& paddrPeer, ServiceFlags nLocalServices)
 {
     CAddress ret(CService(CNetAddr(),GetListenPort()), nLocalServices);
@@ -200,7 +196,6 @@ static int GetnScore(const CService& addr)
     return mapLocalHost[addr].nScore;
 }
 
-// Is our peer's addrLocal potentially useful as an external IP source?
 bool IsPeerAddrLocalGood(CNode& pnode)
 {
     CService addrLocal = pnode.GetAddrLocal();
@@ -208,7 +203,6 @@ bool IsPeerAddrLocalGood(CNode& pnode)
            IsReachable(addrLocal.GetNetwork());
 }
 
-// pushes our own address to a peer
 void AdvertiseLocal(CNode& pnode)
 {
     if (fListen && pnode.fSuccessfullyConnected)
@@ -235,7 +229,6 @@ void AdvertiseLocal(CNode& pnode)
     }
 }
 
-// learn a new local address
 bool AddLocal(const CService& addr, int nScore)
 {
     if (!addr.IsRoutable())
@@ -293,7 +286,6 @@ bool IsReachable(const CNetAddr &addr)
     return IsReachable(addr.GetNetwork());
 }
 
-/** vote for a local address */
 bool SeenLocal(const CService& addr)
 {
     {
@@ -305,8 +297,6 @@ bool SeenLocal(const CService& addr)
     return true;
 }
 
-
-/** check whether a given address is potentially local */
 bool IsLocal(const CService& addr)
 {
     LOCK(cs_mapLocalHost);

--- a/src/net.h
+++ b/src/net.h
@@ -647,8 +647,8 @@ enum
     LOCAL_MAX
 };
 
-bool IsPeerAddrLocalGood(CNode *pnode);
-void AdvertiseLocal(CNode *pnode);
+bool IsPeerAddrLocalGood(CNode& pnode);
+void AdvertiseLocal(CNode& pnode);
 
 /**
  * Mark a network as reachable or unreachable (no automatic connects to it)
@@ -664,7 +664,7 @@ bool AddLocal(const CService& addr, int nScore = LOCAL_NONE);
 void RemoveLocal(const CService& addr);
 bool SeenLocal(const CService& addr);
 bool IsLocal(const CService& addr);
-CAddress GetLocalAddress(const CNetAddr *paddrPeer, ServiceFlags nLocalServices);
+CAddress GetLocalAddress(const CNetAddr& paddrPeer, ServiceFlags nLocalServices);
 
 
 extern bool fDiscover;

--- a/src/net.h
+++ b/src/net.h
@@ -661,11 +661,9 @@ bool IsReachable(enum Network net);
 bool IsReachable(const CNetAddr& addr);
 
 bool AddLocal(const CService& addr, int nScore = LOCAL_NONE);
-bool AddLocal(const CNetAddr& addr, int nScore = LOCAL_NONE);
 void RemoveLocal(const CService& addr);
 bool SeenLocal(const CService& addr);
 bool IsLocal(const CService& addr);
-bool GetLocal(CService &addr, const CNetAddr *paddrPeer = nullptr);
 CAddress GetLocalAddress(const CNetAddr *paddrPeer, ServiceFlags nLocalServices);
 
 

--- a/src/net.h
+++ b/src/net.h
@@ -1004,8 +1004,8 @@ public:
     std::vector<CAddress> vAddrToSend;
     std::unique_ptr<CRollingBloomFilter> m_addr_known{nullptr};
     bool fGetAddr{false};
-    std::chrono::microseconds m_next_addr_send GUARDED_BY(cs_sendProcessing){0};
-    std::chrono::microseconds m_next_local_addr_send GUARDED_BY(cs_sendProcessing){0};
+    std::atomic<std::chrono::microseconds> m_next_addr_send{std::chrono::microseconds{0}};
+    std::atomic<std::chrono::microseconds> m_next_local_addr_send{std::chrono::microseconds{0}};
 
     // List of block ids we still have announce.
     // There is no final sorting before sending, as they are always sent immediately

--- a/src/net.h
+++ b/src/net.h
@@ -647,7 +647,12 @@ enum
     LOCAL_MAX
 };
 
+/** Is our peer's addrLocal potentially useful as an external IP source? */
 bool IsPeerAddrLocalGood(CNode& pnode);
+/**
+ * Add our "best" local address (see GetLocal) to the batch of addresses
+ * we are planning to relay to a given node as scheduled.
+ */
 void AdvertiseLocal(CNode& pnode);
 
 /**
@@ -660,10 +665,18 @@ bool IsReachable(enum Network net);
 /** @returns true if the address is in a reachable network, false otherwise */
 bool IsReachable(const CNetAddr& addr);
 
+/** Learn a new local address */
 bool AddLocal(const CService& addr, int nScore = LOCAL_NONE);
+/** Remove a local address from mapLocalHost */
 void RemoveLocal(const CService& addr);
+/** Vote for a local address */
 bool SeenLocal(const CService& addr);
+/** Check whether a given address is potentially local */
 bool IsLocal(const CService& addr);
+/** Get best local address for a particular peer as a CAddress.
+ *  Otherwise, return the unroutable 0.0.0.0 but filled in with
+ *  the normal parameters, since the IP may be changed to a useful
+ *  one by discovery. */
 CAddress GetLocalAddress(const CNetAddr& paddrPeer, ServiceFlags nLocalServices);
 
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4117,14 +4117,14 @@ bool PeerManager::SendMessages(CNode* pto)
         // Address refresh broadcast
         auto current_time = GetTime<std::chrono::microseconds>();
 
-        if (pto->RelayAddrsWithConn() && !::ChainstateActive().IsInitialBlockDownload() && pto->m_next_local_addr_send < current_time) {
+        if (pto->RelayAddrsWithConn() && !::ChainstateActive().IsInitialBlockDownload() && pto->m_next_local_addr_send.load` < current_time) {
             // If we've sent before, clear the bloom filter for the peer, so that our
             // self-announcement will actually go out.
             // This might be unnecessary if the bloom filter has already rolled
             // over since our last self-announcement, but there is only a small
             // bandwidth cost that we can incur by doing this (which happens
             // once a day on average).
-            if (pto->m_next_local_addr_send != 0us) {
+            if (pto->m_next_local_addr_send.load != 0us) {
                 pto->m_addr_known->reset();
             }
             AdvertiseLocal(pto);
@@ -4134,7 +4134,7 @@ bool PeerManager::SendMessages(CNode* pto)
         //
         // Message: addr
         //
-        if (pto->RelayAddrsWithConn() && pto->m_next_addr_send < current_time) {
+        if (pto->RelayAddrsWithConn() && pto->m_next_addr_send.load() < current_time) {
             pto->m_next_addr_send = PoissonNextSend(current_time, AVG_ADDRESS_BROADCAST_INTERVAL);
             std::vector<CAddress> vAddr;
             vAddr.reserve(pto->vAddrToSend.size());

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2386,32 +2386,14 @@ void PeerManager::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDat
         }
 
         if (!pfrom.IsInboundConn() && !pfrom.IsBlockOnlyConn()) {
-            // For outbound peers, we try to relay our address (so that other
-            // nodes can try to find us more quickly, as we have no guarantee
-            // that an outbound peer is even aware of how to reach us) and do a
-            // one-time address fetch (to help populate/update our addrman). If
-            // we're starting up for the first time, our addrman may be pretty
-            // empty and no one will know who we are, so these mechanisms are
+            // For outbound peers, we do a one-time address fetch
+            // (to help populate/update our addrman).
+            // If we're starting up for the first time, our addrman may be pretty
+            // empty and no one will know who we are, so this mechanism is
             // important to help us connect to the network.
             //
             // We skip this for block-relay-only peers to avoid potentially leaking
             // information about our block-relay-only connections via address relay.
-            if (fListen && !::ChainstateActive().IsInitialBlockDownload() && pfrom.fSuccessfullyConnected)
-            {
-                CAddress addr = GetLocalAddress(pfrom.addr, pfrom.GetLocalServices());
-                FastRandomContext insecure_rand;
-                if (addr.IsRoutable())
-                {
-                    LogPrint(BCLog::NET, "ProcessMessages: advertising address %s\n", addr.ToString());
-                    pfrom.PushAddress(addr, insecure_rand);
-                } else if (IsPeerAddrLocalGood(pfrom)) {
-                    addr.SetIP(addrMe);
-                    LogPrint(BCLog::NET, "ProcessMessages: advertising address %s\n", addr.ToString());
-                    pfrom.PushAddress(addr, insecure_rand);
-                }
-            }
-
-            // Get recent addresses
             m_connman.PushMessage(&pfrom, CNetMsgMaker(greatest_common_version).Make(NetMsgType::GETADDR));
             pfrom.fGetAddr = true;
         }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2396,7 +2396,7 @@ void PeerManager::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDat
             //
             // We skip this for block-relay-only peers to avoid potentially leaking
             // information about our block-relay-only connections via address relay.
-            if (fListen && !::ChainstateActive().IsInitialBlockDownload())
+            if (fListen && !::ChainstateActive().IsInitialBlockDownload() && pfrom.fSuccessfullyConnected)
             {
                 CAddress addr = GetLocalAddress(pfrom.addr, pfrom.GetLocalServices());
                 FastRandomContext insecure_rand;
@@ -4117,7 +4117,8 @@ bool PeerManager::SendMessages(CNode* pto)
         // Address refresh broadcast
         auto current_time = GetTime<std::chrono::microseconds>();
 
-        if (pto->RelayAddrsWithConn() && !::ChainstateActive().IsInitialBlockDownload() && pto->m_next_local_addr_send.load() < current_time) {
+        if (pto->RelayAddrsWithConn() && !::ChainstateActive().IsInitialBlockDownload() &&
+            pto->m_next_local_addr_send.load() < current_time && fListen) {
             // If we've sent before, clear the bloom filter for the peer, so that our
             // self-announcement will actually go out.
             // This might be unnecessary if the bloom filter has already rolled

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4117,14 +4117,14 @@ bool PeerManager::SendMessages(CNode* pto)
         // Address refresh broadcast
         auto current_time = GetTime<std::chrono::microseconds>();
 
-        if (pto->RelayAddrsWithConn() && !::ChainstateActive().IsInitialBlockDownload() && pto->m_next_local_addr_send.load` < current_time) {
+        if (pto->RelayAddrsWithConn() && !::ChainstateActive().IsInitialBlockDownload() && pto->m_next_local_addr_send.load() < current_time) {
             // If we've sent before, clear the bloom filter for the peer, so that our
             // self-announcement will actually go out.
             // This might be unnecessary if the bloom filter has already rolled
             // over since our last self-announcement, but there is only a small
             // bandwidth cost that we can incur by doing this (which happens
             // once a day on average).
-            if (pto->m_next_local_addr_send.load != 0us) {
+            if (pto->m_next_local_addr_send.load() != 0us) {
                 pto->m_addr_known->reset();
             }
             AdvertiseLocal(pto);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2398,13 +2398,13 @@ void PeerManager::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDat
             // information about our block-relay-only connections via address relay.
             if (fListen && !::ChainstateActive().IsInitialBlockDownload())
             {
-                CAddress addr = GetLocalAddress(&pfrom.addr, pfrom.GetLocalServices());
+                CAddress addr = GetLocalAddress(pfrom.addr, pfrom.GetLocalServices());
                 FastRandomContext insecure_rand;
                 if (addr.IsRoutable())
                 {
                     LogPrint(BCLog::NET, "ProcessMessages: advertising address %s\n", addr.ToString());
                     pfrom.PushAddress(addr, insecure_rand);
-                } else if (IsPeerAddrLocalGood(&pfrom)) {
+                } else if (IsPeerAddrLocalGood(pfrom)) {
                     addr.SetIP(addrMe);
                     LogPrint(BCLog::NET, "ProcessMessages: advertising address %s\n", addr.ToString());
                     pfrom.PushAddress(addr, insecure_rand);
@@ -4127,7 +4127,7 @@ bool PeerManager::SendMessages(CNode* pto)
             if (pto->m_next_local_addr_send.load() != 0us) {
                 pto->m_addr_known->reset();
             }
-            AdvertiseLocal(pto);
+            AdvertiseLocal(*pto);
             pto->m_next_local_addr_send = PoissonNextSend(current_time, AVG_LOCAL_ADDRESS_BROADCAST_INTERVAL);
         }
 

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -687,7 +687,7 @@ BOOST_AUTO_TEST_CASE(ipv4_peer_with_ipv6_addrMe_test)
     pnode->SetAddrLocal(addrLocal);
 
     // before patch, this causes undefined behavior detectable with clang's -fsanitize=memory
-    AdvertiseLocal(&*pnode);
+    AdvertiseLocal(*pnode);
 
     // suppress no-checks-run warning; if this test fails, it's by triggering a sanitizer
     BOOST_CHECK(1);


### PR DESCRIPTION
We have (almost) the same code chunk used twice. Improve that by slight refactoring.

The only behavior change is that the following will be also applied to the first (pre-VERACK) self-announcement:
```   
// If discovery is enabled, sometimes give our peer the address it
// tells us that it sees us as in case it has a better idea of our
// address than we do.
```
And I think it's a good change anyway.

The last commit is just to consider the first self-announcement as regular and reset the timer, so that we don't send the second self-announcement too soon.
Note that since the first self-announcement is made at the end of processing VERSION, at that point addrLocal would be already filled with what the peers tells us we are, so this self-announcement would be no worse than any further one.