### PR TITLE
net: CNetAddr: add support to (un)serialize as ADDRv2

### DIFF
--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -53,6 +53,13 @@ void static inline WriteLE64(unsigned char* ptr, uint64_t x)
     memcpy(ptr, (char*)&v, 8);
 }
 
+uint16_t static inline ReadBE16(const unsigned char* ptr)
+{
+    uint16_t x;
+    memcpy((char*)&x, ptr, 2);
+    return be16toh(x);
+}
+
 uint32_t static inline ReadBE32(const unsigned char* ptr)
 {
     uint32_t x;

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -14,10 +14,65 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <ios>
 #include <iterator>
 #include <tuple>
 
 constexpr size_t CNetAddr::V1_SERIALIZATION_SIZE;
+constexpr size_t CNetAddr::MAX_ADDRV2_SIZE;
+
+CNetAddr::BIP155Network CNetAddr::GetBIP155Network() const
+{
+    switch (m_net) {
+    case NET_IPV4:
+        return BIP155Network::IPV4;
+    case NET_IPV6:
+        return BIP155Network::IPV6;
+    case NET_ONION:
+        return BIP155Network::TORV2;
+    case NET_INTERNAL:   // should have been handled before calling this function
+    case NET_UNROUTABLE: // m_net is never and should not be set to NET_UNROUTABLE
+    case NET_MAX:        // m_net is never and should not be set to NET_MAX
+        assert(false);
+    } // no default case, so the compiler can warn about missing cases
+
+    assert(false);
+}
+
+bool CNetAddr::SetNetFromBIP155Network(uint8_t possible_bip155_net, size_t address_size)
+{
+    switch (possible_bip155_net) {
+    case BIP155Network::IPV4:
+        if (address_size == ADDR_IPV4_SIZE) {
+            m_net = NET_IPV4;
+            return true;
+        }
+        throw std::ios_base::failure(
+            strprintf("BIP155 IPv4 address with length %u (should be %u)", address_size,
+                      ADDR_IPV4_SIZE));
+    case BIP155Network::IPV6:
+        if (address_size == ADDR_IPV6_SIZE) {
+            m_net = NET_IPV6;
+            return true;
+        }
+        throw std::ios_base::failure(
+            strprintf("BIP155 IPv6 address with length %u (should be %u)", address_size,
+                      ADDR_IPV6_SIZE));
+    case BIP155Network::TORV2:
+        if (address_size == ADDR_TORV2_SIZE) {
+            m_net = NET_ONION;
+            return true;
+        }
+        throw std::ios_base::failure(
+            strprintf("BIP155 TORv2 address with length %u (should be %u)", address_size,
+                      ADDR_TORV2_SIZE));
+    }
+
+    // Don't throw on addresses with unknown network ids (maybe from the future).
+    // Instead silently drop them and have the unserialization code consume
+    // subsequent ones which may be known to us.
+    return false;
+}
 
 /**
  * Construct an unspecified IPv6 network address (::/128).

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -7,8 +7,9 @@
 
 #include <hash.h>
 #include <tinyformat.h>
-#include <util/strencodings.h>
 #include <util/asmap.h>
+#include <util/strencodings.h>
+#include <util/string.h>
 
 #include <algorithm>
 #include <array>
@@ -48,13 +49,6 @@ void CNetAddr::SetIP(const CNetAddr& ipIn)
 
     m_net = ipIn.m_net;
     m_addr = ipIn.m_addr;
-}
-
-template <typename T1, size_t PREFIX_LEN>
-inline bool HasPrefix(const T1& obj, const std::array<uint8_t, PREFIX_LEN>& prefix)
-{
-    return obj.size() >= PREFIX_LEN &&
-           std::equal(std::begin(prefix), std::end(prefix), std::begin(obj));
 }
 
 void CNetAddr::SetLegacyIPv6(Span<const uint8_t> ipv6)

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -5,7 +5,10 @@
 
 #include <netaddress.h>
 
+#include <crypto/common.h>
+#include <crypto/sha3.h>
 #include <hash.h>
+#include <prevector.h>
 #include <tinyformat.h>
 #include <util/asmap.h>
 #include <util/strencodings.h>
@@ -29,7 +32,18 @@ CNetAddr::BIP155Network CNetAddr::GetBIP155Network() const
     case NET_IPV6:
         return BIP155Network::IPV6;
     case NET_ONION:
-        return BIP155Network::TORV2;
+        switch (m_addr.size()) {
+        case ADDR_TORV2_SIZE:
+            return BIP155Network::TORV2;
+        case ADDR_TORV3_SIZE:
+            return BIP155Network::TORV3;
+        default:
+            assert(false);
+        }
+    case NET_I2P:
+        return BIP155Network::I2P;
+    case NET_CJDNS:
+        return BIP155Network::CJDNS;
     case NET_INTERNAL:   // should have been handled before calling this function
     case NET_UNROUTABLE: // m_net is never and should not be set to NET_UNROUTABLE
     case NET_MAX:        // m_net is never and should not be set to NET_MAX
@@ -66,6 +80,30 @@ bool CNetAddr::SetNetFromBIP155Network(uint8_t possible_bip155_net, size_t addre
         throw std::ios_base::failure(
             strprintf("BIP155 TORv2 address with length %u (should be %u)", address_size,
                       ADDR_TORV2_SIZE));
+    case BIP155Network::TORV3:
+        if (address_size == ADDR_TORV3_SIZE) {
+            m_net = NET_ONION;
+            return true;
+        }
+        throw std::ios_base::failure(
+            strprintf("BIP155 TORv3 address with length %u (should be %u)", address_size,
+                      ADDR_TORV3_SIZE));
+    case BIP155Network::I2P:
+        if (address_size == ADDR_I2P_SIZE) {
+            m_net = NET_I2P;
+            return true;
+        }
+        throw std::ios_base::failure(
+            strprintf("BIP155 I2P address with length %u (should be %u)", address_size,
+                      ADDR_I2P_SIZE));
+    case BIP155Network::CJDNS:
+        if (address_size == ADDR_CJDNS_SIZE) {
+            m_net = NET_CJDNS;
+            return true;
+        }
+        throw std::ios_base::failure(
+            strprintf("BIP155 CJDNS address with length %u (should be %u)", address_size,
+                      ADDR_CJDNS_SIZE));
     }
 
     // Don't throw on addresses with unknown network ids (maybe from the future).
@@ -92,7 +130,13 @@ void CNetAddr::SetIP(const CNetAddr& ipIn)
         assert(ipIn.m_addr.size() == ADDR_IPV6_SIZE);
         break;
     case NET_ONION:
-        assert(ipIn.m_addr.size() == ADDR_TORV2_SIZE);
+        assert(ipIn.m_addr.size() == ADDR_TORV2_SIZE || ipIn.m_addr.size() == ADDR_TORV3_SIZE);
+        break;
+    case NET_I2P:
+        assert(ipIn.m_addr.size() == ADDR_I2P_SIZE);
+        break;
+    case NET_CJDNS:
+        assert(ipIn.m_addr.size() == ADDR_CJDNS_SIZE);
         break;
     case NET_INTERNAL:
         assert(ipIn.m_addr.size() == ADDR_INTERNAL_SIZE);
@@ -150,24 +194,80 @@ bool CNetAddr::SetInternal(const std::string &name)
     return true;
 }
 
+namespace torv3 {
+// https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt#n2135
+static constexpr size_t CHECKSUM_LEN = 2;
+static const unsigned char VERSION[] = {3};
+static constexpr size_t TOTAL_LEN = ADDR_TORV3_SIZE + CHECKSUM_LEN + sizeof(VERSION);
+
+static void Checksum(Span<const uint8_t> addr_pubkey, uint8_t (&checksum)[CHECKSUM_LEN])
+{
+    // TORv3 CHECKSUM = H(".onion checksum" | PUBKEY | VERSION)[:2]
+    static const unsigned char prefix[] = ".onion checksum";
+    static constexpr size_t prefix_len = 15;
+
+    SHA3_256 hasher;
+
+    hasher.Write(MakeSpan(prefix).first(prefix_len));
+    hasher.Write(addr_pubkey);
+    hasher.Write(VERSION);
+
+    uint8_t checksum_full[SHA3_256::OUTPUT_SIZE];
+
+    hasher.Finalize(checksum_full);
+
+    memcpy(checksum, checksum_full, sizeof(checksum));
+}
+
+}; // namespace torv3
+
 /**
- * Parse a TORv2 address and set this object to it.
+ * Parse a TOR address and set this object to it.
  *
  * @returns Whether or not the operation was successful.
  *
  * @see CNetAddr::IsTor()
  */
-bool CNetAddr::SetSpecial(const std::string &strName)
+bool CNetAddr::SetSpecial(const std::string& str)
 {
-    if (strName.size()>6 && strName.substr(strName.size() - 6, 6) == ".onion") {
-        std::vector<unsigned char> vchAddr = DecodeBase32(strName.substr(0, strName.size() - 6).c_str());
-        if (vchAddr.size() != ADDR_TORV2_SIZE) {
+    static const char* suffix{".onion"};
+    static constexpr size_t suffix_len{6};
+
+    if (!ValidAsCString(str) || str.size() <= suffix_len ||
+        str.substr(str.size() - suffix_len) != suffix) {
+        return false;
+    }
+
+    bool invalid;
+    const auto& input = DecodeBase32(str.substr(0, str.size() - suffix_len).c_str(), &invalid);
+
+    if (invalid) {
+        return false;
+    }
+
+    switch (input.size()) {
+    case ADDR_TORV2_SIZE:
+        m_net = NET_ONION;
+        m_addr.assign(input.begin(), input.end());
+        return true;
+    case torv3::TOTAL_LEN: {
+        Span<const uint8_t> input_pubkey{input.data(), ADDR_TORV3_SIZE};
+        Span<const uint8_t> input_checksum{input.data() + ADDR_TORV3_SIZE, torv3::CHECKSUM_LEN};
+        Span<const uint8_t> input_version{input.data() + ADDR_TORV3_SIZE + torv3::CHECKSUM_LEN, sizeof(torv3::VERSION)};
+
+        uint8_t calculated_checksum[torv3::CHECKSUM_LEN];
+        torv3::Checksum(input_pubkey, calculated_checksum);
+
+        if (input_checksum != calculated_checksum || input_version != torv3::VERSION) {
             return false;
         }
+
         m_net = NET_ONION;
-        m_addr.assign(vchAddr.begin(), vchAddr.end());
+        m_addr.assign(input_pubkey.begin(), input_pubkey.end());
         return true;
     }
+    }
+
     return false;
 }
 
@@ -284,12 +384,20 @@ bool CNetAddr::IsHeNet() const
 }
 
 /**
- * @returns Whether or not this is a dummy address that maps an onion address
- *          into IPv6.
- *
+ * Check whether this object represents a TOR address.
  * @see CNetAddr::SetSpecial(const std::string &)
  */
 bool CNetAddr::IsTor() const { return m_net == NET_ONION; }
+
+/**
+ * Check whether this object represents an I2P address.
+ */
+bool CNetAddr::IsI2P() const { return m_net == NET_I2P; }
+
+/**
+ * Check whether this object represents a CJDNS address.
+ */
+bool CNetAddr::IsCJDNS() const { return m_net == NET_CJDNS; }
 
 bool CNetAddr::IsLocal() const
 {
@@ -377,28 +485,72 @@ enum Network CNetAddr::GetNetwork() const
     return m_net;
 }
 
+static std::string IPv6ToString(Span<const uint8_t> a)
+{
+    assert(a.size() == ADDR_IPV6_SIZE);
+    // clang-format off
+    return strprintf("%x:%x:%x:%x:%x:%x:%x:%x",
+                     ReadBE16(&a[0]),
+                     ReadBE16(&a[2]),
+                     ReadBE16(&a[4]),
+                     ReadBE16(&a[6]),
+                     ReadBE16(&a[8]),
+                     ReadBE16(&a[10]),
+                     ReadBE16(&a[12]),
+                     ReadBE16(&a[14]));
+    // clang-format on
+}
+
 std::string CNetAddr::ToStringIP() const
 {
-    if (IsTor())
-        return EncodeBase32(m_addr) + ".onion";
-    if (IsInternal())
-        return EncodeBase32(m_addr) + ".internal";
-    CService serv(*this, 0);
-    struct sockaddr_storage sockaddr;
-    socklen_t socklen = sizeof(sockaddr);
-    if (serv.GetSockAddr((struct sockaddr*)&sockaddr, &socklen)) {
-        char name[1025] = "";
-        if (!getnameinfo((const struct sockaddr*)&sockaddr, socklen, name, sizeof(name), nullptr, 0, NI_NUMERICHOST))
-            return std::string(name);
+    switch (m_net) {
+    case NET_IPV4:
+    case NET_IPV6: {
+        CService serv(*this, 0);
+        struct sockaddr_storage sockaddr;
+        socklen_t socklen = sizeof(sockaddr);
+        if (serv.GetSockAddr((struct sockaddr*)&sockaddr, &socklen)) {
+            char name[1025] = "";
+            if (!getnameinfo((const struct sockaddr*)&sockaddr, socklen, name,
+                             sizeof(name), nullptr, 0, NI_NUMERICHOST))
+                return std::string(name);
+        }
+        if (m_net == NET_IPV4) {
+            return strprintf("%u.%u.%u.%u", m_addr[0], m_addr[1], m_addr[2], m_addr[3]);
+        }
+        return IPv6ToString(m_addr);
     }
-    if (IsIPv4())
-        return strprintf("%u.%u.%u.%u", m_addr[0], m_addr[1], m_addr[2], m_addr[3]);
-    assert(IsIPv6());
-    return strprintf("%x:%x:%x:%x:%x:%x:%x:%x",
-                     m_addr[0] << 8 | m_addr[1], m_addr[2] << 8 | m_addr[3],
-                     m_addr[4] << 8 | m_addr[5], m_addr[6] << 8 | m_addr[7],
-                     m_addr[8] << 8 | m_addr[9], m_addr[10] << 8 | m_addr[11],
-                     m_addr[12] << 8 | m_addr[13], m_addr[14] << 8 | m_addr[15]);
+    case NET_ONION:
+        switch (m_addr.size()) {
+        case ADDR_TORV2_SIZE:
+            return EncodeBase32(m_addr) + ".onion";
+        case ADDR_TORV3_SIZE: {
+
+            uint8_t checksum[torv3::CHECKSUM_LEN];
+            torv3::Checksum(m_addr, checksum);
+
+            // TORv3 onion_address = base32(PUBKEY | CHECKSUM | VERSION) + ".onion"
+            prevector<torv3::TOTAL_LEN, uint8_t> address{m_addr.begin(), m_addr.end()};
+            address.insert(address.end(), checksum, checksum + torv3::CHECKSUM_LEN);
+            address.insert(address.end(), torv3::VERSION, torv3::VERSION + sizeof(torv3::VERSION));
+
+            return EncodeBase32(address) + ".onion";
+        }
+        default:
+            assert(false);
+        }
+    case NET_I2P:
+        return EncodeBase32(m_addr, false /* don't pad with = */) + ".b32.i2p";
+    case NET_CJDNS:
+        return IPv6ToString(m_addr);
+    case NET_INTERNAL:
+        return EncodeBase32(m_addr) + ".internal";
+    case NET_UNROUTABLE: // m_net is never and should not be set to NET_UNROUTABLE
+    case NET_MAX:        // m_net is never and should not be set to NET_MAX
+        assert(false);
+    } // no default case, so the compiler can warn about missing cases
+
+    assert(false);
 }
 
 std::string CNetAddr::ToString() const
@@ -477,21 +629,22 @@ uint32_t CNetAddr::GetLinkedIPv4() const
     assert(false);
 }
 
-uint32_t CNetAddr::GetNetClass() const {
-    uint32_t net_class = NET_IPV6;
-    if (IsLocal()) {
-        net_class = 255;
-    }
+uint32_t CNetAddr::GetNetClass() const
+{
+    // Make sure that if we return NET_IPV6, then IsIPv6() is true. The callers expect that.
+
+    // Check for "internal" first because such addresses are also !IsRoutable()
+    // and we don't want to return NET_UNROUTABLE in that case.
     if (IsInternal()) {
-        net_class = NET_INTERNAL;
-    } else if (!IsRoutable()) {
-        net_class = NET_UNROUTABLE;
-    } else if (HasLinkedIPv4()) {
-        net_class = NET_IPV4;
-    } else if (IsTor()) {
-        net_class = NET_ONION;
+        return NET_INTERNAL;
     }
-    return net_class;
+    if (!IsRoutable()) {
+        return NET_UNROUTABLE;
+    }
+    if (HasLinkedIPv4()) {
+        return NET_IPV4;
+    }
+    return m_net;
 }
 
 uint32_t CNetAddr::GetMappedAS(const std::vector<bool> &asmap) const {
@@ -566,7 +719,7 @@ std::vector<unsigned char> CNetAddr::GetGroup(const std::vector<bool> &asmap) co
         vchRet.push_back((ipv4 >> 24) & 0xFF);
         vchRet.push_back((ipv4 >> 16) & 0xFF);
         return vchRet;
-    } else if (IsTor()) {
+    } else if (IsTor() || IsI2P() || IsCJDNS()) {
         nBits = 4;
     } else if (IsHeNet()) {
         // for he.net, use /36 groups
@@ -791,7 +944,7 @@ std::string CService::ToStringPort() const
 
 std::string CService::ToStringIPPort() const
 {
-    if (IsIPv4() || IsTor() || IsInternal()) {
+    if (IsIPv4() || IsTor() || IsI2P() || IsInternal()) {
         return ToStringIP() + ":" + ToStringPort();
     } else {
         return "[" + ToStringIP() + "]:" + ToStringPort();

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -14,6 +14,12 @@
 
 #include <tuple>
 
+/**
+ * A flag that is ORed into the protocol version to designate that a transaction
+ * should be (un)serialized without witness data.
+ * Make sure that this does not collide with any of the values in `version.h`
+ * or with `ADDRV2_FORMAT`.
+ */
 static const int SERIALIZE_TRANSACTION_NO_WITNESS = 0x40000000;
 
 /** An outpoint - a combination of a transaction hash and an index n into its vout */

--- a/src/test/base32_tests.cpp
+++ b/src/test/base32_tests.cpp
@@ -13,10 +13,13 @@ BOOST_AUTO_TEST_CASE(base32_testvectors)
 {
     static const std::string vstrIn[]  = {"","f","fo","foo","foob","fooba","foobar"};
     static const std::string vstrOut[] = {"","my======","mzxq====","mzxw6===","mzxw6yq=","mzxw6ytb","mzxw6ytboi======"};
+    static const std::string vstrOutNoPadding[] = {"","my","mzxq","mzxw6","mzxw6yq","mzxw6ytb","mzxw6ytboi"};
     for (unsigned int i=0; i<sizeof(vstrIn)/sizeof(vstrIn[0]); i++)
     {
         std::string strEnc = EncodeBase32(vstrIn[i]);
         BOOST_CHECK_EQUAL(strEnc, vstrOut[i]);
+        strEnc = EncodeBase32(vstrIn[i], false);
+        BOOST_CHECK_EQUAL(strEnc, vstrOutNoPadding[i]);
         std::string strDec = DecodeBase32(vstrOut[i]);
         BOOST_CHECK_EQUAL(strDec, vstrIn[i]);
     }

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -36,17 +36,6 @@ struct MinerTestingSetup : public TestingSetup {
 
 BOOST_FIXTURE_TEST_SUITE(miner_tests, MinerTestingSetup)
 
-// BOOST_CHECK_EXCEPTION predicates to check the specific validation error
-class HasReason {
-public:
-    explicit HasReason(const std::string& reason) : m_reason(reason) {}
-    bool operator() (const std::runtime_error& e) const {
-        return std::string(e.what()).find(m_reason) != std::string::npos;
-    };
-private:
-    const std::string m_reason;
-};
-
 static CFeeRate blockMinFeeRate = CFeeRate(DEFAULT_BLOCK_MIN_TX_FEE);
 
 BlockAssembler MinerTestingSetup::AssemblerForTest(const CChainParams& params)

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -10,6 +10,7 @@
 #include <net.h>
 #include <netbase.h>
 #include <serialize.h>
+#include <span.h>
 #include <streams.h>
 #include <test/util/setup_common.h>
 #include <util/memory.h>
@@ -20,6 +21,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <ios>
 #include <memory>
 #include <string>
 
@@ -261,15 +263,205 @@ BOOST_AUTO_TEST_CASE(cnetaddr_basic)
     BOOST_CHECK_EQUAL(addr.ToString(), "esffpvrt3wpeaygy.internal");
 }
 
-BOOST_AUTO_TEST_CASE(cnetaddr_serialize)
+BOOST_AUTO_TEST_CASE(cnetaddr_serialize_v1)
 {
     CNetAddr addr;
     CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "00000000000000000000000000000000");
+    s.clear();
+
+    BOOST_REQUIRE(LookupHost("1.2.3.4", addr, false));
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "00000000000000000000ffff01020304");
+    s.clear();
+
+    BOOST_REQUIRE(LookupHost("1a1b:2a2b:3a3b:4a4b:5a5b:6a6b:7a7b:8a8b", addr, false));
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "1a1b2a2b3a3b4a4b5a5b6a6b7a7b8a8b");
+    s.clear();
+
+    BOOST_REQUIRE(addr.SetSpecial("6hzph5hv6337r6p2.onion"));
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "fd87d87eeb43f1f2f3f4f5f6f7f8f9fa");
+    s.clear();
 
     addr.SetInternal("a");
     s << addr;
     BOOST_CHECK_EQUAL(HexStr(s), "fd6b88c08724ca978112ca1bbdcafac2");
     s.clear();
+}
+
+BOOST_AUTO_TEST_CASE(cnetaddr_serialize_v2)
+{
+    CNetAddr addr;
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    // Add ADDRV2_FORMAT to the version so that the CNetAddr
+    // serialize method produces an address in v2 format.
+    s.SetVersion(s.GetVersion() | ADDRV2_FORMAT);
+
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "021000000000000000000000000000000000");
+    s.clear();
+
+    BOOST_REQUIRE(LookupHost("1.2.3.4", addr, false));
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "010401020304");
+    s.clear();
+
+    BOOST_REQUIRE(LookupHost("1a1b:2a2b:3a3b:4a4b:5a5b:6a6b:7a7b:8a8b", addr, false));
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "02101a1b2a2b3a3b4a4b5a5b6a6b7a7b8a8b");
+    s.clear();
+
+    BOOST_REQUIRE(addr.SetSpecial("6hzph5hv6337r6p2.onion"));
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "030af1f2f3f4f5f6f7f8f9fa");
+    s.clear();
+
+    BOOST_REQUIRE(addr.SetInternal("a"));
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "0210fd6b88c08724ca978112ca1bbdcafac2");
+    s.clear();
+}
+
+BOOST_AUTO_TEST_CASE(cnetaddr_unserialize_v2)
+{
+    CNetAddr addr;
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    // Add ADDRV2_FORMAT to the version so that the CNetAddr
+    // unserialize method expects an address in v2 format.
+    s.SetVersion(s.GetVersion() | ADDRV2_FORMAT);
+
+    // Valid IPv4.
+    s << MakeSpan(ParseHex("01"          // network type (IPv4)
+                           "04"          // address length
+                           "01020304")); // address
+    s >> addr;
+    BOOST_CHECK(addr.IsValid());
+    BOOST_CHECK(addr.IsIPv4());
+    BOOST_CHECK_EQUAL(addr.ToString(), "1.2.3.4");
+    BOOST_REQUIRE(s.empty());
+
+    // Invalid IPv4, valid length but address itself is shorter.
+    s << MakeSpan(ParseHex("01"      // network type (IPv4)
+                           "04"      // address length
+                           "0102")); // address
+    BOOST_CHECK_EXCEPTION(s >> addr, std::ios_base::failure, HasReason("end of data"));
+    BOOST_REQUIRE(!s.empty()); // The stream is not consumed on invalid input.
+    s.clear();
+
+    // Invalid IPv4, with bogus length.
+    s << MakeSpan(ParseHex("01"          // network type (IPv4)
+                           "05"          // address length
+                           "01020304")); // address
+    BOOST_CHECK_EXCEPTION(s >> addr, std::ios_base::failure,
+                          HasReason("BIP155 IPv4 address with length 5 (should be 4)"));
+    BOOST_REQUIRE(!s.empty()); // The stream is not consumed on invalid input.
+    s.clear();
+
+    // Invalid IPv4, with extreme length.
+    s << MakeSpan(ParseHex("01"          // network type (IPv4)
+                           "fd0102"      // address length (513 as CompactSize)
+                           "01020304")); // address
+    BOOST_CHECK_EXCEPTION(s >> addr, std::ios_base::failure,
+                          HasReason("Address too long: 513 > 512"));
+    BOOST_REQUIRE(!s.empty()); // The stream is not consumed on invalid input.
+    s.clear();
+
+    // Valid IPv6.
+    s << MakeSpan(ParseHex("02"                                  // network type (IPv6)
+                           "10"                                  // address length
+                           "0102030405060708090a0b0c0d0e0f10")); // address
+    s >> addr;
+    BOOST_CHECK(addr.IsValid());
+    BOOST_CHECK(addr.IsIPv6());
+    BOOST_CHECK_EQUAL(addr.ToString(), "102:304:506:708:90a:b0c:d0e:f10");
+    BOOST_REQUIRE(s.empty());
+
+    // Valid IPv6, contains embedded "internal".
+    s << MakeSpan(ParseHex(
+        "02"                                  // network type (IPv6)
+        "10"                                  // address length
+        "fd6b88c08724ca978112ca1bbdcafac2")); // address: 0xfd + sha256("bitcoin")[0:5] +
+                                              // sha256(name)[0:10]
+    s >> addr;
+    BOOST_CHECK(addr.IsInternal());
+    BOOST_CHECK_EQUAL(addr.ToString(), "zklycewkdo64v6wc.internal");
+    BOOST_REQUIRE(s.empty());
+
+    // Invalid IPv6, with bogus length.
+    s << MakeSpan(ParseHex("02"    // network type (IPv6)
+                           "04"    // address length
+                           "00")); // address
+    BOOST_CHECK_EXCEPTION(s >> addr, std::ios_base::failure,
+                          HasReason("BIP155 IPv6 address with length 4 (should be 16)"));
+    BOOST_REQUIRE(!s.empty()); // The stream is not consumed on invalid input.
+    s.clear();
+
+    // Invalid IPv6, contains embedded IPv4.
+    s << MakeSpan(ParseHex("02"                                  // network type (IPv6)
+                           "10"                                  // address length
+                           "00000000000000000000ffff01020304")); // address
+    s >> addr;
+    BOOST_CHECK(!addr.IsValid());
+    BOOST_REQUIRE(s.empty());
+
+    // Invalid IPv6, contains embedded TORv2.
+    s << MakeSpan(ParseHex("02"                                  // network type (IPv6)
+                           "10"                                  // address length
+                           "fd87d87eeb430102030405060708090a")); // address
+    s >> addr;
+    BOOST_CHECK(!addr.IsValid());
+    BOOST_REQUIRE(s.empty());
+
+    // Valid TORv2.
+    s << MakeSpan(ParseHex("03"                      // network type (TORv2)
+                           "0a"                      // address length
+                           "f1f2f3f4f5f6f7f8f9fa")); // address
+    s >> addr;
+    BOOST_CHECK(addr.IsValid());
+    BOOST_CHECK(addr.IsTor());
+    BOOST_CHECK_EQUAL(addr.ToString(), "6hzph5hv6337r6p2.onion");
+    BOOST_REQUIRE(s.empty());
+
+    // Invalid TORv2, with bogus length.
+    s << MakeSpan(ParseHex("03"    // network type (TORv2)
+                           "07"    // address length
+                           "00")); // address
+    BOOST_CHECK_EXCEPTION(s >> addr, std::ios_base::failure,
+                          HasReason("BIP155 TORv2 address with length 7 (should be 10)"));
+    BOOST_REQUIRE(!s.empty()); // The stream is not consumed on invalid input.
+    s.clear();
+
+    // Unknown, with extreme length.
+    s << MakeSpan(ParseHex("aa"             // network type (unknown)
+                           "fe00000002"     // address length (CompactSize's MAX_SIZE)
+                           "01020304050607" // address
+                           ));
+    BOOST_CHECK_EXCEPTION(s >> addr, std::ios_base::failure,
+                          HasReason("Address too long: 33554432 > 512"));
+    BOOST_REQUIRE(!s.empty()); // The stream is not consumed on invalid input.
+    s.clear();
+
+    // Unknown, with reasonable length.
+    s << MakeSpan(ParseHex("aa"       // network type (unknown)
+                           "04"       // address length
+                           "01020304" // address
+                           ));
+    s >> addr;
+    BOOST_CHECK(!addr.IsValid());
+    BOOST_REQUIRE(s.empty());
+
+    // Unknown, with zero length.
+    s << MakeSpan(ParseHex("aa" // network type (unknown)
+                           "00" // address length
+                           ""   // address
+                           ));
+    s >> addr;
+    BOOST_CHECK(!addr.IsValid());
+    BOOST_REQUIRE(s.empty());
 }
 
 // prior to PR #14728, this test triggers an undefined behavior

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -153,4 +153,20 @@ CBlock getBlock13b8a();
 // define an implicit conversion here so that uint256 may be used directly in BOOST_CHECK_*
 std::ostream& operator<<(std::ostream& os, const uint256& num);
 
+/**
+ * BOOST_CHECK_EXCEPTION predicates to check the specific validation error.
+ * Use as
+ * BOOST_CHECK_EXCEPTION(code that throws, exception type, HasReason("foo"));
+ */
+class HasReason {
+public:
+    explicit HasReason(const std::string& reason) : m_reason(reason) {}
+    template <typename E>
+    bool operator() (const E& e) const {
+        return std::string(e.what()).find(m_reason) != std::string::npos;
+    };
+private:
+    const std::string m_reason;
+};
+
 #endif

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -201,20 +201,24 @@ std::string DecodeBase64(const std::string& str, bool* pf_invalid)
     return std::string((const char*)vchRet.data(), vchRet.size());
 }
 
-std::string EncodeBase32(Span<const unsigned char> input)
+std::string EncodeBase32(Span<const unsigned char> input, bool pad)
 {
     static const char *pbase32 = "abcdefghijklmnopqrstuvwxyz234567";
 
     std::string str;
     str.reserve(((input.size() + 4) / 5) * 8);
     ConvertBits<8, 5, true>([&](int v) { str += pbase32[v]; }, input.begin(), input.end());
-    while (str.size() % 8) str += '=';
+    if (pad) {
+        while (str.size() % 8) {
+            str += '=';
+        }
+    }
     return str;
 }
 
-std::string EncodeBase32(const std::string& str)
+std::string EncodeBase32(const std::string& str, bool pad)
 {
-    return EncodeBase32(MakeUCharSpan(str));
+    return EncodeBase32(MakeUCharSpan(str), pad);
 }
 
 std::vector<unsigned char> DecodeBase32(const char* p, bool* pf_invalid)

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -52,8 +52,20 @@ std::string EncodeBase64(Span<const unsigned char> input);
 std::string EncodeBase64(const std::string& str);
 std::vector<unsigned char> DecodeBase32(const char* p, bool* pf_invalid = nullptr);
 std::string DecodeBase32(const std::string& str, bool* pf_invalid = nullptr);
-std::string EncodeBase32(Span<const unsigned char> input);
-std::string EncodeBase32(const std::string& str);
+
+/**
+ * Base32 encode.
+ * If `pad` is true, then the output will be padded with '=' so that its length
+ * is a multiple of 8.
+ */
+std::string EncodeBase32(Span<const unsigned char> input, bool pad = true);
+
+/**
+ * Base32 encode.
+ * If `pad` is true, then the output will be padded with '=' so that its length
+ * is a multiple of 8.
+ */
+std::string EncodeBase32(const std::string& str, bool pad = true);
 
 void SplitHostPort(std::string in, int& portOut, std::string& hostOut);
 int64_t atoi64(const std::string& str);

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -7,6 +7,8 @@
 
 #include <attributes.h>
 
+#include <algorithm>
+#include <array>
 #include <cstring>
 #include <locale>
 #include <sstream>
@@ -72,6 +74,17 @@ std::string ToString(const T& t)
     oss.imbue(std::locale::classic());
     oss << t;
     return oss.str();
+}
+
+/**
+ * Check whether a container begins with the given prefix.
+ */
+template <typename T1, size_t PREFIX_LEN>
+NODISCARD inline bool HasPrefix(const T1& obj,
+                                const std::array<uint8_t, PREFIX_LEN>& prefix)
+{
+    return obj.size() >= PREFIX_LEN &&
+           std::equal(std::begin(prefix), std::end(prefix), std::begin(obj));
 }
 
 #endif // BITCOIN_UTIL_STRENCODINGS_H

--- a/src/version.h
+++ b/src/version.h
@@ -38,4 +38,7 @@ static const int INVALID_CB_NO_BAN_VERSION = 70015;
 //! "wtxidrelay" command for wtxid-based relay starts with this version
 static const int WTXID_RELAY_VERSION = 70016;
 
+// Make sure that none of the values above collide with
+// `SERIALIZE_TRANSACTION_NO_WITNESS` or `ADDRV2_FORMAT`.
+
 #endif // BITCOIN_VERSION_H


### PR DESCRIPTION
(chopped off from #19031 to ease review)

Add an optional support to serialize/unserialize `CNetAddr` in ADDRv2 format (BIP155). The new serialization is engaged by ORing a flag into the stream version.

So far this is only used in tests to ensure the new code works as expected.