### PR TITLE
Remove mempool global from interfaces

### DIFF
--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -276,8 +276,9 @@ public:
     }
     RBFTransactionState isRBFOptIn(const CTransaction& tx) override
     {
-        LOCK(::mempool.cs);
-        return IsRBFOptIn(tx, ::mempool);
+        if (!m_node.mempool) return IsRBFOptInEmptyMempool(tx);
+        LOCK(m_node.mempool->cs);
+        return IsRBFOptIn(tx, *m_node.mempool);
     }
     bool hasDescendantsInMempool(const uint256& txid) override
     {

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -36,3 +36,9 @@ RBFTransactionState IsRBFOptIn(const CTransaction& tx, const CTxMemPool& pool)
     }
     return RBFTransactionState::FINAL;
 }
+
+RBFTransactionState IsRBFOptInEmptyMempool(const CTransaction& tx)
+{
+    // If we don't have a local mempool we can only check the transaction itself.
+    return SignalsOptInRBF(tx) ? RBFTransactionState::REPLACEABLE_BIP125 : RBFTransactionState::UNKNOWN;
+}

--- a/src/policy/rbf.h
+++ b/src/policy/rbf.h
@@ -7,16 +7,27 @@
 
 #include <txmempool.h>
 
+/** The rbf state of unconfirmed transactions */
 enum class RBFTransactionState {
+    /** Unconfirmed tx that does not signal rbf and is not in the mempool */
     UNKNOWN,
+    /** Either this tx or a mempool ancestor signals rbf */
     REPLACEABLE_BIP125,
-    FINAL
+    /** Neither this tx nor a mempool ancestor signals rbf */
+    FINAL,
 };
 
-// Determine whether an in-mempool transaction is signaling opt-in to RBF
-// according to BIP 125
-// This involves checking sequence numbers of the transaction, as well
-// as the sequence numbers of all in-mempool ancestors.
+/**
+ * Determine whether an unconfirmed transaction is signaling opt-in to RBF
+ * according to BIP 125
+ * This involves checking sequence numbers of the transaction, as well
+ * as the sequence numbers of all in-mempool ancestors.
+ *
+ * @param tx   The unconfirmed transaction
+ * @param pool The mempool, which may contain the tx
+ *
+ * @return     The rbf state
+ */
 RBFTransactionState IsRBFOptIn(const CTransaction& tx, const CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(pool.cs);
 RBFTransactionState IsRBFOptInEmptyMempool(const CTransaction& tx);
 

--- a/src/policy/rbf.h
+++ b/src/policy/rbf.h
@@ -18,5 +18,6 @@ enum class RBFTransactionState {
 // This involves checking sequence numbers of the transaction, as well
 // as the sequence numbers of all in-mempool ancestors.
 RBFTransactionState IsRBFOptIn(const CTransaction& tx, const CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(pool.cs);
+RBFTransactionState IsRBFOptInEmptyMempool(const CTransaction& tx);
 
 #endif // BITCOIN_POLICY_RBF_H


### PR DESCRIPTION
The chain interface has an `m_node` member, which has a pointer to the mempool global. Use the pointer instead of the global to prepare the removal of the mempool global. See #19556 