### PR TITLE
refactor: Extract ParseOpCode from ParseScript

### DIFF
--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -21,10 +21,10 @@
 #include <algorithm>
 #include <string>
 
-CScript ParseScript(const std::string& s)
-{
-    CScript result;
+namespace {
 
+opcodetype ParseOpCode(const std::string& s)
+{
     static std::map<std::string, opcodetype> mapOpNames;
 
     if (mapOpNames.empty())
@@ -44,6 +44,17 @@ CScript ParseScript(const std::string& s)
             mapOpNames[strName] = static_cast<opcodetype>(op);
         }
     }
+
+    auto it = mapOpNames.find(s);
+    if (it == mapOpNames.end()) throw std::runtime_error("script parse error: unknown opcode");
+    return it->second;
+}
+
+} // namespace
+
+CScript ParseScript(const std::string& s)
+{
+    CScript result;
 
     std::vector<std::string> words;
     boost::algorithm::split(words, s, boost::algorithm::is_any_of(" \t\n"), boost::algorithm::token_compress_on);
@@ -82,14 +93,10 @@ CScript ParseScript(const std::string& s)
             std::vector<unsigned char> value(w->begin()+1, w->end()-1);
             result << value;
         }
-        else if (mapOpNames.count(*w))
-        {
-            // opcode, e.g. OP_ADD or ADD:
-            result << mapOpNames[*w];
-        }
         else
         {
-            throw std::runtime_error("script parse error");
+            // opcode, e.g. OP_ADD or ADD:
+            result << ParseOpCode(*w);
         }
     }
 

--- a/test/util/data/bitcoin-util-test.json
+++ b/test/util/data/bitcoin-util-test.json
@@ -221,7 +221,7 @@
   { "exec": "./bitcoin-tx",
     "args": ["-create", "outscript=0:123badscript"],
     "return_code": 1,
-    "error_txt": "error: script parse error",
+    "error_txt": "error: script parse error: unknown opcode",
     "description": "Create a new transaction with an invalid output script"
   },
   { "exec": "./bitcoin-tx",


### PR DESCRIPTION
Seems more natural to have `mapOpNames` "hidden" in `ParseOpCode` than in `ParseScript`.

A second lookup in `mapOpNames` is also removed.