### PR TITLE
p2p: Improve diversification of new connections

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1914,9 +1914,6 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
                     // free to make, an attacker could make them to prevent us from connecting to
                     // certain peers.
                     case ConnectionType::INBOUND:
-                    // Manually selected connections should not affect how we select outbound
-                    // peers from addrman.
-                    case ConnectionType::MANUAL:
                     // Short-lived outbound connections should not affect how we select outbound
                     // peers from addrman.
                     case ConnectionType::ADDR_FETCH:
@@ -1924,6 +1921,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
                     // peers from addrman.
                     case ConnectionType::FEELER:
                         break;
+                    case ConnectionType::MANUAL:
                     case ConnectionType::OUTBOUND_FULL_RELAY:
                     case ConnectionType::BLOCK_RELAY:
                         setConnected.insert(pnode->addr.GetGroup(addrman.GetAsmap()));

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2037,6 +2037,11 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
                 addr = addrman.Select();
             }
 
+            // The following checks are never applied to MANUAL and ADDR_FETCH,
+            // because those connections are made elsewhere.
+            assert(conn_type != ConnectionType::MANUAL);
+            assert(conn_type != ConnectionType::ADDR_FETCH);
+
             // Require outbound connections, other than feelers, to be to distinct network groups
             if (!fFeeler && setConnected.count(addr.GetGroup(addrman.GetAsmap()))) {
                 break;


### PR DESCRIPTION
This PR improves the logic around netgroup diversity of new connections. More specifically, it improves privacy and fixes a couple things I consider buggy. It also adds a bunch of documentation. 

This PR changes the following:
1. prevents short-lived ADDR_FETCH and FEELER connections from affecting our further peer selection, because they are short-lived and should not matter
2. ~~ADDR_FETCH and FEELER conns are now not included in `count_failure` consideration (see new documentation). Even though it *makes sense* to consider them if they are present at the moment of the call, we should not rely on that luck. Instead, we should be explicit.~~
3. ~Prevents BLOCK_RELAY connections from affecting our further full-relay peer selection, because otherwise, an attacker with sufficient ADDR-related capabilities may infer to which netgroups those (supposedly more private) connections belong.~ Abandoning this feature for now because the trade-offs are unclear, see P2P meeting at #bitcoin-core-dev from Sept. 8.
4. Look at the existing MANUAL peers when enforcing diversity of new outbound conns.

~I’m also not sure whether *new* BLOCK_RELAY connections should be distinct w.r.t *existent* full outbound connections. Seems like another influence vector for an attacker with AddrMan poisoning capabilities, but this threat is probably too advanced. And having a good diversity of BLOCK_RELAY conns is very beneficial.~