### PR TITLE
build: add /usr/local/ to LCOV_FILTER_PATTERN for macOS builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -181,6 +181,7 @@ $(BITCOIN_WALLET_BIN): FORCE
 
 if USE_LCOV
 LCOV_FILTER_PATTERN = \
+	-p "/usr/local/" \
 	-p "/usr/include/" \
 	-p "/usr/lib/" \
 	-p "/usr/lib64/" \


### PR DESCRIPTION
With this commit, the files in /usr/local/ will not be included in
`make cov` or `make cov_fuzz` coverage reports. This behavior could
be observed when generating the reports on macOS with brew-installed
clang.