### PR TITLE
build: Fix target name

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -265,4 +265,4 @@ $(foreach package,$(all_packages),$(eval $(call int_config_attach_build_config,$
 $(foreach package,$(all_packages),$(eval $(call int_add_cmds,$(package))))
 
 #special exception: if a toolchain package exists, all non-native packages depend on it
-$(foreach package,$(packages),$(eval $($(package)_unpacked): |$($($(host_arch)_$(host_os)_native_toolchain)_cached) $($($(host_arch)_$(host_os)_native_binutils)_cached) ))
+$(foreach package,$(packages),$(eval $($(package)_extracted): |$($($(host_arch)_$(host_os)_native_toolchain)_cached) $($($(host_arch)_$(host_os)_native_binutils)_cached) ))


### PR DESCRIPTION
It seems like a typo :)
This PR:
- fixes errors when building a package in depends for `HOST=x86_64-apple-darwin16` (fix #19799)
- is a correct alternative to https://github.com/bitcoin/bitcoin/pull/19764/commits/d25e0e308f51f6b995e5d0033224c424dc8afc2c from #19764
