### PR TITLE
Better intervals between feelers

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -65,9 +65,6 @@ static constexpr std::chrono::seconds DNSSEEDS_DELAY_FEW_PEERS{11};
 static constexpr std::chrono::minutes DNSSEEDS_DELAY_MANY_PEERS{5};
 static constexpr int DNSSEEDS_DELAY_PEER_THRESHOLD = 1000; // "many" vs "few" peers
 
-// We add a random period time (0 to 1 seconds) to feeler connections to prevent synchronization.
-#define FEELER_SLEEP_WINDOW 1
-
 // MSG_NOSIGNAL is not available on some platforms, if it doesn't exist define it as 0
 #if !defined(MSG_NOSIGNAL)
 #define MSG_NOSIGNAL 0
@@ -2013,11 +2010,6 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
 
             if (fFeeler) {
                 next_feeler_time = PoissonNextSend(current_time, FEELER_ATTEMPT_INTERVAL);
-
-                // Add small amount of random noise before connection to avoid synchronization.
-                int randsleep = GetRandInt(FEELER_SLEEP_WINDOW * 1000);
-                if (!interruptNet.sleep_for(std::chrono::milliseconds(randsleep)))
-                    return;
                 LogPrint(BCLog::NET, "Making feeler connection to %s\n", addrConnect.ToString());
             }
 

--- a/src/net.h
+++ b/src/net.h
@@ -52,15 +52,15 @@ static const bool DEFAULT_WHITELISTFORCERELAY = false;
 /** Time after which to disconnect, after waiting for a ping response (or inactivity). */
 static const int TIMEOUT_INTERVAL = 20 * 60;
 /** Delay of the next feeler consideration if a current candidate was attempted to connect to. **/
-static const int FEELER_ATTEMPT_INTERVAL = 120;
+static constexpr std::chrono::minutes FEELER_ATTEMPT_INTERVAL{2};
 /**
  * Delay of the next feeler consideration if a current candidate was not attempted to connect to.
  * For example, if a selected feeler didn't pass pre-validation (e.g., last time it was tried was too recent),
  * we won't even try to connect.
  */
-static const int FEELER_SKIP_INTERVAL = 20;
+static constexpr std::chrono::seconds FEELER_SKIP_INTERVAL{20};
 static_assert(FEELER_ATTEMPT_INTERVAL >= FEELER_SKIP_INTERVAL,
-"FEELER_SKIP_INTERVAL should not exceed FEELER_ATTEMPT_INTERVAL to enforce effective feeler selection");
+"FEELER_SKIP_INTERVAL should not exceed FEELER_ATTEMPT_INTERVAL to have effective feeler selection");
 /** The maximum number of addresses from our addrman to return in response to a getaddr message. */
 static constexpr size_t MAX_ADDR_TO_SEND = 1000;
 /** Maximum length of incoming protocol messages (no message over 4 MB is currently acceptable). */

--- a/src/net.h
+++ b/src/net.h
@@ -51,8 +51,16 @@ static const bool DEFAULT_WHITELISTFORCERELAY = false;
 
 /** Time after which to disconnect, after waiting for a ping response (or inactivity). */
 static const int TIMEOUT_INTERVAL = 20 * 60;
-/** Run the feeler connection loop once every 2 minutes or 120 seconds. **/
-static const int FEELER_INTERVAL = 120;
+/** Delay of the next feeler consideration if a current candidate was attempted to connect to. **/
+static const int FEELER_ATTEMPT_INTERVAL = 120;
+/**
+ * Delay of the next feeler consideration if a current candidate was not attempted to connect to.
+ * For example, if a selected feeler didn't pass pre-validation (e.g., last time it was tried was too recent),
+ * we won't even try to connect.
+ */
+static const int FEELER_SKIP_INTERVAL = 20;
+static_assert(FEELER_ATTEMPT_INTERVAL >= FEELER_SKIP_INTERVAL,
+"FEELER_SKIP_INTERVAL should not exceed FEELER_ATTEMPT_INTERVAL to enforce effective feeler selection");
 /** The maximum number of addresses from our addrman to return in response to a getaddr message. */
 static constexpr size_t MAX_ADDR_TO_SEND = 1000;
 /** Maximum length of incoming protocol messages (no message over 4 MB is currently acceptable). */
@@ -163,7 +171,7 @@ enum class ConnectionType {
      * Note that in the literature ("Eclipse Attacks on Bitcoin’s Peer-to-Peer Network")
      * only the latter feature is referred to as "feeler connections",
      * although in our codebase feeler connections encompass test-before-evict as well.
-     * We make these connections approximately every FEELER_INTERVAL:
+     * We periodically make these connections:
      * first we resolve previously found collisions if they exist (test-before-evict),
      * otherwise connect to a node from the new table.
      */


### PR DESCRIPTION
~_Draft pending on #19958_~

1. If an attempt to connect to a feeler wasn't actually made (an entry from AddrMan we considered was invalid, or we made too many tries, or it didn't have the right flag) — wait less until we try the next feeler.
2. Make those intervals mockable
3. Remove unnecessary extra random noise between feelers

(1) would make transitioning from "new" to "tried" better in the presence of those events. An adversary here fills our "new" table with garbage to prevent us from trying honest peers from "new". This probably won't help much against a very powerful adversary but will help against a moderate adversary. It also may help in natural non-malicious cases.

Moving from "new" to "tried" table is important for p2p security.