### PR TITLE
Avoid locking CTxMemPool::cs recursively in some cases

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -231,7 +231,7 @@ void Shutdown(NodeContext& node)
     node.connman.reset();
     node.banman.reset();
 
-    if (node.mempool && node.mempool->IsLoaded() && node.args->GetArg("-persistmempool", DEFAULT_PERSIST_MEMPOOL)) {
+    if (node.mempool && WITH_LOCK(node.mempool->cs, return node.mempool->IsLoaded()) && node.args->GetArg("-persistmempool", DEFAULT_PERSIST_MEMPOOL)) {
         DumpMempool(*node.mempool);
     }
 

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -336,6 +336,7 @@ public:
     CFeeRate mempoolMinFee() override
     {
         if (!m_node.mempool) return {};
+        LOCK(m_node.mempool->cs);
         return m_node.mempool->GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000);
     }
     CFeeRate relayMinFee() override { return ::minRelayTxFee; }

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -302,6 +302,7 @@ public:
     {
         ancestors = descendants = 0;
         if (!m_node.mempool) return;
+        LOCK(m_node.mempool->cs);
         m_node.mempool->GetTransactionAncestry(txid, ancestors, descendants);
     }
     void getPackageLimits(unsigned int& limit_ancestor_count, unsigned int& limit_descendant_count) override

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -156,7 +156,7 @@ public:
     }
     int64_t getTotalBytesRecv() override { return m_context->connman ? m_context->connman->GetTotalBytesRecv() : 0; }
     int64_t getTotalBytesSent() override { return m_context->connman ? m_context->connman->GetTotalBytesSent() : 0; }
-    size_t getMempoolSize() override { return m_context->mempool ? m_context->mempool->size() : 0; }
+    size_t getMempoolSize() override { return m_context->mempool ? WITH_LOCK(m_context->mempool->cs, return m_context->mempool->size()) : 0; }
     size_t getMempoolDynamicUsage() override { return m_context->mempool ? m_context->mempool->DynamicMemoryUsage() : 0; }
     bool getHeaderTip(int& height, int64_t& block_time) override
     {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4649,7 +4649,8 @@ bool PeerManager::SendMessages(CNode* pto)
         if (pto->m_tx_relay != nullptr && pto->nVersion >= FEEFILTER_VERSION && gArgs.GetBoolArg("-feefilter", DEFAULT_FEEFILTER) &&
             !pto->HasPermission(PF_FORCERELAY) // peers with the forcerelay permission should not filter txs to us
         ) {
-            CAmount currentFilter = m_mempool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK();
+            const auto min_fee = WITH_LOCK(m_mempool.cs, return m_mempool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000));
+            CAmount currentFilter = min_fee.GetFeePerK();
             int64_t timeNow = GetTimeMicros();
             static FeeFilterRounder g_filter_rounder{CFeeRate{DEFAULT_MIN_RELAY_TX_FEE}};
             if (m_chainman.ActiveChainstate().IsInitialBlockDownload()) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -889,7 +889,7 @@ void PeerManager::InitializeNode(CNode *pnode) {
 
 void PeerManager::ReattemptInitialBroadcast(CScheduler& scheduler) const
 {
-    std::map<uint256, uint256> unbroadcast_txids = m_mempool.GetUnbroadcastTxs();
+    std::map<uint256, uint256> unbroadcast_txids = WITH_LOCK(m_mempool.cs, return m_mempool.GetUnbroadcastTxs());
 
     for (const auto& elem : unbroadcast_txids) {
         // Sanity check: all unbroadcast txns should exist in the mempool

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4366,7 +4366,7 @@ bool PeerManager::SendMessages(CNode* pto)
 
                 // Respond to BIP35 mempool requests
                 if (fSendTrickle && pto->m_tx_relay->fSendMempool) {
-                    auto vtxinfo = m_mempool.infoAll();
+                    const auto vtxinfo = WITH_LOCK(m_mempool.cs, return m_mempool.infoAll());
                     pto->m_tx_relay->fSendMempool = false;
                     CFeeRate filterrate;
                     {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3022,7 +3022,8 @@ void PeerManager::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDat
             LogPrint(BCLog::MEMPOOL, "AcceptToMemoryPool: peer=%d: accepted %s (poolsz %u txn, %u kB)\n",
                 pfrom.GetId(),
                 tx.GetHash().ToString(),
-                m_mempool.size(), m_mempool.DynamicMemoryUsage() / 1000);
+                WITH_LOCK(m_mempool.cs, return m_mempool.size()),
+                m_mempool.DynamicMemoryUsage() / 1000);
 
             // Recursively process any orphan transactions that depended on this one
             ProcessOrphanTx(pfrom.orphan_work_set, lRemovedTxn);

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -35,7 +35,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
         // So if the output does exist, then this transaction exists in the chain.
         if (!existingCoin.IsSpent()) return TransactionError::ALREADY_IN_CHAIN;
     }
-    if (!node.mempool->exists(hashTx)) {
+    if (!WITH_LOCK(node.mempool->cs, return node.mempool->exists(hashTx))) {
         // Transaction is not already in the mempool. Submit it.
         TxValidationState state;
         if (!AcceptToMemoryPool(*node.mempool, state, std::move(tx),

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -500,7 +500,7 @@ UniValue MempoolToJSON(const CTxMemPool& pool, bool verbose)
         return o;
     } else {
         std::vector<uint256> vtxid;
-        pool.queryHashes(vtxid);
+        WITH_LOCK(pool.cs, pool.queryHashes(vtxid));
 
         UniValue a(UniValue::VARR);
         for (const uint256& hash : vtxid)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1964,7 +1964,7 @@ static UniValue savemempool(const JSONRPCRequest& request)
 
     const CTxMemPool& mempool = EnsureMemPool(request.context);
 
-    if (!mempool.IsLoaded()) {
+    if (!WITH_LOCK(mempool.cs, return mempool.IsLoaded())) {
         throw JSONRPCError(RPC_MISC_ERROR, "The mempool was not loaded yet");
     }
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -432,7 +432,7 @@ static RPCHelpMan getmininginfo()
     if (BlockAssembler::m_last_block_num_txs) obj.pushKV("currentblocktx", *BlockAssembler::m_last_block_num_txs);
     obj.pushKV("difficulty",       (double)GetDifficulty(::ChainActive().Tip()));
     obj.pushKV("networkhashps",    getnetworkhashps().HandleRequest(request));
-    obj.pushKV("pooledtx",         (uint64_t)mempool.size());
+    obj.pushKV("pooledtx",         (uint64_t)(WITH_LOCK(mempool.cs, return mempool.size())));
     obj.pushKV("chain",            Params().NetworkIDString());
     obj.pushKV("warnings",         GetWarnings(false).original);
     return obj;

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -34,7 +34,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChain100Setup)
 
     LOCK(cs_main);
 
-    unsigned int initialPoolSize = m_node.mempool->size();
+    unsigned int initialPoolSize = WITH_LOCK(m_node.mempool->cs, return m_node.mempool->size());
 
     BOOST_CHECK_EQUAL(
             false,
@@ -44,7 +44,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChain100Setup)
                 0 /* nAbsurdFee */));
 
     // Check that the transaction hasn't been added to mempool.
-    BOOST_CHECK_EQUAL(m_node.mempool->size(), initialPoolSize);
+    BOOST_CHECK_EQUAL(WITH_LOCK(m_node.mempool->cs, return m_node.mempool->size()), initialPoolSize);
 
     // Check that the validation state reflects the unsuccessful attempt.
     BOOST_CHECK(state.IsInvalid());

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -92,7 +92,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
     }
     // spends[1] should have been removed from the mempool when the
     // block with spends[0] is accepted:
-    BOOST_CHECK_EQUAL(m_node.mempool->size(), 0U);
+    BOOST_CHECK_EQUAL(WITH_LOCK(m_node.mempool->cs, return m_node.mempool->size()), 0U);
 }
 
 // Run CheckInputScripts (using CoinsTip()) on the given transaction, for all script

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1104,7 +1104,7 @@ void CTxMemPool::GetTransactionAncestry(const uint256& txid, size_t& ancestors, 
 
 bool CTxMemPool::IsLoaded() const
 {
-    LOCK(cs);
+    AssertLockHeld(cs);
     return m_is_loaded;
 }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -615,7 +615,7 @@ static void CheckInputsAndUpdateCoins(const CTransaction& tx, CCoinsViewCache& m
 
 void CTxMemPool::check(const CCoinsViewCache *pcoins) const
 {
-    LOCK(cs);
+    AssertLockHeld(cs);
     if (nCheckFrequency == 0)
         return;
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -778,7 +778,7 @@ std::vector<CTxMemPool::indexed_transaction_set::const_iterator> CTxMemPool::Get
 
 void CTxMemPool::queryHashes(std::vector<uint256>& vtxid) const
 {
-    LOCK(cs);
+    AssertLockHeld(cs);
     auto iters = GetSortedDepthAndScore();
 
     vtxid.clear();

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -993,8 +993,9 @@ void CTxMemPool::UpdateParent(txiter entry, txiter parent, bool add)
     }
 }
 
-CFeeRate CTxMemPool::GetMinFee(size_t sizelimit) const {
-    LOCK(cs);
+CFeeRate CTxMemPool::GetMinFee(size_t sizelimit) const
+{
+    AssertLockHeld(cs);
     if (!blockSinceLastRollingFeeBump || rollingMinimumFeeRate == 0)
         return CFeeRate(llround(rollingMinimumFeeRate));
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -795,7 +795,7 @@ static TxMempoolInfo GetInfo(CTxMemPool::indexed_transaction_set::const_iterator
 
 std::vector<TxMempoolInfo> CTxMemPool::infoAll() const
 {
-    LOCK(cs);
+    AssertLockHeld(cs);
     auto iters = GetSortedDepthAndScore();
 
     std::vector<TxMempoolInfo> ret;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -928,11 +928,10 @@ size_t CTxMemPool::DynamicMemoryUsage() const {
     return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 15 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(vTxHashes) + cachedInnerUsage;
 }
 
-void CTxMemPool::RemoveUnbroadcastTx(const uint256& txid, const bool unchecked) {
-    LOCK(cs);
-
-    if (m_unbroadcast_txids.erase(txid))
-    {
+void CTxMemPool::RemoveUnbroadcastTx(const uint256& txid, const bool unchecked)
+{
+    AssertLockHeld(cs);
+    if (m_unbroadcast_txids.erase(txid)) {
         LogPrint(BCLog::MEMPOOL, "Removed %i from set of unbroadcast txns%s\n", txid.GetHex(), (unchecked ? " before confirmation that txn was sent out" : ""));
     }
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1091,8 +1091,9 @@ uint64_t CTxMemPool::CalculateDescendantMaximum(txiter entry) const {
     return maximum;
 }
 
-void CTxMemPool::GetTransactionAncestry(const uint256& txid, size_t& ancestors, size_t& descendants) const {
-    LOCK(cs);
+void CTxMemPool::GetTransactionAncestry(const uint256& txid, size_t& ancestors, size_t& descendants) const
+{
+    AssertLockHeld(cs);
     auto it = mapTx.find(txid);
     ancestors = descendants = 0;
     if (it != mapTx.end()) {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -766,7 +766,8 @@ public:
     }
 
     /** Removes a transaction from the unbroadcast set */
-    void RemoveUnbroadcastTx(const uint256& txid, const bool unchecked = false);
+    void RemoveUnbroadcastTx(const uint256& txid, const bool unchecked = false)
+        EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Returns transactions in unbroadcast set */
     std::map<uint256, uint256> GetUnbroadcastTxs() const {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -713,7 +713,7 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** @returns true if the mempool is fully loaded */
-    bool IsLoaded() const;
+    bool IsLoaded() const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Sets the current loaded state */
     void SetIsLoaded(bool loaded);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -606,7 +606,7 @@ public:
      * all inputs are in the mapNextTx array). If sanity-checking is turned off,
      * check does nothing.
      */
-    void check(const CCoinsViewCache *pcoins) const;
+    void check(const CCoinsViewCache *pcoins) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     void setSanityCheck(double dFrequency = 1.0) { LOCK(cs); nCheckFrequency = static_cast<uint32_t>(dFrequency * 4294967295.0); }
 
     // addUnchecked must updated state for all ancestors of a given transaction,

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -718,9 +718,9 @@ public:
     /** Sets the current loaded state */
     void SetIsLoaded(bool loaded);
 
-    unsigned long size() const
+    unsigned long size() const EXCLUSIVE_LOCKS_REQUIRED(cs)
     {
-        LOCK(cs);
+        AssertLockHeld(cs);
         return mapTx.size();
     }
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -752,7 +752,7 @@ public:
     }
     TxMempoolInfo info(const uint256& hash) const;
     TxMempoolInfo info(const GenTxid& gtxid) const;
-    std::vector<TxMempoolInfo> infoAll() const;
+    std::vector<TxMempoolInfo> infoAll() const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     size_t DynamicMemoryUsage() const;
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -694,7 +694,7 @@ public:
       *  takes the fee rate to go back down all the way to 0. When the feerate
       *  would otherwise be half of this, it is set to 0 instead.
       */
-    CFeeRate GetMinFee(size_t sizelimit) const;
+    CFeeRate GetMinFee(size_t sizelimit) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Remove transactions from the mempool until its dynamic size is <= sizelimit.
       *  pvNoSpendsRemaining, if set, will be populated with the list of outpoints

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -709,7 +709,8 @@ public:
      * Calculate the ancestor and descendant count for the given transaction.
      * The counts include the transaction itself.
      */
-    void GetTransactionAncestry(const uint256& txid, size_t& ancestors, size_t& descendants) const;
+    void GetTransactionAncestry(const uint256& txid, size_t& ancestors, size_t& descendants) const
+        EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** @returns true if the mempool is fully loaded */
     bool IsLoaded() const;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -770,8 +770,9 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Returns transactions in unbroadcast set */
-    std::map<uint256, uint256> GetUnbroadcastTxs() const {
-        LOCK(cs);
+    std::map<uint256, uint256> GetUnbroadcastTxs() const EXCLUSIVE_LOCKS_REQUIRED(cs)
+    {
+        AssertLockHeld(cs);
         return m_unbroadcast_txids;
     }
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -730,15 +730,19 @@ public:
         return totalTxSize;
     }
 
-    bool exists(const GenTxid& gtxid) const
+    bool exists(const GenTxid& gtxid) const EXCLUSIVE_LOCKS_REQUIRED(cs)
     {
-        LOCK(cs);
+        AssertLockHeld(cs);
         if (gtxid.IsWtxid()) {
             return (mapTx.get<index_by_wtxid>().count(gtxid.GetHash()) != 0);
         }
         return (mapTx.count(gtxid.GetHash()) != 0);
     }
-    bool exists(const uint256& txid) const { return exists(GenTxid{false, txid}); }
+    bool exists(const uint256& txid) const EXCLUSIVE_LOCKS_REQUIRED(cs)
+    {
+        AssertLockHeld(cs);
+        return exists(GenTxid{false, txid});
+    }
 
     CTransactionRef get(const uint256& hash) const;
     txiter get_iter_from_wtxid(const uint256& wtxid) const EXCLUSIVE_LOCKS_REQUIRED(cs)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -627,7 +627,7 @@ public:
     void clear();
     void _clear() EXCLUSIVE_LOCKS_REQUIRED(cs); //lock free
     bool CompareDepthAndScore(const uint256& hasha, const uint256& hashb, bool wtxid=false);
-    void queryHashes(std::vector<uint256>& vtxid) const;
+    void queryHashes(std::vector<uint256>& vtxid) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     bool isSpent(const COutPoint& outpoint) const;
     unsigned int GetTransactionsUpdated() const;
     void AddTransactionsUpdated(unsigned int n);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -523,7 +523,8 @@ private:
     // Compare a package's feerate against minimum allowed.
     bool CheckFeeRate(size_t package_size, CAmount package_fee, TxValidationState& state)
     {
-        CAmount mempoolRejectFee = m_pool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFee(package_size);
+        const auto min_fee = WITH_LOCK(m_pool.cs, return m_pool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000));
+        const CAmount mempoolRejectFee = min_fee.GetFee(package_size);
         if (mempoolRejectFee > 0 && package_fee < mempoolRejectFee) {
             return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "mempool min fee not met", strprintf("%d < %d", package_fee, mempoolRejectFee));
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5104,7 +5104,7 @@ bool LoadMempool(CTxMemPool& pool)
                     // wallet(s) having loaded it while we were processing
                     // mempool transactions; consider these as valid, instead of
                     // failed, but mark them as 'already there'
-                    if (pool.exists(tx->GetHash())) {
+                    if (WITH_LOCK(pool.cs, return pool.exists(tx->GetHash()))) {
                         ++already_there;
                     } else {
                         ++failed;


### PR DESCRIPTION
This is another step (after #19854) to transit `CTxMemPool::cs` from `RecursiveMutex` to `Mutex`.

Split out from #19306.
Thread safety annotations, lock assertions, and required explicit locking added. No behavior change.

Please note that now, since #19668 has been merged, it is safe to apply `AssertLockHeld()` macros as they do not swallow compile time Thread Safety Analysis warnings.