### PR TITLE
wallet: Fix wallet loading race during node start

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -462,11 +462,7 @@ static UniValue sendtoaddress(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    CWallet* const pwallet = wallet.get();
-
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    pwallet->BlockUntilSyncedToCurrentChain();
+    CWallet* const pwallet = GetReadyWallet(wallet);
 
     LOCK(pwallet->cs_wallet);
 
@@ -538,11 +534,7 @@ static UniValue listaddressgroupings(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    const CWallet* const pwallet = wallet.get();
-
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    pwallet->BlockUntilSyncedToCurrentChain();
+    const CWallet* const pwallet = GetReadyWallet(wallet);
 
     LOCK(pwallet->cs_wallet);
 
@@ -594,7 +586,7 @@ static UniValue signmessage(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    const CWallet* const pwallet = wallet.get();
+    const CWallet* const pwallet = GetReadyWallet(wallet);
 
     LOCK(pwallet->cs_wallet);
 
@@ -695,11 +687,7 @@ static UniValue getreceivedbyaddress(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    const CWallet* const pwallet = wallet.get();
-
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    pwallet->BlockUntilSyncedToCurrentChain();
+    const CWallet* const pwallet = GetReadyWallet(wallet);
 
     LOCK(pwallet->cs_wallet);
 
@@ -732,11 +720,7 @@ static UniValue getreceivedbylabel(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    const CWallet* const pwallet = wallet.get();
-
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    pwallet->BlockUntilSyncedToCurrentChain();
+    const CWallet* const pwallet = GetReadyWallet(wallet);
 
     LOCK(pwallet->cs_wallet);
 
@@ -805,11 +789,7 @@ static UniValue getunconfirmedbalance(const JSONRPCRequest &request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    const CWallet* const pwallet = wallet.get();
-
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    pwallet->BlockUntilSyncedToCurrentChain();
+    const CWallet* const pwallet = GetReadyWallet(wallet);
 
     LOCK(pwallet->cs_wallet);
 
@@ -862,11 +842,7 @@ static UniValue sendmany(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    CWallet* const pwallet = wallet.get();
-
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    pwallet->BlockUntilSyncedToCurrentChain();
+    CWallet* const pwallet = GetReadyWallet(wallet);
 
     LOCK(pwallet->cs_wallet);
 
@@ -1172,11 +1148,7 @@ static UniValue listreceivedbyaddress(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    const CWallet* const pwallet = wallet.get();
-
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    pwallet->BlockUntilSyncedToCurrentChain();
+    const CWallet* const pwallet = GetReadyWallet(wallet);
 
     LOCK(pwallet->cs_wallet);
 
@@ -1213,11 +1185,7 @@ static UniValue listreceivedbylabel(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    const CWallet* const pwallet = wallet.get();
-
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    pwallet->BlockUntilSyncedToCurrentChain();
+    const CWallet* const pwallet = GetReadyWallet(wallet);
 
     LOCK(pwallet->cs_wallet);
 
@@ -1392,11 +1360,7 @@ UniValue listtransactions(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    const CWallet* const pwallet = wallet.get();
-
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    pwallet->BlockUntilSyncedToCurrentChain();
+    const CWallet* const pwallet = GetReadyWallet(wallet);
 
     const std::string* filter_label = nullptr;
     if (!request.params[0].isNull() && request.params[0].get_str() != "*") {
@@ -1509,10 +1473,7 @@ static UniValue listsinceblock(const JSONRPCRequest& request)
     std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
     if (!pwallet) return NullUniValue;
 
-    const CWallet& wallet = *pwallet;
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    wallet.BlockUntilSyncedToCurrentChain();
+    const CWallet& wallet = *GetReadyWallet(pwallet);
 
     LOCK(wallet.cs_wallet);
 
@@ -1648,11 +1609,7 @@ static UniValue gettransaction(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    const CWallet* const pwallet = wallet.get();
-
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    pwallet->BlockUntilSyncedToCurrentChain();
+    const CWallet* const pwallet = GetReadyWallet(wallet);
 
     LOCK(pwallet->cs_wallet);
 
@@ -1720,11 +1677,7 @@ static UniValue abandontransaction(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    CWallet* const pwallet = wallet.get();
-
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    pwallet->BlockUntilSyncedToCurrentChain();
+    CWallet* const pwallet = GetReadyWallet(wallet);
 
     LOCK(pwallet->cs_wallet);
 
@@ -1757,11 +1710,7 @@ static UniValue backupwallet(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    const CWallet* const pwallet = wallet.get();
-
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    pwallet->BlockUntilSyncedToCurrentChain();
+    const CWallet* const pwallet = GetReadyWallet(wallet);
 
     LOCK(pwallet->cs_wallet);
 
@@ -2096,11 +2045,7 @@ static UniValue lockunspent(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    CWallet* const pwallet = wallet.get();
-
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    pwallet->BlockUntilSyncedToCurrentChain();
+    CWallet* const pwallet = GetReadyWallet(wallet);
 
     LOCK(pwallet->cs_wallet);
 
@@ -2300,11 +2245,7 @@ static UniValue getbalances(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const rpc_wallet = GetWalletForJSONRPCRequest(request);
     if (!rpc_wallet) return NullUniValue;
-    CWallet& wallet = *rpc_wallet;
-
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    wallet.BlockUntilSyncedToCurrentChain();
+    CWallet& wallet = *GetReadyWallet(rpc_wallet);
 
     LOCK(wallet.cs_wallet);
 
@@ -2373,11 +2314,7 @@ static UniValue getwalletinfo(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    const CWallet* const pwallet = wallet.get();
-
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    pwallet->BlockUntilSyncedToCurrentChain();
+    const CWallet* const pwallet = GetReadyWallet(wallet);
 
     LOCK(pwallet->cs_wallet);
 
@@ -2785,7 +2722,7 @@ static UniValue listunspent(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    const CWallet* const pwallet = wallet.get();
+    const CWallet* const pwallet = GetReadyWallet(wallet);
 
     int nMinDepth = 1;
     if (!request.params[0].isNull()) {
@@ -2850,10 +2787,6 @@ static UniValue listunspent(const JSONRPCRequest& request)
         if (options.exists("maximumCount"))
             nMaximumCount = options["maximumCount"].get_int64();
     }
-
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    pwallet->BlockUntilSyncedToCurrentChain();
 
     UniValue results(UniValue::VARR);
     std::vector<COutput> vecOutputs;
@@ -2947,10 +2880,6 @@ static UniValue listunspent(const JSONRPCRequest& request)
 
 void FundTransaction(CWallet* const pwallet, CMutableTransaction& tx, CAmount& fee_out, int& change_position, UniValue options, CCoinControl& coinControl)
 {
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    pwallet->BlockUntilSyncedToCurrentChain();
-
     change_position = -1;
     bool lockUnspents = false;
     UniValue subtractFeeFromOutputs;
@@ -3146,7 +3075,7 @@ static UniValue fundrawtransaction(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    CWallet* const pwallet = wallet.get();
+    CWallet* const pwallet = GetReadyWallet(wallet);
 
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValueType(), UniValue::VBOOL});
 
@@ -3324,7 +3253,7 @@ static UniValue bumpfee(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    CWallet* const pwallet = wallet.get();
+    CWallet* const pwallet = GetReadyWallet(wallet);
 
     if (pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) && !want_psbt) {
         if (!pwallet->chain().rpcEnableDeprecated("bumpfee")) {
@@ -3377,10 +3306,6 @@ static UniValue bumpfee(const JSONRPCRequest& request)
         }
         SetFeeEstimateMode(pwallet, coin_control, options["estimate_mode"], conf_target);
     }
-
-    // Make sure the results are valid at least up to the most recent block
-    // the user could have gotten from another RPC command prior to now
-    pwallet->BlockUntilSyncedToCurrentChain();
 
     LOCK(pwallet->cs_wallet);
     EnsureWalletIsUnlocked(pwallet);
@@ -3968,7 +3893,7 @@ static RPCHelpMan send()
 
             std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
             if (!wallet) return NullUniValue;
-            CWallet* const pwallet = wallet.get();
+            CWallet* const pwallet = GetReadyWallet(wallet);
 
             UniValue options = request.params[3];
             if (options.exists("feeRate") || options.exists("fee_rate") || options.exists("estimate_mode") || options.exists("conf_target")) {
@@ -4271,7 +4196,7 @@ UniValue walletcreatefundedpsbt(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    CWallet* const pwallet = wallet.get();
+    CWallet* const pwallet = GetReadyWallet(wallet);
 
     RPCTypeCheck(request.params, {
         UniValue::VARR,

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4151,6 +4151,10 @@ bool CWallet::UpgradeWallet(int version, bilingual_str& error, std::vector<bilin
 
 void CWallet::postInitProcess()
 {
+    syncMempool();
+}
+
+void CWallet::syncMempool() {
     LOCK(cs_wallet);
 
     // Add wallet transactions that aren't already in a block to mempool
@@ -4159,6 +4163,10 @@ void CWallet::postInitProcess()
 
     // Update wallet transactions with current mempool transactions.
     chain().requestMempoolTransactions(*this);
+
+    // After running the initial process the wallet is ready to
+    // respond to typical requests like balances etc.
+    setMempoolSynced();
 }
 
 bool CWallet::BackupWallet(const std::string& strDest) const

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -725,12 +725,21 @@ private:
 
     bool CreateTransactionInternal(const std::vector<CRecipient>& vecSend, CTransactionRef& tx, CAmount& nFeeRet, int& nChangePosInOut, bilingual_str& error, const CCoinControl& coin_control, bool sign);
 
+    /** Wallet was initially synced with the mempool. */
+    bool m_mempool_synced{false};
+
 public:
     /*
      * Main wallet lock.
      * This lock protects all the fields added by CWallet.
      */
     mutable RecursiveMutex cs_wallet;
+
+    /** Indicated the wallet was initially synced with the mempool. */
+    void setMempoolSynced() { m_mempool_synced = true; };
+
+    /** True if the wallet was initially synced with the mempool. */
+    bool mempoolSynced() const { return m_mempool_synced; };
 
     /** Get database handle used by this wallet. Ideally this function would
      * not be necessary.
@@ -1153,6 +1162,8 @@ public:
      * Gives the wallet a chance to register repetitive tasks and complete post-init tasks
      */
     void postInitProcess();
+
+    void syncMempool();
 
     bool BackupWallet(const std::string& strDest) const;
 

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -111,7 +111,6 @@ class MempoolPersistTest(BitcoinTestFramework):
         assert_equal(tx_creation_time, self.nodes[0].getmempoolentry(txid=last_txid)['time'])
 
         # Verify accounting of mempool transactions after restart is correct
-        self.nodes[2].syncwithvalidationinterfacequeue()  # Flush mempool to wallet
         assert_equal(node2_balance, self.nodes[2].getbalance())
 
         # start node0 with wallet disabled so wallet transactions don't get resubmitted

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -596,9 +596,6 @@ class WalletTest(BitcoinTestFramework):
         # wait until the wallet has submitted all transactions to the mempool
         self.wait_until(lambda: len(self.nodes[0].getrawmempool()) == chainlimit * 2)
 
-        # Prevent potential race condition when calling wallet RPCs right after restart
-        self.nodes[0].syncwithvalidationinterfacequeue()
-
         node0_balance = self.nodes[0].getbalance()
         # With walletrejectlongchains we will not create the tx and store it in our wallet.
         assert_raises_rpc_error(-6, "Transaction has too long of a mempool chain", self.nodes[0].sendtoaddress, sending_addr, node0_balance - Decimal('0.01'))


### PR DESCRIPTION
~~Intended to fix 19853~~

There appears to be a race condition when using the wallet RPCs right after starting a node and that causes the tests to be flaky: in the `wallet_basic.py` a node is restarted and `getbalance` gets called right after. `getbalance` then sometimes reports a balance of 0 because the wallet is not loaded yet. It looks like this only appeared after the `zapwallettxs` tests [were removed from this test](https://github.com/bitcoin/bitcoin/commit/3340dbadd38f5624642cf0e14dddbe6f83a3863b#diff-02ae125bb09504d8766277c965a739f9) but it should not directly be caused by the removal, it rather hides the issue less often. I wouldn't be surprised if this is a known issue that has popped up in a different context already but I didn't find anything on it yet.

My naive solution is to track a ready state for `CWallet` but I am very much looking for concept feedback on that. Returning `Null` seems to be the default behavior for wallet RPCs in early failure cases like this. An explicit error might be more helpful for users to figure out what happened but I am opting for consistency for now. Either option is much better than reporting a balance 0 that is incorrect but that could be real and could cause alarm systems to go off because all of a sudden a wallet balance is 0 after a node restarts.

Whether this ends up being the final solution or not, after the conceptual discussion I think it will make sense to add this check to other wallet RPCs and I will also check if there are other open flaky wallet test issues that might be caused by the same bug.

To reproduce the issue see the commented out block of code that I left in the test file. This reproduces the issue on ~4 out of 5 tries on my machine.

EDIT: The actual error that appears in the CI is hit [here](https://github.com/bitcoin/bitcoin/pull/19876/files#diff-02ae125bb09504d8766277c965a739f9R611) where `node0_balance` is 0 and then `sendtoaddress` is called with a negative amount.