### PR TITLE
rawtransaction: fix argument in combinerawtransaction help message

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -627,7 +627,7 @@ static UniValue combinerawtransaction(const JSONRPCRequest& request)
                 {
                     {"txs", RPCArg::Type::ARR, RPCArg::Optional::NO, "The hex strings of partially signed transactions",
                         {
-                            {"hexstring", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "A transaction hash"},
+                            {"hexstring", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "A hex-encoded raw transaction"},
                         },
                         },
                 },


### PR DESCRIPTION
Minor correction in the help message provided for `rpc combinerawtransaction`. The input to the rpc is not an array of transaction hashes (txids) but an array of serialized transactions encoded in raw hex.