### PR TITLE
fix CTxMemPool::TrimToSize to put only confirmed coins in pvNoSpendsRemaining

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1057,21 +1057,18 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
         CalculateDescendants(mapTx.project<0>(it), stage);
         nTxnRemoved += stage.size();
 
-        std::vector<CTransaction> txn;
         if (pvNoSpendsRemaining) {
-            txn.reserve(stage.size());
-            for (txiter iter : stage)
-                txn.push_back(iter->GetTx());
-        }
-        RemoveStaged(stage, false, MemPoolRemovalReason::SIZELIMIT);
-        if (pvNoSpendsRemaining) {
-            for (const CTransaction& tx : txn) {
-                for (const CTxIn& txin : tx.vin) {
-                    if (exists(txin.prevout.hash)) continue;
+            for (txiter iter : stage) {
+                for (const CTxIn &txin : iter->GetTx().vin) {
+                    if (exists(txin.prevout.hash)) {
+                        continue;
+                    }
                     pvNoSpendsRemaining->push_back(txin.prevout);
                 }
             }
         }
+
+        RemoveStaged(stage, false, MemPoolRemovalReason::SIZELIMIT);
     }
 
     if (maxFeeRateRemoved > CFeeRate(0)) {


### PR DESCRIPTION
Only return confirmed (not from mempool) outpoints in `pvNoSpendsRemaining`,
as is the intended behaviour.

With the previous code, removed chains of tx would have all internally-spent outpoints
included in this vector, which is not the intended result. It seems to have been
incorrectly coded from the very start (https://github.com/bitcoin/bitcoin/pull/6872)
but the bug is benign as this result is only used to uncache coins.

As a bonus, no copying of CTransaction is needed now.

An existing test case is modified to test this behaviour (the modified test fails
under prior behaviour).

(this is an upstreaming of https://gitlab.com/bitcoin-cash-node/bitcoin-cash-node/-/merge_requests/761 )