### PR TITLE
net, rpc: expose connection type in getpeerinfo

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -542,6 +542,7 @@ void CNode::copyStats(CNodeStats &stats, const std::vector<bool> &m_asmap)
     }
     stats.fInbound = IsInboundConn();
     stats.m_manual_connection = IsManualConn();
+    stats.m_conn_type = uint8_t(m_conn_type);
     X(nStartingHeight);
     {
         LOCK(cs_vSend);

--- a/src/net.h
+++ b/src/net.h
@@ -117,7 +117,7 @@ struct CSerializedNetMsg
 /** Different types of connections to a peer. This enum encapsulates the
  * information we have available at the time of opening or accepting the
  * connection. Aside from INBOUND, all types are initiated by us. */
-enum class ConnectionType {
+enum class ConnectionType : uint8_t {
     /**
      * Inbound connections are those initiated by a peer. This is the only
      * property we know at the time of connection, until P2P messages are
@@ -688,6 +688,7 @@ public:
     // Bind address of our side of the connection
     CAddress addrBind;
     uint32_t m_mapped_as;
+    uint8_t m_conn_type;
 };
 
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -113,6 +113,13 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
                             {RPCResult::Type::STR, "subver", "The string version"},
                             {RPCResult::Type::BOOL, "inbound", "Inbound (true) or Outbound (false)"},
                             {RPCResult::Type::BOOL, "addnode", "Whether connection was due to addnode/-connect or if it was an automatic/inbound connection"},
+                            {RPCResult::Type::NUM, "conn_type", "Connection type between 0 and 5:\n"
+                                "0 - inbound (initiated by the peer)\n"
+                                "1 - outbound-full-relay (default automatic connections)\n"
+                                "2 - manual (added using the -addnode/-connect configuration options or the addnode RPC)\n"
+                                "3 - feeler (short-lived automatic connection to test addresses)\n"
+                                "4 - block-relay-only (does not relay transactions or addresses)\n"
+                                "5 - addr-fetch (short-lived automatic connection to request addresses)"},
                             {RPCResult::Type::NUM, "startingheight", "The starting height (block) of the peer"},
                             {RPCResult::Type::NUM, "banscore", "The ban score (DEPRECATED, returned only if config option -deprecatedrpc=banscore is passed)"},
                             {RPCResult::Type::NUM, "synced_headers", "The last header we have in common with this peer"},
@@ -193,6 +200,7 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
         obj.pushKV("subver", stats.cleanSubVer);
         obj.pushKV("inbound", stats.fInbound);
         obj.pushKV("addnode", stats.m_manual_connection);
+        obj.pushKV("conn_type", stats.m_conn_type);
         obj.pushKV("startingheight", stats.nStartingHeight);
         if (fStateStats) {
             if (IsDeprecatedRPCEnabled("banscore")) {

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -171,6 +171,8 @@ class NetTest(BitcoinTestFramework):
         assert_equal(peer_info[1][0]['addrbind'], peer_info[0][0]['addr'])
         assert_equal(peer_info[0][0]['minfeefilter'], Decimal("0.00000500"))
         assert_equal(peer_info[1][0]['minfeefilter'], Decimal("0.00001000"))
+        assert_equal(peer_info[0][0]['conn_type'], 0)
+        assert_equal(peer_info[0][1]['conn_type'], 2)
         # check the `servicesnames` field
         for info in peer_info:
             assert_net_servicesnames(int(info[0]["services"], 0x10), info[0]["servicesnames"])


### PR DESCRIPTION
Expose `conn_type` via a practical API for JSON-RPC consumers.

- returns the `conn_type` as an integer id for API clients. It is a simple and small change to implement and maintain, and the API can remain stable even if the `ConnectionType` element naming or order changes.
- adds a `uint8_t` type to the `ConnectionType` enum class; if preferred, this can be dropped

```
$ ./src/bitcoin-cli help getpeerinfo
...
    "inbound" : true|false,        (boolean) Inbound (true) or Outbound (false)
    "addnode" : true|false,        (boolean) Whether connection was due to addnode/-connect or if it was an automatic/inbound connection
    "conn_type" : n,               (numeric) Connection type between 0 and 5:
                                   0 - inbound (initiated by the peer)
                                   1 - outbound-full-relay (default automatic connections)
                                   2 - manual (added using the -addnode/-connect configuration options or the addnode RPC)
                                   3 - feeler (short-lived automatic connection to test addresses)
                                   4 - block-relay-only (does not relay transactions or addresses)
                                   5 - addr-fetch (short-lived automatic connection to request addresses)
```