### PR TITLE
refactor: remove unused header <arpa/inet.h> in protocol.cpp

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -8,10 +8,6 @@
 #include <util/strencodings.h>
 #include <util/system.h>
 
-#ifndef WIN32
-# include <arpa/inet.h>
-#endif
-
 static std::atomic<bool> g_initial_block_download_completed(false);
 
 namespace NetMsgType {


### PR DESCRIPTION
There is no code using types or functions related to "internet operations" anymore in protocol.cpp (since #735, more than 8 years ago!), hence the header include can be removed.