### PR TITLE
depends: Fix `make --just-print` command

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -195,12 +195,12 @@ $($(1)_configured): | $($(1)_dependencies) $($(1)_preprocessed)
 	$(AT)echo Configuring $(1)...
 	$(AT)rm -rf $(host_prefix); mkdir -p $(host_prefix)/lib; cd $(host_prefix); $(foreach package,$($(1)_all_dependencies), tar --no-same-owner -xf $($(package)_cached); )
 	$(AT)mkdir -p $$(@D)
-	$(AT)+cd $$(@D); $($(1)_config_env) $(call $(1)_config_cmds, $(1))
+	$(AT)cd $$(@D); $($(1)_config_env) $(call $(1)_config_cmds, $(1))
 	$(AT)touch $$@
 $($(1)_built): | $($(1)_configured)
 	$(AT)echo Building $(1)...
 	$(AT)mkdir -p $$(@D)
-	$(AT)+cd $$(@D); $($(1)_build_env) $(call $(1)_build_cmds, $(1))
+	$(AT)cd $$(@D); $($(1)_build_env) $(call $(1)_build_cmds, $(1))
 	$(AT)touch $$@
 $($(1)_staged): | $($(1)_built)
 	$(AT)echo Staging $(1)...


### PR DESCRIPTION
Dry run `make` is very useful for debugging. From the [GNU make manual](https://www.gnu.org/software/make/manual/html_node/Instead-of-Execution.html#Instead-of-Execution):
> ‘-n’
> ‘--just-print’
> ‘--dry-run’
> ‘--recon’
>
>    “No-op”. Causes `make` to print the recipes that are needed to make the targets up to date, but not actually execute them. Note that some recipes are still executed, even with this flag (see How the MAKE Variable Works). Also any recipes needed to update included makefiles are still executed (see How Makefiles Are Remade).

On master (03689317021a72431762c1974530f2a980a7fffa) this option is not so useful:
```
$ make -n -C depends zlib
make: Entering directory '/home/hebasto/guix/GitHub/bitcoin/depends'
mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/sources/download-stamps /home/hebasto/guix/GitHub/bitcoin/depends/sources
rm -f /home/hebasto/guix/GitHub/bitcoin/depends/sources/download-stamps/.stamp_fetched-zlib-zlib-1.2.11.tar.gz.hash
touch /home/hebasto/guix/GitHub/bitcoin/depends/sources/download-stamps/.stamp_fetched-zlib-zlib-1.2.11.tar.gz.hash
cd /home/hebasto/guix/GitHub/bitcoin/depends/sources/download-stamps; ( test -f /home/hebasto/guix/GitHub/bitcoin/depends/sources/zlib-1.2.11.tar.gz || (     ( mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11 && echo Fetching zlib-1.2.11.tar.gz from https://www.zlib.net && curl --location --fail --connect-timeout 30 --retry 3 -o "/home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/zlib-1.2.11.tar.gz.temp" "https://www.zlib.net/zlib-1.2.11.tar.gz" && echo "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1  /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/zlib-1.2.11.tar.gz.temp" > /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/.zlib-1.2.11.tar.gz.hash && sha256sum -c /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/.zlib-1.2.11.tar.gz.hash && mv /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/zlib-1.2.11.tar.gz.temp /home/hebasto/guix/GitHub/bitcoin/depends/sources/zlib-1.2.11.tar.gz && rm -rf /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11 ) ||     ( mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11 && echo Fetching zlib-1.2.11.tar.gz from https://bitcoincore.org/depends-sources && curl --location --fail --connect-timeout 30 --retry 3 -o "/home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/zlib-1.2.11.tar.gz.temp" "https://bitcoincore.org/depends-sources/zlib-1.2.11.tar.gz" && echo "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1  /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/zlib-1.2.11.tar.gz.temp" > /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/.zlib-1.2.11.tar.gz.hash && sha256sum -c /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/.zlib-1.2.11.tar.gz.hash && mv /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/zlib-1.2.11.tar.gz.temp /home/hebasto/guix/GitHub/bitcoin/depends/sources/zlib-1.2.11.tar.gz && rm -rf /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11 )))
cd /home/hebasto/guix/GitHub/bitcoin/depends/sources; sha256sum zlib-1.2.11.tar.gz >> /home/hebasto/guix/GitHub/bitcoin/depends/sources/download-stamps/.stamp_fetched-zlib-zlib-1.2.11.tar.gz.hash;
touch /home/hebasto/guix/GitHub/bitcoin/depends/sources/download-stamps/.stamp_fetched-zlib-zlib-1.2.11.tar.gz.hash
echo Extracting zlib...
mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-4416f3f0c58
cd /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-4416f3f0c58; mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-4416f3f0c58 && echo "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1  /home/hebasto/guix/GitHub/bitcoin/depends/sources/zlib-1.2.11.tar.gz" > /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-4416f3f0c58/.zlib-1.2.11.tar.gz.hash &&  sha256sum -c /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-4416f3f0c58/.zlib-1.2.11.tar.gz.hash && tar --no-same-owner --strip-components=1 -xf /home/hebasto/guix/GitHub/bitcoin/depends/sources/zlib-1.2.11.tar.gz
touch /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-4416f3f0c58/.stamp_extracted
echo Preprocessing zlib...
mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-4416f3f0c58 /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-4416f3f0c58/.patches-4416f3f0c58
cd /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-4416f3f0c58; 
touch /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-4416f3f0c58/.stamp_preprocessed
echo Configuring zlib...
rm -rf /home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu; mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu/lib; cd /home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu; 
mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-4416f3f0c58/.
cd /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-4416f3f0c58/.;     PKG_CONFIG_LIBDIR=/home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu/lib/pkgconfig PKG_CONFIG_PATH=/home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu/share/pkgconfig CMAKE_MODULE_PATH=/home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu/lib/cmake PATH=/home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu/native/bin:/home/hebasto/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin   env CC="gcc -m64" CFLAGS="-pipe -O2 -I/home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu/include -fPIC" RANLIB="ranlib" AR="ar"        ./configure --static --prefix=/home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu
/bin/sh: 1: cd: can't cd to /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-4416f3f0c58/.
env: ‘./configure’: No such file or directory
make: *** [funcs.mk:268: /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-4416f3f0c58/./.stamp_configured] Error 127
```

With this PR:
```
$ make -n -C depends zlib
make: Entering directory '/home/hebasto/guix/GitHub/bitcoin/depends'
mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/sources/download-stamps /home/hebasto/guix/GitHub/bitcoin/depends/sources
rm -f /home/hebasto/guix/GitHub/bitcoin/depends/sources/download-stamps/.stamp_fetched-zlib-zlib-1.2.11.tar.gz.hash
touch /home/hebasto/guix/GitHub/bitcoin/depends/sources/download-stamps/.stamp_fetched-zlib-zlib-1.2.11.tar.gz.hash
cd /home/hebasto/guix/GitHub/bitcoin/depends/sources/download-stamps; ( test -f /home/hebasto/guix/GitHub/bitcoin/depends/sources/zlib-1.2.11.tar.gz || (     ( mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11 && echo Fetching zlib-1.2.11.tar.gz from https://www.zlib.net && curl --location --fail --connect-timeout 30 --retry 3 -o "/home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/zlib-1.2.11.tar.gz.temp" "https://www.zlib.net/zlib-1.2.11.tar.gz" && echo "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1  /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/zlib-1.2.11.tar.gz.temp" > /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/.zlib-1.2.11.tar.gz.hash && sha256sum -c /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/.zlib-1.2.11.tar.gz.hash && mv /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/zlib-1.2.11.tar.gz.temp /home/hebasto/guix/GitHub/bitcoin/depends/sources/zlib-1.2.11.tar.gz && rm -rf /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11 ) ||     ( mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11 && echo Fetching zlib-1.2.11.tar.gz from https://bitcoincore.org/depends-sources && curl --location --fail --connect-timeout 30 --retry 3 -o "/home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/zlib-1.2.11.tar.gz.temp" "https://bitcoincore.org/depends-sources/zlib-1.2.11.tar.gz" && echo "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1  /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/zlib-1.2.11.tar.gz.temp" > /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/.zlib-1.2.11.tar.gz.hash && sha256sum -c /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/.zlib-1.2.11.tar.gz.hash && mv /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11/zlib-1.2.11.tar.gz.temp /home/hebasto/guix/GitHub/bitcoin/depends/sources/zlib-1.2.11.tar.gz && rm -rf /home/hebasto/guix/GitHub/bitcoin/depends/work/download/zlib-1.2.11 )))
cd /home/hebasto/guix/GitHub/bitcoin/depends/sources; sha256sum zlib-1.2.11.tar.gz >> /home/hebasto/guix/GitHub/bitcoin/depends/sources/download-stamps/.stamp_fetched-zlib-zlib-1.2.11.tar.gz.hash;
touch /home/hebasto/guix/GitHub/bitcoin/depends/sources/download-stamps/.stamp_fetched-zlib-zlib-1.2.11.tar.gz.hash
echo Extracting zlib...
mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a
cd /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a; mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a && echo "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1  /home/hebasto/guix/GitHub/bitcoin/depends/sources/zlib-1.2.11.tar.gz" > /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a/.zlib-1.2.11.tar.gz.hash &&  sha256sum -c /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a/.zlib-1.2.11.tar.gz.hash && tar --no-same-owner --strip-components=1 -xf /home/hebasto/guix/GitHub/bitcoin/depends/sources/zlib-1.2.11.tar.gz
touch /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a/.stamp_extracted
echo Preprocessing zlib...
mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a/.patches-38eb814ef0a
cd /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a; 
touch /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a/.stamp_preprocessed
echo Configuring zlib...
rm -rf /home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu; mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu/lib; cd /home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu; 
mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a/.
cd /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a/.;     PKG_CONFIG_LIBDIR=/home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu/lib/pkgconfig PKG_CONFIG_PATH=/home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu/share/pkgconfig CMAKE_MODULE_PATH=/home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu/lib/cmake PATH=/home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu/native/bin:/home/hebasto/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin   env CC="gcc -m64" CFLAGS="-pipe -O2 -I/home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu/include -fPIC" RANLIB="ranlib" AR="ar"        ./configure --static --prefix=/home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu
touch /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a/./.stamp_configured
echo Building zlib...
mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a/.
cd /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a/.; PATH=/home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu/native/bin:/home/hebasto/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin   make libz.a
touch /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a/./.stamp_built
echo Staging zlib...
mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/work/staging/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a//home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu
cd /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a/.; PATH=/home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu/native/bin:/home/hebasto/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin   make DESTDIR=/home/hebasto/guix/GitHub/bitcoin/depends/work/staging/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a install
rm -rf /home/hebasto/guix/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a
touch /home/hebasto/guix/GitHub/bitcoin/depends/work/staging/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a/.stamp_staged
echo Postprocessing zlib...
cd /home/hebasto/guix/GitHub/bitcoin/depends/work/staging/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a/home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu; 
touch /home/hebasto/guix/GitHub/bitcoin/depends/work/staging/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a/home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu/.stamp_postprocessed
echo Caching zlib...
cd /home/hebasto/guix/GitHub/bitcoin/depends/work/staging/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a//home/hebasto/guix/GitHub/bitcoin/depends/x86_64-pc-linux-gnu; find . | sort | tar --no-recursion -czf /home/hebasto/guix/GitHub/bitcoin/depends/work/staging/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a/zlib-1.2.11-38eb814ef0a.tar.gz -T -
mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/built/x86_64-pc-linux-gnu/zlib
rm -rf /home/hebasto/guix/GitHub/bitcoin/depends/built/x86_64-pc-linux-gnu/zlib && mkdir -p /home/hebasto/guix/GitHub/bitcoin/depends/built/x86_64-pc-linux-gnu/zlib
mv /home/hebasto/guix/GitHub/bitcoin/depends/work/staging/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a/zlib-1.2.11-38eb814ef0a.tar.gz /home/hebasto/guix/GitHub/bitcoin/depends/built/x86_64-pc-linux-gnu/zlib/zlib-1.2.11-38eb814ef0a.tar.gz
rm -rf /home/hebasto/guix/GitHub/bitcoin/depends/work/staging/x86_64-pc-linux-gnu/zlib/1.2.11-38eb814ef0a
cd /home/hebasto/guix/GitHub/bitcoin/depends/built/x86_64-pc-linux-gnu/zlib; sha256sum zlib-1.2.11-38eb814ef0a.tar.gz > /home/hebasto/guix/GitHub/bitcoin/depends/built/x86_64-pc-linux-gnu/zlib/zlib-1.2.11-38eb814ef0a.tar.gz.hash
make: Leaving directory '/home/hebasto/guix/GitHub/bitcoin/depends'
```