### PR TITLE
Revert back to FILE_CHARS_BLOCKLIST

### DIFF
--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -18,7 +18,7 @@ from test_framework.util import (
 # Windows disallow control characters (0-31) and /\?%:|"<>
 FILE_CHAR_START = 32 if os.name == 'nt' else 1
 FILE_CHAR_END = 128
-FILE_CHARS_DISALLOWED = '/\\?%*:|"<>' if os.name == 'nt' else '/'
+FILE_CHARS_BLACKLIST = '/\\?%*:|"<>' if os.name == 'nt' else '/'
 
 
 def notify_outputname(walletname, txid):
@@ -31,7 +31,7 @@ class NotificationsTest(BitcoinTestFramework):
         self.setup_clean_chain = True
 
     def setup_network(self):
-        self.wallet = ''.join(chr(i) for i in range(FILE_CHAR_START, FILE_CHAR_END) if chr(i) not in FILE_CHARS_DISALLOWED)
+        self.wallet = ''.join(chr(i) for i in range(FILE_CHAR_START, FILE_CHAR_END) if chr(i) not in FILE_CHARS_BLACKLIST)
         self.alertnotify_dir = os.path.join(self.options.tmpdir, "alertnotify")
         self.blocknotify_dir = os.path.join(self.options.tmpdir, "blocknotify")
         self.walletnotify_dir = os.path.join(self.options.tmpdir, "walletnotify")


### PR DESCRIPTION
This reverts commits 637d8bce741213295bd9b9d1982cae663c701ba1 and 6fc641644f7193365cf2b40f5cf20374ec871943.
Also fixes FILE_CHAR_BLOCKLIST to FILE_CHARS_BLOCKLIST.

It is important to keep bitcoin neutral and censorship resistant. The above commits were an attempt to push political activism into bitcoin code, and we shall not allow that to happen.

I am sorry to get back to this issue, but I think it is very important to reaffirm basic bitcoin values and push back on political attacks as serious security issues. 