### PR TITLE
Avoid locking CTxMemPool::cs recursively in CTxMemPool::DynamicMemoryUsage()

### DIFF
--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -157,7 +157,7 @@ public:
     int64_t getTotalBytesRecv() override { return m_context->connman ? m_context->connman->GetTotalBytesRecv() : 0; }
     int64_t getTotalBytesSent() override { return m_context->connman ? m_context->connman->GetTotalBytesSent() : 0; }
     size_t getMempoolSize() override { return m_context->mempool ? m_context->mempool->size() : 0; }
-    size_t getMempoolDynamicUsage() override { return m_context->mempool ? m_context->mempool->DynamicMemoryUsage() : 0; }
+    size_t getMempoolDynamicUsage() override { return m_context->mempool ? WITH_LOCK(m_context->mempool->cs, return m_context->mempool->DynamicMemoryUsage()) : 0; }
     bool getHeaderTip(int& height, int64_t& block_time) override
     {
         LOCK(::cs_main);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3033,7 +3033,7 @@ void PeerLogicValidation::ProcessMessage(CNode& pfrom, const std::string& msg_ty
             LogPrint(BCLog::MEMPOOL, "AcceptToMemoryPool: peer=%d: accepted %s (poolsz %u txn, %u kB)\n",
                 pfrom.GetId(),
                 tx.GetHash().ToString(),
-                m_mempool.size(), m_mempool.DynamicMemoryUsage() / 1000);
+                m_mempool.size(), WITH_LOCK(m_mempool.cs, return m_mempool.DynamicMemoryUsage()) / 1000);
 
             // Recursively process any orphan transactions that depended on this one
             ProcessOrphanTx(m_connman, m_mempool, pfrom.orphan_work_set, lRemovedTxn);

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
 
     constexpr bool is_64_bit = sizeof(void*) == 8;
 
-    LOCK(::cs_main);
+    LOCK2(::cs_main, tx_pool.cs);
     auto& view = chainstate.CoinsTip();
 
     //! Create and add a Coin with DynamicMemoryUsage of 80 bytes to the given view.

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -917,8 +917,9 @@ bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
     return base->GetCoin(outpoint, coin);
 }
 
-size_t CTxMemPool::DynamicMemoryUsage() const {
-    LOCK(cs);
+size_t CTxMemPool::DynamicMemoryUsage() const
+{
+    AssertLockHeld(cs);
     // Estimate the overhead of mapTx to be 15 pointers + an allocation, as no exact formula for boost::multi_index_contained is implemented.
     return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 15 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(mapLinks) + memusage::DynamicUsage(vTxHashes) + cachedInnerUsage;
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -736,7 +736,7 @@ public:
     TxMempoolInfo info(const GenTxid& gtxid) const;
     std::vector<TxMempoolInfo> infoAll() const;
 
-    size_t DynamicMemoryUsage() const;
+    size_t DynamicMemoryUsage() const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Adds a transaction to the unbroadcast set */
     void AddUnbroadcastTx(const uint256& txid, const uint256& wtxid) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1078,7 +1078,8 @@ static bool AcceptToMemoryPoolWithTime(const CChainParams& chainparams, CTxMemPo
     }
     // After we've (potentially) uncached entries, ensure our coins cache is still within its size limits
     BlockValidationState state_dummy;
-    ::ChainstateActive().FlushStateToDisk(chainparams, state_dummy, FlushStateMode::PERIODIC);
+    const auto mempool_usage = pool.DynamicMemoryUsage();
+    ::ChainstateActive().FlushStateToDisk(chainparams, state_dummy, mempool_usage, FlushStateMode::PERIODIC);
     return res;
 }
 
@@ -2261,9 +2262,15 @@ CoinsCacheSizeState CChainState::GetCoinsCacheSizeState(
     return CoinsCacheSizeState::OK;
 }
 
+int64_t CChainState::MempoolUsage() const
+{
+    return m_mempool.DynamicMemoryUsage();
+}
+
 bool CChainState::FlushStateToDisk(
     const CChainParams& chainparams,
     BlockValidationState &state,
+    int64_t mempool_usage,
     FlushStateMode mode,
     int nManualPruneHeight)
 {
@@ -2281,7 +2288,6 @@ bool CChainState::FlushStateToDisk(
     {
         bool fFlushForPrune = false;
         bool fDoFullFlush = false;
-        const auto mempool_usage = m_mempool.DynamicMemoryUsage();
         CoinsCacheSizeState cache_state = GetCoinsCacheSizeState(mempool_usage);
         LOCK(cs_LastBlockFile);
         if (fPruneMode && (fCheckForPruning || nManualPruneHeight > 0) && !fReindex) {
@@ -2395,7 +2401,7 @@ bool CChainState::FlushStateToDisk(
 void CChainState::ForceFlushStateToDisk() {
     BlockValidationState state;
     const CChainParams& chainparams = Params();
-    if (!this->FlushStateToDisk(chainparams, state, FlushStateMode::ALWAYS)) {
+    if (!this->FlushStateToDisk(chainparams, state, MempoolUsage(), FlushStateMode::ALWAYS)) {
         LogPrintf("%s: failed to flush state (%s)\n", __func__, state.ToString());
     }
 }
@@ -2405,7 +2411,7 @@ void CChainState::PruneAndFlush() {
     fCheckForPruning = true;
     const CChainParams& chainparams = Params();
 
-    if (!this->FlushStateToDisk(chainparams, state, FlushStateMode::NONE)) {
+    if (!this->FlushStateToDisk(chainparams, state, MempoolUsage(), FlushStateMode::NONE)) {
         LogPrintf("%s: failed to flush state (%s)\n", __func__, state.ToString());
     }
 }
@@ -2510,7 +2516,7 @@ bool CChainState::DisconnectTip(BlockValidationState& state, const CChainParams&
     }
     LogPrint(BCLog::BENCH, "- Disconnect block: %.2fms\n", (GetTimeMicros() - nStart) * MILLI);
     // Write the chain state to disk, if necessary.
-    if (!FlushStateToDisk(chainparams, state, FlushStateMode::IF_NEEDED))
+    if (!FlushStateToDisk(chainparams, state, MempoolUsage(), FlushStateMode::IF_NEEDED))
         return false;
 
     if (disconnectpool) {
@@ -2627,7 +2633,7 @@ bool CChainState::ConnectTip(BlockValidationState& state, const CChainParams& ch
     int64_t nTime4 = GetTimeMicros(); nTimeFlush += nTime4 - nTime3;
     LogPrint(BCLog::BENCH, "  - Flush: %.2fms [%.2fs (%.2fms/blk)]\n", (nTime4 - nTime3) * MILLI, nTimeFlush * MICRO, nTimeFlush * MILLI / nBlocksTotal);
     // Write the chain state to disk, if necessary.
-    if (!FlushStateToDisk(chainparams, state, FlushStateMode::IF_NEEDED))
+    if (!FlushStateToDisk(chainparams, state, MempoolUsage(), FlushStateMode::IF_NEEDED))
         return false;
     int64_t nTime5 = GetTimeMicros(); nTimeChainState += nTime5 - nTime4;
     LogPrint(BCLog::BENCH, "  - Writing chainstate: %.2fms [%.2fs (%.2fms/blk)]\n", (nTime5 - nTime4) * MILLI, nTimeChainState * MICRO, nTimeChainState * MILLI / nBlocksTotal);
@@ -2940,7 +2946,7 @@ bool CChainState::ActivateBestChain(BlockValidationState &state, const CChainPar
     CheckBlockIndex(chainparams.GetConsensus());
 
     // Write changes periodically to disk, after relay.
-    if (!FlushStateToDisk(chainparams, state, FlushStateMode::PERIODIC)) {
+    if (!FlushStateToDisk(chainparams, state, MempoolUsage(), FlushStateMode::PERIODIC)) {
         return false;
     }
 
@@ -3830,7 +3836,7 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, Block
         return AbortNode(state, std::string("System error: ") + e.what());
     }
 
-    FlushStateToDisk(chainparams, state, FlushStateMode::NONE);
+    FlushStateToDisk(chainparams, state, MempoolUsage(), FlushStateMode::NONE);
 
     CheckBlockIndex(chainparams.GetConsensus());
 
@@ -3985,8 +3991,9 @@ void PruneBlockFilesManual(int nManualPruneHeight)
 {
     BlockValidationState state;
     const CChainParams& chainparams = Params();
+    const auto mempool_usage = ::ChainstateActive().MempoolUsage();
     if (!::ChainstateActive().FlushStateToDisk(
-            chainparams, state, FlushStateMode::NONE, nManualPruneHeight)) {
+            chainparams, state, mempool_usage, FlushStateMode::NONE, nManualPruneHeight)) {
         LogPrintf("%s: failed to flush state (%s)\n", __func__, state.ToString());
     }
 }
@@ -4561,7 +4568,7 @@ bool CChainState::RewindBlockIndex(const CChainParams& params)
         LimitValidationInterfaceQueue();
 
         // Occasionally flush state to disk.
-        if (!FlushStateToDisk(params, state, FlushStateMode::PERIODIC)) {
+        if (!FlushStateToDisk(params, state, MempoolUsage(), FlushStateMode::PERIODIC)) {
             LogPrintf("RewindBlockIndex: unable to flush state to disk (%s)\n", state.ToString());
             return false;
         }
@@ -4580,7 +4587,7 @@ bool CChainState::RewindBlockIndex(const CChainParams& params)
             // and skip it here, we're about to -reindex-chainstate anyway, so
             // it'll get called a bunch real soon.
             BlockValidationState state;
-            if (!FlushStateToDisk(params, state, FlushStateMode::ALWAYS)) {
+            if (!FlushStateToDisk(params, state, MempoolUsage(), FlushStateMode::ALWAYS)) {
                 LogPrintf("RewindBlockIndex: unable to flush state to disk (%s)\n", state.ToString());
                 return false;
             }
@@ -5004,10 +5011,10 @@ bool CChainState::ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
 
     if (coinstip_size > old_coinstip_size) {
         // Likely no need to flush if cache sizes have grown.
-        ret = FlushStateToDisk(chainparams, state, FlushStateMode::IF_NEEDED);
+        ret = FlushStateToDisk(chainparams, state, MempoolUsage(), FlushStateMode::IF_NEEDED);
     } else {
         // Otherwise, flush state to disk and deallocate the in-memory coins map.
-        ret = FlushStateToDisk(chainparams, state, FlushStateMode::ALWAYS);
+        ret = FlushStateToDisk(chainparams, state, MempoolUsage(), FlushStateMode::ALWAYS);
         CoinsTip().ReallocateCache();
     }
     return ret;

--- a/src/validation.h
+++ b/src/validation.h
@@ -688,7 +688,8 @@ public:
 
     std::string ToString() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
-    int64_t MempoolUsage() const;
+    int64_t LockedMempoolUsage() const EXCLUSIVE_LOCKS_REQUIRED(m_mempool.cs);
+    int64_t UnlockedMempoolUsage() const EXCLUSIVE_LOCKS_REQUIRED(!m_mempool.cs);
 
 private:
     bool ActivateBestChainStep(BlockValidationState& state, const CChainParams& chainparams, CBlockIndex* pindexMostWork, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, ConnectTrace& connectTrace) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool.cs);

--- a/src/validation.h
+++ b/src/validation.h
@@ -677,11 +677,11 @@ public:
     //! Dictates whether we need to flush the cache to disk or not.
     //!
     //! @return the state of the size of the coins cache.
-    CoinsCacheSizeState GetCoinsCacheSizeState(const CTxMemPool* tx_pool)
+    CoinsCacheSizeState GetCoinsCacheSizeState(int64_t mempool_usage)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     CoinsCacheSizeState GetCoinsCacheSizeState(
-        const CTxMemPool* tx_pool,
+        int64_t mempool_usage,
         size_t max_coins_cache_size_bytes,
         size_t max_mempool_size_bytes) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -608,6 +608,7 @@ public:
     bool FlushStateToDisk(
         const CChainParams& chainparams,
         BlockValidationState &state,
+        int64_t mempool_usage,
         FlushStateMode mode,
         int nManualPruneHeight = 0);
 
@@ -686,6 +687,8 @@ public:
         size_t max_mempool_size_bytes) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     std::string ToString() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    int64_t MempoolUsage() const;
 
 private:
     bool ActivateBestChainStep(BlockValidationState& state, const CChainParams& chainparams, CBlockIndex* pindexMostWork, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, ConnectTrace& connectTrace) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool.cs);


### PR DESCRIPTION
This is another step to transit `CTxMemPool::cs` from `RecursiveMutex` to `Mutex`.
Split out from #19306. (Along with #19652, #19854 and #19872 it is more than 2/3 of the way to the final goal).

Thread safety annotations, lock assertions, and required explicit locking added. No behavior change.

Please note that now, since #19668 has been merged, it is safe to apply `AssertLockHeld()` macros as they do not swallow compile time Thread Safety Analysis warnings.