### PR TITLE
util: add psbt combiner role

### DIFF
--- a/src/node/psbt.cpp
+++ b/src/node/psbt.cpp
@@ -70,8 +70,8 @@ PSBTAnalysis AnalyzePSBT(PartiallySignedTransaction psbtx)
                 input_analysis.missing_witness_script = outdata.missing_witness_script;
                 input_analysis.missing_sigs = outdata.missing_sigs;
 
-                // If we are only missing signatures and nothing else, then next is signer
-                if (outdata.missing_pubkeys.empty() && outdata.missing_redeem_script.IsNull() && outdata.missing_witness_script.IsNull() && !outdata.missing_sigs.empty()) {
+                // If we are only missing some of the signatures and nothing else, then next is signer
+                if (outdata.missing_redeem_script.IsNull() && outdata.missing_witness_script.IsNull()) {
                     input_analysis.next = PSBTRole::SIGNER;
                 } else {
                     input_analysis.next = PSBTRole::UPDATER;

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -243,7 +243,7 @@ void PSBTOperationsDialog::showTransactionStatus(const PartiallySignedTransactio
             break;
         }
         case PSBTRole::SIGNER: {
-            QString need_sig_text = tr("Transaction still needs signature(s).");
+            QString need_sig_text = tr("Transaction still needs some or all signature(s).");
             StatusLevel level = StatusLevel::INFO;
             if (m_wallet_model->wallet().privateKeysDisabled()) {
                 need_sig_text += " " + tr("(But this wallet cannot sign transactions.)");


### PR DESCRIPTION
Current BIP 174 spec defines combiner role, which is absent from the current Bitcoin Core implementation. This PR adds support for it. 

The role can be easily detected by the fact that PSBT contains only some signatures, but not all of them.

This PR adds new PSBTRole type, corresponding naming and next role, analysis for COMBINER as described above, and support for Qt PSBT interface, re-using existing SIGNER option.