### PR TITLE
refactor: Drop unused `UniqueLock(Mutex*, ...)` constructor in sync.h

### DIFF
--- a/src/sync.h
+++ b/src/sync.h
@@ -164,17 +164,6 @@ public:
             Enter(pszName, pszFile, nLine);
     }
 
-    UniqueLock(Mutex* pmutexIn, const char* pszName, const char* pszFile, int nLine, bool fTry = false) EXCLUSIVE_LOCK_FUNCTION(pmutexIn)
-    {
-        if (!pmutexIn) return;
-
-        *static_cast<Base*>(this) = Base(*pmutexIn, std::defer_lock);
-        if (fTry)
-            TryEnter(pszName, pszFile, nLine);
-        else
-            Enter(pszName, pszFile, nLine);
-    }
-
     ~UniqueLock() UNLOCK_FUNCTION()
     {
         if (Base::owns_lock())

--- a/src/sync.h
+++ b/src/sync.h
@@ -116,20 +116,20 @@ public:
 };
 
 /**
- * Wrapped mutex: supports recursive locking, but no waiting
+ * Wrapped std::recursive_mutex -- supports recursive locking, but no waiting
  * TODO: We should move away from using the recursive lock by default.
  */
 using RecursiveMutex = AnnotatedMixin<std::recursive_mutex>;
 
-/** Wrapped mutex: supports waiting but not recursive locking */
-typedef AnnotatedMixin<std::mutex> Mutex;
+/** Wrapped std::mutex -- supports waiting but not recursive locking */
+using Mutex = AnnotatedMixin<std::mutex>;
 
 #ifdef DEBUG_LOCKCONTENTION
 void PrintLockContention(const char* pszName, const char* pszFile, int nLine);
 #endif
 
-/** Wrapper around std::unique_lock style lock for Mutex. */
-template <typename Mutex, typename Base = typename Mutex::UniqueLock>
+/** Wrapper around std::unique_lock<MutexType> */
+template <typename MutexType, typename Base = typename MutexType::UniqueLock>
 class SCOPED_LOCKABLE UniqueLock : public Base
 {
 private:
@@ -156,7 +156,7 @@ private:
     }
 
 public:
-    UniqueLock(Mutex& mutexIn, const char* pszName, const char* pszFile, int nLine, bool fTry = false) EXCLUSIVE_LOCK_FUNCTION(mutexIn) : Base(mutexIn, std::defer_lock)
+    UniqueLock(MutexType& mutexIn, const char* pszName, const char* pszFile, int nLine, bool fTry = false) EXCLUSIVE_LOCK_FUNCTION(mutexIn) : Base(mutexIn, std::defer_lock)
     {
         if (fTry)
             TryEnter(pszName, pszFile, nLine);


### PR DESCRIPTION
Dropped unused `UniqueLock(Mutex*, ...)` constructor that accepts a pointer to a mutex.

Also minor naming, comments and style improvements. 
