### PR TITLE
refactor: Do not pass chain params to CheckForStaleTipAndEvictPeers twice

### DIFF
--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -76,7 +76,7 @@ public:
     /** Consider evicting an outbound peer based on the amount of time they've been behind our tip */
     void ConsiderEviction(CNode& pto, int64_t time_in_seconds) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     /** Evict extra outbound peers. If we think our tip may be stale, connect to an extra outbound */
-    void CheckForStaleTipAndEvictPeers(const Consensus::Params &consensusParams);
+    void CheckForStaleTipAndEvictPeers();
     /** If we have extra outbound peers, try to disconnect the one with the oldest block announcement */
     void EvictExtraOutboundPeers(int64_t time_in_seconds) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     /** Retrieve unbroadcast transactions from the mempool and reattempt sending to peers */


### PR DESCRIPTION
`PeerManager` already keeps a reference to the chain params as a member variable. No need to pass it in once again as a function parameter.