### PR TITLE
build: allow user to specify DIR_FUZZ_SEED_CORPUS for cov_fuzz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,7 @@ total.coverage/
 fuzz.coverage/
 coverage_percent.txt
 /cov_tool_wrapper.sh
+qa-assets/
 
 #build tests
 linux-coverage-build

--- a/Makefile.am
+++ b/Makefile.am
@@ -193,6 +193,8 @@ LCOV_FILTER_PATTERN = \
 	-p "src/secp256k1" \
 	-p "depends"
 
+DIR_FUZZ_SEED_CORPUS ?= qa-assets/fuzz_seed_corpus
+
 $(COV_TOOL_WRAPPER):
 	@echo 'exec $(COV_TOOL) "$$@"' > $(COV_TOOL_WRAPPER)
 	@chmod +x $(COV_TOOL_WRAPPER)
@@ -205,7 +207,7 @@ baseline_filtered.info: baseline.info
 	$(LCOV) -a $@ $(LCOV_OPTS) -o $@
 
 fuzz.info: baseline_filtered.info
-	@TIMEOUT=15 test/fuzz/test_runner.py qa-assets/fuzz_seed_corpus -l DEBUG
+	@TIMEOUT=15 test/fuzz/test_runner.py $(DIR_FUZZ_SEED_CORPUS) -l DEBUG
 	$(LCOV) -c $(LCOV_OPTS) -d $(abs_builddir)/src --t fuzz-tests -o $@
 	$(LCOV) -z $(LCOV_OPTS) -d $(abs_builddir)/src
 


### PR DESCRIPTION
This PR contains two commits:
- The cov_fuzz target now uses `DIR_FUZZ_SEED_CORPUS` as the seed directory instead of the hard-coded `qa-assets/fuzz_seed_corpus`. Otherwise, running it requires me to copy the corpus to the bitcoin directory first. In case `DIR_FUZZ_SEED_CORPUS` is not specified, the original default is used.
- add qa-assets folder to gitignore

Example usage: 
`make cov_fuzz DIR_FUZZ_SEED_CORPUS=~/workspace/qa-assets/fuzz_seed_corpus`

It can also just be an environment variable.