### PR TITLE
Yet another change to reduce recursive mempool locking

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -890,15 +890,17 @@ void PeerManager::InitializeNode(CNode *pnode) {
 void PeerManager::ReattemptInitialBroadcast(CScheduler& scheduler) const
 {
     std::vector<std::pair<uint256, uint256>> relay_transactions;
-    std::map<uint256, uint256> unbroadcast_txids = m_mempool.GetUnbroadcastTxs();
-
-    relay_transactions.reserve(unbroadcast_txids.size());
-    for (const auto& elem : unbroadcast_txids) {
-        // Sanity check: all unbroadcast txns should exist in the mempool
-        if (m_mempool.exists(elem.first)) {
-            relay_transactions.push_back(elem);
-        } else {
-            m_mempool.RemoveUnbroadcastTx(elem.first, true);
+    {
+        LOCK(m_mempool.cs);
+        std::map<uint256, uint256> unbroadcast_txids = m_mempool.GetUnbroadcastTxs();
+        relay_transactions.reserve(unbroadcast_txids.size());
+        for (const auto& elem : unbroadcast_txids) {
+            // Sanity check: all unbroadcast txns should exist in the mempool
+            if (m_mempool.exists(elem.first)) {
+                relay_transactions.push_back(elem);
+            } else {
+                m_mempool.RemoveUnbroadcastTx(elem.first, true);
+            }
         }
     }
     {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1765,11 +1765,11 @@ void static ProcessGetData(CNode& pfrom, const CChainParams& chainparams, CConnm
             // WTX and WITNESS_TX imply we serialize with witness
             int nSendFlags = (inv.IsMsgTx() ? SERIALIZE_TRANSACTION_NO_WITNESS : 0);
             connman.PushMessage(&pfrom, msgMaker.Make(nSendFlags, NetMsgType::TX, *tx));
-            mempool.RemoveUnbroadcastTx(tx->GetHash());
             // As we're going to send tx, make sure its unconfirmed parents are made requestable.
             std::vector<uint256> parent_ids_to_add;
             {
                 LOCK(mempool.cs);
+                mempool.RemoveUnbroadcastTx(tx->GetHash());
                 auto txiter = mempool.GetIter(tx->GetHash());
                 if (txiter) {
                     const CTxMemPoolEntry::Parents& parents = (*txiter)->GetMemPoolParentsConst();

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1488,7 +1488,7 @@ bool static AlreadyHaveTx(const GenTxid& gtxid, const CTxMemPool& mempool) EXCLU
         if (g_recent_confirmed_transactions->contains(hash)) return true;
     }
 
-    return recentRejects->contains(hash) || mempool.exists(gtxid);
+    return recentRejects->contains(hash) || WITH_LOCK(mempool.cs, return mempool.exists(gtxid));
 }
 
 bool static AlreadyHaveBlock(const uint256& block_hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
@@ -3124,7 +3124,7 @@ void PeerManager::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDat
                 // if they were already in the mempool,
                 // allowing the node to function as a gateway for
                 // nodes hidden behind it.
-                if (!m_mempool.exists(tx.GetHash())) {
+                if (!WITH_LOCK(m_mempool.cs, return m_mempool.exists(tx.GetHash()))) {
                     LogPrintf("Not relaying non-mempool transaction %s from forcerelay peer=%d\n", tx.GetHash().ToString(), pfrom.GetId());
                 } else {
                     LogPrintf("Force relaying tx %s from peer=%d\n", tx.GetHash().ToString(), pfrom.GetId());

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -35,7 +35,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
         // So if the output does exist, then this transaction exists in the chain.
         if (!existingCoin.IsSpent()) return TransactionError::ALREADY_IN_CHAIN;
     }
-    if (!node.mempool->exists(hashTx)) {
+    if (!WITH_LOCK(node.mempool->cs, return node.mempool->exists(hashTx))) {
         // Transaction is not already in the mempool. Submit it.
         TxValidationState state;
         if (!AcceptToMemoryPool(*node.mempool, state, std::move(tx),

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -421,7 +421,7 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
     for (const CTxIn& txin : it->GetTx().vin)
         mapNextTx.erase(txin.prevout);
 
-    RemoveUnbroadcastTx(hash, true /* add logging because unchecked */ );
+    WITH_LOCK(cs, RemoveUnbroadcastTx(hash, true /* add logging because unchecked */ ));
 
     if (vTxHashes.size() > 1) {
         vTxHashes[it->vTxHashesIdx] = std::move(vTxHashes.back());
@@ -929,8 +929,7 @@ size_t CTxMemPool::DynamicMemoryUsage() const {
 }
 
 void CTxMemPool::RemoveUnbroadcastTx(const uint256& txid, const bool unchecked) {
-    LOCK(cs);
-
+    AssertLockHeld(cs);
     if (m_unbroadcast_txids.erase(txid))
     {
         LogPrint(BCLog::MEMPOOL, "Removed %i from set of unbroadcast txns%s\n", txid.GetHex(), (unchecked ? " before confirmation that txn was sent out" : ""));

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -729,15 +729,15 @@ public:
         return totalTxSize;
     }
 
-    bool exists(const GenTxid& gtxid) const
+    bool exists(const GenTxid& gtxid) const EXCLUSIVE_LOCKS_REQUIRED(cs)
     {
-        LOCK(cs);
+        AssertLockHeld(cs);
         if (gtxid.IsWtxid()) {
             return (mapTx.get<index_by_wtxid>().count(gtxid.GetHash()) != 0);
         }
         return (mapTx.count(gtxid.GetHash()) != 0);
     }
-    bool exists(const uint256& txid) const { return exists(GenTxid{false, txid}); }
+    bool exists(const uint256& txid) const EXCLUSIVE_LOCKS_REQUIRED(cs) { return exists(GenTxid{false, txid}); }
 
     CTransactionRef get(const uint256& hash) const;
     txiter get_iter_from_wtxid(const uint256& wtxid) const EXCLUSIVE_LOCKS_REQUIRED(cs)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -761,7 +761,7 @@ public:
     }
 
     /** Removes a transaction from the unbroadcast set */
-    void RemoveUnbroadcastTx(const uint256& txid, const bool unchecked = false);
+    void RemoveUnbroadcastTx(const uint256& txid, const bool unchecked = false) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Returns transactions in unbroadcast set */
     std::map<uint256, uint256> GetUnbroadcastTxs() const {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -764,8 +764,9 @@ public:
     void RemoveUnbroadcastTx(const uint256& txid, const bool unchecked = false) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Returns transactions in unbroadcast set */
-    std::map<uint256, uint256> GetUnbroadcastTxs() const {
-        LOCK(cs);
+    std::map<uint256, uint256> GetUnbroadcastTxs() const EXCLUSIVE_LOCKS_REQUIRED(cs)
+    {
+        AssertLockHeld(cs);
         return m_unbroadcast_txids;
     }
 


### PR DESCRIPTION
First 2 commits avoid unlock/lock `mempool.cs` and `cs_main` interchangeably by turning a loop in two loops - each mutex is locked throughout each corresponding loop.

Then explicit lock in `CTxMemPool::RemoveUnbroadcastTx`, `CTxMemPool::GetUnbroadcastTxs` and `CTxMemPool::exists` is removed forcing just 3 explicit `WITH_LOCK` where `exists()` is called and just 1 where `GetUnbroadcastTxs()` is called. This can be improved by adding an auxiliary function that locks and calls the original.