### PR TITLE
sync: Replace LockAssertion with AssertLockHeldUnverified

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -793,7 +793,7 @@ bool ChainstateManager::ProcessNewBlock(...)
 }
 ```
 
-- When Clang Thread Safety Analysis is unable to determine if a mutex is locked, use `LockAssertion` class instances:
+- When Clang Thread Safety Analysis is unable to determine if a mutex is locked, use `AssertLockHeldUnverified`:
 
 ```C++
 // net_processing.h
@@ -805,7 +805,7 @@ void RelayTransaction(...)
     AssertLockHeld(::cs_main);
 
     connman.ForEachNode([&txid, &wtxid](CNode* pnode) {
-        LockAssertion lock(::cs_main);
+        AssertLockHeldUnverified(::cs_main);
         ...
     });
 }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -663,7 +663,7 @@ static void MaybeSetPeerAsAnnouncingHeaderAndIDs(NodeId nodeid, CConnman& connma
             }
         }
         connman.ForNode(nodeid, [&connman](CNode* pfrom){
-            LockAssertion lock(::cs_main);
+            AssertLockHeldUnverified(::cs_main);
             uint64_t nCMPCTBLOCKVersion = (pfrom->GetLocalServices() & NODE_WITNESS) ? 2 : 1;
             if (lNodesAnnouncingHeaderAndIDs.size() >= 3) {
                 // As per BIP152, we only get 3 of our peers to announce
@@ -1371,7 +1371,7 @@ void PeerLogicValidation::NewPoWValidBlock(const CBlockIndex *pindex, const std:
     }
 
     m_connman.ForEachNode([this, &pcmpctblock, pindex, &msgMaker, fWitnessEnabled, &hashBlock](CNode* pnode) {
-        LockAssertion lock(::cs_main);
+        AssertLockHeldUnverified(::cs_main);
 
         // TODO: Avoid the repeated-serialization here
         if (pnode->nVersion < INVALID_CB_NO_BAN_VERSION || pnode->fDisconnect)
@@ -1506,7 +1506,7 @@ void RelayTransaction(const uint256& txid, const uint256& wtxid, const CConnman&
 {
     connman.ForEachNode([&txid, &wtxid](CNode* pnode)
     {
-        LockAssertion lock(::cs_main);
+        AssertLockHeldUnverified(::cs_main);
 
         CNodeState &state = *State(pnode->GetId());
         if (state.m_wtxid_relay) {
@@ -3999,7 +3999,7 @@ void PeerLogicValidation::EvictExtraOutboundPeers(int64_t time_in_seconds)
         int64_t oldest_block_announcement = std::numeric_limits<int64_t>::max();
 
         m_connman.ForEachNode([&](CNode* pnode) {
-            LockAssertion lock(::cs_main);
+            AssertLockHeldUnverified(::cs_main);
 
             // Ignore non-outbound peers, or nodes marked for disconnect already
             if (!pnode->IsOutboundOrBlockRelayConn() || pnode->fDisconnect) return;
@@ -4016,7 +4016,7 @@ void PeerLogicValidation::EvictExtraOutboundPeers(int64_t time_in_seconds)
         });
         if (worst_peer != -1) {
             bool disconnected = m_connman.ForNode(worst_peer, [&](CNode *pnode) {
-                LockAssertion lock(::cs_main);
+                AssertLockHeldUnverified(::cs_main);
 
                 // Only disconnect a peer that has been connected to us for
                 // some reasonable fraction of our check-frequency, to give


### PR DESCRIPTION
AssertLockHeldUnverified does the same thing LockAssertion except it:

- Correctly reports file and line number where assertion fails instead of location in sync.h.

- Has a simpler syntax that doesn't require declaring an unused variable name.

- Should be harder to confuse with AssertLockHeld. Name should indicate it's an unverified assertion not to be preferred when the safer verified assert is available.

This also adds doxygen comments describing AssertLockHeld, AssertLockHeldUnverified, and AssertLockNotHeld macros.

PR is compared with alternatives in https://github.com/bitcoin-core/bitcoin-devwiki/wiki/AssertLockHeld-PRs