### PR TITLE
bugfix: make LoadWallet assigns status always

### DIFF
--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -212,6 +212,7 @@ enum class DatabaseStatus {
     FAILED_ALREADY_EXISTS,
     FAILED_NOT_FOUND,
     FAILED_CREATE,
+    FAILED_LOAD,
     FAILED_VERIFY,
     FAILED_ENCRYPT,
 };

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -212,6 +212,7 @@ std::shared_ptr<CWallet> LoadWalletInternal(interfaces::Chain& chain, const std:
         std::shared_ptr<CWallet> wallet = CWallet::Create(chain, name, std::move(database), options.create_flags, error, warnings);
         if (!wallet) {
             error = Untranslated("Wallet loading failed.") + Untranslated(" ") + error;
+            status = DatabaseStatus::FAILED_LOAD;
             return nullptr;
         }
         AddWallet(wallet);
@@ -223,6 +224,7 @@ std::shared_ptr<CWallet> LoadWalletInternal(interfaces::Chain& chain, const std:
         return wallet;
     } catch (const std::runtime_error& e) {
         error = Untranslated(e.what());
+        status = DatabaseStatus::FAILED_LOAD;
         return nullptr;
     }
 }
@@ -233,6 +235,7 @@ std::shared_ptr<CWallet> LoadWallet(interfaces::Chain& chain, const std::string&
     auto result = WITH_LOCK(g_loading_wallet_mutex, return g_loading_wallet_set.insert(name));
     if (!result.second) {
         error = Untranslated("Wallet already being loading.");
+        status = DatabaseStatus::FAILED_LOAD;
         return nullptr;
     }
     auto wallet = LoadWalletInternal(chain, name, load_on_start, options, status, error, warnings);


### PR DESCRIPTION
In my enviroment, ```test/functional/wallet_multiwallet.py``` failed in line 237 for master( 147d50d63 ).
It got an expected rpc-error-message, but error code was not (-4) but (-18). 

This is because that although loadwallet() in rpcwallet.cpp assumes LoadWallet() always assign some value to the 'status', but LoadWallet() does not do so in some situation.

This PR intends to fix above and prevends loadwallet() returns ambiguous error code.