### PR TITLE
test: Fuzzing siphash against reference implementation [Request for feedback]

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -197,6 +197,7 @@ FUZZ_SUITE_LDFLAGS_COMMON = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(
 if ENABLE_FUZZ_BINARY
 test_fuzz_fuzz_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_fuzz_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_fuzz_CFLAGS = $(AM_CFLAGS) $(PIE_FLAGS)
 test_fuzz_fuzz_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_fuzz_LDFLAGS = $(FUZZ_SUITE_LDFLAGS_COMMON)
 test_fuzz_fuzz_SOURCES = \
@@ -226,6 +227,8 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/crypto_common.cpp \
  test/fuzz/crypto_hkdf_hmac_sha256_l32.cpp \
  test/fuzz/crypto_poly1305.cpp \
+ test/fuzz/crypto_siphash.cpp \
+ test/fuzz/siphash.c \
  test/fuzz/cuckoocache.cpp \
  test/fuzz/data_stream.cpp \
  test/fuzz/decode_tx.cpp \

--- a/src/test/fuzz/crypto_siphash.cpp
+++ b/src/test/fuzz/crypto_siphash.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <compat/endian.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+constexpr uint8_t sep = 0x07;
+
+extern "C" {
+int siphash(const uint8_t *in, size_t inlen, const uint8_t *k, uint8_t *out, size_t outlen);
+}
+
+
+FUZZ_TARGET(crypto_siphash)
+{
+
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    uint64_t k[2] = {
+        htole64(fuzzed_data_provider.ConsumeIntegral<uint64_t>()),
+        htole64(fuzzed_data_provider.ConsumeIntegral<uint64_t>())
+    };
+
+    auto gradual_siphash = CSipHasher(k[0], k[1]);
+    auto input = fuzzed_data_provider.ConsumeRemainingBytes<uint8_t>();
+
+    auto iterators = std::vector<std::vector<uint8_t>::const_iterator>{};
+    for (auto it = input.cbegin(); it != input.cend(); it = std::find(std::next(it), input.cend(), sep)) {
+        iterators.push_back(it);
+    }
+    iterators.push_back(input.cend());
+
+    for (size_t i = 0; i < iterators.size(); i++) {
+        size_t size;
+        if (i < iterators.size() - 1) {
+            size = std::distance(iterators[i], iterators[i + 1]);
+        } else {
+            size = std::distance(iterators[i], input.cend());
+        }
+        gradual_siphash.Write(iterators[i].base(), size);
+    }
+    uint64_t our_gradual_hash = gradual_siphash.Finalize();
+    uint64_t our_direct_hash = CSipHasher(k[0], k[1]).Write(input.data(), input.size()).Finalize();
+    uint64_t ref_hash;
+    siphash(input.data(), input.size(), reinterpret_cast<const uint8_t*>(&k[0]), reinterpret_cast<uint8_t*>(&ref_hash), sizeof(ref_hash));
+    ref_hash = htole64(ref_hash);
+
+    assert(ref_hash == our_gradual_hash);
+    assert(our_direct_hash == our_gradual_hash);
+}

--- a/src/test/fuzz/siphash.c
+++ b/src/test/fuzz/siphash.c
@@ -1,0 +1,166 @@
+/*
+   SipHash reference C implementation
+
+   Copyright (c) 2012-2016 Jean-Philippe Aumasson
+   <jeanphilippe.aumasson@gmail.com>
+   Copyright (c) 2012-2014 Daniel J. Bernstein <djb@cr.yp.to>
+
+   To the extent possible under law, the author(s) have dedicated all copyright
+   and related and neighboring rights to this software to the public domain
+   worldwide. This software is distributed without any warranty.
+
+   You should have received a copy of the CC0 Public Domain Dedication along
+   with
+   this software. If not, see
+   <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+#include <assert.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/* default: SipHash-2-4 */
+#ifndef cROUNDS
+    #define cROUNDS 2
+#endif
+#ifndef dROUNDS
+    #define dROUNDS 4
+#endif
+
+#define ROTL(x, b) (uint64_t)(((x) << (b)) | ((x) >> (64 - (b))))
+
+#define U32TO8_LE(p, v)                                                        \
+    (p)[0] = (uint8_t)((v));                                                   \
+    (p)[1] = (uint8_t)((v) >> 8);                                              \
+    (p)[2] = (uint8_t)((v) >> 16);                                             \
+    (p)[3] = (uint8_t)((v) >> 24);
+
+#define U64TO8_LE(p, v)                                                        \
+    U32TO8_LE((p), (uint32_t)((v)));                                           \
+    U32TO8_LE((p) + 4, (uint32_t)((v) >> 32));
+
+#define U8TO64_LE(p)                                                           \
+    (((uint64_t)((p)[0])) | ((uint64_t)((p)[1]) << 8) |                        \
+     ((uint64_t)((p)[2]) << 16) | ((uint64_t)((p)[3]) << 24) |                 \
+     ((uint64_t)((p)[4]) << 32) | ((uint64_t)((p)[5]) << 40) |                 \
+     ((uint64_t)((p)[6]) << 48) | ((uint64_t)((p)[7]) << 56))
+
+#define SIPROUND                                                               \
+    do {                                                                       \
+        v0 += v1;                                                              \
+        v1 = ROTL(v1, 13);                                                     \
+        v1 ^= v0;                                                              \
+        v0 = ROTL(v0, 32);                                                     \
+        v2 += v3;                                                              \
+        v3 = ROTL(v3, 16);                                                     \
+        v3 ^= v2;                                                              \
+        v0 += v3;                                                              \
+        v3 = ROTL(v3, 21);                                                     \
+        v3 ^= v0;                                                              \
+        v2 += v1;                                                              \
+        v1 = ROTL(v1, 17);                                                     \
+        v1 ^= v2;                                                              \
+        v2 = ROTL(v2, 32);                                                     \
+    } while (0)
+
+#ifdef DEBUG
+#define TRACE                                                                  \
+    do {                                                                       \
+        printf("(%3zu) v0 %016"PRIx64"\n", inlen, v0);                         \
+        printf("(%3zu) v1 %016"PRIx64"\n", inlen, v1);                         \
+        printf("(%3zu) v2 %016"PRIx64"\n", inlen, v2);                         \
+        printf("(%3zu) v3 %016"PRIx64"\n", inlen, v3);                         \
+    } while (0)
+#else
+#define TRACE
+#endif
+
+int siphash(const uint8_t *in, const size_t inlen, const uint8_t *k,
+            uint8_t *out, const size_t outlen) {
+
+    assert((outlen == 8) || (outlen == 16));
+    uint64_t v0 = UINT64_C(0x736f6d6570736575);
+    uint64_t v1 = UINT64_C(0x646f72616e646f6d);
+    uint64_t v2 = UINT64_C(0x6c7967656e657261);
+    uint64_t v3 = UINT64_C(0x7465646279746573);
+    uint64_t k0 = U8TO64_LE(k);
+    uint64_t k1 = U8TO64_LE(k + 8);
+    uint64_t m;
+    int i;
+    const uint8_t *end = in + inlen - (inlen % sizeof(uint64_t));
+    const int left = inlen & 7;
+    uint64_t b = ((uint64_t)inlen) << 56;
+    v3 ^= k1;
+    v2 ^= k0;
+    v1 ^= k1;
+    v0 ^= k0;
+
+    if (outlen == 16)
+        v1 ^= 0xee;
+
+    for (; in != end; in += 8) {
+        m = U8TO64_LE(in);
+        v3 ^= m;
+
+        TRACE;
+        for (i = 0; i < cROUNDS; ++i)
+            SIPROUND;
+
+        v0 ^= m;
+    }
+
+    switch (left) {
+    case 7:
+        b |= ((uint64_t)in[6]) << 48;
+    case 6:
+        b |= ((uint64_t)in[5]) << 40;
+    case 5:
+        b |= ((uint64_t)in[4]) << 32;
+    case 4:
+        b |= ((uint64_t)in[3]) << 24;
+    case 3:
+        b |= ((uint64_t)in[2]) << 16;
+    case 2:
+        b |= ((uint64_t)in[1]) << 8;
+    case 1:
+        b |= ((uint64_t)in[0]);
+        break;
+    case 0:
+        break;
+    }
+
+    v3 ^= b;
+
+    TRACE;
+    for (i = 0; i < cROUNDS; ++i)
+        SIPROUND;
+
+    v0 ^= b;
+
+    if (outlen == 16)
+        v2 ^= 0xee;
+    else
+        v2 ^= 0xff;
+
+    TRACE;
+    for (i = 0; i < dROUNDS; ++i)
+        SIPROUND;
+
+    b = v0 ^ v1 ^ v2 ^ v3;
+    U64TO8_LE(out, b);
+
+    if (outlen == 8)
+        return 0;
+
+    v1 ^= 0xdd;
+
+    TRACE;
+    for (i = 0; i < dROUNDS; ++i)
+        SIPROUND;
+
+    b = v0 ^ v1 ^ v2 ^ v3;
+    U64TO8_LE(out + 8, b);
+
+    return 0;
+}


### PR DESCRIPTION
Hash functions are complex, and even though the implementations look simple they can easily go wrong, usually in the buffer handling around the hash function itself(the "Writer") examples:
Rewriting the last byte that was written, processing the buffer too "early" when `Write` was called with exactly a full buffer(different hash functions require different behavior in these cases), the wrong amount of zeros were written in the case the buffer was exactly full when finalizing, and more.

I've personally found bugs in an implementation of a hash function via fuzzing against a reference implementation (the bug was actually in the ref impl), and there's a lot of precedent (See https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=924038 for the amount of bugs just in the *reference implementations submitted to NIST's SHA3 competition*)

This can also make PRs like #18014 and future SHA256 optimizations easier to review and be confident in.

I started with siphash specifically because it's small and simple so I can get feedback on this before continuing to SHA256 etc.
The downside of this method is that it means committing another implementation of the same thing separately.

About the implementation itself:
I've used a constant seperator so it would write each time different sizes, and sometimes even empty writes. and it's constant so coverage based fuzzers can easily figure this out and make the inputs cover all the branches.

Any feedback is welcome :)