### PR TITLE
Change CSipHasher's count variable to uint8_t

### DIFF
--- a/src/crypto/siphash.cpp
+++ b/src/crypto/siphash.cpp
@@ -49,7 +49,7 @@ CSipHasher& CSipHasher::Write(const unsigned char* data, size_t size)
 {
     uint64_t v0 = v[0], v1 = v[1], v2 = v[2], v3 = v[3];
     uint64_t t = tmp;
-    int c = count;
+    uint8_t c = count;
 
     while (size--) {
         t |= ((uint64_t)(*(data++))) << (8 * (c % 8));

--- a/src/crypto/siphash.h
+++ b/src/crypto/siphash.h
@@ -15,7 +15,7 @@ class CSipHasher
 private:
     uint64_t v[4];
     uint64_t tmp;
-    int count;
+    uint8_t count; // Only the low 8 bits of the input size matter.
 
 public:
     /** Construct a SipHash calculator initialized with 128-bit key (k0, k1) */


### PR DESCRIPTION
SipHash technically supports arbitrarily long inputs (at least, I couldn't find a limit in the [paper](https://eprint.iacr.org/2012/351.pdf)), but only the low 8 bits of the length matter. Because of that we should use an unsigned type to track the length (as any signed type could overflow, which is UB). `uint8_t` is sufficient, however.

Fixes #19930. 