### PR TITLE
net: remove unused CNetAddr scopeId member

### DIFF
--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -129,10 +129,9 @@ CNetAddr::CNetAddr(const struct in_addr& ipv4Addr)
     m_addr.assign(ptr, ptr + ADDR_IPV4_SIZE);
 }
 
-CNetAddr::CNetAddr(const struct in6_addr& ipv6Addr, const uint32_t scope)
+CNetAddr::CNetAddr(const struct in6_addr& ipv6Addr)
 {
     SetLegacyIPv6(Span<const uint8_t>(reinterpret_cast<const uint8_t*>(&ipv6Addr), sizeof(ipv6Addr)));
-    scopeId = scope;
 }
 
 bool CNetAddr::IsBindAny() const
@@ -648,7 +647,7 @@ CService::CService(const struct sockaddr_in& addr) : CNetAddr(addr.sin_addr), po
     assert(addr.sin_family == AF_INET);
 }
 
-CService::CService(const struct sockaddr_in6 &addr) : CNetAddr(addr.sin6_addr, addr.sin6_scope_id), port(ntohs(addr.sin6_port))
+CService::CService(const struct sockaddr_in6 &addr) : CNetAddr(addr.sin6_addr), port(ntohs(addr.sin6_port))
 {
    assert(addr.sin6_family == AF_INET6);
 }
@@ -716,7 +715,6 @@ bool CService::GetSockAddr(struct sockaddr* paddr, socklen_t *addrlen) const
         memset(paddrin6, 0, *addrlen);
         if (!GetIn6Addr(&paddrin6->sin6_addr))
             return false;
-        paddrin6->sin6_scope_id = scopeId;
         paddrin6->sin6_family = AF_INET6;
         paddrin6->sin6_port = htons(port);
         return true;

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -102,8 +102,6 @@ class CNetAddr
          */
         Network m_net{NET_IPV6};
 
-        uint32_t scopeId{0}; // for scoped/link-local ipv6 addresses
-
     public:
         CNetAddr();
         explicit CNetAddr(const struct in_addr& ipv4Addr);
@@ -164,7 +162,7 @@ class CNetAddr
         std::vector<unsigned char> GetAddrBytes() const;
         int GetReachabilityFrom(const CNetAddr *paddrPartner = nullptr) const;
 
-        explicit CNetAddr(const struct in6_addr& pipv6Addr, const uint32_t scope = 0);
+        explicit CNetAddr(const struct in6_addr& pipv6Addr);
         bool GetIn6Addr(struct in6_addr* pipv6Addr) const;
 
         friend bool operator==(const CNetAddr& a, const CNetAddr& b);

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -120,7 +120,7 @@ bool static LookupIntern(const std::string& name, std::vector<CNetAddr>& vIP, un
         {
             assert(aiTrav->ai_addrlen >= sizeof(sockaddr_in6));
             struct sockaddr_in6* s6 = (struct sockaddr_in6*) aiTrav->ai_addr;
-            resolved = CNetAddr(s6->sin6_addr, s6->sin6_scope_id);
+            resolved = CNetAddr(s6->sin6_addr);
         }
         /* Never allow resolving to an internal address. Consider any such result invalid */
         if (!resolved.IsInternal()) {

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -245,7 +245,7 @@ CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider) noexcept
         if (fuzzed_data_provider.remaining_bytes() >= 16) {
             in6_addr v6_addr = {};
             memcpy(v6_addr.s6_addr, fuzzed_data_provider.ConsumeBytes<uint8_t>(16).data(), 16);
-            net_addr = CNetAddr{v6_addr, fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
+            net_addr = CNetAddr{v6_addr};
         }
     } else if (network == Network::NET_INTERNAL) {
         net_addr.SetInternal(fuzzed_data_provider.ConsumeBytesAsString(32));


### PR DESCRIPTION
I'm probably missing something here but `CNetAddr::scopeId` seems unused. It isn't covered by tests. It was added in eda3d9248971a1c3df6e6c4b23ba89be30508b51 and potentially caused an uninitialized read fixed in b7b36decaf878a8c1dcfdb4a27196c730043474b. Am running master on mainnet with the following asserts as a sanity check.
```diff
--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -132,6 +132,7 @@ CNetAddr::CNetAddr(const struct in_addr& ipv4Addr)
 CNetAddr::CNetAddr(const struct in6_addr& ipv6Addr, const uint32_t scope)
 {
     SetLegacyIPv6(Span<const uint8_t>(reinterpret_cast<const uint8_t*>(&ipv6Addr), sizeof(ipv6Addr)));
+    assert(scope == 0);
     scopeId = scope;
 }
 
@@ -716,6 +717,7 @@ bool CService::GetSockAddr(struct sockaddr* paddr, socklen_t *addrlen) const
+        assert(scopeId == 0);
         paddrin6->sin6_scope_id = scopeId;
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -120,6 +120,7 @@ bool static LookupIntern(const std::string& name, std::vector<CNetAddr>& vIP, un
             struct sockaddr_in6* s6 = (struct sockaddr_in6*) aiTrav->ai_addr;
+            assert(s6->sin6_scope_id == 0);
             resolved = CNetAddr(s6->sin6_addr, s6->sin6_scope_id);
         }
```