### PR TITLE
Test: Cover "change_type" option of "walletcreatefundedpsbt" RPC

### DIFF
--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -320,6 +320,10 @@ class PSBTTest(BitcoinTestFramework):
         psbtx_np2wkh = self.nodes[1].walletcreatefundedpsbt([], [small_output], 0, {"change_type":"p2sh-segwit"})
         self.assert_change_type(psbtx_np2wkh, "scripthash")
 
+        # Make sure the change type cannot be specified if a change address is given
+        invalid_options = {"change_type":"legacy","changeAddress":self.nodes[0].getnewaddress()}
+        assert_raises_rpc_error(-8, "both change address and address type options", self.nodes[0].walletcreatefundedpsbt, [], [small_output], 0, invalid_options)
+
         # Regression test for 14473 (mishandling of already-signed witness transaction):
         psbtx_info = self.nodes[0].walletcreatefundedpsbt([{"txid":unspent["txid"], "vout":unspent["vout"]}], [{self.nodes[2].getnewaddress():unspent["amount"]+1}], 0, {"add_inputs": True})
         complete_psbt = self.nodes[0].walletprocesspsbt(psbtx_info["psbt"])


### PR DESCRIPTION
Increases test coverage of the `walletcreatefundedpsbt` RPC.

Tests the following combinations:
 - Make sure the global option `-changetype` is used as the default value for the `change_type` option if not specified.
 - Make sure the global option `-changetype` can be overwritten by explicitly setting the `change_type` option of the `walletcreatefundedpsbt` RPC call.
 - Make sure the options `change_type` and `changeAddress` are mutually exclusive.