### PR TITLE
rpc: alias helper

### DIFF
--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -74,6 +74,19 @@ void RPCTypeCheckObj(const UniValue& o,
     }
 }
 
+void RPCTypeCheckAliases(UniValue& o,
+    const std::map<std::string, std::string>& aliases)
+{
+    for (const auto& alias : aliases) {
+        if (o.exists(alias.second)) {
+            if (o.exists(alias.first)) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "May not use both " + alias.first + " and " + alias.second + " simultaneously.");
+            }
+            o.pushKV(alias.first, o[alias.second]);
+        }
+    }
+}
+
 CAmount AmountFromValue(const UniValue& value)
 {
     if (!value.isNum() && !value.isStr())

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -82,7 +82,15 @@ void RPCTypeCheckAliases(UniValue& o,
             if (o.exists(alias.first)) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "May not use both " + alias.first + " and " + alias.second + " simultaneously.");
             }
-            o.pushKV(alias.first, o[alias.second]);
+            // we (ab)use the fact UniValue::getKeys() returns a const direct reference to the keys vector
+            // and handwave away the constness and modify the keys directly
+            std::vector<std::string>& keys = const_cast<std::vector<std::string>&>(o.getKeys());
+            for (size_t i = 0; i < keys.size(); ++i) {
+                if (keys.at(i) == alias.second) {
+                    keys[i] = alias.first;
+                    break;
+                }
+            }
         }
     }
 }

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -70,6 +70,15 @@ void RPCTypeCheckObj(const UniValue& o,
     bool fStrict = false);
 
 /**
+ * Check and merge aliased values in an Object.
+ *
+ * Moves all non-null values from the alias (value) to the primary (key).
+ * @throws a JSONRPCError of type RPC_INVALID_PARAMETER if both are non-null for any of the aliases
+ */
+void RPCTypeCheckAliases(UniValue& o,
+    const std::map<std::string, std::string>& aliases);
+
+/**
  * Utilities: convert hex-encoded Values
  * (throws error if not hex).
  */

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2964,20 +2964,15 @@ void FundTransaction(CWallet* const pwallet, CMutableTransaction& tx, CAmount& f
             {
                 {"add_inputs", UniValueType(UniValue::VBOOL)},
                 {"add_to_wallet", UniValueType(UniValue::VBOOL)},
-                {"changeAddress", UniValueType(UniValue::VSTR)},
                 {"change_address", UniValueType(UniValue::VSTR)},
-                {"changePosition", UniValueType(UniValue::VNUM)},
                 {"change_position", UniValueType(UniValue::VNUM)},
                 {"change_type", UniValueType(UniValue::VSTR)},
-                {"includeWatching", UniValueType(UniValue::VBOOL)},
                 {"include_watching", UniValueType(UniValue::VBOOL)},
                 {"inputs", UniValueType(UniValue::VARR)},
-                {"lockUnspents", UniValueType(UniValue::VBOOL)},
                 {"lock_unspents", UniValueType(UniValue::VBOOL)},
                 {"locktime", UniValueType(UniValue::VNUM)},
                 {"feeRate", UniValueType()}, // will be checked below,
                 {"psbt", UniValueType(UniValue::VBOOL)},
-                {"subtractFeeFromOutputs", UniValueType(UniValue::VARR)},
                 {"subtract_fee_from_outputs", UniValueType(UniValue::VARR)},
                 {"replaceable", UniValueType(UniValue::VBOOL)},
                 {"conf_target", UniValueType(UniValue::VNUM)},
@@ -3344,7 +3339,6 @@ static UniValue bumpfee(const JSONRPCRequest& request)
         });
         RPCTypeCheckObj(options,
             {
-                {"confTarget", UniValueType(UniValue::VNUM)},
                 {"conf_target", UniValueType(UniValue::VNUM)},
                 {"fee_rate", UniValueType(UniValue::VNUM)},
                 {"replaceable", UniValueType(UniValue::VBOOL)},

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -116,7 +116,7 @@ class BumpFeeTest(BitcoinTestFramework):
             "estimate_mode": Decimal("3.141592"),
         })
         # confTarget and conf_target
-        assert_raises_rpc_error(-8, "confTarget and conf_target options should not both be set", node.bumpfee, txid, {
+        assert_raises_rpc_error(-8, "May not use both conf_target and confTarget simultaneously", node.bumpfee, txid, {
             "confTarget": 123,
             "conf_target": 456,
         })


### PR DESCRIPTION
Introduce a new "check alias" helper for RPC commands, which checks and moves the values into the "primary" key.

The first commit simply `pushKV`'s the value from the alias, if set, whereas the second commit const-casts the keys vector in UniValue and modifies that directly, i.e. "rename". Some people (cough sipa cough) might object to the approach, so I'm splitting into two commits.

This is partially also a cleanup of #16378.