### PR TITLE
build: patch qt libpng to fix powerpc build

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -11,7 +11,7 @@ $(package)_qt_libs=corelib network widgets gui plugins testlib
 $(package)_patches=fix_qt_pkgconfig.patch mac-qmake.conf fix_configure_mac.patch fix_no_printer.patch
 $(package)_patches+= fix_rcc_determinism.patch fix_riscv64_arch.patch xkb-default.patch no-xlib.patch
 $(package)_patches+= fix_android_qmake_conf.patch fix_android_jni_static.patch dont_hardcode_pwd.patch
-$(package)_patches+= freetype_back_compat.patch drop_lrelease_dependency.patch
+$(package)_patches+= freetype_back_compat.patch drop_lrelease_dependency.patch fix_powerpc_libpng.patch
 
 # Update OSX_QT_TRANSLATIONS when this is updated
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
@@ -194,6 +194,7 @@ endef
 
 define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/freetype_back_compat.patch && \
+  patch -p1 -i $($(package)_patch_dir)/fix_powerpc_libpng.patch && \
   sed -i.old "s|updateqm.commands = \$$$$\$$$$LRELEASE|updateqm.commands = $($(package)_extract_dir)/qttools/bin/lrelease|" qttranslations/translations/translations.pro && \
   patch -p1 -i $($(package)_patch_dir)/drop_lrelease_dependency.patch && \
   patch -p1 -i $($(package)_patch_dir)/dont_hardcode_pwd.patch &&\

--- a/depends/patches/qt/fix_powerpc_libpng.patch
+++ b/depends/patches/qt/fix_powerpc_libpng.patch
@@ -1,0 +1,23 @@
+commit 6f9feb773a43c5abfa3455da2e324180e789285b
+Author: fanquake <fanquake@gmail.com>
+Date:   Tue Sep 15 21:44:31 2020 +0800
+
+    Fix PowerPC build of libpng
+
+    See https://bugreports.qt.io/browse/QTBUG-66388.
+
+    Can be dropped when we are building qt 5.12.0 or later.
+
+diff --git a/qtbase/src/3rdparty/libpng/libpng.pro b/qtbase/src/3rdparty/libpng/libpng.pro
+index 577b61d8..a2f56669 100644
+--- a/qtbase/src/3rdparty/libpng/libpng.pro
++++ b/qtbase/src/3rdparty/libpng/libpng.pro
+@@ -10,7 +10,7 @@ MODULE_INCLUDEPATH = $$PWD
+ 
+ load(qt_helper_lib)
+ 
+-DEFINES += PNG_ARM_NEON_OPT=0
++DEFINES += PNG_ARM_NEON_OPT=0 PNG_POWERPC_VSX_OPT=0
+ SOURCES += \
+     png.c \
+     pngerror.c \


### PR DESCRIPTION
This is an alternative to #19751 that fixes the build without requiring
splitting out libpng. This patch can be dropped once we are building qt
5.12.0 or later.

One of the [concerns posted in #19751](https://github.com/bitcoin/bitcoin/pull/19751#issuecomment-675455993) was:

> the one bundled with Qt is at best a slower "bare minimum".

However for our usage, I don't think the performance of libpng is a concern. If it is, I'd like to see some numbers/justification as to why we should be worried about it.

This patch should be enough to unblock PowerPC binaries (combined with other changes) for 0.21.0, and for 0.22.0, when we switch to qt 5.15.x in depends, we should be able to drop it.

Related upstream issue: https://bugreports.qt.io/browse/QTBUG-66388.
