### PR TITLE
sync.h: fix LockAssertion error reporting

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -793,19 +793,24 @@ bool ChainstateManager::ProcessNewBlock(...)
 }
 ```
 
-- When Clang Thread Safety Analysis is unable to determine if a mutex is locked, use `LockAssertion` class instances:
+- When Clang Thread Safety Analysis is unable to determine that a mutex is always locked, use the `LOCK_ASSERTION` macro to override it:
 
 ```C++
 // net_processing.h
 void RelayTransaction(...) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
 // net_processing.cpp
+static CNodeState *State(NodeId pnode) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{ ... }
+
 void RelayTransaction(...)
 {
     AssertLockHeld(::cs_main);
 
     connman.ForEachNode([&txid, &wtxid](CNode* pnode) {
-        LockAssertion lock(::cs_main);
+        LOCK_ASSERTION(::cs_main);
+
+        CNodeState* state = State(pnode->GetId());
         ...
     });
 }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -663,7 +663,7 @@ static void MaybeSetPeerAsAnnouncingHeaderAndIDs(NodeId nodeid, CConnman& connma
             }
         }
         connman.ForNode(nodeid, [&connman](CNode* pfrom){
-            LockAssertion lock(::cs_main);
+            LOCK_ASSERTION(::cs_main);
             uint64_t nCMPCTBLOCKVersion = (pfrom->GetLocalServices() & NODE_WITNESS) ? 2 : 1;
             if (lNodesAnnouncingHeaderAndIDs.size() >= 3) {
                 // As per BIP152, we only get 3 of our peers to announce
@@ -1356,7 +1356,7 @@ void PeerManager::NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_
     }
 
     m_connman.ForEachNode([this, &pcmpctblock, pindex, &msgMaker, fWitnessEnabled, &hashBlock](CNode* pnode) {
-        LockAssertion lock(::cs_main);
+        LOCK_ASSERTION(::cs_main);
 
         // TODO: Avoid the repeated-serialization here
         if (pnode->nVersion < INVALID_CB_NO_BAN_VERSION || pnode->fDisconnect)
@@ -1491,7 +1491,7 @@ void RelayTransaction(const uint256& txid, const uint256& wtxid, const CConnman&
 {
     connman.ForEachNode([&txid, &wtxid](CNode* pnode)
     {
-        LockAssertion lock(::cs_main);
+        LOCK_ASSERTION(::cs_main);
 
         CNodeState* state = State(pnode->GetId());
         if (state == nullptr) return;
@@ -3980,7 +3980,7 @@ void PeerManager::EvictExtraOutboundPeers(int64_t time_in_seconds)
         int64_t oldest_block_announcement = std::numeric_limits<int64_t>::max();
 
         m_connman.ForEachNode([&](CNode* pnode) {
-            LockAssertion lock(::cs_main);
+            LOCK_ASSERTION(::cs_main);
 
             // Ignore non-outbound peers, or nodes marked for disconnect already
             if (!pnode->IsOutboundOrBlockRelayConn() || pnode->fDisconnect) return;
@@ -3997,7 +3997,7 @@ void PeerManager::EvictExtraOutboundPeers(int64_t time_in_seconds)
         });
         if (worst_peer != -1) {
             bool disconnected = m_connman.ForNode(worst_peer, [&](CNode *pnode) {
-                LockAssertion lock(::cs_main);
+                LOCK_ASSERTION(::cs_main);
 
                 // Only disconnect a peer that has been connected to us for
                 // some reasonable fraction of our check-frequency, to give

--- a/src/sync.h
+++ b/src/sync.h
@@ -356,14 +356,13 @@ public:
 // locked (when it couldn't be determined otherwise).
 struct SCOPED_LOCKABLE LockAssertion
 {
-    template <typename Mutex>
-    explicit LockAssertion(Mutex& mutex) EXCLUSIVE_LOCK_FUNCTION(mutex)
+    template <typename MutexType>
+    explicit LockAssertion(const char* name, const char* file, int line, MutexType* cs) EXCLUSIVE_LOCK_FUNCTION(cs)
     {
-#ifdef DEBUG_LOCKORDER
-        AssertLockHeld(mutex);
-#endif
+        AssertLockHeldInternal(name, file, line, cs);
     }
     ~LockAssertion() UNLOCK_FUNCTION() {}
 };
+#define LOCK_ASSERTION(cs)   LockAssertion PASTE2(lockassertion, __COUNTER__)(#cs, __FILE__, __LINE__, &cs)
 
 #endif // BITCOIN_SYNC_H


### PR DESCRIPTION
This fixes LockAssertion's incorrect line number reporting, with minimal changes.

PR is compared with alternatives in https://github.com/bitcoin-core/bitcoin-devwiki/wiki/AssertLockHeld-PRs