### PR TITLE
fuzz: Add fuzzing harness for node eviction logic

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -233,6 +233,7 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/net.cpp \
  test/fuzz/net_permissions.cpp \
  test/fuzz/netaddress.cpp \
+ test/fuzz/node_eviction.cpp \
  test/fuzz/p2p_transport_deserializer.cpp \
  test/fuzz/parse_hd_keypath.cpp \
  test/fuzz/parse_iso8601.cpp \

--- a/src/test/fuzz/node_eviction.cpp
+++ b/src/test/fuzz/node_eviction.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <net.h>
+#include <optional.h>
+#include <protocol.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+FUZZ_TARGET(node_eviction)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    std::vector<NodeEvictionCandidate> eviction_candidates;
+    while (fuzzed_data_provider.ConsumeBool()) {
+        eviction_candidates.push_back({
+            fuzzed_data_provider.ConsumeIntegral<NodeId>(),
+            fuzzed_data_provider.ConsumeIntegral<int64_t>(),
+            fuzzed_data_provider.ConsumeIntegral<int64_t>(),
+            fuzzed_data_provider.ConsumeIntegral<int64_t>(),
+            fuzzed_data_provider.ConsumeIntegral<int64_t>(),
+            fuzzed_data_provider.ConsumeBool(),
+            fuzzed_data_provider.ConsumeBool(),
+            fuzzed_data_provider.ConsumeBool(),
+            fuzzed_data_provider.ConsumeIntegral<uint64_t>(),
+            fuzzed_data_provider.ConsumeBool(),
+            fuzzed_data_provider.ConsumeBool(),
+        });
+    }
+    // Make a copy since eviction_candidates may be in some valid but otherwise
+    // indeterminate state after the SelectNodeToEvict(&&) call.
+    const std::vector<NodeEvictionCandidate> eviction_candidates_copy = eviction_candidates;
+    const Optional<NodeId> node_to_evict = SelectNodeToEvict(std::move(eviction_candidates));
+    if (node_to_evict) {
+        assert(std::any_of(eviction_candidates_copy.begin(), eviction_candidates_copy.end(), [&node_to_evict](const NodeEvictionCandidate& eviction_candidate) { return *node_to_evict == eviction_candidate.id; }));
+    }
+}


### PR DESCRIPTION
Add fuzzing harness for node eviction logic.

See [`doc/fuzzing.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md) for information on how to fuzz Bitcoin Core. Don't forget to contribute any coverage increasing inputs you find to the [Bitcoin Core fuzzing corpus repo](https://github.com/bitcoin-core/qa-assets).

Happy fuzzing :)