### PR TITLE
log: Remove static log message "Initializing chainstate Chainstate [ibd] @ height -1 (null)"

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1614,7 +1614,6 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
                 bool failed_chainstate_init = false;
 
                 for (CChainState* chainstate : chainman.GetAll()) {
-                    LogPrintf("Initializing chainstate %s\n", chainstate->ToString());
                     chainstate->InitCoinsDB(
                         /* cache_size_bytes */ nCoinDBCache,
                         /* in_memory */ false,


### PR DESCRIPTION
Remove static log message `Initializing chainstate Chainstate [ibd] @ height -1 (null)`.

AFAICT `chainstate->ToString()` will always equal `"Chainstate [ibd] @ height -1 (null)"` here which makes the log message neither relevant nor interesting :)