### PR TITLE
net: Prevent routing of deprecated Site Local IPv6

### DIFF
--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -229,6 +229,11 @@ bool CNetAddr::IsRFC7343() const
            (m_addr[3] & 0xF0) == 0x20;
 }
 
+bool CNetAddr::IsRFC3897() const
+{
+    return IsIPv6() && m_addr[0] == 0xFE && (m_addr[1] & 0xC0) == 0xC0;
+}
+
 bool CNetAddr::IsHeNet() const
 {
     return IsIPv6() && HasPrefix(m_addr, std::array<uint8_t, 4>{0x20, 0x01, 0x04, 0x70});
@@ -304,7 +309,7 @@ bool CNetAddr::IsValid() const
  */
 bool CNetAddr::IsRoutable() const
 {
-    return IsValid() && !(IsRFC1918() || IsRFC2544() || IsRFC3927() || IsRFC4862() || IsRFC6598() || IsRFC5737() || (IsRFC4193() && !IsTor()) || IsRFC4843() || IsRFC7343() || IsLocal() || IsInternal());
+    return IsValid() && !(IsRFC1918() || IsRFC2544() || IsRFC3927() || IsRFC4862() || IsRFC6598() || IsRFC5737() || (IsRFC4193() && !IsTor()) || IsRFC4843() || IsRFC7343() || IsRFC3897() || IsLocal() || IsInternal());
 }
 
 /**

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -137,6 +137,7 @@ class CNetAddr
         bool IsRFC4862() const; // IPv6 autoconfig (FE80::/64)
         bool IsRFC6052() const; // IPv6 well-known prefix for IPv4-embedded address (64:FF9B::/96)
         bool IsRFC6145() const; // IPv6 IPv4-translated address (::FFFF:0:0:0/96) (actually defined in RFC2765)
+        bool IsRFC3897() const; // IPv6 Site Local Addresses (deprecated) (FEC0::/10)
         bool IsHeNet() const;   // IPv6 Hurricane Electric - https://he.net (2001:0470::/36)
         bool IsTor() const;
         bool IsLocal() const;

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -65,12 +65,14 @@ BOOST_AUTO_TEST_CASE(netbase_properties)
     BOOST_CHECK(ResolveIP("2001:10::").IsRFC4843());
     BOOST_CHECK(ResolveIP("2001:20::").IsRFC7343());
     BOOST_CHECK(ResolveIP("FE80::").IsRFC4862());
+    BOOST_CHECK(ResolveIP("FEC0::").IsRFC3897());
     BOOST_CHECK(ResolveIP("64:FF9B::").IsRFC6052());
     BOOST_CHECK(ResolveIP("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca").IsTor());
     BOOST_CHECK(ResolveIP("127.0.0.1").IsLocal());
     BOOST_CHECK(ResolveIP("::1").IsLocal());
     BOOST_CHECK(ResolveIP("8.8.8.8").IsRoutable());
     BOOST_CHECK(ResolveIP("2001::1").IsRoutable());
+    BOOST_CHECK(!ResolveIP("FEC0::").IsRoutable());
     BOOST_CHECK(ResolveIP("127.0.0.1").IsValid());
     BOOST_CHECK(CreateInternal("FD6B:88C0:8724:edb1:8e4:3588:e546:35ca").IsInternal());
     BOOST_CHECK(CreateInternal("bar.com").IsInternal());


### PR DESCRIPTION
This PR fixes https://github.com/bitcoin/bitcoin/issues/19978.
Currently Site Local IPv6 addresses as treated as routable, even though as of [RFC 3879](https://tools.ietf.org/html/rfc3879#section-4) they should not be routed. I therefore implemented a check to detect and flag them as not routable.