### PR TITLE
fix: remove confusing warning (#16343 #19603)

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2470,8 +2470,6 @@ static void UpdateTip(CTxMemPool& mempool, const CBlockIndex* pindexNew, const C
                 ++nUpgraded;
             pindex = pindex->pprev;
         }
-        if (nUpgraded > 0)
-            AppendWarning(warning_messages, strprintf(_("%d of last 100 blocks have unexpected version"), nUpgraded));
     }
     LogPrintf("%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n", __func__,
       pindexNew->GetBlockHash().ToString(), pindexNew->nHeight, pindexNew->nVersion,


### PR DESCRIPTION
This patch removes a log line that some consider as confusing, see #16343, #19603.

    warning=45 of last 100 blocks have unexpected version

This fixes issues #16343 and #19603, for which @MarcoFalke [suggested](https://github.com/bitcoin/bitcoin/issues/16343#issuecomment-619656306) "Pull requests with improvements are always welcome"

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
