### PR TITLE
log: Mitigate disk filling attacks by temporarily rate limiting LogPrintf(…)

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2479,7 +2479,7 @@ static void UpdateTip(CTxMemPool& mempool, const CBlockIndex* pindexNew, const C
         if (nUpgraded > 0)
             AppendWarning(warning_messages, strprintf(_("%d of last 100 blocks have unexpected version"), nUpgraded));
     }
-    LogPrintf("%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n", __func__,
+    LogPrintfWithoutRateLimiting("%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n", __func__,
       pindexNew->GetBlockHash().ToString(), pindexNew->nHeight, pindexNew->nVersion,
       log(pindexNew->nChainWork.getdouble())/log(2.0), (unsigned long)pindexNew->nChainTx,
       FormatISO8601DateTime(pindexNew->GetBlockTime()),


### PR DESCRIPTION
Mitigate disk filling attacks by temporarily rate limiting `LogPrintf(…)`.

A disk fill attack is an attack where an untrusted party (such as a peer) is able to cheaply make your node log to disk excessively. The excessive logging may fill your disk and thus make your node crash either cleanly (best case: if disk fill rate is relatively slow) or uncleanly (worst case: if disk fill rate is relatively fast).

The hourly logging quota is set *per source location*. Every single source location (say `net_processing.cpp:418`) gets a quota of 1 MB of logging per hour.

Notes:
* Only logging to disk is rate limited. Logging to console is not rate limited.
* Only `LogPrintf(…)` is rate limited. `LogPrint(category, …)` (`-debug`) is not rate limited.
* `UpdateTip: new best=[…]` is logged using `LogPrintfWithoutRateLimiting(…)` to avoid rate limiting. High log volume is expected for that source location during IBD.

Live demo:

```diff
$ git diff
diff --git a/src/init.cpp b/src/init.cpp
index 023aa9aba..56a250876 100644
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1232,6 +1232,13 @@ bool AppInitInterfaces(NodeContext& node)
     return true;
 }
 
+void SimulateDiskFillingAttack() {
+    uint64_t n = 0;
+    while (true) {
+        LogPrintf("Chancellor on brink of %d:th bailout for banks. LogPrintf on brink of first disk fill for node.\n", ++n);
+    }
+}
+
 bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 {
     const ArgsManager& args = *Assert(node.args);
@@ -1845,6 +1852,8 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
     }
 #endif
 
+    std::thread{SimulateDiskFillingAttack}.detach();
+
     std::vector<fs::path> vImportFiles;
     for (const std::string& strFile : args.GetArgs("-loadblock")) {
         vImportFiles.push_back(strFile);
$ make -C src/ bitcoind
$ src/bitcoind
$ tail debug.log
2020-09-22T16:11:36Z Chancellor on brink of 8813:th bailout for banks. LogPrintf on brink of first disk fill for node.
2020-09-22T16:11:36Z Chancellor on brink of 8814:th bailout for banks. LogPrintf on brink of first disk fill for node.
2020-09-22T16:11:36Z Chancellor on brink of 8815:th bailout for banks. LogPrintf on brink of first disk fill for node.
2020-09-22T16:11:36Z Chancellor on brink of 8816:th bailout for banks. LogPrintf on brink of first disk fill for node.
2020-09-22T16:11:36Z Chancellor on brink of 8817:th bailout for banks. LogPrintf on brink of first disk fill for node.
2020-09-22T16:11:36Z Chancellor on brink of 8818:th bailout for banks. LogPrintf on brink of first disk fill for node.
2020-09-22T16:11:36Z Chancellor on brink of 8819:th bailout for banks. LogPrintf on brink of first disk fill for node.
2020-09-22T16:11:36Z Chancellor on brink of 8820:th bailout for banks. LogPrintf on brink of first disk fill for node.
2020-09-22T16:11:36Z Excessive logging detected from init.cpp:1238 (SimulateDiskFillingAttack): >1 MiB logged during the last hour. Suppressing logging to disk from this source location for up to one hour. Console logging unaffected. Last log entry: 2020-09-22T16:11:36Z Chancellor on brink of 8821:th bailout for banks. LogPrintf on brink of first disk fill for node.
2020-09-22T16:12:37Z Adding fixed seed nodes as DNS doesn't seem to be available.
$ ls -hl debug.log
–rw------- 1     1.1M Sep 22 16:12 debug.log
```