### PR TITLE
net: Add CNode::ConnectedThroughNetwork member function

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -539,6 +539,11 @@ void CNode::SetAddrLocal(const CService& addrLocalIn) {
     }
 }
 
+Network CNode::ConnectedThroughNetwork() const
+{
+    return IsInboundConn() && m_inbound_onion ? NET_ONION : addr.GetNetClass();
+}
+
 #undef X
 #define X(name) stats.name = name
 void CNode::copyStats(CNodeStats &stats, const std::vector<bool> &m_asmap)

--- a/src/net.h
+++ b/src/net.h
@@ -253,6 +253,7 @@ public:
             LOCK(cs_vAddedNodes);
             vAddedNodes = connOptions.m_added_nodes;
         }
+        m_onion_binds = connOptions.onion_binds;
     }
 
     CConnman(uint64_t seed0, uint64_t seed1, bool network_active = true);
@@ -585,6 +586,12 @@ private:
     std::atomic_bool m_try_another_outbound_peer;
 
     std::atomic<int64_t> m_next_send_inv_to_incoming{0};
+
+    /**
+     * A vector of -bind=<address>:<port>=onion arguments each of which is
+     * an address and port that are designated for incoming Tor connections.
+     */
+    std::vector<CService> m_onion_binds;
 
     friend struct CConnmanTest;
     friend struct ConnmanTestMsg;
@@ -1035,7 +1042,7 @@ public:
 
     std::set<uint256> orphan_work_set;
 
-    CNode(NodeId id, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn, SOCKET hSocketIn, const CAddress &addrIn, uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn, const CAddress &addrBindIn, const std::string &addrNameIn, ConnectionType conn_type_in);
+    CNode(NodeId id, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn, SOCKET hSocketIn, const CAddress &addrIn, uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn, const CAddress &addrBindIn, const std::string &addrNameIn, ConnectionType conn_type_in, bool inbound_onion = false);
     ~CNode();
     CNode(const CNode&) = delete;
     CNode& operator=(const CNode&) = delete;
@@ -1073,6 +1080,10 @@ private:
     // Our address, as reported by the peer
     CService addrLocal GUARDED_BY(cs_addrLocal);
     mutable RecursiveMutex cs_addrLocal;
+
+    //! Whether this peer connected via our Tor onion service.
+    const bool m_inbound_onion{false};
+
 public:
 
     NodeId GetId() const {

--- a/src/net.h
+++ b/src/net.h
@@ -961,6 +961,18 @@ public:
         assert(false);
     }
 
+    /**
+     * Get network the peer connected through.
+     *
+     * Returns Network::NET_ONION for *inbound* onion connections,
+     * and CNetAddr::GetNetClass() otherwise. The latter cannot be used directly
+     * because it doesn't detect the former, and it's not the responsibility of
+     * the CNetAddr class to know the actual network a peer is connected through.
+     *
+     * @return network the peer connected through.
+     */
+    Network ConnectedThroughNetwork() const;
+
 protected:
     mapMsgCmdSize mapSendBytesPerMsgCmd;
     mapMsgCmdSize mapRecvBytesPerMsgCmd GUARDED_BY(cs_vRecv);

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -629,7 +629,7 @@ uint32_t CNetAddr::GetLinkedIPv4() const
     assert(false);
 }
 
-uint32_t CNetAddr::GetNetClass() const
+Network CNetAddr::GetNetClass() const
 {
     // Make sure that if we return NET_IPV6, then IsIPv6() is true. The callers expect that.
 

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -182,7 +182,7 @@ class CNetAddr
         std::string ToStringIP() const;
         uint64_t GetHash() const;
         bool GetInAddr(struct in_addr* pipv4Addr) const;
-        uint32_t GetNetClass() const;
+        Network GetNetClass() const;
 
         //! For IPv4, mapped IPv4, SIIT translated IPv4, Teredo, 6to4 tunneled addresses, return the relevant IPv4 address as a uint32.
         uint32_t GetLinkedIPv4() const;

--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -46,7 +46,8 @@ void test_one_input(const std::vector<uint8_t>& buffer)
                fuzzed_data_provider.ConsumeIntegral<uint64_t>(),
                *address_bind,
                fuzzed_data_provider.ConsumeRandomLengthString(32),
-               fuzzed_data_provider.PickValueInArray({ConnectionType::INBOUND, ConnectionType::OUTBOUND_FULL_RELAY, ConnectionType::MANUAL, ConnectionType::FEELER, ConnectionType::BLOCK_RELAY, ConnectionType::ADDR_FETCH})};
+               fuzzed_data_provider.PickValueInArray({ConnectionType::INBOUND, ConnectionType::OUTBOUND_FULL_RELAY, ConnectionType::MANUAL, ConnectionType::FEELER, ConnectionType::BLOCK_RELAY, ConnectionType::ADDR_FETCH}),
+               fuzzed_data_provider.ConsumeBool()};
     while (fuzzed_data_provider.ConsumeBool()) {
         switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 11)) {
         case 0: {
@@ -148,4 +149,5 @@ void test_one_input(const std::vector<uint8_t>& buffer)
                                                         fuzzed_data_provider.PickValueInArray<NetPermissionFlags>({NetPermissionFlags::PF_NONE, NetPermissionFlags::PF_BLOOMFILTER, NetPermissionFlags::PF_RELAY, NetPermissionFlags::PF_FORCERELAY, NetPermissionFlags::PF_NOBAN, NetPermissionFlags::PF_MEMPOOL, NetPermissionFlags::PF_ISIMPLICIT, NetPermissionFlags::PF_ALL}) :
                                                         static_cast<NetPermissionFlags>(fuzzed_data_provider.ConsumeIntegral<uint32_t>());
     (void)node.HasPermission(net_permission_flags);
+    (void)node.ConnectedThroughNetwork();
 }

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -185,21 +185,60 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
     CAddress addr = CAddress(CService(ipv4Addr, 7777), NODE_NETWORK);
     std::string pszDest;
 
-    std::unique_ptr<CNode> pnode1 = MakeUnique<CNode>(id++, NODE_NETWORK, height, hSocket, addr, 0, 0, CAddress(), pszDest, ConnectionType::OUTBOUND_FULL_RELAY);
+    std::unique_ptr<CNode> pnode1 = MakeUnique<CNode>(
+        id++, NODE_NETWORK, height, hSocket, addr,
+        /* nKeyedNetGroupIn = */ 0,
+        /* nLocalHostNonceIn = */ 0,
+        CAddress(), pszDest, ConnectionType::OUTBOUND_FULL_RELAY);
     BOOST_CHECK(pnode1->IsFullOutboundConn() == true);
     BOOST_CHECK(pnode1->IsManualConn() == false);
     BOOST_CHECK(pnode1->IsBlockOnlyConn() == false);
     BOOST_CHECK(pnode1->IsFeelerConn() == false);
     BOOST_CHECK(pnode1->IsAddrFetchConn() == false);
     BOOST_CHECK(pnode1->IsInboundConn() == false);
+    BOOST_CHECK_EQUAL(pnode1->ConnectedThroughNetwork(), Network::NET_IPV4);
 
-    std::unique_ptr<CNode> pnode2 = MakeUnique<CNode>(id++, NODE_NETWORK, height, hSocket, addr, 1, 1, CAddress(), pszDest, ConnectionType::INBOUND);
+    std::unique_ptr<CNode> pnode2 = MakeUnique<CNode>(
+        id++, NODE_NETWORK, height, hSocket, addr,
+        /* nKeyedNetGroupIn = */ 1,
+        /* nLocalHostNonceIn = */ 1,
+        CAddress(), pszDest, ConnectionType::INBOUND,
+        /* inbound_onion = */ false);
     BOOST_CHECK(pnode2->IsFullOutboundConn() == false);
     BOOST_CHECK(pnode2->IsManualConn() == false);
     BOOST_CHECK(pnode2->IsBlockOnlyConn() == false);
     BOOST_CHECK(pnode2->IsFeelerConn() == false);
     BOOST_CHECK(pnode2->IsAddrFetchConn() == false);
     BOOST_CHECK(pnode2->IsInboundConn() == true);
+    BOOST_CHECK_EQUAL(pnode2->ConnectedThroughNetwork(), Network::NET_IPV4);
+
+    std::unique_ptr<CNode> pnode3 = MakeUnique<CNode>(
+        id++, NODE_NETWORK, height, hSocket, addr,
+        /* nKeyedNetGroupIn = */ 0,
+        /* nLocalHostNonceIn = */ 0,
+        CAddress(), pszDest, ConnectionType::OUTBOUND_FULL_RELAY,
+        /* inbound_onion = */ true);
+    BOOST_CHECK(pnode3->IsFullOutboundConn() == true);
+    BOOST_CHECK(pnode3->IsManualConn() == false);
+    BOOST_CHECK(pnode3->IsBlockOnlyConn() == false);
+    BOOST_CHECK(pnode3->IsFeelerConn() == false);
+    BOOST_CHECK(pnode3->IsAddrFetchConn() == false);
+    BOOST_CHECK(pnode3->IsInboundConn() == false);
+    BOOST_CHECK_EQUAL(pnode3->ConnectedThroughNetwork(), Network::NET_IPV4);
+
+    std::unique_ptr<CNode> pnode4 = MakeUnique<CNode>(
+        id++, NODE_NETWORK, height, hSocket, addr,
+        /* nKeyedNetGroupIn = */ 1,
+        /* nLocalHostNonceIn = */ 1,
+        CAddress(), pszDest, ConnectionType::INBOUND,
+        /* inbound_onion = */ true);
+    BOOST_CHECK(pnode4->IsFullOutboundConn() == false);
+    BOOST_CHECK(pnode4->IsManualConn() == false);
+    BOOST_CHECK(pnode4->IsBlockOnlyConn() == false);
+    BOOST_CHECK(pnode4->IsFeelerConn() == false);
+    BOOST_CHECK(pnode4->IsAddrFetchConn() == false);
+    BOOST_CHECK(pnode4->IsInboundConn() == true);
+    BOOST_CHECK_EQUAL(pnode4->ConnectedThroughNetwork(), Network::NET_ONION);
 }
 
 BOOST_AUTO_TEST_CASE(cnetaddr_basic)


### PR DESCRIPTION
This PR:
- adds `CNode::ConnectedThroughNetwork` member function
- is based on #19991, and only last two commits belong to it
- is required for https://github.com/bitcoin-core/gui/pull/86 and #20002