### PR TITLE
net: Use proxy server 127.0.0.1 if -proxy is specified without arguments (instead of continuing without proxy server)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -810,6 +810,12 @@ void InitParameterInteraction(ArgsManager& args)
         // to protect privacy, do not discover addresses by default
         if (args.SoftSetBoolArg("-discover", false))
             LogPrintf("%s: parameter interaction: -proxy set -> setting -discover=0\n", __func__);
+        // If -proxy is specified without any proxy server argument, default to 127.0.0.1 (DEFAULT_PROXY_HOST)
+        // instead of continuing without a proxy server.
+        if (args.GetArg("-proxy", "").empty()) {
+            args.ForceSetArg("-proxy", DEFAULT_PROXY_HOST);
+            LogPrintf("%s: parameter interaction: -proxy set without argument -> setting -proxy=%s\n", __func__, DEFAULT_PROXY_HOST);
+        }
     }
 
     if (!args.GetBoolArg("-listen", DEFAULT_LISTEN)) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1417,7 +1417,7 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
     SetReachable(NET_ONION, false);
     if (proxyArg != "" && proxyArg != "0") {
         CService proxyAddr;
-        if (!Lookup(proxyArg, proxyAddr, 9050, fNameLookup)) {
+        if (!Lookup(proxyArg, proxyAddr, DEFAULT_PROXY_PORT, fNameLookup)) {
             return InitError(strprintf(_("Invalid -proxy address or hostname: '%s'"), proxyArg));
         }
 
@@ -1441,7 +1441,7 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
             SetReachable(NET_ONION, false);
         } else {
             CService onionProxy;
-            if (!Lookup(onionArg, onionProxy, 9050, fNameLookup)) {
+            if (!Lookup(onionArg, onionProxy, DEFAULT_PROXY_PORT, fNameLookup)) {
                 return InitError(strprintf(_("Invalid -onion address or hostname: '%s'"), onionArg));
             }
             proxyType addrOnion = proxyType(onionProxy, proxyRandomize);

--- a/src/net.h
+++ b/src/net.h
@@ -88,6 +88,9 @@ static const bool DEFAULT_FORCEDNSSEED = false;
 static const size_t DEFAULT_MAXRECEIVEBUFFER = 5 * 1000;
 static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;
 
+static const char* DEFAULT_PROXY_HOST = "127.0.0.1";
+static constexpr uint16_t DEFAULT_PROXY_PORT = 9050;
+
 typedef int64_t NodeId;
 
 struct AddedNodeInfo

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -377,7 +377,7 @@ QValidator::State ProxyAddressValidator::validate(QString &input, int &pos) cons
 {
     Q_UNUSED(pos);
     // Validate the proxy
-    CService serv(LookupNumeric(input.toStdString(), DEFAULT_GUI_PROXY_PORT));
+    CService serv(LookupNumeric(input.toStdString(), DEFAULT_PROXY_PORT));
     proxyType addrProxy = proxyType(serv, true);
     if (addrProxy.IsValid())
         return QValidator::Acceptable;

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -23,8 +23,6 @@
 #include <QSettings>
 #include <QStringList>
 
-const char *DEFAULT_GUI_PROXY_HOST = "127.0.0.1";
-
 static const QString GetDefaultProxyAddress();
 
 OptionsModel::OptionsModel(QObject *parent, bool resetSettings) :
@@ -213,7 +211,7 @@ struct ProxySetting {
 
 static ProxySetting GetProxySetting(QSettings &settings, const QString &name)
 {
-    static const ProxySetting default_val = {false, DEFAULT_GUI_PROXY_HOST, QString("%1").arg(DEFAULT_GUI_PROXY_PORT)};
+    static const ProxySetting default_val = {false, DEFAULT_PROXY_HOST, QString("%1").arg(DEFAULT_PROXY_PORT)};
     // Handle the case that the setting is not set at all
     if (!settings.contains(name)) {
         return default_val;
@@ -234,7 +232,7 @@ static void SetProxySetting(QSettings &settings, const QString &name, const Prox
 
 static const QString GetDefaultProxyAddress()
 {
-    return QString("%1:%2").arg(DEFAULT_GUI_PROXY_HOST).arg(DEFAULT_GUI_PROXY_PORT);
+    return QString("%1:%2").arg(DEFAULT_PROXY_HOST).arg(DEFAULT_PROXY_PORT);
 }
 
 void OptionsModel::SetPruneEnabled(bool prune, bool force)

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -17,9 +17,6 @@ namespace interfaces {
 class Node;
 }
 
-extern const char *DEFAULT_GUI_PROXY_HOST;
-static constexpr uint16_t DEFAULT_GUI_PROXY_PORT = 9050;
-
 /**
  * Convert configured prune target MiB to displayed GB. Round up to avoid underestimating max disk usage.
  */


### PR DESCRIPTION
Use proxy server `127.0.0.1` if `-proxy` is specified without arguments (instead of continuing without proxy server).

Continuing without a proxy server when the end-user has specified `-proxy` may result in accidental loss of privacy. (The end-user might think he/she is using a proxy when he/she is not.)

Before this patch:

```
$ src/bitcoind -proxy
…
2020-09-23T00:24:33Z InitParameterInteraction: parameter interaction: -proxy set -> setting -listen=0
2020-09-23T00:24:33Z InitParameterInteraction: parameter interaction: -proxy set -> setting -upnp=0
2020-09-23T00:24:33Z InitParameterInteraction: parameter interaction: -proxy set -> setting -discover=0
2020-09-23T00:24:33Z InitParameterInteraction: parameter interaction: -listen=0 -> setting -listenonion=0
…
2020-09-23T00:24:33Z init message: Starting network threads...
```

`bitcoind` is now running *without* a proxy server (`GetProxy(…, …) == false`, `HaveNameProxy() == false`, etc.).

Note that the "-proxy set" log messages above which the end-user might interpret as "good, my traffic is now routed via the proxy".

After this patch:

```
$ src/bitcoind -proxy
…
2020-09-23T00:24:33Z InitParameterInteraction: parameter interaction: -proxy set -> setting -listen=0
2020-09-23T00:24:33Z InitParameterInteraction: parameter interaction: -proxy set -> setting -upnp=0
2020-09-23T00:24:33Z InitParameterInteraction: parameter interaction: -proxy set -> setting -discover=0
2020-09-23T00:24:33Z InitParameterInteraction: parameter interaction: -proxy set without argument -> setting -proxy=127.0.0.1
2020-09-23T00:24:33Z InitParameterInteraction: parameter interaction: -listen=0 -> setting -listenonion=0
…
2020-09-23T00:24:33Z init message: Starting network threads...
```

`bitcoind` is now running *with* a proxy server (`GetProxy(…, …) == true`, `HaveNameProxy() == true`, etc.).