### PR TITLE
Fix misleading error message: Clean stack rule

### DIFF
--- a/src/script/script_error.cpp
+++ b/src/script/script_error.cpp
@@ -76,7 +76,7 @@ std::string ScriptErrorString(const ScriptError serror)
         case SCRIPT_ERR_PUBKEYTYPE:
             return "Public key is neither compressed or uncompressed";
         case SCRIPT_ERR_CLEANSTACK:
-            return "Extra items left on stack after execution";
+            return "Stack size must be exactly one after execution";
         case SCRIPT_ERR_WITNESS_PROGRAM_WRONG_LENGTH:
             return "Witness program has incorrect length";
         case SCRIPT_ERR_WITNESS_PROGRAM_WITNESS_EMPTY:


### PR DESCRIPTION
Error messages in clean stack is misleading as it lets the user believe that there are extra
elements on the stack which is incorrect if the stack is empty.

Let me know if this requires additional test. 