### PR TITLE
rpc: normalize parameter names

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -8,6 +8,7 @@
 
 #include <set>
 #include <stdint.h>
+#include <rpc/util.h>
 
 class CRPCConvertParam
 {
@@ -212,7 +213,7 @@ CRPCConvertTable::CRPCConvertTable()
         members.insert(std::make_pair(vRPCConvertParams[i].methodName,
                                       vRPCConvertParams[i].paramIdx));
         membersByName.insert(std::make_pair(vRPCConvertParams[i].methodName,
-                                            vRPCConvertParams[i].paramName));
+                                            NormalizedParameterName(vRPCConvertParams[i].paramName)));
     }
 }
 
@@ -259,7 +260,7 @@ UniValue RPCConvertNamedValues(const std::string &strMethod, const std::vector<s
             throw(std::runtime_error("No '=' in named argument '"+s+"', this needs to be present for every argument (even if it is empty)"));
         }
 
-        std::string name = s.substr(0, pos);
+        std::string name = NormalizedParameterName(s.substr(0, pos));
         std::string value = s.substr(pos+1);
 
         if (!rpcCvtTable.convert(strMethod, name)) {

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -396,13 +396,13 @@ static inline JSONRPCRequest transformNamedArguments(const JSONRPCRequest& in, c
     const std::vector<UniValue>& values = in.params.getValues();
     std::unordered_map<std::string, const UniValue*> argsIn;
     for (size_t i=0; i<keys.size(); ++i) {
-        argsIn[keys[i]] = &values[i];
+        argsIn[NormalizedParameterName(keys[i])] = &values[i];
     }
     // Process expected parameters.
     int hole = 0;
     for (const std::string &argNamePattern: argNames) {
         std::vector<std::string> vargNames;
-        boost::algorithm::split(vargNames, argNamePattern, boost::algorithm::is_any_of("|"));
+        boost::algorithm::split(vargNames, NormalizedParameterName(argNamePattern), boost::algorithm::is_any_of("|"));
         auto fr = argsIn.end();
         for (const std::string & argName : vargNames) {
             fr = argsIn.find(argName);

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -402,10 +402,10 @@ static inline JSONRPCRequest transformNamedArguments(const JSONRPCRequest& in, c
     int hole = 0;
     for (const std::string &argNamePattern: argNames) {
         std::vector<std::string> vargNames;
-        boost::algorithm::split(vargNames, NormalizedParameterName(argNamePattern), boost::algorithm::is_any_of("|"));
+        boost::algorithm::split(vargNames, argNamePattern, boost::algorithm::is_any_of("|"));
         auto fr = argsIn.end();
         for (const std::string & argName : vargNames) {
-            fr = argsIn.find(argName);
+            fr = argsIn.find(NormalizedParameterName(argName));
             if (fr != argsIn.end()) {
                 break;
             }

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -20,6 +20,29 @@
 const std::string UNIX_EPOCH_TIME = "UNIX epoch time";
 const std::string EXAMPLE_ADDRESS[2] = {"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl", "bc1q02ad21edsxd23d32dfgqqsz4vv4nmtfzuklhy3"};
 
+std::string NormalizedParameterName(const std::string& key)
+{
+    std::string result = ToLower(key);
+    std::string::size_type pos = 0;
+    while (std::string::npos != (pos = result.find("_", pos))) {
+        result.erase(pos, 1);
+    }
+    return result;
+}
+
+UniValue NormalizedObject(const UniValue& univalue)
+{
+    if (!univalue.isObject()) return univalue;
+    UniValue r(UniValue::VOBJ);
+    const auto& keys = univalue.getKeys();
+    const auto& values = univalue.getValues();
+    size_t sz = keys.size();
+    for (size_t i = 0; i < sz; ++i) {
+        r.pushKV(NormalizedParameterName(keys[i]), values[i]);
+    }
+    return r;
+}
+
 void RPCTypeCheck(const UniValue& params,
                   const std::list<UniValueType>& typesExpected,
                   bool fAllowNull)

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -20,16 +20,6 @@
 const std::string UNIX_EPOCH_TIME = "UNIX epoch time";
 const std::string EXAMPLE_ADDRESS[2] = {"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl", "bc1q02ad21edsxd23d32dfgqqsz4vv4nmtfzuklhy3"};
 
-std::string NormalizedParameterName(const std::string& key)
-{
-    std::string result = ToLower(key);
-    std::string::size_type pos = 0;
-    while (std::string::npos != (pos = result.find("_", pos))) {
-        result.erase(pos, 1);
-    }
-    return result;
-}
-
 UniValue NormalizedObject(const UniValue& univalue)
 {
     if (!univalue.isObject()) return univalue;

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -49,6 +49,9 @@ struct UniValueType {
     UniValue::VType type;
 };
 
+std::string NormalizedParameterName(const std::string& key);
+UniValue NormalizedObject(const UniValue& univalue);
+
 /**
  * Type-check arguments; throws JSONRPCError if wrong type given. Does not check that
  * the right number of arguments are passed, just that any passed are the correct type.

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -51,6 +51,18 @@ struct UniValueType {
 
 std::string NormalizedParameterName(const std::string& key);
 UniValue NormalizedObject(const UniValue& univalue);
+/**
+ * This is a temporary structure meant to allow a gradual transition to normalized objects.
+ *
+ * It takes a UniValue dictionary (object) in normalized form, and will normalize queries coming in.
+ * I.e. pre-normalization code will work exactly the same with both normalized and non-normalized objects
+ * if using one of these.
+ */
+struct NormalizedUniValue: public UniValue {
+    NormalizedUniValue(const UniValue& univalue) : UniValue(NormalizedObject(univalue)) {}
+    const UniValue& operator[](const std::string& key) const { return UniValue::operator[](NormalizedParameterName(key)); }
+    bool exists(const std::string& key) const { return UniValue::exists(NormalizedParameterName(key)); }
+};
 
 /**
  * Type-check arguments; throws JSONRPCError if wrong type given. Does not check that

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -49,7 +49,16 @@ struct UniValueType {
     UniValue::VType type;
 };
 
-std::string NormalizedParameterName(const std::string& key);
+inline std::string NormalizedParameterName(const std::string& key)
+{
+    std::string result = ToLower(key);
+    std::string::size_type pos = 0;
+    while (std::string::npos != (pos = result.find("_", pos))) {
+        result.erase(pos, 1);
+    }
+    return result;
+}
+
 UniValue NormalizedObject(const UniValue& univalue);
 /**
  * This is a temporary structure meant to allow a gradual transition to normalized objects.

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3008,7 +3008,7 @@ static RPCHelpMan listunspent()
     };
 }
 
-void FundTransaction(CWallet* const pwallet, CMutableTransaction& tx, CAmount& fee_out, int& change_position, UniValue options, CCoinControl& coinControl)
+void FundTransaction(CWallet* const pwallet, CMutableTransaction& tx, CAmount& fee_out, int& change_position, NormalizedUniValue options, CCoinControl& coinControl)
 {
     // Make sure the results are valid at least up to the most recent block
     // the user could have gotten from another RPC command prior to now
@@ -3028,26 +3028,21 @@ void FundTransaction(CWallet* const pwallet, CMutableTransaction& tx, CAmount& f
         RPCTypeCheckArgument(options, UniValue::VOBJ);
         RPCTypeCheckObj(options,
             {
-                {"add_inputs", UniValueType(UniValue::VBOOL)},
-                {"add_to_wallet", UniValueType(UniValue::VBOOL)},
-                {"changeAddress", UniValueType(UniValue::VSTR)},
-                {"change_address", UniValueType(UniValue::VSTR)},
-                {"changePosition", UniValueType(UniValue::VNUM)},
-                {"change_position", UniValueType(UniValue::VNUM)},
-                {"change_type", UniValueType(UniValue::VSTR)},
-                {"includeWatching", UniValueType(UniValue::VBOOL)},
-                {"include_watching", UniValueType(UniValue::VBOOL)},
+                {"addinputs", UniValueType(UniValue::VBOOL)},
+                {"addtowallet", UniValueType(UniValue::VBOOL)},
+                {"changeaddress", UniValueType(UniValue::VSTR)},
+                {"changeposition", UniValueType(UniValue::VNUM)},
+                {"changetype", UniValueType(UniValue::VSTR)},
+                {"includewatching", UniValueType(UniValue::VBOOL)},
                 {"inputs", UniValueType(UniValue::VARR)},
-                {"lockUnspents", UniValueType(UniValue::VBOOL)},
-                {"lock_unspents", UniValueType(UniValue::VBOOL)},
+                {"lockunspents", UniValueType(UniValue::VBOOL)},
                 {"locktime", UniValueType(UniValue::VNUM)},
-                {"feeRate", UniValueType()}, // will be checked below
+                {"feerate", UniValueType()}, // will be checked below
                 {"psbt", UniValueType(UniValue::VBOOL)},
-                {"subtractFeeFromOutputs", UniValueType(UniValue::VARR)},
-                {"subtract_fee_from_outputs", UniValueType(UniValue::VARR)},
+                {"subtractfeefromoutputs", UniValueType(UniValue::VARR)},
                 {"replaceable", UniValueType(UniValue::VBOOL)},
-                {"conf_target", UniValueType(UniValue::VNUM)},
-                {"estimate_mode", UniValueType(UniValue::VSTR)},
+                {"conftarget", UniValueType(UniValue::VNUM)},
+                {"estimatemode", UniValueType(UniValue::VSTR)},
             },
             true, true);
 

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -211,9 +211,6 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         assert_raises_rpc_error(-3, "Unexpected key foo", self.nodes[2].fundrawtransaction, rawtx, {'foo':'bar'})
 
-        # reserveChangeKey was deprecated and is now removed
-        assert_raises_rpc_error(-3, "Unexpected key reserveChangeKey", lambda: self.nodes[2].fundrawtransaction(hexstring=rawtx, options={'reserveChangeKey': True}))
-
     def test_invalid_change_address(self):
         self.log.info("Test fundrawtxn with an invalid change address")
         utx = get_unspent(self.nodes[2].listunspent(), 5)


### PR DESCRIPTION
This PR initiates the transition to using normalized parameter names in objects in RPC commands.

Because this transition all at once would be huge, the PR also includes a during-transition temporary structure which will make it transparent to the user whether the object has been normalized or not.

There is also one conversion in here, for the send RPC, to show what conversion would entail.

This is an alternative to #19957. (A much better alternative, IMO.)