### PR TITLE
doc: Added default signet config for linearize script

### DIFF
--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -13,6 +13,9 @@ port=8332
 #regtest default
 #port=18443
 
+#signet default
+#port=38332
+
 # bootstrap.dat hashlist settings (linearize-hashes)
 max_height=313000
 
@@ -32,6 +35,11 @@ input=/home/example/.bitcoin/blocks
 #netmagic=fabfb5da
 #genesis=0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206
 #input=/home/example/.bitcoin/regtest/blocks
+
+# signet
+#netmagic=0a03cf40
+#genesis=00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6
+#input=/home/example/.bitcoin/signet/blocks
 
 # "output" option causes blockchain files to be written to the given location,
 # with "output_file" ignored. If not used, "output_file" is used instead.


### PR DESCRIPTION
Updated the example-linearize.cfg file to include support for the signet chain network config which is used by the ./linearize-data.py

Problem:
Without the signet magic, genesis hash and path config, the linearize-data.py script cannot generate a bootstrap.dat file.

Example:

```
./linearize-data.py ./linearize.cfg
Read 4776 hashes
Genesis block not found in hashlist
```

Solution:

Added netmagic, genesis and input example parameters to file. Netmagic in terms of signet is derived from the signet-challenge and not static as with other networks. The provided signet magic is based on the default public signet. 

Resolution

```
./linearize-hashes.py ./linearize.cfg > ./hashlist.txt
./linearize-data.py ./linearize.cfg
$ ./linearize-data.py ./linearize.cfg
Read 4776 hashes
Input file /Users/gr0kchain/.bitcoin/signet/blocks/blk00000.dat
Output file /Users/gr0kchain/Downloads/bootstrap.dat
1000 blocks scanned, 1000 blocks written (of 4776, 20.9% complete)
2000 blocks scanned, 2000 blocks written (of 4776, 41.9% complete)
3011 blocks scanned, 3000 blocks written (of 4776, 62.8% complete)
4010 blocks scanned, 4000 blocks written (of 4776, 83.8% complete)
Done (4776 blocks written)
```