### PR TITLE
rpc: Add RPCContext

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -100,11 +100,11 @@ static RPCHelpMan getnetworkhashps()
                     HelpExampleCli("getnetworkhashps", "")
             + HelpExampleRpc("getnetworkhashps", "")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [](const RPCContext& ctx) -> UniValue
 {
-    ChainstateManager& chainman = EnsureAnyChainman(request.context);
+    ChainstateManager& chainman = EnsureAnyChainman(ctx.request.context);
     LOCK(cs_main);
-    return GetNetworkHashPS(!request.params[0].isNull() ? request.params[0].get_int() : 120, !request.params[1].isNull() ? request.params[1].get_int() : -1, chainman.ActiveChain());
+    return GetNetworkHashPS(ctx.param<int>(0), ctx.param<int>(1), chainman.ActiveChain());
 },
     };
 }


### PR DESCRIPTION
This change allows to do
```cpp
[&](const RPCContext& ctx) -> UniValue
```
instead of
```cpp
[&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
```
So `RPCContext` ties `RPCHelpMan` and `JSONRPCRequest`. Then `ctx` is used to get actual parameter values. For instance, before:
```cpp
int timeout = 0;
if (!request.params[0].isNull())	
    timeout = request.params[0].get_int();
```
and now
```cpp
int timeout = ctx.param<int>(0);
```
Not that the default value defined in the RPC spec is used.

It is also possible to iterate an array parameter:
```cpp
    std::set<std::string> stats;
    ctx.param(1).forEach([&](const UniValue& stat) {
        stats.insert(stat.get_str());
    });
```
Or even do custom parameter handling:
```cpp
    int verbosity = ctx.param(1, [](const UniValue& param) -> int {
        if (param.isNull()) return 1;
        if (param.isNum()) return param.get_int();
        return param.get_bool() ? 1 : 0;
    });
```
