### PR TITLE
depends: Properly pass $PATH to configure and pin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,6 +13,7 @@ SUBDIRS += doc/man
 endif
 .PHONY: deploy FORCE
 
+export PATH
 export PYTHONPATH
 
 if BUILD_BITCOIN_LIBS

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,7 +33,7 @@ space := $(empty) $(empty)
 
 OSX_APP=Bitcoin-Qt.app
 OSX_VOLNAME = $(subst $(space),-,$(PACKAGE_NAME))
-OSX_DMG = $(OSX_VOLNAME).dmg
+OSX_DMG = $(PACKAGE)-$(PACKAGE_VERSION).dmg
 OSX_BACKGROUND_SVG=background.svg
 OSX_BACKGROUND_IMAGE=background.tiff
 OSX_BACKGROUND_IMAGE_DPIS=36 72
@@ -138,8 +138,11 @@ $(APP_DIST_DIR)/Applications:
 
 $(APP_DIST_EXTRAS): $(APP_DIST_DIR)/$(OSX_APP)/Contents/MacOS/Bitcoin-Qt
 
-$(OSX_DMG): $(APP_DIST_EXTRAS)
+$(OSX_VOLNAME).iso: $(APP_DIST_EXTRAS)
 	$(GENISOIMAGE) -no-cache-inodes -D -l -probe -V "$(OSX_VOLNAME)" -no-pad -r -dir-mode 0755 -apple -o $@ dist
+
+$(OSX_DMG): $(OSX_VOLNAME).iso
+	$(DMG) dmg "$<" "$@"
 
 dpi%.$(OSX_BACKGROUND_IMAGE): contrib/macdeploy/$(OSX_BACKGROUND_SVG)
 	sed 's/PACKAGE_NAME/$(PACKAGE_NAME)/' < "$<" | $(RSVG_CONVERT) -f png -d $* -p $* | $(IMAGEMAGICK_CONVERT) - $@

--- a/configure.ac
+++ b/configure.ac
@@ -721,6 +721,7 @@ case $host in
            AC_PATH_TOOL([INSTALLNAMETOOL], [install_name_tool], install_name_tool)
            AC_PATH_TOOL([OTOOL], [otool], otool)
            AC_PATH_PROGS([GENISOIMAGE], [genisoimage mkisofs],genisoimage)
+           AC_PATH_PROGS([DMG], [dmg], dmg)
            AC_PATH_PROGS([RSVG_CONVERT], [rsvg-convert rsvg],rsvg-convert)
            AC_PATH_PROGS([IMAGEMAGICK_CONVERT], [convert],convert)
            AC_PATH_PROGS([TIFFCP], [tiffcp],tiffcp)

--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,59 @@ AC_CONFIG_HEADERS([src/config/bitcoin-config.h])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([build-aux/m4])
 
+# BITCOIN_ADD_VAR_HELP(VARNAME, DOCUMENTATION)
+# ----------------------------------
+#
+# Document VARNAME in `configure --help' (but only once). This is just like
+# AC_ARG_VAR, but we do NOT register VARNAME as a precious variable, rather we
+# just add the documentation entry.
+AC_DEFUN([BITCOIN_ADD_VAR_HELP],
+[m4_divert_once([HELP_VAR], [[
+Some influential environment variables:]])dnl
+m4_divert_once([HELP_VAR_END], [[
+Use these variables to override the choices made by `configure' or to help
+it to find libraries and programs with nonstandard names/locations.]])dnl
+m4_expand_once([m4_divert_text([HELP_VAR],
+                               [AS_HELP_STRING([$1], [$2], [              ])])],
+               [$0($1)])dnl
+])# BITCOIN_ADD_VAR_HELP
+
+BITCOIN_ADD_VAR_HELP(PATH_TEMPLATE, [snippet to expand to form PATH, defaults to
+'$PATH' if not set, or '${depends_path_fragment}${PATH_SEPARATOR}${PATH}' if a
+depends-generated CONFIG_SITE is provided])
+
+AS_IF([ test "x${PATH_TEMPLATE+set}" != "xset" ],
+      [ dnl When PATH_TEMPLATE is not set, default to just $PATH
+        PATH_TEMPLATE='${PATH}'
+        AS_IF([ test "x${depends_path_fragment+set}" = "xset" ],
+              [ dnl When configuring for depends, be sure to prepend depends' PATH fragment
+                PATH_TEMPLATE='${depends_path_fragment}${PATH_SEPARATOR}'"$PATH_TEMPLATE" ])])
+
+dnl Log to both config.log and the console, à la AC_ECHO_CHECKING.
+dnl
+dnl Note that no trailing newline is output to the console, it is up to the
+dnl result part of this log message to output the newline. This is exactly what
+dnl AC_ECHO_CHECKING does as well. See comments below.
+_AS_ECHO_LOG([expanding PATH_TEMPLATE to form PATH])
+_AS_ECHO_N([expanding PATH_TEMPLATE to form PATH... ])
+
+dnl The following line evaluates $PATH_TEMPLATE in a $(...) subshell where:
+dnl
+dnl   1. stderr is redirected to config.log
+dnl   2. The '-u' shell option is set, such that unset parameters will error
+dnl      immediately
+maybe_PATH="$(exec 2>&AS_MESSAGE_LOG_FD && set -u && eval echo \"$PATH_TEMPLATE\")"
+
+AS_IF([ test "x${maybe_PATH:-empty}" = "xempty" ],
+      [ dnl Dummy echo to output a newline
+        AS_ECHO([]);
+        dnl When maybe_PATH is empty, the 'set -u' failure was most likely triggered
+        AC_MSG_FAILURE([failed to expand PATH_TEMPLATE: '$PATH_TEMPLATE']) ],
+      [ dnl Pin $PATH by creating an output variable for it with the value of
+        AC_SUBST(PATH, "$maybe_PATH")
+        dnl AC_MSG_RESULT outputs a newline
+        AC_MSG_RESULT([$PATH]) ])
+
 m4_ifndef([PKG_PROG_PKG_CONFIG], [AC_MSG_ERROR([PKG_PROG_PKG_CONFIG macro not found. Please install pkg-config and re-run autogen.sh])])
 PKG_PROG_PKG_CONFIG
 if test "x$PKG_CONFIG" = x; then

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -114,10 +114,8 @@ script: |
   mkdir -p "$(dirname "$GIT_ARCHIVE")"
   git archive --prefix="${DISTNAME}/" --output="$GIT_ARCHIVE" HEAD
 
-  ORIGPATH="$PATH"
   # Extract the git archive into a dir for each host and build
   for i in ${HOSTS}; do
-    export PATH=${BASEPREFIX}/${i}/native/bin:${ORIGPATH}
     if [ "${i}" = "riscv64-linux-gnu" ]; then
       # Workaround for https://bugs.launchpad.net/ubuntu/+source/gcc-8-cross-ports/+bug/1853740
       # TODO: remove this when no longer needed

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -130,7 +130,15 @@ script: |
     tar --strip-components=1 -xf "${GIT_ARCHIVE}"
 
     ./autogen.sh
-    CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}" LDFLAGS="${HOST_LDFLAGS}"
+
+    # This violation is intentional: PATH_TEMPLATE will be expanded/evaluated in
+    # ./configure's environment to fill in the value of $depends_path_fragment,
+    # see PATH_TEMPLATE's entry in `./configure --help' for more details.
+    #
+    # shellcheck disable=SC2016
+    PATH_TEMPLATE="$WRAP_DIR"':${depends_path_fragment}:'"$PATH_orig"
+
+    CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}" LDFLAGS="${HOST_LDFLAGS}" PATH_TEMPLATE="$PATH_TEMPLATE"
     make ${MAKEOPTS}
     make ${MAKEOPTS} -C src check-security
     make ${MAKEOPTS} -C src check-symbols

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -38,7 +38,7 @@ script: |
 
   WRAP_DIR=$HOME/wrapped
   HOSTS="x86_64-apple-darwin16"
-  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests GENISOIMAGE=$WRAP_DIR/genisoimage"
+  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests"
   FAKETIME_HOST_PROGS=""
   FAKETIME_PROGS="ar ranlib date dmg genisoimage"
 
@@ -122,7 +122,15 @@ script: |
     tar --strip-components=1 -xf "${GIT_ARCHIVE}"
 
     ./autogen.sh
-    CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS}
+
+    # This violation is intentional: PATH_TEMPLATE will be expanded/evaluated in
+    # ./configure's environment to fill in the value of $depends_path_fragment,
+    # see PATH_TEMPLATE's entry in `./configure --help' for more details.
+    #
+    # shellcheck disable=SC2016
+    PATH_TEMPLATE="$WRAP_DIR"':${depends_path_fragment}:'"$PATH_orig"
+
+    CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} PATH_TEMPLATE="$PATH_TEMPLATE"
     make ${MAKEOPTS}
     make ${MAKEOPTS} -C src check-security
     make ${MAKEOPTS} -C src check-symbols

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -113,10 +113,8 @@ script: |
   mkdir -p "$(dirname "$GIT_ARCHIVE")"
   git archive --prefix="${DISTNAME}/" --output="$GIT_ARCHIVE" HEAD
 
-  ORIGPATH="$PATH"
   # Extract the git archive into a dir for each host and build
   for i in ${HOSTS}; do
-    export PATH=${BASEPREFIX}/${i}/native/bin:${ORIGPATH}
     mkdir -p distsrc-${i}
     cd distsrc-${i}
     INSTALLPATH="${PWD}/installed/${DISTNAME}"

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -138,7 +138,6 @@ script: |
 
     make osx_volname
     make deploydir
-    OSX_VOLNAME="$(cat osx_volname)"
     mkdir -p unsigned-app-${i}
     cp osx_volname unsigned-app-${i}/
     cp contrib/macdeploy/detached-sig-apply.sh unsigned-app-${i}
@@ -151,8 +150,7 @@ script: |
     find . | sort | tar --mtime="$REFERENCE_DATETIME" --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-osx-unsigned.tar.gz
     popd
 
-    make deploy
-    ${WRAP_DIR}/dmg dmg "${OSX_VOLNAME}.dmg" ${OUTDIR}/${DISTNAME}-osx-unsigned.dmg
+    make deploy OSX_DMG="${OUTDIR}/${DISTNAME}-osx-unsigned.dmg"
 
     cd installed
     find . -name "lib*.la" -delete

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -118,10 +118,8 @@ script: |
   mkdir -p "$(dirname "$GIT_ARCHIVE")"
   git archive --prefix="${DISTNAME}/" --output="$GIT_ARCHIVE" HEAD
 
-  ORIGPATH="$PATH"
   # Extract the git archive into a dir for each host and build
   for i in ${HOSTS}; do
-    export PATH=${BASEPREFIX}/${i}/native/bin:${ORIGPATH}
     mkdir -p distsrc-${i}
     cd distsrc-${i}
     INSTALLPATH="${PWD}/installed/${DISTNAME}"

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -127,7 +127,15 @@ script: |
     tar --strip-components=1 -xf "${GIT_ARCHIVE}"
 
     ./autogen.sh
-    CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}"
+
+    # This violation is intentional: PATH_TEMPLATE will be expanded/evaluated in
+    # ./configure's environment to fill in the value of $depends_path_fragment,
+    # see PATH_TEMPLATE's entry in `./configure --help' for more details.
+    #
+    # shellcheck disable=SC2016
+    PATH_TEMPLATE="$WRAP_DIR"':${depends_path_fragment}:'"$PATH_orig"
+
+    CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}" PATH_TEMPLATE="$PATH_TEMPLATE"
     make ${MAKEOPTS}
     make ${MAKEOPTS} -C src check-security
     make ${MAKEOPTS} -C src check-symbols

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -187,8 +187,6 @@ case "$HOST" in
     *mingw*)  HOST_LDFLAGS="-Wl,--no-insert-timestamp" ;;
 esac
 
-# Make $HOST-specific native binaries from depends available in $PATH
-export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
 (
     cd "$DISTSRC"
 

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -163,12 +163,6 @@ $(host_arch)_$(host_os)_native_toolchain?=$($(host_os)_native_toolchain)
 
 include funcs.mk
 
-binutils_path=$($($(host_arch)_$(host_os)_native_binutils)_prefixbin)
-ifeq ($(strip $(FORCE_USE_SYSTEM_CLANG)),)
-toolchain_path=$($($(host_arch)_$(host_os)_native_toolchain)_prefixbin)
-else
-toolchain_path=
-endif
 final_build_id_long+=$(shell $(build_SHA256SUM) config.site.in)
 final_build_id+=$(shell echo -n "$(final_build_id_long)" | $(build_SHA256SUM) | cut -c-$(HASH_LENGTH))
 $(host_prefix)/.stamp_$(final_build_id): $(native_packages) $(packages)
@@ -182,12 +176,12 @@ $(host_prefix)/.stamp_$(final_build_id): $(native_packages) $(packages)
 $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_build_id)
 	$(AT)@mkdir -p $(@D)
 	$(AT)sed -e 's|@HOST@|$(host)|' \
-            -e 's|@CC@|$(toolchain_path)$(host_CC)|' \
-            -e 's|@CXX@|$(toolchain_path)$(host_CXX)|' \
-            -e 's|@AR@|$(binutils_path)$(host_AR)|' \
-            -e 's|@RANLIB@|$(binutils_path)$(host_RANLIB)|' \
-            -e 's|@NM@|$(binutils_path)$(host_NM)|' \
-            -e 's|@STRIP@|$(binutils_path)$(host_STRIP)|' \
+            -e 's|@CC@|$(host_CC)|' \
+            -e 's|@CXX@|$(host_CXX)|' \
+            -e 's|@AR@|$(host_AR)|' \
+            -e 's|@RANLIB@|$(host_RANLIB)|' \
+            -e 's|@NM@|$(host_NM)|' \
+            -e 's|@STRIP@|$(host_STRIP)|' \
             -e 's|@build_os@|$(build_os)|' \
             -e 's|@host_os@|$(host_os)|' \
             -e 's|@CFLAGS@|$(strip $(host_CFLAGS) $(host_$(release_type)_CFLAGS))|' \

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -79,7 +79,7 @@ fi
 if test -n "@CXX@" -a -z "${CXX}"; then
   CXX="@CXX@"
 fi
-PYTHONPATH=$depends_prefix/native/lib/python3/dist-packages:$PYTHONPATH
+PYTHONPATH="${depends_prefix}/native/lib/python3/dist-packages${PYTHONPATH:+${PATH_SEPARATOR}}${PYTHONPATH}"
 
 if test -n "@AR@"; then
   AR=@AR@

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -1,3 +1,13 @@
+# shellcheck shell=sh disable=SC2034 # Many variables set will be used in
+                                     # ./configure but shellcheck doesn't know
+                                     # that, hence: disable=SC2034
+
+true  # Dummy command because shellcheck treats all directives before first
+      # command as file-wide, and we only want to disable for one line.
+      #
+      # See: https://github.com/koalaman/shellcheck/wiki/Directive
+
+# shellcheck disable=SC2154
 depends_prefix="$(cd "$(dirname ${ac_site_file})/.." && pwd)"
 
 cross_compiling=maybe
@@ -50,7 +60,7 @@ if test x@host_os@ = xdarwin; then
 fi
 
 PATH=$depends_prefix/native/bin:$PATH
-PKG_CONFIG="`which pkg-config` --static"
+PKG_CONFIG="$(which pkg-config) --static"
 
 # These two need to remain exported because pkg-config does not see them
 # otherwise. That means they must be unexported at the end of configure.ac to

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -1,4 +1,4 @@
-depends_prefix="`dirname ${ac_site_file}`/.."
+depends_prefix="$(cd "$(dirname ${ac_site_file})/.." && pwd)"
 
 cross_compiling=maybe
 host_alias=@HOST@

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -59,7 +59,7 @@ if test x@host_os@ = xdarwin; then
   PORT=no
 fi
 
-PATH=$depends_prefix/native/bin:$PATH
+depends_path_fragment="${depends_prefix}/native/bin"
 PKG_CONFIG="$(which pkg-config) --static"
 
 # These two need to remain exported because pkg-config does not see them

--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -36,7 +36,8 @@ fi
 
 SHELLCHECK_CMD=(shellcheck --external-sources --check-sourced)
 EXCLUDE="--exclude=$(IFS=','; echo "${disabled[*]}")"
-if ! "${SHELLCHECK_CMD[@]}" "$EXCLUDE" $(git ls-files -- '*.sh' | grep -vE 'src/(leveldb|secp256k1|univalue)/'); then
+SOURCED_FILES=$(git ls-files | xargs gawk '/^# shellcheck shell=/ {print FILENAME} {nextfile}')  # Check shellcheck directive used for sourced files
+if ! "${SHELLCHECK_CMD[@]}" "$EXCLUDE" $SOURCED_FILES $(git ls-files -- '*.sh' | grep -vE 'src/(leveldb|secp256k1|univalue)/'); then
     EXIT_CODE=1
 fi
 


### PR DESCRIPTION
    Previously, we did not persist the $PATH env var between bitcoin's
    configure-phase and its make-phase.

    This meant that when configuring with $CONFIG_SITE set to one generated
    by depends, we would be configuring with $depends_prefix/native/bin
    prepended to $PATH, as described in depends/config.site.in.

    However, when make-ing, the $PATH would be set to whatever the caller's
    environment is, which didn't include $depends_prefix/native/bin.

    To work around this, we:

    1. Prepended $depends_prefix/native/bin to our CC, CXX, AR, RANLIB,
       NM, and STRIP in order to invoke them with a full path as argv[0].
    2. Manually prepended $depends_prefix/native/bin to $PATH in our
       Gitian/Guix builds.

    These workarounds are not ideal, and there is a better way. Essentially
    we want to make sure that what we feature-test at configure-time _is_
    what we will run at make-time.

    -----

    Using AC_ARG_VAR we ensure the following properties:

    0. We no longer need the 2 workarounds described above. (They are
       dropped in later commits)
    1. By default and without any overrides, whatever $PATH is at
       configure-time, is whatever $PATH is at make-time.
    2. When configuring with depends' CONFIG_SITE, the
       $depends_prefix/native/bin prepend to $PATH stays there unless
       overridden manually by a ./configure PATH=... or make PATH=...

    I believe that this makes using our depends system and our build system
    much more consistent, and still allows overrides to be easily made by
    those who need it.