### PR TITLE
test: use explicit p2p objects where available

### DIFF
--- a/test/functional/p2p_getdata.py
+++ b/test/functional/p2p_getdata.py
@@ -42,7 +42,7 @@ class GetdataTest(BitcoinTestFramework):
         good_getdata = msg_getdata()
         good_getdata.inv.append(CInv(t=2, h=best_block))
         p2p_block_store.send_and_ping(good_getdata)
-        p2p_block_store.wait_until(lambda: self.nodes[0].p2ps[0].blocks[best_block] == 1)
+        p2p_block_store.wait_until(lambda: p2p_block_store.blocks[best_block] == 1)
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -58,7 +58,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         two_min = 2 * 60
         node.setmocktime(now + twelve_hrs - two_min)
         time.sleep(2) # ensure enough time has passed for rebroadcast attempt to occur
-        assert_equal(int(txid, 16) in node.p2ps[1].get_invs(), False)
+        assert_equal(int(txid, 16) in peer_second.get_invs(), False)
 
         self.log.info("Bump time & check that transaction is rebroadcast")
         # Transaction should be rebroadcast approximately 24 hours in the future,


### PR DESCRIPTION
This is a follow-up patch to #19804 as suggested by MarcoFalke (https://github.com/bitcoin/bitcoin/pull/19804#discussion_r494950062).

To make the intent of the tests easier to understand, we reference the
p2p connection objects by their explicit names instead of the p2ps array.
