### PR TITLE
init: Fix incorrect warning "Reducing -maxconnections from N to N-1, because of system limitations"

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1019,7 +1019,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
 
     // Trim requested connection counts, to fit into system limitations
     // <int> in std::min<int>(...) to work around FreeBSD compilation issue described in #2695
-    nFD = RaiseFileDescriptorLimit(nMaxConnections + MIN_CORE_FILEDESCRIPTORS + MAX_ADDNODE_CONNECTIONS);
+    nFD = RaiseFileDescriptorLimit(nMaxConnections + MIN_CORE_FILEDESCRIPTORS + MAX_ADDNODE_CONNECTIONS + nBind);
 #ifdef USE_POLL
     int fd_max = nFD;
 #else


### PR DESCRIPTION
Fix incorrect warning `Reducing -maxconnections from N to N-1, because of system limitations`.

Before this patch (only the first warning is correct):

```
$ src/bitcoind -maxconnections=10000000 | grep Warning
2020-09-26T01:23:45Z Warning: Reducing -maxconnections from 10000000 to 1048417, because of system limitations.

$ src/bitcoind -maxconnections=1000000 | grep Warning
2020-09-26T01:23:45Z Warning: Reducing -maxconnections from 1000000 to 999999, because of system limitations.

$ src/bitcoind -maxconnections=100000 | grep Warning
2020-09-26T01:23:45Z Warning: Reducing -maxconnections from 100000 to 99999, because of system limitations.

$ src/bitcoind -maxconnections=10000 | grep Warning
2020-09-26T01:23:45Z Warning: Reducing -maxconnections from 10000 to 9999, because of system limitations.

$ src/bitcoind -maxconnections=1000 | grep Warning
2020-09-26T01:23:45Z Warning: Reducing -maxconnections from 1000 to 999, because of system limitations.

$ src/bitcoind -maxconnections=100 | grep Warning
[no warning]
```

After this patch (no incorrect warnings):

```
$ src/bitcoind -maxconnections=10000000 | grep Warning
2020-09-26T01:23:45Z Warning: Reducing -maxconnections from 10000000 to 1048417, because of system limitations.

$ src/bitcoind -maxconnections=1000000 | grep Warning
[no warning]

$ src/bitcoind -maxconnections=100000 | grep Warning
[no warning]

$ src/bitcoind -maxconnections=10000 | grep Warning
[no warning]

$ src/bitcoind -maxconnections=1000 | grep Warning
[no warning]

$ src/bitcoind -maxconnections=100 | grep Warning
[no warning]
```
