### PR TITLE
test: typo in a functional test doc

### DIFF
--- a/test/functional/wallet_txn_clone.py
+++ b/test/functional/wallet_txn_clone.py
@@ -25,7 +25,7 @@ class TxnMallTest(BitcoinTestFramework):
         parser.add_argument("--mineblock", dest="mine_block", default=False, action="store_true",
                             help="Test double-spend of 1-confirmed transaction")
         parser.add_argument("--segwit", dest="segwit", default=False, action="store_true",
-                            help="Test behaviour with SegWit txn (which should fail")
+                            help="Test behaviour with SegWit txn (which should fail)")
 
     def setup_network(self):
         # Start with split network:


### PR DESCRIPTION
before:
`  --segwit              Test behaviour with SegWit txn (which should fail`
after:
`  --segwit              Test behaviour with SegWit txn (which should fail)`
