### PR TITLE
test: Check that invalid peer traffic is accounted for

### DIFF
--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -64,13 +64,13 @@ class InvalidMessagesTest(BitcoinTestFramework):
         conn = self.nodes[0].add_p2p_connection(P2PDataStore())
         # Create valid message
         msg = conn.build_message(msg_ping(nonce=12345))
-        cut_pos = 12    # Chosen at an arbitrary position within the header
+        cut_pos = 12  # Chosen at an arbitrary position within the header
         # Send message in two pieces
-        before = int(self.nodes[0].getnettotals()['totalbytesrecv'])
+        before = self.nodes[0].getnettotals()['totalbytesrecv']
         conn.send_raw_message(msg[:cut_pos])
         # Wait until node has processed the first half of the message
-        self.wait_until(lambda: int(self.nodes[0].getnettotals()['totalbytesrecv']) != before)
-        middle = int(self.nodes[0].getnettotals()['totalbytesrecv'])
+        self.wait_until(lambda: self.nodes[0].getnettotals()['totalbytesrecv'] != before)
+        middle = self.nodes[0].getnettotals()['totalbytesrecv']
         # If this assert fails, we've hit an unlikely race
         # where the test framework sent a message in between the two halves
         assert_equal(middle, before + cut_pos)

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -22,11 +22,10 @@ from test_framework.p2p import (
     P2PInterface,
 )
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (
-    assert_equal,
-)
+from test_framework.util import assert_equal
 
 VALID_DATA_LIMIT = MAX_PROTOCOL_MESSAGE_LENGTH - 5  # Account for the 5-byte length prefix
+
 
 class msg_unrecognized:
     """Nonsensical message. Modeled after similar types in test_framework.messages."""
@@ -100,6 +99,8 @@ class InvalidMessagesTest(BitcoinTestFramework):
             msg = msg[:cut_len] + b'\xff' * 4 + msg[cut_len + 4:]
             conn.send_raw_message(msg)
             conn.sync_with_ping(timeout=1)
+        # Check that traffic is accounted for (24 bytes header + 2 bytes payload)
+        assert_equal(self.nodes[0].getpeerinfo()[0]['bytesrecv_per_msg']['*other*'], 26)
         self.nodes[0].disconnect_p2ps()
 
     def test_size(self):
@@ -123,6 +124,8 @@ class InvalidMessagesTest(BitcoinTestFramework):
             msg = msg[:7] + b'\x00' + msg[7 + 1:]
             conn.send_raw_message(msg)
             conn.sync_with_ping(timeout=1)
+        # Check that traffic is accounted for (24 bytes header + 2 bytes payload)
+        assert_equal(self.nodes[0].getpeerinfo()[0]['bytesrecv_per_msg']['*other*'], 26)
         self.nodes[0].disconnect_p2ps()
 
     def test_oversized_msg(self, msg, size):


### PR DESCRIPTION
Couldn't find a test for this and it seems something we should test, so I wrote one.