### PR TITLE
validation: Remove useless call to mempool->clear()

### DIFF
--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -32,7 +32,7 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
     chainman.m_total_coinstip_cache = nCoinCacheUsage;
     chainman.m_total_coinsdb_cache = nCoinDBCache;
 
-    UnloadBlockIndex(mempool, chainman);
+    UnloadBlockIndex(chainman);
 
     auto& pblocktree{chainman.m_blockman.m_block_tree_db};
     // new CBlockTreeDB tries to delete the existing file, which

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -181,7 +181,7 @@ ChainTestingSetup::~ChainTestingSetup()
     m_node.banman.reset();
     m_node.addrman.reset();
     m_node.args = nullptr;
-    WITH_LOCK(::cs_main, UnloadBlockIndex(m_node.mempool.get(), *m_node.chainman));
+    WITH_LOCK(::cs_main, UnloadBlockIndex(*m_node.chainman));
     m_node.mempool.reset();
     m_node.scheduler.reset();
     m_node.chainman.reset();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4117,11 +4117,10 @@ void CChainState::UnloadBlockIndex()
 // May NOT be used after any connections are up as much
 // of the peer-processing logic assumes a consistent
 // block index state
-void UnloadBlockIndex(CTxMemPool* mempool, ChainstateManager& chainman)
+void UnloadBlockIndex(ChainstateManager& chainman)
 {
     AssertLockHeld(::cs_main);
     chainman.Unload();
-    if (mempool) mempool->clear();
     g_versionbitscache.Clear();
     for (int b = 0; b < VERSIONBITS_NUM_BITS; b++) {
         warningcache[b].clear();

--- a/src/validation.h
+++ b/src/validation.h
@@ -135,7 +135,7 @@ extern arith_uint256 nMinimumChainWork;
 extern const std::vector<std::string> CHECKLEVEL_DOC;
 
 /** Unload database information */
-void UnloadBlockIndex(CTxMemPool* mempool, ChainstateManager& chainman) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+void UnloadBlockIndex(ChainstateManager& chainman) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 /** Run instances of script checking worker threads */
 void StartScriptCheckWorkerThreads(int threads_num);
 /** Stop all of the script checking worker threads */
@@ -996,9 +996,10 @@ public:
     //! ResizeCoinsCaches() as needed.
     void MaybeRebalanceCaches() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
-    ~ChainstateManager() {
+    ~ChainstateManager()
+    {
         LOCK(::cs_main);
-        UnloadBlockIndex(/*mempool=*/nullptr, *this);
+        UnloadBlockIndex(*this);
     }
 };
 


### PR DESCRIPTION
The mempool.clear() in UnloadBlockIndex has been added in commit 51598b2
to clear global state between unit tests. Now that there is no global
mempool anymore, this it not needed anymore. Also, the clear isn't used
for anything else in the current code.