### PR TITLE
upstream: add and use defaulted getters to UniValue

### DIFF
--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -12,7 +12,7 @@ fi
 
 test/lint/git-subtree-check.sh src/crypto/ctaes
 test/lint/git-subtree-check.sh src/secp256k1
-test/lint/git-subtree-check.sh src/univalue
+# test/lint/git-subtree-check.sh src/univalue # TEMP DISABLED FOR #20045
 test/lint/git-subtree-check.sh src/leveldb
 test/lint/git-subtree-check.sh src/crc32c
 test/lint/check-doc.py

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -395,8 +395,8 @@ public:
 
         for (const UniValue& peer : getpeerinfo.getValues()) {
             const std::string addr{peer["addr"].get_str()};
-            const std::string addr_local{peer["addrlocal"].isNull() ? "" : peer["addrlocal"].get_str()};
-            const int mapped_as{peer["mapped_as"].isNull() ? 0 : peer["mapped_as"].get_int()};
+            const std::string addr_local{peer["addrlocal"].get("")};
+            const int mapped_as{peer["mapped_as"].get((int)0)};
             const bool is_block_relay{!peer["relaytxes"].get_bool()};
             const bool is_inbound{peer["inbound"].get_bool()};
             NetType net_type{NetType::ipv4};
@@ -433,8 +433,8 @@ public:
                 const int64_t last_recv{peer["lastrecv"].get_int64()};
                 const int64_t last_send{peer["lastsend"].get_int64()};
                 const int64_t last_trxn{peer["last_transaction"].get_int64()};
-                const double min_ping{peer["minping"].isNull() ? -1 : peer["minping"].get_real()};
-                const double ping{peer["pingtime"].isNull() ? -1 : peer["pingtime"].get_real()};
+                const double min_ping{peer["minping"].get(-1.0)};
+                const double ping{peer["pingtime"].get(-1.0)};
                 peers.push_back({peer_id, mapped_as, version, conn_time, last_blck, last_recv, last_send, last_trxn, min_ping, ping, addr, sub_version, net_type, is_block_relay, !is_inbound});
                 max_peer_id_length = std::max(ToString(peer_id).length(), max_peer_id_length);
                 max_addr_length = std::max(addr.length() + 1, max_addr_length);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -258,9 +258,7 @@ static RPCHelpMan waitfornewblock()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    int timeout = 0;
-    if (!request.params[0].isNull())
-        timeout = request.params[0].get_int();
+    int timeout = request.params[0].get((int)0);
 
     CUpdatedBlock block;
     {
@@ -301,12 +299,9 @@ static RPCHelpMan waitforblock()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    int timeout = 0;
+    int timeout = request.params[1].get((int)0);
 
     uint256 hash(ParseHashV(request.params[0], "blockhash"));
-
-    if (!request.params[1].isNull())
-        timeout = request.params[1].get_int();
 
     CUpdatedBlock block;
     {
@@ -348,12 +343,9 @@ static RPCHelpMan waitforblockheight()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    int timeout = 0;
+    int timeout = request.params[1].get((int)0);
 
     int height = request.params[0].get_int();
-
-    if (!request.params[1].isNull())
-        timeout = request.params[1].get_int();
 
     CUpdatedBlock block;
     {
@@ -577,15 +569,8 @@ static RPCHelpMan getrawmempool()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    bool fVerbose = false;
-    if (!request.params[0].isNull())
-        fVerbose = request.params[0].get_bool();
-
-    bool include_mempool_sequence = false;
-    if (!request.params[1].isNull()) {
-        include_mempool_sequence = request.params[1].get_bool();
-    }
-
+    bool fVerbose = request.params[0].get(false);
+    bool include_mempool_sequence = request.params[1].get(false);
     return MempoolToJSON(EnsureMemPool(request.context), fVerbose, include_mempool_sequence);
 },
     };
@@ -615,9 +600,7 @@ static RPCHelpMan getmempoolancestors()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    bool fVerbose = false;
-    if (!request.params[1].isNull())
-        fVerbose = request.params[1].get_bool();
+    bool fVerbose = request.params[1].get(false);
 
     uint256 hash = ParseHashV(request.params[0], "parameter 1");
 
@@ -679,9 +662,7 @@ static RPCHelpMan getmempooldescendants()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    bool fVerbose = false;
-    if (!request.params[1].isNull())
-        fVerbose = request.params[1].get_bool();
+    bool fVerbose = request.params[1].get(false);
 
     uint256 hash = ParseHashV(request.params[0], "parameter 1");
 
@@ -820,9 +801,7 @@ static RPCHelpMan getblockheader()
 {
     uint256 hash(ParseHashV(request.params[0], "hash"));
 
-    bool fVerbose = true;
-    if (!request.params[1].isNull())
-        fVerbose = request.params[1].get_bool();
+    bool fVerbose = request.params[1].get(true);
 
     const CBlockIndex* pblockindex;
     const CBlockIndex* tip;
@@ -939,13 +918,7 @@ static RPCHelpMan getblock()
 {
     uint256 hash(ParseHashV(request.params[0], "blockhash"));
 
-    int verbosity = 1;
-    if (!request.params[1].isNull()) {
-        if(request.params[1].isNum())
-            verbosity = request.params[1].get_int();
-        else
-            verbosity = request.params[1].get_bool() ? 1 : 0;
-    }
+    int verbosity = request.params[1].isNum() ? request.params[1].get_int() : request.params[1].get(true);
 
     CBlock block;
     const CBlockIndex* pblockindex;
@@ -1129,9 +1102,7 @@ static RPCHelpMan gettxout()
     uint256 hash(ParseHashV(request.params[0], "txid"));
     int n = request.params[1].get_int();
     COutPoint out(hash, n);
-    bool fMempool = true;
-    if (!request.params[2].isNull())
-        fMempool = request.params[2].get_bool();
+    bool fMempool = request.params[2].get(true);
 
     Coin coin;
     CCoinsViewCache* coins_view = &::ChainstateActive().CoinsTip();
@@ -1184,8 +1155,8 @@ static RPCHelpMan verifychain()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    const int check_level(request.params[0].isNull() ? DEFAULT_CHECKLEVEL : request.params[0].get_int());
-    const int check_depth{request.params[1].isNull() ? DEFAULT_CHECKBLOCKS : request.params[1].get_int()};
+    const int check_level(request.params[0].get((int)DEFAULT_CHECKLEVEL));
+    const int check_depth{request.params[1].get((int)DEFAULT_CHECKBLOCKS)};
 
     LOCK(cs_main);
 
@@ -2295,10 +2266,7 @@ static RPCHelpMan getblockfilter()
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
     uint256 block_hash = ParseHashV(request.params[0], "blockhash");
-    std::string filtertype_name = "basic";
-    if (!request.params[1].isNull()) {
-        filtertype_name = request.params[1].get_str();
-    }
+    std::string filtertype_name = request.params[1].get("basic");
 
     BlockFilterType filtertype;
     if (!BlockFilterTypeByName(filtertype_name, filtertype)) {

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -496,7 +496,7 @@ static RPCHelpMan getmemoryinfo()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    std::string mode = request.params[0].isNull() ? "stats" : request.params[0].get_str();
+    std::string mode = request.params[0].get("stats");
     if (mode == "stats") {
         UniValue obj(UniValue::VOBJ);
         obj.pushKV("locked", RPCLockedMemoryInfo());
@@ -677,7 +677,7 @@ static RPCHelpMan getindexinfo()
                 [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
     UniValue result(UniValue::VOBJ);
-    const std::string index_name = request.params[0].isNull() ? "" : request.params[0].get_str();
+    const std::string index_name = request.params[0].get("");
 
     if (g_txindex) {
         result.pushKVs(SummaryToJSON(g_txindex->GetSummary(), index_name));

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -265,9 +265,7 @@ static RPCHelpMan addnode()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    std::string strCommand;
-    if (!request.params[1].isNull())
-        strCommand = request.params[1].get_str();
+    std::string strCommand = request.params[1].get("");
     if (request.fHelp || request.params.size() != 2 ||
         (strCommand != "onetry" && strCommand != "add" && strCommand != "remove"))
         throw std::runtime_error(
@@ -607,9 +605,7 @@ static RPCHelpMan setban()
                 },
         [&](const RPCHelpMan& help, const JSONRPCRequest& request) -> UniValue
 {
-    std::string strCommand;
-    if (!request.params[1].isNull())
-        strCommand = request.params[1].get_str();
+    std::string strCommand = request.params[1].get("");
     if (request.fHelp || !help.IsValidNumArgs(request.params.size()) || (strCommand != "add" && strCommand != "remove")) {
         throw std::runtime_error(help.ToString());
     }
@@ -642,13 +638,9 @@ static RPCHelpMan setban()
             throw JSONRPCError(RPC_CLIENT_NODE_ALREADY_ADDED, "Error: IP/Subnet already banned");
         }
 
-        int64_t banTime = 0; //use standard bantime if not specified
-        if (!request.params[2].isNull())
-            banTime = request.params[2].get_int64();
+        int64_t banTime = request.params[2].get((int64_t)0); //use standard bantime if not specified
 
-        bool absolute = false;
-        if (request.params[3].isTrue())
-            absolute = true;
+        bool absolute = request.params[3].get(false);
 
         if (isSubnet) {
             node.banman->Ban(subNet, banTime, absolute);
@@ -795,12 +787,9 @@ static RPCHelpMan getnodeaddresses()
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
     }
 
-    int count = 1;
-    if (!request.params[0].isNull()) {
-        count = request.params[0].get_int();
-        if (count < 0) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Address count out of range");
-        }
+    int count = request.params[0].get((int)1);
+    if (count < 0) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Address count out of range");
     }
     // returns a shuffled list of CAddress
     std::vector<CAddress> vAddr = node.connman->GetAddresses(count, /* max_pct */ 0);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -169,10 +169,7 @@ static RPCHelpMan getrawtransaction()
     }
 
     // Accept either a bool (true) or a num (>=1) to indicate verbose output.
-    bool fVerbose = false;
-    if (!request.params[1].isNull()) {
-        fVerbose = request.params[1].isNum() ? (request.params[1].get_int() != 0) : request.params[1].get_bool();
-    }
+    bool fVerbose = request.params[1].isNum() ? (request.params[1].get_int() != 0) : request.params[1].get(false);
 
     if (!request.params[2].isNull()) {
         LOCK(cs_main);
@@ -428,10 +425,7 @@ static RPCHelpMan createrawtransaction()
         }, true
     );
 
-    bool rbf = false;
-    if (!request.params[3].isNull()) {
-        rbf = request.params[3].isTrue();
-    }
+    bool rbf = request.params[3].get(false);
     CMutableTransaction rawTx = ConstructTransaction(request.params[0], request.params[1], request.params[2], rbf);
 
     return EncodeHexTx(CTransaction(rawTx));
@@ -512,8 +506,8 @@ static RPCHelpMan decoderawtransaction()
 
     CMutableTransaction mtx;
 
-    bool try_witness = request.params[1].isNull() ? true : request.params[1].get_bool();
-    bool try_no_witness = request.params[1].isNull() ? true : !request.params[1].get_bool();
+    bool try_witness = request.params[1].get(true);
+    bool try_no_witness = !request.params[1].get(false); // true if null, otherwise the opposite
 
     if (!DecodeHexTx(mtx, request.params[0].get_str(), try_no_witness, try_witness)) {
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
@@ -1375,7 +1369,7 @@ static RPCHelpMan finalizepsbt()
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("TX decode failed %s", error));
     }
 
-    bool extract = request.params[1].isNull() || (!request.params[1].isNull() && request.params[1].get_bool());
+    bool extract = request.params[1].get(true);
 
     CMutableTransaction mtx;
     bool complete = FinalizeAndExtractPSBT(psbtx, mtx);
@@ -1455,10 +1449,7 @@ static RPCHelpMan createpsbt()
         }, true
     );
 
-    bool rbf = false;
-    if (!request.params[3].isNull()) {
-        rbf = request.params[3].isTrue();
-    }
+    bool rbf = request.params[3].get(false);
     CMutableTransaction rawTx = ConstructTransaction(request.params[0], request.params[1], request.params[2], rbf);
 
     // Make a blank psbt
@@ -1512,7 +1503,7 @@ static RPCHelpMan converttopsbt()
 
     // parse hex string from parameter
     CMutableTransaction tx;
-    bool permitsigdata = request.params[1].isNull() ? false : request.params[1].get_bool();
+    bool permitsigdata = request.params[1].get(false);
     bool witness_specified = !request.params[2].isNull();
     bool iswitness = witness_specified ? request.params[2].get_bool() : false;
     const bool try_witness = witness_specified ? iswitness : true;

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -25,12 +25,7 @@ CMutableTransaction ConstructTransaction(const UniValue& inputs_in, const UniVal
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, output argument must be non-null");
     }
 
-    UniValue inputs;
-    if (inputs_in.isNull()) {
-        inputs = UniValue::VARR;
-    } else {
-        inputs = inputs_in.get_array();
-    }
+    UniValue inputs = inputs_in.get(UniValue(UniValue::VARR));
 
     const bool outputs_is_obj = outputs_in.isObject();
     UniValue outputs = outputs_is_obj ? outputs_in.get_obj() : outputs_in.get_array();

--- a/src/rpc/request.cpp
+++ b/src/rpc/request.cpp
@@ -175,10 +175,8 @@ void JSONRPCRequest::parse(const UniValue& valRequest)
 
     // Parse params
     UniValue valParams = find_value(request, "params");
-    if (valParams.isArray() || valParams.isObject())
-        params = valParams;
-    else if (valParams.isNull())
-        params = UniValue(UniValue::VARR);
+    if (valParams.isArray() || valParams.isObject() || valParams.isNull())
+        params = valParams.get(UniValue(UniValue::VARR));
     else
         throw JSONRPCError(RPC_INVALID_REQUEST, "Params must be an array or object");
 }

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(key_io_valid_parse)
         const UniValue &metadata = test[2].get_obj();
         bool isPrivkey = find_value(metadata, "isPrivkey").get_bool();
         SelectParams(find_value(metadata, "chain").get_str());
-        bool try_case_flip = find_value(metadata, "tryCaseFlip").isNull() ? false : find_value(metadata, "tryCaseFlip").get_bool();
+        bool try_case_flip = find_value(metadata, "tryCaseFlip").get(false);
         if (isPrivkey) {
             bool isCompressed = find_value(metadata, "isCompressed").get_bool();
             // Must be valid private key

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -174,6 +174,15 @@ public:
     const UniValue& get_obj() const;
     const UniValue& get_array() const;
 
+    bool get(bool default_value) const                             { return isNull() ? default_value : get_bool(); }
+    const std::string get(const std::string& default_value) const  { return isNull() ? default_value : get_str(); }
+    const std::string get(const char* default_value) const         { return isNull() ? default_value : get_str(); }
+    int get(int default_value) const                               { return isNull() ? default_value : get_int(); }
+    int64_t get(int64_t default_value) const                       { return isNull() ? default_value : get_int64(); }
+    uint64_t get(uint64_t default_value) const                     { return isNull() ? default_value : (uint64_t)get_int64(); }
+    double get(double default_value) const                         { return isNull() ? default_value : get_real(); }
+    const UniValue& get(const UniValue& default_value) const       { return isNull() ? default_value : default_value.isArray() ? get_array() : get_obj(); }
+
     enum VType type() const { return getType(); }
     friend const UniValue& find_value( const UniValue& obj, const std::string& name);
 };

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -136,13 +136,10 @@ RPCHelpMan importprivkey()
         EnsureWalletIsUnlocked(pwallet);
 
         std::string strSecret = request.params[0].get_str();
-        std::string strLabel = "";
-        if (!request.params[1].isNull())
-            strLabel = request.params[1].get_str();
+        std::string strLabel = request.params[1].get("");
 
         // Whether to perform rescan after import
-        if (!request.params[2].isNull())
-            fRescan = request.params[2].get_bool();
+        fRescan = request.params[2].get(fRescan);
 
         if (fRescan && pwallet->chain().havePruned()) {
             // Exit early and print an error.
@@ -255,14 +252,10 @@ RPCHelpMan importaddress()
 
     EnsureLegacyScriptPubKeyMan(*pwallet, true);
 
-    std::string strLabel;
-    if (!request.params[1].isNull())
-        strLabel = request.params[1].get_str();
+    std::string strLabel = request.params[1].get("");
 
     // Whether to perform rescan after import
-    bool fRescan = true;
-    if (!request.params[2].isNull())
-        fRescan = request.params[2].get_bool();
+    bool fRescan = request.params[2].get(true);
 
     if (fRescan && pwallet->chain().havePruned()) {
         // Exit early and print an error.
@@ -277,9 +270,7 @@ RPCHelpMan importaddress()
     }
 
     // Whether to import a p2sh version, too
-    bool fP2SH = false;
-    if (!request.params[3].isNull())
-        fP2SH = request.params[3].get_bool();
+    bool fP2SH = request.params[3].get(false);
 
     {
         LOCK(pwallet->cs_wallet);
@@ -450,14 +441,10 @@ RPCHelpMan importpubkey()
 
     EnsureLegacyScriptPubKeyMan(*wallet, true);
 
-    std::string strLabel;
-    if (!request.params[1].isNull())
-        strLabel = request.params[1].get_str();
+    std::string strLabel = request.params[1].get("");
 
     // Whether to perform rescan after import
-    bool fRescan = true;
-    if (!request.params[2].isNull())
-        fRescan = request.params[2].get_bool();
+    bool fRescan = request.params[2].get(true);
 
     if (fRescan && pwallet->chain().havePruned()) {
         // Exit early and print an error.
@@ -1345,15 +1332,7 @@ RPCHelpMan importmulti()
     const UniValue& requests = mainRequest.params[0];
 
     //Default options
-    bool fRescan = true;
-
-    if (!mainRequest.params[1].isNull()) {
-        const UniValue& options = mainRequest.params[1];
-
-        if (options.exists("rescan")) {
-            fRescan = options["rescan"].get_bool();
-        }
-    }
+    bool fRescan = mainRequest.params[1].get(UniValue(UniValue::VOBJ))["rescan"].get(true);
 
     WalletRescanReserver reserver(*pwallet);
     if (fRescan && !reserver.reserve()) {


### PR DESCRIPTION
The first commit is supposed to go upstream.

The second commit shows how we could use this to clean up the code substantially. (140 lines removed)
