### PR TITLE
test: use wait_for_{block,header} helpers in p2p_fingerprint.py

### DIFF
--- a/test/functional/p2p_fingerprint.py
+++ b/test/functional/p2p_fingerprint.py
@@ -101,13 +101,11 @@ class P2PFingerprintTest(BitcoinTestFramework):
 
         # Check that getdata request for stale block succeeds
         self.send_block_request(stale_hash, node0)
-        test_function = lambda: self.last_block_equals(stale_hash, node0)
-        self.wait_until(test_function, timeout=3)
+        node0.wait_for_block(stale_hash, timeout=3)
 
         # Check that getheader request for stale block header succeeds
         self.send_header_request(stale_hash, node0)
-        test_function = lambda: self.last_header_equals(stale_hash, node0)
-        self.wait_until(test_function, timeout=3)
+        node0.wait_for_header(hex(stale_hash), timeout=3)
 
         # Longest chain is extended so stale is much older than chain tip
         self.nodes[0].setmocktime(0)
@@ -137,12 +135,10 @@ class P2PFingerprintTest(BitcoinTestFramework):
         node0.sync_with_ping()
 
         self.send_block_request(block_hash, node0)
-        test_function = lambda: self.last_block_equals(block_hash, node0)
-        self.wait_until(test_function, timeout=3)
+        node0.wait_for_block(block_hash, timeout=3)
 
         self.send_header_request(block_hash, node0)
-        test_function = lambda: self.last_header_equals(block_hash, node0)
-        self.wait_until(test_function, timeout=3)
+        node0.wait_for_header(hex(block_hash), timeout=3)
 
 if __name__ == '__main__':
     P2PFingerprintTest().main()


### PR DESCRIPTION
This small PR takes use of the message receiving helper functions `wait_for_block()` and `wait_for_header()` (from module `test_framework.p2p`) in the test `p2p_fingerprint.py`.  It also simplifies the checks for very old stale blocks/headers requests by getting rid of the functions `last_block_equals()` and `last_header_equals()` and rather only testing that not any blocks/headers message is received at all. Unneeded sending of requests are also removed and calls to time.sleep(...) substituted by ping syncs.