### PR TITLE
rpc: Set HTTP Content-Type in bitcoin-cli

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -596,6 +596,7 @@ static UniValue CallRPC(BaseRequestHandler* rh, const std::string& strMethod, co
     assert(output_headers);
     evhttp_add_header(output_headers, "Host", host.c_str());
     evhttp_add_header(output_headers, "Connection", "close");
+    evhttp_add_header(output_headers, "Content-Type", "application/json");
     evhttp_add_header(output_headers, "Authorization", (std::string("Basic ") + EncodeBase64(strRPCUserColonPass)).c_str());
 
     // Attach request data


### PR DESCRIPTION
We don't set any `Content-Type` in the client. It is more consistent with our other JSON-RPC use to set it to `application/json`.

Note that our server doesn't enforce content types, so it doesn't make a difference in practice. But it is fairly strange HTTP behavior to not set it at all for a POST request.

This came up in #18950.