### PR TITLE
refactor: fix -Wbraced-scalar-init warning in validation tests

### DIFF
--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(signet_parse_tests)
     signet_argsman.ForceSetArg("-signetchallenge", "51"); // set challenge to OP_TRUE
     const auto signet_params = CreateChainParams(signet_argsman, CBaseChainParams::SIGNET);
     CBlock block;
-    BOOST_CHECK(signet_params->GetConsensus().signet_challenge == std::vector<uint8_t>{{OP_TRUE}});
+    BOOST_CHECK(signet_params->GetConsensus().signet_challenge == std::vector<uint8_t>{OP_TRUE});
     CScript challenge{OP_TRUE};
 
     // empty block is invalid


### PR DESCRIPTION
Introduced in #20004 (fa29b5ae666bbb4c19188f0dcf8a1ba738aac624).

```
test/validation_tests.cpp:68:88: warning: braces around scalar initializer [-Wbraced-scalar-init]
    BOOST_CHECK(signet_params->GetConsensus().signet_challenge == std::vector<uint8_t>{{OP_TRUE}});
                                                                                       ^~~~~~~~~
/usr/local/include/boost/test/tools/old/interface.hpp:83:6: note: expanded from macro 'BOOST_CHECK'
    (P), BOOST_TEST_STRINGIZE( P ), CHECK, CHECK_PRED, _ )
     ^
/usr/local/include/boost/test/tools/old/interface.hpp:68:61: note: expanded from macro 'BOOST_TEST_TOOL_IMPL'
        BOOST_JOIN( BOOST_TEST_TOOL_PASS_PRED, frwd_type )( P, ARGS ),          \
                                                            ^
/usr/local/include/boost/test/tools/old/interface.hpp:51:47: note: expanded from macro 'BOOST_TEST_TOOL_PASS_PRED2'
                                              ^
1 warning generated.
```