### PR TITLE
RPC: remove duplicate line in getblock help

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -928,7 +928,6 @@ static RPCHelpMan getblock()
                             {RPCResult::Type::ELISION, "", "The transactions in the format of the getrawtransaction RPC. Different from verbosity = 1 \"tx\" result"},
                         }},
                     }},
-                    {RPCResult::Type::ELISION, "", "Same output as verbosity = 1"},
                 }},
         },
                 RPCExamples{


### PR DESCRIPTION
Line simply seems duplicated in error.

Testing instructions:
Run `src/bitcoin-cli help getblock` on master branch to reproduce. Then build this PR and compare its results.