### PR TITLE
refactor: remove use of boost::algorithm::replace_first

### DIFF
--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -15,7 +15,6 @@
 #include <version.h>
 
 #include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/split.hpp>
 
 #include <algorithm>
@@ -40,8 +39,9 @@ CScript ParseScript(const std::string& s)
                 continue;
             mapOpNames[strName] = static_cast<opcodetype>(op);
             // Convenience: OP_ADD and just ADD are both recognized:
-            boost::algorithm::replace_first(strName, "OP_", "");
-            mapOpNames[strName] = static_cast<opcodetype>(op);
+            if (strName.compare(0, 3, "OP_") == 0) {  // strName starts with "OP_"
+                mapOpNames[strName.substr(3)] = static_cast<opcodetype>(op);
+            }
         }
     }
 


### PR DESCRIPTION
As discussed in #19851 (https://github.com/bitcoin/bitcoin/pull/19851#issuecomment-685424702), this trivial PR substitutes the (only) use of `boost::algorithm::replace_first` by a direct implementation.