### PR TITLE
test: Mention commit id in scripted diff error

### DIFF
--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -37,7 +37,7 @@ for commit in $(git rev-list --reverse $1); do
         git reset --quiet --hard HEAD
      else
         if git rev-list "--format=%b" -n1 $commit | grep -q '^-\(BEGIN\|END\)[ a-zA-Z]*-$'; then
-            echo "Error: script block marker but no scripted-diff in title"
+            echo "Error: script block marker but no scripted-diff in title of commit $commit"
             echo "Failed"
             RET=1
         fi


### PR DESCRIPTION
Add commit id to make spotting the issue easier.