### PR TITLE
ci, lint: Remove usage of TRAVIS_COMMIT_RANGE

### DIFF
--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -7,7 +7,11 @@
 export LC_ALL=C
 
 if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then
-  test/lint/commit-script-check.sh $TRAVIS_COMMIT_RANGE
+  # TRAVIS_BRANCH will be present in a Travis environment. For builds triggered
+  # by a pull request this is the name of the branch targeted by the pull request.
+  # https://docs.travis-ci.com/user/environment-variables/
+  COMMIT_RANGE="$TRAVIS_BRANCH..HEAD"
+  test/lint/commit-script-check.sh $COMMIT_RANGE
 fi
 
 test/lint/git-subtree-check.sh src/crypto/ctaes

--- a/test/lint/lint-git-commit-check.sh
+++ b/test/lint/lint-git-commit-check.sh
@@ -23,10 +23,18 @@ while getopts "?" opt; do
   esac
 done
 
+# TRAVIS_BRANCH will be present in a Travis environment. For builds triggered
+# by a pull request this is the name of the branch targeted by the pull request.
+# https://docs.travis-ci.com/user/environment-variables/
+if [ -n "${TRAVIS_BRANCH}" ]; then
+  COMMIT_RANGE="$TRAVIS_BRANCH..HEAD"
+fi
+
 if [ -z "${COMMIT_RANGE}" ]; then
     if [ -n "$1" ]; then
       COMMIT_RANGE="HEAD~$1...HEAD"
     else
+      # This assumes that the target branch of the pull request will be master.
       MERGE_BASE=$(git merge-base HEAD master)
       COMMIT_RANGE="$MERGE_BASE..HEAD"
     fi

--- a/test/lint/lint-whitespace.sh
+++ b/test/lint/lint-whitespace.sh
@@ -13,32 +13,41 @@ while getopts "?" opt; do
   case $opt in
     ?)
       echo "Usage: $0 [N]"
-      echo "       TRAVIS_COMMIT_RANGE='<commit range>' $0"
+      echo "       COMMIT_RANGE='<commit range>' $0"
       echo "       $0 -?"
       echo "Checks unstaged changes, the previous N commits, or a commit range."
-      echo "TRAVIS_COMMIT_RANGE='47ba2c3...ee50c9e' $0"
+      echo "COMMIT_RANGE='47ba2c3...ee50c9e' $0"
       exit 0
     ;;
   esac
 done
 
-if [ -z "${TRAVIS_COMMIT_RANGE}" ]; then
+# TRAVIS_BRANCH will be present in a Travis environment. For builds triggered
+# by a pull request this is the name of the branch targeted by the pull request.
+# https://docs.travis-ci.com/user/environment-variables/
+if [ -n "${TRAVIS_BRANCH}" ]; then
+  COMMIT_RANGE="$TRAVIS_BRANCH..HEAD"
+fi
+
+if [ -z "${COMMIT_RANGE}" ]; then
   if [ -n "$1" ]; then
-    TRAVIS_COMMIT_RANGE="HEAD~$1...HEAD"
+    COMMIT_RANGE="HEAD~$1...HEAD"
   else
-    TRAVIS_COMMIT_RANGE="HEAD"
+    # This assumes that the target branch of the pull request will be master.
+    MERGE_BASE=$(git merge-base HEAD master)
+    COMMIT_RANGE="$MERGE_BASE..HEAD"
   fi
 fi
 
 showdiff() {
-  if ! git diff -U0 "${TRAVIS_COMMIT_RANGE}" -- "." ":(exclude)depends/patches/" ":(exclude)src/leveldb/" ":(exclude)src/crc32c/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" ":(exclude)doc/release-notes/" ":(exclude)src/qt/locale/"; then
+  if ! git diff -U0 "${COMMIT_RANGE}" -- "." ":(exclude)depends/patches/" ":(exclude)src/leveldb/" ":(exclude)src/crc32c/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" ":(exclude)doc/release-notes/" ":(exclude)src/qt/locale/"; then
     echo "Failed to get a diff"
     exit 1
   fi
 }
 
 showcodediff() {
-  if ! git diff -U0 "${TRAVIS_COMMIT_RANGE}" -- *.cpp *.h *.md *.py *.sh ":(exclude)src/leveldb/" ":(exclude)src/crc32c/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" ":(exclude)doc/release-notes/" ":(exclude)src/qt/locale/"; then
+  if ! git diff -U0 "${COMMIT_RANGE}" -- *.cpp *.h *.md *.py *.sh ":(exclude)src/leveldb/" ":(exclude)src/crc32c/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" ":(exclude)doc/release-notes/" ":(exclude)src/qt/locale/"; then
     echo "Failed to get a diff"
     exit 1
   fi


### PR DESCRIPTION
This is causing problems again, very similar to #19654.

UPDATE: This now removes all remaining usages of TRAVIS_COMMIT_RANGE and instead uses TRAVIS_BRANCH for the range, including `lint-git-commit-check` where TRAVIS_COMMIT_RANGE had already been removed. For builds triggered by a pull request, TRAVIS_BRANCH is the name of the branch targeted by the pull request. In the linters there is still a fallback that assumes master as the target branch.