### PR TITLE
validation: Increase robustness when loading malformed mempool.dat files (LoadMempool)

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -25,4 +25,12 @@ static const CAmount COIN = 100000000;
 static const CAmount MAX_MONEY = 21000000 * COIN;
 inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
+/** Check if an amount is a valid fee delta.
+ *
+ * Like MoneyRange(...), but allows for negative money amounts.
+ */
+inline bool FeeDeltaRange(const CAmount fee_delta) {
+    return fee_delta >= -MAX_MONEY && fee_delta <= MAX_MONEY;
+}
+
 #endif //  BITCOIN_AMOUNT_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5080,8 +5080,12 @@ bool LoadMempool(CTxMemPool& pool)
             file >> nFeeDelta;
 
             CAmount amountdelta = nFeeDelta;
-            if (amountdelta && FeeDeltaRange(amountdelta)) {
-                pool.PrioritiseTransaction(tx->GetHash(), amountdelta);
+            if (amountdelta) {
+                if (FeeDeltaRange(amountdelta)) {
+                    pool.PrioritiseTransaction(tx->GetHash(), amountdelta);
+                } else {
+                    LogPrintf("Invalid fee delta encountered (corrupt mempool.dat file?). Skipping PrioritiseTransaction(...).\n");
+                }
             }
             TxValidationState state;
             if (nTime > nNow - nExpiryTimeout) {
@@ -5114,6 +5118,8 @@ bool LoadMempool(CTxMemPool& pool)
         for (const auto& i : mapDeltas) {
             if (FeeDeltaRange(i.second)) {
                 pool.PrioritiseTransaction(i.first, i.second);
+            } else {
+                LogPrintf("Invalid fee delta encountered (corrupt mempool.dat file?). Skipping PrioritiseTransaction(...).\n");
             }
         }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5080,11 +5080,11 @@ bool LoadMempool(CTxMemPool& pool)
             file >> nFeeDelta;
 
             CAmount amountdelta = nFeeDelta;
-            if (amountdelta) {
+            if (amountdelta && FeeDeltaRange(amountdelta)) {
                 pool.PrioritiseTransaction(tx->GetHash(), amountdelta);
             }
             TxValidationState state;
-            if (nTime + nExpiryTimeout > nNow) {
+            if (nTime > nNow - nExpiryTimeout) {
                 LOCK(cs_main);
                 AcceptToMemoryPoolWithTime(chainparams, pool, state, tx, nTime,
                                            nullptr /* plTxnReplaced */, false /* bypass_limits */,
@@ -5112,7 +5112,9 @@ bool LoadMempool(CTxMemPool& pool)
         file >> mapDeltas;
 
         for (const auto& i : mapDeltas) {
-            pool.PrioritiseTransaction(i.first, i.second);
+            if (FeeDeltaRange(i.second)) {
+                pool.PrioritiseTransaction(i.first, i.second);
+            }
         }
 
         // TODO: remove this try except in v0.22


### PR DESCRIPTION
Increase robustness when loading malformed `mempool.dat` files.

Avoids the following three signed integer overflows when loading malformed `mempool.dat` files:

```
$ xxd -p -r > mempool.dat-crash-1 <<EOF
0100000000000000000000000004000000000000000000000000ffffffff
ffffff7f00000000000000000000000000
EOF
$ cp mempool.dat-crash-1 ~/.bitcoin/regtest/mempool.dat
$ UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:report_error_type=1" src/bitcoind -regtest
validation.cpp:5079:23: runtime error: signed integer overflow: 9223372036854775807 + 1209600 cannot be represented in type 'long'
    #0 0x5618d335197f in LoadMempool(CTxMemPool&) src/validation.cpp:5079:23
    #1 0x5618d3350df3 in CChainState::LoadMempool(ArgsManager const&) src/validation.cpp:4217:9
    #2 0x5618d2b9345f in ThreadImport(ChainstateManager&, std::vector<boost::filesystem::path, std::allocator<boost::filesystem::path> >, ArgsManager const&) src/init.cpp:762:33
    #3 0x5618d2b92162 in AppInitMain(util::Ref const&, NodeContext&, interfaces::BlockAndHeaderTipInfo*)::$_14::operator()() const src/init.cpp:1881:9
```

```
$ xxd -p -r > mempool.dat-crash-2 <<EOF
010000000000000000050900000000000509000000000000800000000000
0000000000000000000000800000000000
EOF
$ cp mempool.dat-crash-2 ~/.bitcoin/regtest/mempool.dat
$ UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:report_error_type=1" src/bitcoind -regtest
util/moneystr.cpp:16:34: runtime error: negation of -9223372036854775808 cannot be represented in type 'CAmount' (aka 'long'); cast to an unsigned type to negate this value to itself                                                                                  
    #0 0x5618a4a6366c in FormatMoney[abi:cxx11](long const&) src/util/moneystr.cpp:16:34
    #1 0x5618a406c2f1 in CTxMemPool::PrioritiseTransaction(uint256 const&, long const&) src/txmempool.cpp:861:77
    #2 0x5618a411064f in LoadMempool(CTxMemPool&) src/validation.cpp:5076:22
    #3 0x5618a410fdf3 in CChainState::LoadMempool(ArgsManager const&) src/validation.cpp:4217:9
    #4 0x5618a395245f in ThreadImport(ChainstateManager&, std::vector<boost::filesystem::path, std::allocator<boost::filesystem::path> >, ArgsManager const&) src/init.cpp:762:33
    #5 0x5618a3951162 in AppInitMain(util::Ref const&, NodeContext&, interfaces::BlockAndHeaderTipInfo*)::$_14::operator()() const src/init.cpp:1881:9
```

```
$ xxd -p -r > mempool.dat-crash-3 <<EOF
0100000000000000000000000000000001253d8c0000000000000000006b
00000000f7000000ff00f7000000ff0000000000000000000000800000ff
0000
EOF
$ cp mempool.dat-crash-3 ~/.bitcoin/regtest/mempool.dat
$ UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:report_error_type=1" src/bitcoind -regtest
util/moneystr.cpp:16:34: runtime error: negation of -9223372036854775808 cannot be represented in type 'CAmount' (aka 'long'); cast to an unsigned type to negate this value to itself                                                                                  
    #0 0x5575f515e66c in FormatMoney[abi:cxx11](long const&) src/util/moneystr.cpp:16:34
    #1 0x5575f47672f1 in CTxMemPool::PrioritiseTransaction(uint256 const&, long const&) src/txmempool.cpp:861:77
    #2 0x5575f480bc82 in LoadMempool(CTxMemPool&) src/validation.cpp:5107:18
    #3 0x5575f480adf3 in CChainState::LoadMempool(ArgsManager const&) src/validation.cpp:4217:9
    #4 0x5575f404d45f in ThreadImport(ChainstateManager&, std::vector<boost::filesystem::path, std::allocator<boost::filesystem::path> >, ArgsManager const&) src/init.cpp:762:33
    #5 0x5575f404c162 in AppInitMain(util::Ref const&, NodeContext&, interfaces::BlockAndHeaderTipInfo*)::$_14::operator()() const src/init.cpp:1881:9
```

Fixes #19278.