### PR TITLE
wallet: Unify wallet directory lock error message

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,10 +53,7 @@ test_script:
 - ps:  python test\util\bitcoin-util-test.py
 - cmd: python test\util\rpcauth-test.py
 # Fee estimation test failing on appveyor with: WinError 10048] Only one usage of each socket address (protocol/network address/port) is normally permitted.
-# functional tests disabled for now. See
-# https://github.com/bitcoin/bitcoin/pull/18626#issuecomment-613396202
-# https://github.com/bitcoin/bitcoin/issues/18623
-# - cmd: python test\functional\test_runner.py --ci --quiet --combinedlogslen=4000 --failfast --exclude feature_fee_estimation
+- cmd: python test\functional\test_runner.py --ci --quiet --combinedlogslen=4000 --exclude feature_fee_estimation
 artifacts:
 #- path: bitcoin-%APPVEYOR_BUILD_VERSION%.zip
 deploy: off

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -135,8 +135,7 @@ bool BerkeleyEnvironment::Open(bilingual_str& err)
     fs::path pathIn = strPath;
     TryCreateDirectories(pathIn);
     if (!LockDirectory(pathIn, ".walletlock")) {
-        LogPrintf("Cannot obtain a lock on wallet directory %s. Another instance of bitcoin may be using it.\n", strPath);
-        err = strprintf(_("Error initializing wallet database environment %s!"), Directory());
+        err = strprintf(_("Cannot obtain a lock on wallet directory %s. %s is probably already running."), pathIn.string(), PACKAGE_NAME);
         return false;
     }
 

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -22,7 +22,7 @@ bool VerifyWallets(interfaces::Chain& chain)
         fs::path wallet_dir = gArgs.GetArg("-walletdir", "");
         boost::system::error_code error;
         // The canonical path cleans the path, preventing >1 Berkeley environment instances for the same directory
-        fs::path canonical_wallet_dir = fs::canonical(wallet_dir, error);
+        fs::path canonical_wallet_dir = fs::canonical(wallet_dir, error).make_preferred();
         if (error || !fs::exists(wallet_dir)) {
             chain.initError(strprintf(_("Specified -walletdir \"%s\" does not exist"), wallet_dir.string()));
             return false;

--- a/test/functional/feature_filelock.py
+++ b/test/functional/feature_filelock.py
@@ -6,7 +6,6 @@
 import os
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.test_node import ErrorMatch
 
 class FilelockTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -30,8 +29,8 @@ class FilelockTest(BitcoinTestFramework):
             self.nodes[0].createwallet(self.default_wallet_name)
             wallet_dir = os.path.join(datadir, 'wallets')
             self.log.info("Check that we can't start a second bitcoind instance using the same wallet")
-            expected_msg = "Error: Error initializing wallet database environment"
-            self.nodes[1].assert_start_raises_init_error(extra_args=['-walletdir={}'.format(wallet_dir), '-wallet=' + self.default_wallet_name, '-noserver'], expected_msg=expected_msg, match=ErrorMatch.PARTIAL_REGEX)
+            expected_msg = "Error: Cannot obtain a lock on wallet directory {0}. {1} is probably already running.".format(wallet_dir, self.config['environment']['PACKAGE_NAME'])
+            self.nodes[1].assert_start_raises_init_error(extra_args=['-walletdir={}'.format(wallet_dir), '-wallet=' + self.default_wallet_name, '-noserver'], expected_msg=expected_msg)
 
 if __name__ == '__main__':
     FilelockTest().main()

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -72,7 +72,7 @@ class ToolWalletTest(BitcoinTestFramework):
         self.assert_raises_tool_error('Error parsing command line arguments: Invalid parameter -foo', '-foo')
         locked_dir = os.path.join(self.options.tmpdir, "node0", "regtest", "wallets")
         self.assert_raises_tool_error(
-            'Error initializing wallet database environment "{}"!'.format(locked_dir),
+            'Cannot obtain a lock on wallet directory {0}. {1} is probably already running.'.format(locked_dir, self.config['environment']['PACKAGE_NAME']),
             '-wallet=' + self.default_wallet_name,
             'info',
         )

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -168,7 +168,7 @@ class MultiWalletTest(BitcoinTestFramework):
         os.mkdir(competing_wallet_dir)
         self.restart_node(0, ['-nowallet', '-walletdir=' + competing_wallet_dir])
         self.nodes[0].createwallet(self.default_wallet_name, descriptors=False)
-        exp_stderr = r"Error: Error initializing wallet database environment \"\S+competing_walletdir\S*\"!"
+        exp_stderr = "Error: Cannot obtain a lock on wallet directory {0}. {1} is probably already running.".format(competing_wallet_dir, self.config['environment']['PACKAGE_NAME'])
         self.nodes[1].assert_start_raises_init_error(['-walletdir=' + competing_wallet_dir], exp_stderr, match=ErrorMatch.PARTIAL_REGEX)
 
         self.restart_node(0)
@@ -373,7 +373,8 @@ class MultiWalletTest(BitcoinTestFramework):
         if self.options.descriptors:
             assert_raises_rpc_error(-4, "Unable to obtain an exclusive lock", self.nodes[1].loadwallet, wallet)
         else:
-            assert_raises_rpc_error(-4, "Error initializing wallet database environment", self.nodes[1].loadwallet, wallet)
+            expected_rpc_error = "Cannot obtain a lock on wallet directory {0}. {1} is probably already running.".format(wallet, self.config['environment']['PACKAGE_NAME'])
+            assert_raises_rpc_error(-4, expected_rpc_error, self.nodes[1].loadwallet, wallet)
         self.nodes[0].unloadwallet(wallet)
         self.nodes[1].loadwallet(wallet)
 


### PR DESCRIPTION
On master (875e1ccc9fe01e026e564dfd39a64d9a4b332a89) a redundant log message is printed, and it uses "bitcoin" instead of `PACKAGE_NAME`:

```
2020-10-06T17:36:44Z Using wallet directory /home/hebasto/walletdir
2020-10-06T17:36:44Z init message: Verifying wallet(s)...
2020-10-06T17:36:44Z Using BerkeleyDB version Berkeley DB 5.3.28: (September  9, 2013)
2020-10-06T17:36:44Z Using wallet /home/hebasto/walletdir/wr-201006/wallet.dat
2020-10-06T17:36:44Z ERROR: Error while attempting to lock directory /home/hebasto/walletdir/wr-201006: Resource temporarily unavailable
2020-10-06T17:36:44Z Cannot obtain a lock on wallet directory /home/hebasto/walletdir/wr-201006. Another instance of bitcoin may be using it.
2020-10-06T17:36:44Z Error: Error initializing wallet database environment "/home/hebasto/walletdir/wr-201006"!
Error: Error initializing wallet database environment "/home/hebasto/walletdir/wr-201006"!
2020-10-06T17:36:44Z Shutdown: In progress...
2020-10-06T17:36:44Z scheduler thread exit
2020-10-06T17:36:44Z Shutdown: done
```

This PR removes redundant `LogPrintf` call, and unifies error message wording with the similar datadir lock error message:

```
2020-10-06T17:34:21Z Using wallet directory /home/hebasto/walletdir
2020-10-06T17:34:21Z init message: Verifying wallet(s)...
2020-10-06T17:34:21Z Using BerkeleyDB version Berkeley DB 5.3.28: (September  9, 2013)
2020-10-06T17:34:21Z Using wallet /home/hebasto/walletdir/wr-201006/wallet.dat
2020-10-06T17:34:21Z ERROR: Error while attempting to lock directory /home/hebasto/walletdir/wr-201006: Resource temporarily unavailable
2020-10-06T17:34:21Z Error: Cannot obtain a lock on wallet directory /home/hebasto/walletdir/wr-201006. Bitcoin Core is probably already running.
Error: Cannot obtain a lock on wallet directory /home/hebasto/walletdir/wr-201006. Bitcoin Core is probably already running.
2020-10-06T17:34:21Z Shutdown: In progress...
2020-10-06T17:34:21Z scheduler thread exit
2020-10-06T17:34:21Z Shutdown: done
```