### PR TITLE
wallet: Remove WalletDatabase refcounting and enforce only one Batch access the database at a time

### DIFF
--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -808,6 +808,7 @@ void BerkeleyDatabase::AddRef()
     } else {
         m_refcount++;
     }
+    assert(m_refcount <= 1);
 }
 
 void BerkeleyDatabase::RemoveRef()

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -113,10 +113,12 @@ public:
      */
     bool Rewrite(const char* pszSkip=nullptr) override;
 
+    //! Counts the number of active database users to be sure that the database is not closed while someone is using it
+    std::atomic<int> m_refcount{0};
     /** Indicate the a new database user has began using the database. */
-    void AddRef() override;
+    void AddRef();
     /** Indicate that database user has stopped using the database and that it could be flushed or closed. */
-    void RemoveRef() override;
+    void RemoveRef();
 
     /** Back up the entire database to a file.
      */

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -110,13 +110,6 @@ public:
     /** Open the database if it is not already opened. */
     virtual void Open() = 0;
 
-    //! Counts the number of active database users to be sure that the database is not closed while someone is using it
-    std::atomic<int> m_refcount{0};
-    /** Indicate the a new database user has began using the database. Increments m_refcount */
-    virtual void AddRef() = 0;
-    /** Indicate that database user has stopped using the database and that it could be flushed or closed. Decrement m_refcount */
-    virtual void RemoveRef() = 0;
-
     /** Rewrite the entire database on disk, with the exception of key pszSkip if non-zero
      */
     virtual bool Rewrite(const char* pszSkip=nullptr) = 0;
@@ -181,8 +174,6 @@ class DummyDatabase : public WalletDatabase
 {
 public:
     void Open() override {};
-    void AddRef() override {}
-    void RemoveRef() override {}
     bool Rewrite(const char* pszSkip=nullptr) override { return true; }
     bool Backup(const std::string& strDest) const override { return true; }
     void Close() override {}

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1216,20 +1216,22 @@ bool LegacyScriptPubKeyMan::NewKeyPool()
     }
     {
         LOCK(cs_KeyStore);
-        WalletBatch batch(m_storage.GetDatabase());
+        {
+            WalletBatch batch(m_storage.GetDatabase());
 
-        for (const int64_t nIndex : setInternalKeyPool) {
-            batch.ErasePool(nIndex);
-        }
-        setInternalKeyPool.clear();
+            for (const int64_t nIndex : setInternalKeyPool) {
+                batch.ErasePool(nIndex);
+            }
+            setInternalKeyPool.clear();
 
-        for (const int64_t nIndex : setExternalKeyPool) {
-            batch.ErasePool(nIndex);
-        }
-        setExternalKeyPool.clear();
+            for (const int64_t nIndex : setExternalKeyPool) {
+                batch.ErasePool(nIndex);
+            }
+            setExternalKeyPool.clear();
 
-        for (const int64_t nIndex : set_pre_split_keypool) {
-            batch.ErasePool(nIndex);
+            for (const int64_t nIndex : set_pre_split_keypool) {
+                batch.ErasePool(nIndex);
+            }
         }
         set_pre_split_keypool.clear();
 

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2267,7 +2267,7 @@ bool DescriptorScriptPubKeyMan::GetDescriptorString(std::string& out) const
     return m_wallet_descriptor.descriptor->ToNormalizedString(provider, out, &m_wallet_descriptor.cache);
 }
 
-void DescriptorScriptPubKeyMan::UpgradeDescriptorCache()
+void DescriptorScriptPubKeyMan::UpgradeDescriptorCache(WalletBatch& batch)
 {
     LOCK(cs_desc_man);
     if (m_storage.IsLocked() || m_storage.IsWalletFlagSet(WALLET_FLAG_LAST_HARDENED_XPUB_CACHED)) {
@@ -2291,7 +2291,7 @@ void DescriptorScriptPubKeyMan::UpgradeDescriptorCache()
 
     // Cache the last hardened xpubs
     DescriptorCache diff = m_wallet_descriptor.cache.MergeAndDiff(temp_cache);
-    if (!WalletBatch(m_storage.GetDatabase()).WriteDescriptorCacheItems(GetID(), diff)) {
+    if (!batch.WriteDescriptorCacheItems(GetID(), diff)) {
         throw std::runtime_error(std::string(__func__) + ": writing cache items failed");
     }
 }

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -386,14 +386,13 @@ void LegacyScriptPubKeyMan::MarkUnusedAddresses(const CScript& script)
     }
 }
 
-void LegacyScriptPubKeyMan::UpgradeKeyMetadata()
+void LegacyScriptPubKeyMan::UpgradeKeyMetadata(WalletBatch& batch)
 {
     LOCK(cs_KeyStore);
     if (m_storage.IsLocked() || m_storage.IsWalletFlagSet(WALLET_FLAG_KEY_ORIGIN_METADATA)) {
         return;
     }
 
-    std::unique_ptr<WalletBatch> batch = std::make_unique<WalletBatch>(m_storage.GetDatabase());
     for (auto& meta_pair : mapKeyMetadata) {
         CKeyMetadata& meta = meta_pair.second;
         if (!meta.hd_seed_id.IsNull() && !meta.has_key_origin && meta.hdKeypath != "s") { // If the hdKeypath is "s", that's the seed and it doesn't have a key origin
@@ -415,7 +414,7 @@ void LegacyScriptPubKeyMan::UpgradeKeyMetadata()
             // Write meta to wallet
             CPubKey pubkey;
             if (GetPubKey(meta_pair.first, pubkey)) {
-                batch->WriteKeyMetadata(meta, pubkey, true);
+                batch.WriteKeyMetadata(meta, pubkey, true);
             }
         }
     }

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1935,18 +1935,20 @@ bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(const CExtKey& master_
     m_wallet_descriptor = w_desc;
 
     // Store the master private key, and descriptor
-    WalletBatch batch(m_storage.GetDatabase());
-    if (!AddDescriptorKeyWithDB(batch, master_key.key, master_key.key.GetPubKey())) {
-        throw std::runtime_error(std::string(__func__) + ": writing descriptor master private key failed");
-    }
-    if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
-        throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
+    {
+        WalletBatch batch(m_storage.GetDatabase());
+        if (!AddDescriptorKeyWithDB(batch, master_key.key, master_key.key.GetPubKey())) {
+            throw std::runtime_error(std::string(__func__) + ": writing descriptor master private key failed");
+        }
+        if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
+            throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
+        }
+        m_storage.UnsetBlankWalletFlag(batch);
     }
 
     // TopUp
     TopUp();
 
-    m_storage.UnsetBlankWalletFlag(batch);
     return true;
 }
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -370,7 +370,7 @@ public:
     void MarkUnusedAddresses(const CScript& script) override;
 
     //! Upgrade stored CKeyMetadata objects to store key origin info as KeyOriginInfo
-    void UpgradeKeyMetadata();
+    void UpgradeKeyMetadata(WalletBatch& batch);
 
     bool IsHDEnabled() const override;
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -440,6 +440,7 @@ public:
     bool HaveWatchOnly() const;
     //! Remove a watch only script from the keystore
     bool RemoveWatchOnly(const CScript &dest);
+    bool RemoveWatchOnlyWithDB(WalletBatch& batch, const CScript &dest);
     bool AddWatchOnly(const CScript& dest, int64_t nCreateTime) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
 
     //! Fetches a pubkey from mapWatchKeys if it exists there

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -623,7 +623,7 @@ public:
 
     bool GetDescriptorString(std::string& out) const;
 
-    void UpgradeDescriptorCache();
+    void UpgradeDescriptorCache(WalletBatch& batch);
 };
 
 #endif // BITCOIN_WALLET_SCRIPTPUBKEYMAN_H

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -483,13 +483,13 @@ public:
      * software, as FillableSigningProvider automatically does this implicitly for all
      * keys now.
      */
-    void LearnRelatedScripts(const CPubKey& key, OutputType);
+    void LearnRelatedScripts(WalletBatch& batch, const CPubKey& key, OutputType);
 
     /**
      * Same as LearnRelatedScripts, but when the OutputType is not known (and could
      * be anything).
      */
-    void LearnAllRelatedScripts(const CPubKey& key);
+    void LearnAllRelatedScripts(WalletBatch& batch, const CPubKey& key);
 
     /**
      * Marks all keys in the keypool up to and including reserve_key as used.

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -79,10 +79,6 @@ public:
     /** Close the database */
     void Close() override;
 
-    /* These functions are unused */
-    void AddRef() override { assert(false); }
-    void RemoveRef() override { assert(false); }
-
     /** Rewrite the entire database on disk */
     bool Rewrite(const char* skip = nullptr) override;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -375,7 +375,7 @@ void CWallet::UpgradeKeyMetadata(WalletBatch& batch)
     SetWalletFlagWithDB(batch, WALLET_FLAG_KEY_ORIGIN_METADATA);
 }
 
-void CWallet::UpgradeDescriptorCache()
+void CWallet::UpgradeDescriptorCache(WalletBatch& batch)
 {
     if (!IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS) || IsLocked() || IsWalletFlagSet(WALLET_FLAG_LAST_HARDENED_XPUB_CACHED)) {
         return;
@@ -383,9 +383,9 @@ void CWallet::UpgradeDescriptorCache()
 
     for (ScriptPubKeyMan* spkm : GetAllScriptPubKeyMans()) {
         DescriptorScriptPubKeyMan* desc_spkm = dynamic_cast<DescriptorScriptPubKeyMan*>(spkm);
-        desc_spkm->UpgradeDescriptorCache();
+        desc_spkm->UpgradeDescriptorCache(batch);
     }
-    SetWalletFlag(WALLET_FLAG_LAST_HARDENED_XPUB_CACHED);
+    SetWalletFlagWithDB(batch, WALLET_FLAG_LAST_HARDENED_XPUB_CACHED);
 }
 
 bool CWallet::Unlock(const SecureString& strWalletPassphrase, bool accept_no_keys)
@@ -406,7 +406,7 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase, bool accept_no_key
                 WalletBatch batch(GetDatabase());
                 UpgradeKeyMetadata(batch);
                 // Now that we've unlocked, upgrade the descriptor cache
-                UpgradeDescriptorCache();
+                UpgradeDescriptorCache(batch);
                 return true;
             }
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -359,8 +359,9 @@ const CWalletTx* CWallet::GetWalletTx(const uint256& hash) const
     return &(it->second);
 }
 
-void CWallet::UpgradeKeyMetadata()
+void CWallet::UpgradeKeyMetadata(WalletBatch& batch)
 {
+    AssertLockHeld(cs_wallet);
     if (IsLocked() || IsWalletFlagSet(WALLET_FLAG_KEY_ORIGIN_METADATA)) {
         return;
     }
@@ -370,8 +371,8 @@ void CWallet::UpgradeKeyMetadata()
         return;
     }
 
-    spk_man->UpgradeKeyMetadata();
-    SetWalletFlag(WALLET_FLAG_KEY_ORIGIN_METADATA);
+    spk_man->UpgradeKeyMetadata(batch);
+    SetWalletFlagWithDB(batch, WALLET_FLAG_KEY_ORIGIN_METADATA);
 }
 
 void CWallet::UpgradeDescriptorCache()
@@ -402,7 +403,8 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase, bool accept_no_key
                 continue; // try another master key
             if (Unlock(_vMasterKey, accept_no_keys)) {
                 // Now that we've unlocked, upgrade the key metadata
-                UpgradeKeyMetadata();
+                WalletBatch batch(GetDatabase());
+                UpgradeKeyMetadata(batch);
                 // Now that we've unlocked, upgrade the descriptor cache
                 UpgradeDescriptorCache();
                 return true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1379,13 +1379,19 @@ bool CWallet::CanGetAddresses(bool internal) const
     }
     return false;
 }
+void CWallet::SetWalletFlagWithDB(WalletBatch& batch, uint64_t flags)
+{
+    AssertLockHeld(cs_wallet);
+    m_wallet_flags |= flags;
+    if (!batch.WriteWalletFlags(m_wallet_flags))
+        throw std::runtime_error(std::string(__func__) + ": writing wallet flags failed");
+}
 
 void CWallet::SetWalletFlag(uint64_t flags)
 {
     LOCK(cs_wallet);
-    m_wallet_flags |= flags;
-    if (!WalletBatch(GetDatabase()).WriteWalletFlags(m_wallet_flags))
-        throw std::runtime_error(std::string(__func__) + ": writing wallet flags failed");
+    WalletBatch batch(GetDatabase());
+    SetWalletFlagWithDB(batch, flags);
 }
 
 void CWallet::UnsetWalletFlag(uint64_t flag)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -797,6 +797,7 @@ public:
     void BlockUntilSyncedToCurrentChain() const LOCKS_EXCLUDED(::cs_main) EXCLUSIVE_LOCKS_REQUIRED(!cs_wallet);
 
     /** set a single wallet flag */
+    void SetWalletFlagWithDB(WalletBatch& batch, uint64_t flags) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void SetWalletFlag(uint64_t flags);
 
     /** Unsets a single wallet flag */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -476,7 +476,7 @@ public:
     double ScanningProgress() const { return fScanningWallet ? (double) m_scanning_progress : 0; }
 
     //! Upgrade stored CKeyMetadata objects to store key origin info as KeyOriginInfo
-    void UpgradeKeyMetadata() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void UpgradeKeyMetadata(WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Upgrade DescriptorCaches
     void UpgradeDescriptorCache() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -479,7 +479,7 @@ public:
     void UpgradeKeyMetadata(WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Upgrade DescriptorCaches
-    void UpgradeDescriptorCache() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void UpgradeDescriptorCache(WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     bool LoadMinVersion(int nVersion) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; return true; }
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -885,7 +885,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     // Upgrade all of the wallet keymetadata to have the hd master key id
     // This operation is not atomic, but if it fails, updated entries are still backwards compatible with older software
     try {
-        pwallet->UpgradeKeyMetadata();
+        pwallet->UpgradeKeyMetadata(*this);
     } catch (...) {
         result = DBErrors::CORRUPT;
     }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -893,7 +893,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     // Upgrade all of the descriptor caches to cache the last hardened xpub
     // This operation is not atomic, but if it fails, only new entries are added so it is backwards compatible
     try {
-        pwallet->UpgradeDescriptorCache();
+        pwallet->UpgradeDescriptorCache(*this);
     } catch (...) {
         result = DBErrors::CORRUPT;
     }


### PR DESCRIPTION
We never have multiple threads making able to multiple `WalletBatch`s due to the extensive use of `cs_wallet`, `cs_KeyStore`, and `cs_desc_man`, so the use of refcounting to handle the case where that may happen is unnecessary. Thus we can use an assert to enforce that only one `BerkeleyBatch` is accessing the `BerkeleyDatabase` at a time. The only instances where multiple `BerkeleyBatch`s were being created were where one was made in a caller function, and then the called function created another for itself. For those cases, we instead either pass in the caller's `WalletBatch` or limit the scope of the caller's `WalletBatch` so that there are no overlaps.

The refcounting in `BerkeleyDatabase` is kept because it did more than just count the number of `BerkeleyBatch`s, it also indicated when the database was flushed. However the `AddRef` and `RemoveRef` functions have been removed from `WalletDatabase`.