### PR TITLE
fuzz: Version handshake

### DIFF
--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -48,10 +48,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         peers.push_back(MakeUnique<CNode>(i, service_flags, 0, INVALID_SOCKET, CAddress{CService{in_addr{0x0100007f}, 7777}, NODE_NETWORK}, 0, 0, CAddress{}, std::string{}, conn_type).release());
         CNode& p2p_node = *peers.back();
 
-        p2p_node.fSuccessfullyConnected = true;
         p2p_node.fPauseSend = false;
-        p2p_node.nVersion = PROTOCOL_VERSION;
-        p2p_node.SetCommonVersion(PROTOCOL_VERSION);
         g_setup->m_node.peerman->InitializeNode(&p2p_node);
 
         connman.AddTestNode(p2p_node);


### PR DESCRIPTION
I don't see a reason to exclude the version/verack message from the process_messages fuzzer. Whereas including it will have several benefits:

* Higher coverage (version/verack/handshake/wtxid/...) in net_processing
* Fuzzer can pick the peer versions instead of relying on a hardcoded constant, might increase search space and coverage even further