### PR TITLE
test: Enable mocktime RPC for all test chains

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -238,7 +238,7 @@ public:
         fDefaultConsistencyChecks = false;
         fRequireStandard = false;
         m_is_test_chain = true;
-        m_is_mockable_chain = false;
+        m_is_mockable_chain = true;
 
         checkpointData = {
             {
@@ -348,7 +348,7 @@ public:
         fDefaultConsistencyChecks = false;
         fRequireStandard = true;
         m_is_test_chain = true;
-        m_is_mockable_chain = false;
+        m_is_mockable_chain = true;
     }
 };
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -360,17 +360,17 @@ static RPCHelpMan signmessagewithprivkey()
 static RPCHelpMan setmocktime()
 {
     return RPCHelpMan{"setmocktime",
-                "\nSet the local time to given timestamp (-regtest only)\n",
-                {
-                    {"timestamp", RPCArg::Type::NUM, RPCArg::Optional::NO, UNIX_EPOCH_TIME + "\n"
+        "\nSet the local time to given timestamp (for testing only)\n",
+        {
+            {"timestamp", RPCArg::Type::NUM, RPCArg::Optional::NO, UNIX_EPOCH_TIME + "\n"
             "   Pass 0 to go back to using the system time."},
-                },
-                RPCResult{RPCResult::Type::NONE, "", ""},
-                RPCExamples{""},
+        },
+        RPCResult{RPCResult::Type::NONE, "", ""},
+        RPCExamples{""},
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
     if (!Params().IsMockableChain()) {
-        throw std::runtime_error("setmocktime is for regression testing (-regtest mode) only");
+        throw std::runtime_error("setmocktime is not enabled on current chain");
     }
 
     // For now, don't change mocktime if we're in the middle of validation, as
@@ -397,16 +397,16 @@ static RPCHelpMan setmocktime()
 static RPCHelpMan mockscheduler()
 {
     return RPCHelpMan{"mockscheduler",
-        "\nBump the scheduler into the future (-regtest only)\n",
+        "\nBump the scheduler into the future\n",
         {
-            {"delta_time", RPCArg::Type::NUM, RPCArg::Optional::NO, "Number of seconds to forward the scheduler into the future." },
+            {"delta_time", RPCArg::Type::NUM, RPCArg::Optional::NO, "Number of seconds to forward the scheduler into the future."},
         },
         RPCResult{RPCResult::Type::NONE, "", ""},
         RPCExamples{""},
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
     if (!Params().IsMockableChain()) {
-        throw std::runtime_error("mockscheduler is for regression testing (-regtest mode) only");
+        throw std::runtime_error("mockscheduler is not enabled on current chain");
     }
 
     // check params are valid values

--- a/test/functional/feature_signet.py
+++ b/test/functional/feature_signet.py
@@ -69,6 +69,8 @@ class SignetBasicTest(BitcoinTestFramework):
         with self.nodes[0].assert_debug_log(["Signet derived magic (message start)"]):
             self.restart_node(0)
 
+        self.nodes[0].setmocktime(0)  # Check that mocktime RPC is enabled for signet
+
 
 if __name__ == '__main__':
     SignetBasicTest().main()

--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -11,6 +11,7 @@ from test_framework.p2p import P2PTxInvStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
+
 class ResendWalletTransactionsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
@@ -27,10 +28,10 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         txid = node.sendtoaddress(node.getnewaddress(), 1)
 
         # Wallet rebroadcast is first scheduled 1 sec after startup (see
-        # nNextResend in ResendWalletTransactions()). Sleep for just over a
-        # second to be certain that it has been called before the first
+        # nNextResend in ResendWalletTransactions()). Tell scheduler to call
+        # MaybeResendWalletTxn now to initialize nNextResend before the first
         # setmocktime call below.
-        time.sleep(1.1)
+        node.mockscheduler(1)
 
         # Can take a few seconds due to transaction trickling
         peer_first.wait_for_broadcast([txid])
@@ -57,7 +58,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         twelve_hrs = 12 * 60 * 60
         two_min = 2 * 60
         node.setmocktime(now + twelve_hrs - two_min)
-        time.sleep(2) # ensure enough time has passed for rebroadcast attempt to occur
+        node.mockscheduler(1)  # Tell scheduler to call MaybeResendWalletTxn now
         assert_equal(int(txid, 16) in peer_second.get_invs(), False)
 
         self.log.info("Bump time & check that transaction is rebroadcast")


### PR DESCRIPTION
Seems confusing to disable a test-only RPC for some test chains.

This pull also contains an unrelated test speedup (related to mocktime, though).