### PR TITLE
Release notes and followups from 19339

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -102,8 +102,8 @@ will trigger BIP 125 (replace-by-fee) opt-in. (#11413)
   option `-deprecatedrpc=banscore` is used. The `banscore` field will be fully
   removed in the next major release. (#19469)
 
-- The `testmempoolaccept` RPC returns `vsize` and a `fee` object with the `base` fee
-  if the transaction passes validation. (#19940)
+- The `testmempoolaccept` RPC returns `vsize` and a `fees` object with the `base` fee
+  if the transaction would pass validation. (#19940)
 
 - The `getpeerinfo` RPC now returns a `connection_type` field. This indicates
   the type of connection established with the peer. It will return one of six
@@ -346,6 +346,16 @@ RPC
   - Insufficient funds
   - Fee estimation failed
   - Transaction has too long of a mempool chain
+
+- The `sendrawtransaction` error code for exceeding `maxfeerate` has been changed from
+  `-26` to `-25`. The error string has been changed from "absurdly-high-fee" to
+  "Fee exceeds maximum configured by user (e.g. -maxtxfee, maxfeerate)." The
+  `testmempoolaccept` RPC returns `max-fee-exceeded` rather than `absurdly-high-fee`
+  as the `reject-reason`. (#19339)
+
+- To make wallet and rawtransaction RPCs more consistent, the error message for
+  exceeding maximum feerate has been changed to "Fee exceeds maximum configured by user
+  (e.g. -maxtxfee, maxfeerate)." (#19339)
 
 Tests
 -----

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -13,7 +13,8 @@
 
 #include <future>
 
-static TransactionError HandleATMPError(const TxValidationState& state, std::string& err_string_out) {
+static TransactionError HandleATMPError(const TxValidationState& state, std::string& err_string_out)
+{
     err_string_out = state.ToString();
     if (state.IsInvalid()) {
         if (state.GetResult() == TxValidationResult::TX_MISSING_INPUTS) {
@@ -50,10 +51,10 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
     if (!node.mempool->exists(hashTx)) {
         // Transaction is not already in the mempool.
         TxValidationState state;
-        CAmount fee{0};
-        if (max_tx_fee) {
+        if (max_tx_fee > 0) {
             // First, call ATMP with test_accept and check the fee. If ATMP
             // fails here, return error immediately.
+            CAmount fee{0};
             if (!AcceptToMemoryPool(*node.mempool, state, tx,
                 nullptr /* plTxnReplaced */, false /* bypass_limits */, /* test_accept */ true, &fee)) {
                 return HandleATMPError(state, err_string);


### PR DESCRIPTION
Pretty trivial... addresses some tiny comments from #19339. Also fixes a docs typo from #19940 and adds a release note about the error message change for testmempoolaccept.