### PR TITLE
cli: -netinfo quick updates/fixups for 0.21

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -343,6 +343,12 @@ private:
         if (gArgs.GetChainName() == CBaseChainParams::REGTEST) return " regtest";
         return "";
     }
+    std::string PingTimeToString(double seconds) const
+    {
+        if (seconds < 0) return "";
+        const double milliseconds{round(1000 * seconds)};
+        return milliseconds > 999999 ? "-" : ToString(milliseconds);
+    }
     const int64_t m_time_now{GetSystemTimeInSeconds()};
 
 public:
@@ -428,8 +434,8 @@ public:
                     peer.is_outbound ? "out" : "in",
                     peer.is_block_relay ? "block" : "full",
                     peer.network,
-                    peer.min_ping == -1 ? "" : ToString(round(1000 * peer.min_ping)),
-                    peer.ping == -1 ? "" : ToString(round(1000 * peer.ping)),
+                    PingTimeToString(peer.min_ping),
+                    PingTimeToString(peer.ping),
                     peer.last_send == 0 ? "" : ToString(m_time_now - peer.last_send),
                     peer.last_recv == 0 ? "" : ToString(m_time_now - peer.last_recv),
                     peer.last_trxn == 0 ? "" : ToString((m_time_now - peer.last_trxn) / 60),

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -20,6 +20,7 @@
 #include <util/translation.h>
 #include <util/url.h>
 
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <stdio.h>
@@ -455,12 +456,16 @@ public:
 
         // Report local addresses, ports, and scores.
         result += "\nLocal addresses";
-        const UniValue& local_addrs{networkinfo["localaddresses"]};
+        const std::vector<UniValue>& local_addrs{networkinfo["localaddresses"].getValues()};
         if (local_addrs.empty()) {
             result += ": n/a\n";
         } else {
-            for (const UniValue& addr : local_addrs.getValues()) {
-                result += strprintf("\n%-40i  port %5i     score %6i", addr["address"].get_str(), addr["port"].get_int(), addr["score"].get_int());
+            size_t max_addr_size{0};
+            for (const UniValue& addr : local_addrs) {
+                max_addr_size = std::max(addr["address"].get_str().length() + 1, max_addr_size);
+            }
+            for (const UniValue& addr : local_addrs) {
+                result += strprintf("\n%-*s    port %6i    score %6i", max_addr_size, addr["address"].get_str(), addr["port"].get_int(), addr["score"].get_int());
             }
         }
 


### PR DESCRIPTION
Quick fixups and updates for v0.21.0:

- [x] handle larger BIP155 `addrv2` addresses
- [x] add Signet chain
- [x] add an additional space between the `net` and `mping` columns; add missing `tinyformat` and `algorithm` headers
- [x] s/uptime/age/ per 0xB10C suggestion, and make the column auto-adjusting variable width
- [x] display `-` for oversized mping/ping times like `1.17348e+06`, as reported by practicalswift

Edit: removed the release note commit, as this PR was not merged before the notes were moved to the wiki. It's here:
```
- A new `bitcoin-cli -netinfo` command returns a network peer connections
  dashboard that displays data from the `getpeerinfo` and `getnetworkinfo` RPCs
  in a human-readable format. An optional integer argument from `0` to `4` may
  be passed to see various levels of detail. (#19643)
```