### PR TITLE
configure: Allow users to explicitly enable libsecp256k1's GMP bignum support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1700,7 +1700,7 @@ if test x$need_bundled_univalue = xyes; then
   AC_CONFIG_SUBDIRS([src/univalue])
 fi
 
-ac_configure_args="${ac_configure_args} --disable-shared --with-pic --enable-benchmark=no --with-bignum=no --enable-module-recovery --enable-module-schnorrsig --enable-experimental"
+ac_configure_args="--with-bignum=no ${ac_configure_args} --disable-shared --with-pic --enable-benchmark=no --enable-module-recovery --enable-module-schnorrsig --enable-experimental"
 AC_CONFIG_SUBDIRS([src/secp256k1])
 
 AC_OUTPUT


### PR DESCRIPTION
By moving the `--with-bignum=no` option to the start of the configure args, users can explicitly override it when configuring Bitcoin Core.

When this option was originally added in 2015 (7fd5b801ff16d748b5ca13ded09ed5da8eacf7e7 #6210), there was mention of a runtime crash reported by gmaxwell. Do details of that incident exist anywhere? Was it ever resolved? Did it crash at startup? If not, could it be triggered remotely?