### PR TITLE
Make Assert(…) usable in all contexts. Make implicit assumptions explicit.

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -12,6 +12,7 @@
 #include <primitives/block.h>
 #include <tinyformat.h>
 #include <uint256.h>
+#include <util/check.h>
 
 #include <vector>
 
@@ -400,7 +401,7 @@ public:
 
     /** Efficiently check whether a block is present in this chain. */
     bool Contains(const CBlockIndex *pindex) const {
-        return (*this)[pindex->nHeight] == pindex;
+        return (*this)[Assert(pindex)->nHeight] == pindex;
     }
 
     /** Find the successor of a block in this chain, or nullptr if the given index is not found or is the tip. */

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4273,7 +4273,7 @@ bool PeerManager::SendMessages(CNode* pto)
                     bool fGotBlockFromCache = false;
                     {
                         LOCK(cs_most_recent_block);
-                        if (most_recent_block_hash == pBestIndex->GetBlockHash()) {
+                        if (most_recent_block_hash == Assert(pBestIndex)->GetBlockHash()) {
                             if (state.fWantsCmpctWitness || !fWitnessesPresentInMostRecentCompactBlock)
                                 m_connman.PushMessage(pto, msgMaker.Make(nSendFlags, NetMsgType::CMPCTBLOCK, *most_recent_compact_block));
                             else {

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -54,6 +54,6 @@ T get_pure_r_value(T&& val)
 }
 
 /** Identity function. Abort if the value compares equal to zero */
-#define Assert(val) [&]() -> decltype(get_pure_r_value(val)) { auto&& check = (val); assert(#val && check); return std::forward<decltype(get_pure_r_value(val))>(check); }()
+#define Assert(val) ([&]() -> decltype(get_pure_r_value(val)) { auto&& check = (val); assert(#val && check); return std::forward<decltype(get_pure_r_value(val))>(check); }())
 
 #endif // BITCOIN_UTIL_CHECK_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4321,7 +4321,7 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
         return error("VerifyDB(): *** coin database inconsistencies found (last %i blocks, %i good transactions before that)\n", ::ChainActive().Height() - pindexFailure->nHeight + 1, nGoodTransactions);
 
     // store block count as we move pindex at check level >= 4
-    int block_count = ::ChainActive().Height() - pindex->nHeight;
+    int block_count = ::ChainActive().Height() - Assert(pindex)->nHeight;
 
     // check level 4: try reconnecting blocks
     if (nCheckLevel >= 4) {


### PR DESCRIPTION
* Make `Assert(…)` (`util/check.h`) usable in all contexts.
* Use `Assert(…)` to make implicit assumptions explicit.

Before the first commit:

```
./chain.h:404:23: error: C++11 only allows consecutive left square brackets when introducing an attribute
        return (*this)[Assert(pindex)->nHeight] == pindex;
                      ^
```