### PR TITLE
Missing blockhash prefix (0x) for Testnet and Regtest

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -242,7 +242,7 @@ public:
 
         checkpointData = {
             {
-                {546, uint256S("000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70")},
+                {546, uint256S("0x000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70")},
             }
         };
 
@@ -405,7 +405,7 @@ public:
 
         checkpointData = {
             {
-                {0, uint256S("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206")},
+                {0, uint256S("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206")},
             }
         };
 


### PR DESCRIPTION
Its checkpoint validation is working even with no prefix, because `base_blob<BITS>::SetHex`. However I guess this PR is right way and for code consistency like Mainnet.

https://github.com/bitcoin/bitcoin/blob/0b2abaa666d6f3331e3246ffd64dd47946e9dcdf/src/chainparams.cpp#L146