### PR TITLE
tests: don't export in6addr_loopback

### DIFF
--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -452,17 +452,17 @@ BOOST_AUTO_TEST_CASE(netbase_dont_resolve_strings_with_embedded_nul_characters)
 
 static const std::vector<CAddress> fixture_addresses({
     CAddress(
-        CService(CNetAddr(in6addr_loopback), 0 /* port */),
+        CService(CNetAddr(in6_addr(IN6ADDR_LOOPBACK_INIT)), 0 /* port */),
         NODE_NONE,
         0x4966bc61U /* Fri Jan  9 02:54:25 UTC 2009 */
     ),
     CAddress(
-        CService(CNetAddr(in6addr_loopback), 0x00f1 /* port */),
+        CService(CNetAddr(in6_addr(IN6ADDR_LOOPBACK_INIT)), 0x00f1 /* port */),
         NODE_NETWORK,
         0x83766279U /* Tue Nov 22 11:22:33 UTC 2039 */
     ),
     CAddress(
-        CService(CNetAddr(in6addr_loopback), 0xf1f2 /* port */),
+        CService(CNetAddr(in6_addr(IN6ADDR_LOOPBACK_INIT)), 0xf1f2 /* port */),
         static_cast<ServiceFlags>(NODE_WITNESS | NODE_COMPACT_FILTERS | NODE_NETWORK_LIMITED),
         0xffffffffU /* Sun Feb  7 06:28:15 UTC 2106 */
     )


### PR DESCRIPTION
Don't export `in6addr_loopback` because that upsets
`contrib/devtools/symbol-check.py`

Fixes https://github.com/bitcoin/bitcoin/issues/20127
