### PR TITLE
Wallet: do not return warnings from UpgradeWallet()

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4473,10 +4473,8 @@ static RPCHelpMan upgradewallet()
     if (!request.params[0].isNull()) {
         version = request.params[0].get_int();
     }
-
     bilingual_str error;
-    std::vector<bilingual_str> warnings;
-    if (!pwallet->UpgradeWallet(version, error, warnings)) {
+    if (!pwallet->UpgradeWallet(version, error)) {
         throw JSONRPCError(RPC_WALLET_ERROR, error.original);
     }
     UniValue obj(UniValue::VOBJ);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4122,7 +4122,7 @@ const CAddressBookData* CWallet::FindAddressBookEntry(const CTxDestination& dest
     return &address_book_it->second;
 }
 
-bool CWallet::UpgradeWallet(int version, bilingual_str& error, std::vector<bilingual_str>& warnings)
+bool CWallet::UpgradeWallet(int version, bilingual_str& error)
 {
     int prev_version = GetVersion();
     int nMaxVersion = version;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1201,7 +1201,7 @@ public:
     };
 
     /** Upgrade the wallet */
-    bool UpgradeWallet(int version, bilingual_str& error, std::vector<bilingual_str>& warnings);
+    bool UpgradeWallet(int version, bilingual_str& error);
 
     //! Returns all unique ScriptPubKeyMans in m_internal_spk_managers and m_external_spk_managers
     std::set<ScriptPubKeyMan*> GetActiveScriptPubKeyMans() const;


### PR DESCRIPTION
The `warning` variable was unused in `upgradewallet` so I removed it