### PR TITLE
Restore compatibility with old CSubNet serialization

### DIFF
--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -184,7 +184,7 @@ void BanMan::SweepBanned()
         while (it != m_banned.end()) {
             CSubNet sub_net = (*it).first;
             CBanEntry ban_entry = (*it).second;
-            if (now > ban_entry.nBanUntil) {
+            if (!sub_net.IsValid() || now > ban_entry.nBanUntil) {
                 m_banned.erase(it++);
                 m_is_dirty = true;
                 notify_ui = true;

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -1109,6 +1109,17 @@ bool CSubNet::IsValid() const
     return valid;
 }
 
+bool CSubNet::SanityCheck() const
+{
+    if (!(network.IsIPv4() || network.IsIPv6())) return false;
+
+    for (size_t x = 0; x < network.m_addr.size(); ++x) {
+        if (network.m_addr[x] & ~netmask[x]) return false;
+    }
+
+    return true;
+}
+
 bool operator==(const CSubNet& a, const CSubNet& b)
 {
     return a.valid == b.valid && a.network == b.network && !memcmp(a.netmask, b.netmask, 16);

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -468,7 +468,21 @@ class CSubNet
         friend bool operator!=(const CSubNet& a, const CSubNet& b) { return !(a == b); }
         friend bool operator<(const CSubNet& a, const CSubNet& b);
 
-        SERIALIZE_METHODS(CSubNet, obj) { READWRITE(obj.network, obj.netmask, obj.valid); }
+        SERIALIZE_METHODS(CSubNet, obj)
+        {
+            READWRITE(obj.network);
+            if (obj.network.IsIPv4()) {
+                // Before commit 102867c587f5f7954232fb8ed8e85cda78bb4d32, CSubNet used the last 4 bytes of netmask
+                // to store the relevant bytes for an IPv4 mask. For compatiblity reasons, keep doing so in
+                // serialized form.
+                unsigned char dummy[12] = {0};
+                READWRITE(dummy);
+                READWRITE(MakeSpan(obj.netmask).first(4));
+            } else {
+                READWRITE(obj.netmask);
+            }
+            READWRITE(obj.valid);
+        }
 };
 
 /** A combination of a network address (CNetAddr) and a (TCP) port */

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -451,6 +451,8 @@ class CSubNet
         /// Is this value valid? (only used to signal parse errors)
         bool valid;
 
+        bool SanityCheck() const;
+
     public:
         CSubNet();
         CSubNet(const CNetAddr& addr, uint8_t mask);
@@ -482,6 +484,8 @@ class CSubNet
                 READWRITE(obj.netmask);
             }
             READWRITE(obj.valid);
+            // Mark invalid if the result doesn't pass sanity checking.
+            SER_READ(obj, if (obj.valid) obj.valid = obj.SanityCheck());
         }
 };
 


### PR DESCRIPTION
#19628 changed CSubNet for IPv4 netmasks, using the first 4 bytes of `netmask` rather than the last 4 to store the actual mask. Unfortunately, CSubNet objects are serialized on disk in banlist.dat, breaking compatibility with existing banlists (and bringing them into an inconsistent state where entries reported in `listbanned` cannot be removed).

Fix this by reverting to the old format (just for serialization). Also add a sanity check to the deserializer so that nonsensical banlist.dat entries are ignored (which would otherwise be possible if someone added IPv4 entries after #19628 but without this PR).

Reported by Greg Maxwell.