### PR TITLE
[0.20] build: set minimum required Boost to 1.48.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1140,7 +1140,7 @@ fi
 if test x$use_boost = xyes; then
 
 dnl Minimum required Boost version
-define(MINIMUM_REQUIRED_BOOST, 1.47.0)
+define(MINIMUM_REQUIRED_BOOST, 1.48.0)
 
 dnl Check for boost libs
 AX_BOOST_BASE([MINIMUM_REQUIRED_BOOST])

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -6,7 +6,7 @@ These are the dependencies currently used by Bitcoin Core. You can find instruct
 | Dependency | Version used | Minimum required | CVEs | Shared | [Bundled Qt library](https://doc.qt.io/qt-5/configure-options.html#third-party-libraries) |
 | --- | --- | --- | --- | --- | --- |
 | Berkeley DB | [4.8.30](https://www.oracle.com/technetwork/database/database-technologies/berkeleydb/downloads/index.html) | 4.8.x | No |  |  |
-| Boost | [1.70.0](https://www.boost.org/users/download/) | [1.47.0](https://github.com/bitcoin/bitcoin/pull/8920) | No |  |  |
+| Boost | [1.70.0](https://www.boost.org/users/download/) | [1.48.0](https://github.com/bitcoin/bitcoin/pull/20142) | No |  |  |
 | Clang |  | [3.3+](https://releases.llvm.org/download.html) (C++11 support) |  |  |  |
 | Expat | [2.2.7](https://libexpat.github.io/) |  | No | Yes |  |
 | fontconfig | [2.12.1](https://www.freedesktop.org/software/fontconfig/release/) |  | No | Yes |  |


### PR DESCRIPTION
Due to the use of [`boost::filesystem::canonical()`](https://github.com/bitcoin/bitcoin/blob/80aa83aa406447d9b0932301b37966a30d0e1b6e/src/wallet/load.cpp#L21), the minimum required
version of Boost is actually 1.48.0. Use of canonical was introduced
in #14146.

See also [Boost filesystem 1.48.0 release notes](https://github.com/boostorg/filesystem/blob/6b5e38134a336b6ea777cd8a69b6ae929819db7e/doc/release_history.html#L508). Also discussed in #20080.