### PR TITLE
contrib: add getcoins.py script to get coins from (signet) faucet

### DIFF
--- a/contrib/signet/README.md
+++ b/contrib/signet/README.md
@@ -1,0 +1,19 @@
+Contents
+========
+This directory contains tools related to Signet, both for running a Signet yourself and for using one.
+
+getcoins.py
+===========
+
+A script to call a faucet to get Signet coins.
+
+Syntax: `getcoins.py [-h|--help] [-c|--cmd=<bitcoin-cli path>] [-f|--faucet=<faucet URL>] [-a|--addr=<signet bech32 address>] [-p|--password=<faucet password>] [--] [<bitcoin-cli args>]`
+
+* `--cmd` lets you customize the bitcoin-cli path. By default it will look for it in the PATH
+* `--faucet` lets you specify which faucet to use; the faucet is assumed to be compatible with https://github.com/kallewoof/bitcoin-faucet
+* `--addr` lets you specify a Signet address; by default, the address must be a bech32 address. This and `--cmd` above complement each other (i.e. you do not need `bitcoin-cli` if you use `--addr`)
+* `--password` lets you specify a faucet password; this is handy if you are in a classroom and set up your own faucet for your students; (above faucet does not limit by IP when password is enabled)
+
+If using the default network, invoking the script with no arguments should be sufficient under normal
+circumstances, but if multiple people are behind the same IP address, the faucet will by default only
+accept one claim per day. See `--password` above.

--- a/contrib/signet/getcoins.py
+++ b/contrib/signet/getcoins.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import argparse
+import subprocess
+import requests
+import sys
+
+parser = argparse.ArgumentParser(description='Script to get coins from a faucet.', epilog='You may need to start with double-dash (--) when providing bitcoin-cli arguments.')
+parser.add_argument('-c', '--cmd', dest='cmd', default='bitcoin-cli', help='bitcoin-cli command to use')
+parser.add_argument('-f', '--faucet', dest='faucet', default='https://signetfaucet.com/claim', help='URL of the faucet')
+parser.add_argument('-a', '--addr', dest='addr', default='', help='Bitcoin address to which the faucet should send')
+parser.add_argument('-p', '--password', dest='password', default='', help='Faucet password, if any')
+parser.add_argument('bitcoin_cli_args', nargs='*', help='Arguments to pass on to bitcoin-cli (default: -signet)')
+
+args = parser.parse_args()
+
+if args.addr == '':
+    if args.bitcoin_cli_args == []:
+        args.bitcoin_cli_args = ['-signet']
+    # get address for receiving coins
+    try:
+        args.addr = subprocess.check_output([args.cmd] + args.bitcoin_cli_args + ['getnewaddress', 'faucet', 'bech32']).strip()
+    except FileNotFoundError:
+        print('The binary', args.cmd, 'could not be found.')
+        exit()
+
+data = {'address': args.addr, 'password': args.password}
+try:
+    res = requests.post(args.faucet, data=data)
+except:
+    print('Unexpected error when contacting faucet:', sys.exc_info()[0])
+    exit()
+print(res.text)


### PR DESCRIPTION
This adds a small python script that can be used to fetch Signet coins from the default (or custom) faucet.