### PR TITLE
net: Send post-verack handshake messages at most once

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2555,8 +2555,9 @@ void PeerManager::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDat
     // At this point, the outgoing message serialization version can't change.
     const CNetMsgMaker msgMaker(pfrom.GetCommonVersion());
 
-    if (msg_type == NetMsgType::VERACK)
-    {
+    if (msg_type == NetMsgType::VERACK) {
+        if (pfrom.fSuccessfullyConnected) return;
+
         if (!pfrom.IsInboundConn()) {
             // Mark this node as currently connected, so we update its timestamp later.
             LOCK(cs_main);


### PR DESCRIPTION
There is no need to send `SENDHEADERS` and `SENDCMPCT` messages as a reply to each `VERACK` that is received. For alive checks, a `PING`/`PONG` can be used.