### PR TITLE
test: mining_getblocktemplate_longpoll.py improvements (use MiniWallet, add logging)

### DIFF
--- a/test/functional/mining_getblocktemplate_longpoll.py
+++ b/test/functional/mining_getblocktemplate_longpoll.py
@@ -33,14 +33,14 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
 
     def run_test(self):
         self.log.info("Warning: this test will take about 70 seconds in the best case. Be patient.")
+        self.log.info("Test that longpollid doesn't change between successive getblocktemplate() invocations if nothing else happens")
         self.nodes[0].generate(10)
         template = self.nodes[0].getblocktemplate({'rules': ['segwit']})
         longpollid = template['longpollid']
-        # longpollid should not change between successive invocations if nothing else happens
         template2 = self.nodes[0].getblocktemplate({'rules': ['segwit']})
         assert template2['longpollid'] == longpollid
 
-        # Test 1: test that the longpolling wait if we do nothing
+        self.log.info("Test that longpoll waits if we do nothing")
         thr = LongpollThread(self.nodes[0])
         thr.start()
         # check that thread still lives
@@ -48,13 +48,13 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
         assert thr.is_alive()
 
         miniwallets = [ MiniWallet(node) for node in self.nodes ]
-        # Test 2: test that longpoll will terminate if another node generates a block
+        self.log.info("Test that longpoll will terminate if another node generates a block")
         miniwallets[1].generate(1)  # generate a block on another node
         # check that thread will exit now that new transaction entered mempool
         thr.join(5)  # wait 5 seconds or until thread exits
         assert not thr.is_alive()
 
-        # Test 3: test that longpoll will terminate if we generate a block ourselves
+        self.log.info("Test that longpoll will terminate if we generate a block ourselves")
         thr = LongpollThread(self.nodes[0])
         thr.start()
         miniwallets[0].generate(1)  # generate a block on own node
@@ -65,7 +65,7 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
         self.nodes[0].generate(100)
         self.sync_blocks()
 
-        # Test 4: test that introducing a new transaction into the mempool will terminate the longpoll
+        self.log.info("Test that introducing a new transaction into the mempool will terminate the longpoll")
         thr = LongpollThread(self.nodes[0])
         thr.start()
         # generate a random transaction and submit it


### PR DESCRIPTION
This PR enables one more of the non-wallet functional tests (mining_getblocktemplate_longpoll.py) to be run even with the Bitcoin Core wallet disabled by using the new MiniWallet instead, as proposed in #20078. Also adds missing log messages for the subtests.

This was the only functional test that used the `random_transaction` helper in `test_framework/util.py`, hence it is removed, together with other helpers (`make_change` and `gather_inputs`) that were again only used by `random_transaction`.
