### PR TITLE
contrib: Fix gen_key_io_test_vectors.py imports

### DIFF
--- a/contrib/testgen/gen_key_io_test_vectors.py
+++ b/contrib/testgen/gen_key_io_test_vectors.py
@@ -15,8 +15,7 @@ import os
 from itertools import islice
 from base58 import b58encode_chk, b58decode_chk, b58chars
 import random
-from binascii import b2a_hex
-from segwit_addr import bech32_encode, decode, convertbits, CHARSET
+from segwit_addr import bech32_encode, decode_segwit_address, convertbits, CHARSET
 
 # key types
 PUBKEY_ADDRESS = 0
@@ -109,7 +108,7 @@ def is_valid(v):
 def is_valid_bech32(v):
     '''Check vector v for bech32 validity'''
     for hrp in ['bc', 'tb', 'bcrt']:
-        if decode(hrp, v) != (None, None):
+        if decode_segwit_address(hrp, v) != (None, None):
             return True
     return False
 
@@ -141,9 +140,7 @@ def gen_valid_vectors():
             rv, payload = valid_vector_generator(template)
             assert is_valid(rv)
             metadata = {x: y for x, y in zip(metadata_keys,template[3]) if y is not None}
-            hexrepr = b2a_hex(payload)
-            if isinstance(hexrepr, bytes):
-                hexrepr = hexrepr.decode('utf8')
+            hexrepr = payload.hex()
             yield (rv, hexrepr, metadata)
 
 def gen_invalid_base58_vector(template):


### PR DESCRIPTION
The script currently fails with 

```
Traceback (most recent call last):
  File "./gen_key_io_test_vectors.py", line 18, in <module>
    from segwit_addr import bech32_encode, decode, convertbits, CHARSET
ImportError: cannot import name 'decode' from 'segwit_addr'
```

Fix that.
Also, unrelated cleanup to use the `bytearray.hex()` method instead of importing a library. https://docs.python.org/3.5/library/stdtypes.html#bytes.hex