### PR TITLE
rpc, net: Expose connections_onion_only in getnetworkinfo RPC output

### DIFF
--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -87,10 +87,17 @@ public:
         }
     }
     bool getProxy(Network net, proxyType& proxy_info) override { return GetProxy(net, proxy_info); }
-    size_t getNodeCount(CConnman::NumConnections flags) override
+
+    size_t peerCount() override
     {
-        return m_context->connman ? m_context->connman->GetNodeCount(flags) : 0;
+        return m_context->connman ? m_context->connman->PeerCount() : 0;
     }
+
+    ConnCounts connectionCounts() override
+    {
+        return m_context->connman ? m_context->connman->GetConnectionCounts() : ConnCounts();
+    }
+
     bool getNodesStats(NodesStats& stats) override
     {
         stats.clear();

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -6,7 +6,7 @@
 #define BITCOIN_INTERFACES_NODE_H
 
 #include <amount.h>     // For CAmount
-#include <net.h>        // For CConnman::NumConnections
+#include <net.h>        // For ConnCounts
 #include <net_types.h>  // For banmap_t
 #include <netaddress.h> // For Network
 #include <support/allocators/secure.h> // For SecureString
@@ -87,8 +87,11 @@ public:
     //! Get proxy.
     virtual bool getProxy(Network net, proxyType& proxy_info) = 0;
 
-    //! Get number of connections.
-    virtual size_t getNodeCount(CConnman::NumConnections flags) = 0;
+    //! Get number of peers.
+    virtual size_t peerCount() = 0;
+
+    //! Get numbers of connections of different types.
+    virtual ConnCounts connectionCounts() = 0;
 
     //! Get stats for connected nodes.
     using NodesStats = std::vector<std::tuple<CNodeStats, bool, CNodeStateStats>>;

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -196,7 +196,7 @@ public:
     virtual std::unique_ptr<Handler> handleShowProgress(ShowProgressFn fn) = 0;
 
     //! Register handler for number of connections changed messages.
-    using NotifyNumConnectionsChangedFn = std::function<void(int new_num_connections)>;
+    using NotifyNumConnectionsChangedFn = std::function<void()>;
     virtual std::unique_ptr<Handler> handleNotifyNumConnectionsChanged(NotifyNumConnectionsChangedFn fn) = 0;
 
     //! Register handler for network active messages.

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -200,7 +200,7 @@ public:
     virtual std::unique_ptr<Handler> handleNotifyNumConnectionsChanged(NotifyNumConnectionsChangedFn fn) = 0;
 
     //! Register handler for network active messages.
-    using NotifyNetworkActiveChangedFn = std::function<void(bool network_active)>;
+    using NotifyNetworkActiveChangedFn = std::function<void()>;
     virtual std::unique_ptr<Handler> handleNotifyNetworkActiveChanged(NotifyNetworkActiveChangedFn fn) = 0;
 
     //! Register handler for notify alert messages.

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2729,20 +2729,17 @@ bool CConnman::RemoveAddedNode(const std::string& strNode)
     return false;
 }
 
-size_t CConnman::GetNodeCount(NumConnections flags)
+ConnCounts CConnman::GetConnectionCounts()
 {
-    LOCK(cs_vNodes);
-    if (flags == CConnman::CONNECTIONS_ALL) // Shortcut if we want total
-        return vNodes.size();
-
-    int nNum = 0;
-    for (const auto& pnode : vNodes) {
-        if (flags & (pnode->IsInboundConn() ? CONNECTIONS_IN : CONNECTIONS_OUT)) {
-            nNum++;
+    int num_in{0};
+    int num_out{0};
+    {
+        LOCK(cs_vNodes);
+        for (const auto& pnode : vNodes) {
+            pnode->IsInboundConn() ? ++num_in : ++num_out;
         }
     }
-
-    return nNum;
+    return {num_in, num_out};
 }
 
 void CConnman::GetNodeStats(std::vector<CNodeStats>& vstats)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2733,13 +2733,16 @@ ConnCounts CConnman::GetConnectionCounts()
 {
     int num_in{0};
     int num_out{0};
+    bool onion_only{false};
     {
         LOCK(cs_vNodes);
+        if (!vNodes.empty()) onion_only = true;
         for (const auto& pnode : vNodes) {
             pnode->IsInboundConn() ? ++num_in : ++num_out;
+            if (pnode->ConnectedThroughNetwork() != NET_ONION) onion_only = false;
         }
     }
-    return {num_in, num_out};
+    return {num_in, num_out, onion_only};
 }
 
 void CConnman::GetNodeStats(std::vector<CNodeStats>& vstats)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2354,7 +2354,7 @@ void CConnman::SetNetworkActive(bool active)
 
     fNetworkActive = active;
     if (clientInterface) {
-        clientInterface->NotifyNetworkActiveChanged(fNetworkActive);
+        clientInterface->NotifyNetworkActiveChanged();
     }
 }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1213,15 +1213,12 @@ void CConnman::DisconnectNodes()
 
 void CConnman::NotifyNumConnectionsChanged()
 {
-    size_t vNodesSize;
-    {
-        LOCK(cs_vNodes);
-        vNodesSize = vNodes.size();
-    }
-    if(vNodesSize != nPrevNodeCount) {
+    const size_t vNodesSize = WITH_LOCK(cs_vNodes, return vNodes.size());
+    if (vNodesSize != nPrevNodeCount) {
         nPrevNodeCount = vNodesSize;
-        if(clientInterface)
-            clientInterface->NotifyNumConnectionsChanged(vNodesSize);
+        if (clientInterface) {
+            clientInterface->NotifyNumConnectionsChanged();
+        }
     }
 }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2353,8 +2353,9 @@ void CConnman::SetNetworkActive(bool active)
     }
 
     fNetworkActive = active;
-
-    uiInterface.NotifyNetworkActiveChanged(fNetworkActive);
+    if (clientInterface) {
+        clientInterface->NotifyNetworkActiveChanged(fNetworkActive);
+    }
 }
 
 CConnman::CConnman(uint64_t nSeed0In, uint64_t nSeed1In, bool network_active)
@@ -2471,7 +2472,9 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
         LogPrintf("%i block-relay-only anchors will be tried for connections.\n", m_anchors.size());
     }
 
-    uiInterface.InitMessage(_("Starting network threads...").translated);
+    if (clientInterface) {
+        clientInterface->InitMessage(_("Starting network threads...").translated);
+    }
 
     fAddressesInitialized = true;
 

--- a/src/net.h
+++ b/src/net.h
@@ -183,17 +183,20 @@ enum class ConnectionType {
     ADDR_FETCH,
 };
 
+struct ConnCounts {
+    const int all{0};
+    const int in{0};
+    const int out{0};
+
+    ConnCounts() {}
+    ConnCounts(int num_in, int num_out)
+        : all(num_in + num_out), in(num_in), out(num_out) {}
+};
+
 class NetEventsInterface;
 class CConnman
 {
 public:
-
-    enum NumConnections {
-        CONNECTIONS_NONE = 0,
-        CONNECTIONS_IN = (1U << 0),
-        CONNECTIONS_OUT = (1U << 1),
-        CONNECTIONS_ALL = (CONNECTIONS_IN | CONNECTIONS_OUT),
-    };
 
     struct Options
     {
@@ -346,7 +349,8 @@ public:
     bool RemoveAddedNode(const std::string& node);
     std::vector<AddedNodeInfo> GetAddedNodeInfo();
 
-    size_t GetNodeCount(NumConnections num);
+    size_t PeerCount() { return WITH_LOCK(cs_vNodes, return vNodes.size()); }
+    ConnCounts GetConnectionCounts();
     void GetNodeStats(std::vector<CNodeStats>& vstats);
     bool DisconnectNode(const std::string& node);
     bool DisconnectNode(const CSubNet& subnet);

--- a/src/net.h
+++ b/src/net.h
@@ -187,10 +187,11 @@ struct ConnCounts {
     const int all{0};
     const int in{0};
     const int out{0};
+    const bool onion_only{false};
 
     ConnCounts() {}
-    ConnCounts(int num_in, int num_out)
-        : all(num_in + num_out), in(num_in), out(num_out) {}
+    ConnCounts(int num_in, int num_out, bool is_onion_only)
+        : all(num_in + num_out), in(num_in), out(num_out), onion_only(is_onion_only) {}
 };
 
 class NetEventsInterface;

--- a/src/node/ui_interface.cpp
+++ b/src/node/ui_interface.cpp
@@ -45,7 +45,7 @@ ADD_SIGNALS_IMPL_WRAPPER(BannedListChanged);
 bool CClientUIInterface::ThreadSafeMessageBox(const bilingual_str& message, const std::string& caption, unsigned int style) { return g_ui_signals.ThreadSafeMessageBox(message, caption, style).value_or(false);}
 bool CClientUIInterface::ThreadSafeQuestion(const bilingual_str& message, const std::string& non_interactive_message, const std::string& caption, unsigned int style) { return g_ui_signals.ThreadSafeQuestion(message, non_interactive_message, caption, style).value_or(false);}
 void CClientUIInterface::InitMessage(const std::string& message) { return g_ui_signals.InitMessage(message); }
-void CClientUIInterface::NotifyNumConnectionsChanged(int newNumConnections) { return g_ui_signals.NotifyNumConnectionsChanged(newNumConnections); }
+void CClientUIInterface::NotifyNumConnectionsChanged() { return g_ui_signals.NotifyNumConnectionsChanged(); }
 void CClientUIInterface::NotifyNetworkActiveChanged() { return g_ui_signals.NotifyNetworkActiveChanged(); }
 void CClientUIInterface::NotifyAlertChanged() { return g_ui_signals.NotifyAlertChanged(); }
 void CClientUIInterface::ShowProgress(const std::string& title, int nProgress, bool resume_possible) { return g_ui_signals.ShowProgress(title, nProgress, resume_possible); }

--- a/src/node/ui_interface.cpp
+++ b/src/node/ui_interface.cpp
@@ -46,7 +46,7 @@ bool CClientUIInterface::ThreadSafeMessageBox(const bilingual_str& message, cons
 bool CClientUIInterface::ThreadSafeQuestion(const bilingual_str& message, const std::string& non_interactive_message, const std::string& caption, unsigned int style) { return g_ui_signals.ThreadSafeQuestion(message, non_interactive_message, caption, style).value_or(false);}
 void CClientUIInterface::InitMessage(const std::string& message) { return g_ui_signals.InitMessage(message); }
 void CClientUIInterface::NotifyNumConnectionsChanged(int newNumConnections) { return g_ui_signals.NotifyNumConnectionsChanged(newNumConnections); }
-void CClientUIInterface::NotifyNetworkActiveChanged(bool networkActive) { return g_ui_signals.NotifyNetworkActiveChanged(networkActive); }
+void CClientUIInterface::NotifyNetworkActiveChanged() { return g_ui_signals.NotifyNetworkActiveChanged(); }
 void CClientUIInterface::NotifyAlertChanged() { return g_ui_signals.NotifyAlertChanged(); }
 void CClientUIInterface::ShowProgress(const std::string& title, int nProgress, bool resume_possible) { return g_ui_signals.ShowProgress(title, nProgress, resume_possible); }
 void CClientUIInterface::NotifyBlockTip(SynchronizationState s, const CBlockIndex* i) { return g_ui_signals.NotifyBlockTip(s, i); }

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -86,7 +86,7 @@ public:
     ADD_SIGNALS_DECL_WRAPPER(NotifyNumConnectionsChanged, void, int newNumConnections);
 
     /** Network activity state changed. */
-    ADD_SIGNALS_DECL_WRAPPER(NotifyNetworkActiveChanged, void, bool networkActive);
+    ADD_SIGNALS_DECL_WRAPPER(NotifyNetworkActiveChanged, void, void);
 
     /**
      * Status bar alerts changed.

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -83,7 +83,7 @@ public:
     ADD_SIGNALS_DECL_WRAPPER(InitMessage, void, const std::string& message);
 
     /** Number of network connections changed. */
-    ADD_SIGNALS_DECL_WRAPPER(NotifyNumConnectionsChanged, void, int newNumConnections);
+    ADD_SIGNALS_DECL_WRAPPER(NotifyNumConnectionsChanged, void, void);
 
     /** Network activity state changed. */
     ADD_SIGNALS_DECL_WRAPPER(NotifyNetworkActiveChanged, void, void);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -925,7 +925,7 @@ void BitcoinGUI::updateNetworkState()
     connectionsControl->setPixmap(platformStyle->SingleColorIcon(icon).pixmap(STATUSBAR_ICONSIZE,STATUSBAR_ICONSIZE));
 }
 
-void BitcoinGUI::setNumConnections(int count)
+void BitcoinGUI::setNumConnections()
 {
     updateNetworkState();
 }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -898,7 +898,7 @@ void BitcoinGUI::gotoLoadPSBT(bool from_clipboard)
 
 void BitcoinGUI::updateNetworkState()
 {
-    int count = clientModel->getNumConnections();
+    int count = m_node.peerCount();
     QString icon;
     switch(count)
     {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -930,7 +930,7 @@ void BitcoinGUI::setNumConnections(int count)
     updateNetworkState();
 }
 
-void BitcoinGUI::setNetworkActive(bool networkActive)
+void BitcoinGUI::setNetworkActive()
 {
     updateNetworkState();
 }

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -220,7 +220,7 @@ public Q_SLOTS:
     /** Set number of connections shown in the UI */
     void setNumConnections(int count);
     /** Set network state shown in the UI */
-    void setNetworkActive(bool networkActive);
+    void setNetworkActive();
     /** Set number of blocks and last block date shown in the UI */
     void setNumBlocks(int count, const QDateTime& blockDate, double nVerificationProgress, bool headers, SynchronizationState sync_state);
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -218,7 +218,7 @@ Q_SIGNALS:
 
 public Q_SLOTS:
     /** Set number of connections shown in the UI */
-    void setNumConnections(int count);
+    void setNumConnections();
     /** Set network state shown in the UI */
     void setNetworkActive();
     /** Set number of blocks and last block date shown in the UI */

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -146,9 +146,9 @@ void ClientModel::updateNumConnections(int numConnections)
     Q_EMIT numConnectionsChanged(numConnections);
 }
 
-void ClientModel::updateNetworkActive(bool networkActive)
+void ClientModel::updateNetworkActive()
 {
-    Q_EMIT networkActiveChanged(networkActive);
+    Q_EMIT networkActiveChanged();
 }
 
 void ClientModel::updateAlert()
@@ -241,10 +241,9 @@ static void NotifyNumConnectionsChanged(ClientModel *clientmodel, int newNumConn
     assert(invoked);
 }
 
-static void NotifyNetworkActiveChanged(ClientModel *clientmodel, bool networkActive)
+static void NotifyNetworkActiveChanged(ClientModel* clientmodel)
 {
-    bool invoked = QMetaObject::invokeMethod(clientmodel, "updateNetworkActive", Qt::QueuedConnection,
-                              Q_ARG(bool, networkActive));
+    bool invoked = QMetaObject::invokeMethod(clientmodel, "updateNetworkActive", Qt::QueuedConnection);
     assert(invoked);
 }
 
@@ -296,7 +295,7 @@ void ClientModel::subscribeToCoreSignals()
     // Connect signals to client
     m_handler_show_progress = m_node.handleShowProgress(std::bind(ShowProgress, this, std::placeholders::_1, std::placeholders::_2));
     m_handler_notify_num_connections_changed = m_node.handleNotifyNumConnectionsChanged(std::bind(NotifyNumConnectionsChanged, this, std::placeholders::_1));
-    m_handler_notify_network_active_changed = m_node.handleNotifyNetworkActiveChanged(std::bind(NotifyNetworkActiveChanged, this, std::placeholders::_1));
+    m_handler_notify_network_active_changed = m_node.handleNotifyNetworkActiveChanged(std::bind(NotifyNetworkActiveChanged, this));
     m_handler_notify_alert_changed = m_node.handleNotifyAlertChanged(std::bind(NotifyAlertChanged, this));
     m_handler_banned_list_changed = m_node.handleBannedListChanged(std::bind(BannedListChanged, this));
     m_handler_notify_block_tip = m_node.handleNotifyBlockTip(std::bind(BlockTipChanged, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, false));

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -141,9 +141,9 @@ uint256 ClientModel::getBestBlockHash()
     return m_cached_tip_blocks;
 }
 
-void ClientModel::updateNumConnections(int numConnections)
+void ClientModel::updateNumConnections()
 {
-    Q_EMIT numConnectionsChanged(numConnections);
+    Q_EMIT numConnectionsChanged();
 }
 
 void ClientModel::updateNetworkActive()
@@ -233,11 +233,10 @@ static void ShowProgress(ClientModel *clientmodel, const std::string &title, int
     assert(invoked);
 }
 
-static void NotifyNumConnectionsChanged(ClientModel *clientmodel, int newNumConnections)
+static void NotifyNumConnectionsChanged(ClientModel* clientmodel)
 {
     // Too noisy: qDebug() << "NotifyNumConnectionsChanged: " + QString::number(newNumConnections);
-    bool invoked = QMetaObject::invokeMethod(clientmodel, "updateNumConnections", Qt::QueuedConnection,
-                              Q_ARG(int, newNumConnections));
+    bool invoked = QMetaObject::invokeMethod(clientmodel, "updateNumConnections", Qt::QueuedConnection);
     assert(invoked);
 }
 
@@ -294,7 +293,7 @@ void ClientModel::subscribeToCoreSignals()
 {
     // Connect signals to client
     m_handler_show_progress = m_node.handleShowProgress(std::bind(ShowProgress, this, std::placeholders::_1, std::placeholders::_2));
-    m_handler_notify_num_connections_changed = m_node.handleNotifyNumConnectionsChanged(std::bind(NotifyNumConnectionsChanged, this, std::placeholders::_1));
+    m_handler_notify_num_connections_changed = m_node.handleNotifyNumConnectionsChanged(std::bind(NotifyNumConnectionsChanged, this));
     m_handler_notify_network_active_changed = m_node.handleNotifyNetworkActiveChanged(std::bind(NotifyNetworkActiveChanged, this));
     m_handler_notify_alert_changed = m_node.handleNotifyAlertChanged(std::bind(NotifyAlertChanged, this));
     m_handler_banned_list_changed = m_node.handleBannedListChanged(std::bind(BannedListChanged, this));

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -68,20 +68,6 @@ ClientModel::~ClientModel()
     m_thread->wait();
 }
 
-int ClientModel::getNumConnections(unsigned int flags) const
-{
-    CConnman::NumConnections connections = CConnman::CONNECTIONS_NONE;
-
-    if(flags == CONNECTIONS_IN)
-        connections = CConnman::CONNECTIONS_IN;
-    else if (flags == CONNECTIONS_OUT)
-        connections = CConnman::CONNECTIONS_OUT;
-    else if (flags == CONNECTIONS_ALL)
-        connections = CConnman::CONNECTIONS_ALL;
-
-    return m_node.getNodeCount(connections);
-}
-
 int ClientModel::getHeaderTipHeight() const
 {
     if (cachedBestHeaderHeight == -1) {
@@ -162,7 +148,7 @@ enum BlockSource ClientModel::getBlockSource() const
         return BlockSource::REINDEX;
     else if (m_node.getImporting())
         return BlockSource::DISK;
-    else if (getNumConnections() > 0)
+    else if (m_node.peerCount() > 0)
         return BlockSource::NETWORK;
 
     return BlockSource::NONE;

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -108,7 +108,7 @@ Q_SIGNALS:
     void numConnectionsChanged(int count);
     void numBlocksChanged(int count, const QDateTime& blockDate, double nVerificationProgress, bool header, SynchronizationState sync_state);
     void mempoolSizeChanged(long count, size_t mempoolSizeInBytes);
-    void networkActiveChanged(bool networkActive);
+    void networkActiveChanged();
     void alertsChanged(const QString &warnings);
     void bytesChanged(quint64 totalBytesIn, quint64 totalBytesOut);
 
@@ -120,7 +120,7 @@ Q_SIGNALS:
 
 public Q_SLOTS:
     void updateNumConnections(int numConnections);
-    void updateNetworkActive(bool networkActive);
+    void updateNetworkActive();
     void updateAlert();
     void updateBanlist();
 };

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -35,13 +35,6 @@ enum class BlockSource {
     NETWORK
 };
 
-enum NumConnections {
-    CONNECTIONS_NONE = 0,
-    CONNECTIONS_IN   = (1U << 0),
-    CONNECTIONS_OUT  = (1U << 1),
-    CONNECTIONS_ALL  = (CONNECTIONS_IN | CONNECTIONS_OUT),
-};
-
 /** Model for Bitcoin network client. */
 class ClientModel : public QObject
 {
@@ -55,9 +48,6 @@ public:
     OptionsModel *getOptionsModel();
     PeerTableModel *getPeerTableModel();
     BanTableModel *getBanTableModel();
-
-    //! Return number of connections, default is in- and outbound (total)
-    int getNumConnections(unsigned int flags = CONNECTIONS_ALL) const;
     int getNumBlocks() const;
     uint256 getBestBlockHash();
     int getHeaderTipHeight() const;

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -105,7 +105,7 @@ private:
     void unsubscribeFromCoreSignals();
 
 Q_SIGNALS:
-    void numConnectionsChanged(int count);
+    void numConnectionsChanged();
     void numBlocksChanged(int count, const QDateTime& blockDate, double nVerificationProgress, bool header, SynchronizationState sync_state);
     void mempoolSizeChanged(long count, size_t mempoolSizeInBytes);
     void networkActiveChanged();
@@ -119,7 +119,7 @@ Q_SIGNALS:
     void showProgress(const QString &title, int nProgress);
 
 public Q_SLOTS:
-    void updateNumConnections(int numConnections);
+    void updateNumConnections();
     void updateNetworkActive();
     void updateAlert();
     void updateBanlist();

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -844,9 +844,10 @@ void RPCConsole::message(int category, const QString &message, bool html)
 
 void RPCConsole::updateNetworkState()
 {
-    QString connections = QString::number(clientModel->getNumConnections()) + " (";
-    connections += tr("In:") + " " + QString::number(clientModel->getNumConnections(CONNECTIONS_IN)) + " / ";
-    connections += tr("Out:") + " " + QString::number(clientModel->getNumConnections(CONNECTIONS_OUT)) + ")";
+    const ConnCounts conn_counts = m_node.connectionCounts();
+    QString connections = QString::number(conn_counts.all) + " (";
+    connections += tr("In:") + " " + QString::number(conn_counts.in) + " / ";
+    connections += tr("Out:") + " " + QString::number(conn_counts.out) + ")";
 
     if(!clientModel->node().getNetworkActive()) {
         connections += " (" + tr("Network activity disabled") + ")";

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -863,7 +863,7 @@ void RPCConsole::setNumConnections(int count)
     updateNetworkState();
 }
 
-void RPCConsole::setNetworkActive(bool networkActive)
+void RPCConsole::setNetworkActive()
 {
     updateNetworkState();
 }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -574,7 +574,7 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
     ui->trafficGraph->setClientModel(model);
     if (model && clientModel->getPeerTableModel() && clientModel->getBanTableModel()) {
         // Keep up to date with client
-        setNumConnections(model->getNumConnections());
+        setNumConnections();
         connect(model, &ClientModel::numConnectionsChanged, this, &RPCConsole::setNumConnections);
 
         setNumBlocks(bestblock_height, QDateTime::fromTime_t(bestblock_date), verification_progress, false);
@@ -855,7 +855,7 @@ void RPCConsole::updateNetworkState()
     ui->numberOfConnections->setText(connections);
 }
 
-void RPCConsole::setNumConnections(int count)
+void RPCConsole::setNumConnections()
 {
     if (!clientModel)
         return;

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -106,7 +106,7 @@ public Q_SLOTS:
     /** Set number of connections shown in the UI */
     void setNumConnections(int count);
     /** Set network state shown in the UI */
-    void setNetworkActive(bool networkActive);
+    void setNetworkActive();
     /** Set number of blocks and last block date shown in the UI */
     void setNumBlocks(int count, const QDateTime& blockDate, double nVerificationProgress, bool headers);
     /** Set size (number of transactions and memory usage) of the mempool in the UI */

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -104,7 +104,7 @@ public Q_SLOTS:
     void message(int category, const QString &msg) { message(category, msg, false); }
     void message(int category, const QString &message, bool html);
     /** Set number of connections shown in the UI */
-    void setNumConnections(int count);
+    void setNumConnections();
     /** Set network state shown in the UI */
     void setNetworkActive();
     /** Set number of blocks and last block date shown in the UI */

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -663,8 +663,9 @@ static RPCHelpMan getblocktemplate()
     if(!node.connman)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
 
-    if (node.connman->GetNodeCount(CConnman::CONNECTIONS_ALL) == 0)
+    if (node.connman->PeerCount() == 0) {
         throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, PACKAGE_NAME " is not connected!");
+    }
 
     if (::ChainstateActive().IsInitialBlockDownload())
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, PACKAGE_NAME " is in initial sync and waiting for blocks...");

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -533,10 +533,11 @@ static RPCHelpMan getnetworkinfo()
                         }},
                         {RPCResult::Type::BOOL, "localrelay", "true if transaction relay is requested from peers"},
                         {RPCResult::Type::NUM, "timeoffset", "the time offset"},
+                        {RPCResult::Type::BOOL, "networkactive", "whether p2p networking is enabled"},
                         {RPCResult::Type::NUM, "connections", "the total number of connections"},
                         {RPCResult::Type::NUM, "connections_in", "the number of inbound connections"},
                         {RPCResult::Type::NUM, "connections_out", "the number of outbound connections"},
-                        {RPCResult::Type::BOOL, "networkactive", "whether p2p networking is enabled"},
+                        {RPCResult::Type::BOOL, "connections_onion_only", "whether all connections are through the onion network"},
                         {RPCResult::Type::ARR, "networks", "information per network",
                         {
                             {RPCResult::Type::OBJ, "", "",
@@ -587,6 +588,7 @@ static RPCHelpMan getnetworkinfo()
         obj.pushKV("connections", conn_counts.all);
         obj.pushKV("connections_in", conn_counts.in);
         obj.pushKV("connections_out", conn_counts.out);
+        obj.pushKV("connections_onion_only", conn_counts.onion_only);
     }
     obj.pushKV("networks",      GetNetworksInfo());
     obj.pushKV("relayfee",      ValueFromAmount(::minRelayTxFee.GetFeePerK()));

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -56,7 +56,7 @@ static RPCHelpMan getconnectioncount()
     if(!node.connman)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
 
-    return (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_ALL);
+    return (int)node.connman->PeerCount();
 },
     };
 }
@@ -583,9 +583,10 @@ static RPCHelpMan getnetworkinfo()
     obj.pushKV("timeoffset",    GetTimeOffset());
     if (node.connman) {
         obj.pushKV("networkactive", node.connman->GetNetworkActive());
-        obj.pushKV("connections", (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_ALL));
-        obj.pushKV("connections_in", (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_IN));
-        obj.pushKV("connections_out", (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_OUT));
+        const ConnCounts conn_counts = node.connman->GetConnectionCounts();
+        obj.pushKV("connections", conn_counts.all);
+        obj.pushKV("connections_in", conn_counts.in);
+        obj.pushKV("connections_out", conn_counts.out);
     }
     obj.pushKV("networks",      GetNetworksInfo());
     obj.pushKV("relayfee",      ValueFromAmount(::minRelayTxFee.GetFeePerK()));

--- a/test/functional/feature_onion.py
+++ b/test/functional/feature_onion.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test bitcoind with 'onion'-tagged peers.
+
+Tested inbound and outbound peers.
+"""
+
+import os
+
+from test_framework.p2p import P2PInterface
+from test_framework.socks5 import Socks5Configuration, Socks5Server
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    PORT_MIN,
+    PORT_RANGE,
+    assert_equal,
+)
+
+
+class OnionTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+
+    def setup_network(self):
+        port = PORT_MIN + 2 * PORT_RANGE + (os.getpid() % 1000)
+        self.bind_onion = '127.0.0.1:{}'.format(port)
+
+        proxy_conf = Socks5Configuration()
+        port += 1
+        proxy_conf.addr = ('127.0.0.1', port)
+        proxy_conf.unauth = True
+        Socks5Server(proxy_conf).start()
+
+        args = [
+            ['-bind={}=onion'.format(self.bind_onion), '-onion={0[0]}:{0[1]}'.format(proxy_conf.addr)],
+            [],
+            ]
+        self.add_nodes(self.num_nodes, extra_args=args)
+        self.start_nodes()
+
+    def reset_connections(self):
+        with self.nodes[0].assert_debug_log(expected_msgs=['SetNetworkActive: false\n']):
+            self.nodes[0].setnetworkactive(state=False)
+        assert_equal(self.nodes[0].getnetworkinfo()['networkactive'], False)
+        self.wait_until(lambda: self.nodes[0].getnetworkinfo()['connections'] == 0)
+        with self.nodes[0].assert_debug_log(expected_msgs=['SetNetworkActive: true\n']):
+            self.nodes[0].setnetworkactive(state=True)
+        assert_equal(self.nodes[0].getnetworkinfo()['networkactive'], True)
+
+    def test_connections(self, in_clearnet=0, in_onion=0, out_onion=0):
+        self.reset_connections()
+
+        for i in range(in_clearnet):
+            self.nodes[0].add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
+        self.wait_until(lambda: self.nodes[0].getnetworkinfo()['connections'] == in_clearnet)
+
+        if in_onion > 0:
+            if in_onion > 1:
+                self.log.warning("Maximum 1 inbound 'onion'-tagged connection is supported.")
+                in_onion = 1
+            self.nodes[1].addnode(self.bind_onion, 'onetry')
+        self.wait_until(lambda: self.nodes[0].getnetworkinfo()['connections'] == in_clearnet + in_onion)
+
+        # Create a connection to a dummy Socks5 server just before
+        # the getnetworkinfo RPC, as such connections are short-lived.
+        if out_onion > 0:
+            if out_onion > 1:
+                self.log.warning("Maximum 1 outbound onion connection is supported.")
+                out_onion = 1
+            self.nodes[0].addnode('bitcoinostk4e4re.onion:18444', 'onetry')
+
+        network_info = self.nodes[0].getnetworkinfo()
+        assert_equal(network_info["connections"], in_clearnet + in_onion + out_onion)
+        assert_equal(network_info["connections_in"], in_clearnet + in_onion)
+        assert_equal(network_info["connections_out"], out_onion)
+        assert_equal(network_info["connections_onion_only"], in_clearnet == 0 and (in_onion + out_onion) > 0)
+
+    def run_test(self):
+        self.log.info("Checking a node without any peers...")
+        self.test_connections(in_clearnet=0, in_onion=0, out_onion=0)
+
+        self.log.info("Checking onion only connections...")
+        self.test_connections(in_clearnet=0, in_onion=0, out_onion=1)
+        self.test_connections(in_clearnet=0, in_onion=1, out_onion=0)
+        self.test_connections(in_clearnet=0, in_onion=1, out_onion=1)
+
+        self.log.info("Checking clearnet only connections...")
+        self.test_connections(in_clearnet=1, in_onion=0, out_onion=0)
+        self.test_connections(in_clearnet=2, in_onion=0, out_onion=0)
+
+        self.log.info("Checking mixed type connections...")
+        self.test_connections(in_clearnet=1, in_onion=0, out_onion=1)
+        self.test_connections(in_clearnet=1, in_onion=1, out_onion=0)
+        self.test_connections(in_clearnet=1, in_onion=1, out_onion=1)
+        self.test_connections(in_clearnet=2, in_onion=0, out_onion=1)
+        self.test_connections(in_clearnet=2, in_onion=1, out_onion=0)
+        self.test_connections(in_clearnet=2, in_onion=1, out_onion=1)
+
+
+if __name__ == '__main__':
+    OnionTest().main()

--- a/test/functional/test_framework/socks5.py
+++ b/test/functional/test_framework/socks5.py
@@ -6,6 +6,7 @@
 
 import socket
 import threading
+import time
 import queue
 import logging
 
@@ -116,6 +117,8 @@ class Socks5Connection():
             cmdin = Socks5Command(cmd, atyp, addr, port, username, password)
             self.serv.queue.put(cmdin)
             logger.info('Proxy: %s', cmdin)
+            # Some tests, e.g., feature_onion.py, require prolonged lifetime of a connection.
+            time.sleep(0.25)
             # Fall through to disconnect
         except Exception as e:
             logger.exception("socks5 request handling failed.")

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -225,6 +225,7 @@ BASE_SCRIPTS = [
     'feature_dersig.py',
     'feature_cltv.py',
     'rpc_uptime.py',
+    'feature_onion.py',
     'wallet_resendwallettransactions.py',
     'wallet_fallbackfee.py',
     'rpc_dumptxoutset.py',


### PR DESCRIPTION
This is a non-gui part of adding Tor icon to the GUI.

Split from https://github.com/bitcoin-core/gui/pull/86 as [requested](https://github.com/bitcoin-core/gui/pull/86#discussion_r492689909):
> Also, the RPC and net changes are not gui related, so should go into the main repo

The first approach was in #19926.