### PR TITLE
test: Fix intermittent issue in wallet_import_rescan

### DIFF
--- a/test/functional/wallet_import_rescan.py
+++ b/test/functional/wallet_import_rescan.py
@@ -182,6 +182,7 @@ class ImportRescanTest(BitcoinTestFramework):
             self.nodes[0].generate(1)  # Generate one block for each send
             variant.confirmation_height = self.nodes[0].getblockcount()
             variant.timestamp = self.nodes[0].getblockheader(self.nodes[0].getbestblockhash())["time"]
+        self.sync_all() # Conclude sync before calling setmocktime to avoid timeouts
 
         # Generate a block further in the future (past the rescan window).
         assert_equal(self.nodes[0].getrawmempool(), [])

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -316,6 +316,7 @@ class WalletSendTest(BitcoinTestFramework):
         res = self.nodes[0].sendrawtransaction(hex)
         self.nodes[0].generate(1)
         assert_equal(self.nodes[0].gettransaction(txid)["confirmations"], 1)
+        self.sync_all()
 
         self.log.info("Lock unspents...")
         utxo1 = w0.listunspent()[0]


### PR DESCRIPTION
Fixes the issue

```
 node2 2020-10-16T14:26:28.699593Z (mocktime: 2020-10-16T16:26:46Z) [msghand] Timeout downloading block 1131f0318b913e078402524f1e63e53d52171844dd8246a03b970e540cb56924 from peer=0, disconnecting
