### PR TITLE
tests: Add fuzzing harness for CConnman

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -35,6 +35,7 @@ FUZZ_TARGETS = \
   test/fuzz/checkqueue \
   test/fuzz/coins_deserialize \
   test/fuzz/coins_view \
+  test/fuzz/connman \
   test/fuzz/crypto \
   test/fuzz/crypto_aes256 \
   test/fuzz/crypto_aes256cbc \
@@ -519,6 +520,12 @@ test_fuzz_coins_view_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_coins_view_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_coins_view_LDFLAGS = $(FUZZ_SUITE_LDFLAGS_COMMON)
 test_fuzz_coins_view_SOURCES = test/fuzz/coins_view.cpp
+
+test_fuzz_connman_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_connman_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_connman_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_connman_LDFLAGS = $(FUZZ_SUITE_LDFLAGS_COMMON)
+test_fuzz_connman_SOURCES = test/fuzz/connman.cpp
 
 test_fuzz_crypto_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_crypto_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -1,0 +1,162 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <chainparamsbase.h>
+#include <net.h>
+#include <netaddress.h>
+#include <protocol.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <util/translation.h>
+
+#include <cstdint>
+#include <vector>
+
+void initialize()
+{
+    InitializeFuzzingContext();
+}
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    CConnman connman{fuzzed_data_provider.ConsumeIntegral<uint64_t>(), fuzzed_data_provider.ConsumeIntegral<uint64_t>(), fuzzed_data_provider.ConsumeBool()};
+    CAddress random_address;
+    CNetAddr random_netaddr;
+    CNode random_node = ConsumeNode(fuzzed_data_provider);
+    CService random_service;
+    CSubNet random_subnet;
+    std::string random_string;
+    while (fuzzed_data_provider.ConsumeBool()) {
+        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 30)) {
+        case 0:
+            random_address = ConsumeAddress(fuzzed_data_provider);
+            break;
+        case 1:
+            random_netaddr = ConsumeNetAddr(fuzzed_data_provider);
+            break;
+        case 2:
+            random_service = ConsumeService(fuzzed_data_provider);
+            break;
+        case 3:
+            random_subnet = ConsumeSubNet(fuzzed_data_provider);
+            break;
+        case 4:
+            random_string = fuzzed_data_provider.ConsumeRandomLengthString(64);
+            break;
+        case 5: {
+            std::vector<CAddress> addresses;
+            while (fuzzed_data_provider.ConsumeBool()) {
+                addresses.push_back(ConsumeAddress(fuzzed_data_provider));
+            }
+            // Limit nTimePenalty to int32_t to avoid signed integer overflow
+            (void)connman.AddNewAddresses(addresses, ConsumeAddress(fuzzed_data_provider), fuzzed_data_provider.ConsumeIntegral<int32_t>());
+            break;
+        }
+        case 6:
+            connman.AddNode(random_string);
+            break;
+        case 7:
+            connman.CheckIncomingNonce(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+            break;
+        case 8:
+            connman.DisconnectNode(fuzzed_data_provider.ConsumeIntegral<NodeId>());
+            break;
+        case 9:
+            connman.DisconnectNode(random_netaddr);
+            break;
+        case 10:
+            connman.DisconnectNode(random_string);
+            break;
+        case 11:
+            connman.DisconnectNode(random_subnet);
+            break;
+        case 12:
+            connman.ForEachNode([](auto) {});
+            break;
+        case 13:
+            connman.ForEachNodeThen([](auto) {}, []() {});
+            break;
+        case 14:
+            (void)connman.ForNode(fuzzed_data_provider.ConsumeIntegral<NodeId>(), [&](auto) { return fuzzed_data_provider.ConsumeBool(); });
+            break;
+        case 15:
+            (void)connman.GetAddresses(fuzzed_data_provider.ConsumeIntegral<size_t>(), fuzzed_data_provider.ConsumeIntegral<size_t>());
+            break;
+        case 16: {
+            (void)connman.GetAddresses(random_node, fuzzed_data_provider.ConsumeIntegral<size_t>(), fuzzed_data_provider.ConsumeIntegral<size_t>());
+            break;
+        }
+        case 17:
+            (void)connman.GetDeterministicRandomizer(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+            break;
+        case 18:
+            (void)connman.GetNodeCount(fuzzed_data_provider.PickValueInArray({CConnman::CONNECTIONS_NONE, CConnman::CONNECTIONS_IN, CConnman::CONNECTIONS_OUT, CConnman::CONNECTIONS_ALL}));
+            break;
+        case 19:
+            connman.MarkAddressGood(random_address);
+            break;
+        case 20:
+            (void)connman.OutboundTargetReached(fuzzed_data_provider.ConsumeBool());
+            break;
+        case 21:
+            // Limit now to int32_t to avoid signed integer overflow
+            (void)connman.PoissonNextSendInbound(fuzzed_data_provider.ConsumeIntegral<int32_t>(), fuzzed_data_provider.ConsumeIntegral<int>());
+            break;
+        case 22: {
+            CSerializedNetMsg serialized_net_msg;
+            serialized_net_msg.m_type = fuzzed_data_provider.ConsumeRandomLengthString(CMessageHeader::COMMAND_SIZE);
+            serialized_net_msg.data = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+            connman.PushMessage(&random_node, std::move(serialized_net_msg));
+            break;
+        }
+        case 23:
+            connman.RemoveAddedNode(random_string);
+            break;
+        case 24: {
+            const std::vector<bool> asmap = ConsumeRandomLengthIntegralVector<bool>(fuzzed_data_provider, 512);
+            if (SanityCheckASMap(asmap)) {
+                connman.SetAsmap(asmap);
+            }
+            break;
+        }
+        case 25:
+            connman.SetBestHeight(fuzzed_data_provider.ConsumeIntegral<int>());
+            break;
+        case 26:
+            connman.SetMaxOutboundTarget(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+            break;
+        case 27:
+            connman.SetMaxOutboundTimeframe(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+            break;
+        case 28:
+            connman.SetNetworkActive(fuzzed_data_provider.ConsumeBool());
+            break;
+        case 29:
+            connman.SetServices(random_service, static_cast<ServiceFlags>(fuzzed_data_provider.ConsumeIntegral<uint64_t>()));
+            break;
+        case 30:
+            connman.SetTryNewOutboundPeer(fuzzed_data_provider.ConsumeBool());
+            break;
+        }
+    }
+    (void)connman.GetAddedNodeInfo();
+    (void)connman.GetBestHeight();
+    (void)connman.GetExtraOutboundCount();
+    (void)connman.GetLocalServices();
+    (void)connman.GetMaxOutboundTarget();
+    (void)connman.GetMaxOutboundTimeframe();
+    (void)connman.GetMaxOutboundTimeLeftInCycle();
+    (void)connman.GetNetworkActive();
+    std::vector<CNodeStats> stats;
+    connman.GetNodeStats(stats);
+    (void)connman.GetOutboundTargetBytesLeft();
+    (void)connman.GetReceiveFloodSize();
+    (void)connman.GetTotalBytesRecv();
+    (void)connman.GetTotalBytesSent();
+    (void)connman.GetTryNewOutboundPeer();
+    (void)connman.GetUseAddrmanOutgoing();
+}

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -11,6 +11,7 @@
 #include <chainparamsbase.h>
 #include <coins.h>
 #include <consensus/consensus.h>
+#include <net.h>
 #include <netaddress.h>
 #include <netbase.h>
 #include <primitives/transaction.h>
@@ -258,6 +259,32 @@ CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider) noexcept
 CSubNet ConsumeSubNet(FuzzedDataProvider& fuzzed_data_provider) noexcept
 {
     return {ConsumeNetAddr(fuzzed_data_provider), fuzzed_data_provider.ConsumeIntegral<uint8_t>()};
+}
+
+CService ConsumeService(FuzzedDataProvider& fuzzed_data_provider) noexcept
+{
+    return {ConsumeNetAddr(fuzzed_data_provider), fuzzed_data_provider.ConsumeIntegral<uint16_t>()};
+}
+
+CAddress ConsumeAddress(FuzzedDataProvider& fuzzed_data_provider) noexcept
+{
+    return {ConsumeService(fuzzed_data_provider), static_cast<ServiceFlags>(fuzzed_data_provider.ConsumeIntegral<uint64_t>()), fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
+}
+
+CNode ConsumeNode(FuzzedDataProvider& fuzzed_data_provider) noexcept
+{
+    const NodeId node_id = fuzzed_data_provider.ConsumeIntegral<NodeId>();
+    const ServiceFlags local_services = static_cast<ServiceFlags>(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+    const int my_starting_height = fuzzed_data_provider.ConsumeIntegral<int>();
+    const SOCKET socket = INVALID_SOCKET;
+    const CAddress address = ConsumeAddress(fuzzed_data_provider);
+    const uint64_t keyed_net_group = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
+    const uint64_t local_host_nonce = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
+    const CAddress addr_bind = ConsumeAddress(fuzzed_data_provider);
+    const std::string addr_name = fuzzed_data_provider.ConsumeRandomLengthString(64);
+    const ConnectionType conn_type = fuzzed_data_provider.PickValueInArray({ConnectionType::INBOUND, ConnectionType::OUTBOUND_FULL_RELAY, ConnectionType::MANUAL, ConnectionType::FEELER, ConnectionType::BLOCK_RELAY, ConnectionType::ADDR_FETCH});
+    const bool inbound_onion = fuzzed_data_provider.ConsumeBool();
+    return {node_id, local_services, my_starting_height, socket, address, keyed_net_group, local_host_nonce, addr_bind, addr_name, conn_type, inbound_onion};
 }
 
 void InitializeFuzzingContext(const std::string& chain_name = CBaseChainParams::REGTEST)


### PR DESCRIPTION
Add fuzzing harness for `CConnman`.

See [`doc/fuzzing.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md) for information on how to fuzz Bitcoin Core. Don't forget to contribute any coverage increasing inputs you find to the [Bitcoin Core fuzzing corpus repo](https://github.com/bitcoin-core/qa-assets).

Happy fuzzing :)