### PR TITLE
test: Switch to BIP341's suggested scheme for outputs without script

### DIFF
--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -787,7 +787,7 @@ def TaprootSignatureHash(txTo, spent_utxos, hash_type, input_index = 0, scriptpa
 
 def taproot_tree_helper(scripts):
     if len(scripts) == 0:
-        return ([], bytes(0 for _ in range(32)))
+        return ([], bytes())
     if len(scripts) == 1:
         # One entry: treat as a leaf
         script = scripts[0]


### PR DESCRIPTION
BIP341 suggests using Hash<sub>TapTweak</sub>(pubkey) to derive the tweak in case of key-only outputs. The functional test framework currently uses Hash<sub>TapTweak</sub>(pubkey || 0x00...00) instead. Change this.

There is no technical reason to prefer one over the other, but in case someone looks at it for inspiration, it's better to be consistent with the BIP.