### PR TITLE
p2p: improve onion detection in AttemptToEvictConnection

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -951,7 +951,7 @@ bool CConnman::AttemptToEvictConnection()
                                                node->nLastBlockTime, node->nLastTXTime,
                                                HasAllDesirableServiceFlags(node->nServices),
                                                peer_relay_txes, peer_filter_not_null, node->addr, node->nKeyedNetGroup,
-                                               node->m_prefer_evict, node->addr.IsLocal()};
+                                               node->m_prefer_evict, node->m_inbound_onion};
             vEvictionCandidates.push_back(candidate);
         }
     }


### PR DESCRIPTION
Now that #19991 is merged, we may have a more robust way to determine inbound onion peers using `CNode::m_inbound_onion` rather than `IsLocal()`.

Use it for the new `AttemptToEvictConnection` logic added in #19670 to address https://github.com/bitcoin/bitcoin/issues/19500.
