### PR TITLE
wallet: ignore (but warn) on duplicate -wallet parameters

### DIFF
--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -65,8 +65,8 @@ bool VerifyWallets(interfaces::Chain& chain)
         const fs::path path = fs::absolute(wallet_file, GetWalletDir());
 
         if (!wallet_paths.insert(path).second) {
-            chain.initError(strprintf(_("Error loading wallet %s. Duplicate -wallet filename specified."), wallet_file));
-            return false;
+            chain.initWarning(strprintf(_("Ignoring duplicate -wallet %s."), wallet_file));
+            continue;
         }
 
         DatabaseOptions options;
@@ -90,7 +90,11 @@ bool VerifyWallets(interfaces::Chain& chain)
 bool LoadWallets(interfaces::Chain& chain)
 {
     try {
+        std::set<fs::path> wallet_paths;
         for (const std::string& name : gArgs.GetArgs("-wallet")) {
+            if (!wallet_paths.insert(name).second) {
+                continue;
+            }
             DatabaseOptions options;
             DatabaseStatus status;
             options.require_existing = true;

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -134,8 +134,8 @@ class MultiWalletTest(BitcoinTestFramework):
         self.nodes[0].assert_start_raises_init_error(['-walletdir=wallets'], 'Error: Specified -walletdir "wallets" is a relative path', cwd=data_dir())
         self.nodes[0].assert_start_raises_init_error(['-walletdir=debug.log'], 'Error: Specified -walletdir "debug.log" is not a directory', cwd=data_dir())
 
-        # should not initialize if there are duplicate wallets
-        self.nodes[0].assert_start_raises_init_error(['-wallet=w1', '-wallet=w1'], 'Error: Error loading wallet w1. Duplicate -wallet filename specified.')
+        self.start_node(0, ['-wallet=w1', '-wallet=w1'])
+        self.stop_node(0, 'Warning: Ignoring duplicate -wallet w1.')
 
         if not self.options.descriptors:
             # Only BDB doesn't open duplicate wallet files. SQLite does not have this limitation. While this may be desired in the future, it is not necessary


### PR DESCRIPTION
I expect that there are many users with load on startup wallet definitions in `bitcoin.conf` or via startup CLI argument. 
With the new `settings.json` r/w configuration file, users unloading and loading a wallet through the GUI or via the RPC calls might end up with a duplicate `-wallet` entry (one that still remains in bitcoin.conf or CLI) plus the new duplication in `settings.json` due to the unload/load.

Steps to reproduce
* create wallet (if via RPC set `load_on_startup` or unloadwallet/loadwallet then set `load_on_startup`).
* stop bitcoin
* start bitcoind again with same `--wallet=mywallet`

I guess it is acceptable to skip duplicates.