### PR TITLE
doc: rename CODEOWNERS to REVIEWERS

### DIFF
--- a/REVIEWERS
+++ b/REVIEWERS
@@ -1,20 +1,15 @@
 # ==============================================================================
-#                          Bitcoin Core CODEOWNERS
+#                          Bitcoin Core REVIEWERS
 # ==============================================================================
 
-# Configuration of code ownership and review approvals for the bitcoin/bitcoin
-# repo.
+# Configuration of automated review requests for the bitcoin/bitcoin repo
+# via DrahtBot.
 
-# Order is important; the last matching pattern takes the most precedence.
-# More info on how this file works can be found at:
-# https://help.github.com/articles/about-codeowners/
+# Order is not important; if a modified file or directory matches a fnmatch,
+# the reviewer will be mentioned in a PR comment requesting a review.
 
-# This file is called CODEOWNERS because it is a magic file for GitHub to
-# automatically suggest reviewers. In this project's case, the names below
-# should be thought of as code reviewers rather than owners. Regular
-# contributors are free to add their names to specific directories or files
-# provided that they are willing to provide a review when automatically
-# assigned.
+# Regular contributors are free to add their names to specific directories or
+# files provided that they are willing to provide a review.
 
 # Absence from this list should not be interpreted as a discouragement to
 # review a pull request. Peer review is always welcome and is a critical
@@ -23,12 +18,12 @@
 
 
 # Maintainers
-#   @laanwj
-#   @sipa
 #   @fanquake
 #   @jonasschnelli
+#   @laanwj
 #   @marcofalke
 #   @meshcollider
+#   @sipa
 
 # Docs
 /doc/*[a-zA-Z-].md                          @harding


### PR DESCRIPTION
This PR renames the CODEOWNERS file to REVIEWERS and works with DrahtBot to leave a comment requesting a review. 

Testing of the functionality was done on https://github.com/adamjonas/bitcoin-codeowners-sandbox/pulls.

~EDIT: [after further testing of a fake organization](https://github.com/jonasorg/bitcoin-codeowners-sandbox-org/pulls), it appears that in order to be automatically tagged, the reviewer requires write level permissions. This is undocumented and will obviously close the circle of who can be tagged and so this PR reverts the addition of the file in #18949.~

~This removes a line not being parsed in the CODEOWNERS file introduced in #18949. While the pattern [checked out](https://github.com/bitcoin/bitcoin/pull/18949#issuecomment-648859076) using `git ls-files`, it is preventing the CODEOWNERS file from automatically tagging reviewers. For future modifications to this file, note that [any line failing to parse causes the entire file to stop identifying codeowners](http://www.benjaminoakes.com/git/2018/08/10/Testing-changes-to-GitHub-CODEOWNERS/#:~:text=warning).~

~I experimented in a [sandbox repo](https://github.com/adamjonas/bitcoin-codeowners-sandbox/pulls) to discover the offending line and this change appears to fix the problem.~

