### PR TITLE
wallet: Properly support a wallet id

### DIFF
--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -850,4 +850,13 @@ std::unique_ptr<BerkeleyDatabase> MakeBerkeleyDatabase(const fs::path& path, con
     status = DatabaseStatus::SUCCESS;
     return db;
 }
+
+uint160 BerkeleyDatabase::MakeNewWalletID() const
+{
+    uint160 id;
+    std::string filename = fs::PathToString(m_filename);
+    assert(id.size() == sizeof(env->m_fileids[filename].value));
+    memcpy(id.data(), env->m_fileids[filename].value, id.size());
+    return id;
+}
 } // namespace wallet

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -163,6 +163,10 @@ public:
 
     /** Make a BerkeleyBatch connected to this database */
     std::unique_ptr<DatabaseBatch> MakeBatch(bool flush_on_close = true) override;
+
+    /** Get the database ID.
+     * For BDB, this is not a random ID, but rather the BDB Unique ID */
+    uint160 MakeNewWalletID() const override;
 };
 
 /** RAII class that provides access to a Berkeley database */

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -6,6 +6,7 @@
 #include <chainparams.h>
 #include <fs.h>
 #include <logging.h>
+#include <random.h>
 #include <util/system.h>
 #include <wallet/db.h>
 
@@ -147,4 +148,12 @@ void ReadDatabaseArgs(const ArgsManager& args, DatabaseOptions& options)
     options.max_log_mb = args.GetIntArg("-dblogsize", options.max_log_mb);
 }
 
+
+uint160 WalletDatabase::MakeNewWalletID() const
+{
+    // Generate a random ID
+    uint160 id;
+    GetStrongRandBytes(id);
+    return id;
+}
 } // namespace wallet

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -10,6 +10,7 @@
 #include <fs.h>
 #include <streams.h>
 #include <support/allocators/secure.h>
+#include <uint256.h>
 
 #include <atomic>
 #include <memory>
@@ -154,6 +155,9 @@ public:
 
     /** Make a DatabaseBatch connected to this database */
     virtual std::unique_ptr<DatabaseBatch> MakeBatch(bool flush_on_close = true) = 0;
+
+    /** Make a new unique ID for this wallet database. For most wallets, this will be a random 20 byte id. */
+    virtual uint160 MakeNewWalletID() const;
 };
 
 /** RAII class that provides access to a DummyDatabase. Never fails. */

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4131,4 +4131,24 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
     }
     return res;
 }
+
+void CWallet::LoadWalletID(const uint160& id)
+{
+    assert(wallet_id.IsNull());
+    wallet_id = id;
+}
+
+const uint160& CWallet::GetWalletID() const
+{
+    assert(!wallet_id.IsNull());
+    return wallet_id;
+}
+
+void CWallet::EnsureWalletIDWithDB(WalletBatch& batch)
+{
+    if (!wallet_id.IsNull()) return;
+
+    wallet_id = GetDatabase().MakeNewWalletID();
+    batch.WriteWalletID(wallet_id);
+}
 } // namespace wallet

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -341,6 +341,8 @@ private:
     // ScriptPubKeyMan::GetID. In many cases it will be the hash of an internal structure
     std::map<uint256, std::unique_ptr<ScriptPubKeyMan>> m_spk_managers;
 
+    uint160 wallet_id;
+
     /**
      * Catch wallet up to current chain, scanning new blocks, updating the best
      * block locator and m_last_block_processed, and registering for
@@ -933,6 +935,13 @@ public:
     //! Adds the ScriptPubKeyMans given in MigrationData to this wallet, removes LegacyScriptPubKeyMan,
     //! and where needed, moves tx and address book entries to watchonly_wallet or solvable_wallet
     bool ApplyMigrationData(MigrationData& data, bilingual_str& error) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
+    //! Set the wallet ID
+    void LoadWalletID(const uint160& id);
+    //! Get the wallet iD
+    const uint160& GetWalletID() const;
+    //! Ensure that a wallet ID already exists. If one does not, add it.
+    void EnsureWalletIDWithDB(WalletBatch& batch);
 };
 
 /**

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -83,6 +83,7 @@ extern const std::string VERSION;
 extern const std::string WALLETDESCRIPTOR;
 extern const std::string WALLETDESCRIPTORCKEY;
 extern const std::string WALLETDESCRIPTORKEY;
+extern const std::string WALLETID;
 extern const std::string WATCHMETA;
 extern const std::string WATCHS;
 
@@ -282,6 +283,8 @@ public:
 
     //! Delete records of the given types
     bool EraseRecords(const std::unordered_set<std::string>& types);
+
+    bool WriteWalletID(const uint160& id);
 
     bool WriteWalletFlags(const uint64_t flags);
     //! Begin a new transaction


### PR DESCRIPTION
Adds a unique id for each wallet that is saved in a new "walletid" record. For compatibility, wallets using BDB will use the BDB generated id. All other wallets will have a randomly generated id if an id does not already exist.

Alternative to #20204