### PR TITLE
test: Fix rpc_net intermittent issue

### DIFF
--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -54,6 +54,7 @@ class NetTest(BitcoinTestFramework):
         # Connect nodes both ways.
         self.connect_nodes(0, 1)
         self.connect_nodes(1, 0)
+        self.sync_all()
 
         self.test_connection_count()
         self.test_getpeerinfo()


### PR DESCRIPTION
Without the sync, the nodes might generate blocks at the same height and thus never be able to sync