### PR TITLE
net: compat.h related cleanup

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -18,11 +18,7 @@
 #undef FD_SETSIZE // prevent redefinition compiler warning
 #endif
 #define FD_SETSIZE 1024 // max number of fds in fd_set
-
-#include <winsock2.h>     // Must be included before mswsock.h and windows.h
-
-#include <mswsock.h>
-#include <windows.h>
+#include <winsock2.h>
 #include <ws2tcpip.h>
 #include <stdint.h>
 #else

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -33,13 +33,6 @@
 
 #include <support/events.h>
 
-#ifdef EVENT__HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#ifdef _XOPEN_SOURCE_EXTENDED
-#include <arpa/inet.h>
-#endif
-#endif
-
 /** Maximum size of http request (request line + headers) */
 static const size_t MAX_HEADERS_SIZE = 8192;
 

--- a/src/net.h
+++ b/src/net.h
@@ -33,11 +33,6 @@
 #include <memory>
 #include <condition_variable>
 
-#ifndef WIN32
-#include <arpa/inet.h>
-#endif
-
-
 class CScheduler;
 class CNode;
 class BanMan;

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -7,6 +7,7 @@
 
 #include <chainparams.h>
 #include <chainparamsbase.h>
+#include <compat.h>
 #include <crypto/hmac_sha256.h>
 #include <net.h>
 #include <netaddress.h>


### PR DESCRIPTION
It is the `compat.h` header's job to provide platform-agnostic interfaces for internet operations.
No need in `#include <arpa/inet.h>` scattered around.