### PR TITLE
script: fix linter error in test runner

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -39,7 +39,17 @@ except UnicodeDecodeError:
     CROSS = "x "
     CIRCLE = "o "
 
-if os.name != 'nt' or sys.getwindowsversion() >= (10, 0, 14393):
+def set_ansi_formatting():
+    """Set primitive formatting on supported terminals via ANSI escape sequences."""
+    global BOLD, GREEN, RED, GREY
+    BOLD = ('\033[0m', '\033[1m')
+    GREEN = ('\033[0m', '\033[0;32m')
+    RED = ('\033[0m', '\033[0;31m')
+    GREY = ('\033[0m', '\033[1;30m')
+
+if sys.platform != "win32":
+    set_ansi_formatting()
+elif os.name != 'nt' or sys.getwindowsversion() >= (10, 0, 14393):
     if os.name == 'nt':
         import ctypes
         kernel32 = ctypes.windll.kernel32  # type: ignore
@@ -56,12 +66,7 @@ if os.name != 'nt' or sys.getwindowsversion() >= (10, 0, 14393):
         stderr_mode = ctypes.c_int32()
         kernel32.GetConsoleMode(stderr, ctypes.byref(stderr_mode))
         kernel32.SetConsoleMode(stderr, stderr_mode.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
-    # primitive formatting on supported
-    # terminal via ANSI escape sequences:
-    BOLD = ('\033[0m', '\033[1m')
-    GREEN = ('\033[0m', '\033[0;32m')
-    RED = ('\033[0m', '\033[0;31m')
-    GREY = ('\033[0m', '\033[1;30m')
+    set_ansi_formatting()
 
 TEST_EXIT_PASSED = 0
 TEST_EXIT_SKIPPED = 77


### PR DESCRIPTION
I started noticing this recently:

before this commit
```
$ ./test/lint/lint-python.sh
test/functional/test_runner.py:42: error: Module has no attribute "getwindowsversion"
Found 1 error in 1 file (checked 180 source files)
```
after
```
$ ./test/lint/lint-python.sh
Success: no issues found in 180 source files
```
versions
```
$ python3 -V -V
Python 3.8.6 (default, Sep 25 2020, 09:36:53)
[GCC 10.2.0]

$ flake8 --version
3.7.8 (mccabe: 0.6.1, pycodestyle: 2.5.0, pyflakes: 2.1.1) CPython 3.8.6 on Linux
```

There may be a better way to fix it, but this works for me.