### PR TITLE
fuzz: Properly initialize PrecomputedTransactionData

### DIFF
--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -31,7 +31,6 @@ void test_one_input(const std::vector<uint8_t>& buffer)
 
     try {
         const CTransaction tx(deserialize, ds);
-        const PrecomputedTransactionData txdata(tx);
 
         unsigned int verify_flags;
         ds >> verify_flags;
@@ -41,10 +40,17 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         unsigned int fuzzed_flags;
         ds >> fuzzed_flags;
 
+        std::vector<CTxOut> spent_outputs;
         for (unsigned i = 0; i < tx.vin.size(); ++i) {
             CTxOut prevout;
             ds >> prevout;
+            spent_outputs.push_back(prevout);
+        }
+        PrecomputedTransactionData txdata;
+        txdata.Init(tx, std::move(spent_outputs));
 
+        for (unsigned i = 0; i < tx.vin.size(); ++i) {
+            const CTxOut& prevout = txdata.m_spent_outputs.at(i);
             const TransactionSignatureChecker checker{&tx, i, prevout.nValue, txdata};
 
             ScriptError serror;


### PR DESCRIPTION
Fixes:

```
script_flags: script/interpreter.cpp:1512: bool SignatureHashSchnorr(uint256 &, const ScriptExecutionData &, const T &, uint32_t, uint8_t, SigVersion, const PrecomputedTransactionData &) [T = CTransaction]: Assertion `cache.m_bip341_taproot_ready && cache.m_spent_outputs_ready' failed.
==34989== ERROR: libFuzzer: deadly signal
    #0 0x55e90077ff11 in __sanitizer_print_stack_trace (/tmp/bitcoin-core/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/test/fuzz/script_flags+0x20cf11)
    #1 0x55e9006cb068 in fuzzer::PrintStackTrace() (/tmp/bitcoin-core/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/test/fuzz/script_flags+0x158068)
    #2 0x55e9006b01b3 in fuzzer::Fuzzer::CrashCallback() (/tmp/bitcoin-core/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/test/fuzz/script_flags+0x13d1b3)
    #3 0x7f6fb89383bf  (/lib/x86_64-linux-gnu/libpthread.so.0+0x153bf)
    #4 0x7f6fb855018a in raise (/lib/x86_64-linux-gnu/libc.so.6+0x4618a)
    #5 0x7f6fb852f858 in abort (/lib/x86_64-linux-gnu/libc.so.6+0x25858)
    #6 0x7f6fb852f728  (/lib/x86_64-linux-gnu/libc.so.6+0x25728)
    #7 0x7f6fb8540f35 in __assert_fail (/lib/x86_64-linux-gnu/libc.so.6+0x36f35)
    #8 0x55e9008275bd in bool SignatureHashSchnorr<CTransaction>(uint256&, ScriptExecutionData const&, CTransaction const&, unsigned int, unsigned char, SigVersion, PrecomputedTransactionData const&) /tmp/bitcoin-core/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/script/interpreter.cpp:1512:5
    #9 0x55e900825a3f in GenericTransactionSignatureChecker<CTransaction>::CheckSchnorrSignature(Span<unsigned char const>, Span<unsigned char const>, SigVersion, ScriptExecutionData const&, ScriptError_t*) const /tmp/bitcoin-core/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/script/interpreter.cpp:1699:10
    #10 0x55e900832503 in VerifyWitnessProgram(CScriptWitness const&, int, std::vector<unsigned char, std::allocator<unsigned char> > const&, unsigned int, BaseSignatureChecker const&, ScriptError_t*, bool) /tmp/bitcoin-core/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/script/interpreter.cpp:1900:26
    #11 0x55e90082ecb5 in VerifyScript(CScript const&, CScript const&, CScriptWitness const*, unsigned int, BaseSignatureChecker const&, ScriptError_t*) /tmp/bitcoin-core/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/script/interpreter.cpp:1977:18
    #12 0x55e9007a9b61 in test_one_input(std::vector<unsigned char, std::allocator<unsigned char> > const&) /tmp/bitcoin-core/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/test/fuzz/script_flags.cpp:51:30
    #13 0x55e9007d0b49 in LLVMFuzzerTestOneInput /tmp/bitcoin-core/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/test/fuzz/fuzz.cpp:36:5
    #14 0x55e9006b1871 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/tmp/bitcoin-core/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/test/fuzz/script_flags+0x13e871)
    #15 0x55e9006b0fb5 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool*) (/tmp/bitcoin-core/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/test/fuzz/script_flags+0x13dfb5)
    #16 0x55e9006b38d7 in fuzzer::Fuzzer::ReadAndExecuteSeedCorpora(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) (/tmp/bitcoin-core/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/test/fuzz/script_flags+0x1408d7)
    #17 0x55e9006b3c39 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) (/tmp/bitcoin-core/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/test/fuzz/script_flags+0x140c39)
    #18 0x55e9006a290e in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/tmp/bitcoin-core/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/test/fuzz/script_flags+0x12f90e)
    #19 0x55e9006cb752 in main (/tmp/bitcoin-core/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/test/fuzz/script_flags+0x158752)
    #20 0x7f6fb85310b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #21 0x55e9006776ad in _start (/tmp/bitcoin-core/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/test/fuzz/script_flags+0x1046ad)