### PR TITLE
Bugfix: RPC/Wallet: Make BTC/kB and sat/B fee modes work sanely

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -223,6 +223,9 @@ static void SetFeeEstimateMode(const CWallet* pwallet, CCoinControl& cc, const U
         }
 
         cc.m_feerate = CFeeRate(fee_rate);
+        if (*cc.m_feerate <= CFeeRate(0)) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid fee_rate %s (must be greater than 0)", cc.m_feerate->ToString()));
+        }
 
         // default RBF to true for explicit fee rate modes
         if (cc.m_signal_bip125_rbf == nullopt) cc.m_signal_bip125_rbf = true;
@@ -3466,9 +3469,6 @@ static RPCHelpMan bumpfee_helper(std::string method_name)
             coin_control.m_confirm_target = ParseConfirmTarget(conf_target, pwallet->chain().estimateMaxBlocks());
         } else if (options.exists("fee_rate")) {
             CFeeRate fee_rate(AmountFromValue(options["fee_rate"]));
-            if (fee_rate <= CFeeRate(0)) {
-                throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid fee_rate %s (must be greater than 0)", fee_rate.ToString()));
-            }
             coin_control.m_feerate = fee_rate;
         }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4014,7 +4014,7 @@ static RPCHelpMan send()
                     },
                 },
             },
-            {"conf_target", RPCArg::Type::NUM, /* default */ "wallet default", "Confirmation target (in blocks), or fee rate (for " + CURRENCY_UNIT + "/kB or " + CURRENCY_ATOM + "/B estimate modes)"},
+            {"conf_target", RPCArg::Type::NUM, /* default */ "wallet default", "Confirmation target (in blocks)"},
             {"estimate_mode", RPCArg::Type::STR, /* default */ "unset", std::string() + "The fee estimate mode, must be one of (case insensitive):\n"
                         "       \"" + FeeModes("\"\n\"") + "\""},
             {"options", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED_NAMED_ARG, "",
@@ -4024,9 +4024,10 @@ static RPCHelpMan send()
                     {"change_address", RPCArg::Type::STR_HEX, /* default */ "pool address", "The bitcoin address to receive the change"},
                     {"change_position", RPCArg::Type::NUM, /* default */ "random", "The index of the change output"},
                     {"change_type", RPCArg::Type::STR, /* default */ "set by -changetype", "The output type to use. Only valid if change_address is not specified. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\"."},
-                    {"conf_target", RPCArg::Type::NUM, /* default */ "wallet default", "Confirmation target (in blocks), or fee rate (for " + CURRENCY_UNIT + "/kB or " + CURRENCY_ATOM + "/B estimate modes)"},
+                    {"conf_target", RPCArg::Type::NUM, /* default */ "wallet default", "Confirmation target (in blocks)"},
                     {"estimate_mode", RPCArg::Type::STR, /* default */ "unset", std::string() + "The fee estimate mode, must be one of (case insensitive):\n"
             "       \"" + FeeModes("\"\n\"") + "\""},
+                    {"fee_rate", RPCArg::Type::NUM, /* default */ "wallet default", "Fee rate (for " + CURRENCY_UNIT + "/kB or " + CURRENCY_ATOM + "/B estimate modes)"},
                     {"include_watching", RPCArg::Type::BOOL, /* default */ "true for watch-only wallets, otherwise false", "Also select inputs which are watch only.\n"
                                           "Only solvable inputs can be used. Watch-only destinations are solvable if the public key and/or output script was imported,\n"
                                           "e.g. with 'importpubkey' or 'importmulti' with the 'pubkeys' or 'desc' field."},
@@ -4085,7 +4086,7 @@ static RPCHelpMan send()
             UniValue options = request.params[3];
             if (options.exists("feeRate") || options.exists("fee_rate") || options.exists("estimate_mode") || options.exists("conf_target")) {
                 if (!request.params[1].isNull() || !request.params[2].isNull()) {
-                    throw JSONRPCError(RPC_INVALID_PARAMETER, "Use either conf_target and estimate_mode or the options dictionary to control fee rate");
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, "Use either conf_target and estimate_mode params or the options dictionary to control fee rate");
                 }
             } else {
                 options.pushKV("conf_target", request.params[1]);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -443,7 +443,7 @@ static RPCHelpMan sendtoaddress()
                     {"subtractfeefromamount", RPCArg::Type::BOOL, /* default */ "false", "The fee will be deducted from the amount being sent.\n"
                                          "The recipient will receive less bitcoins than you enter in the amount field."},
                     {"replaceable", RPCArg::Type::BOOL, /* default */ "wallet default", "Allow this transaction to be replaced by a transaction with higher fees via BIP 125"},
-                    {"conf_target", RPCArg::Type::NUM, /* default */ "wallet default", "Confirmation target (in blocks), or fee rate (for " + CURRENCY_UNIT + "/kB or " + CURRENCY_ATOM + "/B estimate modes)"},
+                    {"conf_target|fee_rate", RPCArg::Type::NUM, /* default */ "wallet default", "Confirmation target (in blocks), or fee rate (for " + CURRENCY_UNIT + "/kB or " + CURRENCY_ATOM + "/B estimate modes)"},
                     {"estimate_mode", RPCArg::Type::STR, /* default */ "unset", std::string() + "The fee estimate mode, must be one of (case insensitive):\n"
             "       \"" + FeeModes("\"\n\"") + "\""},
                     {"avoid_reuse", RPCArg::Type::BOOL, /* default */ "true", "(only available if avoid_reuse wallet flag is set) Avoid spending from dirty addresses; addresses are considered\n"
@@ -871,7 +871,7 @@ static RPCHelpMan sendmany()
                         },
                     },
                     {"replaceable", RPCArg::Type::BOOL, /* default */ "wallet default", "Allow this transaction to be replaced by a transaction with higher fees via BIP 125"},
-                    {"conf_target", RPCArg::Type::NUM, /* default */ "wallet default", "Confirmation target (in blocks), or fee rate (for " + CURRENCY_UNIT + "/kB or " + CURRENCY_ATOM + "/B estimate modes)"},
+                    {"conf_target|fee_rate", RPCArg::Type::NUM, /* default */ "wallet default", "Confirmation target (in blocks), or fee rate (for " + CURRENCY_UNIT + "/kB or " + CURRENCY_ATOM + "/B estimate modes)"},
                     {"estimate_mode", RPCArg::Type::STR, /* default */ "unset", std::string() + "The fee estimate mode, must be one of (case insensitive):\n"
             "       \"" + FeeModes("\"\n\"") + "\""},
                     {"verbose", RPCArg::Type::BOOL, /* default */ "false", "If true, return extra infomration about the transaction."},
@@ -4533,8 +4533,8 @@ static const CRPCCommand commands[] =
     { "wallet",             "removeprunedfunds",                &removeprunedfunds,             {"txid"} },
     { "wallet",             "rescanblockchain",                 &rescanblockchain,              {"start_height", "stop_height"} },
     { "wallet",             "send",                             &send,                          {"outputs","conf_target","estimate_mode","options"} },
-    { "wallet",             "sendmany",                         &sendmany,                      {"dummy","amounts","minconf","comment","subtractfeefrom","replaceable","conf_target","estimate_mode","verbose"} },
-    { "wallet",             "sendtoaddress",                    &sendtoaddress,                 {"address","amount","comment","comment_to","subtractfeefromamount","replaceable","conf_target","estimate_mode","avoid_reuse","verbose"} },
+    { "wallet",             "sendmany",                         &sendmany,                      {"dummy","amounts","minconf","comment","subtractfeefrom","replaceable","conf_target|fee_rate","estimate_mode","verbose"} },
+    { "wallet",             "sendtoaddress",                    &sendtoaddress,                 {"address","amount","comment","comment_to","subtractfeefromamount","replaceable","conf_target|fee_rate","estimate_mode","avoid_reuse","verbose"} },
     { "wallet",             "sethdseed",                        &sethdseed,                     {"newkeypool","seed"} },
     { "wallet",             "setlabel",                         &setlabel,                      {"address","label"} },
     { "wallet",             "settxfee",                         &settxfee,                      {"amount"} },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -217,7 +217,7 @@ static void SetFeeEstimateMode(const CWallet* pwallet, CCoinControl& cc, const U
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Selected estimate_mode requires a fee rate");
         }
         if (&conf_target_param != &fee_rate_param && !conf_target_param.isNull()) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "conf_target can't be set with fee_rate");
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot specify both conf_target and fee_rate. Please provide either a confirmation target in blocks for automatic fee estimation, or an explicit fee rate.");
         }
 
         CAmount fee_rate = AmountFromValue(fee_rate_param);
@@ -3387,7 +3387,7 @@ static RPCHelpMan bumpfee_helper(std::string method_name)
         "The command will pay the additional fee by reducing change outputs or adding inputs when necessary. It may add a new change output if one does not already exist.\n"
         "All inputs in the original transaction will be included in the replacement transaction.\n"
         "The command will fail if the wallet or mempool contains a transaction that spends one of T's outputs.\n"
-        "By default, the new fee will be calculated automatically using estimatesmartfee.\n"
+        "By default, the new fee will be calculated automatically using the estimatesmartfee RPC.\n"
         "The user can specify a confirmation target for estimatesmartfee.\n"
         "Alternatively, the user can specify a fee_rate (" + CURRENCY_UNIT + " per kB) for the new transaction.\n"
         "At a minimum, the new fee rate must be high enough to pay an additional new relay fee (incrementalfee\n"

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -172,8 +172,11 @@ class PSBTTest(BitcoinTestFramework):
             elif out['scriptPubKey']['addresses'][0] == p2pkh:
                 p2pkh_pos = out['n']
 
+        inputs = [{"txid": txid, "vout": p2wpkh_pos}, {"txid": txid, "vout": p2sh_p2wpkh_pos}, {"txid": txid, "vout": p2pkh_pos}]
+        addr = {self.nodes[1].getnewaddress(): 29.99}
+
         # spend single key from node 1
-        created_psbt = self.nodes[1].walletcreatefundedpsbt([{"txid":txid,"vout":p2wpkh_pos},{"txid":txid,"vout":p2sh_p2wpkh_pos},{"txid":txid,"vout":p2pkh_pos}], {self.nodes[1].getnewaddress():29.99})
+        created_psbt = self.nodes[1].walletcreatefundedpsbt(inputs, addr)
         walletprocesspsbt_out = self.nodes[1].walletprocesspsbt(created_psbt['psbt'])
         # Make sure it has both types of UTXOs
         decoded = self.nodes[1].decodepsbt(walletprocesspsbt_out['psbt'])
@@ -184,14 +187,15 @@ class PSBTTest(BitcoinTestFramework):
         assert_equal(walletprocesspsbt_out['complete'], True)
         self.nodes[1].sendrawtransaction(self.nodes[1].finalizepsbt(walletprocesspsbt_out['psbt'])['hex'])
 
-        # feeRate of 0.1 BTC / KB produces a total fee slightly below -maxtxfee (~0.05280000):
-        res = self.nodes[1].walletcreatefundedpsbt([{"txid":txid,"vout":p2wpkh_pos},{"txid":txid,"vout":p2sh_p2wpkh_pos},{"txid":txid,"vout":p2pkh_pos}], {self.nodes[1].getnewaddress():29.99}, 0, {"feeRate": 0.1, "add_inputs": True})
+        self.log.info("Test feeRate of 0.1 BTC / KB produces a total fee slightly below -maxtxfee (~0.05280000)")
+        res = self.nodes[1].walletcreatefundedpsbt(inputs, addr, 0, {"feeRate": 0.1, "add_inputs": True})
         assert_approx(res["fee"], 0.055, 0.005)
 
-        # feeRate of 10 BTC / KB produces a total fee well above -maxtxfee
+        self.log.info("Test feeRate of 10 BTC/KB produces total fee well above -maxtxfee and raises RPC error")
         # previously this was silently capped at -maxtxfee
-        assert_raises_rpc_error(-4, "Fee exceeds maximum configured by user (e.g. -maxtxfee, maxfeerate)", self.nodes[1].walletcreatefundedpsbt, [{"txid":txid,"vout":p2wpkh_pos},{"txid":txid,"vout":p2sh_p2wpkh_pos},{"txid":txid,"vout":p2pkh_pos}], {self.nodes[1].getnewaddress():29.99}, 0, {"feeRate": 10, "add_inputs": True})
-        assert_raises_rpc_error(-4, "Fee exceeds maximum configured by user (e.g. -maxtxfee, maxfeerate)", self.nodes[1].walletcreatefundedpsbt, [{"txid":txid,"vout":p2wpkh_pos},{"txid":txid,"vout":p2sh_p2wpkh_pos},{"txid":txid,"vout":p2pkh_pos}], {self.nodes[1].getnewaddress():1}, 0, {"feeRate": 10, "add_inputs": False})
+        for bool_add, addr in {True: addr, False: {self.nodes[1].getnewaddress(): 1}}.items():
+            assert_raises_rpc_error(-4, "Fee exceeds maximum configured by user (e.g. -maxtxfee, maxfeerate)",
+                                    self.nodes[1].walletcreatefundedpsbt, inputs, addr, 0, {"feeRate": 10, "add_inputs": bool_add})
 
         # partially sign multisig things with node 1
         psbtx = wmulti.walletcreatefundedpsbt(inputs=[{"txid":txid,"vout":p2wsh_pos},{"txid":txid,"vout":p2sh_pos},{"txid":txid,"vout":p2sh_p2wsh_pos}], outputs={self.nodes[1].getnewaddress():29.99}, options={'changeAddress': self.nodes[1].getrawchangeaddress()})['psbt']

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -235,13 +235,13 @@ class WalletTest(BitcoinTestFramework):
         assert_raises_rpc_error(-3, "Amount out of range",
             self.nodes[2].sendmany,
             amounts={ address: 10 },
-            conf_target=-1,
+            fee_rate=-1,
             estimate_mode='bTc/kB')
         fee_per_kb = 0.0002500
         explicit_fee_per_byte = Decimal(fee_per_kb) / 1000
         txid = self.nodes[2].sendmany(
             amounts={ address: 10 },
-            conf_target=fee_per_kb,
+            fee_rate=fee_per_kb,
             estimate_mode='bTc/kB',
         )
         self.nodes[2].generate(1)
@@ -261,14 +261,14 @@ class WalletTest(BitcoinTestFramework):
         assert_raises_rpc_error(-3, "Amount out of range",
             self.nodes[2].sendmany,
             amounts={ address: 10 },
-            conf_target=-1,
+            fee_rate=-1,
             estimate_mode='sat/b')
         fee_sat_per_b = 2
         fee_per_kb = fee_sat_per_b / 100000.0
         explicit_fee_per_byte = Decimal(fee_per_kb) / 1000
         txid = self.nodes[2].sendmany(
             amounts={ address: 10 },
-            conf_target=fee_sat_per_b,
+            fee_rate=fee_sat_per_b,
             estimate_mode='sAT/b',
         )
         self.nodes[2].generate(1)
@@ -430,12 +430,12 @@ class WalletTest(BitcoinTestFramework):
                 self.nodes[2].sendtoaddress,
                 address=address,
                 amount=1.0,
-                conf_target=-1,
+                fee_rate=-1,
                 estimate_mode='btc/kb')
             txid = self.nodes[2].sendtoaddress(
                 address=address,
                 amount=1.0,
-                conf_target=0.00002500,
+                fee_rate=0.00002500,
                 estimate_mode='btc/kb',
             )
             tx_size = self.get_vsize(self.nodes[2].gettransaction(txid)['hex'])
@@ -464,12 +464,12 @@ class WalletTest(BitcoinTestFramework):
                 self.nodes[2].sendtoaddress,
                 address=address,
                 amount=1.0,
-                conf_target=-1,
+                fee_rate=-1,
                 estimate_mode='SAT/b')
             txid = self.nodes[2].sendtoaddress(
                 address=address,
                 amount=1.0,
-                conf_target=2,
+                fee_rate=2,
                 estimate_mode='SAT/B',
             )
             tx_size = self.get_vsize(self.nodes[2].gettransaction(txid)['hex'])

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -168,24 +168,63 @@ def test_simple_bumpfee_succeeds(self, mode, rbf_node, peer_node, dest_address):
 
 
 def test_feerate_args(self, rbf_node, peer_node, dest_address):
-    self.log.info('Test fee_rate args')
+    self.log.info('Test feerate args')
     rbfid = spend_one_input(rbf_node, dest_address)
     self.sync_mempools((rbf_node, peer_node))
     assert rbfid in rbf_node.getrawmempool() and rbfid in peer_node.getrawmempool()
 
-    assert_raises_rpc_error(-8, "conf_target can't be set with fee_rate", rbf_node.bumpfee, rbfid, {"fee_rate": NORMAL, "confTarget": 1})
-
     assert_raises_rpc_error(-3, "Unexpected key totalFee", rbf_node.bumpfee, rbfid, {"totalFee": NORMAL})
-    assert_raises_rpc_error(-8, "conf_target can't be set with fee_rate", rbf_node.bumpfee, rbfid, {"fee_rate":0.00001, "confTarget": 1})
 
     # Bumping to just above minrelay should fail to increase total fee enough, at least
     assert_raises_rpc_error(-8, "Insufficient total fee", rbf_node.bumpfee, rbfid, {"fee_rate": INSUFFICIENT})
-
     assert_raises_rpc_error(-3, "Amount out of range", rbf_node.bumpfee, rbfid, {"fee_rate": -1})
-
     assert_raises_rpc_error(-4, "is too high (cannot be higher than", rbf_node.bumpfee, rbfid, {"fee_rate": TOO_HIGH})
-    self.clear_mempool()
 
+    self.log.info("Test explicit feerate raises RPC error if estimate_mode is passed without a fee_rate")
+    assert_raises_rpc_error(-8, "Selected estimate_mode requires a fee rate", rbf_node.bumpfee, rbfid, {"estimate_mode": BTC_MODE})
+    assert_raises_rpc_error(-8, "Selected estimate_mode requires a fee rate", rbf_node.bumpfee, rbfid, {"estimate_mode": SAT_MODE})
+
+    self.log.info("Test explicit feerate raises RPC error if both fee_rate and conf_target are passed")
+    msg = "Cannot specify both conf_target and fee_rate. Please provide either a confirmation " \
+          "target in blocks for automatic fee estimation, or an explicit fee rate."
+    assert_raises_rpc_error(-8, msg, rbf_node.bumpfee, rbfid, {"conf_target": NORMAL, "fee_rate": NORMAL})
+
+    self.log.info("Test invalid conf_target settings")
+    for field in ["confTarget", "conf_target"]:
+        assert_raises_rpc_error(-8, msg, rbf_node.bumpfee, rbfid, {field: 1, "fee_rate": NORMAL})
+    too_high = "is too high (cannot be higher than -maxtxfee"
+    assert_raises_rpc_error(-4, too_high, lambda: rbf_node.bumpfee(rbfid, {"estimate_mode": BTC_MODE, "fee_rate": 2009}))
+    assert_raises_rpc_error(-4, too_high, lambda: rbf_node.bumpfee(rbfid, {"estimate_mode": SAT_MODE, "fee_rate": 2009 * 10000}))
+
+    self.log.info("Test invalid estimate_mode settings")
+    for k, v in {"number": 42, "object": {"foo": "bar"}}.items():
+        assert_raises_rpc_error(-3, "Expected type string for estimate_mode, got {}".format(k),
+                                lambda: rbf_node.bumpfee(rbfid, {"estimate_mode": v, "fee_rate": NORMAL}))
+    for mode in ["foo", Decimal("3.141592")]:
+        assert_raises_rpc_error(-8, "Invalid estimate_mode parameter",
+                                lambda: rbf_node.bumpfee(rbfid, {"estimate_mode": mode, "fee_rate": NORMAL}))
+
+    self.log.info("Test invalid fee_rate settings")
+    for mode in ["unset", "economical", "conservative"]:
+        self.log.debug("{}".format(mode))
+        for k, v in {"string": "", "object": {"foo": "bar"}}.items():
+            assert_raises_rpc_error(-3, "Expected type number for fee_rate, got {}".format(k),
+                                    lambda: rbf_node.bumpfee(rbfid, {"estimate_mode": mode, "fee_rate": v}))
+        assert_raises_rpc_error(-8, "Must specify an explicit-fee estimate_mode to set fee_rate. Please provide either a confirmation target in blocks for automatic fee estimation, or an explicit fee mode.",
+                                lambda: rbf_node.bumpfee(rbfid, {"estimate_mode": mode, "fee_rate": -1}))
+        assert_raises_rpc_error(-8, "Must specify an explicit-fee estimate_mode to set fee_rate. Please provide either a confirmation target in blocks for automatic fee estimation, or an explicit fee mode.",
+                                lambda: rbf_node.bumpfee(rbfid, {"estimate_mode": mode, "fee_rate": 0}))
+    for mode in [BTC_MODE, SAT_MODE]:
+        self.log.debug("{}".format(mode))
+        for k, v in {"string": "", "object": {"foo": "bar"}}.items():
+            assert_raises_rpc_error(-3, "Expected type number for fee_rate, got {}".format(k),
+                                    lambda: rbf_node.bumpfee(rbfid, {"estimate_mode": mode, "fee_rate": v}))
+        assert_raises_rpc_error(-3, "Amount out of range",
+                                lambda: rbf_node.bumpfee(rbfid, {"estimate_mode": mode, "fee_rate": -1}))
+        assert_raises_rpc_error(-8, "Invalid fee_rate 0.00000000 BTC/kB (must be greater than 0)",
+                                lambda: rbf_node.bumpfee(rbfid, {"estimate_mode": mode, "fee_rate": 0}))
+
+    self.clear_mempool()
 
 def test_segwit_bumpfee_succeeds(self, rbf_node, dest_address):
     self.log.info('Test that segwit-sourcing bumpfee works')

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -164,10 +164,10 @@ def test_feerate_args(self, rbf_node, peer_node, dest_address):
     self.sync_mempools((rbf_node, peer_node))
     assert rbfid in rbf_node.getrawmempool() and rbfid in peer_node.getrawmempool()
 
-    assert_raises_rpc_error(-8, "conf_target can't be set with fee_rate. Please provide either a confirmation target in blocks for automatic fee estimation, or an explicit fee rate.", rbf_node.bumpfee, rbfid, {"fee_rate": NORMAL, "confTarget": 1})
+    assert_raises_rpc_error(-8, "conf_target can't be set with fee_rate", rbf_node.bumpfee, rbfid, {"fee_rate": NORMAL, "confTarget": 1})
 
     assert_raises_rpc_error(-3, "Unexpected key totalFee", rbf_node.bumpfee, rbfid, {"totalFee": NORMAL})
-    assert_raises_rpc_error(-8, "conf_target can't be set with fee_rate. Please provide either a confirmation target in blocks for automatic fee estimation, or an explicit fee rate.", rbf_node.bumpfee, rbfid, {"fee_rate":0.00001, "confTarget": 1})
+    assert_raises_rpc_error(-8, "conf_target can't be set with fee_rate", rbf_node.bumpfee, rbfid, {"fee_rate":0.00001, "confTarget": 1})
 
     # Bumping to just above minrelay should fail to increase total fee enough, at least
     assert_raises_rpc_error(-8, "Insufficient total fee", rbf_node.bumpfee, rbfid, {"fee_rate": INSUFFICIENT})

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -17,7 +17,7 @@ from decimal import Decimal
 import io
 
 from test_framework.blocktools import add_witness_commitment, create_block, create_coinbase, send_to_witness
-from test_framework.messages import BIP125_SEQUENCE_NUMBER, CTransaction
+from test_framework.messages import BIP125_SEQUENCE_NUMBER, COIN, CTransaction
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -36,6 +36,8 @@ NORMAL       = 0.00100000
 HIGH         = 0.00500000
 TOO_HIGH     = 1.00000000
 
+BTC_MODE = "BTC/kB"
+SAT_MODE = "sat/B"
 
 class BumpFeeTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -77,8 +79,8 @@ class BumpFeeTest(BitcoinTestFramework):
         self.log.info("Running tests")
         dest_address = peer_node.getnewaddress()
         self.test_invalid_parameters(rbf_node, dest_address)
-        test_simple_bumpfee_succeeds(self, "default", rbf_node, peer_node, dest_address)
-        test_simple_bumpfee_succeeds(self, "fee_rate", rbf_node, peer_node, dest_address)
+        for mode in ["default", "fee_rate", BTC_MODE, SAT_MODE]:
+            test_simple_bumpfee_succeeds(self, mode, rbf_node, peer_node, dest_address)
         test_feerate_args(self, rbf_node, peer_node, dest_address)
         test_segwit_bumpfee_succeeds(self, rbf_node, dest_address)
         test_nonrbf_bumpfee_fails(self, peer_node, dest_address)
@@ -132,6 +134,13 @@ def test_simple_bumpfee_succeeds(self, mode, rbf_node, peer_node, dest_address):
     if mode == "fee_rate":
         bumped_psbt = rbf_node.psbtbumpfee(rbfid, {"fee_rate": NORMAL})
         bumped_tx = rbf_node.bumpfee(rbfid, {"fee_rate": NORMAL})
+    elif mode == BTC_MODE:
+        bumped_psbt = rbf_node.psbtbumpfee(rbfid, {"fee_rate": NORMAL, "estimate_mode": BTC_MODE})
+        bumped_tx = rbf_node.bumpfee(rbfid, {"fee_rate": NORMAL, "estimate_mode": BTC_MODE})
+    elif mode == SAT_MODE:
+        sat_fee = NORMAL * COIN / 1000  # convert NORMAL from BTC/kB to sat/B
+        bumped_psbt = rbf_node.psbtbumpfee(rbfid, {"fee_rate": sat_fee, "estimate_mode": SAT_MODE})
+        bumped_tx = rbf_node.bumpfee(rbfid, {"fee_rate": sat_fee, "estimate_mode": SAT_MODE})
     else:
         bumped_psbt = rbf_node.psbtbumpfee(rbfid)
         bumped_tx = rbf_node.bumpfee(rbfid)

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -29,7 +29,7 @@ class WalletSendTest(BitcoinTestFramework):
 
     def test_send(self, from_wallet, to_wallet=None, amount=None, data=None,
                   arg_conf_target=None, arg_estimate_mode=None,
-                  conf_target=None, estimate_mode=None, add_to_wallet=None, psbt=None,
+                  conf_target=None, fee_rate=None, estimate_mode=None, add_to_wallet=None, psbt=None,
                   inputs=None, add_inputs=None, change_address=None, change_position=None, change_type=None,
                   include_watching=None, locktime=None, lock_unspents=None, replaceable=None, subtract_fee_from_outputs=None,
                   expect_error=None):
@@ -60,6 +60,8 @@ class WalletSendTest(BitcoinTestFramework):
             options["psbt"] = psbt
         if conf_target is not None:
             options["conf_target"] = conf_target
+        if fee_rate is not None:
+            options["feeRate"] = fee_rate
         if estimate_mode is not None:
             options["estimate_mode"] = estimate_mode
         if inputs is not None:
@@ -247,21 +249,21 @@ class WalletSendTest(BitcoinTestFramework):
         assert res["complete"]
 
         self.log.info("Set fee rate...")
-        res = self.test_send(from_wallet=w0, to_wallet=w1, amount=1, conf_target=2, estimate_mode="sat/b", add_to_wallet=False)
+        res = self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=2, estimate_mode="sat/b", add_to_wallet=False)
         fee = self.nodes[1].decodepsbt(res["psbt"])["fee"]
         assert_fee_amount(fee, Decimal(len(res["hex"]) / 2), Decimal("0.00002"))
-        self.test_send(from_wallet=w0, to_wallet=w1, amount=1, conf_target=-1, estimate_mode="sat/b",
+        self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=-1, estimate_mode="sat/b",
                        expect_error=(-3, "Amount out of range"))
         # Fee rate of 0.1 satoshi per byte should throw an error
         # TODO: error should use sat/b
-        self.test_send(from_wallet=w0, to_wallet=w1, amount=1, conf_target=0.1, estimate_mode="sat/b",
+        self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=0.1, estimate_mode="sat/b",
                        expect_error=(-4, "Fee rate (0.00000100 BTC/kB) is lower than the minimum fee rate setting (0.00001000 BTC/kB)"))
 
-        self.test_send(from_wallet=w0, to_wallet=w1, amount=1, conf_target=0.000001, estimate_mode="BTC/KB",
+        self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=0.000001, estimate_mode="BTC/KB",
                        expect_error=(-4, "Fee rate (0.00000100 BTC/kB) is lower than the minimum fee rate setting (0.00001000 BTC/kB)"))
 
         # TODO: Return hex if fee rate is below -maxmempool
-        # res = self.test_send(from_wallet=w0, to_wallet=w1, amount=1, conf_target=0.1, estimate_mode="sat/b", add_to_wallet=False)
+        # res = self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=0.1, estimate_mode="sat/b", add_to_wallet=False)
         # assert res["hex"]
         # hex = res["hex"]
         # res = self.nodes[0].testmempoolaccept([hex])

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -227,7 +227,7 @@ class WalletSendTest(BitcoinTestFramework):
                      self.nodes[1].decodepsbt(res2["psbt"])["fee"])
         # but not at the same time
         self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_conf_target=1, arg_estimate_mode="economical",
-                       conf_target=1, estimate_mode="economical", add_to_wallet=False, expect_error=(-8,"Use either conf_target and estimate_mode or the options dictionary to control fee rate"))
+                       conf_target=1, estimate_mode="economical", add_to_wallet=False, expect_error=(-8,"Use either conf_target and estimate_mode params or the options dictionary to control fee rate"))
 
         self.log.info("Create PSBT from watch-only wallet w3, sign with w2...")
         res = self.test_send(from_wallet=w3, to_wallet=w1, amount=1)


### PR DESCRIPTION
Expects `fee_mode` for explicit feerate modes instead of overloading `conf_target` (positional args still accept either for now; that can be restricted once we finally have #17356).

`fundrawtransaction` used to expect its option to be called `feeRate`, diverging from other `fee_rate` option names. It now accepts either, with `feeRate` soft-deprecated.

`fundrawtransaction` and `bumpfee` still accept `fee_rate` without `estimate_mode` for backward compatibility.

Borrows tests from #20220 (adapted for interface changes). (NOTE: *NOT* including 9ea6d390c26975c98a9cf28cf816bcbded9aa3d1 77a4f98897ab4430311cff3f2226f274fad20d6a f97a3cd3e6e229305a4451d611d77cbf3892381f)