### PR TITLE
Add I2P support using statically configured destinations

### DIFF
--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -151,7 +151,12 @@ class CNetAddr
 
         bool SetInternal(const std::string& name);
 
-        bool SetSpecial(const std::string &strName); // for Tor addresses
+        /**
+         * Parse a Tor or I2P address and set this object to it.
+         * @returns whether or not the operation was successful.
+         * @see CNetAddr::IsTor(), CNetAddr::IsI2P()
+         */
+        bool SetSpecial(const std::string& name);
         bool IsBindAny() const; // INADDR_ANY equivalent
         bool IsIPv4() const;    // IPv4 mapped address (::FFFF:0:0/96, 0.0.0.0/0)
         bool IsIPv6() const;    // IPv6 address (not mapped IPv4, not Tor)
@@ -248,6 +253,20 @@ class CNetAddr
         friend class CSubNet;
 
     private:
+        /**
+         * Parse a Tor address and set this object to it.
+         * @returns Whether or not the operation was successful.
+         * @see CNetAddr::IsTor()
+         */
+        bool SetTor(const std::string& name);
+
+        /**
+         * Parse an I2P address and set this object to it.
+         * @returns Whether or not the operation was successful.
+         * @see CNetAddr::IsI2P()
+         */
+        bool SetI2P(const std::string& name);
+
         /**
          * BIP155 network ids recognized by this software.
          */

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -58,6 +58,7 @@ std::string GetNetworkName(enum Network net) {
     case NET_IPV4: return "ipv4";
     case NET_IPV6: return "ipv6";
     case NET_ONION: return "onion";
+    case NET_I2P: return "i2p";
     default: return "";
     }
 }

--- a/src/test/base32_tests.cpp
+++ b/src/test/base32_tests.cpp
@@ -16,12 +16,16 @@ BOOST_AUTO_TEST_CASE(base32_testvectors)
     static const std::string vstrOutNoPadding[] = {"","my","mzxq","mzxw6","mzxw6yq","mzxw6ytb","mzxw6ytboi"};
     for (unsigned int i=0; i<sizeof(vstrIn)/sizeof(vstrIn[0]); i++)
     {
-        std::string strEnc = EncodeBase32(vstrIn[i]);
-        BOOST_CHECK_EQUAL(strEnc, vstrOut[i]);
-        strEnc = EncodeBase32(vstrIn[i], false);
-        BOOST_CHECK_EQUAL(strEnc, vstrOutNoPadding[i]);
-        std::string strDec = DecodeBase32(vstrOut[i]);
-        BOOST_CHECK_EQUAL(strDec, vstrIn[i]);
+        BOOST_CHECK_EQUAL(EncodeBase32(vstrIn[i]), vstrOut[i]);
+        BOOST_CHECK_EQUAL(EncodeBase32(vstrIn[i], false), vstrOutNoPadding[i]);
+
+        bool invalid;
+
+        BOOST_CHECK_EQUAL(DecodeBase32(vstrOut[i], &invalid), vstrIn[i]);
+        BOOST_CHECK(!invalid);
+
+        BOOST_CHECK_EQUAL(DecodeBase32(vstrOutNoPadding[i], &invalid, false), vstrIn[i]);
+        BOOST_CHECK(!invalid);
     }
 
     // Decoding strings with embedded NUL characters should fail

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -221,7 +221,7 @@ std::string EncodeBase32(const std::string& str, bool pad)
     return EncodeBase32(MakeUCharSpan(str), pad);
 }
 
-std::vector<unsigned char> DecodeBase32(const char* p, bool* pf_invalid)
+std::vector<unsigned char> DecodeBase32(const char* p, bool* pf_invalid, bool require_padding)
 {
     static const int decode32_table[256] =
     {
@@ -262,13 +262,14 @@ std::vector<unsigned char> DecodeBase32(const char* p, bool* pf_invalid)
         }
         ++p;
     }
-    valid = valid && (p - e) % 8 == 0 && p - q < 8;
+    const bool pad_ok = (p - e) % 8 == 0 || !require_padding;
+    valid = valid && pad_ok && p - q < 8;
     if (pf_invalid) *pf_invalid = !valid;
 
     return ret;
 }
 
-std::string DecodeBase32(const std::string& str, bool* pf_invalid)
+std::string DecodeBase32(const std::string& str, bool* pf_invalid, bool require_padding)
 {
     if (!ValidAsCString(str)) {
         if (pf_invalid) {
@@ -276,7 +277,7 @@ std::string DecodeBase32(const std::string& str, bool* pf_invalid)
         }
         return {};
     }
-    std::vector<unsigned char> vchRet = DecodeBase32(str.c_str(), pf_invalid);
+    std::vector<unsigned char> vchRet = DecodeBase32(str.c_str(), pf_invalid, require_padding);
     return std::string((const char*)vchRet.data(), vchRet.size());
 }
 

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -50,8 +50,26 @@ std::vector<unsigned char> DecodeBase64(const char* p, bool* pf_invalid = nullpt
 std::string DecodeBase64(const std::string& str, bool* pf_invalid = nullptr);
 std::string EncodeBase64(Span<const unsigned char> input);
 std::string EncodeBase64(const std::string& str);
-std::vector<unsigned char> DecodeBase32(const char* p, bool* pf_invalid = nullptr);
-std::string DecodeBase32(const std::string& str, bool* pf_invalid = nullptr);
+
+/**
+ * Base32 decode.
+ * If `allow_nopad` is true, then the input is allowed to have length that is not
+ * a multiple of 8 and is assumed to have been padded with `=` up to a multiple
+ * of 8.
+ */
+std::vector<unsigned char> DecodeBase32(const char* p,
+                                        bool* pf_invalid = nullptr,
+                                        bool require_padding = true);
+
+/**
+ * Base32 decode.
+ * If `allow_nopad` is true, then the input is allowed to have length that is not
+ * a multiple of 8 and is assumed to have been padded with `=` up to a multiple
+ * of 8.
+ */
+std::string DecodeBase32(const std::string& str,
+                         bool* pf_invalid = nullptr,
+                         bool require_padding = true);
 
 /**
  * Base32 encode.

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -46,11 +46,12 @@ NET_UNROUTABLE = ""
 NET_IPV4 = "ipv4"
 NET_IPV6 = "ipv6"
 NET_ONION = "onion"
+NET_I2P = "i2p"
 
 
 class ProxyTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.num_nodes = 4
+        self.num_nodes = 5
         self.setup_clean_chain = True
 
     def setup_nodes(self):
@@ -61,7 +62,7 @@ class ProxyTest(BitcoinTestFramework):
         self.conf1.addr = ('127.0.0.1', RANGE_BEGIN + (os.getpid() % 1000))
         self.conf1.unauth = True
         self.conf1.auth = False
-        # ... one supporting authenticated and unauthenticated (Tor)
+        # ... one supporting authenticated and unauthenticated (Tor and I2P)
         self.conf2 = Socks5Configuration()
         self.conf2.addr = ('127.0.0.1', RANGE_BEGIN + 1000 + (os.getpid() % 1000))
         self.conf2.unauth = True
@@ -90,7 +91,8 @@ class ProxyTest(BitcoinTestFramework):
             ['-listen', '-proxy=%s:%i' % (self.conf1.addr),'-proxyrandomize=1'],
             ['-listen', '-proxy=%s:%i' % (self.conf1.addr),'-onion=%s:%i' % (self.conf2.addr),'-proxyrandomize=0'],
             ['-listen', '-proxy=%s:%i' % (self.conf2.addr),'-proxyrandomize=1'],
-            []
+            [],
+            ['-listen', '-proxy=%s:%i' % (self.conf1.addr),'-i2pproxy=%s:%i' % (self.conf2.addr),'-proxyrandomize=1'],
             ]
         if self.have_ipv6:
             args[3] = ['-listen', '-proxy=[%s]:%i' % (self.conf3.addr),'-proxyrandomize=0', '-noonion']
@@ -102,7 +104,7 @@ class ProxyTest(BitcoinTestFramework):
             if peer["addr"] == addr:
                 assert_equal(peer["network"], network)
 
-    def node_test(self, node, proxies, auth, test_onion=True):
+    def node_test(self, node, proxies, auth, test_onion=True, test_i2p=False):
         rv = []
         addr = "15.61.23.23:1234"
         self.log.debug("Test: outgoing IPv4 connection through node for address {}".format(addr))
@@ -164,6 +166,21 @@ class ProxyTest(BitcoinTestFramework):
         rv.append(cmd)
         self.network_test(node, addr, network=NET_UNROUTABLE)
 
+        if test_i2p:
+            addr = "ukeu3k5oycgaauneqgtnvselmt4yemvoilkln7jpvamvfx7dnkdq.b32.i2p:8333"
+            self.log.debug("Test: outgoing I2P connection through node for address {}".format(addr))
+            node.addnode(addr, "onetry")
+            cmd = proxies[2].queue.get()
+            assert isinstance(cmd, Socks5Command)
+            assert_equal(cmd.atyp, AddressType.DOMAINNAME)
+            assert_equal(cmd.addr, b"ukeu3k5oycgaauneqgtnvselmt4yemvoilkln7jpvamvfx7dnkdq.b32.i2p")
+            assert_equal(cmd.port, 8333)
+            if not auth:
+                assert_equal(cmd.username, None)
+                assert_equal(cmd.password, None)
+            rv.append(cmd)
+            self.network_test(node, addr, network=NET_I2P)
+
         return rv
 
     def run_test(self):
@@ -182,6 +199,10 @@ class ProxyTest(BitcoinTestFramework):
         if self.have_ipv6:
             # proxy on IPv6 localhost
             self.node_test(self.nodes[3], [self.serv3, self.serv3, self.serv3, self.serv3], False, False)
+
+        # -proxy plus -i2pproxy
+        self.node_test(self.nodes[4], [self.serv1, self.serv1, self.serv2, self.serv1],
+                       auth=True, test_onion=False, test_i2p=True)
 
         def networks_dict(d):
             r = {}
@@ -216,6 +237,13 @@ class ProxyTest(BitcoinTestFramework):
                 assert_equal(n3[net]['proxy'], '[%s]:%i' % (self.conf3.addr))
                 assert_equal(n3[net]['proxy_randomize_credentials'], False)
             assert_equal(n3['onion']['reachable'], False)
+
+        n4 = networks_dict(self.nodes[4].getnetworkinfo())
+        for net in ['ipv4','ipv6','onion']:
+            assert_equal(n4[net]['proxy'], '%s:%i' % (self.conf1.addr))
+            assert_equal(n4[net]['proxy_randomize_credentials'], True)
+        assert_equal(n4['i2p']['reachable'], True)
+        assert_equal(n4['i2p']['proxy'], '%s:%i' % (self.conf2.addr))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
_This PR is mostly for experiments, testing and discussion. It works but see below._

Add I2P support:

* Outgoing connections to I2P destinations use the I2P socks5 proxy <sup>[i2pd](https://i2pd.readthedocs.io/en/latest/user-guide/configuration/#socks-proxy), [i2p](https://geti2p.net/en/docs/api/socks)</sup> from the newly added option `-i2pproxy=addr:port`.
* Incoming connections from I2P (listen) use statically configured destinations <sup>[i2pd](https://i2pd.readthedocs.io/en/latest/user-guide/tunnels/#servergeneric-tunnels), [i2p](https://geti2p.net/spec/configuration#i2ptunnel-i2ptunnel-config)</sup>, similarly to statically configured Tor hidden services where the I2P/Tor daemon redirects incoming connections to an application listening on a normal TCP port. The user has to configure the I2P/Tor daemon separately from `bitcoind`.

What's missing:
* `-onlynet=i2p`
* `-bind=127.0.0.1:8335=i2p` in order to distinguish incoming I2P from incoming clearnet connections

---

It is possible to accept incoming connections using the [SAM](https://geti2p.net/en/docs/api/samv3) I2P protocol. This would make it possible to configure the destination (hidden service) automatically (so the user does not have to extra-configure the I2P daemon). It would also resolve the problem with distinguishing incoming I2P connections. I am looking into doing that.

If that is done, it will supersede this PR because both outgoing and incoming connections would be made via [SAM](https://geti2p.net/en/docs/api/samv3). Thus this PR is a draft.

---

A bitcoin node is running at `yfsvsy467mt5xafaq7zaukkjyzehvmew445yaaejvrwpk53acejq.b32.i2p:31872`.