### PR TITLE
Update secp256k1 subtree to latest master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
     - CFLAGS=-O0 CTIMETEST=no
     - ECMULTGENPRECISION=2
     - ECMULTGENPRECISION=8
-    - RUN_VALGRIND=yes BIGNUM=no ASM=x86_64 EXPERIMENTAL=yes ECDH=yes  RECOVERY=yes EXTRAFLAGS="--disable-openssl-tests" BUILD=
+    - RUN_VALGRIND=yes BIGNUM=no ASM=x86_64 ECDH=yes  RECOVERY=yes EXPERIMENTAL=yes SCHNORRSIG=yes EXTRAFLAGS="--disable-openssl-tests" BUILD=
 matrix:
   fast_finish: true
   include:
@@ -81,7 +81,7 @@ matrix:
             - libc6-dbg:i386
     # S390x build (big endian system)
     - compiler: gcc
-      env: HOST=s390x-unknown-linux-gnu ECDH=yes RECOVERY=yes EXPERIMENTAL=yes CTIMETEST=
+      env: HOST=s390x-unknown-linux-gnu ECDH=yes RECOVERY=yes EXPERIMENTAL=yes SCHNORRSIG=yes CTIMETEST=
       arch: s390x
 
 # We use this to install macOS dependencies instead of the built in `homebrew` plugin,

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Features:
 * Very efficient implementation.
 * Suitable for embedded systems.
 * Optional module for public key recovery.
-* Optional module for ECDH key exchange (experimental).
+* Optional module for ECDH key exchange.
 
 Experimental features have not received enough scrutiny to satisfy the standard of quality of this library but are made available for testing and review by the community. The APIs of these features should not be considered stable.
 

--- a/build-aux/m4/bitcoin_secp.m4
+++ b/build-aux/m4/bitcoin_secp.m4
@@ -36,16 +36,39 @@ if test x"$has_libcrypto" = x"yes" && test x"$has_openssl_ec" = x; then
   CPPFLAGS_TEMP="$CPPFLAGS"
   CPPFLAGS="$CRYPTO_CPPFLAGS $CPPFLAGS"
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    #include <openssl/bn.h>
     #include <openssl/ec.h>
     #include <openssl/ecdsa.h>
     #include <openssl/obj_mac.h>]],[[
-    EC_KEY *eckey = EC_KEY_new_by_curve_name(NID_secp256k1);
-    ECDSA_sign(0, NULL, 0, NULL, NULL, eckey);
+    # if OPENSSL_VERSION_NUMBER < 0x10100000L
+    void ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps) {(void)sig->r; (void)sig->s;}
+    # endif
+
+    unsigned int zero = 0;
+    const unsigned char *zero_ptr = (unsigned char*)&zero;
+    EC_KEY_free(EC_KEY_new_by_curve_name(NID_secp256k1));
+    EC_KEY *eckey = EC_KEY_new();
+    EC_GROUP *group = EC_GROUP_new_by_curve_name(NID_secp256k1);
+    EC_KEY_set_group(eckey, group);
+    ECDSA_sign(0, NULL, 0, NULL, &zero, eckey);
     ECDSA_verify(0, NULL, 0, NULL, 0, eckey);
+    o2i_ECPublicKey(&eckey, &zero_ptr, 0);
+    d2i_ECPrivateKey(&eckey, &zero_ptr, 0);
+    EC_KEY_check_key(eckey);
     EC_KEY_free(eckey);
+    EC_GROUP_free(group);
     ECDSA_SIG *sig_openssl;
     sig_openssl = ECDSA_SIG_new();
+    d2i_ECDSA_SIG(&sig_openssl, &zero_ptr, 0);
+    i2d_ECDSA_SIG(sig_openssl, NULL);
+    ECDSA_SIG_get0(sig_openssl, NULL, NULL);
     ECDSA_SIG_free(sig_openssl);
+    const BIGNUM *bignum = BN_value_one();
+    BN_is_negative(bignum);
+    BN_num_bits(bignum);
+    if (sizeof(zero) >= BN_num_bytes(bignum)) {
+        BN_bn2bin(bignum, (unsigned char*)&zero);
+    }
   ]])],[has_openssl_ec=yes],[has_openssl_ec=no])
   AC_MSG_RESULT([$has_openssl_ec])
   CPPFLAGS="$CPPFLAGS_TEMP"

--- a/configure.ac
+++ b/configure.ac
@@ -122,7 +122,7 @@ AC_ARG_ENABLE(ecmult_static_precomputation,
     [use_ecmult_static_precomputation=auto])
 
 AC_ARG_ENABLE(module_ecdh,
-    AS_HELP_STRING([--enable-module-ecdh],[enable ECDH shared secret computation (experimental)]),
+    AS_HELP_STRING([--enable-module-ecdh],[enable ECDH shared secret computation]),
     [enable_module_ecdh=$enableval],
     [enable_module_ecdh=no])
 
@@ -395,8 +395,8 @@ esac
 
 if test x"$use_tests" = x"yes"; then
   SECP_OPENSSL_CHECK
-  if test x"$has_openssl_ec" = x"yes"; then
-    if test x"$enable_openssl_tests" != x"no"; then
+  if test x"$enable_openssl_tests" != x"no" && test x"$has_openssl_ec" = x"yes"; then
+      enable_openssl_tests=yes
       AC_DEFINE(ENABLE_OPENSSL_TESTS, 1, [Define this symbol if OpenSSL EC functions are available])
       SECP_TEST_INCLUDES="$SSL_CFLAGS $CRYPTO_CFLAGS $CRYPTO_CPPFLAGS"
       SECP_TEST_LIBS="$CRYPTO_LIBS"
@@ -406,16 +406,17 @@ if test x"$use_tests" = x"yes"; then
         SECP_TEST_LIBS="$SECP_TEST_LIBS -lgdi32"
         ;;
       esac
-    fi
   else
     if test x"$enable_openssl_tests" = x"yes"; then
       AC_MSG_ERROR([OpenSSL tests requested but OpenSSL with EC support is not available])
     fi
+    enable_openssl_tests=no
   fi
 else
   if test x"$enable_openssl_tests" = x"yes"; then
     AC_MSG_ERROR([OpenSSL tests requested but tests are not enabled])
   fi
+  enable_openssl_tests=no
 fi
 
 if test x"$set_bignum" = x"gmp"; then
@@ -458,14 +459,10 @@ if test x"$enable_experimental" = x"yes"; then
   AC_MSG_NOTICE([******])
   AC_MSG_NOTICE([WARNING: experimental build])
   AC_MSG_NOTICE([Experimental features do not have stable APIs or properties, and may not be safe for production use.])
-  AC_MSG_NOTICE([Building ECDH module: $enable_module_ecdh])
   AC_MSG_NOTICE([Building extrakeys module: $enable_module_extrakeys])
   AC_MSG_NOTICE([Building schnorrsig module: $enable_module_schnorrsig])
   AC_MSG_NOTICE([******])
 else
-  if test x"$enable_module_ecdh" = x"yes"; then
-    AC_MSG_ERROR([ECDH module is experimental. Use --enable-experimental to allow.])
-  fi
   if test x"$enable_module_extrakeys" = x"yes"; then
     AC_MSG_ERROR([extrakeys module is experimental. Use --enable-experimental to allow.])
   fi
@@ -507,6 +504,8 @@ echo "Build Options:"
 echo "  with ecmult precomp     = $set_precomp"
 echo "  with external callbacks = $use_external_default_callbacks"
 echo "  with benchmarks         = $use_benchmark"
+echo "  with tests              = $use_tests"
+echo "  with openssl tests      = $enable_openssl_tests"
 echo "  with coverage           = $enable_coverage"
 echo "  module ecdh             = $enable_module_ecdh"
 echo "  module recovery         = $enable_module_recovery"

--- a/src/ecmult_impl.h
+++ b/src/ecmult_impl.h
@@ -443,7 +443,7 @@ struct secp256k1_strauss_state {
     struct secp256k1_strauss_point_state* ps;
 };
 
-static void secp256k1_ecmult_strauss_wnaf(const secp256k1_ecmult_context *ctx, const struct secp256k1_strauss_state *state, secp256k1_gej *r, int num, const secp256k1_gej *a, const secp256k1_scalar *na, const secp256k1_scalar *ng) {
+static void secp256k1_ecmult_strauss_wnaf(const secp256k1_ecmult_context *ctx, const struct secp256k1_strauss_state *state, secp256k1_gej *r, size_t num, const secp256k1_gej *a, const secp256k1_scalar *na, const secp256k1_scalar *ng) {
     secp256k1_ge tmpa;
     secp256k1_fe Z;
     /* Splitted G factors. */
@@ -454,8 +454,8 @@ static void secp256k1_ecmult_strauss_wnaf(const secp256k1_ecmult_context *ctx, c
     int bits_ng_128 = 0;
     int i;
     int bits = 0;
-    int np;
-    int no = 0;
+    size_t np;
+    size_t no = 0;
 
     for (np = 0; np < num; ++np) {
         if (secp256k1_scalar_is_zero(&na[np]) || secp256k1_gej_is_infinity(&a[np])) {


### PR DESCRIPTION
Nothing important changed, but this silences this (erroneous) warning in certain GCC 9 versions:

```
In file included from src/secp256k1.c:16:
src/ecmult_impl.h: In function ‘secp256k1_ecmult’:
src/ecmult_impl.h:496:48: warning: array subscript [1, 268435456] is outside array bounds of ‘struct secp256k1_strauss_point_state[1]’ [-Warray-bounds]
  496 |             secp256k1_gej tmp = a[state->ps[np].input_pos];
      |                                   ~~~~~~~~~~~~~^~~~~~~~~~
src/ecmult_impl.h:565:42: note: while referencing ‘ps’
  565 |     struct secp256k1_strauss_point_state ps[1];
      |                                          ^~
src/ecmult_impl.h:502:139: warning: array subscript [1, 268435456] is outside array bounds of ‘struct secp256k1_strauss_point_state[1]’ [-Warray-bounds]
  502 |             secp256k1_fe_mul(state->zr + np * ECMULT_TABLE_SIZE(WINDOW_A), state->zr + np * ECMULT_TABLE_SIZE(WINDOW_A), &(a[state->ps[np].input_pos].z));
      |                                                                                                                              ~~~~~~~~~~~~~^~~~~~~~~~
src/ecmult_impl.h:565:42: note: while referencing ‘ps’
  565 |     struct secp256k1_strauss_point_state ps[1];
      |                                          ^~
```

(see https://github.com/bitcoin-core/secp256k1/issues/834)