### PR TITLE
Add missing thread safety annotations

### DIFF
--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -14,7 +14,7 @@
 
 #include <vector>
 
-static void AssembleBlock(benchmark::Bench& bench)
+static void AssembleBlock(benchmark::Bench& bench) EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
 {
     TestingSetup test_setup{
         CBaseChainParams::REGTEST,

--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -25,7 +25,8 @@ static void BlockToJsonVerbose(benchmark::Bench& bench)
     blockindex.phashBlock = &blockHash;
     blockindex.nBits = 403014710;
 
-    bench.run([&] {
+    bench.run([&]() NO_THREAD_SAFETY_ANALYSIS {
+        AssertLockNotHeld(cs_main);
         (void)blockToJSON(block, &blockindex, &blockindex, /*verbose*/ true);
     });
 }

--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -12,7 +12,10 @@
 #include <validationinterface.h>
 #include <wallet/wallet.h>
 
-static void WalletBalance(benchmark::Bench& bench, const bool set_dirty, const bool add_watchonly, const bool add_mine)
+static void WalletBalance(benchmark::Bench& bench,
+                          const bool set_dirty,
+                          const bool add_watchonly,
+                          const bool add_mine) EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
 {
     TestingSetup test_setup{
         CBaseChainParams::REGTEST,
@@ -53,10 +56,25 @@ static void WalletBalance(benchmark::Bench& bench, const bool set_dirty, const b
     });
 }
 
-static void WalletBalanceDirty(benchmark::Bench& bench) { WalletBalance(bench, /* set_dirty */ true, /* add_watchonly */ true, /* add_mine */ true); }
-static void WalletBalanceClean(benchmark::Bench& bench) { WalletBalance(bench, /* set_dirty */ false, /* add_watchonly */ true, /* add_mine */ true); }
-static void WalletBalanceMine(benchmark::Bench& bench) { WalletBalance(bench, /* set_dirty */ false, /* add_watchonly */ false, /* add_mine */ true); }
-static void WalletBalanceWatch(benchmark::Bench& bench) { WalletBalance(bench, /* set_dirty */ false, /* add_watchonly */ true, /* add_mine */ false); }
+static void WalletBalanceDirty(benchmark::Bench& bench) EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
+{
+    WalletBalance(bench, /* set_dirty */ true, /* add_watchonly */ true, /* add_mine */ true);
+}
+
+static void WalletBalanceClean(benchmark::Bench& bench) EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
+{
+    WalletBalance(bench, /* set_dirty */ false, /* add_watchonly */ true, /* add_mine */ true);
+}
+
+static void WalletBalanceMine(benchmark::Bench& bench) EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
+{
+    WalletBalance(bench, /* set_dirty */ false, /* add_watchonly */ false, /* add_mine */ true);
+}
+
+static void WalletBalanceWatch(benchmark::Bench& bench) EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
+{
+    WalletBalance(bench, /* set_dirty */ false, /* add_watchonly */ true, /* add_mine */ false);
+}
 
 BENCHMARK(WalletBalanceDirty);
 BENCHMARK(WalletBalanceClean);

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -109,7 +109,7 @@ public:
     /// sync once and only needs to process blocks in the ValidationInterface
     /// queue. If the index is catching up from far behind, this method does
     /// not block and immediately returns false.
-    bool BlockUntilSyncedToCurrentChain() const;
+    bool BlockUntilSyncedToCurrentChain() const EXCLUSIVE_LOCKS_REQUIRED(!cs_main);
 
     void Interrupt();
 

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -362,6 +362,7 @@ public:
         return MakeUnique<NotificationsHandlerImpl>(std::move(notifications));
     }
     void waitForNotificationsIfTipChanged(const uint256& old_tip) override
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
     {
         if (!old_tip.IsNull()) {
             LOCK(::cs_main);

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -65,7 +65,9 @@ public:
     * @param[in]   pfrom           The node which we have received messages from.
     * @param[in]   interrupt       Interrupt condition for processing threads
     */
-    bool ProcessMessages(CNode* pfrom, std::atomic<bool>& interrupt) override;
+    bool ProcessMessages(CNode* pfrom, std::atomic<bool>& interrupt) override
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_main);
+
     /**
     * Send queued protocol messages to be sent to a give node.
     *
@@ -84,8 +86,12 @@ public:
     void ReattemptInitialBroadcast(CScheduler& scheduler) const;
 
     /** Process a single message from a peer. Public for fuzz testing */
-    void ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStream& vRecv,
-                        const std::chrono::microseconds time_received, const std::atomic<bool>& interruptMsgProc);
+    void ProcessMessage(CNode& pfrom,
+                        const std::string& msg_type,
+                        CDataStream& vRecv,
+                        const std::chrono::microseconds time_received,
+                        const std::atomic<bool>& interruptMsgProc)
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_main);
 
     /**
      * Increment peer's misbehavior score. If the new value >= DISCOURAGEMENT_THRESHOLD, mark the node

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -131,7 +131,7 @@ void BumpFee(TransactionView& view, const uint256& txid, bool expectDisabled, st
 //     QT_QPA_PLATFORM=xcb     src/qt/test/test_bitcoin-qt  # Linux
 //     QT_QPA_PLATFORM=windows src/qt/test/test_bitcoin-qt  # Windows
 //     QT_QPA_PLATFORM=cocoa   src/qt/test/test_bitcoin-qt  # macOS
-void TestGUI(interfaces::Node& node)
+static void TestGUI(interfaces::Node& node) EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
 {
     // Set up wallet and chain with 105 blocks (5 mature blocks for spending).
     TestChain100Setup test;
@@ -269,7 +269,7 @@ void TestGUI(interfaces::Node& node)
 
 } // namespace
 
-void WalletTests::walletTests()
+void WalletTests::walletTests() EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
 {
 #ifdef Q_OS_MAC
     if (QApplication::platformName() == "minimal") {

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -376,6 +376,7 @@ static bool rest_mempool_contents(const util::Ref& context, HTTPRequest* req, co
 }
 
 static bool rest_tx(const util::Ref& context, HTTPRequest* req, const std::string& strURIPart)
+    EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
 {
     if (!CheckWarmup(req))
         return false;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -382,7 +382,8 @@ static RPCHelpMan syncwithvalidationinterfacequeue()
                     HelpExampleCli("syncwithvalidationinterfacequeue","")
             + HelpExampleRpc("syncwithvalidationinterfacequeue","")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     SyncWithValidationInterfaceQueue();
     return NullUniValue;

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -46,7 +46,7 @@ UniValue MempoolInfoToJSON(const CTxMemPool& pool);
 UniValue MempoolToJSON(const CTxMemPool& pool, bool verbose = false, bool include_mempool_sequence = false);
 
 /** Block header to JSON */
-UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex) LOCKS_EXCLUDED(cs_main);
+UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex) EXCLUSIVE_LOCKS_REQUIRED(!cs_main);
 
 /** Used by getblockstats to get feerates at different percentiles by weight  */
 void CalculatePercentilesByWeight(CAmount result[NUM_GETBLOCKSTATS_PERCENTILES], std::vector<std::pair<CAmount, int64_t>>& scores, int64_t total_weight);

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -37,7 +37,10 @@ double GetDifficulty(const CBlockIndex* blockindex);
 void RPCNotifyBlockChange(const CBlockIndex*);
 
 /** Block description to JSON */
-UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIndex* blockindex, bool txDetails = false) LOCKS_EXCLUDED(cs_main);
+UniValue blockToJSON(const CBlock& block,
+                     const CBlockIndex* tip,
+                     const CBlockIndex* blockindex,
+                     bool txDetails = false) EXCLUSIVE_LOCKS_REQUIRED(!cs_main);
 
 /** Mempool information to JSON */
 UniValue MempoolInfoToJSON(const CTxMemPool& pool);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -840,7 +840,7 @@ static RPCHelpMan sendrawtransaction()
             "\nAs a JSON-RPC call\n"
             + HelpExampleRpc("sendrawtransaction", "\"signedhex\"")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     RPCTypeCheck(request.params, {
         UniValue::VSTR,

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -155,7 +155,7 @@ static RPCHelpMan getrawtransaction()
             + HelpExampleCli("getrawtransaction", "\"mytxid\" false \"myblockhash\"")
             + HelpExampleCli("getrawtransaction", "\"mytxid\" true \"myblockhash\"")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     const NodeContext& node = EnsureNodeContext(request.context);
 

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -20,7 +20,10 @@ BOOST_AUTO_TEST_SUITE(blockfilter_index_tests)
 
 struct BuildChainTestingSetup : public TestChain100Setup {
     CBlock CreateBlock(const CBlockIndex* prev, const std::vector<CMutableTransaction>& txns, const CScript& scriptPubKey);
-    bool BuildChain(const CBlockIndex* pindex, const CScript& coinbase_script_pub_key, size_t length, std::vector<std::shared_ptr<CBlock>>& chain);
+    bool BuildChain(const CBlockIndex* pindex,
+                    const CScript& coinbase_script_pub_key,
+                    size_t length,
+                    std::vector<std::shared_ptr<CBlock>>& chain) EXCLUSIVE_LOCKS_REQUIRED(!cs_main);
 };
 
 static bool CheckFilterLookups(BlockFilterIndex& filter_index, const CBlockIndex* block_index,

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(findAncestorByHash)
     BOOST_CHECK(!chain->findAncestorByHash(active[10]->GetBlockHash(), active[20]->GetBlockHash()));
 }
 
-BOOST_AUTO_TEST_CASE(findCommonAncestor)
+BOOST_AUTO_TEST_CASE(findCommonAncestor) EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
 {
     auto chain = interfaces::MakeChain(m_node);
     auto& active = ChainActive();

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -12,7 +12,7 @@
 
 BOOST_AUTO_TEST_SUITE(txindex_tests)
 
-BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
+BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup) EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
 {
     TxIndex txindex(1 << 20, true);
 

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -18,6 +18,7 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState &state, const C
 BOOST_AUTO_TEST_SUITE(txvalidationcache_tests)
 
 BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
+EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
 {
     // Make sure skipping validation of transactions that were
     // validated going into the memory pool does not allow

--- a/src/test/util/mining.h
+++ b/src/test/util/mining.h
@@ -5,8 +5,12 @@
 #ifndef BITCOIN_TEST_UTIL_MINING_H
 #define BITCOIN_TEST_UTIL_MINING_H
 
+#include <sync.h>
+
 #include <memory>
 #include <string>
+
+extern RecursiveMutex cs_main;
 
 class CBlock;
 class CScript;
@@ -14,12 +18,12 @@ class CTxIn;
 struct NodeContext;
 
 /** Returns the generated coin */
-CTxIn MineBlock(const NodeContext&, const CScript& coinbase_scriptPubKey);
+CTxIn MineBlock(const NodeContext&, const CScript& coinbase_scriptPubKey) EXCLUSIVE_LOCKS_REQUIRED(!cs_main);
 
 /** Prepare a block to be mined */
 std::shared_ptr<CBlock> PrepareBlock(const NodeContext&, const CScript& coinbase_scriptPubKey);
 
 /** RPC-like helper function, returns the generated coin */
-CTxIn generatetoaddress(const NodeContext&, const std::string& address);
+CTxIn generatetoaddress(const NodeContext&, const std::string& address) EXCLUSIVE_LOCKS_REQUIRED(!cs_main);
 
 #endif // BITCOIN_TEST_UTIL_MINING_H

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -113,7 +113,7 @@ struct TestChain100Setup : public RegTestingSetup {
      * scriptPubKey, and try to add it to the current chain.
      */
     CBlock CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns,
-                                 const CScript& scriptPubKey);
+                                 const CScript& scriptPubKey) EXCLUSIVE_LOCKS_REQUIRED(!cs_main);
 
     ~TestChain100Setup();
 

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -148,7 +148,7 @@ void MinerTestingSetup::BuildChain(const uint256& root, int height, const unsign
     }
 }
 
-BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
+BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering) EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
 {
     // build a large-ish chain that's likely to have some forks
     std::vector<std::shared_ptr<const CBlock>> blocks;
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
     // will subscribe to events generated during block validation and assert on ordering invariance
     std::vector<std::thread> threads;
     for (int i = 0; i < 10; i++) {
-        threads.emplace_back([&]() {
+        threads.emplace_back([&]() EXCLUSIVE_LOCKS_REQUIRED(!cs_main) {
             bool ignored;
             FastRandomContext insecure;
             for (int i = 0; i < 1000; i++) {
@@ -229,10 +229,11 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
  * or consistent with the chain state after the reorg, and not just consistent
  * with some intermediate state during the reorg.
  */
-BOOST_AUTO_TEST_CASE(mempool_locks_reorg)
+BOOST_AUTO_TEST_CASE(mempool_locks_reorg) EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
 {
     bool ignored;
-    auto ProcessBlock = [&](std::shared_ptr<const CBlock> block) -> bool {
+    auto ProcessBlock = [&](std::shared_ptr<const CBlock> block)
+                            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> bool {
         return Assert(m_node.chainman)->ProcessNewBlock(Params(), block, /* fForceProcessing */ true, /* fNewBlock */ &ignored);
     };
 

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -20,7 +20,7 @@ BOOST_FIXTURE_TEST_SUITE(validation_chainstatemanager_tests, TestingSetup)
 //! Basic tests for ChainstateManager.
 //!
 //! First create a legacy (IBD) chainstate, then create a snapshot chainstate.
-BOOST_AUTO_TEST_CASE(chainstatemanager)
+BOOST_AUTO_TEST_CASE(chainstatemanager) EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
 {
     ChainstateManager manager;
     CTxMemPool mempool;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2857,7 +2857,7 @@ static bool NotifyHeaderTip() LOCKS_EXCLUDED(cs_main) {
     return fNotify;
 }
 
-static void LimitValidationInterfaceQueue() LOCKS_EXCLUDED(cs_main) {
+static void LimitValidationInterfaceQueue() EXCLUSIVE_LOCKS_REQUIRED(!cs_main) {
     AssertLockNotHeld(cs_main);
 
     if (GetMainSignals().CallbacksPending() > 10) {

--- a/src/validation.h
+++ b/src/validation.h
@@ -179,7 +179,11 @@ CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMe
  * May not be called with cs_main held. May not be called in a
  * validationinterface callback.
  */
-bool ActivateBestChain(BlockValidationState& state, const CChainParams& chainparams, std::shared_ptr<const CBlock> pblock = std::shared_ptr<const CBlock>());
+bool ActivateBestChain(BlockValidationState& state,
+                       const CChainParams& chainparams,
+                       std::shared_ptr<const CBlock> pblock = std::shared_ptr<const CBlock>())
+    EXCLUSIVE_LOCKS_REQUIRED(!cs_main);
+
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams);
 
 /** Guess verification progress (as a fraction between 0.0=genesis and 1.0=current tip). */
@@ -661,7 +665,7 @@ public:
     bool ActivateBestChain(
         BlockValidationState& state,
         const CChainParams& chainparams,
-        std::shared_ptr<const CBlock> pblock) LOCKS_EXCLUDED(cs_main);
+        std::shared_ptr<const CBlock> pblock) EXCLUSIVE_LOCKS_REQUIRED(!cs_main);
 
     bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
@@ -911,7 +915,10 @@ public:
      * @param[out]  fNewBlock A boolean which is set to indicate if the block was first received via this call
      * @returns     If the block was processed, independently of block validity
      */
-    bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool* fNewBlock) LOCKS_EXCLUDED(cs_main);
+    bool ProcessNewBlock(const CChainParams& chainparams,
+                         const std::shared_ptr<const CBlock> pblock,
+                         bool fForceProcessing,
+                         bool* fNewBlock) EXCLUSIVE_LOCKS_REQUIRED(!cs_main);
 
     /**
      * Process incoming block headers.
@@ -924,7 +931,11 @@ public:
      * @param[in]  chainparams The params for the chain we want to connect to
      * @param[out] ppindex If set, the pointer will be set to point to the last new block index object for the given headers
      */
-    bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& block, BlockValidationState& state, const CChainParams& chainparams, const CBlockIndex** ppindex = nullptr) LOCKS_EXCLUDED(cs_main);
+    bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& block,
+                                BlockValidationState& state,
+                                const CChainParams& chainparams,
+                                const CBlockIndex** ppindex = nullptr)
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_main);
 
     //! Load the block tree and coins database from disk, initializing state if we're running with -reindex
     bool LoadBlockIndex(const CChainParams& chainparams) EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -58,7 +58,7 @@ void CallFunctionInValidationInterfaceQueue(std::function<void ()> func);
  *     });
  *     promise.get_future().wait();
  */
-void SyncWithValidationInterfaceQueue() LOCKS_EXCLUDED(cs_main);
+void SyncWithValidationInterfaceQueue() EXCLUSIVE_LOCKS_REQUIRED(!cs_main);
 
 /**
  * Implement this to subscribe to events generated in validation

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -422,7 +422,7 @@ void BerkeleyEnvironment::CloseDb(const std::string& strFile)
     }
 }
 
-void BerkeleyEnvironment::ReloadDbEnv()
+void BerkeleyEnvironment::ReloadDbEnv() EXCLUSIVE_LOCKS_REQUIRED(!cs_db)
 {
     // Make sure that no Db's are in use
     AssertLockNotHeld(cs_db);
@@ -650,7 +650,7 @@ void BerkeleyDatabase::Close()
     env->Flush(true);
 }
 
-void BerkeleyDatabase::ReloadDbEnv()
+void BerkeleyDatabase::ReloadDbEnv() EXCLUSIVE_LOCKS_REQUIRED(!cs_db)
 {
     env->ReloadDbEnv();
 }

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -733,7 +733,8 @@ RPCHelpMan dumpwallet()
                     HelpExampleCli("dumpwallet", "\"test\"")
             + HelpExampleRpc("dumpwallet", "\"test\"")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
     if (!pwallet) return NullUniValue;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -467,7 +467,8 @@ static RPCHelpMan sendtoaddress()
             + HelpExampleCli("sendtoaddress", "\"" + EXAMPLE_ADDRESS[0] + "\" 0.1 \"\" \"\" false true 2 " + (CURRENCY_ATOM + "/B"))
             + HelpExampleRpc("sendtoaddress", "\"" + EXAMPLE_ADDRESS[0] + "\", 0.1, \"donation\", \"seans outpost\"")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -546,7 +547,8 @@ static RPCHelpMan listaddressgroupings()
                     HelpExampleCli("listaddressgroupings", "")
             + HelpExampleRpc("listaddressgroupings", "")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -707,7 +709,8 @@ static RPCHelpMan getreceivedbyaddress()
             "\nAs a JSON-RPC call\n"
             + HelpExampleRpc("getreceivedbyaddress", "\"" + EXAMPLE_ADDRESS[0] + "\", 6")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -746,7 +749,8 @@ static RPCHelpMan getreceivedbylabel()
             "\nAs a JSON-RPC call\n"
             + HelpExampleRpc("getreceivedbylabel", "\"tabby\", 6")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -787,7 +791,8 @@ static RPCHelpMan getbalance()
             "\nAs a JSON-RPC call\n"
             + HelpExampleRpc("getbalance", "\"*\", 6")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -827,7 +832,8 @@ static RPCHelpMan getunconfirmedbalance()
                 {},
                 RPCResult{RPCResult::Type::NUM, "", "The balance"},
                 RPCExamples{""},
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -897,7 +903,8 @@ static RPCHelpMan sendmany()
             "\nAs a JSON-RPC call\n"
             + HelpExampleRpc("sendmany", "\"\", {\"" + EXAMPLE_ADDRESS[0] + "\":0.01,\"" + EXAMPLE_ADDRESS[1] + "\":0.02}, 6, \"testing\"")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -1213,7 +1220,8 @@ static RPCHelpMan listreceivedbyaddress()
             + HelpExampleRpc("listreceivedbyaddress", "6, true, true")
             + HelpExampleRpc("listreceivedbyaddress", "6, true, true, \"" + EXAMPLE_ADDRESS[0] + "\"")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -1256,7 +1264,8 @@ static RPCHelpMan listreceivedbylabel()
             + HelpExampleCli("listreceivedbylabel", "6 true")
             + HelpExampleRpc("listreceivedbylabel", "6, true, true")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -1437,7 +1446,8 @@ static RPCHelpMan listtransactions()
             "\nAs a JSON-RPC call\n"
             + HelpExampleRpc("listtransactions", "\"*\", 20, 100")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -1555,7 +1565,8 @@ static RPCHelpMan listsinceblock()
             + HelpExampleCli("listsinceblock", "\"000000000000000bacf66f7497b7dc45ef753ee9a7d38571037cdb1a57f663ad\" 6")
             + HelpExampleRpc("listsinceblock", "\"000000000000000bacf66f7497b7dc45ef753ee9a7d38571037cdb1a57f663ad\", 6")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
     if (!pwallet) return NullUniValue;
@@ -1697,7 +1708,8 @@ static RPCHelpMan gettransaction()
             + HelpExampleCli("gettransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\" false true")
             + HelpExampleRpc("gettransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -1771,7 +1783,8 @@ static RPCHelpMan abandontransaction()
                     HelpExampleCli("abandontransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
             + HelpExampleRpc("abandontransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -1810,7 +1823,8 @@ static RPCHelpMan backupwallet()
                     HelpExampleCli("backupwallet", "\"backup.dat\"")
             + HelpExampleRpc("backupwallet", "\"backup.dat\"")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -2161,7 +2175,8 @@ static RPCHelpMan lockunspent()
             "\nAs a JSON-RPC call\n"
             + HelpExampleRpc("lockunspent", "false, \"[{\\\"txid\\\":\\\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\\\",\\\"vout\\\":1}]\"")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -2371,7 +2386,8 @@ static RPCHelpMan getbalances()
         RPCExamples{
             HelpExampleCli("getbalances", "") +
             HelpExampleRpc("getbalances", "")},
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const rpc_wallet = GetWalletForJSONRPCRequest(request);
     if (!rpc_wallet) return NullUniValue;
@@ -2447,7 +2463,8 @@ static RPCHelpMan getwalletinfo()
                     HelpExampleCli("getwalletinfo", "")
             + HelpExampleRpc("getwalletinfo", "")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -2878,7 +2895,8 @@ static RPCHelpMan listunspent()
             + HelpExampleCli("listunspent", "6 9999999 '[]' true '{ \"minimumAmount\": 0.005 }'")
             + HelpExampleRpc("listunspent", "6, 9999999, [] , true, { \"minimumAmount\": 0.005 } ")
                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -3044,7 +3062,12 @@ static RPCHelpMan listunspent()
     };
 }
 
-void FundTransaction(CWallet* const pwallet, CMutableTransaction& tx, CAmount& fee_out, int& change_position, UniValue options, CCoinControl& coinControl)
+static void FundTransaction(CWallet* const pwallet,
+                            CMutableTransaction& tx,
+                            CAmount& fee_out,
+                            int& change_position,
+                            UniValue options,
+                            CCoinControl& coinControl) EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
 {
     // Make sure the results are valid at least up to the most recent block
     // the user could have gotten from another RPC command prior to now
@@ -3241,7 +3264,8 @@ static RPCHelpMan fundrawtransaction()
                             "\nSend the transaction\n"
                             + HelpExampleCli("sendrawtransaction", "\"signedtransactionhex\"")
                                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -3423,7 +3447,8 @@ static RPCHelpMan bumpfee_helper(std::string method_name)
     "\nBump the fee, get the new transaction\'s" + std::string(want_psbt ? "psbt" : "txid") + "\n" +
             HelpExampleCli(method_name, "<txid>")
         },
-        [want_psbt](const RPCHelpMan& self, const JSONRPCRequest& request) mutable -> UniValue
+        [want_psbt](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) mutable -> UniValue
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -4068,7 +4093,8 @@ static RPCHelpMan send()
             "\nCreate a transaction that should confirm the next block, with a specific input, and return result without adding to wallet or broadcasting to the network\n"
         + HelpExampleCli("send", "'{\"" + EXAMPLE_ADDRESS[0] + "\": 0.1}' 1 economical '{\"add_to_wallet\": false, \"inputs\": [{\"txid\":\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\", \"vout\":1}]}'")
         },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
         {
             RPCTypeCheck(request.params, {
                 UniValueType(), // ARR or OBJ, checked later
@@ -4381,7 +4407,8 @@ static RPCHelpMan walletcreatefundedpsbt()
                             "\nCreate a transaction with no inputs\n"
                             + HelpExampleCli("walletcreatefundedpsbt", "\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"[{\\\"data\\\":\\\"00010203\\\"}]\"")
                                 },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request)
+            EXCLUSIVE_LOCKS_REQUIRED(!cs_main) -> UniValue
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -76,6 +76,7 @@ static void AddKey(CWallet& wallet, const CKey& key)
 }
 
 BOOST_FIXTURE_TEST_CASE(scan_for_wallet_transactions, TestChain100Setup)
+EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
 {
     // Cap last block file size, and mine new block in a new block file.
     CBlockIndex* oldTip = ::ChainActive().Tip();
@@ -175,7 +176,7 @@ BOOST_FIXTURE_TEST_CASE(scan_for_wallet_transactions, TestChain100Setup)
     }
 }
 
-BOOST_FIXTURE_TEST_CASE(importmulti_rescan, TestChain100Setup)
+BOOST_FIXTURE_TEST_CASE(importmulti_rescan, TestChain100Setup) EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
 {
     // Cap last block file size, and mine new block in a new block file.
     CBlockIndex* oldTip = ::ChainActive().Tip();
@@ -240,7 +241,7 @@ BOOST_FIXTURE_TEST_CASE(importmulti_rescan, TestChain100Setup)
 // greater or equal than key birthday. Previously there was a bug where
 // importwallet RPC would start the scan at the latest block with timestamp less
 // than or equal to key birthday.
-BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
+BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup) EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
 {
     // Create two blocks with same timestamp to verify that importwallet rescan
     // will pick up both blocks, not just the first.
@@ -517,7 +518,7 @@ public:
         wallet.reset();
     }
 
-    CWalletTx& AddTx(CRecipient recipient)
+    CWalletTx& AddTx(CRecipient recipient) EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
     {
         CTransactionRef tx;
         CAmount fee;
@@ -549,7 +550,7 @@ public:
     std::unique_ptr<CWallet> wallet;
 };
 
-BOOST_FIXTURE_TEST_CASE(ListCoins, ListCoinsTestingSetup)
+BOOST_FIXTURE_TEST_CASE(ListCoins, ListCoinsTestingSetup) EXCLUSIVE_LOCKS_REQUIRED(!cs_main)
 {
     std::string coinbaseAddress = coinbaseKey.GetPubKey().GetID().ToString();
 


### PR DESCRIPTION
Fix a pile compilation warnings due to missing thread safety annotations.

I don't know why I started seeing these now. Maybe because I upgraded my compiler: `clang version 12.0.0 (git@github.com:freebsd/freebsd-ports.git 65a9ee72e496521f839dcf5ac36a833c27a88022)`