### PR TITLE
util: Drop redundant NDEBUG check

### DIFF
--- a/src/compat/assumptions.h
+++ b/src/compat/assumptions.h
@@ -10,13 +10,6 @@
 
 #include <limits>
 
-// Assumption: We assume that the macro NDEBUG is not defined.
-// Example(s): We use assert(...) extensively with the assumption of it never
-//             being a noop at runtime.
-#if defined(NDEBUG)
-# error "Bitcoin cannot be compiled without assertions."
-#endif
-
 // Assumption: We assume a C++11 (ISO/IEC 14882:2011) compiler (minimum requirement).
 // Example(s): We assume the presence of C++11 features everywhere :-)
 // Note:       MSVC does not report the expected __cplusplus value due to legacy

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -11,6 +11,7 @@
 #include <script/standard.h>
 #include <test/util/blockfilter.h>
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <util/time.h>
 #include <validation.h>
 


### PR DESCRIPTION
The `util/check.h` does this job: https://github.com/bitcoin/bitcoin/blob/42b66a6b814bca130a9ccf0a3f747cf33d628232/src/util/check.h#L45-L47