### PR TITLE
test: Extend p2p_ibd_tx_relay.py to verify no-transaction are requested during IBD

### DIFF
--- a/test/functional/p2p_ibd_txrelay.py
+++ b/test/functional/p2p_ibd_txrelay.py
@@ -2,12 +2,30 @@
 # Copyright (c) 2020 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test fee filters during and after IBD."""
+"""This test covers tx-relay behaviors which are function of IBD
+    * switching fee filter setting during and after IBD
+    * stop tx-requesting during IBD
+"""
 
 from decimal import Decimal
 
-from test_framework.messages import COIN
+from test_framework.messages import (
+    COIN,
+    CInv,
+    MSG_WTX,
+    msg_inv,
+)
+from test_framework.p2p import (
+    P2PInterface,
+    p2p_lock,
+    NONPREF_PEER_TX_DELAY,
+)
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+
+import time
 
 MAX_FEE_FILTER = Decimal(9170997) / COIN
 NORMAL_FEE_FILTER = Decimal(100) / COIN
@@ -22,7 +40,21 @@ class P2PIBDTxRelayTest(BitcoinTestFramework):
             ["-minrelaytxfee={}".format(NORMAL_FEE_FILTER)],
         ]
 
-    def run_test(self):
+    def test_inv_ibd(self):
+        self.log.info("Check that nodes don't request txn while still in IBD")
+        peer = self.nodes[0].add_p2p_connection(P2PInterface())
+        peer.send_message(msg_inv([CInv(t=MSG_WTX, h=0xffaa)]))
+        # As tx-announcing connection is inbound, wait for the inbound delay applied by requester.
+
+        mock_time = int(time.time() + NONPREF_PEER_TX_DELAY)
+        self.nodes[0].setmocktime(mock_time)
+        peer.sync_with_ping()
+        with p2p_lock:
+            assert_equal(peer.tx_getdata_count, 0)
+        peer.peer_disconnect()
+        peer.wait_for_disconnect()
+
+    def test_feefilter_ibd(self):
         self.log.info("Check that nodes set minfilter to MAX_MONEY while still in IBD")
         for node in self.nodes:
             assert node.getblockchaininfo()['initialblockdownload']
@@ -37,6 +69,9 @@ class P2PIBDTxRelayTest(BitcoinTestFramework):
             assert not node.getblockchaininfo()['initialblockdownload']
             self.wait_until(lambda: all(peer['minfeefilter'] == NORMAL_FEE_FILTER for peer in node.getpeerinfo()))
 
+    def run_test(self):
+        self.test_inv_ibd()
+        self.test_feefilter_ibd()
 
 if __name__ == '__main__':
     P2PIBDTxRelayTest().main()


### PR DESCRIPTION
This PR extends our functional test coverage of `net_processing.cpp`, following the overhaul of transaction request.

It extends `p2p_ibd_txrelay.py` to verify that we don't request transaction during IBD, even lawfully ones from tx-relay peers. It also move network constants/methods in `p2p.py` to serve generically across the test framework.