### PR TITLE
wallet: change upgradewallet return type to be an object

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4443,7 +4443,12 @@ static RPCHelpMan upgradewallet()
         {
             {"version", RPCArg::Type::NUM, /* default */ strprintf("%d", FEATURE_LATEST), "The version number to upgrade to. Default is the latest wallet version"}
         },
-        RPCResults{},
+        RPCResult{
+            RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR, "error", /* optional */ true, "Error message (if there is one)"}
+            },
+        },
         RPCExamples{
             HelpExampleCli("upgradewallet", "169900")
             + HelpExampleRpc("upgradewallet", "169900")
@@ -4468,7 +4473,11 @@ static RPCHelpMan upgradewallet()
     if (!pwallet->UpgradeWallet(version, error, warnings)) {
         throw JSONRPCError(RPC_WALLET_ERROR, error.original);
     }
-    return error.original;
+    UniValue obj(UniValue::VOBJ);
+    if (!error.empty()) {
+        obj.pushKV("error", error.original);
+    }
+    return obj;
 },
     };
 }

--- a/test/functional/wallet_upgradewallet.py
+++ b/test/functional/wallet_upgradewallet.py
@@ -107,7 +107,7 @@ class UpgradeWalletTest(BitcoinTestFramework):
 
         # calling upgradewallet without version arguments
         # should return nothing if successful
-        assert_equal(wallet.upgradewallet(), "")
+        assert_equal(wallet.upgradewallet(), {})
         new_version = wallet.getwalletinfo()["walletversion"]
         # upgraded wallet version should be greater than older one
         assert_greater_than(new_version, old_version)
@@ -130,7 +130,7 @@ class UpgradeWalletTest(BitcoinTestFramework):
         assert_equal('hdseedid' in wallet.getwalletinfo(), False)
         # calling upgradewallet with explicit version number
         # should return nothing if successful
-        assert_equal(wallet.upgradewallet(169900), "")
+        assert_equal(wallet.upgradewallet(169900), {})
         new_version = wallet.getwalletinfo()["walletversion"]
         # upgraded wallet should have version 169900
         assert_equal(new_version, 169900)


### PR DESCRIPTION
Change the return type of upgradewallet to be an object for future extensibility.

Also return any error string returned from the `UpgradeWallet()` function.
