### PR TITLE
script, doc: contrib/seeds updates

### DIFF
--- a/contrib/seeds/README.md
+++ b/contrib/seeds/README.md
@@ -16,6 +16,12 @@ The seeds compiled into the release are created from sipa's DNS seed data, like 
 
 ## Dependencies
 
-Ubuntu:
+Ubuntu, Debian:
 
     sudo apt-get install python3-dnspython
+
+and/or for other operating systems:
+
+    pip install dnspython
+
+See https://dnspython.readthedocs.io/en/latest/installation.html for more information.

--- a/contrib/seeds/makeseeds.py
+++ b/contrib/seeds/makeseeds.py
@@ -135,7 +135,7 @@ def lookup_asn(net, ip):
             ipaddr = res.rstrip('.')            # 2.0.0.1.4.8.6.0.b.0.0.2.0.0.2.3
             prefix = '.origin6'
 
-        asn = int([x.to_text() for x in dns.resolver.query('.'.join(
+        asn = int([x.to_text() for x in dns.resolver.resolve('.'.join(
                    reversed(ipaddr.split('.'))) + prefix + '.asn.cymru.com',
                    'TXT').response.answer][0].split('\"')[1].split(' ')[0])
         return asn


### PR DESCRIPTION
Seen while reviewing #20237.

1. Fix a deprecation warning in `contrib/seeds/makeseeds.py`
```
    makeseeds.py:139: DeprecationWarning: please use dns.resolver.resolve() instead
      asn = int([x.to_text() for x in dns.resolver.query('.'.join(
```
  - Per https://dnspython.readthedocs.io/en/latest/whatsnew.html, `dns.resolver.query()` was deprecated in `dnspython` version 2.0.0.

  - See https://dnspython.readthedocs.io/en/latest/resolver-class.html for more info on the resolver class.

2. Update the `dnspython` dependency installation instructions in `contrib/seeds/README`

  - The markdown rendering can be seen here: https://github.com/jonatack/bitcoin/tree/contrib-seeds-fixups/contrib/seeds