### PR TITLE
fuzz: Check for addrv1 compatibility before using addrv1 serializer/deserializer on CService

### DIFF
--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -191,7 +191,10 @@ void test_one_input(const std::vector<uint8_t>& buffer)
 #elif SERVICE_DESERIALIZE
         CService s;
         DeserializeFromFuzzingInput(buffer, s);
-        AssertEqualAfterSerializeDeserialize(s);
+        if (s.IsAddrV1Compatible()) {
+            AssertEqualAfterSerializeDeserialize(s);
+        }
+        AssertEqualAfterSerializeDeserialize(s, INIT_PROTO_VERSION | ADDRV2_FORMAT);
 #elif MESSAGEHEADER_DESERIALIZE
         CMessageHeader mh;
         DeserializeFromFuzzingInput(buffer, mh);


### PR DESCRIPTION
Check for addrv1 compatibility before using addrv1 serializer/deserializer on `CService`:

Before this patch:

```
$ src/test/fuzz/service_deserialize
service_deserialize: test/fuzz/deserialize.cpp:85:
    void (anonymous namespace)::AssertEqualAfterSerializeDeserialize(const T &, const int) [T = CService]:
    Assertion `Deserialize<T>(Serialize(obj, version)) == obj' failed.
```

After this patch:

```
$ src/test/fuzz/service_deserialize
…
```

Related change: #20247