### PR TITLE
fuzz: Fix DecodeHexTx fuzzing harness issue

### DIFF
--- a/src/test/fuzz/decode_tx.cpp
+++ b/src/test/fuzz/decode_tx.cpp
@@ -24,8 +24,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     if (result_try_witness_and_maybe_no_witness) {
         assert(result_try_no_witness || result_try_witness);
     }
-    // if (result_try_no_witness) { // Uncomment when https://github.com/bitcoin/bitcoin/pull/17775 is merged
-    if (result_try_witness) { // Remove stop-gap when https://github.com/bitcoin/bitcoin/pull/17775 is merged
+    if (result_try_no_witness) {
         assert(result_try_witness_and_maybe_no_witness);
     }
 }


### PR DESCRIPTION
Fix `DecodeHexTx` fuzzing harness issue.

Before this patch:

```
$ src/test/fuzz/decode_tx
decode_tx: test/fuzz/decode_tx.cpp:29: 
    void test_one_input(const std::vector<uint8_t> &):
    Assertion `result_try_witness_and_maybe_no_witness' failed.
…
```

After this patch:

```
$ src/test/fuzz/decode_tx
…
```
