### PR TITLE
fuzz: Add missing ECC_Start to descriptor_parse test

### DIFF
--- a/src/test/fuzz/descriptor_parse.cpp
+++ b/src/test/fuzz/descriptor_parse.cpp
@@ -11,7 +11,8 @@
 void initialize()
 {
     static const ECCVerifyHandle verify_handle;
-    SelectParams(CBaseChainParams::REGTEST);
+    ECC_Start();
+    SelectParams(CBaseChainParams::MAIN);
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)


### PR DESCRIPTION
Fixes fuzzing harness.

I also observed that the corpus for this test consists only of `xprv...` keys while we are using regtest parameters. So for proper fuzzing we need either A) to update the corpus and replace `xprv...` with `tprv...` B) switch to main net in the test