### PR TITLE
net: Make it easier to reason about node eviction by removing unused NodeEvictionCandidate::addr (CAddress)

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -863,7 +863,6 @@ struct NodeEvictionCandidate
     bool fRelevantServices;
     bool fRelayTxes;
     bool fBloomFilter;
-    CAddress addr;
     uint64_t nKeyedNetGroup;
     bool prefer_evict;
     bool m_is_local;
@@ -955,7 +954,7 @@ bool CConnman::AttemptToEvictConnection()
             NodeEvictionCandidate candidate = {node->GetId(), node->nTimeConnected, node->nMinPingUsecTime,
                                                node->nLastBlockTime, node->nLastTXTime,
                                                HasAllDesirableServiceFlags(node->nServices),
-                                               peer_relay_txes, peer_filter_not_null, node->addr, node->nKeyedNetGroup,
+                                               peer_relay_txes, peer_filter_not_null, node->nKeyedNetGroup,
                                                node->m_prefer_evict, node->addr.IsLocal()};
             vEvictionCandidates.push_back(candidate);
         }


### PR DESCRIPTION
Make it easier to reason about node eviction by removing unused `NodeEvictionCandidate::addr` (`CAddress`).