### PR TITLE
fuzz: Assert expected DecodeHexTx behaviour when using legacy decoding

### DIFF
--- a/src/test/fuzz/decode_tx.cpp
+++ b/src/test/fuzz/decode_tx.cpp
@@ -19,12 +19,14 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     const bool result_none = DecodeHexTx(mtx, tx_hex, false, false);
     const bool result_try_witness = DecodeHexTx(mtx, tx_hex, false, true);
     const bool result_try_witness_and_maybe_no_witness = DecodeHexTx(mtx, tx_hex, true, true);
-    const bool result_try_no_witness = DecodeHexTx(mtx, tx_hex, true, false);
+    CMutableTransaction no_witness_mtx;
+    const bool result_try_no_witness = DecodeHexTx(no_witness_mtx, tx_hex, true, false);
     assert(!result_none);
     if (result_try_witness_and_maybe_no_witness) {
         assert(result_try_no_witness || result_try_witness);
     }
     if (result_try_no_witness) {
+        assert(!no_witness_mtx.HasWitness());
         assert(result_try_witness_and_maybe_no_witness);
     }
 }


### PR DESCRIPTION
Assert expected `DecodeHexTx` behaviour when using legacy decoding.

As suggested by MarcoFalke in https://github.com/bitcoin/bitcoin/pull/20290#issuecomment-720989597.