### PR TITLE
Depends: Update FreeType package (CVE-2020-15999)

### DIFF
--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -1,8 +1,8 @@
 package=freetype
-$(package)_version=2.7.1
-$(package)_download_path=https://download.savannah.gnu.org/releases/$(package)
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=3a3bb2c4e15ffb433f2032f50a5b5a92558206822e22bfe8cbe339af4aa82f88
+$(package)_version=2.10.4
+$(package)_download_path=http://download.savannah.gnu.org/releases/$(package)
+$(package)_file_name=$(package)-$($(package)_version).tar.xz
+$(package)_sha256_hash=86a854d8905b19698bbc8f23b860bc104246ce4854dcea8e3b0fb21284f75784
 
 define $(package)_set_vars
   $(package)_config_opts=--without-zlib --without-png --without-harfbuzz --without-bzip2 --disable-static


### PR DESCRIPTION
Update FreeType package to v2.10.4 in Depends to help mitigate against recent 0 day flaw found. 
See CVE-2020-15999