### PR TITLE
wallet: Set DatabaseStatus::SUCCESS in MakeSQLiteDatabase

### DIFF
--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -581,6 +581,7 @@ std::unique_ptr<SQLiteDatabase> MakeSQLiteDatabase(const fs::path& path, const D
             status = DatabaseStatus::FAILED_VERIFY;
             return nullptr;
         }
+        status = DatabaseStatus::SUCCESS;
         return db;
     } catch (const std::runtime_error& e) {
         status = DatabaseStatus::FAILED_LOAD;


### PR DESCRIPTION
This is a refactor to set the status to `SUCCESS` (like it is done in `MakeBerkeleyDatabase`, too). It also happens to fix a false positive valgrind warning (tested with bionic-gcc and focal-clang):

```
 node1 stderr ==28149== Conditional jump or move depends on uninitialised value(s)
==28149==    at 0x464471: LoadWallets(interfaces::Chain&) (load.cpp:105)
==28149==    by 0x44BFBA: interfaces::(anonymous namespace)::WalletClientImpl::load() (wallet.cpp:510)
==28149==    by 0x1640F9: AppInitMain(util::Ref const&, NodeContext&, interfaces::BlockAndHeaderTipInfo*) (init.cpp:1815)
==28149==    by 0x144F3F: AppInit (bitcoind.cpp:142)
==28149==    by 0x144F3F: main (bitcoind.cpp:172)
==28149== 
{
   <insert_a_suppression_name_here>
   Memcheck:Cond
   fun:_Z11LoadWalletsRN10interfaces5ChainE
   fun:_ZN10interfaces12_GLOBAL__N_116WalletClientImpl4loadEv
   fun:_Z11AppInitMainRKN4util3RefER11NodeContextPN10interfaces21BlockAndHeaderTipInfoE
   fun:AppInit
   fun:main
} 

TEST                                             | STATUS    | DURATION

wallet_hd.py --descriptors                       | ✖ Failed  | 69 s
```

