### PR TITLE
allow -loadblock blocks to be unsorted

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -501,6 +501,7 @@ void ThreadImport(ChainstateManager& chainman, std::vector<fs::path> vImportFile
         // -reindex
         if (fReindex) {
             int nFile = 0;
+            std::multimap<uint256, FlatFilePos> blocks_with_unknown_parent;
             while (true) {
                 FlatFilePos pos(nFile, 0);
                 if (!fs::exists(GetBlockPosFilename(pos))) {
@@ -511,7 +512,7 @@ void ThreadImport(ChainstateManager& chainman, std::vector<fs::path> vImportFile
                     break; // This error is logged in OpenBlockFile
                 }
                 LogPrintf("Reindexing block file blk%05u.dat...\n", (unsigned int)nFile);
-                chainman.ActiveChainstate().LoadExternalBlockFile(file, &pos);
+                chainman.ActiveChainstate().LoadExternalBlockFile(file, &pos, &blocks_with_unknown_parent);
                 if (ShutdownRequested()) {
                     LogPrintf("Shutdown requested. Exit %s\n", __func__);
                     return;

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -68,6 +68,7 @@ void UnlinkPrunedFiles(const std::set<int>& setFilesToPrune);
 
 /** Functions for disk access for blocks */
 bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams);
+bool ReadBlockFromDisk(CBlock& block, const fs::path& path, unsigned int offset, const Consensus::Params& consensusParams);
 bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start);
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CBlockIndex* pindex, const CMessageHeader::MessageStartChars& message_start);

--- a/src/test/fuzz/load_external_block_file.cpp
+++ b/src/test/fuzz/load_external_block_file.cpp
@@ -31,6 +31,13 @@ FUZZ_TARGET_INIT(load_external_block_file, initialize_load_external_block_file)
     if (fuzzed_block_file == nullptr) {
         return;
     }
-    FlatFilePos flat_file_pos;
-    g_setup->m_node.chainman->ActiveChainstate().LoadExternalBlockFile(fuzzed_block_file, fuzzed_data_provider.ConsumeBool() ? &flat_file_pos : nullptr);
+    if (fuzzed_data_provider.ConsumeBool()) {
+        // Corresponds to the -reindex case (track orphan blocks across files).
+        FlatFilePos flat_file_pos;
+        std::multimap<uint256, FlatFilePos> blocks_with_unknown_parent;
+        g_setup->m_node.chainman->ActiveChainstate().LoadExternalBlockFile(fuzzed_block_file, &flat_file_pos, &blocks_with_unknown_parent);
+    } else {
+        // Corresponds to the -loadblock= case (orphan blocks aren't tracked across files).
+        g_setup->m_node.chainman->ActiveChainstate().LoadExternalBlockFile(fuzzed_block_file);
+    }
 }

--- a/src/test/fuzz/load_external_block_file.cpp
+++ b/src/test/fuzz/load_external_block_file.cpp
@@ -31,13 +31,8 @@ FUZZ_TARGET_INIT(load_external_block_file, initialize_load_external_block_file)
     if (fuzzed_block_file == nullptr) {
         return;
     }
-    if (fuzzed_data_provider.ConsumeBool()) {
-        // Corresponds to the -reindex case (track orphan blocks across files).
-        FlatFilePos flat_file_pos;
-        std::multimap<uint256, FlatFilePos> blocks_with_unknown_parent;
-        g_setup->m_node.chainman->ActiveChainstate().LoadExternalBlockFile(fuzzed_block_file, &flat_file_pos, &blocks_with_unknown_parent);
-    } else {
-        // Corresponds to the -loadblock= case (orphan blocks aren't tracked across files).
-        g_setup->m_node.chainman->ActiveChainstate().LoadExternalBlockFile(fuzzed_block_file);
-    }
+    std::vector<fs::path> blk_paths = {"no_such_file"};
+    std::multimap<uint256, FlatFilePos> blocks_with_unknown_parent;
+    bool write_to_disk = fuzzed_data_provider.ConsumeBool();
+    g_setup->m_node.chainman->ActiveChainstate().LoadExternalBlockFile(blk_paths, 0, fuzzed_block_file, blocks_with_unknown_parent, write_to_disk);
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -686,9 +686,16 @@ public:
 
     /** Import blocks from an external file */
     void LoadExternalBlockFile(
-        FILE* fileIn,
-        FlatFilePos* dbp = nullptr,
-        std::multimap<uint256, FlatFilePos>* blocks_with_unknown_parent = nullptr);
+        const std::vector<fs::path>& blk_paths,
+        size_t n_file,
+        FILE* file,
+        std::multimap<uint256, FlatFilePos>& blocks_with_unknown_parent,
+        bool write_to_disk);
+
+    /** Import blocks from one or more external files */
+    void LoadExternalBlockFiles(
+        const std::vector<fs::path>& blk_paths,
+        bool write_to_disk);
 
     /**
      * Update the on-disk chain state.

--- a/src/validation.h
+++ b/src/validation.h
@@ -685,7 +685,10 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /** Import blocks from an external file */
-    void LoadExternalBlockFile(FILE* fileIn, FlatFilePos* dbp = nullptr);
+    void LoadExternalBlockFile(
+        FILE* fileIn,
+        FlatFilePos* dbp = nullptr,
+        std::multimap<uint256, FlatFilePos>* blocks_with_unknown_parent = nullptr);
 
     /**
      * Update the on-disk chain state.

--- a/test/functional/feature_loadblock.py
+++ b/test/functional/feature_loadblock.py
@@ -71,6 +71,18 @@ class LoadblockTest(BitcoinTestFramework):
         subprocess.run([sys.executable, linearize_data_file, cfg_file],
                        check=True)
 
+        # Test that -loadblock can work with blocks that are out of order.
+        # In this test environment, blocks will always be in order (since
+        # we're generating them rather than getting them from peers), so to
+        # test out-of-order handling, swap blocks 1 and 2 on disk.
+        with open(bootstrap_file, 'r+b') as bf:
+            b = bf.read(814)
+
+            # Swap the same-size second and third blocks (don't change genesis).
+            bf.seek(293)
+            bf.write(b[553:813])
+            bf.write(b[293:553])
+
         self.log.info("Restart second, unsynced node with bootstrap file")
         self.restart_node(1, extra_args=["-loadblock=" + bootstrap_file])
         assert_equal(self.nodes[1].getblockcount(), 100)  # start_node is blocking on all block files being imported


### PR DESCRIPTION
This PR was suggested in [this comment](https://github.com/bitcoin/bitcoin/pull/19594#issuecomment-721321744) in #19594, and builds on that PR (the first commit here).

This PR allows the blocks in files specified by the `-loadblock=file` command line (configuration) options (there can be multiple) to be unsorted. This is already allowed by `-reindex`, but currently when `-loadblock` encounters a block with an unknown parent, it is ignored. This means the blocks must be sorted by height to be loaded successfully. This PR fixes this restriction, allowing the blocks across all the specified blocks files to be in any order. This makes the `-loadblock` option more useful. Also, the affected code is cleaner and more maintainable.

(I'll simplify this description move details to a separate comment before this PR gets merged.)