### PR TITLE
script: modify security-check.py to use "==" instead of "is" for literal comparison

### DIFF
--- a/contrib/devtools/security-check.py
+++ b/contrib/devtools/security-check.py
@@ -62,7 +62,7 @@ def get_ELF_program_headers(executable):
                     splitline = [x.strip() for x in line.split()]
                     flags = splitline[ofs_flags]
                     # check for 'R', ' E'
-                    if splitline[ofs_flags + 1] is 'E':
+                    if splitline[ofs_flags + 1] == 'E':
                         flags += ' E'
                     headers.append((typ, flags, []))
             count += 1

--- a/test/lint/lint-python.sh
+++ b/test/lint/lint-python.sh
@@ -55,6 +55,7 @@ enabled=(
     F621 # too many expressions in an assignment with star-unpacking
     F622 # two or more starred expressions in an assignment (a, *b, *c = d)
     F631 # assertion test is a tuple, which are always True
+    F632 # use ==/!= to compare str, bytes, and int literals
     F701 # a break statement outside of a while or for loop
     F702 # a continue statement outside of a while or for loop
     F703 # a continue statement in a finally block in a loop


### PR DESCRIPTION
In Python 3.8+ literal comparisons using "is" instead of "==" produce a SyntaxWarning [source](https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior).

I checked the entire devtools directory, this seems to be the only occurrence. 

This is a small fix, but removes the SyntaxWarning.
Fixes: #20338 