### PR TITLE
fuzz: Check for addrv1 compatibility before using addrv1 serializer/deserializer on CSubNet

### DIFF
--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -206,6 +206,13 @@ void test_one_input(const std::vector<uint8_t>& buffer)
             AssertEqualAfterSerializeDeserialize(s);
         }
         AssertEqualAfterSerializeDeserialize(s, INIT_PROTO_VERSION | ADDRV2_FORMAT);
+        CService s1;
+        DeserializeFromFuzzingInput(buffer, s1, INIT_PROTO_VERSION);
+        AssertEqualAfterSerializeDeserialize(s1, INIT_PROTO_VERSION);
+        assert(s1.IsAddrV1Compatible());
+        CService s2;
+        DeserializeFromFuzzingInput(buffer, s2, INIT_PROTO_VERSION | ADDRV2_FORMAT);
+        AssertEqualAfterSerializeDeserialize(s2, INIT_PROTO_VERSION | ADDRV2_FORMAT);
 #elif MESSAGEHEADER_DESERIALIZE
         CMessageHeader mh;
         DeserializeFromFuzzingInput(buffer, mh);

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -15,6 +15,7 @@
 #include <net.h>
 #include <netbase.h>
 #include <node/utxo_snapshot.h>
+#include <optional.h>
 #include <primitives/block.h>
 #include <protocol.h>
 #include <psbt.h>
@@ -61,15 +62,19 @@ T Deserialize(CDataStream ds)
 }
 
 template <typename T>
-void DeserializeFromFuzzingInput(const std::vector<uint8_t>& buffer, T& obj)
+void DeserializeFromFuzzingInput(const std::vector<uint8_t>& buffer, T& obj, const Optional<int> protocol_version = nullopt)
 {
     CDataStream ds(buffer, SER_NETWORK, INIT_PROTO_VERSION);
-    try {
-        int version;
-        ds >> version;
-        ds.SetVersion(version);
-    } catch (const std::ios_base::failure&) {
-        throw invalid_fuzzing_input_exception();
+    if (protocol_version) {
+        ds.SetVersion(*protocol_version);
+    } else {
+        try {
+            int version;
+            ds >> version;
+            ds.SetVersion(version);
+        } catch (const std::ios_base::failure&) {
+            throw invalid_fuzzing_input_exception();
+        }
     }
     try {
         ds >> obj;
@@ -125,9 +130,15 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         CScript script;
         DeserializeFromFuzzingInput(buffer, script);
 #elif SUB_NET_DESERIALIZE
-        CSubNet sub_net;
-        DeserializeFromFuzzingInput(buffer, sub_net);
-        AssertEqualAfterSerializeDeserialize(sub_net);
+        CSubNet sub_net_1;
+        DeserializeFromFuzzingInput(buffer, sub_net_1, INIT_PROTO_VERSION);
+        AssertEqualAfterSerializeDeserialize(sub_net_1, INIT_PROTO_VERSION);
+        CSubNet sub_net_2;
+        DeserializeFromFuzzingInput(buffer, sub_net_2, INIT_PROTO_VERSION | ADDRV2_FORMAT);
+        AssertEqualAfterSerializeDeserialize(sub_net_2, INIT_PROTO_VERSION | ADDRV2_FORMAT);
+        CSubNet sub_net_3;
+        DeserializeFromFuzzingInput(buffer, sub_net_3);
+        AssertEqualAfterSerializeDeserialize(sub_net_3, INIT_PROTO_VERSION | ADDRV2_FORMAT);
 #elif TX_IN_DESERIALIZE
         CTxIn tx_in;
         DeserializeFromFuzzingInput(buffer, tx_in);


### PR DESCRIPTION
Check for `addrv1` compatibility before using `addrv1` serializer/deserializer on `CSubNet`. As requested by MarcoFalke in https://github.com/bitcoin/bitcoin/pull/20289#issuecomment-724012969.

Assert roundtrip equality for both `addrv1` and `addrv2` versions of `CService`.