### PR TITLE
src/randomenv.cpp: fix build on uclibc

### DIFF
--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -53,7 +53,7 @@
 #include <sys/vmmeter.h>
 #endif
 #endif
-#ifdef __linux__
+#if defined(HAVE_STRONG_GETAUXVAL) || defined(HAVE_WEAK_GETAUXVAL)
 #include <sys/auxv.h>
 #endif
 
@@ -326,7 +326,7 @@ void RandAddStaticEnv(CSHA512& hasher)
     // Bitcoin client version
     hasher << CLIENT_VERSION;
 
-#ifdef __linux__
+#if defined(HAVE_STRONG_GETAUXVAL) || defined(HAVE_WEAK_GETAUXVAL)
     // Information available through getauxval()
 #  ifdef AT_HWCAP
     hasher << getauxval(AT_HWCAP);
@@ -346,7 +346,7 @@ void RandAddStaticEnv(CSHA512& hasher)
     const char* exec_str = (const char*)getauxval(AT_EXECFN);
     if (exec_str) hasher.Write((const unsigned char*)exec_str, strlen(exec_str) + 1);
 #  endif
-#endif // __linux__
+#endif // HAVE_STRONG_GETAUXVAL || HAVE_WEAK_GETAUXVAL
 
 #ifdef HAVE_GETCPUID
     AddAllCPUID(hasher);


### PR DESCRIPTION
Check for HAVE_STRONG_GETAUXVAL or HAVE_WEAK_GETAUXVAL before using
getauxval to avoid a build failure on uclibc

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>