### PR TITLE
depends: Various config.site.in improvements and linting 

### DIFF
--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -79,7 +79,7 @@ fi
 if test -n "@CXX@" -a -z "${CXX}"; then
   CXX="@CXX@"
 fi
-PYTHONPATH=$depends_prefix/native/lib/python3/dist-packages:$PYTHONPATH
+PYTHONPATH="${depends_prefix}/native/lib/python3/dist-packages${PYTHONPATH:+${PATH_SEPARATOR}}${PYTHONPATH}"
 
 if test -n "@AR@"; then
   AR=@AR@

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -1,3 +1,13 @@
+# shellcheck shell=sh disable=SC2034 # Many variables set will be used in
+                                     # ./configure but shellcheck doesn't know
+                                     # that, hence: disable=SC2034
+
+true  # Dummy command because shellcheck treats all directives before first
+      # command as file-wide, and we only want to disable for one line.
+      #
+      # See: https://github.com/koalaman/shellcheck/wiki/Directive
+
+# shellcheck disable=SC2154
 depends_prefix="$(cd "$(dirname ${ac_site_file})/.." && pwd)"
 
 cross_compiling=maybe
@@ -50,7 +60,7 @@ if test x@host_os@ = xdarwin; then
 fi
 
 PATH=$depends_prefix/native/bin:$PATH
-PKG_CONFIG="`which pkg-config` --static"
+PKG_CONFIG="$(which pkg-config) --static"
 
 # These two need to remain exported because pkg-config does not see them
 # otherwise. That means they must be unexported at the end of configure.ac to

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -1,4 +1,4 @@
-depends_prefix="`dirname ${ac_site_file}`/.."
+depends_prefix="$(cd "$(dirname ${ac_site_file})/.." && pwd)"
 
 cross_compiling=maybe
 host_alias=@HOST@

--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -36,7 +36,8 @@ fi
 
 SHELLCHECK_CMD=(shellcheck --external-sources --check-sourced)
 EXCLUDE="--exclude=$(IFS=','; echo "${disabled[*]}")"
-if ! "${SHELLCHECK_CMD[@]}" "$EXCLUDE" $(git ls-files -- '*.sh' | grep -vE 'src/(leveldb|secp256k1|univalue)/'); then
+SOURCED_FILES=$(git ls-files | xargs gawk '/^# shellcheck shell=/ {print FILENAME} {nextfile}')  # Check shellcheck directive used for sourced files
+if ! "${SHELLCHECK_CMD[@]}" "$EXCLUDE" $SOURCED_FILES $(git ls-files -- '*.sh' | grep -vE 'src/(leveldb|secp256k1|univalue)/'); then
     EXIT_CODE=1
 fi
 


### PR DESCRIPTION
This changeset:

1. Allows the `CONFIG_SITE` env var to be a relative path rather than requiring an absolute one
2. Enables linting of the `config.site.in` file with `shellcheck` in our linting scripts
3. Sets the `PYTHONPATH` var sensibly in `config.site.in`

Please see commit messages for more details