### PR TITLE
ci: Remove redundant valgrind fuzz task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -113,14 +113,6 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_native_fuzz.sh"
 
 task:
-  name: 'x86_64 Linux  [GOAL: install]  [focal]  [no depends, only system libs, fuzzers under valgrind]'
-  << : *GLOBAL_TASK_TEMPLATE
-  container:
-    image: ubuntu:focal
-  env:
-    FILE_ENV: "./ci/test/00_setup_env_native_fuzz_with_valgrind.sh"
-
-task:
   name: 'x86_64 Linux [GOAL: install]  [focal]  [multiprocess]'
   << : *GLOBAL_TASK_TEMPLATE
   container:


### PR DESCRIPTION
This task has several issues:

* It slows down other tasks and times out: It needs a lot of resources (CPU, RAM, time), because it builds more than 100 fuzzers, clones a 2 GB repo with 100k seeds and pipes them all through valgrind
* It doesn't add a lot of value: Except for one issue in the boost time library, it hasn't found any issues that the existing fuzz,asan,ubsan fuzzer has already found
* It is redundant: It is already run in the bitcoin-core/qa-assets repo on every push of new seeds and once daily

Fix all issues by removing it here.