### PR TITLE
fuzz: Fill various small fuzzing gaps

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -210,6 +210,7 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/crypto_hkdf_hmac_sha256_l32.cpp \
  test/fuzz/crypto_poly1305.cpp \
  test/fuzz/cuckoocache.cpp \
+ test/fuzz/data_stream.cpp \
  test/fuzz/decode_tx.cpp \
  test/fuzz/descriptor_parse.cpp \
  test/fuzz/deserialize.cpp \

--- a/src/test/fuzz/data_stream.cpp
+++ b/src/test/fuzz/data_stream.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <addrman.h>
+#include <net.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cstdint>
+#include <vector>
+
+void initialize_data_stream_addr_man()
+{
+    InitializeFuzzingContext();
+}
+
+FUZZ_TARGET_INIT(data_stream_addr_man, initialize_data_stream_addr_man)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    CDataStream data_stream = ConsumeDataStream(fuzzed_data_provider);
+    CAddrMan addr_man;
+    CAddrDB::Read(addr_man, data_stream);
+}

--- a/src/test/fuzz/kitchen_sink.cpp
+++ b/src/test/fuzz/kitchen_sink.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <merkleblock.h>
+#include <policy/fees.h>
 #include <rpc/util.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
@@ -9,8 +11,36 @@
 #include <util/error.h>
 #include <util/translation.h>
 
+#include <array>
 #include <cstdint>
 #include <vector>
+
+namespace {
+constexpr TransactionError ALL_TRANSACTION_ERROR[] = {
+    TransactionError::OK,
+    TransactionError::MISSING_INPUTS,
+    TransactionError::ALREADY_IN_CHAIN,
+    TransactionError::P2P_DISABLED,
+    TransactionError::MEMPOOL_REJECTED,
+    TransactionError::MEMPOOL_ERROR,
+    TransactionError::INVALID_PSBT,
+    TransactionError::PSBT_MISMATCH,
+    TransactionError::SIGHASH_MISMATCH,
+    TransactionError::MAX_FEE_EXCEEDED,
+};
+
+constexpr FeeEstimateHorizon ALL_FEE_EST_HORIZON[] = {
+    FeeEstimateHorizon::SHORT_HALFLIFE,
+    FeeEstimateHorizon::MED_HALFLIFE,
+    FeeEstimateHorizon::LONG_HALFLIFE,
+};
+
+constexpr OutputType ALL_OUTPUT_TYPE[] = {
+    OutputType::LEGACY,
+    OutputType::P2SH_SEGWIT,
+    OutputType::BECH32,
+};
+}; // namespace
 
 // The fuzzing kitchen sink: Fuzzing harness for functions that need to be
 // fuzzed but a.) don't belong in any existing fuzzing harness file, and
@@ -19,8 +49,23 @@ FUZZ_TARGET(kitchen_sink)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
 
-    const TransactionError transaction_error = fuzzed_data_provider.PickValueInArray<TransactionError>({TransactionError::OK, TransactionError::MISSING_INPUTS, TransactionError::ALREADY_IN_CHAIN, TransactionError::P2P_DISABLED, TransactionError::MEMPOOL_REJECTED, TransactionError::MEMPOOL_ERROR, TransactionError::INVALID_PSBT, TransactionError::PSBT_MISMATCH, TransactionError::SIGHASH_MISMATCH, TransactionError::MAX_FEE_EXCEEDED});
+    const TransactionError transaction_error = fuzzed_data_provider.PickValueInArray(ALL_TRANSACTION_ERROR);
     (void)JSONRPCTransactionError(transaction_error);
     (void)RPCErrorFromTransactionError(transaction_error);
     (void)TransactionErrorString(transaction_error);
+
+    (void)StringForFeeEstimateHorizon(fuzzed_data_provider.PickValueInArray(ALL_FEE_EST_HORIZON));
+
+    const OutputType output_type = fuzzed_data_provider.PickValueInArray(ALL_OUTPUT_TYPE);
+    const std::string& output_type_string = FormatOutputType(output_type);
+    OutputType output_type_parsed;
+    const bool parsed = ParseOutputType(output_type_string, output_type_parsed);
+    assert(parsed);
+    assert(output_type == output_type_parsed);
+    (void)ParseOutputType(fuzzed_data_provider.ConsumeRandomLengthString(64), output_type_parsed);
+
+    const std::vector<uint8_t> bytes = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+    const std::vector<bool> bits = BytesToBits(bytes);
+    const std::vector<uint8_t> bytes_decoded = BitsToBytes(bits);
+    assert(bytes == bytes_decoded);
 }


### PR DESCRIPTION
Fill various small fuzzing gaps.

See [`doc/fuzzing.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md) for information on how to fuzz Bitcoin Core. Don't forget to contribute any coverage increasing inputs you find to the [Bitcoin Core fuzzing corpus repo](https://github.com/bitcoin-core/qa-assets).

Happy fuzzing :)