### PR TITLE
Avoid signed integer overflow and invalid integer negation when loading malformed mempool.dat files

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -240,6 +240,7 @@ BITCOIN_CORE_H = \
   util/memory.h \
   util/message.h \
   util/moneystr.h \
+  util/overflow.h \
   util/rbf.h \
   util/ref.h \
   util/settings.h \

--- a/src/amount.h
+++ b/src/amount.h
@@ -24,5 +24,6 @@ static const CAmount COIN = 100000000;
  * */
 static const CAmount MAX_MONEY = 21000000 * COIN;
 inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
+inline bool FeeDeltaRange(const CAmount& fee_delta) { return -MAX_MONEY <= fee_delta && fee_delta <= MAX_MONEY; }
 
 #endif //  BITCOIN_AMOUNT_H

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -444,14 +444,14 @@ static RPCHelpMan prioritisetransaction()
                 {
                     {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id."},
                     {"dummy", RPCArg::Type::NUM, RPCArg::Optional::OMITTED_NAMED_ARG, "API-Compatibility for previous API. Must be zero or null.\n"
-            "                  DEPRECATED. For forward compatibility use named arguments and omit this parameter."},
-                    {"fee_delta", RPCArg::Type::NUM, RPCArg::Optional::NO, "The fee value (in satoshis) to add (or subtract, if negative).\n"
-            "                  Note, that this value is not a fee rate. It is a value to modify absolute fee of the TX.\n"
-            "                  The fee is not actually paid, only the algorithm for selecting transactions into a block\n"
-            "                  considers the transaction as it would have paid a higher (or lower) fee."},
+                              "DEPRECATED. For forward compatibility use named arguments and omit this parameter."},
+                    {"fee_delta", RPCArg::Type::NUM, RPCArg::Optional::NO, "The fee value (in satoshis) to add (or subtract, if negative). Must be in the range +-" + ToString(MAX_MONEY) + " sat.\n"
+                              "Note, that this value is not a fee rate. It is a value to modify absolute fee of the TX.\n"
+                              "The fee is not actually paid, only the algorithm for selecting transactions into a block\n"
+                              "considers the transaction as it would have paid a higher (or lower) fee."},
                 },
                 RPCResult{
-                    RPCResult::Type::BOOL, "", "Returns true"},
+                    RPCResult::Type::BOOL, "", "Returns true or throws on error"},
                 RPCExamples{
                     HelpExampleCli("prioritisetransaction", "\"txid\" 0.0 10000")
             + HelpExampleRpc("prioritisetransaction", "\"txid\", 0.0, 10000")
@@ -460,15 +460,16 @@ static RPCHelpMan prioritisetransaction()
 {
     LOCK(cs_main);
 
-    uint256 hash(ParseHashV(request.params[0], "txid"));
-    CAmount nAmount = request.params[2].get_int64();
+    const uint256 hash{ParseHashV(request.params[0], "txid")};
+    const CAmount nAmount = request.params[2].get_int64();
 
     if (!(request.params[1].isNull() || request.params[1].get_real() == 0)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Priority is no longer supported, dummy argument to prioritisetransaction must be 0.");
     }
 
-    if (!EnsureMemPool(request.context).PrioritiseTransaction(hash, nAmount)) {
-        throw JSONRPCError(RPC_MISC_ERROR, "PrioritiseTransaction(...) failed. Invalid fee_delta argument?");
+    CTxMemPool& mempool = EnsureMemPool(request.context);
+    if (!mempool.PrioritiseTransaction(hash, nAmount)) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid fee_delta passed");
     }
     return true;
 },

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -467,7 +467,9 @@ static RPCHelpMan prioritisetransaction()
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Priority is no longer supported, dummy argument to prioritisetransaction must be 0.");
     }
 
-    EnsureMemPool(request.context).PrioritiseTransaction(hash, nAmount);
+    if (!EnsureMemPool(request.context).PrioritiseTransaction(hash, nAmount)) {
+        throw JSONRPCError(RPC_MISC_ERROR, "PrioritiseTransaction(...) failed. Invalid fee_delta argument?");
+    }
     return true;
 },
     };

--- a/src/test/fuzz/addition_overflow.cpp
+++ b/src/test/fuzz/addition_overflow.cpp
@@ -5,6 +5,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/overflow.h>
 
 #include <cstdint>
 #include <string>

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -26,6 +26,7 @@
 #include <test/util/setup_common.h>
 #include <txmempool.h>
 #include <uint256.h>
+#include <util/overflow.h>
 #include <util/time.h>
 #include <util/vector.h>
 #include <version.h>
@@ -226,17 +227,6 @@ template <typename T>
     } else {
         return j != 0 && i > std::numeric_limits<T>::max() / j;
     }
-}
-
-template <class T>
-[[nodiscard]] bool AdditionOverflow(const T i, const T j) noexcept
-{
-    static_assert(std::is_integral<T>::value, "Integral required.");
-    if (std::numeric_limits<T>::is_signed) {
-        return (i > 0 && j > std::numeric_limits<T>::max() - i) ||
-               (i < 0 && j < std::numeric_limits<T>::min() - i);
-    }
-    return std::numeric_limits<T>::max() - i < j;
 }
 
 [[nodiscard]] inline bool ContainsSpentInput(const CTransaction& tx, const CCoinsViewCache& inputs) noexcept

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include <amount.h>
+#include <attributes.h>
 #include <coins.h>
 #include <indirectmap.h>
 #include <optional.h>
@@ -634,7 +635,7 @@ public:
     bool HasNoInputsOf(const CTransaction& tx) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Affect CreateNewBlock prioritisation of transactions */
-    void PrioritiseTransaction(const uint256& hash, const CAmount& nFeeDelta);
+    [[nodiscard]] bool PrioritiseTransaction(const uint256& hash, const CAmount& nFeeDelta);
     void ApplyDelta(const uint256& hash, CAmount &nFeeDelta) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     void ClearPrioritisation(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs);
 

--- a/src/util/moneystr.cpp
+++ b/src/util/moneystr.cpp
@@ -9,6 +9,9 @@
 #include <util/strencodings.h>
 #include <util/string.h>
 
+// FormatMoney(CAmount n) is not defined for n == std::numeric_limits<CAmount>::min().
+// The negation of std::numeric_limits<CAmount>::min() (-9223372036854775808) cannot be
+// represented in the type CAmount (int64_t).
 std::string FormatMoney(const CAmount& n)
 {
     // Note: not using straight sprintf here because we do NOT want

--- a/src/util/overflow.h
+++ b/src/util/overflow.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_OVERFLOW_H
+#define BITCOIN_UTIL_OVERFLOW_H
+
+#include <attributes.h>
+
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+/** Return `true` if the addition of `i` and `j` of integral type `T` would overflow.
+ */
+template <class T>
+[[nodiscard]] bool AdditionOverflow(const T i, const T j) noexcept
+{
+    static_assert(std::is_integral<T>::value, "Integral required.");
+    if (std::numeric_limits<T>::is_signed) {
+        return (i > 0 && j > std::numeric_limits<T>::max() - i) ||
+               (i < 0 && j < std::numeric_limits<T>::min() - i);
+    }
+    return std::numeric_limits<T>::max() - i < j;
+}
+
+#endif // BITCOIN_UTIL_OVERFLOW_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5027,7 +5027,9 @@ bool LoadMempool(CTxMemPool& pool)
 
             CAmount amountdelta = nFeeDelta;
             if (amountdelta) {
-                pool.PrioritiseTransaction(tx->GetHash(), amountdelta);
+                if (!pool.PrioritiseTransaction(tx->GetHash(), amountdelta)) {
+                    LogPrintf("PrioritiseTransaction(...) failed. Invalid fee delta?\n");
+                }
             }
             TxValidationState state;
             if (nTime > nNow - nExpiryTimeout) {
@@ -5058,7 +5060,9 @@ bool LoadMempool(CTxMemPool& pool)
         file >> mapDeltas;
 
         for (const auto& i : mapDeltas) {
-            pool.PrioritiseTransaction(i.first, i.second);
+            if (!pool.PrioritiseTransaction(i.first, i.second)) {
+                LogPrintf("PrioritiseTransaction(...) failed. Invalid fee delta?\n");
+            }
         }
 
         std::set<uint256> unbroadcast_txids;

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -44,6 +44,9 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         # Test `prioritisetransaction` invalid `fee_delta`
         assert_raises_rpc_error(-1, "JSON value is not an integer as expected", self.nodes[0].prioritisetransaction, txid=txid, fee_delta='foo')
 
+        # Test invalid fee_delta check: -9223372036854775808 (std::numeric_limits<CAmount>::min()) is not a valid fee_delta.
+        assert_raises_rpc_error(-8, "Invalid fee_delta passed", self.nodes[0].prioritisetransaction, txid=txid, fee_delta=-9223372036854775808)
+
         self.txouts = gen_return_txouts()
         self.relayfee = self.nodes[0].getnetworkinfo()['relayfee']
 


### PR DESCRIPTION
Closes #19278.

Avoid signed integer overflow when loading malformed `mempool.dat` files.

Avoid invalid integer negation when loading malformed `mempool.dat` files (or when processing `prioritisetransaction` RPC calls).

Add note about the valid range of inputs for `FormatMoney(...)`.

Add test.

Before this patch:

```
$ xxd -p -r > mempool-signed-integer-overflow.dat << "EOF"
01000000000000003f2d3f3f21f800000000000000000000000000000000
6d697464657363656e64616e00000001000000ec000000003d6a6c000000
000000000000ec9bf601000000000000000000ec9b0001000000000001ff
fffef900000001000000ec0000000000ec9b000001000000000101000100
00000001000000ec000000003d6a6a000000000000000020ec9b000000fa
00
EOF
$ cp mempool-signed-integer-overflow.dat ~/.bitcoin/regtest/mempool.dat
$ UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:report_error_type=1" src/bitcoind -regtest
…
txmempool.cpp:839:15: runtime error: signed integer overflow: -7211388903327006720 + -7211353718954917888 cannot be represented in type 'long'
…
```

```
$ xxd -p -r > mempool-invalid-negation.dat << "EOF"
0100000000000000002e000000005d2d000d020000000000000000000000
200000000000000000000080fc0000002d
EOF
$ cp mempool-invalid-negation.dat ~/.bitcoin/regtest/mempool.dat
$ UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:report_error_type=1" src/bitcoind -regtest
…
util/moneystr.cpp:16:34: runtime error: negation of -9223372036854775808 cannot be represented in type 'CAmount' (aka 'long'); cast to an unsigned type to negate this value to itself
…
```

After this patch:

```
$ xxd -p -r > mempool-signed-integer-overflow.dat << "EOF"
01000000000000003f2d3f3f21f800000000000000000000000000000000
6d697464657363656e64616e00000001000000ec000000003d6a6c000000
000000000000ec9bf601000000000000000000ec9b0001000000000001ff
fffef900000001000000ec0000000000ec9b000001000000000101000100
00000001000000ec000000003d6a6a000000000000000020ec9b000000fa
00
EOF
$ cp mempool-signed-integer-overflow.dat ~/.bitcoin/regtest/mempool.dat
$ UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:report_error_type=1" src/bitcoind -regtest
…
2020-11-13T12:34:56Z PrioritiseTransaction(...) failed. Invalid fee delta?
…
```

```
$ xxd -p -r > mempool-invalid-negation.dat << "EOF"
0100000000000000002e000000005d2d000d020000000000000000000000
200000000000000000000080fc0000002d
EOF
$ cp mempool-invalid-negation.dat ~/.bitcoin/regtest/mempool.dat
$ UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:report_error_type=1" src/bitcoind -regtest
…
2020-11-13T12:34:56Z PrioritiseTransaction(...) failed. Invalid fee delta?
…
```