### PR TITLE
Silence false positive GCC warning in wallet/rpcwallet.cpp

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -8,6 +8,7 @@
 #include <interfaces/chain.h>
 #include <key_io.h>
 #include <node/context.h>
+#include <optional.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
 #include <policy/fees.h>

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3593,7 +3593,7 @@ static RPCHelpMan rescanblockchain()
     }
 
     int start_height = 0;
-    Optional<int> stop_height;
+    Optional<int> stop_height = MakeOptional(false, int());
     uint256 start_block;
     {
         LOCK(pwallet->cs_wallet);


### PR DESCRIPTION
Resolves #20381.