### PR TITLE
CI/Cirrus: Skip merge_base step for non-PRs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,6 +29,7 @@ global_task_template: &GLOBAL_TASK_TEMPLATE
   depends_releases_cache:
     folder: "/tmp/cirrus-ci-build/releases"
   merge_base_script:
+    - if [ "$CIRRUS_PR" = "" ]; then exit 0; fi
     - bash -c "$PACKAGE_MANAGER_INSTALL git"
     - git fetch $CIRRUS_REPO_CLONE_URL $CIRRUS_BASE_BRANCH
     - git config --global user.email "ci@ci.ci"


### PR DESCRIPTION
CIRRUS_BASE_BRANCH is a PR-specific variable and undocumented on non-PR builds.
In practice (at the moment), it seems to be HEAD, which in private repositories can be pretty much anything, causing CI to fail if it can't be cleanly merged.

By checking CIRRUS_PR first, we can reliably do CI builds of branches outside PRs.
