### PR TITLE
wallet: introduce setfeerate (an improved settxfee, in sat/vB)

### DIFF
--- a/doc/release-notes-20391.md
+++ b/doc/release-notes-20391.md
@@ -1,3 +1,10 @@
+Updated RPCs
+------------
+
+- `settxfee` is marked as deprecated in favor of the new `setfeerate` RPC
+  described in the "New RPCs" section. This change is part of a larger migration
+  from BTC/kvB to sat/vB units for fee rates. (#20391)
+
 New RPCs
 ------------
 

--- a/doc/release-notes-20391.md
+++ b/doc/release-notes-20391.md
@@ -1,9 +1,9 @@
 Updated RPCs
 ------------
 
-- `settxfee` is marked as deprecated in favor of the new `setfeerate` RPC
-  described in the "New RPCs" section. This change is part of a larger migration
-  from BTC/kvB to sat/vB units for fee rates. (#20391)
+- `settxfee` is now a hidden RPC and marked as deprecated in favor of the new
+  `setfeerate` RPC described in the "New RPCs" section. This change is part of a
+  larger migration from BTC/kvB to sat/vB units for fee rates. (#20391)
 
 New RPCs
 ------------

--- a/doc/release-notes-20391.md
+++ b/doc/release-notes-20391.md
@@ -1,0 +1,9 @@
+New RPCs
+------------
+
+- A new `setfeerate` RPC is added to set the transaction fee for a wallet in
+  sat/vB, instead of in BTC/kvB like `settxfee`. This RPC is intended to replace
+  `settxfee`, which becomes a hidden RPC and is marked as deprecated. This
+  change is part of a larger migration from BTC/kvB to sat/vB units for fee
+  rates. (#20391)
+

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -7,12 +7,14 @@
 
 #include <amount.h>
 #include <attributes.h>
+#include <policy/feerate.h>
 
 #include <string>
 #include <vector>
 
 class CBlock;
 class CBlockHeader;
+class CFeeRate;
 class CScript;
 class CTransaction;
 struct CMutableTransaction;
@@ -41,6 +43,7 @@ int ParseSighashString(const UniValue& sighash);
 
 // core_write.cpp
 UniValue ValueFromAmount(const CAmount& amount);
+UniValue ValueFromFeeRate(const CFeeRate& fee_rate, FeeEstimateMode mode = FeeEstimateMode::SAT_VB);
 std::string FormatScript(const CScript& script);
 std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags = 0);
 std::string SighashToStr(unsigned char sighash_type);

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -7,6 +7,7 @@
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
 #include <key_io.h>
+#include <policy/feerate.h>
 #include <script/script.h>
 #include <script/standard.h>
 #include <serialize.h>
@@ -25,6 +26,11 @@ UniValue ValueFromAmount(const CAmount& amount)
     int64_t remainder = n_abs % COIN;
     return UniValue(UniValue::VNUM,
             strprintf("%s%d.%08d", sign ? "-" : "", quotient, remainder));
+}
+
+UniValue ValueFromFeeRate(const CFeeRate& fee_rate, FeeEstimateMode mode)
+{
+    return UniValue(UniValue::VNUM, fee_rate.ToString(mode, /* with_units */ false));
 }
 
 std::string FormatScript(const CScript& script)

--- a/src/policy/feerate.cpp
+++ b/src/policy/feerate.cpp
@@ -35,10 +35,21 @@ CAmount CFeeRate::GetFee(size_t nBytes_) const
     return nFee;
 }
 
-std::string CFeeRate::ToString(const FeeEstimateMode& fee_estimate_mode) const
+std::string CFeeRate::ToString(FeeEstimateMode mode, bool with_units) const
 {
-    switch (fee_estimate_mode) {
-    case FeeEstimateMode::SAT_VB: return strprintf("%d.%03d %s/vB", nSatoshisPerK / 1000, nSatoshisPerK % 1000, CURRENCY_ATOM);
-    default:                      return strprintf("%d.%08d %s/kvB", nSatoshisPerK / COIN, nSatoshisPerK % COIN, CURRENCY_UNIT);
+    if (with_units) {
+        switch (mode) {
+        case FeeEstimateMode::SAT_VB:
+            return strprintf("%d.%03d %s/vB", nSatoshisPerK / 1000, nSatoshisPerK % 1000, CURRENCY_ATOM);
+        default:
+            return strprintf("%d.%08d %s/kvB", nSatoshisPerK / COIN, nSatoshisPerK % COIN, CURRENCY_UNIT);
+        }
+    } else {
+        switch (mode) {
+        case FeeEstimateMode::SAT_VB:
+            return strprintf("%d.%03d", nSatoshisPerK / 1000, nSatoshisPerK % 1000);
+        default:
+            return strprintf("%d.%08d", nSatoshisPerK / COIN, nSatoshisPerK % COIN);
+        }
     }
 }

--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -39,6 +39,8 @@ public:
         // We've previously had bugs creep in from silent double->int conversion...
         static_assert(std::is_integral<I>::value, "CFeeRate should be used without floats");
     }
+    static CFeeRate FromSatB(CAmount fee_rate);
+    static CFeeRate FromBtcKb(CAmount fee_rate);
     /** Constructor for a fee rate in satoshis per kvB (sat/kvB). The size in bytes must not exceed (2^63 - 1).
      *
      *  Passing an nBytes value of COIN (1e8) returns a fee rate in satoshis per vB (sat/vB),
@@ -69,5 +71,11 @@ public:
 
     SERIALIZE_METHODS(CFeeRate, obj) { READWRITE(obj.nSatoshisPerK); }
 };
+
+/** Construct a CFeeRate from a CAmount in sat/vB */
+inline CFeeRate CFeeRate::FromSatB(CAmount fee_rate) { return CFeeRate(fee_rate, COIN); }
+
+/** Construct a CFeeRate from a CAmount in BTC/kvB */
+inline CFeeRate CFeeRate::FromBtcKb(CAmount fee_rate) { return CFeeRate(fee_rate, 1000); }
 
 #endif //  BITCOIN_POLICY_FEERATE_H

--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -67,7 +67,13 @@ public:
     friend bool operator>=(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK >= b.nSatoshisPerK; }
     friend bool operator!=(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK != b.nSatoshisPerK; }
     CFeeRate& operator+=(const CFeeRate& a) { nSatoshisPerK += a.nSatoshisPerK; return *this; }
-    std::string ToString(const FeeEstimateMode& fee_estimate_mode = FeeEstimateMode::BTC_KVB) const;
+    /**
+     * Return the fee rate in BTC/kvB or sat/vB, with or without units, as a string.
+     *
+     *  @param[in] mode        FeeEstimateMode::SAT_VB or FeeEstimateMode::BTC_KVB
+     *  @param[in] with_units  bool whether to append the fee rate units ("sat/vB" or "BTC/kvB")
+     */
+    std::string ToString(FeeEstimateMode mode = FeeEstimateMode::BTC_KVB, bool with_units = true) const;
 
     SERIALIZE_METHODS(CFeeRate, obj) { READWRITE(obj.nSatoshisPerK); }
 };

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -43,6 +43,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendtoaddress", 8, "avoid_reuse" },
     { "sendtoaddress", 9, "fee_rate"},
     { "sendtoaddress", 10, "verbose"},
+    { "setfeerate", 0, "amount" },
     { "settxfee", 0, "amount" },
     { "sethdseed", 0, "newkeypool" },
     { "getreceivedbyaddress", 1, "minconf" },

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -129,11 +129,20 @@ BOOST_AUTO_TEST_CASE(BinaryOperatorTest)
 
 BOOST_AUTO_TEST_CASE(ToStringTest)
 {
-    CFeeRate feeRate;
-    feeRate = CFeeRate(1);
-    BOOST_CHECK_EQUAL(feeRate.ToString(), "0.00000001 BTC/kvB");
-    BOOST_CHECK_EQUAL(feeRate.ToString(FeeEstimateMode::BTC_KVB), "0.00000001 BTC/kvB");
-    BOOST_CHECK_EQUAL(feeRate.ToString(FeeEstimateMode::SAT_VB), "0.001 sat/vB");
+    CFeeRate fee_rate{CFeeRate(1)};
+    BOOST_CHECK_EQUAL(fee_rate.ToString(), "0.00000001 BTC/kvB");
+    BOOST_CHECK_EQUAL(fee_rate.ToString(FeeEstimateMode::BTC_KVB), "0.00000001 BTC/kvB");
+    BOOST_CHECK_EQUAL(fee_rate.ToString(FeeEstimateMode::SAT_VB), "0.001 sat/vB");
+
+    BOOST_CHECK_EQUAL(fee_rate.ToString(FeeEstimateMode::BTC_KVB, /* with_units */ true), "0.00000001 BTC/kvB");
+    BOOST_CHECK_EQUAL(fee_rate.ToString(FeeEstimateMode::SAT_VB, /* with_units */ true), "0.001 sat/vB");
+
+    BOOST_CHECK_EQUAL(CFeeRate(1).ToString(FeeEstimateMode::SAT_VB, /* with_units */ false), "0.001");
+    BOOST_CHECK_EQUAL(CFeeRate(70).ToString(FeeEstimateMode::SAT_VB, /* with_units */ false), "0.070");
+    BOOST_CHECK_EQUAL(CFeeRate(3141).ToString(FeeEstimateMode::SAT_VB, /* with_units */ false), "3.141");
+    BOOST_CHECK_EQUAL(CFeeRate(10002).ToString(FeeEstimateMode::SAT_VB, /* with_units */ false), "10.002");
+    BOOST_CHECK_EQUAL(CFeeRate(3141).ToString(FeeEstimateMode::BTC_KVB, /* with_units */ false), "0.00003141");
+    BOOST_CHECK_EQUAL(CFeeRate(10002).ToString(FeeEstimateMode::BTC_KVB, /* with_units */ false), "0.00010002");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -67,8 +67,12 @@ BOOST_AUTO_TEST_CASE(GetFeeTest)
     feeRate = CFeeRate(1000);
     altFeeRate = CFeeRate(feeRate);
     BOOST_CHECK_EQUAL(feeRate.GetFee(100), altFeeRate.GetFee(100));
+}
 
-    // Check full constructor
+BOOST_AUTO_TEST_CASE(CFeeRateConstructorTest)
+{
+    // Test CFeeRate(CAmount fee_rate, size_t bytes) constructor
+    // full constructor
     BOOST_CHECK(CFeeRate(CAmount(-1), 0) == CFeeRate(0));
     BOOST_CHECK(CFeeRate(CAmount(0), 0) == CFeeRate(0));
     BOOST_CHECK(CFeeRate(CAmount(1), 0) == CFeeRate(0));
@@ -84,6 +88,26 @@ BOOST_AUTO_TEST_CASE(GetFeeTest)
     BOOST_CHECK(CFeeRate(CAmount(27), 789) == CFeeRate(34));
     // Maximum size in bytes, should not crash
     CFeeRate(MAX_MONEY, std::numeric_limits<size_t>::max() >> 1).GetFeePerK();
+}
+
+BOOST_AUTO_TEST_CASE(CFeeRateNamedConstructorsTest)
+{
+    // Test CFeerate(CAmount fee_rate, FeeEstimatemode mode) constructor
+    // ...with BTC/kvB, returns same values as CFeeRate(CAmount fee_rate)
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(-1)) == CFeeRate(-1));
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(0)) == CFeeRate(0));
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(1)) == CFeeRate(1));
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(26)) == CFeeRate(26));
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(123)) == CFeeRate(123));
+    // ...with sat/vB, returns values that are 1e5 smaller
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(-100000)) == CFeeRate(-1));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(-99999)) == CFeeRate(0));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(0)) == CFeeRate(0));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(99999)) == CFeeRate(0));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(100000)) == CFeeRate(1));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(100001)) == CFeeRate(1));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(2690000)) == CFeeRate(26));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(123456789)) == CFeeRate(1234));
 }
 
 BOOST_AUTO_TEST_CASE(BinaryOperatorTest)

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -216,6 +216,29 @@ BOOST_AUTO_TEST_CASE(rpc_parse_monetary_values)
     BOOST_CHECK_THROW(AmountFromValue(ValueFromString("93e+9")), UniValue); //overflow error
 }
 
+BOOST_AUTO_TEST_CASE(rpc_parse_fee_rate_values)
+{
+    // Test ValueFromFeeRate() and CFeeRate()
+    // ...using default CFeeRate constructor
+    BOOST_CHECK_EQUAL(ValueFromFeeRate(CFeeRate(AmountFromValue(0.00001234))).get_real(), 1.234);
+    BOOST_CHECK_EQUAL(ValueFromFeeRate(CFeeRate(AmountFromValue(0.1234))).get_real(), 12340.000);
+    BOOST_CHECK_EQUAL(ValueFromFeeRate(CFeeRate(AmountFromValue(1234))).get_real(), 123400000.000);
+    // ...using CFeeRate constructor with bytes 1000
+    BOOST_CHECK_EQUAL(ValueFromFeeRate(CFeeRate(AmountFromValue(0.00001234), 1000)).get_real(), 1.234);
+    // ...using CFeeRate constructor with FeeEstimateMode::SAT_VB
+    BOOST_CHECK_EQUAL(ValueFromFeeRate(CFeeRate::FromSatB(AmountFromValue(0.001))).get_real(), 0.001);
+    BOOST_CHECK_EQUAL(ValueFromFeeRate(CFeeRate::FromSatB(AmountFromValue(0.999))).get_real(), 0.999);
+    BOOST_CHECK_EQUAL(ValueFromFeeRate(CFeeRate::FromSatB(AmountFromValue(1))).get_real(), 1);
+    BOOST_CHECK_EQUAL(ValueFromFeeRate(CFeeRate::FromSatB(AmountFromValue(1.02))).get_real(), 1.02);
+    BOOST_CHECK_EQUAL(ValueFromFeeRate(CFeeRate::FromSatB(AmountFromValue(1.234))).get_real(), 1.234);
+    // ...using CFeeRate constructor with FeeEstimateMode::BTC_KVB
+    BOOST_CHECK_EQUAL(ValueFromFeeRate(CFeeRate::FromBtcKb(AmountFromValue(0.00000001))).get_real(), 0.001);
+    BOOST_CHECK_EQUAL(ValueFromFeeRate(CFeeRate::FromBtcKb(AmountFromValue(0.0000099))).get_real(), 0.99);
+    BOOST_CHECK_EQUAL(ValueFromFeeRate(CFeeRate::FromBtcKb(AmountFromValue(0.00001))).get_real(), 1);
+    BOOST_CHECK_EQUAL(ValueFromFeeRate(CFeeRate::FromBtcKb(AmountFromValue(0.00001234))).get_real(), 1.234);
+    BOOST_CHECK_EQUAL(ValueFromFeeRate(CFeeRate::FromBtcKb(AmountFromValue(0.1234))).get_real(), 12340);
+}
+
 BOOST_AUTO_TEST_CASE(json_parse_errors)
 {
     // Valid

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2310,10 +2310,12 @@ static RPCHelpMan listlockunspent()
 static RPCHelpMan settxfee()
 {
     return RPCHelpMan{"settxfee",
-                "\nSet the transaction fee per kB for this wallet. Overrides the global -paytxfee command line parameter.\n"
-                "Can be deactivated by passing 0 as the fee. In that case automatic fee selection will be used by default.\n",
+                "\n(Deprecated in favor of the setfeerate RPC in " + CURRENCY_ATOM + "/vB, which it is recommended to use instead.)\n"
+                "Set the transaction fee rate in " + CURRENCY_UNIT + "/kvB for this wallet.\n"
+                "Overrides the global -paytxfee configuration option. Like -paytxfee, it is not persisted after bitcoind shutdown/restart.\n"
+                "Can be deactivated by passing 0 as the fee rate, in which case automatic fee selection will be used by default.\n",
                 {
-                    {"amount", RPCArg::Type::AMOUNT, RPCArg::Optional::NO, "The transaction fee in " + CURRENCY_UNIT + "/kvB"},
+                    {"amount", RPCArg::Type::AMOUNT, RPCArg::Optional::NO, "The transaction fee rate in " + CURRENCY_UNIT + "/kvB to set (0 to unset)"},
                 },
                 RPCResult{
                     RPCResult::Type::BOOL, "", "Returns true if successful"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4601,15 +4601,15 @@ static RPCHelpMan upgradewallet()
             result = strprintf("Wallet upgraded successfully from version %i to version %i.", previous_version, current_version);
         }
     }
+    CHECK_NONFATAL(result.empty() != error.empty());
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("wallet_name", pwallet->GetName());
     obj.pushKV("previous_version", previous_version);
     obj.pushKV("current_version", current_version);
-    if (!result.empty()) {
+    if (error.empty()) {
         obj.pushKV("result", result);
     } else {
-        CHECK_NONFATAL(!error.empty());
         obj.pushKV("error", error.original);
     }
     return obj;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4687,7 +4687,6 @@ static const CRPCCommand commands[] =
     { "wallet",             &setfeerate,                     },
     { "wallet",             &sethdseed,                      },
     { "wallet",             &setlabel,                       },
-    { "wallet",             &settxfee,                       },
     { "wallet",             &setwalletflag,                  },
     { "wallet",             &signmessage,                    },
     { "wallet",             &signrawtransactionwithwallet,   },
@@ -4698,6 +4697,7 @@ static const CRPCCommand commands[] =
     { "wallet",             &walletpassphrase,               },
     { "wallet",             &walletpassphrasechange,         },
     { "wallet",             &walletprocesspsbt,              },
+    { "hidden",             &settxfee,                       },
 };
 // clang-format on
     return MakeSpan(commands);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -216,7 +216,7 @@ static void SetFeeEstimateMode(const CWallet& wallet, CCoinControl& cc, const Un
         if (!estimate_mode.isNull() && estimate_mode.get_str() != "unset") {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot specify both estimate_mode and fee_rate");
         }
-        cc.m_feerate = CFeeRate(AmountFromValue(fee_rate), COIN);
+        cc.m_feerate = CFeeRate::FromSatB(AmountFromValue(fee_rate));
         if (override_min_fee) cc.fOverrideFeeRate = true;
         // Default RBF to true for explicit fee_rate, if unset.
         if (cc.m_signal_bip125_rbf == nullopt) cc.m_signal_bip125_rbf = true;
@@ -2331,8 +2331,8 @@ static RPCHelpMan settxfee()
     LOCK(pwallet->cs_wallet);
 
     CAmount nAmount = AmountFromValue(request.params[0]);
-    CFeeRate tx_fee_rate(nAmount, 1000);
-    CFeeRate max_tx_fee_rate(pwallet->m_default_max_tx_fee, 1000);
+    CFeeRate tx_fee_rate{CFeeRate::FromBtcKb(nAmount)};
+    CFeeRate max_tx_fee_rate{CFeeRate::FromBtcKb(pwallet->m_default_max_tx_fee)};
     if (tx_fee_rate == CFeeRate(0)) {
         // automatic selection
     } else if (tx_fee_rate < pwallet->chain().relayMinFee()) {
@@ -3157,7 +3157,7 @@ void FundTransaction(CWallet* const pwallet, CMutableTransaction& tx, CAmount& f
             if (options.exists("estimate_mode")) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot specify both estimate_mode and feeRate");
             }
-            coinControl.m_feerate = CFeeRate(AmountFromValue(options["feeRate"]));
+            coinControl.m_feerate = CFeeRate::FromBtcKb(AmountFromValue(options["feeRate"]));
             coinControl.fOverrideFeeRate = true;
         }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2349,6 +2349,81 @@ static RPCHelpMan settxfee()
     };
 }
 
+static RPCHelpMan setfeerate()
+{
+    return RPCHelpMan{
+        "setfeerate",
+        "\nSet the transaction fee rate in " + CURRENCY_ATOM + "/vB for this wallet.\n"
+        "Overrides the global -paytxfee configuration option. Like -paytxfee, it is not persisted after bitcoind shutdown/restart.\n"
+        "Can be deactivated by passing 0 as the fee rate, in which case automatic fee selection will be used by default.\n",
+        {
+            {"amount", RPCArg::Type::AMOUNT, RPCArg::Optional::NO, "The transaction fee rate in " + CURRENCY_ATOM + "/vB to set (0 to unset)"},
+        },
+        RPCResult{
+            RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR, "wallet_name", "Name of the wallet the fee rate setting applies to"},
+                {RPCResult::Type::NUM, "fee_rate", "Fee rate in " + CURRENCY_ATOM + "/vB for the wallet after this operation"},
+                {RPCResult::Type::STR, "result", /* optional */ true, "Description of result, if successful"},
+                {RPCResult::Type::STR, "error", /* optional */ true, "Description of error, if any"},
+            },
+        },
+        RPCExamples{
+            ""
+            "\nSet a fee rate of 1 " + CURRENCY_ATOM + "/vB\n"
+            + HelpExampleCli("setfeerate", "1") +
+            "\nSet a fee rate of 3.141 " + CURRENCY_ATOM + "/vB\n"
+            + HelpExampleCli("setfeerate", "3.141") +
+            "\nSet a fee rate of 7.75 " + CURRENCY_ATOM + "/vB with named arguments\n"
+            + HelpExampleCli("-named setfeerate", "amount=\"7.75\"") +
+            "\nSet a fee rate of 25 " + CURRENCY_ATOM + "/vB with the RPC\n"
+            + HelpExampleRpc("setfeerate", "25")
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            std::shared_ptr<CWallet> const rpc_wallet{GetWalletForJSONRPCRequest(request)};
+            if (!rpc_wallet) return NullUniValue;
+            CWallet& wallet = *rpc_wallet;
+
+            LOCK(wallet.cs_wallet);
+
+            const CFeeRate amount{CFeeRate::FromSatB(AmountFromValue(request.params[0]))};
+            const CFeeRate relay_min_feerate{wallet.chain().relayMinFee().GetFeePerK()};
+            const CFeeRate wallet_min_feerate{wallet.m_min_fee.GetFeePerK()};
+            const CFeeRate wallet_max_feerate{CFeeRate::FromBtcKb(wallet.m_default_max_tx_fee)};
+            const CFeeRate zero{CFeeRate{0}};
+            const std::string amount_str{amount.ToString(FeeEstimateMode::SAT_VB)};
+            const std::string current_setting{strprintf("The current setting of %s for this wallet remains unchanged.", wallet.m_pay_tx_fee == zero ? "0 (unset)" : wallet.m_pay_tx_fee.ToString(FeeEstimateMode::SAT_VB))};
+            std::string result, error;
+
+            if (amount == zero) {
+                if (request.params[0].get_real() != 0) throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
+                wallet.m_pay_tx_fee = amount;
+                result = "Fee rate for transactions with this wallet successfully unset. By default, automatic fee selection will be used.";
+            } else if (amount < relay_min_feerate) {
+                error = strprintf("The requested fee rate of %s cannot be less than the minimum relay fee rate of %s. %s", amount_str, relay_min_feerate.ToString(FeeEstimateMode::SAT_VB), current_setting);
+            } else if (amount < wallet_min_feerate) {
+                error = strprintf("The requested fee rate of %s cannot be less than the wallet min fee rate of %s. %s", amount_str, wallet_min_feerate.ToString(FeeEstimateMode::SAT_VB), current_setting);
+            } else if (amount > wallet_max_feerate) {
+                error = strprintf("The requested fee rate of %s cannot be greater than the wallet max fee rate of %s. %s", amount_str, wallet_max_feerate.ToString(FeeEstimateMode::SAT_VB), current_setting);
+            } else {
+                wallet.m_pay_tx_fee = amount;
+                result = "Fee rate for transactions with this wallet successfully set to " + amount_str;
+            }
+            CHECK_NONFATAL(result.empty() != error.empty());
+
+            UniValue obj{UniValue::VOBJ};
+            obj.pushKV("wallet_name", wallet.GetName());
+            obj.pushKV("fee_rate", ValueFromFeeRate(wallet.m_pay_tx_fee));
+            if (error.empty()) {
+                obj.pushKV("result", result);
+            } else {
+                obj.pushKV("error", error);
+            }
+            return obj;
+        },
+    };
+}
+
 static RPCHelpMan getbalances()
 {
     return RPCHelpMan{
@@ -4607,6 +4682,7 @@ static const CRPCCommand commands[] =
     { "wallet",             &send,                           },
     { "wallet",             &sendmany,                       },
     { "wallet",             &sendtoaddress,                  },
+    { "wallet",             &setfeerate,                     },
     { "wallet",             &sethdseed,                      },
     { "wallet",             &setlabel,                       },
     { "wallet",             &settxfee,                       },

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -39,13 +39,12 @@ class MempoolLimitTest(BitcoinTestFramework):
         inputs = [{ "txid" : us0["txid"], "vout" : us0["vout"]}]
         outputs = {self.nodes[0].getnewaddress() : 0.0001}
         tx = self.nodes[0].createrawtransaction(inputs, outputs)
-        self.nodes[0].settxfee(relayfee) # specifically fund this tx with low fee
+        self.nodes[0].setfeerate(relayfee * Decimal(1e8 / 1e3))  # fund this tx with a low fee
         txF = self.nodes[0].fundrawtransaction(tx)
-        self.nodes[0].settxfee(0) # return to automatic fee selection
+        self.nodes[0].setfeerate(0)  # return to automatic fee selection
         txFS = self.nodes[0].signrawtransactionwithwallet(txF['hex'])
         txid = self.nodes[0].sendrawtransaction(txFS['hex'])
 
-        relayfee = self.nodes[0].getnetworkinfo()['relayfee']
         base_fee = relayfee*100
         for i in range (3):
             txids.append([])

--- a/test/functional/mempool_unbroadcast.py
+++ b/test/functional/mempool_unbroadcast.py
@@ -5,6 +5,7 @@
 """Test that the mempool ensures transaction delivery by periodically sending
 to peers until a GETDATA is received."""
 
+from decimal import Decimal
 import time
 
 from test_framework.p2p import P2PTxInvStore
@@ -47,7 +48,8 @@ class MempoolUnbroadcastTest(BitcoinTestFramework):
         inputs = [{"txid": us0["txid"], "vout": us0["vout"]}]
         outputs = {addr: 0.0001}
         tx = node.createrawtransaction(inputs, outputs)
-        node.settxfee(min_relay_fee)
+        btc_kvb_to_sat_vb = Decimal(1e8 / 1e3)
+        node.setfeerate(min_relay_fee * btc_kvb_to_sat_vb)
         txF = node.fundrawtransaction(tx)
         txFS = node.signrawtransactionwithwallet(txF["hex"])
         rpc_tx_hsh = node.sendrawtransaction(txFS["hex"])

--- a/test/functional/rpc_getblockstats.py
+++ b/test/functional/rpc_getblockstats.py
@@ -50,7 +50,7 @@ class GetblockstatsTest(BitcoinTestFramework):
 
         self.nodes[0].sendtoaddress(address=address, amount=10, subtractfeefromamount=True)
         self.nodes[0].sendtoaddress(address=address, amount=10, subtractfeefromamount=False)
-        self.nodes[0].settxfee(amount=0.003)
+        self.nodes[0].setfeerate(amount=300)
         self.nodes[0].sendtoaddress(address=address, amount=1, subtractfeefromamount=True)
         self.sync_all()
         self.nodes[0].generate(1)
@@ -107,7 +107,7 @@ class GetblockstatsTest(BitcoinTestFramework):
         assert_equal(stats[self.max_stat_pos]['height'], self.start_height + self.max_stat_pos)
 
         for i in range(self.max_stat_pos+1):
-            self.log.info('Checking block %d\n' % (i))
+            self.log.info(f"Checking block {i}")
             assert_equal(stats[i], self.expected_stats[i])
 
             # Check selecting block by hash too

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -86,6 +86,7 @@ class HelpRpcTest(BitcoinTestFramework):
                 assert argname == 'dummy', ('WARNING: conversion mismatch for argument named %s (%s)' % (argname, list(zip(all_methods_by_argname[argname], converts_by_argname[argname]))))
 
     def test_categories(self):
+        self.log.info("Test RPC help categories")
         node = self.nodes[0]
 
         # wrong argument count
@@ -111,6 +112,7 @@ class HelpRpcTest(BitcoinTestFramework):
         assert_equal(titles, components)
 
     def dump_help(self):
+        self.log.info("Test dump RPC help")
         dump_dir = os.path.join(self.options.tmpdir, 'rpc_help_dump')
         os.mkdir(dump_dir)
         calls = [line.split(' ', 1)[0] for line in self.nodes[0].help().splitlines() if line and not line.startswith('==')]
@@ -120,9 +122,11 @@ class HelpRpcTest(BitcoinTestFramework):
                 f.write(self.nodes[0].help(call))
 
     def wallet_help(self):
+        self.log.info("Test wallet RPC help")
         assert 'getnewaddress ( "label" "address_type" )' in self.nodes[0].help('getnewaddress')
         self.restart_node(0, extra_args=['-nowallet=1'])
         assert 'getnewaddress ( "label" "address_type" )' in self.nodes[0].help('getnewaddress')
+        assert "setfeerate amount" in self.nodes[0].help("setfeerate")
 
 
 if __name__ == '__main__':

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -53,6 +53,7 @@ class HelpRpcTest(BitcoinTestFramework):
         self.dump_help()
         if self.is_wallet_compiled():
             self.wallet_help()
+            self.test_hidden_wallet_rpcs()
 
     def test_client_conversion_table(self):
         file_conversion_table = os.path.join(self.config["environment"]["SRCDIR"], 'src', 'rpc', 'client.cpp')
@@ -127,6 +128,11 @@ class HelpRpcTest(BitcoinTestFramework):
         self.restart_node(0, extra_args=['-nowallet=1'])
         assert 'getnewaddress ( "label" "address_type" )' in self.nodes[0].help('getnewaddress')
         assert "setfeerate amount" in self.nodes[0].help("setfeerate")
+
+    def test_hidden_wallet_rpcs(self):
+        self.log.info("Test hidden wallet RPCs")
+        assert "settxfee" not in self.nodes[0].help()  # settxfee help is hidden from general help...
+        assert "settxfee amount" in self.nodes[0].help("settxfee")  # ...but can be called directly
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -6,6 +6,7 @@
 from decimal import Decimal
 from itertools import product
 
+from test_framework.messages import COIN
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_array_result,
@@ -197,7 +198,7 @@ class WalletTest(BitcoinTestFramework):
         # Send 10 BTC normal
         address = self.nodes[0].getnewaddress("test")
         fee_per_byte = Decimal('0.001') / 1000
-        self.nodes[2].settxfee(fee_per_byte * 1000)
+        self.nodes[2].setfeerate(fee_per_byte * COIN)
         txid = self.nodes[2].sendtoaddress(address, 10, "", "", False)
         self.nodes[2].generate(1)
         self.sync_all(self.nodes[0:3])

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -17,7 +17,7 @@ from decimal import Decimal
 import io
 
 from test_framework.blocktools import add_witness_commitment, create_block, create_coinbase, send_to_witness
-from test_framework.messages import BIP125_SEQUENCE_NUMBER, CTransaction
+from test_framework.messages import BIP125_SEQUENCE_NUMBER, COIN, CTransaction
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -46,6 +46,7 @@ class BumpFeeTest(BitcoinTestFramework):
             "-mintxfee=0.00002",
             "-addresstype=bech32",
         ] for i in range(self.num_nodes)]
+        self.wallet_names = [self.default_wallet_name, "RBF wallet"]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
@@ -91,6 +92,7 @@ class BumpFeeTest(BitcoinTestFramework):
         test_bumpfee_metadata(self, rbf_node, dest_address)
         test_locked_wallet_fails(self, rbf_node, dest_address)
         test_change_script_match(self, rbf_node, dest_address)
+        test_setfeerate(self, rbf_node, dest_address)
         test_settxfee(self, rbf_node, dest_address)
         test_maxtxfee_fails(self, rbf_node, dest_address)
         # These tests wipe out a number of utxos that are expected in other tests
@@ -312,6 +314,42 @@ def test_dust_to_fee(self, rbf_node, dest_address):
     assert_equal(len(fulltx["vout"]), 2)
     assert_equal(len(full_bumped_tx["vout"]), 1)  # change output is eliminated
     assert_equal(full_bumped_tx["vout"][0]['value'], Decimal("0.00050000"))
+    self.clear_mempool()
+
+
+def test_setfeerate(self, rbf_node, dest_address):
+    self.log.info("Test setfeerate")
+
+    def test_response(*, wallet="RBF wallet", requested=0, expected=0, error=None, msg):
+        assert_equal(rbf_node.setfeerate(requested), {"wallet_name": wallet, "fee_rate": expected, ("error" if error else "result"): msg})
+
+    # Test setfeerate with too high/low values returns expected errors
+    new = Decimal("10000.001")
+    test_response(requested=new, error=True, msg=f"The requested fee rate of {new} sat/vB cannot be greater than the wallet max fee rate of 10000.000 sat/vB. The current setting of 0 (unset) for this wallet remains unchanged.")
+    new = Decimal("0.999")
+    test_response(requested=new, error=True, msg=f"The requested fee rate of {new} sat/vB cannot be less than the minimum relay fee rate of 1.000 sat/vB. The current setting of 0 (unset) for this wallet remains unchanged.")
+    fee_rate = Decimal("2.001")
+    test_response(requested=fee_rate, expected=fee_rate, msg=f"Fee rate for transactions with this wallet successfully set to {fee_rate} sat/vB")
+    new = Decimal("1.999")
+    test_response(requested=new, expected=fee_rate, error=True, msg=f"The requested fee rate of {new} sat/vB cannot be less than the wallet min fee rate of 2.000 sat/vB. The current setting of {fee_rate} sat/vB for this wallet remains unchanged.")
+
+    # Test setfeerate with valid values returns expected results
+    rbfid = spend_one_input(rbf_node, dest_address)
+    fee_rate = 25
+    test_response(requested=fee_rate, expected=fee_rate, msg="Fee rate for transactions with this wallet successfully set to 25.000 sat/vB")
+    bumped_tx = rbf_node.bumpfee(rbfid)
+    actual_feerate = bumped_tx["fee"] * COIN / rbf_node.getrawtransaction(bumped_tx["txid"], True)["vsize"]
+    assert_greater_than(Decimal("0.01"), abs(fee_rate - actual_feerate))
+    test_response(msg="Fee rate for transactions with this wallet successfully unset. By default, automatic fee selection will be used.")
+
+    # Test setfeerate with a different -maxtxfee
+    self.restart_node(1, ["-maxtxfee=0.000025"] + self.extra_args[1])
+    new = "2.501"
+    test_response(requested=new, error=True, msg=f"The requested fee rate of {new} sat/vB cannot be greater than the wallet max fee rate of 2.500 sat/vB. The current setting of 0 (unset) for this wallet remains unchanged.")
+
+    self.restart_node(1, self.extra_args[1])
+    rbf_node.walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
+    self.connect_nodes(1, 0)
     self.clear_mempool()
 
 

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -3,13 +3,13 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+from decimal import Decimal
+
+from test_framework.blocktools import TIME_GENESIS_BLOCK
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-)
-from test_framework.blocktools import (
-    TIME_GENESIS_BLOCK,
 )
 
 
@@ -17,6 +17,7 @@ class CreateTxWalletTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
+        self.wallet_names = ["test_wallet"]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
@@ -29,6 +30,7 @@ class CreateTxWalletTest(BitcoinTestFramework):
 
         self.test_anti_fee_sniping()
         self.test_tx_size_too_large()
+        self.test_setfeerate()
 
     def test_anti_fee_sniping(self):
         self.log.info('Check that we have some (old) blocks and that anti-fee-sniping is disabled')
@@ -76,6 +78,51 @@ class CreateTxWalletTest(BitcoinTestFramework):
             lambda: self.nodes[0].fundrawtransaction(hexstring=raw_tx),
         )
         self.nodes[0].settxfee(0)
+
+    def test_setfeerate(self):
+        self.log.info("Test setfeerate")
+        self.restart_node(0, extra_args=["-mintxfee=0.00003141"])  # 3.141 sat/vB
+        node = self.nodes[0]
+
+        def test_response(*, requested=0, expected=0, error=None, msg):
+            assert_equal(node.setfeerate(requested), {"wallet_name": "test_wallet", "fee_rate": expected, ("error" if error else "result"): msg})
+
+        # Test setfeerate with 10.0001 (CFeeRate rounding), "10.001" and "4" sat/vB
+        test_response(requested=10.0001, expected=10, msg="Fee rate for transactions with this wallet successfully set to 10.000 sat/vB")
+        assert_equal(node.getwalletinfo()["paytxfee"], Decimal("0.00010000"))
+        test_response(requested="10.001", expected=Decimal("10.001"), msg="Fee rate for transactions with this wallet successfully set to 10.001 sat/vB")
+        assert_equal(node.getwalletinfo()["paytxfee"], Decimal("0.00010001"))
+        test_response(requested="4", expected=4, msg="Fee rate for transactions with this wallet successfully set to 4.000 sat/vB")
+        assert_equal(node.getwalletinfo()["paytxfee"], Decimal("0.00004000"))
+
+        # Test setfeerate with too-high/low values returns expected errors
+        test_response(requested=Decimal("10000.001"), expected=4, error=True, msg="The requested fee rate of 10000.001 sat/vB cannot be greater than the wallet max fee rate of 10000.000 sat/vB. The current setting of 4.000 sat/vB for this wallet remains unchanged.")
+        test_response(requested=Decimal("0.999"), expected=4, error=True, msg="The requested fee rate of 0.999 sat/vB cannot be less than the minimum relay fee rate of 1.000 sat/vB. The current setting of 4.000 sat/vB for this wallet remains unchanged.")
+        test_response(requested=Decimal("3.140"), expected=4, error=True, msg="The requested fee rate of 3.140 sat/vB cannot be less than the wallet min fee rate of 3.141 sat/vB. The current setting of 4.000 sat/vB for this wallet remains unchanged.")
+        assert_equal(node.getwalletinfo()["paytxfee"], Decimal("0.00004000"))
+
+        # Test setfeerate to 3.141 sat/vB
+        test_response(requested=3.141, expected=Decimal("3.141"), msg="Fee rate for transactions with this wallet successfully set to 3.141 sat/vB")
+        assert_equal(node.getwalletinfo()["paytxfee"], Decimal("0.00003141"))
+
+        # Test setfeerate with values non-representable by CFeeRate
+        for invalid_value in [0.00000001, 0.0009, 0.00099999]:
+            assert_raises_rpc_error(-3, "Invalid amount", node.setfeerate, amount=invalid_value)
+
+        # Test setfeerate with values rejected by ParseFixedPoint() called in AmountFromValue()
+        for invalid_value in ["", 0.000000001, "1.111111111", 11111111111]:
+            assert_raises_rpc_error(-3, "Invalid amount", node.setfeerate, amount=invalid_value)
+
+        # Test deactivating setfeerate
+        test_response(msg="Fee rate for transactions with this wallet successfully unset. By default, automatic fee selection will be used.")
+        assert_equal(node.getwalletinfo()["paytxfee"], 0)
+
+        # Test currently-unset setfeerate with too-high/low values returns expected errors
+        test_response(requested=Decimal("10000.001"), error=True, msg="The requested fee rate of 10000.001 sat/vB cannot be greater than the wallet max fee rate of 10000.000 sat/vB. The current setting of 0 (unset) for this wallet remains unchanged.")
+        assert_equal(node.getwalletinfo()["paytxfee"], 0)
+        test_response(requested=Decimal("0.999"), error=True, msg="The requested fee rate of 0.999 sat/vB cannot be less than the minimum relay fee rate of 1.000 sat/vB. The current setting of 0 (unset) for this wallet remains unchanged.")
+        test_response(requested=Decimal("3.140"), error=True, msg="The requested fee rate of 3.140 sat/vB cannot be less than the wallet min fee rate of 3.141 sat/vB. The current setting of 0 (unset) for this wallet remains unchanged.")
+        assert_equal(node.getwalletinfo()["paytxfee"], 0)
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -247,11 +247,17 @@ class MultiWalletTest(BitcoinTestFramework):
         assert_equal(batch[0]["result"]["chain"], self.chain)
         assert_equal(batch[1]["result"]["walletname"], "w1")
 
-        self.log.info('Check for per-wallet settxfee call')
+        self.log.info('Test per-wallet setfeerate and settxfee calls')
         assert_equal(w1.getwalletinfo()['paytxfee'], 0)
         assert_equal(w2.getwalletinfo()['paytxfee'], 0)
+        w2.setfeerate(200)
+        assert_equal(w1.getwalletinfo()['paytxfee'], 0)
+        assert_equal(w2.getwalletinfo()['paytxfee'], Decimal('0.00200000'))
         w2.settxfee(0.001)
         assert_equal(w1.getwalletinfo()['paytxfee'], 0)
+        assert_equal(w2.getwalletinfo()['paytxfee'], Decimal('0.00100000'))
+        w1.setfeerate(30)
+        assert_equal(w1.getwalletinfo()['paytxfee'], Decimal('0.00030000'))
         assert_equal(w2.getwalletinfo()['paytxfee'], Decimal('0.00100000'))
 
         self.log.info("Test dynamic wallet loading")

--- a/test/functional/wallet_txn_clone.py
+++ b/test/functional/wallet_txn_clone.py
@@ -42,7 +42,7 @@ class TxnMallTest(BitcoinTestFramework):
             assert_equal(self.nodes[i].getbalance(), starting_balance)
             self.nodes[i].getnewaddress()  # bug workaround, coins generated assigned to first getnewaddress!
 
-        self.nodes[0].settxfee(.001)
+        self.nodes[0].setfeerate(100)
 
         node0_address1 = self.nodes[0].getnewaddress(address_type=output_type)
         node0_txid1 = self.nodes[0].sendtoaddress(node0_address1, 1219)

--- a/test/functional/wallet_upgradewallet.py
+++ b/test/functional/wallet_upgradewallet.py
@@ -90,7 +90,7 @@ class UpgradeWalletTest(BitcoinTestFramework):
             v16_3_node.submitblock(b)
         assert_equal(v16_3_node.getblockcount(), to_height)
 
-    def test_upgradewallet(self, wallet, previous_version, requested_version=None, expected_version=None):
+    def test_upgradewallet(self, wallet, *, previous_version, requested_version=None, expected_version=None):
         unchanged = expected_version == previous_version
         new_version = previous_version if unchanged else expected_version if expected_version else requested_version
         assert_equal(wallet.getwalletinfo()["walletversion"], previous_version)
@@ -104,7 +104,7 @@ class UpgradeWalletTest(BitcoinTestFramework):
         )
         assert_equal(wallet.getwalletinfo()["walletversion"], new_version)
 
-    def test_upgradewallet_error(self, wallet, previous_version, requested_version, msg):
+    def test_upgradewallet_error(self, wallet, *, previous_version, requested_version, msg):
         assert_equal(wallet.getwalletinfo()["walletversion"], previous_version)
         assert_equal(wallet.upgradewallet(requested_version),
             {


### PR DESCRIPTION
Continuing the work on issue #19543, this proposes a `setfeerate` RPC in sat/vB and makes `settxfee` a hidden RPC per the plan described in https://github.com/bitcoin/bitcoin/pull/20484#issuecomment-734786305.