### PR TITLE
WIP: Switch appveyor build from Release to Debug

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
 version: '{branch}.{build}'
 skip_tags: true
 image: Previous Visual Studio 2019
-configuration: Release
+configuration: Debug
 platform: x64
 clone_depth: 5
 environment:


### PR DESCRIPTION
As per [brief discussion](https://github.com/bitcoin/bitcoin/pull/17736#issuecomment-727264508). Visual Studio 2019 and Appveyor images have recently been updated. While it's only a minor update that doesn't break ABI compatibility it does seem to have broken compatibility for Release builds. This apparently occurs if compiler optimisations are turned on.

This PR switches the Appveyor CI job from a Release build to a Debug build in order to fix the CI failures.

Subsequent to this PR I will commence a new build of the Qt static libraries with the latest Visual Studio 2019 toolset so that release build can work again.