### PR TITLE
ci: Use the previous build worker image in AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 version: '{branch}.{build}'
 skip_tags: true
-image: Visual Studio 2019
+image: Previous Visual Studio 2019
 configuration: Release
 platform: x64
 clone_depth: 5


### PR DESCRIPTION
This is a workaround as the [recent](https://www.appveyor.com/updates/2020/11/14/) Visual Studio 2019 image update breaks our builds.

This PR is alternative to #20392 due to its build [failure](https://ci.appveyor.com/project/DrahtBot/bitcoin/builds/36314660).