### PR TITLE
Remove names from translatable strings

### DIFF
--- a/doc/translation_strings_policy.md
+++ b/doc/translation_strings_policy.md
@@ -30,6 +30,15 @@ This includes messages passed to the GUI through the UI interface through `InitM
 General recommendations
 ------------------------
 
+### Do not translate names
+
+The following tokens must not be parts of the strings are to be translated:
+- command line option names
+- RPC names
+- file names
+
+Use `%s` substitution, e.g., `strprintf(_("Unknown %s value %s."), "-blockfilterindex", name)`.
+
 ### Avoid unnecessary translation strings
 
 Try not to burden translators with translating messages that are e.g. slight variations of other messages.

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -23,7 +23,7 @@ static void FatalError(const char* fmt, const Args&... args)
     std::string strMessage = tfm::format(fmt, args...);
     SetMiscWarning(Untranslated(strMessage));
     LogPrintf("*** %s\n", strMessage);
-    AbortError(_("A fatal internal error occurred, see debug.log for details"));
+    AbortError(strprintf(_("A fatal internal error occurred, see %s for details."), gArgs.GetArg("-debuglogfile", DEFAULT_DEBUGLOGFILE)));
     StartShutdown();
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1296,7 +1296,7 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
         LogPrintf("Config file: %s\n", config_file_path.string());
     } else if (args.IsArgSet("-conf")) {
         // Warn if no conf file exists at path provided by user
-        InitWarning(strprintf(_("The specified config file %s does not exist\n"), config_file_path.string()));
+        InitWarning(strprintf(_("The specified config file %s does not exist."), config_file_path.string()));
     } else {
         // Not categorizing as "Warning" because it's the default behavior
         LogPrintf("Config file: %s (not found, skipping)\n", config_file_path.string());

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2459,7 +2459,7 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
     if (fListen && !InitBinds(connOptions.vBinds, connOptions.vWhiteBinds, connOptions.onion_binds)) {
         if (clientInterface) {
             clientInterface->ThreadSafeMessageBox(
-                _("Failed to listen on any port. Use -listen=0 if you want this."),
+                strprintf(_("Failed to listen on any port. Use %s if you want this."), "-listen=0"),
                 "", CClientUIInterface::MSG_ERROR);
         }
         return false;

--- a/src/net_permissions.cpp
+++ b/src/net_permissions.cpp
@@ -94,7 +94,7 @@ bool NetWhitebindPermissions::TryParse(const std::string str, NetWhitebindPermis
         return false;
     }
     if (addrBind.GetPort() == 0) {
-        error = strprintf(_("Need to specify a port with -whitebind: '%s'"), strBind);
+        error = strprintf(_("Need to specify a port with %s: '%s'"), "-whitebind", strBind);
         return false;
     }
 
@@ -114,7 +114,7 @@ bool NetWhitelistPermissions::TryParse(const std::string str, NetWhitelistPermis
     CSubNet subnet;
     LookupSubNet(net, subnet);
     if (!subnet.IsValid()) {
-        error = strprintf(_("Invalid netmask specified in -whitelist: '%s'"), net);
+        error = strprintf(_("Invalid netmask specified in %s: '%s'"), "-whitelist", net);
         return false;
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1662,7 +1662,7 @@ static bool AbortNode(const std::string& strMessage, bilingual_str user_message 
     SetMiscWarning(Untranslated(strMessage));
     LogPrintf("*** %s\n", strMessage);
     if (user_message.empty()) {
-        user_message = _("A fatal internal error occurred, see debug.log for details");
+        user_message = strprintf(_("A fatal internal error occurred, see %s for details."), gArgs.GetArg("-debuglogfile", DEFAULT_DEBUGLOGFILE));
     }
     AbortError(user_message);
     StartShutdown();

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -24,14 +24,14 @@ bool VerifyWallets(interfaces::Chain& chain)
         // The canonical path cleans the path, preventing >1 Berkeley environment instances for the same directory
         fs::path canonical_wallet_dir = fs::canonical(wallet_dir, error);
         if (error || !fs::exists(wallet_dir)) {
-            chain.initError(strprintf(_("Specified -walletdir \"%s\" does not exist"), wallet_dir.string()));
+            chain.initError(strprintf(_("Specified %s \"%s\" does not exist"), "-walletdir", wallet_dir.string()));
             return false;
         } else if (!fs::is_directory(wallet_dir)) {
-            chain.initError(strprintf(_("Specified -walletdir \"%s\" is not a directory"), wallet_dir.string()));
+            chain.initError(strprintf(_("Specified %s \"%s\" is not a directory"), "-walletdir", wallet_dir.string()));
             return false;
         // The canonical path transforms relative paths into absolute ones, so we check the non-canonical version
         } else if (!wallet_dir.is_absolute()) {
-            chain.initError(strprintf(_("Specified -walletdir \"%s\" is a relative path"), wallet_dir.string()));
+            chain.initError(strprintf(_("Specified %s \"%s\" is a relative path"), "-walletdir", wallet_dir.string()));
             return false;
         }
         gArgs.ForceSetArg("-walletdir", canonical_wallet_dir.string());
@@ -65,7 +65,7 @@ bool VerifyWallets(interfaces::Chain& chain)
         const fs::path path = fs::absolute(wallet_file, GetWalletDir());
 
         if (!wallet_paths.insert(path).second) {
-            chain.initWarning(strprintf(_("Ignoring duplicate -wallet %s."), wallet_file));
+            chain.initWarning(strprintf(_("Ignoring duplicate %s %s."), "-wallet", wallet_file));
             continue;
         }
 

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -23,7 +23,7 @@ bool LegacyScriptPubKeyMan::GetNewDestination(const OutputType type, CTxDestinat
     // Generate a new key that is added to wallet
     CPubKey new_key;
     if (!GetKeyFromPool(new_key, type)) {
-        error = _("Error: Keypool ran out, please call keypoolrefill first").translated;
+        error = strprintf(_("Error: Keypool ran out, please call %s first"), "keypoolrefill").translated;
         return false;
     }
     LearnRelatedScripts(new_key, type);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2961,7 +2961,7 @@ bool CWallet::CreateTransactionInternal(
                 nFeeNeeded = GetMinimumFee(*this, nBytes, coin_control, &feeCalc);
                 if (feeCalc.reason == FeeReason::FALLBACK && !m_allow_fallback_fee) {
                     // eventually allow a fallback fee
-                    error = _("Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.");
+                    error = strprintf(_("Fee estimation failed. %s is disabled. Wait a few blocks or enable %s."), "-fallbackfee", "-fallbackfee");
                     return false;
                 }
 
@@ -3920,7 +3920,7 @@ std::shared_ptr<CWallet> CWallet::Create(interfaces::Chain& chain, const std::st
     if (gArgs.IsArgSet("-fallbackfee")) {
         CAmount nFeePerK = 0;
         if (!ParseMoney(gArgs.GetArg("-fallbackfee", ""), nFeePerK)) {
-            error = strprintf(_("Invalid amount for -fallbackfee=<amount>: '%s'"), gArgs.GetArg("-fallbackfee", ""));
+            error = strprintf(_("Invalid amount for %s=<amount>: '%s'"), "-fallbackfee", gArgs.GetArg("-fallbackfee", ""));
             return nullptr;
         }
         if (nFeePerK > HIGH_TX_FEE_PER_KB) {
@@ -3935,7 +3935,7 @@ std::shared_ptr<CWallet> CWallet::Create(interfaces::Chain& chain, const std::st
     if (gArgs.IsArgSet("-discardfee")) {
         CAmount nFeePerK = 0;
         if (!ParseMoney(gArgs.GetArg("-discardfee", ""), nFeePerK)) {
-            error = strprintf(_("Invalid amount for -discardfee=<amount>: '%s'"), gArgs.GetArg("-discardfee", ""));
+            error = strprintf(_("Invalid amount for %s=<amount>: '%s'"), "-discardfee", gArgs.GetArg("-discardfee", ""));
             return nullptr;
         }
         if (nFeePerK > HIGH_TX_FEE_PER_KB) {
@@ -3956,8 +3956,8 @@ std::shared_ptr<CWallet> CWallet::Create(interfaces::Chain& chain, const std::st
         }
         walletInstance->m_pay_tx_fee = CFeeRate(nFeePerK, 1000);
         if (walletInstance->m_pay_tx_fee < chain.relayMinFee()) {
-            error = strprintf(_("Invalid amount for -paytxfee=<amount>: '%s' (must be at least %s)"),
-                gArgs.GetArg("-paytxfee", ""), chain.relayMinFee().ToString());
+            error = strprintf(_("Invalid amount for %s=<amount>: '%s' (must be at least %s)."),
+                "-paytxfee", gArgs.GetArg("-paytxfee", ""), chain.relayMinFee().ToString());
             return nullptr;
         }
     }
@@ -3969,11 +3969,11 @@ std::shared_ptr<CWallet> CWallet::Create(interfaces::Chain& chain, const std::st
             return nullptr;
         }
         if (nMaxFee > HIGH_MAX_TX_FEE) {
-            warnings.push_back(_("-maxtxfee is set very high! Fees this large could be paid on a single transaction."));
+            warnings.push_back(strprintf(_("%s is set very high! Fees this large could be paid on a single transaction."), "-maxtxfee"));
         }
         if (CFeeRate(nMaxFee, 1000) < chain.relayMinFee()) {
-            error = strprintf(_("Invalid amount for -maxtxfee=<amount>: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)"),
-                gArgs.GetArg("-maxtxfee", ""), chain.relayMinFee().ToString());
+            error = strprintf(_("Invalid amount for %s=<amount>: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)."),
+                "-maxtxfee", gArgs.GetArg("-maxtxfee", ""), chain.relayMinFee().ToString());
             return nullptr;
         }
         walletInstance->m_default_max_tx_fee = nMaxFee;
@@ -4041,7 +4041,7 @@ std::shared_ptr<CWallet> CWallet::Create(interfaces::Chain& chain, const std::st
             }
 
             if (rescan_height != block_height) {
-                error = _("Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)");
+                error = strprintf(_("Prune: last wallet synchronisation goes beyond pruned data. You need to %s (download the whole block chain again in case of pruned node)."), "-reindex");
                 return nullptr;
             }
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2800,7 +2800,7 @@ bool CWallet::CreateTransactionInternal(
                 // destination in case we don't need change.
                 CTxDestination dest;
                 if (!reservedest.GetReservedDestination(dest, true)) {
-                    error = _("Transaction needs a change address, but we can't generate it. Please call keypoolrefill first.");
+                    error = strprintf(_("Transaction needs a change address, but we can't generate it. Please call %s first."), "keypoolrefill");
                 }
                 scriptChange = GetScriptForDestination(dest);
                 // A valid destination implies a change script (and
@@ -3346,7 +3346,7 @@ bool CWallet::GetNewChangeDestination(const OutputType type, CTxDestination& des
 
     ReserveDestination reservedest(this, type);
     if (!reservedest.GetReservedDestination(dest, true)) {
-        error = _("Error: Keypool ran out, please call keypoolrefill first").translated;
+        error = strprintf(_("Error: Keypool ran out, please call %s first"), "keypoolrefill").translated;
         return false;
     }
 

--- a/test/functional/feature_uacomment.py
+++ b/test/functional/feature_uacomment.py
@@ -27,7 +27,7 @@ class UacommentTest(BitcoinTestFramework):
 
         self.log.info("test -uacomment max length")
         self.stop_node(0)
-        expected = r"Error: Total length of network version string \([0-9]+\) exceeds maximum length \(256\). Reduce the number or size of uacomments."
+        expected = r"Error: Total length of network version string \([0-9]+\) exceeds maximum length \(256\). Reduce the number or size of -uacomment."
         self.nodes[0].assert_start_raises_init_error(["-uacomment=" + 'a' * 256], expected, match=ErrorMatch.FULL_REGEX)
 
         self.log.info("test -uacomment unsafe characters")


### PR DESCRIPTION
This PR removes the following tokens from translatable strings:
- command line option names
- RPC names
- debug log file name

All of them are untranslatable by their nature.

The Translation Strings Policy updated accordingly.

This was done while reviewing #20401. Good to get it just after 0.21 branch off :)