### PR TITLE
p2p: avoid calculating onion address checksum when version is not 3 

### DIFF
--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -255,10 +255,14 @@ bool CNetAddr::SetSpecial(const std::string& str)
         Span<const uint8_t> input_checksum{input.data() + ADDR_TORV3_SIZE, torv3::CHECKSUM_LEN};
         Span<const uint8_t> input_version{input.data() + ADDR_TORV3_SIZE + torv3::CHECKSUM_LEN, sizeof(torv3::VERSION)};
 
+        if (input_version != torv3::VERSION) {
+            return false;
+        }
+
         uint8_t calculated_checksum[torv3::CHECKSUM_LEN];
         torv3::Checksum(input_pubkey, calculated_checksum);
 
-        if (input_checksum != calculated_checksum || input_version != torv3::VERSION) {
+        if (input_checksum != calculated_checksum) {
             return false;
         }
 


### PR DESCRIPTION
Currently when parsing an onion v3 address the pubic key checksum is calculated in order to compare it with the received address checksum. However this step is not necessary if the address version byte is not 3, in which case the method can return with false immediately.

