### PR TITLE
test: Fix Version Message Deserialization Discrepancy

### DIFF
--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -227,7 +227,7 @@ class FilterTest(BitcoinTestFramework):
         version_without_fRelay = msg_version()
         version_without_fRelay.nVersion = P2P_VERSION
         version_without_fRelay.nServices = P2P_SERVICES
-        version_without_fRelay.strSubVer = P2P_SUBVERSION
+        version_without_fRelay.strSubVer = P2P_SUBVERSION.encode('utf-8')
         version_without_fRelay.relay = 0
         filter_peer_without_nrelay.send_message(version_without_fRelay)
         filter_peer_without_nrelay.wait_for_verack()

--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -21,6 +21,7 @@ from test_framework.messages import (
 )
 from test_framework.p2p import (
     P2PInterface,
+    P2P_SERVICES,
     P2P_SUBVERSION,
     P2P_VERSION,
     p2p_lock,
@@ -225,6 +226,7 @@ class FilterTest(BitcoinTestFramework):
         # Send version with relay=False
         version_without_fRelay = msg_version()
         version_without_fRelay.nVersion = P2P_VERSION
+        version_without_fRelay.nServices = P2P_SERVICES
         version_without_fRelay.strSubVer = P2P_SUBVERSION
         version_without_fRelay.relay = 0
         filter_peer_without_nrelay.send_message(version_without_fRelay)

--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -222,11 +222,11 @@ class FilterTest(BitcoinTestFramework):
         self.log.info('Test BIP 37 for a node with fRelay = False')
         # Add peer but do not send version yet
         filter_peer_without_nrelay = self.nodes[0].add_p2p_connection(P2PBloomFilter(), send_version=False, wait_for_verack=False)
-        # Send version with fRelay=False
+        # Send version with relay=False
         version_without_fRelay = msg_version()
         version_without_fRelay.nVersion = P2P_VERSION
         version_without_fRelay.strSubVer = P2P_SUBVERSION
-        version_without_fRelay.nRelay = 0
+        version_without_fRelay.relay = 0
         filter_peer_without_nrelay.send_message(version_without_fRelay)
         filter_peer_without_nrelay.wait_for_verack()
         assert not self.nodes[0].getpeerinfo()[0]['relaytxes']

--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -21,6 +21,7 @@ from test_framework.messages import (
 )
 from test_framework.p2p import (
     P2PInterface,
+    P2P_SUBVERSION,
     P2P_VERSION,
     p2p_lock,
 )
@@ -224,6 +225,7 @@ class FilterTest(BitcoinTestFramework):
         # Send version with fRelay=False
         version_without_fRelay = msg_version()
         version_without_fRelay.nVersion = P2P_VERSION
+        version_without_fRelay.strSubVer = P2P_SUBVERSION
         version_without_fRelay.nRelay = 0
         filter_peer_without_nrelay.send_message(version_without_fRelay)
         filter_peer_without_nrelay.wait_for_verack()

--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -19,7 +19,11 @@ from test_framework.messages import (
     msg_mempool,
     msg_version,
 )
-from test_framework.p2p import P2PInterface, p2p_lock
+from test_framework.p2p import (
+    P2PInterface,
+    P2P_VERSION,
+    p2p_lock,
+)
 from test_framework.script import MAX_SCRIPT_ELEMENT_SIZE
 from test_framework.test_framework import BitcoinTestFramework
 
@@ -219,6 +223,7 @@ class FilterTest(BitcoinTestFramework):
         filter_peer_without_nrelay = self.nodes[0].add_p2p_connection(P2PBloomFilter(), send_version=False, wait_for_verack=False)
         # Send version with fRelay=False
         version_without_fRelay = msg_version()
+        version_without_fRelay.nVersion = P2P_VERSION
         version_without_fRelay.nRelay = 0
         filter_peer_without_nrelay.send_message(version_without_fRelay)
         filter_peer_without_nrelay.wait_for_verack()

--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -20,6 +20,7 @@ from test_framework.messages import (
 from test_framework.p2p import (
     P2PInterface,
     P2P_SUBVERSION,
+    P2P_VERSION_RELAY,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -145,13 +146,14 @@ class P2PLeakTest(BitcoinTestFramework):
         assert_equal(ver.addrFrom.port, 0)
         assert_equal(ver.addrFrom.ip, '0.0.0.0')
         assert_equal(ver.nStartingHeight, 201)
-        assert_equal(ver.nRelay, 1)
+        assert_equal(ver.relay, 1)
 
         self.log.info('Check that old peers are disconnected')
         p2p_old_peer = self.nodes[0].add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
         old_version_msg = msg_version()
         old_version_msg.nVersion = 31799
         old_version_msg.strSubVer = P2P_SUBVERSION
+        old_version_msg.relay = P2P_VERSION_RELAY
         with self.nodes[0].assert_debug_log(['peer=4 using obsolete version 31799; disconnecting']):
             p2p_old_peer.send_message(old_version_msg)
             p2p_old_peer.wait_for_disconnect()

--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -20,6 +20,7 @@ from test_framework.messages import (
 from test_framework.p2p import (
     P2PInterface,
     P2P_SUBVERSION,
+    P2P_SERVICES,
     P2P_VERSION_RELAY,
 )
 from test_framework.test_framework import BitcoinTestFramework
@@ -152,6 +153,7 @@ class P2PLeakTest(BitcoinTestFramework):
         p2p_old_peer = self.nodes[0].add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
         old_version_msg = msg_version()
         old_version_msg.nVersion = 31799
+        old_version_msg.nServices = P2P_SERVICES
         old_version_msg.strSubVer = P2P_SUBVERSION
         old_version_msg.relay = P2P_VERSION_RELAY
         with self.nodes[0].assert_debug_log(['peer=4 using obsolete version 31799; disconnecting']):

--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -154,7 +154,7 @@ class P2PLeakTest(BitcoinTestFramework):
         old_version_msg = msg_version()
         old_version_msg.nVersion = 31799
         old_version_msg.nServices = P2P_SERVICES
-        old_version_msg.strSubVer = P2P_SUBVERSION
+        old_version_msg.strSubVer = P2P_SUBVERSION.encode('utf-8')
         old_version_msg.relay = P2P_VERSION_RELAY
         with self.nodes[0].assert_debug_log(['peer=4 using obsolete version 31799; disconnecting']):
             p2p_old_peer.send_message(old_version_msg)

--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -17,7 +17,10 @@ from test_framework.messages import (
     msg_ping,
     msg_version,
 )
-from test_framework.p2p import P2PInterface
+from test_framework.p2p import (
+    P2PInterface,
+    P2P_SUBVERSION,
+)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -148,6 +151,7 @@ class P2PLeakTest(BitcoinTestFramework):
         p2p_old_peer = self.nodes[0].add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
         old_version_msg = msg_version()
         old_version_msg.nVersion = 31799
+        old_version_msg.strSubVer = P2P_SUBVERSION
         with self.nodes[0].assert_debug_log(['peer=4 using obsolete version 31799; disconnecting']):
             p2p_old_peer.send_message(old_version_msg)
             p2p_old_peer.wait_for_disconnect()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -31,7 +31,6 @@ import time
 from test_framework.siphash import siphash256
 from test_framework.util import hex_str_to_bytes, assert_equal
 
-MIN_VERSION_SUPPORTED = 60001
 MY_VERSION = 70016  # past wtxid relay
 MY_SUBVERSION = b"/python-p2p-tester:0.0.3/"
 MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version messages (BIP37)

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1043,13 +1043,13 @@ class msg_version:
 
         self.nStartingHeight = struct.unpack("<i", f.read(4))[0]
 
-        if self.nVersion >= 70001:
-            # Relay field is optional for version 70001 onwards
-            try:
-                self.relay = struct.unpack("<b", f.read(1))[0]
-            except:
-                self.relay = 0
-        else:
+        # Relay field is optional for version 70001 onwards
+        # But, unconditionally check it to match behaviour in bitcoind
+        try:
+            self.relay = struct.unpack("<b", f.read(1))[0]
+        except KeyboardInterrupt:
+            raise KeyboardInterrupt
+        except:
             self.relay = 0
 
     def serialize(self):

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -31,7 +31,6 @@ import time
 from test_framework.siphash import siphash256
 from test_framework.util import hex_str_to_bytes, assert_equal
 
-MY_SUBVERSION = b"/python-p2p-tester:0.0.3/"
 MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version messages (BIP37)
 
 MAX_LOCATOR_SZ = 101
@@ -1028,7 +1027,7 @@ class msg_version:
         self.addrTo = CAddress()
         self.addrFrom = CAddress()
         self.nNonce = random.getrandbits(64)
-        self.strSubVer = MY_SUBVERSION
+        self.strSubVer = b''
         self.nStartingHeight = -1
         self.nRelay = MY_RELAY
 

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -31,8 +31,6 @@ import time
 from test_framework.siphash import siphash256
 from test_framework.util import hex_str_to_bytes, assert_equal
 
-MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version messages (BIP37)
-
 MAX_LOCATOR_SZ = 101
 MAX_BLOCK_BASE_SIZE = 1000000
 MAX_BLOOM_FILTER_SIZE = 36000
@@ -1016,7 +1014,7 @@ class CMerkleBlock:
 
 # Objects that correspond to messages on the wire
 class msg_version:
-    __slots__ = ("addrFrom", "addrTo", "nNonce", "nRelay", "nServices",
+    __slots__ = ("addrFrom", "addrTo", "nNonce", "relay", "nServices",
                  "nStartingHeight", "nTime", "nVersion", "strSubVer")
     msgtype = b"version"
 
@@ -1029,7 +1027,7 @@ class msg_version:
         self.nNonce = random.getrandbits(64)
         self.strSubVer = b''
         self.nStartingHeight = -1
-        self.nRelay = MY_RELAY
+        self.relay = 0
 
     def deserialize(self, f):
         self.nVersion = struct.unpack("<i", f.read(4))[0]
@@ -1048,11 +1046,11 @@ class msg_version:
         if self.nVersion >= 70001:
             # Relay field is optional for version 70001 onwards
             try:
-                self.nRelay = struct.unpack("<b", f.read(1))[0]
+                self.relay = struct.unpack("<b", f.read(1))[0]
             except:
-                self.nRelay = 0
+                self.relay = 0
         else:
-            self.nRelay = 0
+            self.relay = 0
 
     def serialize(self):
         r = b""
@@ -1064,14 +1062,14 @@ class msg_version:
         r += struct.pack("<Q", self.nNonce)
         r += ser_string(self.strSubVer)
         r += struct.pack("<i", self.nStartingHeight)
-        r += struct.pack("<b", self.nRelay)
+        r += struct.pack("<b", self.relay)
         return r
 
     def __repr__(self):
-        return 'msg_version(nVersion=%i nServices=%i nTime=%s addrTo=%s addrFrom=%s nNonce=0x%016X strSubVer=%s nStartingHeight=%i nRelay=%i)' \
+        return 'msg_version(nVersion=%i nServices=%i nTime=%s addrTo=%s addrFrom=%s nNonce=0x%016X strSubVer=%s nStartingHeight=%i relay=%i)' \
             % (self.nVersion, self.nServices, time.ctime(self.nTime),
                repr(self.addrTo), repr(self.addrFrom), self.nNonce,
-               self.strSubVer, self.nStartingHeight, self.nRelay)
+               self.strSubVer, self.nStartingHeight, self.relay)
 
 
 class msg_verack:

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1020,7 +1020,7 @@ class msg_version:
 
     def __init__(self):
         self.nVersion = 0
-        self.nServices = NODE_NETWORK | NODE_WITNESS
+        self.nServices = 0
         self.nTime = int(time.time())
         self.addrTo = CAddress()
         self.addrFrom = CAddress()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -31,7 +31,6 @@ import time
 from test_framework.siphash import siphash256
 from test_framework.util import hex_str_to_bytes, assert_equal
 
-MY_VERSION = 70016  # past wtxid relay
 MY_SUBVERSION = b"/python-p2p-tester:0.0.3/"
 MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version messages (BIP37)
 
@@ -326,22 +325,20 @@ class CBlockLocator:
     __slots__ = ("nVersion", "vHave")
 
     def __init__(self):
-        self.nVersion = MY_VERSION
         self.vHave = []
 
     def deserialize(self, f):
-        self.nVersion = struct.unpack("<i", f.read(4))[0]
+        struct.unpack("<i", f.read(4))[0]  # Ignore version field.
         self.vHave = deser_uint256_vector(f)
 
     def serialize(self):
         r = b""
-        r += struct.pack("<i", self.nVersion)
+        r += struct.pack("<i", 0)  # Bitcoin Core ignores version field. Set it to 0.
         r += ser_uint256_vector(self.vHave)
         return r
 
     def __repr__(self):
-        return "CBlockLocator(nVersion=%i vHave=%s)" \
-            % (self.nVersion, repr(self.vHave))
+        return "CBlockLocator(vHave=%s)" % (repr(self.vHave))
 
 
 class COutPoint:
@@ -1025,7 +1022,7 @@ class msg_version:
     msgtype = b"version"
 
     def __init__(self):
-        self.nVersion = MY_VERSION
+        self.nVersion = 0
         self.nServices = NODE_NETWORK | NODE_WITNESS
         self.nTime = int(time.time())
         self.addrTo = CAddress()

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -76,6 +76,9 @@ logger = logging.getLogger("TestFramework.p2p")
 
 # The minimum P2P version that this test framework supports
 MIN_P2P_VERSION_SUPPORTED = 60001
+# The P2P version that this test framework implements and sends in its `version` message
+# Version 70016 supports wtxid relay
+P2P_VERSION = 70016
 
 MESSAGEMAP = {
     b"addr": msg_addr,
@@ -317,6 +320,7 @@ class P2PInterface(P2PConnection):
         if send_version:
             # Send a version msg
             vt = msg_version()
+            vt.nVersion = P2P_VERSION
             vt.nServices = services
             vt.addrTo.ip = self.dstaddr
             vt.addrTo.port = self.dstport

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -81,6 +81,9 @@ MIN_P2P_VERSION_SUPPORTED = 60001
 P2P_VERSION = 70016
 # The P2P user agent string that this test framework sends in its `version` message
 P2P_SUBVERSION = b"/python-p2p-tester:0.0.3/"
+# Value for relay that this test framework sends in its `version` message
+P2P_VERSION_RELAY = 1
+
 
 MESSAGEMAP = {
     b"addr": msg_addr,
@@ -324,6 +327,7 @@ class P2PInterface(P2PConnection):
             vt = msg_version()
             vt.nVersion = P2P_VERSION
             vt.strSubVer = P2P_SUBVERSION
+            vt.relay = P2P_VERSION_RELAY
             vt.nServices = services
             vt.addrTo.ip = self.dstaddr
             vt.addrTo.port = self.dstport

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -79,6 +79,8 @@ MIN_P2P_VERSION_SUPPORTED = 60001
 # The P2P version that this test framework implements and sends in its `version` message
 # Version 70016 supports wtxid relay
 P2P_VERSION = 70016
+# The P2P user agent string that this test framework sends in its `version` message
+P2P_SUBVERSION = b"/python-p2p-tester:0.0.3/"
 
 MESSAGEMAP = {
     b"addr": msg_addr,
@@ -321,6 +323,7 @@ class P2PInterface(P2PConnection):
             # Send a version msg
             vt = msg_version()
             vt.nVersion = P2P_VERSION
+            vt.strSubVer = P2P_SUBVERSION
             vt.nServices = services
             vt.addrTo.ip = self.dstaddr
             vt.addrTo.port = self.dstport

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -31,7 +31,6 @@ import threading
 from test_framework.messages import (
     CBlockHeader,
     MAX_HEADERS_RESULTS,
-    MIN_VERSION_SUPPORTED,
     msg_addr,
     msg_addrv2,
     msg_block,
@@ -74,6 +73,9 @@ from test_framework.messages import (
 from test_framework.util import wait_until_helper
 
 logger = logging.getLogger("TestFramework.p2p")
+
+# The minimum P2P version that this test framework supports
+MIN_P2P_VERSION_SUPPORTED = 60001
 
 MESSAGEMAP = {
     b"addr": msg_addr,
@@ -393,7 +395,7 @@ class P2PInterface(P2PConnection):
         pass
 
     def on_version(self, message):
-        assert message.nVersion >= MIN_VERSION_SUPPORTED, "Version {} received. Test framework only supports versions greater than {}".format(message.nVersion, MIN_VERSION_SUPPORTED)
+        assert message.nVersion >= MIN_P2P_VERSION_SUPPORTED, "Version {} received. Test framework only supports versions greater than {}".format(message.nVersion, MIN_P2P_VERSION_SUPPORTED)
         if message.nVersion >= 70016:
             self.send_message(msg_wtxidrelay())
         self.send_message(msg_verack())

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -79,6 +79,8 @@ MIN_P2P_VERSION_SUPPORTED = 60001
 # The P2P version that this test framework implements and sends in its `version` message
 # Version 70016 supports wtxid relay
 P2P_VERSION = 70016
+# The services that this test framework offers in its `version` message
+P2P_SERVICES = NODE_NETWORK | NODE_WITNESS
 # The P2P user agent string that this test framework sends in its `version` message
 P2P_SUBVERSION = b"/python-p2p-tester:0.0.3/"
 # Value for relay that this test framework sends in its `version` message
@@ -319,7 +321,7 @@ class P2PInterface(P2PConnection):
 
         self.support_addrv2 = support_addrv2
 
-    def peer_connect(self, *args, services=NODE_NETWORK|NODE_WITNESS, send_version=True, **kwargs):
+    def peer_connect(self, *args, services=P2P_SERVICES, send_version=True, **kwargs):
         create_conn = super().peer_connect(*args, **kwargs)
 
         if send_version:

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -82,7 +82,7 @@ P2P_VERSION = 70016
 # The services that this test framework offers in its `version` message
 P2P_SERVICES = NODE_NETWORK | NODE_WITNESS
 # The P2P user agent string that this test framework sends in its `version` message
-P2P_SUBVERSION = b"/python-p2p-tester:0.0.3/"
+P2P_SUBVERSION = "/python-p2p-tester:0.0.3/"
 # Value for relay that this test framework sends in its `version` message
 P2P_VERSION_RELAY = 1
 
@@ -328,7 +328,7 @@ class P2PInterface(P2PConnection):
             # Send a version msg
             vt = msg_version()
             vt.nVersion = P2P_VERSION
-            vt.strSubVer = P2P_SUBVERSION
+            vt.strSubVer = P2P_SUBVERSION.encode('utf-8')
             vt.relay = P2P_VERSION_RELAY
             vt.nServices = services
             vt.addrTo.ip = self.dstaddr

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -23,7 +23,7 @@ import sys
 
 from .authproxy import JSONRPCException
 from .descriptors import descsum_create
-from .messages import MY_SUBVERSION
+from .p2p import P2P_SUBVERSION
 from .util import (
     MAX_NODES,
     append_config,
@@ -544,7 +544,7 @@ class TestNode():
 
     def num_test_p2p_connections(self):
         """Return number of test framework p2p connections to the node."""
-        return len([peer for peer in self.getpeerinfo() if peer['subver'] == MY_SUBVERSION.decode("utf-8")])
+        return len([peer for peer in self.getpeerinfo() if peer['subver'] == P2P_SUBVERSION.decode("utf-8")])
 
     def disconnect_p2ps(self):
         """Close all p2p connections to the node."""

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -26,6 +26,7 @@ from .descriptors import descsum_create
 from .p2p import P2P_SUBVERSION
 from .util import (
     MAX_NODES,
+    assert_equal,
     append_config,
     delete_cookie_file,
     get_auth_cookie,
@@ -540,11 +541,16 @@ class TestNode():
             # in comparison to the upside of making tests less fragile and unexpected intermittent errors less likely.
             p2p_conn.sync_with_ping()
 
+            # Consistency check that the Bitcoin Core has received our user agent string. This checks the
+            # node's newest peer. It could be racy if another Bitcoin Core node has connected since we opened
+            # our connection, but we don't expect that to happen.
+            assert_equal(self.getpeerinfo()[-1]['subver'], P2P_SUBVERSION)
+
         return p2p_conn
 
     def num_test_p2p_connections(self):
         """Return number of test framework p2p connections to the node."""
-        return len([peer for peer in self.getpeerinfo() if peer['subver'] == P2P_SUBVERSION.decode("utf-8")])
+        return len([peer for peer in self.getpeerinfo() if peer['subver'] == P2P_SUBVERSION])
 
     def disconnect_p2ps(self):
         """Close all p2p connections to the node."""


### PR DESCRIPTION
Inspired by theStack's in Per-Peer Message Capture [here](https://github.com/bitcoin/bitcoin/pull/19509#issuecomment-727627176).  More context [here](https://github.com/bitcoin/bitcoin/pull/19509#issuecomment-729302211) and relevant BIPs are [BIP37](https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki?rgh-link-date=2020-11-15T19%3A59%3A03Z#Extensions_to_existing_messages) and [BIP60](https://github.com/bitcoin/bips/blob/master/bip-0060.mediawiki?rgh-link-date=2020-11-15T19%3A59%3A03Z) (draft).

There is a discrepancy in the implementation of our p2p protocol between bitcoind and the testing framework.  The fRelay field is an optional field at the end of a version message as of protocol version 70001. However, when deserializing a message in bitcoind, we don't check the version to see if it can have an fRelay field or not.  Instead we unconditionally attempt to deserialize into the field.

This commit brings the testing framework in line with the implementation in core.

This matters for a version message with the following fields:

Version = 60000
fRelay = 1

Bitcoind would deserialize this into a version message with Version=60000 and fRelay=1, whereas (before this PR) our testing framework would deserialize this into a version message with Version=60000 and fRelay=0.

~~Concept ACK needed.  Alternative: Change behavior in core?~~  Got a few 😄 