### PR TITLE
net: Remove SetMaxOutboundTimeframe()

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2874,18 +2874,6 @@ uint64_t CConnman::GetMaxOutboundTimeLeftInCycle()
     return (cycleEndTime < now) ? 0 : cycleEndTime - GetTime();
 }
 
-void CConnman::SetMaxOutboundTimeframe(uint64_t timeframe)
-{
-    LOCK(cs_totalBytesSent);
-    if (nMaxOutboundTimeframe != timeframe)
-    {
-        // reset measure-cycle in case of changing
-        // the timeframe
-        nMaxOutboundCycleStartTime = GetTime();
-    }
-    nMaxOutboundTimeframe = timeframe;
-}
-
 bool CConnman::OutboundTargetReached(bool historicalBlockServingLimit)
 {
     LOCK(cs_totalBytesSent);

--- a/src/net.h
+++ b/src/net.h
@@ -365,8 +365,6 @@ public:
     void SetMaxOutboundTarget(uint64_t limit);
     uint64_t GetMaxOutboundTarget();
 
-    //!set the timeframe for the max outbound target
-    void SetMaxOutboundTimeframe(uint64_t timeframe);
     uint64_t GetMaxOutboundTimeframe();
 
     //! check if the outbound target is reached

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -31,7 +31,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     CSubNet random_subnet;
     std::string random_string;
     while (fuzzed_data_provider.ConsumeBool()) {
-        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 30)) {
+        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 29)) {
         case 0:
             random_address = ConsumeAddress(fuzzed_data_provider);
             break;
@@ -130,15 +130,12 @@ void test_one_input(const std::vector<uint8_t>& buffer)
             connman.SetMaxOutboundTarget(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
             break;
         case 27:
-            connman.SetMaxOutboundTimeframe(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
-            break;
-        case 28:
             connman.SetNetworkActive(fuzzed_data_provider.ConsumeBool());
             break;
-        case 29:
+        case 28:
             connman.SetServices(random_service, static_cast<ServiceFlags>(fuzzed_data_provider.ConsumeIntegral<uint64_t>()));
             break;
-        case 30:
+        case 29:
             connman.SetTryNewOutboundPeer(fuzzed_data_provider.ConsumeBool());
             break;
         }


### PR DESCRIPTION
This has been unused since it was introduced in 872fee3fccc8b33b9af0a401b5f85ac5504b57eb.