### PR TITLE
wallet: Don't upgrade to HD split if it is already supported

### DIFF
--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -453,7 +453,7 @@ bool LegacyScriptPubKeyMan::Upgrade(int prev_version, int new_version, bilingual
         hd_upgrade = true;
     }
     // Upgrade to HD chain split if necessary
-    if (IsFeatureSupported(new_version, FEATURE_HD_SPLIT)) {
+    if (!IsFeatureSupported(prev_version, FEATURE_HD_SPLIT) && IsFeatureSupported(new_version, FEATURE_HD_SPLIT)) {
         WalletLogPrintf("Upgrading wallet to use HD chain split\n");
         m_storage.SetMinVersion(FEATURE_PRE_SPLIT_KEYPOOL);
         split_upgrade = FEATURE_HD_SPLIT > prev_version;

--- a/test/functional/wallet_upgradewallet.py
+++ b/test/functional/wallet_upgradewallet.py
@@ -338,6 +338,7 @@ class UpgradeWalletTest(BitcoinTestFramework):
         new_kvs = dump_bdb_kv(node_master_wallet)
         up_defaultkey = new_kvs[b'\x0adefaultkey']
         assert_equal(defaultkey, up_defaultkey)
+        assert_equal(wallet.getwalletinfo()["walletversion"], 159900)
         # 0.16.3 doesn't have a default key
         v16_3_kvs = dump_bdb_kv(v16_3_wallet)
         assert b'\x0adefaultkey' not in v16_3_kvs


### PR DESCRIPTION
It is unnecessary to upgrade to FEATURE_HD_SPLIT if this feature is already supported by the wallet. Because upgrading to FEATURE_HD_SPLIT actually requires upgrading to FEATURE_PRE_SPLIT_KEYPOOL, users would accidentally be upgraded to FEATURE_PRE_SPLIT_KEYPOOL instead of nothing being done.

Fixes the issue described at https://github.com/bitcoin/bitcoin/pull/20403#discussion_r526063920

Needs backport to 0.21