### PR TITLE
build: Update univalue subtree

### DIFF
--- a/include/univalue.h
+++ b/include/univalue.h
@@ -100,6 +100,10 @@ public:
         UniValue tmpVal(val_);
         return push_back(tmpVal);
     }
+    bool push_back(bool val_) {
+        UniValue tmpVal(val_);
+        return push_back(tmpVal);
+    }
     bool push_back(int val_) {
         UniValue tmpVal(val_);
         return push_back(tmpVal);
@@ -129,7 +133,7 @@ public:
         return pushKV(key, tmpVal);
     }
     bool pushKV(const std::string& key, bool val_) {
-        UniValue tmpVal((bool)val_);
+        UniValue tmpVal(val_);
         return pushKV(key, tmpVal);
     }
     bool pushKV(const std::string& key, int val_) {

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -210,19 +210,31 @@ BOOST_AUTO_TEST_CASE(univalue_array)
     BOOST_CHECK(arr.push_back((int64_t) -400LL));
     BOOST_CHECK(arr.push_back((int) -401));
     BOOST_CHECK(arr.push_back(-40.1));
+    BOOST_CHECK(arr.push_back(true));
 
     BOOST_CHECK_EQUAL(arr.empty(), false);
-    BOOST_CHECK_EQUAL(arr.size(), 9);
+    BOOST_CHECK_EQUAL(arr.size(), 10);
 
     BOOST_CHECK_EQUAL(arr[0].getValStr(), "1023");
+    BOOST_CHECK_EQUAL(arr[0].getType(), UniValue::VNUM);
     BOOST_CHECK_EQUAL(arr[1].getValStr(), "zippy");
+    BOOST_CHECK_EQUAL(arr[1].getType(), UniValue::VSTR);
     BOOST_CHECK_EQUAL(arr[2].getValStr(), "pippy");
+    BOOST_CHECK_EQUAL(arr[2].getType(), UniValue::VSTR);
     BOOST_CHECK_EQUAL(arr[3].getValStr(), "boing");
+    BOOST_CHECK_EQUAL(arr[3].getType(), UniValue::VSTR);
     BOOST_CHECK_EQUAL(arr[4].getValStr(), "going");
+    BOOST_CHECK_EQUAL(arr[4].getType(), UniValue::VSTR);
     BOOST_CHECK_EQUAL(arr[5].getValStr(), "400");
+    BOOST_CHECK_EQUAL(arr[5].getType(), UniValue::VNUM);
     BOOST_CHECK_EQUAL(arr[6].getValStr(), "-400");
+    BOOST_CHECK_EQUAL(arr[6].getType(), UniValue::VNUM);
     BOOST_CHECK_EQUAL(arr[7].getValStr(), "-401");
+    BOOST_CHECK_EQUAL(arr[7].getType(), UniValue::VNUM);
     BOOST_CHECK_EQUAL(arr[8].getValStr(), "-40.1");
+    BOOST_CHECK_EQUAL(arr[8].getType(), UniValue::VNUM);
+    BOOST_CHECK_EQUAL(arr[9].getValStr(), "1");
+    BOOST_CHECK_EQUAL(arr[9].getType(), UniValue::VBOOL);
 
     BOOST_CHECK_EQUAL(arr[999].getValStr(), "");
 


### PR DESCRIPTION
Just a minor bugfix: Currently we don't push booleans into arrays, but if we did they'd be pushed as integers.

Can be tested by reverting the diff in `include/` and observing a test failure.