### PR TITLE
fuzz: Make CAddrMan fuzzing harness deterministic

### DIFF
--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -22,12 +22,22 @@ void initialize()
     SelectParams(CBaseChainParams::REGTEST);
 }
 
+class CAddrManDeterministic : public CAddrMan
+{
+public:
+    void MakeDeterministic(const uint256& random_seed)
+    {
+        insecure_rand = FastRandomContext{random_seed};
+        Clear();
+    }
+};
+
 void test_one_input(const std::vector<uint8_t>& buffer)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-
     SetMockTime(ConsumeTime(fuzzed_data_provider));
-    CAddrMan addr_man;
+    CAddrManDeterministic addr_man;
+    addr_man.MakeDeterministic(ConsumeUInt256(fuzzed_data_provider));
     if (fuzzed_data_provider.ConsumeBool()) {
         addr_man.m_asmap = ConsumeRandomLengthBitVector(fuzzed_data_provider);
         if (!SanityCheckASMap(addr_man.m_asmap)) {

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -98,7 +98,8 @@ NODISCARD inline CAmount ConsumeMoney(FuzzedDataProvider& fuzzed_data_provider) 
 
 NODISCARD inline int64_t ConsumeTime(FuzzedDataProvider& fuzzed_data_provider) noexcept
 {
-    static const int64_t time_min = ParseISO8601DateTime("1970-01-01T00:00:00Z");
+    // Avoid t=0 (1970-01-01T00:00:00Z) since SetMockTime(0) is a no-op.
+    static const int64_t time_min = ParseISO8601DateTime("1970-01-01T00:00:01Z");
     static const int64_t time_max = ParseISO8601DateTime("9999-12-31T23:59:59Z");
     return fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(time_min, time_max);
 }


### PR DESCRIPTION
Make `CAddrMan` fuzzing harness deterministic.

See [`doc/fuzzing.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md) for information on how to fuzz Bitcoin Core. Don't forget to contribute any coverage increasing inputs you find to the [Bitcoin Core fuzzing corpus repo](https://github.com/bitcoin-core/qa-assets).

Happy fuzzing :)