### PR TITLE
sanitizers: Add suppression for unsigned-integer-overflow in libstdc++

### DIFF
--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -6,6 +6,7 @@
 # contains files in which we expect unsigned integer overflows to occur. The
 # list is used to suppress -fsanitize=integer warnings when running our CI UBSan
 # job.
+unsigned-integer-overflow:*/include/c++/*/bits/basic_string.tcc
 unsigned-integer-overflow:arith_uint256.h
 unsigned-integer-overflow:basic_string.h
 unsigned-integer-overflow:bench/bench.h


### PR DESCRIPTION
Reported here: https://bitcoinbuilds.org/logs/e35cd579-0f0f-47e4-b49a-4ceba8ff9830.log
Issue: https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/include/bits/basic_string.tcc#L1271