### PR TITLE
util: use stronger-guarantee rename method

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -71,7 +71,9 @@
 #endif
 
 #include <boost/algorithm/string/replace.hpp>
+#include <filesystem>
 #include <optional>
+#include <system_error>
 #include <thread>
 #include <typeinfo>
 #include <univalue.h>
@@ -1064,13 +1066,9 @@ void ArgsManager::LogArgs() const
 
 bool RenameOver(fs::path src, fs::path dest)
 {
-#ifdef WIN32
-    return MoveFileExW(src.wstring().c_str(), dest.wstring().c_str(),
-                       MOVEFILE_REPLACE_EXISTING) != 0;
-#else
-    int rc = std::rename(src.c_str(), dest.c_str());
-    return (rc == 0);
-#endif /* WIN32 */
+    std::error_code error;
+    std::filesystem::rename(src, dest, error);
+    return !error;
 }
 
 /**

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -69,7 +69,13 @@ void DirectoryCommit(const fs::path &dirname);
 bool TruncateFile(FILE *file, unsigned int length);
 int RaiseFileDescriptorLimit(int nMinFD);
 void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length);
+
+/**
+ * Rename src to dest.
+ * @return true if the rename was successful.
+ */
 [[nodiscard]] bool RenameOver(fs::path src, fs::path dest);
+
 bool LockDirectory(const fs::path& directory, const std::string lockfile_name, bool probe_only=false);
 void UnlockDirectory(const fs::path& directory, const std::string& lockfile_name);
 bool DirIsWritable(const fs::path& directory);


### PR DESCRIPTION
Use `std::filesystem::rename()` instead of `std::rename()`. We rely on the
destination to be overwritten if it exists, but `std::rename()`'s behavior
is implementation-defined in this case.