### PR TITLE
depends: Add a nasty qt hack to work around clang non-determinism

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -238,7 +238,8 @@ define $(package)_config_cmds
   cd ../qttranslations && ../qtbase/bin/qmake qttranslations.pro -o Makefile && \
   cd translations && ../../qtbase/bin/qmake translations.pro -o Makefile && cd ../.. && \
   cd qttools/src/linguist/lrelease/ && ../../../../qtbase/bin/qmake lrelease.pro -o Makefile && \
-  cd ../lupdate/ && ../../../../qtbase/bin/qmake lupdate.pro -o Makefile && cd ../../../..
+  cd ../lupdate/ && ../../../../qtbase/bin/qmake lupdate.pro -o Makefile && cd ../../../.. && \
+  echo ".obj/qpaintengine_raster.o: CXXFLAGS += -O2" >> qtbase/src/gui/Makefile
 endef
 
 define $(package)_build_cmds


### PR DESCRIPTION
PR'ing into 0.21 because I don't think we want a hack like this in master.

Clang fixed a determinism bug in the 9.x series: https://github.com/llvm/llvm-project/commit/db101864bdc938deb1d63fe4f7da761bd38e5cae

It was never backported to 8.x, however. I have manually back-ported the fix to 8.x here in case it's useful (with Guix, for example): https://github.com/theuni/llvm-project/commit/df4158d8577618c1f728f89ca88aad5eead656a7

Credit Carl Dong for discovering the determinism problem while working on Guix.

Clang 8.x emits non-deterministic code, but only with certain compile options enabled (-O2 is fine but -O3 is problematic; I haven't tracked down the exact guilty flag), and only when compiling very specific code.

Qt builds with -O3, so we special-case the source file that manages to trigger the bug and force it to -O2. gcc/clang honor the _last_ -O option, so appending is fine.

I suspect @fanquake will hate the fact that we're echoing into a generated file. This would be much cleaner if done at the qmake level, but I'm not sure how to do that.

This is a quick nasty work-around, so here are some other potential options:
- Bump to clang9 where this is fixed
- As @dongcarl suggested: rewrite the some of the qt function (`qt_intersect_spans` in qpaintengine_raster.cpp) to avoid hitting the non-determinism
- Disable the buggy behavior via cmdline option

I've opted for the last option (Using -O2 as a large hammer), because it was the quickest to write, but the second option would be fine as well. I don't have much of a preference, this is a huge layer violation either way. :)

I'd prefer not to bump clang this late in the release process, though.