### PR TITLE
build: fix determinism issue when building qt with Clang 8

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -12,7 +12,7 @@ $(package)_patches=fix_qt_pkgconfig.patch mac-qmake.conf fix_configure_mac.patch
 $(package)_patches+= fix_rcc_determinism.patch fix_riscv64_arch.patch xkb-default.patch no-xlib.patch
 $(package)_patches+= fix_android_qmake_conf.patch fix_android_jni_static.patch dont_hardcode_pwd.patch
 $(package)_patches+= freetype_back_compat.patch drop_lrelease_dependency.patch fix_powerpc_libpng.patch
-$(package)_patches+= fix_mingw_cross_compile.patch
+$(package)_patches+= fix_mingw_cross_compile.patch fix_llvm_determinism.patch
 
 # Update OSX_QT_TRANSLATIONS when this is updated
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
@@ -217,6 +217,7 @@ endef
 # 8. Adjust a regex in toolchain.prf, to accomodate Guix's usage of
 # CROSS_LIBRARY_PATH. See #15277.
 define $(package)_preprocess_cmds
+  patch -p1 -i $($(package)_patch_dir)/fix_llvm_determinism.patch && \
   patch -p1 -i $($(package)_patch_dir)/freetype_back_compat.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_powerpc_libpng.patch && \
   patch -p1 -i $($(package)_patch_dir)/drop_lrelease_dependency.patch && \

--- a/depends/patches/qt/fix_llvm_determinism.patch
+++ b/depends/patches/qt/fix_llvm_determinism.patch
@@ -1,0 +1,46 @@
+commit f967441837e0f7f88234d18177850e0aefc57dba
+Author: fanquake <fanquake@gmail.com>
+Date:   Sat Nov 21 11:44:47 2020 +0800
+
+    build: fix determinism issue when compiling with Clang 8.0.0
+    
+    When building Qt using LLVM/Clang 8 under -O3 (it's default),
+    we run into a determinism issue in qt_intersect_spans (qpaintengine_raster.cpp).
+    
+    The issue has been fixed upstream
+    https://github.com/llvm/llvm-project/commit/db101864bdc938deb1d63fe4f7da761bd38e5cae
+    & https://reviews.llvm.org/D64601, however the fix has not been
+    backported to the 8.x branch.
+    
+    To work around this, we special-case the file causing the issue, and
+    compile it with -O2.
+    
+    The patch is also scoped to only darwin builds, as that is the only
+    platform which is built using the non-deterministic compiler.
+
+diff --git a/qtbase/src/gui/painting/painting.pri b/qtbase/src/gui/painting/painting.pri
+index 63e345545c0..2a671d71cc0 100644
+--- a/qtbase/src/gui/painting/painting.pri
++++ b/qtbase/src/gui/painting/painting.pri
+@@ -133,3 +133,21 @@ MIPS_DSP_ASM += painting/qdrawhelper_mips_dsp_asm.S
+ MIPS_DSPR2_ASM += painting/qdrawhelper_mips_dspr2_asm.S
+ 
+ include($$PWD/../../3rdparty/zlib_dependency.pri)
++
++darwin {
++    PAINTENGINE_RASTER_SOURCES = painting/qpaintengine_raster.cpp
++
++    qpaintengine_raster_O2.commands = $$QMAKE_CXX -c $(CXXFLAGS) $(INCPATH)
++
++    # use -O2 instead of -O3 to work around a determinism issue when building with Clang 8
++    qpaintengine_raster_O2.commands += -O2
++
++    qpaintengine_raster_O2.commands += -o ${QMAKE_FILE_OUT} ${QMAKE_FILE_IN}
++    qpaintengine_raster_O2.dependency_type = TYPE_C
++    qpaintengine_raster_O2.output = ${QMAKE_VAR_OBJECTS_DIR}${QMAKE_FILE_BASE}$${first(QMAKE_EXT_OBJ)}
++    qpaintengine_raster_O2.input = PAINTENGINE_RASTER_SOURCES
++    qpaintengine_raster_O2.variable_out = OBJECTS
++    qpaintengine_raster_O2.name = compiling[qpaintengine_raster_O2] ${QMAKE_FILE_IN}
++    silent: qpaintengine_raster_O2.commands = @echo compiling[qpaintengine_raster_O2] ${QMAKE_FILE_IN} && $$qpaintengine_raster_O2.commands
++    QMAKE_EXTRA_COMPILERS += qpaintengine_raster_O2
++}


### PR DESCRIPTION
Potential alternative to #20436. This is a patch, rather than changes being `echo`'d into the `src/gui/Makefile` post configure. It's also scoped to just darwin. Changes are based off `versiontagging_compiler` in corelib/global/global.pri.

From #20436:
> I suspect @fanquake will hate the fact that we're echoing into a generated file. This would be much cleaner if done at the qmake level

I guess this is at the `qmake` level, but still feels like a bit of a hack. If we decide to go this way will add Carl/Cory as co-authors.