### PR TITLE
test: add is_bdb_compiled helper

### DIFF
--- a/test/config.ini.in
+++ b/test/config.ini.in
@@ -17,6 +17,7 @@ RPCAUTH=@abs_top_srcdir@/share/rpcauth/rpcauth.py
 # Which components are enabled. These are commented out by `configure` if they were disabled when running config.
 @ENABLE_WALLET_TRUE@ENABLE_WALLET=true
 @USE_SQLITE_TRUE@USE_SQLITE=true
+@USE_BDB_TRUE@USE_BDB=true
 @BUILD_BITCOIN_CLI_TRUE@ENABLE_CLI=true
 @BUILD_BITCOIN_WALLET_TRUE@ENABLE_WALLET_TOOL=true
 @BUILD_BITCOIND_TRUE@ENABLE_BITCOIND=true

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -782,6 +782,11 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         if not self.is_sqlite_compiled():
             raise SkipTest("sqlite has not been compiled.")
 
+    def skip_if_no_bdb(self):
+        """Skip the running test if BDB has not been compiled."""
+        if not self.is_bdb_compiled():
+            raise SkipTest("BDB has not been compiled.")
+
     def skip_if_no_wallet_tool(self):
         """Skip the running test if bitcoin-wallet has not been compiled."""
         if not self.is_wallet_tool_compiled():
@@ -822,5 +827,9 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         return self.config["components"].getboolean("ENABLE_ZMQ")
 
     def is_sqlite_compiled(self):
-        """Checks whether the wallet module was compiled."""
+        """Checks whether the wallet module was compiled with Sqlite support."""
         return self.config["components"].getboolean("USE_SQLITE")
+
+    def is_bdb_compiled(self):
+        """Checks whether the wallet module was compiled with BDB support."""
+        return self.config["components"].getboolean("USE_BDB")


### PR DESCRIPTION
Followup for #20202, needed by #16546.

Allow the functional test suite to skip tests that require BDB, as well as introduce specific logic to handle whether BDB support is enabled or not. It follows the same pattern as `skip_if_no_sqlite` and `is_sqlite_compiled`.