### PR TITLE
rpc: Validate -rpcauth arguments

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -80,6 +80,8 @@ Updated settings
 
 Changes to Wallet or GUI related settings can be found in the GUI or Wallet section below.
 
+- Passing an invalid `-rpcauth` argument now cause bitcoind to fail to start.  (#20461)
+
 Tools and Utilities
 -------------------
 

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -253,11 +253,14 @@ static bool InitRPCAuthentication()
     if (gArgs.GetArg("-rpcauth","") != "")
     {
         LogPrintf("Using rpcauth authentication.\n");
-        for (std::string rpcauth : gArgs.GetArgs("-rpcauth")) {
+        for (const std::string& rpcauth : gArgs.GetArgs("-rpcauth")) {
             std::vector<std::string> fields;
             boost::split(fields, rpcauth, boost::is_any_of(":$"));
             if (fields.size() == 3) {
                 g_rpcauth.push_back(fields);
+            } else {
+                LogPrintf("Invalid -rpcauth argument.\n");
+                return false;
             }
         }
     }

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -68,6 +68,8 @@ private:
 static std::string strRPCUserColonPass;
 /* Stored RPC timer interface (for unregistration) */
 static std::unique_ptr<HTTPRPCTimerInterface> httpRPCTimerInterface;
+/* List of -rpcauth values */
+static std::vector<std::vector<std::string>> g_rpcauth;
 /* RPC Auth Whitelist */
 static std::map<std::string, std::set<std::string>> g_rpc_whitelist;
 static bool g_rpc_whitelist_default = false;
@@ -99,15 +101,7 @@ static bool multiUserAuthorized(std::string strUserPass)
     std::string strUser = strUserPass.substr(0, strUserPass.find(':'));
     std::string strPass = strUserPass.substr(strUserPass.find(':') + 1);
 
-    for (const std::string& strRPCAuth : gArgs.GetArgs("-rpcauth")) {
-        //Search for multi-user login/pass "rpcauth" from config
-        std::vector<std::string> vFields;
-        boost::split(vFields, strRPCAuth, boost::is_any_of(":$"));
-        if (vFields.size() != 3) {
-            //Incorrect formatting in config file
-            continue;
-        }
-
+    for (const auto& vFields : g_rpcauth) {
         std::string strName = vFields[0];
         if (!TimingResistantEqual(strName, strUser)) {
             continue;
@@ -259,6 +253,13 @@ static bool InitRPCAuthentication()
     if (gArgs.GetArg("-rpcauth","") != "")
     {
         LogPrintf("Using rpcauth authentication.\n");
+        for (std::string rpcauth : gArgs.GetArgs("-rpcauth")) {
+            std::vector<std::string> fields;
+            boost::split(fields, rpcauth, boost::is_any_of(":$"));
+            if (fields.size() == 3) {
+                g_rpcauth.push_back(fields);
+            }
+        }
     }
 
     g_rpc_whitelist_default = gArgs.GetBoolArg("-rpcwhitelistdefault", gArgs.IsArgSet("-rpcwhitelist"));

--- a/test/functional/rpc_users.py
+++ b/test/functional/rpc_users.py
@@ -99,11 +99,18 @@ class HTTPBasicsTest(BitcoinTestFramework):
 
         self.test_auth(self.nodes[1], self.rpcuser, self.rpcpassword)
 
-        self.log.info('Check that failure to write cookie file will abort the node gracefully')
+        init_error = 'Error: Unable to start HTTP server. See debug log for details.'
+
+        self.log.info('Check -rpcauth are validated')
+        # Empty -rpcauth= are ignored
+        self.restart_node(0, extra_args=['-rpcauth='])
         self.stop_node(0)
+        self.nodes[0].assert_start_raises_init_error(expected_msg=init_error, extra_args=['-rpcauth=foo'])
+        self.nodes[0].assert_start_raises_init_error(expected_msg=init_error, extra_args=['-rpcauth=foo:bar'])
+
+        self.log.info('Check that failure to write cookie file will abort the node gracefully')
         cookie_file = os.path.join(get_datadir_path(self.options.tmpdir, 0), self.chain, '.cookie.tmp')
         os.mkdir(cookie_file)
-        init_error = 'Error: Unable to start HTTP server. See debug log for details.'
         self.nodes[0].assert_start_raises_init_error(expected_msg=init_error)
 
 


### PR DESCRIPTION
Invalid `-rpcauth` arguments are currently silently ignored. This make server initialization fail if any `-rpcauth` is invalid.