### PR TITLE
test: Fix intermittent p2p_fingerprint issue

### DIFF
--- a/test/functional/p2p_fingerprint.py
+++ b/test/functional/p2p_fingerprint.py
@@ -98,9 +98,9 @@ class P2PFingerprintTest(BitcoinTestFramework):
 
         # Longest chain is extended so stale is much older than chain tip
         self.nodes[0].setmocktime(0)
-        self.nodes[0].generatetoaddress(1, self.nodes[0].get_deterministic_priv_key().address)
+        block_hash = int(self.nodes[0].generatetoaddress(1, self.nodes[0].get_deterministic_priv_key().address)[-1], 16)
         assert_equal(self.nodes[0].getblockcount(), 14)
-        node0.sync_with_ping()
+        node0.wait_for_block(block_hash, timeout=3)
 
         # Request for very old stale block should now fail
         with p2p_lock:
@@ -127,6 +127,7 @@ class P2PFingerprintTest(BitcoinTestFramework):
 
         self.send_header_request(block_hash, node0)
         node0.wait_for_header(hex(block_hash), timeout=3)
+
 
 if __name__ == '__main__':
     P2PFingerprintTest().main()


### PR DESCRIPTION
A single sync_with_ping can't be used to drop a block announcement, as the block might be sent *after* the ping has been responded to.

Fix that by waiting for the block.