### PR TITLE
Add depends qt fix for ARM macs

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -128,6 +128,9 @@ $(package)_config_opts_darwin += -device-option MAC_TARGET=$(host)
 $(package)_config_opts_darwin += -device-option XCODE_VERSION=$(XCODE_VERSION)
 endif
 
+# for macOS on Apple Silicon (ARM) see https://bugreports.qt.io/browse/QTBUG-85279
+$(package)_config_opts_arm_darwin += -device-option QMAKE_APPLE_DEVICE_ARCHS=arm64
+
 $(package)_config_opts_linux  = -qt-xkbcommon-x11
 $(package)_config_opts_linux += -qt-xcb
 $(package)_config_opts_linux += -no-xcb-xlib


### PR DESCRIPTION
With this, depends builds fine on macOS 11 on an Apple Silicon Mac (ARM64).