### PR TITLE
wallet: deprecate feeRate in fundrawtransaction/walletcreatefundedpsbt

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3140,6 +3140,10 @@ void FundTransaction(CWallet* const pwallet, CMutableTransaction& tx, CAmount& f
         }
 
         if (options.exists("feeRate")) {
+            if (!pwallet->chain().rpcEnableDeprecated("feeRate")) {
+                // feeRate is deprecated in v0.21 for removal in v0.22
+                throw JSONRPCError(RPC_METHOD_DEPRECATED, "The feeRate (BTC/kvB) option is deprecated and will be removed in 0.22. Use fee_rate (sat/vB) instead or restart bitcoind with -deprecatedrpc=feeRate.");
+            }
             if (options.exists("fee_rate")) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot specify both fee_rate (" + CURRENCY_ATOM + "/vB) and feeRate (" + CURRENCY_UNIT + "/kvB)");
             }
@@ -3217,7 +3221,8 @@ static RPCHelpMan fundrawtransaction()
                                                           "e.g. with 'importpubkey' or 'importmulti' with the 'pubkeys' or 'desc' field."},
                             {"lockUnspents", RPCArg::Type::BOOL, /* default */ "false", "Lock selected unspent outputs"},
                             {"fee_rate", RPCArg::Type::AMOUNT, /* default */ "not set, fall back to wallet fee estimation", "Specify a fee rate in " + CURRENCY_ATOM + "/vB."},
-                            {"feeRate", RPCArg::Type::AMOUNT, /* default */ "not set, fall back to wallet fee estimation", "Specify a fee rate in " + CURRENCY_UNIT + "/kvB."},
+                            {"feeRate", RPCArg::Type::AMOUNT, /* default */ "not set, fall back to wallet fee estimation", "Specify a fee rate in " + CURRENCY_UNIT + "/kvB.\n"
+                                                          "DEPRECATED, available only if config option -deprecatedrpc=feeRate is passed. Replaced by fee_rate."},
                             {"subtractFeeFromOutputs", RPCArg::Type::ARR, /* default */ "empty array", "The integers.\n"
                                                           "The fee will be equally deducted from the amount of each specified output.\n"
                                                           "Those recipients will receive less bitcoins than you enter in their corresponding amount field.\n"
@@ -4380,7 +4385,8 @@ static RPCHelpMan walletcreatefundedpsbt()
                             {"includeWatching", RPCArg::Type::BOOL, /* default */ "true for watch-only wallets, otherwise false", "Also select inputs which are watch only"},
                             {"lockUnspents", RPCArg::Type::BOOL, /* default */ "false", "Lock selected unspent outputs"},
                             {"fee_rate", RPCArg::Type::AMOUNT, /* default */ "not set, fall back to wallet fee estimation", "Specify a fee rate in " + CURRENCY_ATOM + "/vB."},
-                            {"feeRate", RPCArg::Type::AMOUNT, /* default */ "not set, fall back to wallet fee estimation", "Specify a fee rate in " + CURRENCY_UNIT + "/kvB."},
+                            {"feeRate", RPCArg::Type::AMOUNT, /* default */ "not set, fall back to wallet fee estimation", "Specify a fee rate in " + CURRENCY_UNIT + "/kvB.\n"
+                                                          "DEPRECATED, available only if config option -deprecatedrpc=feeRate is passed. Replaced by fee_rate."},
                             {"subtractFeeFromOutputs", RPCArg::Type::ARR, /* default */ "empty array", "The outputs to subtract the fee from.\n"
                                                           "The fee will be equally deducted from the amount of each specified output.\n"
                                                           "Those recipients will receive less bitcoins than you enter in their corresponding amount field.\n"

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -66,7 +66,8 @@ class MempoolLimitTest(BitcoinTestFramework):
         outputs = {self.nodes[0].getnewaddress() : 0.0001}
         tx = self.nodes[0].createrawtransaction(inputs, outputs)
         # specifically fund this tx with a fee < mempoolminfee, >= than minrelaytxfee
-        txF = self.nodes[0].fundrawtransaction(tx, {'feeRate': relayfee})
+        relayfee_sat_vb = relayfee * Decimal(1e8 / 1e3)  # convert from BTC/kvB to sat/vB
+        txF = self.nodes[0].fundrawtransaction(tx, {"fee_rate": relayfee_sat_vb})
         txFS = self.nodes[0].signrawtransactionwithwallet(txF['hex'])
         assert_raises_rpc_error(-26, "mempool min fee not met", self.nodes[0].sendrawtransaction, txFS['hex'])
 

--- a/test/functional/rpc_deprecated.py
+++ b/test/functional/rpc_deprecated.py
@@ -10,7 +10,7 @@ class DeprecatedRpcTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.setup_clean_chain = True
-        self.extra_args = [[], ['-deprecatedrpc=bumpfee']]
+        self.extra_args = [['-deprecatedrpc=feeRate'], ['-deprecatedrpc=bumpfee']]
 
     def run_test(self):
         # This test should be used to verify correct behaviour of deprecated
@@ -25,36 +25,56 @@ class DeprecatedRpcTest(BitcoinTestFramework):
         # self.nodes[1].generate(1)
 
         if self.is_wallet_compiled():
-            self.log.info("Test bumpfee RPC")
             self.nodes[0].generate(101)
-            self.nodes[0].createwallet(wallet_name='nopriv', disable_private_keys=True)
-            noprivs0 = self.nodes[0].get_wallet_rpc('nopriv')
-            w0 = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
-            self.nodes[1].createwallet(wallet_name='nopriv', disable_private_keys=True)
-            noprivs1 = self.nodes[1].get_wallet_rpc('nopriv')
-
-            address = w0.getnewaddress()
-            desc = w0.getaddressinfo(address)['desc']
-            change_addr = w0.getrawchangeaddress()
-            change_desc = w0.getaddressinfo(change_addr)['desc']
-            txid = w0.sendtoaddress(address=address, amount=10)
-            vout = find_vout_for_address(w0, txid, address)
-            self.nodes[0].generate(1)
-            rawtx = w0.createrawtransaction([{'txid': txid, 'vout': vout}], {w0.getnewaddress(): 5}, 0, True)
-            rawtx = w0.fundrawtransaction(rawtx, {'changeAddress': change_addr})
-            signed_tx = w0.signrawtransactionwithwallet(rawtx['hex'])['hex']
-
-            noprivs0.importmulti([{'desc': desc, 'timestamp': 0}, {'desc': change_desc, 'timestamp': 0, 'internal': True}])
-            noprivs1.importmulti([{'desc': desc, 'timestamp': 0}, {'desc': change_desc, 'timestamp': 0, 'internal': True}])
-
-            txid = w0.sendrawtransaction(signed_tx)
-            self.sync_all()
-
-            assert_raises_rpc_error(-32, 'Using bumpfee with wallets that have private keys disabled is deprecated. Use psbtbumpfee instead or restart bitcoind with -deprecatedrpc=bumpfee. This functionality will be removed in 0.22', noprivs0.bumpfee, txid)
-            bumped_psbt = noprivs1.bumpfee(txid)
-            assert 'psbt' in bumped_psbt
+            self.test_feeRate_deprecation()
+            self.test_bumpfee_privkey_deprecation()
         else:
             self.log.info("No tested deprecated RPC methods")
+
+    def test_feeRate_deprecation(self):
+        self.log.info("Test feeRate deprecation in RPCs fundrawtransaction and walletcreatefundedpsbt")
+        inputs = []
+        outputs = {self.nodes[0].getnewaddress() : 1}
+        rawtx = self.nodes[1].createrawtransaction(inputs, outputs)
+
+        # Node 0 with -deprecatedrpc=feeRate can still use deprecated feeRate option.
+        self.nodes[0].fundrawtransaction(rawtx, {"feeRate": 0.0001})
+        self.nodes[0].walletcreatefundedpsbt(inputs, outputs, 0, {"feeRate": 0.0001})
+
+        # Node 1 cannot use deprecated feeRate option.
+        msg = "The feeRate (BTC/kvB) option is deprecated and will be removed in 0.22. Use fee_rate (sat/vB) instead or restart bitcoind with -deprecatedrpc=feeRate."
+        assert_raises_rpc_error(-32, msg, self.nodes[1].fundrawtransaction, rawtx, {"feeRate": 0.0001})
+        assert_raises_rpc_error(-32, msg, self.nodes[1].walletcreatefundedpsbt, inputs, outputs, 0, {"feeRate": 0.1})
+
+    def test_bumpfee_privkey_deprecation(self):
+        self.log.info("Test bumpfee RPC")
+        self.nodes[0].createwallet(wallet_name='nopriv', disable_private_keys=True)
+        noprivs0 = self.nodes[0].get_wallet_rpc('nopriv')
+        w0 = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+        self.nodes[1].createwallet(wallet_name='nopriv', disable_private_keys=True)
+        noprivs1 = self.nodes[1].get_wallet_rpc('nopriv')
+
+        address = w0.getnewaddress()
+        desc = w0.getaddressinfo(address)['desc']
+        change_addr = w0.getrawchangeaddress()
+        change_desc = w0.getaddressinfo(change_addr)['desc']
+        txid = w0.sendtoaddress(address=address, amount=10)
+        vout = find_vout_for_address(w0, txid, address)
+        self.nodes[0].generate(1)
+        rawtx = w0.createrawtransaction([{'txid': txid, 'vout': vout}], {w0.getnewaddress(): 5}, 0, True)
+        rawtx = w0.fundrawtransaction(rawtx, {'changeAddress': change_addr})
+        signed_tx = w0.signrawtransactionwithwallet(rawtx['hex'])['hex']
+
+        noprivs0.importmulti([{'desc': desc, 'timestamp': 0}, {'desc': change_desc, 'timestamp': 0, 'internal': True}])
+        noprivs1.importmulti([{'desc': desc, 'timestamp': 0}, {'desc': change_desc, 'timestamp': 0, 'internal': True}])
+
+        txid = w0.sendrawtransaction(signed_tx)
+        self.sync_all()
+
+        assert_raises_rpc_error(-32, 'Using bumpfee with wallets that have private keys disabled is deprecated. Use psbtbumpfee instead or restart bitcoind with -deprecatedrpc=bumpfee. This functionality will be removed in 0.22', noprivs0.bumpfee, txid)
+        bumped_psbt = noprivs1.bumpfee(txid)
+        assert 'psbt' in bumped_psbt
+
 
 if __name__ == '__main__':
     DeprecatedRpcTest().main()

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -31,7 +31,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         # This test isn't testing tx relay. Set whitelist on the peers for
         # instant tx relay.
-        self.extra_args = [['-whitelist=noban@127.0.0.1']] * self.num_nodes
+        self.extra_args = [['-whitelist=noban@127.0.0.1', '-deprecatedrpc=feeRate']] * self.num_nodes
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -28,7 +28,7 @@ class PSBTTest(BitcoinTestFramework):
         self.num_nodes = 3
         self.extra_args = [
             ["-walletrbf=1"],
-            ["-walletrbf=0", "-changetype=legacy"],
+            ["-walletrbf=0", "-changetype=legacy", "-deprecatedrpc=feeRate"],
             []
         ]
         self.supports_cli = False

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -23,6 +23,7 @@ class WalletTest(BitcoinTestFramework):
         self.num_nodes = 4
         self.extra_args = [[
             "-acceptnonstdtxn=1",
+            "-deprecatedrpc=feeRate",
         ]] * self.num_nodes
         self.setup_clean_chain = True
         self.supports_cli = False

--- a/test/functional/wallet_keypool.py
+++ b/test/functional/wallet_keypool.py
@@ -159,32 +159,32 @@ class KeyPoolTest(BitcoinTestFramework):
         nodes[0].generate(1)
         destination = addr.pop()
 
-        # Using a fee rate (10 sat / byte) well above the minimum relay rate
+        # Using a fee rate (10 sat/vB) well above the minimum relay rate
         # creating a 5,000 sat transaction with change should not be possible
-        assert_raises_rpc_error(-4, "Transaction needs a change address, but we can't generate it. Please call keypoolrefill first.", w2.walletcreatefundedpsbt, inputs=[], outputs=[{addr.pop(): 0.00005000}], options={"subtractFeeFromOutputs": [0], "feeRate": 0.00010})
+        assert_raises_rpc_error(-4, "Transaction needs a change address, but we can't generate it. Please call keypoolrefill first.", w2.walletcreatefundedpsbt, inputs=[], outputs=[{addr.pop(): 0.00005000}], options={"subtractFeeFromOutputs": [0], "fee_rate": 10})
 
         # creating a 10,000 sat transaction without change, with a manual input, should still be possible
-        res = w2.walletcreatefundedpsbt(inputs=w2.listunspent(), outputs=[{destination: 0.00010000}], options={"subtractFeeFromOutputs": [0], "feeRate": 0.00010})
+        res = w2.walletcreatefundedpsbt(inputs=w2.listunspent(), outputs=[{destination: 0.00010000}], options={"subtractFeeFromOutputs": [0], "fee_rate": 10})
         assert_equal("psbt" in res, True)
 
         # creating a 10,000 sat transaction without change should still be possible
-        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00010000}], options={"subtractFeeFromOutputs": [0], "feeRate": 0.00010})
+        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00010000}], options={"subtractFeeFromOutputs": [0], "fee_rate": 10})
         assert_equal("psbt" in res, True)
         # should work without subtractFeeFromOutputs if the exact fee is subtracted from the amount
-        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00008900}], options={"feeRate": 0.00010})
+        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00008900}], options={"fee_rate": 10})
         assert_equal("psbt" in res, True)
 
         # dust change should be removed
-        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00008800}], options={"feeRate": 0.00010})
+        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00008800}], options={"fee_rate": 10})
         assert_equal("psbt" in res, True)
 
         # create a transaction without change at the maximum fee rate, such that the output is still spendable:
-        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00010000}], options={"subtractFeeFromOutputs": [0], "feeRate": 0.0008824})
+        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00010000}], options={"subtractFeeFromOutputs": [0], "fee_rate": 88.24})
         assert_equal("psbt" in res, True)
         assert_equal(res["fee"], Decimal("0.00009706"))
 
         # creating a 10,000 sat transaction with a manual change address should be possible
-        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00010000}], options={"subtractFeeFromOutputs": [0], "feeRate": 0.00010, "changeAddress": addr.pop()})
+        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00010000}], options={"subtractFeeFromOutputs": [0], "fee_rate": 10, "changeAddress": addr.pop()})
         assert_equal("psbt" in res, True)
 
 

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -20,10 +20,7 @@ class WalletSendTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         # whitelist all peers to speed up tx relay / mempool sync
-        self.extra_args = [
-            ["-whitelist=127.0.0.1","-walletrbf=1"],
-            ["-whitelist=127.0.0.1","-walletrbf=1"],
-        ]
+        self.extra_args = [["-whitelist=noban@127.0.0.1", "-walletrbf=1", "-deprecatedrpc=feeRate"]] * self.num_nodes
         getcontext().prec = 8 # Satoshi precision for Decimal
 
     def skip_test_if_missing_module(self):


### PR DESCRIPTION
Continuing work on #19543 and following the plan outlined in https://github.com/bitcoin/bitcoin/pull/20484#issuecomment-734786305, deprecate the `feeRate` option in fundrawtransaction and walletcreatefundedpsbt to avoid confusion with `fee_rate`, as the two options have different units (BTC/kvB and sat/vB) and similar spellings.

This PR currently targets deprecation for 0.21 and so no release notes are added here, as the wiki would be edited instead. Will update if tagged for 0.22 instead.

The last commit, "test: add feeRate tests to rpc_deprecate.py," is best reviewed with `-w`.

Related to #20391.