### PR TITLE
CI msvc: only build vcpkg dependencies for release (not debug) to reduce build times

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,6 +24,7 @@ install:
       git pull origin master > $null
       git -c advice.detachedHead=false checkout $env:VCPKG_COMMIT_ID
       .\bootstrap-vcpkg.bat > $null
+      Add-Content "C:\tools\vcpkg\triplets\$env:PLATFORM-windows-static.cmake" "set(VCPKG_BUILD_TYPE release)"
       cd "$env:APPVEYOR_BUILD_FOLDER"
 before_build:
 # Powershell block below is to download and extract the Qt static libraries. The pseudo code is:


### PR DESCRIPTION
This change to the appveyor CI config for msvc builds reverses a change introduced in #19960. It re-applies a setting to inform vcpkg to only build release versions of the dependencies rather than the default of debug and release.

It had been expected that the vcpkg manifest mechanism introduced in #19960 would do this automatically but it turns out not to be the case.