### PR TITLE
refactor: Drop noop gcc version checks

### DIFF
--- a/src/bench/prevector.cpp
+++ b/src/bench/prevector.cpp
@@ -9,24 +9,16 @@
 
 #include <bench/bench.h>
 
-// GCC 4.8 is missing some C++11 type_traits,
-// https://www.gnu.org/software/gcc/gcc-5/changes.html
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
-#define IS_TRIVIALLY_CONSTRUCTIBLE std::has_trivial_default_constructor
-#else
-#define IS_TRIVIALLY_CONSTRUCTIBLE std::is_trivially_default_constructible
-#endif
-
 struct nontrivial_t {
     int x;
     nontrivial_t() :x(-1) {}
     SERIALIZE_METHODS(nontrivial_t, obj) { READWRITE(obj.x); }
 };
-static_assert(!IS_TRIVIALLY_CONSTRUCTIBLE<nontrivial_t>::value,
+static_assert(!std::is_trivially_default_constructible<nontrivial_t>::value,
               "expected nontrivial_t to not be trivially constructible");
 
 typedef unsigned char trivial_t;
-static_assert(IS_TRIVIALLY_CONSTRUCTIBLE<trivial_t>::value,
+static_assert(std::is_trivially_default_constructible<trivial_t>::value,
               "expected trivial_t to be trivially constructible");
 
 template <typename T>

--- a/src/test/fuzz/addition_overflow.cpp
+++ b/src/test/fuzz/addition_overflow.cpp
@@ -14,7 +14,7 @@
 #if __has_builtin(__builtin_add_overflow)
 #define HAVE_BUILTIN_ADD_OVERFLOW
 #endif
-#elif defined(__GNUC__) && (__GNUC__ >= 5)
+#elif defined(__GNUC__)
 #define HAVE_BUILTIN_ADD_OVERFLOW
 #endif
 

--- a/src/test/fuzz/multiplication_overflow.cpp
+++ b/src/test/fuzz/multiplication_overflow.cpp
@@ -14,7 +14,7 @@
 #if __has_builtin(__builtin_mul_overflow)
 #define HAVE_BUILTIN_MUL_OVERFLOW
 #endif
-#elif defined(__GNUC__) && (__GNUC__ >= 5)
+#elif defined(__GNUC__)
 #define HAVE_BUILTIN_MUL_OVERFLOW
 #endif
 


### PR DESCRIPTION
Since #20413 the minimum required GCC version is 7.