### PR TITLE
sync: print proper lock order location when double lock is detected

### DIFF
--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -150,7 +150,9 @@ static void double_lock_detected(const void* mutex, LockStack& lock_stack)
         LogPrintf(" %s\n", i.second.ToString());
     }
     if (g_debug_lockorder_abort) {
-        tfm::format(std::cerr, "Assertion failed: detected double lock at %s:%i, details in debug log.\n", __FILE__, __LINE__);
+        tfm::format(std::cerr,
+                    "Assertion failed: detected double lock for %s, details in debug log.\n",
+                    lock_stack.back().second.ToString());
         abort();
     }
     throw std::logic_error("double lock detected");

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -139,7 +139,7 @@ static void potential_deadlock_detected(const LockPair& mismatch, const LockStac
     throw std::logic_error(strprintf("potential deadlock detected: %s -> %s -> %s", mutex_b, mutex_a, mutex_b));
 }
 
-static void double_lock_detected(const void* mutex, LockStack& lock_stack)
+static void double_lock_detected(const void* mutex, const LockStack& lock_stack)
 {
     LogPrintf("DOUBLE LOCK DETECTED\n");
     LogPrintf("Lock order:\n");

--- a/src/test/sync_tests.cpp
+++ b/src/test/sync_tests.cpp
@@ -50,10 +50,8 @@ void TestDoubleLock(bool should_throw)
     MutexType m;
     ENTER_CRITICAL_SECTION(m);
     if (should_throw) {
-        BOOST_CHECK_EXCEPTION(
-            TestDoubleLock2(m), std::logic_error, [](const std::logic_error& e) {
-                return strcmp(e.what(), "double lock detected") == 0;
-            });
+        BOOST_CHECK_EXCEPTION(TestDoubleLock2(m), std::logic_error,
+                              HasReason("double lock detected"));
     } else {
         BOOST_CHECK_NO_THROW(TestDoubleLock2(m));
     }


### PR DESCRIPTION
Before:
```
Assertion failed: detected double lock at src/sync.cpp:153, details in debug log.
```

After:
```
Assertion failed: detected double lock for 'm' in src/test/sync_tests.cpp:40 (in thread ''), details in debug log.
```