### PR TITLE
IGNORE: Testing appveyor CI build with pre-built dependencies

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -60,14 +60,14 @@ before_build:
       }
 - cmd: python build_msvc\msvc-autogen.py
 build_script:
-- cmd: msbuild /m build_msvc\bitcoin.sln /p:Configuration=Release /p:Platform=x64 /v:q
+- cmd: msbuild /m build_msvc\bitcoin.sln /p:Configuration=Release /p:Platform=x64 /t:build
 after_build:
 #- 7z a bitcoin-%APPVEYOR_BUILD_VERSION%.zip %APPVEYOR_BUILD_FOLDER%\build_msvc\%platform%\%configuration%\*.exe
 test_script:
-- cmd: src\test_bitcoin.exe -l test_suite
-- cmd: src\bench_bitcoin.exe > NUL
-- ps:  python test\util\bitcoin-util-test.py
-- cmd: python test\util\rpcauth-test.py
+#- cmd: src\test_bitcoin.exe -l test_suite
+#- cmd: src\bench_bitcoin.exe > NUL
+#- ps:  python test\util\bitcoin-util-test.py
+#- cmd: python test\util\rpcauth-test.py
 # Fee estimation test failing on appveyor with: WinError 10048] Only one usage of each socket address (protocol/network address/port) is normally permitted.
 # functional tests disabled for now. See
 # https://github.com/bitcoin/bitcoin/pull/18626#issuecomment-613396202

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,16 +1,18 @@
 version: '{branch}.{build}'
 skip_tags: true
-image: Previous Visual Studio 2019
+image: Visual Studio 2019
 configuration: Release
 platform: x64
 clone_depth: 5
 environment:
   PATH: 'C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%'
   PYTHONUTF8: 1
-  QT_DOWNLOAD_URL: 'https://github.com/sipsorcery/qt_win_binary/releases/download/v1.6/Qt5.9.8_x64_static_vs2019.zip'
-  QT_DOWNLOAD_HASH: '9a8c6eb20967873785057fdcd329a657c7f922b0af08c5fde105cc597dd37e21'
+  QT_DOWNLOAD_URL: 'https://github.com/sipsorcery/qt_win_binary/releases/download/qt598x64_vs2019_v1681/qt598_x64_vs2019_1681.zip'
+  QT_DOWNLOAD_HASH: '00cf7327818c07d74e0b1a4464ffe987c2728b00d49d4bf333065892af0515c3'
   QT_LOCAL_PATH: 'C:\Qt5.9.8_x64_static_vs2019'
-  VCPKG_INSTALL_PATH: 'C:\tools\vcpkg\installed'
+  VCPKG_DEPS_DOWNLOAD_URL: 'https://github.com/sipsorcery/qt_win_binary/releases/download/vcpkg_vs2019_v1681/vcpkg_installed_vs2019_1681.zip'
+  VCPKG_DEPS_DOWNLOAD_HASH: 'e94161b23f9ac0622ffce5754218f8f08fc6bf6a73450e770d29ad2e18459637'
+  VCPKG_DEPS_LOCAL_PATH: 'build_msvc\vcpkg_installed'
   VCPKG_COMMIT_ID: '40230b8e3f6368dcb398d649331be878ca1e9007'
 install:
 # Disable zmq test for now since python zmq library on Windows would cause Access violation sometimes.
@@ -43,9 +45,22 @@ before_build:
         Write-Host "ERROR: Qt binary download did not match the expected hash.";
         Exit-AppveyorBuild;
       }
+- ps: |
+      Write-Host "Downloading vcpkg dependencies.";
+      Invoke-WebRequest -Uri $env:VCPKG_DEPS_DOWNLOAD_URL -Out vcpkg-deps.zip;
+      Write-Host "vcpkg dependencies successfully downloaded, checking hash against $env:VCPKG_DEPS_DOWNLOAD_HASH...";
+      if((Get-FileHash vcpkg-deps.zip).Hash -eq $env:VCPKG_DEPS_DOWNLOAD_HASH) {
+        Write-Host "vcpkg dependencies download matched the expected hash."
+        Write-Host "Extracting to $env:APPVEYOR_BUILD_FOLDER\$env:VCPKG_DEPS_LOCAL_PATH...";
+        Expand-Archive vcpkg-deps.zip -DestinationPath "$env:APPVEYOR_BUILD_FOLDER\$env:VCPKG_DEPS_LOCAL_PATH";
+        dir "$env:APPVEYOR_BUILD_FOLDER\$env:VCPKG_DEPS_LOCAL_PATH"
+      }
+      else {
+        Write-Host "ERROR: vcpkg dependencies download did not match the expected hash.";
+      }
 - cmd: python build_msvc\msvc-autogen.py
 build_script:
-- cmd: msbuild /p:TrackFileAccess=false build_msvc\bitcoin.sln /m /v:q /nologo
+- cmd: msbuild /m build_msvc\bitcoin.sln /p:Configuration=Release /p:Platform=x64 /v:q
 after_build:
 #- 7z a bitcoin-%APPVEYOR_BUILD_VERSION%.zip %APPVEYOR_BUILD_FOLDER%\build_msvc\%platform%\%configuration%\*.exe
 test_script:

--- a/build_msvc/common.init.vcxproj
+++ b/build_msvc/common.init.vcxproj
@@ -12,7 +12,7 @@
    <PropertyGroup Label="Vcpkg">
     <VcpkgEnabled>true</VcpkgEnabled>
     <VcpkgEnableManifest>true</VcpkgEnableManifest>
-    <VcpkgManifestInstall>true</VcpkgManifestInstall>
+    <VcpkgManifestInstall>false</VcpkgManifestInstall>
     <VcpkgUseStatic>true</VcpkgUseStatic>
     <VcpkgAutoLink>true</VcpkgAutoLink>
     <VcpkgConfiguration>$(Configuration)</VcpkgConfiguration>


### PR DESCRIPTION
Ignore this PR. It's purpose is to test the appveyor build time with pre-built Qt and vcpkg dependencies. My personal appveyor account typically times out after 60 minutes when attempting this build. This experiment is to see how long the Bitcoin Core appveyor account takes.

As a reference point the time taken for this build in other environments:

 - Free appveyor account: typically times out after 60 minutes.
 - Personal dev machine with i7 CPU: approx. 10 minutes.
 - GitHub Actions CI: approx. 21 mins.