### PR TITLE
net: CAddress deser: use stream's version, not what's coming from disk

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -383,7 +383,7 @@ public:
             // nTime.
             READWRITE(obj.nTime);
         }
-        if (nVersion & ADDRV2_FORMAT) {
+        if (s.GetVersion() & ADDRV2_FORMAT) {
             uint64_t services_tmp;
             SER_WRITE(obj, services_tmp = obj.nServices);
             READWRITE(Using<CompactSizeFormatter<false>>(services_tmp));


### PR DESCRIPTION
During `CAddress` deserialization we use `nVersion` to decide whether to
use CompactSize format for `nServices`. However, that variable `nVersion`
is first assigned `s.GetVersion()` and is later overwritten with
whatever is coming from disk by `READWRITE(nVersion)`.

We should use `s.GetVersion()` instead, which is also used by
`READWRITEAS(CService, obj);`, called at the end of `CAddress`
deserialization.