### PR TITLE
doc: Add bash as an OpenBSD dependency

### DIFF
--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -15,6 +15,7 @@ pkg_add qt5 # (optional for enabling the GUI)
 pkg_add autoconf # (select highest version, e.g. 2.69)
 pkg_add automake # (select highest version, e.g. 1.16)
 pkg_add python # (select highest version, e.g. 3.8)
+pkg_add bash
 
 git clone https://github.com/bitcoin/bitcoin.git
 ```


### PR DESCRIPTION
If we require Python for the test framework, we should also require
bash. It is required for the linters and other scripts and does not
comes in a default OpenBSD installation.
