### PR TITLE
Release notes: remove mention of default wallet creation

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -337,8 +337,7 @@ Setting `descriptors` to `true` will create a Descriptor Wallet instead of a Leg
 In the GUI, a checkbox has been added to the Create Wallet Dialog to indicate that a
 Descriptor Wallet should be created.
 
-Without those options being set, a Legacy Wallet will be created instead. Additionally the
-Default Wallet created upon first startup of Bitcoin Core will be a Legacy Wallet.
+Without those options being set, a Legacy Wallet will be created instead.
 
 #### `IsMine` Semantics
 


### PR DESCRIPTION
The release notes for upcoming 0.21 still have a mention of the default wallet created upon first startup, something which is no longer done since #15454.