### PR TITLE
refactor: replace manual Satoshis-to-BTC conversions with FormatMoney()

### DIFF
--- a/src/policy/feerate.cpp
+++ b/src/policy/feerate.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <policy/feerate.h>
+#include <util/moneystr.h>
 
 #include <tinyformat.h>
 
@@ -39,6 +40,6 @@ std::string CFeeRate::ToString(const FeeEstimateMode& fee_estimate_mode) const
 {
     switch (fee_estimate_mode) {
     case FeeEstimateMode::SAT_VB: return strprintf("%d.%03d %s/vB", nSatoshisPerK / 1000, nSatoshisPerK % 1000, CURRENCY_ATOM);
-    default:                      return strprintf("%d.%08d %s/kvB", nSatoshisPerK / COIN, nSatoshisPerK % COIN, CURRENCY_UNIT);
+    default:                      return strprintf("%s %s/kvB", FormatMoney(nSatoshisPerK), CURRENCY_UNIT);
     }
 }

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -7,6 +7,7 @@
 
 #include <hash.h>
 #include <tinyformat.h>
+#include <util/moneystr.h>
 #include <util/strencodings.h>
 
 #include <assert.h>
@@ -53,7 +54,7 @@ CTxOut::CTxOut(const CAmount& nValueIn, CScript scriptPubKeyIn)
 
 std::string CTxOut::ToString() const
 {
-    return strprintf("CTxOut(nValue=%d.%08d, scriptPubKey=%s)", nValue / COIN, nValue % COIN, HexStr(scriptPubKey).substr(0, 30));
+    return strprintf("CTxOut(nValue=%s, scriptPubKey=%s)", FormatMoney(nValue), HexStr(scriptPubKey).substr(0, 30));
 }
 
 CMutableTransaction::CMutableTransaction() : nVersion(CTransaction::CURRENT_VERSION), nLockTime(0) {}


### PR DESCRIPTION
This tiny PR replaces all remaining occurences of manual conversion of Satoshi amounts (`CAmount`) to a currency unit string via division and modulo operation on `COIN` (100000000) by the utility function `FormatMoney(...)`. The instances were found with the command

```
git grep "\%[ ]*COIN"
```

Only `ToString()`-functions are affected, but still I'd argue that the constants `COIN` should only be used:
* for money constants (like in benchmark/tests, chainparams, `GetBlockSubsidy(...)` etc.) and
* for utility functions that need it (like `{Parse,Format}Money`, `ValueFromAmount` etc.)

Note that strictly speaking, this is not a pure refactor, as the function `FormatMoney(...)` drops excess zero after two decimal places.