### PR TITLE
Avoid rebucketing on restart when it's not necessary

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -527,7 +527,7 @@ public:
             CAddrInfo &info = mapInfo[n];
             int bucket = entryToBucket[n];
             int nUBucketPos = info.GetBucketPosition(nKey, true, bucket);
-            if (format >= Format::V2_ASMAP && nUBuckets == ADDRMAN_NEW_BUCKET_COUNT && vvNew[bucket][nUBucketPos] == -1 &&
+            if (nUBuckets == ADDRMAN_NEW_BUCKET_COUNT && vvNew[bucket][nUBucketPos] == -1 &&
                 info.nRefCount < ADDRMAN_NEW_BUCKETS_PER_ADDRESS && serialized_asmap_version == supplied_asmap_version) {
                 // Bucketing has not changed, using existing bucket positions for the new table
                 vvNew[bucket][nUBucketPos] = n;


### PR DESCRIPTION
Previously, we would re-bucket AddrMan entries if, at a restart, a node reads a peers.dat file of pre-asmap format.

This should not happen if an actual asmap file was not provided, because bucket assignment won't change.

Re-bucketing should be avoided because it leads to a data loss: since we don't remember where those addrs came from, they will be placed only into 1 bucket (as opposed to placing in up to 8, if we receive them from 8 different peers during node operation).

For peers.dat files with pre-asmap format, re-bucket only if an asmap file was supported.