### PR TITLE
wallet: check for non-representable CFeeRates

### DIFF
--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -34,6 +34,7 @@ private:
 public:
     /** Fee rate of 0 satoshis per kB */
     CFeeRate() : nSatoshisPerK(0) { }
+    bool IsZero() const { return nSatoshisPerK == 0; }
     template<typename I>
     explicit CFeeRate(const I _nSatoshisPerK): nSatoshisPerK(_nSatoshisPerK) {
         // We've previously had bugs creep in from silent double->int conversion...

--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -39,6 +39,8 @@ public:
         // We've previously had bugs creep in from silent double->int conversion...
         static_assert(std::is_integral<I>::value, "CFeeRate should be used without floats");
     }
+    static CFeeRate FromSatB(CAmount fee_rate);
+    static CFeeRate FromBtcKb(CAmount fee_rate);
     /** Constructor for a fee rate in satoshis per kvB (sat/kvB). The size in bytes must not exceed (2^63 - 1).
      *
      *  Passing an nBytes value of COIN (1e8) returns a fee rate in satoshis per vB (sat/vB),
@@ -69,5 +71,11 @@ public:
 
     SERIALIZE_METHODS(CFeeRate, obj) { READWRITE(obj.nSatoshisPerK); }
 };
+
+/** Construct a CFeeRate from a CAmount in sat/vB */
+inline CFeeRate CFeeRate::FromSatB(CAmount fee_rate) { return CFeeRate(fee_rate, COIN); }
+
+/** Construct a CFeeRate from a CAmount in BTC/kvB */
+inline CFeeRate CFeeRate::FromBtcKb(CAmount fee_rate) { return CFeeRate(fee_rate, 1000); }
 
 #endif //  BITCOIN_POLICY_FEERATE_H

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1075,7 +1075,7 @@ static RPCHelpMan estimatesmartfee()
     UniValue errors(UniValue::VARR);
     FeeCalculation feeCalc;
     CFeeRate feeRate = fee_estimator.estimateSmartFee(conf_target, &feeCalc, conservative);
-    if (feeRate != CFeeRate(0)) {
+    if (!feeRate.IsZero()) {
         result.pushKV("feerate", ValueFromAmount(feeRate.GetFeePerK()));
     } else {
         errors.push_back("Insufficient data or no feerate found");
@@ -1186,7 +1186,7 @@ static RPCHelpMan estimaterawfee()
         failbucket.pushKV("leftmempool", round(buckets.fail.leftMempool * 100.0) / 100.0);
 
         // CFeeRate(0) is used to indicate error as a return value from estimateRawFee
-        if (feeRate != CFeeRate(0)) {
+        if (!feeRate.IsZero()) {
             horizon_result.pushKV("feerate", ValueFromAmount(feeRate.GetFeePerK()));
             horizon_result.pushKV("decay", buckets.decay);
             horizon_result.pushKV("scale", (int)buckets.scale);

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -4,6 +4,7 @@
 
 #include <key_io.h>
 #include <outputtype.h>
+#include <policy/feerate.h>
 #include <rpc/util.h>
 #include <script/descriptor.h>
 #include <script/signingprovider.h>
@@ -84,6 +85,17 @@ CAmount AmountFromValue(const UniValue& value)
     if (!MoneyRange(amount))
         throw JSONRPCError(RPC_TYPE_ERROR, "Amount out of range");
     return amount;
+}
+
+CFeeRate FeeRateFromValueInSatB(const UniValue& value)
+{
+    const CAmount amount{AmountFromValue(value)};
+    const CFeeRate fee_rate{CFeeRate::FromSatB(amount)};
+    if (fee_rate.IsZero() && amount != 0) {
+        // passed value is an unrepresentable fee rate between 0 and 0.001 sat/vB
+        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
+    }
+    return fee_rate;
 }
 
 uint256 ParseHashV(const UniValue& v, std::string strName)

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -8,6 +8,7 @@
 #include <node/coinstats.h>
 #include <node/transaction.h>
 #include <outputtype.h>
+#include <policy/feerate.h>
 #include <protocol.h>
 #include <pubkey.h>
 #include <rpc/protocol.h>
@@ -81,6 +82,10 @@ extern std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKe
 CoinStatsHashType ParseHashType(const UniValue& param, const CoinStatsHashType default_type);
 
 extern CAmount AmountFromValue(const UniValue& value);
+
+/** Return a fee rate from a UniValue number or string in sat/vB */
+extern CFeeRate FeeRateFromValueInSatB(const UniValue& value);
+
 extern std::string HelpExampleCli(const std::string& methodname, const std::string& args);
 extern std::string HelpExampleRpc(const std::string& methodname, const std::string& args);
 

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -67,8 +67,12 @@ BOOST_AUTO_TEST_CASE(GetFeeTest)
     feeRate = CFeeRate(1000);
     altFeeRate = CFeeRate(feeRate);
     BOOST_CHECK_EQUAL(feeRate.GetFee(100), altFeeRate.GetFee(100));
+}
 
-    // Check full constructor
+BOOST_AUTO_TEST_CASE(CFeeRateConstructorTest)
+{
+    // Test CFeeRate(CAmount fee_rate, size_t bytes) constructor
+    // full constructor
     BOOST_CHECK(CFeeRate(CAmount(-1), 0) == CFeeRate(0));
     BOOST_CHECK(CFeeRate(CAmount(0), 0) == CFeeRate(0));
     BOOST_CHECK(CFeeRate(CAmount(1), 0) == CFeeRate(0));
@@ -84,6 +88,27 @@ BOOST_AUTO_TEST_CASE(GetFeeTest)
     BOOST_CHECK(CFeeRate(CAmount(27), 789) == CFeeRate(34));
     // Maximum size in bytes, should not crash
     CFeeRate(MAX_MONEY, std::numeric_limits<size_t>::max() >> 1).GetFeePerK();
+}
+
+BOOST_AUTO_TEST_CASE(CFeeRateNamedConstructorsTest)
+{
+    // Test CFeerate(CAmount fee_rate, FeeEstimatemode mode) constructor
+    // with BTC/kvB, returns same values as CFeeRate(amount) or CFeeRate(amount, 1000)
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(-1)) == CFeeRate(-1));
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(0)) == CFeeRate(0));
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(1)) == CFeeRate(1, 1000));
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(26)) == CFeeRate(26));
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(123)) == CFeeRate(123, 1000));
+    // with sat/vB, returns values that are 1e5 smaller
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(-100000)) == CFeeRate(-1));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(-99999)) == CFeeRate(0));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(0)) == CFeeRate(0));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(99999)) == CFeeRate(0));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(100000)) == CFeeRate(1));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(100001)) == CFeeRate(1));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(2690000)) == CFeeRate(26));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(123456789)) == CFeeRate(1234));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(123456789)) == CFeeRate(1234, 1000));
 }
 
 BOOST_AUTO_TEST_CASE(BinaryOperatorTest)

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -111,6 +111,19 @@ BOOST_AUTO_TEST_CASE(CFeeRateNamedConstructorsTest)
     BOOST_CHECK(CFeeRate::FromSatB(CAmount(123456789)) == CFeeRate(1234, 1000));
 }
 
+BOOST_AUTO_TEST_CASE(CFeeRateIsZeroTest)
+{
+    BOOST_CHECK(CFeeRate(0).IsZero());
+    BOOST_CHECK(!CFeeRate(1000).IsZero());
+    BOOST_CHECK(!CFeeRate(-1000).IsZero());
+    BOOST_CHECK(CFeeRate(CAmount(0), 0).IsZero());
+    BOOST_CHECK(CFeeRate(CAmount(1), 1001).IsZero());
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(0)).IsZero());
+    BOOST_CHECK(!CFeeRate::FromBtcKb(CAmount(1)).IsZero());
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(0.000)).IsZero());
+    BOOST_CHECK(!CFeeRate::FromSatB(CAmount(100001)).IsZero());
+}
+
 BOOST_AUTO_TEST_CASE(BinaryOperatorTest)
 {
     CFeeRate a, b;

--- a/src/wallet/fees.cpp
+++ b/src/wallet/fees.cpp
@@ -41,7 +41,7 @@ CFeeRate GetMinimumFeeRate(const CWallet& wallet, const CCoinControl& coin_contr
         // Allow to override automatic min/max check over coin control instance
         if (coin_control.fOverrideFeeRate) return feerate_needed;
     }
-    else if (!coin_control.m_confirm_target && wallet.m_pay_tx_fee != CFeeRate(0)) { // 3. TODO: remove magic value of 0 for wallet member m_pay_tx_fee
+    else if (!coin_control.m_confirm_target && !wallet.m_pay_tx_fee.IsZero()) { // 3. TODO: remove magic value of 0 for wallet member m_pay_tx_fee
         feerate_needed = wallet.m_pay_tx_fee;
         if (feeCalc) feeCalc->reason = FeeReason::PAYTXFEE;
     }
@@ -55,13 +55,13 @@ CFeeRate GetMinimumFeeRate(const CWallet& wallet, const CCoinControl& coin_contr
         else if (coin_control.m_fee_mode == FeeEstimateMode::ECONOMICAL) conservative_estimate = false;
 
         feerate_needed = wallet.chain().estimateSmartFee(target, conservative_estimate, feeCalc);
-        if (feerate_needed == CFeeRate(0)) {
+        if (feerate_needed.IsZero()) {
             // if we don't have enough data for estimateSmartFee, then use fallback fee
             feerate_needed = wallet.m_fallback_fee;
             if (feeCalc) feeCalc->reason = FeeReason::FALLBACK;
 
             // directly return if fallback fee is disabled (feerate 0 == disabled)
-            if (wallet.m_fallback_fee == CFeeRate(0)) return feerate_needed;
+            if (wallet.m_fallback_fee.IsZero()) return feerate_needed;
         }
         // Obey mempool min fee when using smart fee estimation
         CFeeRate min_mempool_feerate = wallet.chain().mempoolMinFee();
@@ -85,7 +85,7 @@ CFeeRate GetDiscardRate(const CWallet& wallet)
     unsigned int highest_target = wallet.chain().estimateMaxBlocks();
     CFeeRate discard_rate = wallet.chain().estimateSmartFee(highest_target, false /* conservative */);
     // Don't let discard_rate be greater than longest possible fee estimate if we get a valid fee estimate
-    discard_rate = (discard_rate == CFeeRate(0)) ? wallet.m_discard_rate : std::min(discard_rate, wallet.m_discard_rate);
+    discard_rate = discard_rate.IsZero() ? wallet.m_discard_rate : std::min(discard_rate, wallet.m_discard_rate);
     // Discard rate must be at least dustRelayFee
     discard_rate = std::max(discard_rate, wallet.chain().relayDustFee());
     return discard_rate;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -216,7 +216,7 @@ static void SetFeeEstimateMode(const CWallet& wallet, CCoinControl& cc, const Un
         if (!estimate_mode.isNull() && estimate_mode.get_str() != "unset") {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot specify both estimate_mode and fee_rate");
         }
-        cc.m_feerate = CFeeRate::FromSatB(AmountFromValue(fee_rate));
+        cc.m_feerate = FeeRateFromValueInSatB(fee_rate);
         if (override_min_fee) cc.fOverrideFeeRate = true;
         // Default RBF to true for explicit fee_rate, if unset.
         if (cc.m_signal_bip125_rbf == nullopt) cc.m_signal_bip125_rbf = true;
@@ -3089,7 +3089,7 @@ void FundTransaction(CWallet* const pwallet, CMutableTransaction& tx, CAmount& f
                 {"lockUnspents", UniValueType(UniValue::VBOOL)},
                 {"lock_unspents", UniValueType(UniValue::VBOOL)},
                 {"locktime", UniValueType(UniValue::VNUM)},
-                {"fee_rate", UniValueType()}, // will be checked by AmountFromValue() in SetFeeEstimateMode()
+                {"fee_rate", UniValueType()}, // will be checked by FeeRateFromValueInSatB() in SetFeeEstimateMode()
                 {"feeRate", UniValueType()}, // will be checked by AmountFromValue() below
                 {"psbt", UniValueType(UniValue::VBOOL)},
                 {"subtractFeeFromOutputs", UniValueType(UniValue::VARR)},
@@ -3470,7 +3470,7 @@ static RPCHelpMan bumpfee_helper(std::string method_name)
             {
                 {"confTarget", UniValueType(UniValue::VNUM)},
                 {"conf_target", UniValueType(UniValue::VNUM)},
-                {"fee_rate", UniValueType()}, // will be checked by AmountFromValue() in SetFeeEstimateMode()
+                {"fee_rate", UniValueType()}, // will be checked by FeeRateFromValueInSatB() in SetFeeEstimateMode()
                 {"replaceable", UniValueType(UniValue::VBOOL)},
                 {"estimate_mode", UniValueType(UniValue::VSTR)},
             },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -216,7 +216,7 @@ static void SetFeeEstimateMode(const CWallet& wallet, CCoinControl& cc, const Un
         if (!estimate_mode.isNull() && estimate_mode.get_str() != "unset") {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot specify both estimate_mode and fee_rate");
         }
-        cc.m_feerate = CFeeRate(AmountFromValue(fee_rate), COIN);
+        cc.m_feerate = CFeeRate::FromSatB(AmountFromValue(fee_rate));
         if (override_min_fee) cc.fOverrideFeeRate = true;
         // Default RBF to true for explicit fee_rate, if unset.
         if (cc.m_signal_bip125_rbf == nullopt) cc.m_signal_bip125_rbf = true;
@@ -2332,8 +2332,8 @@ static RPCHelpMan settxfee()
     LOCK(pwallet->cs_wallet);
 
     CAmount nAmount = AmountFromValue(request.params[0]);
-    CFeeRate tx_fee_rate(nAmount, 1000);
-    CFeeRate max_tx_fee_rate(pwallet->m_default_max_tx_fee, 1000);
+    CFeeRate tx_fee_rate{CFeeRate::FromBtcKb(nAmount)};
+    CFeeRate max_tx_fee_rate{CFeeRate::FromBtcKb(pwallet->m_default_max_tx_fee)};
     if (tx_fee_rate == CFeeRate(0)) {
         // automatic selection
     } else if (tx_fee_rate < pwallet->chain().relayMinFee()) {
@@ -3147,7 +3147,7 @@ void FundTransaction(CWallet* const pwallet, CMutableTransaction& tx, CAmount& f
             if (options.exists("estimate_mode")) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot specify both estimate_mode and feeRate");
             }
-            coinControl.m_feerate = CFeeRate(AmountFromValue(options["feeRate"]));
+            coinControl.m_feerate = CFeeRate::FromBtcKb(AmountFromValue(options["feeRate"]));
             coinControl.fOverrideFeeRate = true;
         }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2334,7 +2334,7 @@ static RPCHelpMan settxfee()
     CAmount nAmount = AmountFromValue(request.params[0]);
     CFeeRate tx_fee_rate{CFeeRate::FromBtcKb(nAmount)};
     CFeeRate max_tx_fee_rate{CFeeRate::FromBtcKb(pwallet->m_default_max_tx_fee)};
-    if (tx_fee_rate == CFeeRate(0)) {
+    if (tx_fee_rate.IsZero()) {
         // automatic selection
     } else if (tx_fee_rate < pwallet->chain().relayMinFee()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("txfee cannot be less than min relay tx fee (%s)", pwallet->chain().relayMinFee().ToString()));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3959,7 +3959,7 @@ std::shared_ptr<CWallet> CWallet::Create(interfaces::Chain& chain, const std::st
             warnings.push_back(AmountHighWarn("-paytxfee") + Untranslated(" ") +
                                _("This is the transaction fee you will pay if you send a transaction."));
         }
-        walletInstance->m_pay_tx_fee = CFeeRate(nFeePerK, 1000);
+        walletInstance->m_pay_tx_fee = CFeeRate::FromBtcKb(nFeePerK);
         if (walletInstance->m_pay_tx_fee < chain.relayMinFee()) {
             error = strprintf(_("Invalid amount for -paytxfee=<amount>: '%s' (must be at least %s)"),
                 gArgs.GetArg("-paytxfee", ""), chain.relayMinFee().ToString());
@@ -3976,7 +3976,7 @@ std::shared_ptr<CWallet> CWallet::Create(interfaces::Chain& chain, const std::st
         if (nMaxFee > HIGH_MAX_TX_FEE) {
             warnings.push_back(_("-maxtxfee is set very high! Fees this large could be paid on a single transaction."));
         }
-        if (CFeeRate(nMaxFee, 1000) < chain.relayMinFee()) {
+        if (CFeeRate::FromBtcKb(nMaxFee) < chain.relayMinFee()) {
             error = strprintf(_("Invalid amount for -maxtxfee=<amount>: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)"),
                 gArgs.GetArg("-maxtxfee", ""), chain.relayMinFee().ToString());
             return nullptr;

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -5,6 +5,8 @@
 """Test the fundrawtransaction RPC."""
 
 from decimal import Decimal
+from itertools import product
+
 from test_framework.descriptors import descsum_create
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -721,17 +723,16 @@ class RawTransactionsTest(BitcoinTestFramework):
         result2 = node.fundrawtransaction(rawtx, {"feeRate": 2 * self.min_relay_tx_fee})
         result3 = node.fundrawtransaction(rawtx, {"fee_rate": 10 * btc_kvb_to_sat_vb * self.min_relay_tx_fee})
         result4 = node.fundrawtransaction(rawtx, {"feeRate": str(10 * self.min_relay_tx_fee)})
-        # Test that funding non-standard "zero-fee" transactions is valid.
-        result5 = self.nodes[3].fundrawtransaction(rawtx, {"fee_rate": 0})
-        result6 = self.nodes[3].fundrawtransaction(rawtx, {"feeRate": 0})
 
         result_fee_rate = result['fee'] * 1000 / count_bytes(result['hex'])
-        assert_fee_amount(result1['fee'], count_bytes(result2['hex']), 2 * result_fee_rate)
+        assert_fee_amount(result1['fee'], count_bytes(result1['hex']), 2 * result_fee_rate)
         assert_fee_amount(result2['fee'], count_bytes(result2['hex']), 2 * result_fee_rate)
         assert_fee_amount(result3['fee'], count_bytes(result3['hex']), 10 * result_fee_rate)
-        assert_fee_amount(result4['fee'], count_bytes(result3['hex']), 10 * result_fee_rate)
-        assert_fee_amount(result5['fee'], count_bytes(result5['hex']), 0)
-        assert_fee_amount(result6['fee'], count_bytes(result6['hex']), 0)
+        assert_fee_amount(result4['fee'], count_bytes(result4['hex']), 10 * result_fee_rate)
+
+        # Test that funding non-standard "zero-fee" transactions is valid.
+        for param, zero_value in product(["fee_rate", "feeRate"], [0, 0.000, 0.00000000, "0", "0.000", "0.00000000"]):
+            assert_equal(self.nodes[3].fundrawtransaction(rawtx, {param: zero_value})["fee"], 0)
 
         # With no arguments passed, expect fee of 141 satoshis.
         assert_approx(node.fundrawtransaction(rawtx)["fee"], vexp=0.00000141, vspan=0.00000001)

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -768,6 +768,10 @@ class RawTransactionsTest(BitcoinTestFramework):
                 node.fundrawtransaction, rawtx, {param: {"foo": "bar"}, "add_inputs": True})
             assert_raises_rpc_error(-3, "Invalid amount",
                 node.fundrawtransaction, rawtx, {param: "", "add_inputs": True})
+        # Test fee_rate values non-representable by CFeeRate
+        for invalid_value in [0.00000001, 0.00099999, "0.00000001", "0.00099999"]:
+            assert_raises_rpc_error(-3, "Invalid amount",
+                node.fundrawtransaction, rawtx, {"fee_rate": invalid_value, "add_inputs": True})
 
         self.log.info("Test min fee rate checks are bypassed with fundrawtxn, e.g. a fee_rate under 1 sat/vB is allowed")
         node.fundrawtransaction(rawtx, {"fee_rate": 0.99999999, "add_inputs": True})

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -766,8 +766,9 @@ class RawTransactionsTest(BitcoinTestFramework):
                 node.fundrawtransaction, rawtx, {param: -1, "add_inputs": True})
             assert_raises_rpc_error(-3, "Amount is not a number or string",
                 node.fundrawtransaction, rawtx, {param: {"foo": "bar"}, "add_inputs": True})
-            assert_raises_rpc_error(-3, "Invalid amount",
-                node.fundrawtransaction, rawtx, {param: "", "add_inputs": True})
+            # Test fee_rate values that don't pass fixed-point parsing checks
+            for invalid_value in ["", 0.000000001, 1.111111111, 11111111111]:
+                assert_raises_rpc_error(-3, "Invalid amount", node.fundrawtransaction, rawtx, {param: invalid_value, "add_inputs": True})
         # Test fee_rate values non-representable by CFeeRate
         for invalid_value in [0.00000001, 0.00099999, "0.00000001", "0.00099999"]:
             assert_raises_rpc_error(-3, "Invalid amount",

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -215,6 +215,10 @@ class PSBTTest(BitcoinTestFramework):
                 self.nodes[1].walletcreatefundedpsbt, inputs, outputs, 0, {param: {"foo": "bar"}, "add_inputs": True})
             assert_raises_rpc_error(-3, "Invalid amount",
                 self.nodes[1].walletcreatefundedpsbt, inputs, outputs, 0, {param: "", "add_inputs": True})
+        # Test fee_rate values non-representable by CFeeRate
+        for invalid_value in [0.00000001, 0.00099999, "0.00000001", "0.00099999"]:
+            assert_raises_rpc_error(-3, "Invalid amount",
+                self.nodes[1].walletcreatefundedpsbt, inputs, outputs, 0, {"fee_rate": invalid_value, "add_inputs": True})
 
         self.log.info("- raises RPC error if both feeRate and fee_rate are passed")
         assert_raises_rpc_error(-8, "Cannot specify both fee_rate (sat/vB) and feeRate (BTC/kvB)",

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -6,6 +6,8 @@
 """
 
 from decimal import Decimal
+from itertools import product
+
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_approx,
@@ -200,8 +202,8 @@ class PSBTTest(BitcoinTestFramework):
         assert_approx(res4["fee"], 0.00000381, 0.0000001)
 
         self.log.info("Test min fee rate checks with walletcreatefundedpsbt are bypassed and that funding non-standard 'zero-fee' transactions is valid")
-        for param in ["fee_rate", "feeRate"]:
-            assert_equal(self.nodes[1].walletcreatefundedpsbt(inputs, outputs, 0, {param: 0, "add_inputs": True})["fee"], 0)
+        for param, zero_value in product(["fee_rate", "feeRate"], [0, 0.000, 0.00000000, "0", "0.000", "0.00000000"]):
+            assert_equal(0, self.nodes[1].walletcreatefundedpsbt(inputs, outputs, 0, {param: zero_value, "add_inputs": True})["fee"])
 
         self.log.info("Test invalid fee rate settings")
         for param, value in {("fee_rate", 100000), ("feeRate", 1)}:

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -213,8 +213,10 @@ class PSBTTest(BitcoinTestFramework):
                 self.nodes[1].walletcreatefundedpsbt, inputs, outputs, 0, {param: -1, "add_inputs": True})
             assert_raises_rpc_error(-3, "Amount is not a number or string",
                 self.nodes[1].walletcreatefundedpsbt, inputs, outputs, 0, {param: {"foo": "bar"}, "add_inputs": True})
-            assert_raises_rpc_error(-3, "Invalid amount",
-                self.nodes[1].walletcreatefundedpsbt, inputs, outputs, 0, {param: "", "add_inputs": True})
+            # Test fee_rate values that don't pass fixed-point parsing checks
+            for invalid_value in ["", 0.000000001, 1.111111111, 11111111111]:
+                assert_raises_rpc_error(-3, "Invalid amount",
+                    self.nodes[1].walletcreatefundedpsbt, inputs, outputs, 0, {param: invalid_value, "add_inputs": True})
         # Test fee_rate values non-representable by CFeeRate
         for invalid_value in [0.00000001, 0.00099999, "0.00000001", "0.00099999"]:
             assert_raises_rpc_error(-3, "Invalid amount",

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -15,6 +15,7 @@ from test_framework.util import (
 )
 from test_framework.wallet_util import test_address
 
+NOT_A_NUMBER_OR_STRING = "Amount is not a number or string"
 OUT_OF_RANGE = "Amount out of range"
 
 
@@ -278,6 +279,9 @@ class WalletTest(BitcoinTestFramework):
             assert_raises_rpc_error(-3, msg, self.nodes[2].sendmany, amounts={address: 1.0}, fee_rate=invalid_value)
         # Test fee_rate out of range (negative number)
         assert_raises_rpc_error(-3, OUT_OF_RANGE, self.nodes[2].sendmany, amounts={address: 10}, fee_rate=-1)
+        # Test type error
+        for invalid_value in [True, {"foo": "bar"}]:
+            assert_raises_rpc_error(-3, NOT_A_NUMBER_OR_STRING, self.nodes[2].sendmany, amounts={address: 10}, fee_rate=invalid_value)
 
         self.log.info("Test sendmany raises if an invalid conf_target or estimate_mode is passed")
         for target, mode in product([-1, 0, 1009], ["economical", "conservative"]):
@@ -471,6 +475,9 @@ class WalletTest(BitcoinTestFramework):
                 assert_raises_rpc_error(-3, msg, self.nodes[2].sendtoaddress, address=address, amount=1.0, fee_rate=invalid_value)
             # Test fee_rate out of range (negative number)
             assert_raises_rpc_error(-3, OUT_OF_RANGE, self.nodes[2].sendtoaddress, address=address, amount=1.0, fee_rate=-1)
+            # Test type error
+            for invalid_value in [True, {"foo": "bar"}]:
+                assert_raises_rpc_error(-3, NOT_A_NUMBER_OR_STRING, self.nodes[2].sendtoaddress, address=address, amount=1.0, fee_rate=invalid_value)
 
             self.log.info("Test sendtoaddress raises if an invalid conf_target or estimate_mode is passed")
             for target, mode in product([-1, 0, 1009], ["economical", "conservative"]):

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -265,8 +265,11 @@ class WalletTest(BitcoinTestFramework):
             self.nodes[2].sendmany, amounts={address: 10}, fee_rate=0.99999999)
 
         self.log.info("Test sendmany raises if fee_rate of 0 or -1 is passed")
-        assert_raises_rpc_error(-6, "Fee rate (0.000 sat/vB) is lower than the minimum fee rate setting (1.000 sat/vB)",
-            self.nodes[2].sendmany, amounts={address: 10}, fee_rate=0)
+        # Test fee_rate with zero values
+        msg = "Fee rate (0.000 sat/vB) is lower than the minimum fee rate setting (1.000 sat/vB)"
+        for zero_value in [0, 0.000, 0.00000000, "0", "0.000", "0.00000000"]:
+            assert_raises_rpc_error(-6, msg, self.nodes[2].sendmany, amounts={address: 1}, fee_rate=zero_value)
+        # Test fee_rate out of range (negative number)
         assert_raises_rpc_error(-3, OUT_OF_RANGE, self.nodes[2].sendmany, amounts={address: 10}, fee_rate=-1)
 
         self.log.info("Test sendmany raises if an invalid conf_target or estimate_mode is passed")
@@ -448,8 +451,11 @@ class WalletTest(BitcoinTestFramework):
                 self.nodes[2].sendtoaddress, address=address, amount=1, fee_rate=0.99999999)
 
             self.log.info("Test sendtoaddress raises if fee_rate of 0 or -1 is passed")
-            assert_raises_rpc_error(-6, "Fee rate (0.000 sat/vB) is lower than the minimum fee rate setting (1.000 sat/vB)",
-                self.nodes[2].sendtoaddress, address=address, amount=10, fee_rate=0)
+            # Test fee_rate with zero values
+            msg = "Fee rate (0.000 sat/vB) is lower than the minimum fee rate setting (1.000 sat/vB)"
+            for zero_value in [0, 0.000, 0.00000000, "0", "0.000", "0.00000000"]:
+                assert_raises_rpc_error(-6, msg, self.nodes[2].sendtoaddress, address=address, amount=1, fee_rate=zero_value)
+            # Test fee_rate out of range (negative number)
             assert_raises_rpc_error(-3, OUT_OF_RANGE, self.nodes[2].sendtoaddress, address=address, amount=1.0, fee_rate=-1)
 
             self.log.info("Test sendtoaddress raises if an invalid conf_target or estimate_mode is passed")

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -264,11 +264,15 @@ class WalletTest(BitcoinTestFramework):
         assert_raises_rpc_error(-6, "Fee rate (0.999 sat/vB) is lower than the minimum fee rate setting (1.000 sat/vB)",
             self.nodes[2].sendmany, amounts={address: 10}, fee_rate=0.99999999)
 
-        self.log.info("Test sendmany raises if fee_rate of 0 or -1 is passed")
+        self.log.info("Test sendmany raises RPC error when invalid fee rates are passed")
         # Test fee_rate with zero values
         msg = "Fee rate (0.000 sat/vB) is lower than the minimum fee rate setting (1.000 sat/vB)"
         for zero_value in [0, 0.000, 0.00000000, "0", "0.000", "0.00000000"]:
             assert_raises_rpc_error(-6, msg, self.nodes[2].sendmany, amounts={address: 1}, fee_rate=zero_value)
+        # Test fee_rate values non-representable by CFeeRate
+        msg = "Invalid amount"
+        for invalid_value in [0.00000001, 0.00099999, "0.00000001", "0.00099999"]:
+            assert_raises_rpc_error(-3, msg, self.nodes[2].sendmany, amounts={address: 10}, fee_rate=invalid_value)
         # Test fee_rate out of range (negative number)
         assert_raises_rpc_error(-3, OUT_OF_RANGE, self.nodes[2].sendmany, amounts={address: 10}, fee_rate=-1)
 
@@ -450,11 +454,15 @@ class WalletTest(BitcoinTestFramework):
             assert_raises_rpc_error(-6, "Fee rate (0.999 sat/vB) is lower than the minimum fee rate setting (1.000 sat/vB)",
                 self.nodes[2].sendtoaddress, address=address, amount=1, fee_rate=0.99999999)
 
-            self.log.info("Test sendtoaddress raises if fee_rate of 0 or -1 is passed")
+            self.log.info("Test sendtoaddress raises RPC error when invalid fee rates are passed")
             # Test fee_rate with zero values
             msg = "Fee rate (0.000 sat/vB) is lower than the minimum fee rate setting (1.000 sat/vB)"
             for zero_value in [0, 0.000, 0.00000000, "0", "0.000", "0.00000000"]:
                 assert_raises_rpc_error(-6, msg, self.nodes[2].sendtoaddress, address=address, amount=1, fee_rate=zero_value)
+            # Test fee_rate values non-representable by CFeeRate
+            msg = "Invalid amount"
+            for invalid_value in [0.00000001, 0.00099999, "0.00000001", "0.00099999"]:
+                assert_raises_rpc_error(-3, msg, self.nodes[2].sendtoaddress, address=address, amount=10, fee_rate=invalid_value)
             # Test fee_rate out of range (negative number)
             assert_raises_rpc_error(-3, OUT_OF_RANGE, self.nodes[2].sendtoaddress, address=address, amount=1.0, fee_rate=-1)
 

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -273,6 +273,9 @@ class WalletTest(BitcoinTestFramework):
         msg = "Invalid amount"
         for invalid_value in [0.00000001, 0.00099999, "0.00000001", "0.00099999"]:
             assert_raises_rpc_error(-3, msg, self.nodes[2].sendmany, amounts={address: 10}, fee_rate=invalid_value)
+        # Test fee_rate values that don't pass fixed-point parsing checks
+        for invalid_value in ["", 0.000000001, 1.111111111, 11111111111]:
+            assert_raises_rpc_error(-3, msg, self.nodes[2].sendmany, amounts={address: 1.0}, fee_rate=invalid_value)
         # Test fee_rate out of range (negative number)
         assert_raises_rpc_error(-3, OUT_OF_RANGE, self.nodes[2].sendmany, amounts={address: 10}, fee_rate=-1)
 
@@ -463,6 +466,9 @@ class WalletTest(BitcoinTestFramework):
             msg = "Invalid amount"
             for invalid_value in [0.00000001, 0.00099999, "0.00000001", "0.00099999"]:
                 assert_raises_rpc_error(-3, msg, self.nodes[2].sendtoaddress, address=address, amount=10, fee_rate=invalid_value)
+            # Test fee_rate values that don't pass fixed-point parsing checks
+            for invalid_value in ["", 0.000000001, 1.111111111, 11111111111]:
+                assert_raises_rpc_error(-3, msg, self.nodes[2].sendtoaddress, address=address, amount=1.0, fee_rate=invalid_value)
             # Test fee_rate out of range (negative number)
             assert_raises_rpc_error(-3, OUT_OF_RANGE, self.nodes[2].sendtoaddress, address=address, amount=1.0, fee_rate=-1)
 

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -110,9 +110,13 @@ class BumpFeeTest(BitcoinTestFramework):
         assert_raises_rpc_error(-8, "Insufficient total fee 0.00000141", rbf_node.bumpfee, rbfid, {"fee_rate": INSUFFICIENT})
 
         self.log.info("Test invalid fee rate settings")
-        assert_raises_rpc_error(-8, "Insufficient total fee 0.00", rbf_node.bumpfee, rbfid, {"fee_rate": 0})
         assert_raises_rpc_error(-4, "Specified or calculated fee 0.141 is too high (cannot be higher than -maxtxfee 0.10",
             rbf_node.bumpfee, rbfid, {"fee_rate": TOO_HIGH})
+        # Test fee_rate with zero values
+        msg = "Insufficient total fee 0.00"
+        for zero_value in [0, 0.000, 0.00000000, "0", "0.000", "0.00000000"]:
+            assert_raises_rpc_error(-8, msg, rbf_node.bumpfee, rbfid, {"fee_rate": zero_value})
+        # Test fee_rate out of range (negative number)
         assert_raises_rpc_error(-3, "Amount out of range", rbf_node.bumpfee, rbfid, {"fee_rate": -1})
         for value in [{"foo": "bar"}, True]:
             assert_raises_rpc_error(-3, "Amount is not a number or string", rbf_node.bumpfee, rbfid, {"fee_rate": value})

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -116,11 +116,16 @@ class BumpFeeTest(BitcoinTestFramework):
         msg = "Insufficient total fee 0.00"
         for zero_value in [0, 0.000, 0.00000000, "0", "0.000", "0.00000000"]:
             assert_raises_rpc_error(-8, msg, rbf_node.bumpfee, rbfid, {"fee_rate": zero_value})
+        # Test fee_rate values non-representable by CFeeRate
+        msg = "Invalid amount"
+        for invalid_value in [0.00000001, 0.00099999, "0.00000001", "0.00099999"]:
+            assert_raises_rpc_error(-3, msg, rbf_node.bumpfee, rbfid, {"fee_rate": invalid_value})
+        assert_raises_rpc_error(-3, msg, rbf_node.bumpfee, rbfid, {"fee_rate": ""})
         # Test fee_rate out of range (negative number)
         assert_raises_rpc_error(-3, "Amount out of range", rbf_node.bumpfee, rbfid, {"fee_rate": -1})
+        # Test type error
         for value in [{"foo": "bar"}, True]:
             assert_raises_rpc_error(-3, "Amount is not a number or string", rbf_node.bumpfee, rbfid, {"fee_rate": value})
-        assert_raises_rpc_error(-3, "Invalid amount", rbf_node.bumpfee, rbfid, {"fee_rate": ""})
 
         self.log.info("Test explicit fee rate raises RPC error if both fee_rate and conf_target are passed")
         assert_raises_rpc_error(-8, "Cannot specify both conf_target and fee_rate. Please provide either a confirmation "

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -121,6 +121,9 @@ class BumpFeeTest(BitcoinTestFramework):
         for invalid_value in [0.00000001, 0.00099999, "0.00000001", "0.00099999"]:
             assert_raises_rpc_error(-3, msg, rbf_node.bumpfee, rbfid, {"fee_rate": invalid_value})
         assert_raises_rpc_error(-3, msg, rbf_node.bumpfee, rbfid, {"fee_rate": ""})
+        # Test fee_rate values that don't pass fixed-point parsing checks
+        for invalid_value in ["", 0.000000001, 1.111111111, 11111111111]:
+            assert_raises_rpc_error(-3, msg, rbf_node.bumpfee, rbfid, {"fee_rate": invalid_value})
         # Test fee_rate out of range (negative number)
         assert_raises_rpc_error(-3, "Amount out of range", rbf_node.bumpfee, rbfid, {"fee_rate": -1})
         # Test type error

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -304,14 +304,14 @@ class WalletSendTest(BitcoinTestFramework):
 
         # Test setting explicit fee rate just below the minimum and at zero.
         self.log.info("Explicit fee rate raises RPC error 'fee rate too low' if fee_rate of 0.99999999 is passed")
-        self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=0.99999999,
-            expect_error=(-4, "Fee rate (0.999 sat/vB) is lower than the minimum fee rate setting (1.000 sat/vB)"))
-        self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=0.99999999,
-            expect_error=(-4, "Fee rate (0.999 sat/vB) is lower than the minimum fee rate setting (1.000 sat/vB)"))
-        self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=0,
-            expect_error=(-4, "Fee rate (0.000 sat/vB) is lower than the minimum fee rate setting (1.000 sat/vB)"))
-        self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=0,
-            expect_error=(-4, "Fee rate (0.000 sat/vB) is lower than the minimum fee rate setting (1.000 sat/vB)"))
+        msg = "Fee rate (0.999 sat/vB) is lower than the minimum fee rate setting (1.000 sat/vB)"
+        self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=0.99999999, expect_error=(-4, msg))
+        self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=0.99999999, expect_error=(-4, msg))
+        # Test fee_rate with zero values
+        msg = "Fee rate (0.000 sat/vB) is lower than the minimum fee rate setting (1.000 sat/vB)"
+        for zero_value in [0, 0.000, 0.00000000, "0", "0.000", "0.00000000"]:
+            self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=zero_value, expect_error=(-4, msg))
+            self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=zero_value, expect_error=(-4, msg))
 
         # TODO: Return hex if fee rate is below -maxmempool
         # res = self.test_send(from_wallet=w0, to_wallet=w1, amount=1, conf_target=0.1, estimate_mode="sat/b", add_to_wallet=False)

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -302,16 +302,23 @@ class WalletSendTest(BitcoinTestFramework):
                 self.test_send(from_wallet=w0, to_wallet=w1, amount=1, conf_target=v, estimate_mode=mode,
                     expect_error=(-3, "Expected type number for conf_target, got {}".format(k)))
 
-        # Test setting explicit fee rate just below the minimum and at zero.
+        # Test setting explicit fee rate just below the minimum.
         self.log.info("Explicit fee rate raises RPC error 'fee rate too low' if fee_rate of 0.99999999 is passed")
         msg = "Fee rate (0.999 sat/vB) is lower than the minimum fee rate setting (1.000 sat/vB)"
         self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=0.99999999, expect_error=(-4, msg))
         self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=0.99999999, expect_error=(-4, msg))
+
+        self.log.info("Explicit fee rate raises RPC error when invalid fee rates are passed")
         # Test fee_rate with zero values
         msg = "Fee rate (0.000 sat/vB) is lower than the minimum fee rate setting (1.000 sat/vB)"
         for zero_value in [0, 0.000, 0.00000000, "0", "0.000", "0.00000000"]:
             self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=zero_value, expect_error=(-4, msg))
             self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=zero_value, expect_error=(-4, msg))
+        # Test fee_rate values non-representable by CFeeRate
+        msg = "Invalid amount"
+        for invalid_value in [0.00000001, 0.0009, 0.00099999]:
+            self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=invalid_value, expect_error=(-3, msg))
+            self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=invalid_value, expect_error=(-3, msg))
 
         # TODO: Return hex if fee rate is below -maxmempool
         # res = self.test_send(from_wallet=w0, to_wallet=w1, amount=1, conf_target=0.1, estimate_mode="sat/b", add_to_wallet=False)

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -296,11 +296,10 @@ class WalletSendTest(BitcoinTestFramework):
             self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_conf_target=0.1, arg_estimate_mode=mode, expect_error=(-8, msg))
             assert_raises_rpc_error(-8, msg, w0.send, {w1.getnewaddress(): 1}, 0.1, mode)
 
-        for mode in ["economical", "conservative", "btc/kb", "sat/b"]:
-            self.log.debug("{}".format(mode))
-            for k, v in {"string": "true", "object": {"foo": "bar"}}.items():
+        for mode in ["economical", "conservative"]:
+            for k, v in {"string": "true", "bool": True, "object": {"foo": "bar"}}.items():
                 self.test_send(from_wallet=w0, to_wallet=w1, amount=1, conf_target=v, estimate_mode=mode,
-                    expect_error=(-3, "Expected type number for conf_target, got {}".format(k)))
+                    expect_error=(-3, f"Expected type number for conf_target, got {k}"))
 
         # Test setting explicit fee rate just below the minimum.
         self.log.info("Explicit fee rate raises RPC error 'fee rate too low' if fee_rate of 0.99999999 is passed")
@@ -321,6 +320,15 @@ class WalletSendTest(BitcoinTestFramework):
             self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=invalid_value, expect_error=(-3, msg))
         # Test fee_rate values that don't pass fixed-point parsing checks
         for invalid_value in ["", 0.000000001, 1.111111111, 11111111111]:
+            self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=invalid_value, expect_error=(-3, msg))
+            self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=invalid_value, expect_error=(-3, msg))
+        # Test fee_rate out of range (negative number)
+        msg = "Amount out of range"
+        self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=-1, expect_error=(-3, msg))
+        self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=-1, expect_error=(-3, msg))
+        # Test type error
+        msg = "Amount is not a number or string"
+        for invalid_value in [True, {"foo": "bar"}]:
             self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=invalid_value, expect_error=(-3, msg))
             self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=invalid_value, expect_error=(-3, msg))
 

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -319,6 +319,10 @@ class WalletSendTest(BitcoinTestFramework):
         for invalid_value in [0.00000001, 0.0009, 0.00099999]:
             self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=invalid_value, expect_error=(-3, msg))
             self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=invalid_value, expect_error=(-3, msg))
+        # Test fee_rate values that don't pass fixed-point parsing checks
+        for invalid_value in ["", 0.000000001, 1.111111111, 11111111111]:
+            self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=invalid_value, expect_error=(-3, msg))
+            self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=invalid_value, expect_error=(-3, msg))
 
         # TODO: Return hex if fee rate is below -maxmempool
         # res = self.test_send(from_wallet=w0, to_wallet=w1, amount=1, conf_target=0.1, estimate_mode="sat/b", add_to_wallet=False)


### PR DESCRIPTION
As part of our migration to sat/vB feerates that began with #20305, this pull should resolve #20534 and improve/reduce the size of #20391 that adds a `setfeerate` RPC in sat/vB, as well as for a future `estimatefeerate` RPC in sat/vB. The code changes are less than 40 lines. Most of the diff is test coverage, as these changes touch a number of RPCs.

Changes:

- add `CFeeRate::FromSatB` and `CFeeRate::FromBtcKb` named constructors
- add a `CFeeRate::IsZero()` class member helper to replace `== CFeeRate(0)` conditionals and avoid object allocations/constructions
- add a `FeeRateFromValueInSatB()` utility function that calls `AmountFromValue()` and then performs an additional check for non-representable `CFeeRate` values in the range between 0 and 0.001 sat/vB
- add unit and functional tests and fill some current fee rate gaps in the functional test coverage
