### PR TITLE
RPC: Tolerate invalid rpcauth options

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -80,8 +80,6 @@ Updated settings
 
 Changes to Wallet or GUI related settings can be found in the GUI or Wallet section below.
 
-- Passing an invalid `-rpcauth` argument now cause bitcoind to fail to start.  (#20461)
-
 Tools and Utilities
 -------------------
 

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -259,8 +259,7 @@ static bool InitRPCAuthentication()
             if (fields.size() == 3) {
                 g_rpcauth.push_back(fields);
             } else {
-                LogPrintf("Invalid -rpcauth argument.\n");
-                return false;
+                LogPrintf("Ignoring invalid -rpcauth argument.\n");
             }
         }
     }

--- a/test/functional/rpc_users.py
+++ b/test/functional/rpc_users.py
@@ -103,12 +103,17 @@ class HTTPBasicsTest(BitcoinTestFramework):
 
         self.log.info('Check -rpcauth are validated')
         # Empty -rpcauth= are ignored
-        self.restart_node(0, extra_args=['-rpcauth='])
-        self.stop_node(0)
-        self.nodes[0].assert_start_raises_init_error(expected_msg=init_error, extra_args=['-rpcauth=foo'])
-        self.nodes[0].assert_start_raises_init_error(expected_msg=init_error, extra_args=['-rpcauth=foo:bar'])
+        with self.nodes[0].assert_debug_log(unexpected_msgs=['Ignoring invalid -rpcauth argument.']):
+            self.restart_node(0, extra_args=['-rpcauth='])
+        with self.nodes[0].assert_debug_log(expected_msgs=['Ignoring invalid -rpcauth argument.']):
+            self.restart_node(0, extra_args=['-rpcauth=foo'])
+        with self.nodes[0].assert_debug_log(expected_msgs=['Ignoring invalid -rpcauth argument.']):
+            self.restart_node(0, extra_args=['-rpcauth=foo:bar'])
+        with self.nodes[0].assert_debug_log(expected_msgs=['Ignoring invalid -rpcauth argument.']):
+            self.restart_node(0, extra_args=['-rpcauth=foo:bar:baz:foo'])
 
         self.log.info('Check that failure to write cookie file will abort the node gracefully')
+        self.stop_node(0)
         cookie_file = os.path.join(get_datadir_path(self.options.tmpdir, 0), self.chain, '.cookie.tmp')
         os.mkdir(cookie_file)
         self.nodes[0].assert_start_raises_init_error(expected_msg=init_error)

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -362,7 +362,9 @@ class TestNode():
         wait_until_helper(self.is_node_stopped, timeout=timeout, timeout_factor=self.timeout_factor)
 
     @contextlib.contextmanager
-    def assert_debug_log(self, expected_msgs, unexpected_msgs=None, timeout=2):
+    def assert_debug_log(self, expected_msgs=None, unexpected_msgs=None, timeout=2):
+        if expected_msgs is None:
+            expected_msgs = []
         if unexpected_msgs is None:
             unexpected_msgs = []
         time_end = time.time() + timeout * self.timeout_factor


### PR DESCRIPTION
By tolerating unknown extra rpcauth parameters (and ignoring the rpcauth), we can ensure a limited forward compatibility by not forcing users to downgrade their config file to switch back to older versions (perhaps temporarily).

Same as #20548, but without the additional effort to explain the situation at runtime.