### PR TITLE
addrman: Fix new table bucketing during unserialization

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -504,14 +504,14 @@ public:
         // so we store all bucket-entry_index pairs to iterate through later.
         std::vector<std::pair<int, int>> bucket_entries;
 
-        for (int bucket = 0; bucket < nUBuckets; bucket++) {
-            int nSize = 0;
-            s >> nSize;
-            for (int n = 0; n < nSize; n++) {
-                int nIndex = 0;
-                s >> nIndex;
-                if (nIndex >= 0 && nIndex < nNew) {
-                    bucket_entries.emplace_back(bucket, nIndex);
+        for (int bucket = 0; bucket < nUBuckets; ++bucket) {
+            int num_entries{0};
+            s >> num_entries;
+            for (int n = 0; n < num_entries; ++n) {
+                int entry_index{0};
+                s >> entry_index;
+                if (entry_index >= 0 && entry_index < nNew) {
+                    bucket_entries.emplace_back(bucket, entry_index);
                 }
             }
         }
@@ -527,13 +527,13 @@ public:
 
         for (auto bucket_entry : bucket_entries) {
             int bucket{bucket_entry.first};
-            const int n{bucket_entry.second};
-            CAddrInfo& info = mapInfo[n];
+            const int entry_index{bucket_entry.second};
+            CAddrInfo& info = mapInfo[entry_index];
             int nUBucketPos = info.GetBucketPosition(nKey, true, bucket);
             if (format >= Format::V2_ASMAP && nUBuckets == ADDRMAN_NEW_BUCKET_COUNT && vvNew[bucket][nUBucketPos] == -1 &&
                 info.nRefCount < ADDRMAN_NEW_BUCKETS_PER_ADDRESS && serialized_asmap_version == supplied_asmap_version) {
                 // Bucketing has not changed, using existing bucket positions for the new table
-                vvNew[bucket][nUBucketPos] = n;
+                vvNew[bucket][nUBucketPos] = entry_index;
                 info.nRefCount++;
             } else {
                 // In case the new table data cannot be used (format unknown, bucket count wrong or new asmap),
@@ -542,7 +542,7 @@ public:
                 bucket = info.GetNewBucket(nKey, m_asmap);
                 nUBucketPos = info.GetBucketPosition(nKey, true, bucket);
                 if (vvNew[bucket][nUBucketPos] == -1) {
-                    vvNew[bucket][nUBucketPos] = n;
+                    vvNew[bucket][nUBucketPos] = entry_index;
                     info.nRefCount++;
                 }
             }

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -517,8 +517,9 @@ public:
             }
         }
 
-        // Attempt to restore the entry's new buckets if the bucket count and asmap
-        // checksum haven't changed
+        // If the bucket count and asmap checksum haven't changed, then attempt
+        // to restore the entries to the buckets/positions they were in before
+        // serialization.
         uint256 supplied_asmap_checksum;
         if (m_asmap.size() != 0) {
             supplied_asmap_checksum = SerializeHash(m_asmap);
@@ -540,20 +541,20 @@ public:
             // this bucket_entry.
             if (info.nRefCount >= ADDRMAN_NEW_BUCKETS_PER_ADDRESS) continue;
 
-            int nUBucketPos = info.GetBucketPosition(nKey, true, bucket);
-            if (restore_bucketing && vvNew[bucket][nUBucketPos] == -1) {
+            int bucket_position = info.GetBucketPosition(nKey, true, bucket);
+            if (restore_bucketing && vvNew[bucket][bucket_position] == -1) {
                 // Bucketing has not changed, using existing bucket positions for the new table
-                vvNew[bucket][nUBucketPos] = entry_index;
-                info.nRefCount++;
+                vvNew[bucket][bucket_position] = entry_index;
+                ++info.nRefCount;
             } else {
                 // In case the new table data cannot be used (bucket count wrong or new asmap),
                 // try to give them a reference based on their primary source address.
                 LogPrint(BCLog::ADDRMAN, "Bucketing method was updated, re-bucketing addrman entries from disk\n");
                 bucket = info.GetNewBucket(nKey, m_asmap);
-                nUBucketPos = info.GetBucketPosition(nKey, true, bucket);
-                if (vvNew[bucket][nUBucketPos] == -1) {
-                    vvNew[bucket][nUBucketPos] = entry_index;
-                    info.nRefCount++;
+                bucket_position = info.GetBucketPosition(nKey, true, bucket);
+                if (vvNew[bucket][bucket_position] == -1) {
+                    vvNew[bucket][bucket_position] = entry_index;
+                    ++info.nRefCount;
                 }
             }
         }

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -335,22 +335,19 @@ public:
      * * nNew
      * * nTried
      * * number of "new" buckets XOR 2**30
-     * * all nNew addrinfos in vvNew
-     * * all nTried addrinfos in vvTried
-     * * for each bucket:
+     * * all new addresses (total count: nNew)
+     * * all tried addresses (total count: nTried)
+     * * for each new bucket:
      *   * number of elements
-     *   * for each element: index
+     *   * for each element: index in the serialized "all new addresses"
      * * asmap checksum
      *
      * 2**30 is xorred with the number of buckets to make addrman deserializer v0 detect it
      * as incompatible. This is necessary because it did not check the version number on
      * deserialization.
      *
-     * Notice that vvTried, mapAddr and vVector are never encoded explicitly;
+     * vvNew, vvTried, mapInfo, mapAddr and vRandom are never encoded explicitly;
      * they are instead reconstructed from the other information.
-     *
-     * vvNew is serialized, but only used if ADDRMAN_NEW_BUCKET_COUNT and the asmap checksum
-     * didn't change, otherwise it is reconstructed as well.
      *
      * This format is more complex, but significantly smaller (at most 1.5 MiB), and supports
      * changes to the ADDRMAN_ parameters without breaking the on-disk structure.

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -528,6 +528,10 @@ public:
         const bool restore_bucketing{nUBuckets == ADDRMAN_NEW_BUCKET_COUNT &&
                                      serialized_asmap_checksum == supplied_asmap_checksum};
 
+        if (!restore_bucketing) {
+            LogPrint(BCLog::ADDRMAN, "Bucketing method was updated, re-bucketing addrman entries from disk\n");
+        }
+
         for (auto bucket_entry : bucket_entries) {
             int bucket{bucket_entry.first};
             const int entry_index{bucket_entry.second};
@@ -546,7 +550,6 @@ public:
             } else {
                 // In case the new table data cannot be used (bucket count wrong or new asmap),
                 // try to give them a reference based on their primary source address.
-                LogPrint(BCLog::ADDRMAN, "Bucketing method was updated, re-bucketing addrman entries from disk\n");
                 bucket = info.GetNewBucket(nKey, m_asmap);
                 bucket_position = info.GetBucketPosition(nKey, true, bucket);
                 if (vvNew[bucket][bucket_position] == -1) {


### PR DESCRIPTION
This fixes three issues in addrman unserialization.

1. An addrman entry can appear in up to 8 new table buckets. We store this entry->bucket indexing during shutdown so that on restart we can restore the entries to their correct buckets. Commit ec45646de9e62b3d42c85716bfeb06d8f2b507dc broke the deserialization code so that each entry could only be put in up to one new bucket.

2. Unserialization may result in an entry appearing in a 9th bucket. If the entry already appears in 8 buckets don't try to place it in another bucket.

3. We unnecessarily rebucket when reading a peers.dat with file version 1. Don't do that.