### PR TITLE
test: Add option to git-subtree-check to do full check, add help

### DIFF
--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -14,6 +14,8 @@ if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then
   test/lint/commit-script-check.sh $COMMIT_RANGE
 fi
 
+# This only checks that the trees are pure subtrees, it is not doing a full
+# check with -r to not have to fetch all the remotes.
 test/lint/git-subtree-check.sh src/crypto/ctaes
 test/lint/git-subtree-check.sh src/secp256k1
 test/lint/git-subtree-check.sh src/univalue

--- a/test/lint/README.md
+++ b/test/lint/README.md
@@ -15,7 +15,16 @@ git-subtree-check.sh
 Run this script from the root of the repository to verify that a subtree matches the contents of
 the commit it claims to have been updated to.
 
-To use, make sure that you have fetched the upstream repository branch in which the subtree is
+```
+Usage: test/lint/git-subtree-check.sh [-r] DIR [COMMIT]
+       test/lint/git-subtree-check.sh -?
+```
+
+- `DIR` is the prefix within the repository to check.
+- `COMMIT` is the commit to check, if it is not provided, HEAD will be used.
+- `-r` checks that subtree commit is present in repository.
+
+To do a full check with `-r`, make sure that you have fetched the upstream repository branch in which the subtree is
 maintained:
 * for `src/secp256k1`: https://github.com/bitcoin-core/secp256k1.git (branch master)
 * for `src/leveldb`: https://github.com/bitcoin-core/leveldb.git (branch bitcoin-fork)
@@ -28,10 +37,6 @@ To do so, add the upstream repository as remote:
 ```
 git remote add --fetch secp256k1 https://github.com/bitcoin-core/secp256k1.git
 ```
-
-Usage: `git-subtree-check.sh DIR (COMMIT)`
-
-`COMMIT` may be omitted, in which case `HEAD` is used.
 
 lint-all.sh
 ===========

--- a/test/lint/git-subtree-check.sh
+++ b/test/lint/git-subtree-check.sh
@@ -4,6 +4,39 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 export LC_ALL=C
+
+check_remote=0
+while getopts "?hr" opt; do
+  case $opt in
+    '?' | h)
+      echo "Usage: $0 [-r] DIR [COMMIT]"
+      echo "       $0 -?"
+      echo ""
+      echo "Checks that a certain prefix is pure subtree, and optionally whether the"
+      echo "referenced commit is present in any fetched remote."
+      echo ""
+      echo "DIR is the prefix within the repository to check."
+      echo "COMMIT is the commit to check, if it is not provided, HEAD will be used."
+      echo ""
+      echo "-r      Check that subtree commit is present in repository."
+      echo "        To do this check, fetch the subtreed remote first. Example:"
+      echo ""
+      echo "            git fetch https://github.com/bitcoin-core/secp256k1.git"
+      echo "            test/lint/git-subtree-check.sh -r src/secp256k1"
+      exit 1
+    ;;
+    r)
+      check_remote=1
+    ;;
+  esac
+done
+shift $((OPTIND-1))
+
+if [ -z "$1" ]; then
+    echo "Need to provide a DIR, see $0 -?"
+    exit 1
+fi
+
 # Strip trailing / from directory path (in case it was added by autocomplete)
 DIR="${1%/}"
 COMMIT="$2"
@@ -79,18 +112,20 @@ if [ "$tree_actual_tree" != "$tree_commit" ]; then
     exit 1
 fi
 
-# get the tree in the subtree commit referred to
-if [ "d$(git cat-file -t $rev 2>/dev/null)" != dcommit ]; then
-    echo "subtree commit $rev unavailable: cannot compare. Did you add and fetch the remote?" >&2
-    exit
-fi
-tree_subtree=$(git show -s --format="%T" $rev)
-echo "$DIR in $COMMIT was last updated to upstream commit $rev (tree $tree_subtree)"
+if [ "$check_remote" != "0" ]; then
+    # get the tree in the subtree commit referred to
+    if [ "d$(git cat-file -t $rev 2>/dev/null)" != dcommit ]; then
+        echo "subtree commit $rev unavailable: cannot compare. Did you add and fetch the remote?" >&2
+        exit 1
+    fi
+    tree_subtree=$(git show -s --format="%T" $rev)
+    echo "$DIR in $COMMIT was last updated to upstream commit $rev (tree $tree_subtree)"
 
-# ... and compare the actual tree with it
-if [ "$tree_actual_tree" != "$tree_subtree" ]; then
-    echo "FAIL: subtree update commit differs from upstream tree!" >&2
-    exit 1
+    # ... and compare the actual tree with it
+    if [ "$tree_actual_tree" != "$tree_subtree" ]; then
+        echo "FAIL: subtree update commit differs from upstream tree!" >&2
+        exit 1
+    fi
 fi
 
 echo "GOOD"


### PR DESCRIPTION
This adds a brief help text to `git-subtree-check.sh` and adds an option to do a full remote check instead of having two different code paths with a successful exit status. Also make it explicit that the CI is not doing this.