### PR TITLE
test: Fix intermittent wallet_multiwallet issue with got_loading_error

### DIFF
--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -27,7 +27,7 @@ got_loading_error = False
 
 def test_load_unload(node, name):
     global got_loading_error
-    for _ in range(10):
+    while True:
         if got_loading_error:
             return
         try:

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -23,6 +23,8 @@ from test_framework.util import (
 )
 
 got_loading_error = False
+
+
 def test_load_unload(node, name):
     global got_loading_error
     for _ in range(10):
@@ -68,7 +70,7 @@ class MultiWalletTest(BitcoinTestFramework):
                 return wallet_dir(name, "wallet.dat")
             return wallet_dir(name)
 
-        assert_equal(self.nodes[0].listwalletdir(), { 'wallets': [{ 'name': self.default_wallet_name }] })
+        assert_equal(self.nodes[0].listwalletdir(), {'wallets': [{'name': self.default_wallet_name}]})
 
         # check wallet.dat is created
         self.stop_nodes()
@@ -278,7 +280,7 @@ class MultiWalletTest(BitcoinTestFramework):
         threads = []
         for _ in range(3):
             n = node.cli if self.options.usecli else get_rpc_proxy(node.url, 1, timeout=600, coveragedir=node.coverage_dir)
-            t = Thread(target=test_load_unload, args=(n, wallet_names[2], ))
+            t = Thread(target=test_load_unload, args=(n, wallet_names[2]))
             t.start()
             threads.append(t)
         for t in threads:


### PR DESCRIPTION
Failing the test after 10 iterations without a loading error is problematic because it may take 11 iterations to get a loading error.

Fix that by running until a loading error occurs, which should happen in almost all runs within the first 10 iterations.