### PR TITLE
refactor: Use deduction guide for std::array<uint8_t, N>

### DIFF
--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -315,7 +315,8 @@ bool CNetAddr::IsRFC2544() const
 
 bool CNetAddr::IsRFC3927() const
 {
-    return IsIPv4() && HasPrefix(m_addr, std::array<uint8_t, 2>{169, 254});
+    constexpr std::array prefix{169_u8, 254_u8};
+    return IsIPv4() && HasPrefix(m_addr, prefix);
 }
 
 bool CNetAddr::IsRFC6598() const
@@ -325,37 +326,42 @@ bool CNetAddr::IsRFC6598() const
 
 bool CNetAddr::IsRFC5737() const
 {
-    return IsIPv4() && (HasPrefix(m_addr, std::array<uint8_t, 3>{192, 0, 2}) ||
-                        HasPrefix(m_addr, std::array<uint8_t, 3>{198, 51, 100}) ||
-                        HasPrefix(m_addr, std::array<uint8_t, 3>{203, 0, 113}));
+    constexpr std::array prefix_a{192_u8, 0_u8, 2_u8};
+    constexpr std::array prefix_b{198_u8, 51_u8, 100_u8};
+    constexpr std::array prefix_c{203_u8, 0_u8, 113_u8};
+    return IsIPv4() && (HasPrefix(m_addr, prefix_a) || HasPrefix(m_addr, prefix_b) || HasPrefix(m_addr, prefix_c));
 }
 
 bool CNetAddr::IsRFC3849() const
 {
-    return IsIPv6() && HasPrefix(m_addr, std::array<uint8_t, 4>{0x20, 0x01, 0x0D, 0xB8});
+    constexpr std::array prefix{0x20_u8, 0x01_u8, 0x0D_u8, 0xB8_u8};
+    return IsIPv6() && HasPrefix(m_addr, prefix);
 }
 
 bool CNetAddr::IsRFC3964() const
 {
-    return IsIPv6() && HasPrefix(m_addr, std::array<uint8_t, 2>{0x20, 0x02});
+    constexpr std::array prefix{0x20_u8, 0x02_u8};
+    return IsIPv6() && HasPrefix(m_addr, prefix);
 }
 
 bool CNetAddr::IsRFC6052() const
 {
-    return IsIPv6() &&
-           HasPrefix(m_addr, std::array<uint8_t, 12>{0x00, 0x64, 0xFF, 0x9B, 0x00, 0x00,
-                                                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+    constexpr std::array prefix{0x00_u8, 0x64_u8, 0xFF_u8, 0x9B_u8, 0x00_u8, 0x00_u8,
+                                0x00_u8, 0x00_u8, 0x00_u8, 0x00_u8, 0x00_u8, 0x00_u8};
+    return IsIPv6() && HasPrefix(m_addr, prefix);
 }
 
 bool CNetAddr::IsRFC4380() const
 {
-    return IsIPv6() && HasPrefix(m_addr, std::array<uint8_t, 4>{0x20, 0x01, 0x00, 0x00});
+    constexpr std::array prefix{0x20_u8, 0x01_u8, 0x00_u8, 0x00_u8};
+    return IsIPv6() && HasPrefix(m_addr, prefix);
 }
 
 bool CNetAddr::IsRFC4862() const
 {
-    return IsIPv6() && HasPrefix(m_addr, std::array<uint8_t, 8>{0xFE, 0x80, 0x00, 0x00,
-                                                                0x00, 0x00, 0x00, 0x00});
+    constexpr std::array prefix{0xFE_u8, 0x80_u8, 0x00_u8, 0x00_u8,
+                                0x00_u8, 0x00_u8, 0x00_u8, 0x00_u8};
+    return IsIPv6() && HasPrefix(m_addr, prefix);
 }
 
 bool CNetAddr::IsRFC4193() const
@@ -365,26 +371,27 @@ bool CNetAddr::IsRFC4193() const
 
 bool CNetAddr::IsRFC6145() const
 {
-    return IsIPv6() &&
-           HasPrefix(m_addr, std::array<uint8_t, 12>{0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                                     0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00});
+    constexpr std::array prefix{0x00_u8, 0x00_u8, 0x00_u8, 0x00_u8, 0x00_u8, 0x00_u8,
+                                0x00_u8, 0x00_u8, 0xFF_u8, 0xFF_u8, 0x00_u8, 0x00_u8};
+    return IsIPv6() && HasPrefix(m_addr, prefix);
 }
 
 bool CNetAddr::IsRFC4843() const
 {
-    return IsIPv6() && HasPrefix(m_addr, std::array<uint8_t, 3>{0x20, 0x01, 0x00}) &&
-           (m_addr[3] & 0xF0) == 0x10;
+    constexpr std::array prefix{0x20_u8, 0x01_u8, 0x00_u8};
+    return IsIPv6() && HasPrefix(m_addr, prefix) && (m_addr[3] & 0xF0) == 0x10;
 }
 
 bool CNetAddr::IsRFC7343() const
 {
-    return IsIPv6() && HasPrefix(m_addr, std::array<uint8_t, 3>{0x20, 0x01, 0x00}) &&
-           (m_addr[3] & 0xF0) == 0x20;
+    constexpr std::array prefix{0x20_u8, 0x01_u8, 0x00_u8};
+    return IsIPv6() && HasPrefix(m_addr, prefix) && (m_addr[3] & 0xF0) == 0x20;
 }
 
 bool CNetAddr::IsHeNet() const
 {
-    return IsIPv6() && HasPrefix(m_addr, std::array<uint8_t, 4>{0x20, 0x01, 0x04, 0x70});
+    constexpr std::array prefix{0x20_u8, 0x01_u8, 0x04_u8, 0x70_u8};
+    return IsIPv6() && HasPrefix(m_addr, prefix);
 }
 
 /**

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -70,16 +70,16 @@ enum Network
 
 /// Prefix of an IPv6 address when it contains an embedded IPv4 address.
 /// Used when (un)serializing addresses in ADDRv1 format (pre-BIP155).
-static const std::array<uint8_t, 12> IPV4_IN_IPV6_PREFIX{
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF
+static constexpr std::array IPV4_IN_IPV6_PREFIX{
+    0x00_u8, 0x00_u8, 0x00_u8, 0x00_u8, 0x00_u8, 0x00_u8, 0x00_u8, 0x00_u8, 0x00_u8, 0x00_u8, 0xFF_u8, 0xFF_u8
 };
 
 /// Prefix of an IPv6 address when it contains an embedded TORv2 address.
 /// Used when (un)serializing addresses in ADDRv1 format (pre-BIP155).
 /// Such dummy IPv6 addresses are guaranteed to not be publicly routable as they
 /// fall under RFC4193's fc00::/7 subnet allocated to unique-local addresses.
-static const std::array<uint8_t, 6> TORV2_IN_IPV6_PREFIX{
-    0xFD, 0x87, 0xD8, 0x7E, 0xEB, 0x43
+static constexpr std::array TORV2_IN_IPV6_PREFIX{
+    0xFD_u8, 0x87_u8, 0xD8_u8, 0x7E_u8, 0xEB_u8, 0x43_u8
 };
 
 /// Prefix of an IPv6 address when it contains an embedded "internal" address.
@@ -87,8 +87,8 @@ static const std::array<uint8_t, 6> TORV2_IN_IPV6_PREFIX{
 /// The prefix comes from 0xFD + SHA256("bitcoin")[0:5].
 /// Such dummy IPv6 addresses are guaranteed to not be publicly routable as they
 /// fall under RFC4193's fc00::/7 subnet allocated to unique-local addresses.
-static const std::array<uint8_t, 6> INTERNAL_IN_IPV6_PREFIX{
-    0xFD, 0x6B, 0x88, 0xC0, 0x87, 0x24 // 0xFD + sha256("bitcoin")[0:5].
+static constexpr std::array INTERNAL_IN_IPV6_PREFIX{
+    0xFD_u8, 0x6B_u8, 0x88_u8, 0xC0_u8, 0x87_u8, 0x24_u8 // 0xFD + sha256("bitcoin")[0:5].
 };
 
 /// Size of IPv4 address (in bytes).

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <array>
 #include <cstring>
+#include <limits>
 #include <locale>
 #include <sstream>
 #include <string>
@@ -85,6 +86,14 @@ template <typename T1, size_t PREFIX_LEN>
 {
     return obj.size() >= PREFIX_LEN &&
            std::equal(std::begin(prefix), std::end(prefix), std::begin(obj));
+}
+
+/**
+ * User-defined literal for byte constants.
+ */
+constexpr uint8_t operator ""_u8(unsigned long long byte)
+{
+    return byte <= std::numeric_limits<uint8_t>::max() ? byte : throw std::overflow_error("The value does not fit uint8_t.");
 }
 
 #endif // BITCOIN_UTIL_STRENCODINGS_H


### PR DESCRIPTION
> Using the C++11 std::array with explicit template parameters is problematic because overshooting the size will fill the memory with default constructed types.

[Credits](https://github.com/bitcoin/bitcoin/pull/20566) to **MarcoFalke**.