### PR TITLE
bug fix: bitcoind -h & -version output logic fixes issue #20596

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -57,11 +57,11 @@ static bool AppInit(int argc, char* argv[])
     if (HelpRequested(args) || args.IsArgSet("-version")) {
         std::string strUsage = PACKAGE_NAME " version " + FormatFullVersion() + "\n";
 
-        if (!args.IsArgSet("-version")) {
-            strUsage += FormatParagraph(LicenseInfo()) + "\n"
-                "\nUsage:  bitcoind [options]                     Start " PACKAGE_NAME "\n"
-                "\n";
-            strUsage += args.GetHelpMessage();
+        if (args.IsArgSet("-version")) {
+            strUsage += FormatParagraph(LicenseInfo()) + "\n";
+        } else {
+            strUsage += "\nUsage:  bitcoind [options]                     Start " PACKAGE_NAME "\n";
+            strUsage += "\n" + args.GetHelpMessage();
         }
 
         tfm::format(std::cout, "%s", strUsage);


### PR DESCRIPTION
This change reverts a change that broke bitcoind -h / -version logic.

https://github.com/bitcoin/bitcoin/commit/6690adba08006739da0060eb4937126bdfa1181a#diff-214c41e31f440626f2b20c3858589d9270c843e254f38f2f97f5098ca83ef886R60

