### PR TITLE
util: Allow use of C++14 chrono literals

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -1016,7 +1016,7 @@ public:
         // Used for BIP35 mempool sending
         bool fSendMempool GUARDED_BY(cs_tx_inventory){false};
         // Last time a "MEMPOOL" request was serviced.
-        std::atomic<std::chrono::seconds> m_last_mempool_req{std::chrono::seconds{0}};
+        std::atomic<std::chrono::seconds> m_last_mempool_req{0s};
         std::chrono::microseconds nNextInvSend{0};
 
         RecursiveMutex cs_feeFilter;
@@ -1049,7 +1049,7 @@ public:
     // The pong reply we're expecting, or 0 if no pong expected.
     std::atomic<uint64_t> nPingNonceSent{0};
     /** When the last ping was sent, or 0 if no ping was ever sent */
-    std::atomic<std::chrono::microseconds> m_ping_start{std::chrono::microseconds{0}};
+    std::atomic<std::chrono::microseconds> m_ping_start{0us};
     // Last measured round-trip time.
     std::atomic<int64_t> nPingUsecTime{0};
     // Best measured round-trip time.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4080,7 +4080,7 @@ bool PeerManager::SendMessages(CNode* pto)
             // over since our last self-announcement, but there is only a small
             // bandwidth cost that we can incur by doing this (which happens
             // once a day on average).
-            if (pto->m_next_local_addr_send != std::chrono::microseconds::zero()) {
+            if (pto->m_next_local_addr_send != 0us) {
                 pto->m_addr_known->reset();
             }
             AdvertiseLocal(pto);

--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -69,7 +69,7 @@ void RandAddSeedPerfmon(CSHA512& hasher)
 
     // This can take up to 2 seconds, so only do it every 10 minutes.
     // Initialize last_perfmon to 0 seconds, we don't skip the first call.
-    static std::atomic<std::chrono::seconds> last_perfmon{std::chrono::seconds{0}};
+    static std::atomic<std::chrono::seconds> last_perfmon{0s};
     auto last_time = last_perfmon.load();
     auto current_time = GetTime<std::chrono::seconds>();
     if (current_time < last_time + std::chrono::minutes{10}) return;

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -6,9 +6,11 @@
 #ifndef BITCOIN_UTIL_TIME_H
 #define BITCOIN_UTIL_TIME_H
 
+#include <chrono>
 #include <stdint.h>
 #include <string>
-#include <chrono>
+
+using namespace std::chrono_literals;
 
 void UninterruptibleSleep(const std::chrono::microseconds& n);
 


### PR DESCRIPTION
I think we should allow the use of chrono literals for new code to make it less verbose. Obviously old code can stay as-is.

This patch pulls in the needed namespace and replaces some lines for illustrative purposes.