### PR TITLE
configure: output notice that test binary is disabled by fuzzing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1585,7 +1585,11 @@ AM_CONDITIONAL([ENABLE_ZMQ], [test "x$use_zmq" = "xyes"])
 
 AC_MSG_CHECKING([whether to build test_bitcoin])
 if test x$use_tests = xyes; then
-  AC_MSG_RESULT([yes])
+  if test "x$enable_fuzz" = "xyes"; then
+    AC_MSG_RESULT([no, because fuzzing is enabled])
+  else
+    AC_MSG_RESULT([yes])
+  fi
   BUILD_TEST="yes"
 else
   AC_MSG_RESULT([no])
@@ -1761,8 +1765,10 @@ if test x$bitcoin_enable_qt != xno; then
     echo "    with qr     = $use_qr"
 fi
 echo "  with zmq      = $use_zmq"
-echo "  with test     = $use_tests"
-if test x$use_tests != xno; then
+if test x$enable_fuzz == xno; then
+    echo "  with test     = $use_tests"
+else
+    echo "  with test     = not building test_bitcoin because fuzzing is enabled"
     echo "    with fuzz   = $enable_fuzz"
 fi
 echo "  with bench    = $use_bench"


### PR DESCRIPTION
I wasted a bit of time today running a stale `test_bitcoin` and not understanding why, until I remembered that I'd ./configured my working directory with --enable-fuzz.