### PR TITLE
cirrus: Schedule one task with paid credits for faster CI feedback

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -81,6 +81,8 @@ task:
 
 task:
   name: '[previous releases, uses qt5 dev package and some depends packages] [unsigned char] [bionic]'
+  # For faster CI feedback, immediately schedule a task that compiles most modules. https://cirrus-ci.org/pricing/#compute-credits
+  use_compute_credits: $CIRRUS_REPO_FULL_NAME == 'bitcoin/bitcoin'
   << : *GLOBAL_TASK_TEMPLATE
   container:
     image: ubuntu:bionic


### PR DESCRIPTION
During times of high activity in the repo, the scheduling of Cirrus CI tasks might put them a few hours in the future. This is fine when all the tasks eventually pass. Though for failing tasks, a failure should ideally be shown to the author and reviewer as soon as possible.

Compute credits can be used to schedule immediately: https://cirrus-ci.org/pricing/#compute-credits. Running all tasks with compute credits will probably be more expensive than our previous CI invoice. However, they are also more flexible.

As a start we could enable only a single task and revisit/re-evaluate the next steps in a month.