### PR TITLE
Check CJDNS address is valid

### DIFF
--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -437,6 +437,11 @@ bool CNetAddr::IsValid() const
         return false;
     }
 
+    // CJDNS addresses always start with 0xfc
+    if (IsCJDNS() && (m_addr[0] != 0xFC)) {
+        return false;
+    }
+
     // documentation IPv6 address
     if (IsRFC3849())
         return false;

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -604,6 +604,16 @@ BOOST_AUTO_TEST_CASE(cnetaddr_unserialize_v2)
     BOOST_CHECK_EQUAL(addr.ToString(), "fc00:1:2:3:4:5:6:7");
     BOOST_REQUIRE(s.empty());
 
+    // Invalid CJDNS, wrong prefix.
+    s << MakeSpan(ParseHex("06"                               // network type (CJDNS)
+                           "10"                               // address length
+                           "aa000001000200030004000500060007" // address
+                           ));
+    s >> addr;
+    BOOST_CHECK(addr.IsCJDNS());
+    BOOST_CHECK(!addr.IsValid());
+    BOOST_REQUIRE(s.empty());
+
     // Invalid CJDNS, with bogus length.
     s << MakeSpan(ParseHex("06" // network type (CJDNS)
                            "01" // address length


### PR DESCRIPTION
CJDNS addresses start with 0xFC and for that reason if a netaddr was unserialized with network type cjdns but its address prefix is not 0xFC then that netaddr should be considered invalid.