### PR TITLE
net processing: Remove nStartingHeight check from block relay

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1293,8 +1293,7 @@ void PeerManager::NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_
  * in ::ChainActive() to our peers.
  */
 void PeerManager::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {
-    const int nNewHeight = pindexNew->nHeight;
-    m_connman.SetBestHeight(nNewHeight);
+    m_connman.SetBestHeight(pindexNew->nHeight);
     SetServiceFlagsIBDCache(!fInitialDownload);
 
     // Relay inventory, but don't relay old inventory during initial block download.
@@ -1311,7 +1310,7 @@ void PeerManager::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockInde
                 break;
             }
         }
-        m_connman.ForEachNode([nNewHeight, &vHashes](CNode* pnode) {
+        m_connman.ForEachNode([&vHashes](CNode* pnode) {
             LOCK(pnode->cs_inventory);
             for (const uint256& hash : reverse_iterate(vHashes)) {
                 pnode->vBlockHashesToAnnounce.push_back(hash);


### PR DESCRIPTION
nStartingHeight was introduced in commit 7a47324c7 (Bitcoin version
0.2.9, P2P version 209) with the comment "better prevention of inventory
relaying during initial download". At that time, there was no function
to determine whether the node was still in Initial Block Download, so to
prevent syncing nodes from relaying old blocks to their peers, a check
was added to never relay a block to a peer where the height was lower
than 2000 less than the peer's best block. That check was updated
several times in later commits to ensure that we weren't relaying blocks
before the latest checkpoint if the peer didn't provide a
startingheight. The checkpoint comparison was changed to compare with an
estimate of the highest block in commit eae82d8e.

In commit 202e0194, all block relay was gated on being out of Initial
Block Download. In commit 0278fb5f, the comparison to nBlockEstimate was
removed since "we already checked IsIBD()".

We can remove the check against nStartingHeight entirely. If the node is
out of Initial Block Download, then its tip height must have been within
24 hours of current time, so should not be more than ~144 blocks behind
the most work tip.

This simplifies moving block inventory state into the `Peer` object (#19829).