### PR TITLE
Allow providing local signatures in gitian osx signer

### DIFF
--- a/contrib/gitian-descriptors/gitian-osx-signer.yml
+++ b/contrib/gitian-descriptors/gitian-osx-signer.yml
@@ -12,6 +12,7 @@ remotes:
   "dir": "signature"
 files:
 - "bitcoin-osx-unsigned.tar.gz"
+- "signature-osx.tar.gz"
 script: |
   set -e -o pipefail
 
@@ -32,6 +33,13 @@ script: |
 
   UNSIGNED=bitcoin-osx-unsigned.tar.gz
   SIGNED=bitcoin-osx-signed.dmg
+
+  # copy local provided detached signature
+  # allows testing signature before they have been pushed to the git repository
+  if [ -e signature-osx.tar.gz ]; then
+    mkdir -p signature
+    tar -xzf signature-osx.tar.gz -C signature
+  fi
 
   tar -xf ${UNSIGNED}
   OSX_VOLNAME="$(cat osx_volname)"


### PR DESCRIPTION
Gitian mac signer: This allows to place a `signature-osx.tar.gz` in gitian inputs to avoid creating a shadow git repository for testing signatures.