### PR TITLE
doc: fix case of GitHub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -412,7 +412,7 @@ when needed (the original author does not need to worry about it).
 A backport should contain the following metadata in the commit body:
 
 ```
-Github-Pull: #<PR number>
+GitHub-Pull: #<PR number>
 Rebased-From: <commit hash of the original commit>
 ```
 


### PR DESCRIPTION
Changed `Github` to `GitHub`
