### PR TITLE
Add patch to make codesign_allocate compatible with Apple's

### DIFF
--- a/depends/packages/native_cctools.mk
+++ b/depends/packages/native_cctools.mk
@@ -4,7 +4,7 @@ $(package)_download_path=https://github.com/tpoechtrager/cctools-port/archive
 $(package)_file_name=$($(package)_version).tar.gz
 $(package)_sha256_hash=e51995a843533a3dac155dd0c71362dd471597a2d23f13dff194c6285362f875
 $(package)_build_subdir=cctools
-$(package)_patches=ld64_disable_threading.patch
+$(package)_patches=ld64_disable_threading.patch segalign.patch
 
 ifeq ($(strip $(FORCE_USE_SYSTEM_CLANG)),)
 $(package)_clang_version=8.0.0
@@ -80,7 +80,8 @@ endef
 define $(package)_preprocess_cmds
   CC=$($(package)_cc) CXX=$($(package)_cxx) INSTALLPREFIX=$($(package)_extract_dir) ./libtapi/build.sh && \
   CC=$($(package)_cc) CXX=$($(package)_cxx) INSTALLPREFIX=$($(package)_extract_dir) ./libtapi/install.sh && \
-  patch -p1 < $($(package)_patch_dir)/ld64_disable_threading.patch
+  patch -p1 < $($(package)_patch_dir)/ld64_disable_threading.patch && \
+  patch -p1 < $($(package)_patch_dir)/segalign.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/native_cctools/segalign.patch
+++ b/depends/patches/native_cctools/segalign.patch
@@ -1,0 +1,19 @@
+commit 7f2eb11ce6ebec7eb9b8e1429535e453054143e5
+Author: Pieter Wuille <pieter@wuille.net>
+Date:   Sun Dec 13 11:34:21 2020 -0800
+
+    Make cctools_port's codesign_allocate compatible with Apple's
+
+diff --git a/cctools/libstuff/arch.c b/cctools/libstuff/arch.c
+index 6f2332f..d85c25c 100644
+--- a/cctools/libstuff/arch.c
++++ b/cctools/libstuff/arch.c
+@@ -134,7 +134,7 @@ static const struct cpu_entry cpu_entries[] = {
+     { CPU_TYPE_ARM,	    LITTLE_ENDIAN_BYTE_SEX, 0,		       0x4000 },
+     
+     /* desktop */
+-    { CPU_TYPE_X86_64,	    LITTLE_ENDIAN_BYTE_SEX, 0x7fff5fc00000LL,  0x1000 },
++    { CPU_TYPE_X86_64,	    LITTLE_ENDIAN_BYTE_SEX, 0x7fff5fc00000LL,  0x2000 /* Used to be 0x1000; changed to 0x2000 to match Apple's distributed codesign_allocate. */},
+     { CPU_TYPE_I386,	    LITTLE_ENDIAN_BYTE_SEX, 0xc0000000,        0x1000 },
+     { CPU_TYPE_POWERPC,	    BIG_ENDIAN_BYTE_SEX,    0xc0000000,	       0x1000 },
+     { CPU_TYPE_POWERPC64,   BIG_ENDIAN_BYTE_SEX,    0x7ffff00000000LL, 0x1000 },


### PR DESCRIPTION
This is an alternative to #20638.

The problem is that Apple's codesign(_allocate) apparently rounds the "vmsize" attribute on the __LINKEDIT section to a multiple of 0x2000 on x86_64 rather than 0x1000 (as their published source code does). This divergence means that the binary signed by codesign is slightly different from the one recreated by our reattach-sig-to-gitian-output process, and the signature being invalid.

This fixes it by patching our codesign_allocate source code to also use 0x2000. In tests, this appears to result in matching binaries.