### PR TITLE
depends: Drop workaround for a fixed bug in Qt build system

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -278,10 +278,7 @@ define $(package)_stage_cmds
   $(MAKE) -C src INSTALL_ROOT=$($(package)_staging_dir) $(addsuffix -install_subtargets,$(addprefix sub-,$($(package)_qt_libs))) && cd .. && \
   $(MAKE) -C qttools/src/linguist/lrelease INSTALL_ROOT=$($(package)_staging_dir) install_target && \
   $(MAKE) -C qttools/src/linguist/lupdate INSTALL_ROOT=$($(package)_staging_dir) install_target && \
-  $(MAKE) -C qttranslations INSTALL_ROOT=$($(package)_staging_dir) install_subtargets && \
-  if `test -f qtbase/src/plugins/platforms/xcb/xcb-static/libxcb-static.a`; then \
-    cp qtbase/src/plugins/platforms/xcb/xcb-static/libxcb-static.a $($(package)_staging_prefix_dir)/lib; \
-  fi
+  $(MAKE) -C qttranslations INSTALL_ROOT=$($(package)_staging_dir) install_subtargets
 endef
 
 define $(package)_postprocess_cmds


### PR DESCRIPTION
This PR drops workaround that was [introduced](https://github.com/bitcoin/bitcoin/pull/4592/commits/1dec09b341f61836147d87656aea7f7be02aab6d) for Qt 5.2.1 for a bug in Qt build system that has been fixed in Qt 5.3.0.

The bug reports:
 - https://bugreports.qt.io/browse/QTBUG-35444
 - https://bugreports.qt.io/browse/QTBUG-32519

I've noted this change is a part of the #19716, but I think that a separate commit with the documented reason will benefit it.