### PR TITLE
Designer fees when coin control is enabled

### DIFF
--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -46,7 +46,7 @@ public:
     ~CoinControlDialog();
 
     // static because also called from sendcoinsdialog
-    static void updateLabels(CCoinControl& m_coin_control, WalletModel*, QDialog*);
+    static CAmount updateLabels(CCoinControl& m_coin_control, WalletModel*, QDialog*, unsigned int tx_size=0);
 
     static QList<CAmount> payAmounts;
     static bool fSubtractFeeFromAmount;

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -907,8 +907,90 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
                </item>
               </layout>
              </item>
+             <item row="2" column="1">
+              <layout class="QVBoxLayout" name="verticalLayoutFee13">
+               <property name="spacing">
+                <number>6</number>
+               </property>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayoutFee14">
+                 <item>
+                  <widget class="QLabel" name="labelDesignerFee">
+                   <property name="toolTip">
+                    <string>Specify a fee, in satoshis, for the transaction.
+
+Note: The exact size of the signed transaction must be known, so you will be prompted for the wallet's password for a temporary transaction to be signed with your private key. Every time the inputs, outputs or change address are modified, the transaction size is altered and must be recalculated with a new signature, thus requiring your password again.</string>
+                   </property>
+                   <property name="text">
+                    <string>exact fee</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="BitcoinAmountField" name="designerFee"/>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_7">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>1</width>
+                     <height>1</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+			   <item>
+                <layout class="QHBoxLayout" name="horizontalLayoutFee15">
+                 <item>
+                  <widget class="QLabel" name="labelDesignerFeeWarning">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="toolTip">
+                    <string>The exact size of the signed transaction must be known, so you will be prompted for the wallet's password for a temporary transaction to be signed with your private key. Every time the inputs, outputs or change address are modified, the transaction size is altered and must be recalculated with a new signature, thus requiring your password again.</string>
+                   </property>
+                   <property name="text">
+                    <string>Enabled when inputs are selected manually. Requires unlocking your wallet (read the tooltip).</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_8">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>1</width>
+                     <height>1</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </item>
              <item row="0" column="0">
               <layout class="QVBoxLayout" name="verticalLayoutFee4" stretch="0,1">
+               <item>
+                <spacer name="verticalSpacer_10">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>1</width>
+                   <height>1</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
                <item>
                 <widget class="QRadioButton" name="radioSmartFee">
                  <property name="text">
@@ -940,6 +1022,19 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
              <item row="1" column="0">
               <layout class="QVBoxLayout" name="verticalLayoutFee9" stretch="0,1">
                <item>
+                <spacer name="verticalSpacer_9">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>1</width>
+                   <height>1</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
                 <widget class="QRadioButton" name="radioCustomFee">
                  <property name="text">
                   <string>Custom:</string>
@@ -951,6 +1046,46 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
                </item>
                <item>
                 <spacer name="verticalSpacer_6">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>1</width>
+                   <height>1</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+             <item row="2" column="0">
+              <layout class="QVBoxLayout" name="verticalLayoutFee10" stretch="0,1">
+               <item>
+                <spacer name="verticalSpacer_8">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>1</width>
+                   <height>1</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QRadioButton" name="radioDesignerFee">
+                 <property name="text">
+                  <string>Designer fee:</string>
+                 </property>
+                 <attribute name="buttonGroup">
+                  <string notr="true">groupFee</string>
+                 </attribute>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer_7">
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>
                  </property>

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -67,6 +67,12 @@ private:
     bool fNewRecipientAllowed;
     bool fFeeMinimized;
     const PlatformStyle *platformStyle;
+    bool changing_fee;
+    unsigned int tx_size;
+    std::vector<COutPoint> previous_input_selection;
+    CTxDestination previous_change_address;
+    std::set<QString> previous_recipient_addresses;
+    bool previously_needed_change;
 
     // Process WalletModel::SendCoinsReturn and generate a pair consisting
     // of a message and message flags for use in Q_EMIT message().
@@ -78,6 +84,10 @@ private:
     void updateFeeMinimizedLabel();
     // Update the passed in CCoinControl with state from the GUI
     void updateCoinControlState(CCoinControl& ctrl);
+    std::unique_ptr<WalletModelTransaction> make_unique_transaction();
+    bool outputsAreValid();
+    bool txSizeProbablyChanged();
+    void updateTxSize();
 
 private Q_SLOTS:
     void on_sendButton_clicked();
@@ -91,6 +101,7 @@ private Q_SLOTS:
     void coinControlChangeChecked(int);
     void coinControlChangeEdited(const QString &);
     void coinControlUpdateLabels();
+    void designerFeeChanged();
     void coinControlClipboardQuantity();
     void coinControlClipboardAmount();
     void coinControlClipboardFee();

--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -17,7 +17,7 @@ void CCoinControl::SetNull()
     m_avoid_address_reuse = false;
     setSelected.clear();
     m_feerate.reset();
-    fOverrideFeeRate = false;
+    fOverrideFeeRate = true;
     m_confirm_target.reset();
     m_signal_bip125_rbf.reset();
     m_fee_mode = FeeEstimateMode::UNSET;


### PR DESCRIPTION
This is an improvement over current UI fee selection.
Current UI only allows kSat/kB fees, calculated over an approximation of the tx size.
Some users may want to set a specific fee in satoshis, including zero, which isn't possible.
This PR adds the UI items necessary for the user to set a specific fee.

Commit comment:

Fees can now be set in satoshis instead of kSat/kB only.
Fees can now be set to zero satoshis.
When switching to designer fee, or when inputs or outputs are changed, tx size is properly calculated (no guesswork). Fees, specified internally in sat/B, used to suffer alterations due to those approximations.
