### PR TITLE
Allow setting I2P addresses

### DIFF
--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -222,18 +222,54 @@ static void Checksum(Span<const uint8_t> addr_pubkey, uint8_t (&checksum)[CHECKS
 }; // namespace torv3
 
 /**
- * Parse a TOR address and set this object to it.
+ * Parse a non-IP address (Tor and I2P) set this object to it.
  *
  * @returns Whether or not the operation was successful.
- *
- * @see CNetAddr::IsTor()
  */
 bool CNetAddr::SetSpecial(const std::string& str)
+{
+    if (!ValidAsCString(str))
+    {
+        return false;
+    }
+    return SetTor(str) || SetI2P(str);
+}
+
+bool CNetAddr::SetI2P(const std::string& str)
+{
+    // Only base 32 addresses are supported (.b32.i2p)
+    static const char* suffix{".b32.i2p"};
+    static constexpr size_t suffix_len{8};
+
+    if (str.size() <= suffix_len ||
+        str.substr(str.size() - suffix_len) != suffix) {
+        return false;
+    }
+
+    // base32-encoded public key hash (SHA256) length (without padding)
+    if ((str.size() - suffix_len) != 52)
+    {
+        return false;
+    }
+
+    bool invalid;
+    const auto& input = DecodeBase32(str.substr(0, str.size() - suffix_len).append("====").c_str(), &invalid);
+
+    if (invalid || input.size() != ADDR_I2P_SIZE) {
+        return false;
+    }
+
+    m_net = NET_I2P;
+    m_addr.assign(input.begin(), input.end());
+    return true;
+}
+
+bool CNetAddr::SetTor(const std::string& str)
 {
     static const char* suffix{".onion"};
     static constexpr size_t suffix_len{6};
 
-    if (!ValidAsCString(str) || str.size() <= suffix_len ||
+    if (str.size() <= suffix_len ||
         str.substr(str.size() - suffix_len) != suffix) {
         return false;
     }

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -150,8 +150,7 @@ class CNetAddr
         void SetLegacyIPv6(Span<const uint8_t> ipv6);
 
         bool SetInternal(const std::string& name);
-
-        bool SetSpecial(const std::string &strName); // for Tor addresses
+        bool SetSpecial(const std::string &strName); // for addresses that doesn't fit in IPv6 addresses
         bool IsBindAny() const; // INADDR_ANY equivalent
         bool IsIPv4() const;    // IPv4 mapped address (::FFFF:0:0/96, 0.0.0.0/0)
         bool IsIPv6() const;    // IPv6 address (not mapped IPv4, not Tor)
@@ -287,6 +286,25 @@ class CNetAddr
          * networks (id 1..6) with wrong address size.
          */
         bool SetNetFromBIP155Network(uint8_t possible_bip155_net, size_t address_size);
+
+        /**
+         * Parse a TOR address and set this object to it.
+         *
+         * @returns Whether or not the operation was successful.
+         *
+         * @see CNetAddr::IsTor()
+         */
+        bool SetTor(const std::string &strName); // for Tor addresses
+
+        /**
+         * Parse a I2P address and set this object to it.
+         *
+         * @returns Whether or not the operation was successful.
+         *
+         * @see CNetAddr::IsI2P()
+         */
+        bool SetI2P(const std::string &strName); // for I2P addresses
+
 
         /**
          * Serialize in pre-ADDRv2/BIP155 format to an array.

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -346,6 +346,27 @@ BOOST_AUTO_TEST_CASE(cnetaddr_basic)
     // TOR, invalid base32
     BOOST_CHECK(!addr.SetSpecial(std::string{"mf*g zak.onion"}));
 
+    // I2P
+    const char* i2p_addr = "udhdrtrcetjm5sxzskjyr5ztpeszydbh4dpl3pl4utgqqw2v4jna.b32.i2p";
+    BOOST_REQUIRE(addr.SetSpecial(i2p_addr));
+    BOOST_REQUIRE(addr.IsValid());
+    BOOST_REQUIRE(addr.IsI2P());
+
+    BOOST_CHECK(!addr.IsBindAny());
+    BOOST_CHECK(!addr.IsAddrV1Compatible());
+    BOOST_CHECK_EQUAL(addr.ToString(), i2p_addr);
+
+    // I2P, malicious
+    BOOST_CHECK(!addr.SetSpecial(std::string{
+        "udhdrtrcetjm5sxzskjyr5ztpeszydbh4dpl3pl4utgqqw2v4jna\0wtf.b32.i2p", 64}));
+
+    // I2P, valid but unsupported
+    BOOST_CHECK(!addr.SetSpecial(std::string{"pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscsad.b32.i2p"}));
+
+    // I2P, invalid base32
+    BOOST_CHECK(!addr.SetSpecial(std::string{"tp*szydbh4dp.b32.i2p"}));
+
+
     // Internal
     addr.SetInternal("esffpp");
     BOOST_REQUIRE(!addr.IsValid()); // "internal" is considered invalid


### PR DESCRIPTION
This PR allows setting `CNetAddr` instances with I2P addresses by extending the existing method `CNetAddr::SetSpecial`. 

Currently the method `SetSpecial` can be used with Tor addresses only. After this PR the same method can be used to set traditional I2P base 32 address (those with suffix `.b32.i2p`) 