### PR TITLE
fuzz: Hide script_assets_test_minimizer

### DIFF
--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -13,15 +13,15 @@
 
 const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
 
-std::map<std::string_view, std::tuple<TypeTestOneInput, TypeInitialize>>& FuzzTargets()
+std::map<std::string_view, std::tuple<TypeTestOneInput, TypeInitialize, TypeHidden>>& FuzzTargets()
 {
-    static std::map<std::string_view, std::tuple<TypeTestOneInput, TypeInitialize>> g_fuzz_targets;
+    static std::map<std::string_view, std::tuple<TypeTestOneInput, TypeInitialize, TypeHidden>> g_fuzz_targets;
     return g_fuzz_targets;
 }
 
-void FuzzFrameworkRegisterTarget(std::string_view name, TypeTestOneInput target, TypeInitialize init)
+void FuzzFrameworkRegisterTarget(std::string_view name, TypeTestOneInput target, TypeInitialize init, TypeHidden hidden)
 {
-    const auto it_ins = FuzzTargets().try_emplace(name, std::move(target), std::move(init));
+    const auto it_ins = FuzzTargets().try_emplace(name, std::move(target), std::move(init), hidden);
     Assert(it_ins.second);
 }
 
@@ -31,6 +31,7 @@ void initialize()
 {
     if (std::getenv("PRINT_ALL_FUZZ_TARGETS_AND_ABORT")) {
         for (const auto& t : FuzzTargets()) {
+            if (std::get<2>(t.second)) continue;
             std::cout << t.first << std::endl;
         }
         Assert(false);

--- a/src/test/fuzz/fuzz.h
+++ b/src/test/fuzz/fuzz.h
@@ -15,22 +15,26 @@ using FuzzBufferType = Span<const uint8_t>;
 
 using TypeTestOneInput = std::function<void(FuzzBufferType)>;
 using TypeInitialize = std::function<void()>;
+using TypeHidden = bool;
 
-void FuzzFrameworkRegisterTarget(std::string_view name, TypeTestOneInput target, TypeInitialize init);
+void FuzzFrameworkRegisterTarget(std::string_view name, TypeTestOneInput target, TypeInitialize init, TypeHidden hidden);
 
-inline void FuzzFrameworkEmptyFun() {}
+inline void FuzzFrameworkEmptyInitFun() {}
 
 #define FUZZ_TARGET(name) \
-    FUZZ_TARGET_INIT(name, FuzzFrameworkEmptyFun)
+    FUZZ_TARGET_INIT(name, FuzzFrameworkEmptyInitFun)
 
-#define FUZZ_TARGET_INIT(name, init_fun)                                      \
-    void name##_fuzz_target(FuzzBufferType);                                  \
-    struct name##_Before_Main {                                               \
-        name##_Before_Main()                                                  \
-        {                                                                     \
-            FuzzFrameworkRegisterTarget(#name, name##_fuzz_target, init_fun); \
-        }                                                                     \
-    } const static g_##name##_before_main;                                    \
+#define FUZZ_TARGET_INIT(name, init_fun) \
+    FUZZ_TARGET_INIT_HIDDEN(name, init_fun, false)
+
+#define FUZZ_TARGET_INIT_HIDDEN(name, init_fun, hidden)                               \
+    void name##_fuzz_target(FuzzBufferType);                                          \
+    struct name##_Before_Main {                                                       \
+        name##_Before_Main()                                                          \
+        {                                                                             \
+            FuzzFrameworkRegisterTarget(#name, name##_fuzz_target, init_fun, hidden); \
+        }                                                                             \
+    } const static g_##name##_before_main;                                            \
     void name##_fuzz_target(FuzzBufferType buffer)
 
 #endif // BITCOIN_TEST_FUZZ_FUZZ_H

--- a/src/test/fuzz/script_assets_test_minimizer.cpp
+++ b/src/test/fuzz/script_assets_test_minimizer.cpp
@@ -190,7 +190,7 @@ ECCVerifyHandle handle;
 
 } // namespace
 
-FUZZ_TARGET(script_assets_test_minimizer)
+FUZZ_TARGET_INIT_HIDDEN(script_assets_test_minimizer, FuzzFrameworkEmptyInitFun, /* hidden */ true)
 {
     if (buffer.size() < 2 || buffer.back() != '\n' || buffer[buffer.size() - 2] != ',') return;
     const std::string str((const char*)buffer.data(), buffer.size() - 2);

--- a/src/test/fuzz/script_assets_test_minimizer.cpp
+++ b/src/test/fuzz/script_assets_test_minimizer.cpp
@@ -28,12 +28,12 @@
 //
 // (normal build)
 // $ mkdir dump
-// $ for N in $(seq 1 10); do TEST_DUMP_DIR=dump test/functional/feature_taproot --dumptests; done
+// $ for N in $(seq 1 10); do TEST_DUMP_DIR=dump test/functional/feature_taproot.py --dumptests; done
 // $ ...
 //
-// (fuzz test build)
+// (libFuzzer build)
 // $ mkdir dump-min
-// $ ./src/test/fuzz/script_assets_test_minimizer -merge=1 dump-min/ dump/
+// $ FUZZ=script_assets_test_minimizer ./src/test/fuzz/fuzz -merge=1 -use_value_profile=1 dump-min/ dump/
 // $ (echo -en '[\n'; cat dump-min/* | head -c -2; echo -en '\n]') >script_assets_test.json
 
 namespace {


### PR DESCRIPTION
This is not an actual fuzz target. It is a hack to exploit the built-in capability of fuzz engines to measure coverage.