### PR TITLE
Add on autoconf as a dependency when building on macOS

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -19,7 +19,7 @@ Then install [Homebrew](https://brew.sh).
 
 ## Dependencies
 ```shell
-brew install automake libtool boost miniupnpc pkg-config python qt libevent qrencode
+brew install autoconf automake libtool boost miniupnpc pkg-config python qt libevent qrencode
 ```
 
 If you run into issues, check [Homebrew's troubleshooting page](https://docs.brew.sh/Troubleshooting).


### PR DESCRIPTION
When trying to build the project locally on the latest version of macOS Big Sur, we need `autoconf` in order to successfully run `./autogen.sh`.

Below is when I first saw the error when trying to build Bitcoin Core locally:

```
bitcoin % ./autogen.sh 
configuration failed, please install autoconf first
```

This is a nonfunctional change; only updated the `build-osx.md` file that way all the dependencies are acquired in the first place.