### PR TITLE
build: Define .INTERMEDIATE target once only

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,7 @@ if ENABLE_MAN
 SUBDIRS += doc/man
 endif
 .PHONY: deploy FORCE
+.INTERMEDIATE: $(OSX_TEMP_ISO) $(COVERAGE_INFO)
 
 export PYTHONPATH
 
@@ -136,7 +137,6 @@ $(APP_DIST_DIR)/Applications:
 
 $(APP_DIST_EXTRAS): $(APP_DIST_DIR)/$(OSX_APP)/Contents/MacOS/Bitcoin-Qt
 
-.INTERMEDIATE: $(OSX_TEMP_ISO)
 $(OSX_TEMP_ISO): $(APP_DIST_EXTRAS)
 	$(XORRISOFS) -D -l -V "$(OSX_VOLNAME)" -no-pad -r -dir-mode 0755 -o $@ dist
 
@@ -331,8 +331,6 @@ EXTRA_DIST += \
     test/util/rpcauth-test.py
 
 CLEANFILES = $(OSX_DMG) $(BITCOIN_WIN_INSTALLER)
-
-.INTERMEDIATE: $(COVERAGE_INFO)
 
 DISTCHECK_CONFIGURE_FLAGS = --enable-man
 


### PR DESCRIPTION
A new warning was introduced in https://github.com/bitcoin/bitcoin/pull/20470/commits/22437fc72e78ba3845a3953853d40093de32c395 (#20470):
```
$ ./autogen.sh 
...
Makefile.am:335: warning: .INTERMEDIATE was already defined in condition !BUILD_DARWIN, which is included in condition TRUE ...
Makefile.am:139: ... '.INTERMEDIATE' previously defined here
...
```

Fixed in this PR.