### PR TITLE
Clean up logging of outbound connection type

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2476,7 +2476,7 @@ void PeerManager::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDat
             LogPrintf("New outbound peer connected: version: %d, blocks=%d, peer=%d%s (%s)\n",
                       pfrom.nVersion.load(), pfrom.nStartingHeight,
                       pfrom.GetId(), (fLogIPs ? strprintf(", peeraddr=%s", pfrom.addr.ToString()) : ""),
-                      pfrom.IsBlockOnlyConn() ? "block-relay" : "full-relay");
+                      pfrom.ConnectionTypeAsString());
         }
 
         if (pfrom.GetCommonVersion() >= SENDHEADERS_VERSION) {


### PR DESCRIPTION
We have a function that converts `ConnectionType` enums to strings, so use it.

Suggested by ajtowns in https://github.com/bitcoin/bitcoin/pull/19858#discussion_r540791588