### PR TITLE
test: run mempool_resurrect.py even with wallet disabled

### DIFF
--- a/test/functional/mempool_resurrect.py
+++ b/test/functional/mempool_resurrect.py
@@ -4,66 +4,59 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test resurrection of mined transactions when the blockchain is re-organized."""
 
-from test_framework.blocktools import create_raw_transaction
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
+from test_framework.wallet import MiniWallet
 
 
 class MempoolCoinbaseTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
+        self.setup_clean_chain = True
 
     def run_test(self):
-        node0_address = self.nodes[0].getnewaddress()
+        node = self.nodes[0]
+        wallet = MiniWallet(node)
+
+        # Add enough mature utxos to the wallet so that all txs spend confirmed coins
+        wallet.generate(3)
+        node.generate(100)
+
         # Spend block 1/2/3's coinbase transactions
-        # Mine a block.
+        # Mine a block
         # Create three more transactions, spending the spends
-        # Mine another block.
+        # Mine another block
         # ... make sure all the transactions are confirmed
         # Invalidate both blocks
         # ... make sure all the transactions are put back in the mempool
         # Mine a new block
-        # ... make sure all the transactions are confirmed again.
-
-        b = [self.nodes[0].getblockhash(n) for n in range(1, 4)]
-        coinbase_txids = [self.nodes[0].getblock(h)['tx'][0] for h in b]
-        spends1_raw = [create_raw_transaction(self.nodes[0], txid, node0_address, amount=49.99) for txid in coinbase_txids]
-        spends1_id = [self.nodes[0].sendrawtransaction(tx) for tx in spends1_raw]
-
+        # ... make sure all the transactions are confirmed again
         blocks = []
-        blocks.extend(self.nodes[0].generate(1))
+        spends1_ids = [wallet.send_self_transfer(from_node=node)['txid'] for _ in range(3)]
+        blocks.extend(node.generate(1))
+        spends2_ids = [wallet.send_self_transfer(from_node=node)['txid'] for _ in range(3)]
+        blocks.extend(node.generate(1))
 
-        spends2_raw = [create_raw_transaction(self.nodes[0], txid, node0_address, amount=49.98) for txid in spends1_id]
-        spends2_id = [self.nodes[0].sendrawtransaction(tx) for tx in spends2_raw]
-
-        blocks.extend(self.nodes[0].generate(1))
+        spends_ids = set(spends1_ids + spends2_ids)
 
         # mempool should be empty, all txns confirmed
-        assert_equal(set(self.nodes[0].getrawmempool()), set())
-        for txid in spends1_id+spends2_id:
-            tx = self.nodes[0].gettransaction(txid)
-            assert tx["confirmations"] > 0
+        assert_equal(set(node.getrawmempool()), set())
+        confirmed_txns = set(node.getblock(blocks[0])['tx'] + node.getblock(blocks[1])['tx'])
+        # Checks that all spend txns are contained in the mined blocks
+        assert(spends_ids < confirmed_txns)
 
         # Use invalidateblock to re-org back
-        for node in self.nodes:
-            node.invalidateblock(blocks[0])
+        node.invalidateblock(blocks[0])
 
         # All txns should be back in mempool with 0 confirmations
-        assert_equal(set(self.nodes[0].getrawmempool()), set(spends1_id+spends2_id))
-        for txid in spends1_id+spends2_id:
-            tx = self.nodes[0].gettransaction(txid)
-            assert tx["confirmations"] == 0
+        assert_equal(set(node.getrawmempool()), spends_ids)
 
         # Generate another block, they should all get mined
-        self.nodes[0].generate(1)
+        node.generate(1)
         # mempool should be empty, all txns confirmed
-        assert_equal(set(self.nodes[0].getrawmempool()), set())
-        for txid in spends1_id+spends2_id:
-            tx = self.nodes[0].gettransaction(txid)
-            assert tx["confirmations"] > 0
+        assert_equal(set(node.getrawmempool()), set())
+        confirmed_txns = set(node.getblock(blocks[0])['tx'] + node.getblock(blocks[1])['tx'])
+        assert(spends_ids < confirmed_txns)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Another functional test rewritten as proposed in #20078

**Request for help:**
`node.gettransaction(txid)` fails for transactions sent with `wallet.send_self_transfer`. Even though the `txid`s look correct, are added to the mempool correctly, and removed from the mempool when a block is mined - all as expected.

However, `node.gettransaction(txid)` throws the error:
```sh
Traceback (most recent call last):
  File "/Users/michaeldietz/Documents/bitcoin/test/functional/test_framework/test_framework.py", line 126, in main
    self.run_test()
  File "/Users/michaeldietz/Documents/bitcoin/test/functional/mempool_resurrect.py", line 43, in run_test
    assert_equal(len(list(filter(lambda txid: node.gettransaction(txid)["confirmations"] > 0, spends_ids))), len(spends_ids))
  File "/Users/michaeldietz/Documents/bitcoin/test/functional/mempool_resurrect.py", line 43, in <lambda>
    assert_equal(len(list(filter(lambda txid: node.gettransaction(txid)["confirmations"] > 0, spends_ids))), len(spends_ids))
  File "/Users/michaeldietz/Documents/bitcoin/test/functional/test_framework/coverage.py", line 47, in __call__
    return_val = self.auth_service_proxy_instance.__call__(*args, **kwargs)
  File "/Users/michaeldietz/Documents/bitcoin/test/functional/test_framework/authproxy.py", line 146, in __call__
    raise JSONRPCException(response['error'], status)
test_framework.authproxy.JSONRPCException: Invalid or non-wallet transaction id (-5)
```

Anyone know what's going wrong / can point me in the right direction if I'm making a mistake, or `MiniWallet` needs to be improved for this to work correctly?