### PR TITLE
ci: Fix COMMIT_RANGE variable value for PRs

### DIFF
--- a/ci/lint/05_before_script.sh
+++ b/ci/lint/05_before_script.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-#
-# Copyright (c) 2018-2019 The Bitcoin Core developers
-# Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-export LC_ALL=C
-
-git fetch

--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -6,8 +6,9 @@
 
 export LC_ALL=C
 
+GIT_HEAD=$(git rev-parse HEAD)
 if [ -n "$CIRRUS_PR" ]; then
-  COMMIT_RANGE="${CIRRUS_BASE_SHA}..HEAD"
+  COMMIT_RANGE="${CIRRUS_BASE_SHA}..$GIT_HEAD"
   test/lint/commit-script-check.sh $COMMIT_RANGE
 fi
 export COMMIT_RANGE
@@ -28,3 +29,6 @@ if [ "$CIRRUS_REPO_FULL_NAME" = "bitcoin/bitcoin" ] && [ -n "$CIRRUS_CRON" ]; th
     ${CI_RETRY_EXE}  gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys $(<contrib/verify-commits/trusted-keys) &&
     ./contrib/verify-commits/verify-commits.py --clean-merge=2;
 fi
+
+echo
+git log --no-merges --oneline $COMMIT_RANGE

--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -7,12 +7,10 @@
 export LC_ALL=C
 
 if [ -n "$CIRRUS_PR" ]; then
-  # CIRRUS_PR will be present in a Cirrus environment. For builds triggered
-  # by a pull request this is the name of the branch targeted by the pull request.
-  # https://cirrus-ci.org/guide/writing-tasks/#environment-variables
-  COMMIT_RANGE="$CIRRUS_BRANCH..HEAD"
+  COMMIT_RANGE="${CIRRUS_BASE_SHA}..HEAD"
   test/lint/commit-script-check.sh $COMMIT_RANGE
 fi
+export COMMIT_RANGE
 
 # This only checks that the trees are pure subtrees, it is not doing a full
 # check with -r to not have to fetch all the remotes.

--- a/ci/lint_run_all.sh
+++ b/ci/lint_run_all.sh
@@ -8,5 +8,4 @@ export LC_ALL=C.UTF-8
 
 set -o errexit; source ./ci/test/00_setup_env.sh
 set -o errexit; source ./ci/lint/04_install.sh
-set -o errexit; source ./ci/lint/05_before_script.sh
 set -o errexit; source ./ci/lint/06_script.sh

--- a/test/lint/lint-git-commit-check.sh
+++ b/test/lint/lint-git-commit-check.sh
@@ -23,13 +23,6 @@ while getopts "?" opt; do
   esac
 done
 
-# TRAVIS_BRANCH will be present in a Travis environment. For builds triggered
-# by a pull request this is the name of the branch targeted by the pull request.
-# https://docs.travis-ci.com/user/environment-variables/
-if [ -n "${TRAVIS_BRANCH}" ]; then
-  COMMIT_RANGE="$TRAVIS_BRANCH..HEAD"
-fi
-
 if [ -z "${COMMIT_RANGE}" ]; then
     if [ -n "$1" ]; then
       COMMIT_RANGE="HEAD~$1...HEAD"

--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -8,14 +8,6 @@
 
 export LC_ALL=C
 
-# The shellcheck binary segfault/coredumps in Travis with LC_ALL=C
-# It does not do so in Ubuntu 14.04, 16.04, 18.04 in versions 0.3.3, 0.3.7, 0.4.6
-# respectively. So export LC_ALL=C is set as required by lint-shell-locale.sh
-# but unset here in case of running in Travis.
-if [ "$TRAVIS" = "true" ]; then
-    unset LC_ALL
-fi
-
 # Disabled warnings:
 disabled=(
     SC2046 # Quote this to prevent word splitting.

--- a/test/lint/lint-whitespace.sh
+++ b/test/lint/lint-whitespace.sh
@@ -22,13 +22,6 @@ while getopts "?" opt; do
   esac
 done
 
-# TRAVIS_BRANCH will be present in a Travis environment. For builds triggered
-# by a pull request this is the name of the branch targeted by the pull request.
-# https://docs.travis-ci.com/user/environment-variables/
-if [ -n "${TRAVIS_BRANCH}" ]; then
-  COMMIT_RANGE="$TRAVIS_BRANCH..HEAD"
-fi
-
 if [ -z "${COMMIT_RANGE}" ]; then
   if [ -n "$1" ]; then
     COMMIT_RANGE="HEAD~$1...HEAD"


### PR DESCRIPTION
This PR:
- is a #20658 and #20682  followup 
- set the `COMMIT_RANGE` variable correctly for PRs
- cleans up Travis-specific code
- prints COMMIT_RANGE value to the log for convenience as it was in Travis CI