### PR TITLE
util: Add ArgsManager::GetCommand() and use it in bitcoin-wallet

### DIFF
--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -111,17 +111,9 @@ int main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    // A name must be provided when creating a file
-    if (method == "create" && !args.IsArgSet("-wallet")) {
-        tfm::format(std::cerr, "Wallet name must be provided when creating a new wallet.\n");
-        return EXIT_FAILURE;
-    }
-
-    std::string name = args.GetArg("-wallet", "");
-
     ECCVerifyHandle globalVerifyHandle;
     ECC_Start();
-    if (!WalletTool::ExecuteWalletToolFunc(args, method, name)) {
+    if (!WalletTool::ExecuteWalletToolFunc(args, method)) {
         return EXIT_FAILURE;
     }
     ECC_Stop();

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -40,44 +40,45 @@ static void SetupWalletToolArgs(ArgsManager& argsman)
     argsman.AddArg("createfromdump", "Create new wallet file from dumped records", ArgsManager::ALLOW_ANY, OptionsCategory::COMMANDS);
 }
 
-static bool WalletAppInit(int argc, char* argv[])
+static bool WalletAppInit(ArgsManager& args, int argc, char* argv[])
 {
-    SetupWalletToolArgs(gArgs);
+    SetupWalletToolArgs(args);
     std::string error_message;
-    if (!gArgs.ParseParameters(argc, argv, error_message)) {
+    if (!args.ParseParameters(argc, argv, error_message)) {
         tfm::format(std::cerr, "Error parsing command line arguments: %s\n", error_message);
         return false;
     }
-    if (argc < 2 || HelpRequested(gArgs) || gArgs.IsArgSet("-version")) {
+    if (argc < 2 || HelpRequested(args) || args.IsArgSet("-version")) {
         std::string strUsage = strprintf("%s bitcoin-wallet version", PACKAGE_NAME) + " " + FormatFullVersion() + "\n";
-            if (!gArgs.IsArgSet("-version")) {
-                strUsage += "\n"
-                    "bitcoin-wallet is an offline tool for creating and interacting with " PACKAGE_NAME " wallet files.\n"
-                    "By default bitcoin-wallet will act on wallets in the default mainnet wallet directory in the datadir.\n"
-                    "To change the target wallet, use the -datadir, -wallet and -testnet/-regtest arguments.\n\n"
-                    "Usage:\n"
-                    "  bitcoin-wallet [options] <command>\n";
-                strUsage += "\n" + gArgs.GetHelpMessage();
-            }
+        if (!args.IsArgSet("-version")) {
+            strUsage += "\n"
+                        "bitcoin-wallet is an offline tool for creating and interacting with " PACKAGE_NAME " wallet files.\n"
+                        "By default bitcoin-wallet will act on wallets in the default mainnet wallet directory in the datadir.\n"
+                        "To change the target wallet, use the -datadir, -wallet and -testnet/-regtest arguments.\n\n"
+                        "Usage:\n"
+                        "  bitcoin-wallet [options] <command>\n";
+            strUsage += "\n" + args.GetHelpMessage();
+        }
         tfm::format(std::cout, "%s", strUsage);
         return false;
     }
 
     // check for printtoconsole, allow -debug
-    LogInstance().m_print_to_console = gArgs.GetBoolArg("-printtoconsole", gArgs.GetBoolArg("-debug", false));
+    LogInstance().m_print_to_console = args.GetBoolArg("-printtoconsole", args.GetBoolArg("-debug", false));
 
     if (!CheckDataDirOption()) {
-        tfm::format(std::cerr, "Error: Specified data directory \"%s\" does not exist.\n", gArgs.GetArg("-datadir", ""));
+        tfm::format(std::cerr, "Error: Specified data directory \"%s\" does not exist.\n", args.GetArg("-datadir", ""));
         return false;
     }
     // Check for chain settings (Params() calls are only valid after this clause)
-    SelectParams(gArgs.GetChainName());
+    SelectParams(args.GetChainName());
 
     return true;
 }
 
 int main(int argc, char* argv[])
 {
+    ArgsManager& args = gArgs;
 #ifdef WIN32
     util::WinCmdLineArgs winArgs;
     std::tie(argc, argv) = winArgs.get();
@@ -85,7 +86,7 @@ int main(int argc, char* argv[])
     SetupEnvironment();
     RandomInit();
     try {
-        if (!WalletAppInit(argc, argv)) return EXIT_FAILURE;
+        if (!WalletAppInit(args, argc, argv)) return EXIT_FAILURE;
     } catch (const std::exception& e) {
         PrintExceptionContinue(&e, "WalletAppInit()");
         return EXIT_FAILURE;
@@ -111,16 +112,16 @@ int main(int argc, char* argv[])
     }
 
     // A name must be provided when creating a file
-    if (method == "create" && !gArgs.IsArgSet("-wallet")) {
+    if (method == "create" && !args.IsArgSet("-wallet")) {
         tfm::format(std::cerr, "Wallet name must be provided when creating a new wallet.\n");
         return EXIT_FAILURE;
     }
 
-    std::string name = gArgs.GetArg("-wallet", "");
+    std::string name = args.GetArg("-wallet", "");
 
     ECCVerifyHandle globalVerifyHandle;
     ECC_Start();
-    if (!WalletTool::ExecuteWalletToolFunc(gArgs, method, name)) {
+    if (!WalletTool::ExecuteWalletToolFunc(args, method, name)) {
         return EXIT_FAILURE;
     }
     ECC_Stop();

--- a/src/test/fuzz/system.cpp
+++ b/src/test/fuzz/system.cpp
@@ -54,7 +54,7 @@ FUZZ_TARGET(system)
                 if (args_manager.GetArgFlags(argument_name) != nullopt) {
                     return;
                 }
-                args_manager.AddArg(argument_name, fuzzed_data_provider.ConsumeRandomLengthString(16), fuzzed_data_provider.ConsumeIntegral<unsigned int>(), options_category);
+                args_manager.AddArg(argument_name, fuzzed_data_provider.ConsumeRandomLengthString(16), fuzzed_data_provider.ConsumeIntegral<unsigned int>() & ~ArgsManager::COMMAND, options_category);
             },
             [&] {
                 // Avoid hitting:

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -183,6 +183,7 @@ public:
         NETWORK_ONLY = 0x200,
         // This argument's value is sensitive (such as a password).
         SENSITIVE = 0x400,
+        COMMAND = 0x800,
     };
 
 protected:
@@ -195,9 +196,11 @@ protected:
 
     mutable RecursiveMutex cs_args;
     util::Settings m_settings GUARDED_BY(cs_args);
+    std::vector<std::string> m_command GUARDED_BY(cs_args);
     std::string m_network GUARDED_BY(cs_args);
     std::set<std::string> m_network_only_args GUARDED_BY(cs_args);
     std::map<OptionsCategory, std::map<std::string, Arg>> m_available_args GUARDED_BY(cs_args);
+    bool m_accept_any_command GUARDED_BY(cs_args){true};
     std::list<SectionInfo> m_config_sections GUARDED_BY(cs_args);
 
     [[nodiscard]] bool ReadConfigStream(std::istream& stream, const std::string& filepath, std::string& error, bool ignore_invalid_keys = false);
@@ -247,6 +250,20 @@ public:
      * Log warnings for unrecognized section names in the config file.
      */
     const std::list<SectionInfo> GetUnrecognizedSections() const;
+
+    struct Command {
+        /** The command (if one has been registered with AddCommand), or empty */
+        std::string command;
+        /**
+         * If command is non-empty: Any args that followed it
+         * If command is empty: The unregistered command and any args that followed it
+         */
+        std::vector<std::string> args;
+    };
+    /**
+     * Get the command and command args (returns std::nullopt if no command provided)
+     */
+    std::optional<const Command> GetCommand() const;
 
     /**
      * Return a vector of strings of the given argument
@@ -332,6 +349,11 @@ public:
      * Add argument
      */
     void AddArg(const std::string& name, const std::string& help, unsigned int flags, const OptionsCategory& cat);
+
+    /**
+     * Add subcommand
+     */
+    void AddCommand(const std::string& cmd, const std::string& help, const OptionsCategory& cat);
 
     /**
      * Add many hidden arguments

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -103,10 +103,8 @@ static void WalletShowInfo(CWallet* wallet_instance)
     tfm::format(std::cout, "Address Book: %zu\n", wallet_instance->m_address_book.size());
 }
 
-bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command, const std::string& name)
+bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
 {
-    const fs::path path = fsbridge::AbsPathJoin(GetWalletDir(), name);
-
     if (args.IsArgSet("-format") && command != "createfromdump") {
         tfm::format(std::cerr, "The -format option can only be used with the \"createfromdump\" command.\n");
         return false;
@@ -119,6 +117,12 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command, 
         tfm::format(std::cerr, "The -descriptors option can only be used with the 'create' command.\n");
         return false;
     }
+    if (command == "create" && !args.IsArgSet("-wallet")) {
+        tfm::format(std::cerr, "Wallet name must be provided when creating a new wallet.\n");
+        return false;
+    }
+    const std::string name = args.GetArg("-wallet", "");
+    const fs::path path = fsbridge::AbsPathJoin(GetWalletDir(), name);
 
     if (command == "create") {
         DatabaseOptions options;

--- a/src/wallet/wallettool.h
+++ b/src/wallet/wallettool.h
@@ -10,7 +10,7 @@
 namespace WalletTool {
 
 void WalletShowInfo(CWallet* wallet_instance);
-bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command, const std::string& file);
+bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command);
 
 } // namespace WalletTool
 

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -188,6 +188,8 @@ class ToolWalletTest(BitcoinTestFramework):
         self.assert_raises_tool_error('Invalid command: help', 'help')
         self.assert_raises_tool_error('Error: two methods provided (info and create). Only one method should be provided.', 'info', 'create')
         self.assert_raises_tool_error('Error parsing command line arguments: Invalid parameter -foo', '-foo')
+        self.assert_raises_tool_error('No method provided. Run `bitcoin-wallet -help` for valid methods.')
+        self.assert_raises_tool_error('Wallet name must be provided when creating a new wallet.', 'create')
         locked_dir = os.path.join(self.options.tmpdir, "node0", "regtest", "wallets")
         error = 'Error initializing wallet database environment "{}"!'.format(locked_dir)
         if self.options.descriptors:

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -183,10 +183,10 @@ class ToolWalletTest(BitcoinTestFramework):
 
     def test_invalid_tool_commands_and_args(self):
         self.log.info('Testing that various invalid commands raise with specific error messages')
-        self.assert_raises_tool_error('Invalid command: foo', 'foo')
+        self.assert_raises_tool_error("Error parsing command line arguments: Invalid command 'foo'", 'foo')
         # `bitcoin-wallet help` raises an error. Use `bitcoin-wallet -help`.
-        self.assert_raises_tool_error('Invalid command: help', 'help')
-        self.assert_raises_tool_error('Error: two methods provided (info and create). Only one method should be provided.', 'info', 'create')
+        self.assert_raises_tool_error("Error parsing command line arguments: Invalid command 'help'", 'help')
+        self.assert_raises_tool_error('Error: Additional arguments provided (create). Methods do not take arguments. Please refer to `-help`.', 'info', 'create')
         self.assert_raises_tool_error('Error parsing command line arguments: Invalid parameter -foo', '-foo')
         self.assert_raises_tool_error('No method provided. Run `bitcoin-wallet -help` for valid methods.')
         self.assert_raises_tool_error('Wallet name must be provided when creating a new wallet.', 'create')


### PR DESCRIPTION
This not only moves the parsing responsibility out from the wallet tool, but it also makes it easier to implement bitcoin-util #19937 

Fixes: #20902