### PR TITLE
ci: Fix COMMIT_RANGE variable value for cloned repos

### DIFF
--- a/ci/lint/05_before_script.sh
+++ b/ci/lint/05_before_script.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-#
-# Copyright (c) 2018-2019 The Bitcoin Core developers
-# Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-export LC_ALL=C
-
-git fetch

--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -7,12 +7,11 @@
 export LC_ALL=C
 
 if [ -n "$CIRRUS_PR" ]; then
-  # CIRRUS_PR will be present in a Cirrus environment. For builds triggered
-  # by a pull request this is the name of the branch targeted by the pull request.
-  # https://cirrus-ci.org/guide/writing-tasks/#environment-variables
-  COMMIT_RANGE="$CIRRUS_BRANCH..HEAD"
+  git fetch $CIRRUS_REPO_CLONE_URL $CIRRUS_BASE_SHA
+  COMMIT_RANGE="${CIRRUS_BASE_SHA}..HEAD"
   test/lint/commit-script-check.sh $COMMIT_RANGE
 fi
+export COMMIT_RANGE
 
 # This only checks that the trees are pure subtrees, it is not doing a full
 # check with -r to not have to fetch all the remotes.

--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -10,6 +10,8 @@ if [ -n "$CIRRUS_PR" ]; then
   git fetch $CIRRUS_REPO_CLONE_URL $CIRRUS_BASE_SHA
   COMMIT_RANGE="${CIRRUS_BASE_SHA}..HEAD"
   test/lint/commit-script-check.sh $COMMIT_RANGE
+else
+  COMMIT_RANGE="$(git fetch $CIRRUS_REPO_CLONE_URL ${CIRRUS_LAST_GREEN_CHANGE:-$CIRRUS_DEFAULT_BRANCH} && git merge-base FETCH_HEAD HEAD)..HEAD"
 fi
 export COMMIT_RANGE
 

--- a/ci/lint_run_all.sh
+++ b/ci/lint_run_all.sh
@@ -8,5 +8,4 @@ export LC_ALL=C.UTF-8
 
 set -o errexit; source ./ci/test/00_setup_env.sh
 set -o errexit; source ./ci/lint/04_install.sh
-set -o errexit; source ./ci/lint/05_before_script.sh
 set -o errexit; source ./ci/lint/06_script.sh

--- a/test/lint/lint-git-commit-check.sh
+++ b/test/lint/lint-git-commit-check.sh
@@ -23,13 +23,6 @@ while getopts "?" opt; do
   esac
 done
 
-# TRAVIS_BRANCH will be present in a Travis environment. For builds triggered
-# by a pull request this is the name of the branch targeted by the pull request.
-# https://docs.travis-ci.com/user/environment-variables/
-if [ -n "${TRAVIS_BRANCH}" ]; then
-  COMMIT_RANGE="$TRAVIS_BRANCH..HEAD"
-fi
-
 if [ -z "${COMMIT_RANGE}" ]; then
     if [ -n "$1" ]; then
       COMMIT_RANGE="HEAD~$1...HEAD"

--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -8,14 +8,6 @@
 
 export LC_ALL=C
 
-# The shellcheck binary segfault/coredumps in Travis with LC_ALL=C
-# It does not do so in Ubuntu 14.04, 16.04, 18.04 in versions 0.3.3, 0.3.7, 0.4.6
-# respectively. So export LC_ALL=C is set as required by lint-shell-locale.sh
-# but unset here in case of running in Travis.
-if [ "$TRAVIS" = "true" ]; then
-    unset LC_ALL
-fi
-
 # Disabled warnings:
 disabled=(
     SC2046 # Quote this to prevent word splitting.

--- a/test/lint/lint-whitespace.sh
+++ b/test/lint/lint-whitespace.sh
@@ -22,13 +22,6 @@ while getopts "?" opt; do
   esac
 done
 
-# TRAVIS_BRANCH will be present in a Travis environment. For builds triggered
-# by a pull request this is the name of the branch targeted by the pull request.
-# https://docs.travis-ci.com/user/environment-variables/
-if [ -n "${TRAVIS_BRANCH}" ]; then
-  COMMIT_RANGE="$TRAVIS_BRANCH..HEAD"
-fi
-
 if [ -z "${COMMIT_RANGE}" ]; then
   if [ -n "$1" ]; then
     COMMIT_RANGE="HEAD~$1...HEAD"


### PR DESCRIPTION
This change is split out from #20697 as [requested](https://github.com/bitcoin/bitcoin/pull/20697#discussion_r545826069) by **MarcoFalke**, and allows using lint task in forked repos with personal Cirrus CI accounts.

Based on #20697, only the last commit should be reviewed.