### PR TITLE
p2p: Add DISABLETX message for negotiating block-relay-only connections

### DIFF
--- a/doc/bips.md
+++ b/doc/bips.md
@@ -49,6 +49,7 @@ BIPs that are implemented by Bitcoin Core (up-to-date up to **v23.0**):
 * [`BIP 174`](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki): RPCs to operate on Partially Signed Bitcoin Transactions (PSBT) are present as of **v0.17.0** ([PR 13557](https://github.com/bitcoin/bitcoin/pull/13557)).
 * [`BIP 176`](https://github.com/bitcoin/bips/blob/master/bip-0176.mediawiki): Bits Denomination [QT only] is supported as of **v0.16.0** ([PR 12035](https://github.com/bitcoin/bitcoin/pull/12035)).
 * [`BIP 325`](https://github.com/bitcoin/bips/blob/master/bip-0325.mediawiki): Signet test network is supported as of **v0.21.0** ([PR 18267](https://github.com/bitcoin/bitcoin/pull/18267)).
+* [`BIP 338`](https://github.com/bitcoin/bips/blob/master/bip-0338.mediawiki): disabletx messages are respected and sent to block-relay-only peers with version `>=70017` as of **v24.0** ([PR 20726](https://github.com/bitcoin/bitcoin/pull/20726)).
 * [`BIP 339`](https://github.com/bitcoin/bips/blob/master/bip-0339.mediawiki): Relay of transactions by wtxid is supported as of **v0.21.0** ([PR 18044](https://github.com/bitcoin/bitcoin/pull/18044)).
 * [`BIP 340`](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki)
   [`341`](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1381,6 +1381,7 @@ bool PeerManagerImpl::GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) c
     stats.m_addr_processed = peer->m_addr_processed.load();
     stats.m_addr_rate_limited = peer->m_addr_rate_limited.load();
     stats.m_addr_relay_enabled = peer->m_addr_relay_enabled.load();
+    stats.m_received_disabletx = peer->m_disable_tx.load();
 
     return true;
 }

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -34,6 +34,7 @@ struct CNodeStateStats {
     uint64_t m_addr_processed = 0;
     uint64_t m_addr_rate_limited = 0;
     bool m_addr_relay_enabled{false};
+    bool m_received_disabletx{false}; // whether DISABLETX has been received from this peer (BIP 338)
 };
 
 class PeerManager : public CValidationInterface, public NetEventsInterface

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -44,6 +44,7 @@ const char *CFHEADERS="cfheaders";
 const char *GETCFCHECKPT="getcfcheckpt";
 const char *CFCHECKPT="cfcheckpt";
 const char *WTXIDRELAY="wtxidrelay";
+const char *DISABLETX="disabletx";
 } // namespace NetMsgType
 
 /** All known message types. Keep this in the same order as the list of
@@ -84,6 +85,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::GETCFCHECKPT,
     NetMsgType::CFCHECKPT,
     NetMsgType::WTXIDRELAY,
+    NetMsgType::DISABLETX,
 };
 const static std::vector<std::string> allNetMessageTypesVec(std::begin(allNetMessageTypes), std::end(allNetMessageTypes));
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -262,6 +262,13 @@ extern const char* CFCHECKPT;
  * @since protocol version 70016 as described by BIP 339.
  */
 extern const char* WTXIDRELAY;
+/**
+ * Indicates that a node will not relay transactions, and (for now) also
+ * not relay addresses. This can be used by nodes implementing
+ * block-relay-only connections.
+ * @since protocol version 70017.
+ */
+extern const char* DISABLETX;
 }; // namespace NetMsgType
 
 /* Get a vector of all valid message types (see above) */

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -266,7 +266,7 @@ extern const char* WTXIDRELAY;
  * Indicates that a node will not relay transactions, and (for now) also
  * not relay addresses. This can be used by nodes implementing
  * block-relay-only connections.
- * @since protocol version 70017.
+ * @since protocol version 70017 as described by BIP 338.
  */
 extern const char* DISABLETX;
 }; // namespace NetMsgType

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -140,6 +140,7 @@ static RPCHelpMan getpeerinfo()
                     {RPCResult::Type::BOOL, "addr_relay_enabled", /*optional=*/true, "Whether we participate in address relay with this peer"},
                     {RPCResult::Type::NUM, "addr_processed", /*optional=*/true, "The total number of addresses processed, excluding those dropped due to rate limiting"},
                     {RPCResult::Type::NUM, "addr_rate_limited", /*optional=*/true, "The total number of addresses dropped due to rate limiting"},
+                    {RPCResult::Type::BOOL, "disabletx_received", /*optional=*/true, "Whether transaction relay was disabled by this peer (BIP 338)"},
                     {RPCResult::Type::ARR, "permissions", "Any special permissions that have been granted to this peer",
                     {
                         {RPCResult::Type::STR, "permission_type", Join(NET_PERMISSIONS_DOC, ",\n") + ".\n"},
@@ -236,6 +237,7 @@ static RPCHelpMan getpeerinfo()
             obj.pushKV("addr_relay_enabled", statestats.m_addr_relay_enabled);
             obj.pushKV("addr_processed", statestats.m_addr_processed);
             obj.pushKV("addr_rate_limited", statestats.m_addr_rate_limited);
+            obj.pushKV("disabletx_received", statestats.m_received_disabletx);
         }
         UniValue permissions(UniValue::VARR);
         for (const auto& permission : NetPermissions::ToStrings(stats.m_permissionFlags)) {

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -110,6 +110,7 @@ FUZZ_TARGET_MSG(cfcheckpt);
 FUZZ_TARGET_MSG(cfheaders);
 FUZZ_TARGET_MSG(cfilter);
 FUZZ_TARGET_MSG(cmpctblock);
+FUZZ_TARGET_MSG(disabletx);
 FUZZ_TARGET_MSG(feefilter);
 FUZZ_TARGET_MSG(filteradd);
 FUZZ_TARGET_MSG(filterclear);

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70016;
+static constexpr int PROTOCOL_VERSION = 70017;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -37,6 +37,9 @@ static const int INVALID_CB_NO_BAN_VERSION = 70015;
 
 //! "wtxidrelay" command for wtxid-based relay starts with this version
 static const int WTXID_RELAY_VERSION = 70016;
+
+//! "disabletx" message (eg used for block-relay-only connections) starts with this version
+static constexpr int DISABLE_TX_VERSION = 70017;
 
 // Make sure that none of the values above collide with
 // `SERIALIZE_TRANSACTION_NO_WITNESS` or `ADDRV2_FORMAT`.

--- a/test/functional/p2p_disabletx.py
+++ b/test/functional/p2p_disabletx.py
@@ -37,6 +37,7 @@ from test_framework.p2p import (
     P2PInterface,
 )
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
 
 
 class DisableTxTest(BitcoinTestFramework):
@@ -166,6 +167,22 @@ class DisableTxTest(BitcoinTestFramework):
         peer.send_message(msg_feefilter())
         peer.wait_for_disconnect()
 
+    def peerinfo_includes_disabletx_test(self):
+        self.log.info('Check that getpeerinfo() returns the disabletx status on a connection')
+
+        peer = self.nodes[0].add_p2p_connection(P2PInterface(disabletx=True))
+        peer.sync_with_ping()
+
+        assert_equal(self.nodes[0].getpeerinfo()[0]['disabletx_received'], True)
+        peer.peer_disconnect()
+        peer.wait_for_disconnect()
+
+        peer = self.nodes[0].add_p2p_connection(P2PInterface(disabletx=False))
+        peer.sync_with_ping()
+        assert_equal(self.nodes[0].getpeerinfo()[0]['disabletx_received'], False)
+        peer.peer_disconnect()
+        peer.wait_for_disconnect()
+
     def run_test(self):
         self.tip_hash = int(self.generate(self.nodes[0], 1)[0], 16)
 
@@ -180,6 +197,7 @@ class DisableTxTest(BitcoinTestFramework):
         self.mempool_after_disabletx_test()
         self.notfound_after_disabletx_test()
         self.feefilter_after_disabletx_test()
+        self.peerinfo_includes_disabletx_test()
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_disabletx.py
+++ b/test/functional/p2p_disabletx.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Tests disabletx message.
+
+Test that bitcoind will disconnect us if we deviate from BIP338, and
+send disallowed messages or invalid message combinations involving
+disabletx."""
+
+from test_framework.messages import (
+    CInv,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxOut,
+    MSG_FILTERED_BLOCK,
+    MSG_TX,
+    MSG_WTX,
+    MSG_WITNESS_FLAG,
+    msg_disabletx,
+    msg_feefilter,
+    msg_filteradd,
+    msg_filterclear,
+    msg_filterload,
+    msg_getdata,
+    msg_inv,
+    msg_mempool,
+    msg_notfound,
+    msg_tx,
+    msg_version,
+)
+from test_framework.p2p import (
+    P2P_SERVICES,
+    P2P_SUBVERSION,
+    P2P_VERSION,
+    P2PInterface,
+)
+from test_framework.test_framework import BitcoinTestFramework
+
+
+class DisableTxTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [['-peerbloomfilters=1']]
+
+    def expect_disabletx_for_outbound_block_relay_test(self):
+        self.log.info('Check that bitcoind will send disabletx when making block-relay-only connections')
+        peer = self.nodes[0].add_outbound_p2p_connection(P2PInterface(disabletx=True), p2p_idx=0, connection_type='block-relay-only')
+
+        def test_function():
+            return "disabletx" in peer.last_message
+
+        peer.wait_until(test_function, timeout=60)
+        peer.peer_disconnect()
+        peer.wait_for_disconnect()
+
+    def disabletx_after_verack_test(self):
+        self.log.info('Check for disconnection when sending disabletx after verack')
+        peer = self.nodes[0].add_p2p_connection(P2PInterface())
+        peer.sync_with_ping()
+
+        peer.send_message(msg_disabletx())
+        peer.wait_for_disconnect()
+
+    def disabletx_without_frelay_test(self):
+        self.log.info('Check for disconnection when sending disabletx without fRelay=0')
+        peer = self.nodes[0].add_p2p_connection(P2PInterface(disabletx=True), send_version=False, wait_for_verack=False)
+        version = msg_version()
+        version.nVersion = P2P_VERSION
+        version.strSubVer = P2P_SUBVERSION
+        version.relay = 1
+        version.nServices = P2P_SERVICES
+        version.addrTo.ip = peer.dstaddr
+        version.addrTo.port = peer.dstport
+        version.addrFrom.ip = "0.0.0.0"
+        version.addrFrom.port = 0
+        peer.send_message(version)
+
+        peer.wait_for_disconnect()
+
+    def disabletx_as_outbound_peer_test(self):
+        self.log.info('Check for disconnection if we connect outbound to a disabletx peer')
+        peer = self.nodes[0].add_outbound_p2p_connection(P2PInterface(disabletx=True), p2p_idx=0, connection_type='outbound-full-relay', expect_disconnect=True)
+        peer.wait_for_disconnect()
+
+    def getdata_after_disabletx_test(self):
+        self.log.info('Check for disconnection when sending getdata(tx) or getdata(merkleblock) after disabletx')
+        for inv_type in (MSG_TX, MSG_TX | MSG_WITNESS_FLAG, MSG_WTX, MSG_FILTERED_BLOCK):
+            wtxidrelay = False
+            if inv_type == MSG_WTX:
+                wtxidrelay = True
+            peer = self.nodes[0].add_p2p_connection(P2PInterface(wtxidrelay=wtxidrelay, disabletx=True))
+            peer.sync_with_ping()
+
+            peer.send_message(msg_getdata(inv=[CInv(t=inv_type, h=self.tip_hash)]))
+            peer.wait_for_disconnect()
+
+    def inv_after_disabletx_test(self):
+        self.log.info('Check for disconnection when sending inv(tx) after disabletx')
+        for inv_type in (MSG_TX, MSG_WTX):
+            wtxidrelay = False
+            if inv_type == MSG_WTX:
+                wtxidrelay = True
+            peer = self.nodes[0].add_p2p_connection(P2PInterface(wtxidrelay=wtxidrelay, disabletx=True))
+            peer.sync_with_ping()
+
+            peer.send_message(msg_inv(inv=[CInv(t=inv_type, h=0xdeadbeef)]))
+            peer.wait_for_disconnect()
+
+    def tx_after_disabletx_test(self):
+        self.log.info('Check for disconnection when sending a tx after disabletx')
+
+        peer = self.nodes[0].add_p2p_connection(P2PInterface(disabletx=True))
+        peer.sync_with_ping()
+
+        # Construct a dummy transaction. Inputs will be missing so no
+        # validation will occur (this is easier than constructing a valid
+        # transaction, which should be unnecessary for this test).
+        tx = CTransaction()
+        tx.vin = [CTxIn(outpoint=COutPoint(0xdeadbeef, 0))]
+        tx.vout = [CTxOut()]
+
+        peer.send_message(msg_tx(tx))
+        peer.wait_for_disconnect()
+
+    def bloom_filter_after_disabletx_test(self):
+        self.log.info('Check for disconnection when sending a bip37 filter* message after disabletx')
+
+        for msg in (msg_filterload(), msg_filterclear(), msg_filteradd(data=b'00')):
+            peer = self.nodes[0].add_p2p_connection(P2PInterface(disabletx=True))
+            peer.sync_with_ping()
+
+            peer.send_message(msg)
+            peer.wait_for_disconnect()
+
+    def mempool_after_disabletx_test(self):
+        self.log.info('Check for disconnection when sending a mempool message after disabletx')
+
+        peer = self.nodes[0].add_p2p_connection(P2PInterface(disabletx=True))
+        peer.sync_with_ping()
+
+        peer.send_message(msg_mempool())
+        peer.wait_for_disconnect()
+
+    def notfound_after_disabletx_test(self):
+        self.log.info('Check for disconnection when sending a notfound(tx) message after disabletx')
+
+        for inv_type in (MSG_TX, MSG_WTX):
+            wtxidrelay = False
+            if inv_type == MSG_WTX:
+                wtxidrelay = True
+            peer = self.nodes[0].add_p2p_connection(P2PInterface(wtxidrelay=wtxidrelay, disabletx=True))
+            peer.sync_with_ping()
+
+            peer.send_message(msg_notfound(vec=[CInv(t=inv_type, h=0xdeadbeef)]))
+            peer.wait_for_disconnect()
+
+    def feefilter_after_disabletx_test(self):
+        self.log.info('Check for disconnection when sending a feefilter message after disabletx')
+
+        peer = self.nodes[0].add_p2p_connection(P2PInterface(disabletx=True))
+        peer.sync_with_ping()
+
+        peer.send_message(msg_feefilter())
+        peer.wait_for_disconnect()
+
+    def run_test(self):
+        self.tip_hash = int(self.generate(self.nodes[0], 1)[0], 16)
+
+        self.expect_disabletx_for_outbound_block_relay_test()
+        self.disabletx_after_verack_test()
+        self.disabletx_without_frelay_test()
+        self.disabletx_as_outbound_peer_test()
+        self.getdata_after_disabletx_test()
+        self.inv_after_disabletx_test()
+        self.tx_after_disabletx_test()
+        self.bloom_filter_after_disabletx_test()
+        self.mempool_after_disabletx_test()
+        self.notfound_after_disabletx_test()
+        self.feefilter_after_disabletx_test()
+
+
+if __name__ == '__main__':
+    DisableTxTest().main()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1269,6 +1269,22 @@ class msg_wtxidrelay:
     def __repr__(self):
         return "msg_wtxidrelay()"
 
+class msg_disabletx:
+    __slots__ = ()
+    msgtype = b"disabletx"
+
+    def __init__(self):
+        pass
+
+    def deserialize(self, f):
+        pass
+
+    def serialize(self):
+        return b""
+
+    def __repr__(self):
+        return "msg_disabletx()"
+
 
 class msg_no_witness_tx(msg_tx):
     __slots__ = ()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -293,6 +293,7 @@ BASE_SCRIPTS = [
     'p2p_unrequested_blocks.py',
     'p2p_blockfilters.py',
     'p2p_message_capture.py',
+    'p2p_disabletx.py',
     'feature_includeconf.py',
     'feature_addrman.py',
     'feature_asmap.py',


### PR DESCRIPTION
Implement BIP 338.

When we initiate a block-relay-only connection today, our peer doesn't know that we won't send transactions ourselves, or even that we won't try to turn on transaction relay at some later point during the connection's lifetime.

This PR adds a new p2p message, DISABLETX, to be sent between VERSION and VERACK so that peers can signal to each other that they only want blocks/compactblocks/headers to be sent on the link, and not transaction-relay traffic (or addr messages, unless otherwise indicated).