### PR TITLE
ci: Provide `COMMIT_RANGE` variable for non-PRs

### DIFF
--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -10,6 +10,8 @@ GIT_HEAD=$(git rev-parse HEAD)
 if [ -n "$CIRRUS_PR" ]; then
   COMMIT_RANGE="${CIRRUS_BASE_SHA}..$GIT_HEAD"
   test/lint/commit-script-check.sh "$COMMIT_RANGE"
+else
+  COMMIT_RANGE="$(git fetch "$CIRRUS_REPO_CLONE_URL" "${CIRRUS_LAST_GREEN_CHANGE:-$CIRRUS_DEFAULT_BRANCH}" && git merge-base FETCH_HEAD HEAD)..$GIT_HEAD"
 fi
 export COMMIT_RANGE
 


### PR DESCRIPTION
This PR provides the `COMMIT_RANGE` environment variable, which is used in `lint-git-commit-check.py` and `lint-whitespace.py`, for non-PR cases, including our release branches and personal repos.

Fixes https://github.com/bitcoin/bitcoin/runs/8664441400

Has been split out from bitcoin/bitcoin#20697 as [requested](https://github.com/bitcoin/bitcoin/pull/20697#discussion_r545826069) by **MarcoFalke**.