### PR TITLE
p2p: standardize outbound full/block relay connection type naming

### DIFF
--- a/doc/files.md
+++ b/doc/files.md
@@ -54,7 +54,7 @@ Subdirectory       | File(s)               | Description
 `indexes/blockfilter/basic/db/` | LevelDB database      | Blockfilter index LevelDB database for the basic filtertype; *optional*, used if `-blockfilterindex=basic`
 `indexes/blockfilter/basic/`    | `fltrNNNNN.dat`<sup>[\[2\]](#note2)</sup> | Blockfilter index filters for the basic filtertype; *optional*, used if `-blockfilterindex=basic`
 `wallets/`         |                       | [Contains wallets](#multi-wallet-environment); can be specified by `-walletdir` option; if `wallets/` subdirectory does not exist, wallets reside in the [data directory](#data-directory-location)
-`./`               | `anchors.dat`         | Anchor IP address database, created on shutdown and deleted at startup. Anchors are last known outgoing block-relay-only peers that are tried to re-connect to on startup
+`./`               | `anchors.dat`         | Anchor IP address database, created on shutdown and deleted at startup. Anchors are last known outbound-block-relay peers that are tried to re-connect to on startup
 `./`               | `banlist.dat`         | Stores the IPs/subnets of banned nodes
 `./`               | `bitcoin.conf`        | User-defined [configuration settings](bitcoin-conf.md) for `bitcoind` or `bitcoin-qt`. File is not written to by the software and must be created manually. Path can be specified by `-conf` option
 `./`               | `bitcoind.pid`        | Stores the process ID (PID) of `bitcoind` or `bitcoin-qt` while running; created at start and deleted on shutdown; can be specified by `-pid` option

--- a/doc/reduce-memory.md
+++ b/doc/reduce-memory.md
@@ -26,7 +26,7 @@ The size of some in-memory caches can be reduced. As caches trade off memory usa
 
 - `-maxconnections=<n>` - the maximum number of connections, this defaults to 125. Each active connection takes up some
   memory. This option applies only if incoming connections are enabled, otherwise the number of connections will never
-  be more than 10. Of the 10 outbound peers, there can be 8 full-relay connections and 2 block-relay-only ones.
+  be more than 10. Of the 10 outbound peers, there can be 8 outbound-full-relay connections and 2 outbound-block-relay ones.
 
 ## Thread configuration
 

--- a/doc/reduce-traffic.md
+++ b/doc/reduce-traffic.md
@@ -5,8 +5,8 @@ Some node operators need to deal with bandwidth caps imposed by their ISPs.
 
 By default, Bitcoin Core allows up to 125 connections to different peers, 10 of
 which are outbound. You can therefore, have at most 115 inbound connections.
-Of the 10 outbound peers, there can be 8 full-relay connections and 2
-block-relay-only ones.
+Of the 10 outbound peers, there can be 8 outbound-full-relay connections and 2
+outbound-block-relay ones.
 
 The default settings can result in relatively significant traffic consumption.
 

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -160,7 +160,7 @@ bool CAddrDB::Read(CAddrMan& addr, CDataStream& ssPeers)
 
 void DumpAnchors(const fs::path& anchors_db_path, const std::vector<CAddress>& anchors)
 {
-    LOG_TIME_SECONDS(strprintf("Flush %d outbound block-relay-only peer addresses to anchors.dat", anchors.size()));
+    LOG_TIME_SECONDS(strprintf("Flush %d outbound-block-relay peer addresses to anchors.dat", anchors.size()));
     SerializeFileDB("anchors", anchors_db_path, anchors);
 }
 

--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -76,7 +76,7 @@ public:
 /**
  * Dump the anchor IP address database (anchors.dat)
  *
- * Anchors are last known outgoing block-relay-only peers that are
+ * Anchors are last known outbound-block-relay peers that are
  * tried to re-connect to on startup.
  */
 void DumpAnchors(const fs::path& anchors_db_path, const std::vector<CAddress>& anchors);

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -304,7 +304,7 @@ private:
     static constexpr uint8_t m_networks_size{4};
     const std::array<std::string, m_networks_size> m_networks{{"ipv4", "ipv6", "onion", "i2p"}};
     std::array<std::array<uint16_t, m_networks_size + 1>, 3> m_counts{{{}}}; //!< Peer counts by (in/out/total, networks/total)
-    uint8_t m_block_relay_peers_count{0};
+    uint8_t m_outbound_block_relay_peers_count{0};
     uint8_t m_manual_peers_count{0};
     int8_t NetworkStringToId(const std::string& str) const
     {
@@ -361,7 +361,7 @@ private:
     std::string ConnectionTypeForNetinfo(const std::string& conn_type) const
     {
         if (conn_type == "outbound-full-relay") return "full";
-        if (conn_type == "block-relay-only") return "block";
+        if (conn_type == "outbound-block-relay") return "block";
         if (conn_type == "manual" || conn_type == "feeler") return conn_type;
         if (conn_type == "addr-fetch") return "addr";
         return "";
@@ -479,7 +479,7 @@ public:
             ++m_counts.at(is_outbound).at(m_networks_size); // in/out overall
             ++m_counts.at(2).at(network_id);                // total by network
             ++m_counts.at(2).at(m_networks_size);           // total overall
-            if (conn_type == "block-relay-only") ++m_block_relay_peers_count;
+            if (conn_type == "outbound-block-relay") ++m_outbound_block_relay_peers_count;
             if (conn_type == "manual") ++m_manual_peers_count;
             if (DetailsRequested()) {
                 // Push data for this peer to the peers vector.
@@ -553,7 +553,7 @@ public:
             if (m_is_i2p_on) result += strprintf("   %5i", m_counts.at(i).at(3)); // i2p peers count
             result += strprintf("   %5i", m_counts.at(i).at(m_networks_size)); // total peers count
             if (i == 1) { // the outbound row has two extra columns for block relay and manual peer counts
-                result += strprintf("   %5i", m_block_relay_peers_count);
+                result += strprintf("   %5i", m_outbound_block_relay_peers_count);
                 if (m_manual_peers_count) result += strprintf("   %5i", m_manual_peers_count);
             }
         }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -200,7 +200,7 @@ void Shutdown(NodeContext& node)
     // using the other before destroying them.
     if (node.peerman) UnregisterValidationInterface(node.peerman.get());
     // Follow the lock order requirements:
-    // * CheckForStaleTipAndEvictPeers locks cs_main before indirectly calling GetExtraFullOutboundCount
+    // * CheckForStaleTipAndEvictPeers locks cs_main before indirectly calling GetExtraOutboundFullRelayCount
     //   which locks cs_vNodes.
     // * ProcessMessage locks cs_main and g_cs_orphans before indirectly calling ForEachNode which
     //   locks cs_vNodes.
@@ -1916,7 +1916,7 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
     connOptions.nLocalServices = nLocalServices;
     connOptions.nMaxConnections = nMaxConnections;
     connOptions.m_max_outbound_full_relay = std::min(MAX_OUTBOUND_FULL_RELAY_CONNECTIONS, connOptions.nMaxConnections);
-    connOptions.m_max_outbound_block_relay = std::min(MAX_BLOCK_RELAY_ONLY_CONNECTIONS, connOptions.nMaxConnections-connOptions.m_max_outbound_full_relay);
+    connOptions.m_max_outbound_block_relay = std::min(MAX_OUTBOUND_BLOCK_RELAY_CONNECTIONS, connOptions.nMaxConnections-connOptions.m_max_outbound_full_relay);
     connOptions.nMaxAddnode = MAX_ADDNODE_CONNECTIONS;
     connOptions.nMaxFeeler = MAX_FEELER_CONNECTIONS;
     connOptions.uiInterface = &uiInterface;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -41,9 +41,9 @@
 
 #include <math.h>
 
-/** Maximum number of block-relay-only anchor connections */
-static constexpr size_t MAX_BLOCK_RELAY_ONLY_ANCHORS = 2;
-static_assert (MAX_BLOCK_RELAY_ONLY_ANCHORS <= static_cast<size_t>(MAX_BLOCK_RELAY_ONLY_CONNECTIONS), "MAX_BLOCK_RELAY_ONLY_ANCHORS must not exceed MAX_BLOCK_RELAY_ONLY_CONNECTIONS.");
+/** Maximum number of outbound-block-relay anchor connections */
+static constexpr size_t MAX_OUTBOUND_BLOCK_RELAY_ANCHORS = 2;
+static_assert (MAX_OUTBOUND_BLOCK_RELAY_ANCHORS <= static_cast<size_t>(MAX_OUTBOUND_BLOCK_RELAY_CONNECTIONS), "MAX_OUTBOUND_BLOCK_RELAY_ANCHORS must not exceed MAX_OUTBOUND_BLOCK_RELAY_CONNECTIONS.");
 /** Anchor IP address database file name */
 const char* const ANCHORS_DATABASE_FILENAME = "anchors.dat";
 
@@ -513,8 +513,8 @@ std::string ConnectionTypeAsString(ConnectionType conn_type)
         return "feeler";
     case ConnectionType::OUTBOUND_FULL_RELAY:
         return "outbound-full-relay";
-    case ConnectionType::BLOCK_RELAY:
-        return "block-relay-only";
+    case ConnectionType::OUTBOUND_BLOCK_RELAY:
+        return "outbound-block-relay";
     case ConnectionType::ADDR_FETCH:
         return "addr-fetch";
     } // no default case, so the compiler can warn about missing cases
@@ -872,7 +872,7 @@ static bool CompareNodeTXTime(const NodeEvictionCandidate &a, const NodeEviction
     return a.nTimeConnected > b.nTimeConnected;
 }
 
-// Pick out the potential block-relay only peers, and sort them by last block time.
+// Pick out the potential outbound-block-relay peers, and sort them by last block time.
 static bool CompareNodeBlockRelayOnlyTime(const NodeEvictionCandidate &a, const NodeEvictionCandidate &b)
 {
     if (a.fRelayTxes != b.fRelayTxes) return a.fRelayTxes;
@@ -1129,7 +1129,7 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
 
 bool CConnman::AddConnection(const std::string& address, ConnectionType conn_type)
 {
-    if (conn_type != ConnectionType::OUTBOUND_FULL_RELAY && conn_type != ConnectionType::BLOCK_RELAY) return false;
+    if (conn_type != ConnectionType::OUTBOUND_FULL_RELAY && conn_type != ConnectionType::OUTBOUND_BLOCK_RELAY) return false;
 
     const int max_connections = conn_type == ConnectionType::OUTBOUND_FULL_RELAY ? m_max_outbound_full_relay : m_max_outbound_block_relay;
 
@@ -1703,15 +1703,15 @@ void CConnman::ProcessAddrFetch()
     }
 }
 
-bool CConnman::GetTryNewOutboundPeer()
+bool CConnman::GetTryNewOutboundFullRelayPeer()
 {
-    return m_try_another_outbound_peer;
+    return m_try_another_outbound_full_relay_peer;
 }
 
-void CConnman::SetTryNewOutboundPeer(bool flag)
+void CConnman::SetTryNewOutboundFullRelayPeer(bool flag)
 {
-    m_try_another_outbound_peer = flag;
-    LogPrint(BCLog::NET, "net: setting try another outbound peer=%s\n", flag ? "true" : "false");
+    m_try_another_outbound_full_relay_peer = flag;
+    LogPrint(BCLog::NET, "net: setting try another outbound-full-relay peer=%s\n", flag ? "true" : "false");
 }
 
 // Return the number of peers we have over our outbound connection limit
@@ -1720,32 +1720,32 @@ void CConnman::SetTryNewOutboundPeer(bool flag)
 // Also exclude peers that haven't finished initial connection handshake yet
 // (so that we don't decide we're over our desired connection limit, and then
 // evict some peer that has finished the handshake)
-int CConnman::GetExtraFullOutboundCount()
+int CConnman::GetExtraOutboundFullRelayCount()
 {
-    int full_outbound_peers = 0;
+    int outbound_full_relay_peers = 0;
     {
         LOCK(cs_vNodes);
         for (const CNode* pnode : vNodes) {
-            if (pnode->fSuccessfullyConnected && !pnode->fDisconnect && pnode->IsFullOutboundConn()) {
-                ++full_outbound_peers;
+            if (pnode->fSuccessfullyConnected && !pnode->fDisconnect && pnode->IsOutboundFullRelayConn()) {
+                ++outbound_full_relay_peers;
             }
         }
     }
-    return std::max(full_outbound_peers - m_max_outbound_full_relay, 0);
+    return std::max(outbound_full_relay_peers - m_max_outbound_full_relay, 0);
 }
 
-int CConnman::GetExtraBlockRelayCount()
+int CConnman::GetExtraOutboundBlockRelayCount()
 {
-    int block_relay_peers = 0;
+    int outbound_block_relay_peers = 0;
     {
         LOCK(cs_vNodes);
         for (const CNode* pnode : vNodes) {
-            if (pnode->fSuccessfullyConnected && !pnode->fDisconnect && pnode->IsBlockOnlyConn()) {
-                ++block_relay_peers;
+            if (pnode->fSuccessfullyConnected && !pnode->fDisconnect && pnode->IsOutboundBlockRelayConn()) {
+                ++outbound_block_relay_peers;
             }
         }
     }
-    return std::max(block_relay_peers - m_max_outbound_block_relay, 0);
+    return std::max(outbound_block_relay_peers - m_max_outbound_block_relay, 0);
 }
 
 void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
@@ -1777,7 +1777,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
     // Minimum time before next feeler connection (in microseconds).
 
     int64_t nNextFeeler = PoissonNextSend(count_microseconds(start), FEELER_INTERVAL);
-    int64_t nNextExtraBlockRelay = PoissonNextSend(count_microseconds(start), EXTRA_BLOCK_RELAY_ONLY_PEER_INTERVAL);
+    int64_t nNextExtraBlockRelay = PoissonNextSend(count_microseconds(start), EXTRA_OUTBOUND_BLOCK_RELAY_PEER_INTERVAL);
     const bool dnsseed = gArgs.GetBoolArg("-dnsseed", DEFAULT_DNSSEED);
     bool add_fixed_seeds = gArgs.GetBoolArg("-fixedseeds", DEFAULT_FIXEDSEEDS);
 
@@ -1838,8 +1838,8 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
         {
             LOCK(cs_vNodes);
             for (const CNode* pnode : vNodes) {
-                if (pnode->IsFullOutboundConn()) nOutboundFullRelay++;
-                if (pnode->IsBlockOnlyConn()) nOutboundBlockRelay++;
+                if (pnode->IsOutboundFullRelayConn()) nOutboundFullRelay++;
+                if (pnode->IsOutboundBlockRelayConn()) nOutboundBlockRelay++;
 
                 // Netgroups for inbound and manual peers are not excluded because our goal here
                 // is to not use multiple of our limited outbound slots on a single netgroup
@@ -1851,7 +1851,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
                     case ConnectionType::MANUAL:
                         break;
                     case ConnectionType::OUTBOUND_FULL_RELAY:
-                    case ConnectionType::BLOCK_RELAY:
+                    case ConnectionType::OUTBOUND_BLOCK_RELAY:
                     case ConnectionType::ADDR_FETCH:
                     case ConnectionType::FEELER:
                         setConnected.insert(pnode->addr.GetGroup(addrman.m_asmap));
@@ -1865,26 +1865,26 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
         bool fFeeler = false;
 
         // Determine what type of connection to open. Opening
-        // BLOCK_RELAY connections to addresses from anchors.dat gets the highest
+        // OUTBOUND_BLOCK_RELAY connections to addresses from anchors.dat gets the highest
         // priority. Then we open OUTBOUND_FULL_RELAY priority until we
-        // meet our full-relay capacity. Then we open BLOCK_RELAY connection
-        // until we hit our block-relay-only peer limit.
-        // GetTryNewOutboundPeer() gets set when a stale tip is detected, so we
+        // meet our outbound-full-relay capacity. Then we open OUTBOUND_BLOCK_RELAY connection
+        // until we hit our outbound-block-relay peer limit.
+        // GetTryNewOutboundFullRelayPeer() gets set when a stale tip is detected, so we
         // try opening an additional OUTBOUND_FULL_RELAY connection. If none of
         // these conditions are met, check to see if it's time to try an extra
-        // block-relay-only peer (to confirm our tip is current, see below) or the nNextFeeler
+        // outbound-block-relay peer (to confirm our tip is current, see below) or the nNextFeeler
         // timer to decide if we should open a FEELER.
 
         if (!m_anchors.empty() && (nOutboundBlockRelay < m_max_outbound_block_relay)) {
-            conn_type = ConnectionType::BLOCK_RELAY;
+            conn_type = ConnectionType::OUTBOUND_BLOCK_RELAY;
             anchor = true;
         } else if (nOutboundFullRelay < m_max_outbound_full_relay) {
             // OUTBOUND_FULL_RELAY
         } else if (nOutboundBlockRelay < m_max_outbound_block_relay) {
-            conn_type = ConnectionType::BLOCK_RELAY;
-        } else if (GetTryNewOutboundPeer()) {
+            conn_type = ConnectionType::OUTBOUND_BLOCK_RELAY;
+        } else if (GetTryNewOutboundFullRelayPeer()) {
             // OUTBOUND_FULL_RELAY
-        } else if (nTime > nNextExtraBlockRelay && m_start_extra_block_relay_peers) {
+        } else if (nTime > nNextExtraBlockRelay && m_start_extra_outbound_block_relay_peers) {
             // Periodically connect to a peer (using regular outbound selection
             // methodology from addrman) and stay connected long enough to sync
             // headers, but not much else.
@@ -1895,19 +1895,19 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
             // because every few minutes we're finding a new peer to learn headers
             // from.
             //
-            // This is similar to the logic for trying extra outbound (full-relay)
+            // This is similar to the logic for trying extra outbound-full-relay
             // peers, except:
             // - we do this all the time on a poisson timer, rather than just when
             //   our tip is stale
-            // - we potentially disconnect our next-youngest block-relay-only peer, if our
-            //   newest block-relay-only peer delivers a block more recently.
+            // - we potentially disconnect our next-youngest outbound-block-relay peer, if our
+            //   newest outbound-block-relay peer delivers a block more recently.
             //   See the eviction logic in net_processing.cpp.
             //
-            // Because we can promote these connections to block-relay-only
+            // Because we can promote these connections to outbound-block-relay
             // connections, they do not get their own ConnectionType enum
-            // (similar to how we deal with extra outbound peers).
-            nNextExtraBlockRelay = PoissonNextSend(nTime, EXTRA_BLOCK_RELAY_ONLY_PEER_INTERVAL);
-            conn_type = ConnectionType::BLOCK_RELAY;
+            // (similar to how we deal with extra outbound-full-relay peers).
+            nNextExtraBlockRelay = PoissonNextSend(nTime, EXTRA_OUTBOUND_BLOCK_RELAY_PEER_INTERVAL);
+            conn_type = ConnectionType::OUTBOUND_BLOCK_RELAY;
         } else if (nTime > nNextFeeler) {
             nNextFeeler = PoissonNextSend(nTime, FEELER_INTERVAL);
             conn_type = ConnectionType::FEELER;
@@ -2025,7 +2025,7 @@ std::vector<CAddress> CConnman::GetCurrentBlockRelayOnlyConns() const
     std::vector<CAddress> ret;
     LOCK(cs_vNodes);
     for (const CNode* pnode : vNodes) {
-        if (pnode->IsBlockOnlyConn()) {
+        if (pnode->IsOutboundBlockRelayConn()) {
             ret.push_back(pnode->addr);
         }
     }
@@ -2327,7 +2327,7 @@ void CConnman::SetNetworkActive(bool active)
 CConnman::CConnman(uint64_t nSeed0In, uint64_t nSeed1In, bool network_active)
     : nSeed0(nSeed0In), nSeed1(nSeed1In)
 {
-    SetTryNewOutboundPeer(false);
+    SetTryNewOutboundFullRelayPeer(false);
 
     Options connOptions;
     Init(connOptions);
@@ -2421,10 +2421,10 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
     if (m_use_addrman_outgoing) {
         // Load addresses from anchors.dat
         m_anchors = ReadAnchors(GetDataDir() / ANCHORS_DATABASE_FILENAME);
-        if (m_anchors.size() > MAX_BLOCK_RELAY_ONLY_ANCHORS) {
-            m_anchors.resize(MAX_BLOCK_RELAY_ONLY_ANCHORS);
+        if (m_anchors.size() > MAX_OUTBOUND_BLOCK_RELAY_ANCHORS) {
+            m_anchors.resize(MAX_OUTBOUND_BLOCK_RELAY_ANCHORS);
         }
-        LogPrintf("%i block-relay-only anchors will be tried for connections.\n", m_anchors.size());
+        LogPrintf("%i outbound-block-relay anchors will be tried for connections.\n", m_anchors.size());
     }
 
     uiInterface.InitMessage(_("Starting network threads...").translated);
@@ -2546,8 +2546,8 @@ void CConnman::StopNodes()
         if (m_use_addrman_outgoing) {
             // Anchor connections are only dumped during clean shutdown.
             std::vector<CAddress> anchors_to_dump = GetCurrentBlockRelayOnlyConns();
-            if (anchors_to_dump.size() > MAX_BLOCK_RELAY_ONLY_ANCHORS) {
-                anchors_to_dump.resize(MAX_BLOCK_RELAY_ONLY_ANCHORS);
+            if (anchors_to_dump.size() > MAX_OUTBOUND_BLOCK_RELAY_ANCHORS) {
+                anchors_to_dump.resize(MAX_OUTBOUND_BLOCK_RELAY_ANCHORS);
             }
             DumpAnchors(GetDataDir() / ANCHORS_DATABASE_FILENAME, anchors_to_dump);
         }
@@ -2865,7 +2865,7 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, SOCKET hSocketIn, const
     if (inbound_onion) assert(conn_type_in == ConnectionType::INBOUND);
     hSocket = hSocketIn;
     addrName = addrNameIn == "" ? addr.ToStringIPPort() : addrNameIn;
-    if (conn_type_in != ConnectionType::BLOCK_RELAY) {
+    if (conn_type_in != ConnectionType::OUTBOUND_BLOCK_RELAY) {
         m_tx_relay = MakeUnique<TxRelay>();
     }
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -771,7 +771,7 @@ QString ConnectionTypeToQString(ConnectionType conn_type)
     switch (conn_type) {
     case ConnectionType::INBOUND: return QObject::tr("Inbound");
     case ConnectionType::OUTBOUND_FULL_RELAY: return QObject::tr("Outbound Full Relay");
-    case ConnectionType::BLOCK_RELAY: return QObject::tr("Outbound Block Relay");
+    case ConnectionType::OUTBOUND_BLOCK_RELAY: return QObject::tr("Outbound Block Relay");
     case ConnectionType::MANUAL: return QObject::tr("Outbound Manual");
     case ConnectionType::FEELER: return QObject::tr("Outbound Feeler");
     case ConnectionType::ADDR_FETCH: return QObject::tr("Outbound Address Fetch");

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -32,7 +32,7 @@
 
 const std::vector<std::string> CONNECTION_TYPE_DOC{
         "outbound-full-relay (default automatic connections)",
-        "block-relay-only (does not relay transactions or addresses)",
+        "outbound-block-relay (does not relay transactions or addresses)",
         "inbound (initiated by the peer)",
         "manual (added via addnode RPC or -addnode/-connect configuration options)",
         "addr-fetch (short-lived automatic connection for soliciting addresses)",
@@ -321,7 +321,7 @@ static RPCHelpMan addconnection()
         "\nOpen an outbound connection to a specified node. This RPC is for testing only.\n",
         {
             {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The IP address and port to attempt connecting to."},
-            {"connection_type", RPCArg::Type::STR, RPCArg::Optional::NO, "Type of connection to open, either \"outbound-full-relay\" or \"block-relay-only\"."},
+            {"connection_type", RPCArg::Type::STR, RPCArg::Optional::NO, "Type of connection to open, either \"outbound-full-relay\" or \"outbound-block-relay\"."},
         },
         RPCResult{
             RPCResult::Type::OBJ, "", "",
@@ -345,8 +345,8 @@ static RPCHelpMan addconnection()
     ConnectionType conn_type{};
     if (conn_type_in == "outbound-full-relay") {
         conn_type = ConnectionType::OUTBOUND_FULL_RELAY;
-    } else if (conn_type_in == "block-relay-only") {
-        conn_type = ConnectionType::BLOCK_RELAY;
+    } else if (conn_type_in == "outbound-block-relay") {
+        conn_type = ConnectionType::OUTBOUND_BLOCK_RELAY;
     } else {
         throw JSONRPCError(RPC_INVALID_PARAMETER, self.ToString());
     }

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -179,7 +179,7 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
     // Now tip should definitely be stale, and we should look for an extra
     // outbound peer
     peerLogic->CheckForStaleTipAndEvictPeers();
-    BOOST_CHECK(connman->GetTryNewOutboundPeer());
+    BOOST_CHECK(connman->GetTryNewOutboundFullRelayPeer());
 
     // Still no peers should be marked for disconnection
     for (const CNode *node : vNodes) {

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -128,11 +128,11 @@ FUZZ_TARGET_INIT(connman, initialize_connman)
                 connman.SetServices(random_service, ConsumeWeakEnum(fuzzed_data_provider, ALL_SERVICE_FLAGS));
             },
             [&] {
-                connman.SetTryNewOutboundPeer(fuzzed_data_provider.ConsumeBool());
+                connman.SetTryNewOutboundFullRelayPeer(fuzzed_data_provider.ConsumeBool());
             });
     }
     (void)connman.GetAddedNodeInfo();
-    (void)connman.GetExtraFullOutboundCount();
+    (void)connman.GetExtraOutboundFullRelayCount();
     (void)connman.GetLocalServices();
     (void)connman.GetMaxOutboundTarget();
     (void)connman.GetMaxOutboundTimeframe();
@@ -144,6 +144,6 @@ FUZZ_TARGET_INIT(connman, initialize_connman)
     (void)connman.GetReceiveFloodSize();
     (void)connman.GetTotalBytesRecv();
     (void)connman.GetTotalBytesSent();
-    (void)connman.GetTryNewOutboundPeer();
+    (void)connman.GetTryNewOutboundFullRelayPeer();
     (void)connman.GetUseAddrmanOutgoing();
 }

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -193,9 +193,9 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
         /* nKeyedNetGroupIn = */ 0,
         /* nLocalHostNonceIn = */ 0,
         CAddress(), pszDest, ConnectionType::OUTBOUND_FULL_RELAY);
-    BOOST_CHECK(pnode1->IsFullOutboundConn() == true);
+    BOOST_CHECK(pnode1->IsOutboundFullRelayConn() == true);
     BOOST_CHECK(pnode1->IsManualConn() == false);
-    BOOST_CHECK(pnode1->IsBlockOnlyConn() == false);
+    BOOST_CHECK(pnode1->IsOutboundBlockRelayConn() == false);
     BOOST_CHECK(pnode1->IsFeelerConn() == false);
     BOOST_CHECK(pnode1->IsAddrFetchConn() == false);
     BOOST_CHECK(pnode1->IsInboundConn() == false);
@@ -208,9 +208,9 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
         /* nLocalHostNonceIn = */ 1,
         CAddress(), pszDest, ConnectionType::INBOUND,
         /* inbound_onion = */ false);
-    BOOST_CHECK(pnode2->IsFullOutboundConn() == false);
+    BOOST_CHECK(pnode2->IsOutboundFullRelayConn() == false);
     BOOST_CHECK(pnode2->IsManualConn() == false);
-    BOOST_CHECK(pnode2->IsBlockOnlyConn() == false);
+    BOOST_CHECK(pnode2->IsOutboundBlockRelayConn() == false);
     BOOST_CHECK(pnode2->IsFeelerConn() == false);
     BOOST_CHECK(pnode2->IsAddrFetchConn() == false);
     BOOST_CHECK(pnode2->IsInboundConn() == true);
@@ -223,9 +223,9 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
         /* nLocalHostNonceIn = */ 0,
         CAddress(), pszDest, ConnectionType::OUTBOUND_FULL_RELAY,
         /* inbound_onion = */ false);
-    BOOST_CHECK(pnode3->IsFullOutboundConn() == true);
+    BOOST_CHECK(pnode3->IsOutboundFullRelayConn() == true);
     BOOST_CHECK(pnode3->IsManualConn() == false);
-    BOOST_CHECK(pnode3->IsBlockOnlyConn() == false);
+    BOOST_CHECK(pnode3->IsOutboundBlockRelayConn() == false);
     BOOST_CHECK(pnode3->IsFeelerConn() == false);
     BOOST_CHECK(pnode3->IsAddrFetchConn() == false);
     BOOST_CHECK(pnode3->IsInboundConn() == false);
@@ -238,9 +238,9 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
         /* nLocalHostNonceIn = */ 1,
         CAddress(), pszDest, ConnectionType::INBOUND,
         /* inbound_onion = */ true);
-    BOOST_CHECK(pnode4->IsFullOutboundConn() == false);
+    BOOST_CHECK(pnode4->IsOutboundFullRelayConn() == false);
     BOOST_CHECK(pnode4->IsManualConn() == false);
-    BOOST_CHECK(pnode4->IsBlockOnlyConn() == false);
+    BOOST_CHECK(pnode4->IsOutboundBlockRelayConn() == false);
     BOOST_CHECK(pnode4->IsFeelerConn() == false);
     BOOST_CHECK(pnode4->IsAddrFetchConn() == false);
     BOOST_CHECK(pnode4->IsInboundConn() == true);

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -57,7 +57,7 @@ constexpr ConnectionType ALL_CONNECTION_TYPES[]{
     ConnectionType::OUTBOUND_FULL_RELAY,
     ConnectionType::MANUAL,
     ConnectionType::FEELER,
-    ConnectionType::BLOCK_RELAY,
+    ConnectionType::OUTBOUND_BLOCK_RELAY,
     ConnectionType::ADDR_FETCH,
 };
 

--- a/test/functional/p2p_add_connections.py
+++ b/test/functional/p2p_add_connections.py
@@ -24,32 +24,32 @@ class P2PAddConnections(BitcoinTestFramework):
         # Don't connect the nodes
 
     def run_test(self):
-        self.log.info("Add 8 outbounds to node 0")
+        self.log.info("Add 8 outbound-full-relay connections to node 0")
         for i in range(8):
-            self.log.info(f"outbound: {i}")
+            self.log.info(f"outbound-full-relay: {i}")
             self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=i, connection_type="outbound-full-relay")
 
-        self.log.info("Add 2 block-relay-only connections to node 0")
+        self.log.info("Add 2 outbound-block-relay connections to node 0")
         for i in range(2):
-            self.log.info(f"block-relay-only: {i}")
+            self.log.info(f"outbound-block-relay: {i}")
             # set p2p_idx based on the outbound connections already open to the
-            # node, so add 8 to account for the previous full-relay connections
-            self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=i + 8, connection_type="block-relay-only")
+            # node, so add 8 to account for the previous outbound-full-relay connections
+            self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=i + 8, connection_type="outbound-block-relay")
 
-        self.log.info("Add 2 block-relay-only connections to node 1")
+        self.log.info("Add 2 outbound-block-relay connections to node 1")
         for i in range(2):
-            self.log.info(f"block-relay-only: {i}")
-            self.nodes[1].add_outbound_p2p_connection(P2PInterface(), p2p_idx=i, connection_type="block-relay-only")
+            self.log.info(f"outbound-block-relay: {i}")
+            self.nodes[1].add_outbound_p2p_connection(P2PInterface(), p2p_idx=i, connection_type="outbound-block-relay")
 
         self.log.info("Add 5 inbound connections to node 1")
         for i in range(5):
             self.log.info(f"inbound: {i}")
             self.nodes[1].add_p2p_connection(P2PInterface())
 
-        self.log.info("Add 8 outbounds to node 1")
+        self.log.info("Add 8 outbound-full-relay connections to node 1")
         for i in range(8):
-            self.log.info(f"outbound: {i}")
-            # bump p2p_idx to account for the 2 existing outbounds on node 1
+            self.log.info(f"outbound-full-relay: {i}")
+            # bump p2p_idx to account for the 2 existing outbound-full-relay connections on node 1
             self.nodes[1].add_outbound_p2p_connection(P2PInterface(), p2p_idx=i + 2)
 
         self.log.info("Check the connections opened as expected")
@@ -60,33 +60,33 @@ class P2PAddConnections(BitcoinTestFramework):
         self.nodes[0].disconnect_p2ps()
         check_node_connections(node=self.nodes[0], num_in=0, num_out=0)
 
-        self.log.info("Add 8 outbounds to node 0")
+        self.log.info("Add 8 outbound-full-relay connections to node 0")
         for i in range(8):
-            self.log.info(f"outbound: {i}")
+            self.log.info(f"outbound-full-relay: {i}")
             self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=i)
         check_node_connections(node=self.nodes[0], num_in=0, num_out=8)
 
-        self.log.info("Add 2 block-relay-only connections to node 0")
+        self.log.info("Add 2 outbound-block-relay connections to node 0")
         for i in range(2):
-            self.log.info(f"block-relay-only: {i}")
-            # bump p2p_idx to account for the 8 existing outbounds on node 0
-            self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=i + 8, connection_type="block-relay-only")
+            self.log.info(f"outbound-block-relay: {i}")
+            # bump p2p_idx to account for the 8 existing outbound-full-relay connections on node 0
+            self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=i + 8, connection_type="outbound-block-relay")
         check_node_connections(node=self.nodes[0], num_in=0, num_out=10)
 
         self.log.info("Restart node 0 and try to reconnect to p2ps")
         self.restart_node(0)
 
-        self.log.info("Add 4 outbounds to node 0")
+        self.log.info("Add 4 outbound-full-relay connections to node 0")
         for i in range(4):
-            self.log.info(f"outbound: {i}")
+            self.log.info(f"outbound-full-relay: {i}")
             self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=i)
         check_node_connections(node=self.nodes[0], num_in=0, num_out=4)
 
-        self.log.info("Add 2 block-relay-only connections to node 0")
+        self.log.info("Add 2 outbound-block-relay connections to node 0")
         for i in range(2):
-            self.log.info(f"block-relay-only: {i}")
-            # bump p2p_idx to account for the 4 existing outbounds on node 0
-            self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=i + 4, connection_type="block-relay-only")
+            self.log.info(f"outbound-block-relay: {i}")
+            # bump p2p_idx to account for the 4 existing outbound-full-relay connections on node 0
+            self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=i + 4, connection_type="outbound-block-relay")
         check_node_connections(node=self.nodes[0], num_in=0, num_out=6)
 
         check_node_connections(node=self.nodes[1], num_in=5, num_out=10)

--- a/test/functional/p2p_blocksonly.py
+++ b/test/functional/p2p_blocksonly.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2019-2020 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test p2p blocksonly mode & block-relay-only connections."""
+"""Test p2p blocksonly mode & outbound-block-relay connections."""
 
 import time
 
@@ -72,17 +72,17 @@ class P2PBlocksOnly(BitcoinTestFramework):
         self.nodes[0].generate(1)
 
     def blocks_relay_conn_tests(self):
-        self.log.info('Tests with node in normal mode with block-relay-only connections')
+        self.log.info('Tests with node in normal mode with outbound-block-relay connections')
         self.restart_node(0, ["-noblocksonly"])  # disables blocks only mode
         assert_equal(self.nodes[0].getnetworkinfo()['localrelay'], True)
 
-        # Ensure we disconnect if a block-relay-only connection sends us a transaction
-        self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=0, connection_type="block-relay-only")
+        # Ensure we disconnect if an outbound-block-relay connection sends us a transaction
+        self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=0, connection_type="outbound-block-relay")
         assert_equal(self.nodes[0].getpeerinfo()[0]['relaytxes'], False)
         _, txid, tx_hex = self.check_p2p_tx_violation(index=2)
 
         self.log.info("Check that txs from RPC are not sent to blockrelay connection")
-        conn = self.nodes[0].add_outbound_p2p_connection(P2PTxInvStore(), p2p_idx=1, connection_type="block-relay-only")
+        conn = self.nodes[0].add_outbound_p2p_connection(P2PTxInvStore(), p2p_idx=1, connection_type="outbound-block-relay")
 
         self.nodes[0].sendrawtransaction(tx_hex)
 

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -549,8 +549,8 @@ class TestNode():
 
     def add_outbound_p2p_connection(self, p2p_conn, *, p2p_idx, connection_type="outbound-full-relay", **kwargs):
         """Add an outbound p2p connection from node. Either
-        full-relay("outbound-full-relay") or
-        block-relay-only("block-relay-only") connection.
+        outbound-full-relay("outbound-full-relay") or
+        outbound-block-relay("outbound-block-relay") connection.
 
         This method adds the p2p connection to the self.p2ps list and returns
         the connection to the caller.


### PR DESCRIPTION
We've accumulated many different ways of referring to outbound full relay and outbound block relay connection types in the codebase. In places, it is becoming less clear which type of connection is referred to. This PR proposes standardizing the naming to `outbound-{full, block}-relay` with a scripted diff as follows:

```
-BEGIN VERIFY SCRIPT-
s() { git grep -l "$1" src test/functional doc/files.md doc/reduce-*.md | xargs sed -i "s/$1/$2/g"; }

s 'ConnectionType::OUTBOUND '            'ConnectionType::OUTBOUND_FULL_RELAY '
s 'IsFullOutboundConn'                   'IsOutboundFullRelayConn'
s 'GetExtraFullOutboundCount'            'GetExtraOutboundFullRelayCount'
s 'full_outbound_peers'                  'outbound_full_relay_peers'
s 'GetTryNewOutboundPeer'                'GetTryNewOutboundFullRelayPeer'
s 'SetTryNewOutboundPeer'                'SetTryNewOutboundFullRelayPeer'
s 'm_try_another_outbound_peer'          'm_try_another_outbound_full_relay_peer'
s 'outbound (full-relay)'                'outbound-full-relay'
s 'outbound full-relay'                  'outbound-full-relay'
s 'outbound, full-relay'                 'outbound-full-relay'
s 'outbounds'                            'outbound-full-relay connections'
s 'f"outbound: '                         'f"outbound-full-relay: '
s ' full-relay'                          ' outbound-full-relay'
s 'to an extra outbound peer'            'to an extra outbound-full-relay peer'
s 'try another outbound peer'            'try another outbound-full-relay peer'
s '(tx, block, addr) outbound'           '(tx, block, addr)'
s 'we deal with extra outbound peers'    'we deal with extra outbound-full-relay peers'
s 'outbound peers we have in excess'     'outbound-full-relay peers we have in excess'
s 'some outbound connections are not'    'some outbound-full-relay connections are not'
s 'or this is a'                         'or if this is an'

s 'ConnectionType::BLOCK_RELAY'          'ConnectionType::OUTBOUND_BLOCK_RELAY'
s ' BLOCK_RELAY'                         ' OUTBOUND_BLOCK_RELAY'
s 'IsBlockOnlyConn'                      'IsOutboundBlockRelayConn'
s 'GetExtraBlockRelayCount'              'GetExtraOutboundBlockRelayCount'
s 'block_relay_peers'                    'outbound_block_relay_peers'
s 'MAX_BLOCK_RELAY_ONLY_ANCHORS'         'MAX_OUTBOUND_BLOCK_RELAY_ANCHORS'
s 'MAX_BLOCK_RELAY_ONLY_CONNECTIONS'     'MAX_OUTBOUND_BLOCK_RELAY_CONNECTIONS'
s 'EXTRA_BLOCK_RELAY_ONLY_PEER_INTERVAL' 'EXTRA_OUTBOUND_BLOCK_RELAY_PEER_INTERVAL'
s 'm_start_extra_block_relay_peers'      'm_start_extra_outbound_block_relay_peers'
s 'outgoing block-relay-only'            'outbound-block-relay'
s 'outbound block-relay-only'            'outbound-block-relay'
s 'outbound block-relay'                 'outbound-block-relay'
s 'block-relay only outbound'            'outbound-block-relay'
s 'block-relay-only outgoing'            'outbound-block-relay'
s 'block-relay only peers'               'outbound-block-relay peers'
s 'block-relay-only'                     'outbound-block-relay'

s ' a outbound'                          ' an outbound'
-END VERIFY SCRIPT-
```
