### PR TITLE
build: Make platform-specific targets available for proper platform builds only

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -90,6 +90,7 @@ $(BITCOIN_WIN_INSTALLER): all-recursive
 	  echo error: could not build $@
 	@echo built $@
 
+if TARGET_DARWIN
 $(OSX_APP)/Contents/PkgInfo:
 	$(MKDIR_P) $(@D)
 	@echo "APPL????" > $@
@@ -133,7 +134,7 @@ $(OSX_BACKGROUND_IMAGE): $(OSX_BACKGROUND_IMAGE).png $(OSX_BACKGROUND_IMAGE)@2x.
 	tiffutil -cathidpicheck $^ -out $@
 
 deploydir: $(OSX_DMG)
-else
+else !BUILD_DARWIN
 APP_DIST_DIR=$(top_builddir)/dist
 APP_DIST_EXTRAS=$(APP_DIST_DIR)/.background/$(OSX_BACKGROUND_IMAGE) $(APP_DIST_DIR)/.DS_Store $(APP_DIST_DIR)/Applications
 
@@ -160,12 +161,12 @@ $(APP_DIST_DIR)/$(OSX_APP)/Contents/MacOS/Bitcoin-Qt: $(OSX_APP_BUILT) $(OSX_PAC
 	INSTALLNAMETOOL=$(INSTALLNAMETOOL) OTOOL=$(OTOOL) STRIP=$(STRIP) $(PYTHON) $(OSX_DEPLOY_SCRIPT) $(OSX_APP) $(OSX_VOLNAME) -translations-dir=$(QT_TRANSLATION_DIR)
 
 deploydir: $(APP_DIST_EXTRAS)
-endif
+endif !BUILD_DARWIN
 
-if TARGET_DARWIN
 appbundle: $(OSX_APP_BUILT)
 deploy: $(OSX_DMG)
 endif
+
 if TARGET_WINDOWS
 deploy: $(BITCOIN_WIN_INSTALLER)
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -78,6 +78,7 @@ COVERAGE_INFO = $(COV_TOOL_WRAPPER) baseline.info \
 dist-hook:
 	-$(GIT) archive --format=tar HEAD -- src/clientversion.cpp | $(AMTAR) -C $(top_distdir) -xf -
 
+if TARGET_WINDOWS
 $(BITCOIN_WIN_INSTALLER): all-recursive
 	$(MKDIR_P) $(top_builddir)/release
 	STRIPPROG="$(STRIP)" $(INSTALL_STRIP_PROGRAM) $(BITCOIND_BIN) $(top_builddir)/release
@@ -89,6 +90,9 @@ $(BITCOIN_WIN_INSTALLER): all-recursive
 	@test -f $(MAKENSIS) && echo 'OutFile "$@"' | cat $(top_builddir)/share/setup.nsi - | $(MAKENSIS) -V2 - || \
 	  echo error: could not build $@
 	@echo built $@
+
+deploy: $(BITCOIN_WIN_INSTALLER)
+endif
 
 if TARGET_DARWIN
 $(OSX_APP)/Contents/PkgInfo:
@@ -165,10 +169,6 @@ endif !BUILD_DARWIN
 
 appbundle: $(OSX_APP_BUILT)
 deploy: $(OSX_DMG)
-endif
-
-if TARGET_WINDOWS
-deploy: $(BITCOIN_WIN_INSTALLER)
 endif
 
 $(BITCOIN_QT_BIN): FORCE


### PR DESCRIPTION
On master (f1dbf92ff0475a01d20170ea422c1d086acbbc57) it is possible to point `make` to macOS and Windows specific targets even the build system is configured to build for Linux platforms:
```
$ make Bitcoin-Core.dmg
...
$ make bitcoin-21.99.0-win64-setup
...
```

Such behavior makes no sense, and it is confused. Fixed in this PR.