### PR TITLE
qa: Correct epoll_ctl data race suppression

### DIFF
--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -13,6 +13,7 @@ mutex:CConnman::SocketHandler
 mutex:UpdateTip
 mutex:PeerManager::UpdatedBlockTip
 mutex:g_best_block_mutex
+
 # race (TODO fix)
 race:CConnman::WakeMessageHandler
 race:CConnman::ThreadMessageHandler
@@ -27,6 +28,7 @@ race:DatabaseBatch
 race:leveldb::DBImpl::DeleteObsoleteFiles
 race:zmq::*
 race:bitcoin-qt
+
 # deadlock (TODO fix)
 deadlock:CConnman::ForNode
 deadlock:CConnman::GetNodeStats
@@ -46,4 +48,6 @@ deadlock:src/qt/test/*
 # External libraries
 deadlock:libdb
 race:libzmq
-race:epoll_ctl  # https://github.com/bitcoin/bitcoin/pull/20218
+
+# https://github.com/bitcoin/bitcoin/pull/20218, https://github.com/bitcoin/bitcoin/pull/20745
+race:epoll_ctl


### PR DESCRIPTION
Fixup of #20218. Comments must start from the beginning of the line.

See [ThreadSanitizerSuppressions docs](https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions):
> Comment lines start with `#`.