### PR TITLE
test: Add race:SendZmqMessage tsan suppression

### DIFF
--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -1,5 +1,7 @@
 # ThreadSanitizer suppressions
 # ============================
+#
+# https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
 
 # double locks (TODO fix)
 mutex:g_genesis_wait_mutex
@@ -48,6 +50,15 @@ deadlock:src/qt/test/*
 # External libraries
 deadlock:libdb
 race:libzmq
+
+# Intermittent issues
+# -------------------
+#
+# Suppressions that follow might only happen intermittently, thus they are not
+# reproducible. Make sure to include a link to a full trace.
+
+# https://github.com/bitcoin/bitcoin/issues/20618
+race:CZMQAbstractPublishNotifier::SendZmqMessage
 
 # https://github.com/bitcoin/bitcoin/pull/20218, https://github.com/bitcoin/bitcoin/pull/20745
 race:epoll_ctl


### PR DESCRIPTION
Add suppression for `race:SendZmqMessage`, which isn't covered by the existing `zmq::*` suppression 

Fixes #20618
