### PR TITLE
rpc: Allow to ignore specific policy reject reasons

### DIFF
--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -49,7 +49,7 @@ static void AssembleBlock(benchmark::Bench& bench)
 
         for (const auto& txr : txs) {
             TxValidationState state;
-            bool ret{::AcceptToMemoryPool(*test_setup.m_node.mempool, state, txr, nullptr /* plTxnReplaced */, false /* bypass_limits */)};
+            bool ret{::AcceptToMemoryPool(*test_setup.m_node.mempool, state, txr, nullptr /* plTxnReplaced */, {} /* ignore_rejects */, false /* bypass_limits */)};
             assert(ret);
         }
     }

--- a/src/bench/ccoins_caching.cpp
+++ b/src/bench/ccoins_caching.cpp
@@ -44,8 +44,9 @@ static void CCoinsCaching(benchmark::Bench& bench)
 
     // Benchmark.
     const CTransaction tx_1(t1);
+    std::string reason_dummy;
     bench.run([&] {
-        bool success = AreInputsStandard(tx_1, coins, false);
+        bool success = AreInputsStandard(tx_1, coins, reason_dummy, false);
         assert(success);
     });
     ECC_Stop();

--- a/src/bench/ccoins_caching.cpp
+++ b/src/bench/ccoins_caching.cpp
@@ -46,7 +46,7 @@ static void CCoinsCaching(benchmark::Bench& bench)
     const CTransaction tx_1(t1);
     std::string reason_dummy;
     bench.run([&] {
-        bool success = AreInputsStandard(tx_1, coins, reason_dummy, false);
+        bool success = AreInputsStandard(tx_1, coins, reason_dummy, /* ignore_rejects */ {}, false);
         assert(success);
     });
     ECC_Stop();

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1986,7 +1986,7 @@ void PeerManager::ProcessOrphanTx(std::set<uint256>& orphan_work_set)
         TxValidationState state;
         std::list<CTransactionRef> removed_txn;
 
-        if (AcceptToMemoryPool(m_mempool, state, porphanTx, &removed_txn, false /* bypass_limits */)) {
+        if (AcceptToMemoryPool(m_mempool, state, porphanTx, &removed_txn, {} /* ignore_rejects */, false /* bypass_limits */)) {
             LogPrint(BCLog::MEMPOOL, "   accepted orphan tx %s\n", orphanHash.ToString());
             RelayTransaction(orphanHash, porphanTx->GetWitnessHash(), m_connman);
             for (unsigned int i = 0; i < porphanTx->vout.size(); i++) {
@@ -2992,7 +2992,7 @@ void PeerManager::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDat
         TxValidationState state;
         std::list<CTransactionRef> lRemovedTxn;
 
-        if (AcceptToMemoryPool(m_mempool, state, ptx, &lRemovedTxn, false /* bypass_limits */)) {
+        if (AcceptToMemoryPool(m_mempool, state, ptx, &lRemovedTxn, {} /* ignore_rejects */, false /* bypass_limits */)) {
             m_mempool.check(&::ChainstateActive().CoinsTip());
             // As this version of the transaction was acceptable, we can forget about any
             // requests for it.

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -545,7 +545,7 @@ public:
         bool relay,
         std::string& err_string) override
     {
-        const TransactionError err = BroadcastTransaction(m_node, tx, err_string, max_tx_fee, relay, /*wait_callback*/ false);
+        const TransactionError err = BroadcastTransaction(m_node, tx, err_string, /* rejects_ignore */ {}, max_tx_fee, relay, /*wait_callback*/ false);
         // Chain clients only care about failures to accept the tx to the mempool. Disregard non-mempool related failures.
         // Note: this will need to be updated if BroadcastTransactions() is updated to return other non-mempool failures
         // that Chain clients do not need to know about.

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -26,7 +26,7 @@ static TransactionError HandleATMPError(const TxValidationState& state, std::str
     }
 }
 
-TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef tx, std::string& err_string, const CAmount& max_tx_fee, bool relay, bool wait_callback)
+TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef tx, std::string& err_string, const IgnoreRejectsType& ignore_rejects, const CAmount& max_tx_fee, bool relay, bool wait_callback)
 {
     // BroadcastTransaction can be called by either sendrawtransaction RPC or wallet RPCs.
     // node.connman is assigned both before chain clients and before RPC server is accepting calls,
@@ -56,7 +56,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
             // fails here, return error immediately.
             CAmount fee{0};
             if (!AcceptToMemoryPool(*node.mempool, state, tx,
-                nullptr /* plTxnReplaced */, false /* bypass_limits */, /* test_accept */ true, &fee)) {
+                                    nullptr /* plTxnReplaced */, ignore_rejects, false /* bypass_limits */, /* test_accept */ true, &fee)) {
                 return HandleATMPError(state, err_string);
             } else if (fee > max_tx_fee) {
                 return TransactionError::MAX_FEE_EXCEEDED;
@@ -64,7 +64,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
         }
         // Try to submit the transaction to the mempool.
         if (!AcceptToMemoryPool(*node.mempool, state, tx,
-                nullptr /* plTxnReplaced */, false /* bypass_limits */)) {
+                                nullptr /* plTxnReplaced */, ignore_rejects, false /* bypass_limits */)) {
             return HandleATMPError(state, err_string);
         }
 

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -7,6 +7,7 @@
 
 #include <attributes.h>
 #include <policy/feerate.h>
+#include <policy/policy.h> // For IgnoreRejectsType
 #include <primitives/transaction.h>
 #include <util/error.h>
 
@@ -36,6 +37,6 @@ static const CFeeRate DEFAULT_MAX_RAW_TX_FEE_RATE{COIN / 10};
  * @param[in]  wait_callback wait until callbacks have been processed to avoid stale result due to a sequentially RPC.
  * return error
  */
-[[nodiscard]] TransactionError BroadcastTransaction(NodeContext& node, CTransactionRef tx, std::string& err_string, const CAmount& max_tx_fee, bool relay, bool wait_callback);
+[[nodiscard]] TransactionError BroadcastTransaction(NodeContext& node, CTransactionRef tx, std::string& err_string, const IgnoreRejectsType& ignore_rejects, const CAmount& max_tx_fee, bool relay, bool wait_callback);
 
 #endif // BITCOIN_NODE_TRANSACTION_H

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -156,7 +156,7 @@ bool IsStandardTx(const CTransaction& tx, bool permit_bare_multisig, const CFeeR
  *
  * Note that only the non-witness portion of the transaction is checked here.
  */
-bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, bool taproot_active)
+static bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, bool taproot_active)
 {
     if (tx.IsCoinBase())
         return true; // Coinbases don't use vin normally
@@ -192,8 +192,16 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs,
 
     return true;
 }
+bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, std::string& reason_out, bool taproot_active)
+{
+    if (!AreInputsStandard(tx, mapInputs, taproot_active)) {
+        reason_out = "bad-txns-nonstandard-inputs";
+        return false;
+    }
+    return true;
+}
 
-bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
+static bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 {
     if (tx.IsCoinBase())
         return true; // Coinbases are skipped
@@ -273,6 +281,14 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
                 return false;
             }
         }
+    }
+    return true;
+}
+bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, std::string& reason_out)
+{
+    if (!IsWitnessStandard(tx, mapInputs)) {
+        reason_out = "bad-witness-nonstandard";
+        return false;
     }
     return true;
 }

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -73,7 +73,7 @@ bool IsStandard(const CScript& scriptPubKey, TxoutType& whichType)
     return true;
 }
 
-bool IsStandardTx(const CTransaction& tx, bool permit_bare_multisig, const CFeeRate& dust_relay_fee, std::string& reason)
+bool IsStandardTx(const CTransaction& tx, bool permit_bare_multisig, const CFeeRate& dust_relay_fee, std::string& reason, const IgnoreRejectsType& ignore_rejects)
 {
     if (tx.nVersion > TX_MAX_STANDARD_VERSION || tx.nVersion < 1) {
         reason = "version";
@@ -192,7 +192,7 @@ static bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& map
 
     return true;
 }
-bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, std::string& reason_out, bool taproot_active)
+bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, std::string& reason_out, const IgnoreRejectsType& ignore_rejects, bool taproot_active)
 {
     if (!AreInputsStandard(tx, mapInputs, taproot_active)) {
         reason_out = "bad-txns-nonstandard-inputs";
@@ -284,7 +284,7 @@ static bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& map
     }
     return true;
 }
-bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, std::string& reason_out)
+bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, std::string& reason_out, const IgnoreRejectsType& ignore_rejects)
 {
     if (!IsWitnessStandard(tx, mapInputs)) {
         reason_out = "bad-witness-nonstandard";

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -91,6 +91,7 @@ bool IsDust(const CTxOut& txout, const CFeeRate& dustRelayFee);
 
 bool IsStandard(const CScript& scriptPubKey, TxoutType& whichType);
 
+using IgnoreRejectsType = std::set<std::string>;
 
 // Changing the default transaction version requires a two step process: first
 // adapting relay policy by bumping TX_MAX_STANDARD_VERSION, and then later
@@ -101,14 +102,14 @@ static constexpr decltype(CTransaction::nVersion) TX_MAX_STANDARD_VERSION{2};
 * Check for standard transaction types
 * @return True if all outputs (scriptPubKeys) use only standard transaction forms
 */
-bool IsStandardTx(const CTransaction& tx, bool permit_bare_multisig, const CFeeRate& dust_relay_fee, std::string& reason);
+bool IsStandardTx(const CTransaction& tx, bool permit_bare_multisig, const CFeeRate& dust_relay_fee, std::string& reason, const IgnoreRejectsType& ignore_rejects);
 /**
 * Check for standard transaction types
 * @param[in] mapInputs       Map of previous transactions that have outputs we're spending
 * @param[in] taproot_active  Whether or taproot consensus rules are active (used to decide whether spends of them are permitted)
 * @return True if all inputs (scriptSigs) use only standard transaction forms
 */
-bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, std::string& reason_out, bool taproot_active);
+bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, std::string& reason_out, const IgnoreRejectsType& ignore_rejects, bool taproot_active);
 /**
 * Check if the transaction is over standard P2WSH resources limit:
 * 3600bytes witnessScript size, 80bytes per witness stack element, 100 witness stack elements
@@ -116,7 +117,7 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs,
 *
 * Also enforce a maximum stack item size limit and no annexes for tapscript spends.
 */
-bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, std::string& reason_out);
+bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, std::string& reason_out, const IgnoreRejectsType& ignore_rejects);
 
 /** Compute the virtual transaction size (weight reinterpreted as bytes). */
 int64_t GetVirtualTransactionSize(int64_t nWeight, int64_t nSigOpCost, unsigned int bytes_per_sigop);

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -108,7 +108,7 @@ bool IsStandardTx(const CTransaction& tx, bool permit_bare_multisig, const CFeeR
 * @param[in] taproot_active  Whether or taproot consensus rules are active (used to decide whether spends of them are permitted)
 * @return True if all inputs (scriptSigs) use only standard transaction forms
 */
-bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, bool taproot_active);
+bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, std::string& reason_out, bool taproot_active);
 /**
 * Check if the transaction is over standard P2WSH resources limit:
 * 3600bytes witnessScript size, 80bytes per witness stack element, 100 witness stack elements
@@ -116,7 +116,7 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs,
 *
 * Also enforce a maximum stack item size limit and no annexes for tapscript spends.
 */
-bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs);
+bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, std::string& reason_out);
 
 /** Compute the virtual transaction size (weight reinterpreted as bytes). */
 int64_t GetVirtualTransactionSize(int64_t nWeight, int64_t nSigOpCost, unsigned int bytes_per_sigop);

--- a/src/policy/settings.h
+++ b/src/policy/settings.h
@@ -17,9 +17,9 @@ extern CFeeRate dustRelayFee;
 extern unsigned int nBytesPerSigOp;
 extern bool fIsBareMultisigStd;
 
-static inline bool IsStandardTx(const CTransaction& tx, std::string& reason)
+static inline bool IsStandardTx(const CTransaction& tx, std::string& reason, const IgnoreRejectsType& ignore_rejects)
 {
-    return IsStandardTx(tx, ::fIsBareMultisigStd, ::dustRelayFee, reason);
+    return IsStandardTx(tx, ::fIsBareMultisigStd, ::dustRelayFee, reason, ignore_rejects);
 }
 
 static inline int64_t GetVirtualTransactionSize(int64_t weight, int64_t sigop_cost)

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -102,7 +102,7 @@ void PSBTOperationsDialog::broadcastTransaction()
     CTransactionRef tx = MakeTransactionRef(mtx);
     std::string err_string;
     TransactionError error = BroadcastTransaction(
-        *m_client_model->node().context(), tx, err_string, DEFAULT_MAX_RAW_TX_FEE_RATE.GetFeePerK(), /* relay */ true, /* await_callback */ false);
+        *m_client_model->node().context(), tx, err_string, /* ignore_rejects */ {}, DEFAULT_MAX_RAW_TX_FEE_RATE.GetFeePerK(), /* relay */ true, /* await_callback */ false);
 
     if (error == TransactionError::OK) {
         showStatus(tr("Transaction broadcast successfully! Transaction ID: %1")

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -229,8 +229,9 @@ FUZZ_TARGET_INIT(coins_view, initialize_coins_view)
             break;
         }
         case 1: {
-            (void)AreInputsStandard(CTransaction{random_mutable_transaction}, coins_view_cache, false);
-            (void)AreInputsStandard(CTransaction{random_mutable_transaction}, coins_view_cache, true);
+            std::string reason_dummy;
+            (void)AreInputsStandard(CTransaction{random_mutable_transaction}, coins_view_cache, reason_dummy, false);
+            (void)AreInputsStandard(CTransaction{random_mutable_transaction}, coins_view_cache, reason_dummy, true);
             break;
         }
         case 2: {
@@ -287,7 +288,8 @@ FUZZ_TARGET_INIT(coins_view, initialize_coins_view)
             break;
         }
         case 6: {
-            (void)IsWitnessStandard(CTransaction{random_mutable_transaction}, coins_view_cache);
+            std::string reason_dummy;
+            (void)IsWitnessStandard(CTransaction{random_mutable_transaction}, coins_view_cache, reason_dummy);
             break;
         }
         }

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -230,8 +230,8 @@ FUZZ_TARGET_INIT(coins_view, initialize_coins_view)
         }
         case 1: {
             std::string reason_dummy;
-            (void)AreInputsStandard(CTransaction{random_mutable_transaction}, coins_view_cache, reason_dummy, false);
-            (void)AreInputsStandard(CTransaction{random_mutable_transaction}, coins_view_cache, reason_dummy, true);
+            (void)AreInputsStandard(CTransaction{random_mutable_transaction}, coins_view_cache, reason_dummy, {}, false);
+            (void)AreInputsStandard(CTransaction{random_mutable_transaction}, coins_view_cache, reason_dummy, {}, true);
             break;
         }
         case 2: {
@@ -289,7 +289,7 @@ FUZZ_TARGET_INIT(coins_view, initialize_coins_view)
         }
         case 6: {
             std::string reason_dummy;
-            (void)IsWitnessStandard(CTransaction{random_mutable_transaction}, coins_view_cache, reason_dummy);
+            (void)IsWitnessStandard(CTransaction{random_mutable_transaction}, coins_view_cache, reason_dummy, {});
             break;
         }
         }

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -95,9 +95,10 @@ FUZZ_TARGET_INIT(transaction, initialize_transaction)
 
     CCoinsView coins_view;
     const CCoinsViewCache coins_view_cache(&coins_view);
-    (void)AreInputsStandard(tx, coins_view_cache, false);
-    (void)AreInputsStandard(tx, coins_view_cache, true);
-    (void)IsWitnessStandard(tx, coins_view_cache);
+    std::string reason_dummy;
+    (void)AreInputsStandard(tx, coins_view_cache, reason_dummy, false);
+    (void)AreInputsStandard(tx, coins_view_cache, reason_dummy, true);
+    (void)IsWitnessStandard(tx, coins_view_cache, reason_dummy);
 
     UniValue u(UniValue::VOBJ);
     // ValueFromAmount(i) not defined when i == std::numeric_limits<int64_t>::min()

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -66,8 +66,8 @@ FUZZ_TARGET_INIT(transaction, initialize_transaction)
 
     const CFeeRate dust_relay_fee{DUST_RELAY_TX_FEE};
     std::string reason;
-    const bool is_standard_with_permit_bare_multisig = IsStandardTx(tx, /* permit_bare_multisig= */ true, dust_relay_fee, reason);
-    const bool is_standard_without_permit_bare_multisig = IsStandardTx(tx, /* permit_bare_multisig= */ false, dust_relay_fee, reason);
+    const bool is_standard_with_permit_bare_multisig = IsStandardTx(tx, /* permit_bare_multisig= */ true, dust_relay_fee, reason, {});
+    const bool is_standard_without_permit_bare_multisig = IsStandardTx(tx, /* permit_bare_multisig= */ false, dust_relay_fee, reason, {});
     if (is_standard_without_permit_bare_multisig) {
         assert(is_standard_with_permit_bare_multisig);
     }
@@ -89,16 +89,16 @@ FUZZ_TARGET_INIT(transaction, initialize_transaction)
     (void)GetTransactionWeight(tx);
     (void)GetVirtualTransactionSize(tx);
     (void)IsFinalTx(tx, /* nBlockHeight= */ 1024, /* nBlockTime= */ 1024);
-    (void)IsStandardTx(tx, reason);
+    (void)IsStandardTx(tx, reason, {});
     (void)RecursiveDynamicUsage(tx);
     (void)SignalsOptInRBF(tx);
 
     CCoinsView coins_view;
     const CCoinsViewCache coins_view_cache(&coins_view);
     std::string reason_dummy;
-    (void)AreInputsStandard(tx, coins_view_cache, reason_dummy, false);
-    (void)AreInputsStandard(tx, coins_view_cache, reason_dummy, true);
-    (void)IsWitnessStandard(tx, coins_view_cache, reason_dummy);
+    (void)AreInputsStandard(tx, coins_view_cache, reason_dummy, {}, false);
+    (void)AreInputsStandard(tx, coins_view_cache, reason_dummy, {}, true);
+    (void)IsWitnessStandard(tx, coins_view_cache, reason_dummy, {});
 
     UniValue u(UniValue::VOBJ);
     // ValueFromAmount(i) not defined when i == std::numeric_limits<int64_t>::min()

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(sign)
         txFrom.vout[i+4].scriptPubKey = standardScripts[i];
         txFrom.vout[i+4].nValue = COIN;
     }
-    BOOST_CHECK(IsStandardTx(CTransaction(txFrom), reason));
+    BOOST_CHECK(IsStandardTx(CTransaction(txFrom), reason, {}));
 
     CMutableTransaction txTo[8]; // Spending transactions
     for (int i = 0; i < 8; i++)
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE(set)
         txFrom.vout[i].scriptPubKey = outer[i];
         txFrom.vout[i].nValue = CENT;
     }
-    BOOST_CHECK(IsStandardTx(CTransaction(txFrom), reason));
+    BOOST_CHECK(IsStandardTx(CTransaction(txFrom), reason, {}));
 
     CMutableTransaction txTo[4]; // Spending transactions
     for (int i = 0; i < 4; i++)
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(set)
     for (int i = 0; i < 4; i++)
     {
         BOOST_CHECK_MESSAGE(SignSignature(keystore, CTransaction(txFrom), txTo[i], 0, SIGHASH_ALL), strprintf("SignSignature %d", i));
-        BOOST_CHECK_MESSAGE(IsStandardTx(CTransaction(txTo[i]), reason), strprintf("txTo[%d].IsStandard", i));
+        BOOST_CHECK_MESSAGE(IsStandardTx(CTransaction(txTo[i]), reason, {}), strprintf("txTo[%d].IsStandard", i));
     }
 }
 
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     txTo.vin[3].scriptSig << OP_11 << OP_11 << std::vector<unsigned char>(oneAndTwo.begin(), oneAndTwo.end());
     txTo.vin[4].scriptSig << std::vector<unsigned char>(fifteenSigops.begin(), fifteenSigops.end());
 
-    BOOST_CHECK(::AreInputsStandard(CTransaction(txTo), coins, reason_dummy, false));
+    BOOST_CHECK(::AreInputsStandard(CTransaction(txTo), coins, reason_dummy, {}, false));
     // 22 P2SH sigops for all inputs (1 for vin[0], 6 for vin[3], 15 for vin[4]
     BOOST_CHECK_EQUAL(GetP2SHSigOpCount(CTransaction(txTo), coins), 22U);
 
@@ -357,7 +357,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     txToNonStd1.vin[0].prevout.hash = txFrom.GetHash();
     txToNonStd1.vin[0].scriptSig << std::vector<unsigned char>(sixteenSigops.begin(), sixteenSigops.end());
 
-    BOOST_CHECK(!::AreInputsStandard(CTransaction(txToNonStd1), coins, reason_dummy, false));
+    BOOST_CHECK(!::AreInputsStandard(CTransaction(txToNonStd1), coins, reason_dummy, {}, false));
     BOOST_CHECK_EQUAL(GetP2SHSigOpCount(CTransaction(txToNonStd1), coins), 16U);
 
     CMutableTransaction txToNonStd2;
@@ -369,7 +369,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     txToNonStd2.vin[0].prevout.hash = txFrom.GetHash();
     txToNonStd2.vin[0].scriptSig << std::vector<unsigned char>(twentySigops.begin(), twentySigops.end());
 
-    BOOST_CHECK(!::AreInputsStandard(CTransaction(txToNonStd2), coins, reason_dummy, false));
+    BOOST_CHECK(!::AreInputsStandard(CTransaction(txToNonStd2), coins, reason_dummy, {}, false));
     BOOST_CHECK_EQUAL(GetP2SHSigOpCount(CTransaction(txToNonStd2), coins), 20U);
 }
 

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -263,6 +263,7 @@ BOOST_AUTO_TEST_CASE(switchover)
 
 BOOST_AUTO_TEST_CASE(AreInputsStandard)
 {
+    std::string reason_dummy;
     LOCK(cs_main);
     CCoinsView coinsDummy;
     CCoinsViewCache coins(&coinsDummy);
@@ -343,7 +344,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     txTo.vin[3].scriptSig << OP_11 << OP_11 << std::vector<unsigned char>(oneAndTwo.begin(), oneAndTwo.end());
     txTo.vin[4].scriptSig << std::vector<unsigned char>(fifteenSigops.begin(), fifteenSigops.end());
 
-    BOOST_CHECK(::AreInputsStandard(CTransaction(txTo), coins, false));
+    BOOST_CHECK(::AreInputsStandard(CTransaction(txTo), coins, reason_dummy, false));
     // 22 P2SH sigops for all inputs (1 for vin[0], 6 for vin[3], 15 for vin[4]
     BOOST_CHECK_EQUAL(GetP2SHSigOpCount(CTransaction(txTo), coins), 22U);
 
@@ -356,7 +357,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     txToNonStd1.vin[0].prevout.hash = txFrom.GetHash();
     txToNonStd1.vin[0].scriptSig << std::vector<unsigned char>(sixteenSigops.begin(), sixteenSigops.end());
 
-    BOOST_CHECK(!::AreInputsStandard(CTransaction(txToNonStd1), coins, false));
+    BOOST_CHECK(!::AreInputsStandard(CTransaction(txToNonStd1), coins, reason_dummy, false));
     BOOST_CHECK_EQUAL(GetP2SHSigOpCount(CTransaction(txToNonStd1), coins), 16U);
 
     CMutableTransaction txToNonStd2;
@@ -368,7 +369,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     txToNonStd2.vin[0].prevout.hash = txFrom.GetHash();
     txToNonStd2.vin[0].scriptSig << std::vector<unsigned char>(twentySigops.begin(), twentySigops.end());
 
-    BOOST_CHECK(!::AreInputsStandard(CTransaction(txToNonStd2), coins, false));
+    BOOST_CHECK(!::AreInputsStandard(CTransaction(txToNonStd2), coins, reason_dummy, false));
     BOOST_CHECK_EQUAL(GetP2SHSigOpCount(CTransaction(txToNonStd2), coins), 20U);
 }
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -305,7 +305,8 @@ BOOST_AUTO_TEST_CASE(test_Get)
     t1.vout[0].nValue = 90*CENT;
     t1.vout[0].scriptPubKey << OP_1;
 
-    BOOST_CHECK(AreInputsStandard(CTransaction(t1), coins, false));
+    std::string reason_dummy;
+    BOOST_CHECK(AreInputsStandard(CTransaction(t1), coins, reason_dummy, false));
 }
 
 static void CreateCreditAndSpend(const FillableSigningProvider& keystore, const CScript& outscript, CTransactionRef& output, CMutableTransaction& input, bool success = true)

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -302,11 +302,11 @@ BOOST_AUTO_TEST_CASE(test_Get)
     t1.vin[2].prevout.n = 1;
     t1.vin[2].scriptSig << std::vector<unsigned char>(65, 0) << std::vector<unsigned char>(33, 4);
     t1.vout.resize(2);
-    t1.vout[0].nValue = 90*CENT;
+    t1.vout[0].nValue = 90 * CENT;
     t1.vout[0].scriptPubKey << OP_1;
 
     std::string reason_dummy;
-    BOOST_CHECK(AreInputsStandard(CTransaction(t1), coins, reason_dummy, false));
+    BOOST_CHECK(AreInputsStandard(CTransaction(t1), coins, reason_dummy, {}, false));
 }
 
 static void CreateCreditAndSpend(const FillableSigningProvider& keystore, const CScript& outscript, CTransactionRef& output, CMutableTransaction& input, bool success = true)
@@ -669,6 +669,10 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     CKey key;
     key.MakeNewKey(true);
     t.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
+
+    const auto IsStandardTx = [](const CTransaction& tx, std::string& reason) {
+        return ::IsStandardTx(tx, reason, {});
+    };
 
     std::string reason;
     BOOST_CHECK(IsStandardTx(CTransaction(t), reason));

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -37,10 +37,10 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChain100Setup)
     unsigned int initialPoolSize = m_node.mempool->size();
 
     BOOST_CHECK_EQUAL(
-            false,
-            AcceptToMemoryPool(*m_node.mempool, state, MakeTransactionRef(coinbaseTx),
-                nullptr /* plTxnReplaced */,
-                true /* bypass_limits */));
+        false,
+        AcceptToMemoryPool(*m_node.mempool, state, MakeTransactionRef(coinbaseTx),
+                           nullptr /* plTxnReplaced */, {} /* ignore_rejects */,
+                           true /* bypass_limits */));
 
     // Check that the transaction hasn't been added to mempool.
     BOOST_CHECK_EQUAL(m_node.mempool->size(), initialPoolSize);

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -30,7 +30,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
 
         TxValidationState state;
         return AcceptToMemoryPool(*m_node.mempool, state, MakeTransactionRef(tx),
-            nullptr /* plTxnReplaced */, true /* bypass_limits */);
+                                  nullptr /* plTxnReplaced */, {} /* ignore_rejects */, true /* bypass_limits */);
     };
 
     // Create a double-spend of mature coinbase txn:

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -291,6 +291,7 @@ BOOST_AUTO_TEST_CASE(mempool_locks_reorg)
                     state,
                     tx,
                     &plTxnReplaced,
+                    /* ignore_rejects */ {},
                     /* bypass_limits */ false));
             }
         }

--- a/src/validation.h
+++ b/src/validation.h
@@ -16,13 +16,14 @@
 #include <fs.h>
 #include <optional.h>
 #include <policy/feerate.h>
+#include <policy/policy.h> // For IgnoreRejectsType
 #include <protocol.h> // For CMessageHeader::MessageStartChars
 #include <script/script_error.h>
-#include <sync.h>
-#include <txmempool.h> // For CTxMemPool::cs
-#include <txdb.h>
-#include <versionbits.h>
 #include <serialize.h>
+#include <sync.h>
+#include <txdb.h>
+#include <txmempool.h> // For CTxMemPool::cs
+#include <versionbits.h>
 
 #include <atomic>
 #include <map>
@@ -198,7 +199,7 @@ void PruneBlockFilesManual(int nManualPruneHeight);
  * plTxnReplaced will be appended to with all transactions replaced from mempool
  * @param[out] fee_out optional argument to return tx fee to the caller **/
 bool AcceptToMemoryPool(CTxMemPool& pool, TxValidationState &state, const CTransactionRef &tx,
-                        std::list<CTransactionRef>* plTxnReplaced,
+                        std::list<CTransactionRef>* plTxnReplaced, const IgnoreRejectsType& ignore_rejects,
                         bool bypass_limits, bool test_accept=false, CAmount* fee_out=nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** Get the BIP9 state for a given deployment at the current tip. */


### PR DESCRIPTION
The `-acceptnonstdtxn` footgun is only enabled for regtest/testnet due to several shortcomings:
* It can't be changed without restarting the node
* It applies to all txs and all reject reasons

This pull adds a new optional RPC parameter to ignore specific reject reasons for a specific tx.