### PR TITLE
[doc] Add missing field (permissions) to the getpeerinfo help

### DIFF
--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -143,6 +143,10 @@ static RPCHelpMan getpeerinfo()
                             }},
                             {RPCResult::Type::BOOL, "whitelisted", /* optional */ true, "Whether the peer is whitelisted with default permissions\n"
                                                                                         "(DEPRECATED, returned only if config option -deprecatedrpc=whitelisted is passed)"},
+                            {RPCResult::Type::ARR, "permissions", "Any special permissions that have been granted to this peer",
+                            {
+                                {RPCResult::Type::STR, "permission_type", Join(NET_PERMISSIONS_DOC, ",\n") + ".\n"},
+                            }},
                             {RPCResult::Type::NUM, "minfeefilter", "The minimum fee rate for transactions this peer accepts"},
                             {RPCResult::Type::OBJ_DYN, "bytessent_per_msg", "",
                             {


### PR DESCRIPTION
This field was previously being returned, but missing from the RPCHelpMan. This PR uses the existing `NET_PERMISSIONS_DOC` to inform RPC users about this field.

```
   "permissions" : [                 (json array) Any special permissions that have been granted to this peer
      "str",                          (string) bloomfilter (allow requesting BIP37 filtered blocks and transactions),
                                      noban (do not ban for misbehavior; implies download),
                                      forcerelay (relay transactions that are already in the mempool; implies relay),
                                      relay (relay even in -blocksonly mode, and unlimited transaction announcements),
                                      mempool (allow requesting BIP35 mempool contents),
                                      download (allow getheaders during IBD, no disconnect after maxuploadtarget limit),
                                      addr (responses to GETADDR avoid hitting the cache and contain random records with the most up-to-date info).

      ...
    ],

```