### PR TITLE
net-processing refactoring -- lose globals, move implementation details from .h to .cpp

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1420,7 +1420,7 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
 
     assert(!node.peerman);
     node.peerman = PeerManager::make(chainparams, *node.connman, node.banman.get(),
-                                     *node.scheduler, chainman, *node.mempool, ignores_incoming_txs);
+                                     *node.scheduler, chainman, *node.mempool, gArgs);
     RegisterValidationInterface(node.peerman.get());
 
     // sanitize comments per BIP-0014, format user agent and check total size

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1112,7 +1112,7 @@ void CConnman::CreateNodeFromAcceptedSocket(SOCKET hSocket,
     pnode->AddRef();
     pnode->m_permissionFlags = permissionFlags;
     pnode->m_prefer_evict = discouraged;
-    m_msgproc->InitializeNode(pnode);
+    m_msgproc->InitializeNode(*pnode);
 
     LogPrint(BCLog::NET, "connection from %s accepted\n", addr.ToString());
 
@@ -2132,7 +2132,7 @@ void CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
     if (grantOutbound)
         grantOutbound->MoveTo(pnode->grantOutbound);
 
-    m_msgproc->InitializeNode(pnode);
+    m_msgproc->InitializeNode(*pnode);
     {
         LOCK(cs_vNodes);
         vNodes.push_back(pnode);
@@ -2160,14 +2160,14 @@ void CConnman::ThreadMessageHandler()
                 continue;
 
             // Receive messages
-            bool fMoreNodeWork = m_msgproc->ProcessMessages(pnode, flagInterruptMsgProc);
+            bool fMoreNodeWork = m_msgproc->ProcessMessages(*pnode, flagInterruptMsgProc);
             fMoreWork |= (fMoreNodeWork && !pnode->fPauseSend);
             if (flagInterruptMsgProc)
                 return;
             // Send messages
             {
                 LOCK(pnode->cs_sendProcessing);
-                m_msgproc->SendMessages(pnode);
+                m_msgproc->SendMessages(*pnode);
             }
 
             if (flagInterruptMsgProc)

--- a/src/net.h
+++ b/src/net.h
@@ -766,7 +766,7 @@ class NetEventsInterface
 {
 public:
     /** Initialize a peer (setup state, queue any initial messages) */
-    virtual void InitializeNode(CNode* pnode) = 0;
+    virtual void InitializeNode(CNode& node) = 0;
 
     /** Handle removal of a peer (clear state) */
     virtual void FinalizeNode(const CNode& node, bool& update_connection_time) = 0;
@@ -774,20 +774,19 @@ public:
     /**
     * Process protocol messages received from a given node
     *
-    * @param[in]   pnode           The node which we have received messages from.
+    * @param[in]   node            The node which we have received messages from.
     * @param[in]   interrupt       Interrupt condition for processing threads
     * @return                      True if there is more work to be done
     */
-    virtual bool ProcessMessages(CNode* pnode, std::atomic<bool>& interrupt) = 0;
+    virtual bool ProcessMessages(CNode& node, std::atomic<bool>& interrupt) = 0;
 
     /**
     * Send queued protocol messages to a given node.
     *
-    * @param[in]   pnode           The node which we are sending messages to.
+    * @param[in]   node            The node which we are sending messages to.
     * @return                      True if there is more work to be done
     */
-    virtual bool SendMessages(CNode* pnode) EXCLUSIVE_LOCKS_REQUIRED(pnode->cs_sendProcessing) = 0;
-
+    virtual bool SendMessages(CNode& node) EXCLUSIVE_LOCKS_REQUIRED(node.cs_sendProcessing) = 0;
 
 protected:
     /**

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -536,25 +536,26 @@ private:
     std::unique_ptr<CRollingBloomFilter> recentRejects GUARDED_BY(cs_main);
     uint256 hashRecentRejectsChainTip GUARDED_BY(cs_main);
 
-    /*
+    /**
      * Filter for transactions that have been recently confirmed.
      * We use this to avoid requesting transactions that have already been
-     * confirnmed.
+     * confirmed.
      */
     Mutex m_recent_confirmed_transactions_mutex;
     std::unique_ptr<CRollingBloomFilter> m_recent_confirmed_transactions GUARDED_BY(m_recent_confirmed_transactions_mutex);
 
-    /* Returns a bool indicating whether we requested this block.
+    /** Returns a bool indicating whether we requested this block.
      * Also used if a block was /not/ received and timed out or started with another peer
      */
     bool MarkBlockAsReceived(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-    /* Mark a block as in flight
+    /** Mark a block as in flight
      * Returns false, still setting pit, if the block was already in flight from the same peer
      * pit will only be valid as long as the same cs_main lock is being held
      */
     bool MarkBlockAsInFlight(NodeId nodeid, const uint256& hash, const CBlockIndex* pindex = nullptr, std::list<QueuedBlock>::iterator** pit = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+    /** Determine if tip may be stale based on when last blocks was received */
     bool TipMayBeStale() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /** Update pindexLastCommonBlock and add not-in-flight missing successors to vBlocks, until it has

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1790,7 +1790,7 @@ void PeerManagerImpl::ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic
                 // Relaying a transaction with a recent but unconfirmed parent.
                 if (WITH_LOCK(pfrom.m_tx_relay->cs_tx_inventory, return !pfrom.m_tx_relay->filterInventoryKnown.contains(parent_txid))) {
                     LOCK(cs_main);
-                    State(pfrom)->m_recently_announced_invs.insert(parent_txid);
+                    peer.nodestate.m_recently_announced_invs.insert(parent_txid);
                 }
             }
         } else {
@@ -4226,7 +4226,7 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
     {
         LOCK(cs_main);
 
-        CNodeState &state = *State(*pto);
+        CNodeState& state = peer->nodestate;
 
         // Address refresh broadcast
         auto current_time = GetTime<std::chrono::microseconds>();
@@ -4566,7 +4566,7 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                         }
                         if (pto->m_tx_relay->pfilter && !pto->m_tx_relay->pfilter->IsRelevantAndUpdate(*txinfo.tx)) continue;
                         // Send
-                        State(*pto)->m_recently_announced_invs.insert(hash);
+                        peer->nodestate.m_recently_announced_invs.insert(hash);
                         vInv.push_back(inv);
                         nRelayedTransactions++;
                         {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -596,12 +596,12 @@ private:
     std::vector<std::pair<uint256, CTransactionRef>> vExtraTxnForCompact GUARDED_BY(g_cs_orphans);
     /** Offset into vExtraTxnForCompact to insert the next tx */
     size_t vExtraTxnForCompactIt GUARDED_BY(g_cs_orphans) = 0;
-};
-} // namespace
 
-namespace {
+    void UpdatePreferredDownload(const CNode& node, CNodeState* state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
     /** Number of preferable block download peers. */
     int nPreferredDownload GUARDED_BY(cs_main) = 0;
+};
 } // namespace
 
 namespace {
@@ -617,7 +617,7 @@ static CNodeState *State(NodeId pnode) EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
     return &it->second;
 }
 
-static void UpdatePreferredDownload(const CNode& node, CNodeState* state) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+void PeerManagerImpl::UpdatePreferredDownload(const CNode& node, CNodeState* state) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     nPreferredDownload -= state->fPreferredDownload;
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -571,7 +571,7 @@ private:
     /** Determine whether or not a peer can request a transaction, and return it (or nullptr if not found or not allowed). */
     CTransactionRef FindTxForGetData(const CNode& peer, const GenTxid& gtxid, const std::chrono::seconds mempool_req, const std::chrono::seconds now) LOCKS_EXCLUDED(cs_main);
 
-    void ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic<bool>& interruptMsgProc) EXCLUSIVE_LOCKS_REQUIRED(!cs_main, peer.m_getdata_requests_mutex);
+    void ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic<bool>& interruptMsgProc) LOCKS_EXCLUDED(cs_main) EXCLUSIVE_LOCKS_REQUIRED(peer.m_getdata_requests_mutex);
 
     /** Relay map (txid or wtxid -> CTransactionRef) */
     typedef std::map<uint256, CTransactionRef> MapRelay;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -612,6 +612,13 @@ private:
 
     /** Map maintaining per-node state. */
     std::map<NodeId, CNodeState> mapNodeState GUARDED_BY(cs_main);
+
+    // All of the following cache a recent block, and are protected by cs_most_recent_block
+    RecursiveMutex cs_most_recent_block;
+    std::shared_ptr<const CBlock> most_recent_block GUARDED_BY(cs_most_recent_block);
+    std::shared_ptr<const CBlockHeaderAndShortTxIDs> most_recent_compact_block GUARDED_BY(cs_most_recent_block);
+    uint256 most_recent_block_hash GUARDED_BY(cs_most_recent_block);
+    bool fWitnessesPresentInMostRecentCompactBlock GUARDED_BY(cs_most_recent_block) = false;
 };
 } // namespace
 
@@ -1304,13 +1311,6 @@ void PeerManagerImpl::BlockDisconnected(const std::shared_ptr<const CBlock> &blo
     LOCK(m_recent_confirmed_transactions_mutex);
     m_recent_confirmed_transactions->reset();
 }
-
-// All of the following cache a recent block, and are protected by cs_most_recent_block
-static RecursiveMutex cs_most_recent_block;
-static std::shared_ptr<const CBlock> most_recent_block GUARDED_BY(cs_most_recent_block);
-static std::shared_ptr<const CBlockHeaderAndShortTxIDs> most_recent_compact_block GUARDED_BY(cs_most_recent_block);
-static uint256 most_recent_block_hash GUARDED_BY(cs_most_recent_block);
-static bool fWitnessesPresentInMostRecentCompactBlock GUARDED_BY(cs_most_recent_block);
 
 /**
  * Maintain state about the best-seen block and fast-announce a compact block

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -41,6 +41,9 @@ public:
                                              bool ignore_incoming_txs);
     virtual ~PeerManager() { }
 
+    /** Relay transaction to every node */
+    virtual void RelayTransaction(const uint256& txid, const uint256& wtxid, const CConnman& connman) EXCLUSIVE_LOCKS_REQUIRED(cs_main) = 0;
+
     /** Get statistics from node state */
     virtual bool GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) = 0;
 
@@ -69,9 +72,8 @@ public:
     /** Process a single message from a peer. Public for fuzz testing */
     virtual void ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStream& vRecv,
                                 const std::chrono::microseconds time_received, const std::atomic<bool>& interruptMsgProc) = 0;
-};
 
-/** Relay transaction to every node */
-void RelayTransaction(const uint256& txid, const uint256& wtxid, const CConnman& connman) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    virtual void UpdateLastBlockAnnounceTime(NodeId node, int64_t time_in_seconds) = 0;
+};
 
 #endif // BITCOIN_NET_PROCESSING_H

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -42,7 +42,7 @@ public:
     virtual ~PeerManager() { }
 
     /** Relay transaction to every node */
-    virtual void RelayTransaction(const uint256& txid, const uint256& wtxid, const CConnman& connman) EXCLUSIVE_LOCKS_REQUIRED(cs_main) = 0;
+    virtual void RelayTransaction(const uint256& txid, const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(cs_main) = 0;
 
     /** Get statistics from node state */
     virtual bool GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) = 0;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -10,6 +10,7 @@
 #include <sync.h>
 #include <validationinterface.h>
 
+class ArgsManager;
 class CChainParams;
 class CTxMemPool;
 class ChainstateManager;
@@ -38,7 +39,7 @@ class PeerManager : public CValidationInterface, public NetEventsInterface
 public:
     static std::unique_ptr<PeerManager> make(const CChainParams& chainparams, CConnman& connman, BanMan* banman,
                                              CScheduler& scheduler, ChainstateManager& chainman, CTxMemPool& pool,
-                                             bool ignore_incoming_txs);
+                                             const ArgsManager& args);
     virtual ~PeerManager() { }
 
     /** Relay transaction to every node */

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -33,6 +33,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
     // and reset after chain clients and RPC sever are stopped. node.connman should never be null here.
     assert(node.connman);
     assert(node.mempool);
+    assert(node.peerman);
     std::promise<void> promise;
     uint256 hashTx = tx->GetHash();
     bool callback_set = false;
@@ -100,7 +101,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
         node.mempool->AddUnbroadcastTx(hashTx);
 
         LOCK(cs_main);
-        RelayTransaction(hashTx, tx->GetWitnessHash(), *node.connman);
+        node.peerman->RelayTransaction(hashTx, tx->GetWitnessHash(), *node.connman);
     }
 
     return TransactionError::OK;

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -29,11 +29,10 @@ static TransactionError HandleATMPError(const TxValidationState& state, std::str
 TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef tx, std::string& err_string, const CAmount& max_tx_fee, bool relay, bool wait_callback)
 {
     // BroadcastTransaction can be called by either sendrawtransaction RPC or wallet RPCs.
-    // node.connman is assigned both before chain clients and before RPC server is accepting calls,
-    // and reset after chain clients and RPC sever are stopped. node.connman should never be null here.
-    assert(node.connman);
-    assert(node.mempool);
+    // node.peerman is assigned both before chain clients and before RPC server is accepting calls,
+    // and reset after chain clients and RPC sever are stopped. node.peerman should never be null here.
     assert(node.peerman);
+    assert(node.mempool);
     std::promise<void> promise;
     uint256 hashTx = tx->GetHash();
     bool callback_set = false;
@@ -101,7 +100,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
         node.mempool->AddUnbroadcastTx(hashTx);
 
         LOCK(cs_main);
-        node.peerman->RelayTransaction(hashTx, tx->GetWitnessHash(), *node.connman);
+        node.peerman->RelayTransaction(hashTx, tx->GetWitnessHash());
     }
 
     return TransactionError::OK;

--- a/src/sync.h
+++ b/src/sync.h
@@ -56,7 +56,7 @@ std::string LocksHeld();
 template <typename MutexType>
 void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, MutexType* cs) EXCLUSIVE_LOCKS_REQUIRED(cs);
 template <typename MutexType>
-void AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, MutexType* cs) EXCLUSIVE_LOCKS_REQUIRED(!cs);
+void AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, MutexType* cs) LOCKS_EXCLUDED(cs);
 void DeleteLock(void* cs);
 bool LockStackEmpty();
 

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     const CChainParams& chainparams = Params();
     auto connman = MakeUnique<CConnman>(0x1337, 0x1337);
     auto peerLogic = PeerManager::make(chainparams, *connman, nullptr, *m_node.scheduler,
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, *m_node.mempool, gArgs);
 
     // Mock an outbound peer
     CAddress addr1(ip(0xa0b0c001), NODE_NONE);
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
     const CChainParams& chainparams = Params();
     auto connman = MakeUnique<CConnmanTest>(0x1337, 0x1337);
     auto peerLogic = PeerManager::make(chainparams, *connman, nullptr, *m_node.scheduler,
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, *m_node.mempool, gArgs);
 
     constexpr int max_outbound_full_relay = MAX_OUTBOUND_FULL_RELAY_CONNECTIONS;
     CConnman::Options options;
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     auto banman = MakeUnique<BanMan>(GetDataDir() / "banlist.dat", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = MakeUnique<CConnman>(0x1337, 0x1337);
     auto peerLogic = PeerManager::make(chainparams, *connman, banman.get(), *m_node.scheduler,
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, *m_node.mempool, gArgs);
 
     banman->ClearBanned();
     CAddress addr1(ip(0xa0b0c001), NODE_NONE);
@@ -259,7 +259,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     auto banman = MakeUnique<BanMan>(GetDataDir() / "banlist.dat", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = MakeUnique<CConnman>(0x1337, 0x1337);
     auto peerLogic = PeerManager::make(chainparams, *connman, banman.get(), *m_node.scheduler,
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, *m_node.mempool, gArgs);
 
     banman->ClearBanned();
     int64_t nStartTime = GetTime();

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -53,8 +53,6 @@ static CService ip(uint32_t i)
 
 static NodeId id = 0;
 
-void UpdateLastBlockAnnounceTime(NodeId node, int64_t time_in_seconds);
-
 BOOST_FIXTURE_TEST_SUITE(denialofservice_tests, TestingSetup)
 
 // Test eviction of an outbound peer whose chain never advances
@@ -191,7 +189,7 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
 
     // Update the last announced block time for the last
     // peer, and check that the next newest node gets evicted.
-    UpdateLastBlockAnnounceTime(vNodes.back()->GetId(), GetTime());
+    peerLogic->UpdateLastBlockAnnounceTime(vNodes.back()->GetId(), GetTime());
 
     peerLogic->CheckForStaleTipAndEvictPeers();
     for (int i = 0; i < max_outbound_full_relay - 1; ++i) {

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     CNode dummyNode1(id++, ServiceFlags(NODE_NETWORK | NODE_WITNESS), INVALID_SOCKET, addr1, /* nKeyedNetGroupIn */ 0, /* nLocalHostNonceIn */ 0, CAddress(), /* pszDest */ "", ConnectionType::OUTBOUND_FULL_RELAY, /* inbound_onion */ false);
     dummyNode1.SetCommonVersion(PROTOCOL_VERSION);
 
-    peerLogic->InitializeNode(&dummyNode1);
+    peerLogic->InitializeNode(dummyNode1);
     dummyNode1.fSuccessfullyConnected = true;
 
     // This test requires that we have a chain with non-zero work.
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     // Test starts here
     {
         LOCK(dummyNode1.cs_sendProcessing);
-        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1)); // should result in getheaders
+        BOOST_CHECK(peerLogic->SendMessages(dummyNode1)); // should result in getheaders
     }
     {
         LOCK(dummyNode1.cs_vSend);
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     SetMockTime(nStartTime+21*60);
     {
         LOCK(dummyNode1.cs_sendProcessing);
-        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1)); // should result in getheaders
+        BOOST_CHECK(peerLogic->SendMessages(dummyNode1)); // should result in getheaders
     }
     {
         LOCK(dummyNode1.cs_vSend);
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     SetMockTime(nStartTime+24*60);
     {
         LOCK(dummyNode1.cs_sendProcessing);
-        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1)); // should result in disconnect
+        BOOST_CHECK(peerLogic->SendMessages(dummyNode1)); // should result in disconnect
     }
     BOOST_CHECK(dummyNode1.fDisconnect == true);
     SetMockTime(0);
@@ -127,7 +127,7 @@ static void AddRandomOutboundPeer(std::vector<CNode *> &vNodes, PeerManager &pee
     CNode &node = *vNodes.back();
     node.SetCommonVersion(PROTOCOL_VERSION);
 
-    peerLogic.InitializeNode(&node);
+    peerLogic.InitializeNode(node);
     node.fSuccessfullyConnected = true;
 
     connman->AddNode(node);
@@ -218,12 +218,12 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     CAddress addr1(ip(0xa0b0c001), NODE_NONE);
     CNode dummyNode1(id++, NODE_NETWORK, INVALID_SOCKET, addr1, /* nKeyedNetGroupIn */ 0, /* nLocalHostNonceIn */ 0, CAddress(), /* pszDest */ "", ConnectionType::INBOUND, /* inbound_onion */ false);
     dummyNode1.SetCommonVersion(PROTOCOL_VERSION);
-    peerLogic->InitializeNode(&dummyNode1);
+    peerLogic->InitializeNode(dummyNode1);
     dummyNode1.fSuccessfullyConnected = true;
     peerLogic->Misbehaving(dummyNode1.GetId(), DISCOURAGEMENT_THRESHOLD, /* message */ ""); // Should be discouraged
     {
         LOCK(dummyNode1.cs_sendProcessing);
-        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
+        BOOST_CHECK(peerLogic->SendMessages(dummyNode1));
     }
     BOOST_CHECK(banman->IsDiscouraged(addr1));
     BOOST_CHECK(!banman->IsDiscouraged(ip(0xa0b0c001|0x0000ff00))); // Different IP, not discouraged
@@ -231,19 +231,19 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     CAddress addr2(ip(0xa0b0c002), NODE_NONE);
     CNode dummyNode2(id++, NODE_NETWORK, INVALID_SOCKET, addr2, /* nKeyedNetGroupIn */ 1, /* nLocalHostNonceIn */ 1, CAddress(), /* pszDest */ "", ConnectionType::INBOUND, /* inbound_onion */ false);
     dummyNode2.SetCommonVersion(PROTOCOL_VERSION);
-    peerLogic->InitializeNode(&dummyNode2);
+    peerLogic->InitializeNode(dummyNode2);
     dummyNode2.fSuccessfullyConnected = true;
     peerLogic->Misbehaving(dummyNode2.GetId(), DISCOURAGEMENT_THRESHOLD - 1, /* message */ "");
     {
         LOCK(dummyNode2.cs_sendProcessing);
-        BOOST_CHECK(peerLogic->SendMessages(&dummyNode2));
+        BOOST_CHECK(peerLogic->SendMessages(dummyNode2));
     }
     BOOST_CHECK(!banman->IsDiscouraged(addr2)); // 2 not discouraged yet...
     BOOST_CHECK(banman->IsDiscouraged(addr1));  // ... but 1 still should be
     peerLogic->Misbehaving(dummyNode2.GetId(), 1, /* message */ "");         // 2 reaches discouragement threshold
     {
         LOCK(dummyNode2.cs_sendProcessing);
-        BOOST_CHECK(peerLogic->SendMessages(&dummyNode2));
+        BOOST_CHECK(peerLogic->SendMessages(dummyNode2));
     }
     BOOST_CHECK(banman->IsDiscouraged(addr1));  // Expect both 1 and 2
     BOOST_CHECK(banman->IsDiscouraged(addr2));  // to be discouraged now
@@ -268,13 +268,13 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     CAddress addr(ip(0xa0b0c001), NODE_NONE);
     CNode dummyNode(id++, NODE_NETWORK, INVALID_SOCKET, addr, /* nKeyedNetGroupIn */ 4, /* nLocalHostNonceIn */ 4, CAddress(), /* pszDest */ "", ConnectionType::INBOUND, /* inbound_onion */ false);
     dummyNode.SetCommonVersion(PROTOCOL_VERSION);
-    peerLogic->InitializeNode(&dummyNode);
+    peerLogic->InitializeNode(dummyNode);
     dummyNode.fSuccessfullyConnected = true;
 
     peerLogic->Misbehaving(dummyNode.GetId(), DISCOURAGEMENT_THRESHOLD, /* message */ "");
     {
         LOCK(dummyNode.cs_sendProcessing);
-        BOOST_CHECK(peerLogic->SendMessages(&dummyNode));
+        BOOST_CHECK(peerLogic->SendMessages(dummyNode));
     }
     BOOST_CHECK(banman->IsDiscouraged(addr));
 

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -83,7 +83,7 @@ void fuzz_target(FuzzBufferType buffer, const std::string& LIMIT_TO_MESSAGE_TYPE
     const bool successfully_connected{fuzzed_data_provider.ConsumeBool()};
     p2p_node.fSuccessfullyConnected = successfully_connected;
     connman.AddTestNode(p2p_node);
-    g_setup->m_node.peerman->InitializeNode(&p2p_node);
+    g_setup->m_node.peerman->InitializeNode(p2p_node);
     FillNode(fuzzed_data_provider, p2p_node, /* init_version */ successfully_connected);
 
     const auto mock_time = ConsumeTime(fuzzed_data_provider);
@@ -98,7 +98,7 @@ void fuzz_target(FuzzBufferType buffer, const std::string& LIMIT_TO_MESSAGE_TYPE
     }
     {
         LOCK(p2p_node.cs_sendProcessing);
-        g_setup->m_node.peerman->SendMessages(&p2p_node);
+        g_setup->m_node.peerman->SendMessages(p2p_node);
     }
     SyncWithValidationInterfaceQueue();
     LOCK2(::cs_main, g_cs_orphans); // See init.cpp for rationale for implicit locking order requirement

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -50,7 +50,7 @@ FUZZ_TARGET_INIT(process_messages, initialize_process_messages)
         const bool successfully_connected{fuzzed_data_provider.ConsumeBool()};
         p2p_node.fSuccessfullyConnected = successfully_connected;
         p2p_node.fPauseSend = false;
-        g_setup->m_node.peerman->InitializeNode(&p2p_node);
+        g_setup->m_node.peerman->InitializeNode(p2p_node);
         FillNode(fuzzed_data_provider, p2p_node, /* init_version */ successfully_connected);
 
         connman.AddTestNode(p2p_node);
@@ -77,7 +77,7 @@ FUZZ_TARGET_INIT(process_messages, initialize_process_messages)
         }
         {
             LOCK(random_node.cs_sendProcessing);
-            g_setup->m_node.peerman->SendMessages(&random_node);
+            g_setup->m_node.peerman->SendMessages(random_node);
         }
     }
     SyncWithValidationInterfaceQueue();

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -23,7 +23,7 @@ struct ConnmanTestMsg : public CConnman {
         vNodes.clear();
     }
 
-    void ProcessMessagesOnce(CNode& node) { m_msgproc->ProcessMessages(&node, flagInterruptMsgProc); }
+    void ProcessMessagesOnce(CNode& node) { m_msgproc->ProcessMessages(node, flagInterruptMsgProc); }
 
     void NodeReceiveMsgBytes(CNode& node, Span<const uint8_t> msg_bytes, bool& complete) const;
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -191,8 +191,7 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
     m_node.banman = MakeUnique<BanMan>(GetDataDir() / "banlist.dat", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     m_node.connman = MakeUnique<CConnman>(0x1337, 0x1337); // Deterministic randomness for tests.
     m_node.peerman = PeerManager::make(chainparams, *m_node.connman, m_node.banman.get(),
-                                       *m_node.scheduler, *m_node.chainman, *m_node.mempool,
-                                       false);
+                                       *m_node.scheduler, *m_node.chainman, *m_node.mempool, gArgs);
     {
         CConnman::Options options;
         options.m_msgproc = m_node.peerman.get();

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -107,9 +107,8 @@ unsigned int TxOrphanage::LimitOrphans(unsigned int max_orphans)
     AssertLockHeld(g_cs_orphans);
 
     unsigned int nEvicted = 0;
-    static int64_t nNextSweep; // GUARDED_BY(g_cs_orphans)
     int64_t nNow = GetTime();
-    if (nNextSweep <= nNow) {
+    if (m_next_sweep <= nNow) {
         // Sweep out expired orphan pool entries:
         int nErased = 0;
         int64_t nMinExpTime = nNow + ORPHAN_TX_EXPIRE_TIME - ORPHAN_TX_EXPIRE_INTERVAL;
@@ -124,7 +123,7 @@ unsigned int TxOrphanage::LimitOrphans(unsigned int max_orphans)
             }
         }
         // Sweep again 5 minutes after the next entry that expires in order to batch the linear scan.
-        nNextSweep = nMinExpTime + ORPHAN_TX_EXPIRE_INTERVAL;
+        m_next_sweep = nMinExpTime + ORPHAN_TX_EXPIRE_INTERVAL;
         if (nErased > 0) LogPrint(BCLog::MEMPOOL, "Erased %d orphan tx due to expiration\n", nErased);
     }
     FastRandomContext rng;

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -107,7 +107,7 @@ unsigned int TxOrphanage::LimitOrphans(unsigned int max_orphans)
     AssertLockHeld(g_cs_orphans);
 
     unsigned int nEvicted = 0;
-    static int64_t nNextSweep;
+    static int64_t nNextSweep; // GUARDED_BY(g_cs_orphans)
     int64_t nNow = GetTime();
     if (nNextSweep <= nNow) {
         // Sweep out expired orphan pool entries:

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -24,7 +24,7 @@ public:
     bool AddTx(const CTransactionRef& tx, NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans);
 
     /** Check if we already have an orphan transaction (by txid or wtxid) */
-    bool HaveTx(const GenTxid& gtxid) const EXCLUSIVE_LOCKS_REQUIRED(!g_cs_orphans);
+    bool HaveTx(const GenTxid& gtxid) const LOCKS_EXCLUDED(g_cs_orphans);
 
     /** Get an orphan transaction and its orginating peer
      * (Transaction ref will be nullptr if not found)
@@ -38,7 +38,7 @@ public:
     void EraseForPeer(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans);
 
     /** Erase all orphans included in or invalidated by a new block */
-    void EraseForBlock(const CBlock& block) EXCLUSIVE_LOCKS_REQUIRED(!g_cs_orphans);
+    void EraseForBlock(const CBlock& block) LOCKS_EXCLUDED(g_cs_orphans);
 
     /** Limit the orphanage to the given maximum */
     unsigned int LimitOrphans(unsigned int max_orphans) EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans);

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -80,6 +80,9 @@ protected:
     /** Index from wtxid into the m_orphans to lookup orphan
      *  transactions using their witness ids. */
     std::map<uint256, OrphanMap::iterator> m_wtxid_to_orphan_it GUARDED_BY(g_cs_orphans);
+
+    /** Timestamp for next sweep of orphans by LimitOrphanTxSize */
+    int64_t m_next_sweep GUARDED_BY(g_cs_orphans) = 0;
 };
 
 #endif // BITCOIN_TXORPHANAGE_H

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1175,7 +1175,7 @@ public:
      * Obviously holding cs_main/cs_wallet when going into this call may cause
      * deadlock
      */
-    void BlockUntilSyncedToCurrentChain() const EXCLUSIVE_LOCKS_REQUIRED(!::cs_main, !cs_wallet);
+    void BlockUntilSyncedToCurrentChain() const LOCKS_EXCLUDED(::cs_main, cs_wallet);
 
     /** set a single wallet flag */
     void SetWalletFlag(uint64_t flags);


### PR DESCRIPTION
Done in #20811 :
* Moves implementation details of PeerManager into PeerManagerImpl; moves PeerManagerImpl into .cpp
* Moves struct Peer definition into .cpp

Done in #20942:
* Moves net_processing globals into PeerManagerImpl.
* Moves a lot of net_processing functions into PeerManagerImpl and simplifies some of their arguments as a result.

In #21148:
* Split orphan management into its own module
* More more globals/functions into PeerManagerImpl

Additional things in this PR:
* Moves more globals/functions into PeerManagerImpl; simplify their arguments.
* Makes test/denialofservice_tests use the PeerManager api instead of directly accessing net_processing implementation details
* Introduces State(CNode&) and State(Peer&) alternatives to calling State(node.GetId()) all the time.
* Moves CNodeState into Peer as a step towards consolidating state information
* Make NetEventsInterface take a CNode& instead of a CNode*
* Pass ArgsManager into the constructor and collect parameters once rather than calling GetArgs regularly at runtime

Not done yet:
* Split parts of PeerManager into their own modules a la txrequest (block downloads?)