### PR TITLE
fuzz: Check that NULL_DATA is unspendable

### DIFF
--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -72,6 +72,13 @@ FUZZ_TARGET_INIT(script, initialize_script)
 
     TxoutType which_type;
     (void)IsStandard(script, which_type);
+    if (which_type == TxoutType::NULL_DATA) {
+        assert(script.IsUnspendable());
+    }
+    if (script.IsUnspendable()) {
+        assert(which_type == TxoutType::NULL_DATA ||
+               which_type == TxoutType::NONSTANDARD);
+    }
 
     (void)RecursiveDynamicUsage(script);
 
@@ -82,7 +89,6 @@ FUZZ_TARGET_INIT(script, initialize_script)
     (void)script.IsPayToScriptHash();
     (void)script.IsPayToWitnessScriptHash();
     (void)script.IsPushOnly();
-    (void)script.IsUnspendable();
     (void)script.GetSigOpCount(/* fAccurate= */ false);
 
     (void)FormatScript(script);


### PR DESCRIPTION
* Every script of type NULL_DATA must be unspendable
* The only know types of unspendable scripts are NULL_DATA and certain NONSTANDARD scripts