### PR TITLE
cli -netinfo peer connections dashboard updates 🎄 ✨

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -318,7 +318,7 @@ private:
     bool IsVersionSelected() const { return m_details_level == 3 || m_details_level == 4; }
     bool m_is_asmap_on{false};
     size_t m_max_addr_length{0};
-    size_t m_max_age_length{4};
+    size_t m_max_age_length{3};
     size_t m_max_id_length{2};
     struct Peer {
         std::string addr;
@@ -335,6 +335,8 @@ private:
         int id;
         int mapped_as;
         int version;
+        bool is_bip152_hb_from;
+        bool is_bip152_hb_to;
         bool is_block_relay;
         bool is_outbound;
         bool operator<(const Peer& rhs) const { return std::tie(is_outbound, min_ping) < std::tie(rhs.is_outbound, rhs.min_ping); }
@@ -399,6 +401,9 @@ private:
             "  recv     Time since last message received from the peer, in seconds\n"
             "  txn      Time since last novel transaction received from the peer and accepted into our mempool, in minutes\n"
             "  blk      Time since last novel block passing initial validity checks received from the peer, in minutes\n"
+            "  hb       High-bandwidth BIP152 compact block relay\n"
+            "           \".\" (to)   - we selected the peer as a high-bandwidth peer\n"
+            "           \"*\" (from) - the peer selected us as a high-bandwidth peer\n"
             "  age      Duration of connection to the peer, in minutes\n"
             "  asmap    Mapped AS (Autonomous System) number in the BGP route to the peer, used for diversifying\n"
             "           peer selection (only displayed if the -asmap config option is set)\n"
@@ -490,7 +495,9 @@ public:
                 const std::string addr{peer["addr"].get_str()};
                 const std::string age{conn_time == 0 ? "" : ToString((m_time_now - conn_time) / 60)};
                 const std::string sub_version{peer["subver"].get_str()};
-                m_peers.push_back({addr, sub_version, conn_type, network, age, min_ping, ping, last_blck, last_recv, last_send, last_trxn, peer_id, mapped_as, version, is_block_relay, is_outbound});
+                const bool is_bip152_hb_from{peer["bip152_hb_from"].get_bool()};
+                const bool is_bip152_hb_to{peer["bip152_hb_to"].get_bool()};
+                m_peers.push_back({addr, sub_version, conn_type, network, age, min_ping, ping, last_blck, last_recv, last_send, last_trxn, peer_id, mapped_as, version, is_bip152_hb_from, is_bip152_hb_to, is_block_relay, is_outbound});
                 m_max_addr_length = std::max(addr.length() + 1, m_max_addr_length);
                 m_max_age_length = std::max(age.length(), m_max_age_length);
                 m_max_id_length = std::max(ToString(peer_id).length(), m_max_id_length);
@@ -504,13 +511,13 @@ public:
         // Report detailed peer connections list sorted by direction and minimum ping time.
         if (DetailsRequested() && !m_peers.empty()) {
             std::sort(m_peers.begin(), m_peers.end());
-            result += strprintf("<->   type   net  mping   ping send recv  txn  blk %*s ", m_max_age_length, "age");
+            result += strprintf("<->   type   net  mping   ping send recv  txn  blk  hb %*s ", m_max_age_length, "age");
             if (m_is_asmap_on) result += " asmap ";
             result += strprintf("%*s %-*s%s\n", m_max_id_length, "id", IsAddressSelected() ? m_max_addr_length : 0, IsAddressSelected() ? "address" : "", IsVersionSelected() ? "version" : "");
             for (const Peer& peer : m_peers) {
                 std::string version{ToString(peer.version) + peer.sub_version};
                 result += strprintf(
-                    "%3s %6s %5s%7s%7s%5s%5s%5s%5s %*s%*i %*s %-*s%s\n",
+                    "%3s %6s %5s%7s%7s%5s%5s%5s%5s  %2s %*s%*i %*s %-*s%s\n",
                     peer.is_outbound ? "out" : "in",
                     ConnectionTypeForNetinfo(peer.conn_type),
                     peer.network,
@@ -520,6 +527,7 @@ public:
                     peer.last_recv == 0 ? "" : ToString(m_time_now - peer.last_recv),
                     peer.last_trxn == 0 ? "" : ToString((m_time_now - peer.last_trxn) / 60),
                     peer.last_blck == 0 ? "" : ToString((m_time_now - peer.last_blck) / 60),
+                    strprintf("%s%s", peer.is_bip152_hb_to ? "." : " ", peer.is_bip152_hb_from ? "*" : " "),
                     m_max_age_length, // variable spacing
                     peer.age,
                     m_is_asmap_on ? 7 : 0, // variable spacing
@@ -530,7 +538,7 @@ public:
                     IsAddressSelected() ? peer.addr : "",
                     IsVersionSelected() && version != "0" ? version : "");
             }
-            result += strprintf("                     ms     ms  sec  sec  min  min %*s\n\n", m_max_age_length, "min");
+            result += strprintf("                     ms     ms  sec  sec  min  min     %*s\n\n", m_max_age_length, "min");
         }
 
         // Report peer connection totals by type.

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -351,6 +351,14 @@ private:
         const double milliseconds{round(1000 * seconds)};
         return milliseconds > 999999 ? "-" : ToString(milliseconds);
     }
+    std::string ConnectionTypeForNetinfo(const std::string& conn_type) const
+    {
+        if (conn_type == "outbound-full-relay") return "full";
+        if (conn_type == "block-relay-only") return "block";
+        if (conn_type == "manual" || conn_type == "feeler") return conn_type;
+        if (conn_type == "addr-fetch") return "addr";
+        return "";
+    }
     const UniValue NetinfoHelp()
     {
         return std::string{


### PR DESCRIPTION
Merry Bitcoin Christmas! Ho ho ho 🎄 ✨

This PR updates `-netinfo` to:
- use the getpeerinfo `connection_type` field (and no longer use getpeerinfo `relaytxes` for block-relay detection)
- display manual peers count, if any, in the outbound row
- display the block relay counts in the outbound row only
- display high-bandwidth BIP152 compact block relay peers (`hb` column, to `.` and from `*`)
- add support for displaying I2P network peers, if any are present

Testing and review welcome! How to test:

- to run the full live dashboard (on Linux): `$ watch --interval 1 --no-title ./src/bitcoin-cli -netinfo 4`
- to run the full dashboard: ``$ ./src/bitcoin-cli -netinfo 4``
- to see the help: `$ ./src/bitcoin-cli -netinfo help`
- to see the help summary: `$ ./src/bitcoin-cli -help | grep -A4 netinfo`
