### PR TITLE
fuzz: check that certain script TxoutType are nonstandard

### DIFF
--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -71,7 +71,15 @@ FUZZ_TARGET_INIT(script, initialize_script)
     (void)IsSolvable(signing_provider, script);
 
     TxoutType which_type;
-    (void)IsStandard(script, which_type);
+    bool is_standard_ret = IsStandard(script, which_type);
+    if (!is_standard_ret) {
+        assert(which_type == TxoutType::NONSTANDARD ||
+               which_type == TxoutType::NULL_DATA ||
+               which_type == TxoutType::MULTISIG);
+    }
+    if (which_type == TxoutType::NONSTANDARD) {
+        assert(!is_standard_ret);
+    }
     if (which_type == TxoutType::NULL_DATA) {
         assert(script.IsUnspendable());
     }


### PR DESCRIPTION
- Every transaction of type NONSTANDARD must not be a standard script
- The only know types of nonstandard scripts are NONSTANDARD and certain NULL_DATA and MULTISIG scripts

When reviewing https://github.com/bitcoin/bitcoin/pull/20761 I figured this is very similar and might also be good to have
