### PR TITLE
net, p2p, gui: replace direction with connection type in gui peer details window

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -629,6 +629,7 @@ void CNode::copyStats(CNodeStats &stats, const std::vector<bool> &m_asmap)
     CService addrLocalUnlocked = GetAddrLocal();
     stats.addrLocal = addrLocalUnlocked.IsValid() ? addrLocalUnlocked.ToString() : "";
 
+    X(m_conn_type);
     stats.m_conn_type_string = ConnectionTypeAsString();
 }
 #undef X

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -507,9 +507,9 @@ void CConnman::AddWhitelistPermissionFlags(NetPermissionFlags& flags, const CNet
     }
 }
 
-std::string CNode::ConnectionTypeAsString() const
+std::string ConnectionTypeAsString(ConnectionType conn_type)
 {
-    switch (m_conn_type) {
+    switch (conn_type) {
     case ConnectionType::INBOUND:
         return "inbound";
     case ConnectionType::MANUAL:
@@ -630,7 +630,6 @@ void CNode::copyStats(CNodeStats &stats, const std::vector<bool> &m_asmap)
     stats.addrLocal = addrLocalUnlocked.IsValid() ? addrLocalUnlocked.ToString() : "";
 
     X(m_conn_type);
-    stats.m_conn_type_string = ConnectionTypeAsString();
 }
 #undef X
 

--- a/src/net.h
+++ b/src/net.h
@@ -725,6 +725,7 @@ public:
     // Name of the network the peer connected through
     std::string m_network;
     uint32_t m_mapped_as;
+    ConnectionType m_conn_type;
     std::string m_conn_type_string;
 };
 

--- a/src/net.h
+++ b/src/net.h
@@ -180,6 +180,9 @@ enum class ConnectionType {
     ADDR_FETCH,
 };
 
+/** Convert ConnectionType enum to a string value */
+std::string ConnectionTypeAsString(ConnectionType conn_type);
+
 class NetEventsInterface;
 class CConnman
 {
@@ -726,7 +729,6 @@ public:
     std::string m_network;
     uint32_t m_mapped_as;
     ConnectionType m_conn_type;
-    std::string m_conn_type_string;
 };
 
 
@@ -1223,7 +1225,7 @@ public:
     //! Sets the addrName only if it was not previously set
     void MaybeSetAddrName(const std::string& addrNameIn);
 
-    std::string ConnectionTypeAsString() const;
+    std::string ConnectionTypeAsString() const { return ::ConnectionTypeAsString(m_conn_type); }
 };
 
 /** Return a timestamp in the future (in microseconds) for exponentially distributed events. */

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1079,7 +1079,7 @@
                <item row="1" column="0">
                 <widget class="QLabel" name="peerConnectionTypeLabel">
                  <property name="toolTip">
-                  <string>The type of peer connection: Outbound Full Relay (default), Outbound Block Relay (does not relay transactions or addresses), Inbound (initiated by peer), Outbound Manual (added using RPC addnode or -addnode/-connect config options), Outbound Feeler (short-lived, for testing addresses), or Outbound Address Fetch (short-lived, for soliciting addresses).</string>
+                  <string>The type of peer connection: Outbound Full Relay (default), Outbound Block Relay (does not relay transactions or addresses), Inbound (initiated by peer), Outbound Manual (added using RPC %1 or %2/%3 config options), Outbound Feeler (short-lived, for testing addresses), or Outbound Address Fetch (short-lived, for soliciting addresses).</string>
                  </property>
                  <property name="text">
                   <string>Connection Type</string>

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1077,14 +1077,17 @@
                 </widget>
                </item>
                <item row="1" column="0">
-                <widget class="QLabel" name="label_23">
+                <widget class="QLabel" name="peerConnectionTypeLabel">
+                 <property name="toolTip">
+                  <string>The type of peer connection: Outbound Full Relay (default), Outbound Block Relay (does not relay transactions or addresses), Inbound (initiated by peer), Outbound Manual (added using RPC addnode or -addnode/-connect config options), Outbound Feeler (short-lived, for testing addresses), or Outbound Address Fetch (short-lived, for soliciting addresses).</string>
+                 </property>
                  <property name="text">
-                  <string>Direction</string>
+                  <string>Connection Type</string>
                  </property>
                 </widget>
                </item>
                <item row="1" column="1">
-                <widget class="QLabel" name="peerDirection">
+                <widget class="QLabel" name="peerConnectionType">
                  <property name="cursor">
                   <cursorShape>IBeamCursor</cursorShape>
                  </property>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -749,6 +749,19 @@ QString boostPathToQString(const fs::path &path)
     return QString::fromStdString(path.string());
 }
 
+QString ConnectionTypeToQString(ConnectionType conn_type)
+{
+    switch (conn_type) {
+    case ConnectionType::INBOUND: return QObject::tr("Inbound");
+    case ConnectionType::OUTBOUND_FULL_RELAY: return QObject::tr("Outbound Full Relay");
+    case ConnectionType::BLOCK_RELAY: return QObject::tr("Outbound Block Relay");
+    case ConnectionType::MANUAL: return QObject::tr("Outbound Manual");
+    case ConnectionType::FEELER: return QObject::tr("Outbound Feeler");
+    case ConnectionType::ADDR_FETCH: return QObject::tr("Outbound Address Fetch");
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
+}
+
 QString formatDurationStr(int secs)
 {
     QStringList strList;

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -7,6 +7,7 @@
 
 #include <amount.h>
 #include <fs.h>
+#include <net.h>
 
 #include <QEvent>
 #include <QHeaderView>
@@ -223,6 +224,9 @@ namespace GUIUtil
 
     /* Convert OS specific boost path to QString through UTF-8 */
     QString boostPathToQString(const fs::path &path);
+
+    /** Convert ConnectionType enum to QString */
+    QString ConnectionTypeToQString(ConnectionType conn_type);
 
     /* Convert seconds into a QString with days, hours, mins, secs */
     QString formatDurationStr(int secs);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1108,7 +1108,8 @@ void RPCConsole::updateDetailWidget()
     ui->timeoffset->setText(GUIUtil::formatTimeOffset(stats->nodeStats.nTimeOffset));
     ui->peerVersion->setText(QString::number(stats->nodeStats.nVersion));
     ui->peerSubversion->setText(QString::fromStdString(stats->nodeStats.cleanSubVer));
-    ui->peerDirection->setText(stats->nodeStats.fInbound ? tr("Inbound") : tr("Outbound"));
+    ui->peerConnectionType->setText(GUIUtil::ConnectionTypeToQString(stats->nodeStats.m_conn_type));
+
     if (stats->nodeStats.m_permissionFlags == PF_NONE) {
         ui->peerPermissions->setText(tr("N/A"));
     } else {

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -496,6 +496,8 @@ RPCConsole::RPCConsole(interfaces::Node& node, const PlatformStyle *_platformSty
     clear();
 
     GUIUtil::handleCloseWindowShortcut(this);
+
+    ui->peerConnectionTypeLabel->setToolTip(ui->peerConnectionTypeLabel->toolTip().arg("addnode").arg(QString(nonbreaking_hyphen) + "addnode").arg(QString(nonbreaking_hyphen) + "connect"));
 }
 
 RPCConsole::~RPCConsole()

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -262,7 +262,7 @@ static RPCHelpMan getpeerinfo()
                 recvPerMsgCmd.pushKV(i.first, i.second);
         }
         obj.pushKV("bytesrecv_per_msg", recvPerMsgCmd);
-        obj.pushKV("connection_type", stats.m_conn_type_string);
+        obj.pushKV("connection_type", ConnectionTypeAsString(stats.m_conn_type));
 
         ret.push_back(obj);
     }


### PR DESCRIPTION
This is a migration of https://github.com/bitcoin-core/gui/pull/163 @ [`3707f8c` (#163)](https://github.com/bitcoin-core/gui/pull/163/commits/3707f8c50803a5088159cfc4f229c1e6912b852a) to this repo. The initial version of the pull only changed gui code; however, reviewers suggested changes and refactoring that involve this repo, so I've ported it here. Please see the original pull for the review up to this point. Closes https://github.com/bitcoin-core/gui/issues/159.

 ![Screenshot from 2020-12-25 22-40-09](https://user-images.githubusercontent.com/2415484/103142370-f4098e00-46f9-11eb-8246-81b7a41b693d.jpg)
