### PR TITLE
net: [refactor] Prefer integral types in CNodeStats

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -507,9 +507,9 @@ void CConnman::AddWhitelistPermissionFlags(NetPermissionFlags& flags, const CNet
     }
 }
 
-std::string CNode::ConnectionTypeAsString() const
+std::string ConnectionTypeAsString(ConnectionType conn_type)
 {
-    switch (m_conn_type) {
+    switch (conn_type) {
     case ConnectionType::INBOUND:
         return "inbound";
     case ConnectionType::MANUAL:
@@ -627,7 +627,7 @@ void CNode::copyStats(CNodeStats &stats, const std::vector<bool> &m_asmap)
     CService addrLocalUnlocked = GetAddrLocal();
     stats.addrLocal = addrLocalUnlocked.IsValid() ? addrLocalUnlocked.ToString() : "";
 
-    stats.m_conn_type_string = ConnectionTypeAsString();
+    X(m_conn_type);
 }
 #undef X
 

--- a/src/net.h
+++ b/src/net.h
@@ -180,6 +180,8 @@ enum class ConnectionType {
     ADDR_FETCH,
 };
 
+/** Convert ConnectionType enum to a string value */
+std::string ConnectionTypeAsString(ConnectionType conn_type);
 void Discover();
 void StartMapPort();
 void InterruptMapPort();
@@ -273,9 +275,8 @@ public:
     // Network the peer connected through
     Network m_network;
     uint32_t m_mapped_as;
-    std::string m_conn_type_string;
+    ConnectionType m_conn_type;
 };
-
 
 
 /** Transport protocol agnostic message container.
@@ -765,7 +766,7 @@ public:
     //! Sets the addrName only if it was not previously set
     void MaybeSetAddrName(const std::string& addrNameIn);
 
-    std::string ConnectionTypeAsString() const;
+    std::string ConnectionTypeAsString() const { return ::ConnectionTypeAsString(m_conn_type); }
 
     /** Whether this peer is an inbound onion, e.g. connected via our Tor onion service. */
     bool IsInboundOnion() const { return m_inbound_onion; }

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -249,7 +249,7 @@ static RPCHelpMan getpeerinfo()
                 recvPerMsgCmd.pushKV(i.first, i.second);
         }
         obj.pushKV("bytesrecv_per_msg", recvPerMsgCmd);
-        obj.pushKV("connection_type", stats.m_conn_type_string);
+        obj.pushKV("connection_type", ConnectionTypeAsString(stats.m_conn_type));
 
         ret.push_back(obj);
     }


### PR DESCRIPTION
Currently, strings are stored for what are actually integral (strong) enum types. This is fine, because the strings are only used as-is for the debug log and RPC. However, it complicates using them in the GUI. User facing strings in the GUI should be translated and only string literals can be picked up for translation, not runtime `std::string`s.

Fix that by removing the `std::string` members and replace them by strong enum integral types.