### PR TITLE
policy, refactor: CFeeRate::FromSatB/FromBtcKb named constructors

### DIFF
--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -39,6 +39,8 @@ public:
         // We've previously had bugs creep in from silent double->int conversion...
         static_assert(std::is_integral<I>::value, "CFeeRate should be used without floats");
     }
+    static CFeeRate FromSatB(CAmount fee_rate);
+    static CFeeRate FromBtcKb(CAmount fee_rate);
     /** Constructor for a fee rate in satoshis per kvB (sat/kvB). The size in bytes must not exceed (2^63 - 1).
      *
      *  Passing an nBytes value of COIN (1e8) returns a fee rate in satoshis per vB (sat/vB),
@@ -69,5 +71,11 @@ public:
 
     SERIALIZE_METHODS(CFeeRate, obj) { READWRITE(obj.nSatoshisPerK); }
 };
+
+/** Construct a CFeeRate from a CAmount in sat/vB */
+inline CFeeRate CFeeRate::FromSatB(CAmount fee_rate) { return CFeeRate(fee_rate, COIN); }
+
+/** Construct a CFeeRate from a CAmount in BTC/kvB */
+inline CFeeRate CFeeRate::FromBtcKb(CAmount fee_rate) { return CFeeRate(fee_rate, 1000); }
 
 #endif //  BITCOIN_POLICY_FEERATE_H

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -67,8 +67,12 @@ BOOST_AUTO_TEST_CASE(GetFeeTest)
     feeRate = CFeeRate(1000);
     altFeeRate = CFeeRate(feeRate);
     BOOST_CHECK_EQUAL(feeRate.GetFee(100), altFeeRate.GetFee(100));
+}
 
-    // Check full constructor
+BOOST_AUTO_TEST_CASE(CFeeRateConstructorTest)
+{
+    // Test CFeeRate(CAmount fee_rate, size_t bytes) constructor
+    // full constructor
     BOOST_CHECK(CFeeRate(CAmount(-1), 0) == CFeeRate(0));
     BOOST_CHECK(CFeeRate(CAmount(0), 0) == CFeeRate(0));
     BOOST_CHECK(CFeeRate(CAmount(1), 0) == CFeeRate(0));
@@ -84,6 +88,31 @@ BOOST_AUTO_TEST_CASE(GetFeeTest)
     BOOST_CHECK(CFeeRate(CAmount(27), 789) == CFeeRate(34));
     // Maximum size in bytes, should not crash
     CFeeRate(MAX_MONEY, std::numeric_limits<size_t>::max() >> 1).GetFeePerK();
+}
+
+BOOST_AUTO_TEST_CASE(CFeeRateNamedConstructorsTest)
+{
+    // Test CFeerate(CAmount fee_rate, FeeEstimatemode mode) constructor
+    // with BTC/kvB, returns same values as CFeeRate(amount) or CFeeRate(amount, 1000)
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(-1)) == CFeeRate(-1));
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(-1)) == CFeeRate(-1, 1000));
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(0)) == CFeeRate(0));
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(1)) == CFeeRate(1));
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(1)) == CFeeRate(1, 1000));
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(26)) == CFeeRate(26));
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(26)) == CFeeRate(26, 1000));
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(123)) == CFeeRate(123));
+    BOOST_CHECK(CFeeRate::FromBtcKb(CAmount(123)) == CFeeRate(123, 1000));
+    // with sat/vB, returns values that are 1e5 smaller
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(-100000)) == CFeeRate(-1));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(-99999)) == CFeeRate(0));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(0)) == CFeeRate(0));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(99999)) == CFeeRate(0));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(100000)) == CFeeRate(1));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(100001)) == CFeeRate(1));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(2690000)) == CFeeRate(26));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(123456789)) == CFeeRate(1234));
+    BOOST_CHECK(CFeeRate::FromSatB(CAmount(123456789)) == CFeeRate(1234, 1000));
 }
 
 BOOST_AUTO_TEST_CASE(BinaryOperatorTest)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -216,7 +216,7 @@ static void SetFeeEstimateMode(const CWallet& wallet, CCoinControl& cc, const Un
         if (!estimate_mode.isNull() && estimate_mode.get_str() != "unset") {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot specify both estimate_mode and fee_rate");
         }
-        cc.m_feerate = CFeeRate(AmountFromValue(fee_rate), COIN);
+        cc.m_feerate = CFeeRate::FromSatB(AmountFromValue(fee_rate));
         if (override_min_fee) cc.fOverrideFeeRate = true;
         // Default RBF to true for explicit fee_rate, if unset.
         if (cc.m_signal_bip125_rbf == nullopt) cc.m_signal_bip125_rbf = true;
@@ -2331,8 +2331,8 @@ static RPCHelpMan settxfee()
     LOCK(pwallet->cs_wallet);
 
     CAmount nAmount = AmountFromValue(request.params[0]);
-    CFeeRate tx_fee_rate(nAmount, 1000);
-    CFeeRate max_tx_fee_rate(pwallet->m_default_max_tx_fee, 1000);
+    CFeeRate tx_fee_rate{CFeeRate::FromBtcKb(nAmount)};
+    CFeeRate max_tx_fee_rate{CFeeRate::FromBtcKb(pwallet->m_default_max_tx_fee)};
     if (tx_fee_rate == CFeeRate(0)) {
         // automatic selection
     } else if (tx_fee_rate < pwallet->chain().relayMinFee()) {
@@ -3146,7 +3146,7 @@ void FundTransaction(CWallet* const pwallet, CMutableTransaction& tx, CAmount& f
             if (options.exists("estimate_mode")) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot specify both estimate_mode and feeRate");
             }
-            coinControl.m_feerate = CFeeRate(AmountFromValue(options["feeRate"]));
+            coinControl.m_feerate = CFeeRate::FromBtcKb(AmountFromValue(options["feeRate"]));
             coinControl.fOverrideFeeRate = true;
         }
 


### PR DESCRIPTION
This simple patch is the start of a series of `CFeeRate` refactoring changes and improvements. It contains changes from both #20391 and #20546 as well as a future pull to create `estimatefeerate` in sat/vB. It also resolves feedback in #20305 and #20546 to have a simpler fee rate constructor interface for most needs (BTC/kvB, sat/vB) without exposing CFeeRate internals.