### PR TITLE
p2p: remove unused legacyWhitelisted in AcceptConnection()

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1038,14 +1038,12 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     NetPermissionFlags permissionFlags = NetPermissionFlags::PF_NONE;
     hListenSocket.AddSocketPermissionFlags(permissionFlags);
     AddWhitelistPermissionFlags(permissionFlags, addr);
-    bool legacyWhitelisted = false;
     if (NetPermissions::HasFlag(permissionFlags, NetPermissionFlags::PF_ISIMPLICIT)) {
         NetPermissions::ClearFlag(permissionFlags, PF_ISIMPLICIT);
         if (gArgs.GetBoolArg("-whitelistforcerelay", DEFAULT_WHITELISTFORCERELAY)) NetPermissions::AddFlag(permissionFlags, PF_FORCERELAY);
         if (gArgs.GetBoolArg("-whitelistrelay", DEFAULT_WHITELISTRELAY)) NetPermissions::AddFlag(permissionFlags, PF_RELAY);
         NetPermissions::AddFlag(permissionFlags, PF_MEMPOOL);
         NetPermissions::AddFlag(permissionFlags, PF_NOBAN);
-        legacyWhitelisted = true;
     }
 
     {


### PR DESCRIPTION
Noticed while compiling master:

```
net.cpp: In member function ‘void CConnman::AcceptConnection(const CConnman::ListenSocket&)’:
net.cpp:1041:10: warning: variable ‘legacyWhitelisted’ set but not used [-Wunused-but-set-variable]
 1041 |     bool legacyWhitelisted = false;
      |          ^~~~~~~~~~~~~~~~~
```
