### PR TITLE
consensus: fix maybe uninitialized CTxMemPool::GetIter()

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -880,7 +880,7 @@ Optional<CTxMemPool::txiter> CTxMemPool::GetIter(const uint256& txid) const
 {
     auto it = mapTx.find(txid);
     if (it != mapTx.end()) return it;
-    return Optional<txiter>{};
+    return Optional<txiter>{nullptr};
 }
 
 CTxMemPool::setEntries CTxMemPool::GetIterSet(const std::set<uint256>& hashes) const


### PR DESCRIPTION
Seen while compiling with clang:
```
  CXX      libbitcoin_server_a-validationinterface.o
txmempool.cpp: In member function ‘CTxMemPool::setEntries CTxMemPool::GetIterSet(const std::set<uint256>&)’:
txmempool.cpp:883:29: warning: ‘<anonymous>’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  883 |     return Optional<txiter>{};
```

```
clang --version
clang version 9.0.1
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```