### PR TITLE
Revert "Don't send 'sendaddrv2' to pre-70016 software"

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2353,13 +2353,7 @@ void PeerManager::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDat
         }
 
         // Signal ADDRv2 support (BIP155).
-        if (greatest_common_version >= 70016) {
-            // BIP155 defines addrv2 and sendaddrv2 for all protocol versions, but some
-            // implementations reject messages they don't know. As a courtesy, don't send
-            // it to nodes with a version before 70016, as no software is known to support
-            // BIP155 that doesn't announce at least that protocol version number.
-            m_connman.PushMessage(&pfrom, msg_maker.Make(NetMsgType::SENDADDRV2));
-        }
+        m_connman.PushMessage(&pfrom, msg_maker.Make(NetMsgType::SENDADDRV2));
 
         m_connman.PushMessage(&pfrom, msg_maker.Make(NetMsgType::VERACK));
 


### PR DESCRIPTION
Now that other software projects can handle `sendaddrv2` messages, either by explicitly allowing them or by ignoring unknown messages, the temporary workaround can be removed. See also the mailing list post explaining that `addrv2` is not dependent on a p2p protocol version: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2020-December/018301.html

Some references:

* https://github.com/bitcoin-s/bitcoin-s/pull/2315 (ignores unknown messages)
* https://github.com/bcoin-org/bcoin/blob/master/test/net-test.js#L821(ignores unknown messages)
* https://github.com/btcsuite/btcd/pull/1670 (explicit support for `sendaddrv2`)