### PR TITLE
test: Run rpc_generateblock.py even with wallet disabled

### DIFF
--- a/test/functional/rpc_generateblock.py
+++ b/test/functional/rpc_generateblock.py
@@ -25,9 +25,6 @@ class GenerateBlockTest(BitcoinTestFramework):
         self.log.info('Generate an empty block to address')
         hash = node.generateblock(output=miniwallet.address, transactions=[])['hash']
         block = node.getblock(blockhash=hash, verbose=2)
-        tx = block['tx'][0]
-        utxo = {'txid': tx['txid'], 'vout': 0, 'value': tx['vout'][0]['value']}
-        miniwallet._utxos.append(utxo)
         assert_equal(len(block['tx']), 1)
         assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['addresses'][0], miniwallet.address)
 

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -64,8 +64,8 @@ class MiniWallet:
             index = self._utxos.index(utxo)
         return self._utxos.pop(index)
 
-    def send_self_transfer(self, *, fee_rate=Decimal("0.003"), from_node, utxo_to_spend=None):
-        """Create and send a tx with the specified fee_rate. Fee may be exact or at most one satoshi higher than needed."""
+    def send_self_transfer(self, *, fee_rate=Decimal("0.003"), from_node, utxo_to_spend=None,  submit_tx=True):
+        """Create and optionally send a tx with the specified fee_rate. Fee may be exact or at most one satoshi higher than needed."""
         self._utxos = sorted(self._utxos, key=lambda k: k['value'])
         utxo_to_spend = utxo_to_spend or self._utxos.pop()  # Pick the largest utxo (if none provided) and hope it covers the fee
         vsize = Decimal(96)
@@ -82,7 +82,8 @@ class MiniWallet:
 
         tx_info = from_node.testmempoolaccept([tx_hex])[0]
         self._utxos.append({'txid': tx_info['txid'], 'vout': 0, 'value': send_value})
-        from_node.sendrawtransaction(tx_hex)
+        if submit_tx:
+            from_node.sendrawtransaction(tx_hex)
         assert_equal(tx_info['vsize'], vsize)
         assert_equal(tx_info['fees']['base'], fee)
         return {'txid': tx_info['txid'], 'wtxid': tx_info['wtxid'], 'hex': tx_hex}

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -29,8 +29,8 @@ class MiniWallet:
     def __init__(self, test_node):
         self._test_node = test_node
         self._utxos = []
-        self._address = ADDRESS_BCRT1_P2WSH_OP_TRUE
-        self._scriptPubKey = hex_str_to_bytes(self._test_node.validateaddress(self._address)['scriptPubKey'])
+        self.address = ADDRESS_BCRT1_P2WSH_OP_TRUE
+        self._scriptPubKey = hex_str_to_bytes(self._test_node.validateaddress(self.address)['scriptPubKey'])
 
     def scan_blocks(self, *, start=1, num):
         """Scan the blocks for self._address outputs and add them to self._utxos"""
@@ -43,7 +43,7 @@ class MiniWallet:
 
     def generate(self, num_blocks):
         """Generate blocks with coinbase outputs to the internal address, and append the outputs to the internal list"""
-        blocks = self._test_node.generatetoaddress(num_blocks, self._address)
+        blocks = self._test_node.generatetoaddress(num_blocks, self.address)
         for b in blocks:
             cb_tx = self._test_node.getblock(blockhash=b, verbosity=2)['tx'][0]
             self._utxos.append({'txid': cb_tx['txid'], 'vout': 0, 'value': cb_tx['vout'][0]['value']})


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
This PR enables one more of the non-wallet functional tests (rpc_generateblock.py) to be run even with the Bitcoin Core wallet disabled by using the new MiniWallet instead, as proposed in #20078. 