### PR TITLE
qt: Request Android permissions on APi >= 23

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -66,7 +66,7 @@ Q_IMPORT_PLUGIN(QAndroidPlatformIntegrationPlugin);
 #endif
 
 #if defined (Q_OS_ANDROID)
-#include <QtAndroid>
+#include <QtAndroidExtras/QtAndroid>
 const QVector<QString> permissions({"android.permission.ACCESS_COARSE_LOCATION",
                                     "android.permission.ACCESS_NETWORK_STATE",
                                     "android.permission.ACCESS_WIFI_STATE",

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -541,7 +541,7 @@ int GuiMain(int argc, char* argv[])
                 auto resultHash = QtAndroid::requestPermissionsSync(QStringList({permission}));
                 if(resultHash[permission] == QtAndroid::PermissionResult::Denied){
 					//if(QtAndroid::shouldShowRequestPermissionRationale(permissions)){
-					    QMessageBox::information(this, "Info", "This permission is requested and required for Xequium to work.");
+					    QMessageBox::information(this, "Info", "This permission is requested and required for bitcoin to work.");
 						auto resultHash = QtAndroid::requestPermissionsSync(QStringList({permission}));
 						if(resultHash[permission] == QtAndroid::PermissionResult::Denied)
 							return EXIT_FAILURE;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -67,8 +67,7 @@ Q_IMPORT_PLUGIN(QAndroidPlatformIntegrationPlugin);
 
 #if defined (Q_OS_ANDROID)
 #include <QtAndroidExtras/QtAndroid>
-const QVector<QString> permissions({"android.permission.ACCESS_COARSE_LOCATION",
-                                    "android.permission.ACCESS_NETWORK_STATE",
+const QVector<QString> permissions({"android.permission.ACCESS_NETWORK_STATE",
                                     "android.permission.ACCESS_WIFI_STATE",
                                     "android.permission.BLUETOOTH",
                                     "android.permission.CAMERA",


### PR DESCRIPTION
Starting from Android 6.0 (API 23), users are not asked for permissions at the time of installation rather apps need to request for the permissions at run time. Note : Only the permissions that are defined in the manifest file can be requested at run time.

see :- [Permissions](https://developer.android.com/training/permissions/requesting)
