### PR TITLE
net: Move RecordBytesSent() call out of cs_vSend lock

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1512,16 +1512,10 @@ void CConnman::SocketHandler()
             }
         }
 
-        //
-        // Send
-        //
-        if (sendSet)
-        {
-            LOCK(pnode->cs_vSend);
-            size_t nBytes = SocketSendData(pnode);
-            if (nBytes) {
-                RecordBytesSent(nBytes);
-            }
+        if (sendSet) {
+            // Send data
+            size_t bytes_sent = WITH_LOCK(pnode->cs_vSend, return SocketSendData(pnode));
+            if (bytes_sent) RecordBytesSent(bytes_sent);
         }
 
         InactivityCheck(pnode);

--- a/src/net.h
+++ b/src/net.h
@@ -857,8 +857,10 @@ public:
     // socket
     std::atomic<ServiceFlags> nServices{NODE_NONE};
     SOCKET hSocket GUARDED_BY(cs_hSocket);
-    size_t nSendSize{0}; // total size of all vSendMsg entries
-    size_t nSendOffset{0}; // offset inside the first vSendMsg already sent
+    /** Total size of all vSendMsg entries */
+    size_t nSendSize GUARDED_BY(cs_vSend){0};
+    /** Offset inside the first vSendMsg already sent */
+    size_t nSendOffset GUARDED_BY(cs_vSend){0};
     uint64_t nSendBytes GUARDED_BY(cs_vSend){0};
     std::deque<std::vector<unsigned char>> vSendMsg GUARDED_BY(cs_vSend);
     RecursiveMutex cs_vSend;
@@ -989,7 +991,7 @@ public:
     Network ConnectedThroughNetwork() const;
 
 protected:
-    mapMsgCmdSize mapSendBytesPerMsgCmd;
+    mapMsgCmdSize mapSendBytesPerMsgCmd GUARDED_BY(cs_vSend);
     mapMsgCmdSize mapRecvBytesPerMsgCmd GUARDED_BY(cs_vRecv);
 
 public:


### PR DESCRIPTION
RecordBytesSent() does not require cs_vSend to be locked, so reduce the scope of cs_vSend.

Also correctly annotate the CNode data members that are guarded by cs_vSend.

This is a simpler alternative to #19673.