### PR TITLE
build: Do not set _FORTIFY_SOURCE if it causes compiler warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -832,10 +832,13 @@ if test x$use_hardening != xno; then
   dnl Since FORTIFY_SOURCE is a no-op without optimizations, do not enable it when enable_debug is yes.
   if test x$enable_debug != xyes; then
     AX_CHECK_PREPROC_FLAG([-D_FORTIFY_SOURCE=2],[
-      AX_CHECK_PREPROC_FLAG([-U_FORTIFY_SOURCE],[
-        HARDENED_CPPFLAGS="$HARDENED_CPPFLAGS -U_FORTIFY_SOURCE"
-      ])
-      HARDENED_CPPFLAGS="$HARDENED_CPPFLAGS -D_FORTIFY_SOURCE=2"
+      AX_CHECK_COMPILE_FLAG([-D_FORTIFY_SOURCE=2], [
+        AX_CHECK_PREPROC_FLAG([-U_FORTIFY_SOURCE], [HARDENED_CPPFLAGS="$HARDENED_CPPFLAGS -U_FORTIFY_SOURCE"])
+        HARDENED_CPPFLAGS="$HARDENED_CPPFLAGS -D_FORTIFY_SOURCE=2"
+      ], [], [$CXXFLAG_WERROR], [AC_LANG_SOURCE([[
+        #define _FORTIFY_SOURCE 2
+        #include <memory.h>
+      ]])])
     ])
   fi
 


### PR DESCRIPTION
On master (e75f91eae3936269b40b4bfdfe540d5526270936) passing `CXXFLAGS` variable to the `configure` script causes the default `-O2` optimization flag is not set in the [`AC_PROG_CXX`](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/autoconf.html#index-AC_005fPROG_005fCXX-934) macro:
> If output variable `CXXFLAGS` was not already set, set it to `-g -O2` for the GNU C++ compiler (`-O2` on systems where G++ does not accept `-g`), or `-g` for other compilers.

Such behavior leads to multiple warnings when compiling with clang 11.0 (on Fedora 33):
```
/usr/include/features.h:397:4: warning: _FORTIFY_SOURCE requires compiling with optimization (-O) [-W#warnings]
#  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
   ^
1 warning generated.
```

This PR ensures that `-D_FORTIFY_SOURCE` flag won't cause such warnings.