### PR TITLE
fuzz: Introduce CallOneOf helper to replace switch-case

### DIFF
--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -45,83 +45,71 @@ FUZZ_TARGET_INIT(addrman, initialize_addrman)
         }
     }
     while (fuzzed_data_provider.ConsumeBool()) {
-        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 11)) {
-        case 0: {
-            addr_man.Clear();
-            break;
-        }
-        case 1: {
-            addr_man.ResolveCollisions();
-            break;
-        }
-        case 2: {
-            (void)addr_man.SelectTriedCollision();
-            break;
-        }
-        case 3: {
-            (void)addr_man.Select(fuzzed_data_provider.ConsumeBool());
-            break;
-        }
-        case 4: {
-            (void)addr_man.GetAddr(fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
-            break;
-        }
-        case 5: {
-            const std::optional<CAddress> opt_address = ConsumeDeserializable<CAddress>(fuzzed_data_provider);
-            const std::optional<CNetAddr> opt_net_addr = ConsumeDeserializable<CNetAddr>(fuzzed_data_provider);
-            if (opt_address && opt_net_addr) {
-                addr_man.Add(*opt_address, *opt_net_addr, fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(0, 100000000));
-            }
-            break;
-        }
-        case 6: {
-            std::vector<CAddress> addresses;
-            while (fuzzed_data_provider.ConsumeBool()) {
+        CallOneOf(
+            fuzzed_data_provider,
+            [&] {
+                addr_man.Clear();
+            },
+            [&] {
+                addr_man.ResolveCollisions();
+            },
+            [&] {
+                (void)addr_man.SelectTriedCollision();
+            },
+            [&] {
+                (void)addr_man.Select(fuzzed_data_provider.ConsumeBool());
+            },
+            [&] {
+                (void)addr_man.GetAddr(fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
+            },
+            [&] {
                 const std::optional<CAddress> opt_address = ConsumeDeserializable<CAddress>(fuzzed_data_provider);
-                if (!opt_address) {
-                    break;
+                const std::optional<CNetAddr> opt_net_addr = ConsumeDeserializable<CNetAddr>(fuzzed_data_provider);
+                if (opt_address && opt_net_addr) {
+                    addr_man.Add(*opt_address, *opt_net_addr, fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(0, 100000000));
                 }
-                addresses.push_back(*opt_address);
-            }
-            const std::optional<CNetAddr> opt_net_addr = ConsumeDeserializable<CNetAddr>(fuzzed_data_provider);
-            if (opt_net_addr) {
-                addr_man.Add(addresses, *opt_net_addr, fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(0, 100000000));
-            }
-            break;
-        }
-        case 7: {
-            const std::optional<CService> opt_service = ConsumeDeserializable<CService>(fuzzed_data_provider);
-            if (opt_service) {
-                addr_man.Good(*opt_service, fuzzed_data_provider.ConsumeBool(), ConsumeTime(fuzzed_data_provider));
-            }
-            break;
-        }
-        case 8: {
-            const std::optional<CService> opt_service = ConsumeDeserializable<CService>(fuzzed_data_provider);
-            if (opt_service) {
-                addr_man.Attempt(*opt_service, fuzzed_data_provider.ConsumeBool(), ConsumeTime(fuzzed_data_provider));
-            }
-            break;
-        }
-        case 9: {
-            const std::optional<CService> opt_service = ConsumeDeserializable<CService>(fuzzed_data_provider);
-            if (opt_service) {
-                addr_man.Connected(*opt_service, ConsumeTime(fuzzed_data_provider));
-            }
-            break;
-        }
-        case 10: {
-            const std::optional<CService> opt_service = ConsumeDeserializable<CService>(fuzzed_data_provider);
-            if (opt_service) {
-                addr_man.SetServices(*opt_service, ServiceFlags{fuzzed_data_provider.ConsumeIntegral<uint64_t>()});
-            }
-            break;
-        }
-        case 11: {
-            (void)addr_man.Check();
-            break;
-        }
-        }
+            },
+            [&] {
+                std::vector<CAddress> addresses;
+                while (fuzzed_data_provider.ConsumeBool()) {
+                    const std::optional<CAddress> opt_address = ConsumeDeserializable<CAddress>(fuzzed_data_provider);
+                    if (!opt_address) {
+                        break;
+                    }
+                    addresses.push_back(*opt_address);
+                }
+                const std::optional<CNetAddr> opt_net_addr = ConsumeDeserializable<CNetAddr>(fuzzed_data_provider);
+                if (opt_net_addr) {
+                    addr_man.Add(addresses, *opt_net_addr, fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(0, 100000000));
+                }
+            },
+            [&] {
+                const std::optional<CService> opt_service = ConsumeDeserializable<CService>(fuzzed_data_provider);
+                if (opt_service) {
+                    addr_man.Good(*opt_service, fuzzed_data_provider.ConsumeBool(), ConsumeTime(fuzzed_data_provider));
+                }
+            },
+            [&] {
+                const std::optional<CService> opt_service = ConsumeDeserializable<CService>(fuzzed_data_provider);
+                if (opt_service) {
+                    addr_man.Attempt(*opt_service, fuzzed_data_provider.ConsumeBool(), ConsumeTime(fuzzed_data_provider));
+                }
+            },
+            [&] {
+                const std::optional<CService> opt_service = ConsumeDeserializable<CService>(fuzzed_data_provider);
+                if (opt_service) {
+                    addr_man.Connected(*opt_service, ConsumeTime(fuzzed_data_provider));
+                }
+            },
+            [&] {
+                const std::optional<CService> opt_service = ConsumeDeserializable<CService>(fuzzed_data_provider);
+                if (opt_service) {
+                    addr_man.SetServices(*opt_service, ServiceFlags{fuzzed_data_provider.ConsumeIntegral<uint64_t>()});
+                }
+            },
+            [&] {
+                (void)addr_man.Check();
+            });
     }
     (void)addr_man.size();
     CDataStream data_stream(SER_NETWORK, PROTOCOL_VERSION);

--- a/src/test/fuzz/autofile.cpp
+++ b/src/test/fuzz/autofile.cpp
@@ -21,43 +21,37 @@ FUZZ_TARGET(autofile)
     FuzzedAutoFileProvider fuzzed_auto_file_provider = ConsumeAutoFile(fuzzed_data_provider);
     CAutoFile auto_file = fuzzed_auto_file_provider.open();
     while (fuzzed_data_provider.ConsumeBool()) {
-        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 5)) {
-        case 0: {
-            std::array<uint8_t, 4096> arr{};
-            try {
-                auto_file.read((char*)arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
-            } catch (const std::ios_base::failure&) {
-            }
-            break;
-        }
-        case 1: {
-            const std::array<uint8_t, 4096> arr{};
-            try {
-                auto_file.write((const char*)arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
-            } catch (const std::ios_base::failure&) {
-            }
-            break;
-        }
-        case 2: {
-            try {
-                auto_file.ignore(fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
-            } catch (const std::ios_base::failure&) {
-            }
-            break;
-        }
-        case 3: {
-            auto_file.fclose();
-            break;
-        }
-        case 4: {
-            ReadFromStream(fuzzed_data_provider, auto_file);
-            break;
-        }
-        case 5: {
-            WriteToStream(fuzzed_data_provider, auto_file);
-            break;
-        }
-        }
+        CallOneOf(
+            fuzzed_data_provider,
+            [&] {
+                std::array<uint8_t, 4096> arr{};
+                try {
+                    auto_file.read((char*)arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
+                } catch (const std::ios_base::failure&) {
+                }
+            },
+            [&] {
+                const std::array<uint8_t, 4096> arr{};
+                try {
+                    auto_file.write((const char*)arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
+                } catch (const std::ios_base::failure&) {
+                }
+            },
+            [&] {
+                try {
+                    auto_file.ignore(fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
+                } catch (const std::ios_base::failure&) {
+                }
+            },
+            [&] {
+                auto_file.fclose();
+            },
+            [&] {
+                ReadFromStream(fuzzed_data_provider, auto_file);
+            },
+            [&] {
+                WriteToStream(fuzzed_data_provider, auto_file);
+            });
     }
     (void)auto_file.Get();
     (void)auto_file.GetType();

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -38,51 +38,43 @@ FUZZ_TARGET_INIT(banman, initialize_banman)
     {
         BanMan ban_man{banlist_file, nullptr, ConsumeBanTimeOffset(fuzzed_data_provider)};
         while (fuzzed_data_provider.ConsumeBool()) {
-            switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 11)) {
-            case 0: {
-                ban_man.Ban(ConsumeNetAddr(fuzzed_data_provider),
-                    ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
-                break;
-            }
-            case 1: {
-                ban_man.Ban(ConsumeSubNet(fuzzed_data_provider),
-                    ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
-                break;
-            }
-            case 2: {
-                ban_man.ClearBanned();
-                break;
-            }
-            case 4: {
-                ban_man.IsBanned(ConsumeNetAddr(fuzzed_data_provider));
-                break;
-            }
-            case 5: {
-                ban_man.IsBanned(ConsumeSubNet(fuzzed_data_provider));
-                break;
-            }
-            case 6: {
-                ban_man.Unban(ConsumeNetAddr(fuzzed_data_provider));
-                break;
-            }
-            case 7: {
-                ban_man.Unban(ConsumeSubNet(fuzzed_data_provider));
-                break;
-            }
-            case 8: {
-                banmap_t banmap;
-                ban_man.GetBanned(banmap);
-                break;
-            }
-            case 9: {
-                ban_man.DumpBanlist();
-                break;
-            }
-            case 11: {
-                ban_man.Discourage(ConsumeNetAddr(fuzzed_data_provider));
-                break;
-            }
-            }
+            CallOneOf(
+                fuzzed_data_provider,
+                [&] {
+                    ban_man.Ban(ConsumeNetAddr(fuzzed_data_provider),
+                                ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
+                },
+                [&] {
+                    ban_man.Ban(ConsumeSubNet(fuzzed_data_provider),
+                                ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
+                },
+                [&] {
+                    ban_man.ClearBanned();
+                },
+                [] {},
+                [&] {
+                    ban_man.IsBanned(ConsumeNetAddr(fuzzed_data_provider));
+                },
+                [&] {
+                    ban_man.IsBanned(ConsumeSubNet(fuzzed_data_provider));
+                },
+                [&] {
+                    ban_man.Unban(ConsumeNetAddr(fuzzed_data_provider));
+                },
+                [&] {
+                    ban_man.Unban(ConsumeSubNet(fuzzed_data_provider));
+                },
+                [&] {
+                    banmap_t banmap;
+                    ban_man.GetBanned(banmap);
+                },
+                [&] {
+                    ban_man.DumpBanlist();
+                },
+                [] {},
+                [&] {
+                    ban_man.Discourage(ConsumeNetAddr(fuzzed_data_provider));
+                });
         }
     }
     fs::remove(banlist_file);

--- a/src/test/fuzz/bloom_filter.cpp
+++ b/src/test/fuzz/bloom_filter.cpp
@@ -25,47 +25,43 @@ FUZZ_TARGET(bloom_filter)
         fuzzed_data_provider.ConsumeIntegral<unsigned int>(),
         static_cast<unsigned char>(fuzzed_data_provider.PickValueInArray({BLOOM_UPDATE_NONE, BLOOM_UPDATE_ALL, BLOOM_UPDATE_P2PUBKEY_ONLY, BLOOM_UPDATE_MASK}))};
     while (fuzzed_data_provider.remaining_bytes() > 0) {
-        switch (fuzzed_data_provider.ConsumeIntegralInRange(0, 3)) {
-        case 0: {
-            const std::vector<unsigned char> b = ConsumeRandomLengthByteVector(fuzzed_data_provider);
-            (void)bloom_filter.contains(b);
-            bloom_filter.insert(b);
-            const bool present = bloom_filter.contains(b);
-            assert(present);
-            break;
-        }
-        case 1: {
-            const std::optional<COutPoint> out_point = ConsumeDeserializable<COutPoint>(fuzzed_data_provider);
-            if (!out_point) {
-                break;
-            }
-            (void)bloom_filter.contains(*out_point);
-            bloom_filter.insert(*out_point);
-            const bool present = bloom_filter.contains(*out_point);
-            assert(present);
-            break;
-        }
-        case 2: {
-            const std::optional<uint256> u256 = ConsumeDeserializable<uint256>(fuzzed_data_provider);
-            if (!u256) {
-                break;
-            }
-            (void)bloom_filter.contains(*u256);
-            bloom_filter.insert(*u256);
-            const bool present = bloom_filter.contains(*u256);
-            assert(present);
-            break;
-        }
-        case 3: {
-            const std::optional<CMutableTransaction> mut_tx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
-            if (!mut_tx) {
-                break;
-            }
-            const CTransaction tx{*mut_tx};
-            (void)bloom_filter.IsRelevantAndUpdate(tx);
-            break;
-        }
-        }
+        CallOneOf(
+            fuzzed_data_provider,
+            [&] {
+                const std::vector<unsigned char> b = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+                (void)bloom_filter.contains(b);
+                bloom_filter.insert(b);
+                const bool present = bloom_filter.contains(b);
+                assert(present);
+            },
+            [&] {
+                const std::optional<COutPoint> out_point = ConsumeDeserializable<COutPoint>(fuzzed_data_provider);
+                if (!out_point) {
+                    return;
+                }
+                (void)bloom_filter.contains(*out_point);
+                bloom_filter.insert(*out_point);
+                const bool present = bloom_filter.contains(*out_point);
+                assert(present);
+            },
+            [&] {
+                const std::optional<uint256> u256 = ConsumeDeserializable<uint256>(fuzzed_data_provider);
+                if (!u256) {
+                    return;
+                }
+                (void)bloom_filter.contains(*u256);
+                bloom_filter.insert(*u256);
+                const bool present = bloom_filter.contains(*u256);
+                assert(present);
+            },
+            [&] {
+                const std::optional<CMutableTransaction> mut_tx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+                if (!mut_tx) {
+                    return;
+                }
+                const CTransaction tx{*mut_tx};
+                (void)bloom_filter.IsRelevantAndUpdate(tx);
+            });
         (void)bloom_filter.IsWithinSizeConstraints();
     }
 }

--- a/src/test/fuzz/buffered_file.cpp
+++ b/src/test/fuzz/buffered_file.cpp
@@ -31,41 +31,36 @@ FUZZ_TARGET(buffered_file)
     if (opt_buffered_file && fuzzed_file != nullptr) {
         bool setpos_fail = false;
         while (fuzzed_data_provider.ConsumeBool()) {
-            switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 4)) {
-            case 0: {
-                std::array<uint8_t, 4096> arr{};
-                try {
-                    opt_buffered_file->read((char*)arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
-                } catch (const std::ios_base::failure&) {
-                }
-                break;
-            }
-            case 1: {
-                opt_buffered_file->SetLimit(fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(0, 4096));
-                break;
-            }
-            case 2: {
-                if (!opt_buffered_file->SetPos(fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(0, 4096))) {
-                    setpos_fail = true;
-                }
-                break;
-            }
-            case 3: {
-                if (setpos_fail) {
-                    // Calling FindByte(...) after a failed SetPos(...) call may result in an infinite loop.
-                    break;
-                }
-                try {
-                    opt_buffered_file->FindByte(fuzzed_data_provider.ConsumeIntegral<char>());
-                } catch (const std::ios_base::failure&) {
-                }
-                break;
-            }
-            case 4: {
-                ReadFromStream(fuzzed_data_provider, *opt_buffered_file);
-                break;
-            }
-            }
+            CallOneOf(
+                fuzzed_data_provider,
+                [&] {
+                    std::array<uint8_t, 4096> arr{};
+                    try {
+                        opt_buffered_file->read((char*)arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
+                    } catch (const std::ios_base::failure&) {
+                    }
+                },
+                [&] {
+                    opt_buffered_file->SetLimit(fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(0, 4096));
+                },
+                [&] {
+                    if (!opt_buffered_file->SetPos(fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(0, 4096))) {
+                        setpos_fail = true;
+                    }
+                },
+                [&] {
+                    if (setpos_fail) {
+                        // Calling FindByte(...) after a failed SetPos(...) call may result in an infinite loop.
+                        return;
+                    }
+                    try {
+                        opt_buffered_file->FindByte(fuzzed_data_provider.ConsumeIntegral<char>());
+                    } catch (const std::ios_base::failure&) {
+                    }
+                },
+                [&] {
+                    ReadFromStream(fuzzed_data_provider, *opt_buffered_file);
+                });
         }
         opt_buffered_file->GetPos();
         opt_buffered_file->GetType();

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -50,103 +50,93 @@ FUZZ_TARGET_INIT(coins_view, initialize_coins_view)
     Coin random_coin;
     CMutableTransaction random_mutable_transaction;
     while (fuzzed_data_provider.ConsumeBool()) {
-        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 9)) {
-        case 0: {
-            if (random_coin.IsSpent()) {
-                break;
-            }
-            Coin coin = random_coin;
-            bool expected_code_path = false;
-            const bool possible_overwrite = fuzzed_data_provider.ConsumeBool();
-            try {
-                coins_view_cache.AddCoin(random_out_point, std::move(coin), possible_overwrite);
-                expected_code_path = true;
-            } catch (const std::logic_error& e) {
-                if (e.what() == std::string{"Attempted to overwrite an unspent coin (when possible_overwrite is false)"}) {
-                    assert(!possible_overwrite);
-                    expected_code_path = true;
+        CallOneOf(
+            fuzzed_data_provider,
+            [&] {
+                if (random_coin.IsSpent()) {
+                    return;
                 }
-            }
-            assert(expected_code_path);
-            break;
-        }
-        case 1: {
-            (void)coins_view_cache.Flush();
-            break;
-        }
-        case 2: {
-            coins_view_cache.SetBestBlock(ConsumeUInt256(fuzzed_data_provider));
-            break;
-        }
-        case 3: {
-            Coin move_to;
-            (void)coins_view_cache.SpendCoin(random_out_point, fuzzed_data_provider.ConsumeBool() ? &move_to : nullptr);
-            break;
-        }
-        case 4: {
-            coins_view_cache.Uncache(random_out_point);
-            break;
-        }
-        case 5: {
-            if (fuzzed_data_provider.ConsumeBool()) {
-                backend_coins_view = CCoinsView{};
-            }
-            coins_view_cache.SetBackend(backend_coins_view);
-            break;
-        }
-        case 6: {
-            const std::optional<COutPoint> opt_out_point = ConsumeDeserializable<COutPoint>(fuzzed_data_provider);
-            if (!opt_out_point) {
-                break;
-            }
-            random_out_point = *opt_out_point;
-            break;
-        }
-        case 7: {
-            const std::optional<Coin> opt_coin = ConsumeDeserializable<Coin>(fuzzed_data_provider);
-            if (!opt_coin) {
-                break;
-            }
-            random_coin = *opt_coin;
-            break;
-        }
-        case 8: {
-            const std::optional<CMutableTransaction> opt_mutable_transaction = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
-            if (!opt_mutable_transaction) {
-                break;
-            }
-            random_mutable_transaction = *opt_mutable_transaction;
-            break;
-        }
-        case 9: {
-            CCoinsMap coins_map;
-            while (fuzzed_data_provider.ConsumeBool()) {
-                CCoinsCacheEntry coins_cache_entry;
-                coins_cache_entry.flags = fuzzed_data_provider.ConsumeIntegral<unsigned char>();
-                if (fuzzed_data_provider.ConsumeBool()) {
-                    coins_cache_entry.coin = random_coin;
-                } else {
-                    const std::optional<Coin> opt_coin = ConsumeDeserializable<Coin>(fuzzed_data_provider);
-                    if (!opt_coin) {
-                        break;
+                Coin coin = random_coin;
+                bool expected_code_path = false;
+                const bool possible_overwrite = fuzzed_data_provider.ConsumeBool();
+                try {
+                    coins_view_cache.AddCoin(random_out_point, std::move(coin), possible_overwrite);
+                    expected_code_path = true;
+                } catch (const std::logic_error& e) {
+                    if (e.what() == std::string{"Attempted to overwrite an unspent coin (when possible_overwrite is false)"}) {
+                        assert(!possible_overwrite);
+                        expected_code_path = true;
                     }
-                    coins_cache_entry.coin = *opt_coin;
                 }
-                coins_map.emplace(random_out_point, std::move(coins_cache_entry));
-            }
-            bool expected_code_path = false;
-            try {
-                coins_view_cache.BatchWrite(coins_map, fuzzed_data_provider.ConsumeBool() ? ConsumeUInt256(fuzzed_data_provider) : coins_view_cache.GetBestBlock());
-                expected_code_path = true;
-            } catch (const std::logic_error& e) {
-                if (e.what() == std::string{"FRESH flag misapplied to coin that exists in parent cache"}) {
+                assert(expected_code_path);
+            },
+            [&] {
+                (void)coins_view_cache.Flush();
+            },
+            [&] {
+                coins_view_cache.SetBestBlock(ConsumeUInt256(fuzzed_data_provider));
+            },
+            [&] {
+                Coin move_to;
+                (void)coins_view_cache.SpendCoin(random_out_point, fuzzed_data_provider.ConsumeBool() ? &move_to : nullptr);
+            },
+            [&] {
+                coins_view_cache.Uncache(random_out_point);
+            },
+            [&] {
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    backend_coins_view = CCoinsView{};
+                }
+                coins_view_cache.SetBackend(backend_coins_view);
+            },
+            [&] {
+                const std::optional<COutPoint> opt_out_point = ConsumeDeserializable<COutPoint>(fuzzed_data_provider);
+                if (!opt_out_point) {
+                    return;
+                }
+                random_out_point = *opt_out_point;
+            },
+            [&] {
+                const std::optional<Coin> opt_coin = ConsumeDeserializable<Coin>(fuzzed_data_provider);
+                if (!opt_coin) {
+                    return;
+                }
+                random_coin = *opt_coin;
+            },
+            [&] {
+                const std::optional<CMutableTransaction> opt_mutable_transaction = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+                if (!opt_mutable_transaction) {
+                    return;
+                }
+                random_mutable_transaction = *opt_mutable_transaction;
+            },
+            [&] {
+                CCoinsMap coins_map;
+                while (fuzzed_data_provider.ConsumeBool()) {
+                    CCoinsCacheEntry coins_cache_entry;
+                    coins_cache_entry.flags = fuzzed_data_provider.ConsumeIntegral<unsigned char>();
+                    if (fuzzed_data_provider.ConsumeBool()) {
+                        coins_cache_entry.coin = random_coin;
+                    } else {
+                        const std::optional<Coin> opt_coin = ConsumeDeserializable<Coin>(fuzzed_data_provider);
+                        if (!opt_coin) {
+                            return;
+                        }
+                        coins_cache_entry.coin = *opt_coin;
+                    }
+                    coins_map.emplace(random_out_point, std::move(coins_cache_entry));
+                }
+                bool expected_code_path = false;
+                try {
+                    coins_view_cache.BatchWrite(coins_map, fuzzed_data_provider.ConsumeBool() ? ConsumeUInt256(fuzzed_data_provider) : coins_view_cache.GetBestBlock());
                     expected_code_path = true;
+                } catch (const std::logic_error& e) {
+                    if (e.what() == std::string{"FRESH flag misapplied to coin that exists in parent cache"}) {
+                        expected_code_path = true;
+                    }
                 }
-            }
-            assert(expected_code_path);
-            break;
-        }
-        }
+                assert(expected_code_path);
+            });
     }
 
     {
@@ -199,97 +189,90 @@ FUZZ_TARGET_INIT(coins_view, initialize_coins_view)
     }
 
     if (fuzzed_data_provider.ConsumeBool()) {
-        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 6)) {
-        case 0: {
-            const CTransaction transaction{random_mutable_transaction};
-            bool is_spent = false;
-            for (const CTxOut& tx_out : transaction.vout) {
-                if (Coin{tx_out, 0, transaction.IsCoinBase()}.IsSpent()) {
-                    is_spent = true;
+        CallOneOf(
+            fuzzed_data_provider,
+            [&] {
+                const CTransaction transaction{random_mutable_transaction};
+                bool is_spent = false;
+                for (const CTxOut& tx_out : transaction.vout) {
+                    if (Coin{tx_out, 0, transaction.IsCoinBase()}.IsSpent()) {
+                        is_spent = true;
+                    }
                 }
-            }
-            if (is_spent) {
-                // Avoid:
-                // coins.cpp:69: void CCoinsViewCache::AddCoin(const COutPoint &, Coin &&, bool): Assertion `!coin.IsSpent()' failed.
-                break;
-            }
-            bool expected_code_path = false;
-            const int height = fuzzed_data_provider.ConsumeIntegral<int>();
-            const bool possible_overwrite = fuzzed_data_provider.ConsumeBool();
-            try {
-                AddCoins(coins_view_cache, transaction, height, possible_overwrite);
-                expected_code_path = true;
-            } catch (const std::logic_error& e) {
-                if (e.what() == std::string{"Attempted to overwrite an unspent coin (when possible_overwrite is false)"}) {
-                    assert(!possible_overwrite);
+                if (is_spent) {
+                    // Avoid:
+                    // coins.cpp:69: void CCoinsViewCache::AddCoin(const COutPoint &, Coin &&, bool): Assertion `!coin.IsSpent()' failed.
+                    return;
+                }
+                bool expected_code_path = false;
+                const int height = fuzzed_data_provider.ConsumeIntegral<int>();
+                const bool possible_overwrite = fuzzed_data_provider.ConsumeBool();
+                try {
+                    AddCoins(coins_view_cache, transaction, height, possible_overwrite);
+                    expected_code_path = true;
+                } catch (const std::logic_error& e) {
+                    if (e.what() == std::string{"Attempted to overwrite an unspent coin (when possible_overwrite is false)"}) {
+                        assert(!possible_overwrite);
+                        expected_code_path = true;
+                    }
+                }
+                assert(expected_code_path);
+            },
+            [&] {
+                (void)AreInputsStandard(CTransaction{random_mutable_transaction}, coins_view_cache, false);
+                (void)AreInputsStandard(CTransaction{random_mutable_transaction}, coins_view_cache, true);
+            },
+            [&] {
+                TxValidationState state;
+                CAmount tx_fee_out;
+                const CTransaction transaction{random_mutable_transaction};
+                if (ContainsSpentInput(transaction, coins_view_cache)) {
+                    // Avoid:
+                    // consensus/tx_verify.cpp:171: bool Consensus::CheckTxInputs(const CTransaction &, TxValidationState &, const CCoinsViewCache &, int, CAmount &): Assertion `!coin.IsSpent()' failed.
+                    return;
+                }
+                try {
+                    (void)Consensus::CheckTxInputs(transaction, state, coins_view_cache, fuzzed_data_provider.ConsumeIntegralInRange<int>(0, std::numeric_limits<int>::max()), tx_fee_out);
+                    assert(MoneyRange(tx_fee_out));
+                } catch (const std::runtime_error&) {
+                }
+            },
+            [&] {
+                const CTransaction transaction{random_mutable_transaction};
+                if (ContainsSpentInput(transaction, coins_view_cache)) {
+                    // Avoid:
+                    // consensus/tx_verify.cpp:130: unsigned int GetP2SHSigOpCount(const CTransaction &, const CCoinsViewCache &): Assertion `!coin.IsSpent()' failed.
+                    return;
+                }
+                (void)GetP2SHSigOpCount(transaction, coins_view_cache);
+            },
+            [&] {
+                const CTransaction transaction{random_mutable_transaction};
+                if (ContainsSpentInput(transaction, coins_view_cache)) {
+                    // Avoid:
+                    // consensus/tx_verify.cpp:130: unsigned int GetP2SHSigOpCount(const CTransaction &, const CCoinsViewCache &): Assertion `!coin.IsSpent()' failed.
+                    return;
+                }
+                const int flags = fuzzed_data_provider.ConsumeIntegral<int>();
+                if (!transaction.vin.empty() && (flags & SCRIPT_VERIFY_WITNESS) != 0 && (flags & SCRIPT_VERIFY_P2SH) == 0) {
+                    // Avoid:
+                    // script/interpreter.cpp:1705: size_t CountWitnessSigOps(const CScript &, const CScript &, const CScriptWitness *, unsigned int): Assertion `(flags & SCRIPT_VERIFY_P2SH) != 0' failed.
+                    return;
+                }
+                (void)GetTransactionSigOpCost(transaction, coins_view_cache, flags);
+            },
+            [&] {
+                CCoinsStats stats;
+                bool expected_code_path = false;
+                try {
+                    (void)GetUTXOStats(&coins_view_cache, stats, CoinStatsHashType::HASH_SERIALIZED);
+                } catch (const std::logic_error&) {
                     expected_code_path = true;
                 }
-            }
-            assert(expected_code_path);
-            break;
-        }
-        case 1: {
-            (void)AreInputsStandard(CTransaction{random_mutable_transaction}, coins_view_cache, false);
-            (void)AreInputsStandard(CTransaction{random_mutable_transaction}, coins_view_cache, true);
-            break;
-        }
-        case 2: {
-            TxValidationState state;
-            CAmount tx_fee_out;
-            const CTransaction transaction{random_mutable_transaction};
-            if (ContainsSpentInput(transaction, coins_view_cache)) {
-                // Avoid:
-                // consensus/tx_verify.cpp:171: bool Consensus::CheckTxInputs(const CTransaction &, TxValidationState &, const CCoinsViewCache &, int, CAmount &): Assertion `!coin.IsSpent()' failed.
-                break;
-            }
-            try {
-                (void)Consensus::CheckTxInputs(transaction, state, coins_view_cache, fuzzed_data_provider.ConsumeIntegralInRange<int>(0, std::numeric_limits<int>::max()), tx_fee_out);
-                assert(MoneyRange(tx_fee_out));
-            } catch (const std::runtime_error&) {
-            }
-            break;
-        }
-        case 3: {
-            const CTransaction transaction{random_mutable_transaction};
-            if (ContainsSpentInput(transaction, coins_view_cache)) {
-                // Avoid:
-                // consensus/tx_verify.cpp:130: unsigned int GetP2SHSigOpCount(const CTransaction &, const CCoinsViewCache &): Assertion `!coin.IsSpent()' failed.
-                break;
-            }
-            (void)GetP2SHSigOpCount(transaction, coins_view_cache);
-            break;
-        }
-        case 4: {
-            const CTransaction transaction{random_mutable_transaction};
-            if (ContainsSpentInput(transaction, coins_view_cache)) {
-                // Avoid:
-                // consensus/tx_verify.cpp:130: unsigned int GetP2SHSigOpCount(const CTransaction &, const CCoinsViewCache &): Assertion `!coin.IsSpent()' failed.
-                break;
-            }
-            const int flags = fuzzed_data_provider.ConsumeIntegral<int>();
-            if (!transaction.vin.empty() && (flags & SCRIPT_VERIFY_WITNESS) != 0 && (flags & SCRIPT_VERIFY_P2SH) == 0) {
-                // Avoid:
-                // script/interpreter.cpp:1705: size_t CountWitnessSigOps(const CScript &, const CScript &, const CScriptWitness *, unsigned int): Assertion `(flags & SCRIPT_VERIFY_P2SH) != 0' failed.
-                break;
-            }
-            (void)GetTransactionSigOpCost(transaction, coins_view_cache, flags);
-            break;
-        }
-        case 5: {
-            CCoinsStats stats;
-            bool expected_code_path = false;
-            try {
-                (void)GetUTXOStats(&coins_view_cache, stats, CoinStatsHashType::HASH_SERIALIZED);
-            } catch (const std::logic_error&) {
-                expected_code_path = true;
-            }
-            assert(expected_code_path);
-            break;
-        }
-        case 6: {
-            (void)IsWitnessStandard(CTransaction{random_mutable_transaction}, coins_view_cache);
-            break;
-        }
-        }
+                assert(expected_code_path);
+            },
+            [&] {
+                (void)IsWitnessStandard(CTransaction{random_mutable_transaction}, coins_view_cache);
+            });
     }
 }

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -32,108 +32,104 @@ FUZZ_TARGET_INIT(connman, initialize_connman)
     CSubNet random_subnet;
     std::string random_string;
     while (fuzzed_data_provider.ConsumeBool()) {
-        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 27)) {
-        case 0:
-            random_address = ConsumeAddress(fuzzed_data_provider);
-            break;
-        case 1:
-            random_netaddr = ConsumeNetAddr(fuzzed_data_provider);
-            break;
-        case 2:
-            random_service = ConsumeService(fuzzed_data_provider);
-            break;
-        case 3:
-            random_subnet = ConsumeSubNet(fuzzed_data_provider);
-            break;
-        case 4:
-            random_string = fuzzed_data_provider.ConsumeRandomLengthString(64);
-            break;
-        case 5: {
-            std::vector<CAddress> addresses;
-            while (fuzzed_data_provider.ConsumeBool()) {
-                addresses.push_back(ConsumeAddress(fuzzed_data_provider));
-            }
-            // Limit nTimePenalty to int32_t to avoid signed integer overflow
-            (void)connman.AddNewAddresses(addresses, ConsumeAddress(fuzzed_data_provider), fuzzed_data_provider.ConsumeIntegral<int32_t>());
-            break;
-        }
-        case 6:
-            connman.AddNode(random_string);
-            break;
-        case 7:
-            connman.CheckIncomingNonce(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
-            break;
-        case 8:
-            connman.DisconnectNode(fuzzed_data_provider.ConsumeIntegral<NodeId>());
-            break;
-        case 9:
-            connman.DisconnectNode(random_netaddr);
-            break;
-        case 10:
-            connman.DisconnectNode(random_string);
-            break;
-        case 11:
-            connman.DisconnectNode(random_subnet);
-            break;
-        case 12:
-            connman.ForEachNode([](auto) {});
-            break;
-        case 13:
-            connman.ForEachNodeThen([](auto) {}, []() {});
-            break;
-        case 14:
-            (void)connman.ForNode(fuzzed_data_provider.ConsumeIntegral<NodeId>(), [&](auto) { return fuzzed_data_provider.ConsumeBool(); });
-            break;
-        case 15:
-            (void)connman.GetAddresses(fuzzed_data_provider.ConsumeIntegral<size_t>(), fuzzed_data_provider.ConsumeIntegral<size_t>());
-            break;
-        case 16: {
-            (void)connman.GetAddresses(random_node, fuzzed_data_provider.ConsumeIntegral<size_t>(), fuzzed_data_provider.ConsumeIntegral<size_t>());
-            break;
-        }
-        case 17:
-            (void)connman.GetDeterministicRandomizer(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
-            break;
-        case 18:
-            (void)connman.GetNodeCount(fuzzed_data_provider.PickValueInArray({CConnman::CONNECTIONS_NONE, CConnman::CONNECTIONS_IN, CConnman::CONNECTIONS_OUT, CConnman::CONNECTIONS_ALL}));
-            break;
-        case 19:
-            connman.MarkAddressGood(random_address);
-            break;
-        case 20:
-            (void)connman.OutboundTargetReached(fuzzed_data_provider.ConsumeBool());
-            break;
-        case 21:
-            // Limit now to int32_t to avoid signed integer overflow
-            (void)connman.PoissonNextSendInbound(fuzzed_data_provider.ConsumeIntegral<int32_t>(), fuzzed_data_provider.ConsumeIntegral<int>());
-            break;
-        case 22: {
-            CSerializedNetMsg serialized_net_msg;
-            serialized_net_msg.m_type = fuzzed_data_provider.ConsumeRandomLengthString(CMessageHeader::COMMAND_SIZE);
-            serialized_net_msg.data = ConsumeRandomLengthByteVector(fuzzed_data_provider);
-            connman.PushMessage(&random_node, std::move(serialized_net_msg));
-            break;
-        }
-        case 23:
-            connman.RemoveAddedNode(random_string);
-            break;
-        case 24: {
-            const std::vector<bool> asmap = ConsumeRandomLengthBitVector(fuzzed_data_provider);
-            if (SanityCheckASMap(asmap)) {
-                connman.SetAsmap(asmap);
-            }
-            break;
-        }
-        case 25:
-            connman.SetNetworkActive(fuzzed_data_provider.ConsumeBool());
-            break;
-        case 26:
-            connman.SetServices(random_service, ConsumeWeakEnum(fuzzed_data_provider, ALL_SERVICE_FLAGS));
-            break;
-        case 27:
-            connman.SetTryNewOutboundPeer(fuzzed_data_provider.ConsumeBool());
-            break;
-        }
+        CallOneOf(
+            fuzzed_data_provider,
+            [&] {
+                random_address = ConsumeAddress(fuzzed_data_provider);
+            },
+            [&] {
+                random_netaddr = ConsumeNetAddr(fuzzed_data_provider);
+            },
+            [&] {
+                random_service = ConsumeService(fuzzed_data_provider);
+            },
+            [&] {
+                random_subnet = ConsumeSubNet(fuzzed_data_provider);
+            },
+            [&] {
+                random_string = fuzzed_data_provider.ConsumeRandomLengthString(64);
+            },
+            [&] {
+                std::vector<CAddress> addresses;
+                while (fuzzed_data_provider.ConsumeBool()) {
+                    addresses.push_back(ConsumeAddress(fuzzed_data_provider));
+                }
+                // Limit nTimePenalty to int32_t to avoid signed integer overflow
+                (void)connman.AddNewAddresses(addresses, ConsumeAddress(fuzzed_data_provider), fuzzed_data_provider.ConsumeIntegral<int32_t>());
+            },
+            [&] {
+                connman.AddNode(random_string);
+            },
+            [&] {
+                connman.CheckIncomingNonce(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+            },
+            [&] {
+                connman.DisconnectNode(fuzzed_data_provider.ConsumeIntegral<NodeId>());
+            },
+            [&] {
+                connman.DisconnectNode(random_netaddr);
+            },
+            [&] {
+                connman.DisconnectNode(random_string);
+            },
+            [&] {
+                connman.DisconnectNode(random_subnet);
+            },
+            [&] {
+                connman.ForEachNode([](auto) {});
+            },
+            [&] {
+                connman.ForEachNodeThen([](auto) {}, []() {});
+            },
+            [&] {
+                (void)connman.ForNode(fuzzed_data_provider.ConsumeIntegral<NodeId>(), [&](auto) { return fuzzed_data_provider.ConsumeBool(); });
+            },
+            [&] {
+                (void)connman.GetAddresses(fuzzed_data_provider.ConsumeIntegral<size_t>(), fuzzed_data_provider.ConsumeIntegral<size_t>());
+            },
+            [&] {
+                (void)connman.GetAddresses(random_node, fuzzed_data_provider.ConsumeIntegral<size_t>(), fuzzed_data_provider.ConsumeIntegral<size_t>());
+            },
+            [&] {
+                (void)connman.GetDeterministicRandomizer(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+            },
+            [&] {
+                (void)connman.GetNodeCount(fuzzed_data_provider.PickValueInArray({CConnman::CONNECTIONS_NONE, CConnman::CONNECTIONS_IN, CConnman::CONNECTIONS_OUT, CConnman::CONNECTIONS_ALL}));
+            },
+            [&] {
+                connman.MarkAddressGood(random_address);
+            },
+            [&] {
+                (void)connman.OutboundTargetReached(fuzzed_data_provider.ConsumeBool());
+            },
+            [&] {
+                // Limit now to int32_t to avoid signed integer overflow
+                (void)connman.PoissonNextSendInbound(fuzzed_data_provider.ConsumeIntegral<int32_t>(), fuzzed_data_provider.ConsumeIntegral<int>());
+            },
+            [&] {
+                CSerializedNetMsg serialized_net_msg;
+                serialized_net_msg.m_type = fuzzed_data_provider.ConsumeRandomLengthString(CMessageHeader::COMMAND_SIZE);
+                serialized_net_msg.data = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+                connman.PushMessage(&random_node, std::move(serialized_net_msg));
+            },
+            [&] {
+                connman.RemoveAddedNode(random_string);
+            },
+            [&] {
+                const std::vector<bool> asmap = ConsumeRandomLengthBitVector(fuzzed_data_provider);
+                if (SanityCheckASMap(asmap)) {
+                    connman.SetAsmap(asmap);
+                }
+            },
+            [&] {
+                connman.SetNetworkActive(fuzzed_data_provider.ConsumeBool());
+            },
+            [&] {
+                connman.SetServices(random_service, ConsumeWeakEnum(fuzzed_data_provider, ALL_SERVICE_FLAGS));
+            },
+            [&] {
+                connman.SetTryNewOutboundPeer(fuzzed_data_provider.ConsumeBool());
+            });
     }
     (void)connman.GetAddedNodeInfo();
     (void)connman.GetExtraFullOutboundCount();

--- a/src/test/fuzz/crypto.cpp
+++ b/src/test/fuzz/crypto.cpp
@@ -39,109 +39,95 @@ FUZZ_TARGET(crypto)
     MuHash3072 muhash;
 
     while (fuzzed_data_provider.ConsumeBool()) {
-        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 2)) {
-        case 0: {
-            if (fuzzed_data_provider.ConsumeBool()) {
-                data = ConsumeRandomLengthByteVector(fuzzed_data_provider);
-                if (data.empty()) {
-                    data.resize(fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 4096), fuzzed_data_provider.ConsumeIntegral<uint8_t>());
+        CallOneOf(
+            fuzzed_data_provider,
+            [&] {
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    data = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+                    if (data.empty()) {
+                        data.resize(fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 4096), fuzzed_data_provider.ConsumeIntegral<uint8_t>());
+                    }
                 }
-            }
 
-            (void)hash160.Write(data);
-            (void)hash256.Write(data);
-            (void)hmac_sha256.Write(data.data(), data.size());
-            (void)hmac_sha512.Write(data.data(), data.size());
-            (void)ripemd160.Write(data.data(), data.size());
-            (void)sha1.Write(data.data(), data.size());
-            (void)sha256.Write(data.data(), data.size());
-            (void)sha3.Write(data);
-            (void)sha512.Write(data.data(), data.size());
-            (void)sip_hasher.Write(data.data(), data.size());
+                (void)hash160.Write(data);
+                (void)hash256.Write(data);
+                (void)hmac_sha256.Write(data.data(), data.size());
+                (void)hmac_sha512.Write(data.data(), data.size());
+                (void)ripemd160.Write(data.data(), data.size());
+                (void)sha1.Write(data.data(), data.size());
+                (void)sha256.Write(data.data(), data.size());
+                (void)sha3.Write(data);
+                (void)sha512.Write(data.data(), data.size());
+                (void)sip_hasher.Write(data.data(), data.size());
 
-            (void)Hash(data);
-            (void)Hash160(data);
-            (void)sha512.Size();
+                (void)Hash(data);
+                (void)Hash160(data);
+                (void)sha512.Size();
 
-            if (fuzzed_data_provider.ConsumeBool()) {
-                muhash *= MuHash3072(data);
-            } else {
-                muhash /= MuHash3072(data);
-            }
-            break;
-        }
-        case 1: {
-            (void)hash160.Reset();
-            (void)hash256.Reset();
-            (void)ripemd160.Reset();
-            (void)sha1.Reset();
-            (void)sha256.Reset();
-            (void)sha3.Reset();
-            (void)sha512.Reset();
-            muhash = MuHash3072();
-            break;
-        }
-        case 2: {
-            switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 10)) {
-            case 0: {
-                data.resize(CHash160::OUTPUT_SIZE);
-                hash160.Finalize(data);
-                break;
-            }
-            case 1: {
-                data.resize(CHash256::OUTPUT_SIZE);
-                hash256.Finalize(data);
-                break;
-            }
-            case 2: {
-                data.resize(CHMAC_SHA256::OUTPUT_SIZE);
-                hmac_sha256.Finalize(data.data());
-                break;
-            }
-            case 3: {
-                data.resize(CHMAC_SHA512::OUTPUT_SIZE);
-                hmac_sha512.Finalize(data.data());
-                break;
-            }
-            case 4: {
-                data.resize(CRIPEMD160::OUTPUT_SIZE);
-                ripemd160.Finalize(data.data());
-                break;
-            }
-            case 5: {
-                data.resize(CSHA1::OUTPUT_SIZE);
-                sha1.Finalize(data.data());
-                break;
-            }
-            case 6: {
-                data.resize(CSHA256::OUTPUT_SIZE);
-                sha256.Finalize(data.data());
-                break;
-            }
-            case 7: {
-                data.resize(CSHA512::OUTPUT_SIZE);
-                sha512.Finalize(data.data());
-                break;
-            }
-            case 8: {
-                data.resize(1);
-                data[0] = sip_hasher.Finalize() % 256;
-                break;
-            }
-            case 9: {
-                data.resize(SHA3_256::OUTPUT_SIZE);
-                sha3.Finalize(data);
-                break;
-            }
-            case 10: {
-                uint256 out;
-                muhash.Finalize(out);
-                break;
-            }
-            }
-            break;
-        }
-        }
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    muhash *= MuHash3072(data);
+                } else {
+                    muhash /= MuHash3072(data);
+                }
+            },
+            [&] {
+                (void)hash160.Reset();
+                (void)hash256.Reset();
+                (void)ripemd160.Reset();
+                (void)sha1.Reset();
+                (void)sha256.Reset();
+                (void)sha3.Reset();
+                (void)sha512.Reset();
+                muhash = MuHash3072();
+            },
+            [&] {
+                CallOneOf(
+                    fuzzed_data_provider,
+                    [&] {
+                        data.resize(CHash160::OUTPUT_SIZE);
+                        hash160.Finalize(data);
+                    },
+                    [&] {
+                        data.resize(CHash256::OUTPUT_SIZE);
+                        hash256.Finalize(data);
+                    },
+                    [&] {
+                        data.resize(CHMAC_SHA256::OUTPUT_SIZE);
+                        hmac_sha256.Finalize(data.data());
+                    },
+                    [&] {
+                        data.resize(CHMAC_SHA512::OUTPUT_SIZE);
+                        hmac_sha512.Finalize(data.data());
+                    },
+                    [&] {
+                        data.resize(CRIPEMD160::OUTPUT_SIZE);
+                        ripemd160.Finalize(data.data());
+                    },
+                    [&] {
+                        data.resize(CSHA1::OUTPUT_SIZE);
+                        sha1.Finalize(data.data());
+                    },
+                    [&] {
+                        data.resize(CSHA256::OUTPUT_SIZE);
+                        sha256.Finalize(data.data());
+                    },
+                    [&] {
+                        data.resize(CSHA512::OUTPUT_SIZE);
+                        sha512.Finalize(data.data());
+                    },
+                    [&] {
+                        data.resize(1);
+                        data[0] = sip_hasher.Finalize() % 256;
+                    },
+                    [&] {
+                        data.resize(SHA3_256::OUTPUT_SIZE);
+                        sha3.Finalize(data);
+                    },
+                    [&] {
+                        uint256 out;
+                        muhash.Finalize(out);
+                    });
+            });
     }
     if (fuzzed_data_provider.ConsumeBool()) {
         uint64_t state[25];

--- a/src/test/fuzz/crypto_chacha20.cpp
+++ b/src/test/fuzz/crypto_chacha20.cpp
@@ -20,31 +20,26 @@ FUZZ_TARGET(crypto_chacha20)
         chacha20 = ChaCha20{key.data(), key.size()};
     }
     while (fuzzed_data_provider.ConsumeBool()) {
-        switch (fuzzed_data_provider.ConsumeIntegralInRange(0, 4)) {
-        case 0: {
-            const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(16, 32));
-            chacha20.SetKey(key.data(), key.size());
-            break;
-        }
-        case 1: {
-            chacha20.SetIV(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
-            break;
-        }
-        case 2: {
-            chacha20.Seek(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
-            break;
-        }
-        case 3: {
-            std::vector<uint8_t> output(fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
-            chacha20.Keystream(output.data(), output.size());
-            break;
-        }
-        case 4: {
-            std::vector<uint8_t> output(fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
-            const std::vector<uint8_t> input = ConsumeFixedLengthByteVector(fuzzed_data_provider, output.size());
-            chacha20.Crypt(input.data(), output.data(), input.size());
-            break;
-        }
-        }
+        CallOneOf(
+            fuzzed_data_provider,
+            [&] {
+                const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(16, 32));
+                chacha20.SetKey(key.data(), key.size());
+            },
+            [&] {
+                chacha20.SetIV(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+            },
+            [&] {
+                chacha20.Seek(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+            },
+            [&] {
+                std::vector<uint8_t> output(fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
+                chacha20.Keystream(output.data(), output.size());
+            },
+            [&] {
+                std::vector<uint8_t> output(fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
+                const std::vector<uint8_t> input = ConsumeFixedLengthByteVector(fuzzed_data_provider, output.size());
+                chacha20.Crypt(input.data(), output.data(), input.size());
+            });
     }
 }

--- a/src/test/fuzz/crypto_chacha20_poly1305_aead.cpp
+++ b/src/test/fuzz/crypto_chacha20_poly1305_aead.cpp
@@ -29,44 +29,37 @@ FUZZ_TARGET(crypto_chacha20_poly1305_aead)
     std::vector<uint8_t> out(buffer_size + CHACHA20_POLY1305_AEAD_AAD_LEN + POLY1305_TAGLEN, 0);
     bool is_encrypt = fuzzed_data_provider.ConsumeBool();
     while (fuzzed_data_provider.ConsumeBool()) {
-        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 6)) {
-        case 0: {
-            buffer_size = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(64, 4096);
-            in = std::vector<uint8_t>(buffer_size + CHACHA20_POLY1305_AEAD_AAD_LEN + POLY1305_TAGLEN, 0);
-            out = std::vector<uint8_t>(buffer_size + CHACHA20_POLY1305_AEAD_AAD_LEN + POLY1305_TAGLEN, 0);
-            break;
-        }
-        case 1: {
-            (void)aead.Crypt(seqnr_payload, seqnr_aad, aad_pos, out.data(), out.size(), in.data(), buffer_size, is_encrypt);
-            break;
-        }
-        case 2: {
-            uint32_t len = 0;
-            const bool ok = aead.GetLength(&len, seqnr_aad, aad_pos, in.data());
-            assert(ok);
-            break;
-        }
-        case 3: {
-            seqnr_payload += 1;
-            aad_pos += CHACHA20_POLY1305_AEAD_AAD_LEN;
-            if (aad_pos + CHACHA20_POLY1305_AEAD_AAD_LEN > CHACHA20_ROUND_OUTPUT) {
-                aad_pos = 0;
-                seqnr_aad += 1;
-            }
-            break;
-        }
-        case 4: {
-            seqnr_payload = fuzzed_data_provider.ConsumeIntegral<int>();
-            break;
-        }
-        case 5: {
-            seqnr_aad = fuzzed_data_provider.ConsumeIntegral<int>();
-            break;
-        }
-        case 6: {
-            is_encrypt = fuzzed_data_provider.ConsumeBool();
-            break;
-        }
-        }
+        CallOneOf(
+            fuzzed_data_provider,
+            [&] {
+                buffer_size = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(64, 4096);
+                in = std::vector<uint8_t>(buffer_size + CHACHA20_POLY1305_AEAD_AAD_LEN + POLY1305_TAGLEN, 0);
+                out = std::vector<uint8_t>(buffer_size + CHACHA20_POLY1305_AEAD_AAD_LEN + POLY1305_TAGLEN, 0);
+            },
+            [&] {
+                (void)aead.Crypt(seqnr_payload, seqnr_aad, aad_pos, out.data(), out.size(), in.data(), buffer_size, is_encrypt);
+            },
+            [&] {
+                uint32_t len = 0;
+                const bool ok = aead.GetLength(&len, seqnr_aad, aad_pos, in.data());
+                assert(ok);
+            },
+            [&] {
+                seqnr_payload += 1;
+                aad_pos += CHACHA20_POLY1305_AEAD_AAD_LEN;
+                if (aad_pos + CHACHA20_POLY1305_AEAD_AAD_LEN > CHACHA20_ROUND_OUTPUT) {
+                    aad_pos = 0;
+                    seqnr_aad += 1;
+                }
+            },
+            [&] {
+                seqnr_payload = fuzzed_data_provider.ConsumeIntegral<int>();
+            },
+            [&] {
+                seqnr_aad = fuzzed_data_provider.ConsumeIntegral<int>();
+            },
+            [&] {
+                is_encrypt = fuzzed_data_provider.ConsumeBool();
+            });
     }
 }

--- a/src/test/fuzz/merkleblock.cpp
+++ b/src/test/fuzz/merkleblock.cpp
@@ -17,33 +17,31 @@ FUZZ_TARGET(merkleblock)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     CPartialMerkleTree partial_merkle_tree;
-    switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 1)) {
-    case 0: {
-        const std::optional<CPartialMerkleTree> opt_partial_merkle_tree = ConsumeDeserializable<CPartialMerkleTree>(fuzzed_data_provider);
-        if (opt_partial_merkle_tree) {
-            partial_merkle_tree = *opt_partial_merkle_tree;
-        }
-        break;
-    }
-    case 1: {
-        CMerkleBlock merkle_block;
-        const std::optional<CBlock> opt_block = ConsumeDeserializable<CBlock>(fuzzed_data_provider);
-        CBloomFilter bloom_filter;
-        std::set<uint256> txids;
-        if (opt_block && !opt_block->vtx.empty()) {
-            if (fuzzed_data_provider.ConsumeBool()) {
-                merkle_block = CMerkleBlock{*opt_block, bloom_filter};
-            } else if (fuzzed_data_provider.ConsumeBool()) {
-                while (fuzzed_data_provider.ConsumeBool()) {
-                    txids.insert(ConsumeUInt256(fuzzed_data_provider));
-                }
-                merkle_block = CMerkleBlock{*opt_block, txids};
+    CallOneOf(
+        fuzzed_data_provider,
+        [&] {
+            const std::optional<CPartialMerkleTree> opt_partial_merkle_tree = ConsumeDeserializable<CPartialMerkleTree>(fuzzed_data_provider);
+            if (opt_partial_merkle_tree) {
+                partial_merkle_tree = *opt_partial_merkle_tree;
             }
-        }
-        partial_merkle_tree = merkle_block.txn;
-        break;
-    }
-    }
+        },
+        [&] {
+            CMerkleBlock merkle_block;
+            const std::optional<CBlock> opt_block = ConsumeDeserializable<CBlock>(fuzzed_data_provider);
+            CBloomFilter bloom_filter;
+            std::set<uint256> txids;
+            if (opt_block && !opt_block->vtx.empty()) {
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    merkle_block = CMerkleBlock{*opt_block, bloom_filter};
+                } else if (fuzzed_data_provider.ConsumeBool()) {
+                    while (fuzzed_data_provider.ConsumeBool()) {
+                        txids.insert(ConsumeUInt256(fuzzed_data_provider));
+                    }
+                    merkle_block = CMerkleBlock{*opt_block, txids};
+                }
+            }
+            partial_merkle_tree = merkle_block.txn;
+        });
     (void)partial_merkle_tree.GetNumTransactions();
     std::vector<uint256> matches;
     std::vector<unsigned int> indices;

--- a/src/test/fuzz/policy_estimator.cpp
+++ b/src/test/fuzz/policy_estimator.cpp
@@ -24,46 +24,42 @@ FUZZ_TARGET_INIT(policy_estimator, initialize_policy_estimator)
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     CBlockPolicyEstimator block_policy_estimator;
     while (fuzzed_data_provider.ConsumeBool()) {
-        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 3)) {
-        case 0: {
-            const std::optional<CMutableTransaction> mtx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
-            if (!mtx) {
-                break;
-            }
-            const CTransaction tx{*mtx};
-            block_policy_estimator.processTransaction(ConsumeTxMemPoolEntry(fuzzed_data_provider, tx), fuzzed_data_provider.ConsumeBool());
-            if (fuzzed_data_provider.ConsumeBool()) {
-                (void)block_policy_estimator.removeTx(tx.GetHash(), /* inBlock */ fuzzed_data_provider.ConsumeBool());
-            }
-            break;
-        }
-        case 1: {
-            std::vector<CTxMemPoolEntry> mempool_entries;
-            while (fuzzed_data_provider.ConsumeBool()) {
+        CallOneOf(
+            fuzzed_data_provider,
+            [&] {
                 const std::optional<CMutableTransaction> mtx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
                 if (!mtx) {
-                    break;
+                    return;
                 }
                 const CTransaction tx{*mtx};
-                mempool_entries.push_back(ConsumeTxMemPoolEntry(fuzzed_data_provider, tx));
-            }
-            std::vector<const CTxMemPoolEntry*> ptrs;
-            ptrs.reserve(mempool_entries.size());
-            for (const CTxMemPoolEntry& mempool_entry : mempool_entries) {
-                ptrs.push_back(&mempool_entry);
-            }
-            block_policy_estimator.processBlock(fuzzed_data_provider.ConsumeIntegral<unsigned int>(), ptrs);
-            break;
-        }
-        case 2: {
-            (void)block_policy_estimator.removeTx(ConsumeUInt256(fuzzed_data_provider), /* inBlock */ fuzzed_data_provider.ConsumeBool());
-            break;
-        }
-        case 3: {
-            block_policy_estimator.FlushUnconfirmed();
-            break;
-        }
-        }
+                block_policy_estimator.processTransaction(ConsumeTxMemPoolEntry(fuzzed_data_provider, tx), fuzzed_data_provider.ConsumeBool());
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    (void)block_policy_estimator.removeTx(tx.GetHash(), /* inBlock */ fuzzed_data_provider.ConsumeBool());
+                }
+            },
+            [&] {
+                std::vector<CTxMemPoolEntry> mempool_entries;
+                while (fuzzed_data_provider.ConsumeBool()) {
+                    const std::optional<CMutableTransaction> mtx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+                    if (!mtx) {
+                        break;
+                    }
+                    const CTransaction tx{*mtx};
+                    mempool_entries.push_back(ConsumeTxMemPoolEntry(fuzzed_data_provider, tx));
+                }
+                std::vector<const CTxMemPoolEntry*> ptrs;
+                ptrs.reserve(mempool_entries.size());
+                for (const CTxMemPoolEntry& mempool_entry : mempool_entries) {
+                    ptrs.push_back(&mempool_entry);
+                }
+                block_policy_estimator.processBlock(fuzzed_data_provider.ConsumeIntegral<unsigned int>(), ptrs);
+            },
+            [&] {
+                (void)block_policy_estimator.removeTx(ConsumeUInt256(fuzzed_data_provider), /* inBlock */ fuzzed_data_provider.ConsumeBool());
+            },
+            [&] {
+                block_policy_estimator.FlushUnconfirmed();
+            });
         (void)block_policy_estimator.estimateFee(fuzzed_data_provider.ConsumeIntegral<int>());
         EstimationResult result;
         (void)block_policy_estimator.estimateRawFee(fuzzed_data_provider.ConsumeIntegral<int>(), fuzzed_data_provider.ConsumeFloatingPoint<double>(), fuzzed_data_provider.PickValueInArray({FeeEstimateHorizon::SHORT_HALFLIFE, FeeEstimateHorizon::MED_HALFLIFE, FeeEstimateHorizon::LONG_HALFLIFE}), fuzzed_data_provider.ConsumeBool() ? &result : nullptr);

--- a/src/test/fuzz/rolling_bloom_filter.cpp
+++ b/src/test/fuzz/rolling_bloom_filter.cpp
@@ -22,29 +22,27 @@ FUZZ_TARGET(rolling_bloom_filter)
         fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(1, 1000),
         0.999 / fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(1, std::numeric_limits<unsigned int>::max())};
     while (fuzzed_data_provider.remaining_bytes() > 0) {
-        switch (fuzzed_data_provider.ConsumeIntegralInRange(0, 2)) {
-        case 0: {
-            const std::vector<unsigned char> b = ConsumeRandomLengthByteVector(fuzzed_data_provider);
-            (void)rolling_bloom_filter.contains(b);
-            rolling_bloom_filter.insert(b);
-            const bool present = rolling_bloom_filter.contains(b);
-            assert(present);
-            break;
-        }
-        case 1: {
-            const std::optional<uint256> u256 = ConsumeDeserializable<uint256>(fuzzed_data_provider);
-            if (!u256) {
-                break;
-            }
-            (void)rolling_bloom_filter.contains(*u256);
-            rolling_bloom_filter.insert(*u256);
-            const bool present = rolling_bloom_filter.contains(*u256);
-            assert(present);
-            break;
-        }
-        case 2:
-            rolling_bloom_filter.reset();
-            break;
-        }
+        CallOneOf(
+            fuzzed_data_provider,
+            [&] {
+                const std::vector<unsigned char> b = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+                (void)rolling_bloom_filter.contains(b);
+                rolling_bloom_filter.insert(b);
+                const bool present = rolling_bloom_filter.contains(b);
+                assert(present);
+            },
+            [&] {
+                const std::optional<uint256> u256 = ConsumeDeserializable<uint256>(fuzzed_data_provider);
+                if (!u256) {
+                    return;
+                }
+                (void)rolling_bloom_filter.contains(*u256);
+                rolling_bloom_filter.insert(*u256);
+                const bool present = rolling_bloom_filter.contains(*u256);
+                assert(present);
+            },
+            [&] {
+                rolling_bloom_filter.reset();
+            });
     }
 }

--- a/src/test/fuzz/script_ops.cpp
+++ b/src/test/fuzz/script_ops.cpp
@@ -16,56 +16,53 @@ FUZZ_TARGET(script_ops)
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     CScript script = ConsumeScript(fuzzed_data_provider);
     while (fuzzed_data_provider.remaining_bytes() > 0) {
-        switch (fuzzed_data_provider.ConsumeIntegralInRange(0, 7)) {
-        case 0: {
-            CScript s = ConsumeScript(fuzzed_data_provider);
-            script = std::move(s);
-            break;
-        }
-        case 1: {
-            const CScript& s = ConsumeScript(fuzzed_data_provider);
-            script = s;
-            break;
-        }
-        case 2:
-            script << fuzzed_data_provider.ConsumeIntegral<int64_t>();
-            break;
-        case 3:
-            script << ConsumeOpcodeType(fuzzed_data_provider);
-            break;
-        case 4:
-            script << ConsumeScriptNum(fuzzed_data_provider);
-            break;
-        case 5:
-            script << ConsumeRandomLengthByteVector(fuzzed_data_provider);
-            break;
-        case 6:
-            script.clear();
-            break;
-        case 7: {
-            (void)script.GetSigOpCount(false);
-            (void)script.GetSigOpCount(true);
-            (void)script.GetSigOpCount(script);
-            (void)script.HasValidOps();
-            (void)script.IsPayToScriptHash();
-            (void)script.IsPayToWitnessScriptHash();
-            (void)script.IsPushOnly();
-            (void)script.IsUnspendable();
-            {
-                CScript::const_iterator pc = script.begin();
-                opcodetype opcode;
-                (void)script.GetOp(pc, opcode);
-                std::vector<uint8_t> data;
-                (void)script.GetOp(pc, opcode, data);
-                (void)script.IsPushOnly(pc);
-            }
-            {
-                int version;
-                std::vector<uint8_t> program;
-                (void)script.IsWitnessProgram(version, program);
-            }
-            break;
-        }
-        }
+        CallOneOf(
+            fuzzed_data_provider,
+            [&] {
+                CScript s = ConsumeScript(fuzzed_data_provider);
+                script = std::move(s);
+            },
+            [&] {
+                const CScript& s = ConsumeScript(fuzzed_data_provider);
+                script = s;
+            },
+            [&] {
+                script << fuzzed_data_provider.ConsumeIntegral<int64_t>();
+            },
+            [&] {
+                script << ConsumeOpcodeType(fuzzed_data_provider);
+            },
+            [&] {
+                script << ConsumeScriptNum(fuzzed_data_provider);
+            },
+            [&] {
+                script << ConsumeRandomLengthByteVector(fuzzed_data_provider);
+            },
+            [&] {
+                script.clear();
+            },
+            [&] {
+                (void)script.GetSigOpCount(false);
+                (void)script.GetSigOpCount(true);
+                (void)script.GetSigOpCount(script);
+                (void)script.HasValidOps();
+                (void)script.IsPayToScriptHash();
+                (void)script.IsPayToWitnessScriptHash();
+                (void)script.IsPushOnly();
+                (void)script.IsUnspendable();
+                {
+                    CScript::const_iterator pc = script.begin();
+                    opcodetype opcode;
+                    (void)script.GetOp(pc, opcode);
+                    std::vector<uint8_t> data;
+                    (void)script.GetOp(pc, opcode, data);
+                    (void)script.IsPushOnly(pc);
+                }
+                {
+                    int version;
+                    std::vector<uint8_t> program;
+                    (void)script.IsWitnessProgram(version, program);
+                }
+            });
     }
 }

--- a/src/test/fuzz/scriptnum_ops.cpp
+++ b/src/test/fuzz/scriptnum_ops.cpp
@@ -29,105 +29,99 @@ FUZZ_TARGET(scriptnum_ops)
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     CScriptNum script_num = ConsumeScriptNum(fuzzed_data_provider);
     while (fuzzed_data_provider.remaining_bytes() > 0) {
-        switch (fuzzed_data_provider.ConsumeIntegralInRange(0, 11)) {
-        case 0: {
-            const int64_t i = fuzzed_data_provider.ConsumeIntegral<int64_t>();
-            assert((script_num == i) != (script_num != i));
-            assert((script_num <= i) != (script_num > i));
-            assert((script_num >= i) != (script_num < i));
-            // Avoid signed integer overflow:
-            // script/script.h:264:93: runtime error: signed integer overflow: -2261405121394637306 + -9223372036854775802 cannot be represented in type 'long'
-            if (IsValidAddition(script_num, CScriptNum{i})) {
-                assert((script_num + i) - i == script_num);
-            }
-            // Avoid signed integer overflow:
-            // script/script.h:265:93: runtime error: signed integer overflow: 9223371895120855039 - -9223372036854710486 cannot be represented in type 'long'
-            if (IsValidSubtraction(script_num, CScriptNum{i})) {
-                assert((script_num - i) + i == script_num);
-            }
-            break;
-        }
-        case 1: {
-            const CScriptNum random_script_num = ConsumeScriptNum(fuzzed_data_provider);
-            assert((script_num == random_script_num) != (script_num != random_script_num));
-            assert((script_num <= random_script_num) != (script_num > random_script_num));
-            assert((script_num >= random_script_num) != (script_num < random_script_num));
-            // Avoid signed integer overflow:
-            // script/script.h:264:93: runtime error: signed integer overflow: -9223126527765971126 + -9223372036854756825 cannot be represented in type 'long'
-            if (IsValidAddition(script_num, random_script_num)) {
-                assert((script_num + random_script_num) - random_script_num == script_num);
-            }
-            // Avoid signed integer overflow:
-            // script/script.h:265:93: runtime error: signed integer overflow: 6052837899185946624 - -9223372036854775808 cannot be represented in type 'long'
-            if (IsValidSubtraction(script_num, random_script_num)) {
-                assert((script_num - random_script_num) + random_script_num == script_num);
-            }
-            break;
-        }
-        case 2: {
-            const CScriptNum random_script_num = ConsumeScriptNum(fuzzed_data_provider);
-            if (!IsValidAddition(script_num, random_script_num)) {
-                // Avoid assertion failure:
-                // ./script/script.h:292: CScriptNum &CScriptNum::operator+=(const int64_t &): Assertion `rhs == 0 || (rhs > 0 && m_value <= std::numeric_limits<int64_t>::max() - rhs) || (rhs < 0 && m_value >= std::numeric_limits<int64_t>::min() - rhs)' failed.
-                break;
-            }
-            script_num += random_script_num;
-            break;
-        }
-        case 3: {
-            const CScriptNum random_script_num = ConsumeScriptNum(fuzzed_data_provider);
-            if (!IsValidSubtraction(script_num, random_script_num)) {
-                // Avoid assertion failure:
-                // ./script/script.h:300: CScriptNum &CScriptNum::operator-=(const int64_t &): Assertion `rhs == 0 || (rhs > 0 && m_value >= std::numeric_limits<int64_t>::min() + rhs) || (rhs < 0 && m_value <= std::numeric_limits<int64_t>::max() + rhs)' failed.
-                break;
-            }
-            script_num -= random_script_num;
-            break;
-        }
-        case 4:
-            script_num = script_num & fuzzed_data_provider.ConsumeIntegral<int64_t>();
-            break;
-        case 5:
-            script_num = script_num & ConsumeScriptNum(fuzzed_data_provider);
-            break;
-        case 6:
-            script_num &= ConsumeScriptNum(fuzzed_data_provider);
-            break;
-        case 7:
-            if (script_num == CScriptNum{std::numeric_limits<int64_t>::min()}) {
-                // Avoid assertion failure:
-                // ./script/script.h:279: CScriptNum CScriptNum::operator-() const: Assertion `m_value != std::numeric_limits<int64_t>::min()' failed.
-                break;
-            }
-            script_num = -script_num;
-            break;
-        case 8:
-            script_num = fuzzed_data_provider.ConsumeIntegral<int64_t>();
-            break;
-        case 9: {
-            const int64_t random_integer = fuzzed_data_provider.ConsumeIntegral<int64_t>();
-            if (!IsValidAddition(script_num, CScriptNum{random_integer})) {
-                // Avoid assertion failure:
-                // ./script/script.h:292: CScriptNum &CScriptNum::operator+=(const int64_t &): Assertion `rhs == 0 || (rhs > 0 && m_value <= std::numeric_limits<int64_t>::max() - rhs) || (rhs < 0 && m_value >= std::numeric_limits<int64_t>::min() - rhs)' failed.
-                break;
-            }
-            script_num += random_integer;
-            break;
-        }
-        case 10: {
-            const int64_t random_integer = fuzzed_data_provider.ConsumeIntegral<int64_t>();
-            if (!IsValidSubtraction(script_num, CScriptNum{random_integer})) {
-                // Avoid assertion failure:
-                // ./script/script.h:300: CScriptNum &CScriptNum::operator-=(const int64_t &): Assertion `rhs == 0 || (rhs > 0 && m_value >= std::numeric_limits<int64_t>::min() + rhs) || (rhs < 0 && m_value <= std::numeric_limits<int64_t>::max() + rhs)' failed.
-                break;
-            }
-            script_num -= random_integer;
-            break;
-        }
-        case 11:
-            script_num &= fuzzed_data_provider.ConsumeIntegral<int64_t>();
-            break;
-        }
+        CallOneOf(
+            fuzzed_data_provider,
+            [&] {
+                const int64_t i = fuzzed_data_provider.ConsumeIntegral<int64_t>();
+                assert((script_num == i) != (script_num != i));
+                assert((script_num <= i) != (script_num > i));
+                assert((script_num >= i) != (script_num < i));
+                // Avoid signed integer overflow:
+                // script/script.h:264:93: runtime error: signed integer overflow: -2261405121394637306 + -9223372036854775802 cannot be represented in type 'long'
+                if (IsValidAddition(script_num, CScriptNum{i})) {
+                    assert((script_num + i) - i == script_num);
+                }
+                // Avoid signed integer overflow:
+                // script/script.h:265:93: runtime error: signed integer overflow: 9223371895120855039 - -9223372036854710486 cannot be represented in type 'long'
+                if (IsValidSubtraction(script_num, CScriptNum{i})) {
+                    assert((script_num - i) + i == script_num);
+                }
+            },
+            [&] {
+                const CScriptNum random_script_num = ConsumeScriptNum(fuzzed_data_provider);
+                assert((script_num == random_script_num) != (script_num != random_script_num));
+                assert((script_num <= random_script_num) != (script_num > random_script_num));
+                assert((script_num >= random_script_num) != (script_num < random_script_num));
+                // Avoid signed integer overflow:
+                // script/script.h:264:93: runtime error: signed integer overflow: -9223126527765971126 + -9223372036854756825 cannot be represented in type 'long'
+                if (IsValidAddition(script_num, random_script_num)) {
+                    assert((script_num + random_script_num) - random_script_num == script_num);
+                }
+                // Avoid signed integer overflow:
+                // script/script.h:265:93: runtime error: signed integer overflow: 6052837899185946624 - -9223372036854775808 cannot be represented in type 'long'
+                if (IsValidSubtraction(script_num, random_script_num)) {
+                    assert((script_num - random_script_num) + random_script_num == script_num);
+                }
+            },
+            [&] {
+                const CScriptNum random_script_num = ConsumeScriptNum(fuzzed_data_provider);
+                if (!IsValidAddition(script_num, random_script_num)) {
+                    // Avoid assertion failure:
+                    // ./script/script.h:292: CScriptNum &CScriptNum::operator+=(const int64_t &): Assertion `rhs == 0 || (rhs > 0 && m_value <= std::numeric_limits<int64_t>::max() - rhs) || (rhs < 0 && m_value >= std::numeric_limits<int64_t>::min() - rhs)' failed.
+                    return;
+                }
+                script_num += random_script_num;
+            },
+            [&] {
+                const CScriptNum random_script_num = ConsumeScriptNum(fuzzed_data_provider);
+                if (!IsValidSubtraction(script_num, random_script_num)) {
+                    // Avoid assertion failure:
+                    // ./script/script.h:300: CScriptNum &CScriptNum::operator-=(const int64_t &): Assertion `rhs == 0 || (rhs > 0 && m_value >= std::numeric_limits<int64_t>::min() + rhs) || (rhs < 0 && m_value <= std::numeric_limits<int64_t>::max() + rhs)' failed.
+                    return;
+                }
+                script_num -= random_script_num;
+            },
+            [&] {
+                script_num = script_num & fuzzed_data_provider.ConsumeIntegral<int64_t>();
+            },
+            [&] {
+                script_num = script_num & ConsumeScriptNum(fuzzed_data_provider);
+            },
+            [&] {
+                script_num &= ConsumeScriptNum(fuzzed_data_provider);
+            },
+            [&] {
+                if (script_num == CScriptNum{std::numeric_limits<int64_t>::min()}) {
+                    // Avoid assertion failure:
+                    // ./script/script.h:279: CScriptNum CScriptNum::operator-() const: Assertion `m_value != std::numeric_limits<int64_t>::min()' failed.
+                    return;
+                }
+                script_num = -script_num;
+            },
+            [&] {
+                script_num = fuzzed_data_provider.ConsumeIntegral<int64_t>();
+            },
+            [&] {
+                const int64_t random_integer = fuzzed_data_provider.ConsumeIntegral<int64_t>();
+                if (!IsValidAddition(script_num, CScriptNum{random_integer})) {
+                    // Avoid assertion failure:
+                    // ./script/script.h:292: CScriptNum &CScriptNum::operator+=(const int64_t &): Assertion `rhs == 0 || (rhs > 0 && m_value <= std::numeric_limits<int64_t>::max() - rhs) || (rhs < 0 && m_value >= std::numeric_limits<int64_t>::min() - rhs)' failed.
+                    return;
+                }
+                script_num += random_integer;
+            },
+            [&] {
+                const int64_t random_integer = fuzzed_data_provider.ConsumeIntegral<int64_t>();
+                if (!IsValidSubtraction(script_num, CScriptNum{random_integer})) {
+                    // Avoid assertion failure:
+                    // ./script/script.h:300: CScriptNum &CScriptNum::operator-=(const int64_t &): Assertion `rhs == 0 || (rhs > 0 && m_value >= std::numeric_limits<int64_t>::min() + rhs) || (rhs < 0 && m_value <= std::numeric_limits<int64_t>::max() + rhs)' failed.
+                    return;
+                }
+                script_num -= random_integer;
+            },
+            [&] {
+                script_num &= fuzzed_data_provider.ConsumeIntegral<int64_t>();
+            });
         (void)script_num.getint();
         (void)script_num.getvch();
     }

--- a/src/test/fuzz/strprintf.cpp
+++ b/src/test/fuzz/strprintf.cpp
@@ -4,6 +4,7 @@
 
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
 #include <tinyformat.h>
 #include <util/strencodings.h>
 #include <util/translation.h>
@@ -109,32 +110,32 @@ FUZZ_TARGET(str_printf)
     }
 
     try {
-        switch (fuzzed_data_provider.ConsumeIntegralInRange(0, 5)) {
-        case 0:
-            (void)strprintf(format_string, fuzzed_data_provider.ConsumeRandomLengthString(32));
-            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeRandomLengthString(32));
-            break;
-        case 1:
-            (void)strprintf(format_string, fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
-            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
-            break;
-        case 2:
-            (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<signed char>());
-            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<signed char>());
-            break;
-        case 3:
-            (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<unsigned char>());
-            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<unsigned char>());
-            break;
-        case 4:
-            (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<char>());
-            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<char>());
-            break;
-        case 5:
-            (void)strprintf(format_string, fuzzed_data_provider.ConsumeBool());
-            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeBool());
-            break;
-        }
+        CallOneOf(
+            fuzzed_data_provider,
+            [&] {
+                (void)strprintf(format_string, fuzzed_data_provider.ConsumeRandomLengthString(32));
+                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeRandomLengthString(32));
+            },
+            [&] {
+                (void)strprintf(format_string, fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
+                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
+            },
+            [&] {
+                (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<signed char>());
+                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<signed char>());
+            },
+            [&] {
+                (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<unsigned char>());
+                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<unsigned char>());
+            },
+            [&] {
+                (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<char>());
+                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<char>());
+            },
+            [&] {
+                (void)strprintf(format_string, fuzzed_data_provider.ConsumeBool());
+                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeBool());
+            });
     } catch (const tinyformat::format_error&) {
     }
 
@@ -155,40 +156,40 @@ FUZZ_TARGET(str_printf)
     }
 
     try {
-        switch (fuzzed_data_provider.ConsumeIntegralInRange(0, 7)) {
-        case 0:
-            (void)strprintf(format_string, fuzzed_data_provider.ConsumeFloatingPoint<float>());
-            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeFloatingPoint<float>());
-            break;
-        case 1:
-            (void)strprintf(format_string, fuzzed_data_provider.ConsumeFloatingPoint<double>());
-            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeFloatingPoint<double>());
-            break;
-        case 2:
-            (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<int16_t>());
-            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int16_t>());
-            break;
-        case 3:
-            (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<uint16_t>());
-            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint16_t>());
-            break;
-        case 4:
-            (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<int32_t>());
-            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int32_t>());
-            break;
-        case 5:
-            (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<uint32_t>());
-            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint32_t>());
-            break;
-        case 6:
-            (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<int64_t>());
-            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int64_t>());
-            break;
-        case 7:
-            (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<uint64_t>());
-            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint64_t>());
-            break;
-        }
+        CallOneOf(
+            fuzzed_data_provider,
+            [&] {
+                (void)strprintf(format_string, fuzzed_data_provider.ConsumeFloatingPoint<float>());
+                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeFloatingPoint<float>());
+            },
+            [&] {
+                (void)strprintf(format_string, fuzzed_data_provider.ConsumeFloatingPoint<double>());
+                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeFloatingPoint<double>());
+            },
+            [&] {
+                (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<int16_t>());
+                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int16_t>());
+            },
+            [&] {
+                (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<uint16_t>());
+                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint16_t>());
+            },
+            [&] {
+                (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<int32_t>());
+                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int32_t>());
+            },
+            [&] {
+                (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<uint32_t>());
+                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint32_t>());
+            },
+            [&] {
+                (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<int64_t>());
+                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int64_t>());
+            },
+            [&] {
+                (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+                (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+            });
     } catch (const tinyformat::format_error&) {
     }
 }

--- a/src/test/fuzz/system.cpp
+++ b/src/test/fuzz/system.cpp
@@ -32,71 +32,63 @@ FUZZ_TARGET(system)
     }
 
     while (fuzzed_data_provider.ConsumeBool()) {
-        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 7)) {
-        case 0: {
-            args_manager.SelectConfigNetwork(fuzzed_data_provider.ConsumeRandomLengthString(16));
-            break;
-        }
-        case 1: {
-            args_manager.SoftSetArg(fuzzed_data_provider.ConsumeRandomLengthString(16), fuzzed_data_provider.ConsumeRandomLengthString(16));
-            break;
-        }
-        case 2: {
-            args_manager.ForceSetArg(fuzzed_data_provider.ConsumeRandomLengthString(16), fuzzed_data_provider.ConsumeRandomLengthString(16));
-            break;
-        }
-        case 3: {
-            args_manager.SoftSetBoolArg(fuzzed_data_provider.ConsumeRandomLengthString(16), fuzzed_data_provider.ConsumeBool());
-            break;
-        }
-        case 4: {
-            const OptionsCategory options_category = fuzzed_data_provider.PickValueInArray<OptionsCategory>({OptionsCategory::OPTIONS, OptionsCategory::CONNECTION, OptionsCategory::WALLET, OptionsCategory::WALLET_DEBUG_TEST, OptionsCategory::ZMQ, OptionsCategory::DEBUG_TEST, OptionsCategory::CHAINPARAMS, OptionsCategory::NODE_RELAY, OptionsCategory::BLOCK_CREATION, OptionsCategory::RPC, OptionsCategory::GUI, OptionsCategory::COMMANDS, OptionsCategory::REGISTER_COMMANDS, OptionsCategory::HIDDEN});
-            // Avoid hitting:
-            // util/system.cpp:425: void ArgsManager::AddArg(const std::string &, const std::string &, unsigned int, const OptionsCategory &): Assertion `ret.second' failed.
-            const std::string argument_name = GetArgumentName(fuzzed_data_provider.ConsumeRandomLengthString(16));
-            if (args_manager.GetArgFlags(argument_name) != nullopt) {
-                break;
-            }
-            args_manager.AddArg(argument_name, fuzzed_data_provider.ConsumeRandomLengthString(16), fuzzed_data_provider.ConsumeIntegral<unsigned int>(), options_category);
-            break;
-        }
-        case 5: {
-            // Avoid hitting:
-            // util/system.cpp:425: void ArgsManager::AddArg(const std::string &, const std::string &, unsigned int, const OptionsCategory &): Assertion `ret.second' failed.
-            const std::vector<std::string> names = ConsumeRandomLengthStringVector(fuzzed_data_provider);
-            std::vector<std::string> hidden_arguments;
-            for (const std::string& name : names) {
-                const std::string hidden_argument = GetArgumentName(name);
-                if (args_manager.GetArgFlags(hidden_argument) != nullopt) {
-                    continue;
+        CallOneOf(
+            fuzzed_data_provider,
+            [&] {
+                args_manager.SelectConfigNetwork(fuzzed_data_provider.ConsumeRandomLengthString(16));
+            },
+            [&] {
+                args_manager.SoftSetArg(fuzzed_data_provider.ConsumeRandomLengthString(16), fuzzed_data_provider.ConsumeRandomLengthString(16));
+            },
+            [&] {
+                args_manager.ForceSetArg(fuzzed_data_provider.ConsumeRandomLengthString(16), fuzzed_data_provider.ConsumeRandomLengthString(16));
+            },
+            [&] {
+                args_manager.SoftSetBoolArg(fuzzed_data_provider.ConsumeRandomLengthString(16), fuzzed_data_provider.ConsumeBool());
+            },
+            [&] {
+                const OptionsCategory options_category = fuzzed_data_provider.PickValueInArray<OptionsCategory>({OptionsCategory::OPTIONS, OptionsCategory::CONNECTION, OptionsCategory::WALLET, OptionsCategory::WALLET_DEBUG_TEST, OptionsCategory::ZMQ, OptionsCategory::DEBUG_TEST, OptionsCategory::CHAINPARAMS, OptionsCategory::NODE_RELAY, OptionsCategory::BLOCK_CREATION, OptionsCategory::RPC, OptionsCategory::GUI, OptionsCategory::COMMANDS, OptionsCategory::REGISTER_COMMANDS, OptionsCategory::HIDDEN});
+                // Avoid hitting:
+                // util/system.cpp:425: void ArgsManager::AddArg(const std::string &, const std::string &, unsigned int, const OptionsCategory &): Assertion `ret.second' failed.
+                const std::string argument_name = GetArgumentName(fuzzed_data_provider.ConsumeRandomLengthString(16));
+                if (args_manager.GetArgFlags(argument_name) != nullopt) {
+                    return;
                 }
-                if (std::find(hidden_arguments.begin(), hidden_arguments.end(), hidden_argument) != hidden_arguments.end()) {
-                    continue;
+                args_manager.AddArg(argument_name, fuzzed_data_provider.ConsumeRandomLengthString(16), fuzzed_data_provider.ConsumeIntegral<unsigned int>(), options_category);
+            },
+            [&] {
+                // Avoid hitting:
+                // util/system.cpp:425: void ArgsManager::AddArg(const std::string &, const std::string &, unsigned int, const OptionsCategory &): Assertion `ret.second' failed.
+                const std::vector<std::string> names = ConsumeRandomLengthStringVector(fuzzed_data_provider);
+                std::vector<std::string> hidden_arguments;
+                for (const std::string& name : names) {
+                    const std::string hidden_argument = GetArgumentName(name);
+                    if (args_manager.GetArgFlags(hidden_argument) != nullopt) {
+                        continue;
+                    }
+                    if (std::find(hidden_arguments.begin(), hidden_arguments.end(), hidden_argument) != hidden_arguments.end()) {
+                        continue;
+                    }
+                    hidden_arguments.push_back(hidden_argument);
                 }
-                hidden_arguments.push_back(hidden_argument);
-            }
-            args_manager.AddHiddenArgs(hidden_arguments);
-            break;
-        }
-        case 6: {
-            args_manager.ClearArgs();
-            break;
-        }
-        case 7: {
-            const std::vector<std::string> random_arguments = ConsumeRandomLengthStringVector(fuzzed_data_provider);
-            std::vector<const char*> argv;
-            argv.reserve(random_arguments.size());
-            for (const std::string& random_argument : random_arguments) {
-                argv.push_back(random_argument.c_str());
-            }
-            try {
-                std::string error;
-                (void)args_manager.ParseParameters(argv.size(), argv.data(), error);
-            } catch (const std::logic_error&) {
-            }
-            break;
-        }
-        }
+                args_manager.AddHiddenArgs(hidden_arguments);
+            },
+            [&] {
+                args_manager.ClearArgs();
+            },
+            [&] {
+                const std::vector<std::string> random_arguments = ConsumeRandomLengthStringVector(fuzzed_data_provider);
+                std::vector<const char*> argv;
+                argv.reserve(random_arguments.size());
+                for (const std::string& random_argument : random_arguments) {
+                    argv.push_back(random_argument.c_str());
+                }
+                try {
+                    std::string error;
+                    (void)args_manager.ParseParameters(argv.size(), argv.data(), error);
+                } catch (const std::logic_error&) {
+                }
+            });
     }
 
     const std::string s1 = fuzzed_data_provider.ConsumeRandomLengthString(16);


### PR DESCRIPTION
The current `switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, nn)) { case 0: ... case 1: ... case nn: ...` has several problems:

* It makes it hard to review newly added targets, because it requires manual counting of cases
* It makes it hard to update a target, because updating all case labels is trivial, but tedious to review and causes merge conflicts
* ~~Updating the target raises the question whether the case labels should be preserved to not invalidate the existing fuzz inputs format. Fuzz input format might already change implicitly on every commit, so this isn't something worthwhile to pursue.~~ Edit: This pull doesn't fix this problem.

Fix all issues by adding a new `CallOneOf` helper