### PR TITLE
doc: Corrected Typos in Documentation

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -107,7 +107,7 @@ each_dict_entry_on_separate_line=True
 i18n_comment=
 
 # The i18n function call names. The presence of this function stops
-# reformattting on that line, because the string it has cannot be moved
+# reformatting on that line, because the string it has cannot be moved
 # away from the i18n comment.
 i18n_function_call=
 

--- a/doc/psbt.md
+++ b/doc/psbt.md
@@ -1,4 +1,4 @@
-# PSBT Howto for Bitcoin Core
+# PSBT How-to for Bitcoin Core
 
 Since Bitcoin Core 0.17, an RPC interface exists for Partially Signed Bitcoin
 Transactions (PSBTs, as specified in

--- a/src/bench/nanobench.h
+++ b/src/bench/nanobench.h
@@ -170,7 +170,7 @@ class BigO;
  *    Apart from these tags, it is also possible to use some mathematical operations on the measurement data. The operations
  *    are of the form `{{command(name)}}`.  Currently `name` can be one of `elapsed`, `iterations`. If performance counters
  *    are available (currently only on current Linux systems), you also have `pagefaults`, `cpucycles`,
- *    `contextswitches`, `instructions`, `branchinstructions`, and `branchmisses`. All the measuers (except `iterations`) are
+ *    `contextswitches`, `instructions`, `branchinstructions`, and `branchmisses`. All the measures (except `iterations`) are
  *    provided for a single iteration (so `elapsed` is the time a single iteration took). The following tags are available:
  *
  *    * `{{median(<name>>)}}` Calculate median of a measurement data set, e.g. `{{median(elapsed)}}`.

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -30,7 +30,7 @@ bool DecodeHexBlockHeader(CBlockHeader&, const std::string& hex_header);
 /**
  * Parse a hex string into 256 bits
  * @param[in] strHex a hex-formatted, 64-character string
- * @param[out] result the result of the parasing
+ * @param[out] result the result of the parsing
  * @returns true if successful, false if not
  *
  * @see ParseHashV for an RPC-oriented version of this

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -128,7 +128,7 @@ static bool DecodeTx(CMutableTransaction& tx, const std::vector<unsigned char>& 
 {
     // General strategy:
     // - Decode both with extended serialization (which interprets the 0x0001 tag as a marker for
-    //   the presense of witnesses) and with legacy serialization (which interprets the tag as a
+    //   the presence of witnesses) and with legacy serialization (which interprets the tag as a
     //   0-input 1-output incomplete transaction).
     //   - Restricted by try_no_witness (which disables legacy if false) and try_witness (which
     //     disables extended if false).

--- a/src/crc32c/.ycm_extra_conf.py
+++ b/src/crc32c/.ycm_extra_conf.py
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 """YouCompleteMe configuration that interprets a .clang_complete file.
 
-This module implementes the YouCompleteMe configuration API documented at:
+This module implements the YouCompleteMe configuration API documented at:
 https://github.com/Valloric/ycmd#ycm_extra_confpy-specification
 
 The implementation loads and processes a .clang_complete file, documented at:

--- a/src/leveldb/db/snapshot.h
+++ b/src/leveldb/db/snapshot.h
@@ -25,7 +25,7 @@ class SnapshotImpl : public Snapshot {
   friend class SnapshotList;
 
   // SnapshotImpl is kept in a doubly-linked circular list. The SnapshotList
-  // implementation operates on the next/previous fields direcly.
+  // implementation operates on the next/previous fields directly.
   SnapshotImpl* prev_;
   SnapshotImpl* next_;
 

--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -59,7 +59,7 @@ uint256 CPartialMerkleTree::CalcHash(int height, unsigned int pos, const std::ve
     //if we do not have this assert, we can hit a memory access violation when indexing into vTxid
     assert(vTxid.size() != 0);
     if (height == 0) {
-        // hash at height 0 is the txids themself
+        // hash at height 0 is the txids themselves
         return vTxid[pos];
     } else {
         // calculate left hash

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -64,7 +64,7 @@ struct Peer {
 
     /** Protects block inventory data members */
     Mutex m_block_inv_mutex;
-    /** List of blocks that we'll anounce via an `inv` message.
+    /** List of blocks that we'll announce via an `inv` message.
      * There is no final sorting before sending, as they are always sent
      * immediately and in the order requested. */
     std::vector<uint256> m_blocks_for_inv_relay GUARDED_BY(m_block_inv_mutex);

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -483,7 +483,7 @@ class CSubNet
             READWRITE(obj.network);
             if (obj.network.IsIPv4()) {
                 // Before commit 102867c587f5f7954232fb8ed8e85cda78bb4d32, CSubNet used the last 4 bytes of netmask
-                // to store the relevant bytes for an IPv4 mask. For compatiblity reasons, keep doing so in
+                // to store the relevant bytes for an IPv4 mask. For compatibility reasons, keep doing so in
                 // serialized form.
                 unsigned char dummy[12] = {0};
                 READWRITE(dummy);

--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -127,10 +127,10 @@ void RPCNestedTests::rpcNestedTests()
     QVERIFY_EXCEPTION_THROWN(RPCConsole::RPCExecuteCommandLine(m_node, result, "getblockchaininfo() .\n"), std::runtime_error); //invalid syntax
     QVERIFY_EXCEPTION_THROWN(RPCConsole::RPCExecuteCommandLine(m_node, result, "getblockchaininfo() getblockchaininfo()"), std::runtime_error); //invalid syntax
     (RPCConsole::RPCExecuteCommandLine(m_node, result, "getblockchaininfo(")); //tolerate non closing brackets if we have no arguments
-    (RPCConsole::RPCExecuteCommandLine(m_node, result, "getblockchaininfo()()()")); //tolerate non command brackts
+    (RPCConsole::RPCExecuteCommandLine(m_node, result, "getblockchaininfo()()()")); //tolerate non command brackets
     QVERIFY_EXCEPTION_THROWN(RPCConsole::RPCExecuteCommandLine(m_node, result, "getblockchaininfo(True)"), UniValue); //invalid argument
     QVERIFY_EXCEPTION_THROWN(RPCConsole::RPCExecuteCommandLine(m_node, result, "a(getblockchaininfo(True))"), UniValue); //method not found
-    QVERIFY_EXCEPTION_THROWN(RPCConsole::RPCExecuteCommandLine(m_node, result, "rpcNestedTest abc,,abc"), std::runtime_error); //don't tollerate empty arguments when using ,
-    QVERIFY_EXCEPTION_THROWN(RPCConsole::RPCExecuteCommandLine(m_node, result, "rpcNestedTest(abc,,abc)"), std::runtime_error); //don't tollerate empty arguments when using ,
-    QVERIFY_EXCEPTION_THROWN(RPCConsole::RPCExecuteCommandLine(m_node, result, "rpcNestedTest(abc,,)"), std::runtime_error); //don't tollerate empty arguments when using ,
+    QVERIFY_EXCEPTION_THROWN(RPCConsole::RPCExecuteCommandLine(m_node, result, "rpcNestedTest abc,,abc"), std::runtime_error); //don't tolerate empty arguments when using ,
+    QVERIFY_EXCEPTION_THROWN(RPCConsole::RPCExecuteCommandLine(m_node, result, "rpcNestedTest(abc,,abc)"), std::runtime_error); //don't tolerate empty arguments when using ,
+    QVERIFY_EXCEPTION_THROWN(RPCConsole::RPCExecuteCommandLine(m_node, result, "rpcNestedTest(abc,,)"), std::runtime_error); //don't tolerate empty arguments when using ,
 }

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -152,7 +152,7 @@ WalletModel* WalletController::getOrCreateWallet(std::unique_ptr<interfaces::Wal
 
     connect(wallet_model, &WalletModel::unload, this, [this, wallet_model] {
         // Defer removeAndDeleteWallet when no modal widget is active.
-        // TODO: remove this workaround by removing usage of QDiallog::exec.
+        // TODO: remove this workaround by removing usage of QDialog::exec.
         if (QApplication::activeModalWidget()) {
             connect(qApp, &QApplication::focusWindowChanged, wallet_model, [this, wallet_model]() {
                 if (!QApplication::activeModalWidget()) {

--- a/src/secp256k1/include/secp256k1.h
+++ b/src/secp256k1/include/secp256k1.h
@@ -43,7 +43,7 @@ extern "C" {
  */
 typedef struct secp256k1_context_struct secp256k1_context;
 
-/** Opaque data structure that holds rewritable "scratch space"
+/** Opaque data structure that holds rewriteable "scratch space"
  *
  *  The purpose of this structure is to replace dynamic memory allocations,
  *  because we target architectures where this may not be available. It is

--- a/src/secp256k1/include/secp256k1.h
+++ b/src/secp256k1/include/secp256k1.h
@@ -43,7 +43,7 @@ extern "C" {
  */
 typedef struct secp256k1_context_struct secp256k1_context;
 
-/** Opaque data structure that holds rewriteable "scratch space"
+/** Opaque data structure that holds rewritable "scratch space"
  *
  *  The purpose of this structure is to replace dynamic memory allocations,
  *  because we target architectures where this may not be available. It is

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_too_easy_target)
     BOOST_CHECK(!CheckProofOfWork(hash, nBits, consensus));
 }
 
-BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_biger_hash_than_target)
+BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_bigger_hash_than_target)
 {
     const auto consensus = CreateChainParams(*m_node.args, CBaseChainParams::MAIN)->GetConsensus();
     uint256 hash;

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -37,7 +37,7 @@ public:
     explicit SQLiteBatch(SQLiteDatabase& database);
     ~SQLiteBatch() override { Close(); }
 
-    /* No-op. See commeng on SQLiteDatabase::Flush */
+    /* No-op. See comment on SQLiteDatabase::Flush */
     void Flush() override {}
 
     void Close() override;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -426,7 +426,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 uint256 checksum;
                 ssValue >> checksum;
                 if ((checksum_valid = Hash(vchPrivKey) != checksum)) {
-                    strErr = "Error reading wallet database: Crypted key corrupt";
+                    strErr = "Error reading wallet database: Encrypted key corrupt";
                     return false;
                 }
             }

--- a/test/functional/feature_nulldummy.py
+++ b/test/functional/feature_nulldummy.py
@@ -60,7 +60,7 @@ class NULLDUMMYTest(BitcoinTestFramework):
         self.wit_address = w0.getnewaddress(address_type='p2sh-segwit')
         self.wit_ms_address = wmulti.addmultisigaddress(1, [self.pubkey], '', 'p2sh-segwit')['address']
         if not self.options.descriptors:
-            # Legacy wallets need to import these so that they are watched by the wallet. This is unnecssary (and does not need to be tested) for descriptor wallets
+            # Legacy wallets need to import these so that they are watched by the wallet. This is unnecessary (and does not need to be tested) for descriptor wallets
             wmulti.importaddress(self.ms_address)
             wmulti.importaddress(self.wit_ms_address)
 

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -94,7 +94,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         for node in self.nodes:
             node.invalidateblock(last_block[0])
         # Time-locked transaction is now too immature and has been removed from the mempool
-        # spend_103_1 has been re-orged out of the chain and is back in the mempool
+        # spend_103_1 has been reorged out of the chain and is back in the mempool
         assert_equal(set(self.nodes[0].getrawmempool()), {spend_101_id, spend_102_1_id, spend_103_1_id})
 
         # Use invalidateblock to re-org back and make all those coinbase spends

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -143,7 +143,7 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         }
         # Transactions that do not end up in the mempool
         # tx_orphan_no_fee, because it has too low fee (p2ps[0] is not disconnected for relaying that tx)
-        # tx_orphan_invaid, because it has negative fee (p2ps[1] is disconnected for relaying that tx)
+        # tx_orphan_invalid, because it has negative fee (p2ps[1] is disconnected for relaying that tx)
 
         self.wait_until(lambda: 1 == len(node.getpeerinfo()), timeout=12)  # p2ps[1] is no longer connected
         assert_equal(expected_mempool, set(node.getrawmempool()))


### PR DESCRIPTION
Scanned the whole source code for typing errors and corrected. Added a translation correction.


> If you're going to fix typos, can you please fix all of them as seen in the spelling linter script `test/lint/lint-spelling.sh`, e.g. I believe:
> 
> src/core_read.cpp:131: presense ==> presence
> src/net_processing.h:68: anounce ==> announce
> src/netaddress.h:486: compatiblity ==> compatibility
> src/wallet/walletdb.cpp:429: Crypted ==> Encrypted
> src/test/validation_tests.cpp:78: excercise ==> exercise
> test/functional/feature_nulldummy.py:63: unnecssary ==> unnecessary
> 
> and update `test/lint/lint-spelling.ignore-words.txt` to ignore all of the current false positives.
