### PR TITLE
fuzz: Avoid extraneous copy of input data, using Span<>

### DIFF
--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -30,8 +30,6 @@
 #include <stdint.h>
 #include <unistd.h>
 
-#include <vector>
-
 #include <test/fuzz/fuzz.h>
 
 void initialize_deserialize()
@@ -71,7 +69,7 @@ T Deserialize(CDataStream ds)
 }
 
 template <typename T>
-void DeserializeFromFuzzingInput(const std::vector<uint8_t>& buffer, T& obj, const Optional<int> protocol_version = nullopt)
+void DeserializeFromFuzzingInput(FuzzBufferType buffer, T& obj, const Optional<int> protocol_version = nullopt)
 {
     CDataStream ds(buffer, SER_NETWORK, INIT_PROTO_VERSION);
     if (protocol_version) {

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -59,8 +59,7 @@ static bool read_stdin(std::vector<uint8_t>& data)
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     static const auto& test_one_input = *Assert(g_test_one_input);
-    const std::vector<uint8_t> input(data, data + size);
-    test_one_input(input);
+    test_one_input({data, size});
     return 0;
 }
 

--- a/src/test/fuzz/fuzz.h
+++ b/src/test/fuzz/fuzz.h
@@ -5,12 +5,15 @@
 #ifndef BITCOIN_TEST_FUZZ_FUZZ_H
 #define BITCOIN_TEST_FUZZ_FUZZ_H
 
+#include <span.h>
+
 #include <cstdint>
 #include <functional>
 #include <string_view>
-#include <vector>
 
-using TypeTestOneInput = std::function<void(const std::vector<uint8_t>&)>;
+using FuzzBufferType = Span<const uint8_t>;
+
+using TypeTestOneInput = std::function<void(FuzzBufferType)>;
 using TypeInitialize = std::function<void()>;
 
 void FuzzFrameworkRegisterTarget(std::string_view name, TypeTestOneInput target, TypeInitialize init);
@@ -21,13 +24,13 @@ inline void FuzzFrameworkEmptyFun() {}
     FUZZ_TARGET_INIT(name, FuzzFrameworkEmptyFun)
 
 #define FUZZ_TARGET_INIT(name, init_fun)                                      \
-    void name##_fuzz_target(const std::vector<uint8_t>&);                     \
+    void name##_fuzz_target(FuzzBufferType);                                  \
     struct name##_Before_Main {                                               \
         name##_Before_Main()                                                  \
         {                                                                     \
             FuzzFrameworkRegisterTarget(#name, name##_fuzz_target, init_fun); \
         }                                                                     \
     } const static g_##name##_before_main;                                    \
-    void name##_fuzz_target(const std::vector<uint8_t>& buffer)
+    void name##_fuzz_target(FuzzBufferType buffer)
 
 #endif // BITCOIN_TEST_FUZZ_FUZZ_H

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -30,7 +30,6 @@
 #include <iostream>
 #include <memory>
 #include <string>
-#include <vector>
 
 namespace {
 const TestingSetup* g_setup;
@@ -46,7 +45,7 @@ void initialize_process_message()
     SyncWithValidationInterfaceQueue();
 }
 
-void fuzz_target(const std::vector<uint8_t>& buffer, const std::string& LIMIT_TO_MESSAGE_TYPE)
+void fuzz_target(FuzzBufferType buffer, const std::string& LIMIT_TO_MESSAGE_TYPE)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
 


### PR DESCRIPTION
Seeing speedup here in the fuzz framework part (non-fuzz-target part). Speedup is only visible for input data larger than 100kB.