### PR TITLE
net: Log to net debug in MaybeDiscourageAndDisconnect except for noban and manual peers

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4052,7 +4052,8 @@ bool PeerManagerImpl::MaybeDiscourageAndDisconnect(CNode& pnode, Peer& peer)
     if (pnode.addr.IsLocal()) {
         // We disconnect local peers for bad behavior but don't discourage (since that would discourage
         // all peers on the same local address)
-        LogPrintf("Warning: disconnecting but not discouraging local peer %d!\n", peer.m_id);
+        LogPrint(BCLog::NET, "Warning: disconnecting but not discouraging %s peer %d!\n",
+                 pnode.m_inbound_onion ? "inbound onion" : "local", peer.m_id);
         pnode.fDisconnect = true;
         return true;
     }


### PR DESCRIPTION
The goal is to avoid local peers (e.g. untrusted peers on the local network or inbound onion peers via a local onion proxy) filling the debug log (and thus the disk).