### PR TITLE
[mempool] Remove unnecessary try-block

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5035,15 +5035,9 @@ bool LoadMempool(CTxMemPool& pool)
             pool.PrioritiseTransaction(i.first, i.second);
         }
 
-        // TODO: remove this try except in v0.22
         std::set<uint256> unbroadcast_txids;
-        try {
-          file >> unbroadcast_txids;
-          unbroadcast = unbroadcast_txids.size();
-        } catch (const std::exception&) {
-          // mempool.dat files created prior to v0.21 will not have an
-          // unbroadcast set. No need to log a failure if parsing fails here.
-        }
+        file >> unbroadcast_txids;
+        unbroadcast = unbroadcast_txids.size();
         for (const auto& txid : unbroadcast_txids) {
             // Ensure transactions were accepted to mempool then add to
             // unbroadcast set.


### PR DESCRIPTION
In 0.21, we added unbroadcast txids to mempool.dat (#18038). When users upgraded from 0.21 to 0.22, this would throw a misleading "failed to deserialize mempool data" error even though everything actually loaded properly. So, commit 9c8a55d added a try-block to prevent throwing the error. After upgrading to 0.22, this exception handling is no longer useful, so now we can remove it.