### PR TITLE
BIP 350: Implement Bech32m and use it for v1+ segwit addresses

### DIFF
--- a/contrib/testgen/README.md
+++ b/contrib/testgen/README.md
@@ -4,5 +4,5 @@ Utilities to generate test vectors for the data-driven Bitcoin tests.
 
 Usage:
 
-    PYTHONPATH=../../test/functional/test_framework ./gen_key_io_test_vectors.py valid 50 > ../../src/test/data/key_io_valid.json
-    PYTHONPATH=../../test/functional/test_framework ./gen_key_io_test_vectors.py invalid 50 > ../../src/test/data/key_io_invalid.json
+    PYTHONPATH=../../test/functional/test_framework ./gen_key_io_test_vectors.py valid 70 > ../../src/test/data/key_io_valid.json
+    PYTHONPATH=../../test/functional/test_framework ./gen_key_io_test_vectors.py invalid 70 > ../../src/test/data/key_io_invalid.json

--- a/contrib/testgen/gen_key_io_test_vectors.py
+++ b/contrib/testgen/gen_key_io_test_vectors.py
@@ -3,11 +3,11 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 '''
-Generate valid and invalid base58 address and private key test vectors.
+Generate valid and invalid base58/bech32(m) address and private key test vectors.
 
 Usage:
-    PYTHONPATH=../../test/functional/test_framework ./gen_key_io_test_vectors.py valid 50 > ../../src/test/data/key_io_valid.json
-    PYTHONPATH=../../test/functional/test_framework ./gen_key_io_test_vectors.py invalid 50 > ../../src/test/data/key_io_invalid.json
+    PYTHONPATH=../../test/functional/test_framework ./gen_key_io_test_vectors.py valid 70 > ../../src/test/data/key_io_valid.json
+    PYTHONPATH=../../test/functional/test_framework ./gen_key_io_test_vectors.py invalid 70 > ../../src/test/data/key_io_invalid.json
 '''
 # 2012 Wladimir J. van der Laan
 # Released under MIT License
@@ -56,12 +56,16 @@ templates = [
   ((SCRIPT_ADDRESS,),         20, (),   (False, 'main',    None,  None), script_prefix, script_suffix),
   ((PUBKEY_ADDRESS_TEST,),    20, (),   (False, 'test',    None,  None), pubkey_prefix, pubkey_suffix),
   ((SCRIPT_ADDRESS_TEST,),    20, (),   (False, 'test',    None,  None), script_prefix, script_suffix),
+  ((PUBKEY_ADDRESS_TEST,),    20, (),   (False, 'signet',  None,  None), pubkey_prefix, pubkey_suffix),
+  ((SCRIPT_ADDRESS_TEST,),    20, (),   (False, 'signet',  None,  None), script_prefix, script_suffix),
   ((PUBKEY_ADDRESS_REGTEST,), 20, (),   (False, 'regtest', None,  None), pubkey_prefix, pubkey_suffix),
   ((SCRIPT_ADDRESS_REGTEST,), 20, (),   (False, 'regtest', None,  None), script_prefix, script_suffix),
   ((PRIVKEY,),                32, (),   (True,  'main',    False, None), (),            ()),
   ((PRIVKEY,),                32, (1,), (True,  'main',    True,  None), (),            ()),
   ((PRIVKEY_TEST,),           32, (),   (True,  'test',    False, None), (),            ()),
   ((PRIVKEY_TEST,),           32, (1,), (True,  'test',    True,  None), (),            ()),
+  ((PRIVKEY_TEST,),           32, (),   (True,  'signet',  False, None), (),            ()),
+  ((PRIVKEY_TEST,),           32, (1,), (True,  'signet',  True,  None), (),            ()),
   ((PRIVKEY_REGTEST,),        32, (),   (True,  'regtest', False, None), (),            ()),
   ((PRIVKEY_REGTEST,),        32, (1,), (True,  'regtest', True,  None), (),            ())
 ]
@@ -76,6 +80,10 @@ bech32_templates = [
   ('tb',    0, 32, (False, 'test',    None, True), Encoding.BECH32,  p2wsh_prefix),
   ('tb',    1, 32, (False, 'test',    None, True), Encoding.BECH32M, p2tr_prefix),
   ('tb',    3, 16, (False, 'test',    None, True), Encoding.BECH32M, (OP_3, 16)),
+  ('tb',    0, 20, (False, 'signet',  None, True), Encoding.BECH32,  p2wpkh_prefix),
+  ('tb',    0, 32, (False, 'signet',  None, True), Encoding.BECH32,  p2wsh_prefix),
+  ('tb',    1, 32, (False, 'signet',  None, True), Encoding.BECH32M, p2tr_prefix),
+  ('tb',    3, 32, (False, 'signet',  None, True), Encoding.BECH32M, (OP_3, 32)),
   ('bcrt',  0, 20, (False, 'regtest', None, True), Encoding.BECH32,  p2wpkh_prefix),
   ('bcrt',  0, 32, (False, 'regtest', None, True), Encoding.BECH32,  p2wsh_prefix),
   ('bcrt',  1, 32, (False, 'regtest', None, True), Encoding.BECH32M, p2tr_prefix),

--- a/doc/bips.md
+++ b/doc/bips.md
@@ -1,4 +1,4 @@
-BIPs that are implemented by Bitcoin Core (up-to-date up to **v0.21.0**):
+BIPs that are implemented by Bitcoin Core (up-to-date up to **v22.0**):
 
 * [`BIP 9`](https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki): The changes allowing multiple soft-forks to be deployed in parallel have been implemented since **v0.12.1**  ([PR #7575](https://github.com/bitcoin/bitcoin/pull/7575))
 * [`BIP 11`](https://github.com/bitcoin/bips/blob/master/bip-0011.mediawiki): Multisig outputs are standard since **v0.6.0** ([PR #669](https://github.com/bitcoin/bitcoin/pull/669)).
@@ -50,3 +50,4 @@ BIPs that are implemented by Bitcoin Core (up-to-date up to **v0.21.0**):
 * [`BIP 325`](https://github.com/bitcoin/bips/blob/master/bip-0325.mediawiki): Signet test network is supported as of **v0.21.0** ([PR 18267](https://github.com/bitcoin/bitcoin/pull/18267)).
 * [`BIP 339`](https://github.com/bitcoin/bips/blob/master/bip-0339.mediawiki): Relay of transactions by wtxid is supported as of **v0.21.0** ([PR 18044](https://github.com/bitcoin/bitcoin/pull/18044)).
 * [`BIP 340`](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) [`341`](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki) [`342`](https://github.com/bitcoin/bips/blob/master/bip-0342.mediawiki): Validation rules for Taproot (including Schnorr signatures and Tapscript leaves) are implemented as of **v0.21.0** ([PR 19953](https://github.com/bitcoin/bitcoin/pull/19953)), without mainnet activation.
+* [`BIP 350`](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki): Addresses for native v1+ segregated Witness outputs use Bech32m instead of Bech32 as of **v22.0** ([PR 20861](https://github.com/bitcoin/bitcoin/pull/20861)).

--- a/doc/release-notes-20861.md
+++ b/doc/release-notes-20861.md
@@ -1,0 +1,13 @@
+Updated RPCs
+------------
+
+- Due to [BIP 350](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki)
+  being implemented, behavior for all RPCs that accept addresses is changed when
+  a native witness version 1 (or higher) is passed. These now require a Bech32m
+  encoding instead of a Bech32 one, and Bech32m encoding will be used for such
+  addresses in RPC output as well. No version 1 addresses should be created
+  for mainnet until consensus rules are adopted that give them meaning
+  (e.g. through [BIP 341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki)).
+  Once that happens, Bech32m is expected to be used for them, so this shouldn't
+  affect any production systems, but may be observed on other networks where such
+  addresses already have meaning (like signet).

--- a/src/bech32.cpp
+++ b/src/bech32.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Pieter Wuille
+// Copyright (c) 2017, 2021 Pieter Wuille
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,6 +6,9 @@
 #include <util/vector.h>
 
 #include <assert.h>
+
+namespace bech32
+{
 
 namespace
 {
@@ -26,6 +29,12 @@ const int8_t CHARSET_REV[128] = {
     -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
      1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1
 };
+
+/* Determine the final constant to use for the specified encoding. */
+uint32_t EncodingConstant(Encoding encoding) {
+    assert(encoding == Encoding::BECH32 || encoding == Encoding::BECH32M);
+    return encoding == Encoding::BECH32 ? 1 : 0x2bc830a3;
+}
 
 /** This function will compute what 6 5-bit values to XOR into the last 6 input values, in order to
  *  make the checksum 0. These 6 values are packed together in a single 30-bit integer. The higher
@@ -111,21 +120,24 @@ data ExpandHRP(const std::string& hrp)
 }
 
 /** Verify a checksum. */
-bool VerifyChecksum(const std::string& hrp, const data& values)
+Encoding VerifyChecksum(const std::string& hrp, const data& values)
 {
     // PolyMod computes what value to xor into the final values to make the checksum 0. However,
     // if we required that the checksum was 0, it would be the case that appending a 0 to a valid
     // list of values would result in a new valid list. For that reason, Bech32 requires the
-    // resulting checksum to be 1 instead.
-    return PolyMod(Cat(ExpandHRP(hrp), values)) == 1;
+    // resulting checksum to be 1 instead. In Bech32m, this constant was amended.
+    const uint32_t check = PolyMod(Cat(ExpandHRP(hrp), values));
+    if (check == EncodingConstant(Encoding::BECH32)) return Encoding::BECH32;
+    if (check == EncodingConstant(Encoding::BECH32M)) return Encoding::BECH32M;
+    return Encoding::INVALID;
 }
 
 /** Create a checksum. */
-data CreateChecksum(const std::string& hrp, const data& values)
+data CreateChecksum(Encoding encoding, const std::string& hrp, const data& values)
 {
     data enc = Cat(ExpandHRP(hrp), values);
     enc.resize(enc.size() + 6); // Append 6 zeroes
-    uint32_t mod = PolyMod(enc) ^ 1; // Determine what to XOR into those 6 zeroes.
+    uint32_t mod = PolyMod(enc) ^ EncodingConstant(encoding); // Determine what to XOR into those 6 zeroes.
     data ret(6);
     for (size_t i = 0; i < 6; ++i) {
         // Convert the 5-bit groups in mod to checksum values.
@@ -136,16 +148,13 @@ data CreateChecksum(const std::string& hrp, const data& values)
 
 } // namespace
 
-namespace bech32
-{
-
-/** Encode a Bech32 string. */
-std::string Encode(const std::string& hrp, const data& values) {
+/** Encode a Bech32 or Bech32m string. */
+std::string Encode(Encoding encoding, const std::string& hrp, const data& values) {
     // First ensure that the HRP is all lowercase. BIP-173 requires an encoder
     // to return a lowercase Bech32 string, but if given an uppercase HRP, the
     // result will always be invalid.
     for (const char& c : hrp) assert(c < 'A' || c > 'Z');
-    data checksum = CreateChecksum(hrp, values);
+    data checksum = CreateChecksum(encoding, hrp, values);
     data combined = Cat(values, checksum);
     std::string ret = hrp + '1';
     ret.reserve(ret.size() + combined.size());
@@ -155,8 +164,8 @@ std::string Encode(const std::string& hrp, const data& values) {
     return ret;
 }
 
-/** Decode a Bech32 string. */
-std::pair<std::string, data> Decode(const std::string& str) {
+/** Decode a Bech32 or Bech32m string. */
+DecodeResult Decode(const std::string& str) {
     bool lower = false, upper = false;
     for (size_t i = 0; i < str.size(); ++i) {
         unsigned char c = str[i];
@@ -183,10 +192,9 @@ std::pair<std::string, data> Decode(const std::string& str) {
     for (size_t i = 0; i < pos; ++i) {
         hrp += LowerCase(str[i]);
     }
-    if (!VerifyChecksum(hrp, values)) {
-        return {};
-    }
-    return {hrp, data(values.begin(), values.end() - 6)};
+    Encoding result = VerifyChecksum(hrp, values);
+    if (result == Encoding::INVALID) return {};
+    return {result, std::move(hrp), data(values.begin(), values.end() - 6)};
 }
 
 } // namespace bech32

--- a/src/bech32.cpp
+++ b/src/bech32.cpp
@@ -15,10 +15,10 @@ namespace
 
 typedef std::vector<uint8_t> data;
 
-/** The Bech32 character set for encoding. */
+/** The Bech32 and Bech32m character set for encoding. */
 const char* CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
 
-/** The Bech32 character set for decoding. */
+/** The Bech32 and Bech32m character set for decoding. */
 const int8_t CHARSET_REV[128] = {
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
@@ -150,8 +150,8 @@ data CreateChecksum(Encoding encoding, const std::string& hrp, const data& value
 
 /** Encode a Bech32 or Bech32m string. */
 std::string Encode(Encoding encoding, const std::string& hrp, const data& values) {
-    // First ensure that the HRP is all lowercase. BIP-173 requires an encoder
-    // to return a lowercase Bech32 string, but if given an uppercase HRP, the
+    // First ensure that the HRP is all lowercase. BIP-173 and BIP350 require an encoder
+    // to return a lowercase Bech32/Bech32m string, but if given an uppercase HRP, the
     // result will always be invalid.
     for (const char& c : hrp) assert(c < 'A' || c > 'Z');
     data checksum = CreateChecksum(encoding, hrp, values);

--- a/src/bech32.h
+++ b/src/bech32.h
@@ -2,10 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-// Bech32 is a string encoding format used in newer address types.
-// The output consists of a human-readable part (alphanumeric), a
-// separator character (1), and a base32 data section, the last
-// 6 characters of which are a checksum.
+// Bech32 and Bech32m are string encoding formats used in newer
+// address types. The outputs consist of a human-readable part
+// (alphanumeric), a separator character (1), and a base32 data
+// section, the last 6 characters of which are a checksum. The
+// module is namespaced under bech32 for historical reasons.
 //
 // For more information, see BIP 173 and BIP 350.
 
@@ -40,7 +41,7 @@ struct DecodeResult
     DecodeResult(Encoding enc, std::string&& h, std::vector<uint8_t>&& d) : encoding(enc), hrp(std::move(h)), data(std::move(d)) {}
 };
 
-/** Decode a Bech32 string. */
+/** Decode a Bech32 or Bech32m string. */
 DecodeResult Decode(const std::string& str);
 
 } // namespace bech32

--- a/src/bech32.h
+++ b/src/bech32.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Pieter Wuille
+// Copyright (c) 2017, 2021 Pieter Wuille
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,7 +7,7 @@
 // separator character (1), and a base32 data section, the last
 // 6 characters of which are a checksum.
 //
-// For more information, see BIP 173.
+// For more information, see BIP 173 and BIP 350.
 
 #ifndef BITCOIN_BECH32_H
 #define BITCOIN_BECH32_H
@@ -19,11 +19,29 @@
 namespace bech32
 {
 
-/** Encode a Bech32 string. If hrp contains uppercase characters, this will cause an assertion error. */
-std::string Encode(const std::string& hrp, const std::vector<uint8_t>& values);
+enum class Encoding {
+    INVALID, //!< Failed decoding
 
-/** Decode a Bech32 string. Returns (hrp, data). Empty hrp means failure. */
-std::pair<std::string, std::vector<uint8_t>> Decode(const std::string& str);
+    BECH32,  //!< Bech32 encoding as defined in BIP173
+    BECH32M, //!< Bech32m encoding as defined in BIP350
+};
+
+/** Encode a Bech32 or Bech32m string. If hrp contains uppercase characters, this will cause an
+ *  assertion error. Encoding must be one of BECH32 or BECH32M. */
+std::string Encode(Encoding encoding, const std::string& hrp, const std::vector<uint8_t>& values);
+
+struct DecodeResult
+{
+    Encoding encoding;         //!< What encoding was detected in the result; Encoding::INVALID if failed.
+    std::string hrp;           //!< The human readable part
+    std::vector<uint8_t> data; //!< The payload (excluding checksum)
+
+    DecodeResult() : encoding(Encoding::INVALID) {}
+    DecodeResult(Encoding enc, std::string&& h, std::vector<uint8_t>&& d) : encoding(enc), hrp(std::move(h)), data(std::move(d)) {}
+};
+
+/** Decode a Bech32 string. */
+DecodeResult Decode(const std::string& str);
 
 } // namespace bech32
 

--- a/src/bench/bech32.cpp
+++ b/src/bench/bech32.cpp
@@ -19,7 +19,7 @@ static void Bech32Encode(benchmark::Bench& bench)
     tmp.reserve(1 + 32 * 8 / 5);
     ConvertBits<8, 5, true>([&](unsigned char c) { tmp.push_back(c); }, v.begin(), v.end());
     bench.batch(v.size()).unit("byte").run([&] {
-        bech32::Encode("bc", tmp);
+        bech32::Encode(bech32::Encoding::BECH32, "bc", tmp);
     });
 }
 

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -43,7 +43,7 @@ public:
         std::vector<unsigned char> data = {0};
         data.reserve(33);
         ConvertBits<8, 5, true>([&](unsigned char c) { data.push_back(c); }, id.begin(), id.end());
-        return bech32::Encode(m_params.Bech32HRP(), data);
+        return bech32::Encode(bech32::Encoding::BECH32, m_params.Bech32HRP(), data);
     }
 
     std::string operator()(const WitnessV0ScriptHash& id) const
@@ -51,7 +51,7 @@ public:
         std::vector<unsigned char> data = {0};
         data.reserve(53);
         ConvertBits<8, 5, true>([&](unsigned char c) { data.push_back(c); }, id.begin(), id.end());
-        return bech32::Encode(m_params.Bech32HRP(), data);
+        return bech32::Encode(bech32::Encoding::BECH32, m_params.Bech32HRP(), data);
     }
 
     std::string operator()(const WitnessUnknown& id) const
@@ -62,7 +62,7 @@ public:
         std::vector<unsigned char> data = {(unsigned char)id.version};
         data.reserve(1 + (id.length * 8 + 4) / 5);
         ConvertBits<8, 5, true>([&](unsigned char c) { data.push_back(c); }, id.program, id.program + id.length);
-        return bech32::Encode(m_params.Bech32HRP(), data);
+        return bech32::Encode(bech32::Encoding::BECH32, m_params.Bech32HRP(), data);
     }
 
     std::string operator()(const CNoDestination& no) const { return {}; }
@@ -95,20 +95,18 @@ CTxDestination DecodeDestination(const std::string& str, const CChainParams& par
         error_str = "Invalid prefix for Base58-encoded address";
     }
     data.clear();
-    auto bech = bech32::Decode(str);
-    if (bech.second.size() > 0) {
+    const auto dec = bech32::Decode(str);
+    if (dec.encoding == bech32::Encoding::BECH32 && dec.data.size() > 0) {
+        // Bech32 decoding
         error_str = "";
-
-        if (bech.first != params.Bech32HRP()) {
+        if (dec.hrp != params.Bech32HRP()) {
             error_str = "Invalid prefix for Bech32 address";
             return CNoDestination();
         }
-
-        // Bech32 decoding
-        int version = bech.second[0]; // The first 5 bit symbol is the witness version (0-16)
+        int version = dec.data[0]; // The first 5 bit symbol is the witness version (0-16)
         // The rest of the symbols are converted witness program bytes.
-        data.reserve(((bech.second.size() - 1) * 5) / 8);
-        if (ConvertBits<5, 8, false>([&](unsigned char c) { data.push_back(c); }, bech.second.begin() + 1, bech.second.end())) {
+        data.reserve(((dec.data.size() - 1) * 5) / 8);
+        if (ConvertBits<5, 8, false>([&](unsigned char c) { data.push_back(c); }, dec.data.begin() + 1, dec.data.end())) {
             if (version == 0) {
                 {
                     WitnessV0KeyHash keyid;

--- a/src/test/bech32_tests.cpp
+++ b/src/test/bech32_tests.cpp
@@ -10,7 +10,7 @@
 
 BOOST_FIXTURE_TEST_SUITE(bech32_tests, BasicTestingSetup)
 
-BOOST_AUTO_TEST_CASE(bip173_testvectors_valid)
+BOOST_AUTO_TEST_CASE(bech32_testvectors_valid)
 {
     static const std::string CASES[] = {
         "A12UEL5L",
@@ -30,7 +30,27 @@ BOOST_AUTO_TEST_CASE(bip173_testvectors_valid)
     }
 }
 
-BOOST_AUTO_TEST_CASE(bip173_testvectors_invalid)
+BOOST_AUTO_TEST_CASE(bech32m_testvectors_valid)
+{
+    static const std::string CASES[] = {
+        "A1LQFN3A",
+        "a1lqfn3a",
+        "an83characterlonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11sg7hg6",
+        "abcdef1l7aum6echk45nj3s0wdvt2fg8x9yrzpqzd3ryx",
+        "11llllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllludsr8",
+        "split1checkupstagehandshakeupstreamerranterredcaperredlc445v",
+        "?1v759aa"
+    };
+    for (const std::string& str : CASES) {
+        const auto dec = bech32::Decode(str);
+        BOOST_CHECK(dec.encoding == bech32::Encoding::BECH32M);
+        std::string recode = bech32::Encode(bech32::Encoding::BECH32M, dec.hrp, dec.data);
+        BOOST_CHECK(!recode.empty());
+        BOOST_CHECK(CaseInsensitiveEqual(str, recode));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(bech32_testvectors_invalid)
 {
     static const std::string CASES[] = {
         " 1nwldj5",
@@ -50,7 +70,31 @@ BOOST_AUTO_TEST_CASE(bip173_testvectors_invalid)
     };
     for (const std::string& str : CASES) {
         const auto dec = bech32::Decode(str);
-        BOOST_CHECK(dec.encoding != bech32::Encoding::BECH32);
+        BOOST_CHECK(dec.encoding == bech32::Encoding::INVALID);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(bech32m_testvectors_invalid)
+{
+    static const std::string CASES[] = {
+        " 1xj0phk",
+        "\x7f""1g6xzxy",
+        "\x80""1vctc34",
+        "an84characterslonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11d6pts4",
+        "qyrz8wqd2c9m",
+        "1qyrz8wqd2c9m",
+        "y1b0jsk6g",
+        "lt1igcx5c0",
+        "in1muywd",
+        "mm1crxm3i",
+        "au1s5cgom",
+        "M1VUXWEZ",
+        "16plkw9",
+        "1p2gdwpf"
+    };
+    for (const std::string& str : CASES) {
+        const auto dec = bech32::Decode(str);
+        BOOST_CHECK(dec.encoding == bech32::Encoding::INVALID);
     }
 }
 

--- a/src/test/bech32_tests.cpp
+++ b/src/test/bech32_tests.cpp
@@ -22,9 +22,9 @@ BOOST_AUTO_TEST_CASE(bip173_testvectors_valid)
         "?1ezyfcl",
     };
     for (const std::string& str : CASES) {
-        auto ret = bech32::Decode(str);
-        BOOST_CHECK(!ret.first.empty());
-        std::string recode = bech32::Encode(ret.first, ret.second);
+        const auto dec = bech32::Decode(str);
+        BOOST_CHECK(dec.encoding == bech32::Encoding::BECH32);
+        std::string recode = bech32::Encode(bech32::Encoding::BECH32, dec.hrp, dec.data);
         BOOST_CHECK(!recode.empty());
         BOOST_CHECK(CaseInsensitiveEqual(str, recode));
     }
@@ -49,8 +49,8 @@ BOOST_AUTO_TEST_CASE(bip173_testvectors_invalid)
         "A12uEL5L",
     };
     for (const std::string& str : CASES) {
-        auto ret = bech32::Decode(str);
-        BOOST_CHECK(ret.first.empty());
+        const auto dec = bech32::Decode(str);
+        BOOST_CHECK(dec.encoding != bech32::Encoding::BECH32);
     }
 }
 

--- a/src/test/data/key_io_invalid.json
+++ b/src/test/data/key_io_invalid.json
@@ -6,177 +6,147 @@
         "x"
     ],
     [
-        "37qgekLpCCHrQuSjvX3fs496FWTGsHFHizjJAs6NPcR47aefnnCWECAhHV6E3g4YN7u7Yuwod5Y"
+        "1KyjgD9vFKmFSysJPUqQdXT8Yy5r82D6y74dfsg1ANTteuHJuP2q1aP1WgGX3oetFRtatKVXxPU"
     ],
     [
-        "dzb7VV1Ui55BARxv7ATxAtCUeJsANKovDGWFVgpTbhq9gvPqP3yv"
+        "2CwgfUPJ6BCa16PuFjKeMzLJJUpqnXm9mCtoXVGiGN7s9dNCKfCN5SdT7cu4nMY5omWHPrQLAqYL"
     ],
     [
-        "MuNu7ZAEDFiHthiunm7dPjwKqrVNCM3mAz6rP9zFveQu14YA8CxExSJTHcVP9DErn6u84E6Ej7S"
+        "grEx1jdq4kpgsvorxP5PRyjgbXpvAVpaL5HEcqpDmF6ZpwuqRbzHX64GZ9eUwoSTvmbQb9fnqnh"
     ],
     [
-        "rPpQpYknyNQ5AEHuY6H8ijJJrYc2nDKKk9jjmKEXsWzyAQcFGpDLU2Zvsmoi8JLR7hAwoy3RQWf"
+        "7RSWWNt7pyiZkNnLTuocsLMM6e3c7Mvvq8phtaBVyhuceG37y9r"
     ],
     [
-        "4Uc3FmN6NQ6zLBK5QQBXRBUREaaHwCZYsGCueHauuDmJpZKn6jkEskMB2Zi2CNgtb5r6epWEFfUJq"
+        "7VXvPTB9ZdTRUS2W1KpcykSA1XHaVrfUGhKvWQXQLMVUNefmaLkF9DFC4fZJ5aMCxmj4HRQcLFGix"
     ],
     [
-        "7aQgR5DFQ25vyXmqZAWmnVCjL3PkBcdVkBUpjrjMTcghHx3E8wb"
+        "91bBALqY4D1Mmz4vqnCwdGSB4U1sqnZPrKZ8aHENoT5irq6bB9Nc"
     ],
     [
-        "17QpPprjeg69fW1DV8DcYYCKvWjYhXvWkov6MJ1iTTvMFj6weAqW7wybZeH57WTNxXVCRH4veVs"
+        "tc19jm4rn"
     ],
     [
-        "KxuACDviz8Xvpn1xAh9MfopySZNuyajYMZWz16Dv2mHHryznWUp3"
+        "bt1py306q853jeddsuaasstjxjz6l9uehmx8kgpe94lvvwj85rah56asxg35e3"
     ],
     [
-        "7nK3GSmqdXJQtdohvGfJ7KsSmn3TmGqExug49583bDAL91pVSGq5xS9SHoAYL3Wv3ijKTit65th"
+        "tb13u87aul665v37upwmu9a4nh82rj9cv94x5tps52e39e6k56t2ryzqv9mkxa"
     ],
     [
-        "cTivdBmq7bay3RFGEBBuNfMh2P1pDCgRYN2Wbxmgwr4ki3jNUL2va"
+        "bcrt1rkqk977nr"
     ],
     [
-        "gjMV4vjNjyMrna4fsAr8bWxAbwtmMUBXJS3zL4NJt5qjozpbQLmAfK1uA3CquSqsZQMpoD1g2nk"
+        "bc10v6wh2rtujsn9hnsyfzzsd9y3rx9n8xhue0agk7c8q9tv3lga7css5jku9rstle93e5fhc8dl"
     ],
     [
-        "emXm1naBMoVzPjbk7xpeTVMFy4oDEe25UmoyGgKEB1gGWsK8kRGs"
+        "tb1q9quwy0k48ne8ppmr7p0jhj6hks7smd7l"
     ],
     [
-        "7VThQnNRj1o3Zyvc7XHPRrjDf8j2oivPTeDXnRPYWeYGE4pXeRJDZgf28ppti5hsHWXS2GSobdqyo"
+        "bcrt1q5l6rmlw2et02krnfgl9uuxp8q30dktcjvuzsw7gyk2ykkkm2td0prkw9de"
     ],
     [
-        "1G9u6oCVCPh2o8m3t55ACiYvG1y5BHewUkDSdiQarDcYXXhFHYdzMdYfUAhfxn5vNZBwpgUNpso"
+        "bc1q5ezcdrt4qqmkcqz8n50hgww88gqzfx4m6"
     ],
     [
-        "31QQ7ZMLkScDiB4VyZjuptr7AEc9j1SjstF7pRoLhHTGkW4Q2y9XELobQmhhWxeRvqcukGd1XCq"
+        "tb1q5gcna4un84qevljj3wk6rvm97f8f00gwtcu7v258cvn880wkf7gqesasqn"
     ],
     [
-        "DHqKSnpxa8ZdQyH8keAhvLTrfkyBMQxqngcQA5N8LQ9KVt25kmGN"
+        "bcrt1qtevjqsc85md7pa0CQEnpvdx977juj30usufphy"
     ],
     [
-        "2LUHcJPbwLCy9GLH1qXmfmAwvadWw4bp4PCpDfduLqV17s6iDcy1imUwhQJhAoNoN1XNmweiJP4i"
+        "bc1qret0yy8cmhsh6vw87lxtzt7w0sk4026l5qrvy7"
     ],
     [
-        "7USRzBXAnmck8fX9HmW7RAb4qt92VFX6soCnts9s74wxm4gguVhtG5of8fZGbNPJA83irHVY6bCos"
+        "tb1qnw0xfgkucr4ysapsj8gd0u40fpj05n8cn24unkql8mc4ckkcp0mqc7acjd"
     ],
     [
-        "1DGezo7BfVebZxAbNT3XGujdeHyNNBF3vnficYoTSp4PfK2QaML9bHzAMxke3wdKdHYWmsMTJVu"
+        "bcrt1qu26l525vmxfv59gxm2r0c8alnkpzmat2mga2qw"
     ],
     [
-        "2D12DqDZKwCxxkzs1ZATJWvgJGhQ4cFi3WrizQ5zLAyhN5HxuAJ1yMYaJp8GuYsTLLxTAz6otCfb"
+        "bc1prjkeqgknynar5tj6v76yn3u27rep8jf366kmhglq898yn3aczk9ss73nrl"
     ],
     [
-        "8AFJzuTujXjw1Z6M3fWhQ1ujDW7zsV4ePeVjVo7D1egERqSW9nZ"
+        "tb1zq0vsl9pta9uwh2txtrmxyedjtqcfkqt5"
     ],
     [
-        "163Q17qLbTCue8YY3AvjpUhotuaodLm2uqMhpYirsKjVqnxJRWTEoywMVY3NbBAHuhAJ2cF9GAZ"
+        "bcrt1suvw5wa9elxy3a43ctljjn8avcmqpzwz5m4tycs"
     ],
     [
-        "2MnmgiRH4eGLyLc9eAqStzk7dFgBjFtUCtu"
+        "gf7t7z22jkuKcEjc8gELEYau3NzgGFLtLNEdMpJKcVt6z7mmvEJHH37y36MNGSmriFaPAbGghdh"
     ],
     [
-        "461QQ2sYWxU7H2PV4oBwJGNch8XVTYYbZxU"
+        "mn9CPaeodb6L1CtJu1KaLtJhDbYL55Hxwe"
     ],
     [
-        "2UCtv53VttmQYkVU4VMtXB31REvQg4ABzs41AEKZ8UcB7DAfVzdkV9JDErwGwyj5AUHLkmgZeobs"
+        "cTSecEa3nqxF4mgYkGrxRKeWLpXWng6nUgL4sVeAhrNbtdf1z8hz1VFesD492QWZ4JprpRW1Drr"
     ],
     [
-        "cSNjAsnhgtiFMi6MtfvgscMB2Cbhn2v1FUYfviJ1CdjfidvmeW6mn"
+        "4UjQEEvAT4Y9a3mtLFjzhcVBBKz8NiqAMfGhMwaSKgMqatpGT3qWzKY2f9HedshfSaAa439Vn3yNc"
     ],
     [
-        "gmsow2Y6EWAFDFE1CE4Hd3Tpu2BvfmBfG1SXsuRARbnt1WjkZnFh1qGTiptWWbjsq2Q6qvpgJVj"
+        "5ip19k2UhwhpHMK8ym6ZGnLA8J9JvHzv418AwohCMf3WrCfwLhG"
     ],
     [
-        "nksUKSkzS76v8EsSgozXGMoQFiCoCHzCVajFKAXqzK5on9ZJYVHMD5CKwgmX3S3c7M1U3xabUny"
+        "tc1qe7avhvpmn9le76kxlcvwl69ldm0n66gefjetyn"
     ],
     [
-        "L3favK1UzFGgdzYBF2oBT5tbayCo4vtVBLJhg2iYuMeePxWG8SQc"
+        "bt1pz4l3ja200jyyhtaxvz4ffm3t33ares72745gwjspttzdllvmte5qs0kd5q"
     ],
     [
-        "7VxLxGGtYT6N99GdEfi6xz56xdQ8nP2dG1CavuXx7Rf2PrvNMTBNevjkfgs9JmkcGm6EXpj8ipyPZ"
+        "tb13wthrv4wkvpxl57d0plyfqjxvzu9qmdzg7eldaeut2hmcpp02mw2q3ep6tw"
     ],
     [
-        "2mbZwFXF6cxShaCo2czTRB62WTx9LxhTtpP"
+        "bcrt1rqg9chz23"
     ],
     [
-        "dB7cwYdcPSgiyAwKWL3JwCVwSk6epU2txw"
+        "BC102A2J0QF2MX8926EQ3WZGDC45PXL4QN267673J7P7JMJ6VD0RDTAWVQ2ZFNP4JJAW85JXP080"
     ],
     [
-        "HPhFUhUAh8ZQQisH8QQWafAxtQYju3SFTX"
+        "tb1qx0shsrwmrl57djkm0yyqdyp02cmpjmlw"
     ],
     [
-        "4ctAH6AkHzq5ioiM1m9T3E2hiYEev5mTsB"
+        "bcrt17capp7"
     ],
     [
-        "Hn1uFi4dNexWrqARpjMqgT6cX1UsNPuV3cHdGg9ExyXw8HTKadbktRDtdeVmY3M1BxJStiL4vjJ"
+        "bc1qvgrlqspye3z2ufaekn7qygm7guqjx982l"
     ],
     [
-        "Sq3fDbvutABmnAHHExJDgPLQn44KnNC7UsXuT7KZecpaYDMU9Txs"
+        "tb1qk8lfs3l8df9gkw69240g0ckg4ywmw9qvmcm0pltxt8udk9szrhxqkhd5n2"
     ],
     [
-        "6TqWyrqdgUEYDQU1aChMuFMMEimHX44qHFzCUgGfqxGgZNMUVWJ"
+        "bcrt1qKW6Cxkky8a7gyvmkw9p3v5l2gx8zgyjtjv7dl7"
     ],
     [
-        "giqJo7oWqFxNKWyrgcBxAVHXnjJ1t6cGoEffce5Y1y7u649Noj5wJ4mmiUAKEVVrYAGg2KPB3Y4"
+        "bc1a8xfp7"
     ],
     [
-        "cNzHY5e8vcmM3QVJUcjCyiKMYfeYvyueq5qCMV3kqcySoLyGLYUK"
+        "tb1dclvmr"
     ],
     [
-        "37uTe568EYc9WLoHEd9jXEvUiWbq5LFLscNyqvAzLU5vBArUJA6eydkLmnMwJDjkL5kXc2VK7ig"
+        "bcrt1q26vevm7x046n9h3jg6zsgyd3228ra25ck7jah2"
     ],
     [
-        "EsYbG4tWWWY45G31nox838qNdzksbPySWc"
+        "BC1PCCNQDKKS5ZQ0AC69MQYQXU8ADGSGE53UY3AXXHJYFDG77Y0WX9AQHEHRL7"
     ],
     [
-        "nbuzhfwMoNzA3PaFnyLcRxE9bTJPDkjZ6Rf6Y6o2ckXZfzZzXBT"
+        "tb1zys2pfhe9fslxat85y7uc5e78uq7449ct"
     ],
     [
-        "cQN9PoxZeCWK1x56xnz6QYAsvR11XAce3Ehp3gMUdfSQ53Y2mPzx"
+        "bcrt1slnwcpwf88ffa708xpfkm6a5wsaq9me7y0fmvg3"
     ],
     [
-        "1Gm3N3rkef6iMbx4voBzaxtXcmmiMTqZPhcuAepRzYUJQW4qRpEnHvMojzof42hjFRf8PE2jPde"
+        "dhBi3wYUjrVsW1pA4XhLjdavSQYSnsECskAoZ1dqLnV8hCSxuo9EZ9tf4cCoxn7fnKgCoJK3mcE"
     ],
     [
-        "2TAq2tuN6x6m233bpT7yqdYQPELdTDJn1eU"
+        "2UFHPygbpDdbzmQx688QnMqSunZi97Yn5T7DVBdKyTD7sCfGi5fi8r2ct92FNUZPMm1xswo8Ve8c"
     ],
     [
-        "ntEtnnGhqPii4joABvBtSEJG6BxjT2tUZqE8PcVYgk3RHpgxgHDCQxNbLJf7ardf1dDk2oCQ7Cf"
+        "2yAaXFzjninFv5dn3JnWQ5y9nYkK5ZCMAkDWr4Y9WUiCGa3UiYfs"
     ],
     [
-        "Ky1YjoZNgQ196HJV3HpdkecfhRBmRZdMJk89Hi5KGfpfPwS2bUbfd"
+        "tc1qmfcz6l7gfwwt0tucqgtmhwlkgtd47a3urnjpt4"
     ],
     [
-        "2A1q1YsMZowabbvta7kTy2Fd6qN4r5ZCeG3qLpvZBMzCixMUdkN2Y4dHB1wPsZAeVXUGD83MfRED"
-    ],
-    [
-        "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty"
-    ],
-    [
-        "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5"
-    ],
-    [
-        "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2"
-    ],
-    [
-        "bc1rw5uspcuh"
-    ],
-    [
-        "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90"
-    ],
-    [
-        "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P"
-    ],
-    [
-        "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7"
-    ],
-    [
-        "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du"
-    ],
-    [
-        "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv"
-    ],
-    [
-        "bc1gmk9yu"
+        "bt1flep4g"
     ]
 ]

--- a/src/test/data/key_io_invalid.json
+++ b/src/test/data/key_io_invalid.json
@@ -6,147 +6,207 @@
         "x"
     ],
     [
-        "1KyjgD9vFKmFSysJPUqQdXT8Yy5r82D6y74dfsg1ANTteuHJuP2q1aP1WgGX3oetFRtatKVXxPU"
+        "2v7k5Bb8Lr1MMgTgW6HAf5YHXi6BzpPjHpQ4srD4RSwHYpzXKiXmLAgiLhkXvp3JF5v7nq45EWr"
     ],
     [
-        "2CwgfUPJ6BCa16PuFjKeMzLJJUpqnXm9mCtoXVGiGN7s9dNCKfCN5SdT7cu4nMY5omWHPrQLAqYL"
+        "RAZzCGtMbiUgMiiyrZySrSpdfnQReFXA3r"
     ],
     [
-        "grEx1jdq4kpgsvorxP5PRyjgbXpvAVpaL5HEcqpDmF6ZpwuqRbzHX64GZ9eUwoSTvmbQb9fnqnh"
+        "NYamy7tcPQTzoU5iyQojD3sqhiz7zxkvn8"
     ],
     [
-        "7RSWWNt7pyiZkNnLTuocsLMM6e3c7Mvvq8phtaBVyhuceG37y9r"
+        "geaFG555Ex5nyRf7JjW6Pj2GwZA8KYxtJJLbr1eZhVW75STbYBZeRszy3wg4pkKdF4ez9J4wQiz"
     ],
     [
-        "7VXvPTB9ZdTRUS2W1KpcykSA1XHaVrfUGhKvWQXQLMVUNefmaLkF9DFC4fZJ5aMCxmj4HRQcLFGix"
+        "2Cxmid3c2XQ2zvQ8SA1ha2TKqvqbJS9XFmXRsCneBS3Po7Qqb65z5zNdsoF9AfieXFcpoVPmkmfa"
     ],
     [
-        "91bBALqY4D1Mmz4vqnCwdGSB4U1sqnZPrKZ8aHENoT5irq6bB9Nc"
+        "gaJ7UVge2njVg9tFTetJrtHgruMm7aQDiSAxfHrVEgzK8N2ooagDVmDkdph434xzc4K96Gjyxcs"
     ],
     [
-        "tc19jm4rn"
+        "5JN5BEVQPZ3tAiatz1RGXkrJuE3EC6bervMaPb38wTNgEuZCeqp"
     ],
     [
-        "bt1py306q853jeddsuaasstjxjz6l9uehmx8kgpe94lvvwj85rah56asxg35e3"
+        "3TnFbyUtBRS5rE1KTW81qLVspjJNaB3uu6uuvLjxhZo2DB6PCGh"
     ],
     [
-        "tb13u87aul665v37upwmu9a4nh82rj9cv94x5tps52e39e6k56t2ryzqv9mkxa"
+        "7UgSZGaMaTc4d2mdEgcGBFiMeS6eMsithGUqvBsKTQdGzD7XQDbMEYo3gojdbXEPbUdFF3CQoK72f"
     ],
     [
-        "bcrt1rkqk977nr"
+        "9261wfqQqruNDnBDhbbb4tN9oKA1KpRFHeoYeufyJApVGixyAG4V"
     ],
     [
-        "bc10v6wh2rtujsn9hnsyfzzsd9y3rx9n8xhue0agk7c8q9tv3lga7css5jku9rstle93e5fhc8dl"
+        "cS824CTUh18scFmYuqt6BgxuRhdR4dEEnCHs3fzBbcyQgbfasHbw"
     ],
     [
-        "tb1q9quwy0k48ne8ppmr7p0jhj6hks7smd7l"
+        "tc1q0ywf7wkz6t580n3yemd3ucfw8jxn93tpc6wskt"
     ],
     [
-        "bcrt1q5l6rmlw2et02krnfgl9uuxp8q30dktcjvuzsw7gyk2ykkkm2td0prkw9de"
+        "bt1pxeeuh96wpm5c6u3kavts2qgwlv6y8um7u7ga6ltlwrhrv7w9vers8lgt3k"
     ],
     [
-        "bc1q5ezcdrt4qqmkcqz8n50hgww88gqzfx4m6"
+        "tb130lvl2lyugsk2tf3zhwcjjv39dmwt2tt7ytqaexy8edwcuwks6p5scll5kz"
     ],
     [
-        "tb1q5gcna4un84qevljj3wk6rvm97f8f00gwtcu7v258cvn880wkf7gqesasqn"
+        "bcrt1rhsveeudk"
     ],
     [
-        "bcrt1qtevjqsc85md7pa0CQEnpvdx977juj30usufphy"
+        "bc10rmfwl8nxdweeyc4sf89t0tn9fv9w6qpyzsnl2r4k48vjqh03qas9asdje0rlr0phru0wqw0p"
     ],
     [
-        "bc1qret0yy8cmhsh6vw87lxtzt7w0sk4026l5qrvy7"
+        "tb1qjqnfsuatr54e957xzg9sqk7yqcry9lns"
     ],
     [
-        "tb1qnw0xfgkucr4ysapsj8gd0u40fpj05n8cn24unkql8mc4ckkcp0mqc7acjd"
+        "bcrt1q8p08mv8echkf3es027u4cdswxlylm3th76ls8v6y4zy4vwsavngpr4e4td"
     ],
     [
-        "bcrt1qu26l525vmxfv59gxm2r0c8alnkpzmat2mga2qw"
+        "BC1QNC2H66VLWTWTW52DP0FYUSNU3QQG5VT4V"
     ],
     [
-        "bc1prjkeqgknynar5tj6v76yn3u27rep8jf366kmhglq898yn3aczk9ss73nrl"
+        "tb1qgk665m2auw09rc7pqyf7aulcuhmatz9xqtr5mxew7zuysacaascqs9v0vn"
     ],
     [
-        "tb1zq0vsl9pta9uwh2txtrmxyedjtqcfkqt5"
+        "bcrt17CAPP7"
     ],
     [
-        "bcrt1suvw5wa9elxy3a43ctljjn8avcmqpzwz5m4tycs"
+        "bc1qxmf2d6aerjzam3rur0zufqxqnyqfts5u302s7x"
     ],
     [
-        "gf7t7z22jkuKcEjc8gELEYau3NzgGFLtLNEdMpJKcVt6z7mmvEJHH37y36MNGSmriFaPAbGghdh"
+        "tb1qn8x5dnzpexq7nnvrvnhwr9c3wkakpcyu9wwsjzq9pstkwg0t6qhs4l3rv6"
     ],
     [
-        "mn9CPaeodb6L1CtJu1KaLtJhDbYL55Hxwe"
+        "BCRT1Q397G2RNVYRL5LK07CE8NCKHVKP8Z4SC9U0MVH9"
     ],
     [
-        "cTSecEa3nqxF4mgYkGrxRKeWLpXWng6nUgL4sVeAhrNbtdf1z8hz1VFesD492QWZ4JprpRW1Drr"
+        "bc1pgxwyajq0gdn389f69uwn2fw9q0z5c9s063j5dgkdd23ajaud4hpsercr9h"
     ],
     [
-        "4UjQEEvAT4Y9a3mtLFjzhcVBBKz8NiqAMfGhMwaSKgMqatpGT3qWzKY2f9HedshfSaAa439Vn3yNc"
-    ],
-    [
-        "5ip19k2UhwhpHMK8ym6ZGnLA8J9JvHzv418AwohCMf3WrCfwLhG"
-    ],
-    [
-        "tc1qe7avhvpmn9le76kxlcvwl69ldm0n66gefjetyn"
-    ],
-    [
-        "bt1pz4l3ja200jyyhtaxvz4ffm3t33ares72745gwjspttzdllvmte5qs0kd5q"
-    ],
-    [
-        "tb13wthrv4wkvpxl57d0plyfqjxvzu9qmdzg7eldaeut2hmcpp02mw2q3ep6tw"
-    ],
-    [
-        "bcrt1rqg9chz23"
-    ],
-    [
-        "BC102A2J0QF2MX8926EQ3WZGDC45PXL4QN267673J7P7JMJ6VD0RDTAWVQ2ZFNP4JJAW85JXP080"
-    ],
-    [
-        "tb1qx0shsrwmrl57djkm0yyqdyp02cmpjmlw"
+        "tb1z6mnmp5k542l6yk4ul0mp4rq3yvz44lfm"
     ],
     [
         "bcrt17capp7"
     ],
     [
-        "bc1qvgrlqspye3z2ufaekn7qygm7guqjx982l"
+        "2D2bqvKseKHdoKjCNvjVULUgmxHu9hjKGwDbPRjTRH59tsHNLeyKwq3vyVBbo9LByY9wiapqjwFY"
     ],
     [
-        "tb1qk8lfs3l8df9gkw69240g0ckg4ywmw9qvmcm0pltxt8udk9szrhxqkhd5n2"
+        "2SSjAim4wZpeQRe5zTj1qqS6Li9ttJDaZ3ze"
     ],
     [
-        "bcrt1qKW6Cxkky8a7gyvmkw9p3v5l2gx8zgyjtjv7dl7"
+        "mi9H6MjLwXxy9kxe1x4ToxyLRBsmcZxgVi"
     ],
     [
-        "bc1a8xfp7"
+        "VciXoxEitcn88jy197J9n9cpJ1pZahzU3SyWUiHqLgcfjttLEEJz"
     ],
     [
-        "tb1dclvmr"
+        "KppmwADGoExPT9Eq5hjRWpWFDbzJyfzHFgsfxBiDHNpVBgWPRNuy"
     ],
     [
-        "bcrt1q26vevm7x046n9h3jg6zsgyd3228ra25ck7jah2"
+        "TN7EQXMxKffzvHo54yHHu9R4ks9f5gWBW3MMVf5k72zAqrgVK9ys"
     ],
     [
-        "BC1PCCNQDKKS5ZQ0AC69MQYQXU8ADGSGE53UY3AXXHJYFDG77Y0WX9AQHEHRL7"
+        "92dbrMEYzP5dD5UhQ6maNkCQ4GLG42BM4Gc6XKZzSSMSfosfkkcB"
     ],
     [
-        "tb1zys2pfhe9fslxat85y7uc5e78uq7449ct"
+        "J7VQxPxyzuWEkRstQWpCz2AgysEz1APgnWCEQrFvkN3umAnCrhQF"
     ],
     [
-        "bcrt1slnwcpwf88ffa708xpfkm6a5wsaq9me7y0fmvg3"
-    ],
-    [
-        "dhBi3wYUjrVsW1pA4XhLjdavSQYSnsECskAoZ1dqLnV8hCSxuo9EZ9tf4cCoxn7fnKgCoJK3mcE"
-    ],
-    [
-        "2UFHPygbpDdbzmQx688QnMqSunZi97Yn5T7DVBdKyTD7sCfGi5fi8r2ct92FNUZPMm1xswo8Ve8c"
-    ],
-    [
-        "2yAaXFzjninFv5dn3JnWQ5y9nYkK5ZCMAkDWr4Y9WUiCGa3UiYfs"
-    ],
-    [
-        "tc1qmfcz6l7gfwwt0tucqgtmhwlkgtd47a3urnjpt4"
+        "tc1qymllj6c96v5qj2504y27ldtner6eh8ldx38t83"
     ],
     [
         "bt1flep4g"
+    ],
+    [
+        "tb13c553hwygcgj48qwmr9f8q0hgdcfklyaye5sxzcpcjnmxv4z506xs90tchn"
+    ],
+    [
+        "bcrt1tyddyu"
+    ],
+    [
+        "bc10qssq2mknjqf0glwe2f3587wc4jysvs3f8s6chysae6hcl6fxzdm4wxyyscrl5k9f5qmnf05a"
+    ],
+    [
+        "tb1q425lmgvxdgtyl2m6xuu2pc354y4fvgg8"
+    ],
+    [
+        "bcrt1q9wp8e5d2u3u4g0pll0cy7smeeuqezdun9xl439n3p2gg4fvgfvk3hu52hj"
+    ],
+    [
+        "bc1qrz5acazpue8vl4zsaxn8fxtmeuqmyjkq3"
+    ],
+    [
+        "tb1qkeuglpgmnex9tv3fr7htzfrh3rwrk23r52rx9halxzmv9fr85lwq0fwhmp"
+    ],
+    [
+        "bcrt1qd0t2wrhl7s57z99rsyaekpq0dyjcQRSSmz80r4"
+    ],
+    [
+        "BC1QXLFDUCGX90T3E53PQCNKJ2PK25MSF3VLPMVY6T"
+    ],
+    [
+        "tb1qmycg4zszgnk34vaurx3cu8wpvteg9h40yq6cp52gt26gjel03t3su3x3xu"
+    ],
+    [
+        "bcrt1q9hy58r4fnuxqzdqndpmq9pptc9nt2dw3rczf5e"
+    ],
+    [
+        "BC1PA7682NAY6JQSLUWAJYTC0ERWTMW7A4RPWLNTUS32LCXWLHVKKKTQ2UL8CG"
+    ],
+    [
+        "tb1z850dpxnwz2fzae5h2myatj4yvu6rq5xq"
+    ],
+    [
+        "bcrt1sp525pzjsmpqvcrawjreww36e9keg876skjvpwt"
+    ],
+    [
+        "xcAvW5jurCpzSpLxBKEhCewCgwwuGhqJnC"
+    ],
+    [
+        "2Cvv8yp9kXbQt8EKh6Yma95yJ1uwYF9YKXuVhGJyu3dHGVsb2AVpTC62TFACZZ3KDNrALxR2CVNs"
+    ],
+    [
+        "niUuL46hCuEVvkAzZKHvD746qbmLmzip9Pv3F6UZV14JxzEXBnTkVxCT4URapChJG6qAEgsZs6G"
+    ],
+    [
+        "2UHHgGfiipzvB8Eumnmvq6SowvrMJimjT3NwwG1839XEiUfwtpSdkUrseNsQuagXv21ce7aZu6yo"
+    ],
+    [
+        "8u9djKu4u6o3bsgeR4BKNnLK3akpo64FYzDAmA9239wKeshgF97"
+    ],
+    [
+        "TC1QPAARXSLVMXHVRR0474LZXQYZWLGFZYPSFVL9E4"
+    ],
+    [
+        "bt1pakek0n2267t9yaksxaczgr2syhv9y3xkx0wnsdwchfa6xkmjtvuqg3kgyr"
+    ],
+    [
+        "tb13h83rtwq62udrhwpn87uely7cyxcjrj0azz6a4r3n9s87x5uj98ys6ufp83"
+    ],
+    [
+        "bcrt1rk5vw5qf2"
+    ],
+    [
+        "bc10d3rmtg62h747en5j6fju5g5qyvsransrkty6ghh96pu647wumctejlsngh9pf26cysrys2x2"
+    ],
+    [
+        "tb1qajuy2cdwqgmrzc7la85al5cwcq374tsp"
+    ],
+    [
+        "bcrt1q3udxvj6x20chqh723mn064mzz65yr56ef00xk8czvu3jnx04ydapzk02s5"
+    ],
+    [
+        "bc1qule2szwzyaq4qy0s3aa4mauucyqt6fewe"
+    ],
+    [
+        "tb1ql0qny5vg9gh5tyzke6dw36px5ulkrp24x53x0pl2t5lpwrtejw3s2seej2"
+    ],
+    [
+        "bcrt17CAPP7"
+    ],
+    [
+        "bc1qtvm6davyf725wfedc2d5mrgfewqgcrce8gjrpl"
+    ],
+    [
+        "tb1q5acjgtqrrw3an0dzavxxxzlex8k7aukjzjk9v2u4rmfdqxjphcyq7ge97e"
     ]
 ]

--- a/src/test/data/key_io_valid.json
+++ b/src/test/data/key_io_valid.json
@@ -1,533 +1,438 @@
 [
     [
-        "1AGNa15ZQXAZUgFiqJ2i7Z2DPU2J6hW62i",
-        "76a91465a16059864a2fdbc7c99a4723a8395bc6f188eb88ac",
+        "1LsN3xZdsNiSMiVc45AGBdhtkQZG53tKpx",
+        "76a914d9f0c2ae3652e96389b4481a510f0b2b96da1d0888ac",
         {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "3CMNFxN1oHBc4R1EpboAL5yzHGgE611Xou",
-        "a91474f209f6ea907e2ea48f74fae05782ae8a66525787",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs",
-        "76a91453c0307d6851aa0ce7825ba883c6bd9ad242b48688ac",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs",
-        "76a91453c0307d6851aa0ce7825ba883c6bd9ad242b48688ac",
-        {
-            "isPrivkey": false,
-            "chain": "regtest"
-        }
-    ],
-    [
-        "2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br",
-        "a9146349a418fc4578d10a372b54b45c280cc8c4382f87",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "5Kd3NBUAdUnhyzenEwVLy9pBKxSwXvE9FMPyR4UKZvpe6E3AgLr",
-        "eddbdc1168f1daeadbd3e44c1e3f8f5a284c2029f78ad26af98583a499de5b19",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "Kz6UJmQACJmLtaQj5A3JAge4kVTNQ8gbvXuwbmCj7bsaabudb3RD",
-        "55c9bccb9ed68446d1b75273bbce89d7fe013a8acd1625514420fb2aca1a21c4",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "9213qJab2HNEpMpYNBa7wHGFKKbkDn24jpANDs2huN3yi4J11ko",
-        "36cb93b9ab1bdabf7fb9f2c04f1b9cc879933530ae7842398eef5a63a56800c2",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "9213qJab2HNEpMpYNBa7wHGFKKbkDn24jpANDs2huN3yi4J11ko",
-        "36cb93b9ab1bdabf7fb9f2c04f1b9cc879933530ae7842398eef5a63a56800c2",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "regtest"
-        }
-    ],
-    [
-        "cTpB4YiyKiBcPxnefsDpbnDxFDffjqJob8wGCEDXxgQ7zQoMXJdH",
-        "b9f4892c9e8282028fea1d2667c4dc5213564d41fc5783896a0d843fc15089f3",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "cTpB4YiyKiBcPxnefsDpbnDxFDffjqJob8wGCEDXxgQ7zQoMXJdH",
-        "b9f4892c9e8282028fea1d2667c4dc5213564d41fc5783896a0d843fc15089f3",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "regtest"
-        }
-    ],
-    [
-        "1Ax4gZtb7gAit2TivwejZHYtNNLT18PUXJ",
-        "76a9146d23156cbbdcc82a5a47eee4c2c7c583c18b6bf488ac",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "3QjYXhTkvuj8qPaXHTTWb5wjXhdsLAAWVy",
-        "a914fcc5460dd6e2487c7d75b1963625da0e8f4c597587",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "n3ZddxzLvAY9o7184TB4c6FJasAybsw4HZ",
-        "76a914f1d470f9b02370fdec2e6b708b08ac431bf7a5f788ac",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "2NBFNJTktNa7GZusGbDbGKRZTxdK9VVez3n",
-        "a914c579342c2c4c9220205e2cdc285617040c924a0a87",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "5K494XZwps2bGyeL71pWid4noiSNA2cfCibrvRWqcHSptoFn7rc",
-        "a326b95ebae30164217d7a7f57d72ab2b54e3be64928a19da0210b9568d4015e",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "L1RrrnXkcKut5DEMwtDthjwRcTTwED36thyL1DebVrKuwvohjMNi",
-        "7d998b45c219a1e38e99e7cbd312ef67f77a455a9b50c730c27f02c6f730dfb4",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "93DVKyFYwSN6wEo3E2fCrFPUp17FtrtNi2Lf7n4G3garFb16CRj",
-        "d6bca256b5abc5602ec2e1c121a08b0da2556587430bcf7e1898af2224885203",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "cTDVKtMGVYWTHCb1AFjmVbEbWjvKpKqKgMaR3QJxToMSQAhmCeTN",
-        "a81ca4e8f90181ec4b61b6a7eb998af17b2cb04de8a03b504b9e34c4c61db7d9",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "1C5bSj1iEGUgSTbziymG7Cn18ENQuT36vv",
-        "76a9147987ccaa53d02c8873487ef919677cd3db7a691288ac",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "3AnNxabYGoTxYiTEZwFEnerUoeFXK2Zoks",
-        "a91463bcc565f9e68ee0189dd5cc67f1b0e5f02f45cb87",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "n3LnJXCqbPjghuVs8ph9CYsAe4Sh4j97wk",
-        "76a914ef66444b5b17f14e8fae6e7e19b045a78c54fd7988ac",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "2NB72XtkjpnATMggui83aEtPawyyKvnbX2o",
-        "a914c3e55fceceaa4391ed2a9677f4a4d34eacd021a087",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "5KaBW9vNtWNhc3ZEDyNCiXLPdVPHCikRxSBWwV9NrpLLa4LsXi9",
-        "e75d936d56377f432f404aabb406601f892fd49da90eb6ac558a733c93b47252",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "L1axzbSyynNYA8mCAhzxkipKkfHtAXYF4YQnhSKcLV8YXA874fgT",
-        "8248bd0375f2f75d7e274ae544fb920f51784480866b102384190b1addfbaa5c",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "927CnUkUbasYtDwYwVn2j8GdTuACNnKkjZ1rpZd2yBB1CLcnXpo",
-        "44c4f6a096eac5238291a94cc24c01e3b19b8d8cef72874a079e00a242237a52",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "cUcfCMRjiQf85YMzzQEk9d1s5A4K7xL5SmBCLrezqXFuTVefyhY7",
-        "d1de707020a9059d6d3abaf85e17967c6555151143db13dbb06db78df0f15c69",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "1Gqk4Tv79P91Cc1STQtU3s1W6277M2CVWu",
-        "76a914adc1cc2081a27206fae25792f28bbc55b831549d88ac",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "33vt8ViH5jsr115AGkW6cEmEz9MpvJSwDk",
-        "a914188f91a931947eddd7432d6e614387e32b24470987",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "mhaMcBxNh5cqXm4aTQ6EcVbKtfL6LGyK2H",
-        "76a9141694f5bc1a7295b600f40018a618a6ea48eeb49888ac",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "2MxgPqX1iThW3oZVk9KoFcE5M4JpiETssVN",
-        "a9143b9b3fd7a50d4f08d1a5b0f62f644fa7115ae2f387",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "5HtH6GdcwCJA4ggWEL1B3jzBBUB8HPiBi9SBc5h9i4Wk4PSeApR",
-        "091035445ef105fa1bb125eccfb1882f3fe69592265956ade751fd095033d8d0",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "L2xSYmMeVo3Zek3ZTsv9xUrXVAmrWxJ8Ua4cw8pkfbQhcEFhkXT8",
-        "ab2b4bcdfc91d34dee0ae2a8c6b6668dadaeb3a88b9859743156f462325187af",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "92xFEve1Z9N8Z641KQQS7ByCSb8kGjsDzw6fAmjHN1LZGKQXyMq",
-        "b4204389cef18bbe2b353623cbf93e8678fbc92a475b664ae98ed594e6cf0856",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "92xFEve1Z9N8Z641KQQS7ByCSb8kGjsDzw6fAmjHN1LZGKQXyMq",
-        "b4204389cef18bbe2b353623cbf93e8678fbc92a475b664ae98ed594e6cf0856",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "regtest"
-        }
-    ],
-    [
-        "cVM65tdYu1YK37tNoAyGoJTR13VBYFva1vg9FLuPAsJijGvG6NEA",
-        "e7b230133f1b5489843260236b06edca25f66adb1be455fbd38d4010d48faeef",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "1JwMWBVLtiqtscbaRHai4pqHokhFCbtoB4",
-        "76a914c4c1b72491ede1eedaca00618407ee0b772cad0d88ac",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "3QCzvfL4ZRvmJFiWWBVwxfdaNBT8EtxB5y",
-        "a914f6fe69bcb548a829cce4c57bf6fff8af3a5981f987",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "mizXiucXRCsEriQCHUkCqef9ph9qtPbZZ6",
-        "76a914261f83568a098a8638844bd7aeca039d5f2352c088ac",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "2NEWDzHWwY5ZZp8CQWbB7ouNMLqCia6YRda",
-        "a914e930e1834a4d234702773951d627cce82fbb5d2e87",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "5KQmDryMNDcisTzRp3zEq9e4awRmJrEVU1j5vFRTKpRNYPqYrMg",
-        "d1fab7ab7385ad26872237f1eb9789aa25cc986bacc695e07ac571d6cdac8bc0",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "L39Fy7AC2Hhj95gh3Yb2AU5YHh1mQSAHgpNixvm27poizcJyLtUi",
-        "b0bbede33ef254e8376aceb1510253fc3550efd0fcf84dcd0c9998b288f166b3",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "91cTVUcgydqyZLgaANpf1fvL55FH53QMm4BsnCADVNYuWuqdVys",
-        "037f4192c630f399d9271e26c575269b1d15be553ea1a7217f0cb8513cef41cb",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "cQspfSzsgLeiJGB2u8vrAiWpCU4MxUT6JseWo2SjXy4Qbzn2fwDw",
-        "6251e205e8ad508bab5596bee086ef16cd4b239e0cc0c5d7c4e6035441e7d5de",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "19dcawoKcZdQz365WpXWMhX6QCUpR9SY4r",
-        "76a9145eadaf9bb7121f0f192561a5a62f5e5f5421029288ac",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "37Sp6Rv3y4kVd1nQ1JV5pfqXccHNyZm1x3",
-        "a9143f210e7277c899c3a155cc1c90f4106cbddeec6e87",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "myoqcgYiehufrsnnkqdqbp69dddVDMopJu",
-        "76a914c8a3c2a09a298592c3e180f02487cd91ba3400b588ac",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "2N7FuwuUuoTBrDFdrAZ9KxBmtqMLxce9i1C",
-        "a91499b31df7c9068d1481b596578ddbb4d3bd90baeb87",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "5KL6zEaMtPRXZKo1bbMq7JDjjo1bJuQcsgL33je3oY8uSJCR5b4",
-        "c7666842503db6dc6ea061f092cfb9c388448629a6fe868d068c42a488b478ae",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "KwV9KAfwbwt51veZWNscRTeZs9CKpojyu1MsPnaKTF5kz69H1UN2",
-        "07f0803fc5399e773555ab1e8939907e9badacc17ca129e67a2f5f2ff84351dd",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "93N87D6uxSBzwXvpokpzg8FFmfQPmvX4xHoWQe3pLdYpbiwT5YV",
-        "ea577acfb5d1d14d3b7b195c321566f12f87d2b77ea3a53f68df7ebf8604a801",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "cMxXusSihaX58wpJ3tNuuUcZEQGt6DKJ1wEpxys88FFaQCYjku9h",
-        "0b3b34f0958d8a268193a9814da92c3e8b58b4a4378a542863e34ac289cd830c",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "13p1ijLwsnrcuyqcTvJXkq2ASdXqcnEBLE",
-        "76a9141ed467017f043e91ed4c44b4e8dd674db211c4e688ac",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "3ALJH9Y951VCGcVZYAdpA3KchoP9McEj1G",
-        "a9145ece0cadddc415b1980f001785947120acdb36fc87",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
-        "0014751e76e8199196d454941c45d1b3a323f1433bd6",
-        {
-            "isPrivkey": false,
             "chain": "main",
-            "tryCaseFlip": true
+            "isPrivkey": false
         }
     ],
     [
-        "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080",
-        "0014751e76e8199196d454941c45d1b3a323f1433bd6",
+        "3MJLKTjYK8U2LSE5G8qH66P6cTkd2fbYKo",
+        "a914d7184dd5b2ac5ffa6b808271b51d39610ca2952187",
         {
-            "isPrivkey": false,
-            "chain": "regtest",
-            "tryCaseFlip": true
+            "chain": "main",
+            "isPrivkey": false
         }
     ],
     [
-        "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
-        "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
+        "mvAUuoN11iBG6xx7AiX3ifUV9WpDfmPa8u",
+        "76a914a0aab571f298b042bc9bce37d8a45f9d37e9c5ef88ac",
         {
-            "isPrivkey": false,
             "chain": "test",
-            "tryCaseFlip": true
+            "isPrivkey": false
         }
     ],
     [
-        "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx",
-        "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6",
+        "2MsFPtk8t5LQw7nBpFmsCjf8r9e5vfMMdPX",
+        "a914000844921919a97eca8adb5b63c02ecf7dc212eb87",
         {
-            "isPrivkey": false,
-            "chain": "main",
-            "tryCaseFlip": true
-        }
-    ],
-    [
-        "bc1sw50qa3jx3s",
-        "6002751e",
-        {
-            "isPrivkey": false,
-            "chain": "main",
-            "tryCaseFlip": true
-        }
-    ],
-    [
-        "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj",
-        "5210751e76e8199196d454941c45d1b3a323",
-        {
-            "isPrivkey": false,
-            "chain": "main",
-            "tryCaseFlip": true
-        }
-    ],
-    [
-        "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
-        "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
-        {
-            "isPrivkey": false,
             "chain": "test",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "mjC3aAxQcm6QeeJJ81pnpX61xMMgUXuJUG",
+        "76a914284d017134105d53e712d7801def91cfe6b3b26088ac",
+        {
+            "chain": "regtest",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "2N7sKNwAst83ARAqh1z5Ahrt1UieLQZARvc",
+        "a914a0653c424a38b1c7d43ccafb83c90e96da58149c87",
+        {
+            "chain": "regtest",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "5J8KazNMuftbk6azCPQb5YhuiQJddSUmJcyYMbSwo8wiUFNcNQJ",
+        "28f3200da1464c7a9d7456f03980471142a63bcf2bd65f87096694a10c20c6ee",
+        {
+            "chain": "main",
+            "isCompressed": false,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "L44JDntsb8mGGLLJXwoEtbYbH1Sf5PZTigvVcA18184sexkwG65w",
+        "cc04f03e141b18f3debe86edf6daaa2f1b84169515774c5489db97b5a2d09153",
+        {
+            "chain": "main",
+            "isCompressed": true,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "93A1NRTKmTeKHinsqaPDLqMnsrhZtdgNJJ4SxEB6n7mGtfxk4Bo",
+        "ced49a2c0d95a062b2da31cc3e04dbad74cf4f93a928c77fd32e8fcca0552926",
+        {
+            "chain": "test",
+            "isCompressed": false,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "cQmrxBnJjdhJFJo98LnNysqDaxUKWBQANYsArzrxsRZhKtaCAqkr",
+        "5f40e71ffb52d0c31786fb6018db39e964c7d5a6b946590461fd7b28e1c4571e",
+        {
+            "chain": "test",
+            "isCompressed": true,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "92kU7nc1yidzKyJdJGDNhNHvjD26KGB2JtTdKK7XyEvm7hWnb1m",
+        "9961f71b7f22fe502330464805548ac3f5391ff013b91d56608ca0d18e5d9e75",
+        {
+            "chain": "regtest",
+            "isCompressed": false,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "cSdQEjZBzGGsZT5td11rRJqcbQ3fvz8pVrM6rkKUuJLSUFwPEWTe",
+        "96936c11e60fc08e0fb288776368ad7d754eee11753c39bad4211a5b671c875d",
+        {
+            "chain": "regtest",
+            "isCompressed": true,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "bc1qqsjhe0x35lnvcxhf0de0djyqj8gfxwc90g7w8u",
+        "001404257cbcd1a7e6cc1ae97b72f6c88091d0933b05",
+        {
+            "chain": "main",
+            "isPrivkey": false,
             "tryCaseFlip": true
         }
     ],
     [
-        "bcrt1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvseswlauz7",
-        "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
+        "bc1qxdyx9mr8hp39mnjdamv5f4m9908nm98zv0tt34pzd0xhrkgnelcqjh32xa",
+        "0020334862ec67b8625dce4deed944d7652bcf3d94e263d6b8d4226bcd71d913cff0",
         {
+            "chain": "main",
             "isPrivkey": false,
-            "chain": "regtest",
             "tryCaseFlip": true
+        }
+    ],
+    [
+        "bc1p2g8z7e58vl5epg9x7en4m5e9x67ekastycnlucc2z2n3ucvmppxqnjtw5m",
+        "5120520e2f668767e990a0a6f6675dd32536bd9b760b2627fe630a12a71e619b084c",
+        {
+            "chain": "main",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "bc1zyczqag2mv2",
+        "52022604",
+        {
+            "chain": "main",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "tb1qx3wv854zd2emkzfc83j2t2adzftkdq4kc0t05d",
+        "0014345cc3d2a26ab3bb09383c64a5abad12576682b6",
+        {
+            "chain": "test",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "tb1qgjr9pkgglh8sw4ksg406xfyl7n2rz5awa5uddeqgn4y96w9khf9s2awvsc",
+        "0020448650d908fdcf0756d0455fa3249ff4d43153aeed38d6e4089d485d38b6ba4b",
+        {
+            "chain": "test",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "tb1pqhdwj0m7xg6c95vn07qwce4hy5nmhmqvhayx5w8zvf2hye27vruswrc2t7",
+        "512005dae93f7e323582d1937f80ec66b72527bbec0cbf486a38e2625572655e60f9",
+        {
+            "chain": "test",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "tb1rjfpgh7cnpkqfrq76ekkgucwdqgklltya",
+        "531092428bfb130d809183dacdac8e61cd02",
+        {
+            "chain": "test",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "bcrt1qq6dlzfmth08txpj06gm0jj5qaw7j8jj8qlkwdu",
+        "0014069bf1276bbbceb3064fd236f94a80ebbd23ca47",
+        {
+            "chain": "regtest",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "bcrt1q3708vp22qn6ezk47lx2g0ck3tvrm7s0dj7naajlxwegm4289gjlqcwwf29",
+        "00208f9e76054a04f5915abef99487e2d15b07bf41ed97a7decbe67651baa8e544be",
+        {
+            "chain": "regtest",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "bcrt1pdt8nx0wk2xmv0fv0tg9l4ps87nes44dwz8s7yd0xppnxv22k2lcsssg874",
+        "51206acf333dd651b6c7a58f5a0bfa8607f4f30ad5ae11e1e235e6086666295657f1",
+        {
+            "chain": "regtest",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "bcrt1sxs49j3ctsrqpvju8wtszynehlcmgx82hmhs6kckvkyzw24d3r6j29kf3gjmmpmxwx00n7m",
+        "6028342a59470b80c0164b8772e0224f37fe36831d57dde1ab62ccb104e555b11ea4a2d93144b7b0ecce",
+        {
+            "chain": "regtest",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "1HYHMSsBJnA3tkACp8Yet1DEfbc63u4ku4",
+        "76a914b56c8ec8a6297b2804113ddabd34fb95c574fca788ac",
+        {
+            "chain": "main",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "3BiJtoZKF93YdYARkHxDdCYbRzwWuN9Dwa",
+        "a9146defd6f293368f683654fefac42f0fe20add132f87",
+        {
+            "chain": "main",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "n2FK7HfSTMg8M5A4haEhSr92xUmRFsi5PS",
+        "76a914e3655c6d2ae661c1a2e3a84a8ebb3663d2a5478d88ac",
+        {
+            "chain": "test",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "2NFiGy8rTrrNKtb7NHoWDpuPtJitNAg2KYr",
+        "a914f6707c684df7be7e37402fb86578b7d31bcff88387",
+        {
+            "chain": "test",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "mqvNPprrNJxRnN7aopLgcgzfuZFa9pZRNw",
+        "76a914721ef1357a0e3a55920e1cbbafabaa1f675befda88ac",
+        {
+            "chain": "regtest",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "2N1hdjsHKpLrbXFh1uFLoP8LF9ykukL8mfz",
+        "a9145cbfa5e24b2a9c85202c1a49d949cd202c9d24b087",
+        {
+            "chain": "regtest",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "5JEgGYoTJ9dwkvhM1RBtTYHFCLKHYSsetvuusjT8jBRgxkLHbVw",
+        "376213ede0cff4e5a9a99dc62621849edd12e84e32e50b4c2fd872b2a90a539b",
+        {
+            "chain": "main",
+            "isCompressed": false,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "L4eTMSFgakGfGEv88oZfZTHPicfSpSRLmqkd5xUwM5mRvGdUNWcG",
+        "dd97572e04e485cb3459c25bd5673159e37a5dfce8f6683c03886cf52c766df0",
+        {
+            "chain": "main",
+            "isCompressed": true,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "92Vw1zxCpQeadmn9oo3DcaAzYYATC8E4dxYWcLEpJvmLDGCTpV6",
+        "78605efe8bc054d0ee79eed107446856c3c359add661a5f450e9a34dcfd9c7a0",
+        {
+            "chain": "test",
+            "isCompressed": false,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "cNUakHTv7yJopxUZQ3cM5RC4VfMFkUdCAyQ9jtefhomhpyqpjKiL",
+        "1ab086b845c8776e6f86468b2d7cf782a5b81096274a10b5a21dbf2fbbb20cc6",
+        {
+            "chain": "test",
+            "isCompressed": true,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "92KS5stuYsoRe4PsxD6DTQsL3HL8oicdVwgwKvJTBeLe9JbFsAV",
+        "60899bbfa276d9263c47b92d0f3508acb42810ce00f44de1e8cb0abd628aae13",
+        {
+            "chain": "regtest",
+            "isCompressed": false,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "cTz7XPo8zzoemHZVoATACAE9L9jzrdJ8Fkkg7a2ZQ52p9gqAASCL",
+        "bf11771d24fd18daa0a4d9b379cecb9cc7c82177e66f233515351cc05b207007",
+        {
+            "chain": "regtest",
+            "isCompressed": true,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "bc1q6xw4mq83zgpzyedqtpgh65u7psaarrz768pwsc",
+        "0014d19d5d80f112022265a058517d539e0c3bd18c5e",
+        {
+            "chain": "main",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "bc1quncjnjmmk4tyxdypl80wqv90lc7qfksp3mcv8lr5zyg9e9y7pv8s09h58f",
+        "0020e4f129cb7bb556433481f9dee030affe3c04da018ef0c3fc7411105c949e0b0f",
+        {
+            "chain": "main",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "bc1prf34k6kzuf7vugngsz36guj5ykknjt3l36ch5ykdgemuaflfzvhs45h9c3",
+        "51201a635b6ac2e27cce226880a3a4725425ad392e3f8eb17a12cd4677cea7e9132f",
+        {
+            "chain": "main",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "bc1zaxgqtcvx3y",
+        "5202e990",
+        {
+            "chain": "main",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "tb1q0xeygzklzdcke5fpae8dj4gp7favyg285gy3ez",
+        "001479b2440adf13716cd121ee4ed95501f27ac22147",
+        {
+            "chain": "test",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "tb1qmrryvv8jl4cdkce3s856whutzrkfcd2lytv3rqwxkj23ktf9fzzqcylgum",
+        "0020d8c64630f2fd70db633181e9a75f8b10ec9c355f22d91181c6b4951b2d254884",
+        {
+            "chain": "test",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "tb1pv5235wgguf7fu8ajjs0vfpzhgwvwdvxsu88mjrr82cp9esy6467sgt7uws",
+        "512065151a3908e27c9e1fb2941ec484574398e6b0d0e1cfb90c6756025cc09aaebd",
+        {
+            "chain": "test",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "tb1rzhkfz2she865pjqz2dqa3kv0lvfftkeu",
+        "531015ec912a17c9f540c8025341d8d98ffb",
+        {
+            "chain": "test",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "bcrt1qp09acyw3823sggs8uyq6yv2vpxe4lq8scuxmef",
+        "00140bcbdc11d13aa3042207e101a2314c09b35f80f0",
+        {
+            "chain": "regtest",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "bcrt1qlnpqh99rp80qn6jkgc0zs7acyc50erwp8eefr3zzkrj7ps739fzqzla273",
+        "0020fcc20b94a309de09ea56461e287bb82628fc8dc13e7291c442b0e5e0c3d12a44",
+        {
+            "chain": "regtest",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "bcrt1p3zd30ugrjyl587qqyu48vqclt3yawauzw6pwt3cpkskvczrytywsjpyxnq",
+        "5120889b17f103913f43f800272a76031f5c49d777827682e5c701b42ccc0864591d",
+        {
+            "chain": "regtest",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "bcrt1stgtmagdaa9dqf0rtsxszgcd232g62t43dvkqmmmpf7deqllv576373vc5k9fps08hq3hek",
+        "60285a17bea1bde95a04bc6b81a02461aa8a91a52eb16b2c0def614f9b907feca7b51f4598a58a90c1e7",
+        {
+            "chain": "regtest",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "1Au8D5w97THBxXDyjCn5o8UcUWHFgZeoWv",
+        "76a9146c94c780911ea77c43eee9dc7ce4cd5eeab1e2fa88ac",
+        {
+            "chain": "main",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "3R2FhhgAE4fM6npLMavoBeedrnDJCN4Ho6",
+        "a914ffee4c4faa197a760f901d25880c56f9d635fc8987",
+        {
+            "chain": "main",
+            "isPrivkey": false
         }
     ]
 ]

--- a/src/test/data/key_io_valid.json
+++ b/src/test/data/key_io_valid.json
@@ -1,55 +1,71 @@
 [
     [
-        "1LsN3xZdsNiSMiVc45AGBdhtkQZG53tKpx",
-        "76a914d9f0c2ae3652e96389b4481a510f0b2b96da1d0888ac",
+        "1BShJZ8A5q53oJJfMJoEF1gfZCWdZqZwwD",
+        "76a914728d4cc27d19707b0197cfcd7c412d43287864b588ac",
         {
             "chain": "main",
             "isPrivkey": false
         }
     ],
     [
-        "3MJLKTjYK8U2LSE5G8qH66P6cTkd2fbYKo",
-        "a914d7184dd5b2ac5ffa6b808271b51d39610ca2952187",
+        "3L1YkZjdeNSqaZcNKZFXQfyokx3zVYm7r6",
+        "a914c8f37c3cc21561296ad81f4bec6b5de10ebc185187",
         {
             "chain": "main",
             "isPrivkey": false
         }
     ],
     [
-        "mvAUuoN11iBG6xx7AiX3ifUV9WpDfmPa8u",
-        "76a914a0aab571f298b042bc9bce37d8a45f9d37e9c5ef88ac",
+        "mhJuoGLgnJC8gdBgBzEigsoyG4omQXejPT",
+        "76a91413a92d1998e081354d36c13ce0c9dc04b865d40a88ac",
         {
             "chain": "test",
             "isPrivkey": false
         }
     ],
     [
-        "2MsFPtk8t5LQw7nBpFmsCjf8r9e5vfMMdPX",
-        "a914000844921919a97eca8adb5b63c02ecf7dc212eb87",
+        "2N5VpzKEuYvZJbmg6eUNGnfrrD1ir92FWGu",
+        "a91486648cc2faaf05660e72c04c7a837bcc3e986f1787",
         {
             "chain": "test",
             "isPrivkey": false
         }
     ],
     [
-        "mjC3aAxQcm6QeeJJ81pnpX61xMMgUXuJUG",
-        "76a914284d017134105d53e712d7801def91cfe6b3b26088ac",
+        "mtQueCtmAnP3E4aBHXCiFNEQAuPaLMuQNy",
+        "76a9148d74ecd86c845baf9c6d4484d2d00e731b79e34788ac",
+        {
+            "chain": "signet",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "2NEvWRTHjh89gV52fkperFtwzoFWQiQmiCh",
+        "a914edc895152c67ccff0ba620bcc373b789ec68266f87",
+        {
+            "chain": "signet",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "mngdx94qJFhSf7A7SAEgQSC9fQJuapujJp",
+        "76a9144e9dba545455a80ce94c343d1cac9dec62cbf22288ac",
         {
             "chain": "regtest",
             "isPrivkey": false
         }
     ],
     [
-        "2N7sKNwAst83ARAqh1z5Ahrt1UieLQZARvc",
-        "a914a0653c424a38b1c7d43ccafb83c90e96da58149c87",
+        "2NBzRN3pV56k3JUvSHifaHyzjGHv7ZS9FZZ",
+        "a914cd9da5642451273e5b6d088854cc1fad4a8d442187",
         {
             "chain": "regtest",
             "isPrivkey": false
         }
     ],
     [
-        "5J8KazNMuftbk6azCPQb5YhuiQJddSUmJcyYMbSwo8wiUFNcNQJ",
-        "28f3200da1464c7a9d7456f03980471142a63bcf2bd65f87096694a10c20c6ee",
+        "5KcrFZvJ2p4dM6QVUPu53cKXcCfozA1PJLHm1mNAxkDYhgThLu4",
+        "ed6c796e2f62377410766214f55aa81ac9a6590ad7ed57c509c983bf648409ac",
         {
             "chain": "main",
             "isCompressed": false,
@@ -57,8 +73,8 @@
         }
     ],
     [
-        "L44JDntsb8mGGLLJXwoEtbYbH1Sf5PZTigvVcA18184sexkwG65w",
-        "cc04f03e141b18f3debe86edf6daaa2f1b84169515774c5489db97b5a2d09153",
+        "L195WBrf2G3nCnun4CLxrb8XKk9LbCqH43THh4n4QrL5SzRzpq9j",
+        "74f76c106e38d20514a99a86e4fe3bb28319e7dd2ad21dbc170cbb516a5358fa",
         {
             "chain": "main",
             "isCompressed": true,
@@ -66,8 +82,8 @@
         }
     ],
     [
-        "93A1NRTKmTeKHinsqaPDLqMnsrhZtdgNJJ4SxEB6n7mGtfxk4Bo",
-        "ced49a2c0d95a062b2da31cc3e04dbad74cf4f93a928c77fd32e8fcca0552926",
+        "92z6HnMQR4tWqjfVA3UaUN5EuUMgoVMdCa5rZFYZfmgyD7wxYCw",
+        "b8511e1d74549e305517d48a1d394d1be2cfa5d0f3c0d83f9f450316ffa01276",
         {
             "chain": "test",
             "isCompressed": false,
@@ -75,8 +91,8 @@
         }
     ],
     [
-        "cQmrxBnJjdhJFJo98LnNysqDaxUKWBQANYsArzrxsRZhKtaCAqkr",
-        "5f40e71ffb52d0c31786fb6018db39e964c7d5a6b946590461fd7b28e1c4571e",
+        "cTPnaF52x4w4Tq6afPxRHux3wbYb86thS7S45A7r3oZc1AHTQ6Qm",
+        "ad68c48d337181da125de9061933ececcdf7d917631af7d34f7e38082bff9a11",
         {
             "chain": "test",
             "isCompressed": true,
@@ -84,8 +100,26 @@
         }
     ],
     [
-        "92kU7nc1yidzKyJdJGDNhNHvjD26KGB2JtTdKK7XyEvm7hWnb1m",
-        "9961f71b7f22fe502330464805548ac3f5391ff013b91d56608ca0d18e5d9e75",
+        "924U35yFcYkxe2JXGmuhSRVaShGyhRDZx1ysPmw1sAHuszGMoxq",
+        "3e8dfaf78d4f02b11d0b645648a4f3080d71d0d068979c47f7255c9a29eee01d",
+        {
+            "chain": "signet",
+            "isCompressed": false,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "cRy1qCf2LUesGPQagTkYwk2V3PyN2KCPKgxeg6k6KoJPzH7nrVjw",
+        "82d4187690d6b59bcffda27dae52f2ecb87313cfc0904e0b674a27d906a65fde",
+        {
+            "chain": "signet",
+            "isCompressed": true,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "932NTcHK35Apf2C3K9Zv1ZdeZEmB1x7ZT2Ju3SjoEY6pUgUpT7H",
+        "bd7dba24df9e003e145ae9b4862776413a0bb6fa5b4e42753397f2d9536e58a9",
         {
             "chain": "regtest",
             "isCompressed": false,
@@ -93,8 +127,8 @@
         }
     ],
     [
-        "cSdQEjZBzGGsZT5td11rRJqcbQ3fvz8pVrM6rkKUuJLSUFwPEWTe",
-        "96936c11e60fc08e0fb288776368ad7d754eee11753c39bad4211a5b671c875d",
+        "cNa75orYQ2oos52zCnMaS5PG6XbNZKc5LpGxTHacrxwWeX4WAK3E",
+        "1d87e3c58b08766fea03598380ec8d59f8c88d5392bf683ab1088bd4caf073ee",
         {
             "chain": "regtest",
             "isCompressed": true,
@@ -102,8 +136,8 @@
         }
     ],
     [
-        "bc1qqsjhe0x35lnvcxhf0de0djyqj8gfxwc90g7w8u",
-        "001404257cbcd1a7e6cc1ae97b72f6c88091d0933b05",
+        "bc1q5cuatynjmk4szh40mmunszfzh7zrc5xm9w8ccy",
+        "0014a639d59272ddab015eafdef9380922bf843c50db",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -111,8 +145,8 @@
         }
     ],
     [
-        "bc1qxdyx9mr8hp39mnjdamv5f4m9908nm98zv0tt34pzd0xhrkgnelcqjh32xa",
-        "0020334862ec67b8625dce4deed944d7652bcf3d94e263d6b8d4226bcd71d913cff0",
+        "bc1qkw7lz3ahms6e0ajv27mzh7g62tchjpmve4afc29u7w49tddydy2syv0087",
+        "0020b3bdf147b7dc3597f64c57b62bf91a52f179076ccd7a9c28bcf3aa55b5a46915",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -120,8 +154,8 @@
         }
     ],
     [
-        "bc1p2g8z7e58vl5epg9x7en4m5e9x67ekastycnlucc2z2n3ucvmppxqnjtw5m",
-        "5120520e2f668767e990a0a6f6675dd32536bd9b760b2627fe630a12a71e619b084c",
+        "bc1p5rgvqejqh9dh37t9g94dd9cm8vtqns7dndgj423egwggsggcdzmsspvr7j",
+        "5120a0d0c06640b95b78f965416ad6971b3b1609c3cd9b512aaa39439088211868b7",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -129,8 +163,8 @@
         }
     ],
     [
-        "bc1zyczqag2mv2",
-        "52022604",
+        "bc1zr4pq63udck",
+        "52021d42",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -138,8 +172,8 @@
         }
     ],
     [
-        "tb1qx3wv854zd2emkzfc83j2t2adzftkdq4kc0t05d",
-        "0014345cc3d2a26ab3bb09383c64a5abad12576682b6",
+        "tb1q74fxwnvhsue0l8wremgq66xzvn48jlc5zthsvz",
+        "0014f552674d978732ff9dc3ced00d68c264ea797f14",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -147,8 +181,8 @@
         }
     ],
     [
-        "tb1qgjr9pkgglh8sw4ksg406xfyl7n2rz5awa5uddeqgn4y96w9khf9s2awvsc",
-        "0020448650d908fdcf0756d0455fa3249ff4d43153aeed38d6e4089d485d38b6ba4b",
+        "tb1qpt7cqgq8ukv92dcraun9c3n0s3aswrt62vtv8nqmkfpa2tjfghesv9ln74",
+        "00200afd802007e598553703ef265c466f847b070d7a5316c3cc1bb243d52e4945f3",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -156,8 +190,8 @@
         }
     ],
     [
-        "tb1pqhdwj0m7xg6c95vn07qwce4hy5nmhmqvhayx5w8zvf2hye27vruswrc2t7",
-        "512005dae93f7e323582d1937f80ec66b72527bbec0cbf486a38e2625572655e60f9",
+        "tb1ph9v3e8nxct57hknlkhkz75p5pnxnkn05cw8ewpxu6tek56g29xgqydzfu7",
+        "5120b9591c9e66c2e9ebda7fb5ec2f50340ccd3b4df4c38f9704dcd2f36a690a2990",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -165,8 +199,8 @@
         }
     ],
     [
-        "tb1rjfpgh7cnpkqfrq76ekkgucwdqgklltya",
-        "531092428bfb130d809183dacdac8e61cd02",
+        "tb1ray6e8gxfx49ers6c4c70l3c8lsxtcmlx",
+        "5310e93593a0c9354b91c358ae3cffc707fc",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -174,8 +208,44 @@
         }
     ],
     [
-        "bcrt1qq6dlzfmth08txpj06gm0jj5qaw7j8jj8qlkwdu",
-        "0014069bf1276bbbceb3064fd236f94a80ebbd23ca47",
+        "tb1q0sqzfp3zj42u0perxr6jahhu4y03uw4dypk6sc",
+        "00147c002486229555c7872330f52edefca91f1e3aad",
+        {
+            "chain": "signet",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "tb1q9jv4qnawnuevqaeadn47gkq05ev78m4qg3zqejykdr9u0cm7yutq6gu5dj",
+        "00202c99504fae9f32c0773d6cebe4580fa659e3eea044440cc89668cbc7e37e2716",
+        {
+            "chain": "signet",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "tb1pxqf7d825wjtcftj7uep8w24jq3tz8vudfaqj20rns8ahqya56gcs92eqtu",
+        "51203013e69d54749784ae5ee642772ab2045623b38d4f41253c7381fb7013b4d231",
+        {
+            "chain": "signet",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "tb1rsrzkyvu2rt0dcgexajtazlw5nft4j7494ay396q6auw9375wxsrsgag884",
+        "532080c562338a1adedc2326ec97d17dd49a57597aa5af4912e81aef1c58fa8e3407",
+        {
+            "chain": "signet",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "bcrt1qwf52dt9y2sv0f7fwkcpmtfjf74d4np2saeljt6",
+        "00147268a6aca45418f4f92eb603b5a649f55b598550",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -183,8 +253,8 @@
         }
     ],
     [
-        "bcrt1q3708vp22qn6ezk47lx2g0ck3tvrm7s0dj7naajlxwegm4289gjlqcwwf29",
-        "00208f9e76054a04f5915abef99487e2d15b07bf41ed97a7decbe67651baa8e544be",
+        "bcrt1q0lma84unycxl4n96etffthqlf7y5axyp4fxf64kmhymvw8l6pwfs39futd",
+        "00207ff7d3d793260dfaccbacad295dc1f4f894e9881aa4c9d56dbb936c71ffa0b93",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -192,8 +262,8 @@
         }
     ],
     [
-        "bcrt1pdt8nx0wk2xmv0fv0tg9l4ps87nes44dwz8s7yd0xppnxv22k2lcsssg874",
-        "51206acf333dd651b6c7a58f5a0bfa8607f4f30ad5ae11e1e235e6086666295657f1",
+        "bcrt1p3xat2ryucc2v0adrktqnavfzttvezrr27ngltsa2726p2ehvxz4se722v2",
+        "512089bab50c9cc614c7f5a3b2c13eb1225ad9910c6af4d1f5c3aaf2b41566ec30ab",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -201,8 +271,8 @@
         }
     ],
     [
-        "bcrt1sxs49j3ctsrqpvju8wtszynehlcmgx82hmhs6kckvkyzw24d3r6j29kf3gjmmpmxwx00n7m",
-        "6028342a59470b80c0164b8772e0224f37fe36831d57dde1ab62ccb104e555b11ea4a2d93144b7b0ecce",
+        "bcrt1saflydw6e26xhp29euhy5jke5jjqyywk3wvtc9ulgw9dvxyuqy9hdnxthyw755c7ldavy7u",
+        "6028ea7e46bb59568d70a8b9e5c9495b349480423ad1731782f3e8715ac31380216ed9997723bd4a63df",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -210,56 +280,72 @@
         }
     ],
     [
-        "1HYHMSsBJnA3tkACp8Yet1DEfbc63u4ku4",
-        "76a914b56c8ec8a6297b2804113ddabd34fb95c574fca788ac",
+        "16y3Q1XVRZqMR9T1XL1FkvNtD2E1bXBuYa",
+        "76a9144171ec673aeb9fcf42af6094a3c82207e3b9a78188ac",
         {
             "chain": "main",
             "isPrivkey": false
         }
     ],
     [
-        "3BiJtoZKF93YdYARkHxDdCYbRzwWuN9Dwa",
-        "a9146defd6f293368f683654fefac42f0fe20add132f87",
+        "3CmZZnAiHVQgiAKSakf864oJMxN2BP1eLC",
+        "a914798575fc1041b9440c4e63c28e57e597d00b7e4387",
         {
             "chain": "main",
             "isPrivkey": false
         }
     ],
     [
-        "n2FK7HfSTMg8M5A4haEhSr92xUmRFsi5PS",
-        "76a914e3655c6d2ae661c1a2e3a84a8ebb3663d2a5478d88ac",
+        "mtCB3SoBo7EYUv8j54kUubGY4x3aJPY8nk",
+        "76a9148b0c5f9ee714e0d1d24642ad63d9d5f398d9b56588ac",
         {
             "chain": "test",
             "isPrivkey": false
         }
     ],
     [
-        "2NFiGy8rTrrNKtb7NHoWDpuPtJitNAg2KYr",
-        "a914f6707c684df7be7e37402fb86578b7d31bcff88387",
+        "2N5ymzzKpx6EdUR4UdMZ7t9hcuwqtpHwgw5",
+        "a9148badb3c3b5c0d39f906f7618e0018b7eae4baf7387",
         {
             "chain": "test",
             "isPrivkey": false
         }
     ],
     [
-        "mqvNPprrNJxRnN7aopLgcgzfuZFa9pZRNw",
-        "76a914721ef1357a0e3a55920e1cbbafabaa1f675befda88ac",
+        "myXnpYbub28zgiJupDdZSWZtDbjcyfJVby",
+        "76a914c59ac57661b57daadd7c0caf7318c14f54c6c0fa88ac",
+        {
+            "chain": "signet",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "2MtLg8jS5jSXm9evMzTtvpLjy26dBmjFEoT",
+        "a9140c0007e89cea625d3bf9543baa5a470bb7e5b67287",
+        {
+            "chain": "signet",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "mzCyqdf2UNGdpgkD9NBgLcxdwXRg1i9buY",
+        "76a914cd04311bdd1ef9c5c24e41930e032aade82a863a88ac",
         {
             "chain": "regtest",
             "isPrivkey": false
         }
     ],
     [
-        "2N1hdjsHKpLrbXFh1uFLoP8LF9ykukL8mfz",
-        "a9145cbfa5e24b2a9c85202c1a49d949cd202c9d24b087",
+        "2N3zGiwFku2vQjYnAqXv5Qu2ztfYRhh7tbF",
+        "a91475d56d75c88e704d6c72fbe84ac1505abf736b4087",
         {
             "chain": "regtest",
             "isPrivkey": false
         }
     ],
     [
-        "5JEgGYoTJ9dwkvhM1RBtTYHFCLKHYSsetvuusjT8jBRgxkLHbVw",
-        "376213ede0cff4e5a9a99dc62621849edd12e84e32e50b4c2fd872b2a90a539b",
+        "5JUHCgyxNSHg64wwju72eNsG6ajqo4Z2fHHw9iLDLfh69rSiL7w",
+        "5644d06d88855dacf3192a31df8f4acd8e4c155c52a86d2c1fa48303f5cff053",
         {
             "chain": "main",
             "isCompressed": false,
@@ -267,8 +353,8 @@
         }
     ],
     [
-        "L4eTMSFgakGfGEv88oZfZTHPicfSpSRLmqkd5xUwM5mRvGdUNWcG",
-        "dd97572e04e485cb3459c25bd5673159e37a5dfce8f6683c03886cf52c766df0",
+        "L2kZaexG69VSriMe9T2m1jkS86iPe3xNbjcdfakRC1PHe7ay78Ji",
+        "a50ee94aefcabf5a5d7c85be5b3844dee03c5604861dbfc77fe388c91e5a30f8",
         {
             "chain": "main",
             "isCompressed": true,
@@ -276,8 +362,8 @@
         }
     ],
     [
-        "92Vw1zxCpQeadmn9oo3DcaAzYYATC8E4dxYWcLEpJvmLDGCTpV6",
-        "78605efe8bc054d0ee79eed107446856c3c359add661a5f450e9a34dcfd9c7a0",
+        "927JwT1ViCr5TD2ZX8CsMNhg17dXmou5xu4y2KiH54zD7i34UJq",
+        "4502a54c0026b0150281d41f40860d1e23870c63cdc32645bbed688f2ee41f64",
         {
             "chain": "test",
             "isCompressed": false,
@@ -285,8 +371,8 @@
         }
     ],
     [
-        "cNUakHTv7yJopxUZQ3cM5RC4VfMFkUdCAyQ9jtefhomhpyqpjKiL",
-        "1ab086b845c8776e6f86468b2d7cf782a5b81096274a10b5a21dbf2fbbb20cc6",
+        "cTpGGNPVy2Eagawohbr4aGtRJzpLnjxGsGYh9DUcBM45f3KdKGF6",
+        "ba005a0cb39587aab00bd54c848b59e8adaed47403228567ddc739c2a344ff59",
         {
             "chain": "test",
             "isCompressed": true,
@@ -294,8 +380,26 @@
         }
     ],
     [
-        "92KS5stuYsoRe4PsxD6DTQsL3HL8oicdVwgwKvJTBeLe9JbFsAV",
-        "60899bbfa276d9263c47b92d0f3508acb42810ce00f44de1e8cb0abd628aae13",
+        "932PLCLA19yPNqV67qwHBSGjxi82LVzWBF7josL9ab4Q1kxgPGF",
+        "bd8677e076eb39770bf7e9f9e8d3f2cf257effab9b4c220fd3439ccfc208c984",
+        {
+            "chain": "signet",
+            "isCompressed": false,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "cViUpEy8URSsLjUvxwL7cEuNgCVqM7oKBzd1ZPbA4khcQsQJuj1j",
+        "f2b36ade8393e29dc71e52cb75ba1109ba210203cd7d0a5ae881ad6846516203",
+        {
+            "chain": "signet",
+            "isCompressed": true,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "92jddDjJCVDmJtgvBHQ9i58PMash8kwsYhRdNo22ea2MYPXdCBE",
+        "977bf8686f1bcad28f86c4c14afbd33215746bd19203647bf7ff9c6fddc9cc87",
         {
             "chain": "regtest",
             "isCompressed": false,
@@ -303,8 +407,8 @@
         }
     ],
     [
-        "cTz7XPo8zzoemHZVoATACAE9L9jzrdJ8Fkkg7a2ZQ52p9gqAASCL",
-        "bf11771d24fd18daa0a4d9b379cecb9cc7c82177e66f233515351cc05b207007",
+        "cVwAuMoUqRo399X7vXzuzQyPEvZJMXM8c82zHzRkFCxPCSGx8A6y",
+        "f93acbbce02b8cb9ddca3fad495441e324cc01eb640b0a7b4c9f0e31644c822a",
         {
             "chain": "regtest",
             "isCompressed": true,
@@ -312,8 +416,8 @@
         }
     ],
     [
-        "bc1q6xw4mq83zgpzyedqtpgh65u7psaarrz768pwsc",
-        "0014d19d5d80f112022265a058517d539e0c3bd18c5e",
+        "bc1qz377zwe5awr68dnggengqx9vrjt05k98q3sw2n",
+        "0014147de13b34eb87a3b66846668018ac1c96fa58a7",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -321,8 +425,8 @@
         }
     ],
     [
-        "bc1quncjnjmmk4tyxdypl80wqv90lc7qfksp3mcv8lr5zyg9e9y7pv8s09h58f",
-        "0020e4f129cb7bb556433481f9dee030affe3c04da018ef0c3fc7411105c949e0b0f",
+        "bc1qkmhskpdzg8kdkfywhu09kswwn9qan9vnkrf6mk40jvnr06s6sz5ssf82ya",
+        "0020b6ef0b05a241ecdb248ebf1e5b41ce9941d99593b0d3addaaf932637ea1a80a9",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -330,8 +434,8 @@
         }
     ],
     [
-        "bc1prf34k6kzuf7vugngsz36guj5ykknjt3l36ch5ykdgemuaflfzvhs45h9c3",
-        "51201a635b6ac2e27cce226880a3a4725425ad392e3f8eb17a12cd4677cea7e9132f",
+        "bc1ps8cndas60cntk8x79sg9f5e5jz7x050z8agyugln2ukkks23rryqpejzkc",
+        "512081f136f61a7e26bb1cde2c1054d33490bc67d1e23f504e23f3572d6b415118c8",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -339,8 +443,8 @@
         }
     ],
     [
-        "bc1zaxgqtcvx3y",
-        "5202e990",
+        "bc1zn4tsczge9l",
+        "52029d57",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -348,8 +452,8 @@
         }
     ],
     [
-        "tb1q0xeygzklzdcke5fpae8dj4gp7favyg285gy3ez",
-        "001479b2440adf13716cd121ee4ed95501f27ac22147",
+        "tb1q6xw0wwd9n9d7ge87dryz4vm5vtahzhvz6yett3",
+        "0014d19cf739a5995be464fe68c82ab37462fb715d82",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -357,8 +461,8 @@
         }
     ],
     [
-        "tb1qmrryvv8jl4cdkce3s856whutzrkfcd2lytv3rqwxkj23ktf9fzzqcylgum",
-        "0020d8c64630f2fd70db633181e9a75f8b10ec9c355f22d91181c6b4951b2d254884",
+        "tb1qwn9zq9fu5uk35ykpgsc7rz4uawy4yh0r5m5er26768h5ur50su3qj6evun",
+        "002074ca20153ca72d1a12c14431e18abceb89525de3a6e991ab5ed1ef4e0e8f8722",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -366,8 +470,8 @@
         }
     ],
     [
-        "tb1pv5235wgguf7fu8ajjs0vfpzhgwvwdvxsu88mjrr82cp9esy6467sgt7uws",
-        "512065151a3908e27c9e1fb2941ec484574398e6b0d0e1cfb90c6756025cc09aaebd",
+        "tb1pmcdc5d8gr92rtemfsnhpeqanvs0nr82upn5dktxluz9n0qcv34lqxke0wq",
+        "5120de1b8a34e8195435e76984ee1c83b3641f319d5c0ce8db2cdfe08b37830c8d7e",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -375,8 +479,8 @@
         }
     ],
     [
-        "tb1rzhkfz2she865pjqz2dqa3kv0lvfftkeu",
-        "531015ec912a17c9f540c8025341d8d98ffb",
+        "tb1rgxjvtfzp0xczz6dlzqv8d5cmuykk4qkk",
+        "531041a4c5a44179b02169bf101876d31be1",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -384,8 +488,44 @@
         }
     ],
     [
-        "bcrt1qp09acyw3823sggs8uyq6yv2vpxe4lq8scuxmef",
-        "00140bcbdc11d13aa3042207e101a2314c09b35f80f0",
+        "tb1qa9dlyt6fydestul4y4wh72yshh044w32np8etk",
+        "0014e95bf22f49237305f3f5255d7f2890bddf5aba2a",
+        {
+            "chain": "signet",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "tb1qu4p26n0033720xm0rjgkds5ehdwf039k2fgv75um5krrvfhrrj7qckl9r2",
+        "0020e542ad4def8c7ca79b6f1c9166c299bb5c97c4b65250cf539ba5863626e31cbc",
+        {
+            "chain": "signet",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "tb1pjyukm4n4flwd0ey3lrl06c9kalr60ggmlkcxq2rhhxmy4lvkmkpqexdzqy",
+        "512091396dd6754fdcd7e491f8fefd60b6efc7a7a11bfdb0602877b9b64afd96dd82",
+        {
+            "chain": "signet",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "tb1r4k75s5syvewsvxufdc3xfhf4tw4u30alw39xny3dnxrl6hau7systymfdv",
+        "5320adbd485204665d061b896e2264dd355babc8bfbf744a69922d9987fd5fbcf409",
+        {
+            "chain": "signet",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "bcrt1qnk3tdwwj47ppc4pqmxkjdusegedn9ru5gvccwa",
+        "00149da2b6b9d2af821c5420d9ad26f219465b328f94",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -393,8 +533,8 @@
         }
     ],
     [
-        "bcrt1qlnpqh99rp80qn6jkgc0zs7acyc50erwp8eefr3zzkrj7ps739fzqzla273",
-        "0020fcc20b94a309de09ea56461e287bb82628fc8dc13e7291c442b0e5e0c3d12a44",
+        "bcrt1qz7prfshfkwsxuk72pt6mzr6uumq4qllxe4vmwqt89tat48d362yqlykk6a",
+        "0020178234c2e9b3a06e5bca0af5b10f5ce6c1507fe6cd59b701672afaba9db1d288",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -402,8 +542,8 @@
         }
     ],
     [
-        "bcrt1p3zd30ugrjyl587qqyu48vqclt3yawauzw6pwt3cpkskvczrytywsjpyxnq",
-        "5120889b17f103913f43f800272a76031f5c49d777827682e5c701b42ccc0864591d",
+        "bcrt1pumee3wj80xvyr7wjmj7zsk26x5pn095aegy862yhx6f2j9sgc9hq6cj4cm",
+        "5120e6f398ba47799841f9d2dcbc28595a350337969dca087d28973692a91608c16e",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -411,8 +551,8 @@
         }
     ],
     [
-        "bcrt1stgtmagdaa9dqf0rtsxszgcd232g62t43dvkqmmmpf7deqllv576373vc5k9fps08hq3hek",
-        "60285a17bea1bde95a04bc6b81a02461aa8a91a52eb16b2c0def614f9b907feca7b51f4598a58a90c1e7",
+        "bcrt1szqz8hj64d2hhc6nt65v09jxal66pgff2xpcp9kj648qkk8kjzxelsts4dktd799g47uase",
+        "602810047bcb556aaf7c6a6bd518f2c8ddfeb414252a307012da5aa9c16b1ed211b3f82e156d96df14a8",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -420,18 +560,50 @@
         }
     ],
     [
-        "1Au8D5w97THBxXDyjCn5o8UcUWHFgZeoWv",
-        "76a9146c94c780911ea77c43eee9dc7ce4cd5eeab1e2fa88ac",
+        "12agZTajtRE3STSchwWNWnrm467zzTQ916",
+        "76a9141156e00f70061e5faba8b71593a8c7554b47090c88ac",
         {
             "chain": "main",
             "isPrivkey": false
         }
     ],
     [
-        "3R2FhhgAE4fM6npLMavoBeedrnDJCN4Ho6",
-        "a914ffee4c4faa197a760f901d25880c56f9d635fc8987",
+        "3NXqB6iZiPYbKruNT3d9xNBTmtb73xMvvf",
+        "a914e49decc9e5d97e0547d3642f3a4795b13ae62bca87",
         {
             "chain": "main",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "mjgt4BoCYxjzWvJFoh68x7cj5GeaKDYhyx",
+        "76a9142dc11fc7b8072f733f690ffb0591c00f4062295c88ac",
+        {
+            "chain": "test",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "2NCT6FdQ5MxorHgnFxLeHyGwTGRdkHcrJDH",
+        "a914d2a8ec992b0894a0d9391ca5d9c45c388c41be7e87",
+        {
+            "chain": "test",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "mpomiA7wqDnMcxaNLC23eBuXAb4U6H4ZqW",
+        "76a91465e75e340415ed297c58d6a14d3c17ceeaa17bbd88ac",
+        {
+            "chain": "signet",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "2N1pGAA5uatbU2PKvMA9BnJmHcK6yHfMiZa",
+        "a9145e008b6cc232164570befc23d216060bf4ea793b87",
+        {
+            "chain": "signet",
             "isPrivkey": false
         }
     ]

--- a/src/test/fuzz/bech32.cpp
+++ b/src/test/fuzz/bech32.cpp
@@ -16,28 +16,28 @@
 FUZZ_TARGET(bech32)
 {
     const std::string random_string(buffer.begin(), buffer.end());
-    const std::pair<std::string, std::vector<uint8_t>> r1 = bech32::Decode(random_string);
-    if (r1.first.empty()) {
-        assert(r1.second.empty());
+    const auto r1 = bech32::Decode(random_string);
+    if (r1.hrp.empty()) {
+        assert(r1.encoding == bech32::Encoding::INVALID);
+        assert(r1.data.empty());
     } else {
-        const std::string& hrp = r1.first;
-        const std::vector<uint8_t>& data = r1.second;
-        const std::string reencoded = bech32::Encode(hrp, data);
+        assert(r1.encoding != bech32::Encoding::INVALID);
+        const std::string reencoded = bech32::Encode(r1.encoding, r1.hrp, r1.data);
         assert(CaseInsensitiveEqual(random_string, reencoded));
     }
 
     std::vector<unsigned char> input;
     ConvertBits<8, 5, true>([&](unsigned char c) { input.push_back(c); }, buffer.begin(), buffer.end());
-    const std::string encoded = bech32::Encode("bc", input);
-    assert(!encoded.empty());
 
-    const std::pair<std::string, std::vector<uint8_t>> r2 = bech32::Decode(encoded);
-    if (r2.first.empty()) {
-        assert(r2.second.empty());
-    } else {
-        const std::string& hrp = r2.first;
-        const std::vector<uint8_t>& data = r2.second;
-        assert(hrp == "bc");
-        assert(data == input);
+    if (input.size() + 3 + 6 <= 90) {
+        // If it's possible to encode input in Bech32(m) without exceeding the 90-character limit:
+        for (auto encoding : {bech32::Encoding::BECH32, bech32::Encoding::BECH32M}) {
+            const std::string encoded = bech32::Encode(encoding, "bc", input);
+            assert(!encoded.empty());
+            const auto r2 = bech32::Decode(encoded);
+            assert(r2.encoding == encoding);
+            assert(r2.hrp == "bc");
+            assert(r2.data == input);
+        }
     }
 }

--- a/test/functional/rpc_invalid_address_message.py
+++ b/test/functional/rpc_invalid_address_message.py
@@ -12,8 +12,12 @@ from test_framework.util import (
 )
 
 BECH32_VALID = 'bcrt1qtmp74ayg7p24uslctssvjm06q5phz4yrxucgnv'
-BECH32_INVALID_SIZE = 'bcrt1sqqpl9r5c'
-BECH32_INVALID_PREFIX = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'
+BECH32_INVALID_BECH32 = 'bcrt1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqdmchcc'
+BECH32_INVALID_BECH32M = 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7k35mrzd'
+BECH32_INVALID_VERSION = 'bcrt130xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqynjegk'
+BECH32_INVALID_SIZE = 'bcrt1s0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v8n0nx0muaewav25430mtr'
+BECH32_INVALID_V0_SIZE = 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kqqq5k3my'
+BECH32_INVALID_PREFIX = 'bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx'
 
 BASE58_VALID = 'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn'
 BASE58_INVALID_PREFIX = '17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem'
@@ -39,6 +43,18 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
         info = node.validateaddress(BECH32_INVALID_PREFIX)
         assert not info['isvalid']
         assert_equal(info['error'], 'Invalid prefix for Bech32 address')
+
+        info = node.validateaddress(BECH32_INVALID_BECH32)
+        assert not info['isvalid']
+        assert_equal(info['error'], 'Version 1+ witness address must use Bech32m checksum')
+
+        info = node.validateaddress(BECH32_INVALID_BECH32M)
+        assert not info['isvalid']
+        assert_equal(info['error'], 'Version 0 witness address must use Bech32 checksum')
+
+        info = node.validateaddress(BECH32_INVALID_V0_SIZE)
+        assert not info['isvalid']
+        assert_equal(info['error'], 'Invalid Bech32 v0 address data size')
 
         info = node.validateaddress(BECH32_VALID)
         assert info['isvalid']

--- a/test/functional/test_framework/segwit_addr.py
+++ b/test/functional/test_framework/segwit_addr.py
@@ -2,10 +2,18 @@
 # Copyright (c) 2017 Pieter Wuille
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Reference implementation for Bech32 and segwit addresses."""
+"""Reference implementation for Bech32/Bech32m and segwit addresses."""
 import unittest
+from enum import Enum
 
 CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+BECH32_CONST = 1
+BECH32M_CONST = 0x2bc830a3
+
+class Encoding(Enum):
+    """Enumeration type to list the various supported encodings."""
+    BECH32 = 1
+    BECH32M = 2
 
 
 def bech32_polymod(values):
@@ -27,38 +35,45 @@ def bech32_hrp_expand(hrp):
 
 def bech32_verify_checksum(hrp, data):
     """Verify a checksum given HRP and converted data characters."""
-    return bech32_polymod(bech32_hrp_expand(hrp) + data) == 1
+    check = bech32_polymod(bech32_hrp_expand(hrp) + data)
+    if check == BECH32_CONST:
+        return Encoding.BECH32
+    elif check == BECH32M_CONST:
+        return Encoding.BECH32M
+    else:
+        return None
 
-
-def bech32_create_checksum(hrp, data):
+def bech32_create_checksum(encoding, hrp, data):
     """Compute the checksum values given HRP and data."""
     values = bech32_hrp_expand(hrp) + data
-    polymod = bech32_polymod(values + [0, 0, 0, 0, 0, 0]) ^ 1
+    const = BECH32M_CONST if encoding == Encoding.BECH32M else BECH32_CONST
+    polymod = bech32_polymod(values + [0, 0, 0, 0, 0, 0]) ^ const
     return [(polymod >> 5 * (5 - i)) & 31 for i in range(6)]
 
 
-def bech32_encode(hrp, data):
-    """Compute a Bech32 string given HRP and data values."""
-    combined = data + bech32_create_checksum(hrp, data)
+def bech32_encode(encoding, hrp, data):
+    """Compute a Bech32 or Bech32m string given HRP and data values."""
+    combined = data + bech32_create_checksum(encoding, hrp, data)
     return hrp + '1' + ''.join([CHARSET[d] for d in combined])
 
 
 def bech32_decode(bech):
-    """Validate a Bech32 string, and determine HRP and data."""
+    """Validate a Bech32/Bech32m string, and determine HRP and data."""
     if ((any(ord(x) < 33 or ord(x) > 126 for x in bech)) or
             (bech.lower() != bech and bech.upper() != bech)):
-        return (None, None)
+        return (None, None, None)
     bech = bech.lower()
     pos = bech.rfind('1')
     if pos < 1 or pos + 7 > len(bech) or len(bech) > 90:
-        return (None, None)
+        return (None, None, None)
     if not all(x in CHARSET for x in bech[pos+1:]):
-        return (None, None)
+        return (None, None, None)
     hrp = bech[:pos]
     data = [CHARSET.find(x) for x in bech[pos+1:]]
-    if not bech32_verify_checksum(hrp, data):
-        return (None, None)
-    return (hrp, data[:-6])
+    encoding = bech32_verify_checksum(hrp, data)
+    if encoding is None:
+        return (None, None, None)
+    return (encoding, hrp, data[:-6])
 
 
 def convertbits(data, frombits, tobits, pad=True):
@@ -86,7 +101,7 @@ def convertbits(data, frombits, tobits, pad=True):
 
 def decode_segwit_address(hrp, addr):
     """Decode a segwit address."""
-    hrpgot, data = bech32_decode(addr)
+    encoding, hrpgot, data = bech32_decode(addr)
     if hrpgot != hrp:
         return (None, None)
     decoded = convertbits(data[1:], 5, 8, False)
@@ -96,12 +111,15 @@ def decode_segwit_address(hrp, addr):
         return (None, None)
     if data[0] == 0 and len(decoded) != 20 and len(decoded) != 32:
         return (None, None)
+    if (data[0] == 0 and encoding != Encoding.BECH32) or (data[0] != 0 and encoding != Encoding.BECH32M):
+        return (None, None)
     return (data[0], decoded)
 
 
 def encode_segwit_address(hrp, witver, witprog):
     """Encode a segwit address."""
-    ret = bech32_encode(hrp, [witver] + convertbits(witprog, 8, 5))
+    encoding = Encoding.BECH32 if witver == 0 else Encoding.BECH32M
+    ret = bech32_encode(encoding, hrp, [witver] + convertbits(witprog, 8, 5))
     if decode_segwit_address(hrp, ret) == (None, None):
         return None
     return ret
@@ -119,3 +137,5 @@ class TestFrameworkScript(unittest.TestCase):
         # P2WSH
         test_python_bech32('bcrt1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3xueyj')
         test_python_bech32('bcrt1qft5p2uhsdcdc3l2ua4ap5qqfg4pjaqlp250x7us7a8qqhrxrxfsqseac85')
+        # P2TR
+        test_python_bech32('bcrt1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqc8gma6')

--- a/test/functional/wallet_labels.py
+++ b/test/functional/wallet_labels.py
@@ -138,13 +138,13 @@ class WalletLabelsTest(BitcoinTestFramework):
         node.createwallet(wallet_name='watch_only', disable_private_keys=True)
         wallet_watch_only = node.get_wallet_rpc('watch_only')
         BECH32_VALID = {
-            '✔️_VER15_PROG40': 'bcrt10qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqn2cjv3',
-            '✔️_VER16_PROG03': 'bcrt1sqqqqqjq8pdp',
-            '✔️_VER16_PROB02': 'bcrt1sqqqqqjq8pv',
+            '✔️_VER15_PROG40': 'bcrt10qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqxkg7fn',
+            '✔️_VER16_PROG03': 'bcrt1sqqqqq8uhdgr',
+            '✔️_VER16_PROB02': 'bcrt1sqqqq4wstyw',
         }
         BECH32_INVALID = {
-            '❌_VER15_PROG41': 'bcrt10qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzc7xyq',
-            '❌_VER16_PROB01': 'bcrt1sqqpl9r5c',
+            '❌_VER15_PROG41': 'bcrt1sqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqajlxj8',
+            '❌_VER16_PROB01': 'bcrt1sqq5r4036',
         }
         for l in BECH32_VALID:
             ad = BECH32_VALID[l]


### PR DESCRIPTION
This implements [BIP 350](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki):
* For segwit v1+ addresses, a new checksum algorithm called Bech32m is used.
* Segwit v0 address keep using Bech32 as specified in [BIP 173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki).
