### PR TITLE
net: Move SocketSendData lock annotation to header

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -778,7 +778,7 @@ class NetEventsInterface
 {
 public:
     virtual bool ProcessMessages(CNode* pnode, std::atomic<bool>& interrupt) = 0;
-    virtual bool SendMessages(CNode* pnode) = 0;
+    virtual bool SendMessages(CNode* pnode) EXCLUSIVE_LOCKS_REQUIRED(pnode->cs_sendProcessing) = 0;
     virtual void InitializeNode(CNode* pnode) = 0;
     virtual void FinalizeNode(const CNode& node, bool& update_connection_time) = 0;
 
@@ -1057,7 +1057,7 @@ private:
 
     NodeId GetNewNodeId();
 
-    size_t SocketSendData(CNode *pnode) const;
+    size_t SocketSendData(CNode& node) const EXCLUSIVE_LOCKS_REQUIRED(node.cs_vSend);
     void DumpAddresses();
 
     // Network stats


### PR DESCRIPTION
Lock annotations must be in the header, otherwise the will have limited or no effect