### PR TITLE
test: Run mempool_limit.py even with wallet disabled

### DIFF
--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -7,7 +7,9 @@
 from decimal import Decimal
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_greater_than, assert_raises_rpc_error, create_confirmed_utxos, create_lots_of_big_transactions, gen_return_txouts
+from test_framework.util import assert_equal, assert_greater_than, assert_raises_rpc_error, gen_return_txouts
+from test_framework.wallet import MiniWallet
+from test_framework.messages import CTransaction, FromHex
 
 class MempoolLimitTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -20,55 +22,49 @@ class MempoolLimitTest(BitcoinTestFramework):
         ]]
         self.supports_cli = False
 
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
-
     def run_test(self):
         txouts = gen_return_txouts()
-        relayfee = self.nodes[0].getnetworkinfo()['relayfee']
+        node = self.nodes[0]
+        miniwallet = MiniWallet(node)
+        relayfee = node.getnetworkinfo()['relayfee']
 
         self.log.info('Check that mempoolminfee is minrelytxfee')
-        assert_equal(self.nodes[0].getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
-        assert_equal(self.nodes[0].getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
+        assert_equal(node.getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
+        assert_equal(node.getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
 
-        txids = []
-        utxos = create_confirmed_utxos(relayfee, self.nodes[0], 91)
+        txids=[]
+        miniwallet.generate(92)
+        node.generate(100)
 
         self.log.info('Create a mempool tx that will be evicted')
-        us0 = utxos.pop()
-        inputs = [{ "txid" : us0["txid"], "vout" : us0["vout"]}]
-        outputs = {self.nodes[0].getnewaddress() : 0.0001}
-        tx = self.nodes[0].createrawtransaction(inputs, outputs)
-        self.nodes[0].settxfee(relayfee) # specifically fund this tx with low fee
-        txF = self.nodes[0].fundrawtransaction(tx)
-        self.nodes[0].settxfee(0) # return to automatic fee selection
-        txFS = self.nodes[0].signrawtransactionwithwallet(txF['hex'])
-        txid = self.nodes[0].sendrawtransaction(txFS['hex'])
-
-        relayfee = self.nodes[0].getnetworkinfo()['relayfee']
-        base_fee = relayfee*100
+        txid = miniwallet.send_self_transfer(fee_rate = relayfee, from_node = node)['txid']
+        mempool_min_fee = node.getmempoolinfo()['mempoolminfee']
+        base_fee = relayfee*1000
         for i in range (3):
             txids.append([])
-            txids[i] = create_lots_of_big_transactions(self.nodes[0], txouts, utxos[30*i:30*i+30], 30, (i+1)*base_fee)
+            txids[i] = self.create_large_transactions(node, txouts, miniwallet, 30, (i+1)*base_fee, mempool_min_fee)
 
         self.log.info('The tx should be evicted by now')
-        assert txid not in self.nodes[0].getrawmempool()
-        txdata = self.nodes[0].gettransaction(txid)
-        assert txdata['confirmations'] ==  0  #confirmation should still be 0
+        assert_greater_than(len([txid for batch in txids for txid in batch]), len(node.getrawmempool()))
+        assert txid not in node.getrawmempool() # check txid in the raw mempool
 
         self.log.info('Check that mempoolminfee is larger than minrelytxfee')
-        assert_equal(self.nodes[0].getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
-        assert_greater_than(self.nodes[0].getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
+        assert_equal(node.getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
+        assert_greater_than(node.getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
 
         self.log.info('Create a mempool tx that will not pass mempoolminfee')
-        us0 = utxos.pop()
-        inputs = [{ "txid" : us0["txid"], "vout" : us0["vout"]}]
-        outputs = {self.nodes[0].getnewaddress() : 0.0001}
-        tx = self.nodes[0].createrawtransaction(inputs, outputs)
-        # specifically fund this tx with a fee < mempoolminfee, >= than minrelaytxfee
-        txF = self.nodes[0].fundrawtransaction(tx, {'feeRate': relayfee})
-        txFS = self.nodes[0].signrawtransactionwithwallet(txF['hex'])
-        assert_raises_rpc_error(-26, "mempool min fee not met", self.nodes[0].sendrawtransaction, txFS['hex'])
+        assert_raises_rpc_error(-26, "mempool min fee not met", miniwallet.send_self_transfer, from_node=node, fee_rate=relayfee)
+
+    def create_large_transactions(self, node, txouts, miniwallet, num, fee, mempool_min_fee):
+        large_txids = []
+        for j in range(num):
+            hex = miniwallet.send_self_transfer(from_node=node, fee_rate=fee, submit_tx=False)['hex']
+            tx = FromHex(CTransaction(), hex)
+            tx.vout.extend(txouts)
+            tx_hex = tx.serialize().hex()
+            txid = node.sendrawtransaction(tx_hex, 0)
+            large_txids.append(txid)
+        return large_txids
 
 if __name__ == '__main__':
     MempoolLimitTest().main()

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -123,7 +123,7 @@ class MiniWallet:
         else:
             return self._utxos[index]
 
-    def send_self_transfer(self, *, fee_rate=Decimal("0.003"), from_node, utxo_to_spend=None):
+    def send_self_transfer(self, *, fee_rate=Decimal("0.003"), from_node, utxo_to_spend=None, submit_tx=True):
         """Create and send a tx with the specified fee_rate. Fee may be exact or at most one satoshi higher than needed."""
         tx = self.create_self_transfer(fee_rate=fee_rate, from_node=from_node, utxo_to_spend=utxo_to_spend)
         self.sendrawtransaction(from_node=from_node, tx_hex=tx['hex'])
@@ -154,6 +154,7 @@ class MiniWallet:
             tx.wit.vtxinwit[0].scriptWitness.stack = [CScript([OP_TRUE])]
         tx_hex = tx.serialize().hex()
 
+        tx_hex = tx.serialize().hex()
         tx_info = from_node.testmempoolaccept([tx_hex])[0]
         assert_equal(mempool_valid, tx_info['allowed'])
         if mempool_valid:


### PR DESCRIPTION
This is a PR proposed in #20078.

This PR enables one more of the non-wallet functional tests by running `mempool_limit.py` even when the wallet is disabled. While restructuring the code, I added an extra method, `send_multi_self_transfer` in  `MiniWallet` class. This method allows the creation of large transactions (by appending txouts to `tx.vout`) which will be useful in other files like `mining_prioritisetransaction.py` as well.

While my approach may not be the cleanest or the most efficient, I totally appreciate any suggestion to improve it.  Thank you very much! 