### PR TITLE
[*.cc,*.cpp] Reduce push_back

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -242,11 +242,12 @@ public:
         if (!args.empty()) {
             throw std::runtime_error("-getinfo takes no arguments");
         }
-        UniValue result(UniValue::VARR);
-        result.push_back(JSONRPCRequestObj("getnetworkinfo", NullUniValue, ID_NETWORKINFO));
-        result.push_back(JSONRPCRequestObj("getblockchaininfo", NullUniValue, ID_BLOCKCHAININFO));
-        result.push_back(JSONRPCRequestObj("getwalletinfo", NullUniValue, ID_WALLETINFO));
-        result.push_back(JSONRPCRequestObj("getbalances", NullUniValue, ID_BALANCES));
+        UniValue result(UniValue::VARR) = {
+                JSONRPCRequestObj("getnetworkinfo", NullUniValue, ID_NETWORKINFO),
+                JSONRPCRequestObj("getblockchaininfo", NullUniValue, ID_BLOCKCHAININFO),
+                JSONRPCRequestObj("getwalletinfo", NullUniValue, ID_WALLETINFO),
+                JSONRPCRequestObj("getbalances", NullUniValue, ID_BALANCES)
+        };
         return result;
     }
 

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -242,7 +242,7 @@ public:
         if (!args.empty()) {
             throw std::runtime_error("-getinfo takes no arguments");
         }
-        UniValue result(UniValue::VARR) = {
+        UniValue result(UniValue::VARR) {
                 JSONRPCRequestObj("getnetworkinfo", NullUniValue, ID_NETWORKINFO),
                 JSONRPCRequestObj("getblockchaininfo", NullUniValue, ID_BLOCKCHAININFO),
                 JSONRPCRequestObj("getwalletinfo", NullUniValue, ID_WALLETINFO),

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -295,8 +295,8 @@ static bool HTTPBindAddresses(struct evhttp* http)
 
     // Determine what addresses to bind to
     if (!(gArgs.IsArgSet("-rpcallowip") && gArgs.IsArgSet("-rpcbind"))) { // Default to loopback if not allowing external IPs
-        endpoints.push_back(std::make_pair("::1", http_port));
-        endpoints.push_back(std::make_pair("127.0.0.1", http_port));
+        endpoints.emplace_back(std::make_pair("::1", http_port));
+        endpoints.emplace_back(std::make_pair("127.0.0.1", http_port));
         if (gArgs.IsArgSet("-rpcallowip")) {
             LogPrintf("WARNING: option -rpcallowip was specified without -rpcbind; this doesn't usually make sense\n");
         }

--- a/src/leveldb/util/coding_test.cc
+++ b/src/leveldb/util/coding_test.cc
@@ -98,12 +98,13 @@ TEST(Coding, Varint32) {
 
 TEST(Coding, Varint64) {
   // Construct the list of values to check
-  std::vector<uint64_t> values;
-  // Some special values
-  values.push_back(0);
-  values.push_back(100);
-  values.push_back(~static_cast<uint64_t>(0));
-  values.push_back(~static_cast<uint64_t>(0) - 1);
+  std::vector<uint64_t> values = {
+          // Some special values
+          0,
+          100,
+          (~static_cast<uint64_t>(0)),
+          (~static_cast<uint64_t>(0) - 1)
+  };
   for (uint32_t k = 0; k < 64; k++) {
     // Test values near powers of two
     const uint64_t power = 1ull << k;

--- a/src/leveldb/util/coding_test.cc
+++ b/src/leveldb/util/coding_test.cc
@@ -98,13 +98,12 @@ TEST(Coding, Varint32) {
 
 TEST(Coding, Varint64) {
   // Construct the list of values to check
-  std::vector<uint64_t> values {
-          // Some special values
-          0,
-          100,
-          (~static_cast<uint64_t>(0)),
-          (~static_cast<uint64_t>(0) - 1)
-  };
+  std::vector<uint64_t> values;
+  // Some special values
+  values.push_back(0);
+  values.push_back(100);
+  values.push_back(~static_cast<uint64_t>(0));
+  values.push_back(~static_cast<uint64_t>(0) - 1);
   for (uint32_t k = 0; k < 64; k++) {
     // Test values near powers of two
     const uint64_t power = 1ull << k;

--- a/src/leveldb/util/coding_test.cc
+++ b/src/leveldb/util/coding_test.cc
@@ -98,7 +98,7 @@ TEST(Coding, Varint32) {
 
 TEST(Coding, Varint64) {
   // Construct the list of values to check
-  std::vector<uint64_t> values = {
+  std::vector<uint64_t> values {
           // Some special values
           0,
           100,

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -503,7 +503,7 @@ static bool Socks5(const std::string& strDest, int port, const ProxyCredentials 
     } else {
         return error("Proxy requested wrong authentication method %02x", pchRet1[1]);
     }
-    std::vector<uint8_t> vSocks5 = {
+    std::vector<uint8_t> vSocks5 {
             SOCKSVersion::SOCKS5, // VER protocol version
             SOCKS5Command::CONNECT, // CMD CONNECT
             0x00, // RSV Reserved must be 0

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -503,12 +503,13 @@ static bool Socks5(const std::string& strDest, int port, const ProxyCredentials 
     } else {
         return error("Proxy requested wrong authentication method %02x", pchRet1[1]);
     }
-    std::vector<uint8_t> vSocks5;
-    vSocks5.push_back(SOCKSVersion::SOCKS5); // VER protocol version
-    vSocks5.push_back(SOCKS5Command::CONNECT); // CMD CONNECT
-    vSocks5.push_back(0x00); // RSV Reserved must be 0
-    vSocks5.push_back(SOCKS5Atyp::DOMAINNAME); // ATYP DOMAINNAME
-    vSocks5.push_back(strDest.size()); // Length<=255 is checked at beginning of function
+    std::vector<uint8_t> vSocks5 = {
+            SOCKSVersion::SOCKS5, // VER protocol version
+            SOCKS5Command::CONNECT, // CMD CONNECT
+            0x00, // RSV Reserved must be 0
+            SOCKS5Atyp::DOMAINNAME, // ATYP DOMAINNAME
+            strDest.size() // Length<=255 is checked at beginning of function
+    };
     vSocks5.insert(vSocks5.end(), strDest.begin(), strDest.end());
     vSocks5.push_back((port >> 8) & 0xFF);
     vSocks5.push_back((port >> 0) & 0xFF);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -798,15 +798,16 @@ static RPCHelpMan getblocktemplate()
 
     arith_uint256 hashTarget = arith_uint256().SetCompact(pblock->nBits);
 
-    UniValue aMutable(UniValue::VARR) = {
+    UniValue aMutable(UniValue::VARR) {
         "time",
         "transactions",
         "prevblock"
     };
 
-    UniValue result(UniValue::VOBJ) = {("capabilities", aCaps)};
+    UniValue result(UniValue::VOBJ);
+    result.pushKV("capabilities", aCaps);
 
-    UniValue aRules(UniValue::VARR) = {
+    UniValue aRules(UniValue::VARR) {
         "csv"
     };
     if (!fPreSegWit) aRules.push_back("!segwit");

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -798,16 +798,17 @@ static RPCHelpMan getblocktemplate()
 
     arith_uint256 hashTarget = arith_uint256().SetCompact(pblock->nBits);
 
-    UniValue aMutable(UniValue::VARR);
-    aMutable.push_back("time");
-    aMutable.push_back("transactions");
-    aMutable.push_back("prevblock");
+    UniValue aMutable(UniValue::VARR) = {
+        "time",
+        "transactions",
+        "prevblock"
+    };
 
-    UniValue result(UniValue::VOBJ);
-    result.pushKV("capabilities", aCaps);
+    UniValue result(UniValue::VOBJ) = {("capabilities", aCaps)};
 
-    UniValue aRules(UniValue::VARR);
-    aRules.push_back("csv");
+    UniValue aRules(UniValue::VARR) = {
+        "csv"
+    };
     if (!fPreSegWit) aRules.push_back("!segwit");
     UniValue vbavailable(UniValue::VOBJ);
     for (int j = 0; j < (int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++j) {

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -318,9 +318,10 @@ BOOST_AUTO_TEST_CASE(merkle_test_LeftSubtreeRightSubtree)
     uint256 root = BlockMerkleRoot(block);
     uint256 rootOfLeftSubtree = BlockMerkleRoot(leftSubtreeBlock);
     uint256 rootOfRightSubtree = BlockMerkleRoot(rightSubtreeBlock);
-    std::vector<uint256> leftRight;
-    leftRight.push_back(rootOfLeftSubtree);
-    leftRight.push_back(rootOfRightSubtree);
+    std::vector<uint256> leftRight = {
+        rootOfLeftSubtree,
+        rootOfRightSubtree
+    };
     uint256 rootOfLR = ComputeMerkleRoot(leftRight);
 
     BOOST_CHECK_EQUAL(root, rootOfLR);

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -318,7 +318,7 @@ BOOST_AUTO_TEST_CASE(merkle_test_LeftSubtreeRightSubtree)
     uint256 root = BlockMerkleRoot(block);
     uint256 rootOfLeftSubtree = BlockMerkleRoot(leftSubtreeBlock);
     uint256 rootOfRightSubtree = BlockMerkleRoot(rightSubtreeBlock);
-    std::vector<uint256> leftRight = {
+    std::vector<uint256> leftRight {
         rootOfLeftSubtree,
         rootOfRightSubtree
     };

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -392,7 +392,7 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction)
     CKeyID hash = key.GetPubKey().GetID();
     CScript scriptPubKey = CScript() << OP_0 << std::vector<unsigned char>(hash.begin(), hash.end());
 
-    std::vector<int> sigHashes = {
+    std::vector<int> sigHashes {
             SIGHASH_NONE | SIGHASH_ANYONECANPAY,
             SIGHASH_SINGLE | SIGHASH_ANYONECANPAY,
             SIGHASH_ALL | SIGHASH_ANYONECANPAY,
@@ -447,7 +447,7 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction)
     }
 
     for(uint32_t i = 0; i < mtx.vin.size(); i++) {
-        std::vector<CScriptCheck> vChecks = {CScriptCheck()};
+        std::vector<CScriptCheck> vChecks {CScriptCheck()};
         CScriptCheck check(coins[tx.vin[i].prevout.n].out, tx, i, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, false, &txdata);
         check.swap(vChecks.back());
         control.Add(vChecks);
@@ -493,7 +493,7 @@ BOOST_AUTO_TEST_CASE(test_witness)
     scriptPubkey2 << ToByteVector(pubkey2) << OP_CHECKSIG;
     scriptPubkey1L << ToByteVector(pubkey1L) << OP_CHECKSIG;
     scriptPubkey2L << ToByteVector(pubkey2L) << OP_CHECKSIG;
-    std::vector<CPubKey> oneandthree = {
+    std::vector<CPubKey> oneandthree {
             pubkey1,
             pubkey3
     };

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -392,13 +392,14 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction)
     CKeyID hash = key.GetPubKey().GetID();
     CScript scriptPubKey = CScript() << OP_0 << std::vector<unsigned char>(hash.begin(), hash.end());
 
-    std::vector<int> sigHashes;
-    sigHashes.push_back(SIGHASH_NONE | SIGHASH_ANYONECANPAY);
-    sigHashes.push_back(SIGHASH_SINGLE | SIGHASH_ANYONECANPAY);
-    sigHashes.push_back(SIGHASH_ALL | SIGHASH_ANYONECANPAY);
-    sigHashes.push_back(SIGHASH_NONE);
-    sigHashes.push_back(SIGHASH_SINGLE);
-    sigHashes.push_back(SIGHASH_ALL);
+    std::vector<int> sigHashes = {
+            SIGHASH_NONE | SIGHASH_ANYONECANPAY,
+            SIGHASH_SINGLE | SIGHASH_ANYONECANPAY,
+            SIGHASH_ALL | SIGHASH_ANYONECANPAY,
+            SIGHASH_NONE,
+            SIGHASH_SINGLE,
+            SIGHASH_ALL
+    };
 
     // create a big transaction of 4500 inputs signed by the same key
     for(uint32_t ij = 0; ij < 4500; ij++) {
@@ -446,9 +447,8 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction)
     }
 
     for(uint32_t i = 0; i < mtx.vin.size(); i++) {
-        std::vector<CScriptCheck> vChecks;
+        std::vector<CScriptCheck> vChecks = {CScriptCheck()};
         CScriptCheck check(coins[tx.vin[i].prevout.n].out, tx, i, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, false, &txdata);
-        vChecks.push_back(CScriptCheck());
         check.swap(vChecks.back());
         control.Add(vChecks);
     }
@@ -493,9 +493,10 @@ BOOST_AUTO_TEST_CASE(test_witness)
     scriptPubkey2 << ToByteVector(pubkey2) << OP_CHECKSIG;
     scriptPubkey1L << ToByteVector(pubkey1L) << OP_CHECKSIG;
     scriptPubkey2L << ToByteVector(pubkey2L) << OP_CHECKSIG;
-    std::vector<CPubKey> oneandthree;
-    oneandthree.push_back(pubkey1);
-    oneandthree.push_back(pubkey3);
+    std::vector<CPubKey> oneandthree = {
+            pubkey1,
+            pubkey3
+    };
     scriptMulti = GetScriptForMultisig(2, oneandthree);
     BOOST_CHECK(keystore.AddCScript(scriptPubkey1));
     BOOST_CHECK(keystore.AddCScript(scriptPubkey2));

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1608,11 +1608,11 @@ BOOST_AUTO_TEST_CASE(test_FormatParagraph)
 
 BOOST_AUTO_TEST_CASE(test_FormatSubVersion)
 {
-    std::vector<std::string> comments;
-    comments.push_back(std::string("comment1"));
-    std::vector<std::string> comments2;
-    comments2.push_back(std::string("comment1"));
-    comments2.push_back(SanitizeString(std::string("Comment2; .,_?@-; !\"#$%&'()*+/<=>[]\\^`{|}~"), SAFE_CHARS_UA_COMMENT)); // Semicolon is discouraged but not forbidden by BIP-0014
+    std::vector<std::string> comments = {std::string("comment1")};
+    std::vector<std::string> comments2 = {
+            std::string("comment1"),
+            SanitizeString(std::string("Comment2; .,_?@-; !\"#$%&'()*+/<=>[]\\^`{|}~"), SAFE_CHARS_UA_COMMENT)) // Semicolon is discouraged but not forbidden by BIP-0014
+    };
     BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, std::vector<std::string>()),std::string("/Test:9.99.0/"));
     BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments),std::string("/Test:9.99.0(comment1)/"));
     BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments2),std::string("/Test:9.99.0(comment1; Comment2; .,_?@-; )/"));

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1608,8 +1608,8 @@ BOOST_AUTO_TEST_CASE(test_FormatParagraph)
 
 BOOST_AUTO_TEST_CASE(test_FormatSubVersion)
 {
-    std::vector<std::string> comments = {std::string("comment1")};
-    std::vector<std::string> comments2 = {
+    std::vector<std::string> comments {std::string("comment1")};
+    std::vector<std::string> comments2 {
             std::string("comment1"),
             SanitizeString(std::string("Comment2; .,_?@-; !\"#$%&'()*+/<=>[]\\^`{|}~"), SAFE_CHARS_UA_COMMENT)) // Semicolon is discouraged but not forbidden by BIP-0014
     };

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3152,8 +3152,7 @@ void CChainState::ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pi
 
     if (pindexNew->pprev == nullptr || pindexNew->pprev->HaveTxsDownloaded()) {
         // If pindexNew is the genesis block or all parents are BLOCK_VALID_TRANSACTIONS.
-        std::deque<CBlockIndex*> queue;
-        queue.push_back(pindexNew);
+        std::deque<CBlockIndex*> queue = {pindexNew};
 
         // Recursively process any descendant blocks that now may be eligible to be connected.
         while (!queue.empty()) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3152,7 +3152,7 @@ void CChainState::ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pi
 
     if (pindexNew->pprev == nullptr || pindexNew->pprev->HaveTxsDownloaded()) {
         // If pindexNew is the genesis block or all parents are BLOCK_VALID_TRANSACTIONS.
-        std::deque<CBlockIndex*> queue = {pindexNew};
+        std::deque<CBlockIndex*> queue {pindexNew};
 
         // Recursively process any descendant blocks that now may be eligible to be connected.
         while (!queue.empty()) {

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -404,8 +404,7 @@ RPCHelpMan removeprunedfunds()
     LOCK(pwallet->cs_wallet);
 
     uint256 hash(ParseHashV(request.params[0], "txid"));
-    std::vector<uint256> vHash;
-    vHash.push_back(hash);
+    std::vector<uint256> vHash {hash};
     std::vector<uint256> vHashOut;
 
     if (pwallet->ZapSelectTx(vHash, vHashOut) != DBErrors::LOAD_OK) {


### PR DESCRIPTION
Expecting lots of push back to reduce [`push_back`](https://en.cppreference.com/w/cpp/container/vector/push_back). These are extremely minor micro-optimisations, so feel free to just close the issue based on that.

PS: There are also a number of other minor optimisations whence elements are individually `push_back`ed in succession, that could be replaced through a trivial [`vector::insert`](https://en.cppreference.com/w/cpp/container/vector/insert) of a list (brace) initialisation.

What do you think? - Worth caring about / merging, or best to close a PR for such minor an optimisation?