### PR TITLE
gitian: Use custom MacOS code signing tool

### DIFF
--- a/contrib/gitian-descriptors/gitian-osx-signer.yml
+++ b/contrib/gitian-descriptors/gitian-osx-signer.yml
@@ -8,9 +8,13 @@ architectures:
 packages:
 - "faketime"
 - "xorriso"
+- "python3-pip"
 remotes:
 - "url": "https://github.com/bitcoin-core/bitcoin-detached-sigs.git"
   "dir": "signature"
+- "url": "https://github.com/achow101/signapple.git"
+  "dir": "signapple"
+  "commit": "c7e73aa27a7615ac9506559173f787e2906b25eb"
 files:
 - "bitcoin-osx-unsigned.tar.gz"
 script: |
@@ -30,6 +34,13 @@ script: |
     echo "\$REAL \$@" >> $WRAP_DIR/${prog}
     chmod +x ${WRAP_DIR}/${prog}
   done
+
+  # Install signapple
+  cd signapple
+  python3 -m pip install -U pip setuptools
+  python3 -m pip install .
+  export PATH="$HOME/.local/bin":$PATH
+  cd ..
 
   UNSIGNED=bitcoin-osx-unsigned.tar.gz
   SIGNED=bitcoin-osx-signed.dmg

--- a/contrib/gitian-descriptors/gitian-osx-signer.yml
+++ b/contrib/gitian-descriptors/gitian-osx-signer.yml
@@ -42,11 +42,12 @@ script: |
   export PATH="$HOME/.local/bin":$PATH
   cd ..
 
-  UNSIGNED=bitcoin-osx-unsigned.tar.gz
+  UNSIGNED_TARBALL=bitcoin-osx-unsigned.tar.gz
+  UNSIGNED_APP=dist/Bitcoin-Qt.app
   SIGNED=bitcoin-osx-signed.dmg
 
-  tar -xf ${UNSIGNED}
+  tar -xf ${UNSIGNED_TARBALL}
   OSX_VOLNAME="$(cat osx_volname)"
-  ./detached-sig-apply.sh ${UNSIGNED} signature/osx
+  ./detached-sig-apply.sh ${UNSIGNED_APP} signature/osx/dist
   ${WRAP_DIR}/xorrisofs -D -l -V "${OSX_VOLNAME}" -no-pad -r -dir-mode 0755 -o uncompressed.dmg signed-app
   ${WRAP_DIR}/dmg dmg uncompressed.dmg ${OUTDIR}/${SIGNED}

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -138,8 +138,6 @@ script: |
     cp contrib/macdeploy/detached-sig-apply.sh unsigned-app-${i}
     cp contrib/macdeploy/detached-sig-create.sh unsigned-app-${i}
     cp ${BASEPREFIX}/${i}/native/bin/dmg unsigned-app-${i}
-    cp ${BASEPREFIX}/${i}/native/bin/${i}-codesign_allocate unsigned-app-${i}/codesign_allocate
-    cp ${BASEPREFIX}/${i}/native/bin/${i}-pagestuff unsigned-app-${i}/pagestuff
     mv dist unsigned-app-${i}
     pushd unsigned-app-${i}
     find . | sort | tar --mtime="$REFERENCE_DATETIME" --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-osx-unsigned.tar.gz

--- a/contrib/macdeploy/detached-sig-apply.sh
+++ b/contrib/macdeploy/detached-sig-apply.sh
@@ -8,10 +8,9 @@ set -e
 
 UNSIGNED="$1"
 SIGNATURE="$2"
-ARCH=x86_64
 ROOTDIR=dist
-TEMPDIR=signed.temp
 OUTDIR=signed-app
+SIGNAPPLE=signapple
 
 if [ -z "$UNSIGNED" ]; then
   echo "usage: $0 <unsigned app> <signature>"
@@ -23,35 +22,6 @@ if [ -z "$SIGNATURE" ]; then
   exit 1
 fi
 
-rm -rf ${TEMPDIR} && mkdir -p ${TEMPDIR}
-tar -C ${TEMPDIR} -xf ${UNSIGNED}
-cp -rf "${SIGNATURE}"/* ${TEMPDIR}
-
-if [ -z "${PAGESTUFF}" ]; then
-  PAGESTUFF=${TEMPDIR}/pagestuff
-fi
-
-if [ -z "${CODESIGN_ALLOCATE}" ]; then
-  CODESIGN_ALLOCATE=${TEMPDIR}/codesign_allocate
-fi
-
-find ${TEMPDIR} -name "*.sign" | while read i; do
-  SIZE=$(stat -c %s "${i}")
-  TARGET_FILE="$(echo "${i}" | sed 's/\.sign$//')"
-
-  echo "Allocating space for the signature of size ${SIZE} in ${TARGET_FILE}"
-  ${CODESIGN_ALLOCATE} -i "${TARGET_FILE}" -a ${ARCH} ${SIZE} -o "${i}.tmp"
-
-  OFFSET=$(${PAGESTUFF} "${i}.tmp" -p | tail -2 | grep offset | sed 's/[^0-9]*//g')
-  if [ -z ${QUIET} ]; then
-    echo "Attaching signature at offset ${OFFSET}"
-  fi
-
-  dd if="$i" of="${i}.tmp" bs=1 seek=${OFFSET} count=${SIZE} 2>/dev/null
-  mv "${i}.tmp" "${TARGET_FILE}"
-  rm "${i}"
-  echo "Success."
-done
-mv ${TEMPDIR}/${ROOTDIR} ${OUTDIR}
-rm -rf ${TEMPDIR}
+${SIGNAPPLE} apply ${UNSIGNED} ${SIGNATURE}
+mv ${ROOTDIR} ${OUTDIR}
 echo "Signed: ${OUTDIR}"

--- a/contrib/macdeploy/detached-sig-create.sh
+++ b/contrib/macdeploy/detached-sig-create.sh
@@ -8,44 +8,21 @@ set -e
 
 ROOTDIR=dist
 BUNDLE="${ROOTDIR}/Bitcoin-Qt.app"
-CODESIGN=codesign
+SIGNAPPLE=signapple
 TEMPDIR=sign.temp
-TEMPLIST=${TEMPDIR}/signatures.txt
 OUT=signature-osx.tar.gz
-OUTROOT=osx
+OUTROOT=osx/dist
 
 if [ -z "$1" ]; then
-  echo "usage: $0 <codesign args>"
-  echo "example: $0 -s MyIdentity"
+  echo "usage: $0 <signapple args>"
+  echo "example: $0 <path to key>"
   exit 1
 fi
 
-rm -rf ${TEMPDIR} ${TEMPLIST}
+rm -rf ${TEMPDIR}
 mkdir -p ${TEMPDIR}
 
-${CODESIGN} -f --file-list ${TEMPLIST} "$@" "${BUNDLE}"
-
-grep -v CodeResources < "${TEMPLIST}" | while read i; do
-  TARGETFILE="${BUNDLE}/$(echo "${i}" | sed "s|.*${BUNDLE}/||")"
-  SIZE=$(pagestuff "$i" -p | tail -2 | grep size | sed 's/[^0-9]*//g')
-  OFFSET=$(pagestuff "$i" -p | tail -2 | grep offset | sed 's/[^0-9]*//g')
-  SIGNFILE="${TEMPDIR}/${OUTROOT}/${TARGETFILE}.sign"
-  DIRNAME="$(dirname "${SIGNFILE}")"
-  mkdir -p "${DIRNAME}"
-  echo "Adding detached signature for: ${TARGETFILE}. Size: ${SIZE}. Offset: ${OFFSET}"
-  dd if="$i" of="${SIGNFILE}" bs=1 skip=${OFFSET} count=${SIZE} 2>/dev/null
-done
-
-grep CodeResources < "${TEMPLIST}" | while read i; do
-  TARGETFILE="${BUNDLE}/$(echo "${i}" | sed "s|.*${BUNDLE}/||")"
-  RESOURCE="${TEMPDIR}/${OUTROOT}/${TARGETFILE}"
-  DIRNAME="$(dirname "${RESOURCE}")"
-  mkdir -p "${DIRNAME}"
-  echo "Adding resource for: \"${TARGETFILE}\""
-  cp "${i}" "${RESOURCE}"
-done
-
-rm ${TEMPLIST}
+${SIGNAPPLE} sign -f --detach "${TEMPDIR}/${OUTROOT}"  "$@" "${BUNDLE}"
 
 tar -C "${TEMPDIR}" -czf "${OUT}" .
 rm -rf "${TEMPDIR}"


### PR DESCRIPTION
The MacOS code signing issues that were encountered during the 0.21.0 release cycle have shown that it is necessary for us to use a code signing tool for which the source code is available and modifiable by us. Given that there appears to not be such a tool available, I have written such a tool, [signapple](https://github.com/achow101/signapple), that we can use. This tool is able to create a valid MacOS code signature, detach it in a way that we were doing previously, and attach it to the unsigned binary. This tool can also verify that the signature is correct.

This PR implements the usage of that tool in the gitian build for the code signed MacOS binary. The code signer will use this tool to create the detached signature. Gitian builders will use this tool to apply the detached signature. The `gitian-osx-signer.yml` descriptor has been modified to install this tool so that the `detached-sig-apply.sh` script can use it. Additionally, the `codesign_allocate` and `pagestuff` tools are no longer necessary so they are no longer added to the tarball used in code signing. Lastly, both the `detached-sig-create.sh` and `detached-sig-apply.sh` scripts are made to be significantly less complex and to not do unexpected things such as unpacking an already unpacked tarball.

The detached code signature that signapple creates is almost identical to that which we were previously creating. The only difference is that the cpu architecture name is included in the extension (e.g. we have `bitcoin-qt.x86_64sign` instead of `bitcoin-qt.sign`). This was done in order to support signing universal binaries which we may want to do in the future. However signapple can still apply existing code signatures as it will accept the `.sign` extension. If it is desired, it can be modified to produce signatures with just the `.sign` extension. However I do not think it is necessary to maintain compatibility with the old process.