### PR TITLE
script: Improve robustness of bitcoind.service on startup

### DIFF
--- a/contrib/init/README.md
+++ b/contrib/init/README.md
@@ -1,6 +1,6 @@
 Sample configuration files for:
 ```
-SystemD: bitcoind.service
+systemd: bitcoind.service
 Upstart: bitcoind.conf
 OpenRC:  bitcoind.openrc
          bitcoind.openrcconf
@@ -9,4 +9,4 @@ macOS:   org.bitcoin.bitcoind.plist
 ```
 have been made available to assist packagers in creating node packages here.
 
-See doc/init.md for more information.
+See [doc/init.md](../../doc/init.md) for more information.

--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -11,7 +11,10 @@
 
 [Unit]
 Description=Bitcoin daemon
-After=network.target
+
+# https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 ExecStart=/usr/bin/bitcoind -daemon \

--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -11,6 +11,7 @@
 
 [Unit]
 Description=Bitcoin daemon
+Documentation=https://github.com/bitcoin/bitcoin/blob/master/doc/init.md
 
 # https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/
 After=network-online.target


### PR DESCRIPTION
If network interfaces are not properly up the following happens:
```
...
2021-01-08T10:17:11Z scheduler thread start
2021-01-08T10:17:11Z libevent: getaddrinfo: address family for nodename not supported
2021-01-08T10:17:11Z Binding RPC on address 127.0.0.1 port 8332 failed.
2021-01-08T10:17:11Z HTTP: creating work queue of depth 16
2021-01-08T10:17:11Z Using random cookie authentication.
2021-01-08T10:17:11Z Generated RPC authentication cookie /var/lib/bitcoind/.cookie
2021-01-08T10:17:11Z HTTP: starting 2 worker threads
2021-01-08T10:17:11Z init message: Loading banlist...
2021-01-08T10:17:11Z SetNetworkActive: true
2021-01-08T10:17:11Z Error: Cannot resolve -externalip address: <EDITED>
2021-01-08T10:17:11Z Shutdown: In progress...
2021-01-08T10:17:11Z scheduler thread exit
2021-01-08T10:17:11Z Shutdown: done
```

This PR improves robustness on startup in such cases in documented way:
https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/

Also minor doc improvements are added.