### PR TITLE
doc: Add explicit macdeployqtplus dependencies install step

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -30,6 +30,11 @@ If you want to build the disk image with `make deploy` (.dmg / optional), you ne
 brew install librsvg
 ```
 
+and [`macdeployqtplus`](../contrib/macdeploy/README.md) dependencies:
+```shell
+pip3 install ds_store mac_alias
+```
+
 The wallet support requires one or both of the dependencies ([*SQLite*](#sqlite) and [*Berkeley DB*](#berkeley-db)) in the sections below.
 To build Bitcoin Core without wallet, see [*Disable-wallet mode*](#disable-wallet-mode).
 


### PR DESCRIPTION
This PR adds to macOS docs an explicit step to install `macdeployqtplus` script dependencies that are not part of the [Python Standard Library](https://docs.python.org/3/library/index.html):
- https://pypi.org/project/ds-store/
- https://pypi.org/project/mac-alias/

This change is required on macOS 11 Big Sur:

-  #20371
- #20878

Close #20878.