### PR TITLE
rpc: Remove deprecated bumpfee behavior

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3449,10 +3449,7 @@ static RPCHelpMan bumpfee_helper(std::string method_name)
     CWallet* const pwallet = wallet.get();
 
     if (pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) && !want_psbt) {
-        if (!pwallet->chain().rpcEnableDeprecated("bumpfee")) {
-            throw JSONRPCError(RPC_METHOD_DEPRECATED, "Using bumpfee with wallets that have private keys disabled is deprecated. Use psbtbumpfee instead or restart bitcoind with -deprecatedrpc=bumpfee. This functionality will be removed in 0.22");
-        }
-        want_psbt = true;
+        throw JSONRPCError(RPC_WALLET_ERROR, "bumpfee is not available with wallets that have private keys disabled. Use psbtbumpfee instead.");
     }
 
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VOBJ});

--- a/test/functional/rpc_deprecated.py
+++ b/test/functional/rpc_deprecated.py
@@ -4,7 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test deprecation of RPC calls."""
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_raises_rpc_error, find_vout_for_address
 
 class DeprecatedRpcTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -24,37 +23,7 @@ class DeprecatedRpcTest(BitcoinTestFramework):
         # assert_raises_rpc_error(-32, 'The wallet generate rpc method is deprecated', self.nodes[0].rpc.generate, 1)
         # self.nodes[1].generate(1)
 
-        if self.is_wallet_compiled():
-            self.log.info("Test bumpfee RPC")
-            self.nodes[0].generate(101)
-            self.nodes[0].createwallet(wallet_name='nopriv', disable_private_keys=True)
-            noprivs0 = self.nodes[0].get_wallet_rpc('nopriv')
-            w0 = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
-            self.nodes[1].createwallet(wallet_name='nopriv', disable_private_keys=True)
-            noprivs1 = self.nodes[1].get_wallet_rpc('nopriv')
-
-            address = w0.getnewaddress()
-            desc = w0.getaddressinfo(address)['desc']
-            change_addr = w0.getrawchangeaddress()
-            change_desc = w0.getaddressinfo(change_addr)['desc']
-            txid = w0.sendtoaddress(address=address, amount=10)
-            vout = find_vout_for_address(w0, txid, address)
-            self.nodes[0].generate(1)
-            rawtx = w0.createrawtransaction([{'txid': txid, 'vout': vout}], {w0.getnewaddress(): 5}, 0, True)
-            rawtx = w0.fundrawtransaction(rawtx, {'changeAddress': change_addr})
-            signed_tx = w0.signrawtransactionwithwallet(rawtx['hex'])['hex']
-
-            noprivs0.importmulti([{'desc': desc, 'timestamp': 0}, {'desc': change_desc, 'timestamp': 0, 'internal': True}])
-            noprivs1.importmulti([{'desc': desc, 'timestamp': 0}, {'desc': change_desc, 'timestamp': 0, 'internal': True}])
-
-            txid = w0.sendrawtransaction(signed_tx)
-            self.sync_all()
-
-            assert_raises_rpc_error(-32, 'Using bumpfee with wallets that have private keys disabled is deprecated. Use psbtbumpfee instead or restart bitcoind with -deprecatedrpc=bumpfee. This functionality will be removed in 0.22', noprivs0.bumpfee, txid)
-            bumped_psbt = noprivs1.bumpfee(txid)
-            assert 'psbt' in bumped_psbt
-        else:
-            self.log.info("No tested deprecated RPC methods")
+        self.log.info("No tested deprecated RPC methods")
 
 if __name__ == '__main__':
     DeprecatedRpcTest().main()

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -425,6 +425,9 @@ def test_watchonly_psbt(self, peer_node, rbf_node, dest_address):
     original_txid = watcher.sendrawtransaction(psbt_final["hex"])
     assert_equal(len(watcher.decodepsbt(psbt)["tx"]["vin"]), 1)
 
+    # bumpfee can't be used on watchonly wallets
+    assert_raises_rpc_error(-4, "bumpfee is not available with wallets that have private keys disabled. Use psbtbumpfee instead.", watcher.bumpfee, original_txid)
+
     # Bump fee, obnoxiously high to add additional watchonly input
     bumped_psbt = watcher.psbtbumpfee(original_txid, {"fee_rate": HIGH})
     assert_greater_than(len(watcher.decodepsbt(bumped_psbt['psbt'])["tx"]["vin"]), 1)


### PR DESCRIPTION
Removes the deprecation message, behavior, and test.

This was marked for removal in 22.0.