### PR TITLE
p2p: mildly discourage peers that violate feefilter

### DIFF
--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -48,9 +48,8 @@ static void AssembleBlock(benchmark::Bench& bench)
         LOCK(::cs_main); // Required for ::AcceptToMemoryPool.
 
         for (const auto& txr : txs) {
-            TxValidationState state;
-            bool ret{::AcceptToMemoryPool(*test_setup.m_node.mempool, state, txr, nullptr /* plTxnReplaced */, false /* bypass_limits */)};
-            assert(ret);
+            const MempoolAcceptResult res = ::AcceptToMemoryPool(*test_setup.m_node.mempool, txr, false /* bypass_limits */);
+            assert(res.m_accepted);
         }
     }
 

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -50,23 +50,21 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
     }
     if (!node.mempool->exists(hashTx)) {
         // Transaction is not already in the mempool.
-        TxValidationState state;
         if (max_tx_fee > 0) {
             // First, call ATMP with test_accept and check the fee. If ATMP
             // fails here, return error immediately.
-            CAmount fee{0};
-            if (!AcceptToMemoryPool(*node.mempool, state, tx,
-                nullptr /* plTxnReplaced */, false /* bypass_limits */, /* test_accept */ true, &fee)) {
-                return HandleATMPError(state, err_string);
-            } else if (fee > max_tx_fee) {
+            const MempoolAcceptResult result =
+                AcceptToMemoryPool(*node.mempool, tx, false /* bypass_limits */, true /* test_accept */);
+            if (!result.m_accepted) {
+                return HandleATMPError(result.m_state, err_string);
+            } else if (result.m_fee > max_tx_fee) {
                 return TransactionError::MAX_FEE_EXCEEDED;
             }
         }
         // Try to submit the transaction to the mempool.
-        if (!AcceptToMemoryPool(*node.mempool, state, tx,
-                nullptr /* plTxnReplaced */, false /* bypass_limits */)) {
-            return HandleATMPError(state, err_string);
-        }
+        const MempoolAcceptResult result =
+            AcceptToMemoryPool(*node.mempool, tx, false /* bypass_limits */, false /* test_accept */);
+        if (!result.m_accepted) return HandleATMPError(result.m_state, err_string);
 
         // Transaction was accepted to the mempool.
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -944,14 +944,15 @@ static RPCHelpMan testmempoolaccept()
     UniValue result_0(UniValue::VOBJ);
     result_0.pushKV("txid", tx_hash.GetHex());
 
-    TxValidationState state;
-    bool test_accept_res;
-    CAmount fee{0};
+    MempoolAcceptResult accept_result(std::move(tx));
     {
         LOCK(cs_main);
-        test_accept_res = AcceptToMemoryPool(mempool, state, std::move(tx),
-            nullptr /* plTxnReplaced */, false /* bypass_limits */, /* test_accept */ true, &fee);
+        accept_result = AcceptToMemoryPool(mempool, std::move(tx),
+            false /* bypass_limits */, true /* test_accept */);
     }
+    const bool test_accept_res = accept_result.m_accepted;
+    const TxValidationState state = accept_result.m_state;
+    const CAmount fee = accept_result.m_fee;
 
     // Check that fee does not exceed maximum fee
     if (test_accept_res && max_raw_tx_fee && fee > max_raw_tx_fee) {

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -30,25 +30,21 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChain100Setup)
 
     BOOST_CHECK(CTransaction(coinbaseTx).IsCoinBase());
 
-    TxValidationState state;
-
     LOCK(cs_main);
 
     unsigned int initialPoolSize = m_node.mempool->size();
+    const MempoolAcceptResult result = AcceptToMemoryPool(*m_node.mempool, MakeTransactionRef(coinbaseTx),
+                true /* bypass_limits */);
 
-    BOOST_CHECK_EQUAL(
-            false,
-            AcceptToMemoryPool(*m_node.mempool, state, MakeTransactionRef(coinbaseTx),
-                nullptr /* plTxnReplaced */,
-                true /* bypass_limits */));
+    BOOST_CHECK_EQUAL(false, result.m_accepted);
 
     // Check that the transaction hasn't been added to mempool.
     BOOST_CHECK_EQUAL(m_node.mempool->size(), initialPoolSize);
 
     // Check that the validation state reflects the unsuccessful attempt.
-    BOOST_CHECK(state.IsInvalid());
-    BOOST_CHECK_EQUAL(state.GetRejectReason(), "coinbase");
-    BOOST_CHECK(state.GetResult() == TxValidationResult::TX_CONSENSUS);
+    BOOST_CHECK(result.m_state.IsInvalid());
+    BOOST_CHECK_EQUAL(result.m_state.GetRejectReason(), "coinbase");
+    BOOST_CHECK(result.m_state.GetResult() == TxValidationResult::TX_CONSENSUS);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -28,9 +28,9 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
     const auto ToMemPool = [this](const CMutableTransaction& tx) {
         LOCK(cs_main);
 
-        TxValidationState state;
-        return AcceptToMemoryPool(*m_node.mempool, state, MakeTransactionRef(tx),
-            nullptr /* plTxnReplaced */, true /* bypass_limits */);
+        const MempoolAcceptResult result = AcceptToMemoryPool(*m_node.mempool, MakeTransactionRef(tx),
+            true /* bypass_limits */);
+        return result.m_accepted;
     };
 
     // Create a double-spend of mature coinbase txn:

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -286,12 +286,8 @@ BOOST_AUTO_TEST_CASE(mempool_locks_reorg)
             TxValidationState state;
             std::list<CTransactionRef> plTxnReplaced;
             for (const auto& tx : txs) {
-                BOOST_REQUIRE(AcceptToMemoryPool(
-                    *m_node.mempool,
-                    state,
-                    tx,
-                    &plTxnReplaced,
-                    /* bypass_limits */ false));
+                const MempoolAcceptResult result = AcceptToMemoryPool(*m_node.mempool, tx, false /* bypass_limits */);
+                BOOST_REQUIRE(result.m_accepted);
             }
         }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -12,6 +12,7 @@
 
 #include <amount.h>
 #include <coins.h>
+#include <consensus/validation.h>
 #include <crypto/common.h> // for ReadLE64
 #include <fs.h>
 #include <optional.h>
@@ -44,7 +45,6 @@ class CConnman;
 class CScriptCheck;
 class CTxMemPool;
 class ChainstateManager;
-class TxValidationState;
 struct ChainTxData;
 
 struct DisconnectedBlockTransactions;
@@ -194,12 +194,22 @@ void UnlinkPrunedFiles(const std::set<int>& setFilesToPrune);
 /** Prune block files up to a given height */
 void PruneBlockFilesManual(int nManualPruneHeight);
 
-/** (try to) add transaction to memory pool
- * plTxnReplaced will be appended to with all transactions replaced from mempool
- * @param[out] fee_out optional argument to return tx fee to the caller **/
-bool AcceptToMemoryPool(CTxMemPool& pool, TxValidationState &state, const CTransactionRef &tx,
-                        std::list<CTransactionRef>* plTxnReplaced,
-                        bool bypass_limits, bool test_accept=false, CAmount* fee_out=nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+/** Per-transaction result from trying to accept a transaction to the memory pool. */
+struct MempoolAcceptResult {
+    MempoolAcceptResult(const CTransactionRef& ptx) : txid(ptx->GetHash()) {}
+
+    uint256 txid;
+    bool m_accepted = false;
+    TxValidationState m_state;
+    std::list<CTransactionRef> m_replaced_transactions{};
+    CAmount m_fee = CAmount(0);
+};
+
+/**
+ * (Try to) add a transaction to the memory pool.
+ */
+MempoolAcceptResult AcceptToMemoryPool(CTxMemPool& pool, const CTransactionRef &tx,
+                        bool bypass_limits, bool test_accept=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** Get the BIP9 state for a given deployment at the current tip. */
 ThresholdState VersionBitsTipState(const Consensus::Params& params, Consensus::DeploymentPos pos);


### PR DESCRIPTION
I found it surprising that we don't care if a peer sends us a transaction with fee lower than the fee filter we send them. This is in the spec for [BIP 133](https://github.com/bitcoin/bips/blob/master/bip-0133.mediawiki#specification) so it's not a bug. But it seems like we send fee filters to limit resource usage and if we don't care when peers violate it, it's kind of ineffective. I can see why we wouldn't want to severely punish - particularly because it's possible that they're responding to a `GETDATA` we sent before the `FEEFILTER`.

This PR adds `Misbehaving(1)` when peers send us transactions that get rejected for fee-related mempool policy and the fee is lower than the feefilter we sent them. This means they get disconnected after 100 of these transactions. Hopefully this seems reasonable.

(Note that the first commit is from a refactor from #20833... I needed it to check the fee after calling ATMP).