### PR TITLE
net: (de)serialize CSubNet in addrv2 format

### DIFF
--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -13,6 +13,7 @@
 #include <compat.h>
 #include <prevector.h>
 #include <serialize.h>
+#include <streams.h>
 #include <tinyformat.h>
 #include <util/strencodings.h>
 #include <util/string.h>
@@ -500,22 +501,45 @@ class CSubNet
         friend bool operator!=(const CSubNet& a, const CSubNet& b) { return !(a == b); }
         friend bool operator<(const CSubNet& a, const CSubNet& b);
 
-        SERIALIZE_METHODS(CSubNet, obj)
+        template <typename Stream>
+        void Serialize(Stream& s_) const
         {
-            READWRITE(obj.network);
-            if (obj.network.IsIPv4()) {
+            OverrideStream<Stream> s(&s_, s_.GetType(), s_.GetVersion() | ADDRV2_FORMAT);
+
+            s << network;
+            if (network.IsIPv4()) {
                 // Before commit 102867c587f5f7954232fb8ed8e85cda78bb4d32, CSubNet used the last 4 bytes of netmask
                 // to store the relevant bytes for an IPv4 mask. For compatibility reasons, keep doing so in
                 // serialized form.
                 unsigned char dummy[12] = {0};
-                READWRITE(dummy);
-                READWRITE(MakeSpan(obj.netmask).first(4));
+                s << dummy;
+                s << MakeSpan(netmask).first(4);
             } else {
-                READWRITE(obj.netmask);
+                s << netmask;
             }
-            READWRITE(obj.valid);
-            // Mark invalid if the result doesn't pass sanity checking.
-            SER_READ(obj, if (obj.valid) obj.valid = obj.SanityCheck());
+            s << valid;
+        }
+
+        template <typename Stream>
+        void Unserialize(Stream& s_)
+        {
+            OverrideStream<Stream> s(&s_, s_.GetType(), s_.GetVersion() | ADDRV2_FORMAT);
+
+            s >> network;
+            if (network.IsIPv4()) {
+                // Before commit 102867c587f5f7954232fb8ed8e85cda78bb4d32, CSubNet used the last 4 bytes of netmask
+                // to store the relevant bytes for an IPv4 mask. For compatibility reasons, keep doing so in
+                // serialized form.
+                unsigned char dummy[12];
+                s >> dummy;
+                s >> MakeSpan(netmask).first(4);
+            } else {
+                s >> netmask;
+            }
+            s >> valid;
+            if (valid) {
+                valid = SanityCheck();
+            }
         }
 };
 

--- a/test/functional/rpc_setban.py
+++ b/test/functional/rpc_setban.py
@@ -51,10 +51,20 @@ class SetBanTests(BitcoinTestFramework):
         ip_addr = "1.2.3.4"
         assert(not self.is_banned(node, tor_addr))
         assert(not self.is_banned(node, ip_addr))
+
         node.setban(tor_addr, "add")
         assert(self.is_banned(node, tor_addr))
         assert(not self.is_banned(node, ip_addr))
+
+        self.restart_node(1)
+        assert(self.is_banned(node, tor_addr))
+        assert(not self.is_banned(node, ip_addr))
+
         node.setban(tor_addr, "remove")
+        assert(not self.is_banned(self.nodes[1], tor_addr))
+        assert(not self.is_banned(node, ip_addr))
+
+        self.restart_node(1)
         assert(not self.is_banned(self.nodes[1], tor_addr))
         assert(not self.is_banned(node, ip_addr))
 


### PR DESCRIPTION
This is a followup to https://github.com/bitcoin/bitcoin/pull/20852
which allowed non-IP subnets, but some of them, e.g. torv3, cannot be
serialized in 16 bytes (addrv1) and must use addrv2.

This PR changes the format of `banlist.dat` in such a way that old
versions (before this commit) will not be able to read a file written by
new versions (after this commit).