### PR TITLE
doc: Add manual page generation for bitcoin-util

### DIFF
--- a/contrib/devtools/gen-manpages.sh
+++ b/contrib/devtools/gen-manpages.sh
@@ -14,13 +14,14 @@ BITCOIND=${BITCOIND:-$BINDIR/bitcoind}
 BITCOINCLI=${BITCOINCLI:-$BINDIR/bitcoin-cli}
 BITCOINTX=${BITCOINTX:-$BINDIR/bitcoin-tx}
 WALLET_TOOL=${WALLET_TOOL:-$BINDIR/bitcoin-wallet}
+BITCOINUTIL=${BITCOINQT:-$BINDIR/bitcoin-util}
 BITCOINQT=${BITCOINQT:-$BINDIR/qt/bitcoin-qt}
 
 [ ! -x $BITCOIND ] && echo "$BITCOIND not found or not executable." && exit 1
 
 # Don't allow man pages to be generated for binaries built from a dirty tree
 DIRTY=""
-for cmd in $BITCOIND $BITCOINCLI $BITCOINTX $WALLET_TOOL $BITCOINQT; do
+for cmd in $BITCOIND $BITCOINCLI $BITCOINTX $WALLET_TOOL $BITCOINUTIL $BITCOINQT; do
   VERSION_OUTPUT=$($cmd --version)
   if [[ $VERSION_OUTPUT == *"dirty"* ]]; then
     DIRTY="${DIRTY}${cmd}\n"
@@ -43,7 +44,7 @@ read -r -a BTCVER <<< "$($BITCOINCLI --version | head -n1 | awk -F'[ -]' '{ prin
 echo "[COPYRIGHT]" > footer.h2m
 $BITCOIND --version | sed -n '1!p' >> footer.h2m
 
-for cmd in $BITCOIND $BITCOINCLI $BITCOINTX $WALLET_TOOL $BITCOINQT; do
+for cmd in $BITCOIND $BITCOINCLI $BITCOINTX $WALLET_TOOL $BITCOINUTIL $BITCOINQT; do
   cmdname="${cmd##*/}"
   help2man -N --version-string=${BTCVER[0]} --include=footer.h2m -o ${MANDIR}/${cmdname}.1 ${cmd}
   sed -i "s/\\\-${BTCVER[1]}//g" ${MANDIR}/${cmdname}.1

--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -16,6 +16,10 @@ if BUILD_BITCOIN_TX
   dist_man1_MANS+=bitcoin-tx.1
 endif
 
+if BUILD_BITCOIN_UTIL
+  dist_man1_MANS+=bitcoin-util.1
+endif
+
 if ENABLE_WALLET
 if BUILD_BITCOIN_WALLET
   dist_man1_MANS+=bitcoin-wallet.1

--- a/doc/man/bitcoin-cli.1
+++ b/doc/man/bitcoin-cli.1
@@ -2,4 +2,4 @@
 .SH NAME
 bitcoin-cli \- manual page for bitcoin-cli
 
-This is a placefolder file. Please follow the instructions in \fIcontrib/devtools/README.md\fR to generate the manual pages after a release.
+This is a placeholder file. Please follow the instructions in \fIcontrib/devtools/README.md\fR to generate the manual pages after a release.

--- a/doc/man/bitcoin-qt.1
+++ b/doc/man/bitcoin-qt.1
@@ -2,4 +2,4 @@
 .SH NAME
 bitcoin-qt \- manual page for bitcoin-qt
 
-This is a placefolder file. Please follow the instructions in \fIcontrib/devtools/README.md\fR to generate the manual pages after a release.
+This is a placeholder file. Please follow the instructions in \fIcontrib/devtools/README.md\fR to generate the manual pages after a release.

--- a/doc/man/bitcoin-tx.1
+++ b/doc/man/bitcoin-tx.1
@@ -2,4 +2,4 @@
 .SH NAME
 bitcoin-tx \- manual page for bitcoin-tx
 
-This is a placefolder file. Please follow the instructions in \fIcontrib/devtools/README.md\fR to generate the manual pages after a release.
+This is a placeholder file. Please follow the instructions in \fIcontrib/devtools/README.md\fR to generate the manual pages after a release.

--- a/doc/man/bitcoin-util.1
+++ b/doc/man/bitcoin-util.1
@@ -1,0 +1,5 @@
+.TH BITCOIN-UTIL "1"
+.SH NAME
+bitcoin-util \- manual page for bitcoin-util
+
+This is a placefolder file. Please follow the instructions in \fIcontrib/devtools/README.md\fR to generate the manual pages after a release.

--- a/doc/man/bitcoin-util.1
+++ b/doc/man/bitcoin-util.1
@@ -2,4 +2,4 @@
 .SH NAME
 bitcoin-util \- manual page for bitcoin-util
 
-This is a placefolder file. Please follow the instructions in \fIcontrib/devtools/README.md\fR to generate the manual pages after a release.
+This is a placeholder file. Please follow the instructions in \fIcontrib/devtools/README.md\fR to generate the manual pages after a release.

--- a/doc/man/bitcoin-wallet.1
+++ b/doc/man/bitcoin-wallet.1
@@ -2,4 +2,4 @@
 .SH NAME
 bitcoin-wallet \- manual page for bitcoin-wallet
 
-This is a placefolder file. Please follow the instructions in \fIcontrib/devtools/README.md\fR to generate the manual pages after a release.
+This is a placeholder file. Please follow the instructions in \fIcontrib/devtools/README.md\fR to generate the manual pages after a release.

--- a/doc/man/bitcoind.1
+++ b/doc/man/bitcoind.1
@@ -2,4 +2,4 @@
 .SH NAME
 bitcoind \- manual page for bitcoind
 
-This is a placefolder file. Please follow the instructions in \fIcontrib/devtools/README.md\fR to generate the manual pages after a release.
+This is a placeholder file. Please follow the instructions in \fIcontrib/devtools/README.md\fR to generate the manual pages after a release.

--- a/src/bitcoin-util.cpp
+++ b/src/bitcoin-util.cpp
@@ -40,6 +40,8 @@ static void SetupBitcoinUtilArgs(ArgsManager &argsman)
 {
     SetupHelpOptions(argsman);
 
+    argsman.AddArg("-version", "Print version and exit", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+
     SetupChainParamsBaseOptions(argsman);
 }
 
@@ -62,12 +64,14 @@ static int AppInitUtil(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    if (argc < 2 || HelpRequested(gArgs)) {
+    if (argc < 2 || HelpRequested(gArgs) || gArgs.IsArgSet("-version")) {
         // First part of help message is specific to this utility
-        std::string strUsage = PACKAGE_NAME " bitcoin-util utility version " + FormatFullVersion() + "\n\n" +
-            "Usage:  bitcoin-util [options] [commands]  Do stuff\n" +
-            "\n";
-        strUsage += gArgs.GetHelpMessage();
+        std::string strUsage = PACKAGE_NAME " bitcoin-util utility version " + FormatFullVersion() + "\n";
+        if (!gArgs.IsArgSet("-version")) {
+            strUsage += "\n"
+                "Usage:  bitcoin-util [options] [commands]  Do stuff\n";
+            strUsage += "\n" + gArgs.GetHelpMessage();
+        }
 
         tfm::format(std::cout, "%s", strUsage);
 


### PR DESCRIPTION
- Add `-version` option to `bitcoin-util`
- Add `bitcoin-util` call to `gen-manpages.sh`
- Add stub manual page `bitcoin-util.1`
- Add install of `bitcoin-util.1` to build system