### PR TITLE
add include for std::bind.

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -30,6 +30,8 @@
 #include <qt/macdockiconhandler.h>
 #endif
 
+#include <functional>
+
 #include <chain.h>
 #include <chainparams.h>
 #include <interfaces/handler.h>

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -18,6 +18,7 @@
 #include <util/threadnames.h>
 #include <validation.h>
 
+#include <functional>
 #include <stdint.h>
 
 #include <QDebug>

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -18,6 +18,8 @@
 #include <util/system.h>
 #include <util/translation.h>
 
+#include <functional>
+
 #include <QApplication>
 #include <QCloseEvent>
 #include <QPainter>

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -19,6 +19,7 @@
 #include <uint256.h>
 
 #include <algorithm>
+#include <functional>
 
 #include <QColor>
 #include <QDateTime>

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -28,6 +28,7 @@
 #include <wallet/coincontrol.h>
 #include <wallet/wallet.h> // for CRecipient
 
+#include <functional>
 #include <stdint.h>
 
 #include <QDebug>


### PR DESCRIPTION
Hi, this patch adds in `<functional>` because the GUI code makes use of std::bind.
That's all.