### PR TITLE
validation: don't try to invalidate genesis block in CChainState::InvalidateBlock

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2923,6 +2923,10 @@ bool PreciousBlock(BlockValidationState& state, const CChainParams& params, CBlo
 
 bool CChainState::InvalidateBlock(BlockValidationState& state, const CChainParams& chainparams, CBlockIndex *pindex)
 {
+    // Genesis block can't be invalidated
+    assert(pindex);
+    if (pindex->nHeight == 0) return false;
+
     CBlockIndex* to_mark_failed = pindex;
     bool pindex_was_in_chain = false;
     int disconnected = 0;


### PR DESCRIPTION
In the block invalidation method (`CChainState::InvalidateBlock`), the code for creating the candidate block map assumes that the passed block's previous block (`pindex->pprev`) is available and otherwise segfaults due to null-pointer deference in `CBlockIndexWorkComparator()` (see analysis by practicalswift in #20914), i.e. it doesn't work with the genesis block. Rather than analyzing all possible code paths and implications for this corner case, simply fail early if the genesis block is passed.

Fixes #20914. 