### PR TITLE
switch over to std::shared_mutex.

### DIFF
--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -11,7 +11,8 @@
 #include <util/system.h>
 
 #include <cuckoocache.h>
-#include <boost/thread/shared_mutex.hpp>
+
+#include <shared_mutex>
 
 namespace {
 /**
@@ -27,7 +28,7 @@ private:
     CSHA256 m_salted_hasher_schnorr;
     typedef CuckooCache::cache<uint256, SignatureCacheHasher> map_type;
     map_type setValid;
-    boost::shared_mutex cs_sigcache;
+    std::shared_mutex cs_sigcache;
 
 public:
     CSignatureCache()
@@ -62,13 +63,13 @@ public:
     bool
     Get(const uint256& entry, const bool erase)
     {
-        boost::shared_lock<boost::shared_mutex> lock(cs_sigcache);
+        boost::shared_lock<std::shared_mutex> lock(cs_sigcache);
         return setValid.contains(entry, erase);
     }
 
     void Set(const uint256& entry)
     {
-        boost::unique_lock<boost::shared_mutex> lock(cs_sigcache);
+        boost::unique_lock<std::shared_mutex> lock(cs_sigcache);
         setValid.insert(entry);
     }
     uint32_t setup_bytes(size_t n)

--- a/src/test/cuckoocache_tests.cpp
+++ b/src/test/cuckoocache_tests.cpp
@@ -1,11 +1,13 @@
 // Copyright (c) 2012-2020 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include <boost/test/unit_test.hpp>
 #include <cuckoocache.h>
 #include <deque>
 #include <random.h>
 #include <script/sigcache.h>
+#include <shared_mutex>
 #include <test/util/setup_common.h>
 #include <thread>
 
@@ -199,11 +201,11 @@ static void test_cache_erase_parallel(size_t megabytes)
      * "future proofed".
      */
     std::vector<uint256> hashes_insert_copy = hashes;
-    boost::shared_mutex mtx;
+    std::shared_mutex mtx;
 
     {
         /** Grab lock to make sure we release inserts */
-        boost::unique_lock<boost::shared_mutex> l(mtx);
+        boost::unique_lock<std::shared_mutex> l(mtx);
         /** Insert the first half */
         for (uint32_t i = 0; i < (n_insert / 2); ++i)
             set.insert(hashes_insert_copy[i]);
@@ -217,7 +219,7 @@ static void test_cache_erase_parallel(size_t megabytes)
         /** Each thread is emplaced with x copy-by-value
         */
         threads.emplace_back([&, x] {
-            boost::shared_lock<boost::shared_mutex> l(mtx);
+            boost::shared_lock<std::shared_mutex> l(mtx);
             size_t ntodo = (n_insert/4)/3;
             size_t start = ntodo*x;
             size_t end = ntodo*(x+1);
@@ -232,7 +234,7 @@ static void test_cache_erase_parallel(size_t megabytes)
     for (std::thread& t : threads)
         t.join();
     /** Grab lock to make sure we observe erases */
-    boost::unique_lock<boost::shared_mutex> l(mtx);
+    boost::unique_lock<std::shared_mutex> l(mtx);
     /** Insert the second half */
     for (uint32_t i = (n_insert / 2); i < n_insert; ++i)
         set.insert(hashes_insert_copy[i]);

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -69,7 +69,6 @@ EXPECTED_BOOST_INCLUDES=(
     boost/test/unit_test.hpp
     boost/thread/condition_variable.hpp
     boost/thread/mutex.hpp
-    boost/thread/shared_mutex.hpp
     boost/thread/thread.hpp
 )
 


### PR DESCRIPTION
Hello. Since we're on C++17 now, we can switch over to using std::shared_mutex.