### PR TITLE
guix: Make nsis reproducible by respecting SOURCE-DATE-EPOCH

### DIFF
--- a/contrib/guix/patches/nsis-SConstruct-sde-support.patch
+++ b/contrib/guix/patches/nsis-SConstruct-sde-support.patch
@@ -1,0 +1,15 @@
+diff --git a/SConstruct b/SConstruct
+index e8252c9..41786f2 100755
+--- a/SConstruct
++++ b/SConstruct
+@@ -95,8 +95,8 @@ default_doctype = 'html'
+ if defenv.WhereIs('hhc', os.environ['PATH']):
+ 	default_doctype = 'chm'
+ 
+-from time import strftime, gmtime
+-cvs_version = strftime('%d-%b-%Y.cvs', gmtime())
++import time
++cvs_version = time.strftime('%d-%b-%Y.cvs', time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))))
+ 
+ opts = Variables()
+ 

--- a/test/lint/lint-whitespace.sh
+++ b/test/lint/lint-whitespace.sh
@@ -33,7 +33,7 @@ if [ -z "${COMMIT_RANGE}" ]; then
 fi
 
 showdiff() {
-  if ! git diff -U0 "${COMMIT_RANGE}" -- "." ":(exclude)depends/patches/" ":(exclude)src/leveldb/" ":(exclude)src/crc32c/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" ":(exclude)doc/release-notes/" ":(exclude)src/qt/locale/"; then
+  if ! git diff -U0 "${COMMIT_RANGE}" -- "." ":(exclude)depends/patches/" ":(exclude)contrib/guix/patches/" ":(exclude)src/leveldb/" ":(exclude)src/crc32c/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" ":(exclude)doc/release-notes/" ":(exclude)src/qt/locale/"; then
     echo "Failed to get a diff"
     exit 1
   fi


### PR DESCRIPTION
```
When building nsis, if VERSION is not specified, it defaults to
cvs_version which is non-deterministic as it includes the current date.

This patches nsis to default to SOURCE_DATE_EPOCH if it exists so that
nsis is reproducible.

Upstream change: https://github.com/kichik/nsis/pull/13
```

Sidenote: also a good demonstration of how Guix allows us to flexibly patch our tools!

Note to reviewers: if you want to compare hashes, please build after Jan 16th 2021 without my substitute server enabled!