### PR TITLE
build: fix linking against -latomic when building for riscv

### DIFF
--- a/build-aux/m4/l_atomic.m4
+++ b/build-aux/m4/l_atomic.m4
@@ -14,6 +14,9 @@ m4_define([_CHECK_ATOMIC_testbody], [[
   #include <cstdint>
 
   int main() {
+    std::atomic<bool> lock{true};
+    std::atomic_exchange(&lock, false);
+
     std::atomic<int64_t> a{};
 
     int64_t v = 5;

--- a/src/bitcoin-util.cpp
+++ b/src/bitcoin-util.cpp
@@ -25,6 +25,7 @@
 #include <util/system.h>
 #include <util/translation.h>
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <stdio.h>


### PR DESCRIPTION
Since the merge of #19937, riscv builds have been failing, due to a link issue with [`std::atomic_exchange`](https://en.cppreference.com/w/cpp/atomic/atomic_exchange) in `bitcoin-util`:
```bash
  CXXLD    bitcoin-util
bitcoin_util-bitcoin-util.o: In function `grind_task':
/home/ubuntu/build/bitcoin/distsrc-riscv64-linux-gnu/src/bitcoin-util.cpp:98: undefined reference to `__atomic_exchange_1'
collect2: error: ld returned 1 exit status

```

We have a [macro](https://github.com/bitcoin/bitcoin/blob/master/build-aux/m4/l_atomic.m4) that tries to determine when `-latomic` is required, however it doesn't quite work well enough, as it's currently determining it isn't needed:
```bash
./autogen.sh
./configure --prefix=/home/ubuntu/bitcoin/depends/riscv64-linux-gnu
...
checking whether std::atomic can be used without link library... yes
```

This PR adds a call to `std::atomic_exchange` to the macro, which will get us properly linked against `-latomic` on riscv:
```bash
checking whether std::atomic can be used without link library... no
checking whether std::atomic needs -latomic... yes
```

Also adds an `<atomic>` include to `bitcoin-util.cpp`.