### PR TITLE
build: fix RELOC_SECTION security check for bitcoin-util

### DIFF
--- a/src/bitcoin-util.cpp
+++ b/src/bitcoin-util.cpp
@@ -181,7 +181,16 @@ static int CommandLineUtil(int argc, char* argv[])
     return nRet;
 }
 
+#ifdef WIN32
+// Export main() and ensure working ASLR on Windows.
+// Exporting a symbol will prevent the linker from stripping
+// the .reloc section from the binary, which is a requirement
+// for ASLR. This is a temporary workaround until a fixed
+// version of binutils is used for releases.
+__declspec(dllexport) int main(int argc, char* argv[])
+#else
 int main(int argc, char* argv[])
+#endif
 {
     SetupEnvironment();
 


### PR DESCRIPTION
The binutils we use for gitian builds strips the reloc section from
Windows binaries, which breaks ASLR. As a temporary workaround, export
main(). This is the same workaround as #18702 (bitcoin-cli), and will
fix the currently failing security check:
```bash
+ make -j1 -C src check-security
make: Entering directory '/home/ubuntu/build/bitcoin/distsrc-x86_64-w64-mingw32/src'
Checking binary security...
bitcoin-util.exe: failed RELOC_SECTION
make: *** [check-security] Error 1
```

Relevant upstream issue:
https://sourceware.org/bugzilla/show_bug.cgi?id=19011