### PR TITLE
fuzz: Consolidate fuzzing TestingSetup initialization

### DIFF
--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -26,7 +26,7 @@ int64_t ConsumeBanTimeOffset(FuzzedDataProvider& fuzzed_data_provider) noexcept
 
 void initialize_banman()
 {
-    InitializeFuzzingContext();
+    static const auto testing_setup = MakeFuzzingContext<>();
 }
 
 FUZZ_TARGET_INIT(banman, initialize_banman)

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -36,9 +36,7 @@ bool operator==(const Coin& a, const Coin& b)
 
 void initialize_coins_view()
 {
-    static const ECCVerifyHandle ecc_verify_handle;
-    ECC_Start();
-    SelectParams(CBaseChainParams::REGTEST);
+    static const auto testing_setup = MakeFuzzingContext<const TestingSetup>();
 }
 
 FUZZ_TARGET_INIT(coins_view, initialize_coins_view)

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -17,7 +17,7 @@
 
 void initialize_connman()
 {
-    InitializeFuzzingContext();
+    static const auto testing_setup = MakeFuzzingContext<>();
 }
 
 FUZZ_TARGET_INIT(connman, initialize_connman)

--- a/src/test/fuzz/data_stream.cpp
+++ b/src/test/fuzz/data_stream.cpp
@@ -13,7 +13,7 @@
 
 void initialize_data_stream_addr_man()
 {
-    InitializeFuzzingContext();
+    static const auto testing_setup = MakeFuzzingContext<>();
 }
 
 FUZZ_TARGET_INIT(data_stream_addr_man, initialize_data_stream_addr_man)

--- a/src/test/fuzz/load_external_block_file.cpp
+++ b/src/test/fuzz/load_external_block_file.cpp
@@ -15,7 +15,7 @@
 
 void initialize_load_external_block_file()
 {
-    static const auto testing_setup = MakeFuzzingContext<>();
+    static const auto testing_setup = MakeFuzzingContext<const TestingSetup>();
 }
 
 FUZZ_TARGET_INIT(load_external_block_file, initialize_load_external_block_file)

--- a/src/test/fuzz/load_external_block_file.cpp
+++ b/src/test/fuzz/load_external_block_file.cpp
@@ -15,7 +15,7 @@
 
 void initialize_load_external_block_file()
 {
-    InitializeFuzzingContext();
+    static const auto testing_setup = MakeFuzzingContext<>();
 }
 
 FUZZ_TARGET_INIT(load_external_block_file, initialize_load_external_block_file)

--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -22,7 +22,7 @@
 
 void initialize_net()
 {
-    static const BasicTestingSetup basic_testing_setup;
+    static const auto testing_setup = MakeFuzzingContext<>(CBaseChainParams::MAIN);
 }
 
 FUZZ_TARGET_INIT(net, initialize_net)

--- a/src/test/fuzz/policy_estimator.cpp
+++ b/src/test/fuzz/policy_estimator.cpp
@@ -16,7 +16,7 @@
 
 void initialize_policy_estimator()
 {
-    InitializeFuzzingContext();
+    static const auto testing_setup = MakeFuzzingContext<>();
 }
 
 FUZZ_TARGET_INIT(policy_estimator, initialize_policy_estimator)

--- a/src/test/fuzz/policy_estimator_io.cpp
+++ b/src/test/fuzz/policy_estimator_io.cpp
@@ -12,7 +12,7 @@
 
 void initialize_policy_estimator_io()
 {
-    InitializeFuzzingContext();
+    static const auto testing_setup = MakeFuzzingContext<>();
 }
 
 FUZZ_TARGET_INIT(policy_estimator_io, initialize_policy_estimator_io)

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -38,14 +38,8 @@ const TestingSetup* g_setup;
 
 void initialize_process_message()
 {
-    static TestingSetup setup{
-        CBaseChainParams::REGTEST,
-        {
-            "-nodebuglogfile",
-        },
-    };
-    g_setup = &setup;
-
+    static const auto testing_setup = MakeFuzzingContext<const TestingSetup>();
+    g_setup = testing_setup.get();
     for (int i = 0; i < 2 * COINBASE_MATURITY; i++) {
         MineBlock(g_setup->m_node, CScript() << OP_TRUE);
     }

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -17,18 +17,14 @@
 #include <validation.h>
 #include <validationinterface.h>
 
+namespace {
 const TestingSetup* g_setup;
+} // namespace
 
 void initialize_process_messages()
 {
-    static TestingSetup setup{
-        CBaseChainParams::REGTEST,
-        {
-            "-nodebuglogfile",
-        },
-    };
-    g_setup = &setup;
-
+    static const auto testing_setup = MakeFuzzingContext<const TestingSetup>();
+    g_setup = testing_setup.get();
     for (int i = 0; i < 2 * COINBASE_MATURITY; i++) {
         MineBlock(g_setup->m_node, CScript() << OP_TRUE);
     }

--- a/src/test/fuzz/signet.cpp
+++ b/src/test/fuzz/signet.cpp
@@ -17,7 +17,7 @@
 
 void initialize_signet()
 {
-    InitializeFuzzingContext(CBaseChainParams::SIGNET);
+    static const auto testing_setup = MakeFuzzingContext<>(CBaseChainParams::SIGNET);
 }
 
 FUZZ_TARGET_INIT(signet, initialize_signet)

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -27,6 +27,7 @@
 #include <txmempool.h>
 #include <uint256.h>
 #include <util/time.h>
+#include <util/vector.h>
 #include <version.h>
 
 #include <algorithm>
@@ -338,9 +339,17 @@ inline void FillNode(FuzzedDataProvider& fuzzed_data_provider, CNode& node, cons
     }
 }
 
-inline void InitializeFuzzingContext(const std::string& chain_name = CBaseChainParams::REGTEST)
+template <class T = const BasicTestingSetup>
+std::unique_ptr<T> MakeFuzzingContext(const std::string& chain_name = CBaseChainParams::REGTEST, const std::vector<const char*>& extra_args = {})
 {
-    static const BasicTestingSetup basic_testing_setup{chain_name, {"-nodebuglogfile"}};
+    // Prepend default arguments for fuzzing
+    const std::vector<const char*> arguments = Cat(
+        {
+            "-nodebuglogfile",
+        },
+        extra_args);
+
+    return MakeUnique<T>(chain_name, arguments);
 }
 
 class FuzzedFileProvider


### PR DESCRIPTION
```
Previously, the {Basic,}TestingSetup for fuzzers were set up in many ways:

1. Calling InitializeFuzzingContext, which implicitly constructs a static
   const BasicTestingSetup
2. Directly constructing a static const BasicTestingSetup in the initialize_*
   function
3. Directly constructing a static TestingSetup and reproducing the
   initialization arguments (I'm assuming because
   InitializeFuzzingContext only initializes a BasicTestingSetup)

The new, relatively-simple MakeFuzzingContext function allows us to
consolidate these methods of initialization by being flexible enough to
be used in all situations. It:

1. Is templated so that we can choose to initialize any of
   the *TestingSetup classes
2. Has sane defaults which are often used in fuzzers but are also
   easily overridable
3. Returns a unique_ptr, explicitly transferring ownership to the caller
   to deal with according to its situation
```

~~Question for fuzzing people: was it intentional that `src/test/fuzz/net.cpp` would directly instantiate the `BasicTestingSetup` and thus omit the `"-nodebuglogfile"` flag?~~ [Answered](https://github.com/bitcoin/bitcoin/pull/20946#issuecomment-761537108)