### PR TITLE
doc: APS explanation clarified in 0.21.0 release notes

### DIFF
--- a/doc/release-notes/release-notes-0.21.0.md
+++ b/doc/release-notes/release-notes-0.21.0.md
@@ -287,10 +287,9 @@ Wallet
   same with and without APS). Setting it to -1 will disable APS, unless
   `-avoidpartialspends` is set. (#14582)
 
-- The wallet will now avoid partial spends (APS) by default, if this does not
-  result in a difference in fees compared to the non-APS variant. The allowed
-  fee threshold can be adjusted using the new `-maxapsfee` configuration
-  option. (#14582)
+- By default, the wallet will now do partial spends only if it decreases fees
+  compared to avoiding partial spends (APS). The allowed fee threshold can be 
+  adjusted using the new `-maxapsfee` configuration option. (#14582)
 
 - The `createwallet`, `loadwallet`, and `unloadwallet` RPCs now accept
   `load_on_startup` options to modify the settings list. Unless these options


### PR DESCRIPTION
There is no point in engaging in partial spends if it costs less to avoid them.  The sentence I changed meant that avoiding the partial spend will occur only if the fee is exactly the same, and if avoiding partial spends *decreases* fees (avoiding **does result in a difference**), then it won't avoid them, and instead make the higher fee transaction.  While it may be impossible for the coin selection algorithm to create a lower fee transaction by avoiding partial spends, the language is now clearer and suggests this rather than leaving the reader to guess.
