### PR TITLE
test: Fix get_previous_releases.py for aarch64

### DIFF
--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -175,6 +175,7 @@ def check_host(args) -> int:
         './depends/config.guess').decode())
     if args.download_binary:
         platforms = {
+            'aarch64-*-linux*': 'aarch64-linux-gnu',
             'x86_64-*-linux*': 'x86_64-linux-gnu',
             'x86_64-apple-darwin*': 'osx64',
         }


### PR DESCRIPTION
Otherwise it will fail with "Not sure which binary to download..."