### PR TITLE
test: check that getblockfilter RPC fails without block filter index

### DIFF
--- a/test/functional/rpc_getblockfilter.py
+++ b/test/functional/rpc_getblockfilter.py
@@ -54,5 +54,11 @@ class GetBlockFilterTest(BitcoinTestFramework):
         genesis_hash = self.nodes[0].getblockhash(0)
         assert_raises_rpc_error(-5, "Unknown filtertype", self.nodes[0].getblockfilter, genesis_hash, "unknown")
 
+        # Test getblockfilter fails on node without compact block filter index
+        self.restart_node(0, extra_args=["-blockfilterindex=0"])
+        for filter_type in FILTER_TYPES:
+            assert_raises_rpc_error(-1, "Index is not enabled for filtertype {}".format(filter_type),
+                                    self.nodes[0].getblockfilter, genesis_hash, filter_type)
+
 if __name__ == '__main__':
     GetBlockFilterTest().main()


### PR DESCRIPTION
If a node was started without compact block filter index (parameter `--blockfilterindex=0`), the `getblockfilter` RPC call should fail.