### PR TITLE
test: add test for corrupt wallet bdb logs

### DIFF
--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -94,9 +94,9 @@ void BerkeleyEnvironment::Close()
     }
 
     FILE* error_file = nullptr;
-    m_db_env.get_errfile(&error_file);
+    dbenv->get_errfile(&error_file);
 
-    int ret = m_db_env.close(0);
+    int ret = dbenv->close(0);
     if (ret != 0)
         LogPrintf("BerkeleyEnvironment::Close: Error %d closing database environment: %s\n", ret, DbEnv::strerror(ret));
     if (!fMockDb)
@@ -142,17 +142,17 @@ bool BerkeleyEnvironment::Open(bilingual_str& err)
         nEnvFlags |= DB_PRIVATE;
     }
 
-    m_db_env.set_lg_dir(fs::PathToString(pathLogDir).c_str());
-    m_db_env.set_cachesize(0, 0x100000, 1); // 1 MiB should be enough for just the wallet
-    m_db_env.set_lg_bsize(0x10000);
-    m_db_env.set_lg_max(1048576);
-    m_db_env.set_lk_max_locks(40000);
-    m_db_env.set_lk_max_objects(40000);
-    m_db_env.set_errfile(fsbridge::fopen(pathErrorFile, "a")); /// debug
-    m_db_env.set_flags(DB_AUTO_COMMIT, 1);
-    m_db_env.set_flags(DB_TXN_WRITE_NOSYNC, 1);
-    m_db_env.log_set_config(DB_LOG_AUTO_REMOVE, 1);
-    int ret = m_db_env.open(strPath.c_str(),
+    dbenv->set_lg_dir(fs::PathToString(pathLogDir).c_str());
+    dbenv->set_cachesize(0, 0x100000, 1); // 1 MiB should be enough for just the wallet
+    dbenv->set_lg_bsize(0x10000);
+    dbenv->set_lg_max(1048576);
+    dbenv->set_lk_max_locks(40000);
+    dbenv->set_lk_max_objects(40000);
+    dbenv->set_errfile(fsbridge::fopen(pathErrorFile, "a")); /// debug
+    dbenv->set_flags(DB_AUTO_COMMIT, 1);
+    dbenv->set_flags(DB_TXN_WRITE_NOSYNC, 1);
+    dbenv->log_set_config(DB_LOG_AUTO_REMOVE, 1);
+    int ret = dbenv->open(strPath.c_str(),
                          DB_CREATE |
                              DB_INIT_LOCK |
                              DB_INIT_LOG |
@@ -164,7 +164,7 @@ bool BerkeleyEnvironment::Open(bilingual_str& err)
                          S_IRUSR | S_IWUSR);
     if (ret != 0) {
         LogPrintf("BerkeleyEnvironment::Open: Error %d opening database environment: %s\n", ret, DbEnv::strerror(ret));
-        int ret2 = m_db_env.close(0);
+        int ret2 = dbenv->close(0);
         if (ret2 != 0) {
             LogPrintf("BerkeleyEnvironment::Open: Error %d closing failed database environment: %s\n", ret2, DbEnv::strerror(ret2));
         }
@@ -185,14 +185,14 @@ BerkeleyEnvironment::BerkeleyEnvironment() : m_use_shared_memory(false)
 {
     LogPrint(BCLog::WALLETDB, "BerkeleyEnvironment::MakeMock\n");
 
-    m_db_env.set_cachesize(1, 0, 1);
-    m_db_env.set_lg_bsize(10485760 * 4);
-    m_db_env.set_lg_max(10485760);
-    m_db_env.set_lk_max_locks(10000);
-    m_db_env.set_lk_max_objects(10000);
-    m_db_env.set_flags(DB_AUTO_COMMIT, 1);
-    m_db_env.log_set_config(DB_LOG_IN_MEMORY, 1);
-    int ret = m_db_env.open(nullptr,
+    dbenv->set_cachesize(1, 0, 1);
+    dbenv->set_lg_bsize(10485760 * 4);
+    dbenv->set_lg_max(10485760);
+    dbenv->set_lk_max_locks(10000);
+    dbenv->set_lk_max_objects(10000);
+    dbenv->set_flags(DB_AUTO_COMMIT, 1);
+    dbenv->log_set_config(DB_LOG_IN_MEMORY, 1);
+    int ret = dbenv->open(nullptr,
                          DB_CREATE |
                              DB_INIT_LOCK |
                              DB_INIT_LOG |
@@ -264,7 +264,7 @@ bool BerkeleyDatabase::Verify(bilingual_str& errorStr)
     {
         assert(m_refcount == 0);
 
-        Db db(&env->m_db_env, 0);
+        Db db(env->dbenv.get(), 0);
         const std::string strFile = fs::PathToString(m_filename);
         int result = db.verify(strFile.c_str(), nullptr, nullptr, 0);
         if (result != 0) {
@@ -278,10 +278,10 @@ bool BerkeleyDatabase::Verify(bilingual_str& errorStr)
 
 void BerkeleyEnvironment::CheckpointLSN(const std::string& strFile)
 {
-    m_db_env.txn_checkpoint(0, 0, 0);
+    dbenv->txn_checkpoint(0, 0, 0);
     if (fMockDb)
         return;
-    m_db_env.lsn_reset(strFile.c_str(), 0);
+    dbenv->lsn_reset(strFile.c_str(), 0);
 }
 
 BerkeleyDatabase::~BerkeleyDatabase()
@@ -319,7 +319,7 @@ void BerkeleyDatabase::Open()
 
         if (m_db == nullptr) {
             int ret;
-            std::unique_ptr<Db> pdb_temp = std::make_unique<Db>(&env->m_db_env, 0);
+            std::unique_ptr<Db> pdb_temp = std::make_unique<Db>(env->dbenv.get(), 0);
             const std::string strFile = fs::PathToString(m_filename);
 
             bool fMockDb = env->IsMock();
@@ -364,7 +364,7 @@ void BerkeleyBatch::Flush()
         nMinutes = 1;
 
     if (env) { // env is nullptr for dummy databases (i.e. in tests). Don't actually flush if env is nullptr so we don't segfault
-        env->m_db_env.txn_checkpoint(nMinutes ? m_database.m_max_log_mb * 1024 : 0, nMinutes, 0);
+        env->dbenv->txn_checkpoint(nMinutes ? m_database.m_max_log_mb * 1024 : 0, nMinutes, 0);
     }
 }
 
@@ -430,6 +430,7 @@ void BerkeleyEnvironment::ReloadDbEnv()
     }
     // Reset the environment
     Flush(true); // This will flush and close the environment
+    dbenv = std::make_unique<DbEnv>(DB_CXX_NO_EXCEPTIONS);
     fDbEnvInit = false;
     fMockDb = false;
     bilingual_str open_err;
@@ -453,7 +454,7 @@ bool BerkeleyDatabase::Rewrite(const char* pszSkip)
                 std::string strFileRes = strFile + ".rewrite";
                 { // surround usage of db with extra {}
                     BerkeleyBatch db(*this, true);
-                    std::unique_ptr<Db> pdbCopy = std::make_unique<Db>(&env->m_db_env, 0);
+                    std::unique_ptr<Db> pdbCopy = std::make_unique<Db>(env->dbenv.get(), 0);
 
                     int ret = pdbCopy->open(nullptr,               // Txn pointer
                                             strFileRes.c_str(), // Filename
@@ -504,10 +505,10 @@ bool BerkeleyDatabase::Rewrite(const char* pszSkip)
                     }
                 }
                 if (fSuccess) {
-                    Db dbA(&env->m_db_env, 0);
+                    Db dbA(env->dbenv.get(), 0);
                     if (dbA.remove(strFile.c_str(), nullptr, 0))
                         fSuccess = false;
-                    Db dbB(&env->m_db_env, 0);
+                    Db dbB(env->dbenv.get(), 0);
                     if (dbB.rename(strFileRes.c_str(), nullptr, strFile.c_str(), 0))
                         fSuccess = false;
                 }
@@ -541,10 +542,10 @@ void BerkeleyEnvironment::Flush(bool fShutdown)
                 // Move log data to the dat file
                 CloseDb(filename);
                 LogPrint(BCLog::WALLETDB, "BerkeleyEnvironment::Flush: %s checkpoint\n", strFile);
-                m_db_env.txn_checkpoint(0, 0, 0);
+                dbenv->txn_checkpoint(0, 0, 0);
                 LogPrint(BCLog::WALLETDB, "BerkeleyEnvironment::Flush: %s detach\n", strFile);
                 if (!fMockDb)
-                    m_db_env.lsn_reset(strFile.c_str(), 0);
+                    dbenv->lsn_reset(strFile.c_str(), 0);
                 LogPrint(BCLog::WALLETDB, "BerkeleyEnvironment::Flush: %s closed\n", strFile);
                 nRefCount = -1;
             } else {
@@ -555,7 +556,7 @@ void BerkeleyEnvironment::Flush(bool fShutdown)
         if (fShutdown) {
             char** listp;
             if (no_dbs_accessed) {
-                m_db_env.log_archive(&listp, DB_ARCH_REMOVE);
+                dbenv->log_archive(&listp, DB_ARCH_REMOVE);
                 Close();
                 if (!fMockDb) {
                     fs::remove_all(fs::PathFromString(strPath) / "database");

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -94,9 +94,9 @@ void BerkeleyEnvironment::Close()
     }
 
     FILE* error_file = nullptr;
-    dbenv->get_errfile(&error_file);
+    m_db_env.get_errfile(&error_file);
 
-    int ret = dbenv->close(0);
+    int ret = m_db_env.close(0);
     if (ret != 0)
         LogPrintf("BerkeleyEnvironment::Close: Error %d closing database environment: %s\n", ret, DbEnv::strerror(ret));
     if (!fMockDb)
@@ -107,16 +107,8 @@ void BerkeleyEnvironment::Close()
     UnlockDirectory(fs::PathFromString(strPath), ".walletlock");
 }
 
-void BerkeleyEnvironment::Reset()
-{
-    dbenv.reset(new DbEnv(DB_CXX_NO_EXCEPTIONS));
-    fDbEnvInit = false;
-    fMockDb = false;
-}
-
 BerkeleyEnvironment::BerkeleyEnvironment(const fs::path& dir_path, bool use_shared_memory) : strPath(fs::PathToString(dir_path)), m_use_shared_memory(use_shared_memory)
 {
-    Reset();
 }
 
 BerkeleyEnvironment::~BerkeleyEnvironment()
@@ -150,17 +142,17 @@ bool BerkeleyEnvironment::Open(bilingual_str& err)
         nEnvFlags |= DB_PRIVATE;
     }
 
-    dbenv->set_lg_dir(fs::PathToString(pathLogDir).c_str());
-    dbenv->set_cachesize(0, 0x100000, 1); // 1 MiB should be enough for just the wallet
-    dbenv->set_lg_bsize(0x10000);
-    dbenv->set_lg_max(1048576);
-    dbenv->set_lk_max_locks(40000);
-    dbenv->set_lk_max_objects(40000);
-    dbenv->set_errfile(fsbridge::fopen(pathErrorFile, "a")); /// debug
-    dbenv->set_flags(DB_AUTO_COMMIT, 1);
-    dbenv->set_flags(DB_TXN_WRITE_NOSYNC, 1);
-    dbenv->log_set_config(DB_LOG_AUTO_REMOVE, 1);
-    int ret = dbenv->open(strPath.c_str(),
+    m_db_env.set_lg_dir(fs::PathToString(pathLogDir).c_str());
+    m_db_env.set_cachesize(0, 0x100000, 1); // 1 MiB should be enough for just the wallet
+    m_db_env.set_lg_bsize(0x10000);
+    m_db_env.set_lg_max(1048576);
+    m_db_env.set_lk_max_locks(40000);
+    m_db_env.set_lk_max_objects(40000);
+    m_db_env.set_errfile(fsbridge::fopen(pathErrorFile, "a")); /// debug
+    m_db_env.set_flags(DB_AUTO_COMMIT, 1);
+    m_db_env.set_flags(DB_TXN_WRITE_NOSYNC, 1);
+    m_db_env.log_set_config(DB_LOG_AUTO_REMOVE, 1);
+    int ret = m_db_env.open(strPath.c_str(),
                          DB_CREATE |
                              DB_INIT_LOCK |
                              DB_INIT_LOG |
@@ -172,11 +164,10 @@ bool BerkeleyEnvironment::Open(bilingual_str& err)
                          S_IRUSR | S_IWUSR);
     if (ret != 0) {
         LogPrintf("BerkeleyEnvironment::Open: Error %d opening database environment: %s\n", ret, DbEnv::strerror(ret));
-        int ret2 = dbenv->close(0);
+        int ret2 = m_db_env.close(0);
         if (ret2 != 0) {
             LogPrintf("BerkeleyEnvironment::Open: Error %d closing failed database environment: %s\n", ret2, DbEnv::strerror(ret2));
         }
-        Reset();
         err = strprintf(_("Error initializing wallet database environment %s!"), fs::quoted(fs::PathToString(Directory())));
         if (ret == DB_RUNRECOVERY) {
             err += Untranslated(" ") + _("This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet");
@@ -192,18 +183,16 @@ bool BerkeleyEnvironment::Open(bilingual_str& err)
 //! Construct an in-memory mock Berkeley environment for testing
 BerkeleyEnvironment::BerkeleyEnvironment() : m_use_shared_memory(false)
 {
-    Reset();
-
     LogPrint(BCLog::WALLETDB, "BerkeleyEnvironment::MakeMock\n");
 
-    dbenv->set_cachesize(1, 0, 1);
-    dbenv->set_lg_bsize(10485760 * 4);
-    dbenv->set_lg_max(10485760);
-    dbenv->set_lk_max_locks(10000);
-    dbenv->set_lk_max_objects(10000);
-    dbenv->set_flags(DB_AUTO_COMMIT, 1);
-    dbenv->log_set_config(DB_LOG_IN_MEMORY, 1);
-    int ret = dbenv->open(nullptr,
+    m_db_env.set_cachesize(1, 0, 1);
+    m_db_env.set_lg_bsize(10485760 * 4);
+    m_db_env.set_lg_max(10485760);
+    m_db_env.set_lk_max_locks(10000);
+    m_db_env.set_lk_max_objects(10000);
+    m_db_env.set_flags(DB_AUTO_COMMIT, 1);
+    m_db_env.log_set_config(DB_LOG_IN_MEMORY, 1);
+    int ret = m_db_env.open(nullptr,
                          DB_CREATE |
                              DB_INIT_LOCK |
                              DB_INIT_LOG |
@@ -275,7 +264,7 @@ bool BerkeleyDatabase::Verify(bilingual_str& errorStr)
     {
         assert(m_refcount == 0);
 
-        Db db(env->dbenv.get(), 0);
+        Db db(&env->m_db_env, 0);
         const std::string strFile = fs::PathToString(m_filename);
         int result = db.verify(strFile.c_str(), nullptr, nullptr, 0);
         if (result != 0) {
@@ -289,10 +278,10 @@ bool BerkeleyDatabase::Verify(bilingual_str& errorStr)
 
 void BerkeleyEnvironment::CheckpointLSN(const std::string& strFile)
 {
-    dbenv->txn_checkpoint(0, 0, 0);
+    m_db_env.txn_checkpoint(0, 0, 0);
     if (fMockDb)
         return;
-    dbenv->lsn_reset(strFile.c_str(), 0);
+    m_db_env.lsn_reset(strFile.c_str(), 0);
 }
 
 BerkeleyDatabase::~BerkeleyDatabase()
@@ -330,7 +319,7 @@ void BerkeleyDatabase::Open()
 
         if (m_db == nullptr) {
             int ret;
-            std::unique_ptr<Db> pdb_temp = std::make_unique<Db>(env->dbenv.get(), 0);
+            std::unique_ptr<Db> pdb_temp = std::make_unique<Db>(&env->m_db_env, 0);
             const std::string strFile = fs::PathToString(m_filename);
 
             bool fMockDb = env->IsMock();
@@ -375,7 +364,7 @@ void BerkeleyBatch::Flush()
         nMinutes = 1;
 
     if (env) { // env is nullptr for dummy databases (i.e. in tests). Don't actually flush if env is nullptr so we don't segfault
-        env->dbenv->txn_checkpoint(nMinutes ? m_database.m_max_log_mb * 1024 : 0, nMinutes, 0);
+        env->m_db_env.txn_checkpoint(nMinutes ? m_database.m_max_log_mb * 1024 : 0, nMinutes, 0);
     }
 }
 
@@ -441,7 +430,8 @@ void BerkeleyEnvironment::ReloadDbEnv()
     }
     // Reset the environment
     Flush(true); // This will flush and close the environment
-    Reset();
+    fDbEnvInit = false;
+    fMockDb = false;
     bilingual_str open_err;
     Open(open_err);
 }
@@ -463,7 +453,7 @@ bool BerkeleyDatabase::Rewrite(const char* pszSkip)
                 std::string strFileRes = strFile + ".rewrite";
                 { // surround usage of db with extra {}
                     BerkeleyBatch db(*this, true);
-                    std::unique_ptr<Db> pdbCopy = std::make_unique<Db>(env->dbenv.get(), 0);
+                    std::unique_ptr<Db> pdbCopy = std::make_unique<Db>(&env->m_db_env, 0);
 
                     int ret = pdbCopy->open(nullptr,               // Txn pointer
                                             strFileRes.c_str(), // Filename
@@ -514,10 +504,10 @@ bool BerkeleyDatabase::Rewrite(const char* pszSkip)
                     }
                 }
                 if (fSuccess) {
-                    Db dbA(env->dbenv.get(), 0);
+                    Db dbA(&env->m_db_env, 0);
                     if (dbA.remove(strFile.c_str(), nullptr, 0))
                         fSuccess = false;
-                    Db dbB(env->dbenv.get(), 0);
+                    Db dbB(&env->m_db_env, 0);
                     if (dbB.rename(strFileRes.c_str(), nullptr, strFile.c_str(), 0))
                         fSuccess = false;
                 }
@@ -551,10 +541,10 @@ void BerkeleyEnvironment::Flush(bool fShutdown)
                 // Move log data to the dat file
                 CloseDb(filename);
                 LogPrint(BCLog::WALLETDB, "BerkeleyEnvironment::Flush: %s checkpoint\n", strFile);
-                dbenv->txn_checkpoint(0, 0, 0);
+                m_db_env.txn_checkpoint(0, 0, 0);
                 LogPrint(BCLog::WALLETDB, "BerkeleyEnvironment::Flush: %s detach\n", strFile);
                 if (!fMockDb)
-                    dbenv->lsn_reset(strFile.c_str(), 0);
+                    m_db_env.lsn_reset(strFile.c_str(), 0);
                 LogPrint(BCLog::WALLETDB, "BerkeleyEnvironment::Flush: %s closed\n", strFile);
                 nRefCount = -1;
             } else {
@@ -565,7 +555,7 @@ void BerkeleyEnvironment::Flush(bool fShutdown)
         if (fShutdown) {
             char** listp;
             if (no_dbs_accessed) {
-                dbenv->log_archive(&listp, DB_ARCH_REMOVE);
+                m_db_env.log_archive(&listp, DB_ARCH_REMOVE);
                 Close();
                 if (!fMockDb) {
                     fs::remove_all(fs::PathFromString(strPath) / "database");

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -50,7 +50,7 @@ private:
     std::string strPath;
 
 public:
-    DbEnv m_db_env{DB_CXX_NO_EXCEPTIONS};
+    std::unique_ptr<DbEnv> dbenv{std::make_unique<DbEnv>(DB_CXX_NO_EXCEPTIONS)};
     std::map<fs::path, std::reference_wrapper<BerkeleyDatabase>> m_databases;
     std::unordered_map<std::string, WalletDatabaseFileId> m_fileids;
     std::condition_variable_any m_db_in_use;
@@ -75,7 +75,7 @@ public:
     DbTxn* TxnBegin(int flags = DB_TXN_WRITE_NOSYNC)
     {
         DbTxn* ptxn = nullptr;
-        int ret = m_db_env.txn_begin(nullptr, &ptxn, flags);
+        int ret = dbenv->txn_begin(nullptr, &ptxn, flags);
         if (!ptxn || ret != 0)
             return nullptr;
         return ptxn;

--- a/src/wallet/salvage.cpp
+++ b/src/wallet/salvage.cpp
@@ -52,7 +52,7 @@ bool RecoverDatabaseFile(const ArgsManager& args, const fs::path& file_path, bil
     int64_t now = GetTime();
     std::string newFilename = strprintf("%s.%d.bak", filename, now);
 
-    int result = env->dbenv->dbrename(nullptr, filename.c_str(), nullptr,
+    int result = env->m_db_env.dbrename(nullptr, filename.c_str(), nullptr,
                                        newFilename.c_str(), DB_AUTO_COMMIT);
     if (result != 0)
     {
@@ -70,7 +70,7 @@ bool RecoverDatabaseFile(const ArgsManager& args, const fs::path& file_path, bil
 
     std::stringstream strDump;
 
-    Db db(env->dbenv.get(), 0);
+    Db db(&env->m_db_env, 0);
     result = db.verify(newFilename.c_str(), nullptr, &strDump, DB_SALVAGE | DB_AGGRESSIVE);
     if (result == DB_VERIFY_BAD) {
         warnings.push_back(Untranslated("Salvage: Database salvage found errors, all data may not be recoverable."));
@@ -121,7 +121,7 @@ bool RecoverDatabaseFile(const ArgsManager& args, const fs::path& file_path, bil
         return false;
     }
 
-    std::unique_ptr<Db> pdbCopy = std::make_unique<Db>(env->dbenv.get(), 0);
+    std::unique_ptr<Db> pdbCopy = std::make_unique<Db>(&env->m_db_env, 0);
     int ret = pdbCopy->open(nullptr,               // Txn pointer
                             filename.c_str(),   // Filename
                             "main",             // Logical db name

--- a/src/wallet/salvage.cpp
+++ b/src/wallet/salvage.cpp
@@ -52,7 +52,7 @@ bool RecoverDatabaseFile(const ArgsManager& args, const fs::path& file_path, bil
     int64_t now = GetTime();
     std::string newFilename = strprintf("%s.%d.bak", filename, now);
 
-    int result = env->m_db_env.dbrename(nullptr, filename.c_str(), nullptr,
+    int result = env->dbenv->dbrename(nullptr, filename.c_str(), nullptr,
                                        newFilename.c_str(), DB_AUTO_COMMIT);
     if (result != 0)
     {
@@ -70,7 +70,7 @@ bool RecoverDatabaseFile(const ArgsManager& args, const fs::path& file_path, bil
 
     std::stringstream strDump;
 
-    Db db(&env->m_db_env, 0);
+    Db db(env->dbenv.get(), 0);
     result = db.verify(newFilename.c_str(), nullptr, &strDump, DB_SALVAGE | DB_AGGRESSIVE);
     if (result == DB_VERIFY_BAD) {
         warnings.push_back(Untranslated("Salvage: Database salvage found errors, all data may not be recoverable."));
@@ -121,7 +121,7 @@ bool RecoverDatabaseFile(const ArgsManager& args, const fs::path& file_path, bil
         return false;
     }
 
-    std::unique_ptr<Db> pdbCopy = std::make_unique<Db>(&env->m_db_env, 0);
+    std::unique_ptr<Db> pdbCopy = std::make_unique<Db>(env->dbenv.get(), 0);
     int ret = pdbCopy->open(nullptr,               // Txn pointer
                             filename.c_str(),   // Filename
                             "main",             // Logical db name

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -191,6 +191,7 @@ BASE_SCRIPTS = [
     'wallet_createwallet.py --descriptors',
     'wallet_watchonly.py --legacy-wallet',
     'wallet_watchonly.py --usecli --legacy-wallet',
+    'wallet_db.py',
     'wallet_reorgsrestore.py',
     'interface_http.py',
     'interface_rpc.py',

--- a/test/functional/wallet_db.py
+++ b/test/functional/wallet_db.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test wallet database layer & recovery features.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_raises_rpc_error
+
+from pathlib import Path
+
+class WalletDbTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = False
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        # Unload default wallet, write corrupt log file, verify fails to reload
+        node.unloadwallet("")
+        Path(node.datadir, self.chain, "database", "log.0000000001").write_bytes(b'\1'*1024)
+        assert_raises_rpc_error(-4, "This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB.", node.loadwallet, "")
+
+if __name__ == '__main__':
+    WalletDbTest().main()


### PR DESCRIPTION
This PR adds a wallet test testing handling of corrupt BDB logs. It restores commit c6a2c265f5d0b424fc8226c2f3426e82856779d0 from #18907 which was dropped because it triggered a memory leak, which is reported as #19034