### PR TITLE
doc: fix broken link to whitepaper in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ software which enables the use of this currency.
 
 For more information, as well as an immediately usable, binary version of
 the Bitcoin Core software, see https://bitcoincore.org/en/download/, or read the
-[original whitepaper](https://bitcoincore.org/bitcoin.pdf).
+[original whitepaper](https://bitcoin.org/bitcoin.pdf).
 
 License
 -------


### PR DESCRIPTION
Earlier today the Bitcoin whitepaper has been removed from the bitcoincore.org website. A decision I strongly disagree with but nevertheless fully respect and understand.

I hope the Core maintainers would reconsider this decision, but in case it is final, this PR fixes the link which the `README.md` has to the whitepaper by targeting the bitcoin.org website instead of the bitcoincore.org, where the page no longer exists.