### PR TITLE
guix: Test security-check sanity before performing them

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -58,6 +58,7 @@ DIST_SHARE = \
 
 BIN_CHECKS=$(top_srcdir)/contrib/devtools/symbol-check.py \
            $(top_srcdir)/contrib/devtools/security-check.py \
+           $(top_srcdir)/contrib/devtools/utils.py \
            $(top_srcdir)/contrib/devtools/pixie.py
 
 WINDOWS_PACKAGING = $(top_srcdir)/share/pixmaps/bitcoin.ico \
@@ -366,14 +367,14 @@ clean-local: clean-docs
 
 test-security-check:
 if TARGET_DARWIN
-	$(AM_V_at) $(PYTHON) $(top_srcdir)/contrib/devtools/test-security-check.py TestSecurityChecks.test_MACHO
-	$(AM_V_at) $(PYTHON) $(top_srcdir)/contrib/devtools/test-symbol-check.py TestSymbolChecks.test_MACHO
+	$(AM_V_at) CC='$(CC)' $(PYTHON) $(top_srcdir)/contrib/devtools/test-security-check.py TestSecurityChecks.test_MACHO
+	$(AM_V_at) CC='$(CC)' $(PYTHON) $(top_srcdir)/contrib/devtools/test-symbol-check.py TestSymbolChecks.test_MACHO
 endif
 if TARGET_WINDOWS
-	$(AM_V_at) $(PYTHON) $(top_srcdir)/contrib/devtools/test-security-check.py TestSecurityChecks.test_PE
-	$(AM_V_at) $(PYTHON) $(top_srcdir)/contrib/devtools/test-symbol-check.py TestSymbolChecks.test_PE
+	$(AM_V_at) CC='$(CC)' $(PYTHON) $(top_srcdir)/contrib/devtools/test-security-check.py TestSecurityChecks.test_PE
+	$(AM_V_at) CC='$(CC)' $(PYTHON) $(top_srcdir)/contrib/devtools/test-symbol-check.py TestSymbolChecks.test_PE
 endif
 if TARGET_LINUX
-	$(AM_V_at) $(PYTHON) $(top_srcdir)/contrib/devtools/test-security-check.py TestSecurityChecks.test_ELF
-	$(AM_V_at) $(PYTHON) $(top_srcdir)/contrib/devtools/test-symbol-check.py TestSymbolChecks.test_ELF
+	$(AM_V_at) CC='$(CC)' $(PYTHON) $(top_srcdir)/contrib/devtools/test-security-check.py TestSecurityChecks.test_ELF
+	$(AM_V_at) CC='$(CC)' CPPFILT='$(CPPFILT)' $(PYTHON) $(top_srcdir)/contrib/devtools/test-symbol-check.py TestSymbolChecks.test_ELF
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -905,6 +905,7 @@ if test x$use_hardening != xno; then
     ])
   fi
 
+  AX_CHECK_LINK_FLAG([[-Wl,--enable-reloc-section]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,--enable-reloc-section"],, [[$LDFLAG_WERROR]])
   AX_CHECK_LINK_FLAG([[-Wl,--dynamicbase]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,--dynamicbase"],, [[$LDFLAG_WERROR]])
   AX_CHECK_LINK_FLAG([[-Wl,--nxcompat]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,--nxcompat"],, [[$LDFLAG_WERROR]])
   AX_CHECK_LINK_FLAG([[-Wl,--high-entropy-va]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,--high-entropy-va"],, [[$LDFLAG_WERROR]])

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -12,11 +12,12 @@ Example usage:
 '''
 import subprocess
 import sys
-import os
 from typing import List, Optional
 
 import lief
 import pixie
+
+from utils import determine_wellknown_cmd
 
 # Debian 8 (Jessie) EOL: 2020. https://wiki.debian.org/DebianReleases#Production_Releases
 #
@@ -52,7 +53,6 @@ IGNORE_EXPORTS = {
 '_edata', '_end', '__end__', '_init', '__bss_start', '__bss_start__', '_bss_end__', '__bss_end__', '_fini', '_IO_stdin_used', 'stdin', 'stdout', 'stderr',
 'environ', '_environ', '__environ',
 }
-CPPFILT_CMD = os.getenv('CPPFILT', '/usr/bin/c++filt')
 
 # Allowed NEEDED libraries
 ELF_ALLOWED_LIBRARIES = {
@@ -140,7 +140,7 @@ class CPPFilt(object):
     Use a pipe to the 'c++filt' command.
     '''
     def __init__(self):
-        self.proc = subprocess.Popen(CPPFILT_CMD, stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
+        self.proc = subprocess.Popen(determine_wellknown_cmd('CPPFILT', 'c++filt'), stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
 
     def __call__(self, mangled):
         self.proc.stdin.write(mangled + '\n')

--- a/contrib/devtools/test-security-check.py
+++ b/contrib/devtools/test-security-check.py
@@ -9,6 +9,8 @@ import os
 import subprocess
 import unittest
 
+from utils import determine_wellknown_cmd
+
 def write_testcode(filename):
     with open(filename, 'w', encoding="utf8") as f:
         f.write('''
@@ -25,7 +27,7 @@ def clean_files(source, executable):
     os.remove(executable)
 
 def call_security_check(cc, source, executable, options):
-    subprocess.run([cc,source,'-o',executable] + options, check=True)
+    subprocess.run([*cc,source,'-o',executable] + options, check=True)
     p = subprocess.run(['./contrib/devtools/security-check.py',executable], stdout=subprocess.PIPE, universal_newlines=True)
     return (p.returncode, p.stdout.rstrip())
 
@@ -33,7 +35,7 @@ class TestSecurityChecks(unittest.TestCase):
     def test_ELF(self):
         source = 'test1.c'
         executable = 'test1'
-        cc = 'gcc'
+        cc = determine_wellknown_cmd('CC', 'gcc')
         write_testcode(source)
 
         self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-zexecstack','-fno-stack-protector','-Wl,-znorelro','-no-pie','-fno-PIE', '-Wl,-z,separate-code']),
@@ -54,7 +56,7 @@ class TestSecurityChecks(unittest.TestCase):
     def test_PE(self):
         source = 'test1.c'
         executable = 'test1.exe'
-        cc = 'x86_64-w64-mingw32-gcc'
+        cc = determine_wellknown_cmd('CC', 'x86_64-w64-mingw32-gcc')
         write_testcode(source)
 
         self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--no-nxcompat','-Wl,--no-dynamicbase','-Wl,--no-high-entropy-va','-no-pie','-fno-PIE']),
@@ -73,7 +75,7 @@ class TestSecurityChecks(unittest.TestCase):
     def test_MACHO(self):
         source = 'test1.c'
         executable = 'test1'
-        cc = 'clang'
+        cc = determine_wellknown_cmd('CC', 'clang')
         write_testcode(source)
 
         self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-no_pie','-Wl,-flat_namespace','-Wl,-allow_stack_execute','-fno-stack-protector']),
@@ -93,4 +95,3 @@ class TestSecurityChecks(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/contrib/devtools/test-security-check.py
+++ b/contrib/devtools/test-security-check.py
@@ -59,15 +59,17 @@ class TestSecurityChecks(unittest.TestCase):
         cc = determine_wellknown_cmd('CC', 'x86_64-w64-mingw32-gcc')
         write_testcode(source)
 
-        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--no-nxcompat','-Wl,--no-dynamicbase','-Wl,--no-high-entropy-va','-no-pie','-fno-PIE']),
-            (1, executable+': failed DYNAMIC_BASE HIGH_ENTROPY_VA NX RELOC_SECTION'))
-        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--no-dynamicbase','-Wl,--no-high-entropy-va','-no-pie','-fno-PIE']),
-            (1, executable+': failed DYNAMIC_BASE HIGH_ENTROPY_VA RELOC_SECTION'))
-        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--dynamicbase','-Wl,--no-high-entropy-va','-no-pie','-fno-PIE']),
-            (1, executable+': failed HIGH_ENTROPY_VA RELOC_SECTION'))
-        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--dynamicbase','-Wl,--high-entropy-va','-no-pie','-fno-PIE']),
-            (1, executable+': failed RELOC_SECTION'))
-        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--dynamicbase','-Wl,--high-entropy-va','-pie','-fPIE']),
+        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--no-nxcompat','-Wl,--disable-reloc-section','-Wl,--no-dynamicbase','-Wl,--no-high-entropy-va','-no-pie','-fno-PIE']),
+            (1, executable+': failed PIE DYNAMIC_BASE HIGH_ENTROPY_VA NX RELOC_SECTION'))
+        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--disable-reloc-section','-Wl,--no-dynamicbase','-Wl,--no-high-entropy-va','-no-pie','-fno-PIE']),
+            (1, executable+': failed PIE DYNAMIC_BASE HIGH_ENTROPY_VA RELOC_SECTION'))
+        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--enable-reloc-section','-Wl,--no-dynamicbase','-Wl,--no-high-entropy-va','-no-pie','-fno-PIE']),
+            (1, executable+': failed PIE DYNAMIC_BASE HIGH_ENTROPY_VA'))
+        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--enable-reloc-section','-Wl,--no-dynamicbase','-Wl,--no-high-entropy-va','-pie','-fPIE']),
+            (1, executable+': failed PIE DYNAMIC_BASE HIGH_ENTROPY_VA'))  # -pie -fPIE does nothing unless --dynamicbase is also supplied
+        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--enable-reloc-section','-Wl,--dynamicbase','-Wl,--no-high-entropy-va','-pie','-fPIE']),
+            (1, executable+': failed HIGH_ENTROPY_VA'))
+        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--enable-reloc-section','-Wl,--dynamicbase','-Wl,--high-entropy-va','-pie','-fPIE']),
             (0, ''))
 
         clean_files(source, executable)

--- a/contrib/devtools/test-symbol-check.py
+++ b/contrib/devtools/test-symbol-check.py
@@ -7,10 +7,13 @@ Test script for symbol-check.py
 '''
 import os
 import subprocess
+from typing import List
 import unittest
 
-def call_symbol_check(cc, source, executable, options):
-    subprocess.run([cc,source,'-o',executable] + options, check=True)
+from utils import determine_wellknown_cmd
+
+def call_symbol_check(cc: List[str], source, executable, options):
+    subprocess.run([*cc,source,'-o',executable] + options, check=True)
     p = subprocess.run(['./contrib/devtools/symbol-check.py',executable], stdout=subprocess.PIPE, universal_newlines=True)
     os.remove(source)
     os.remove(executable)
@@ -20,7 +23,7 @@ class TestSymbolChecks(unittest.TestCase):
     def test_ELF(self):
         source = 'test1.c'
         executable = 'test1'
-        cc = 'gcc'
+        cc = determine_wellknown_cmd('CC', 'gcc')
 
         # renameat2 was introduced in GLIBC 2.28, so is newer than the upper limit
         # of glibc for all platforms
@@ -82,7 +85,7 @@ class TestSymbolChecks(unittest.TestCase):
     def test_MACHO(self):
         source = 'test1.c'
         executable = 'test1'
-        cc = 'clang'
+        cc = determine_wellknown_cmd('CC', 'clang')
 
         with open(source, 'w', encoding="utf8") as f:
             f.write('''
@@ -119,7 +122,7 @@ class TestSymbolChecks(unittest.TestCase):
     def test_PE(self):
         source = 'test1.c'
         executable = 'test1.exe'
-        cc = 'x86_64-w64-mingw32-gcc'
+        cc = determine_wellknown_cmd('CC', 'x86_64-w64-mingw32-gcc')
 
         with open(source, 'w', encoding="utf8") as f:
             f.write('''
@@ -155,4 +158,3 @@ class TestSymbolChecks(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/contrib/devtools/utils.py
+++ b/contrib/devtools/utils.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+'''
+Common utility functions
+'''
+import shutil
+import sys
+import os
+from typing import List
+
+
+def determine_wellknown_cmd(envvar, progname) -> List[str]:
+    maybe_env = os.getenv(envvar)
+    maybe_which = shutil.which(progname)
+    if maybe_env:
+        return maybe_env.split(' ')  # Well-known vars are often meant to be word-split
+    elif maybe_which:
+        return [ maybe_which ]
+    else:
+        sys.exit(f"{progname} not found")

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -305,10 +305,11 @@ mkdir -p "$DISTSRC"
     # Build Bitcoin Core
     make --jobs="$JOBS" ${V:+V=1}
 
-    # Perform basic ELF security checks on a series of executables.
+    # Check that symbol/security checks tools are sane.
+    make test-security-check ${V:+V=1}
+    # Perform basic security checks on a series of executables.
     make -C src --jobs=1 check-security ${V:+V=1}
-    # Check that executables only contain allowed gcc, glibc and libstdc++
-    # version symbols for Linux distro back-compatibility.
+    # Check that executables only contain allowed version symbols.
     make -C src --jobs=1 check-symbols  ${V:+V=1}
 
     mkdir -p "$OUTDIR"

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -75,6 +75,10 @@ http://www.linuxfromscratch.org/hlfs/view/development/chapter05/gcc-pass1.html"
                 (("-rpath=") "-rpath-link="))
               #t))))))))
 
+(define (make-binutils-with-mingw-w64-disable-flags xbinutils)
+  (package-with-extra-patches xbinutils
+    (search-our-patches "binutils-mingw-w64-disable-flags.patch")))
+
 (define (make-cross-toolchain target
                               base-gcc-for-libc
                               base-kernel-headers
@@ -145,7 +149,7 @@ desirable for building Bitcoin Core release binaries."
 
 (define (make-mingw-pthreads-cross-toolchain target)
   "Create a cross-compilation toolchain package for TARGET"
-  (let* ((xbinutils (cross-binutils target))
+  (let* ((xbinutils (make-binutils-with-mingw-w64-disable-flags (cross-binutils target)))
          (pthreads-xlibc mingw-w64-x86_64-winpthreads)
          (pthreads-xgcc (make-gcc-with-pthreads
                          (cross-gcc target

--- a/contrib/guix/patches/binutils-mingw-w64-disable-flags.patch
+++ b/contrib/guix/patches/binutils-mingw-w64-disable-flags.patch
@@ -1,0 +1,171 @@
+Description: Add disable opposites to the security-related flags
+Author: Stephen Kitt <skitt@debian.org>
+
+This patch adds "no-" variants to disable the various security flags:
+"no-dynamicbase", "no-nxcompat", "no-high-entropy-va", "disable-reloc-section".
+
+--- a/ld/emultempl/pe.em
++++ b/ld/emultempl/pe.em
+@@ -259,9 +261,11 @@
+ 					(OPTION_ENABLE_LONG_SECTION_NAMES + 1)
+ /* DLLCharacteristics flags.  */
+ #define OPTION_DYNAMIC_BASE		(OPTION_DISABLE_LONG_SECTION_NAMES + 1)
+-#define OPTION_FORCE_INTEGRITY		(OPTION_DYNAMIC_BASE + 1)
++#define OPTION_NO_DYNAMIC_BASE		(OPTION_DYNAMIC_BASE + 1)
++#define OPTION_FORCE_INTEGRITY		(OPTION_NO_DYNAMIC_BASE + 1)
+ #define OPTION_NX_COMPAT		(OPTION_FORCE_INTEGRITY + 1)
+-#define OPTION_NO_ISOLATION		(OPTION_NX_COMPAT + 1)
++#define OPTION_NO_NX_COMPAT		(OPTION_NX_COMPAT + 1)
++#define OPTION_NO_ISOLATION		(OPTION_NO_NX_COMPAT + 1)
+ #define OPTION_NO_SEH			(OPTION_NO_ISOLATION + 1)
+ #define OPTION_NO_BIND			(OPTION_NO_SEH + 1)
+ #define OPTION_WDM_DRIVER		(OPTION_NO_BIND + 1)
+@@ -271,6 +275,7 @@
+ #define OPTION_NO_INSERT_TIMESTAMP	(OPTION_INSERT_TIMESTAMP + 1)
+ #define OPTION_BUILD_ID			(OPTION_NO_INSERT_TIMESTAMP + 1)
+ #define OPTION_ENABLE_RELOC_SECTION	(OPTION_BUILD_ID + 1)
++#define OPTION_DISABLE_RELOC_SECTION	(OPTION_ENABLE_RELOC_SECTION + 1)
+ 
+ static void
+ gld${EMULATION_NAME}_add_options
+@@ -342,8 +347,10 @@
+     {"enable-long-section-names", no_argument, NULL, OPTION_ENABLE_LONG_SECTION_NAMES},
+     {"disable-long-section-names", no_argument, NULL, OPTION_DISABLE_LONG_SECTION_NAMES},
+     {"dynamicbase",no_argument, NULL, OPTION_DYNAMIC_BASE},
++    {"no-dynamicbase", no_argument, NULL, OPTION_NO_DYNAMIC_BASE},
+     {"forceinteg", no_argument, NULL, OPTION_FORCE_INTEGRITY},
+     {"nxcompat", no_argument, NULL, OPTION_NX_COMPAT},
++    {"no-nxcompat", no_argument, NULL, OPTION_NO_NX_COMPAT},
+     {"no-isolation", no_argument, NULL, OPTION_NO_ISOLATION},
+     {"no-seh", no_argument, NULL, OPTION_NO_SEH},
+     {"no-bind", no_argument, NULL, OPTION_NO_BIND},
+@@ -351,6 +358,7 @@
+     {"tsaware", no_argument, NULL, OPTION_TERMINAL_SERVER_AWARE},
+     {"build-id", optional_argument, NULL, OPTION_BUILD_ID},
+     {"enable-reloc-section", no_argument, NULL, OPTION_ENABLE_RELOC_SECTION},
++    {"disable-reloc-section", no_argument, NULL, OPTION_DISABLE_RELOC_SECTION},
+     {NULL, no_argument, NULL, 0}
+   };
+ 
+@@ -485,9 +494,12 @@
+                                        in object files\n"));
+   fprintf (file, _("  --dynamicbase                      Image base address may be relocated using\n\
+                                        address space layout randomization (ASLR)\n"));
++  fprintf (file, _("  --no-dynamicbase                   Image base address may not be relocated\n"));
+   fprintf (file, _("  --enable-reloc-section             Create the base relocation table\n"));
++  fprintf (file, _("  --disable-reloc-section            Disable the base relocation table\n"));
+   fprintf (file, _("  --forceinteg               Code integrity checks are enforced\n"));
+   fprintf (file, _("  --nxcompat                 Image is compatible with data execution prevention\n"));
++  fprintf (file, _("  --no-nxcompat              Image is not compatible with data execution prevention\n"));
+   fprintf (file, _("  --no-isolation             Image understands isolation but do not isolate the image\n"));
+   fprintf (file, _("  --no-seh                   Image does not use SEH. No SE handler may\n\
+                                        be called in this image\n"));
+@@ -862,12 +874,21 @@
+     case OPTION_ENABLE_RELOC_SECTION:
+       pe_dll_enable_reloc_section = 1;
+       break;
++    case OPTION_DISABLE_RELOC_SECTION:
++      pe_dll_enable_reloc_section = 0;
++      /* fall through */
++    case OPTION_NO_DYNAMIC_BASE:
++      pe_dll_characteristics &= ~IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE;
++      break;
+     case OPTION_FORCE_INTEGRITY:
+       pe_dll_characteristics |= IMAGE_DLL_CHARACTERISTICS_FORCE_INTEGRITY;
+       break;
+     case OPTION_NX_COMPAT:
+       pe_dll_characteristics |= IMAGE_DLL_CHARACTERISTICS_NX_COMPAT;
+       break;
++    case OPTION_NO_NX_COMPAT:
++      pe_dll_characteristics &= ~IMAGE_DLL_CHARACTERISTICS_NX_COMPAT;
++      break;
+     case OPTION_NO_ISOLATION:
+       pe_dll_characteristics |= IMAGE_DLLCHARACTERISTICS_NO_ISOLATION;
+       break;
+--- a/ld/emultempl/pep.em
++++ b/ld/emultempl/pep.em
+@@ -237,9 +240,12 @@
+   OPTION_ENABLE_LONG_SECTION_NAMES,
+   OPTION_DISABLE_LONG_SECTION_NAMES,
+   OPTION_HIGH_ENTROPY_VA,
++  OPTION_NO_HIGH_ENTROPY_VA,
+   OPTION_DYNAMIC_BASE,
++  OPTION_NO_DYNAMIC_BASE,
+   OPTION_FORCE_INTEGRITY,
+   OPTION_NX_COMPAT,
++  OPTION_NO_NX_COMPAT,
+   OPTION_NO_ISOLATION,
+   OPTION_NO_SEH,
+   OPTION_NO_BIND,
+@@ -248,7 +254,8 @@
+   OPTION_NO_INSERT_TIMESTAMP,
+   OPTION_TERMINAL_SERVER_AWARE,
+   OPTION_BUILD_ID,
+-  OPTION_ENABLE_RELOC_SECTION
++  OPTION_ENABLE_RELOC_SECTION,
++  OPTION_DISABLE_RELOC_SECTION
+ };
+ 
+ static void
+@@ -315,9 +322,12 @@
+     {"enable-long-section-names", no_argument, NULL, OPTION_ENABLE_LONG_SECTION_NAMES},
+     {"disable-long-section-names", no_argument, NULL, OPTION_DISABLE_LONG_SECTION_NAMES},
+     {"high-entropy-va", no_argument, NULL, OPTION_HIGH_ENTROPY_VA},
++    {"no-high-entropy-va", no_argument, NULL, OPTION_NO_HIGH_ENTROPY_VA},
+     {"dynamicbase",no_argument, NULL, OPTION_DYNAMIC_BASE},
++    {"no-dynamicbase", no_argument, NULL, OPTION_NO_DYNAMIC_BASE},
+     {"forceinteg", no_argument, NULL, OPTION_FORCE_INTEGRITY},
+     {"nxcompat", no_argument, NULL, OPTION_NX_COMPAT},
++    {"no-nxcompat", no_argument, NULL, OPTION_NO_NX_COMPAT},
+     {"no-isolation", no_argument, NULL, OPTION_NO_ISOLATION},
+     {"no-seh", no_argument, NULL, OPTION_NO_SEH},
+     {"no-bind", no_argument, NULL, OPTION_NO_BIND},
+@@ -327,6 +337,7 @@
+     {"no-insert-timestamp", no_argument, NULL, OPTION_NO_INSERT_TIMESTAMP},
+     {"build-id", optional_argument, NULL, OPTION_BUILD_ID},
+     {"enable-reloc-section", no_argument, NULL, OPTION_ENABLE_RELOC_SECTION},
++    {"disable-reloc-section", no_argument, NULL, OPTION_DISABLE_RELOC_SECTION},
+     {NULL, no_argument, NULL, 0}
+   };
+ 
+@@ -448,11 +461,15 @@
+                                        in object files\n"));
+   fprintf (file, _("  --high-entropy-va                  Image is compatible with 64-bit address space\n\
+                                        layout randomization (ASLR)\n"));
++  fprintf (file, _("  --no-high-entropy-va               Image is not compatible with 64-bit ASLR\n"));
+   fprintf (file, _("  --dynamicbase                      Image base address may be relocated using\n\
+                                        address space layout randomization (ASLR)\n"));
++  fprintf (file, _("  --no-dynamicbase                   Image base address may not be relocated\n"));
+   fprintf (file, _("  --enable-reloc-section             Create the base relocation table\n"));
++  fprintf (file, _("  --disable-reloc-section            Disable the base relocation table\n"));
+   fprintf (file, _("  --forceinteg               Code integrity checks are enforced\n"));
+   fprintf (file, _("  --nxcompat                 Image is compatible with data execution prevention\n"));
++  fprintf (file, _("  --no-nxcompat              Image is not compatible with data execution prevention\n"));
+   fprintf (file, _("  --no-isolation             Image understands isolation but do not isolate the image\n"));
+   fprintf (file, _("  --no-seh                   Image does not use SEH; no SE handler may\n\
+                                        be called in this image\n"));
+@@ -809,12 +826,24 @@
+     case OPTION_ENABLE_RELOC_SECTION:
+       pep_dll_enable_reloc_section = 1;
+       break;
++    case OPTION_DISABLE_RELOC_SECTION:
++      pep_dll_enable_reloc_section = 0;
++      /* fall through */
++    case OPTION_NO_DYNAMIC_BASE:
++      pe_dll_characteristics &= ~IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE;
++      /* fall through */
++    case OPTION_NO_HIGH_ENTROPY_VA:
++      pe_dll_characteristics &= ~IMAGE_DLL_CHARACTERISTICS_HIGH_ENTROPY_VA;
++      break;
+     case OPTION_FORCE_INTEGRITY:
+       pe_dll_characteristics |= IMAGE_DLL_CHARACTERISTICS_FORCE_INTEGRITY;
+       break;
+     case OPTION_NX_COMPAT:
+       pe_dll_characteristics |= IMAGE_DLL_CHARACTERISTICS_NX_COMPAT;
+       break;
++    case OPTION_NO_NX_COMPAT:
++      pe_dll_characteristics &= ~IMAGE_DLL_CHARACTERISTICS_NX_COMPAT;
++      break;
+     case OPTION_NO_ISOLATION:
+       pe_dll_characteristics |= IMAGE_DLLCHARACTERISTICS_NO_ISOLATION;
+       break;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -801,23 +801,23 @@ clean-local:
 check-symbols: $(bin_PROGRAMS)
 if TARGET_DARWIN
 	@echo "Checking macOS dynamic libraries..."
-	$(AM_V_at) OTOOL=$(OTOOL) $(PYTHON) $(top_srcdir)/contrib/devtools/symbol-check.py $(bin_PROGRAMS)
+	$(AM_V_at) $(PYTHON) $(top_srcdir)/contrib/devtools/symbol-check.py $(bin_PROGRAMS)
 endif
 
 if TARGET_WINDOWS
 	@echo "Checking Windows dynamic libraries..."
-	$(AM_V_at) OBJDUMP=$(OBJDUMP) $(PYTHON) $(top_srcdir)/contrib/devtools/symbol-check.py $(bin_PROGRAMS)
+	$(AM_V_at) $(PYTHON) $(top_srcdir)/contrib/devtools/symbol-check.py $(bin_PROGRAMS)
 endif
 
 if GLIBC_BACK_COMPAT
 	@echo "Checking glibc back compat..."
-	$(AM_V_at) CPPFILT=$(CPPFILT) $(PYTHON) $(top_srcdir)/contrib/devtools/symbol-check.py $(bin_PROGRAMS)
+	$(AM_V_at) CPPFILT='$(CPPFILT)' $(PYTHON) $(top_srcdir)/contrib/devtools/symbol-check.py $(bin_PROGRAMS)
 endif
 
 check-security: $(bin_PROGRAMS)
 if HARDEN
 	@echo "Checking binary security..."
-	$(AM_V_at) OBJDUMP=$(OBJDUMP) OTOOL=$(OTOOL) $(PYTHON) $(top_srcdir)/contrib/devtools/security-check.py $(bin_PROGRAMS)
+	$(AM_V_at) $(PYTHON) $(top_srcdir)/contrib/devtools/security-check.py $(bin_PROGRAMS)
 endif
 
 libbitcoin_ipc_mpgen_input = \

--- a/test/lint/lint-python.sh
+++ b/test/lint/lint-python.sh
@@ -102,7 +102,7 @@ if ! PYTHONWARNINGS="ignore" flake8 --ignore=B,C,E,F,I,N,W --select=$(IFS=","; e
     EXIT_CODE=1
 fi
 
-if ! mypy --ignore-missing-imports $(git ls-files "test/functional/*.py" "contrib/devtools/*.py"); then
+if ! mypy --ignore-missing-imports --show-error-codes $(git ls-files "test/functional/*.py" "contrib/devtools/*.py"); then
     EXIT_CODE=1
 fi
 

--- a/test/lint/lint-spelling.sh
+++ b/test/lint/lint-spelling.sh
@@ -15,6 +15,6 @@ if ! command -v codespell > /dev/null; then
 fi
 
 IGNORE_WORDS_FILE=test/lint/lint-spelling.ignore-words.txt
-if ! codespell --check-filenames --disable-colors --quiet-level=7 --ignore-words=${IGNORE_WORDS_FILE} $(git ls-files -- ":(exclude)build-aux/m4/" ":(exclude)contrib/seeds/*.txt" ":(exclude)depends/" ":(exclude)doc/release-notes/" ":(exclude)src/leveldb/" ":(exclude)src/crc32c/" ":(exclude)src/qt/locale/" ":(exclude)src/qt/*.qrc" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" ":(exclude)contrib/gitian-keys/keys.txt"); then
+if ! codespell --check-filenames --disable-colors --quiet-level=7 --ignore-words=${IGNORE_WORDS_FILE} $(git ls-files -- ":(exclude)build-aux/m4/" ":(exclude)contrib/seeds/*.txt" ":(exclude)depends/" ":(exclude)doc/release-notes/" ":(exclude)src/leveldb/" ":(exclude)src/crc32c/" ":(exclude)src/qt/locale/" ":(exclude)src/qt/*.qrc" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" ":(exclude)contrib/gitian-keys/keys.txt" ":(exclude)contrib/guix/patches"); then
     echo "^ Warning: codespell identified likely spelling errors. Any false positives? Add them to the list of ignored words in ${IGNORE_WORDS_FILE}"
 fi


### PR DESCRIPTION
These changes allow us to make use of the `test-security-check` target to check the sanity
of our security/symbol checking suite before running them.