### PR TITLE
docs: update developer notes to discourage very long lines

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -75,6 +75,11 @@ tool to clean up patches automatically before submission.
     on the same line as the `if`, without braces. In every other case,
     braces are required, and the `then` and `else` clauses must appear
     correctly indented on a new line.
+  - There's no hard limit on line width, but prefer to keep lines to <100
+    characters if doing so does not decrease readability. Break up long
+    function declarations over multiple lines using the Clang Format
+    [AlignAfterOpenBracket](https://clang.llvm.org/docs/ClangFormatStyleOptions.html)
+    style option.
 
 - **Symbol naming conventions**. These are preferred in new code, but are not
 required when doing so would need changes to significant pieces of existing


### PR DESCRIPTION
Mandatory rules on line lengths are bad - there will always be cases where a longer line is more readable than the alternative.

However, very long lines for no good reason _do_ hurt readability. For example, this declaration in validation.h is 274 chars:

```c++
    bool ConnectTip(BlockValidationState& state, const CChainParams& chainparams, CBlockIndex* pindexNew, const std::shared_ptr<const CBlock>& pblock, ConnectTrace& connectTrace, DisconnectedBlockTransactions& disconnectpool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool.cs);
```

That won't fit on one line without wrapping on my 27" monitor with a comfortable font size. Much easier to read is something like:

```c++
    bool ConnectTip(BlockValidationState& state, const CChainParams& chainparams,
                    CBlockIndex* pindexNew, const std::shared_ptr<const CBlock>& pblock,
                    ConnectTrace& connectTrace, DisconnectedBlockTransactions& disconnectpool)
        EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool.cs);
```

Therefore, _discourage_ (don't forbid) line lengths greater than 100 characters in our developer style guide.

100 chars is somewhat arbitrary. The old standard was 80, but that seems very limiting with modern displays.