### PR TITLE
doc: add instructions for generating RPC docs

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -326,6 +326,18 @@ bitcoin.org (see below for bitcoin.org update instructions).
 
   - bitcoincore.org RPC documentation update
 
+      - Install [golang](https://golang.org/doc/install)
+
+      - Install the new Bitcoin Core release
+
+      - Run bitcoind on regtest
+
+      - Clone the [bitcoincore.org repository](https://github.com/bitcoin-core/bitcoincore.org)
+
+      - Run: `go run generate.go` while being in `contrib/doc-gen` folder, and with bitcoin-cli in PATH
+
+      - Add the generated files to git
+
   - Update packaging repo
 
       - Push the flatpak to flathub, e.g. https://github.com/flathub/org.bitcoincore.bitcoin-qt/pull/2


### PR DESCRIPTION
Added instructions on how to generate the up to date RPC docs for the bitcoincore.org website in the relevant release-process subsection.