### PR TITLE
doc: remove trailing whitespace from the release notes

### DIFF
--- a/contrib/init/bitcoind.openrc
+++ b/contrib/init/bitcoind.openrc
@@ -1,6 +1,6 @@
 #!/sbin/openrc-run
 
-# backward compatibility for existing gentoo layout 
+# backward compatibility for existing gentoo layout
 #
 if [ -d "/var/lib/bitcoin/.bitcoin" ]; then
 	BITCOIND_DEFAULT_DATADIR="/var/lib/bitcoin/.bitcoin"

--- a/doc/release-notes/release-notes-0.10.0.md
+++ b/doc/release-notes/release-notes-0.10.0.md
@@ -79,7 +79,7 @@ This release automatically estimates how high a transaction fee (or how
 high a priority) transactions require to be confirmed quickly. The default
 settings will create transactions that confirm quickly; see the new
 'txconfirmtarget' setting to control the tradeoff between fees and
-confirmation times. Fees are added by default unless the 'sendfreetransactions' 
+confirmation times. Fees are added by default unless the 'sendfreetransactions'
 setting is enabled.
 
 Prior releases used hard-coded fees (and priorities), and would
@@ -93,7 +93,7 @@ New command line options for transaction fee changes:
 - `-txconfirmtarget=n` : create transactions that have enough fees (or priority)
 so they are likely to begin confirmation within n blocks (default: 1). This setting
 is over-ridden by the -paytxfee option.
-- `-sendfreetransactions` : Send transactions as zero-fee transactions if possible 
+- `-sendfreetransactions` : Send transactions as zero-fee transactions if possible
 (default: 0)
 
 New RPC commands for fee estimation:
@@ -234,7 +234,7 @@ Its interface is defined in the C header [bitcoinconsensus.h](https://github.com
 
 In its initial version the API includes two functions:
 
-- `bitcoinconsensus_verify_script` verifies a script. It returns whether the indicated input of the provided serialized transaction 
+- `bitcoinconsensus_verify_script` verifies a script. It returns whether the indicated input of the provided serialized transaction
 correctly spends the passed scriptPubKey under additional constraints indicated by flags
 - `bitcoinconsensus_version` returns the API version, currently at an experimental `0`
 
@@ -306,8 +306,8 @@ if this is 1.
 - `-datacarriersize=n` : Maximum size, in bytes, we consider acceptable for
 "data carrier" outputs.
 
-The relay policy has changed to more properly implement the desired behavior of not 
-relaying free (or very low fee) transactions unless they have a priority above the 
+The relay policy has changed to more properly implement the desired behavior of not
+relaying free (or very low fee) transactions unless they have a priority above the
 AllowFreeThreshold(), in which case they are relayed subject to the rate limiter.
 
 BIP 66: strict DER encoding for signatures
@@ -499,7 +499,7 @@ Build system:
 - `a7d1f03` build: fix dynamic boost check when --with-boost= is used
 - `d5fd094` build: fix qt test build when libprotobuf is in a non-standard path
 - `2cf5f16` Add libbitcoinconsensus library
-- `914868a` build: add a deterministic dmg signer 
+- `914868a` build: add a deterministic dmg signer
 - `2d375fe` depends: bump openssl to 1.0.1k
 - `b7a4ecc` Build: Only check for boost when building code that requires it
 

--- a/doc/release-notes/release-notes-0.10.1.md
+++ b/doc/release-notes/release-notes-0.10.1.md
@@ -2,7 +2,7 @@ Bitcoin Core version 0.10.1 is now available from:
 
   <https://bitcoin.org/bin/bitcoin-core-0.10.1/>
 
-This is a new minor version release, bringing bug fixes and translation 
+This is a new minor version release, bringing bug fixes and translation
 updates. It is recommended to upgrade to this version.
 
 Please report bugs using the issue tracker at github:

--- a/doc/release-notes/release-notes-0.10.2.md
+++ b/doc/release-notes/release-notes-0.10.2.md
@@ -2,7 +2,7 @@ Bitcoin Core version 0.10.2 is now available from:
 
   <https://bitcoin.org/bin/bitcoin-core-0.10.2/>
 
-This is a new minor version release, bringing minor bug fixes and translation 
+This is a new minor version release, bringing minor bug fixes and translation
 updates. It is recommended to upgrade to this version.
 
 Please report bugs using the issue tracker at github:

--- a/doc/release-notes/release-notes-0.10.3.md
+++ b/doc/release-notes/release-notes-0.10.3.md
@@ -2,7 +2,7 @@ Bitcoin Core version 0.10.3 is now available from:
 
   <https://bitcoin.org/bin/bitcoin-core-0.10.3/>
 
-This is a new minor version release, bringing security fixes and translation 
+This is a new minor version release, bringing security fixes and translation
 updates. It is recommended to upgrade to this version as soon as possible.
 
 Please report bugs using the issue tracker at github:

--- a/doc/release-notes/release-notes-0.11.0.md
+++ b/doc/release-notes/release-notes-0.11.0.md
@@ -69,7 +69,7 @@ to free transactions.
 
 For example, add the following to `bitcoin.conf`:
 
-    minrelaytxfee=0.00005 
+    minrelaytxfee=0.00005
     limitfreerelay=5
 
 More robust solutions are being worked on for a follow-up release.
@@ -80,50 +80,50 @@ Notable changes
 Block file pruning
 ----------------------
 
-This release supports running a fully validating node without maintaining a copy 
-of the raw block and undo data on disk. To recap, there are four types of data 
-related to the blockchain in the bitcoin system: the raw blocks as received over 
-the network (blk???.dat), the undo data (rev???.dat), the block index and the 
+This release supports running a fully validating node without maintaining a copy
+of the raw block and undo data on disk. To recap, there are four types of data
+related to the blockchain in the bitcoin system: the raw blocks as received over
+the network (blk???.dat), the undo data (rev???.dat), the block index and the
 UTXO set (both LevelDB databases). The databases are built from the raw data.
 
-Block pruning allows Bitcoin Core to delete the raw block and undo data once 
-it's been validated and used to build the databases. At that point, the raw data 
-is used only to relay blocks to other nodes, to handle reorganizations, to look 
-up old transactions (if -txindex is enabled or via the RPC/REST interfaces), or 
-for rescanning the wallet. The block index continues to hold the metadata about 
+Block pruning allows Bitcoin Core to delete the raw block and undo data once
+it's been validated and used to build the databases. At that point, the raw data
+is used only to relay blocks to other nodes, to handle reorganizations, to look
+up old transactions (if -txindex is enabled or via the RPC/REST interfaces), or
+for rescanning the wallet. The block index continues to hold the metadata about
 all blocks in the blockchain.
 
-The user specifies how much space to allot for block & undo files. The minimum 
-allowed is 550MB. Note that this is in addition to whatever is required for the 
-block index and UTXO databases. The minimum was chosen so that Bitcoin Core will 
-be able to maintain at least 288 blocks on disk (two days worth of blocks at 10 
-minutes per block). In rare instances it is possible that the amount of space 
-used will exceed the pruning target in order to keep the required last 288 
+The user specifies how much space to allot for block & undo files. The minimum
+allowed is 550MB. Note that this is in addition to whatever is required for the
+block index and UTXO databases. The minimum was chosen so that Bitcoin Core will
+be able to maintain at least 288 blocks on disk (two days worth of blocks at 10
+minutes per block). In rare instances it is possible that the amount of space
+used will exceed the pruning target in order to keep the required last 288
 blocks on disk.
 
-Block pruning works during initial sync in the same way as during steady state, 
-by deleting block files "as you go" whenever disk space is allocated. Thus, if 
-the user specifies 550MB, once that level is reached the program will begin 
-deleting the oldest block and undo files, while continuing to download the 
+Block pruning works during initial sync in the same way as during steady state,
+by deleting block files "as you go" whenever disk space is allocated. Thus, if
+the user specifies 550MB, once that level is reached the program will begin
+deleting the oldest block and undo files, while continuing to download the
 blockchain.
 
-For now, block pruning disables block relay.  In the future, nodes with block 
-pruning will at a minimum relay "new" blocks, meaning blocks that extend their 
-active chain. 
+For now, block pruning disables block relay.  In the future, nodes with block
+pruning will at a minimum relay "new" blocks, meaning blocks that extend their
+active chain.
 
-Block pruning is currently incompatible with running a wallet due to the fact 
-that block data is used for rescanning the wallet and importing keys or 
-addresses (which require a rescan.) However, running the wallet with block 
+Block pruning is currently incompatible with running a wallet due to the fact
+that block data is used for rescanning the wallet and importing keys or
+addresses (which require a rescan.) However, running the wallet with block
 pruning will be supported in the near future, subject to those limitations.
 
-Block pruning is also incompatible with -txindex and will automatically disable 
+Block pruning is also incompatible with -txindex and will automatically disable
 it.
 
-Once you have pruned blocks, going back to unpruned state requires 
-re-downloading the entire blockchain. To do this, re-start the node with 
--reindex. Note also that any problem that would cause a user to reindex (e.g., 
-disk corruption) will cause a pruned node to redownload the entire blockchain. 
-Finally, note that when a pruned node reindexes, it will delete any blk???.dat 
+Once you have pruned blocks, going back to unpruned state requires
+re-downloading the entire blockchain. To do this, re-start the node with
+-reindex. Note also that any problem that would cause a user to reindex (e.g.,
+disk corruption) will cause a pruned node to redownload the entire blockchain.
+Finally, note that when a pruned node reindexes, it will delete any blk???.dat
 and rev???.dat files in the data directory prior to restarting the download.
 
 To enable block pruning on the command line:
@@ -133,10 +133,10 @@ To enable block pruning on the command line:
 Modified RPC calls:
 
 - `getblockchaininfo` now includes whether we are in pruned mode or not.
-- `getblock` will check if the block's data has been pruned and if so, return an 
+- `getblock` will check if the block's data has been pruned and if so, return an
 error.
-- `getrawtransaction` will no longer be able to locate a transaction that has a 
-UTXO but where its block file has been pruned. 
+- `getrawtransaction` will no longer be able to locate a transaction that has a
+UTXO but where its block file has been pruned.
 
 Pruning is disabled by default.
 
@@ -377,7 +377,7 @@ git merge commit are mentioned.
 - #6074 `948beaf` Correct the PUSHDATA4 minimal encoding test in script_invalid.json
 - #6032 `e08886d` Stop nodes after RPC tests, even with --nocleanup
 - #6075 `df1609f` Add additional script edge condition tests
-- #5981 `da38dc6` Python P2P testing 
+- #5981 `da38dc6` Python P2P testing
 - #5958 `9ef00c3` Add multisig rpc tests
 - #6112 `fec5c0e` Add more script edge condition tests
 

--- a/doc/release-notes/release-notes-0.12.1.md
+++ b/doc/release-notes/release-notes-0.12.1.md
@@ -43,7 +43,7 @@ This release includes a soft fork deployment to enforce [BIP68][],
 [BIP112][] and [BIP113][] using the [BIP9][] deployment mechanism.
 
 The deployment sets the block version number to 0x20000001 between
-midnight 1st May 2016 and midnight 1st May 2017 to signal readiness for 
+midnight 1st May 2016 and midnight 1st May 2017 to signal readiness for
 deployment. The version number consists of 0x20000000 to indicate version
 bits together with setting bit 0 to indicate support for this combined
 deployment, shown as "csv" in the `getblockchaininfo` RPC call.

--- a/doc/release-notes/release-notes-0.13.0.md
+++ b/doc/release-notes/release-notes-0.13.0.md
@@ -325,10 +325,10 @@ Low-level RPC changes
 
 - Asm script outputs replacements for OP_NOP2 and OP_NOP3
 
-  - OP_NOP2 has been renamed to OP_CHECKLOCKTIMEVERIFY by [BIP 
+  - OP_NOP2 has been renamed to OP_CHECKLOCKTIMEVERIFY by [BIP
 65](https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki)
 
-  - OP_NOP3 has been renamed to OP_CHECKSEQUENCEVERIFY by [BIP 
+  - OP_NOP3 has been renamed to OP_CHECKSEQUENCEVERIFY by [BIP
 112](https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki)
 
   - The following outputs are affected by this change:

--- a/doc/release-notes/release-notes-0.13.1.md
+++ b/doc/release-notes/release-notes-0.13.1.md
@@ -36,8 +36,8 @@ No attempt is made to prevent installing or running the software on Windows XP,
 you can still do so at your own risk, but do not expect it to work: do not
 report issues about Windows XP to the issue tracker.
 
-From 0.13.1 onwards OS X 10.7 is no longer supported. 0.13.0 was intended to work on 10.7+, 
-but severe issues with the libc++ version on 10.7.x keep it from running reliably. 
+From 0.13.1 onwards OS X 10.7 is no longer supported. 0.13.0 was intended to work on 10.7+,
+but severe issues with the libc++ version on 10.7.x keep it from running reliably.
 0.13.1 now requires 10.8+, and will communicate that to 10.7 users, rather than crashing unexpectedly.
 
 Notable changes

--- a/doc/release-notes/release-notes-0.13.2.md
+++ b/doc/release-notes/release-notes-0.13.2.md
@@ -35,8 +35,8 @@ No attempt is made to prevent installing or running the software on Windows XP,
 you can still do so at your own risk, but do not expect it to work: do not
 report issues about Windows XP to the issue tracker.
 
-From 0.13.1 onwards OS X 10.7 is no longer supported. 0.13.0 was intended to work on 10.7+, 
-but severe issues with the libc++ version on 10.7.x keep it from running reliably. 
+From 0.13.1 onwards OS X 10.7 is no longer supported. 0.13.0 was intended to work on 10.7+,
+but severe issues with the libc++ version on 10.7.x keep it from running reliably.
 0.13.1 now requires 10.8+, and will communicate that to 10.7 users, rather than crashing unexpectedly.
 
 Notable changes

--- a/doc/release-notes/release-notes-0.14.0.md
+++ b/doc/release-notes/release-notes-0.14.0.md
@@ -108,7 +108,7 @@ command without running the commands separately.
 
 The nested RPC commands use bracket syntax (i.e. `getwalletinfo()`) and can
 be nested (i.e. `getblock(getblockhash(1))`). Simple queries can be
-done with square brackets where object values are accessed with either an 
+done with square brackets where object values are accessed with either an
 array index or a non-quoted string (i.e. `listunspent()[0][txid]`). Both
 commas and spaces can be used to separate parameters in both the bracket syntax
 and normal RPC command syntax.
@@ -117,9 +117,9 @@ Network Activity Toggle
 -----------------------
 
 A RPC command and GUI toggle have been added to enable or disable all p2p
-network activity. The network status icon in the bottom right hand corner 
+network activity. The network status icon in the bottom right hand corner
 is now the GUI toggle. Clicking the icon will either enable or disable all
-p2p network activity. If network activity is disabled, the icon will 
+p2p network activity. If network activity is disabled, the icon will
 be grayed out with an X on top of it.
 
 Additionally the `setnetworkactive` RPC command has been added which does
@@ -189,7 +189,7 @@ commands such as `prioritisetransaction` so that those changes will not be lost.
 Final Alert
 -----------
 
-The Alert System was [disabled and deprecated](https://bitcoin.org/en/alert/2016-11-01-alert-retirement) in Bitcoin Core 0.12.1 and removed in 0.13.0. 
+The Alert System was [disabled and deprecated](https://bitcoin.org/en/alert/2016-11-01-alert-retirement) in Bitcoin Core 0.12.1 and removed in 0.13.0.
 The Alert System was retired with a maximum sequence final alert which causes any nodes
 supporting the Alert System to display a static hard-coded "Alert Key Compromised" message which also
 prevents any other alerts from overriding it. This final alert is hard-coded into this release
@@ -198,15 +198,15 @@ so that all old nodes receive the final alert.
 GUI Changes
 -----------
 
- - After resetting the options by clicking the `Reset Options` button 
-   in the options dialog or with the `-resetguioptions` startup option, 
-   the user will be prompted to choose the data directory again. This 
-   is to ensure that custom data directories will be kept after the 
-   option reset which clears the custom data directory set via the choose 
+ - After resetting the options by clicking the `Reset Options` button
+   in the options dialog or with the `-resetguioptions` startup option,
+   the user will be prompted to choose the data directory again. This
+   is to ensure that custom data directories will be kept after the
+   option reset which clears the custom data directory set via the choose
    datadir dialog.
 
- - Multiple peers can now be selected in the list of peers in the debug 
-   window. This allows for users to ban or disconnect multiple peers 
+ - Multiple peers can now be selected in the list of peers in the debug
+   window. This allows for users to ban or disconnect multiple peers
    simultaneously instead of banning them one at a time.
 
  - An indicator has been added to the bottom right hand corner of the main
@@ -221,7 +221,7 @@ Low-level RPC changes
    an optional third arg, which was always ignored. Make sure to never pass more
    than two arguments.
 
- - The first boolean argument to `getaddednodeinfo` has been removed. This is 
+ - The first boolean argument to `getaddednodeinfo` has been removed. This is
    an incompatible change.
 
  - RPC command `getmininginfo` loses the "testnet" field in favor of the more
@@ -231,8 +231,8 @@ Low-level RPC changes
    precious. A precious block will be treated as if it were received earlier
    than a competing block.
 
- - A new RPC command `importmulti` has been added which receives an array of 
-   JSON objects representing the intention of importing a public key, a 
+ - A new RPC command `importmulti` has been added which receives an array of
+   JSON objects representing the intention of importing a public key, a
    private key, an address and script/p2sh
 
  - Use of `getrawtransaction` for retrieving confirmed transactions with unspent
@@ -254,7 +254,7 @@ HTTP REST Changes
 -----------------
 
  - UTXO set query (`GET /rest/getutxos/<checkmempool>/<txid>-<n>/<txid>-<n>
-   /.../<txid>-<n>.<bin|hex|json>`) responses were changed to return status 
+   /.../<txid>-<n>.<bin|hex|json>`) responses were changed to return status
    code `HTTP_BAD_REQUEST` (400) instead of `HTTP_INTERNAL_SERVER_ERROR` (500)
    when requests contain invalid parameters.
 

--- a/doc/release-notes/release-notes-0.14.3.md
+++ b/doc/release-notes/release-notes-0.14.3.md
@@ -56,7 +56,7 @@ git merge commit are mentioned.
 
 ### Consensus
 - #14247 `52965fb` Fix crash bug with duplicate inputs within a transaction (TheBlueMatt, sdaftuar)
- 
+
 ### RPC and other APIs
 
 - #10445 `87a21d5` Fix: make CCoinsViewDbCursor::Seek work for missing keys (Pieter Wuille, Gregory Maxwell)

--- a/doc/release-notes/release-notes-0.15.0.1.md
+++ b/doc/release-notes/release-notes-0.15.0.1.md
@@ -20,7 +20,7 @@ How to Upgrade
 ==============
 
 If you are running an older version, shut it down. Wait until it has completely
-shut down (which might take a few minutes for older versions), then run the 
+shut down (which might take a few minutes for older versions), then run the
 installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
 or `bitcoind`/`bitcoin-qt` (on Linux).
 

--- a/doc/release-notes/release-notes-0.15.0.md
+++ b/doc/release-notes/release-notes-0.15.0.md
@@ -17,7 +17,7 @@ How to Upgrade
 ==============
 
 If you are running an older version, shut it down. Wait until it has completely
-shut down (which might take a few minutes for older versions), then run the 
+shut down (which might take a few minutes for older versions), then run the
 installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
 or `bitcoind`/`bitcoin-qt` (on Linux).
 

--- a/doc/release-notes/release-notes-0.15.1.md
+++ b/doc/release-notes/release-notes-0.15.1.md
@@ -21,7 +21,7 @@ How to Upgrade
 ==============
 
 If you are running an older version, shut it down. Wait until it has completely
-shut down (which might take a few minutes for older versions), then run the 
+shut down (which might take a few minutes for older versions), then run the
 installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
 or `bitcoind`/`bitcoin-qt` (on Linux).
 
@@ -70,7 +70,7 @@ have been made, as a safety precaution against blockchain forks and misbehaving 
 
 - Unrequested blocks with less work than the minimum-chain-work are now no longer processed even
 if they have more work than the tip (a potential issue during IBD where the tip may have low-work).
-This prevents peers wasting the resources of a node. 
+This prevents peers wasting the resources of a node.
 
 - Peers which provide a chain with less work than the minimum-chain-work during IBD will now be disconnected.
 

--- a/doc/release-notes/release-notes-0.15.2.md
+++ b/doc/release-notes/release-notes-0.15.2.md
@@ -17,7 +17,7 @@ How to Upgrade
 ==============
 
 If you are running an older version, shut it down. Wait until it has completely
-shut down (which might take a few minutes for older versions), then run the 
+shut down (which might take a few minutes for older versions), then run the
 installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
 or `bitcoind`/`bitcoin-qt` (on Linux).
 
@@ -77,11 +77,11 @@ the vulnerable versions to 0.15.2 or 0.16.3 as soon as possible.
 
 ### Consensus
 - #14247 `4b8a3f5` Fix crash bug with duplicate inputs within a transaction (TheBlueMatt, sdaftuar)
- 
+
 ### RPC
 - #11676 `7af2457` contrib/init: Update openrc-run filename (Luke Dashjr)
 - #11277 `7026845` Fix uninitialized URI in batch RPC requests (Russell Yanofsky)
- 
+
 ### Wallet
 - #11289 `3f1db56` Wrap dumpwallet warning and note scripts aren't dumped (MeshCollider)
 - #11289 `42ea47d` Add wallet backup text to import*, add* and dumpwallet RPCs (MeshCollider)

--- a/doc/release-notes/release-notes-0.17.1.md
+++ b/doc/release-notes/release-notes-0.17.1.md
@@ -4,7 +4,7 @@ Bitcoin Core version 0.17.1 is now available from:
 
 or through BitTorrent:
 
-    magnet:?xt=urn:btih:c56c87ccfaa8e6fbccc90d549121e61efd97cb6f&dn=bitcoin-core-0.17.1&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fexplodie.org%3A6969    
+    magnet:?xt=urn:btih:c56c87ccfaa8e6fbccc90d549121e61efd97cb6f&dn=bitcoin-core-0.17.1&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fexplodie.org%3A6969
 
 This is a new minor version release, with various bugfixes
 and performance improvements, as well as updated translations.

--- a/doc/release-notes/release-notes-0.18.1.md
+++ b/doc/release-notes/release-notes-0.18.1.md
@@ -84,9 +84,9 @@ not to use coin control features with multiple wallets loaded.
 - #15957 Show "No wallets available" in open menu instead of nothing (meshcollider)
 - #16118 Enable open wallet menu on setWalletController (promag)
 - #16135 Set progressDialog to nullptr (promag)
-- #16231 Fix open wallet menu initialization order (promag) 
-- #16254 Set `AA_EnableHighDpiScaling` attribute early (hebasto) 
-- #16122 Enable console line edit on setClientModel (promag) 
+- #16231 Fix open wallet menu initialization order (promag)
+- #16254 Set `AA_EnableHighDpiScaling` attribute early (hebasto)
+- #16122 Enable console line edit on setClientModel (promag)
 - #16348 Assert QMetaObject::invokeMethod result (promag)
 
 ### Build system

--- a/doc/release-notes/release-notes-0.21.0.md
+++ b/doc/release-notes/release-notes-0.21.0.md
@@ -172,10 +172,10 @@ Updated RPCs
   it is recommended to instead use the `connection_type` field (it will return
   `manual` when addnode is true). (#19725)
 
-- The `getpeerinfo` RPC no longer returns the `whitelisted` field by default. 
-  This field will be fully removed in the next major release. It can be accessed 
-  with the configuration option `-deprecatedrpc=getpeerinfo_whitelisted`. However, 
-  it is recommended to instead use the `permissions` field to understand if specific 
+- The `getpeerinfo` RPC no longer returns the `whitelisted` field by default.
+  This field will be fully removed in the next major release. It can be accessed
+  with the configuration option `-deprecatedrpc=getpeerinfo_whitelisted`. However,
+  it is recommended to instead use the `permissions` field to understand if specific
   privileges have been granted to the peer. (#19770)
 
 - The `walletcreatefundedpsbt` RPC call will now fail with

--- a/doc/release-notes/release-notes-0.3.18.md
+++ b/doc/release-notes/release-notes-0.3.18.md
@@ -3,7 +3,7 @@ Changes:
 * IsStandard() check to only include known transaction types in blocks
 * Jgarzik's optimisation to speed up the initial block download a little
 
-The main addition in this release is the Accounts-Based JSON-RPC commands that Gavin's been working on (more details at http://www.bitcoin.org/smf/index.php?topic=1886.0).  
+The main addition in this release is the Accounts-Based JSON-RPC commands that Gavin's been working on (more details at http://www.bitcoin.org/smf/index.php?topic=1886.0).
 * getaccountaddress
 * sendfrom
 * move

--- a/doc/release-notes/release-notes-0.3.19.md
+++ b/doc/release-notes/release-notes-0.3.19.md
@@ -1,7 +1,7 @@
 There's more work to do on DoS, but I'm doing a quick build of what I have so far in case it's needed, before venturing into more complex ideas.  The build for this is version 0.3.19.
 
 - Added some DoS controls
-As Gavin and I have said clearly before, the software is not at all resistant to DoS attack.  This is one improvement, but there are still more ways to attack than I can count.  
+As Gavin and I have said clearly before, the software is not at all resistant to DoS attack.  This is one improvement, but there are still more ways to attack than I can count.
 
 I'm leaving the -limitfreerelay part as a switch for now and it's there if you need it.
 

--- a/doc/release-notes/release-notes-0.3.21.md
+++ b/doc/release-notes/release-notes-0.3.21.md
@@ -13,7 +13,7 @@ For developers, changes to bitcoin's remote-procedure-call API:
 
 * New rpc command "sendmany" to send bitcoins to more than one address in a single transaction.
 
-* Several bug fixes, including a serious intermittent bug that would sometimes cause bitcoind to stop accepting rpc requests. 
+* Several bug fixes, including a serious intermittent bug that would sometimes cause bitcoind to stop accepting rpc requests.
 
 * -logtimestamps option, to add a timestamp to each line in debug.log.
 

--- a/doc/release-notes/release-notes-0.6.0.md
+++ b/doc/release-notes/release-notes-0.6.0.md
@@ -57,7 +57,7 @@ short keys are not compatible with earlier
 versions of Bitcoin-Qt/bitcoind.
 
 New command-line argument -blocknotify=<command>
-that will spawn a shell process to run <command> 
+that will spawn a shell process to run <command>
 when a new block is accepted.
 
 New command-line argument -splash=0 to disable

--- a/doc/release-notes/release-notes-0.7.0.md
+++ b/doc/release-notes/release-notes-0.7.0.md
@@ -13,7 +13,7 @@ source-only tarballs/zipballs directly from there:
   https://github.com/bitcoin/bitcoin/zipball/v0.7.0  # .zip
 
 Ubuntu Linux users can use the "Personal Package Archive" (PPA)
-maintained by Matt Corallo to automatically keep 
+maintained by Matt Corallo to automatically keep
 bitcoin up-to-date.  Just type
   sudo apt-add-repository ppa:bitcoin/bitcoin
   sudo apt-get update

--- a/doc/release-notes/release-notes-0.7.1.md
+++ b/doc/release-notes/release-notes-0.7.1.md
@@ -12,7 +12,7 @@ source-only tarballs/zipballs directly from there:
   https://github.com/bitcoin/bitcoin/zipball/v0.7.1  # .zip
 
 Ubuntu Linux users can use the "Personal Package Archive" (PPA)
-maintained by Matt Corallo to automatically keep 
+maintained by Matt Corallo to automatically keep
 up-to-date.  Just type:
   sudo apt-add-repository ppa:bitcoin/bitcoin
   sudo apt-get update

--- a/doc/release-notes/release-notes-0.8.0.md
+++ b/doc/release-notes/release-notes-0.8.0.md
@@ -90,7 +90,7 @@ Important Bug Fixes
 
 Privacy leak: the position of the "change" output in most transactions was not being
 properly randomized, making network analysis of the transaction graph to identify
-users' wallets easier. 
+users' wallets easier.
 
 Zero-confirmation transaction vulnerability: accepting zero-confirmation transactions
 (transactions that have not yet been included in a block) from somebody you do not

--- a/doc/release-notes/release-notes-0.8.2.md
+++ b/doc/release-notes/release-notes-0.8.2.md
@@ -24,7 +24,7 @@ your machine.
 
 Fee Policy changes
 
-The default fee for low-priority transactions is lowered from 0.0005 BTC 
+The default fee for low-priority transactions is lowered from 0.0005 BTC
 (for each 1,000 bytes in the transaction; an average transaction is
 about 500 bytes) to 0.0001 BTC.
 

--- a/doc/release-notes/release-notes-0.8.6.md
+++ b/doc/release-notes/release-notes-0.8.6.md
@@ -47,7 +47,7 @@ your machine.
 
 - Additional debug.log logging for diagnosis of network problems, log timestamps by default
 
-- Fix Bitcoin-Qt startup crash when clicking dock icon on OSX 
+- Fix Bitcoin-Qt startup crash when clicking dock icon on OSX
 
 - Fix memory leaks in CKey::SetCompactSignature() and Key::SignCompact()
 

--- a/doc/release-notes/release-notes-0.9.0.md
+++ b/doc/release-notes/release-notes-0.9.0.md
@@ -18,7 +18,7 @@ earlier versions of Bitcoin, then run the installer (on Windows) or just copy
 over /Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
 
 If you are upgrading from version 0.7.2 or earlier, the first time you run
-0.9.0 your blockchain files will be re-indexed, which will take anywhere from 
+0.9.0 your blockchain files will be re-indexed, which will take anywhere from
 30 minutes to several hours, depending on the speed of your machine.
 
 On Windows, do not forget to uninstall all earlier versions of the Bitcoin
@@ -86,7 +86,7 @@ For 0.9.0 we switched to an autotools-based build system instead of individual
 (q)makefiles.
 
 Using the standard "./autogen.sh; ./configure; make" to build Bitcoin-Qt and
-bitcoind makes it easier for experienced open source developers to contribute 
+bitcoind makes it easier for experienced open source developers to contribute
 to the project.
 
 Be sure to check doc/build-*.md for your platform before building from source.
@@ -124,7 +124,7 @@ the old one:
 Transaction malleability-related fixes
 --------------------------------------
 
-This release contains a few fixes for transaction ID (TXID) malleability 
+This release contains a few fixes for transaction ID (TXID) malleability
 issues:
 
 - -nospendzeroconfchange command-line option, to avoid spending
@@ -270,7 +270,7 @@ Validation:
 Build system:
 
 - Switch to autotools-based build system
-- Build without wallet by passing `--disable-wallet` to configure, this 
+- Build without wallet by passing `--disable-wallet` to configure, this
   removes the BerkeleyDB dependency
 - Upgrade gitian dependencies (libpng, libz, libupnpc, boost, openssl) to more
   recent versions
@@ -301,7 +301,7 @@ GUI:
 - Don't regenerate autostart link on every client startup
 - Show and store message of normal bitcoin:URI
 - Fix richtext detection hang issue on very old Qt versions
-- OS X: Make use of the 10.8+ user notification center to display Growl-like 
+- OS X: Make use of the 10.8+ user notification center to display Growl-like
   notifications
 - OS X: Added NSHighResolutionCapable flag to Info.plist for better font
   rendering on Retina displays.

--- a/doc/release-notes/release-notes-0.9.1.md
+++ b/doc/release-notes/release-notes-0.9.1.md
@@ -24,7 +24,7 @@ installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
 bitcoind/bitcoin-qt (on Linux).
 
 If you are upgrading from version 0.7.2 or earlier, the first time you run
-0.9.1 your blockchain files will be re-indexed, which will take anywhere from 
+0.9.1 your blockchain files will be re-indexed, which will take anywhere from
 30 minutes to several hours, depending on the speed of your machine.
 
 0.9.1 Release notes

--- a/doc/release-notes/release-notes-0.9.2.1.md
+++ b/doc/release-notes/release-notes-0.9.2.1.md
@@ -19,7 +19,7 @@ installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
 bitcoind/bitcoin-qt (on Linux).
 
 If you are upgrading from version 0.7.2 or earlier, the first time you run
-0.9.2.1 your blockchain files will be re-indexed, which will take anywhere from 
+0.9.2.1 your blockchain files will be re-indexed, which will take anywhere from
 30 minutes to several hours, depending on the speed of your machine.
 
 Downgrading warnings

--- a/doc/release-notes/release-notes-0.9.2.md
+++ b/doc/release-notes/release-notes-0.9.2.md
@@ -19,7 +19,7 @@ installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
 bitcoind/bitcoin-qt (on Linux).
 
 If you are upgrading from version 0.7.2 or earlier, the first time you run
-0.9.2 your blockchain files will be re-indexed, which will take anywhere from 
+0.9.2 your blockchain files will be re-indexed, which will take anywhere from
 30 minutes to several hours, depending on the speed of your machine.
 
 Downgrading warnings

--- a/doc/release-notes/release-notes-0.9.3.md
+++ b/doc/release-notes/release-notes-0.9.3.md
@@ -21,7 +21,7 @@ installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
 bitcoind/bitcoin-qt (on Linux).
 
 If you are upgrading from version 0.7.2 or earlier, the first time you run
-0.9.3 your blockchain files will be re-indexed, which will take anywhere from 
+0.9.3 your blockchain files will be re-indexed, which will take anywhere from
 30 minutes to several hours, depending on the speed of your machine.
 
 Downgrading warnings


### PR DESCRIPTION
This PR removes the trailing whitespace from the release notes.

As can be seen here, there are indeed only whitespace changes: https://github.com/bitcoin/bitcoin/pull/20994/files?w=1