### PR TITLE
test: Fix BlockToJsonVerbose benchmark

### DIFF
--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -7,12 +7,15 @@
 
 #include <rpc/blockchain.h>
 #include <streams.h>
+#include <test/util/setup_common.h>
 #include <validation.h>
 
 #include <univalue.h>
 
 static void BlockToJsonVerbose(benchmark::Bench& bench)
 {
+    TestingSetup test_setup{};
+
     CDataStream stream(benchmark::data::block413567, SER_NETWORK, PROTOCOL_VERSION);
     char a = '\0';
     stream.write(&a, 1); // Prevent compaction


### PR DESCRIPTION
Currently it was not possible to run just the BlockToJsonVerbose benchmark because it did not set up everything it needed, running `bench_bitcoin -filter=BlockToJsonVerbose` caused this assert to fail:

```
bench_bitcoin: chainparams.cpp:506: const CChainParams& Params(): Assertion `globalChainParams' failed.
```

Initializing TestingSetup fixes this.
