### PR TITLE
rpc: faster JSON generation

### DIFF
--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -7,12 +7,15 @@
 
 #include <rpc/blockchain.h>
 #include <streams.h>
+#include <test/util/setup_common.h>
 #include <validation.h>
 
 #include <univalue.h>
 
 static void BlockToJsonVerbose(benchmark::Bench& bench)
 {
+    TestingSetup test_setup{};
+
     CDataStream stream(benchmark::data::block413567, SER_NETWORK, PROTOCOL_VERSION);
     char a = '\0';
     stream.write(&a, 1); // Prevent compaction

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -176,7 +176,7 @@ void ScriptPubKeyToUniv(const CScript& scriptPubKey,
     for (const CTxDestination& addr : addresses) {
         a.push_back(EncodeDestination(addr));
     }
-    out.pushKV("addresses", a);
+    out.pushKV("addresses", std::move(a));
 }
 
 void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry, bool include_hex, int serialize_flags, const CTxUndo* txundo)
@@ -210,23 +210,23 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry,
             UniValue o(UniValue::VOBJ);
             o.pushKV("asm", ScriptToAsmStr(txin.scriptSig, true));
             o.pushKV("hex", HexStr(txin.scriptSig));
-            in.pushKV("scriptSig", o);
+            in.pushKV("scriptSig", std::move(o));
         }
         if (!tx.vin[i].scriptWitness.IsNull()) {
             UniValue txinwitness(UniValue::VARR);
             for (const auto& item : tx.vin[i].scriptWitness.stack) {
                 txinwitness.push_back(HexStr(item));
             }
-            in.pushKV("txinwitness", txinwitness);
+            in.pushKV("txinwitness", std::move(txinwitness));
         }
         if (calculate_fee) {
             const CTxOut& prev_txout = txundo->vprevout[i].out;
             amt_total_in += prev_txout.nValue;
         }
         in.pushKV("sequence", (int64_t)txin.nSequence);
-        vin.push_back(in);
+        vin.push_back(std::move(in));
     }
-    entry.pushKV("vin", vin);
+    entry.pushKV("vin", std::move(vin));
 
     UniValue vout(UniValue::VARR);
     for (unsigned int i = 0; i < tx.vout.size(); i++) {
@@ -239,14 +239,14 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry,
 
         UniValue o(UniValue::VOBJ);
         ScriptPubKeyToUniv(txout.scriptPubKey, o, true);
-        out.pushKV("scriptPubKey", o);
-        vout.push_back(out);
+        out.pushKV("scriptPubKey", std::move(o));
+        vout.push_back(std::move(out));
 
         if (calculate_fee) {
             amt_total_out += txout.nValue;
         }
     }
-    entry.pushKV("vout", vout);
+    entry.pushKV("vout", std::move(vout));
 
     if (calculate_fee) {
         const CAmount fee = amt_total_in - amt_total_out;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -604,9 +604,9 @@ static bool rest_getutxos(const util::Ref& context, HTTPRequest* req, const std:
             UniValue o(UniValue::VOBJ);
             ScriptPubKeyToUniv(coin.out.scriptPubKey, o, true);
             utxo.pushKV("scriptPubKey", o);
-            utxos.push_back(utxo);
+            utxos.push_back(std::move(utxo));
         }
-        objGetUTXOResponse.pushKV("utxos", utxos);
+        objGetUTXOResponse.pushKV("utxos", std::move(utxos));
 
         // return json string
         std::string strJSON = objGetUTXOResponse.write() + "\n";

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -269,10 +269,10 @@ UniValue RPCConvertNamedValues(const std::string &strMethod, const std::vector<s
 
         if (!rpcCvtTable.convert(strMethod, name)) {
             // insert string value directly
-            params.pushKV(name, value);
+            params.pushKV(std::move(name), std::move(value));
         } else {
             // parse string as JSON, insert bool/number/object/etc. value
-            params.pushKV(name, ParseNonRFCJSONValue(value));
+            params.pushKV(std::move(name), ParseNonRFCJSONValue(value));
         }
     }
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -789,7 +789,7 @@ static RPCHelpMan getblocktemplate()
             if (setTxIndex.count(in.prevout.hash))
                 deps.push_back(setTxIndex[in.prevout.hash]);
         }
-        entry.pushKV("depends", deps);
+        entry.pushKV("depends", std::move(deps));
 
         int index_in_template = i - 1;
         entry.pushKV("fee", pblocktemplate->vTxFees[index_in_template]);

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -151,7 +151,7 @@ static void TxInErrorToJSON(const CTxIn& txin, UniValue& vErrorsRet, const std::
     entry.pushKV("scriptSig", HexStr(txin.scriptSig));
     entry.pushKV("sequence", (uint64_t)txin.nSequence);
     entry.pushKV("error", strMessage);
-    vErrorsRet.push_back(entry);
+    vErrorsRet.push_back(std::move(entry));
 }
 
 void ParsePrevouts(const UniValue& prevTxsUnival, FillableSigningProvider* keystore, std::map<COutPoint, Coin>& coins)
@@ -304,6 +304,6 @@ void SignTransactionResultToJSON(CMutableTransaction& mtx, bool complete, const 
         if (result.exists("errors")) {
             vErrors.push_backV(result["errors"].getValues());
         }
-        result.pushKV("errors", vErrors);
+        result.pushKV("errors", std::move(vErrors));
     }
 }

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -25,6 +25,9 @@ public:
         typ = initialType;
         val = initialStr;
     }
+    UniValue(UniValue::VType initialType, std::string&& initialStr)
+        : typ(initialType), val(std::move(initialStr)) {
+    }
     UniValue(uint64_t val_) {
         setInt(val_);
     }
@@ -84,70 +87,124 @@ public:
     bool isObject() const { return (typ == VOBJ); }
 
     bool push_back(const UniValue& val);
+    bool push_back(UniValue&& val);
+    
     bool push_back(const std::string& val_) {
         UniValue tmpVal(VSTR, val_);
-        return push_back(tmpVal);
+        return push_back(std::move(tmpVal));
     }
+    bool push_back(std::string&& val_) {
+        UniValue tmpVal(VSTR, std::move(val_));
+        return push_back(std::move(tmpVal));
+    }
+
     bool push_back(const char *val_) {
         std::string s(val_);
-        return push_back(s);
+        return push_back(std::move(s));
     }
     bool push_back(uint64_t val_) {
         UniValue tmpVal(val_);
-        return push_back(tmpVal);
+        return push_back(std::move(tmpVal));
     }
     bool push_back(int64_t val_) {
         UniValue tmpVal(val_);
-        return push_back(tmpVal);
+        return push_back(std::move(tmpVal));
     }
     bool push_back(bool val_) {
         UniValue tmpVal(val_);
-        return push_back(tmpVal);
+        return push_back(std::move(tmpVal));
     }
     bool push_back(int val_) {
         UniValue tmpVal(val_);
-        return push_back(tmpVal);
+        return push_back(std::move(tmpVal));
     }
     bool push_back(double val_) {
         UniValue tmpVal(val_);
-        return push_back(tmpVal);
+        return push_back(std::move(tmpVal));
     }
     bool push_backV(const std::vector<UniValue>& vec);
 
+    void __pushKV(const std::string& key, UniValue&& val);
     void __pushKV(const std::string& key, const UniValue& val);
+    void __pushKV(std::string&& key, UniValue&& val);
+    void __pushKV(std::string&& key, const UniValue& val);
     bool pushKV(const std::string& key, const UniValue& val);
+    bool pushKV(const std::string& key, UniValue&& val);
+    bool pushKV(std::string&& key, const UniValue& val);
+    bool pushKV(std::string&& key, UniValue&& val);
+
+    bool pushKV(const std::string& key, std::string&& val_) {
+        UniValue tmpVal(VSTR, std::move(val_));
+        return pushKV(key, std::move(tmpVal));
+    }
+    bool pushKV(std::string&& key, std::string&& val_) {
+        UniValue tmpVal(VSTR, std::move(val_));
+        return pushKV(std::move(key), std::move(tmpVal));
+    }
+
     bool pushKV(const std::string& key, const std::string& val_) {
         UniValue tmpVal(VSTR, val_);
-        return pushKV(key, tmpVal);
+        return pushKV(key, std::move(tmpVal));
+    }
+    bool pushKV(std::string&& key, const std::string& val_) {
+        UniValue tmpVal(VSTR, val_);
+        return pushKV(std::move(key), std::move(tmpVal));
     }
     bool pushKV(const std::string& key, const char *val_) {
         std::string _val(val_);
         return pushKV(key, _val);
     }
+    bool pushKV(std::string&& key, const char *val_) {
+        std::string _val(val_);
+        return pushKV(std::move(key), std::move(_val));
+    }
     bool pushKV(const std::string& key, int64_t val_) {
         UniValue tmpVal(val_);
-        return pushKV(key, tmpVal);
+        return pushKV(key, std::move(tmpVal));
     }
+    bool pushKV(std::string&& key, int64_t val_) {
+        UniValue tmpVal(val_);
+        return pushKV(std::move(key), std::move(tmpVal));
+    }    
     bool pushKV(const std::string& key, uint64_t val_) {
         UniValue tmpVal(val_);
-        return pushKV(key, tmpVal);
+        return pushKV(key, std::move(tmpVal));
+    }
+    bool pushKV(std::string&& key, uint64_t val_) {
+        UniValue tmpVal(val_);
+        return pushKV(std::move(key), std::move(tmpVal));
     }
     bool pushKV(const std::string& key, bool val_) {
         UniValue tmpVal(val_);
-        return pushKV(key, tmpVal);
+        return pushKV(key, std::move(tmpVal));
     }
+    bool pushKV(std::string&& key, bool val_) {
+        UniValue tmpVal(val_);
+        return pushKV(std::move(key), std::move(tmpVal));
+    }    
     bool pushKV(const std::string& key, int val_) {
         UniValue tmpVal((int64_t)val_);
-        return pushKV(key, tmpVal);
+        return pushKV(key, std::move(tmpVal));
+    }
+    bool pushKV(std::string&& key, int val_) {
+        UniValue tmpVal((int64_t)val_);
+        return pushKV(std::move(key), std::move(tmpVal));
     }
     bool pushKV(const std::string& key, double val_) {
         UniValue tmpVal(val_);
-        return pushKV(key, tmpVal);
+        return pushKV(key, std::move(tmpVal));
+    }
+    bool pushKV(std::string&& key, double val_) {
+        UniValue tmpVal(val_);
+        return pushKV(std::move(key), std::move(tmpVal));
     }
     bool pushKVs(const UniValue& obj);
+    bool pushKVs(UniValue&& obj);
 
     std::string write(unsigned int prettyIndent = 0,
                       unsigned int indentLevel = 0) const;
+
+    void append(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const;
 
     bool read(const char *raw, size_t len);
     bool read(const char *raw) { return read(raw, strlen(raw)); }

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -579,13 +579,13 @@ std::string Capitalize(std::string str)
 
 std::string HexStr(const Span<const uint8_t> s)
 {
-    std::string rv;
+    std::string rv(s.size() * 2, '-');
     static constexpr char hexmap[16] = { '0', '1', '2', '3', '4', '5', '6', '7',
                                          '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
-    rv.reserve(s.size() * 2);
+    auto* out = rv.data();
     for (uint8_t v: s) {
-        rv.push_back(hexmap[v >> 4]);
-        rv.push_back(hexmap[v & 15]);
+        *out++ = hexmap[v >> 4];
+        *out++ = hexmap[v & 15];
     }
     return rv;
 }


### PR DESCRIPTION
**This PR is not ready**: I know univalue is handled in a separate repository, so I guess I have to split the PR up? Where should the univalue changes go to, into https://github.com/bitcoin-core/univalue or into https://github.com/jgarzik/univalue?

Anyways, here is some motivational data for the changes:

----

For my [BitcoinUtxoVisualizer](https://github.com/martinus/BitcoinUtxoVisualizer) the limiting factor seems to be mostly bitcoind's JSON generation speed. Here are some optimizations that speed this up quite a bit for me. Here are some numbers:

`./bench_bitcoin -filter=BlockToJsonVerbose`

|               ns/op |  err% |         bra/op |   miss% | benchmarked commit
|--------------------:|------:|---------------:|--------:|:----------
|       66,877,763.00 |  0.1% | 101,638,376.00 |    0.4% | 349f17e
|       57,915,056.00 |  1.2% |  85,882,830.00 |    0.5% | 26fd10a
|       36,585,334.00 |  1.6% |  50,966,277.00 |    0.4% | 93f8240
|       28,508,105.00 |  0.2% |  40,138,962.00 |    0.4% | 9b59b15

So the benchmark improves from 66.9ms to 28.5ms for me. I ran an a benchmark with `bitcoind` as well, with that protocol:

1. start bitcoind, with this `bitcoin.conf`:
    ```
   server=1
   rest=1
   rpcport=8332
   rpcthreads=32
   rpcworkqueue=64
   txindex=1
   dbcache=2000
   ```
2. Wait until fully synced, and log message shows `loadblk thread exit`, so that bitcoind is idle.
2. Run apache benchmark: 2000 requests, 12 parallel threads, fetching block nr. 600000:
   ```
   ab -n 2000 -c 12 "http://127.0.0.1:8332/rest/block/00000000000000000007316856900e76b4f7a9139cfbfba89842c8d196cd5f91.json"
   ```

Results for master, 349f17e: 
```
    Concurrency Level:      12
    Time taken for tests:   26.535 seconds
    Complete requests:      2000
    Failed requests:        0
    Total transferred:      11192226000 bytes
    HTML transferred:       11192124000 bytes
    Requests per second:    75.37 [#/sec] (mean)
    Time per request:       159.208 [ms] (mean)
    Time per request:       13.267 [ms] (mean, across all concurrent requests)
    Transfer rate:          411911.64 [Kbytes/sec] received

    Connection Times (ms)
                min  mean[+/-sd] median   max
    Connect:        0    0   0.0      0       0
    Processing:    93  158  15.0    156     283
    Waiting:       91  154  14.8    152     280
    Total:         93  158  15.0    156     283

    Percentage of the requests served within a certain time (ms)
    50%    156
    66%    161
    75%    164
    80%    167
    90%    174
    95%    184
    98%    200
    99%    216
    100%    283 (longest request)
```

Results for this PR, 9b59b15:

```
    Concurrency Level:      12
    Time taken for tests:   16.801 seconds
    Complete requests:      2000
    Failed requests:        0
    Total transferred:      11192226000 bytes
    HTML transferred:       11192124000 bytes
    Requests per second:    119.04 [#/sec] (mean)
    Time per request:       100.805 [ms] (mean)
    Time per request:       8.400 [ms] (mean, across all concurrent requests)
    Transfer rate:          650556.74 [Kbytes/sec] received

    Connection Times (ms)
                min  mean[+/-sd] median   max
    Connect:        0    0   0.0      0       0
    Processing:    38  100  19.1     98     211
    Waiting:       36   98  19.0     96     208
    Total:         38  100  19.1     98     211

    Percentage of the requests served within a certain time (ms)
    50%     98
    66%    105
    75%    110
    80%    113
    90%    123
    95%    138
    98%    155
    99%    163
    100%    211 (longest request)
```