### PR TITLE
fuzz: Add UBSan suppressions needed for fuzz tests to not warn under -fsanitize=integer

### DIFF
--- a/src/test/fuzz/crypto_chacha20_poly1305_aead.cpp
+++ b/src/test/fuzz/crypto_chacha20_poly1305_aead.cpp
@@ -45,18 +45,24 @@ FUZZ_TARGET(crypto_chacha20_poly1305_aead)
                 assert(ok);
             },
             [&] {
+                if (AdditionOverflow(seqnr_payload, static_cast<uint64_t>(1))) {
+                    return;
+                }
                 seqnr_payload += 1;
                 aad_pos += CHACHA20_POLY1305_AEAD_AAD_LEN;
                 if (aad_pos + CHACHA20_POLY1305_AEAD_AAD_LEN > CHACHA20_ROUND_OUTPUT) {
                     aad_pos = 0;
+                    if (AdditionOverflow(seqnr_aad, static_cast<uint64_t>(1))) {
+                        return;
+                    }
                     seqnr_aad += 1;
                 }
             },
             [&] {
-                seqnr_payload = fuzzed_data_provider.ConsumeIntegral<int>();
+                seqnr_payload = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
             },
             [&] {
-                seqnr_aad = fuzzed_data_provider.ConsumeIntegral<int>();
+                seqnr_aad = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
             },
             [&] {
                 is_encrypt = fuzzed_data_provider.ConsumeBool();

--- a/src/test/fuzz/pow.cpp
+++ b/src/test/fuzz/pow.cpp
@@ -43,7 +43,10 @@ FUZZ_TARGET_INIT(pow, initialize_pow)
                 current_block.nHeight = current_height;
             }
             if (fuzzed_data_provider.ConsumeBool()) {
-                current_block.nTime = fixed_time + current_height * consensus_params.nPowTargetSpacing;
+                const uint32_t seconds = current_height * consensus_params.nPowTargetSpacing;
+                if (!AdditionOverflow(fixed_time, seconds)) {
+                    current_block.nTime = fixed_time + seconds;
+                }
             }
             if (fuzzed_data_provider.ConsumeBool()) {
                 current_block.nBits = fixed_bits;

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -154,13 +154,13 @@ FUZZ_TARGET_INIT(script, initialize_script)
 
     {
         WitnessUnknown witness_unknown_1{};
-        witness_unknown_1.version = fuzzed_data_provider.ConsumeIntegral<int>();
+        witness_unknown_1.version = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
         const std::vector<uint8_t> witness_unknown_program_1 = fuzzed_data_provider.ConsumeBytes<uint8_t>(40);
         witness_unknown_1.length = witness_unknown_program_1.size();
         std::copy(witness_unknown_program_1.begin(), witness_unknown_program_1.end(), witness_unknown_1.program);
 
         WitnessUnknown witness_unknown_2{};
-        witness_unknown_2.version = fuzzed_data_provider.ConsumeIntegral<int>();
+        witness_unknown_2.version = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
         const std::vector<uint8_t> witness_unknown_program_2 = fuzzed_data_provider.ConsumeBytes<uint8_t>(40);
         witness_unknown_2.length = witness_unknown_program_2.size();
         std::copy(witness_unknown_program_2.begin(), witness_unknown_program_2.end(), witness_unknown_2.program);

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -196,7 +196,7 @@ template <typename WeakEnumType, size_t size>
         },
         [&] {
             WitnessUnknown witness_unknown{};
-            witness_unknown.version = fuzzed_data_provider.ConsumeIntegral<int>();
+            witness_unknown.version = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
             const std::vector<uint8_t> witness_unknown_program_1 = fuzzed_data_provider.ConsumeBytes<uint8_t>(40);
             witness_unknown.length = witness_unknown_program_1.size();
             std::copy(witness_unknown_program_1.begin(), witness_unknown_program_1.end(), witness_unknown.program);

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -1,3 +1,7 @@
+# -fsanitize=undefined suppressions
+# =================================
+# No suppressions at the moment. Hooray!
+
 # -fsanitize=integer suppressions
 # ===============================
 # Unsigned integer overflow occurs when the result of an unsigned integer
@@ -6,7 +10,8 @@
 # contains files in which we expect unsigned integer overflows to occur. The
 # list is used to suppress -fsanitize=integer warnings when running our CI UBSan
 # job.
-unsigned-integer-overflow:*/include/c++/*/bits/basic_string.tcc
+unsigned-integer-overflow:*/include/c++/
+unsigned-integer-overflow:addrman.cpp
 unsigned-integer-overflow:arith_uint256.h
 unsigned-integer-overflow:basic_string.h
 unsigned-integer-overflow:bench/bench.h
@@ -15,34 +20,41 @@ unsigned-integer-overflow:bloom.cpp
 unsigned-integer-overflow:chain.cpp
 unsigned-integer-overflow:chain.h
 unsigned-integer-overflow:coded_stream.h
+unsigned-integer-overflow:coins.cpp
+unsigned-integer-overflow:compressor.cpp
 unsigned-integer-overflow:core_write.cpp
-unsigned-integer-overflow:crypto/*
+unsigned-integer-overflow:crypto/
+# unsigned-integer-overflow in FuzzedDataProvider's ConsumeIntegralInRange
+unsigned-integer-overflow:FuzzedDataProvider.h
 unsigned-integer-overflow:hash.cpp
-unsigned-integer-overflow:leveldb/db/log_reader.cc
-unsigned-integer-overflow:leveldb/util/bloom.cc
-unsigned-integer-overflow:leveldb/util/crc32c.h
-unsigned-integer-overflow:leveldb/util/hash.cc
+unsigned-integer-overflow:leveldb/
 unsigned-integer-overflow:policy/fees.cpp
 unsigned-integer-overflow:prevector.h
+unsigned-integer-overflow:pubkey.h
 unsigned-integer-overflow:script/interpreter.cpp
 unsigned-integer-overflow:stl_bvector.h
 unsigned-integer-overflow:txmempool.cpp
 unsigned-integer-overflow:util/strencodings.cpp
 unsigned-integer-overflow:validation.cpp
-
-implicit-integer-sign-change:*/include/c++/*/bits/*.h
+implicit-integer-sign-change:*/include/boost/
+implicit-integer-sign-change:*/include/c++/
 implicit-integer-sign-change:*/new_allocator.h
-implicit-integer-sign-change:/usr/include/boost/date_time/format_date_parser.hpp
+implicit-integer-sign-change:addrman.h
 implicit-integer-sign-change:arith_uint256.cpp
 implicit-integer-sign-change:bech32.cpp
 implicit-integer-sign-change:bloom.cpp
-implicit-integer-sign-change:chain.*
+implicit-integer-sign-change:chain.cpp
+implicit-integer-sign-change:chain.h
 implicit-integer-sign-change:coins.h
 implicit-integer-sign-change:compat/stdin.cpp
 implicit-integer-sign-change:compressor.h
-implicit-integer-sign-change:crypto/*
+implicit-integer-sign-change:crc32c/
+implicit-integer-sign-change:crypto/
+# implicit-integer-sign-change in FuzzedDataProvider's ConsumeIntegralInRange
+implicit-integer-sign-change:FuzzedDataProvider.h
 implicit-integer-sign-change:key.cpp
 implicit-integer-sign-change:noui.cpp
+implicit-integer-sign-change:policy/fees.cpp
 implicit-integer-sign-change:prevector.h
 implicit-integer-sign-change:protocol.cpp
 implicit-integer-sign-change:script/bitcoinconsensus.cpp
@@ -53,24 +65,37 @@ implicit-integer-sign-change:test/coins_tests.cpp
 implicit-integer-sign-change:test/pow_tests.cpp
 implicit-integer-sign-change:test/prevector_tests.cpp
 implicit-integer-sign-change:test/sighash_tests.cpp
+implicit-integer-sign-change:test/skiplist_tests.cpp
 implicit-integer-sign-change:test/streams_tests.cpp
 implicit-integer-sign-change:test/transaction_tests.cpp
 implicit-integer-sign-change:txmempool.cpp
-implicit-integer-sign-change:util/strencodings.*
+implicit-integer-sign-change:util/strencodings.cpp
+implicit-integer-sign-change:util/strencodings.h
 implicit-integer-sign-change:validation.cpp
 implicit-integer-sign-change:zmq/zmqpublishnotifier.cpp
 implicit-signed-integer-truncation,implicit-integer-sign-change:chain.h
 implicit-signed-integer-truncation,implicit-integer-sign-change:test/skiplist_tests.cpp
+implicit-signed-integer-truncation:addrman.cpp
+implicit-signed-integer-truncation:addrman.h
 implicit-signed-integer-truncation:chain.h
-implicit-signed-integer-truncation:crypto/*
+implicit-signed-integer-truncation:crypto/
 implicit-signed-integer-truncation:cuckoocache.h
-implicit-signed-integer-truncation:leveldb/*
+implicit-signed-integer-truncation:leveldb/
+implicit-signed-integer-truncation:net.cpp
+implicit-signed-integer-truncation:net_processing.cpp
 implicit-signed-integer-truncation:streams.h
 implicit-signed-integer-truncation:test/arith_uint256_tests.cpp
 implicit-signed-integer-truncation:test/skiplist_tests.cpp
 implicit-signed-integer-truncation:torcontrol.cpp
-implicit-unsigned-integer-truncation:crypto/*
-implicit-unsigned-integer-truncation:leveldb/*
+implicit-unsigned-integer-truncation:crypto/
+implicit-unsigned-integer-truncation:leveldb/
 # std::variant warning fixed in https://github.com/gcc-mirror/gcc/commit/074436cf8cdd2a9ce75cadd36deb8301f00e55b9
 implicit-unsigned-integer-truncation:std::__detail::__variant::_Variant_storage
-implicit-integer-sign-change:crc32c/*
+shift-base:*/include/c++/
+shift-base:arith_uint256.cpp
+shift-base:crypto/
+shift-base:hash.cpp
+shift-base:leveldb/
+shift-base:net_processing.cpp
+shift-base:streams.h
+shift-base:util/bip32.cpp


### PR DESCRIPTION
Add UBSan suppressions needed for fuzz tests to not warn under `-fsanitize=integer`.

Avoid `-fsanitize=integer` warnings in fuzzing harnesses.

Suppressed warnings (excluding warnings from `src/crypto/` and `src/test/`):

```
addrman.cpp:306:24: runtime error: implicit conversion from type 'long' of value 5190149478 (64-bit, signed) to type 'uint32_t' (aka 'unsigned int') changed the value to 895182182 (32-bit, unsigned)
addrman.h:446:43: runtime error: implicit conversion from type 'int' of value -22 (32-bit, signed) to type 'const uint8_t' (aka 'const unsigned char') changed the value to 234 (8-bit, unsigned)
arith_uint256.cpp:32:35: runtime error: left shift of 1712128 by 24 places cannot be represented in type 'uint32_t' (aka 'unsigned int')
arith_uint256.cpp:47:39: runtime error: left shift of 4294966784 by 31 places cannot be represented in type 'uint32_t' (aka 'unsigned int')
chain.cpp:151:12: runtime error: implicit conversion from type 'int' of value -1 (32-bit, signed) to type 'unsigned long' changed the value to 18446744073709551615 (64-bit, unsigned)
coins.cpp:114:22: runtime error: unsigned integer overflow: 0 - 96 cannot be represented in type 'unsigned long'
compressor.cpp:162:33: runtime error: unsigned integer overflow: 15617702637291228364 * 10 cannot be represented in type 'unsigned long'
compressor.cpp:188:11: runtime error: unsigned integer overflow: 2265760372865400000 * 10 cannot be represented in type 'unsigned long'
hash.cpp:13:15: runtime error: left shift of 1692305888 by 15 places cannot be represented in type 'uint32_t' (aka 'unsigned int')
pubkey.h:152:23: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'unsigned int'
streams.h:570:31: runtime error: left shift of 350879 by 52 places cannot be represented in type 'uint64_t' (aka 'unsigned long')
util/bip32.cpp:57:36: runtime error: left shift of 3241096244 by 1 places cannot be represented in type 'unsigned int'
util/strencodings.cpp:562:38: runtime error: implicit conversion from type 'unsigned char' of value 255 (8-bit, unsigned) to type 'char' changed the value to -1 (8-bit, signed)
util/strencodings.h:164:24: runtime error: implicit conversion from type 'int' of value -74 (32-bit, signed) to type 'unsigned long' changed the value to 18446744073709551542 (64-bit, unsigned)
```

The warnings above happen here:

https://github.com/bitcoin/bitcoin/blob/32b191fb66e644c690c94cbfdae6ddbc754769d7/src/addrman.cpp#L306
https://github.com/bitcoin/bitcoin/blob/32b191fb66e644c690c94cbfdae6ddbc754769d7/src/addrman.h#L446
https://github.com/bitcoin/bitcoin/blob/32b191fb66e644c690c94cbfdae6ddbc754769d7/src/arith_uint256.cpp#L32
https://github.com/bitcoin/bitcoin/blob/32b191fb66e644c690c94cbfdae6ddbc754769d7/src/arith_uint256.cpp#L47
https://github.com/bitcoin/bitcoin/blob/32b191fb66e644c690c94cbfdae6ddbc754769d7/src/chain.cpp#L151
https://github.com/bitcoin/bitcoin/blob/32b191fb66e644c690c94cbfdae6ddbc754769d7/src/coins.cpp#L114
https://github.com/bitcoin/bitcoin/blob/32b191fb66e644c690c94cbfdae6ddbc754769d7/src/compressor.cpp#L162
https://github.com/bitcoin/bitcoin/blob/32b191fb66e644c690c94cbfdae6ddbc754769d7/src/compressor.cpp#L188
https://github.com/bitcoin/bitcoin/blob/32b191fb66e644c690c94cbfdae6ddbc754769d7/src/hash.cpp#L13
https://github.com/bitcoin/bitcoin/blob/32b191fb66e644c690c94cbfdae6ddbc754769d7/src/pubkey.h#L152
https://github.com/bitcoin/bitcoin/blob/32b191fb66e644c690c94cbfdae6ddbc754769d7/src/streams.h#L570
https://github.com/bitcoin/bitcoin/blob/32b191fb66e644c690c94cbfdae6ddbc754769d7/src/util/bip32.cpp#L57
https://github.com/bitcoin/bitcoin/blob/32b191fb66e644c690c94cbfdae6ddbc754769d7/src/util/strencodings.cpp#L562
https://github.com/bitcoin/bitcoin/blob/32b191fb66e644c690c94cbfdae6ddbc754769d7/src/util/strencodings.h#L164