### PR TITLE
refactor: remove straggling boost::mutex usage

### DIFF
--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -13,8 +13,6 @@
 #include <util/strencodings.h>
 #include <util/threadnames.h>
 
-#include <boost/thread/mutex.hpp>
-
 #include <map>
 #include <mutex>
 #include <set>
@@ -224,7 +222,6 @@ template void EnterCritical(const char*, const char*, int, Mutex*, bool);
 template void EnterCritical(const char*, const char*, int, RecursiveMutex*, bool);
 template void EnterCritical(const char*, const char*, int, std::mutex*, bool);
 template void EnterCritical(const char*, const char*, int, std::recursive_mutex*, bool);
-template void EnterCritical(const char*, const char*, int, boost::mutex*, bool);
 
 void CheckLastCritical(void* cs, std::string& lockname, const char* guardname, const char* file, int line)
 {

--- a/src/test/sync_tests.cpp
+++ b/src/test/sync_tests.cpp
@@ -6,7 +6,6 @@
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/thread/mutex.hpp>
 
 #include <mutex>
 
@@ -108,11 +107,6 @@ BOOST_AUTO_TEST_CASE(potential_deadlock_detected)
 BOOST_AUTO_TEST_CASE(double_lock_mutex)
 {
     TestDoubleLock<Mutex>(true /* should throw */);
-}
-
-BOOST_AUTO_TEST_CASE(double_lock_boost_mutex)
-{
-    TestDoubleLock<boost::mutex>(true /* should throw */);
 }
 
 BOOST_AUTO_TEST_CASE(double_lock_recursive_mutex)


### PR DESCRIPTION
After the merge of #18710, the linter is warning:
```bash
A new Boost dependency in the form of "boost/thread/mutex.hpp" appears to have been introduced:
src/sync.cpp:#include <boost/thread/mutex.hpp>
src/test/sync_tests.cpp:#include <boost/thread/mutex.hpp>

^---- failure generated from test/lint/lint-includes.sh
```

#18710 removed `boost/thread/mutex.hpp` from lint-includes, however in the interim #19337 was merged, which introduced more `boost::mutex` usage.

Given we no longer use `boost::mutex`, just remove the double lock test and remaining includes.