### PR TITLE
[Not for merge] pthread sanity check

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -541,6 +541,7 @@ libbitcoin_util_a_SOURCES = \
   clientversion.cpp \
   compat/glibc_sanity.cpp \
   compat/glibcxx_sanity.cpp \
+  compat/pthread_sanity.cpp \
   compat/strnlen.cpp \
   fs.cpp \
   interfaces/handler.cpp \

--- a/src/compat/pthread_sanity.cpp
+++ b/src/compat/pthread_sanity.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2009-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Test case for pthread hang using pthread_rwlock_trywrlock
+// https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1864864
+// https://sourceware.org/bugzilla/show_bug.cgi?id=23844
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <iostream>
+#include <pthread.h>
+
+pthread_rwlock_t rw_lock[1];
+
+void *runner(void *arg) {
+
+   for(int i = 0; i < 1000000; ++i) {
+      int ecode = 0;
+      int idx = i % 1;
+      bool rw = (i & (16|8)) == (16|8);
+      
+      if(rw) {
+         ecode = pthread_rwlock_trywrlock(&rw_lock[idx]);
+         if(ecode == EBUSY) {
+            pthread_rwlock_wrlock(&rw_lock[idx]);
+         }
+      } else {
+         pthread_rwlock_rdlock(&rw_lock[idx]);
+      }
+
+      pthread_rwlock_unlock(&rw_lock[idx]);
+   }
+
+   pthread_exit(nullptr);
+}
+
+int pthread_rw_sanity_test() {
+
+   pthread_rwlockattr_t rw_attr;
+   pthread_t t_list[2];
+
+   std::cout << "Testing pthread trylock_wr\n\n";
+
+   pthread_rwlockattr_init(&rw_attr);
+
+   pthread_rwlock_init(&rw_lock[0], &rw_attr);
+
+   for(int i: {0,1}) {
+      pthread_create(&t_list[i], nullptr, runner, nullptr);
+   }
+   
+   for(int i: {0,1}) {
+      pthread_join(t_list[i], nullptr);
+   }
+
+   pthread_rwlock_destroy(&rw_lock[0]);
+
+   return true;
+}

--- a/src/compat/sanity.h
+++ b/src/compat/sanity.h
@@ -7,5 +7,6 @@
 
 bool glibc_sanity_test();
 bool glibcxx_sanity_test();
+bool pthread_rw_sanity_test();
 
 #endif // BITCOIN_COMPAT_SANITY_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -767,7 +767,7 @@ static bool InitSanityCheck()
         return InitError(Untranslated("Elliptic curve cryptography sanity check failure. Aborting."));
     }
 
-    if (!glibc_sanity_test() || !glibcxx_sanity_test())
+    if (!glibc_sanity_test() || !glibcxx_sanity_test() || !pthread_rw_sanity_test())
         return false;
 
     if (!Random_SanityCheck()) {

--- a/src/test/sanity_tests.cpp
+++ b/src/test/sanity_tests.cpp
@@ -15,6 +15,7 @@ BOOST_AUTO_TEST_CASE(basic_sanity)
   BOOST_CHECK_MESSAGE(glibc_sanity_test() == true, "libc sanity test");
   BOOST_CHECK_MESSAGE(glibcxx_sanity_test() == true, "stdlib sanity test");
   BOOST_CHECK_MESSAGE(ECC_InitSanityCheck() == true, "secp256k1 sanity test");
+  BOOST_CHECK_MESSAGE(pthread_rw_sanity_test() == true, "pthread rwlock sanity test");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
After #21016, `boost::shared_mutex` will basically be the last component of Boost Thread that Bitcoin Core is using. However, [a comment in #16684](https://github.com/bitcoin/bitcoin/issues/16684#issuecomment-726214696), pointed out that `std::shared_mutex` may be unsafe to use, when coupled with a range of glibc versions ~2.26->2.29, which may block our adoption and the removal of Boost Thread. 

Note that the comment first links to ["rdlock stalls indefinitely on an unlocked pthread rwlock"](https://sourceware.org/bugzilla/show_bug.cgi?id=23861), but then to the [Ubuntu bugtracker](https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1864864), which is actually for a different pthread bug: ["pthread_rwlock_trywrlock results in hang"](https://sourceware.org/bugzilla/show_bug.cgi?id=23844). This PR contains a modified version of the code to reproduce the second bug, for which a backport was done for Ubuntu 18.04s glibc (2.27-3ubuntu1.3).

You can reproduce the hanging behaviour using the following. (You could also use any demos from the linked bug reports).

Run a Bionic container, and install build dependencies. Clone the source and checkout this branch:
```bash
docker run -it --rm ubuntu:18.04 /bin/bash

apt update && apt upgrade -y
apt install git build-essential libtool autotools-dev automake pkg-config bsdmainutils python3 libevent-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev libboost-thread-dev -y

git clone https://github.com/bitcoin/bitcoin
git fetch origin pull/21022/head:21022
git checkout 21022
```

Configure, disabling the wallet (unrelated) and enabling glibc back compat, so that our sanity checks are enabled:
```bash
./autogen.sh
./configure --disable-wallet --enable-glibc-back-compat
make src/bitcoind -j8
```

Before running bitcoind, check which version of libc you have installed. `23844` was fixed in `1.3`, so running `1.4` should mean no issues:
```bash
apt-cache policy libc6
libc6:
  Installed: 2.27-3ubuntu1.4
  Candidate: 2.27-3ubuntu1.4
```

Run bitcoind
```
src/bitcoind
Testing pthread trylock_wr

2021-01-28T13:24:39Z Bitcoin Core version v21.99.0-1e601c9d60f9 (release build)
2021-01-28T13:24:39Z Assuming ancestors of block 0000000000000000000b9d2ec5a352ecba0592946514a92f14319dc2b367fc72 have valid signatures.
2021-01-28T13:24:39Z Setting nMinimumChainWork=00000000000000000000000000000000000000001533efd8d716a517fe2c5008
...
# quit
```

Downgrade libc to `1.2`. You may need to uninstall `libc6-dev` first, otherwise it will block the downgrade of `libc6`:
```bash
apt remove libc6-dev -y
apt install libc6=2.27-3ubuntu1.2 -y

# check that you're running 1.2
apt-cache policy libc6
libc6:
  Installed: 2.27-3ubuntu1.2
  Candidate: 2.27-3ubuntu1.4
```


Run `bitcoind` again. Note that this will *hang*. You will not be able to quit.
```bash
# if it doesn't hang, quit and retry
./src/bitcoind
Testing pthread trylock_wr

.... hanging
```

I think it would be good to have more discussion around how we approach these sort of "lower down the stack" issues:

* what sort of bug or issue warrants us from excluding a std library feature, i.e `std::shared_mutex`, from use? If you looked at the glibc issue tracker right now, you'd no doubt find half a dozen bugs across multiple versions of glibc that you may think warrant us excluding various things.
* How widespread does the issue have to be? If it's in a single glibc version that is nearly EOL, that is obviously less of an issue compared to something affecting most recent versions.
* how (in)tolerant are we of assuming that users are taking backports?
* do we need to be more aggressive with runtime sanity checks? Should we be trying to detect more "broken things" that are applicable to us? 

It would certainly be unfortunate if migrating to more standard library components was blocked for extended periods (Ubuntu Bionic is LTS until mid 2023), due to these kinds of bugs.