### PR TITLE
fuzz: Disable shuffle when merge=1

### DIFF
--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -220,6 +220,8 @@ def merge_inputs(*, fuzz_pool, corpus, test_list, build_dir, merge_dir):
         args = [
             os.path.join(build_dir, 'src', 'test', 'fuzz', 'fuzz'),
             '-merge=1',
+            '-shuffle=0',
+            '-prefer_small=1',
             '-use_value_profile=1',  # Also done by oss-fuzz https://github.com/google/oss-fuzz/issues/1406#issuecomment-387790487
             os.path.join(corpus, t),
             os.path.join(merge_dir, t),


### PR DESCRIPTION
This should hopefully help make the deletion of fuzz inputs more deterministic.

My tests (N=1) revealed that without this patch 7000 files differ (https://github.com/bitcoin-core/qa-assets/pull/44#issuecomment-768841467). With this patch, "only" 2000 files differ.