### PR TITLE
Remove pointer cast in CRPCTable::dumpArgMap

### DIFF
--- a/src/rpc/request.h
+++ b/src/rpc/request.h
@@ -34,19 +34,19 @@ public:
     UniValue id;
     std::string strMethod;
     UniValue params;
-    bool fHelp;
+    enum Mode { EXECUTE, GET_HELP } mode = EXECUTE;
     std::string URI;
     std::string authUser;
     std::string peerAddr;
     const util::Ref& context;
 
-    explicit JSONRPCRequest(const util::Ref& context) : id(NullUniValue), params(NullUniValue), fHelp(false), context(context) {}
+    explicit JSONRPCRequest(const util::Ref& context) : id(NullUniValue), params(NullUniValue), context(context) {}
 
     //! Initializes request information from another request object and the
     //! given context. The implementation should be updated if any members are
     //! added or removed above.
     JSONRPCRequest(const JSONRPCRequest& other, const util::Ref& context)
-        : id(other.id), strMethod(other.strMethod), params(other.params), fHelp(other.fHelp), URI(other.URI),
+        : id(other.id), strMethod(other.strMethod), params(other.params), mode(other.mode), URI(other.URI),
           authUser(other.authUser), peerAddr(other.peerAddr), context(context)
     {
     }

--- a/src/rpc/request.h
+++ b/src/rpc/request.h
@@ -34,7 +34,7 @@ public:
     UniValue id;
     std::string strMethod;
     UniValue params;
-    enum Mode { EXECUTE, GET_HELP } mode = EXECUTE;
+    enum Mode { EXECUTE, GET_HELP, GET_ARGS } mode = EXECUTE;
     std::string URI;
     std::string authUser;
     std::string peerAddr;

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -88,7 +88,7 @@ std::string CRPCTable::help(const std::string& strCommand, const JSONRPCRequest&
     sort(vCommands.begin(), vCommands.end());
 
     JSONRPCRequest jreq(helpreq);
-    jreq.fHelp = true;
+    jreq.mode = JSONRPCRequest::GET_HELP;
     jreq.params = UniValue();
 
     for (const std::pair<std::string, const CRPCCommand*>& command : vCommands)

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -148,7 +148,7 @@ public:
     /**
      * Return all named arguments that need to be converted by the client from string to another JSON type
      */
-    UniValue dumpArgMap() const;
+    UniValue dumpArgMap(const JSONRPCRequest& request) const;
 
     /**
      * Appends a CRPCCommand to the dispatch table.

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -476,6 +476,18 @@ std::string RPCExamples::ToDescriptionString() const
     return m_examples.empty() ? m_examples : "\nExamples:\n" + m_examples;
 }
 
+UniValue RPCHelpMan::HandleRequest(const JSONRPCRequest& request)
+{
+    /*
+     * Check if the given request is valid according to this command or if
+     * the user is asking for help information, and throw help when appropriate.
+     */
+    if (request.mode == JSONRPCRequest::GET_HELP || !IsValidNumArgs(request.params.size())) {
+        throw std::runtime_error(ToString());
+    }
+    return m_fun(*this, request);
+}
+
 bool RPCHelpMan::IsValidNumArgs(size_t num_args) const
 {
     size_t num_required_args = 0;

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -478,6 +478,9 @@ std::string RPCExamples::ToDescriptionString() const
 
 UniValue RPCHelpMan::HandleRequest(const JSONRPCRequest& request)
 {
+    if (request.mode == JSONRPCRequest::GET_ARGS) {
+        return GetArgMap();
+    }
     /*
      * Check if the given request is valid according to this command or if
      * the user is asking for help information, and throw help when appropriate.
@@ -561,8 +564,9 @@ std::string RPCHelpMan::ToString() const
     return ret;
 }
 
-void RPCHelpMan::AppendArgMap(UniValue& arr) const
+UniValue RPCHelpMan::GetArgMap() const
 {
+    UniValue arr{UniValue::VARR};
     for (int i{0}; i < int(m_args.size()); ++i) {
         const auto& arg = m_args.at(i);
         std::vector<std::string> arg_names;
@@ -577,6 +581,7 @@ void RPCHelpMan::AppendArgMap(UniValue& arr) const
             arr.push_back(map);
         }
     }
+    return arr;
 }
 
 std::string RPCArg::GetFirstName() const

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -335,26 +335,12 @@ public:
     using RPCMethodImpl = std::function<UniValue(const RPCHelpMan&, const JSONRPCRequest&)>;
     RPCHelpMan(std::string name, std::string description, std::vector<RPCArg> args, RPCResults results, RPCExamples examples, RPCMethodImpl fun);
 
+    UniValue HandleRequest(const JSONRPCRequest& request);
     std::string ToString() const;
     /** Append the named args that need to be converted from string to another JSON type */
     void AppendArgMap(UniValue& arr) const;
-    UniValue HandleRequest(const JSONRPCRequest& request)
-    {
-        Check(request);
-        return m_fun(*this, request);
-    }
     /** If the supplied number of args is neither too small nor too high */
     bool IsValidNumArgs(size_t num_args) const;
-    /**
-     * Check if the given request is valid according to this command or if
-     * the user is asking for help information, and throw help when appropriate.
-     */
-    inline void Check(const JSONRPCRequest& request) const {
-        if (request.fHelp || !IsValidNumArgs(request.params.size())) {
-            throw std::runtime_error(ToString());
-        }
-    }
-
     std::vector<std::string> GetArgNames() const;
 
     const std::string m_name;

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -337,8 +337,8 @@ public:
 
     UniValue HandleRequest(const JSONRPCRequest& request);
     std::string ToString() const;
-    /** Append the named args that need to be converted from string to another JSON type */
-    void AppendArgMap(UniValue& arr) const;
+    /** Return the named args that need to be converted from string to another JSON type */
+    UniValue GetArgMap() const;
     /** If the supplied number of args is neither too small nor too high */
     bool IsValidNumArgs(size_t num_args) const;
     std::vector<std::string> GetArgNames() const;

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -36,7 +36,6 @@ UniValue RPCTestingSetup::CallRPC(std::string args)
     JSONRPCRequest request(context);
     request.strMethod = strMethod;
     request.params = RPCConvertValues(strMethod, vArgs);
-    request.fHelp = false;
     if (RPCIsInWarmup(nullptr)) SetRPCWarmupFinished();
     try {
         UniValue result = tableRPC.execute(request);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -96,7 +96,7 @@ bool GetWalletNameFromJSONRPCRequest(const JSONRPCRequest& request, std::string&
 
 std::shared_ptr<CWallet> GetWalletForJSONRPCRequest(const JSONRPCRequest& request)
 {
-    CHECK_NONFATAL(!request.fHelp);
+    CHECK_NONFATAL(request.mode == JSONRPCRequest::EXECUTE);
     std::string wallet_name;
     if (GetWalletNameFromJSONRPCRequest(request, wallet_name)) {
         std::shared_ptr<CWallet> pwallet = GetWallet(wallet_name);


### PR DESCRIPTION
This change is needed to fix the `rpc_help.py` test failing in #10102: https://cirrus-ci.com/task/5469433013469184?command=ci#L2275

The [`CRPCTable::dumpArgMap`](https://github.com/bitcoin/bitcoin/blob/16b784d953365bb2d7ae65acd2b20a79ef8ba7b6/src/rpc/server.cpp#L492) method currently works by casting RPC `unique_id` integer field to a function pointer, and then calling it. The `unique_id` field wasn't supposed to be used this way (it's meant to be used to detect RPC aliases) and as a result, this code segfaults in the `rpc_help.py` test in multiprocess PR #10102 because wallet RPC functions aren't directly accessible from the node process.

Fix this by adding a new `GET_ARGS` RPC request mode to retrieve argument information similar to the way the `GET_HELP` mode retrieves help information.

---

This PR is part of the [process separation project](https://github.com/bitcoin/bitcoin/projects/10).
