### PR TITLE
fuzz: Avoid designated initialization (C++20) in fuzz tests

### DIFF
--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -269,8 +269,8 @@ inline CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider) noexcep
     const Network network = fuzzed_data_provider.PickValueInArray({Network::NET_IPV4, Network::NET_IPV6, Network::NET_INTERNAL, Network::NET_ONION});
     CNetAddr net_addr;
     if (network == Network::NET_IPV4) {
-        const in_addr v4_addr = {
-            .s_addr = fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
+        in_addr v4_addr = {};
+        v4_addr.s_addr = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
         net_addr = CNetAddr{v4_addr};
     } else if (network == Network::NET_IPV6) {
         if (fuzzed_data_provider.remaining_bytes() >= 16) {


### PR DESCRIPTION
Avoid designated initialization (C++20) in fuzz tests.

Context: https://github.com/bitcoin/bitcoin/pull/20197#discussion_r565270556, https://github.com/bitcoin/bitcoin/pull/20936#discussion_r566708730