### PR TITLE
build: adds switch to enable/disable randomized base address in MSVC builds

### DIFF
--- a/build_msvc/README.md
+++ b/build_msvc/README.md
@@ -77,3 +77,25 @@ For safety reasons the Bitcoin Core .appveyor.yml file has the artifact options 
     #- 7z a bitcoin-%APPVEYOR_BUILD_VERSION%.zip %APPVEYOR_BUILD_FOLDER%\build_msvc\%platform%\%configuration%\*.exe
     #- path: bitcoin-%APPVEYOR_BUILD_VERSION%.zip
 ```
+
+Security
+---------------------
+[Base address randomization](https://docs.microsoft.com/en-us/cpp/build/reference/dynamicbase-use-address-space-layout-randomization?view=msvc-160) is used to make Bitcoin Core more secure. When building Bitcoin using the `build_msvc` process base address randomization can be disabled by editing `common.init.vcproj` to change `RandomizedBaseAddress` from `true` to `false` and then rebuilding the project.
+
+To check if `bitcoind` has `RandomizedBaseAddress` enabled or disabled run
+
+```
+.\dumpbin.exe /headers src/bitcoind.exe
+```
+
+If is it enabled then in the output `Dynamic base` will be listed in the `DLL characteristics` under `OPTIONAL HEADER VALUES` as shown below
+
+```
+            8160 DLL characteristics
+                   High Entropy Virtual Addresses
+                   Dynamic base
+                   NX compatible
+                   Terminal Server Aware
+```
+
+This may not disable all stack randomization as versions of windows employ additional stack randomization protections. These protections must be turned off in the OS configuration.

--- a/build_msvc/common.init.vcxproj
+++ b/build_msvc/common.init.vcxproj
@@ -105,6 +105,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <AdditionalDependencies>Iphlpapi.lib;ws2_32.lib;Shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <RandomizedBaseAddress>true</RandomizedBaseAddress>
     </Link>
     <Lib>
       <AdditionalOptions>/ignore:4221</AdditionalOptions>


### PR DESCRIPTION
In m4 builds we have the --disable-hardening switch that can be given in `./configure` to turn off randomized addresses. This PR provides a simple way of turning off randomized addresses in MSVC builds.

This PR:
* Adds this option the common-init project file so that it can be globally set across the project
* Documents this switch in msvc build readme

I have run the following test to verify this works

I ran the msvc build with `<RandomizedBaseAddress>true</RandomizedBaseAddress>` then checked `bitcoind.exe` and `bitcoin-cli.exe` with `dumpbin.exe`:

bitcoind
```
> .\dumpbin.exe /headers src/bitcoind.exe
Microsoft (R) COFF/PE Dumper Version 14.16.27045.0
...
OPTIONAL HEADER VALUES
             20B magic # (PE32+)
           14.28 linker version
          AE4600 size of code
          345C00 size of initialized data
               0 size of uninitialized data
          6BED74 entry point (00000001406BED74) mainCRTStartup
            1000 base of code
       140000000 image base (0000000140000000 to 0000000140E2DFFF)
            1000 section alignment
             200 file alignment
            6.00 operating system version
            0.00 image version
            6.00 subsystem version
               0 Win32 version
          E2E000 size of image
             400 size of headers
               0 checksum
               3 subsystem (Windows CUI)
            8160 DLL characteristics
                   High Entropy Virtual Addresses
                   Dynamic base
                   NX compatible
                   Terminal Server Aware
```

bitcoin-cli
```
> .\dumpbin.exe /headers src/bitcoin-cli.exe
Microsoft (R) COFF/PE Dumper Version 14.16.27045.0
...
OPTIONAL HEADER VALUES
             20B magic # (PE32+)
           14.28 linker version
          1E3E00 size of code
           92C00 size of initialized data
               0 size of uninitialized data
          104384 entry point (0000000140104384) mainCRTStartup
            1000 base of code
       140000000 image base (0000000140000000 to 0000000140279FFF)
            1000 section alignment
             200 file alignment
            6.00 operating system version
            0.00 image version
            6.00 subsystem version
               0 Win32 version
          27A000 size of image
             400 size of headers
               0 checksum
               3 subsystem (Windows CUI)
            8160 DLL characteristics
                   High Entropy Virtual Addresses
                   Dynamic base
                   NX compatible
                   Terminal Server Aware
```

Then I built with `<RandomizedBaseAddress>false</RandomizedBaseAddress>` then checked `bitcoind.exe` and `bitcoin-cli.exe` with `dumpbin.exe` and observed that `Dynamic base` was longer listed in `OPTIONAL HEADER VALUES`

bitcoind
```
PS C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.16.27023\bin\HostX64\x64> .\dumpbin.exe /headers C:\Users\e0\Documents\GitHub\bitcoin021noaslr/src/bitcoind.exe
Microsoft (R) COFF/PE Dumper Version 14.16.27045.0
...
OPTIONAL HEADER VALUES
             20B magic # (PE32+)
           14.28 linker version
          AE4600 size of code
          33FE00 size of initialized data
               0 size of uninitialized data
          6BED74 entry point (00000001406BED74) mainCRTStartup
            1000 base of code
       140000000 image base (0000000140000000 to 0000000140E27FFF)
            1000 section alignment
             200 file alignment
            6.00 operating system version
            0.00 image version
            6.00 subsystem version
               0 Win32 version
          E28000 size of image
             400 size of headers
               0 checksum
               3 subsystem (Windows CUI)
            8120 DLL characteristics
                   High Entropy Virtual Addresses
                   NX compatible
                   Terminal Server Aware
```

bitcoin-cli
```
> .\dumpbin.exe /headers src/bitcoin-cli.exe
Microsoft (R) COFF/PE Dumper Version 14.16.27045.0
...
OPTIONAL HEADER VALUES
             20B magic # (PE32+)
           14.28 linker version
          1E3E00 size of code
           90C00 size of initialized data
               0 size of uninitialized data
          104384 entry point (0000000140104384) mainCRTStartup
            1000 base of code
       140000000 image base (0000000140000000 to 0000000140277FFF)
            1000 section alignment
             200 file alignment
            6.00 operating system version
            0.00 image version
            6.00 subsystem version
               0 Win32 version
          278000 size of image
             400 size of headers
               0 checksum
               3 subsystem (Windows CUI)
            8120 DLL characteristics
                   High Entropy Virtual Addresses
                   NX compatible
                   Terminal Server Aware
```
