### PR TITLE
refactor: Replace fs::unique_path with GetUniquePath(path) calls

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -233,6 +233,7 @@ BITCOIN_CORE_H = \
   util/check.h \
   util/error.h \
   util/fees.h \
+  util/getuniquepath.h \
   util/golombrice.h \
   util/hasher.h \
   util/macros.h \
@@ -556,6 +557,7 @@ libbitcoin_util_a_SOURCES = \
   util/bytevectorhash.cpp \
   util/error.cpp \
   util/fees.cpp \
+  util/getuniquepath.cpp \
   util/hasher.cpp \
   util/system.cpp \
   util/message.cpp \

--- a/src/test/fs_tests.cpp
+++ b/src/test/fs_tests.cpp
@@ -5,6 +5,7 @@
 #include <fs.h>
 #include <test/util/setup_common.h>
 #include <util/system.h>
+#include <util/getuniquepath.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -68,6 +69,21 @@ BOOST_AUTO_TEST_CASE(fsbridge_fstream)
         // Ensure joining with empty paths does not add trailing path components.
         BOOST_CHECK_EQUAL(tmpfile1, fsbridge::AbsPathJoin(tmpfile1, ""));
         BOOST_CHECK_EQUAL(tmpfile1, fsbridge::AbsPathJoin(tmpfile1, {}));
+    }
+    {
+        fs::path p1 = GetUniquePath(tmpfolder);
+        fs::path p2 = GetUniquePath(tmpfolder);
+        fs::path p3 = GetUniquePath(tmpfolder);
+
+        // Ensure that the parent path is always the same.
+        BOOST_CHECK_EQUAL(tmpfolder, p1.parent_path());
+        BOOST_CHECK_EQUAL(tmpfolder, p2.parent_path());
+        BOOST_CHECK_EQUAL(tmpfolder, p3.parent_path());
+
+        // Ensure that generated paths are actually different.
+        BOOST_CHECK(p1 != p2);
+        BOOST_CHECK(p2 != p3);
+        BOOST_CHECK(p1 != p3);
     }
 }
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -13,6 +13,7 @@
 #include <test/util/setup_common.h>
 #include <test/util/str.h>
 #include <uint256.h>
+#include <util/getuniquepath.h>
 #include <util/message.h> // For MessageSign(), MessageVerify(), MESSAGE_MAGIC
 #include <util/moneystr.h>
 #include <util/spanparsing.h>
@@ -1816,7 +1817,7 @@ BOOST_AUTO_TEST_CASE(test_DirIsWritable)
     BOOST_CHECK_EQUAL(DirIsWritable(tmpdirname), true);
 
     // Should not be able to write to a non-existent dir.
-    tmpdirname = tmpdirname / fs::unique_path();
+    tmpdirname = GetUniquePath(tmpdirname);
     BOOST_CHECK_EQUAL(DirIsWritable(tmpdirname), false);
 
     fs::create_directory(tmpdirname);

--- a/src/util/getuniquepath.cpp
+++ b/src/util/getuniquepath.cpp
@@ -1,0 +1,10 @@
+#include <random.h>
+#include <fs.h>
+#include <util/strencodings.h>
+
+fs::path GetUniquePath(const fs::path& base)
+{
+    FastRandomContext rnd;
+    fs::path tmpFile = base / HexStr(rnd.randbytes(8));
+    return tmpFile;
+}

--- a/src/util/getuniquepath.h
+++ b/src/util/getuniquepath.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_GETUNIQUEPATH_H
+#define BITCOIN_UTIL_GETUNIQUEPATH_H
+
+#include <fs.h>
+
+/**
+ * Helper function for getting a unique path
+ *
+ * @param[in] base  Base path
+ * @returns base joined with a random 8-character long string.
+ * @post Returned path is unique with high probability.
+ */
+fs::path GetUniquePath(const fs::path& base);
+
+#endif // BITCOIN_UTIL_GETUNIQUEPATH_H

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -12,6 +12,7 @@
 #include <chainparamsbase.h>
 #include <sync.h>
 #include <util/check.h>
+#include <util/getuniquepath.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/translation.h>
@@ -124,7 +125,7 @@ void ReleaseDirectoryLocks()
 
 bool DirIsWritable(const fs::path& directory)
 {
-    fs::path tmpFile = directory / fs::unique_path();
+    fs::path tmpFile = GetUniquePath(directory);
 
     FILE* file = fsbridge::fopen(tmpFile, "a");
     if (!file) return false;


### PR DESCRIPTION
This PR makes it easier in #20744 to remove our dependency on the `boost::filesystem::unique_path()` function which does not have a direct equivalent in C++17.

This PR attempts to re-implement `boost::filesystem::unique_path()` as `GetUniquePath(path)` but the implementations are not meant to be the same.

Note:

* Boost 1.75.0 implementation of `unique_path`: https://github.com/boostorg/filesystem/blob/9cab675b71e98706886a87afe7c19eb9da568961/src/unique_path.cpp#L235

* In the previous implementation, I attempted to add:
    ```cpp
    fs::path GetUniquePath(const fs::path& base)
    {
        FastRandomContext rnd;
        fs::path tmpFile = base / HexStr(rnd.randbytes(8));
        return tmpFile;
    }
    ```

    to `fs.cpp` but this leads to a circular dependency: "fs -> random -> logging -> fs". That is why the modified implementation adds a new file.