### PR TITLE
Drop boost/preprocessor dependencies

### DIFF
--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_BENCH_BENCH_H
 #define BITCOIN_BENCH_BENCH_H
 
+#include <util/macros.h>
+
 #include <chrono>
 #include <functional>
 #include <map>
@@ -12,8 +14,6 @@
 #include <vector>
 
 #include <bench/nanobench.h>
-#include <boost/preprocessor/cat.hpp>
-#include <boost/preprocessor/stringize.hpp>
 
 /*
  * Usage:
@@ -56,8 +56,8 @@ public:
     static void RunAll(const Args& args);
 };
 }
-// BENCHMARK(foo) expands to:  benchmark::BenchRunner bench_11foo("foo");
+// BENCHMARK(foo) expands to:  benchmark::BenchRunner bench_11foo("foo", foo);
 #define BENCHMARK(n) \
-    benchmark::BenchRunner BOOST_PP_CAT(bench_, BOOST_PP_CAT(__LINE__, n))(BOOST_PP_STRINGIZE(n), n);
+    benchmark::BenchRunner PASTE2(bench_, PASTE2(__LINE__, n))(STRINGIZE(n), n);
 
 #endif // BITCOIN_BENCH_BENCH_H

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_CLIENTVERSION_H
 #define BITCOIN_CLIENTVERSION_H
 
+#include <util/macros.h>
+
 #if defined(HAVE_CONFIG_H)
 #include <config/bitcoin-config.h>
 #endif //HAVE_CONFIG_H
@@ -13,13 +15,6 @@
 #if !defined(CLIENT_VERSION_MAJOR) || !defined(CLIENT_VERSION_MINOR) || !defined(CLIENT_VERSION_BUILD) || !defined(CLIENT_VERSION_IS_RELEASE) || !defined(COPYRIGHT_YEAR)
 #error Client version information missing: version is not defined by bitcoin-config.h or in any other way
 #endif
-
-/**
- * Converts the parameter X to a string after macro replacement on X has been performed.
- * Don't merge these into one macro!
- */
-#define STRINGIZE(X) DO_STRINGIZE(X)
-#define DO_STRINGIZE(X) #X
 
 //! Copyright string used in Windows .rc files
 #define COPYRIGHT_STR "2009-" STRINGIZE(COPYRIGHT_YEAR) " " COPYRIGHT_HOLDERS_FINAL

--- a/src/util/macros.h
+++ b/src/util/macros.h
@@ -8,4 +8,11 @@
 #define PASTE(x, y) x ## y
 #define PASTE2(x, y) PASTE(x, y)
 
+/**
+ * Converts the parameter X to a string after macro replacement on X has been performed.
+ * Don't merge these into one macro!
+ */
+#define STRINGIZE(X) DO_STRINGIZE(X)
+#define DO_STRINGIZE(X) #X
+
 #endif // BITCOIN_UTIL_MACROS_H

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -60,8 +60,6 @@ EXPECTED_BOOST_INCLUDES=(
     boost/multi_index/ordered_index.hpp
     boost/multi_index/sequenced_index.hpp
     boost/multi_index_container.hpp
-    boost/preprocessor/cat.hpp
-    boost/preprocessor/stringize.hpp
     boost/process.hpp
     boost/signals2/connection.hpp
     boost/signals2/optional_last_value.hpp


### PR DESCRIPTION
Use own macros instead of boost's ones.