### PR TITLE
[p2p] Introduce node rebroadcast module 

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -235,6 +235,7 @@ BITCOIN_CORE_H = \
   txdb.h \
   txmempool.h \
   txorphanage.h \
+  txrebroadcast.h \
   txrequest.h \
   undo.h \
   util/asmap.h \
@@ -364,6 +365,7 @@ libbitcoin_server_a_SOURCES = \
   txdb.cpp \
   txmempool.cpp \
   txorphanage.cpp \
+  txrebroadcast.cpp \
   txrequest.cpp \
   validation.cpp \
   validationinterface.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -135,6 +135,7 @@ BITCOIN_TESTS =\
   test/torcontrol_tests.cpp \
   test/transaction_tests.cpp \
   test/txindex_tests.cpp \
+  test/txrebroadcast_tests.cpp \
   test/txrequest_tests.cpp \
   test/txvalidation_tests.cpp \
   test/txvalidationcache_tests.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -449,6 +449,7 @@ void SetupServerArgs(NodeContext& node)
     argsman.AddArg("-port=<port>", strprintf("Listen for connections on <port>. Nodes not using the default ports (default: %u, testnet: %u, signet: %u, regtest: %u) are unlikely to get incoming connections.", defaultChainParams->GetDefaultPort(), testnetChainParams->GetDefaultPort(), signetChainParams->GetDefaultPort(), regtestChainParams->GetDefaultPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
     argsman.AddArg("-proxy=<ip:port>", "Connect through SOCKS5 proxy, set -noproxy to disable (default: disabled)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-proxyrandomize", strprintf("Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)", DEFAULT_PROXYRANDOMIZE), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-rebroadcast", strprintf("Enable node rebroadcast functionality (default: %u)", DEFAULT_REBROADCAST_ENABLED), ArgsManager::ALLOW_BOOL | ArgsManager::DEBUG_ONLY, OptionsCategory::CONNECTION);
     argsman.AddArg("-seednode=<ip>", "Connect to a node to retrieve peer addresses, and disconnect. This option can be specified multiple times to connect to multiple nodes.", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-networkactive", "Enable all P2P network activity (default: 1). Can be changed by the setnetworkactive RPC command", ArgsManager::ALLOW_BOOL, OptionsCategory::CONNECTION);
     argsman.AddArg("-timeout=<n>", strprintf("Specify socket connection timeout in milliseconds. If an initial attempt to connect is unsuccessful after this amount of time, drop it (minimum: 1, default: %d)", DEFAULT_CONNECT_TIMEOUT), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
@@ -1184,8 +1185,10 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     ChainstateManager& chainman = *Assert(node.chainman);
 
     assert(!node.peerman);
+    const bool enable_rebroadcast {args.GetBoolArg("-rebroadcast", DEFAULT_REBROADCAST_ENABLED)};
     node.peerman = PeerManager::make(chainparams, *node.connman, *node.addrman, node.banman.get(),
-                                     *node.scheduler, chainman, *node.mempool, ignores_incoming_txs);
+                                     *node.scheduler, chainman, *node.mempool, ignores_incoming_txs,
+                                     enable_rebroadcast);
     RegisterValidationInterface(node.peerman.get());
 
     // sanitize comments per BIP-0014, format user agent and check total size

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -305,6 +305,25 @@ void BlockAssembler::SortForBlock(const CTxMemPool::setEntries& package, std::ve
     std::sort(sortedEntries.begin(), sortedEntries.end(), CompareTxIterByAncestorCount());
 }
 
+CFeeRate BlockAssembler::MinTxFeeRate()
+{
+    int packages_selected = 0;
+    int descendants_updated = 0;
+    CFeeRate min_fee_rate = CFeeRate(COIN, 1);
+
+    resetBlock();
+    pblocktemplate = std::make_unique<CBlockTemplate>();
+
+    CBlockIndex* prev_block_index = m_chainstate.m_chain.Tip();
+    assert(prev_block_index != nullptr);
+    nHeight = prev_block_index->nHeight + 1;
+    nLockTimeCutoff = prev_block_index->GetMedianTimePast();
+    fIncludeWitness = IsWitnessEnabled(prev_block_index, chainparams.GetConsensus());
+
+    WITH_LOCK(m_mempool.cs, addPackageTxs(packages_selected, descendants_updated, &min_fee_rate));
+    return min_fee_rate;
+}
+
 // This transaction selection algorithm orders the mempool based
 // on feerate of a transaction including all unconfirmed ancestors.
 // Since we don't remove transactions from the mempool as we select them
@@ -315,7 +334,7 @@ void BlockAssembler::SortForBlock(const CTxMemPool::setEntries& package, std::ve
 // Each time through the loop, we compare the best transaction in
 // mapModifiedTxs with the next transaction in the mempool to decide what
 // transaction package to work on next.
-void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpdated)
+void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpdated, CFeeRate* min_package_fee_rate)
 {
     // mapModifiedTx will store sorted packages after they are modified
     // because some of their txs are already in the block
@@ -397,6 +416,10 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
                 failedTx.insert(iter);
             }
 
+            // We ran out of space, so don't track fee rates of leftover
+            // transactions that can be squeezed in
+            min_package_fee_rate = nullptr;
+
             ++nConsecutiveFailed;
 
             if (nConsecutiveFailed > MAX_CONSECUTIVE_FAILURES && nBlockWeight >
@@ -426,6 +449,12 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
 
         // This transaction will make it in; reset the failed counter.
         nConsecutiveFailed = 0;
+
+        if (min_package_fee_rate) {
+            // Compare package fee rate and potentially update new minimum
+            const CFeeRate new_fee_rate(packageFees, packageSize);
+            if (new_fee_rate < *min_package_fee_rate) *min_package_fee_rate = new_fee_rate;
+        }
 
         // Package can be added. Sort the entries in a valid order.
         std::vector<CTxMemPool::txiter> sortedEntries;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -58,6 +58,7 @@ BlockAssembler::Options::Options() {
 
 BlockAssembler::BlockAssembler(CChainState& chainstate, const CTxMemPool& mempool, const CChainParams& params, const Options& options)
     : m_skip_inclusion_until(options.m_skip_inclusion_until),
+      m_check_block_validity(options.m_check_block_validity),
       chainparams(params),
       m_mempool(mempool),
       m_chainstate(chainstate)
@@ -178,7 +179,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     BlockValidationState state;
     assert(std::addressof(::ChainstateActive()) == std::addressof(m_chainstate));
-    if (!TestBlockValidity(state, chainparams, m_chainstate, *pblock, pindexPrev, false, false)) {
+    if (m_check_block_validity && !TestBlockValidity(state, chainparams, m_chainstate, *pblock, pindexPrev, false, false)) {
         throw std::runtime_error(strprintf("%s: TestBlockValidity failed: %s", __func__, state.ToString()));
     }
     int64_t nTime2 = GetTimeMicros();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -168,7 +168,9 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     pblocktemplate->vchCoinbaseCommitment = GenerateCoinbaseCommitment(*pblock, pindexPrev, chainparams.GetConsensus());
     pblocktemplate->vTxFees[0] = -nFees;
 
-    LogPrintf("CreateNewBlock(): block weight: %u txs: %u fees: %ld sigops %d\n", GetBlockWeight(*pblock), nBlockTx, nFees, nBlockSigOpsCost);
+    if (m_check_block_validity) {
+        LogPrintf("CreateNewBlock(): block weight: %u txs: %u fees: %ld sigops %d\n", GetBlockWeight(*pblock), nBlockTx, nFees, nBlockSigOpsCost);
+    }
 
     // Fill in header
     pblock->hashPrevBlock  = pindexPrev->GetBlockHash();

--- a/src/miner.h
+++ b/src/miner.h
@@ -170,6 +170,12 @@ public:
     inline static std::optional<int64_t> m_last_block_num_txs{};
     inline static std::optional<int64_t> m_last_block_weight{};
 
+    /* This function wraps addPackageTxs to calculate and return the minimum fee
+     * rate required for a package to currently be included in the highest fee rate
+     * block possible based on mempool transactions.
+     */
+    CFeeRate MinTxFeeRate();
+
 private:
     // utility functions
     /** Clear the block's state and prepare for assembling a new block */
@@ -180,8 +186,10 @@ private:
     // Methods for how to add transactions to a block.
     /** Add transactions based on feerate including unconfirmed ancestors
       * Increments nPackagesSelected / nDescendantsUpdated with corresponding
-      * statistics from the package selection (for logging statistics). */
-    void addPackageTxs(int& nPackagesSelected, int& nDescendantsUpdated) EXCLUSIVE_LOCKS_REQUIRED(m_mempool.cs);
+      * statistics from the package selection (for logging statistics).
+      * Populates min_package_fee_rate with the minimum fee rate of a package
+      * included in the block (used for rebroadcast cache). */
+    void addPackageTxs(int& nPackagesSelected, int& nDescendantsUpdated, CFeeRate* min_package_fee_rate = nullptr) EXCLUSIVE_LOCKS_REQUIRED(m_mempool.cs);
 
     // helper functions for addPackageTxs()
     /** Remove confirmed (inBlock) entries from given set */

--- a/src/miner.h
+++ b/src/miner.h
@@ -133,6 +133,7 @@ private:
     bool fIncludeWitness;
     unsigned int nBlockMaxWeight;
     CFeeRate blockMinFeeRate;
+    const std::chrono::microseconds m_skip_inclusion_until;
 
     // Information on the current status of the block
     uint64_t nBlockWeight;
@@ -153,6 +154,7 @@ public:
         Options();
         size_t nBlockMaxWeight;
         CFeeRate blockMinFeeRate;
+        std::chrono::microseconds m_skip_inclusion_until{std::chrono::microseconds::max()};
     };
 
     explicit BlockAssembler(CChainState& chainstate, const CTxMemPool& mempool, const CChainParams& params);
@@ -188,7 +190,10 @@ private:
       * only as an extra check in case of suboptimal node configuration */
     bool TestPackageTransactions(const CTxMemPool::setEntries& package) const;
     /** Return true if given transaction from mapTx has already been evaluated,
-      * or if the transaction's cached data in mapTx is incorrect. */
+      * or if the transaction's cached data in mapTx is incorrect.
+      * If m_skip_inclusion_until is set in the options, we will exclude any
+      * transactions that entered the mempool after the time specified. This is
+      * currently used for rebroadcast logic.*/
     bool SkipMapTxEntry(CTxMemPool::txiter it, indexed_modified_transaction_set& mapModifiedTx, CTxMemPool::setEntries& failedTx) EXCLUSIVE_LOCKS_REQUIRED(m_mempool.cs);
     /** Sort the package in an order that is valid to appear in a block */
     void SortForBlock(const CTxMemPool::setEntries& package, std::vector<CTxMemPool::txiter>& sortedEntries);

--- a/src/miner.h
+++ b/src/miner.h
@@ -135,6 +135,9 @@ private:
     CFeeRate blockMinFeeRate;
     const std::chrono::microseconds m_skip_inclusion_until;
 
+    // To permit disabling block validity check
+    const bool m_check_block_validity;
+
     // Information on the current status of the block
     uint64_t nBlockWeight;
     uint64_t nBlockTx;
@@ -155,6 +158,7 @@ public:
         size_t nBlockMaxWeight;
         CFeeRate blockMinFeeRate;
         std::chrono::microseconds m_skip_inclusion_until{std::chrono::microseconds::max()};
+        bool m_check_block_validity{true};
     };
 
     explicit BlockAssembler(CChainState& chainstate, const CTxMemPool& mempool, const CChainParams& params);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -235,7 +235,7 @@ public:
     /** Overridden from CValidationInterface. */
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex* pindex) override;
-    void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
+    void UpdatedBlockTip(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override;
     void BlockChecked(const CBlock& block, const BlockValidationState& state) override;
     void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& pblock) override;
 
@@ -1403,7 +1403,7 @@ void PeerManagerImpl::NewPoWValidBlock(const CBlockIndex *pindex, const std::sha
  * Update our best height and announce any block hashes which weren't previously
  * in m_chainman.ActiveChain() to our peers.
  */
-void PeerManagerImpl::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
+void PeerManagerImpl::UpdatedBlockTip(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload)
 {
     SetBestHeight(pindexNew->nHeight);
     SetServiceFlagsIBDCache(!fInitialDownload);

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -22,6 +22,8 @@ static const bool DEFAULT_PEERBLOOMFILTERS = false;
 static const bool DEFAULT_PEERBLOCKFILTERS = false;
 /** Threshold for marking a node to be discouraged, e.g. disconnected and added to the discouragement filter. */
 static const int DISCOURAGEMENT_THRESHOLD{100};
+/** Default for node rebroadcast logic */
+static constexpr bool DEFAULT_REBROADCAST_ENABLED = false;
 
 struct CNodeStateStats {
     int nSyncHeight = -1;
@@ -36,7 +38,7 @@ class PeerManager : public CValidationInterface, public NetEventsInterface
 public:
     static std::unique_ptr<PeerManager> make(const CChainParams& chainparams, CConnman& connman, CAddrMan& addrman,
                                              BanMan* banman, CScheduler& scheduler, ChainstateManager& chainman,
-                                             CTxMemPool& pool, bool ignore_incoming_txs);
+                                             CTxMemPool& pool, bool ignore_incoming_txs, bool enable_rebroadcast);
     virtual ~PeerManager() { }
 
     /** Get statistics from node state */

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -360,7 +360,7 @@ public:
     {
         m_notifications->blockDisconnected(*block, index->nHeight);
     }
-    void UpdatedBlockTip(const CBlockIndex* index, const CBlockIndex* fork_index, bool is_ibd) override
+    void UpdatedBlockTip(const std::shared_ptr<const CBlock>& block, const CBlockIndex* index, const CBlockIndex* fork_index, bool is_ibd) override
     {
         m_notifications->updatedBlockTip();
     }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -453,7 +453,9 @@ static RPCHelpMan getmininginfo()
 static RPCHelpMan prioritisetransaction()
 {
     return RPCHelpMan{"prioritisetransaction",
-                "Accepts the transaction into mined blocks at a higher (or lower) priority\n",
+                "Accepts the transaction into mined blocks at a higher (or lower) priority.\n"
+                "\nNote that prioritizing a transaction could leak privacy, through both\n"
+                "block mining and likelihood of rebroadcast.",
                 {
                     {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id."},
                     {"dummy", RPCArg::Type::NUM, RPCArg::Optional::OMITTED_NAMED_ARG, "API-Compatibility for previous API. Must be zero or null.\n"

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -70,7 +70,8 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     const CChainParams& chainparams = Params();
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, nullptr,
-                                       *m_node.scheduler, *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.scheduler, *m_node.chainman, *m_node.mempool,
+                                       false, false);
 
     // Mock an outbound peer
     CAddress addr1(ip(0xa0b0c001), NODE_NONE);
@@ -138,7 +139,8 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
     const CChainParams& chainparams = Params();
     auto connman = std::make_unique<CConnmanTest>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, nullptr,
-                                       *m_node.scheduler, *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.scheduler, *m_node.chainman, *m_node.mempool,
+                                       false, false);
 
     constexpr int max_outbound_full_relay = MAX_OUTBOUND_FULL_RELAY_CONNECTIONS;
     CConnman::Options options;
@@ -211,7 +213,8 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     auto banman = std::make_unique<BanMan>(m_args.GetDataDirPath() / "banlist.dat", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<CConnmanTest>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(),
-                                       *m_node.scheduler, *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.scheduler, *m_node.chainman, *m_node.mempool,
+                                       false, false);
 
     CNetAddr tor_netaddr;
     BOOST_REQUIRE(
@@ -305,7 +308,8 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     auto banman = std::make_unique<BanMan>(m_args.GetDataDirPath() / "banlist.dat", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(),
-                                       *m_node.scheduler, *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.scheduler, *m_node.chainman, *m_node.mempool,
+                                       false, false);
 
     banman->ClearBanned();
     int64_t nStartTime = GetTime();

--- a/src/test/txrebroadcast_tests.cpp
+++ b/src/test/txrebroadcast_tests.cpp
@@ -62,6 +62,49 @@ BOOST_AUTO_TEST_CASE(recency)
     BOOST_CHECK_EQUAL(candidates.front().m_txid, tx_old.GetHash());
 }
 
+BOOST_AUTO_TEST_CASE(fee_rate)
+{
+    // Since the test chain comes with 100 blocks, the first coinbase is
+    // already valid to spend. Generate another block to have two valid
+    // coinbase inputs to spend.
+    CreateAndProcessBlock(std::vector<CMutableTransaction>(), CScript());
+
+    // Instantiate rebroadcast module & mine a block, so when we run
+    // GetRebroadcastTransactions, Chain tip will be beyond m_tip_at_cache_time
+    const auto chain_params = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+    TxRebroadcastHandler tx_rebroadcast(*m_node.mempool, *m_node.chainman, *chain_params);
+    CBlock recent_block = CreateAndProcessBlock(std::vector<CMutableTransaction>(), CScript());
+    CBlockIndex recent_block_index{recent_block.GetBlockHeader()};
+
+    // Update m_cached_fee_rate
+    // The transactions created in this test are each 157 bytes, and they set
+    // the fee at 1 BTC and 2 BTC.
+    CFeeRate cached_fee_rate(1.5 * COIN, 157);
+    tx_rebroadcast.UpdateCachedFeeRate(cached_fee_rate);
+
+    // Create two transactions
+    CKey key;
+    key.MakeNewKey(true);
+    CScript output_destination = GetScriptForDestination(PKHash(key.GetPubKey()));
+
+    // - One with a low fee rate
+    CMutableTransaction tx_low = CreateValidMempoolTransaction(m_coinbase_txns[0], /* vout */ 0, /* input_height */ 0, coinbaseKey, output_destination, CAmount(49 * COIN));
+    // - One with a high fee rate
+    CMutableTransaction tx_high = CreateValidMempoolTransaction(m_coinbase_txns[1], /* vout */ 0, /* input_height */ 1, coinbaseKey, output_destination, CAmount(48 * COIN));
+
+    // Confirm both transactions successfully made it into the mempool
+    BOOST_CHECK_EQUAL(m_node.mempool->size(), 2U);
+
+    // Age transaction to be older than REBROADCAST_MIN_TX_AGE
+    SetMockTime(GetTime<std::chrono::seconds>() + 35min);
+
+    // Check that only the high fee rate transaction would be selected
+    const std::shared_ptr<const CBlock> empty_block;
+    std::vector<TxIds> candidates = tx_rebroadcast.GetRebroadcastTransactions(empty_block, recent_block_index);
+    BOOST_REQUIRE_EQUAL(candidates.size(), 1U);
+    BOOST_CHECK_EQUAL(candidates.front().m_txid, tx_high.GetHash());
+}
+
 BOOST_AUTO_TEST_CASE(max_rebroadcast)
 {
     // Create a transaction

--- a/src/test/txrebroadcast_tests.cpp
+++ b/src/test/txrebroadcast_tests.cpp
@@ -62,4 +62,68 @@ BOOST_AUTO_TEST_CASE(recency)
     BOOST_CHECK_EQUAL(candidates.front().m_txid, tx_old.GetHash());
 }
 
+BOOST_AUTO_TEST_CASE(max_rebroadcast)
+{
+    // Create a transaction
+    CKey key;
+    key.MakeNewKey(true);
+    CScript output_destination = GetScriptForDestination(PKHash(key.GetPubKey()));
+    CMutableTransaction tx = CreateValidMempoolTransaction(m_coinbase_txns[0], /* vout */ 0, /* input_height */ 0, coinbaseKey, output_destination, CAmount(48 * COIN));
+    uint256 txhsh = tx.GetHash();
+
+    // Instantiate rebroadcast module & mine a block, so when we run
+    // GetRebroadcastTransactions, Chain tip will be beyond m_tip_at_cache_time
+    const auto chain_params = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+    TxRebroadcastHandler tx_rebroadcast(*m_node.mempool, *m_node.chainman, *chain_params);
+    CBlock recent_block = CreateAndProcessBlock(std::vector<CMutableTransaction>(), CScript());
+    CBlockIndex recent_block_index{recent_block.GetBlockHeader()};
+
+    // Age transaction by 35 minutes, to be older than REBROADCAST_MIN_TX_AGE
+    std::chrono::seconds current_time = GetTime<std::chrono::seconds>();
+    current_time += 35min;
+    SetMockTime(current_time);
+
+    // Update the fee rate to be >0 so the rebroadcast logic doesn't return early
+    CFeeRate cached_fee_rate(100, 100); // 1 sat/vB
+    tx_rebroadcast.UpdateCachedFeeRate(cached_fee_rate);
+
+    // Check that the transaction gets returned to rebroadcast
+    const std::shared_ptr<const CBlock> empty_block;
+    std::vector<TxIds> candidates = tx_rebroadcast.GetRebroadcastTransactions(empty_block, recent_block_index);
+    BOOST_REQUIRE_EQUAL(candidates.size(), 1U);
+    BOOST_CHECK_EQUAL(candidates.front().m_txid, txhsh);
+
+    // Check if transaction was properly added to m_attempt_tracker
+    // The attempt tracker records wtxids, but since this transaction does not
+    // have a witness, the txhsh = wtxhsh so works for look ups.
+    BOOST_CHECK(tx_rebroadcast.CheckRecordedAttempt(txhsh, 1, current_time));
+
+    // Since the transaction was returned within the last
+    // REBROADCAST_MIN_TX_AGE time, check it does not get returned again
+    candidates = tx_rebroadcast.GetRebroadcastTransactions(empty_block, recent_block_index);
+    BOOST_CHECK_EQUAL(candidates.size(), 0U);
+    // And that the m_attempt_tracker entry is not updated
+    BOOST_CHECK(tx_rebroadcast.CheckRecordedAttempt(txhsh, 1, current_time));
+
+    // Bump time by 4 hours, to pass the MIN_INTERVAL time
+    current_time += 4h;
+    SetMockTime(current_time);
+    // Then check that it gets returned for rebroadacst
+    candidates = tx_rebroadcast.GetRebroadcastTransactions(empty_block, recent_block_index);
+    BOOST_REQUIRE_EQUAL(candidates.size(), 1U);
+    // And that m_attempt_tracker is properly updated
+    BOOST_CHECK(tx_rebroadcast.CheckRecordedAttempt(txhsh, 2, current_time));
+
+    // Update the record to have m_count to be MAX_REBROADCAST_COUNT, and last
+    // attempt time of 4 hours ago
+    auto attempt_time = GetTime<std::chrono::microseconds>() - 4h;
+    tx_rebroadcast.UpdateAttempt(txhsh, 4, attempt_time);
+    // Check that transaction is not rebroadcast
+    candidates = tx_rebroadcast.GetRebroadcastTransactions(empty_block, recent_block_index);
+    BOOST_CHECK_EQUAL(candidates.size(), 0U);
+    // Check that the entry is removed from the m_attempt_tracker
+    // And added to the m_max_filter
+    BOOST_CHECK(tx_rebroadcast.CheckMaxAttempt(txhsh));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txrebroadcast_tests.cpp
+++ b/src/test/txrebroadcast_tests.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2011-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <amount.h>
+#include <clientversion.h>
+#include <consensus/tx_check.h>
+#include <consensus/validation.h>
+#include <core_io.h>
+#include <key_io.h>
+#include <rpc/util.h>
+#include <script/interpreter.h>
+#include <script/script.h>
+#include <streams.h>
+#include <test/util/setup_common.h>
+#include <txmempool.h>
+#include <txrebroadcast.h>
+#include <util/time.h>
+#include <validation.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(txrebroadcast_tests, TestChain100Setup)
+
+BOOST_AUTO_TEST_CASE(recency)
+{
+    // Since the test chain comes with 100 blocks, the first coinbase is
+    // already valid to spend. Generate another block to have two valid
+    // coinbase inputs to spend.
+    CreateAndProcessBlock(std::vector<CMutableTransaction>(), CScript());
+
+    // Create a transaction
+    CKey key;
+    key.MakeNewKey(true);
+    CScript output_destination = GetScriptForDestination(PKHash(key.GetPubKey()));
+    CMutableTransaction tx_old = CreateValidMempoolTransaction(m_coinbase_txns[0], /* vout */ 0, /* input_height */ 0, coinbaseKey, output_destination, CAmount(48 * COIN));
+
+    // Age transaction to be older than REBROADCAST_MIN_TX_AGE
+    SetMockTime(GetTime<std::chrono::seconds>() + 35min);
+
+    // Create a recent transaction
+    CMutableTransaction tx_new = CreateValidMempoolTransaction(m_coinbase_txns[1], /* vout */ 0, /* input_height */ 1, coinbaseKey, output_destination, CAmount(48 * COIN));
+
+    // Confirm both transactions successfully made it into the mempool
+    BOOST_CHECK_EQUAL(m_node.mempool->size(), 2U);
+
+    // Instantiate rebroadcast module & mine a block, so when we run
+    // GetRebroadcastTransactions, Chain tip will be beyond m_tip_at_cache_time
+    const auto chain_params = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+    TxRebroadcastHandler tx_rebroadcast(*m_node.mempool, *m_node.chainman, *chain_params);
+    CBlock recent_block = CreateAndProcessBlock(std::vector<CMutableTransaction>(), CScript());
+    CBlockIndex recent_block_index{recent_block.GetBlockHeader()};
+
+    // Update the fee rate to be >0 so the rebroadcast logic doesn't return early
+    CFeeRate cached_fee_rate(100, 100); // 1 sat/vB
+    tx_rebroadcast.UpdateCachedFeeRate(cached_fee_rate);
+
+    // Confirm that only the old transaction is included
+    const std::shared_ptr<const CBlock> empty_block;
+    std::vector<TxIds> candidates = tx_rebroadcast.GetRebroadcastTransactions(empty_block, recent_block_index);
+    BOOST_REQUIRE_EQUAL(candidates.size(), 1U);
+    BOOST_CHECK_EQUAL(candidates.front().m_txid, tx_old.GetHash());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -199,7 +199,7 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
     m_node.connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman); // Deterministic randomness for tests.
     m_node.peerman = PeerManager::make(chainparams, *m_node.connman, *m_node.addrman,
                                        m_node.banman.get(), *m_node.scheduler, *m_node.chainman,
-                                       *m_node.mempool, false);
+                                       *m_node.mempool, /* ignore_incoming_txs */ false, /* enable_rebroadcast */ true);
     {
         CConnman::Options options;
         options.m_msgproc = m_node.peerman.get();

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -36,7 +36,7 @@ struct TestSubscriber final : public CValidationInterface {
 
     explicit TestSubscriber(uint256 tip) : m_expected_tip(tip) {}
 
-    void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override
+    void UpdatedBlockTip(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override
     {
         BOOST_CHECK_EQUAL(m_expected_tip, pindexNew->GetBlockHash());
     }

--- a/src/txrebroadcast.cpp
+++ b/src/txrebroadcast.cpp
@@ -8,10 +8,14 @@
 #include <node/blockstorage.h>
 #include <script/script.h>
 #include <txrebroadcast.h>
+#include <util/time.h>
 
 /** We rebroadcast upto 3/4 of max block weight to reduce noise due to
  * circumstances such as miners mining priority transactions. */
 static constexpr float REBROADCAST_WEIGHT_RATIO{0.75};
+
+/** Default minimum age for a transaction to be rebroadcast */
+static constexpr std::chrono::minutes REBROADCAST_MIN_TX_AGE{30min};
 
 std::vector<TxIds> TxRebroadcastHandler::GetRebroadcastTransactions(const std::shared_ptr<const CBlock>& recent_block, const CBlockIndex& recent_block_index)
 {
@@ -34,6 +38,7 @@ std::vector<TxIds> TxRebroadcastHandler::GetRebroadcastTransactions(const std::s
 
     BlockAssembler::Options options;
     options.nBlockMaxWeight = rebroadcast_block_weight;
+    options.m_skip_inclusion_until = GetTime<std::chrono::microseconds>() - REBROADCAST_MIN_TX_AGE;
 
     // Use CreateNewBlock to identify rebroadcast candidates
     std::vector<TxIds> rebroadcast_txs;

--- a/src/txrebroadcast.cpp
+++ b/src/txrebroadcast.cpp
@@ -245,3 +245,9 @@ void TxRebroadcastHandler::TrimMaxRebroadcast()
         }
     }
 };
+
+void TxRebroadcastHandler::UpdateCachedFeeRate(const CFeeRate& new_fee_rate)
+{
+    LOCK(m_rebroadcast_mutex);
+    m_cached_fee_rate = new_fee_rate;
+};

--- a/src/txrebroadcast.cpp
+++ b/src/txrebroadcast.cpp
@@ -4,6 +4,7 @@
 
 #include <chainparams.h>
 #include <consensus/consensus.h>
+#include <logging.h>
 #include <miner.h>
 #include <node/blockstorage.h>
 #include <script/script.h>
@@ -125,6 +126,7 @@ std::vector<TxIds> TxRebroadcastHandler::GetRebroadcastTransactions(const std::s
     // Use CreateNewBlock to identify rebroadcast candidates
     auto block_template = BlockAssembler(m_chainman.ActiveChainstate(), m_mempool, m_chainparams, options)
                               .CreateNewBlock(CScript());
+    auto after_cnb_time = GetTime<std::chrono::microseconds>();
     rebroadcast_txs.reserve(block_template->block.vtx.size());
 
     LOCK(m_rebroadcast_mutex);
@@ -177,6 +179,15 @@ std::vector<TxIds> TxRebroadcastHandler::GetRebroadcastTransactions(const std::s
 
     TrimMaxRebroadcast();
 
+    auto delta1 = after_cnb_time - start_time;
+    auto delta2 = GetTime<std::chrono::microseconds>() - start_time;
+    LogPrint(BCLog::BENCH, "GetRebroadcastTransactions(): %d us total, %d us spent in CreateNewBlock.\n", delta2.count(), delta1.count());
+    LogPrint(BCLog::NET, "Queued %d transactions for attempted rebroadcast, filtered from %d candidates with cached fee rate of %s.\n", rebroadcast_txs.size(), block_template->block.vtx.size() - 1, m_cached_fee_rate.ToString(FeeEstimateMode::SAT_VB));
+
+    for (TxIds ids : rebroadcast_txs) {
+        LogPrint(BCLog::NET, "Attempting to rebroadcast txid: %s wtxid: %s\n", ids.m_txid.ToString(), ids.m_wtxid.ToString());
+    }
+
     return rebroadcast_txs;
 };
 
@@ -191,17 +202,21 @@ void TxRebroadcastHandler::CacheMinRebroadcastFee()
 
     CBlockIndex* tip;
     CFeeRate current_fee_rate;
+    auto start_time = GetTime<std::chrono::microseconds>();
     {
         LOCK(cs_main);
         tip = m_chainman.ActiveTip();
         current_fee_rate = BlockAssembler(chain_state, m_mempool, m_chainparams, options).MinTxFeeRate();
     }
+    auto delta_time = GetTime<std::chrono::microseconds>() - start_time;
 
     // Update stored information
     LOCK(m_rebroadcast_mutex);
     m_tip_at_cache_time = tip;
     m_previous_cached_fee_rate = m_cached_fee_rate;
     m_cached_fee_rate = current_fee_rate;
+
+    LogPrint(BCLog::BENCH, "Caching minimum fee for rebroadcast to %s, took %d us to calculate.\n", m_cached_fee_rate.ToString(FeeEstimateMode::SAT_VB), delta_time.count());
 };
 
 void TxRebroadcastHandler::TrimMaxRebroadcast()

--- a/src/txrebroadcast.cpp
+++ b/src/txrebroadcast.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <consensus/consensus.h>
+#include <miner.h>
+#include <node/blockstorage.h>
+#include <script/script.h>
+#include <txrebroadcast.h>
+
+/** We rebroadcast upto 3/4 of max block weight to reduce noise due to
+ * circumstances such as miners mining priority transactions. */
+static constexpr float REBROADCAST_WEIGHT_RATIO{0.75};
+
+std::vector<TxIds> TxRebroadcastHandler::GetRebroadcastTransactions()
+{
+    BlockAssembler::Options options;
+    options.nBlockMaxWeight = REBROADCAST_WEIGHT_RATIO * MAX_BLOCK_WEIGHT;
+
+    // Use CreateNewBlock to identify rebroadcast candidates
+    std::vector<TxIds> rebroadcast_txs;
+    auto block_template = BlockAssembler(m_chainman.ActiveChainstate(), m_mempool, m_chainparams, options)
+                              .CreateNewBlock(CScript());
+    rebroadcast_txs.reserve(block_template->block.vtx.size());
+
+    for (const CTransactionRef& tx : block_template->block.vtx) {
+        if (tx->IsCoinBase()) continue;
+
+        rebroadcast_txs.push_back(TxIds(tx->GetHash(), tx->GetWitnessHash()));
+    }
+
+    return rebroadcast_txs;
+};

--- a/src/txrebroadcast.cpp
+++ b/src/txrebroadcast.cpp
@@ -39,6 +39,7 @@ std::vector<TxIds> TxRebroadcastHandler::GetRebroadcastTransactions(const std::s
     BlockAssembler::Options options;
     options.nBlockMaxWeight = rebroadcast_block_weight;
     options.m_skip_inclusion_until = GetTime<std::chrono::microseconds>() - REBROADCAST_MIN_TX_AGE;
+    options.m_check_block_validity = false;
 
     // Use CreateNewBlock to identify rebroadcast candidates
     std::vector<TxIds> rebroadcast_txs;

--- a/src/txrebroadcast.cpp
+++ b/src/txrebroadcast.cpp
@@ -219,6 +219,13 @@ void TxRebroadcastHandler::CacheMinRebroadcastFee()
     LogPrint(BCLog::BENCH, "Caching minimum fee for rebroadcast to %s, took %d us to calculate.\n", m_cached_fee_rate.ToString(FeeEstimateMode::SAT_VB), delta_time.count());
 };
 
+void TxRebroadcastHandler::RemoveFromAttemptTracker(const CTransactionRef& tx) {
+    LOCK(m_rebroadcast_mutex);
+    const auto it = m_attempt_tracker->find(tx->GetWitnessHash());
+    if (it == m_attempt_tracker->end()) return;
+    m_attempt_tracker->erase(it);
+}
+
 void TxRebroadcastHandler::TrimMaxRebroadcast()
 {
     AssertLockHeld(m_rebroadcast_mutex);

--- a/src/txrebroadcast.cpp
+++ b/src/txrebroadcast.cpp
@@ -41,8 +41,29 @@ std::vector<TxIds> TxRebroadcastHandler::GetRebroadcastTransactions(const std::s
     options.m_skip_inclusion_until = GetTime<std::chrono::microseconds>() - REBROADCAST_MIN_TX_AGE;
     options.m_check_block_validity = false;
 
-    // Use CreateNewBlock to identify rebroadcast candidates
+    // The fee rate condition only filters out transactions if it runs before
+    // we process the recently mined block. If the cache has since been
+    // updated, used the value from the previous run to filter transactions.
+    // Increment the cached value by 1 satoshi / 1000 bytes to avoid
+    // rebroadcasting a long-tail of transactions at a fee rate boundary.
+    {
+        const CBlockIndex* tip = m_chainman.ActiveTip();
+        LOCK(m_rebroadcast_mutex);
+        if (m_tip_at_cache_time == tip) {
+            m_previous_cached_fee_rate += CFeeRate(1);
+            options.blockMinFeeRate = m_previous_cached_fee_rate;
+        } else {
+            m_cached_fee_rate += CFeeRate(1);
+            options.blockMinFeeRate = m_cached_fee_rate;
+        }
+    }
+
+    // Skip if the fee rate cache has not yet run, which could happen once on
+    // startup
     std::vector<TxIds> rebroadcast_txs;
+    if (options.blockMinFeeRate.GetFeePerK() == CAmount(0)) return rebroadcast_txs;
+
+    // Use CreateNewBlock to identify rebroadcast candidates
     auto block_template = BlockAssembler(m_chainman.ActiveChainstate(), m_mempool, m_chainparams, options)
                               .CreateNewBlock(CScript());
     rebroadcast_txs.reserve(block_template->block.vtx.size());
@@ -54,4 +75,28 @@ std::vector<TxIds> TxRebroadcastHandler::GetRebroadcastTransactions(const std::s
     }
 
     return rebroadcast_txs;
+};
+
+void TxRebroadcastHandler::CacheMinRebroadcastFee()
+{
+    CChainState& chain_state = m_chainman.ActiveChainstate();
+    if (chain_state.IsInitialBlockDownload() || !m_mempool.IsLoaded()) return;
+
+    // Calculate a new fee rate
+    BlockAssembler::Options options;
+    options.nBlockMaxWeight = REBROADCAST_WEIGHT_RATIO * MAX_BLOCK_WEIGHT;
+
+    CBlockIndex* tip;
+    CFeeRate current_fee_rate;
+    {
+        LOCK(cs_main);
+        tip = m_chainman.ActiveTip();
+        current_fee_rate = BlockAssembler(chain_state, m_mempool, m_chainparams, options).MinTxFeeRate();
+    }
+
+    // Update stored information
+    LOCK(m_rebroadcast_mutex);
+    m_tip_at_cache_time = tip;
+    m_previous_cached_fee_rate = m_cached_fee_rate;
+    m_cached_fee_rate = current_fee_rate;
 };

--- a/src/txrebroadcast.h
+++ b/src/txrebroadcast.h
@@ -50,6 +50,9 @@ public:
      * */
     void CacheMinRebroadcastFee();
 
+    /** Remove transaction entry from the attempt tracker.*/
+    void RemoveFromAttemptTracker(const CTransactionRef& tx);
+
 private:
     const CTxMemPool& m_mempool;
     const ChainstateManager& m_chainman;

--- a/src/txrebroadcast.h
+++ b/src/txrebroadcast.h
@@ -54,6 +54,15 @@ public:
     void RemoveFromAttemptTracker(const CTransactionRef& tx);
 
     /** Test only */
+    void UpdateAttempt(const uint256& wtxid, const int count, const std::chrono::microseconds last_attempt_time);
+
+    /** Test only */
+    bool CheckRecordedAttempt(const uint256& wtxid, const int expected_count, const std::chrono::microseconds expected_timestamp) const;
+
+    /** Test only */
+    bool CheckMaxAttempt(const uint256& wtxid) const;
+
+    /** Test only */
     void UpdateCachedFeeRate(const CFeeRate& new_fee_rate);
 
 private:
@@ -62,7 +71,7 @@ private:
     const CChainParams& m_chainparams;
 
     /** Protects internal data members */
-    Mutex m_rebroadcast_mutex;
+    mutable Mutex m_rebroadcast_mutex;
 
     /** Block at time of cache */
     CBlockIndex* m_tip_at_cache_time GUARDED_BY(m_rebroadcast_mutex){nullptr};

--- a/src/txrebroadcast.h
+++ b/src/txrebroadcast.h
@@ -53,6 +53,9 @@ public:
     /** Remove transaction entry from the attempt tracker.*/
     void RemoveFromAttemptTracker(const CTransactionRef& tx);
 
+    /** Test only */
+    void UpdateCachedFeeRate(const CFeeRate& new_fee_rate);
+
 private:
     const CTxMemPool& m_mempool;
     const ChainstateManager& m_chainman;

--- a/src/txrebroadcast.h
+++ b/src/txrebroadcast.h
@@ -27,6 +27,9 @@ public:
     TxRebroadcastHandler(const CTxMemPool& mempool, const ChainstateManager& chainman, const CChainParams& chainparams);
     ~TxRebroadcastHandler();
 
+    TxRebroadcastHandler(const TxRebroadcastHandler& other) = delete;
+    TxRebroadcastHandler& operator=(const TxRebroadcastHandler& other) = delete;
+
     /**
      * Identify transaction candidates to be rebroadcast.
      * Calculates the top of the mempool by fee rate, limits the size based on

--- a/src/txrebroadcast.h
+++ b/src/txrebroadcast.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TXREBROADCAST_H
+#define BITCOIN_TXREBROADCAST_H
+
+#include <policy/feerate.h>
+#include <txmempool.h>
+
+struct TxIds {
+    TxIds(uint256 txid, uint256 wtxid) : m_txid(txid), m_wtxid(wtxid) {}
+
+    const uint256 m_txid;
+    const uint256 m_wtxid;
+};
+
+class TxRebroadcastHandler
+{
+public:
+    TxRebroadcastHandler(const CTxMemPool& mempool, const ChainstateManager& chainman, const CChainParams& chainparams)
+        : m_mempool(mempool),
+          m_chainman(chainman),
+          m_chainparams(chainparams){};
+
+    std::vector<TxIds> GetRebroadcastTransactions();
+
+private:
+    const CTxMemPool& m_mempool;
+    const ChainstateManager& m_chainman;
+    const CChainParams& m_chainparams;
+};
+
+#endif // BITCOIN_TXREBROADCAST_H

--- a/src/txrebroadcast.h
+++ b/src/txrebroadcast.h
@@ -23,7 +23,18 @@ public:
           m_chainman(chainman),
           m_chainparams(chainparams){};
 
-    std::vector<TxIds> GetRebroadcastTransactions();
+    /**
+     * Identify transaction candidates to be rebroadcast.
+     * Calculates the top of the mempool by fee rate, limits the size based on
+     * recent block information passed in, rate limits candidates and enforces
+     * a maximum number of rebroadcast attempts per transaction.
+     *
+     * @param[in]  recent_block        Optionally provide a reference to skip a disk read
+     * @param[in]  recent_block_index  An index to the recent block, used to
+     *                                 calculate weight of rebroadcast candidates
+     * @return     std::vector<TxIds>  Returns transaction ids of rebroadcast candidates
+     * */
+    std::vector<TxIds> GetRebroadcastTransactions(const std::shared_ptr<const CBlock>& recent_block, const CBlockIndex& recent_block_index);
 
 private:
     const CTxMemPool& m_mempool;

--- a/src/txrebroadcast.h
+++ b/src/txrebroadcast.h
@@ -92,6 +92,9 @@ private:
      *  further rebroadcasts until this filter rolls over.
      * */
     CRollingBloomFilter m_max_filter GUARDED_BY(m_rebroadcast_mutex);
+
+    /** Limit the size of m_attempt_tracker by deleting the oldest entries */
+    void TrimMaxRebroadcast() EXCLUSIVE_LOCKS_REQUIRED(m_rebroadcast_mutex);
 };
 
 #endif // BITCOIN_TXREBROADCAST_H

--- a/src/txrebroadcast.h
+++ b/src/txrebroadcast.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_TXREBROADCAST_H
 #define BITCOIN_TXREBROADCAST_H
 
+#include <bloom.h>
 #include <policy/feerate.h>
 #include <txmempool.h>
 #include <validation.h>
@@ -83,6 +84,14 @@ private:
      *  of times we will attempt to rebroadcast a transaction.
      * */
     std::unique_ptr<indexed_rebroadcast_set> m_attempt_tracker GUARDED_BY(m_rebroadcast_mutex);
+
+    /** Keep track of transactions we have rebroadcasted a maximum number of times.
+     *
+     *  Once a transaction hits the MAX_REBROADCAST_COUNT on the
+     *  m_attempt_tracker, add it to this bloom filter so we can prevent
+     *  further rebroadcasts until this filter rolls over.
+     * */
+    CRollingBloomFilter m_max_filter GUARDED_BY(m_rebroadcast_mutex);
 };
 
 #endif // BITCOIN_TXREBROADCAST_H

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -185,13 +185,14 @@ void SyncWithValidationInterfaceQueue()
 #define LOG_EVENT(fmt, ...) \
     LogPrint(BCLog::VALIDATION, fmt "\n", __VA_ARGS__)
 
-void CMainSignals::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {
+void CMainSignals::UpdatedBlockTip(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload)
+{
     // Dependencies exist that require UpdatedBlockTip events to be delivered in the order in which
     // the chain actually updates. One way to ensure this is for the caller to invoke this signal
     // in the same critical section where the chain is updated
 
-    auto event = [pindexNew, pindexFork, fInitialDownload, this] {
-        m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.UpdatedBlockTip(pindexNew, pindexFork, fInitialDownload); });
+    auto event = [block, pindexNew, pindexFork, fInitialDownload, this] {
+        m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.UpdatedBlockTip(block, pindexNew, pindexFork, fInitialDownload); });
     };
     ENQUEUE_AND_LOG_EVENT(event, "%s: new block hash=%s fork block hash=%s (in IBD=%s)", __func__,
                           pindexNew->GetBlockHash().ToString(),

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -90,8 +90,10 @@ protected:
      * subscribe to BlockConnected() instead.
      *
      * Called on a background thread.
+     *
+     * @param block Either nullptr or a pointer to the block corresponding to pindexNew
      */
-    virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}
+    virtual void UpdatedBlockTip(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) {}
     /**
      * Notifies listeners of a transaction having been added to mempool.
      *
@@ -196,8 +198,7 @@ public:
 
     size_t CallbacksPending();
 
-
-    void UpdatedBlockTip(const CBlockIndex *, const CBlockIndex *, bool fInitialDownload);
+    void UpdatedBlockTip(const std::shared_ptr<const CBlock>& block, const CBlockIndex*, const CBlockIndex*, bool fInitialDownload);
     void TransactionAddedToMempool(const CTransactionRef&, uint64_t mempool_sequence);
     void TransactionRemovedFromMempool(const CTransactionRef&, MemPoolRemovalReason, uint64_t mempool_sequence);
     void BlockConnected(const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex);

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -129,7 +129,7 @@ void TryForEachAndRemoveFailed(std::list<std::unique_ptr<CZMQAbstractNotifier>>&
 
 } // anonymous namespace
 
-void CZMQNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
+void CZMQNotificationInterface::UpdatedBlockTip(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload)
 {
     if (fInitialDownload || pindexNew == pindexFork) // In IBD or blocks were disconnected without any new ones
         return;

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -30,7 +30,7 @@ protected:
     void TransactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason, uint64_t mempool_sequence) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected) override;
-    void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
+    void UpdatedBlockTip(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override;
 
 private:
     CZMQNotificationInterface();

--- a/test/functional/p2p_rebroadcast.py
+++ b/test/functional/p2p_rebroadcast.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test node rebroadcast logic.
+
+We start by creating a set of transactions to set the rebroadcast minimum fee
+cache to a medium fee rate value.
+
+We then create three sets of transactions:
+    1. aged, high fee rate
+    2. aged, low fee rate
+    3. recent, high fee rate
+
+We add a new connection, trigger the rebroadcast functionality by mining an
+empty block, check that the aged high fee rate transactions were succesfully
+rebroadcast, and that the other two sets were not rebroadcast.
+"""
+
+import time
+from decimal import Decimal
+
+from test_framework.p2p import P2PTxInvStore
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_approx,
+    assert_greater_than,
+    create_confirmed_utxos,
+)
+
+# Constant from consensus.h
+MAX_BLOCK_WEIGHT = 4000000
+
+
+class NodeRebroadcastTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.extra_args = [[
+            "-whitelist=noban@127.0.0.1",
+            "-txindex",
+            "-rebroadcast=1"
+        ]] * self.num_nodes
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def make_txn_at_fee_rate(self, input_utxo, outputs, outputs_sum, desired_fee_rate, change_address):
+        node = self.nodes[0]
+        node1 = self.nodes[1]
+
+        inputs = [{'txid': input_utxo['txid'], 'vout': input_utxo['vout']}]
+
+        # Calculate how much input values add up to
+        input_tx_hsh = input_utxo['txid']
+        raw_tx = node.getrawtransaction(input_tx_hsh, True)
+        inputs_list = raw_tx['vout']
+        if 'coinbase' in raw_tx['vin'][0].keys():
+            return
+        index = raw_tx['vin'][0]['vout']
+        inputs_sum = inputs_list[index]['value']
+
+        # Divide by 1000 because vsize is in bytes & cache fee rate is BTC / kB
+        tx_vsize_with_change = 1660
+        desired_fee_btc = desired_fee_rate * tx_vsize_with_change / 1000
+        current_fee_btc = inputs_sum - Decimal(str(outputs_sum))
+
+        # Add another output with change
+        outputs[change_address] = float(current_fee_btc - desired_fee_btc)
+        outputs_sum += outputs[change_address]
+
+        # Form transaction & submit to mempool of both nodes directly
+        raw_tx_hex = node.createrawtransaction(inputs, outputs)
+        signed_tx = node.signrawtransactionwithwallet(raw_tx_hex)
+        tx_hsh = node.sendrawtransaction(hexstring=signed_tx['hex'], maxfeerate=0)
+        node1.sendrawtransaction(hexstring=signed_tx['hex'], maxfeerate=0)
+
+        # Retrieve mempool transaction to calculate fee rate
+        mempool_entry = node.getmempoolentry(tx_hsh)
+
+        # Check absolute fee matches up to expectations
+        fee_calculated = inputs_sum - Decimal(str(outputs_sum))
+        fee_got = mempool_entry['fee']
+        assert_approx(float(fee_calculated), float(fee_got))
+
+        # mempool_entry['fee'] is in BTC, fee rate should be BTC / kb
+        fee_rate = mempool_entry['fee'] * 1000 / mempool_entry['vsize']
+        assert_approx(float(fee_rate), float(desired_fee_rate))
+
+        return tx_hsh
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        self.log.info("Make transactions to set the cache fee rate")
+        # Create UTXOs that we can spend
+        min_relay_fee = node.getnetworkinfo()["relayfee"]
+        utxos = create_confirmed_utxos(min_relay_fee, node, 2000)
+
+        addresses = []
+        for _ in range(50):
+            addresses.append(node.getnewaddress())
+
+        # Create large transactions by sending to all the addresses
+        outputs = {addr: 0.0001 for addr in addresses}
+        change_address = node.getnewaddress()
+        outputs_sum = 0.0001 * 50
+
+        self.sync_mempools()
+
+        # Create lots of cache_fee_rate transactions with that large output
+        cache_fee_rate = min_relay_fee * 3
+        for _ in range(len(utxos) - 1000):
+            self.make_txn_at_fee_rate(utxos.pop(), outputs, outputs_sum, cache_fee_rate, change_address)
+
+        self.sync_mempools()
+
+        # Confirm we've created enough transactions to fill a cache block,
+        # ensuring the threshold fee rate will be cache_fee_rate
+        # Divide by 4 to convert from weight to virtual bytes
+        assert_greater_than(node.getmempoolinfo()['bytes'], MAX_BLOCK_WEIGHT / 4)
+
+        # Make transactions to later mine into a block
+        block_txns = []
+        for _ in range(600):
+            block_txns.append(self.make_txn_at_fee_rate(utxos.pop(), outputs, outputs_sum, cache_fee_rate, change_address))
+        block_txns = list(filter(None, block_txns))
+
+        # CacheMinRebroadcastFee is scheduled to run every minute
+        # Bump the scheduled jobs by slightly over a minute to trigger it
+        node.mockscheduler(62)
+
+        self.log.info("Make high fee-rate transactions")
+        high_fee_rate_tx_hshs = []
+        high_fee_rate = min_relay_fee * 4
+
+        for _ in range(10):
+            tx_hsh = self.make_txn_at_fee_rate(utxos.pop(), outputs, outputs_sum, high_fee_rate, change_address)
+            high_fee_rate_tx_hshs.append(tx_hsh)
+
+        self.log.info("Make low fee-rate transactions")
+        low_fee_rate_tx_hshs = []
+        low_fee_rate = min_relay_fee * 2
+
+        for _ in range(10):
+            tx_hsh = self.make_txn_at_fee_rate(utxos.pop(), outputs, outputs_sum, low_fee_rate, change_address)
+            low_fee_rate_tx_hshs.append(tx_hsh)
+
+        # Ensure these transactions are removed from the unbroadcast set. Or in
+        # other words, that all GETDATAs have been received before its time to
+        # rebroadcast
+        self.sync_mempools()
+
+        # Confirm that the remaining bytes in the mempool are less than what
+        # fits in the rebroadcast block. Otherwise, we could get a false
+        # positive where the low_fee_rate transactions are not rebroadcast
+        # simply because they do not fit, not because they were filtered out.
+        assert_greater_than(3 * MAX_BLOCK_WEIGHT / 4, node.getmempoolinfo()['bytes'])
+
+        # Bump time forward to ensure existing transactions meet
+        # REBROADCAST_MIN_TX_AGE.
+        node.setmocktime(int(time.time()) + 35 * 60)
+
+        self.log.info("Make recent transactions")
+        recent_tx_hshs = []
+
+        for _ in range(10):
+            tx_hsh = self.make_txn_at_fee_rate(utxos.pop(), outputs, outputs_sum, high_fee_rate, change_address)
+            recent_tx_hshs.append(tx_hsh)
+
+        self.log.info("Trigger rebroadcast by mining a block")
+        conn = node.add_p2p_connection(P2PTxInvStore())
+
+        block_hash = self.nodes[0].generateblock(output=node.getnewaddress(), transactions=block_txns)
+
+        # We identify rebroadcast transaction canadidates by mining a block
+        # with 3/4 the weight of the block received from the network. Ensure
+        # that this test setup triggers rebroadcast functionality with a
+        # sufficiently large block.
+        assert(self.nodes[0].getblock(block_hash['hash'])['weight'] > 3000000)
+
+        self.wait_until(lambda: conn.get_invs(), timeout=30)
+        rebroadcasted_invs = conn.get_invs()
+
+        self.log.info("Check that high fee rate transactions are rebroadcast")
+        for txhsh in high_fee_rate_tx_hshs:
+            wtxhsh = node.getmempoolentry(txhsh)['wtxid']
+            wtxid = int(wtxhsh, 16)
+            assert(wtxid in rebroadcasted_invs)
+
+        self.log.info("Check that low fee rate transactions are NOT rebroadcast")
+        for txhsh in low_fee_rate_tx_hshs:
+            wtxhsh = node.getmempoolentry(txhsh)['wtxid']
+            wtxid = int(wtxhsh, 16)
+            assert(wtxid not in rebroadcasted_invs)
+
+        self.log.info("Check that recent transactions are NOT rebroadcast")
+        for txhsh in recent_tx_hshs:
+            wtxhsh = node.getmempoolentry(txhsh)['wtxid']
+            wtxid = int(wtxhsh, 16)
+            assert(wtxid not in rebroadcasted_invs)
+
+
+if __name__ == '__main__':
+    NodeRebroadcastTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -122,6 +122,7 @@ BASE_SCRIPTS = [
     'wallet_listreceivedby.py --descriptors',
     'wallet_abandonconflict.py --legacy-wallet',
     'wallet_abandonconflict.py --descriptors',
+    'p2p_rebroadcast.py',
     'feature_csv_activation.py',
     'rpc_rawtransaction.py --legacy-wallet',
     'rpc_rawtransaction.py --descriptors',

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -57,6 +57,7 @@ EXPECTED_BOOST_INCLUDES=(
     boost/filesystem.hpp
     boost/filesystem/fstream.hpp
     boost/multi_index/hashed_index.hpp
+    boost/multi_index/member.hpp
     boost/multi_index/ordered_index.hpp
     boost/multi_index/sequenced_index.hpp
     boost/multi_index_container.hpp


### PR DESCRIPTION
## Status
(this section will be updated as the PR progresses, and eventually removed)
- I'm reworking some of the approach, will mark ready for review once that is done. 

## Motivation:
Our legacy rebroadcast mechanism lives in the wallet code. It rebroadcasts only & all transactions which are “mine”, not discerning if the fee rate indicates the transaction should actually have been confirmed by now. This is bad for privacy because it leaks information that allows spy nodes to link bitcoin addresses with IP addresses, a relationship we aim to obfuscate. 

## PR Overview:
This PR introduces a rebroadcast mechanism in the node. Instead of only rebroadcasting our own transactions, we will notify the network about _any_ transactions we identified as missing from blocks based on fee rate expectations in our own mempool. 

The new module is currently behind a configuration flag that defaults to off.

The end goal is to enable node rebroadcast by default, and remove wallet rebroadcast. This would improve privacy for a few main reasons: 
1. We would no longer eagerly rebroadcast all of our wallet transactions regardless of fee-rate. We add logic to rebroadcast the ones which have a competitive rate according to the current blocks being mined. 
2. If a spy observes a bitcoin core node rebroadcasting a transaction, it would no longer know that the node has wallet enabled. 
3. If a spy observed a bitcoin core node rebroadcasting a transaction, it would no longer be able to deduce with high confidence that the associated wallet is participating in that transaction.

## Approach: 
Conceptually, we want to rebroadcast transactions that we believe “should” have been mined by now.  Since we expect miners to prioritize transactions with the highest package fee rates, we select high fee rate transactions that have been in our mempool for some time, but have not yet been mined. 

This PR introduces a `txrebroadcast` module that encapsulates the selection logic. When `PeerManager` gets notified that we have received and processed a block, we trigger the rebroadcast logic. The module calculates the highest fee rate mempool packages that meet some additional conditions- the transaction must be > 30 minutes old, and surpass a fee threshold. This threshold is calculated by periodically (every minute) identifying the top block of transactions in our mempool, and caching the fee rate for a package to be included. We eliminate any of these candidates that we have rebroadcasted recently (last 4 hours), or already rebroadcast more than a maximum amount of times (6). We store any remaining candidates on each peer’s `setInventoryTxToSend`, which they will potentially relay next time we hit `SendMessages` for that peer (subject to general transaction relay conditions). 
