### PR TITLE
wallet, rpc: update listdescriptors response format

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -1747,22 +1747,23 @@ RPCHelpMan listdescriptors()
         "listdescriptors",
         "\nList descriptors imported into a descriptor-enabled wallet.",
         {},
-        RPCResult{
-            RPCResult::Type::ARR, "", "Response is an array of descriptor objects",
+        RPCResult{RPCResult::Type::OBJ, "", "", {
+            {RPCResult::Type::STR, "wallet_name", "Name of wallet this operation was performed on"},
+            {RPCResult::Type::ARR, "descriptors", "Array of descriptor objects",
             {
                 {RPCResult::Type::OBJ, "", "", {
                     {RPCResult::Type::STR, "desc", "Descriptor string representation"},
                     {RPCResult::Type::NUM, "timestamp", "The creation time of the descriptor"},
                     {RPCResult::Type::BOOL, "active", "Activeness flag"},
-                    {RPCResult::Type::BOOL, "internal", true, "Whether this is internal or external descriptor; defined only for active descriptors"},
+                    {RPCResult::Type::BOOL, "internal", true, "Whether this is an internal or external descriptor; defined only for active descriptors"},
                     {RPCResult::Type::ARR_FIXED, "range", true, "Defined only for ranged descriptors", {
                         {RPCResult::Type::NUM, "", "Range start inclusive"},
                         {RPCResult::Type::NUM, "", "Range end inclusive"},
                     }},
                     {RPCResult::Type::NUM, "next", true, "The next index to generate addresses from; defined only for ranged descriptors"},
                 }},
-            }
-        },
+            }}
+        }},
         RPCExamples{
             HelpExampleCli("listdescriptors", "") + HelpExampleRpc("listdescriptors", "")
         },
@@ -1779,7 +1780,7 @@ RPCHelpMan listdescriptors()
 
     LOCK(wallet->cs_wallet);
 
-    UniValue response(UniValue::VARR);
+    UniValue descriptors(UniValue::VARR);
     const auto active_spk_mans = wallet->GetActiveScriptPubKeyMans();
     for (const auto& spk_man : wallet->GetAllScriptPubKeyMans()) {
         const auto desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man);
@@ -1808,8 +1809,12 @@ RPCHelpMan listdescriptors()
             spk.pushKV("range", range);
             spk.pushKV("next", wallet_descriptor.next_index);
         }
-        response.push_back(spk);
+        descriptors.push_back(spk);
     }
+
+    UniValue response(UniValue::VOBJ);
+    response.pushKV("wallet_name", wallet->GetName());
+    response.pushKV("descriptors", descriptors);
 
     return response;
 },

--- a/test/functional/wallet_listdescriptors.py
+++ b/test/functional/wallet_listdescriptors.py
@@ -36,15 +36,16 @@ class ListDescriptorsTest(BitcoinTestFramework):
 
         self.log.info('Test the command for empty descriptors wallet.')
         node.createwallet(wallet_name='w2', blank=True, descriptors=True)
-        assert_equal(0, len(node.get_wallet_rpc('w2').listdescriptors()))
+        assert_equal(0, len(node.get_wallet_rpc('w2').listdescriptors()['descriptors']))
 
         self.log.info('Test the command for a default descriptors wallet.')
         node.createwallet(wallet_name='w3', descriptors=True)
         result = node.get_wallet_rpc('w3').listdescriptors()
-        assert_equal(6, len(result))
-        assert_equal(6, len([d for d in result if d['active']]))
-        assert_equal(3, len([d for d in result if d['internal']]))
-        for item in result:
+        assert_equal("w3", result['wallet_name'])
+        assert_equal(6, len(result['descriptors']))
+        assert_equal(6, len([d for d in result['descriptors'] if d['active']]))
+        assert_equal(3, len([d for d in result['descriptors'] if d['internal']]))
+        for item in result['descriptors']:
             assert item['desc'] != ''
             assert item['next'] == 0
             assert item['range'] == [0, 0]
@@ -59,12 +60,17 @@ class ListDescriptorsTest(BitcoinTestFramework):
             'desc': descsum_create('wpkh(' + xprv + hardened_path + '/0/*)'),
             'timestamp': 1296688602,
         }])
-        expected = {'desc': descsum_create('wpkh([80002067' + hardened_path + ']' + xpub_acc + '/0/*)'),
-                    'timestamp': 1296688602,
-                    'active': False,
-                    'range': [0, 0],
-                    'next': 0}
-        assert_equal([expected], wallet.listdescriptors())
+        expected = {
+            'wallet_name': 'w2',
+            'descriptors': [
+                {'desc': descsum_create('wpkh([80002067' + hardened_path + ']' + xpub_acc + '/0/*)'),
+                 'timestamp': 1296688602,
+                 'active': False,
+                 'range': [0, 0],
+                 'next': 0},
+            ],
+        }
+        assert_equal(expected, wallet.listdescriptors())
 
         self.log.info('Test non-active non-range combo descriptor')
         node.createwallet(wallet_name='w4', blank=True, descriptors=True)
@@ -73,9 +79,14 @@ class ListDescriptorsTest(BitcoinTestFramework):
             'desc': descsum_create('combo(' + node.get_deterministic_priv_key().key + ')'),
             'timestamp': 1296688602,
         }])
-        expected = [{'active': False,
-                     'desc': 'combo(0227d85ba011276cf25b51df6a188b75e604b38770a462b2d0e9fb2fc839ef5d3f)#np574htj',
-                     'timestamp': 1296688602}]
+        expected = {
+            'wallet_name': 'w4',
+            'descriptors': [
+                {'active': False,
+                 'desc': 'combo(0227d85ba011276cf25b51df6a188b75e604b38770a462b2d0e9fb2fc839ef5d3f)#np574htj',
+                 'timestamp': 1296688602},
+            ]
+        }
         assert_equal(expected, wallet.listdescriptors())
 
 


### PR DESCRIPTION
Update `listdescriptors` response format according to [RPC interface guidelines](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#rpc-interface-guidelines).

This is a follow up for #20226

**Before:**
```
Result:
[                               (json array) Response is an array of descriptor objects
  {                             (json object)
    "desc" : "str",             (string) Descriptor string representation
    "timestamp" : n,            (numeric) The creation time of the descriptor
    "active" : true|false,      (boolean) Activeness flag
    "internal" : true|false,    (boolean, optional) Whether this is internal or external descriptor; defined only for active descriptors
    "range" : [                 (json array, optional) Defined only for ranged descriptors
      n,                        (numeric) Range start inclusive
      n                         (numeric) Range end inclusive
    ],
    "next" : n                  (numeric, optional) The next index to generate addresses from; defined only for ranged descriptors
  },
  ...
]
```

**After:**
```
Result:
{                                 (json object)
  "wallet_name" : "str",          (string) Name of wallet this operation was performed on
  "descriptors" : [               (json array) Array of descriptor objects
    {                             (json object)
      "desc" : "str",             (string) Descriptor string representation
      "timestamp" : n,            (numeric) The creation time of the descriptor
      "active" : true|false,      (boolean) Activeness flag
      "internal" : true|false,    (boolean, optional) Whether this is internal or external descriptor; defined only for active descriptors
      "range" : [                 (json array, optional) Defined only for ranged descriptors
        n,                        (numeric) Range start inclusive
        n                         (numeric) Range end inclusive
      ],
      "next" : n                  (numeric, optional) The next index to generate addresses from; defined only for ranged descriptors
    },
    ...
  ]
}
```