### PR TITLE
Fix whitepaper link in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ software which enables the use of this currency.
 
 For more information, as well as an immediately usable, binary version of
 the Bitcoin Core software, see https://bitcoincore.org/en/download/, or read the
-[original whitepaper](https://bitcoincore.org/bitcoin.pdf).
+[original whitepaper](https://bitcoin.org/bitcoin.pdf).
 
 License
 -------


### PR DESCRIPTION
Fixes the link in the readme to point to bitcoin.org's hosted whitepaper as it seems like bitcoincore.org has taken down the pdf.

Alternatively a maintainer of bitcoincore.org could reupload the whitepaper there.