### PR TITLE
wallet: check when create wallets for the reserved name "wallets"

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -420,7 +420,8 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             n = self.nodes[i]
             if wallet_name is not None:
                 n.createwallet(wallet_name=wallet_name, descriptors=self.options.descriptors, load_on_startup=True)
-            n.importprivkey(privkey=n.get_deterministic_priv_key().key, label='coinbase')
+            if self.chain != "main":
+                n.importprivkey(privkey=n.get_deterministic_priv_key().key, label='coinbase')
 
     def run_test(self):
         """Tests must override this method to define test logic"""

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -399,7 +399,10 @@ def get_auth_cookie(datadir, chain):
                     assert password is None  # Ensure that there is only one rpcpassword line
                     password = line.split("=")[1].strip("\n")
     try:
-        with open(os.path.join(datadir, chain, ".cookie"), 'r', encoding="ascii") as f:
+        subdir = chain
+        if subdir == "main":
+            subdir = ""
+        with open(os.path.join(datadir, subdir, ".cookie"), 'r', encoding="ascii") as f:
             userpass = f.read()
             split_userpass = userpass.split(':')
             user = split_userpass[0]
@@ -413,7 +416,10 @@ def get_auth_cookie(datadir, chain):
 
 # If a cookie file exists in the given datadir, delete it.
 def delete_cookie_file(datadir, chain):
-    if os.path.isfile(os.path.join(datadir, chain, ".cookie")):
+    subdir = chain
+    if chain == "main":
+        subdir = ""
+    if os.path.isfile(os.path.join(datadir, subdir, ".cookie")):
         logger.debug("Deleting leftover cookie file")
         os.remove(os.path.join(datadir, chain, ".cookie"))
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -111,6 +111,7 @@ BASE_SCRIPTS = [
     'wallet_listtransactions.py --legacy-wallet',
     'wallet_listtransactions.py --descriptors',
     'feature_taproot.py',
+    'wallet_mainnet_test.py',
     # vv Tests less than 60s vv
     'p2p_sendheaders.py',
     'wallet_importmulti.py --legacy-wallet',

--- a/test/functional/wallet_mainnet_test.py
+++ b/test/functional/wallet_mainnet_test.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test if on mainnet wallets can vanish inaccessible.
+
+Verify that a bitcoind mainnet node will not loose wallets on new startup
+"""
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+
+class WalletSanityTest(BitcoinTestFramework):
+
+    def set_test_params(self):
+        self.chain = 'main'
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        self.log.info('test if we still have the original wallets key')
+        self.log.info(self.nodes[0].listwallets())
+        if self.nodes[0].listwallets() == []:
+            self.nodes[0].createwallet('')
+        assert_equal(self.nodes[0].listwallets(), [''])
+        self.nodes[0].createwallet('w1')
+        self.nodes[0].createwallet('w2')
+        assert_equal(self.nodes[0].listwallets(), ['', 'w1', 'w2'])
+        self.log.info(self.nodes[0].listwallets())
+        n = self.nodes[0].get_wallet_rpc('')
+        address = n.getnewaddress()
+        assert_raises_rpc_error(-4, "Please use a different walletname", self.nodes[0].createwallet, 'wallets')
+        n = self.nodes[0].get_wallet_rpc('')
+        self.log.info('now restart node')
+        self.restart_node(0)
+        self.log.info(self.nodes[0].listwallets())
+        n = self.nodes[0].get_wallet_rpc('')
+        self.log.info('now check if we still have the wallet and the key')
+        n.dumpprivkey(address)
+
+if __name__ == '__main__':
+    WalletSanityTest().main()


### PR DESCRIPTION
We allow since 0.17 to create a wallet with the the name or dirprefix :"wallets".

That might be not a good idea and we should discourage users to do that to prevent unexpected boating accidents and whale heart attacks.

edit@saibato
The wallets subdir is not created when chain == 'main' by default to allow the node to support upgrading or using older walletdirs or datadirs created by older core releases, 
testing could not catch this since this effects only mannet nodes, -regtest behave different and there we don't have this issue.