### PR TITLE
refactor: Treat ArgsManager::Flags as uint32_t explicitly

### DIFF
--- a/src/util/system.h
+++ b/src/util/system.h
@@ -166,7 +166,7 @@ struct SectionInfo
 class ArgsManager
 {
 public:
-    enum Flags {
+    enum Flags : uint32_t {
         // Boolean options can accept negation syntax -noOPTION or -noOPTION=1
         ALLOW_BOOL = 0x01,
         ALLOW_INT = 0x02,


### PR DESCRIPTION
The underlying type might be implementation defined, which is probably why the sanitizer kills the fuzz tests.

Fix that by pinning the underlying type.

This refactor does not change behaviour and only affects the sanitizer in tests.