### PR TITLE
test: enable self.chain = 'main' to work in python bitcoin test framework

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -403,7 +403,8 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             n = self.nodes[i]
             if wallet_name is not None:
                 n.createwallet(wallet_name=wallet_name, descriptors=self.options.descriptors, load_on_startup=True)
-            n.importprivkey(privkey=n.get_deterministic_priv_key().key, label='coinbase')
+            if self.chain != "main":
+                n.importprivkey(privkey=n.get_deterministic_priv_key().key, label='coinbase')
 
     def run_test(self):
         """Tests must override this method to define test logic"""

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -399,7 +399,10 @@ def get_auth_cookie(datadir, chain):
                     assert password is None  # Ensure that there is only one rpcpassword line
                     password = line.split("=")[1].strip("\n")
     try:
-        with open(os.path.join(datadir, chain, ".cookie"), 'r', encoding="ascii") as f:
+        subdir = chain
+        if subdir == "main":
+            subdir = ""
+        with open(os.path.join(datadir, subdir, ".cookie"), 'r', encoding="ascii") as f:
             userpass = f.read()
             split_userpass = userpass.split(':')
             user = split_userpass[0]
@@ -413,7 +416,10 @@ def get_auth_cookie(datadir, chain):
 
 # If a cookie file exists in the given datadir, delete it.
 def delete_cookie_file(datadir, chain):
-    if os.path.isfile(os.path.join(datadir, chain, ".cookie")):
+    subdir = chain
+    if chain == "main":
+        subdir = ""
+    if os.path.isfile(os.path.join(datadir, subdir, ".cookie")):
         logger.debug("Deleting leftover cookie file")
         os.remove(os.path.join(datadir, chain, ".cookie"))
 


### PR DESCRIPTION
mainchain and testchains could behave different.
So make sure we can now easy test also mainnet behavior.

Mainchain would fail until now because the key address pair where only for testnets and
the rpc cookie was placed assuming testnets in an inaccessible subdir for mainchain,

