### PR TITLE
guix: Jump forwards in time-machine and adapt 

### DIFF
--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -150,6 +150,7 @@ time-machine() {
     guix time-machine --url=https://github.com/dongcarl/guix.git \
                       --commit=b066c25026f21fb57677aa34692a5034338e7ee3 \
                       --max-jobs="$MAX_JOBS" \
+                      --keep-failed \
                       ${SUBSTITUTE_URLS:+--substitute-urls="$SUBSTITUTE_URLS"} \
                       ${ADDITIONAL_GUIX_COMMON_FLAGS} ${ADDITIONAL_GUIX_TIMEMACHINE_FLAGS} \
                       -- "$@"
@@ -259,6 +260,12 @@ EOF
         #     make the downloaded depends sources available to it. The sources
         #     should have been downloaded prior to this invocation.
         #
+        #   --keep-failed     keep build tree of failed builds
+        #
+        #     When builds of the Guix environment itself (not Bitcoin Core)
+        #     fail, it is useful for the build tree to be kept for debugging
+        #     purposes.
+        #
         #  ${SUBSTITUTE_URLS:+--substitute-urls="$SUBSTITUTE_URLS"}
         #
         #                     fetch substitute from SUBSTITUTE_URLS if they are
@@ -281,6 +288,7 @@ EOF
                                  ${SOURCES_PATH:+--share="$SOURCES_PATH"} \
                                  ${BASE_CACHE:+--share="$BASE_CACHE"} \
                                  --max-jobs="$MAX_JOBS" \
+                                 --keep-failed \
                                  ${SUBSTITUTE_URLS:+--substitute-urls="$SUBSTITUTE_URLS"} \
                                  ${ADDITIONAL_GUIX_COMMON_FLAGS} ${ADDITIONAL_GUIX_ENVIRONMENT_FLAGS} \
                                  -- env HOST="$host" \

--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -148,7 +148,7 @@ SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log --format=%at -1)}"
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://github.com/dongcarl/guix.git \
-                      --commit=b066c25026f21fb57677aa34692a5034338e7ee3 \
+                      --commit=7d6bd44da57926e0d4af25eba723a61c82beef98 \
                       --max-jobs="$MAX_JOBS" \
                       --keep-failed \
                       ${SUBSTITUTE_URLS:+--substitute-urls="$SUBSTITUTE_URLS"} \

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -44,6 +44,8 @@ store_path() {
 NATIVE_GCC="$(store_path gcc-toolchain)"
 export LIBRARY_PATH="${NATIVE_GCC}/lib:${NATIVE_GCC}/lib64"
 export CPATH="${NATIVE_GCC}/include"
+unset C_INCLUDE_PATH
+unset CPLUS_INCLUDE_PATH
 case "$HOST" in
     *darwin*)
         # When targeting darwin, some native tools built by depends require
@@ -66,7 +68,8 @@ case "$HOST" in
         # Determine output paths to use in CROSS_* environment variables
         CROSS_GLIBC="$(store_path "mingw-w64-x86_64-winpthreads")"
         CROSS_GCC="$(store_path "gcc-cross-${HOST}")"
-        CROSS_GCC_LIBS=( "${CROSS_GCC}/lib/gcc/${HOST}"/* ) # This expands to an array of directories...
+        CROSS_GCC_LIB_STORE="$(store_path "gcc-cross-${HOST}" lib)"
+        CROSS_GCC_LIBS=( "${CROSS_GCC_LIB_STORE}/lib/gcc/${HOST}"/* ) # This expands to an array of directories...
         CROSS_GCC_LIB="${CROSS_GCC_LIBS[0]}" # ...we just want the first one (there should only be one)
 
         # The search path ordering is generally:
@@ -75,7 +78,7 @@ case "$HOST" in
         #    2. kernel-header-related search paths (not applicable to mingw-w64 hosts)
         export CROSS_C_INCLUDE_PATH="${CROSS_GCC_LIB}/include:${CROSS_GCC_LIB}/include-fixed:${CROSS_GLIBC}/include"
         export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GCC}/include/c++/${HOST}:${CROSS_GCC}/include/c++/backward:${CROSS_C_INCLUDE_PATH}"
-        export CROSS_LIBRARY_PATH="${CROSS_GCC}/lib:${CROSS_GCC}/${HOST}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib"
+        export CROSS_LIBRARY_PATH="${CROSS_GCC_LIB_STORE}/lib:${CROSS_GCC}/${HOST}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib"
         ;;
     *darwin*)
         # The CROSS toolchain for darwin uses the SDK and ignores environment variables.
@@ -86,12 +89,13 @@ case "$HOST" in
         CROSS_GLIBC_STATIC="$(store_path "glibc-cross-${HOST}" static)"
         CROSS_KERNEL="$(store_path "linux-libre-headers-cross-${HOST}")"
         CROSS_GCC="$(store_path "gcc-cross-${HOST}")"
-        CROSS_GCC_LIBS=( "${CROSS_GCC}/lib/gcc/${HOST}"/* ) # This expands to an array of directories...
+        CROSS_GCC_LIB_STORE="$(store_path "gcc-cross-${HOST}" lib)"
+        CROSS_GCC_LIBS=( "${CROSS_GCC_LIB_STORE}/lib/gcc/${HOST}"/* ) # This expands to an array of directories...
         CROSS_GCC_LIB="${CROSS_GCC_LIBS[0]}" # ...we just want the first one (there should only be one)
 
         export CROSS_C_INCLUDE_PATH="${CROSS_GCC_LIB}/include:${CROSS_GCC_LIB}/include-fixed:${CROSS_GLIBC}/include:${CROSS_KERNEL}/include"
         export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GCC}/include/c++/${HOST}:${CROSS_GCC}/include/c++/backward:${CROSS_C_INCLUDE_PATH}"
-        export CROSS_LIBRARY_PATH="${CROSS_GCC}/lib:${CROSS_GCC}/${HOST}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib:${CROSS_GLIBC_STATIC}/lib"
+        export CROSS_LIBRARY_PATH="${CROSS_GCC_LIB_STORE}/lib:${CROSS_GCC}/${HOST}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib:${CROSS_GLIBC_STATIC}/lib"
         ;;
     *)
         exit 1 ;;

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -115,7 +115,8 @@ http://www.linuxfromscratch.org/hlfs/view/development/chapter05/gcc-pass1.html"
        `(("binutils" ,xbinutils)
          ("libc" ,xlibc)
          ("libc:static" ,xlibc "static")
-         ("gcc" ,xgcc)))
+         ("gcc" ,xgcc)
+         ("gcc-lib" ,xgcc "lib")))
       (synopsis (string-append "Complete GCC tool chain for " target))
       (description (string-append "This package provides a complete GCC tool
 chain for " target " development."))
@@ -159,7 +160,8 @@ desirable for building Bitcoin Core release binaries."
       (propagated-inputs
        `(("binutils" ,xbinutils)
          ("libc" ,pthreads-xlibc)
-         ("gcc" ,pthreads-xgcc)))
+         ("gcc" ,pthreads-xgcc)
+         ("gcc-lib" ,pthreads-xgcc "lib")))
       (synopsis (string-append "Complete GCC tool chain for " target))
       (description (string-append "This package provides a complete GCC tool
 chain for " target " development."))
@@ -219,7 +221,7 @@ chain for " target " development."))
         pkg-config
         ;; Scripting
         perl
-        python-3.7
+        python-3
         ;; Git
         git
         ;; Native gcc 7 toolchain
@@ -236,5 +238,5 @@ chain for " target " development."))
           ((string-contains target "-linux-")
            (list (make-bitcoin-cross-toolchain target)))
           ((string-contains target "darwin")
-           (list clang-8 libcap binutils imagemagick libtiff librsvg font-tuffy cmake-3.15.5 xorriso))
+           (list clang-8 libcap binutils imagemagick libtiff librsvg font-tuffy cmake xorriso))
           (else '())))))


### PR DESCRIPTION
```
The new time-machine commit is Guix v1.2.0 with a yet-unupstreamed patch
for NSIS.

A few important changes:

1. Guix switched back from using CPATH to C{,PLUS}_INCLUDE_PATH as the
   way to indicate #include search paths.
2. GCC's library is now split into a separate output, whereas before it
   was included in the default output. This means that our gcc toolchain
   packages need to propagate that output.
3. A few package versions were bumped
```

See this compare to review my custom patches to Guix: https://github.com/dongcarl/guix/compare/version-1.2.0...7d6bd44da57926e0d4af25eba723a61c82beef98