### PR TITLE
guix: Add support for powerpc64{,le}

### DIFF
--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -13,11 +13,9 @@ We achieve bootstrappability by using Guix as a functional package manager.
 
 Conservatively, a x86_64 machine with:
 
-- 4GB of free disk space on the partition that /gnu/store will reside in
-- 24GB of free disk space on the partition that the Bitcoin Core git repository
-  resides in
-
-> Note: these requirements are slightly less onerous than those of Gitian builds
+- 16GB of free disk space on the partition that /gnu/store will reside in
+- 8GB of free disk space per platform triple you're planning on building (see
+  the `HOSTS` environment variable description)
 
 ## Setup
 

--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -69,7 +69,7 @@ fi
 ################
 
 # Default to building for all supported HOSTs (overridable by environment)
-export HOSTS="${HOSTS:-x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu
+export HOSTS="${HOSTS:-x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu powerpc64-linux-gnu powerpc64le-linux-gnu
                        x86_64-w64-mingw32
                        x86_64-apple-darwin18}"
 
@@ -148,7 +148,7 @@ SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log --format=%at -1)}"
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://github.com/dongcarl/guix.git \
-                      --commit=7d6bd44da57926e0d4af25eba723a61c82beef98 \
+                      --commit=6c9d16db962a6f7155571b36eced681fd2889e23 \
                       --max-jobs="$MAX_JOBS" \
                       --keep-failed \
                       ${SUBSTITUTE_URLS:+--substitute-urls="$SUBSTITUTE_URLS"} \

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -136,12 +136,14 @@ case "$HOST" in
     *linux*)
         glibc_dynamic_linker=$(
             case "$HOST" in
-                i686-linux-gnu)      echo /lib/ld-linux.so.2 ;;
-                x86_64-linux-gnu)    echo /lib64/ld-linux-x86-64.so.2 ;;
-                arm-linux-gnueabihf) echo /lib/ld-linux-armhf.so.3 ;;
-                aarch64-linux-gnu)   echo /lib/ld-linux-aarch64.so.1 ;;
-                riscv64-linux-gnu)   echo /lib/ld-linux-riscv64-lp64d.so.1 ;;
-                *)                   exit 1 ;;
+                i686-linux-gnu)        echo /lib/ld-linux.so.2 ;;
+                x86_64-linux-gnu)      echo /lib64/ld-linux-x86-64.so.2 ;;
+                arm-linux-gnueabihf)   echo /lib/ld-linux-armhf.so.3 ;;
+                aarch64-linux-gnu)     echo /lib/ld-linux-aarch64.so.1 ;;
+                riscv64-linux-gnu)     echo /lib/ld-linux-riscv64-lp64d.so.1 ;;
+                powerpc64-linux-gnu)   echo /lib/ld64.so.1;;
+                powerpc64le-linux-gnu) echo /lib/ld64.so.2;;
+                *)                     exit 1 ;;
             esac
         )
         ;;
@@ -229,6 +231,10 @@ HOST_CXXFLAGS="$HOST_CFLAGS"
 case "$HOST" in
     *linux*)  HOST_LDFLAGS="-Wl,--as-needed -Wl,--dynamic-linker=$glibc_dynamic_linker -static-libstdc++ -Wl,-O2" ;;
     *mingw*)  HOST_LDFLAGS="-Wl,--no-insert-timestamp" ;;
+esac
+
+case "$HOST" in
+    powerpc64-linux-*) HOST_LDFLAGS="${HOST_LDFLAGS} -Wl,-z,noexecstack" ;;
 esac
 
 # Make $HOST-specific native binaries from depends available in $PATH

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -233,7 +233,10 @@ chain for " target " development."))
                  (make-mingw-pthreads-cross-toolchain "x86_64-w64-mingw32")
                  (make-nsis-with-sde-support nsis-x86_64)))
           ((string-contains target "riscv64-linux-")
-           (list (make-bitcoin-cross-toolchain "riscv64-linux-gnu"
+           (list (make-bitcoin-cross-toolchain target
+                                               #:base-gcc-for-libc gcc-7)))
+          ((string-contains target "powerpc64le-linux-")
+           (list (make-bitcoin-cross-toolchain target
                                                #:base-gcc-for-libc gcc-7)))
           ((string-contains target "-linux-")
            (list (make-bitcoin-cross-toolchain target)))


### PR DESCRIPTION
```
The new time-machine commit contains a few small changes that make the
powerpc cross-toolchain work.
```

See this compare to review my custom patches to Guix: https://github.com/dongcarl/guix/compare/7d6bd44da57926e0d4af25eba723a61c82beef98...6c9d16db962a6f7155571b36eced681fd2889e23