### PR TITLE
test: remove unused function xor_bytes

### DIFF
--- a/test/functional/test_framework/key.py
+++ b/test/functional/test_framework/key.py
@@ -20,10 +20,6 @@ def TaggedHash(tag, data):
     ss += data
     return hashlib.sha256(ss).digest()
 
-def xor_bytes(b0, b1):
-    assert len(b0) == len(b1)
-    return bytes(x ^ y for (x, y) in zip(b0, b1))
-
 def jacobi_symbol(n, k):
     """Compute the Jacobi symbol of n modulo k
 
@@ -510,7 +506,7 @@ class TestFrameworkKey(unittest.TestCase):
             if pubkey is not None:
                 keys[privkey] = pubkey
         for msg in byte_arrays:  # test every combination of message, signing key, verification key
-            for sign_privkey, sign_pubkey in keys.items():
+            for sign_privkey, _ in keys.items():
                 sig = sign_schnorr(sign_privkey, msg)
                 for verify_privkey, verify_pubkey in keys.items():
                     if verify_privkey == sign_privkey:


### PR DESCRIPTION
The function `xor_bytes` was introduced in commit 3c226639eb134314a0640d34e4ccb6148dbde22f (#19953, BIP340-342 validation), even [code-reviewed](https://github.com/bitcoin/bitcoin/pull/19953/files#r509383731), but actually never used. The [default signing algorithm in BIP340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#Default_Signing) needs a xor operation, but this step is currently done by a single xor operation on large integer operands:

```
t = (sec ^ int.from_bytes(TaggedHash("BIP0340/aux", aux), 'big')).to_bytes(32, 'big')
```

Alternatively, we could keep the function and as well use it:
```diff
--- a/test/functional/test_framework/key.py
+++ b/test/functional/test_framework/key.py
@@ -492,7 +492,7 @@ def sign_schnorr(key, msg, aux=None, flip_p=False, flip_r=False):
     P = SECP256K1.affine(SECP256K1.mul([(SECP256K1_G, sec)]))
     if SECP256K1.has_even_y(P) == flip_p:
         sec = SECP256K1_ORDER - sec
-    t = (sec ^ int.from_bytes(TaggedHash("BIP0340/aux", aux), 'big')).to_bytes(32, 'big')
+    t = xor_bytes(sec.to_bytes(32, 'big'), TaggedHash("BIP0340/aux", aux))
     kp = int.from_bytes(TaggedHash("BIP0340/nonce", t + P[0].to_bytes(32, 'big') + msg), 'big') % SECP256K1_ORDER
     assert kp != 0
     R = SECP256K1.affine(SECP256K1.mul([(SECP256K1_G, kp)]))
```