### PR TITLE
persist IBD latch across restarts

### DIFF
--- a/src/test/util/validation.cpp
+++ b/src/test/util/validation.cpp
@@ -11,6 +11,7 @@
 void TestChainState::ResetIbd()
 {
     m_cached_finished_ibd = false;
+    fs::remove(GetDataDir() / ".ibd_complete");
     assert(IsInitialBlockDownload());
 }
 


### PR DESCRIPTION
In the unlikely event that all or most of the listening nodes are restarted
into Initial Block Download mode the network might get stuck with little or
no listening nodes providing headers or blocks.

The timeout is intended to move nodes out of IBD so they will request and
serve blocks and headers to inbound peers.

Edit: By latching IBD across restarts we prevent the network from getting into this state at all.