### PR TITLE
test: remove type: comments in favour of actual annotations

### DIFF
--- a/test/functional/data/invalid_txs.py
+++ b/test/functional/data/invalid_txs.py
@@ -57,7 +57,7 @@ class BadTxTemplate:
     __metaclass__ = abc.ABCMeta
 
     # The expected error code given by bitcoind upon submission of the tx.
-    reject_reason = ""  # type: Optional[str]
+    reject_reason: Optional[str] = ""
 
     # Only specified if it differs from mempool acceptance error.
     block_reject_reason = ""

--- a/test/functional/p2p_message_capture.py
+++ b/test/functional/p2p_message_capture.py
@@ -42,14 +42,14 @@ def mini_parser(dat_file):
             if not tmp_header_raw:
                 break
             tmp_header = BytesIO(tmp_header_raw)
-            int.from_bytes(tmp_header.read(TIME_SIZE), "little")      # type: int
+            tmp_header.read(TIME_SIZE) # skip the timestamp field
             raw_msgtype = tmp_header.read(MSGTYPE_SIZE)
-            msgtype = raw_msgtype.split(b'\x00', 1)[0]     # type: bytes
+            msgtype: bytes = raw_msgtype.split(b'\x00', 1)[0]
             remainder =  raw_msgtype.split(b'\x00', 1)[1]
             assert(len(msgtype) > 0)
             assert(msgtype in MESSAGEMAP)
             assert(len(remainder) == 0 or not remainder.decode().isprintable())
-            length = int.from_bytes(tmp_header.read(LENGTH_SIZE), "little")  # type: int
+            length: int = int.from_bytes(tmp_header.read(LENGTH_SIZE), "little")
             data = f_in.read(length)
             assert_equal(len(data), length)
 

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -29,8 +29,6 @@ MAX_SCRIPT_ELEMENT_SIZE = 520
 LOCKTIME_THRESHOLD = 500000000
 ANNEX_TAG = 0x50
 
-OPCODE_NAMES = {}  # type: Dict[CScriptOp, str]
-
 LEAF_VERSION_TAPSCRIPT = 0xc0
 
 def hash160(s):
@@ -47,7 +45,6 @@ def bn2vch(v):
     # Serialize to bytes
     return encoded_v.to_bytes(n_bytes, 'little')
 
-_opcode_instances = []  # type: List[CScriptOp]
 class CScriptOp(int):
     """A single script opcode"""
     __slots__ = ()
@@ -110,6 +107,9 @@ class CScriptOp(int):
             assert len(_opcode_instances) == n
             _opcode_instances.append(super().__new__(cls, n))
             return _opcode_instances[n]
+
+OPCODE_NAMES: Dict[CScriptOp, str] = {}
+_opcode_instances: List[CScriptOp] = []
 
 # Populate opcode instance table
 for n in range(0xff + 1):


### PR DESCRIPTION
Now that we require Python 3.6+, we should be using variable type
annotations directly rather than `# type:` comments.

Also takes care of the discarded value issue in p2p_message_capture.py.
See: https://github.com/bitcoin/bitcoin/pull/19509/files#r571674446.