### PR TITLE
Improve OpenRC initscript

### DIFF
--- a/contrib/init/bitcoind.openrc
+++ b/contrib/init/bitcoind.openrc
@@ -60,9 +60,9 @@ start_pre() {
 	"${BITCOIND_PIDDIR}"
 
 	checkpath -f \
-	-o ${BITCOIND_USER}:${BITCOIND_GROUP} \
+	-o "${BITCOIND_USER}:${BITCOIND_GROUP}" \
 	-m 0660 \
-	${BITCOIND_CONFIGFILE}
+	"${BITCOIND_CONFIGFILE}"
 
 	checkconfig || return 1
 }

--- a/contrib/init/bitcoind.openrc
+++ b/contrib/init/bitcoind.openrc
@@ -69,7 +69,8 @@ start_pre() {
 
 checkconfig()
 {
-	if ! grep -qs '^rpcpassword=' "${BITCOIND_CONFIGFILE}" ; then
+	if grep -qs '^rpcuser=' "${BITCOIND_CONFIGFILE}" && \
+		! grep -qs '^rpcpassword=' "${BITCOIND_CONFIGFILE}" ; then
 		eerror ""
 		eerror "ERROR: You must set a secure rpcpassword to run bitcoind."
 		eerror "The setting must appear in ${BITCOIND_CONFIGFILE}"


### PR DESCRIPTION
This pull request improves the available OpenRC initscripts in
`contrib/init`.

The first commit (737feadff7c026412039774de0d10931fe0c5bcc) reworks
`checkconfig()` to not fail if **both** `rpcuser` and `rpcpassword`
are unset, because this implies that bitcoind shall use the `.cookie`
file for RPC authentication. Currently, the initscript does not allow
starting bitcoind without a set `rpcuser` and `rpcpassword`.

The second commit (95f97111dd27f32dfcb461c9dd6890aa8d1355ed) simply
quotes some unquoted variables.