### PR TITLE
test: Fix Windows cross build

### DIFF
--- a/src/test/fuzz/netaddress.cpp
+++ b/src/test/fuzz/netaddress.cpp
@@ -9,7 +9,6 @@
 
 #include <cassert>
 #include <cstdint>
-#include <netinet/in.h>
 #include <vector>
 
 FUZZ_TARGET(netaddress)

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -78,7 +78,9 @@ FUZZ_TARGET(string)
     }
     (void)SanitizeString(random_string_1);
     (void)SanitizeString(random_string_1, fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 3));
+#ifndef WIN32
     (void)ShellEscape(random_string_1);
+#endif // WIN32
     int port_out;
     std::string host_out;
     SplitHostPort(random_string_1, port_out, host_out);


### PR DESCRIPTION
On master (e51f6c4dee3d42b2707c31fa1c93a337b6bf5ba7, after #20936 merge), Windows cross compiling fails:
```
$ make > /dev/null
In file included from ./policy/fees.h:12,
                 from policy/fees.cpp:6:
policy/fees.cpp: In member function ‘unsigned int CBlockPolicyEstimator::HighestTargetTracked(FeeEstimateHorizon) const’:
./sync.h:232:104: warning: control reaches end of non-void function [-Wreturn-type]
  232 | #define LOCK(cs) DebugLock<decltype(cs)> PASTE2(criticalblock, __COUNTER__)(cs, #cs, __FILE__, __LINE__)
      |                                                                                                        ^
policy/fees.cpp:680:5: note: in expansion of macro ‘LOCK’
  680 |     LOCK(m_cs_fee_estimator);
      |     ^~~~
test/fuzz/netaddress.cpp:12:10: fatal error: netinet/in.h: No such file or directory
   12 | #include <netinet/in.h>
      |          ^~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [Makefile:13039: test/fuzz/fuzz-netaddress.o] Error 1
make[2]: *** Waiting for unfinished jobs....
libtool: warning: undefined symbols not allowed in x86_64-w64-mingw32 shared libraries; building static only
test/fuzz/string.cpp: In function ‘void string_fuzz_target(FuzzBufferType)’:
test/fuzz/string.cpp:81:11: error: ‘ShellEscape’ was not declared in this scope
   81 |     (void)ShellEscape(random_string_1);
      |           ^~~~~~~~~~~
make[2]: *** [Makefile:13543: test/fuzz/fuzz-string.o] Error 1
make[1]: *** [Makefile:15078: all-recursive] Error 1
make: *** [Makefile:812: all-recursive] Error 1
```

This PR fixes both of errors.