### PR TITLE
test: remove assert_blockchain_height

### DIFF
--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -29,9 +29,11 @@ Start three nodes:
       block 200. node2 will reject block 102 since it's assumed valid, but it
       isn't buried by at least two weeks' work.
 """
-import time
 
-from test_framework.blocktools import (create_block, create_coinbase)
+from test_framework.blocktools import (
+    create_block,
+    create_coinbase,
+)
 from test_framework.key import ECKey
 from test_framework.messages import (
     CBlockHeader,
@@ -77,24 +79,6 @@ class AssumeValidTest(BitcoinTestFramework):
                 p2p_conn.send_message(msg_block(self.blocks[i]))
             except IOError:
                 assert not p2p_conn.is_connected
-                break
-
-    def assert_blockchain_height(self, node, height):
-        """Wait until the blockchain is no longer advancing and verify it's reached the expected height."""
-        last_height = node.getblock(node.getbestblockhash())['height']
-        timeout = 10
-        while True:
-            time.sleep(0.25)
-            current_height = node.getblock(node.getbestblockhash())['height']
-            if current_height != last_height:
-                last_height = current_height
-                if timeout < 0:
-                    assert False, "blockchain too short after timeout: %d" % current_height
-                timeout -= 0.25
-                continue
-            elif current_height > height:
-                assert False, "blockchain too long: %d" % current_height
-            elif current_height == height:
                 break
 
     def run_test(self):
@@ -177,7 +161,8 @@ class AssumeValidTest(BitcoinTestFramework):
 
         # Send blocks to node0. Block 102 will be rejected.
         self.send_blocks_until_disconnected(p2p0)
-        self.assert_blockchain_height(self.nodes[0], 101)
+        self.wait_until(lambda: self.nodes[0].getblockcount() >= 101)
+        assert_equal(self.nodes[0].getblockcount(), 101)
 
         # Send all blocks to node1. All blocks will be accepted.
         for i in range(2202):
@@ -188,7 +173,8 @@ class AssumeValidTest(BitcoinTestFramework):
 
         # Send blocks to node2. Block 102 will be rejected.
         self.send_blocks_until_disconnected(p2p2)
-        self.assert_blockchain_height(self.nodes[2], 101)
+        self.wait_until(lambda: self.nodes[2].getblockcount() >= 101)
+        assert_equal(self.nodes[2].getblockcount(), 101)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This simplifies the code and solves intermittent timeouts caused by commit 0d39b5848a7a341cd2b958336861cdd4098e2616.

E.g. https://cirrus-ci.com/task/5196092369272832?command=ci#L3126

```
 test  2021-02-08T12:27:56.275000Z TestFramework (ERROR): Assertion failed 
                                   Traceback (most recent call last):
                                     File "/tmp/cirrus-ci-build/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/test/functional/test_framework/test_framework.py", line 127, in main
                                       self.run_test()
                                     File "/tmp/cirrus-ci-build/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/test/functional/feature_assumevalid.py", line 180, in run_test
                                       self.assert_blockchain_height(self.nodes[0], 101)
                                     File "/tmp/cirrus-ci-build/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/test/functional/feature_assumevalid.py", line 92, in assert_blockchain_height
                                       assert False, "blockchain too short after timeout: %d" % current_height
                                   AssertionError: blockchain too short after timeout: 101

