### PR TITLE
code style: Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# This is the top-most EditorConfig file.
+root = true
+
+# For all files.
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Source code files
+[*.{h,cpp,py,sh}]
+indent_size = 4
+
+# .cirrus.yml, .appveyor.yml, .fuzzbuzz.yml, etc.
+[*.yml]
+indent_size = 2
+
+# Makefiles
+[{*.am,Makefile.*.include}]
+indent_style = tab
+
+# Autoconf scripts
+[configure.ac]
+indent_size = 2


### PR DESCRIPTION
### Motivation

Developers are supposed to follow [Coding style](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#coding-style-general). However, [from time to time](https://github.com/bitcoin/bitcoin/pull/21075#discussion_r570125634) a PR is created and then its author is asked to change tabs to spaces, for example.

Introducing an `.editorconfig` file can mitigate these formatting issues.

### User story

A contributor wants to create a new PR. She clones Bitcoin Core repo, opens her editor, the editor loads `.editorconfig` rules and writes her patch with correct formatting rules. Less Coding Style issues is then discovered in the PR review process and thus less CI runs are needed.

### What is EditorConfig file?

https://editorconfig.org provides very well and concise explanation:

> What is EditorConfig?

> EditorConfig helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs. The EditorConfig project consists of a file format for defining coding styles and a collection of text editor plugins that enable editors to read the file format and adhere to defined styles. EditorConfig files are easily readable and they work nicely with version control systems.

### Support

`.editorconfig` is supported by many IDEs and text editors. Sometimes, the support is out of the box and sometimes a plugin is needed. However, for example, VS Code detects `.editorconfig` presence and automatically offers you to install the missing plugin.

See https://editorconfig.org/#pre-installed for details on support. To name a few:

* Visual Studio (out of the box) 
* VS Code (plugin)
* JetBrains IDEs (IntelliJ IDEA, PyCharm, etc.) (out of the box)
* Sublime Text (plugin)
* Emacs (plugin)
* Vim (plugin)

Not supported (AFAIK):

* [mcedit](https://github.com/MidnightCommander/mc)

### My editor does not support `.editorconfig`

Then nothing really changes for you.

### `.editorconfig` vs `.clang-format`

As explained [here](https://devblogs.microsoft.com/cppblog/clangformat-support-in-visual-studio-2017-15-7-preview-1/):

> Note that Visual Studio also supports EditorConfig, which works in a similar way. ClangFormat, however, has a [much larger variety of style options](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) than EditorConfig, including some very C++ specific rules that can be set, and it is already used by C++ developers today.

Having both `.editorconfig` and `.clang-format` in a project, may not always work correctly though, I think. As some editors may have a plugin for `.editorconfig` and a plugin for `clang-formatter` which may not work correctly in unison. In VS Code & Visual Studio EditorConfig [takes precedence over other settings](https://github.com/MicrosoftDocs/visualstudio-docs/blob/master/docs/ide/cpp-editorconfig-properties.md#c-editorconfig-formatting-conventions).

### Possible issues

Your editor may change formatting for some 3rd party library if you edit the code. A solution for this would be to make EditorConfig rules more specific (include only certain paths). I'm not sure if it is an issue in practice.

### Testing

Add some trailing whitespace to a Python file and save the file. You should see that the trailing whitespace is removed.

### Possible future work

It would be great to define rules for Makefiles. This would be good start:

```
# Makefiles
[Makefile,*.am]
indent_style = tab
trim_trailing_whitespace = true
```

I don't know makefiles in this project good enough to propose something reasonable. If this PR is well received, it would be great to add it in this PR.

Also, there are actually many different file extensions and so the proposed `.editorconfig` file can be probably improved very much:

```powershell
Get-ChildItem -Recurse | % {$_.Extension.ToLower()} | sort | unique
```

<details><summary>Click to see the output</summary>


```
.1
.ac
.adoc
.am
.bash-completion
.bat
.bmp
.c
.cc
.cert
.cfg
.clang_complete
.clang-format
.cmake
.cmd
.cnf
.com
.conf
.cpp
.css
.csv
.doxyfile
.dtd
.empty
.exe
.exp
.gci
.gitattributes
.github
.gitignore
.gitmodules
.guess
.h
.hex
.hpp
.html
.icns
.ico
.idb
.ilk
.in
.include
.ini
.init
.ipp
.jam
.js
.json
.lastbuildstate
.lib
.list
.log
.m
.m4
.md
.mk
.mm
.moc
.obj
.openrc
.openrcconf
.patch
.pc
.pdb
.pl
.plist
.png
.po
.pro
.py
.python-version
.qbk
.qm
.qml
.qrc
.raw
.rb
.rc
.recipe
.res
.s
.sage
.sass
.scm
.scss
.service
.sgml
.sh
.sln
.spec
.sub
.supp
.svg
.targets
.td
.tlog
.ts
.tx
.txt
.ui
.user
.v2
.vcxproj
.verbatim
.vscode
.xml
.xpm
.xsl
.y
.yapf
.yml
.yy
```

</details>

Fixes #21092