### PR TITLE
test: remove unnecessary assignment in bdb

### DIFF
--- a/test/functional/test_framework/bdb.py
+++ b/test/functional/test_framework/bdb.py
@@ -51,7 +51,6 @@ def dump_leaf_page(data):
     page_info['pgno'] = pgno
     page_info['prev_pgno'] = prev_pgno
     page_info['next_pgno'] = next_pgno
-    page_info['entries'] = entries
     page_info['hf_offset'] = hf_offset
     page_info['level'] = level
     page_info['pg_type'] = pg_type


### PR DESCRIPTION
This PR removes the unnecessary assignment to page_info['entries'] on line 54 since there is another assignment for it in line 59.

I think a lint (#21096) would detect cases like this one.

