### PR TITLE
test: Change BOOST_CHECK to BOOST_CHECK_EQUAL for paths

### DIFF
--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -30,8 +30,8 @@ BOOST_AUTO_TEST_CASE(getwalletenv_file)
 
     std::string filename;
     std::shared_ptr<BerkeleyEnvironment> env = GetWalletEnv(file_path, filename);
-    BOOST_CHECK(filename == test_name);
-    BOOST_CHECK(env->Directory() == datadir);
+    BOOST_CHECK_EQUAL(filename, test_name);
+    BOOST_CHECK_EQUAL(env->Directory(), datadir);
 }
 
 BOOST_AUTO_TEST_CASE(getwalletenv_directory)
@@ -41,8 +41,8 @@ BOOST_AUTO_TEST_CASE(getwalletenv_directory)
 
     std::string filename;
     std::shared_ptr<BerkeleyEnvironment> env = GetWalletEnv(datadir, filename);
-    BOOST_CHECK(filename == expected_name);
-    BOOST_CHECK(env->Directory() == datadir);
+    BOOST_CHECK_EQUAL(filename, expected_name);
+    BOOST_CHECK_EQUAL(env->Directory(), datadir);
 }
 
 BOOST_AUTO_TEST_CASE(getwalletenv_g_dbenvs_multiple)

--- a/src/wallet/test/init_tests.cpp
+++ b/src/wallet/test/init_tests.cpp
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_default)
     BOOST_CHECK(result == true);
     fs::path walletdir = gArgs.GetArg("-walletdir", "");
     fs::path expected_path = fs::canonical(m_walletdir_path_cases["default"]);
-    BOOST_CHECK(walletdir == expected_path);
+    BOOST_CHECK_EQUAL(walletdir, expected_path);
 }
 
 BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_custom)
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_custom)
     BOOST_CHECK(result == true);
     fs::path walletdir = gArgs.GetArg("-walletdir", "");
     fs::path expected_path = fs::canonical(m_walletdir_path_cases["custom"]);
-    BOOST_CHECK(walletdir == expected_path);
+    BOOST_CHECK_EQUAL(walletdir, expected_path);
 }
 
 BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_does_not_exist)
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_no_trailing)
     BOOST_CHECK(result == true);
     fs::path walletdir = gArgs.GetArg("-walletdir", "");
     fs::path expected_path = fs::canonical(m_walletdir_path_cases["default"]);
-    BOOST_CHECK(walletdir == expected_path);
+    BOOST_CHECK_EQUAL(walletdir, expected_path);
 }
 
 BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_no_trailing2)
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_no_trailing2)
     BOOST_CHECK(result == true);
     fs::path walletdir = gArgs.GetArg("-walletdir", "");
     fs::path expected_path = fs::canonical(m_walletdir_path_cases["default"]);
-    BOOST_CHECK(walletdir == expected_path);
+    BOOST_CHECK_EQUAL(walletdir, expected_path);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is useful to see mismatched values when a check fails as specified in the [Boost documentation](https://www.boost.org/doc/libs/1_71_0/libs/test/doc/html/boost_test/utf_reference/testing_tool_ref/assertion_boost_level.html).

This PR would make #20744 PR's diff smaller by a bit.