### PR TITLE
ci: Re-run wine tests once if they fail

### DIFF
--- a/ci/test/wrap-wine.sh
+++ b/ci/test/wrap-wine.sh
@@ -6,8 +6,6 @@
 
 export LC_ALL=C.UTF-8
 
-wine --version
-
 for b_name in {"${BASE_OUTDIR}/bin"/*,src/secp256k1/*tests,src/univalue/{no_nul,test_json,unitester,object}}.exe; do
     # shellcheck disable=SC2044
     for b in $(find "${BASE_ROOT_DIR}" -executable -type f -name "$(basename $b_name)"); do
@@ -15,7 +13,7 @@ for b_name in {"${BASE_OUTDIR}/bin"/*,src/secp256k1/*tests,src/univalue/{no_nul,
         echo "Wrap $b ..."
         mv "$b" "${b}_orig"
         echo '#!/usr/bin/env bash' > "$b"
-        echo "wine \"${b}_orig\" \"\$@\"" >> "$b"
+        echo "( wine \"${b}_orig\" \"\$@\" ) || ( sleep 1 && wine \"${b}_orig\" \"\$@\" )" >> "$b"
         chmod +x "$b"
       fi
     done


### PR DESCRIPTION
Works around the intermittent wine issue: https://github.com/bitcoin/bitcoin/issues/21122#issuecomment-776517563