### PR TITLE
validation/coins: limit MemPoolAccept access to coins cache + make it responsible for uncaching

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -196,14 +196,14 @@ struct MempoolAcceptResult {
         VALID, //!> Fully validated, valid.
         INVALID, //!> Invalid.
     };
-    ResultType m_result_type;
-    TxValidationState m_state;
+    const ResultType m_result_type;
+    const TxValidationState m_state;
 
     // The following fields are only present when m_result_type = ResultType::VALID
     /** Mempool transactions replaced by the tx per BIP 125 rules. */
-    std::optional<std::list<CTransactionRef>> m_replaced_transactions;
-    /** Raw base fees. */
-    std::optional<CAmount> m_base_fees;
+    const std::optional<std::list<CTransactionRef>> m_replaced_transactions;
+    /** Raw base fees in satoshis. */
+    const std::optional<CAmount> m_base_fees;
 
     /** Constructor for failure case */
     explicit MempoolAcceptResult(TxValidationState state)
@@ -214,7 +214,7 @@ struct MempoolAcceptResult {
 
     /** Constructor for success case */
     explicit MempoolAcceptResult(std::list<CTransactionRef>&& replaced_txns, CAmount fees)
-        : m_result_type(ResultType::VALID), m_state(TxValidationState{}),
+        : m_result_type(ResultType::VALID), m_state{},
         m_replaced_transactions(std::move(replaced_txns)), m_base_fees(fees) {}
 };
 


### PR DESCRIPTION
This PR is a subpart of #20833 which enables package validation through `testmempoolaccept`.
The first commit addresses some leftover comments from #21062.


When validating unconfirmed transactions, we want to account for all coins brought in from disk so we can uncache them if the tx is invalid. The disconnection of `CCoinsView`s right now doesn't quite achieve what's it's trying to do (prevent `MemPoolAccept` from unnecessarily accessing the coins cache and forgetting to uncache later). This PR improves it by doing 2 things:
(1) Disconnect `m_viewmempool` from the coins cache when we don't need it to be connected.
(2) Make `MemPoolAccept` destructor clean up after itself by uncaching coins accessed, instead of leaving it up to the caller. Only leave the coins cached when a transaction is accepted to mempool. In the future, if someone edits the `MemPoolAccept` class and forgets to consider uncaching, the default behavior is to uncache (which is safer).