### PR TITLE
test: fix sign comparison warning in socket tests

### DIFF
--- a/src/test/sock_tests.cpp
+++ b/src/test/sock_tests.cpp
@@ -95,7 +95,7 @@ static void CreateSocketPair(int s[2])
 static void SendAndRecvMessage(const Sock& sender, const Sock& receiver)
 {
     const char* msg = "abcd";
-    constexpr size_t msg_len = 4;
+    constexpr ssize_t msg_len = 4;
     char recv_buf[10];
 
     BOOST_CHECK_EQUAL(sender.Send(msg, msg_len, 0), msg_len);


### PR DESCRIPTION
This fixes:
```bash
In file included from test/sock_tests.cpp:10:
In file included from /usr/local/include/boost/test/unit_test.hpp:18:
In file included from /usr/local/include/boost/test/test_tools.hpp:46:
/usr/local/include/boost/test/tools/old/impl.hpp:107:17: warning: comparison of integers of different signs: 'const long' and 'const unsigned long' [-Wsign-compare]
    return left == right;
           ~~~~ ^  ~~~~~
```

which was introduced in #20788.