### PR TITLE
Net Processing: Move RelayTransaction() into PeerManager

### DIFF
--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -47,6 +47,10 @@ public:
     /** Whether this node ignores txs received over p2p. */
     virtual bool IgnoresIncomingTxs() = 0;
 
+    /** Relay transaction to all peers. */
+    virtual void RelayTransaction(const uint256& txid, const uint256& wtxid, const CConnman& connman)
+        EXCLUSIVE_LOCKS_REQUIRED(cs_main) = 0;
+
     /** Send ping message to all peers */
     virtual void SendPings() = 0;
 
@@ -70,8 +74,5 @@ public:
     virtual void ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStream& vRecv,
                                 const std::chrono::microseconds time_received, const std::atomic<bool>& interruptMsgProc) = 0;
 };
-
-/** Relay transaction to every node */
-void RelayTransaction(const uint256& txid, const uint256& wtxid, const CConnman& connman) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 #endif // BITCOIN_NET_PROCESSING_H

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -48,7 +48,7 @@ public:
     virtual bool IgnoresIncomingTxs() = 0;
 
     /** Relay transaction to all peers. */
-    virtual void RelayTransaction(const uint256& txid, const uint256& wtxid, const CConnman& connman)
+    virtual void RelayTransaction(const uint256& txid, const uint256& wtxid)
         EXCLUSIVE_LOCKS_REQUIRED(cs_main) = 0;
 
     /** Send ping message to all peers */

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -32,6 +32,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
     // node.connman is assigned both before chain clients and before RPC server is accepting calls,
     // and reset after chain clients and RPC sever are stopped. node.connman should never be null here.
     assert(node.connman);
+    assert(node.peerman);
     assert(node.mempool);
     std::promise<void> promise;
     uint256 hashTx = tx->GetHash();
@@ -100,7 +101,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
         node.mempool->AddUnbroadcastTx(hashTx);
 
         LOCK(cs_main);
-        RelayTransaction(hashTx, tx->GetWitnessHash(), *node.connman);
+        node.peerman->RelayTransaction(hashTx, tx->GetWitnessHash(), *node.connman);
     }
 
     return TransactionError::OK;

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -29,9 +29,8 @@ static TransactionError HandleATMPError(const TxValidationState& state, std::str
 TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef tx, std::string& err_string, const CAmount& max_tx_fee, bool relay, bool wait_callback)
 {
     // BroadcastTransaction can be called by either sendrawtransaction RPC or wallet RPCs.
-    // node.connman is assigned both before chain clients and before RPC server is accepting calls,
-    // and reset after chain clients and RPC sever are stopped. node.connman should never be null here.
-    assert(node.connman);
+    // node.peerman is assigned both before chain clients and before RPC server is accepting calls,
+    // and reset after chain clients and RPC sever are stopped. node.peerman should never be null here.
     assert(node.peerman);
     assert(node.mempool);
     std::promise<void> promise;
@@ -101,7 +100,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
         node.mempool->AddUnbroadcastTx(hashTx);
 
         LOCK(cs_main);
-        node.peerman->RelayTransaction(hashTx, tx->GetWitnessHash(), *node.connman);
+        node.peerman->RelayTransaction(hashTx, tx->GetWitnessHash());
     }
 
     return TransactionError::OK;


### PR DESCRIPTION
This is the first part of #21160. It moves the RelayTransaction() function to be a member function of the PeerManager class. This is required in order to move the transaction inventory data into the Peer object, since Peer objects are only accessible from within PeerManager.