### PR TITLE
test: Use mocktime in test_seed_peers

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1813,7 +1813,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
                 LOCK2(m_addr_fetches_mutex, cs_vAddedNodes);
                 if (m_addr_fetches.empty() && vAddedNodes.empty()) {
                     add_fixed_seeds_now = true;
-                    LogPrintf("Adding fixed seeds as -dnsseed=0, -addnode is not provided and and all -seednode(s) attempted\n");
+                    LogPrintf("Adding fixed seeds as -dnsseed=0, -addnode is not provided and all -seednode(s) attempted\n");
                 }
             }
 

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -172,7 +172,7 @@ class ConfArgsTest(BitcoinTestFramework):
         with self.nodes[0].assert_debug_log(expected_msgs=[
                 "Loaded 0 addresses from peers.dat",
                 "DNS seeding disabled",
-                "Adding fixed seeds as -dnsseed=0, -addnode is not provided and and all -seednode(s) attempted\n"]):
+                "Adding fixed seeds as -dnsseed=0, -addnode is not provided and all -seednode(s) attempted\n"]):
             self.start_node(0, extra_args=['-dnsseed=0'])
         assert time.time() - start < 60
         self.stop_node(0)

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -149,20 +149,21 @@ class ConfArgsTest(BitcoinTestFramework):
         self.stop_node(0)
 
     def test_seed_peers(self):
-        self.log.info('Test seed peers, this will take about 2 minutes')
+        self.log.info('Test seed peers')
         default_data_dir = self.nodes[0].datadir
 
         # No peers.dat exists and -dnsseed=1
         # We expect the node will use DNS Seeds, but Regtest mode has 0 DNS seeds
         # So after 60 seconds, the node should fallback to fixed seeds (this is a slow test)
         assert not os.path.exists(os.path.join(default_data_dir, "peers.dat"))
-        start = time.time()
+        start = int(time.time())
         with self.nodes[0].assert_debug_log(expected_msgs=[
                 "Loaded 0 addresses from peers.dat",
-                "0 addresses found from DNS seeds",
-                "Adding fixed seeds as 60 seconds have passed and addrman is empty"], timeout=80):
-            self.start_node(0, extra_args=['-dnsseed=1'])
-        assert time.time() - start >= 60
+                "0 addresses found from DNS seeds"]):
+            self.start_node(0, extra_args=['-dnsseed=1 -mocktime={}'.format(start)])
+        with self.nodes[0].assert_debug_log(expected_msgs=[
+                "Adding fixed seeds as 60 seconds have passed and addrman is empty"]):
+            self.nodes[0].setmocktime(start + 65)
         self.stop_node(0)
 
         # No peers.dat exists and -dnsseed=0
@@ -192,14 +193,14 @@ class ConfArgsTest(BitcoinTestFramework):
         # No peers.dat exists and -dnsseed=0, but a -addnode is provided
         # We expect the node will allow 60 seconds prior to using fixed seeds
         assert not os.path.exists(os.path.join(default_data_dir, "peers.dat"))
-        start = time.time()
+        start = int(time.time())
         with self.nodes[0].assert_debug_log(expected_msgs=[
                 "Loaded 0 addresses from peers.dat",
-                "DNS seeding disabled",
-                "Adding fixed seeds as 60 seconds have passed and addrman is empty"],
-                timeout=80):
-            self.start_node(0, extra_args=['-dnsseed=0', '-addnode=fakenodeaddr'])
-        assert time.time() - start >= 60
+                "DNS seeding disabled"]):
+            self.start_node(0, extra_args=['-dnsseed=0', '-addnode=fakenodeaddr -mocktime={}'.format(start)])
+        with self.nodes[0].assert_debug_log(expected_msgs=[
+                "Adding fixed seeds as 60 seconds have passed and addrman is empty"]):
+            self.nodes[0].setmocktime(start + 65)
         self.stop_node(0)
 
 


### PR DESCRIPTION
The test now takes less than 5 seconds instead of more than 2 minutes

Further context: https://github.com/bitcoin/bitcoin/pull/19884/files#r575336503

Before:
```
2021-02-12T17:22:25.980000Z TestFramework (INFO): Test seed peers, this will take about 2 minutes
2021-02-12T17:24:30.472000Z TestFramework (INFO): Test -networkactive option
```

After:
```
2021-02-12T17:33:39.224000Z TestFramework (INFO): Test seed peers
2021-02-12T17:33:43.139000Z TestFramework (INFO): Test -networkactive option
```