### PR TITLE
bench: Add benchmark to write JSON into a string

### DIFF
--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -12,25 +12,49 @@
 
 #include <univalue.h>
 
+namespace {
+
+struct TestBlockAndIndex {
+    TestingSetup test_setup{};
+    CBlock block{};
+    uint256 blockHash{};
+    CBlockIndex blockindex{};
+
+    TestBlockAndIndex()
+    {
+        CDataStream stream(benchmark::data::block413567, SER_NETWORK, PROTOCOL_VERSION);
+        char a = '\0';
+        stream.write(&a, 1); // Prevent compaction
+
+        stream >> block;
+
+        blockHash = block.GetHash();
+        blockindex.phashBlock = &blockHash;
+        blockindex.nBits = 403014710;
+    }
+};
+
+} // namespace
+
 static void BlockToJsonVerbose(benchmark::Bench& bench)
 {
-    TestingSetup test_setup{};
-
-    CDataStream stream(benchmark::data::block413567, SER_NETWORK, PROTOCOL_VERSION);
-    char a = '\0';
-    stream.write(&a, 1); // Prevent compaction
-
-    CBlock block;
-    stream >> block;
-
-    CBlockIndex blockindex;
-    const uint256 blockHash = block.GetHash();
-    blockindex.phashBlock = &blockHash;
-    blockindex.nBits = 403014710;
-
+    TestBlockAndIndex data;
     bench.run([&] {
-        (void)blockToJSON(block, &blockindex, &blockindex, /*verbose*/ true);
+        auto univalue = blockToJSON(data.block, &data.blockindex, &data.blockindex, /*verbose*/ true);
+        ankerl::nanobench::doNotOptimizeAway(univalue);
     });
 }
 
 BENCHMARK(BlockToJsonVerbose);
+
+static void BlockToJsonVerboseWrite(benchmark::Bench& bench)
+{
+    TestBlockAndIndex data;
+    auto univalue = blockToJSON(data.block, &data.blockindex, &data.blockindex, /*verbose*/ true);
+    bench.run([&] {
+        auto str = univalue.write();
+        ankerl::nanobench::doNotOptimizeAway(str);
+    });
+}
+
+BENCHMARK(BlockToJsonVerboseWrite);


### PR DESCRIPTION
The benchmark `BlockToJsonVerbose` only tests generating (and destroying)
the JSON data structure, but serializing into a string is also a
performance critical aspect of the RPC calls.

Extracts test setup into a `struct TestBlockAndIndex`, and uses it in 
both `BlockToJsonVerbose` and `BlockToJsonVerboseWrite`.

Also, use `ankerl::nanobench::doNotOptimizeAway` to make sure the compiler
can't optimize the result of the calls away.

Here are benchmark results on my Intel i7-8700:

|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|       71,807,017.00 |               13.93 |    0.4% |  555,782,961.00 |  220,788,645.00 |  2.517 | 102,279,341.00 |    0.4% |      0.80 | `BlockToJsonVerbose`
|       27,916,835.00 |               35.82 |    0.1% |  235,084,034.00 |   89,033,525.00 |  2.640 |  42,911,139.00 |    0.3% |      0.32 | `BlockToJsonVerboseWrite`
