### PR TITLE
p2p: if no anchors.dat file, log a message instead of an error

### DIFF
--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -167,7 +167,10 @@ void DumpAnchors(const fs::path& anchors_db_path, const std::vector<CAddress>& a
 std::vector<CAddress> ReadAnchors(const fs::path& anchors_db_path)
 {
     std::vector<CAddress> anchors;
-    if (DeserializeFileDB(anchors_db_path, anchors)) {
+    if (!fs::exists(anchors_db_path)) {
+        LogPrintf("Could not find anchors file %s\n", anchors_db_path);
+        anchors.clear();
+    } else if (DeserializeFileDB(anchors_db_path, anchors)) {
         LogPrintf("Loaded %i addresses from %s\n", anchors.size(), anchors_db_path.filename());
     } else {
         anchors.clear();


### PR DESCRIPTION
To not needlessly alarm users upgrading from v0.20 and earlier, log a message rather than an error if the `anchors.dat` file is missing. "ERROR: DeserializeFileDB" will still be printed if `anchors.dat` is found but cannot be read.  Motivation from this [user report](http://www.erisian.com.au/bitcoin-core-dev/log-2021-02-13.html#l-296).

before
```
2021-02-14T14:23:46Z ERROR: DeserializeFileDB: Failed to open file ~/.bitcoin/anchors.dat
2021-02-14T14:23:46Z 0 block-relay-only anchors will be tried for connections.
```
after
```
2021-02-15T06:53:56Z Could not find anchors file "~/.bitcoin/anchors.dat"
2021-02-15T06:53:56Z 0 block-relay-only anchors will be tried for connections.
```
