### PR TITLE
fuzz: Remove expensive and redundant muhash from crypto fuzz target

### DIFF
--- a/src/test/fuzz/crypto.cpp
+++ b/src/test/fuzz/crypto.cpp
@@ -4,7 +4,6 @@
 
 #include <crypto/hmac_sha256.h>
 #include <crypto/hmac_sha512.h>
-#include <crypto/muhash.h>
 #include <crypto/ripemd160.h>
 #include <crypto/sha1.h>
 #include <crypto/sha256.h>
@@ -36,7 +35,6 @@ FUZZ_TARGET(crypto)
     CSHA512 sha512;
     SHA3_256 sha3;
     CSipHasher sip_hasher{fuzzed_data_provider.ConsumeIntegral<uint64_t>(), fuzzed_data_provider.ConsumeIntegral<uint64_t>()};
-    MuHash3072 muhash;
 
     while (fuzzed_data_provider.ConsumeBool()) {
         CallOneOf(
@@ -63,12 +61,6 @@ FUZZ_TARGET(crypto)
                 (void)Hash(data);
                 (void)Hash160(data);
                 (void)sha512.Size();
-
-                if (fuzzed_data_provider.ConsumeBool()) {
-                    muhash *= MuHash3072(data);
-                } else {
-                    muhash /= MuHash3072(data);
-                }
             },
             [&] {
                 (void)hash160.Reset();
@@ -78,7 +70,6 @@ FUZZ_TARGET(crypto)
                 (void)sha256.Reset();
                 (void)sha3.Reset();
                 (void)sha512.Reset();
-                muhash = MuHash3072();
             },
             [&] {
                 CallOneOf(
@@ -122,10 +113,6 @@ FUZZ_TARGET(crypto)
                     [&] {
                         data.resize(SHA3_256::OUTPUT_SIZE);
                         sha3.Finalize(data);
-                    },
-                    [&] {
-                        uint256 out;
-                        muhash.Finalize(out);
                     });
             });
     }

--- a/src/test/fuzz/muhash.cpp
+++ b/src/test/fuzz/muhash.cpp
@@ -41,6 +41,11 @@ FUZZ_TARGET(muhash)
     muhash.Finalize(out2);
 
     assert(out == out2);
+    MuHash3072 muhash3;
+    muhash3 *= muhash;
+    uint256 out3;
+    muhash3.Finalize(out3);
+    assert(out == out3);
 
     // Test that removing all added elements brings the object back to it's initial state
     muhash /= muhash;
@@ -50,4 +55,9 @@ FUZZ_TARGET(muhash)
     muhash2.Finalize(out2);
 
     assert(out == out2);
+
+    muhash3.Remove(data);
+    muhash3.Remove(data2);
+    muhash3.Finalize(out3);
+    assert(out == out3);
 }


### PR DESCRIPTION
Remove because it is redundant with `src/test/fuzz/muhash.cpp` and incredibly expensive