### PR TITLE
doc: Rework internal and external links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ Bitcoin Core integration/staging tree
 
 https://bitcoincore.org
 
+For an immediately usable, binary version of the Bitcoin Core software, see
+https://bitcoincore.org/en/download/.
+
+Further information about Bitcoin Core is available in the [doc folder](/doc).
+
 What is Bitcoin?
 ----------------
 
@@ -12,9 +17,7 @@ with no central authority: managing transactions and issuing money are carried
 out collectively by the network. Bitcoin Core is the name of open source
 software which enables the use of this currency.
 
-For more information, as well as an immediately usable, binary version of
-the Bitcoin Core software, see https://bitcoincore.org/en/download/, or read the
-[original whitepaper](https://bitcoincore.org/bitcoin.pdf).
+For more information read the original Bitcoin whitepaper.
 
 License
 -------
@@ -53,7 +56,7 @@ submit new unit tests for old code. Unit tests can be compiled and run
 and extending unit tests can be found in [/src/test/README.md](/src/test/README.md).
 
 There are also [regression and integration tests](/test), written
-in Python, that are run automatically on the build server.
+in Python.
 These tests can be run (if the [test dependencies](/test) are installed) with: `test/functional/test_runner.py`
 
 The CI (Continuous Integration) systems make sure that every pull request is built for Windows, Linux, and macOS,
@@ -77,5 +80,3 @@ Translations are periodically pulled from Transifex and merged into the git repo
 
 **Important**: We do not accept translation changes as GitHub pull requests because the next
 pull from Transifex would automatically overwrite them again.
-
-Translators should also subscribe to the [mailing list](https://groups.google.com/forum/#!forum/bitcoin-translators).


### PR DESCRIPTION
Some minor changes:
* Move Bitcoin Core download link to the very top. *Reason:* The download link has nothing to do with the section that explains Bitcoin. Also, anyone quickly looking for the download link will find it faster.
* Add a new link to the doc folder. *Reason*: Apart from the documentation that is shipped with the binary software, the doc folder is the primary location for Bitcoin Core related documentation.
* Remove dead link to pdf. *Reason*: The pdf can be trivially found by asking a search engine.
* Remove reference to "build server". *Reason*: There is no "build server". The CI system is explained in the next sentence in detail.
* Remove dead? link to translation mailing list. *Reason*: The translation process is explained in `doc/translation_process.md`, no need to explain it in detail in the main readme.