### PR TITLE
test: Move P2WSH_OP_TRUE to shared test library

### DIFF
--- a/src/Makefile.test_util.include
+++ b/src/Makefile.test_util.include
@@ -12,6 +12,7 @@ TEST_UTIL_H = \
     test/util/logging.h \
     test/util/mining.h \
     test/util/net.h \
+    test/util/script.h \
     test/util/setup_common.h \
     test/util/str.h \
     test/util/transaction_utils.h \

--- a/src/test/util/script.h
+++ b/src/test/util/script.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_UTIL_SCRIPT_H
+#define BITCOIN_TEST_UTIL_SCRIPT_H
+
+#include <crypto/sha256.h>
+#include <script/script.h>
+
+static const std::vector<uint8_t> WITNESS_STACK_ELEM_OP_TRUE{uint8_t{OP_TRUE}};
+static const CScript P2WSH_OP_TRUE{
+    CScript{}
+    << OP_0
+    << ToByteVector([] {
+           uint256 hash;
+           CSHA256().Write(WITNESS_STACK_ELEM_OP_TRUE.data(), WITNESS_STACK_ELEM_OP_TRUE.size()).Finalize(hash.begin());
+           return hash;
+       }())};
+
+#endif // BITCOIN_TEST_UTIL_SCRIPT_H


### PR DESCRIPTION
Otherwise it can't be used in other tests (unit, fuzz, bench, ...)