### PR TITLE
[tools] Allow argument/parameter bin packing in clang-format

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -11,7 +11,8 @@ AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: true
-BinPackParameters: false
+BinPackArguments: true
+BinPackParameters: true
 BreakBeforeBinaryOperators: false
 BreakBeforeBraces: Custom
 BraceWrapping:


### PR DESCRIPTION
clang-format documentation for BinPackArguments:

If `false`, a function call’s arguments will either be all on the same line or will have one line each.

```
true:
void f() {
  f(aaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaa,
    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa);
}

false:
void f() {
  f(aaaaaaaaaaaaaaaaaaaa,
    aaaaaaaaaaaaaaaaaaaa,
    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa);
}
```

https://clang.llvm.org/docs/ClangFormatStyleOptions.html#configurable-format-style-options

There's no reason to forbid this format. Having multiple arguments or parameters per line can be just as readable as having one per line (and is certainly more readable than having extremely long lines).