### PR TITLE
log: Clarify log message when file does not exist

### DIFF
--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -109,15 +109,15 @@ template <typename Data>
 bool DeserializeFileDB(const fs::path& path, Data& data)
 {
     // open input file, and associate with CAutoFile
-    FILE *file = fsbridge::fopen(path, "rb");
+    FILE* file = fsbridge::fopen(path, "rb");
     CAutoFile filein(file, SER_DISK, CLIENT_VERSION);
-    if (filein.IsNull())
-        return error("%s: Failed to open file %s", __func__, path.string());
-
+    if (filein.IsNull()) {
+        LogPrintf("Missing or invalid file %s\n", path.string());
+        return false;
+    }
     return DeserializeDB(filein, data);
 }
-
-}
+} // namespace
 
 CBanDB::CBanDB(fs::path ban_list_path) : m_ban_list_path(std::move(ban_list_path))
 {

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -28,7 +28,7 @@ BanMan::BanMan(fs::path ban_file, CClientUIInterface* client_interface, int64_t 
         LogPrint(BCLog::NET, "Loaded %d banned node ips/subnets from banlist.dat  %dms\n",
             m_banned.size(), GetTimeMillis() - n_start);
     } else {
-        LogPrintf("Invalid or missing banlist.dat; recreating\n");
+        LogPrintf("Recreating banlist.dat\n");
         SetBannedSetDirty(true); // force write
         DumpBanlist();
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2391,7 +2391,7 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
             LogPrintf("Loaded %i addresses from peers.dat  %dms\n", addrman.size(), GetTimeMillis() - nStart);
         else {
             addrman.Clear(); // Addrman can be in an inconsistent state after failure, reset it
-            LogPrintf("Invalid or missing peers.dat; recreating\n");
+            LogPrintf("Recreating peers.dat\n");
             DumpAddresses();
         }
     }


### PR DESCRIPTION
Shorter and broader alternative to #21181 

Rendered diff:

```diff
@@ -1,4 +1,4 @@
-Bitcoin Core version v21.99.0-db656db2ed5a (release build)
+Bitcoin Core version v21.99.0-faf48f20f196 (release build)
 Qt 5.15.2 (dynamic), plugin=wayland (dynamic)
 No static plugins.
 Style: adwaita / Adwaita::Style
@@ -24,8 +24,8 @@ scheduler thread start
 Using wallet directory /tmp/test_001/regtest/wallets
 init message: Verifying wallet(s)...
 init message: Loading banlist...
-ERROR: DeserializeFileDB: Failed to open file /tmp/test_001/regtest/banlist.dat
-Invalid or missing banlist.dat; recreating
+Missing or invalid file /tmp/test_001/regtest/banlist.dat
+Recreating banlist.dat
 SetNetworkActive: true
 Failed to read fee estimates from /tmp/test_001/regtest/fee_estimates.dat. Continue anyway.
 Using /16 prefix for IP bucketing
@@ -63,9 +63,9 @@ Bound to [::]:18444
 Bound to 0.0.0.0:18444
 Bound to 127.0.0.1:18445
 init message: Loading P2P addresses...
-ERROR: DeserializeFileDB: Failed to open file /tmp/test_001/regtest/peers.dat
-Invalid or missing peers.dat; recreating
-ERROR: DeserializeFileDB: Failed to open file /tmp/test_001/regtest/anchors.dat
+Missing or invalid file /tmp/test_001/regtest/peers.dat
+Recreating peers.dat
+Missing or invalid file /tmp/test_001/regtest/anchors.dat
 0 block-relay-only anchors will be tried for connections.
 init message: Starting network threads...
 net thread start
