### PR TITLE
style: make clang-format break long lines

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -19,7 +19,7 @@ BraceWrapping:
   AfterFunction: true
 BreakBeforeTernaryOperators: false
 BreakConstructorInitializersBeforeComma: false
-ColumnLimit:     0
+ColumnLimit: 100
 CommentPragmas:  '^ IWYU pragma:'
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4


### PR DESCRIPTION
Without limit clang-format would join manually broken lines into a
single very long line, hindering readability.