### PR TITLE
[p2p] Halt processing of unrequested transactions

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -61,6 +61,14 @@ Notable changes
 P2P and network changes
 -----------------------
 
+- This release changes the behavior around processing of unrequested transactions.
+  Previously, a transaction message was always submitted for processing, even if a
+  getdata for this identifier have not been previously issued. Henceforth, such
+  unrequested transaction will be rejected without any processing to mitigate about
+  DoS risks. Bitcoin clients on the network relying on unannounced transaction broadcast
+  should adapt their tx-relay to the compliant tx-request sequence. Peers might be
+  authorized to bypass this check with the PF_RELAY permission. (#20277)
+
 Updated RPCs
 ------------
 - `getpeerinfo` no longer returns the following fields: `addnode`, `banscore`,

--- a/src/txrequest.cpp
+++ b/src/txrequest.cpp
@@ -678,6 +678,18 @@ public:
         if (it != m_index.get<ByPeer>().end()) MakeCompleted(m_index.project<ByTxHash>(it));
     }
 
+    bool ExpectedTx(NodeId peer, const uint256& txhash)
+    {
+        auto it_hash = m_index.get<ByTxHash>().lower_bound(ByTxHashView{txhash, State::REQUESTED, 0});
+        // We need to traverse all the REQUESTED/COMPLETED announcements to verify we effectively
+        // requested the txhash from this peer.
+        while (it_hash != m_index.get<ByTxHash>().end() && it_hash->m_txhash == txhash) {
+            if (it_hash->m_peer == peer) return true;
+            ++it_hash;
+        }
+        return false;
+    }
+
     size_t CountInFlight(NodeId peer) const
     {
         auto it = m_peerinfo.find(peer);
@@ -742,6 +754,11 @@ void TxRequestTracker::RequestedTx(NodeId peer, const uint256& txhash, std::chro
 void TxRequestTracker::ReceivedResponse(NodeId peer, const uint256& txhash)
 {
     m_impl->ReceivedResponse(peer, txhash);
+}
+
+bool TxRequestTracker::ExpectedTx(NodeId peer, const uint256& txhash)
+{
+    return m_impl->ExpectedTx(peer, txhash);
 }
 
 std::vector<GenTxid> TxRequestTracker::GetRequestable(NodeId peer, std::chrono::microseconds now,

--- a/src/txrequest.h
+++ b/src/txrequest.h
@@ -181,6 +181,9 @@ public:
      */
     void ReceivedResponse(NodeId peer, const uint256& txhash);
 
+    /** Find if a given txhash has been requested to this peer. */
+    bool ExpectedTx(NodeId peer, const uint256& txhash);
+
     // The operations below inspect the data structure.
 
     /** Count how many REQUESTED announcements a peer has. */


### PR DESCRIPTION
Split-off from #20277 

This PR halts the processing of unrequested transactions in Bitcoin at TX message reception. An unrequested transaction is one defined by which a "getdata" message for its specific identifier (either txid or wtxid) has not been previously issued by the node.

This change is motivated by reducing the CPU DoS surface of Bitcoin Core around mempool acceptance. Currently, an attacker can open multiple inbound connections to a node and send expensive to validate, junk transactions. Once the canonical INV/GETDATA sequence is enforced on the network, a further protection would be to deprioritize bandwidth and validation resources allocation, or even to wither connections with such DoSy peers. A permissioned peer (PF_RELAY) will still be able to bypass such restrictions.

Few high-level questions to go through :

* Is this change ease any privacy attack, such as transaction origin inference or tx-relay connection graph leaks ?
* Is this change ease observation of internal tx-requester configuration, such as preferred peers ?
* As one identified downside of this change is the potential breaking of tx-relay capabilities of non-compliant Bitcoin clients, should we offer them a wider adaptation period ?

See mailing proposal and discussions: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2021-February/018391.html

Note, our tx-relay functional test framework wasn't at all compliant with the canonical inv-getdata sequence. This change modifies some tx-relay tests by introducing INV-GETDATA sequence enforcement (`wait_for_getdata`). It comes with a meaningful delay of running the framework (e.g +4min to run `p2p_segwit.py`)

Better could be either to label such tested nodes with PF_RELAY and such bypass the new restriction but I fear it might mask some behaviors verified and silently break tests (e.g PF_RELAY impacts the max announcements per-peer buffer). Or either to switch the whitelisting of the new restriction under the more-scoped `PF_FORCERELAY` permission or even some new one (e.g `PF_FORCETXPROCESS`)  ?