### PR TITLE
doc: Remove dead whitepaper link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ out collectively by the network. Bitcoin Core is the name of open source
 software which enables the use of this currency.
 
 For more information, as well as an immediately usable, binary version of
-the Bitcoin Core software, see https://bitcoincore.org/en/download/, or read the
-[original whitepaper](https://bitcoincore.org/bitcoin.pdf).
+the Bitcoin Core software, see https://bitcoincore.org/en/download/.
 
 License
 -------


### PR DESCRIPTION
Issue: The bitcoin whitepaper link in the README file is dead.
Solution: Remove the dead link.