### PR TITLE
index: display specific error message when fatal index error occurs

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -23,7 +23,7 @@ static void FatalError(const char* fmt, const Args&... args)
     std::string strMessage = tfm::format(fmt, args...);
     SetMiscWarning(Untranslated(strMessage));
     LogPrintf("*** %s\n", strMessage);
-    AbortError(_("A fatal internal error occurred, see debug.log for details"));
+    AbortError(Untranslated(strMessage));
     StartShutdown();
 }
 


### PR DESCRIPTION
Pass specific fatal index error string into `AbortError` as opposed to generic error currently in place (see #21229 for more details)

Fixes #21229. 