### PR TITLE
guix: Add codesignature attachment support for osx+win

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -149,7 +149,7 @@ $(APP_DIST_DIR)/Applications:
 $(APP_DIST_EXTRAS): $(APP_DIST_DIR)/$(OSX_APP)/Contents/MacOS/Bitcoin-Qt
 
 $(OSX_TEMP_ISO): $(APP_DIST_EXTRAS)
-	$(XORRISOFS) -D -l -V "$(OSX_VOLNAME)" -no-pad -r -dir-mode 0755 -o $@ dist -- $(if $(SOURCE_DATE_EPOCH),-volume_date all_file_dates =$(SOURCE_DATE_EPOCH))
+	$(XORRISOFS) -D -l -V "$(OSX_VOLNAME)" -no-pad -r -dir-mode 0755 -o $@ $(APP_DIST_DIR) -- $(if $(SOURCE_DATE_EPOCH),-volume_date all_file_dates =$(SOURCE_DATE_EPOCH))
 
 $(OSX_DMG): $(OSX_TEMP_ISO)
 	$(DMG) dmg "$<" "$@"

--- a/contrib/guix/guix-codesign
+++ b/contrib/guix/guix-codesign
@@ -18,7 +18,26 @@ source "$(dirname "${BASH_SOURCE[0]}")/libexec/prelude.bash"
 # Required non-builtin commands should be invocable
 ################
 
-check_tools cat mkdir make git guix
+check_tools cat mkdir git guix
+
+################
+# Required env vars should be non-empty
+################
+
+cmd_usage() {
+    cat <<EOF
+Synopsis:
+
+    env DETACHED_SIGS_REPO=<path/to/bitcoin-detached-sigs> \\
+      ./contrib/guix/guix-codesign
+
+EOF
+}
+
+if [ -z "$DETACHED_SIGS_REPO" ]; then
+    cmd_usage
+    exit 1
+fi
 
 ################
 # GUIX_BUILD_OPTIONS should be empty
@@ -49,12 +68,12 @@ exit 1
 fi
 
 ################
-# The git worktree should not be dirty
+# The codesignature git worktree should not be dirty
 ################
 
-if ! git diff-index --quiet HEAD -- && [ -z "$FORCE_DIRTY_WORKTREE" ]; then
-cat << EOF
-ERR: The current git worktree is dirty, which may lead to broken builds.
+if ! git -C "$DETACHED_SIGS_REPO" diff-index --quiet HEAD -- && [ -z "$FORCE_DIRTY_WORKTREE" ]; then
+    cat << EOF
+ERR: The DETACHED CODESIGNATURE git worktree is dirty, which may lead to broken builds.
 
      Aborting...
 
@@ -64,26 +83,22 @@ Hint: To make your git worktree clean, You may want to:
       3. Set the 'FORCE_DIRTY_WORKTREE' environment variable if you insist on
          using a dirty worktree
 EOF
-exit 1
+    exit 1
 fi
-
-mkdir -p "$VERSION_BASE"
 
 ################
 # Build directories should not exist
 ################
 
 # Default to building for all supported HOSTs (overridable by environment)
-export HOSTS="${HOSTS:-x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu powerpc64-linux-gnu powerpc64le-linux-gnu
-                       x86_64-w64-mingw32
-                       x86_64-apple-darwin18}"
+export HOSTS="${HOSTS:-x86_64-w64-mingw32 x86_64-apple-darwin18}"
 
 # Usage: distsrc_for_host HOST
 #
 #   HOST: The current platform triple we're building for
 #
 distsrc_for_host() {
-    echo "${DISTSRC_BASE}/distsrc-${VERSION}-${1}"
+    echo "${DISTSRC_BASE}/distsrc-${VERSION}-${1}-codesigned"
 }
 
 # Accumulate a list of build directories that already exist...
@@ -120,23 +135,54 @@ else
     mkdir -p "$DISTSRC_BASE"
 fi
 
+
 ################
-# When building for darwin, the macOS SDK should exists
+# Unsigned tarballs SHOULD exist
 ################
 
-for host in $HOSTS; do
-    case "$host" in
+# Usage: outdir_for_host HOST SUFFIX
+#
+#   HOST: The current platform triple we're building for
+#
+outdir_for_host() {
+    echo "${OUTDIR_BASE}/${1}${2:+-${2}}"
+}
+
+
+unsigned_tarball_for_host() {
+    case "$1" in
+        *mingw*)
+            echo "$(outdir_for_host "$1")/${DISTNAME}-win-unsigned.tar.gz"
+            ;;
         *darwin*)
-            OSX_SDK="$(make -C "${PWD}/depends" --no-print-directory HOST="$host" print-OSX_SDK | sed 's@^[^=]\+=@@g')"
-            if [ -e "$OSX_SDK" ]; then
-                echo "Found macOS SDK at '${OSX_SDK}', using..."
-            else
-                echo "macOS SDK does not exist at '${OSX_SDK}', please place the extracted, untarred SDK there to perform darwin builds, exiting..."
-                exit 1
-            fi
+            echo "$(outdir_for_host "$1")/${DISTNAME}-osx-unsigned.tar.gz"
+            ;;
+        *)
+            exit 1
             ;;
     esac
+}
+
+# Accumulate a list of build directories that already exist...
+hosts_unsigned_tarball_missing=""
+for host in $HOSTS; do
+    if [ ! -e "$(unsigned_tarball_for_host "$host")" ]; then
+        hosts_unsigned_tarball_missing+=" ${host}"
+    fi
 done
+
+if [ -n "$hosts_unsigned_tarball_missing" ]; then
+    # ...so that we can print them out nicely in an error message
+    cat << EOF
+ERR: Unsigned tarballs do not exist
+...
+
+EOF
+for host in $hosts_unsigned_tarball_missing; do
+    echo "     ${host} '$(unsigned_tarball_for_host "$host")'"
+done
+exit 1
+fi
 
 ################
 # Check that we can connect to the guix-daemon
@@ -150,12 +196,12 @@ Hint: If this hangs, you may want to try turning your guix-daemon off and on
 
 EOF
 if ! guix gc --list-failures > /dev/null; then
-cat << EOF
+    cat << EOF
 
 ERR: Failed to connect to the guix-daemon, please ensure that one is running and
      reachable.
 EOF
-exit 1
+    exit 1
 fi
 
 # Developer note: we could use `guix repl` for this check and run:
@@ -173,19 +219,6 @@ fi
 # environment)
 JOBS="${JOBS:-$(nproc)}"
 
-# Usage: host_to_commonname HOST
-#
-#   HOST: The current platform triple we're building for
-#
-host_to_commonname() {
-    case "$1" in
-        *darwin*) echo osx ;;
-        *mingw*)  echo win ;;
-        *linux*)  echo linux ;;
-        *)        exit 1 ;;
-    esac
-}
-
 # Determine the reference time used for determinism (overridable by environment)
 SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log --format=%at -1)}"
 
@@ -194,86 +227,18 @@ SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log --format=%at -1)}"
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://github.com/dongcarl/guix.git \
-                      --commit=490e39ff303f4f6873a04bfb8253755bdae1b29c \
-                      --cores="$JOBS" \
-                      --keep-failed \
-                      --fallback \
-                      ${SUBSTITUTE_URLS:+--substitute-urls="$SUBSTITUTE_URLS"} \
-                      ${ADDITIONAL_GUIX_COMMON_FLAGS} ${ADDITIONAL_GUIX_TIMEMACHINE_FLAGS} \
-                      -- "$@"
+         --commit=490e39ff303f4f6873a04bfb8253755bdae1b29c \
+         --cores="$JOBS" \
+         --keep-failed \
+         --fallback \
+         ${SUBSTITUTE_URLS:+--substitute-urls="$SUBSTITUTE_URLS"} \
+         ${ADDITIONAL_GUIX_COMMON_FLAGS} ${ADDITIONAL_GUIX_TIMEMACHINE_FLAGS} \
+         -- "$@"
 }
-
-
-# Precious directories are those which should not be cleaned between successive
-# guix builds
-depends_precious_dir_names='SOURCES_PATH BASE_CACHE SDK_PATH'
-precious_dir_names="${depends_precious_dir_names} OUTDIR_BASE PROFILES_BASE"
-
-# Usage: contains IFS-SEPARATED-LIST ITEM
-contains() {
-    for i in ${1}; do
-        if [ "$i" = "${2}" ]; then
-            return 0  # Found!
-        fi
-    done
-    return 1
-}
-
-# If the user explicitly specified a precious directory, create it so we
-# can map it into the container
-for precious_dir_name in $precious_dir_names; do
-    precious_dir_path="${!precious_dir_name}"
-    if [ -n "$precious_dir_path" ]; then
-        if [ ! -e "$precious_dir_path" ]; then
-            mkdir -p "$precious_dir_path"
-        elif [ -L "$precious_dir_path" ]; then
-            echo "ERR: ${precious_dir_name} cannot be a symbolic link"
-            exit 1
-        elif [ ! -d "$precious_dir_path" ]; then
-            echo "ERR: ${precious_dir_name} must be a directory"
-            exit 1
-        fi
-    fi
-done
-
-mkdir -p "$VAR_BASE"
-
-# Record the _effective_ values of precious directories such that guix-clean can
-# avoid clobbering them if appropriate.
-#
-# shellcheck disable=SC2046,SC2086
-{
-    # Get depends precious dir definitions from depends
-    make -C "${PWD}/depends" \
-         --no-print-directory \
-         -- $(printf "print-%s\n" $depends_precious_dir_names)
-
-    # Get remaining precious dir definitions from the environment
-    for precious_dir_name in $precious_dir_names; do
-        precious_dir_path="${!precious_dir_name}"
-        if ! contains "$depends_precious_dir_names" "$precious_dir_name"; then
-            echo "${precious_dir_name}=${precious_dir_path}"
-        fi
-    done
-} > "${VAR_BASE}/precious_dirs"
 
 # Make sure an output directory exists for our builds
 OUTDIR_BASE="${OUTDIR_BASE:-${VERSION_BASE}/output}"
 mkdir -p "$OUTDIR_BASE"
-
-# Download the depends sources now as we won't have internet access in the build
-# container
-for host in $HOSTS; do
-    make -C "${PWD}/depends" -j"$JOBS" download-"$(host_to_commonname "$host")" ${V:+V=1} ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"}
-done
-
-# Usage: outdir_for_host HOST SUFFIX
-#
-#   HOST: The current platform triple we're building for
-#
-outdir_for_host() {
-    echo "${OUTDIR_BASE}/${1}${2:+-${2}}"
-}
 
 # Usage: profiledir_for_host HOST SUFFIX
 #
@@ -283,17 +248,16 @@ profiledir_for_host() {
     echo "${PROFILES_BASE}/${1}${2:+-${2}}"
 }
 
-
 #########
 # BUILD #
 #########
 
-# Function to be called when building for host ${1} and the user interrupts the
-# build
+# Function to be called when codesigning for host ${1} and the user interrupts
+# the codesign
 int_trap() {
 cat << EOF
-** INT received while building ${1}, you may want to clean up the relevant
-   work directories (e.g. distsrc-*) before rebuilding
+** INT received while codesigning ${1}, you may want to clean up the relevant
+   work directories (e.g. distsrc-*) before recodesigning
 
 Hint: To blow everything away, you may want to use:
 
@@ -320,16 +284,18 @@ for host in $HOSTS; do
 
         # shellcheck disable=SC2030
 cat << EOF
-INFO: Building ${VERSION:?not set} for platform triple ${HOST:?not set}:
+INFO: Codesigning ${VERSION:?not set} for platform triple ${HOST:?not set}:
       ...using reference timestamp: ${SOURCE_DATE_EPOCH:?not set}
-      ...running at most ${JOBS:?not set} jobs
       ...from worktree directory: '${PWD}'
           ...bind-mounted in container to: '/bitcoin'
       ...in build directory: '$(distsrc_for_host "$HOST")'
           ...bind-mounted in container to: '$(DISTSRC_BASE=/distsrc-base && distsrc_for_host "$HOST")'
-      ...outputting in: '$(outdir_for_host "$HOST")'
-          ...bind-mounted in container to: '$(OUTDIR_BASE=/outdir-base && outdir_for_host "$HOST")'
+      ...outputting in: '$(outdir_for_host "$HOST" codesigned)'
+          ...bind-mounted in container to: '$(OUTDIR_BASE=/outdir-base && outdir_for_host "$HOST" codesigned)'
+      ...using detached signatures in: '${DETACHED_SIGS_REPO:?not set}'
+          ...bind-mounted in container to: '/detached-sigs'
 EOF
+
 
         # Run the build script 'contrib/guix/libexec/build.sh' in the build
         # container specified by 'contrib/guix/manifest.scm'.
@@ -380,12 +346,6 @@ EOF
         #     make the downloaded depends sources available to it. The sources
         #     should have been downloaded prior to this invocation.
         #
-        #   --keep-failed     keep build tree of failed builds
-        #
-        #     When builds of the Guix environment itself (not Bitcoin Core)
-        #     fail, it is useful for the build tree to be kept for debugging
-        #     purposes.
-        #
         #  ${SUBSTITUTE_URLS:+--substitute-urls="$SUBSTITUTE_URLS"}
         #
         #                     fetch substitute from SUBSTITUTE_URLS if they are
@@ -404,15 +364,15 @@ EOF
                                  --share="$PWD"=/bitcoin \
                                  --share="$DISTSRC_BASE"=/distsrc-base \
                                  --share="$OUTDIR_BASE"=/outdir-base \
+                                 --share="$DETACHED_SIGS_REPO"=/detached-sigs \
                                  --expose="$(git rev-parse --git-common-dir)" \
+                                 --expose="$(git -C "$DETACHED_SIGS_REPO" rev-parse --git-common-dir)" \
                                  ${SOURCES_PATH:+--share="$SOURCES_PATH"} \
-                                 ${BASE_CACHE:+--share="$BASE_CACHE"} \
-                                 ${SDK_PATH:+--share="$SDK_PATH"} \
                                  --cores="$JOBS" \
                                  --keep-failed \
                                  --fallback \
                                  --link-profile \
-                                 --root="$(profiledir_for_host "${HOST}")" \
+                                 --root="$(profiledir_for_host "${HOST}" codesigned)" \
                                  ${SUBSTITUTE_URLS:+--substitute-urls="$SUBSTITUTE_URLS"} \
                                  ${ADDITIONAL_GUIX_COMMON_FLAGS} ${ADDITIONAL_GUIX_ENVIRONMENT_FLAGS} \
                                  -- env HOST="$host" \
@@ -421,12 +381,12 @@ EOF
                                         SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:?unable to determine value}" \
                                         ${V:+V=1} \
                                         ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"} \
-                                        ${BASE_CACHE:+BASE_CACHE="$BASE_CACHE"} \
-                                        ${SDK_PATH:+SDK_PATH="$SDK_PATH"} \
                                         DISTSRC="$(DISTSRC_BASE=/distsrc-base && distsrc_for_host "$HOST")" \
-                                        OUTDIR="$(OUTDIR_BASE=/outdir-base && outdir_for_host "$HOST")" \
+                                        OUTDIR="$(OUTDIR_BASE=/outdir-base && outdir_for_host "$HOST" codesigned)" \
                                         DIST_ARCHIVE_BASE=/outdir-base/dist-archive \
-                                      bash -c "cd /bitcoin && bash contrib/guix/libexec/build.sh"
+                                        DETACHED_SIGS_REPO=/detached-sigs \
+                                        UNSIGNED_TARBALL="$(OUTDIR_BASE=/outdir-base && unsigned_tarball_for_host "$HOST")" \
+                                      bash -c "cd /bitcoin && bash contrib/guix/libexec/codesign.sh"
     )
 
 done

--- a/contrib/guix/libexec/codesign.sh
+++ b/contrib/guix/libexec/codesign.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+export LC_ALL=C
+set -e -o pipefail
+export TZ=UTC
+
+# Although Guix _does_ set umask when building its own packages (in our case,
+# this is all packages in manifest.scm), it does not set it for `guix
+# environment`. It does make sense for at least `guix environment --container`
+# to set umask, so if that change gets merged upstream and we bump the
+# time-machine to a commit which includes the aforementioned change, we can
+# remove this line.
+#
+# This line should be placed before any commands which creates files.
+umask 0022
+
+if [ -n "$V" ]; then
+    # Print both unexpanded (-v) and expanded (-x) forms of commands as they are
+    # read from this file.
+    set -vx
+    # Set VERBOSE for CMake-based builds
+    export VERBOSE="$V"
+fi
+
+# Check that required environment variables are set
+cat << EOF
+Required environment variables as seen inside the container:
+    UNSIGNED_TARBALL: ${UNSIGNED_TARBALL:?not set}
+    DETACHED_SIGS_REPO: ${DETACHED_SIGS_REPO:?not set}
+    DIST_ARCHIVE_BASE: ${DIST_ARCHIVE_BASE:?not set}
+    DISTNAME: ${DISTNAME:?not set}
+    HOST: ${HOST:?not set}
+    SOURCE_DATE_EPOCH: ${SOURCE_DATE_EPOCH:?not set}
+    DISTSRC: ${DISTSRC:?not set}
+    OUTDIR: ${OUTDIR:?not set}
+EOF
+
+ACTUAL_OUTDIR="${OUTDIR}"
+OUTDIR="${DISTSRC}/output"
+
+git_head_version() {
+    local recent_tag
+    if recent_tag="$(git -C "$1" describe --exact-match HEAD 2> /dev/null)"; then
+        echo "${recent_tag#v}"
+    else
+        git -C "$1" rev-parse --short=12 HEAD
+    fi
+}
+
+CODESIGNATURE_GIT_ARCHIVE="${DIST_ARCHIVE_BASE}/${DISTNAME}-codesignatures-$(git_head_version "$DETACHED_SIGS_REPO").tar.gz"
+
+# Create the codesignature tarball if not already there
+if [ ! -e "$CODESIGNATURE_GIT_ARCHIVE" ]; then
+    mkdir -p "$(dirname "$CODESIGNATURE_GIT_ARCHIVE")"
+    git -C "$DETACHED_SIGS_REPO" archive --output="$CODESIGNATURE_GIT_ARCHIVE" HEAD
+fi
+
+mkdir -p "$OUTDIR"
+cat << EOF > "$OUTDIR"/inputs.SHA256SUMS
+$(sha256sum "$UNSIGNED_TARBALL" | cut -d' ' -f1)  inputs/$(basename "$UNSIGNED_TARBALL")
+$(sha256sum "$CODESIGNATURE_GIT_ARCHIVE" | cut -d' ' -f1)  inputs/$(basename "$CODESIGNATURE_GIT_ARCHIVE")
+EOF
+
+mkdir -p "$DISTSRC"
+(
+    cd "$DISTSRC"
+
+    tar -xf "$UNSIGNED_TARBALL"
+
+    mkdir -p codesignatures
+    tar -C codesignatures -xf "$CODESIGNATURE_GIT_ARCHIVE"
+
+    case "$HOST" in
+        *mingw*)
+            find "$PWD" -name "*-unsigned.exe" | while read -r infile; do
+                infile_base="$(basename "$infile")"
+
+                # Codesigned *-unsigned.exe and output to OUTDIR
+                osslsigncode attach-signature \
+                                 -in "$infile" \
+                                 -out "${OUTDIR}/${infile_base/-unsigned}" \
+                                 -sigin codesignatures/win/"$infile_base".pem
+            done
+            ;;
+        *darwin*)
+            # Apply detached codesignatures to dist/ (in-place)
+            signapple apply dist/Bitcoin-Qt.app codesignatures/osx/dist
+
+            # Make an uncompressed DMG from dist/
+            xorrisofs -D -l -V "$(< osx_volname)" -no-pad -r -dir-mode 0755 \
+                      -o uncompressed.dmg \
+                      dist \
+                      -- -volume_date all_file_dates ="$SOURCE_DATE_EPOCH"
+
+            # Compress uncompressed.dmg and output to OUTDIR
+            ./dmg dmg uncompressed.dmg "${OUTDIR}/${DISTNAME}-osx-signed.dmg"
+            ;;
+        *)
+            exit 1
+            ;;
+    esac
+)  # $DISTSRC
+
+mv --no-target-directory "$OUTDIR" "$ACTUAL_OUTDIR"

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -52,28 +52,28 @@ we link against libssp.so, and thus will ensure that this works properly.
 Taken from:
 http://www.linuxfromscratch.org/hlfs/view/development/chapter05/gcc-pass1.html"
   (package
-   (inherit xgcc)
-   (arguments
-    (substitute-keyword-arguments (package-arguments xgcc)
-      ((#:make-flags flags)
-       `(cons "gcc_cv_libc_provides_ssp=yes" ,flags))))))
+    (inherit xgcc)
+    (arguments
+     (substitute-keyword-arguments (package-arguments xgcc)
+       ((#:make-flags flags)
+        `(cons "gcc_cv_libc_provides_ssp=yes" ,flags))))))
 
 (define (make-gcc-rpath-link xgcc)
   "Given a XGCC package, return a modified package that replace each instance of
 -rpath in the default system spec that's inserted by Guix with -rpath-link"
   (package
-   (inherit xgcc)
-   (arguments
-    (substitute-keyword-arguments (package-arguments xgcc)
-      ((#:phases phases)
-       `(modify-phases ,phases
-          (add-after 'pre-configure 'replace-rpath-with-rpath-link
-            (lambda _
-              (substitute* (cons "gcc/config/rs6000/sysv4.h"
-                                 (find-files "gcc/config"
-                                             "^gnu-user.*\\.h$"))
-                (("-rpath=") "-rpath-link="))
-              #t))))))))
+    (inherit xgcc)
+    (arguments
+     (substitute-keyword-arguments (package-arguments xgcc)
+       ((#:phases phases)
+        `(modify-phases ,phases
+           (add-after 'pre-configure 'replace-rpath-with-rpath-link
+             (lambda _
+               (substitute* (cons "gcc/config/rs6000/sysv4.h"
+                                  (find-files "gcc/config"
+                                              "^gnu-user.*\\.h$"))
+                 (("-rpath=") "-rpath-link="))
+               #t))))))))
 
 (define (make-cross-toolchain target
                               base-gcc-for-libc
@@ -127,18 +127,18 @@ chain for " target " development."))
       (license (package-license xgcc)))))
 
 (define* (make-bitcoin-cross-toolchain target
-                                  #:key
-                                  (base-gcc-for-libc gcc-7)
-                                  (base-kernel-headers linux-libre-headers-5.4)
-                                  (base-libc glibc)  ; glibc 2.31
-                                  (base-gcc (make-gcc-rpath-link gcc-8)))
+                                       #:key
+                                       (base-gcc-for-libc gcc-7)
+                                       (base-kernel-headers linux-libre-headers-5.4)
+                                       (base-libc glibc)  ; glibc 2.31
+                                       (base-gcc (make-gcc-rpath-link gcc-8)))
   "Convenience wrapper around MAKE-CROSS-TOOLCHAIN with default values
 desirable for building Bitcoin Core release binaries."
   (make-cross-toolchain target
-                   base-gcc-for-libc
-                   base-kernel-headers
-                   base-libc
-                   base-gcc))
+                        base-gcc-for-libc
+                        base-kernel-headers
+                        base-libc
+                        base-gcc))
 
 (define (make-gcc-with-pthreads gcc)
   (package-with-extra-configure-variable gcc "--enable-threads" "posix"))
@@ -177,22 +177,22 @@ chain for " target " development."))
 
 (define-public font-tuffy
   (package
-   (name "font-tuffy")
-   (version "20120614")
-   (source
-    (origin
-     (method url-fetch)
-     (uri (string-append "http://tulrich.com/fonts/tuffy-" version ".tar.gz"))
-     (file-name (string-append name "-" version ".tar.gz"))
-     (sha256
-      (base32
-       "02vf72bgrp30vrbfhxjw82s115z27dwfgnmmzfb0n9wfhxxfpyf6"))))
-   (build-system font-build-system)
-   (home-page "http://tulrich.com/fonts/")
-   (synopsis "The Tuffy Truetype Font Family")
-   (description
-    "Thatcher Ulrich's first outline font design. He started with the goal of producing a neutral, readable sans-serif text font. There are lots of \"expressive\" fonts out there, but he wanted to start with something very plain and clean, something he might want to actually use. ")
-   (license license:public-domain)))
+    (name "font-tuffy")
+    (version "20120614")
+    (source
+     (origin
+       (method url-fetch)
+       (uri (string-append "http://tulrich.com/fonts/tuffy-" version ".tar.gz"))
+       (file-name (string-append name "-" version ".tar.gz"))
+       (sha256
+        (base32
+         "02vf72bgrp30vrbfhxjw82s115z27dwfgnmmzfb0n9wfhxxfpyf6"))))
+    (build-system font-build-system)
+    (home-page "http://tulrich.com/fonts/")
+    (synopsis "The Tuffy Truetype Font Family")
+    (description
+     "Thatcher Ulrich's first outline font design. He started with the goal of producing a neutral, readable sans-serif text font. There are lots of \"expressive\" fonts out there, but he wanted to start with something very plain and clean, something he might want to actually use. ")
+    (license license:public-domain)))
 
 (define-public lief
   (package

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -4,12 +4,14 @@
              (gnu packages base)
              (gnu packages bash)
              (gnu packages bison)
+             (gnu packages certs)
              (gnu packages cdrom)
              (gnu packages check)
              (gnu packages cmake)
              (gnu packages commencement)
              (gnu packages compression)
              (gnu packages cross-base)
+             (gnu packages curl)
              (gnu packages file)
              (gnu packages gawk)
              (gnu packages gcc)
@@ -23,7 +25,9 @@
              (gnu packages perl)
              (gnu packages pkg-config)
              (gnu packages python)
+             (gnu packages python-web)
              (gnu packages shells)
+             (gnu packages tls)
              (gnu packages version-control)
              (guix build-system font)
              (guix build-system gnu)
@@ -217,6 +221,337 @@ chain for " target " development."))
 parse, modify and abstract ELF, PE and MachO formats.")
    (license license:asl2.0)))
 
+(define osslsigncode
+  (package
+    (name "osslsigncode")
+    (version "2.0")
+    (source (origin
+              (method url-fetch)
+              (uri (string-append "https://github.com/mtrojnar/"
+                                  name "/archive/" version ".tar.gz"))
+              (sha256
+               (base32
+                "0byri6xny770wwb2nciq44j5071122l14bvv65axdd70nfjf0q2s"))))
+    (build-system gnu-build-system)
+    (native-inputs
+     `(("pkg-config" ,pkg-config)
+       ("autoconf" ,autoconf)
+       ("automake" ,automake)
+       ("libtool" ,libtool)))
+    (inputs
+     `(("openssl" ,openssl)))
+    (arguments
+     `(#:configure-flags
+       `("--without-gsf"
+         "--without-curl"
+         "--disable-dependency-tracking")))
+    (home-page "https://github.com/mtrojnar/osslsigncode")
+    (synopsis "Authenticode signing and timestamping tool")
+    (description "osslsigncode is a small tool that implements part of the
+functionality of the Microsoft tool signtool.exe - more exactly the Authenticode
+signing and timestamping. But osslsigncode is based on OpenSSL and cURL, and
+thus should be able to compile on most platforms where these exist.")
+    (license license:gpl3+))) ; license is with openssl exception
+
+(define-public python-asn1crypto
+  (package
+    (name "python-asn1crypto")
+    (version "1.4.0")
+    (source
+     (origin
+       (method git-fetch)
+       (uri (git-reference
+             (url "https://github.com/wbond/asn1crypto")
+             (commit version)))
+       (file-name (git-file-name name version))
+       (sha256
+        (base32
+         "19abibn6jw20mzi1ln4n9jjvpdka8ygm4m439hplyrdfqbvgm01r"))))
+    (build-system python-build-system)
+    (arguments
+     '(#:phases
+       (modify-phases %standard-phases
+         (replace 'check
+           (lambda _
+             (invoke "python" "run.py" "tests"))))))
+    (home-page "https://github.com/wbond/asn1crypto")
+    (synopsis "ASN.1 parser and serializer in Python")
+    (description "asn1crypto is an ASN.1 parser and serializer with definitions
+for private keys, public keys, certificates, CRL, OCSP, CMS, PKCS#3, PKCS#7,
+PKCS#8, PKCS#12, PKCS#5, X.509 and TSP.")
+    (license license:expat)))
+
+(define-public python-elfesteem
+  (let ((commit "87bbd79ab7e361004c98cc8601d4e5f029fd8bd5"))
+    (package
+      (name "python-elfesteem")
+      (version (git-version "0.1" "1" commit))
+      (source
+       (origin
+         (method git-fetch)
+         (uri (git-reference
+               (url "https://github.com/LRGH/elfesteem")
+               (commit commit)))
+         (file-name (git-file-name name commit))
+         (sha256
+          (base32
+           "1nyvjisvyxyxnd0023xjf5846xd03lwawp5pfzr8vrky7wwm5maz"))))
+      (build-system python-build-system)
+      ;; There are no tests, but attempting to run python setup.py test leads to
+      ;; PYTHONPATH problems, just disable the test
+      (arguments '(#:tests? #f))
+      (home-page "https://github.com/LRGH/elfesteem")
+      (synopsis "ELF/PE/Mach-O parsing library")
+      (description "elfesteem parses ELF, PE and Mach-O files.")
+      (license license:lgpl2.1))))
+
+(define-public python-oscrypto
+  (package
+    (name "python-oscrypto")
+    (version "1.2.1")
+    (source
+     (origin
+       (method git-fetch)
+       (uri (git-reference
+             (url "https://github.com/wbond/oscrypto")
+             (commit version)))
+       (file-name (git-file-name name version))
+       (sha256
+        (base32
+         "1d4d8s4z340qhvb3g5m5v3436y3a71yc26wk4749q64m09kxqc3l"))
+       (patches (search-our-patches "oscrypto-hard-code-openssl.patch"))))
+    (build-system python-build-system)
+    (native-search-paths
+     (list (search-path-specification
+            (variable "SSL_CERT_FILE")
+            (file-type 'regular)
+            (separator #f)                ;single entry
+            (files '("etc/ssl/certs/ca-certificates.crt")))))
+
+    (propagated-inputs
+     `(("python-asn1crypto" ,python-asn1crypto)
+       ("openssl" ,openssl)))
+    (arguments
+     `(#:phases
+       (modify-phases %standard-phases
+         (add-after 'unpack 'hard-code-path-to-libscrypt
+           (lambda* (#:key inputs #:allow-other-keys)
+             (let ((openssl (assoc-ref inputs "openssl")))
+               (substitute* "oscrypto/__init__.py"
+                 (("@GUIX_OSCRYPTO_USE_OPENSSL@")
+                  (string-append openssl "/lib/libcrypto.so" "," openssl "/lib/libssl.so")))
+               #t)))
+         (add-after 'unpack 'disable-broken-tests
+           (lambda _
+             ;; This test is broken as there is no keyboard interrupt.
+             (substitute* "tests/test_trust_list.py"
+               (("^(.*)class TrustListTests" line indent)
+                (string-append indent
+                               "@unittest.skip(\"Disabled by Guix\")\n"
+                               line)))
+             (substitute* "tests/test_tls.py"
+               (("^(.*)class TLSTests" line indent)
+                (string-append indent
+                               "@unittest.skip(\"Disabled by Guix\")\n"
+                               line)))
+             #t))
+         (replace 'check
+           (lambda _
+             (invoke "python" "run.py" "tests")
+             #t)))))
+    (home-page "https://github.com/wbond/oscrypto")
+    (synopsis "Compiler-free Python crypto library backed by the OS")
+    (description "oscrypto is a compilation-free, always up-to-date encryption library for Python.")
+    (license license:expat)))
+
+(define-public python-oscryptotests
+  (package (inherit python-oscrypto)
+    (name "python-oscryptotests")
+    (arguments
+     `(#:tests? #f
+       #:phases
+       (modify-phases %standard-phases
+         (add-after 'unpack 'hard-code-path-to-libscrypt
+           (lambda* (#:key inputs #:allow-other-keys)
+             (chdir "tests")
+             #t)))))))
+
+(define-public python-certvalidator
+  (let ((commit "e5bdb4bfcaa09fa0af355eb8867d00dfeecba08c"))
+    (package
+      (name "python-certvalidator")
+      (version (git-version "0.1" "1" commit))
+      (source
+       (origin
+         (method git-fetch)
+         (uri (git-reference
+               (url "https://github.com/achow101/certvalidator")
+               (commit commit)))
+         (file-name (git-file-name name commit))
+         (sha256
+          (base32
+           "18pvxkvpkfkzgvfylv0kx65pmxfcv1hpsg03cip93krfvrrl4c75"))))
+      (build-system python-build-system)
+      (propagated-inputs
+       `(("python-asn1crypto" ,python-asn1crypto)
+         ("python-oscrypto" ,python-oscrypto)
+         ("python-oscryptotests", python-oscryptotests))) ;; certvalidator tests import oscryptotests
+      (arguments
+       `(#:phases
+         (modify-phases %standard-phases
+           (add-after 'unpack 'disable-broken-tests
+             (lambda _
+               (substitute* "tests/test_certificate_validator.py"
+                 (("^(.*)class CertificateValidatorTests" line indent)
+                  (string-append indent
+                                 "@unittest.skip(\"Disabled by Guix\")\n"
+                                 line)))
+               (substitute* "tests/test_crl_client.py"
+                 (("^(.*)def test_fetch_crl" line indent)
+                  (string-append indent
+                                 "@unittest.skip(\"Disabled by Guix\")\n"
+                                 line)))
+               (substitute* "tests/test_ocsp_client.py"
+                 (("^(.*)def test_fetch_ocsp" line indent)
+                  (string-append indent
+                                 "@unittest.skip(\"Disabled by Guix\")\n"
+                                 line)))
+               (substitute* "tests/test_registry.py"
+                 (("^(.*)def test_build_paths" line indent)
+                  (string-append indent
+                                 "@unittest.skip(\"Disabled by Guix\")\n"
+                                 line)))
+               (substitute* "tests/test_validate.py"
+                 (("^(.*)def test_revocation_mode_hard" line indent)
+                  (string-append indent
+                                 "@unittest.skip(\"Disabled by Guix\")\n"
+                                 line)))
+               #t))
+           (replace 'check
+             (lambda _
+               (invoke "python" "run.py" "tests")
+               #t)))))
+      (home-page "https://github.com/wbond/certvalidator")
+      (synopsis "Python library for validating X.509 certificates and paths")
+      (description "certvalidator is a Python library for validating X.509
+certificates or paths. Supports various options, including: validation at a
+specific moment in time, whitelisting and revocation checks.")
+      (license license:expat))))
+
+(define-public python-requests-2.25.1
+  (package (inherit python-requests)
+    (version "2.25.1")
+    (source (origin
+              (method url-fetch)
+              (uri (pypi-uri "requests" version))
+              (sha256
+               (base32
+                "015qflyqsgsz09gnar69s6ga74ivq5kch69s4qxz3904m7a3v5r7"))))))
+
+(define-public python-altgraph
+  (package
+    (name "python-altgraph")
+    (version "0.17")
+    (source
+     (origin
+       (method git-fetch)
+       (uri (git-reference
+             (url "https://github.com/ronaldoussoren/altgraph")
+             (commit (string-append "v" version))))
+       (file-name (git-file-name name version))
+       (sha256
+        (base32
+         "09sm4srvvkw458pn48ga9q7ykr4xlz7q8gh1h9w7nxpf001qgpwb"))))
+    (build-system python-build-system)
+    (home-page "https://github.com/ronaldoussoren/altgraph")
+    (synopsis "Python graph (network) package")
+    (description "altgraph is a fork of graphlib: a graph (network) package for
+constructing graphs, BFS and DFS traversals, topological sort, shortest paths,
+etc. with graphviz output.")
+    (license license:expat)))
+
+
+(define-public python-macholib
+  (package
+    (name "python-macholib")
+    (version "1.14")
+    (source
+     (origin
+       (method git-fetch)
+       (uri (git-reference
+             (url "https://github.com/ronaldoussoren/macholib")
+             (commit (string-append "v" version))))
+       (file-name (git-file-name name version))
+       (sha256
+        (base32
+         "0aislnnfsza9wl4f0vp45ivzlc0pzhp9d4r08700slrypn5flg42"))))
+    (build-system python-build-system)
+    (propagated-inputs
+     `(("python-altgraph" ,python-altgraph)))
+    (arguments
+     '(#:phases
+       (modify-phases %standard-phases
+         (add-after 'unpack 'disable-broken-tests
+           (lambda _
+             ;; This test is broken as there is no keyboard interrupt.
+             (substitute* "macholib_tests/test_command_line.py"
+               (("^(.*)class TestCmdLine" line indent)
+                (string-append indent
+                               "@unittest.skip(\"Disabled by Guix\")\n"
+                               line)))
+             (substitute* "macholib_tests/test_dyld.py"
+               (("^(.*)def test_\\S+_find" line indent)
+                (string-append indent
+                               "@unittest.skip(\"Disabled by Guix\")\n"
+                               line))
+               (("^(.*)def testBasic" line indent)
+                (string-append indent
+                               "@unittest.skip(\"Disabled by Guix\")\n"
+                               line))
+               )
+             #t)))))
+    (home-page "https://github.com/ronaldoussoren/macholib")
+    (synopsis "Python library for analyzing and editing Mach-O headers")
+    (description "macholib is a Macho-O header analyzer and editor. It's
+typically used as a dependency analysis tool, and also to rewrite dylib
+references in Mach-O headers to be @executable_path relative. Though this tool
+targets a platform specific file format, it is pure python code that is platform
+and endian independent.")
+    (license license:expat)))
+
+(define-public python-signapple
+  (let ((commit "4ff1c1754e37042c002a3f6375c47fd931f2030b"))
+    (package
+      (name "python-signapple")
+      (version (git-version "0.1" "1" commit))
+      (source
+       (origin
+         (method git-fetch)
+         (uri (git-reference
+               (url "https://github.com/dongcarl/signapple")
+               (commit commit)))
+         (file-name (git-file-name name commit))
+         (sha256
+          (base32
+           "043czyzfm04rcx5xsp59vsppla3vm5g45dbp1npy2hww4066rlnh"))))
+      (build-system python-build-system)
+      (propagated-inputs
+       `(("python-asn1crypto" ,python-asn1crypto)
+         ("python-oscrypto" ,python-oscrypto)
+         ("python-certvalidator" ,python-certvalidator)
+         ("python-elfesteem" ,python-elfesteem)
+         ("python-requests" ,python-requests-2.25.1)
+         ("python-macholib" ,python-macholib)
+         ("libcrypto" ,openssl)))
+      ;; There are no tests, but attempting to run python setup.py test leads to
+      ;; problems, just disable the test
+      (arguments '(#:tests? #f))
+      (home-page "https://github.com/achow101/signapple")
+      (synopsis "Mach-O binary signature tool")
+      (description "signapple is a Python tool for creating, verifying, and
+inspecting signatures in Mach-O binaries.")
+      (license license:expat))))
+
 (packages->manifest
  (append
   (list ;; The Basics
@@ -262,9 +597,10 @@ parse, modify and abstract ELF, PE and MachO formats.")
            ;; Windows
            (list zip
                  (make-mingw-pthreads-cross-toolchain "x86_64-w64-mingw32")
-                 (make-nsis-with-sde-support nsis-x86_64)))
+                 (make-nsis-with-sde-support nsis-x86_64)
+                 osslsigncode))
           ((string-contains target "-linux-")
            (list (make-bitcoin-cross-toolchain target)))
           ((string-contains target "darwin")
-           (list clang-toolchain-10 binutils imagemagick libtiff librsvg font-tuffy cmake xorriso))
+           (list clang-toolchain-10 binutils imagemagick libtiff librsvg font-tuffy cmake xorriso python-signapple))
           (else '())))))

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -130,12 +130,16 @@ chain for " target " development."))
       (home-page (package-home-page xgcc))
       (license (package-license xgcc)))))
 
+(define base-gcc
+  (package-with-extra-patches gcc-8
+    (search-our-patches "gcc-8-sort-libtool-find-output.patch")))
+
 (define* (make-bitcoin-cross-toolchain target
                                        #:key
                                        (base-gcc-for-libc gcc-7)
                                        (base-kernel-headers linux-libre-headers-5.4)
                                        (base-libc glibc)  ; glibc 2.31
-                                       (base-gcc (make-gcc-rpath-link gcc-8)))
+                                       (base-gcc (make-gcc-rpath-link base-gcc)))
   "Convenience wrapper around MAKE-CROSS-TOOLCHAIN with default values
 desirable for building Bitcoin Core release binaries."
   (make-cross-toolchain target
@@ -153,7 +157,7 @@ desirable for building Bitcoin Core release binaries."
          (pthreads-xlibc mingw-w64-x86_64-winpthreads)
          (pthreads-xgcc (make-gcc-with-pthreads
                          (cross-gcc target
-                                    #:xgcc (make-ssp-fixed-gcc gcc-8)
+                                    #:xgcc (make-ssp-fixed-gcc base-gcc)
                                     #:xbinutils xbinutils
                                     #:libc pthreads-xlibc))))
     ;; Define a meta-package that propagates the resulting XBINUTILS, XLIBC, and

--- a/contrib/guix/patches/gcc-8-sort-libtool-find-output.patch
+++ b/contrib/guix/patches/gcc-8-sort-libtool-find-output.patch
@@ -1,0 +1,392 @@
+diff --git a/gcc/configure b/gcc/configure
+index 97ba7d7d69c..e37a96f0c0c 100755
+--- a/gcc/configure
++++ b/gcc/configure
+@@ -19720,20 +19720,20 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+ 	      prelink_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $objs $libobjs $compile_deplibs~
+-		compile_command="$compile_command `find $tpldir -name \*.o | $NL2SP`"'
++		compile_command="$compile_command `find $tpldir -name \*.o | sort | $NL2SP`"'
+ 	      old_archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $oldobjs$old_deplibs~
+-		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | $NL2SP`~
++		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | sort | $NL2SP`~
+ 		$RANLIB $oldlib'
+ 	      archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+ 	      archive_expsym_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
+ 	      ;;
+ 	    *) # Version 6 and above use weak symbols
+ 	      archive_cmds_CXX='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+diff --git a/libcc1/configure b/libcc1/configure
+index f53a121611c..5740ca90cab 100755
+--- a/libcc1/configure
++++ b/libcc1/configure
+@@ -12221,20 +12221,20 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+ 	      prelink_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $objs $libobjs $compile_deplibs~
+-		compile_command="$compile_command `find $tpldir -name \*.o | $NL2SP`"'
++		compile_command="$compile_command `find $tpldir -name \*.o | sort | $NL2SP`"'
+ 	      old_archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $oldobjs$old_deplibs~
+-		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | $NL2SP`~
++		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | sort | $NL2SP`~
+ 		$RANLIB $oldlib'
+ 	      archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+ 	      archive_expsym_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
+ 	      ;;
+ 	    *) # Version 6 and above use weak symbols
+ 	      archive_cmds_CXX='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+diff --git a/libffi/configure b/libffi/configure
+index 790a291011f..54b1ac18306 100755
+--- a/libffi/configure
++++ b/libffi/configure
+@@ -12661,20 +12661,20 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+ 	      prelink_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $objs $libobjs $compile_deplibs~
+-		compile_command="$compile_command `find $tpldir -name \*.o | $NL2SP`"'
++		compile_command="$compile_command `find $tpldir -name \*.o | sort | $NL2SP`"'
+ 	      old_archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $oldobjs$old_deplibs~
+-		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | $NL2SP`~
++		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | sort | $NL2SP`~
+ 		$RANLIB $oldlib'
+ 	      archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+ 	      archive_expsym_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
+ 	      ;;
+ 	    *) # Version 6 and above use weak symbols
+ 	      archive_cmds_CXX='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+diff --git a/libgo/config/libtool.m4 b/libgo/config/libtool.m4
+index f7005947454..8a84417b828 100644
+--- a/libgo/config/libtool.m4
++++ b/libgo/config/libtool.m4
+@@ -6010,20 +6010,20 @@ if test "$_lt_caught_CXX_error" != yes; then
+ 	      _LT_TAGVAR(prelink_cmds, $1)='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $objs $libobjs $compile_deplibs~
+-		compile_command="$compile_command `find $tpldir -name \*.o | $NL2SP`"'
++		compile_command="$compile_command `find $tpldir -name \*.o | sort | $NL2SP`"'
+ 	      _LT_TAGVAR(old_archive_cmds, $1)='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $oldobjs$old_deplibs~
+-		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | $NL2SP`~
++		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | sort | $NL2SP`~
+ 		$RANLIB $oldlib'
+ 	      _LT_TAGVAR(archive_cmds, $1)='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+ 	      _LT_TAGVAR(archive_expsym_cmds, $1)='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
+ 	      ;;
+ 	    *) # Version 6 and above use weak symbols
+ 	      _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+diff --git a/libgo/config/ltmain.sh b/libgo/config/ltmain.sh
+index ce66b44906a..0f81c401407 100644
+--- a/libgo/config/ltmain.sh
++++ b/libgo/config/ltmain.sh
+@@ -2917,7 +2917,7 @@ func_extract_archives ()
+ 	    darwin_file=
+ 	    darwin_files=
+ 	    for darwin_file in $darwin_filelist; do
+-	      darwin_files=`find unfat-$$ -name $darwin_file -print | $NL2SP`
++	      darwin_files=`find unfat-$$ -name $darwin_file -print | sort | $NL2SP`
+ 	      $LIPO -create -output "$darwin_file" $darwin_files
+ 	    done # $darwin_filelist
+ 	    $RM -rf unfat-$$
+@@ -2932,7 +2932,7 @@ func_extract_archives ()
+         func_extract_an_archive "$my_xdir" "$my_xabs"
+ 	;;
+       esac
+-      my_oldobjs="$my_oldobjs "`find $my_xdir -name \*.$objext -print -o -name \*.lo -print | $NL2SP`
++      my_oldobjs="$my_oldobjs "`find $my_xdir -name \*.$objext -print -o -name \*.lo -print | sort | $NL2SP`
+     done
+ 
+     func_extract_archives_result="$my_oldobjs"
+diff --git a/libhsail-rt/configure b/libhsail-rt/configure
+index a4fcc10c1f9..8e671229fcd 100755
+--- a/libhsail-rt/configure
++++ b/libhsail-rt/configure
+@@ -12244,20 +12244,20 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+ 	      prelink_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $objs $libobjs $compile_deplibs~
+-		compile_command="$compile_command `find $tpldir -name \*.o | $NL2SP`"'
++		compile_command="$compile_command `find $tpldir -name \*.o | sort | $NL2SP`"'
+ 	      old_archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $oldobjs$old_deplibs~
+-		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | $NL2SP`~
++		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | sort | $NL2SP`~
+ 		$RANLIB $oldlib'
+ 	      archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+ 	      archive_expsym_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
+ 	      ;;
+ 	    *) # Version 6 and above use weak symbols
+ 	      archive_cmds_CXX='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+diff --git a/libitm/configure b/libitm/configure
+index dbf386db434..29d4f10611f 100644
+--- a/libitm/configure
++++ b/libitm/configure
+@@ -13067,20 +13067,20 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+ 	      prelink_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $objs $libobjs $compile_deplibs~
+-		compile_command="$compile_command `find $tpldir -name \*.o | $NL2SP`"'
++		compile_command="$compile_command `find $tpldir -name \*.o | sort | $NL2SP`"'
+ 	      old_archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $oldobjs$old_deplibs~
+-		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | $NL2SP`~
++		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | sort | $NL2SP`~
+ 		$RANLIB $oldlib'
+ 	      archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+ 	      archive_expsym_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
+ 	      ;;
+ 	    *) # Version 6 and above use weak symbols
+ 	      archive_cmds_CXX='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+diff --git a/liboffloadmic/configure b/liboffloadmic/configure
+index f873716991b..7aa9186b10e 100644
+--- a/liboffloadmic/configure
++++ b/liboffloadmic/configure
+@@ -12379,20 +12379,20 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+ 	      prelink_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $objs $libobjs $compile_deplibs~
+-		compile_command="$compile_command `find $tpldir -name \*.o | $NL2SP`"'
++		compile_command="$compile_command `find $tpldir -name \*.o | sort | $NL2SP`"'
+ 	      old_archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $oldobjs$old_deplibs~
+-		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | $NL2SP`~
++		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | sort | $NL2SP`~
+ 		$RANLIB $oldlib'
+ 	      archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+ 	      archive_expsym_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
+ 	      ;;
+ 	    *) # Version 6 and above use weak symbols
+ 	      archive_cmds_CXX='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+diff --git a/liboffloadmic/plugin/configure b/liboffloadmic/plugin/configure
+index c031eb3e7fa..67fc7368f21 100644
+--- a/liboffloadmic/plugin/configure
++++ b/liboffloadmic/plugin/configure
+@@ -12086,20 +12086,20 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+ 	      prelink_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $objs $libobjs $compile_deplibs~
+-		compile_command="$compile_command `find $tpldir -name \*.o | $NL2SP`"'
++		compile_command="$compile_command `find $tpldir -name \*.o | sort | $NL2SP`"'
+ 	      old_archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $oldobjs$old_deplibs~
+-		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | $NL2SP`~
++		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | sort | $NL2SP`~
+ 		$RANLIB $oldlib'
+ 	      archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+ 	      archive_expsym_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
+ 	      ;;
+ 	    *) # Version 6 and above use weak symbols
+ 	      archive_cmds_CXX='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+diff --git a/libsanitizer/configure b/libsanitizer/configure
+index 4695bc7d4f7..cb7d25c07e6 100755
+--- a/libsanitizer/configure
++++ b/libsanitizer/configure
+@@ -13308,20 +13308,20 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+ 	      prelink_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $objs $libobjs $compile_deplibs~
+-		compile_command="$compile_command `find $tpldir -name \*.o | $NL2SP`"'
++		compile_command="$compile_command `find $tpldir -name \*.o | sort | $NL2SP`"'
+ 	      old_archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $oldobjs$old_deplibs~
+-		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | $NL2SP`~
++		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | sort | $NL2SP`~
+ 		$RANLIB $oldlib'
+ 	      archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+ 	      archive_expsym_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
+ 	      ;;
+ 	    *) # Version 6 and above use weak symbols
+ 	      archive_cmds_CXX='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+diff --git a/libstdc++-v3/configure b/libstdc++-v3/configure
+index 61457e940ec..21ef1f61e41 100755
+--- a/libstdc++-v3/configure
++++ b/libstdc++-v3/configure
+@@ -13087,20 +13087,20 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+ 	      prelink_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $objs $libobjs $compile_deplibs~
+-		compile_command="$compile_command `find $tpldir -name \*.o | $NL2SP`"'
++		compile_command="$compile_command `find $tpldir -name \*.o | sort | $NL2SP`"'
+ 	      old_archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $oldobjs$old_deplibs~
+-		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | $NL2SP`~
++		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | sort | $NL2SP`~
+ 		$RANLIB $oldlib'
+ 	      archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+ 	      archive_expsym_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
+ 	      ;;
+ 	    *) # Version 6 and above use weak symbols
+ 	      archive_cmds_CXX='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+diff --git a/libtool.m4 b/libtool.m4
+index 24d13f34409..940faaa161d 100644
+--- a/libtool.m4
++++ b/libtool.m4
+@@ -6005,20 +6005,20 @@ if test "$_lt_caught_CXX_error" != yes; then
+ 	      _LT_TAGVAR(prelink_cmds, $1)='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $objs $libobjs $compile_deplibs~
+-		compile_command="$compile_command `find $tpldir -name \*.o | $NL2SP`"'
++		compile_command="$compile_command `find $tpldir -name \*.o | sort | $NL2SP`"'
+ 	      _LT_TAGVAR(old_archive_cmds, $1)='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $oldobjs$old_deplibs~
+-		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | $NL2SP`~
++		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | sort | $NL2SP`~
+ 		$RANLIB $oldlib'
+ 	      _LT_TAGVAR(archive_cmds, $1)='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+ 	      _LT_TAGVAR(archive_expsym_cmds, $1)='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
+ 	      ;;
+ 	    *) # Version 6 and above use weak symbols
+ 	      _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+diff --git a/libvtv/configure b/libvtv/configure
+index a197f750453..31ab3a0637b 100755
+--- a/libvtv/configure
++++ b/libvtv/configure
+@@ -13339,20 +13339,20 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
+ 	      prelink_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $objs $libobjs $compile_deplibs~
+-		compile_command="$compile_command `find $tpldir -name \*.o | $NL2SP`"'
++		compile_command="$compile_command `find $tpldir -name \*.o | sort | $NL2SP`"'
+ 	      old_archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $oldobjs$old_deplibs~
+-		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | $NL2SP`~
++		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | sort | $NL2SP`~
+ 		$RANLIB $oldlib'
+ 	      archive_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+ 	      archive_expsym_cmds_CXX='tpldir=Template.dir~
+ 		rm -rf $tpldir~
+ 		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
+ 	      ;;
+ 	    *) # Version 6 and above use weak symbols
+ 	      archive_cmds_CXX='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+diff --git a/ltmain.sh b/ltmain.sh
+index 9503ec85d70..79f9ba89af5 100644
+--- a/ltmain.sh
++++ b/ltmain.sh
+@@ -2917,7 +2917,7 @@ func_extract_archives ()
+ 	    darwin_file=
+ 	    darwin_files=
+ 	    for darwin_file in $darwin_filelist; do
+-	      darwin_files=`find unfat-$$ -name $darwin_file -print | $NL2SP`
++	      darwin_files=`find unfat-$$ -name $darwin_file -print | sort | $NL2SP`
+ 	      $LIPO -create -output "$darwin_file" $darwin_files
+ 	    done # $darwin_filelist
+ 	    $RM -rf unfat-$$
+@@ -2932,7 +2932,7 @@ func_extract_archives ()
+         func_extract_an_archive "$my_xdir" "$my_xabs"
+ 	;;
+       esac
+-      my_oldobjs="$my_oldobjs "`find $my_xdir -name \*.$objext -print -o -name \*.lo -print | $NL2SP`
++      my_oldobjs="$my_oldobjs "`find $my_xdir -name \*.$objext -print -o -name \*.lo -print | sort | $NL2SP`
+     done
+ 
+     func_extract_archives_result="$my_oldobjs"

--- a/contrib/guix/patches/oscrypto-hard-code-openssl.patch
+++ b/contrib/guix/patches/oscrypto-hard-code-openssl.patch
@@ -1,0 +1,13 @@
+diff --git a/oscrypto/__init__.py b/oscrypto/__init__.py
+index eb27313..371ab24 100644
+--- a/oscrypto/__init__.py
++++ b/oscrypto/__init__.py
+@@ -302,3 +302,8 @@ def load_order():
+         'oscrypto._win.tls',
+         'oscrypto.tls',
+     ]
++
++
++paths = '@GUIX_OSCRYPTO_USE_OPENSSL@'.split(',')
++assert len(paths) == 2, 'Value for OSCRYPTO_USE_OPENSSL env var must be two paths separated by a comma'
++use_openssl(*paths)

--- a/contrib/windeploy/detached-sig-create.sh
+++ b/contrib/windeploy/detached-sig-create.sh
@@ -25,7 +25,7 @@ CERTFILE="win-codesign.cert"
 mkdir -p "${OUTSUBDIR}"
 basename -a $(ls -1 "${SRCDIR}"/*-unsigned.exe) | while read UNSIGNED; do
   echo Signing "${UNSIGNED}"
-  "${OSSLSIGNCODE}" sign -certs "${CERTFILE}" -t "${TIMESERVER}" -in "${SRCDIR}/${UNSIGNED}" -out "${WORKDIR}/${UNSIGNED}" "$@"
+  "${OSSLSIGNCODE}" sign -certs "${CERTFILE}" -t "${TIMESERVER}" -h sha256 -in "${SRCDIR}/${UNSIGNED}" -out "${WORKDIR}/${UNSIGNED}" "$@"
   "${OSSLSIGNCODE}" extract-signature -pem -in "${WORKDIR}/${UNSIGNED}" -out "${OUTSUBDIR}/${UNSIGNED}.pem" && rm "${WORKDIR}/${UNSIGNED}"
 done
 


### PR DESCRIPTION
This is the last PR before we reach feature-parity with the Gitian process!

Note: I tried using the `Makefile` inside the distsrc to make the dmg instead of manually listing out the commands, but `make` seems to want to re-make a lot of other files which broke the dmg.

The workflow looks something like this:
1. `env [ FOO=bar... ] ./contrib/guix/guix-build` (add additional env vars as necessary)
2. Codesigners only:
    1.  Copy `guix-build-<short-id>/output/x86_64-apple-darwin18/bitcoin-<short-id>-osx-unsigned.tar.gz` and `guix-build-<short-id>/output/x86_64-w64-mingw32/bitcoin-<short-id>-win-unsigned.tar.gz` to signing computer
    2. Codesign with `./detached-sig-create.sh` inside the tarball
    3. Upload contents of `signature-{osx,win}.tar.gz` to https://github.com/bitcoin-core/bitcoin-detached-sigs (as a new tag)
3. Checkout new tag for `bitcoin-core/bitcoin-detached-sigs` with the detached signatures
4. `env [ FOO=bar... ] DETACHED_SIGS_REPO=<path/to/bitcoin-detached-sigs> ./contrib/guix/guix-codesign` (modify env vars as necessary)
5. Make sure `guix.sigs` is cloned and updated
6. `env GUIX_SIGS_REPO=<path/to/guix.sigs> SIGNER=0x96AB007F1A7ED999=dongcarl ./contrib/guix/guix-attest` (modify env vars as necessary)
7. Commit your new signatures and SHA256SUMS in `guix.sigs`
8. Optionally, after there are multiple signatures in `guix.sigs`: `env GUIX_SIGS_REPO=<path/to/guix.sigs> ./contrib/guix/guix-verify`