### PR TITLE
ci: Avoid invoking curl on the host

### DIFF
--- a/ci/test/05_before_script.sh
+++ b/ci/test/05_before_script.sh
@@ -19,7 +19,7 @@ OSX_SDK_BASENAME="Xcode-${XCODE_VERSION}-${XCODE_BUILD_ID}-extracted-SDK-with-li
 OSX_SDK_PATH="${DEPENDS_DIR}/sdk-sources/${OSX_SDK_BASENAME}"
 
 if [ -n "$XCODE_VERSION" ] && [ ! -f "$OSX_SDK_PATH" ]; then
-  curl --location --fail "${SDK_URL}/${OSX_SDK_BASENAME}" -o "$OSX_SDK_PATH"
+  DOCKER_EXEC curl --location --fail "${SDK_URL}/${OSX_SDK_BASENAME}" -o "$OSX_SDK_PATH"
 fi
 
 if [[ ${USE_MEMORY_SANITIZER} == "true" ]]; then


### PR DESCRIPTION
The only requirement for the ci system are the programs `docker.io` and `bash`. However, the mac cross build invokes `curl` on the host. Fix that.

Before:

```
$ FILE_ENV="./ci/test/00_setup_env_mac.sh" ./ci/test_run_all.sh
...
./ci/test/05_before_script.sh: line 22: curl: command not found
```

After:

```
... (command passes)