### PR TITLE
Move GetDataDir to ArgsManager

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -637,7 +637,7 @@ static void CleanupBlockRevFiles()
     // Remove the rev files immediately and insert the blk file paths into an
     // ordered map keyed by block file index.
     LogPrintf("Removing unusable blk?????.dat and rev?????.dat files for -reindex with -prune\n");
-    fs::path blocksdir = GetBlocksDir();
+    fs::path blocksdir = gArgs.GetBlocksDirPath();
     for (fs::directory_iterator it(blocksdir); it != fs::directory_iterator(); it++) {
         if (fs::is_regular_file(*it) &&
             it->path().filename().string().length() == 12 &&
@@ -919,7 +919,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
         InitWarning(warnings);
     }
 
-    if (!fs::is_directory(GetBlocksDir())) {
+    if (!fs::is_directory(gArgs.GetBlocksDirPath())) {
         return InitError(strprintf(_("Specified blocks directory \"%s\" does not exist."), args.GetArg("-blocksdir", "")));
     }
 
@@ -1759,8 +1759,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         InitError(strprintf(_("Error: Disk space is low for %s"), GetDataDir()));
         return false;
     }
-    if (!CheckDiskSpace(GetBlocksDir())) {
-        InitError(strprintf(_("Error: Disk space is low for %s"), GetBlocksDir()));
+    if (!CheckDiskSpace(gArgs.GetBlocksDirPath())) {
+        InitError(strprintf(_("Error: Disk space is low for %s"), gArgs.GetBlocksDirPath()));
         return false;
     }
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -216,7 +216,7 @@ QString ClientModel::dataDir() const
 
 QString ClientModel::blocksDir() const
 {
-    return GUIUtil::boostPathToQString(GetBlocksDir());
+    return GUIUtil::boostPathToQString(gArgs.GetBlocksDirPath());
 }
 
 void ClientModel::updateBanlist()

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper)
 {
     // Perform tests both obfuscated and non-obfuscated.
     for (const bool obfuscate : {false, true}) {
-        fs::path ph = GetDataDir() / (obfuscate ? "dbwrapper_obfuscate_true" : "dbwrapper_obfuscate_false");
+        fs::path ph = m_args.GetDataDirPath() / (obfuscate ? "dbwrapper_obfuscate_true" : "dbwrapper_obfuscate_false");
         CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
         char key = 'k';
         uint256 in = InsecureRand256();
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_basic_data)
 {
     // Perform tests both obfuscated and non-obfuscated.
     for (bool obfuscate : {false, true}) {
-        fs::path ph = GetDataDir() / (obfuscate ? "dbwrapper_1_obfuscate_true" : "dbwrapper_1_obfuscate_false");
+        fs::path ph = m_args.GetDataDirPath() / (obfuscate ? "dbwrapper_1_obfuscate_true" : "dbwrapper_1_obfuscate_false");
         CDBWrapper dbw(ph, (1 << 20), false, true, obfuscate);
 
         uint256 res;
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_batch)
 {
     // Perform tests both obfuscated and non-obfuscated.
     for (const bool obfuscate : {false, true}) {
-        fs::path ph = GetDataDir() / (obfuscate ? "dbwrapper_batch_obfuscate_true" : "dbwrapper_batch_obfuscate_false");
+        fs::path ph = m_args.GetDataDirPath() / (obfuscate ? "dbwrapper_batch_obfuscate_true" : "dbwrapper_batch_obfuscate_false");
         CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
 
         char key = 'i';
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
 {
     // Perform tests both obfuscated and non-obfuscated.
     for (const bool obfuscate : {false, true}) {
-        fs::path ph = GetDataDir() / (obfuscate ? "dbwrapper_iterator_obfuscate_true" : "dbwrapper_iterator_obfuscate_false");
+        fs::path ph = m_args.GetDataDirPath() / (obfuscate ? "dbwrapper_iterator_obfuscate_true" : "dbwrapper_iterator_obfuscate_false");
         CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
 
         // The two keys are intentionally chosen for ordering
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
 BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
 {
     // We're going to share this fs::path between two wrappers
-    fs::path ph = GetDataDir() / "existing_data_no_obfuscate";
+    fs::path ph = m_args.GetDataDirPath() / "existing_data_no_obfuscate";
     create_directories(ph);
 
     // Set up a non-obfuscated wrapper to write some initial data.
@@ -243,7 +243,7 @@ BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
 BOOST_AUTO_TEST_CASE(existing_data_reindex)
 {
     // We're going to share this fs::path between two wrappers
-    fs::path ph = GetDataDir() / "existing_data_reindex";
+    fs::path ph = m_args.GetDataDirPath() / "existing_data_reindex";
     create_directories(ph);
 
     // Set up a non-obfuscated wrapper to write some initial data.
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
 
 BOOST_AUTO_TEST_CASE(iterator_ordering)
 {
-    fs::path ph = GetDataDir() / "iterator_ordering";
+    fs::path ph = m_args.GetDataDirPath() / "iterator_ordering";
     CDBWrapper dbw(ph, (1 << 20), true, false, false);
     for (int x=0x00; x<256; ++x) {
         uint8_t key = x;
@@ -358,7 +358,7 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
 {
     char buf[10];
 
-    fs::path ph = GetDataDir() / "iterator_string_ordering";
+    fs::path ph = m_args.GetDataDirPath() / "iterator_string_ordering";
     CDBWrapper dbw(ph, (1 << 20), true, false, false);
     for (int x=0x00; x<10; ++x) {
         for (int y = 0; y < 10; y++) {
@@ -404,7 +404,7 @@ BOOST_AUTO_TEST_CASE(unicodepath)
     // On Windows this test will fail if the directory is created using
     // the ANSI CreateDirectoryA call and the code page isn't UTF8.
     // It will succeed if created with CreateDirectoryW.
-    fs::path ph = GetDataDir() / "test_runner_₿_🏃_20191128_104644";
+    fs::path ph = m_args.GetDataDirPath() / "test_runner_₿_🏃_20191128_104644";
     CDBWrapper dbw(ph, (1 << 20));
 
     fs::path lockPath = ph / "LOCK";

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -208,7 +208,7 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
 BOOST_AUTO_TEST_CASE(peer_discouragement)
 {
     const CChainParams& chainparams = Params();
-    auto banman = std::make_unique<BanMan>(GetDataDir() / "banlist.dat", nullptr, DEFAULT_MISBEHAVING_BANTIME);
+    auto banman = std::make_unique<BanMan>(m_args.GetDataDirPath() / "banlist.dat", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<CConnmanTest>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(),
                                        *m_node.scheduler, *m_node.chainman, *m_node.mempool, false);
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
 BOOST_AUTO_TEST_CASE(DoS_bantime)
 {
     const CChainParams& chainparams = Params();
-    auto banman = std::make_unique<BanMan>(GetDataDir() / "banlist.dat", nullptr, DEFAULT_MISBEHAVING_BANTIME);
+    auto banman = std::make_unique<BanMan>(m_args.GetDataDirPath() / "banlist.dat", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(),
                                        *m_node.scheduler, *m_node.chainman, *m_node.mempool, false);

--- a/src/test/flatfile_tests.cpp
+++ b/src/test/flatfile_tests.cpp
@@ -14,7 +14,7 @@ BOOST_FIXTURE_TEST_SUITE(flatfile_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(flatfile_filename)
 {
-    const auto data_dir = GetDataDir();
+    const auto data_dir = m_args.GetDataDirPath();
 
     FlatFilePos pos(456, 789);
 
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(flatfile_filename)
 
 BOOST_AUTO_TEST_CASE(flatfile_open)
 {
-    const auto data_dir = GetDataDir();
+    const auto data_dir = m_args.GetDataDirPath();
     FlatFileSeq seq(data_dir, "a", 16 * 1024);
 
     std::string line1("A purely peer-to-peer version of electronic cash would allow online "
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(flatfile_open)
 
 BOOST_AUTO_TEST_CASE(flatfile_allocate)
 {
-    const auto data_dir = GetDataDir();
+    const auto data_dir = m_args.GetDataDirPath();
     FlatFileSeq seq(data_dir, "a", 100);
 
     bool out_of_space;
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(flatfile_allocate)
 
 BOOST_AUTO_TEST_CASE(flatfile_flush)
 {
-    const auto data_dir = GetDataDir();
+    const auto data_dir = m_args.GetDataDirPath();
     FlatFileSeq seq(data_dir, "a", 100);
 
     bool out_of_space;

--- a/src/test/fs_tests.cpp
+++ b/src/test/fs_tests.cpp
@@ -13,7 +13,7 @@ BOOST_FIXTURE_TEST_SUITE(fs_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(fsbridge_fstream)
 {
-    fs::path tmpfolder = GetDataDir();
+    fs::path tmpfolder = m_args.GetDataDirPath();
     // tmpfile1 should be the same as tmpfile2
     fs::path tmpfile1 = tmpfolder / "fs_tests_₿_🏃";
     fs::path tmpfile2 = tmpfolder / "fs_tests_₿_🏃";

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -18,7 +18,7 @@ namespace getarg_tests{
         protected:
         void SetupArgs(const std::vector<std::pair<std::string, unsigned int>>& args);
         void ResetArgs(const std::string& strArg);
-        ArgsManager m_args;
+        ArgsManager m_local_args;
     };
 }
 
@@ -39,14 +39,14 @@ void LocalTestingSetup :: ResetArgs(const std::string& strArg)
         vecChar.push_back(s.c_str());
 
     std::string error;
-    BOOST_CHECK(m_args.ParseParameters(vecChar.size(), vecChar.data(), error));
+    BOOST_CHECK(m_local_args.ParseParameters(vecChar.size(), vecChar.data(), error));
 }
 
 void LocalTestingSetup :: SetupArgs(const std::vector<std::pair<std::string, unsigned int>>& args)
 {
-    m_args.ClearArgs();
+    m_local_args.ClearArgs();
     for (const auto& arg : args) {
-        m_args.AddArg(arg.first, "", arg.second, OptionsCategory::OPTIONS);
+        m_local_args.AddArg(arg.first, "", arg.second, OptionsCategory::OPTIONS);
     }
 }
 
@@ -55,52 +55,52 @@ BOOST_AUTO_TEST_CASE(boolarg)
     const auto foo = std::make_pair("-foo", ArgsManager::ALLOW_ANY);
     SetupArgs({foo});
     ResetArgs("-foo");
-    BOOST_CHECK(m_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(m_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(m_local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(m_local_args.GetBoolArg("-foo", true));
 
-    BOOST_CHECK(!m_args.GetBoolArg("-fo", false));
-    BOOST_CHECK(m_args.GetBoolArg("-fo", true));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-fo", false));
+    BOOST_CHECK(m_local_args.GetBoolArg("-fo", true));
 
-    BOOST_CHECK(!m_args.GetBoolArg("-fooo", false));
-    BOOST_CHECK(m_args.GetBoolArg("-fooo", true));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-fooo", false));
+    BOOST_CHECK(m_local_args.GetBoolArg("-fooo", true));
 
     ResetArgs("-foo=0");
-    BOOST_CHECK(!m_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(!m_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", true));
 
     ResetArgs("-foo=1");
-    BOOST_CHECK(m_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(m_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(m_local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(m_local_args.GetBoolArg("-foo", true));
 
     // New 0.6 feature: auto-map -nosomething to !-something:
     ResetArgs("-nofoo");
-    BOOST_CHECK(!m_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(!m_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", true));
 
     ResetArgs("-nofoo=1");
-    BOOST_CHECK(!m_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(!m_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", true));
 
     ResetArgs("-foo -nofoo");  // -nofoo should win
-    BOOST_CHECK(!m_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(!m_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", true));
 
     ResetArgs("-foo=1 -nofoo=1");  // -nofoo should win
-    BOOST_CHECK(!m_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(!m_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", true));
 
     ResetArgs("-foo=0 -nofoo=0");  // -nofoo=0 should win
-    BOOST_CHECK(m_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(m_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(m_local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(m_local_args.GetBoolArg("-foo", true));
 
     // New 0.6 feature: treat -- same as -:
     ResetArgs("--foo=1");
-    BOOST_CHECK(m_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(m_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(m_local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(m_local_args.GetBoolArg("-foo", true));
 
     ResetArgs("--nofoo=1");
-    BOOST_CHECK(!m_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(!m_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", true));
 
 }
 
@@ -110,24 +110,24 @@ BOOST_AUTO_TEST_CASE(stringarg)
     const auto bar = std::make_pair("-bar", ArgsManager::ALLOW_ANY);
     SetupArgs({foo, bar});
     ResetArgs("");
-    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", ""), "");
-    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", "eleven"), "eleven");
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", ""), "");
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", "eleven"), "eleven");
 
     ResetArgs("-foo -bar");
-    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", ""), "");
-    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", "eleven"), "");
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", ""), "");
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", "eleven"), "");
 
     ResetArgs("-foo=");
-    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", ""), "");
-    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", "eleven"), "");
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", ""), "");
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", "eleven"), "");
 
     ResetArgs("-foo=11");
-    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", ""), "11");
-    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", "eleven"), "11");
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", ""), "11");
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", "eleven"), "11");
 
     ResetArgs("-foo=eleven");
-    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", ""), "eleven");
-    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", "eleven"), "eleven");
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", ""), "eleven");
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", "eleven"), "eleven");
 
 }
 
@@ -137,20 +137,20 @@ BOOST_AUTO_TEST_CASE(intarg)
     const auto bar = std::make_pair("-bar", ArgsManager::ALLOW_ANY);
     SetupArgs({foo, bar});
     ResetArgs("");
-    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", 11), 11);
-    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", 0), 0);
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", 11), 11);
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", 0), 0);
 
     ResetArgs("-foo -bar");
-    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", 11), 0);
-    BOOST_CHECK_EQUAL(m_args.GetArg("-bar", 11), 0);
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", 11), 0);
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-bar", 11), 0);
 
     ResetArgs("-foo=11 -bar=12");
-    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", 0), 11);
-    BOOST_CHECK_EQUAL(m_args.GetArg("-bar", 11), 12);
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", 0), 11);
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-bar", 11), 12);
 
     ResetArgs("-foo=NaN -bar=NotANumber");
-    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", 1), 0);
-    BOOST_CHECK_EQUAL(m_args.GetArg("-bar", 11), 0);
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", 1), 0);
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-bar", 11), 0);
 }
 
 BOOST_AUTO_TEST_CASE(doubledash)
@@ -159,11 +159,11 @@ BOOST_AUTO_TEST_CASE(doubledash)
     const auto bar = std::make_pair("-bar", ArgsManager::ALLOW_ANY);
     SetupArgs({foo, bar});
     ResetArgs("--foo");
-    BOOST_CHECK_EQUAL(m_args.GetBoolArg("-foo", false), true);
+    BOOST_CHECK_EQUAL(m_local_args.GetBoolArg("-foo", false), true);
 
     ResetArgs("--foo=verbose --bar=1");
-    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", ""), "verbose");
-    BOOST_CHECK_EQUAL(m_args.GetArg("-bar", 0), 1);
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", ""), "verbose");
+    BOOST_CHECK_EQUAL(m_local_args.GetArg("-bar", 0), 1);
 }
 
 BOOST_AUTO_TEST_CASE(boolargno)
@@ -172,24 +172,24 @@ BOOST_AUTO_TEST_CASE(boolargno)
     const auto bar = std::make_pair("-bar", ArgsManager::ALLOW_ANY);
     SetupArgs({foo, bar});
     ResetArgs("-nofoo");
-    BOOST_CHECK(!m_args.GetBoolArg("-foo", true));
-    BOOST_CHECK(!m_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", false));
 
     ResetArgs("-nofoo=1");
-    BOOST_CHECK(!m_args.GetBoolArg("-foo", true));
-    BOOST_CHECK(!m_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", false));
 
     ResetArgs("-nofoo=0");
-    BOOST_CHECK(m_args.GetBoolArg("-foo", true));
-    BOOST_CHECK(m_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(m_local_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(m_local_args.GetBoolArg("-foo", false));
 
     ResetArgs("-foo --nofoo"); // --nofoo should win
-    BOOST_CHECK(!m_args.GetBoolArg("-foo", true));
-    BOOST_CHECK(!m_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", false));
 
     ResetArgs("-nofoo -foo"); // foo always wins:
-    BOOST_CHECK(m_args.GetBoolArg("-foo", true));
-    BOOST_CHECK(m_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(m_local_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(m_local_args.GetBoolArg("-foo", false));
 }
 
 BOOST_AUTO_TEST_CASE(logargs)
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(logargs)
         });
 
     // Log the arguments
-    m_args.LogArgs();
+    m_local_args.LogArgs();
 
     LogInstance().DeleteCallback(print_connection);
     // Check that what should appear does, and what shouldn't doesn't.

--- a/src/test/settings_tests.cpp
+++ b/src/test/settings_tests.cpp
@@ -45,7 +45,7 @@ BOOST_FIXTURE_TEST_SUITE(settings_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(ReadWrite)
 {
-    fs::path path = GetDataDir() / "settings.json";
+    fs::path path = m_args.GetDataDirPath() / "settings.json";
 
     WriteText(path, R"({
         "string": "string",

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -90,7 +90,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
     fs::create_directories(m_path_root);
     m_args.ForceSetArg("-datadir", m_path_root.string());
     gArgs.ForceSetArg("-datadir", m_path_root.string());
-    ClearDatadirCache();
+    gArgs.ClearPathCache();
     {
         SetupServerArgs(m_node);
         std::string error;

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -71,7 +71,8 @@ std::ostream& operator<<(std::ostream& os, const uint256& num)
 }
 
 BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::vector<const char*>& extra_args)
-    : m_path_root{fs::temp_directory_path() / "test_common_" PACKAGE_NAME / g_insecure_rand_ctx_temp_path.rand256().ToString()}
+    : m_path_root{fs::temp_directory_path() / "test_common_" PACKAGE_NAME / g_insecure_rand_ctx_temp_path.rand256().ToString()},
+      m_args{}
 {
     const std::vector<const char*> arguments = Cat(
         {
@@ -87,6 +88,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
         extra_args);
     util::ThreadRename("test");
     fs::create_directories(m_path_root);
+    m_args.ForceSetArg("-datadir", m_path_root.string());
     gArgs.ForceSetArg("-datadir", m_path_root.string());
     ClearDatadirCache();
     {
@@ -191,7 +193,7 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
     }
 
     m_node.addrman = std::make_unique<CAddrMan>();
-    m_node.banman = std::make_unique<BanMan>(GetDataDir() / "banlist.dat", nullptr, DEFAULT_MISBEHAVING_BANTIME);
+    m_node.banman = std::make_unique<BanMan>(m_args.GetDataDirPath() / "banlist.dat", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     m_node.connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman); // Deterministic randomness for tests.
     m_node.peerman = PeerManager::make(chainparams, *m_node.connman, *m_node.addrman,
                                        m_node.banman.get(), *m_node.scheduler, *m_node.chainman,

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -8,6 +8,7 @@
 #include <chainparamsbase.h>
 #include <fs.h>
 #include <key.h>
+#include <util/system.h>
 #include <node/context.h>
 #include <pubkey.h>
 #include <random.h>
@@ -80,6 +81,7 @@ struct BasicTestingSetup {
     ~BasicTestingSetup();
 
     const fs::path m_path_root;
+    ArgsManager m_args;
 };
 
 /** Testing setup that performs all steps up until right before

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -56,19 +56,19 @@ BOOST_AUTO_TEST_CASE(util_datadir)
     const fs::path dd_norm = args.GetDataDirPath();
 
     args.ForceSetArg("-datadir", dd_norm.string() + "/");
-    ClearDatadirCache();
+    args.ClearPathCache();
     BOOST_CHECK_EQUAL(dd_norm, args.GetDataDirPath());
 
     args.ForceSetArg("-datadir", dd_norm.string() + "/.");
-    ClearDatadirCache();
+    args.ClearPathCache();
     BOOST_CHECK_EQUAL(dd_norm, args.GetDataDirPath());
 
     args.ForceSetArg("-datadir", dd_norm.string() + "/./");
-    ClearDatadirCache();
+    args.ClearPathCache();
     BOOST_CHECK_EQUAL(dd_norm, args.GetDataDirPath());
 
     args.ForceSetArg("-datadir", dd_norm.string() + "/.//");
-    ClearDatadirCache();
+    args.ClearPathCache();
     BOOST_CHECK_EQUAL(dd_norm, args.GetDataDirPath());
 }
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1143,21 +1143,23 @@ BOOST_AUTO_TEST_CASE(util_ReadWriteSettings)
 {
     // Test writing setting.
     TestArgsManager args1;
+    args1.ForceSetArg("-datadir", m_path_root.string());
     args1.LockSettings([&](util::Settings& settings) { settings.rw_settings["name"] = "value"; });
     args1.WriteSettingsFile();
 
     // Test reading setting.
     TestArgsManager args2;
+    args2.ForceSetArg("-datadir", m_path_root.string());
     args2.ReadSettingsFile();
     args2.LockSettings([&](util::Settings& settings) { BOOST_CHECK_EQUAL(settings.rw_settings["name"].get_str(), "value"); });
 
     // Test error logging, and remove previously written setting.
     {
         ASSERT_DEBUG_LOG("Failed renaming settings file");
-        fs::remove(GetDataDir() / "settings.json");
-        fs::create_directory(GetDataDir() / "settings.json");
+        fs::remove(args1.GetDataDirPath() / "settings.json");
+        fs::create_directory(args1.GetDataDirPath() / "settings.json");
         args2.WriteSettingsFile();
-        fs::remove(GetDataDir() / "settings.json");
+        fs::remove(args1.GetDataDirPath() / "settings.json");
     }
 }
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1801,7 +1801,7 @@ static constexpr char ExitCommand = 'X';
 
 BOOST_AUTO_TEST_CASE(test_LockDirectory)
 {
-    fs::path dirname = GetDataDir() / "lock_dir";
+    fs::path dirname = m_args.GetDataDirPath() / "lock_dir";
     const std::string lockname = ".lock";
 #ifndef WIN32
     // Revert SIGCHLD to default, otherwise boost.test will catch and fail on
@@ -1890,7 +1890,7 @@ BOOST_AUTO_TEST_CASE(test_LockDirectory)
 BOOST_AUTO_TEST_CASE(test_DirIsWritable)
 {
     // Should be able to write to the data dir.
-    fs::path tmpdirname = GetDataDir();
+    fs::path tmpdirname = m_args.GetDataDirPath();
     BOOST_CHECK_EQUAL(DirIsWritable(tmpdirname), true);
 
     // Should not be able to write to a non-existent dir.

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -49,24 +49,27 @@ BOOST_FIXTURE_TEST_SUITE(util_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(util_datadir)
 {
-    ClearDatadirCache();
-    const fs::path dd_norm = GetDataDir();
+    // Use local args variable instead of m_args to avoid making assumptions about test setup
+    ArgsManager args;
+    args.ForceSetArg("-datadir", m_path_root.string());
 
-    gArgs.ForceSetArg("-datadir", dd_norm.string() + "/");
-    ClearDatadirCache();
-    BOOST_CHECK_EQUAL(dd_norm, GetDataDir());
+    const fs::path dd_norm = args.GetDataDirPath();
 
-    gArgs.ForceSetArg("-datadir", dd_norm.string() + "/.");
+    args.ForceSetArg("-datadir", dd_norm.string() + "/");
     ClearDatadirCache();
-    BOOST_CHECK_EQUAL(dd_norm, GetDataDir());
+    BOOST_CHECK_EQUAL(dd_norm, args.GetDataDirPath());
 
-    gArgs.ForceSetArg("-datadir", dd_norm.string() + "/./");
+    args.ForceSetArg("-datadir", dd_norm.string() + "/.");
     ClearDatadirCache();
-    BOOST_CHECK_EQUAL(dd_norm, GetDataDir());
+    BOOST_CHECK_EQUAL(dd_norm, args.GetDataDirPath());
 
-    gArgs.ForceSetArg("-datadir", dd_norm.string() + "/.//");
+    args.ForceSetArg("-datadir", dd_norm.string() + "/./");
     ClearDatadirCache();
-    BOOST_CHECK_EQUAL(dd_norm, GetDataDir());
+    BOOST_CHECK_EQUAL(dd_norm, args.GetDataDirPath());
+
+    args.ForceSetArg("-datadir", dd_norm.string() + "/.//");
+    ClearDatadirCache();
+    BOOST_CHECK_EQUAL(dd_norm, args.GetDataDirPath());
 }
 
 BOOST_AUTO_TEST_CASE(util_check)

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -445,7 +445,7 @@ const fs::path& ArgsManager::GetDataDirPath(bool net_specific) const
     return path;
 }
 
-void ArgsManager::ClearDatadirPathCache()
+void ArgsManager::ClearPathCache()
 {
     LOCK(cs_args);
 
@@ -813,11 +813,6 @@ bool CheckDataDirOption()
     return datadir.empty() || fs::is_directory(fs::system_complete(datadir));
 }
 
-void ClearDatadirCache()
-{
-    gArgs.ClearDatadirPathCache();
-}
-
 fs::path GetConfigFile(const std::string& confPath)
 {
     return AbsPathForConfigVal(fs::path(confPath), false);
@@ -976,7 +971,7 @@ bool ArgsManager::ReadConfigFiles(std::string& error, bool ignore_invalid_keys)
     }
 
     // If datadir is changed in .conf file:
-    ClearDatadirCache();
+    gArgs.ClearPathCache();
     if (!CheckDataDirOption()) {
         error = strprintf("specified data directory \"%s\" does not exist.", GetArg("-datadir", ""));
         return false;

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -235,6 +235,19 @@ static bool CheckValid(const std::string& key, const util::SettingsValue& val, u
     return true;
 }
 
+namespace {
+fs::path StripRedundantLastElementsOfPath(const fs::path& path)
+{
+    auto result = path;
+    while (result.filename().string() == ".") {
+        result = result.parent_path();
+    }
+
+    assert(fs::equivalent(result, path));
+    return result;
+}
+} // namespace
+
 // Define default constructor and destructor that are not inline, so code instantiating this class doesn't need to
 // #include class definitions for all members.
 // For example, m_settings has an internal dependency on univalue.
@@ -722,19 +735,6 @@ fs::path GetDefaultDataDir()
 #endif
 #endif
 }
-
-namespace {
-fs::path StripRedundantLastElementsOfPath(const fs::path& path)
-{
-    auto result = path;
-    while (result.filename().string() == ".") {
-        result = result.parent_path();
-    }
-
-    assert(fs::equivalent(result, path));
-    return result;
-}
-} // namespace
 
 static fs::path g_blocks_path_cache_net_specific;
 static fs::path pathCached;

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -94,8 +94,6 @@ fs::path GetDefaultDataDir();
 const fs::path &GetDataDir(bool fNetSpecific = true);
 // Return true if -datadir option points to a valid directory or is not specified.
 bool CheckDataDirOption();
-/** Tests only */
-void ClearDatadirCache();
 fs::path GetConfigFile(const std::string& confPath);
 #ifdef WIN32
 fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
@@ -281,9 +279,9 @@ public:
     const fs::path& GetDataDirPath(bool net_specific = true) const;
 
     /**
-     * For testing
+     * Clear cached directory paths
      */
-    void ClearDatadirPathCache();
+    void ClearPathCache();
 
     /**
      * Return a vector of strings of the given argument

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -91,8 +91,6 @@ void ReleaseDirectoryLocks();
 
 bool TryCreateDirectories(const fs::path& p);
 fs::path GetDefaultDataDir();
-// The blocks directory is always net specific.
-const fs::path &GetBlocksDir();
 const fs::path &GetDataDir(bool fNetSpecific = true);
 // Return true if -datadir option points to a valid directory or is not specified.
 bool CheckDataDirOption();
@@ -200,6 +198,7 @@ protected:
     std::map<OptionsCategory, std::map<std::string, Arg>> m_available_args GUARDED_BY(cs_args);
     bool m_accept_any_command GUARDED_BY(cs_args){true};
     std::list<SectionInfo> m_config_sections GUARDED_BY(cs_args);
+    fs::path m_cached_blocks_path GUARDED_BY(cs_args);
     mutable fs::path m_cached_datadir_path GUARDED_BY(cs_args);
     mutable fs::path m_cached_network_datadir_path GUARDED_BY(cs_args);
 
@@ -264,6 +263,13 @@ public:
      * Get the command and command args (returns std::nullopt if no command provided)
      */
     std::optional<const Command> GetCommand() const;
+
+    /**
+     * Get blocks directory path
+     *
+     * @return Blocks path which is network specific
+     */
+    const fs::path& GetBlocksDirPath();
 
     /**
      * Get data directory path

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -200,6 +200,8 @@ protected:
     std::map<OptionsCategory, std::map<std::string, Arg>> m_available_args GUARDED_BY(cs_args);
     bool m_accept_any_command GUARDED_BY(cs_args){true};
     std::list<SectionInfo> m_config_sections GUARDED_BY(cs_args);
+    mutable fs::path m_cached_datadir_path GUARDED_BY(cs_args);
+    mutable fs::path m_cached_network_datadir_path GUARDED_BY(cs_args);
 
     [[nodiscard]] bool ReadConfigStream(std::istream& stream, const std::string& filepath, std::string& error, bool ignore_invalid_keys = false);
 
@@ -262,6 +264,20 @@ public:
      * Get the command and command args (returns std::nullopt if no command provided)
      */
     std::optional<const Command> GetCommand() const;
+
+    /**
+     * Get data directory path
+     *
+     * @param net_specific Append network identifier to the returned path
+     * @return Absolute path on success, otherwise an empty path when a non-directory path would be returned
+     * @post Returned directory path is created unless it is empty
+     */
+    const fs::path& GetDataDirPath(bool net_specific = true) const;
+
+    /**
+     * For testing
+     */
+    void ClearDatadirPathCache();
 
     /**
      * Return a vector of strings of the given argument

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2204,7 +2204,7 @@ bool CChainState::FlushStateToDisk(
         // Write blocks and block index to disk.
         if (fDoFullFlush || fPeriodicWrite) {
             // Depend on nMinDiskSpace to ensure we can write block index
-            if (!CheckDiskSpace(GetBlocksDir())) {
+            if (!CheckDiskSpace(gArgs.GetBlocksDirPath())) {
                 return AbortNode(state, "Disk space is too low!", _("Disk space is too low!"));
             }
             {
@@ -3890,12 +3890,12 @@ void BlockManager::FindFilesToPrune(std::set<int>& setFilesToPrune, uint64_t nPr
 
 static FlatFileSeq BlockFileSeq()
 {
-    return FlatFileSeq(GetBlocksDir(), "blk", gArgs.GetBoolArg("-fastprune", false) ? 0x4000 /* 16kb */ : BLOCKFILE_CHUNK_SIZE);
+    return FlatFileSeq(gArgs.GetBlocksDirPath(), "blk", gArgs.GetBoolArg("-fastprune", false) ? 0x4000 /* 16kb */ : BLOCKFILE_CHUNK_SIZE);
 }
 
 static FlatFileSeq UndoFileSeq()
 {
-    return FlatFileSeq(GetBlocksDir(), "rev", UNDOFILE_CHUNK_SIZE);
+    return FlatFileSeq(gArgs.GetBlocksDirPath(), "rev", UNDOFILE_CHUNK_SIZE);
 }
 
 FILE* OpenBlockFile(const FlatFilePos &pos, bool fReadOnly) {


### PR DESCRIPTION
This PR attempts to contribute to "Remove gArgs" (#21005).

Main changes:

* `GetDataDir()` function is moved to `ArgsManager.GetDataDirPath()`.
* `GetBlocksDir()` function is moved to `ArgsManager.GetBlocksDirPath()`. 