### PR TITLE
doc: Correction for VerifyTaprootCommitment comments

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1834,7 +1834,7 @@ static bool ExecuteWitnessScript(const Span<const valtype>& stack_span, const CS
 static bool VerifyTaprootCommitment(const std::vector<unsigned char>& control, const std::vector<unsigned char>& program, const CScript& script, uint256& tapleaf_hash)
 {
     const int path_len = (control.size() - TAPROOT_CONTROL_BASE_SIZE) / TAPROOT_CONTROL_NODE_SIZE;
-    //! The inner pubkey (x-only, so no Y coordinate parity).
+    //! The internal pubkey (x-only, so no Y coordinate parity).
     const XOnlyPubKey p{uint256(std::vector<unsigned char>(control.begin() + 1, control.begin() + TAPROOT_CONTROL_BASE_SIZE))};
     //! The output pubkey (taken from the scriptPubKey).
     const XOnlyPubKey q{uint256(program)};
@@ -1852,9 +1852,9 @@ static bool VerifyTaprootCommitment(const std::vector<unsigned char>& control, c
         }
         k = ss_branch.GetSHA256();
     }
-    // Compute the tweak from the Merkle root and the inner pubkey.
+    // Compute the tweak from the Merkle root and the internal pubkey.
     k = (CHashWriter(HASHER_TAPTWEAK) << MakeSpan(p) << k).GetSHA256();
-    // Verify that the output pubkey matches the tweaked inner pubkey, after correcting for parity.
+    // Verify that the output pubkey matches the tweaked internal pubkey, after correcting for parity.
     return q.CheckPayToContract(p, k, control[0] & 1);
 }
 

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -177,17 +177,17 @@ def default_negflag(ctx):
     """Default expression for "negflag": tap.negflag."""
     return get(ctx, "tap").negflag
 
-def default_pubkey_inner(ctx):
-    """Default expression for "pubkey_inner": tap.inner_pubkey."""
-    return get(ctx, "tap").inner_pubkey
+def default_pubkey_internal(ctx):
+    """Default expression for "pubkey_internal": tap.internal_pubkey."""
+    return get(ctx, "tap").internal_pubkey
 
 def default_merklebranch(ctx):
     """Default expression for "merklebranch": tapleaf.merklebranch."""
     return get(ctx, "tapleaf").merklebranch
 
 def default_controlblock(ctx):
-    """Default expression for "controlblock": combine leafversion, negflag, pubkey_inner, merklebranch."""
-    return bytes([get(ctx, "leafversion") + get(ctx, "negflag")]) + get(ctx, "pubkey_inner") + get(ctx, "merklebranch")
+    """Default expression for "controlblock": combine leafversion, negflag, pubkey_internal, merklebranch."""
+    return bytes([get(ctx, "leafversion") + get(ctx, "negflag")]) + get(ctx, "pubkey_internal") + get(ctx, "merklebranch")
 
 def default_sighash(ctx):
     """Default expression for "sighash": depending on mode, compute BIP341, BIP143, or legacy sighash."""
@@ -341,9 +341,9 @@ DEFAULT_CONTEXT = {
     "tapleaf": default_tapleaf,
     # The script to push, and include in the sighash, for a taproot script path spend.
     "script_taproot": default_script_taproot,
-    # The inner pubkey for a taproot script path spend (32 bytes).
-    "pubkey_inner": default_pubkey_inner,
-    # The negation flag of the inner pubkey for a taproot script path spend.
+    # The internal pubkey for a taproot script path spend (32 bytes).
+    "pubkey_internal": default_pubkey_internal,
+    # The negation flag of the internal pubkey for a taproot script path spend.
     "negflag": default_negflag,
     # The leaf version to include in the sighash (this does not affect the one in the control block).
     "leafversion": default_leafversion,
@@ -780,8 +780,8 @@ def spenders_taproot_active():
     add_spender(spenders, "spendpath/negflag", tap=tap, leaf="128deep", **SINGLE_SIG, key=secs[0], failure={"negflag": lambda ctx: 1 - default_negflag(ctx)}, **ERR_WITNESS_PROGRAM_MISMATCH)
     # Test that bitflips in the Merkle branch invalidate it.
     add_spender(spenders, "spendpath/bitflipmerkle", tap=tap, leaf="128deep", **SINGLE_SIG, key=secs[0], failure={"merklebranch": bitflipper(default_merklebranch)}, **ERR_WITNESS_PROGRAM_MISMATCH)
-    # Test that bitflips in the inner pubkey invalidate it.
-    add_spender(spenders, "spendpath/bitflippubkey", tap=tap, leaf="128deep", **SINGLE_SIG, key=secs[0], failure={"pubkey_inner": bitflipper(default_pubkey_inner)}, **ERR_WITNESS_PROGRAM_MISMATCH)
+    # Test that bitflips in the internal pubkey invalidate it.
+    add_spender(spenders, "spendpath/bitflippubkey", tap=tap, leaf="128deep", **SINGLE_SIG, key=secs[0], failure={"pubkey_internal": bitflipper(default_pubkey_internal)}, **ERR_WITNESS_PROGRAM_MISMATCH)
     # Test that empty witnesses are invalid.
     add_spender(spenders, "spendpath/emptywit", tap=tap, leaf="128deep", **SINGLE_SIG, key=secs[0], failure={"witness": []}, **ERR_EMPTY_WITNESS)
     # Test that adding garbage to the control block invalidates it.

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -826,11 +826,11 @@ def taproot_tree_helper(scripts):
 
 # A TaprootInfo object has the following fields:
 # - scriptPubKey: the scriptPubKey (witness v1 CScript)
-# - inner_pubkey: the inner pubkey (32 bytes)
-# - negflag: whether the pubkey in the scriptPubKey was negated from inner_pubkey+tweak*G (bool).
+# - internal_pubkey: the internal pubkey (32 bytes)
+# - negflag: whether the pubkey in the scriptPubKey was negated from internal_pubkey+tweak*G (bool).
 # - tweak: the tweak (32 bytes)
 # - leaves: a dict of name -> TaprootLeafInfo objects for all known leaves
-TaprootInfo = namedtuple("TaprootInfo", "scriptPubKey,inner_pubkey,negflag,tweak,leaves")
+TaprootInfo = namedtuple("TaprootInfo", "scriptPubKey,internal_pubkey,negflag,tweak,leaves")
 
 # A TaprootLeafInfo object has the following fields:
 # - script: the leaf script (CScript or bytes)


### PR DESCRIPTION
According to BIP-341, 'p' is called the taproot *internal* key, not inner key.