### PR TITLE
build: make HAVE_O_CLOEXEC available outside LevelDB (bugfix)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -925,6 +925,8 @@ AC_CHECK_DECLS([strnlen])
 dnl Check for daemon(3), unrelated to --with-daemon (although used by it)
 AC_CHECK_DECLS([daemon])
 
+AC_CHECK_DECLS([pipe2])
+
 AC_CHECK_DECLS([le16toh, le32toh, le64toh, htole16, htole32, htole64, be16toh, be32toh, be64toh, htobe16, htobe32, htobe64],,,
 		[#if HAVE_ENDIAN_H
                  #include <endian.h>

--- a/configure.ac
+++ b/configure.ac
@@ -1151,6 +1151,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <fcntl.h>]],
  [ AC_MSG_RESULT(yes); HAVE_O_CLOEXEC=1 ],
  [ AC_MSG_RESULT(no); HAVE_O_CLOEXEC=0 ]
 )
+AC_DEFINE_UNQUOTED([HAVE_O_CLOEXEC], [$HAVE_O_CLOEXEC], [Define to 1 if O_CLOEXEC flag is available.])
 
 dnl crc32c platform checks
 AC_MSG_CHECKING(for __builtin_prefetch)

--- a/src/shutdown.cpp
+++ b/src/shutdown.cpp
@@ -32,7 +32,7 @@ static int g_shutdown_pipe[2] = {-1, -1};
 bool InitShutdownState()
 {
 #ifndef WIN32
-#if HAVE_O_CLOEXEC
+#if HAVE_O_CLOEXEC && HAVE_DECL_PIPE2
     // If we can, make sure that the file descriptors are closed on exec()
     // to prevent interference.
     if (pipe2(g_shutdown_pipe, O_CLOEXEC) != 0) {


### PR DESCRIPTION
The result of the O_CLOEXEC availability check is currently only set in the Makefile and passed to LevelDB (see `LEVELDB_CPPFLAGS_INT` in `src/Makefile.leveldb.include`), but not defined to be used in our codebase. This means that code within the preprocessor conditional `#if HAVE_O_CLOEXEC` was actually never compiled. On the master branch this is currently used for pipe creation in `src/shutdown.cpp`, PR #21007 moves this part to a new module (I found the issue while testing that PR).

The fix is similar to the one in #19803, which solved the same problem for HAVE_FDATASYNC.

In the course of working on the PR it turned out that pipe2 is not available an all platforms, hence a configure check and a corresponding define HAVE_PIPE2 is introduced and used.

The PR can be tested by anyone with a system that has pipe2 and O_CLOEXEC available by putting gibberish into the HAVE_O_CLOEXEC block: on master, everything should compile fine, on PR, the compiler should abort with an error. At least that's my naive way of testing preprocessor logic, happy to hear more sophisticated ways :-)