### PR TITLE
Add wp link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ with no central authority: managing transactions and issuing money are carried
 out collectively by the network. Bitcoin Core is the name of open source
 software which enables the use of this currency.
 
-For more information read the original Bitcoin whitepaper.
+For more information read the [original Bitcoin whitepaper.](https://web.archive.org/web/20091128185352/http://voxel.dl.sourceforge.net/project/bitcoin/Research%20Paper/bitcoin.pdf/bitcoin.pdf)
+
 
 License
 -------


### PR DESCRIPTION
MarcoFalke suggested using a Stackexchange link which helps with whitepaper. This is the original whitepaper link from sourceforge.net: https://github.com/bitcoin/bitcoin/pull/21210#discussion_r578414190