### PR TITLE
wallet: indicate whether a transaction is in the mempool

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -161,6 +161,7 @@ static void WalletTxToJSON(interfaces::Chain& chain, const CWalletTx& wtx, UniVa
         entry.pushKV("blocktime", block_time);
     } else {
         entry.pushKV("trusted", wtx.IsTrusted());
+        entry.pushKV("in_mempool", wtx.fInMempool);
     }
     uint256 hash = wtx.GetHash();
     entry.pushKV("txid", hash.GetHex());
@@ -181,7 +182,6 @@ static void WalletTxToJSON(interfaces::Chain& chain, const CWalletTx& wtx, UniVa
             rbfStatus = "yes";
     }
     entry.pushKV("bip125-replaceable", rbfStatus);
-
     for (const std::pair<const std::string, std::string>& item : wtx.mapValue)
         entry.pushKV(item.first, item.second);
 }
@@ -1372,6 +1372,7 @@ static const std::vector<RPCResult> TransactionDescriptionString()
                "transaction conflicted that many blocks ago."},
            {RPCResult::Type::BOOL, "generated", "Only present if transaction only input is a coinbase one."},
            {RPCResult::Type::BOOL, "trusted", "Only present if we consider transaction to be trusted and so safe to spend from."},
+           {RPCResult::Type::BOOL, "in_mempool", "Only present on unconfirmed transactions."},
            {RPCResult::Type::STR_HEX, "blockhash", "The block hash containing the transaction."},
            {RPCResult::Type::NUM, "blockheight", "The block height containing the transaction."},
            {RPCResult::Type::NUM, "blockindex", "The index of the transaction in the block that includes it."},

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -622,7 +622,7 @@ class WalletTest(BitcoinTestFramework):
                                  "category": baz["category"],
                                  "vout":     baz["vout"]}
         expected_fields = frozenset({'amount', 'bip125-replaceable', 'confirmations', 'details', 'fee',
-                                     'hex', 'time', 'timereceived', 'trusted', 'txid', 'walletconflicts'})
+                                     'hex', 'in_mempool', 'time', 'timereceived', 'trusted', 'txid', 'walletconflicts'})
         verbose_field = "decoded"
         expected_verbose_fields = expected_fields | {verbose_field}
 

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -107,6 +107,8 @@ class ListTransactionsTest(BitcoinTestFramework):
                                 {"txid": txid, "label": "watchonly"})
 
         self.run_rbf_opt_in_test()
+        self.test_listtransactions_display_in_mempool()
+        self.test_gettransaction_display_in_mempool()
 
     # Check that the opt-in-rbf flag works properly, for sent and received
     # transactions.
@@ -209,6 +211,58 @@ class ListTransactionsTest(BitcoinTestFramework):
         assert txid_3b not in self.nodes[0].getrawmempool()
         assert_equal(self.nodes[0].gettransaction(txid_3b)["bip125-replaceable"], "no")
         assert_equal(self.nodes[0].gettransaction(txid_4)["bip125-replaceable"], "unknown")
+
+    def create_and_send_transaction(self, utxo, address, amt, feeRate):
+        psbtx = self.nodes[0].walletcreatefundedpsbt([{"txid": utxo['txid'], "vout": utxo['vout']}],
+                                                      {address: amt},
+                                                      0,
+                                                      {"replaceable":True, "feeRate":feeRate})['psbt']
+        signed_tx = self.nodes[0].walletprocesspsbt(psbtx)['psbt']
+        final_tx = self.nodes[0].finalizepsbt(signed_tx)['hex']
+        return self.nodes[0].sendrawtransaction(final_tx)
+
+    def test_listtransactions_display_in_mempool(self):
+        self.log.info('Testing that listtransactions correctly displays whether a transaction is in the mempool')
+        utxo = self.nodes[0].listunspent()[0]
+        address = self.nodes[0].getnewaddress()
+
+        tx1_id = self.create_and_send_transaction(utxo, address, 0.1, 0.001)
+
+        new_txs = self.nodes[0].listtransactions(count=2)
+        for tx in new_txs:
+            assert_equal(tx['txid'], tx1_id)
+            assert_equal(tx['in_mempool'], True)
+
+        tx2_id = self.create_and_send_transaction(utxo, address, 0.1, 0.002)
+
+        new_txs = self.nodes[0].listtransactions(count=4)
+        for i in range(2):
+            assert_equal(new_txs[i]['txid'], tx1_id)
+            assert_equal(new_txs[i]['in_mempool'], False)
+
+        for i in range(2, 4):
+            assert_equal(new_txs[i]['txid'], tx2_id)
+            assert_equal(new_txs[i]['in_mempool'], True)
+
+    def test_gettransaction_display_in_mempool(self):
+        self.log.info('Testing that gettransaction correctly displays whether a transaction is in the mempool')
+        utxo = self.nodes[0].listunspent()[0]
+        address = self.nodes[0].getnewaddress()
+
+        tx1_id = self.create_and_send_transaction(utxo, address, 0.1, 0.001)
+
+        tx1 = self.nodes[0].gettransaction(tx1_id)
+        assert_equal(tx1['txid'], tx1_id)
+        assert_equal(tx1['in_mempool'], True)
+
+        tx2_id = self.create_and_send_transaction(utxo, address, 0.1, 0.002)
+        tx1 = self.nodes[0].gettransaction(tx1_id)
+        tx2 = self.nodes[0].gettransaction(tx2_id)
+        assert_equal(tx1['txid'], tx1_id)
+        assert_equal(tx1['in_mempool'], False)
+        assert_equal(tx2['txid'], tx2_id)
+        assert_equal(tx2['in_mempool'], True)
+
 
 if __name__ == '__main__':
     ListTransactionsTest().main()


### PR DESCRIPTION
Added a field to the output of listtransactions/gettransaction to indicate whether a transaction is in the mempool. Closes #21018.