### PR TITLE
guix: Passthrough SDK_PATH into container

### DIFF
--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -118,6 +118,13 @@ find output/ -type f -print0 | sort -z | xargs -r0 sha256sum
   depends tree. Setting this to the same directory across multiple builds of the
   depends tree can eliminate unnecessary building of packages.
 
+* _**SDK_PATH**_
+
+  Set the path where _extracted_ SDKs can be found. This is passed through to
+  the depends tree. Note that this is should be set to the _parent_ directory of
+  the actual SDK (e.g. SDK_PATH=$HOME/Downloads/macOS-SDKs instead of
+  $HOME/Downloads/macOS-SDKs/Xcode-11.3.1-11C505-extracted-SDK-with-libcxx-headers).
+
 * _**MAX_JOBS**_
 
   Override the maximum number of jobs to run simultaneously, you might want to

--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -196,10 +196,11 @@ and untracked files and directories will be wiped, allowing you to start anew.
 EOF
 }
 
-# Create SOURCES_PATH and BASE_CACHE if they are non-empty so that we can map
-# them into the container
+# Create SOURCES_PATH, BASE_CACHE, and SDK_PATH if they are non-empty so that we
+# can map them into the container
 [ -z "$SOURCES_PATH" ] || mkdir -p "$SOURCES_PATH"
 [ -z "$BASE_CACHE" ]   || mkdir -p "$BASE_CACHE"
+[ -z "$SDK_PATH" ]     || mkdir -p "$SDK_PATH"
 
 # Deterministically build Bitcoin Core
 # shellcheck disable=SC2153
@@ -302,6 +303,7 @@ EOF
                                  --expose="$(git rev-parse --git-common-dir)" \
                                  ${SOURCES_PATH:+--share="$SOURCES_PATH"} \
                                  ${BASE_CACHE:+--share="$BASE_CACHE"} \
+                                 ${SDK_PATH:+--share="$SDK_PATH"} \
                                  --max-jobs="$MAX_JOBS" \
                                  --keep-failed \
                                  ${SUBSTITUTE_URLS:+--substitute-urls="$SUBSTITUTE_URLS"} \
@@ -312,6 +314,7 @@ EOF
                                         ${V:+V=1} \
                                         ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"} \
                                         ${BASE_CACHE:+BASE_CACHE="$BASE_CACHE"} \
+                                        ${SDK_PATH:+SDK_PATH="$SDK_PATH"} \
                                         DISTSRC="$(DISTSRC_BASE=/distsrc-base && distsrc_for_host "$HOST")" \
                                         OUTDIR=/outdir \
                                       bash -c "cd /bitcoin && bash contrib/guix/libexec/build.sh"

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -174,6 +174,7 @@ make -C depends --jobs="$MAX_JOBS" HOST="$HOST" \
                                    ${V:+V=1} \
                                    ${SOURCES_PATH+SOURCES_PATH="$SOURCES_PATH"} \
                                    ${BASE_CACHE+BASE_CACHE="$BASE_CACHE"} \
+                                   ${SDK_PATH+SDK_PATH="$SDK_PATH"} \
                                    i686_linux_CC=i686-linux-gnu-gcc \
                                    i686_linux_CXX=i686-linux-gnu-g++ \
                                    i686_linux_AR=i686-linux-gnu-ar \


### PR DESCRIPTION
This is a usability improvement for Guix builders so that they don't have to extract the Xcode tarball into `depends/SDKs` every time.

Inspiration: https://github.com/bitcoin/bitcoin/pull/21089#issuecomment-778639698