### PR TITLE
assumptions:  Assume C++17

### DIFF
--- a/build_msvc/common.init.vcxproj
+++ b/build_msvc/common.init.vcxproj
@@ -96,7 +96,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalOptions>/utf-8 /std:c++17 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/utf-8 /Zc:__cplusplus /std:c++17 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4018;4221;4244;4267;4334;4715;4805;4834</DisableSpecificWarnings>
       <TreatWarningAsError>true</TreatWarningAsError>
       <PreprocessorDefinitions>_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;_SILENCE_CXX17_OLD_ALLOCATOR_MEMBERS_DEPRECATION_WARNING;ZMQ_STATIC;NOMINMAX;WIN32;HAVE_CONFIG_H;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CONSOLE;_WIN32_WINNT=0x0601;_WIN32_IE=0x0501;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/compat/assumptions.h
+++ b/src/compat/assumptions.h
@@ -19,14 +19,10 @@
 
 // Assumption: We assume a C++17 (ISO/IEC 14882:2017) compiler (minimum requirement).
 // Example(s): We assume the presence of C++17 features everywhere :-)
-// Note:       MSVC does not report the expected __cplusplus value due to legacy
-//             reasons.
-#if !defined(_MSC_VER)
 // ISO Standard C++17 [cpp.predefined]p1:
 // "The name __cplusplus is defined to the value 201703L when compiling a C++
 //  translation unit."
 static_assert(__cplusplus >= 201703L, "C++17 standard assumed");
-#endif
 
 // Assumption: We assume the floating-point types to fulfill the requirements of
 //             IEC 559 (IEEE 754) standard.

--- a/src/compat/assumptions.h
+++ b/src/compat/assumptions.h
@@ -17,15 +17,15 @@
 # error "Bitcoin cannot be compiled without assertions."
 #endif
 
-// Assumption: We assume a C++11 (ISO/IEC 14882:2011) compiler (minimum requirement).
-// Example(s): We assume the presence of C++11 features everywhere :-)
+// Assumption: We assume a C++17 (ISO/IEC 14882:2017) compiler (minimum requirement).
+// Example(s): We assume the presence of C++17 features everywhere :-)
 // Note:       MSVC does not report the expected __cplusplus value due to legacy
 //             reasons.
 #if !defined(_MSC_VER)
-// ISO Standard C++11 [cpp.predefined]p1:
-// "The name __cplusplus is defined to the value 201103L when compiling a C++
+// ISO Standard C++17 [cpp.predefined]p1:
+// "The name __cplusplus is defined to the value 201703L when compiling a C++
 //  translation unit."
-static_assert(__cplusplus >= 201103L, "C++11 standard assumed");
+static_assert(__cplusplus >= 201703L, "C++17 standard assumed");
 #endif
 
 // Assumption: We assume the floating-point types to fulfill the requirements of


### PR DESCRIPTION
This has been the case since #20413.

This should also enable the check for MSVC. From my reading of https://docs.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-160 and https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/ if we set the `/Zc:__cplusplus` switch in additional options, MSVC will report the correct value for `__cplusplus`. However I have not tested this.