### PR TITLE
wallet: listdescriptors uses normalized descriptor form

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -1775,6 +1775,8 @@ RPCHelpMan listdescriptors()
         throw JSONRPCError(RPC_WALLET_ERROR, "listdescriptors is not available for non-descriptor wallets");
     }
 
+    EnsureWalletIsUnlocked(wallet.get());
+
     LOCK(wallet->cs_wallet);
 
     UniValue response(UniValue::VARR);
@@ -1787,7 +1789,11 @@ RPCHelpMan listdescriptors()
         UniValue spk(UniValue::VOBJ);
         LOCK(desc_spk_man->cs_desc_man);
         const auto& wallet_descriptor = desc_spk_man->GetWalletDescriptor();
-        spk.pushKV("desc", wallet_descriptor.descriptor->ToString());
+        std::string descriptor;
+        if (!desc_spk_man->GetDescriptorString(descriptor, false)) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "Can't get normalized descriptor string.");
+        }
+        spk.pushKV("desc", descriptor);
         spk.pushKV("timestamp", wallet_descriptor.creation_time);
         const bool active = active_spk_mans.count(desc_spk_man) != 0;
         spk.pushKV("active", active);

--- a/test/functional/wallet_listdescriptors.py
+++ b/test/functional/wallet_listdescriptors.py
@@ -50,6 +50,22 @@ class ListDescriptorsTest(BitcoinTestFramework):
             assert item['range'] == [0, 0]
             assert item['timestamp'] is not None
 
+        self.log.info('Test descriptors with hardened derivations are listed in importable form.')
+        xprv = 'tprv8ZgxMBicQKsPeuVhWwi6wuMQGfPKi9Li5GtX35jVNknACgqe3CY4g5xgkfDDJcmtF7o1QnxWDRYw4H5P26PXq7sbcUkEqeR4fg3Kxp2tigg'
+        xpub_acc = 'tpubDCMVLhErorrAGfApiJSJzEKwqeaf2z3NrkVMxgYQjZLzMjXMBeRw2muGNYbvaekAE8rUFLftyEar4LdrG2wXyyTJQZ26zptmeTEjPTaATts'
+        hardened_path = '/84\'/1\'/0\''
+        wallet = node.get_wallet_rpc('w2')
+        wallet.importdescriptors([{
+            'desc': descsum_create('wpkh(' + xprv + hardened_path + '/0/*)'),
+            'timestamp': 1296688602,
+        }])
+        expected = {'desc': descsum_create('wpkh([80002067' + hardened_path + ']' + xpub_acc + '/0/*)'),
+                    'timestamp': 1296688602,
+                    'active': False,
+                    'range': [0, 0],
+                    'next': 0}
+        assert_equal([expected], wallet.listdescriptors())
+
         self.log.info('Test non-active non-range combo descriptor')
         node.createwallet(wallet_name='w4', blank=True, descriptors=True)
         wallet = node.get_wallet_rpc('w4')


### PR DESCRIPTION
Rationale: show importable descriptors with `listdescriptors` RPC

It uses #19136 to derive xpub at the last hardened step.

**Before**:
```
[
    {
      "desc": "wpkh(tpubD6NzVbkrYhZ4YUQRJL49TWw1VR5v3QKUNYaGGMUfJUm19x5ZqQ2hEiPiYbAQvD2nHoPGQGPg3snLPM8sjmYpvx7XQhkmyfk8xhsUwKbXzyh/84'/1'/0'/0/*)#p4cn3erf",
      "timestamp": 1613982591,
      "active": true,
      "internal": false,
      "range": [
        0,
        999
      ],
      "next": 0
    },
    ...
]
```

**After**:
```
[
  {
    "desc": "wpkh([d4ade89c/84'/1'/0']tpubDDUEYcVXy6Vh5meHvcXN3sAr4k3fWwLZGpAHbkAHL8EnkDxp4d99CjNhJHfM2fUJicANvAKnCZS6XaVAgwAeKYc1KesGCN5qbQ25qQHrRxM/0/*)#8wq8rcft",
    "timestamp": 1613982591,
    "active": true,
    "internal": false,
    "range": [
      0,
      999
    ],
    "next": 0
  },
  ...
]
```