### PR TITLE
contrib: Add explanatory comment to tc.sh

### DIFF
--- a/contrib/qos/tc.sh
+++ b/contrib/qos/tc.sh
@@ -16,7 +16,7 @@ LOCALNET_V4="192.168.0.0/16"
 #defines the IPv6 address space for which you wish to disable rate limiting
 LOCALNET_V6="fe80::/10"
 
-#delete existing rules (Error: Cannot delete qdisc with handle of zero. means there weren't any.)
+#delete existing rules ('Error: Cannot delete qdisc with handle of zero.' means there weren't any.)
 tc qdisc del dev ${IF} root
 
 #add root class

--- a/contrib/qos/tc.sh
+++ b/contrib/qos/tc.sh
@@ -16,7 +16,7 @@ LOCALNET_V4="192.168.0.0/16"
 #defines the IPv6 address space for which you wish to disable rate limiting
 LOCALNET_V6="fe80::/10"
 
-#delete existing rules
+#delete existing rules (Error: Cannot delete qdisc with handle of zero. means there weren't any.)
 tc qdisc del dev ${IF} root
 
 #add root class


### PR DESCRIPTION
I added a comment which would have saved me a lot of time _if it's accurate_.  Is it?

tc.sh is used to limit bandwidth.  I ran it and it is limiting my bandwidth.  When I ran it, I got one error.  I have not found an explanation anywhere of what the error means, but my best guess is consistent with the result, so I propose the explanatory comment to save others time when they use it and also get the error.  A better fix is for tc NOT to report the failure to delete a qdisc when it's a result of there being no such qdisc.  I'll go look for a tc maintainer now to see if it can be changed to a warning.