### PR TITLE
guix: Bump time-machine, glibc, and linux-headers

### DIFF
--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -163,7 +163,7 @@ SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log --format=%at -1)}"
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://github.com/dongcarl/guix.git \
-                      --commit=6c9d16db962a6f7155571b36eced681fd2889e23 \
+                      --commit=490e39ff303f4f6873a04bfb8253755bdae1b29c \
                       --max-jobs="$MAX_JOBS" \
                       --keep-failed \
                       ${SUBSTITUTE_URLS:+--substitute-urls="$SUBSTITUTE_URLS"} \

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -125,9 +125,9 @@ chain for " target " development."))
 
 (define* (make-bitcoin-cross-toolchain target
                                   #:key
-                                  (base-gcc-for-libc gcc-5)
-                                  (base-kernel-headers linux-libre-headers-4.19)
-                                  (base-libc glibc-2.27)
+                                  (base-gcc-for-libc gcc-7)
+                                  (base-kernel-headers linux-libre-headers-5.4)
+                                  (base-libc glibc)  ; glibc 2.31
                                   (base-gcc (make-gcc-rpath-link gcc-9)))
   "Convenience wrapper around MAKE-CROSS-TOOLCHAIN with default values
 desirable for building Bitcoin Core release binaries."
@@ -232,12 +232,6 @@ chain for " target " development."))
            (list zip
                  (make-mingw-pthreads-cross-toolchain "x86_64-w64-mingw32")
                  (make-nsis-with-sde-support nsis-x86_64)))
-          ((string-contains target "riscv64-linux-")
-           (list (make-bitcoin-cross-toolchain target
-                                               #:base-gcc-for-libc gcc-7)))
-          ((string-contains target "powerpc64le-linux-")
-           (list (make-bitcoin-cross-toolchain target
-                                               #:base-gcc-for-libc gcc-7)))
           ((string-contains target "-linux-")
            (list (make-bitcoin-cross-toolchain target)))
           ((string-contains target "darwin")


### PR DESCRIPTION
On bumping the time-machine:

```
A few changes which are useful for us:

1. 'gnu: cross-gcc-arguments: Enable 128 bit long double for POWER9.' is
   now merged into master.
2. gnutls is bumped to 3.6.15 and the temporal test failure in
   status-request-revoked is fixed. Note that this does not fix the case
   where one has installed Guix v1.2.0 and is running a substitute-less
   bootstrap build, since the `guix time-machine` command itself has a
   dependency on gnutls v3.6.12 (the one with the broken test) and will
   thus try to build it before attempting to jump forwards in time. This
   does however, mean that those who build a version of Guix that also
   contains this fix will not go backwards in time to build the broken
   gnutls v3.6.12.
```

On bumping the rest:

```
Bump glibc and linux-headers to match those of our Gitian counterparts.

We also require a glibc >= 2.28 for the test-symbol-check scripts to
work properly.

The default BASE-GCC-FOR-LIBC also has to be bumped since glibc 2.31
requires a gcc >= 6.2
```

This is a prerequisite for #20980
