### PR TITLE
wallet: remove lock during `listaddressgroupings`

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3394,7 +3394,6 @@ std::map<CTxDestination, CAmount> CWallet::GetAddressBalances() const
     std::map<CTxDestination, CAmount> balances;
 
     {
-        LOCK(cs_wallet);
         std::set<uint256> trusted_parents;
         for (const auto& walletEntry : mapWallet)
         {
@@ -3429,7 +3428,6 @@ std::map<CTxDestination, CAmount> CWallet::GetAddressBalances() const
 
 std::set< std::set<CTxDestination> > CWallet::GetAddressGroupings() const
 {
-    AssertLockHeld(cs_wallet);
     std::set< std::set<CTxDestination> > groupings;
     std::set<CTxDestination> grouping;
 


### PR DESCRIPTION
Currently I can't see how many addresses I have, because when I do `listaddressgroupings` it locks my wallet. Because it locks the wallet I can't transfer from my wallet. Stopping the sending from wallet, is not an option for me. 

What I want is to see `listaddressgroupings` and be able to send from wallet at the same time.
Since that, when calling `listaddressgroupings` you have at least 2 locks that I've removed from code. I've double checked that `GetAddressBalances` nor `GetAddressGroupings` is used in code in any other place except for `listaddressgroupings`.


