### PR TITLE
More robust file/directory syncing and error handling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -876,6 +876,8 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ ]], [[
  [ AC_MSG_RESULT(no)]
 )
 
+AC_CHECK_FUNCS([fsync])
+
 dnl Check for malloc_info (for memory statistics information in getmemoryinfo)
 AC_MSG_CHECKING(for getmemoryinfo)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <malloc.h>]],

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -92,7 +92,10 @@ bool FlatFileSeq::Flush(const FlatFilePos& pos, bool finalize)
         fclose(file);
         return error("%s: failed to commit file %d", __func__, pos.nFile);
     }
-    DirectoryCommit(m_dir);
+    if (!DirectoryCommit(m_dir)) {
+        fclose(file);
+        return false;  // DirectoryCommit logs its own error message
+    }
 
     fclose(file);
     return true;

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1045,6 +1045,14 @@ bool FileCommit(FILE *file)
         failure = true;
     }
 #endif
+#if HAVE_FSYNC
+    if (fsync(fileno(file)) == 0) {
+        return true;
+    } else if (errno != EINVAL) {
+        LogPrintf("%s: fsync failed: %d\n", __func__, errno);
+        failure = true;
+    }
+#endif
 
     // If no platform-specific flush mechanisms, entirely dependent on the result of fflush.
     // If platform-specific flush mechanisms exist, they must succeed, or we return failure.

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -69,8 +69,11 @@ bool FileCommit(FILE *file);
 /**
  * Sync directory contents. This is required on some environments to ensure that
  * newly created files are committed to disk.
+ *
+ * @param dirname The directory to be committed.
+ * @return True if we think we succeeded; false if we probably failed.
  */
-void DirectoryCommit(const fs::path &dirname);
+bool DirectoryCommit(const fs::path &dirname);
 
 bool TruncateFile(FILE *file, unsigned int length);
 int RaiseFileDescriptorLimit(int nMinFD);

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -60,6 +60,9 @@ void PrintExceptionContinue(const std::exception *pex, const char* pszThread);
 /**
  * Ensure file contents are fully committed to disk, using a platform-specific
  * feature analogous to fsync().
+ *
+ * @param file The file to be committed.
+ * @return True if we think we succeeded; false if we probably failed.
  */
 bool FileCommit(FILE *file);
 


### PR DESCRIPTION
A few more improvements beyond #14501:

* FileCommit will try multiple sync mechanisms, when supported
* ~~DirectoryCommit adds Windows support~~ (dropped due to bugs)
* DirectoryCommit returns success/failure and gets handled as such

Someone should probably test on BSD, as I recall past directory sync issues