### PR TITLE
util: Make Assume() usable as unary expression

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -76,6 +76,9 @@ BOOST_AUTO_TEST_CASE(util_check)
     const int two = *Assert(p_two);
     Assert(two == 2);
     Assert(true);
+    // Check that Assume can be used as unary expression
+    const bool result{Assume(two == 2)};
+    Assert(result);
 }
 
 BOOST_AUTO_TEST_CASE(util_criticalsection)

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -69,7 +69,7 @@ T get_pure_r_value(T&& val)
 #ifdef ABORT_ON_FAILED_ASSUME
 #define Assume(val) Assert(val)
 #else
-#define Assume(val) ((void)(val))
+#define Assume(val) ([&]() -> decltype(get_pure_r_value(val)) { auto&& check = (val); return std::forward<decltype(get_pure_r_value(val))>(check); }())
 #endif
 
 #endif // BITCOIN_UTIL_CHECK_H


### PR DESCRIPTION
Assume shouldn't behave different at the call site depending on build flags. Currently compilation fails if it is used as expression. Fix that by using the lambda approach from `Assert()` without the `assert()`.