### PR TITLE
guix: Add curl to required tool list

### DIFF
--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -9,7 +9,7 @@ set -e -o pipefail
 ################
 # Check 1: Make sure that we can invoke required tools
 ################
-for cmd in git make guix cat mkdir; do
+for cmd in git make guix cat mkdir curl; do
     if ! command -v "$cmd" > /dev/null 2>&1; then
         echo "ERR: This script requires that '$cmd' is installed and available in your \$PATH"
         exit 1


### PR DESCRIPTION
On Ubuntu Hirsute (minimum installation) with the system `guix` package:
```
$ HOSTS=x86_64-linux-gnu ./contrib/guix/guix-build.sh
make: Entering directory '/home/hebasto/bitcoin/depends'
make[1]: Entering directory '/home/hebasto/bitcoin/depends'
Checksum missing or mismatched for boost source. Forcing re-download.
Fetching boost_1_71_0.tar.bz2 from https://dl.bintray.com/boostorg/release/1.71.0/source/
/bin/sh: 1: curl: not found
Fetching boost_1_71_0.tar.bz2 from https://bitcoincore.org/depends-sources
/bin/sh: 1: curl: not found
make[1]: *** [funcs.mk:276: /home/hebasto/bitcoin/depends/sources/download-stamps/.stamp_fetched-boost-boost_1_71_0.tar.bz2.hash] Error 127
make[1]: Leaving directory '/home/hebasto/bitcoin/depends'
make: *** [Makefile:281: download-linux] Error 2
make: Leaving directory '/home/hebasto/bitcoin/depends'
```

This PR fixes that issue.