### PR TITLE
doc: Update build instructions for Fedora

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -84,23 +84,22 @@ Now, you can either build from self-compiled [depends](/depends/README.md) or in
 
     sudo apt-get install libevent-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev
 
-BerkeleyDB is required for the wallet.
+Berkeley DB is required for the wallet.
 
 Ubuntu and Debian have their own `libdb-dev` and `libdb++-dev` packages, but these will install
-BerkeleyDB 5.1 or later. This will break binary wallet compatibility with the distributed executables, which
+Berkeley DB 5.1 or later. This will break binary wallet compatibility with the distributed executables, which
 are based on BerkeleyDB 4.8. If you do not care about wallet compatibility,
 pass `--with-incompatible-bdb` to configure.
 
-Otherwise, you can build from self-compiled `depends` (see above).
+Otherwise, you can build Berkeley DB [yourself](#berkeley-db).
 
-SQLite is required for the wallet:
+SQLite is required for the descriptor wallet:
 
     sudo apt install libsqlite3-dev
 
-To build Bitcoin Core without wallet, see [*Disable-wallet mode*](/doc/build-unix.md#disable-wallet-mode)
+To build Bitcoin Core without wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
 
-
-Optional port mapping libraries (see: `--with-miniupnpc`, and `--enable-upnp-default`, `--with-natpmp`, `--enable-natpmp-default`):
+Optional port mapping libraries (see: `--with-miniupnpc`, `--enable-upnp-default`, and `--with-natpmp`, `--enable-natpmp-default`):
 
     sudo apt install libminiupnpc-dev libnatpmp-dev
 
@@ -132,15 +131,42 @@ built by default.
 
 Build requirements:
 
-    sudo dnf install gcc-c++ libtool make autoconf automake libevent-devel boost-devel libdb4-devel libdb4-cxx-devel python3
+    sudo dnf install gcc-c++ libtool make autoconf automake python3
 
-Optional port mapping libraries (see: `--with-miniupnpc`, and `--enable-upnp-default`, `--with-natpmp`, `--enable-natpmp-default`):
+Now, you can either build from self-compiled [depends](/depends/README.md) or install the required dependencies:
+
+    sudo dnf install libevent-devel boost-devel
+
+Berkeley DB is required for the wallet:
+
+    sudo dnf install libdb4-devel libdb4-cxx-devel
+
+Newer Fedora releases, since Fedora 33, have only `libdb-devel` and `libdb-cxx-devel` packages, but these will install
+Berkeley DB 5.3 or later. This will break binary wallet compatibility with the distributed executables, which
+are based on Berkeley DB 4.8. If you do not care about wallet compatibility,
+pass `--with-incompatible-bdb` to configure.
+
+Otherwise, you can build Berkeley DB [yourself](#berkeley-db).
+
+SQLite is required for the descriptor wallet:
+
+    sudo dnf install sqlite-devel
+
+To build Bitcoin Core without wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
+
+Optional port mapping libraries (see: `--with-miniupnpc`, `--enable-upnp-default`, and `--with-natpmp`, `--enable-natpmp-default`):
 
     sudo dnf install miniupnpc-devel libnatpmp-devel
 
 ZMQ dependencies (provides ZMQ API):
 
     sudo dnf install zeromq-devel
+
+GUI dependencies:
+
+If you want to build bitcoin-qt, make sure that the required packages for Qt development
+are installed. Qt 5 is necessary to build the GUI.
+To build without GUI pass `--without-gui`.
 
 To build with Qt 5 you need the following:
 
@@ -150,9 +176,8 @@ libqrencode (optional) can be installed with:
 
     sudo dnf install qrencode-devel
 
-SQLite can be installed with:
-
-    sudo dnf install sqlite-devel
+Once these are installed, they will be found by configure and a bitcoin-qt executable will be
+built by default.
 
 Notes
 -----
@@ -193,7 +218,9 @@ like so:
 
 from the root of the repository.
 
-**Note**: You only need Berkeley DB if the wallet is enabled (see [*Disable-wallet mode*](/doc/build-unix.md#disable-wallet-mode)).
+Otherwise, you can build Bitcoin Core from self-compiled [depends](/depends/README.md).
+
+**Note**: You only need Berkeley DB if the wallet is enabled (see [*Disable-wallet mode*](#disable-wallet-mode)).
 
 Boost
 -----


### PR DESCRIPTION
This PR updates build instructions for Fedora, as Fedora 33 has no `libdb4-devel` and `libdb4-cxx-devel` packages in its default repos.