### PR TITLE
lint: Fix spelling errors in comments

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -3,7 +3,7 @@ export LC_ALL=C
 set -e -o pipefail
 export TZ=UTC
 
-# Althought Guix _does_ set umask when building its own packages (in our case,
+# Although Guix _does_ set umask when building its own packages (in our case,
 # this is all packages in manifest.scm), it does not set it for `guix
 # environment`. It does make sense for at least `guix environment --container`
 # to set umask, so if that change gets merged upstream and we bump the

--- a/contrib/verifybinaries/verify.py
+++ b/contrib/verifybinaries/verify.py
@@ -51,7 +51,7 @@ def download_with_wget(remote_file, local_file=None):
     if local_file:
         wget_args = ['wget', '-O', local_file, remote_file]
     else:
-        # use timestamping mechanism if local filename is not explicitely set
+        # use timestamping mechanism if local filename is not explicitly set
         wget_args = ['wget', '-N', remote_file]
 
     result = subprocess.run(wget_args,
@@ -85,7 +85,7 @@ def main(args):
         print("Error: need to specify a version on the command line")
         return 3
 
-    # determine remote dir dependend on provided version string
+    # determine remote dir dependent on provided version string
     version_base, version_rc, os_filter = parse_version_string(args[0])
     remote_dir = f"/bin/{VERSIONPREFIX}{version_base}/"
     if version_rc:


### PR DESCRIPTION
Found some spelling errors while running spelling linter  https://github.com/bitcoin/bitcoin/pull/21245 

This PR fixes them.