### PR TITLE
build: removing xcrun from darwin build

### DIFF
--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -1,23 +1,25 @@
-build_darwin_CC:=$(shell xcrun -f clang) --sysroot $(shell xcrun --show-sdk-path)
-build_darwin_CXX:=$(shell xcrun -f clang++) --sysroot $(shell xcrun --show-sdk-path)
-build_darwin_AR:=$(shell xcrun -f ar)
-build_darwin_RANLIB:=$(shell xcrun -f ranlib)
-build_darwin_STRIP:=$(shell xcrun -f strip)
-build_darwin_OTOOL:=$(shell xcrun -f otool)
-build_darwin_NM:=$(shell xcrun -f nm)
-build_darwin_INSTALL_NAME_TOOL:=$(shell xcrun -f install_name_tool)
+sdk=$(shell xcrun --show-sdk-path)
+
+build_darwin_CC:=clang --sysroot $(sdk)
+build_darwin_CXX:=clang++ --sysroot $(sdk)
+build_darwin_AR:=ar
+build_darwin_RANLIB:=ranlib
+build_darwin_STRIP:=strip
+build_darwin_OTOOL:=otool
+build_darwin_NM:=nm
+build_darwin_INSTALL_NAME_TOOL:=install_name_tool
 build_darwin_SHA256SUM=shasum -a 256
 build_darwin_DOWNLOAD=curl --location --fail --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -o
 
 #darwin host on darwin builder. overrides darwin host preferences.
-darwin_CC=$(shell xcrun -f clang) -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(shell xcrun --show-sdk-path)
-darwin_CXX:=$(shell xcrun -f clang++) -mmacosx-version-min=$(OSX_MIN_VERSION) -stdlib=libc++ --sysroot $(shell xcrun --show-sdk-path)
-darwin_AR:=$(shell xcrun -f ar)
-darwin_RANLIB:=$(shell xcrun -f ranlib)
-darwin_STRIP:=$(shell xcrun -f strip)
-darwin_LIBTOOL:=$(shell xcrun -f libtool)
-darwin_OTOOL:=$(shell xcrun -f otool)
-darwin_NM:=$(shell xcrun -f nm)
-darwin_INSTALL_NAME_TOOL:=$(shell xcrun -f install_name_tool)
+darwin_CC=clang -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(sdk)
+darwin_CXX:=clang++ -mmacosx-version-min=$(OSX_MIN_VERSION) -stdlib=libc++ --sysroot $(sdk)
+darwin_AR:=ar
+darwin_RANLIB:=ranlib
+darwin_STRIP:=strip
+darwin_LIBTOOL:=libtool
+darwin_OTOOL:=otool
+darwin_NM:=nm
+darwin_INSTALL_NAME_TOOL:=install_name_tool
 darwin_native_binutils=
 darwin_native_toolchain=


### PR DESCRIPTION
Hello, 

I'm tackling the issue: https://github.com/bitcoin/bitcoin/issues/18959

Initial discussion: https://github.com/bitcoin/bitcoin/pull/18743#issuecomment-623609571

I was not able to remove the xcrun invocation to get the SDK path. All others removed. 

We can see below how this behaves when multiple Xcode are present and we switch among them. 

```shell 
$ sudo xcode-select --switch /Applications/Xcode11.7.app

$  make -C depends print-darwin_CXX
darwin_CXX = clang++ -mmacosx-version-min=10.14 -stdlib=libc++ --sysroot /Applications/Xcode11.7.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk

$ clang++ -mmacosx-version-min=10.14 -stdlib=libc++ --sysroot /Applications/Xcode11.7.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk --version
Apple clang version 11.0.3 (clang-1103.0.32.62)
Target: x86_64-apple-darwin20.3.0
Thread model: posix
InstalledDir: /Applications/Xcode11.7.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

$ sudo xcode-select --switch /Applications/Xcode12.3.app/

$  make -C depends print-darwin_CXX
darwin_CXX = clang++ -mmacosx-version-min=10.14 -stdlib=libc++ --sysroot /Applications/Xcode12.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk

$ clang++ -mmacosx-version-min=10.14 -stdlib=libc++ --sysroot /Applications/Xcode12.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk --version
Apple clang version 12.0.0 (clang-1200.0.32.28)
Target: x86_64-apple-darwin20.3.0
Thread model: posix
InstalledDir: /Applications/Xcode12.3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

```