### PR TITLE
build: Fix libbitcoinconsensus cross-compiling for Windows with DEBUG=1 

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -724,7 +724,7 @@ if GLIBC_BACK_COMPAT
   libbitcoinconsensus_la_SOURCES += compat/glibc_compat.cpp
 endif
 
-libbitcoinconsensus_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS)
+libbitcoinconsensus_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 libbitcoinconsensus_la_LIBADD = $(LIBSECP256K1)
 libbitcoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL
 libbitcoinconsensus_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)


### PR DESCRIPTION
Fix #19772.

Steps to reproduce the bug on master (4f223e93e9c097c96a1655f9125aec463892da9c):
```
$ make -C depends HOST=x86_64-w64-mingw32 DEBUG=1 NO_QT=1 NO_QR=1 NO_ZMQ=1 NO_WALLET=1 NO_UPNP=1 NO_NATPMP=1
$ ./autogen.sh
$ CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --disable-wallet --disable-tests --disable-bench --without-utils --without-daemon --without-gui
$ make clean
$ make
...
```