### PR TITLE
test: Unconditionally check for fRelay field in test framework

### DIFF
--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1045,13 +1045,11 @@ class msg_version:
 
         self.nStartingHeight = struct.unpack("<i", f.read(4))[0]
 
-        if self.nVersion >= 70001:
-            # Relay field is optional for version 70001 onwards
-            try:
-                self.relay = struct.unpack("<b", f.read(1))[0]
-            except:
-                self.relay = 0
-        else:
+        # Relay field is optional for version 70001 onwards
+        # But, unconditionally check it to match behaviour in bitcoind
+        try:
+            self.relay = struct.unpack("<b", f.read(1))[0]
+        except struct.error:
             self.relay = 0
 
     def serialize(self):


### PR DESCRIPTION
picking up #20411 (rebased onto master)

There is a discrepancy in the implementation of our p2p protocol between
bitcoind and the testing framework.  The fRelay field is an optional
field at the end of a version message as of protocol version 70001.
However, when deserializing a message in bitcoind, we don't check the
version to see if it should have an fRelay field or not.  Instead, we
unconditionally attempt to deserialize into the field.

This commit brings the testing framework in line with the implementation
in core.

This matters for a version message with the following fields:

Version = 60000
fRelay = 1

Bitcoind would deserialize this into a version message with
Version=60000 and fRelay=1, whereas (before this commit) our testing
framework would deserialize this into a version message with
Version=60000 and fRelay=0.