### PR TITLE
qa: testing for the year 2038 problem

### DIFF
--- a/test/functional/example_y2038.py
+++ b/test/functional/example_y2038.py
@@ -6,8 +6,6 @@
 
 https://en.wikipedia.org/wiki/Year_2038_problem
 """
-
-
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -17,7 +15,6 @@ EPOCH_2038_BEFORE = 2147440306 # (GMT): Monday, January 18, 2038 3:11:46 PM
 EPOCH_2038_AFTER = 2147613106 # (GMT): Wednesday, January 20, 2038 3:11:46 PM
 EPOCH_2106 = 4293404400000
 
-import time
 
 class Y2038EpochTest(BitcoinTestFramework):
 
@@ -31,8 +28,11 @@ class Y2038EpochTest(BitcoinTestFramework):
             self.nodes[0].setmocktime(epoch)
             self.nodes[1].setmocktime(epoch)
 
-            # Generates some blocks
+            # Generates a blocks
             self.nodes[0].generate(nblocks=1)
+
+            self.log.info(epoch)
+            self.log.info(time.time())
 
             self.sync_all()
 

--- a/test/functional/example_y2038.py
+++ b/test/functional/example_y2038.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test covering the Year 2038 problem.
+
+https://en.wikipedia.org/wiki/Year_2038_problem
+"""
+
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+
+EPOCH_2038_BEFORE = 2147440306 # (GMT): Monday, January 18, 2038 3:11:46 PM
+EPOCH_2038_AFTER = 2147613106 # (GMT): Wednesday, January 20, 2038 3:11:46 PM
+EPOCH_2106 = 4293404400000
+
+import time
+
+class Y2038EpochTest(BitcoinTestFramework):
+
+    def set_test_params(self):
+        self.num_nodes = 2
+
+    def test_y2038(self):
+
+        for epoch in [EPOCH_2038_BEFORE, EPOCH_2038_AFTER, EPOCH_2106]:
+            # mocks the time to the epoch
+            self.nodes[0].setmocktime(epoch)
+            self.nodes[1].setmocktime(epoch)
+
+            # Generates some blocks
+            self.nodes[0].generate(nblocks=1)
+
+            self.sync_all()
+
+            assert_equal(self.nodes[0].getblockcount(), self.nodes[1].getblockcount())
+
+    def run_test(self):
+        self.log.info('Test about Y2038')
+        self.test_y2038()
+
+if __name__ == '__main__':
+    Y2038EpochTest().main()

--- a/test/functional/example_y2038.py
+++ b/test/functional/example_y2038.py
@@ -31,9 +31,6 @@ class Y2038EpochTest(BitcoinTestFramework):
             # Generates a blocks
             self.nodes[0].generate(nblocks=1)
 
-            self.log.info(epoch)
-            self.log.info(time.time())
-
             self.sync_all()
 
             assert_equal(self.nodes[0].getblockcount(), self.nodes[1].getblockcount())

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -201,6 +201,7 @@ BASE_SCRIPTS = [
     'feature_backwards_compatibility.py --legacy-wallet',
     'feature_backwards_compatibility.py --descriptors',
     'wallet_txn_clone.py --mineblock',
+    'example_y2038.py',
     'feature_notifications.py',
     'rpc_getblockfilter.py',
     'rpc_invalidateblock.py',


### PR DESCRIPTION
This is a functional tests to check for the Y2038 issue. See https://github.com/bitcoin/bitcoin/issues/21356#issuecomment-790476217

More information: https://en.wikipedia.org/wiki/Year_2038_problem 

I'm wondering If this approach is correct. Is so, I can extend it to check for the year 2106 https://github.com/bitcoin/bitcoin/issues/21356#issuecomment-790277909


