### PR TITLE
fuzz: Avoid -Wreturn-type warnings

### DIFF
--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -10,6 +10,7 @@
 #include <attributes.h>
 #include <chainparamsbase.h>
 #include <coins.h>
+#include <compat.h>
 #include <consensus/consensus.h>
 #include <merkleblock.h>
 #include <net.h>
@@ -545,11 +546,13 @@ public:
     SOCKET Get() const override
     {
         assert(false && "Not implemented yet.");
+        return INVALID_SOCKET;
     }
 
     SOCKET Release() override
     {
         assert(false && "Not implemented yet.");
+        return INVALID_SOCKET;
     }
 
     void Reset() override


### PR DESCRIPTION
Avoid `-Wreturn-type` warnings.

Closes #21355.
