### PR TITLE
fuzz: fix gcc Woverloaded-virtual build warnings

### DIFF
--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -543,6 +543,12 @@ public:
     {
     }
 
+    FuzzedSock& operator=(Sock&& other) override
+    {
+        assert(false && "Not implemented yet.");
+        return *this;
+    }
+
     SOCKET Get() const override
     {
         assert(false && "Not implemented yet.");


### PR DESCRIPTION
Possible fixup to gcc build warnings since merge of b22d4c1607b. Closes #21369.