### PR TITLE
RPC: minetxlocally

### DIFF
--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -538,7 +538,7 @@ public:
         bool relay,
         std::string& err_string) override
     {
-        const TransactionError err = BroadcastTransaction(m_node, tx, err_string, max_tx_fee, relay, /*wait_callback*/ false);
+        const TransactionError err = BroadcastTransaction(m_node, tx, err_string, max_tx_fee, relay, /*bypass_policy*/ false, /*wait_callback*/ false);
         // Chain clients only care about failures to accept the tx to the mempool. Disregard non-mempool related failures.
         // Note: this will need to be updated if BroadcastTransactions() is updated to return other non-mempool failures
         // that Chain clients do not need to know about.

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -33,9 +33,10 @@ static const CFeeRate DEFAULT_MAX_RAW_TX_FEE_RATE{COIN / 10};
  * @param[out] err_string reference to std::string to fill with error string if available
  * @param[in]  max_tx_fee reject txs with fees higher than this (if 0, accept any fee)
  * @param[in]  relay flag if both mempool insertion and p2p relay are requested
+ * @param[in]  bypass_policy disable transaction standardness checks
  * @param[in]  wait_callback wait until callbacks have been processed to avoid stale result due to a sequentially RPC.
  * return error
  */
-[[nodiscard]] TransactionError BroadcastTransaction(NodeContext& node, CTransactionRef tx, std::string& err_string, const CAmount& max_tx_fee, bool relay, bool wait_callback);
+[[nodiscard]] TransactionError BroadcastTransaction(NodeContext& node, CTransactionRef tx, std::string& err_string, const CAmount& max_tx_fee, bool relay, bool bypass_policy, bool wait_callback);
 
 #endif // BITCOIN_NODE_TRANSACTION_H

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -102,7 +102,7 @@ void PSBTOperationsDialog::broadcastTransaction()
     CTransactionRef tx = MakeTransactionRef(mtx);
     std::string err_string;
     TransactionError error = BroadcastTransaction(
-        *m_client_model->node().context(), tx, err_string, DEFAULT_MAX_RAW_TX_FEE_RATE.GetFeePerK(), /* relay */ true, /* await_callback */ false);
+        *m_client_model->node().context(), tx, err_string, DEFAULT_MAX_RAW_TX_FEE_RATE.GetFeePerK(), /* relay */ true, /* bypass_policy */ false, /* await_callback */ false);
 
     if (error == TransactionError::OK) {
         showStatus(tr("Transaction broadcast successfully! Transaction ID: %1")

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -66,6 +66,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listtransactions", 3, "include_watchonly" },
     { "walletpassphrase", 1, "timeout" },
     { "getblocktemplate", 0, "template_request" },
+    { "minetxlocally", 1, "fee_delta" },
     { "listsinceblock", 1, "target_confirmations" },
     { "listsinceblock", 2, "include_watchonly" },
     { "listsinceblock", 3, "include_removed" },

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -863,7 +863,7 @@ static RPCHelpMan sendrawtransaction()
     std::string err_string;
     AssertLockNotHeld(cs_main);
     NodeContext& node = EnsureNodeContext(request.context);
-    const TransactionError err = BroadcastTransaction(node, tx, err_string, max_raw_tx_fee, /*relay*/ true, /*wait_callback*/ true);
+    const TransactionError err = BroadcastTransaction(node, tx, err_string, max_raw_tx_fee, /*relay*/ true, /*bypass_policy*/ false, /*wait_callback*/ true);
     if (TransactionError::OK != err) {
         throw JSONRPCTransactionError(err, err_string);
     }
@@ -947,7 +947,8 @@ static RPCHelpMan testmempoolaccept()
     result_0.pushKV("wtxid", tx->GetWitnessHash().GetHex());
 
     const MempoolAcceptResult accept_result = WITH_LOCK(cs_main, return AcceptToMemoryPool(::ChainstateActive(), mempool, std::move(tx),
-                                                  false /* bypass_limits */, /* test_accept */ true));
+                                                  false /* bypass_limits */, false /* bypass_policy*/,
+                                                  true /* test_accept */));
 
     // Only return the fee and vsize if the transaction would pass ATMP.
     // These can be used to calculate the feerate.

--- a/src/validation.h
+++ b/src/validation.h
@@ -221,10 +221,12 @@ struct MempoolAcceptResult {
 /**
  * (Try to) add a transaction to the memory pool.
  * @param[in]  bypass_limits   When true, don't enforce mempool fee limits.
+ * @param[in]  bypass_policy When true, disable standardness checks.
  * @param[in]  test_accept     When true, run validation checks but don't submit to mempool.
  */
 MempoolAcceptResult AcceptToMemoryPool(CChainState& active_chainstate, CTxMemPool& pool, const CTransactionRef& tx,
-                                       bool bypass_limits, bool test_accept=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+                                       bool bypass_limits, bool bypass_policy=false, bool test_accept=false)
+                                       EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 
 /** Apply the effects of this transaction on the UTXO set represented by view */


### PR DESCRIPTION
Function: `sendrawtransaction` + `prioritiserawtransaction` - `relay=true` - `policy`

Rationale: I guess that many pool operators have implemented this in their forks already. Adding it here makes it more convenient for them.

This allows them to mine their high-fee/nonstandard transactions for free.

For example, if a miner needs to consolidate lots of outputs, this allows them to finish this in one large tx and for free.

I might need to rebase it after #21061

Would you `Concept ACK` it?

I need to add tests so that even https://github.com/bitcoin/bitcoin/blob/master/test/functional/p2p_segwit.py#L1466-L1468 passes with this feature enabled.