### PR TITLE
test: generate fewer blocks in feature_nulldummy to fix timeouts, speed up

### DIFF
--- a/test/functional/feature_nulldummy.py
+++ b/test/functional/feature_nulldummy.py
@@ -6,11 +6,11 @@
 
 Connect to a single node.
 Generate 2 blocks (save the coinbases for later).
-Generate 427 more blocks.
-[Policy/Consensus] Check that NULLDUMMY compliant transactions are accepted in the 430th block.
+Generate COINBASE_MATURITY (CB) more blocks to ensure the coinbases are mature.
+[Policy/Consensus] Check that NULLDUMMY compliant transactions are accepted in block CB + 3.
 [Policy] Check that non-NULLDUMMY transactions are rejected before activation.
-[Consensus] Check that the new NULLDUMMY rules are not enforced on the 431st block.
-[Policy/Consensus] Check that the new NULLDUMMY rules are enforced on the 432nd block.
+[Consensus] Check that the new NULLDUMMY rules are not enforced on block CB + 4.
+[Policy/Consensus] Check that the new NULLDUMMY rules are enforced on block CB + 5.
 """
 import time
 
@@ -20,6 +20,7 @@ from test_framework.script import CScript
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error
 
+COINBASE_MATURITY = 427
 NULLDUMMY_ERROR = "non-mandatory-script-verify-flag (Dummy CHECKMULTISIG argument must be zero)"
 
 def trueDummy(tx):
@@ -43,7 +44,7 @@ class NULLDUMMYTest(BitcoinTestFramework):
         # This script tests NULLDUMMY activation, which is part of the 'segwit' deployment, so we go through
         # normal segwit activation here (and don't use the default always-on behaviour).
         self.extra_args = [[
-            '-segwitheight=432',
+            f'-segwitheight={COINBASE_MATURITY + 5}',
             '-addresstype=legacy',
         ]] * 2
 
@@ -64,16 +65,16 @@ class NULLDUMMYTest(BitcoinTestFramework):
             wmulti.importaddress(self.ms_address)
             wmulti.importaddress(self.wit_ms_address)
 
-        self.coinbase_blocks = self.nodes[0].generate(2)  # Block 2
+        self.coinbase_blocks = self.nodes[0].generate(2)  # block height = 2
         coinbase_txid = []
         for i in self.coinbase_blocks:
             coinbase_txid.append(self.nodes[0].getblock(i)['tx'][0])
-        self.nodes[0].generate(427)  # Block 429
+        self.nodes[0].generate(COINBASE_MATURITY)  # block height = COINBASE_MATURITY + 2
         self.lastblockhash = self.nodes[0].getbestblockhash()
-        self.lastblockheight = 429
-        self.lastblocktime = int(time.time()) + 429
+        self.lastblockheight = COINBASE_MATURITY + 2
+        self.lastblocktime = int(time.time()) + self.lastblockheight
 
-        self.log.info("Test 1: NULLDUMMY compliant base transactions should be accepted to mempool and mined before activation [430]")
+        self.log.info(f"Test 1: NULLDUMMY compliant base transactions should be accepted to mempool and mined before activation [{COINBASE_MATURITY + 3}]")
         test1txs = [create_transaction(self.nodes[0], coinbase_txid[0], self.ms_address, amount=49)]
         txid1 = self.nodes[0].sendrawtransaction(test1txs[0].serialize_with_witness().hex(), 0)
         test1txs.append(create_transaction(self.nodes[0], txid1, self.ms_address, amount=48))
@@ -87,7 +88,7 @@ class NULLDUMMYTest(BitcoinTestFramework):
         trueDummy(test2tx)
         assert_raises_rpc_error(-26, NULLDUMMY_ERROR, self.nodes[0].sendrawtransaction, test2tx.serialize_with_witness().hex(), 0)
 
-        self.log.info("Test 3: Non-NULLDUMMY base transactions should be accepted in a block before activation [431]")
+        self.log.info(f"Test 3: Non-NULLDUMMY base transactions should be accepted in a block before activation [{COINBASE_MATURITY + 4}]")
         self.block_submit(self.nodes[0], [test2tx], False, True)
 
         self.log.info("Test 4: Non-NULLDUMMY base multisig transaction is invalid after activation")
@@ -104,7 +105,7 @@ class NULLDUMMYTest(BitcoinTestFramework):
         assert_raises_rpc_error(-26, NULLDUMMY_ERROR, self.nodes[0].sendrawtransaction, test5tx.serialize_with_witness().hex(), 0)
         self.block_submit(self.nodes[0], [test5tx], True)
 
-        self.log.info("Test 6: NULLDUMMY compliant base/witness transactions should be accepted to mempool and in block after activation [432]")
+        self.log.info(f"Test 6: NULLDUMMY compliant base/witness transactions should be accepted to mempool and in block after activation [{COINBASE_MATURITY + 5}]")
         for i in test6txs:
             self.nodes[0].sendrawtransaction(i.serialize_with_witness().hex(), 0)
         self.block_submit(self.nodes[0], test6txs, True, True)
@@ -129,6 +130,7 @@ class NULLDUMMYTest(BitcoinTestFramework):
             self.lastblockheight += 1
         else:
             assert_equal(node.getbestblockhash(), self.lastblockhash)
+
 
 if __name__ == '__main__':
     NULLDUMMYTest().main()

--- a/test/functional/feature_nulldummy.py
+++ b/test/functional/feature_nulldummy.py
@@ -20,14 +20,14 @@ from test_framework.script import CScript
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error
 
-COINBASE_MATURITY = 427
+COINBASE_MATURITY = 100
 NULLDUMMY_ERROR = "non-mandatory-script-verify-flag (Dummy CHECKMULTISIG argument must be zero)"
 
 def trueDummy(tx):
     scriptSig = CScript(tx.vin[0].scriptSig)
     newscript = []
     for i in scriptSig:
-        if (len(newscript) == 0):
+        if len(newscript) == 0:
             assert len(i) == 0
             newscript.append(b'\x51')
         else:
@@ -38,7 +38,7 @@ def trueDummy(tx):
 class NULLDUMMYTest(BitcoinTestFramework):
 
     def set_test_params(self):
-        # Need two nodes only so GBT doesn't complain that it's not connected
+        # Need two nodes so GBT (getblocktemplate) doesn't complain that it's not connected.
         self.num_nodes = 2
         self.setup_clean_chain = True
         # This script tests NULLDUMMY activation, which is part of the 'segwit' deployment, so we go through


### PR DESCRIPTION
The resolved timeout issue seen in the CI can be reproduced locally by running `test/functional/feature_nulldummy.py --valgrind --loglevel=debug`

Speeds up the normal test runtime for me from 3.8 to 2.2 seconds (debug build). Thanks to Marco Falke for the approach suggestion.