### PR TITLE
test: Test improvements for UTXO set hash tests

### DIFF
--- a/src/node/coinstats.cpp
+++ b/src/node/coinstats.cpp
@@ -15,6 +15,7 @@
 
 #include <map>
 
+// Database-independent metric indicating the UTXO set size
 static uint64_t GetBogoSize(const CScript& scriptPubKey)
 {
     return 32 /* txid */ +

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1050,15 +1050,15 @@ static RPCHelpMan gettxoutsetinfo()
                 RPCResult{
                     RPCResult::Type::OBJ, "", "",
                     {
-                        {RPCResult::Type::NUM, "height", "The current block height (index)"},
-                        {RPCResult::Type::STR_HEX, "bestblock", "The hash of the block at the tip of the chain"},
+                        {RPCResult::Type::NUM, "height", "The block height (index) of the returned statistics"},
+                        {RPCResult::Type::STR_HEX, "bestblock", "The hash of the block at which these statistics are calculated"},
                         {RPCResult::Type::NUM, "transactions", "The number of transactions with unspent outputs"},
                         {RPCResult::Type::NUM, "txouts", "The number of unspent transaction outputs"},
                         {RPCResult::Type::NUM, "bogosize", "A meaningless metric for UTXO set size"},
                         {RPCResult::Type::STR_HEX, "hash_serialized_2", /* optional */ true, "The serialized hash (only present if 'hash_serialized_2' hash_type is chosen)"},
                         {RPCResult::Type::STR_HEX, "muhash", /* optional */ true, "The serialized hash (only present if 'muhash' hash_type is chosen)"},
                         {RPCResult::Type::NUM, "disk_size", "The estimated size of the chainstate on disk"},
-                        {RPCResult::Type::STR_AMOUNT, "total_amount", "The total amount"},
+                        {RPCResult::Type::STR_AMOUNT, "total_amount", "The total amount of coins in the UTXO set"},
                     }},
                 RPCExamples{
                     HelpExampleCli("gettxoutsetinfo", "")

--- a/test/functional/feature_utxo_set_hash.py
+++ b/test/functional/feature_utxo_set_hash.py
@@ -21,18 +21,13 @@ class UTXOSetHashTest(BitcoinTestFramework):
         self.num_nodes = 1
         self.setup_clean_chain = True
 
-    def test_deterministic_hash_results(self):
-        self.log.info("Test deterministic UTXO set hash results")
-
-        # These depend on the setup_clean_chain option, the chain loaded from the cache
-        assert_equal(self.nodes[0].gettxoutsetinfo()['hash_serialized_2'], "b32ec1dda5a53cd025b95387aad344a801825fe46a60ff952ce26528f01d3be8")
-        assert_equal(self.nodes[0].gettxoutsetinfo("muhash")['muhash'], "dd5ad2a105c2d29495f577245c357409002329b9f4d6182c0af3dc2f462555c8")
-
     def test_muhash_implementation(self):
         self.log.info("Test MuHash implementation consistency")
 
         node = self.nodes[0]
         wallet = MiniWallet(node)
+        mocktime = node.getblockheader(node.getblockhash(0))['time'] + 1
+        node.setmocktime(mocktime)
 
         # Generate 100 blocks and remove the first since we plan to spend its
         # coinbase
@@ -73,8 +68,11 @@ class UTXOSetHashTest(BitcoinTestFramework):
 
         assert_equal(finalized[::-1].hex(), node_muhash)
 
+        self.log.info("Test deterministic UTXO set hash results")
+        assert_equal(node.gettxoutsetinfo()['hash_serialized_2'], "5b1b44097406226c0eb8e1362cd17a1f346522cf9390a8175a57a5262cb1963f")
+        assert_equal(node.gettxoutsetinfo("muhash")['muhash'], "4b8803075d7151d06fad3e88b68ba726886794873fbfa841d12aefb2cc2b881b")
+
     def run_test(self):
-        self.test_deterministic_hash_results()
         self.test_muhash_implementation()
 
 

--- a/test/functional/feature_utxo_set_hash.py
+++ b/test/functional/feature_utxo_set_hash.py
@@ -6,7 +6,6 @@
 
 import struct
 
-from test_framework.blocktools import create_transaction
 from test_framework.messages import (
     CBlock,
     COutPoint,
@@ -15,14 +14,12 @@ from test_framework.messages import (
 from test_framework.muhash import MuHash3072
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
+from test_framework.wallet import MiniWallet
 
 class UTXOSetHashTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
-
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
 
     def test_deterministic_hash_results(self):
         self.log.info("Test deterministic UTXO set hash results")
@@ -35,18 +32,17 @@ class UTXOSetHashTest(BitcoinTestFramework):
         self.log.info("Test MuHash implementation consistency")
 
         node = self.nodes[0]
+        wallet = MiniWallet(node)
 
         # Generate 100 blocks and remove the first since we plan to spend its
         # coinbase
-        block_hashes = node.generate(100)
+        block_hashes = wallet.generate(1) + node.generate(99)
         blocks = list(map(lambda block: FromHex(CBlock(), node.getblock(block, False)), block_hashes))
-        spending = blocks.pop(0)
+        blocks.pop(0)
 
         # Create a spending transaction and mine a block which includes it
-        tx = create_transaction(node, spending.vtx[0].rehash(), node.getnewaddress(), amount=49)
-        txid = node.sendrawtransaction(hexstring=tx.serialize_with_witness().hex(), maxfeerate=0)
-
-        tx_block = node.generateblock(output=node.getnewaddress(), transactions=[txid])
+        txid = wallet.send_self_transfer(from_node=node)['txid']
+        tx_block = node.generateblock(output=wallet.get_address(), transactions=[txid])
         blocks.append(FromHex(CBlock(), node.getblock(tx_block['hash'], False)))
 
         # Serialize the outputs that should be in the UTXO set and add them to

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -49,6 +49,9 @@ class MiniWallet:
             self._utxos.append({'txid': cb_tx['txid'], 'vout': 0, 'value': cb_tx['vout'][0]['value']})
         return blocks
 
+    def get_address(self):
+        return self._address
+
     def get_utxo(self, *, txid=''):
         """
         Returns a utxo and marks it as spent (pops it from the internal list)


### PR DESCRIPTION
Follow-ups to #19145:
- Small improvement on the help text of RPC gettxoutsetinfo
- Using deterministic blockchain in the test `functional/feature_utxo_set_hash.py`
- Removing wallet dependency in the test `functional/feature_utxo_set_hash.py`

Split out of #19521.