### PR TITLE
[doc] Improve comment about protected peers

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -541,7 +541,7 @@ struct CNodeState {
       *   - its connection type is IsBlockOnlyConn() == false
       *   - it gave us a valid connecting header
       *   - we haven't reached MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT yet
-      *   - it has a better chain than we have
+      *   - its chain tip has at least as much work as ours
       *
       * CHAIN_SYNC_TIMEOUT: if a peer's best known block has less work than our tip,
       * set a timeout CHAIN_SYNC_TIMEOUT seconds in the future:


### PR DESCRIPTION
The comment currently suggests a long-standing node would infrequently protect peers under normal circumstances. Clarify that we also protect peers that are synced to the same work as our chain tip. [Relevant check here](https://github.com/bitcoin/bitcoin/blob/ee0dc02c6f93de2a366bbff490eb4d37bca6a24f/src/net_processing.cpp#L1997).