### PR TITLE
build: Fix regression introduced in #21363

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -306,7 +306,10 @@ AC_DEFUN([_BITCOIN_QT_CHECK_STATIC_PLUGIN], [
   AC_MSG_CHECKING([for $1 ($2)])
   CHECK_STATIC_PLUGINS_TEMP_LIBS="$LIBS"
   LIBS="$2${qt_lib_suffix} $QT_LIBS $LIBS"
-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <QtPlugin> Q_IMPORT_PLUGIN($1)]])],
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+      #include <QtPlugin>
+      Q_IMPORT_PLUGIN($1)
+    ]])],
     [AC_MSG_RESULT([yes]); QT_LIBS="$2${qt_lib_suffix} $QT_LIBS"],
     [AC_MSG_RESULT([no]); BITCOIN_QT_FAIL([$1 not found.])])
   LIBS="$CHECK_STATIC_PLUGINS_TEMP_LIBS"


### PR DESCRIPTION
After #21363 the `_BITCOIN_QT_CHECK_STATIC_PLUGIN` never fails due to the ill-formed code.

Sorry for breaking it.