### PR TITLE
i2p: limit the size of incoming messages

### DIFF
--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -153,7 +153,7 @@ bool Session::Accept(Connection& conn)
             }
 
             const std::string& peer_dest =
-                conn.sock.RecvUntilTerminator('\n', MAX_WAIT_FOR_IO, *m_interrupt);
+                conn.sock.RecvUntilTerminator('\n', MAX_WAIT_FOR_IO, *m_interrupt, MAX_MSG_SIZE);
 
             conn.peer = CService(DestB64ToAddr(peer_dest), Params().GetDefaultPort());
 
@@ -252,7 +252,7 @@ Session::Reply Session::SendRequestAndGetReply(const Sock& sock,
     // signaled.
     static constexpr auto recv_timeout = 3min;
 
-    reply.full = sock.RecvUntilTerminator('\n', recv_timeout, *m_interrupt);
+    reply.full = sock.RecvUntilTerminator('\n', recv_timeout, *m_interrupt, MAX_MSG_SIZE);
 
     for (const auto& kv : spanparsing::Split(reply.full, ' ')) {
         const auto& pos = std::find(kv.begin(), kv.end(), '=');

--- a/src/i2p.h
+++ b/src/i2p.h
@@ -41,6 +41,14 @@ struct Connection {
 namespace sam {
 
 /**
+ * The maximum size of an incoming message from the I2P SAM proxy (in bytes).
+ * Used to avoid a runaway proxy from sending us an "unlimited" amount of data without a terminator.
+ * The longest known message is ~1400 bytes, so this is high enough not to be triggered during
+ * normal operation, yet low enough to avoid a malicious proxy from filling our memory.
+ */
+static constexpr size_t MAX_MSG_SIZE{65536};
+
+/**
  * I2P SAM session.
  */
 class Session

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -135,13 +135,16 @@ public:
      * @param[in] terminator Character up to which to read from the socket.
      * @param[in] timeout Timeout for the entire operation.
      * @param[in] interrupt If this is signaled then the operation is canceled.
+     * @param[in] max_data The maximum amount of data (in bytes) to receive. If this many bytes
+     * are received and there is still no terminator, then this method will throw an exception.
      * @return The data that has been read, without the terminating character.
      * @throws std::runtime_error if the operation cannot be completed. In this case some bytes may
      * have been consumed from the socket.
      */
     virtual std::string RecvUntilTerminator(uint8_t terminator,
                                             std::chrono::milliseconds timeout,
-                                            CThreadInterrupt& interrupt) const;
+                                            CThreadInterrupt& interrupt,
+                                            size_t max_data) const;
 
     /**
      * Check if still connected.


### PR DESCRIPTION
Put a limit on the amount of data `Sock::RecvUntilTerminator()` can read
if no terminator is received.

In the case of I2P this avoids a runaway (or malicious) I2P proxy
sending us tons of data without a terminator before a timeout is
triggered.