### PR TITLE
[rfc] add option to bypass contextual timelocks in testmempoolaccept?

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -231,8 +231,8 @@ public:
     CCoinsViewCache(const CCoinsViewCache &) = delete;
 
     // Standard CCoinsView methods
-    bool GetCoin(const COutPoint &outpoint, Coin &coin) const override;
-    bool HaveCoin(const COutPoint &outpoint) const override;
+    virtual bool GetCoin(const COutPoint &outpoint, Coin &coin) const override;
+    virtual bool HaveCoin(const COutPoint &outpoint) const override;
     uint256 GetBestBlock() const override;
     void SetBestBlock(const uint256 &hashBlock);
     bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) override;
@@ -257,7 +257,7 @@ public:
      * on! To be safe, best to not hold the returned reference through any other
      * calls to this cache.
      */
-    const Coin& AccessCoin(const COutPoint &output) const;
+    virtual const Coin& AccessCoin(const COutPoint &output) const;
 
     /**
      * Add a coin. Set possible_overwrite to true if an unspent version may
@@ -286,7 +286,7 @@ public:
      * Failure to call this method before destruction will cause the changes to be forgotten.
      * If false is returned, the state of this cache (and its backing view) will be undefined.
      */
-    bool Flush();
+    virtual bool Flush();
 
     /**
      * Removes the UTXO with the given outpoint from the cache, if it is

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -105,6 +105,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendrawtransaction", 1, "maxfeerate" },
     { "testmempoolaccept", 0, "rawtxs" },
     { "testmempoolaccept", 1, "maxfeerate" },
+    { "testmempoolaccept", 2, "bypass_timelocks" },
     { "combinerawtransaction", 0, "txs" },
     { "fundrawtransaction", 1, "options" },
     { "fundrawtransaction", 2, "iswitness" },

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -28,7 +28,8 @@ struct MinerTestingSetup : public TestingSetup {
     void TestPackageSelection(const CChainParams& chainparams, const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst) EXCLUSIVE_LOCKS_REQUIRED(::cs_main, m_node.mempool->cs);
     bool TestSequenceLocks(const CTransaction& tx, int flags) EXCLUSIVE_LOCKS_REQUIRED(::cs_main, m_node.mempool->cs)
     {
-        return CheckSequenceLocks(::ChainstateActive(), *m_node.mempool, tx, flags);
+        CCoinsViewMemPool viewMempool(&::ChainstateActive().CoinsTip(), *m_node.mempool);
+        return CheckSequenceLocks(::ChainstateActive(), viewMempool, tx, flags);
     }
     BlockAssembler AssemblerForTest(const CChainParams& params);
 };

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -513,7 +513,9 @@ void CTxMemPool::removeForReorg(CChainState& active_chainstate, int flags)
         LockPoints lp = it->GetLockPoints();
         assert(std::addressof(::ChainstateActive()) == std::addressof(active_chainstate));
         bool validLP =  TestLockPointValidity(active_chainstate.m_chain, &lp);
-        if (!CheckFinalTx(active_chainstate.m_chain.Tip(), tx, flags) || !CheckSequenceLocks(active_chainstate, *this, tx, flags, &lp, validLP)) {
+        CCoinsViewMemPool viewMempool(&::ChainstateActive().CoinsTip(), *this);
+        if (!CheckFinalTx(active_chainstate.m_chain.Tip(), tx, flags)
+            || !CheckSequenceLocks(active_chainstate, viewMempool, tx, flags, &lp, validLP)) {
             // Note if CheckSequenceLocks fails the LockPoints may still be invalid
             // So it's critical that we remove the tx and not depend on the LockPoints.
             txToRemove.insert(it);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -463,6 +463,114 @@ static bool CheckInputsFromMempoolAndCache(const CTransaction& tx, TxValidationS
     return CheckInputScripts(tx, state, view, flags, /* cacheSigStore = */ true, /* cacheFullSciptStore = */ true, txdata);
 }
 
+/** An empty coin used as a placeholder for a spent coin.*/
+static const Coin coin_spent;
+/**
+ * A CoinsView that adds a memory cache to another CoinsView and serves as temporary scratch space.
+ * Used by MemPoolAccept class to validate transactions and packages before submitting to mempool.
+ * A backend can be set to provide read access to chainstate and/or mempool coins, but writing to
+ * the backend is disabled. Avoid using a CCoinsViewTemporary in consensus-critical paths such
+ * as writing to the script cache. See CheckInputsFromMempoolAndCache as an example. When not being
+ * used to validate a package (m_temp_added and m_temp_spent are empty), a CCoinsViewTemporary
+ * behaves exactly like a CCoinsViewCache.
+ */
+class CCoinsViewTemporary : public CCoinsViewCache
+{
+protected:
+    /**
+    * Coins made available by transactions being validated. Tracking these allows for package
+    * validation, since we can access transaction outputs without submitting them to mempool.
+    */
+    std::map<COutPoint, Coin> m_temp_added;
+
+    /**
+    * Coins spent by transactions being validated. When there are multiple, we need to track these
+    * in order to distinguish between missing/spent coins and conflicts within a package.
+    */
+    std::set<COutPoint> m_temp_spent;
+
+public:
+
+    CCoinsViewTemporary(CCoinsView* baseIn) : CCoinsViewCache(baseIn) {}
+
+    // Delete the copy constructor to prevent accidentally using it when one intends to create a
+    // CCoinsViewTemporary on top of a base cache.
+    CCoinsViewTemporary(const CCoinsViewTemporary &) = delete;
+
+    bool GetCoin(const COutPoint& outpoint, Coin& coin) const override {
+        coin = AccessCoin(outpoint);
+        return !coin.IsSpent();
+    }
+
+    const Coin& AccessCoin(const COutPoint& outpoint) const override {
+        // Check to see if another tx in the package has already spent this coin (conflict-in-package).
+        // Coins spent by others in the package are only tracked in m_temp_spent.
+        if (m_temp_spent.count(outpoint)) {
+            return coin_spent;
+        }
+
+        // Check to see if the inputs are made available by another tx in the package.
+        // These Coins would not be available in the underlying CoinsView.
+        if (auto it = m_temp_added.find(outpoint); it != m_temp_added.end()) {
+            assert(!it->second.IsSpent());
+            return it->second;
+        }
+        return CCoinsViewCache::AccessCoin(outpoint);
+    }
+
+    bool HaveCoin(const COutPoint& outpoint) const override {
+        Coin coin;
+        return GetCoin(outpoint, coin);
+    }
+
+    /**
+    * Update with coins spent and created by a transaction.
+    * Only used for package validation.
+    */
+    void PackageAddTransaction(const CTransactionRef& tx)
+    {
+        // Track Coins spent by this transaction. They must exist and not already be spent.
+        for (auto input : tx->vin) {
+            Coin spent_coin;
+            Assume(GetCoin(input.prevout, spent_coin) && !spent_coin.IsSpent());
+            m_temp_spent.insert(input.prevout);
+        }
+        // Track Coins added by this transaction.
+        for (unsigned int n = 0; n < tx->vout.size(); ++n) {
+            m_temp_added.emplace(COutPoint(tx->GetHash(), n), Coin(tx->vout[n], MEMPOOL_HEIGHT, false));
+        }
+    }
+
+    /**
+    * Returns whether an outpoint is spent by a transaction in the package being validated.
+    * Only used for package validation.
+    */
+    bool PackageSpends(const COutPoint& outpoint) const {
+        return m_temp_spent.count(outpoint);
+    }
+
+    /**
+    * Clear temporary coins, undoing any changes that were made using AddPackageTransaction.
+    * Note that any coins brought into cacheCoins from the backend are still there, but this
+    * effectively resets the state to only coins that were available before validation began.
+    * Only used for package validation.
+    */
+    void ClearTemporaryCoins() {
+        m_temp_added.clear();
+        m_temp_spent.clear();
+    }
+
+    // A CCoinsViewTemporary is for temporary scratch space only; it should not write to its backend.
+    bool Flush() override {
+        throw std::logic_error("CCoinsViewTemporary flushing is not supported.");
+    }
+
+    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn) override {
+        throw std::logic_error("CCoinsViewTemporary writing is not supported.");
+    }
+
+};
+
 namespace {
 
 class MemPoolAccept
@@ -555,7 +663,7 @@ private:
 
 private:
     CTxMemPool& m_pool;
-    CCoinsViewCache m_view;
+    CCoinsViewTemporary m_view;
     CCoinsViewMemPool m_viewmempool;
     CCoinsView m_dummy;
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -196,14 +196,14 @@ struct MempoolAcceptResult {
         VALID, //!> Fully validated, valid.
         INVALID, //!> Invalid.
     };
-    ResultType m_result_type;
-    TxValidationState m_state;
+    const ResultType m_result_type;
+    const TxValidationState m_state;
 
     // The following fields are only present when m_result_type = ResultType::VALID
     /** Mempool transactions replaced by the tx per BIP 125 rules. */
-    std::optional<std::list<CTransactionRef>> m_replaced_transactions;
-    /** Raw base fees. */
-    std::optional<CAmount> m_base_fees;
+    const std::optional<std::list<CTransactionRef>> m_replaced_transactions;
+    /** Raw base fees in satoshis. */
+    const std::optional<CAmount> m_base_fees;
 
     /** Constructor for failure case */
     explicit MempoolAcceptResult(TxValidationState state)
@@ -214,7 +214,7 @@ struct MempoolAcceptResult {
 
     /** Constructor for success case */
     explicit MempoolAcceptResult(std::list<CTransactionRef>&& replaced_txns, CAmount fees)
-        : m_result_type(ResultType::VALID), m_state(TxValidationState{}),
+        : m_result_type(ResultType::VALID), m_state{},
         m_replaced_transactions(std::move(replaced_txns)), m_base_fees(fees) {}
 };
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -248,6 +248,8 @@ bool TestLockPointValidity(CChain& active_chain, const LockPoints* lp) EXCLUSIVE
 
 /**
  * Check if transaction will be BIP 68 final in the next block to be created.
+ * @param[in]   viewMemPool     A CoinsView that provides access to relevant coins for
+ *                              checking sequence locks. Any CoinsView can be passed in.
  *
  * Simulates calling SequenceLocks() with data from the tip of the current active chain.
  * Optionally stores in LockPoints the resulting height and time calculated and the hash
@@ -258,11 +260,11 @@ bool TestLockPointValidity(CChain& active_chain, const LockPoints* lp) EXCLUSIVE
  * See consensus/consensus.h for flag definitions.
  */
 bool CheckSequenceLocks(CChainState& active_chainstate,
-                        const CTxMemPool& pool,
+                        CCoinsView& viewMemPool,
                         const CTransaction& tx,
                         int flags,
                         LockPoints* lp = nullptr,
-                        bool useExistingLockPoints = false) EXCLUSIVE_LOCKS_REQUIRED(::cs_main, pool.cs);
+                        bool useExistingLockPoints = false) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
 /**
  * Closure representing one script verification

--- a/src/validation.h
+++ b/src/validation.h
@@ -224,8 +224,8 @@ struct MempoolAcceptResult {
 
 /**
  * (Try to) add a transaction to the memory pool.
- * @param[in]  bypass_limits   When true, don't enforce mempool fee limits.
- * @param[in]  test_accept     When true, run validation checks but don't submit to mempool.
+ * @param[in]  bypass_limits    When true, don't enforce mempool fee limits.
+ * @param[in]  test_accept      When true, run validation checks but don't submit to mempool.
  */
 MempoolAcceptResult AcceptToMemoryPool(CChainState& active_chainstate, CTxMemPool& pool, const CTransactionRef& tx,
                                        bool bypass_limits, bool test_accept=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
@@ -236,12 +236,14 @@ MempoolAcceptResult AcceptToMemoryPool(CChainState& active_chainstate, CTxMemPoo
 *                                   parent-child dependencies. The transactions must not conflict, i.e.
 *                                   must not spend the same inputs, even if it would be a valid BIP125
 *                                   replace-by-fee. Parents must appear before children.
+* @param[in]    bypass_timelocks    When true (test_accept must also be true), don't enforce timelock
+*                                   rules BIP65 and BIP112.
 * @returns a vector of MempoolAcceptResults for each tx in the same order as
 * the input txns. If one transaction fails, some results may be unfinished.
 */
 std::vector<MempoolAcceptResult> ProcessNewPackage(CChainState& active_chainstate, CTxMemPool& pool,
-                                                   std::vector<CTransactionRef>& txns, bool test_accept)
-                                                   EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+                                                   std::vector<CTransactionRef>& txns, bool test_accept,
+                                                   bool bypass_timelocks=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** Apply the effects of this transaction on the UTXO set represented by view */
 void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, int nHeight);

--- a/src/validation.h
+++ b/src/validation.h
@@ -189,13 +189,17 @@ void PruneBlockFilesManual(CChainState& active_chainstate, int nManualPruneHeigh
 * Validation result for a single transaction mempool acceptance.
 */
 struct MempoolAcceptResult {
-    /** Used to indicate the results of mempool validation,
-    * including the possibility of unfinished validation.
+    /** Used to indicate the results of mempool validation.
+    * It's possible for a result to be unknown in the case of
+    * package validation when an earlier tx fails and validation
+    * is terminated early. See ResultType::UNFINISHED.
     */
     enum class ResultType {
         VALID, //!> Fully validated, valid.
         INVALID, //!> Invalid.
+        UNFINISHED, //!> Not fully validated.
     };
+    const CTransaction& m_tx;
     const ResultType m_result_type;
     const TxValidationState m_state;
 
@@ -206,15 +210,15 @@ struct MempoolAcceptResult {
     const std::optional<CAmount> m_base_fees;
 
     /** Constructor for failure case */
-    explicit MempoolAcceptResult(TxValidationState state)
-        : m_result_type(ResultType::INVALID),
+    explicit MempoolAcceptResult(const CTransaction& tx, TxValidationState state, bool finished=true)
+        : m_tx(tx), m_result_type(finished ? ResultType::INVALID : ResultType::UNFINISHED),
         m_state(state), m_replaced_transactions(nullopt), m_base_fees(nullopt) {
-            Assume(!state.IsValid()); // Can be invalid or error
+            if (finished) Assume(!state.IsValid()); // Can be invalid or error
         }
 
     /** Constructor for success case */
-    explicit MempoolAcceptResult(std::list<CTransactionRef>&& replaced_txns, CAmount fees)
-        : m_result_type(ResultType::VALID), m_state{},
+    explicit MempoolAcceptResult(const CTransaction& tx, std::list<CTransactionRef>&& replaced_txns, CAmount fees)
+        : m_tx(tx), m_result_type(ResultType::VALID), m_state{},
         m_replaced_transactions(std::move(replaced_txns)), m_base_fees(fees) {}
 };
 
@@ -226,6 +230,18 @@ struct MempoolAcceptResult {
 MempoolAcceptResult AcceptToMemoryPool(CChainState& active_chainstate, CTxMemPool& pool, const CTransactionRef& tx,
                                        bool bypass_limits, bool test_accept=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+/**
+* Atomically test acceptance of multiple transactions.
+* @param[in]    txns                Group of transactions which may be independent or contain
+*                                   parent-child dependencies. The transactions must not conflict, i.e.
+*                                   must not spend the same inputs, even if it would be a valid BIP125
+*                                   replace-by-fee. Parents must appear before children.
+* @returns a vector of MempoolAcceptResults for each tx in the same order as
+* the input txns. If one transaction fails, some results may be unfinished.
+*/
+std::vector<MempoolAcceptResult> ProcessNewPackage(CChainState& active_chainstate, CTxMemPool& pool,
+                                                   std::vector<CTransactionRef>& txns, bool test_accept)
+                                                   EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** Apply the effects of this transaction on the UTXO set represented by view */
 void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, int nHeight);

--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -247,6 +247,10 @@ class BIP68Test(BitcoinTestFramework):
             if (orig_tx.hash in node.getrawmempool()):
                 # sendrawtransaction should fail if the tx is in the mempool
                 assert_raises_rpc_error(-26, NOT_FINAL_ERROR, node.sendrawtransaction, ToHex(tx))
+
+                # Should pass with bypass_timelocks=True but not otherwise
+                assert not node.testmempoolaccept([ToHex(tx)])[0]["allowed"]
+                assert node.testmempoolaccept(rawtxs=[ToHex(tx)], bypass_timelocks=True)[0]["allowed"]
             else:
                 # sendrawtransaction should succeed if the tx is not in the mempool
                 node.sendrawtransaction(ToHex(tx))
@@ -301,6 +305,9 @@ class BIP68Test(BitcoinTestFramework):
         tx5.vout[0].nValue += int(utxos[0]["amount"]*COIN)
         raw_tx5 = self.nodes[0].signrawtransactionwithwallet(ToHex(tx5))["hex"]
 
+        # Should pass with bypass_timelocks=True but not otherwise
+        assert not self.nodes[0].testmempoolaccept(rawtxs=[raw_tx5])[0]["allowed"]
+        assert self.nodes[0].testmempoolaccept(rawtxs=[raw_tx5], bypass_timelocks=True)[0]["allowed"]
         assert_raises_rpc_error(-26, NOT_FINAL_ERROR, self.nodes[0].sendrawtransaction, raw_tx5)
 
         # Test mempool-BIP68 consistency after reorg

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -125,15 +125,15 @@ class BIP65Test(BitcoinTestFramework):
 
         # First we show that this tx is valid except for CLTV by getting it
         # rejected from the mempool for exactly that reason.
-        assert_equal(
-            [{
-                'txid': spendtx.hash,
-                'wtxid': spendtx.getwtxid(),
-                'allowed': False,
-                'reject-reason': 'non-mandatory-script-verify-flag (Negative locktime)',
-            }],
-            self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], maxfeerate=0),
-        )
+        expected_testres = [{
+            'txid': spendtx.hash,
+            'wtxid': spendtx.getwtxid(),
+            'allowed': False,
+            'reject-reason': 'non-mandatory-script-verify-flag (Negative locktime)',
+        }]
+        assert_equal(expected_testres, self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], maxfeerate=0))
+        # It still shouldn't work with bypass_timelocks=True because this is a script error.
+        assert_equal(expected_testres, self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], maxfeerate=0, bypass_timelocks=True))
 
         # Now we verify that a block with this transaction is also invalid.
         block.vtx.append(spendtx)

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -404,8 +404,10 @@ class BIP68_112_113Test(BitcoinTestFramework):
         self.log.info("Test version 1 txs")
 
         # -1 OP_CSV tx and (empty stack) OP_CSV tx should fail
+        assert not self.nodes[0].testmempoolaccept(rawtxs=[ToHex(bip112tx_special_v1)], bypass_timelocks=True)[0]["allowed"]
         self.send_blocks([self.create_test_block([bip112tx_special_v1])], success=False,
                          reject_reason='non-mandatory-script-verify-flag (Negative locktime)')
+        assert not self.nodes[0].testmempoolaccept(rawtxs=[ToHex(bip112tx_emptystack_v1)], bypass_timelocks=True)[0]["allowed"]
         self.send_blocks([self.create_test_block([bip112tx_emptystack_v1])], success=False,
                          reject_reason='non-mandatory-script-verify-flag (Operation not valid with the current stack size)')
         # If SEQUENCE_LOCKTIME_DISABLE_FLAG is set in argument to OP_CSV, version 1 txs should still pass
@@ -421,12 +423,14 @@ class BIP68_112_113Test(BitcoinTestFramework):
         fail_txs += [tx['tx'] for tx in bip112txs_vary_OP_CSV_v1 if not tx['sdf']]
         fail_txs += [tx['tx'] for tx in bip112txs_vary_OP_CSV_9_v1 if not tx['sdf']]
         for tx in fail_txs:
+            assert not self.nodes[0].testmempoolaccept(rawtxs=[ToHex(tx)], bypass_timelocks=True)[0]["allowed"]
             self.send_blocks([self.create_test_block([tx])], success=False,
                              reject_reason='non-mandatory-script-verify-flag (Locktime requirement not satisfied)')
 
         self.log.info("Test version 2 txs")
 
         # -1 OP_CSV tx and (empty stack) OP_CSV tx should fail
+        assert not self.nodes[0].testmempoolaccept(rawtxs=[ToHex(bip112tx_special_v2)], bypass_timelocks=True)[0]["allowed"]
         self.send_blocks([self.create_test_block([bip112tx_special_v2])], success=False,
                          reject_reason='non-mandatory-script-verify-flag (Negative locktime)')
         self.send_blocks([self.create_test_block([bip112tx_emptystack_v2])], success=False,
@@ -445,12 +449,14 @@ class BIP68_112_113Test(BitcoinTestFramework):
         fail_txs = all_rlt_txs(bip112txs_vary_nSequence_9_v2)
         fail_txs += [tx['tx'] for tx in bip112txs_vary_OP_CSV_9_v2 if not tx['sdf']]
         for tx in fail_txs:
+            assert not self.nodes[0].testmempoolaccept(rawtxs=[ToHex(tx)], bypass_timelocks=True)[0]["allowed"]
             self.send_blocks([self.create_test_block([tx])], success=False,
                              reject_reason='non-mandatory-script-verify-flag (Locktime requirement not satisfied)')
 
         # If SEQUENCE_LOCKTIME_DISABLE_FLAG is set in nSequence, tx should fail
         fail_txs = [tx['tx'] for tx in bip112txs_vary_nSequence_v2 if tx['sdf']]
         for tx in fail_txs:
+            assert not self.nodes[0].testmempoolaccept(rawtxs=[ToHex(tx)], bypass_timelocks=True)[0]["allowed"]
             self.send_blocks([self.create_test_block([tx])], success=False,
                              reject_reason='non-mandatory-script-verify-flag (Locktime requirement not satisfied)')
 
@@ -458,6 +464,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
         fail_txs = [tx['tx'] for tx in bip112txs_vary_nSequence_v2 if not tx['sdf'] and tx['stf']]
         fail_txs += [tx['tx'] for tx in bip112txs_vary_OP_CSV_v2 if not tx['sdf'] and tx['stf']]
         for tx in fail_txs:
+            assert not self.nodes[0].testmempoolaccept(rawtxs=[ToHex(tx)], bypass_timelocks=True)[0]["allowed"]
             self.send_blocks([self.create_test_block([tx])], success=False,
                              reject_reason='non-mandatory-script-verify-flag (Locktime requirement not satisfied)')
 

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -67,7 +67,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
 
         self.log.info('Should not accept garbage to testmempoolaccept')
         assert_raises_rpc_error(-3, 'Expected type array, got string', lambda: node.testmempoolaccept(rawtxs='ff00baar'))
-        assert_raises_rpc_error(-8, 'Array must contain exactly one raw transaction for now', lambda: node.testmempoolaccept(rawtxs=['ff00baar', 'ff22']))
+        assert_raises_rpc_error(-8, 'Array cannot contain more than 25 transactions.', lambda: node.testmempoolaccept(rawtxs=['ff22']*26))
         assert_raises_rpc_error(-22, 'TX decode failed', lambda: node.testmempoolaccept(rawtxs=['ff00baar']))
 
         self.log.info('A transaction already in the blockchain')

--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""RPCs that handle raw transaction packages."""
+
+from decimal import Decimal
+from io import BytesIO
+
+from test_framework.address import ADDRESS_BCRT1_P2WSH_OP_TRUE
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.messages import (
+    BIP125_SEQUENCE_NUMBER,
+    COIN,
+    CTransaction,
+    CTxInWitness,
+)
+from test_framework.script import (
+    CScript,
+    OP_TRUE,
+)
+from test_framework.util import (
+    assert_equal,
+    hex_str_to_bytes,
+)
+
+class RPCPackagesTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        self.log.info("Generate blocks to create UTXOs")
+        node = self.nodes[0]
+        self.privkeys = [node.get_deterministic_priv_key().key]
+        self.address = node.get_deterministic_priv_key().address
+        self.coins = []
+        # The last 100 coinbase transactions are premature
+        for b in node.generatetoaddress(120, self.address)[:20]:
+            coinbase = node.getblock(blockhash=b, verbosity=2)["tx"][0]
+            self.coins.append({
+                "txid": coinbase["txid"],
+                "amount": coinbase["vout"][0]["value"],
+                "scriptPubKey": coinbase["vout"][0]["scriptPubKey"],
+            })
+
+        # Create some transactions that can be reused throughout the test. Never submit these to mempool.
+        self.independent_txns_hex = []
+        self.independent_txns_testres = []
+        for _ in range(3):
+            coin = self.coins.pop()
+            rawtx = node.createrawtransaction([{"txid" : coin["txid"], "vout" : 0}],
+                {self.address : coin["amount"] - Decimal("0.0001")})
+            signedtx = node.signrawtransactionwithkey(hexstring=rawtx, privkeys=self.privkeys)
+            assert signedtx["complete"]
+            testres = node.testmempoolaccept([signedtx["hex"]])
+            assert testres[0]["allowed"]
+            self.independent_txns_hex.append(signedtx["hex"])
+            # testmempoolaccept returns a list of length one, avoid creating a 2D list
+            self.independent_txns_testres.append(testres[0])
+
+        self.test_independent()
+        self.test_chain()
+        self.test_multiple_children()
+        self.test_multiple_parents()
+        self.test_conflicting()
+        self.test_rbf()
+
+    def chain_transaction(self, parent_txid, value, n=0, parent_locking_script=None):
+        """Build a transaction that spends parent_txid.vout[n] and produces one output with amount=value.
+        Return tuple (CTransaction object, raw hex, scriptPubKey of the output created).
+        """
+        node = self.nodes[0]
+        inputs = [{"txid" : parent_txid, "vout" : n}]
+        outputs = {self.address : value}
+        rawtx = node.createrawtransaction(inputs, outputs)
+        prevtxs = [{
+            "txid": parent_txid,
+            "vout": n,
+            "scriptPubKey": parent_locking_script,
+            "amount": value + Decimal("0.0001"),
+        }] if parent_locking_script else None
+        signedtx = node.signrawtransactionwithkey(hexstring=rawtx, privkeys=self.privkeys, prevtxs=prevtxs)
+        tx = CTransaction()
+        assert signedtx["complete"]
+        tx.deserialize(BytesIO(hex_str_to_bytes(signedtx["hex"])))
+        return (tx, signedtx["hex"], tx.vout[0].scriptPubKey.hex())
+
+    def test_independent(self):
+        self.log.info("Test multiple independent transactions in a package")
+        node = self.nodes[0]
+        assert_equal(self.independent_txns_testres, node.testmempoolaccept(rawtxs=self.independent_txns_hex))
+
+        self.log.info("Test a valid package with garbage inserted")
+        garbage_tx = node.createrawtransaction([{"txid": "00" * 32, "vout": 5}], {self.address: 1})
+        tx = CTransaction()
+        tx.deserialize(BytesIO(hex_str_to_bytes(garbage_tx)))
+        testres_bad = node.testmempoolaccept(self.independent_txns_hex + [garbage_tx])
+        testres_independent_ids = [{"txid": res["txid"], "wtxid": res["wtxid"]} for res in self.independent_txns_testres]
+        assert_equal(testres_bad, testres_independent_ids + [
+            {"txid": tx.rehash(), "wtxid": tx.getwtxid(), "allowed": False, "reject-reason": "missing-inputs"}
+        ])
+
+        self.log.info("Check testmempoolaccept tells us when some transactions completed validation successfully")
+        coin = self.coins.pop()
+        tx_bad_sig_hex = node.createrawtransaction([{"txid" : coin["txid"], "vout" : 0}],
+                                           {self.address : coin["amount"] - Decimal("0.0001")})
+        tx_bad_sig = CTransaction()
+        tx_bad_sig.deserialize(BytesIO(hex_str_to_bytes(tx_bad_sig_hex)))
+        testres_bad_sig = node.testmempoolaccept(self.independent_txns_hex + [tx_bad_sig_hex])
+        assert_equal(testres_bad_sig, self.independent_txns_testres + [{
+            "txid": tx_bad_sig.rehash(),
+            "wtxid": tx_bad_sig.getwtxid(), "allowed": False,
+            "reject-reason": "mandatory-script-verify-flag-failed (Operation not valid with the current stack size)"
+        }])
+
+        self.log.info("Check testmempoolaccept reports txns in packages that exceed max feerate")
+        coin = self.coins.pop()
+        tx_high_fee_raw = node.createrawtransaction([{"txid" : coin["txid"], "vout" : 0}],
+                                           {self.address : coin["amount"] - Decimal("0.999")})
+        tx_high_fee_signed = node.signrawtransactionwithkey(hexstring=tx_high_fee_raw, privkeys=self.privkeys)
+        assert tx_high_fee_signed["complete"]
+        tx_high_fee = CTransaction()
+        tx_high_fee.deserialize(BytesIO(hex_str_to_bytes(tx_high_fee_signed["hex"])))
+        testres_high_fee = node.testmempoolaccept([tx_high_fee_signed["hex"]])
+        assert_equal(testres_high_fee, [
+            {"txid": tx_high_fee.rehash(), "wtxid": tx_high_fee.getwtxid(), "allowed": False, "reject-reason": "max-fee-exceeded"}
+        ])
+        testres_package_high_fee = node.testmempoolaccept(self.independent_txns_hex + [tx_high_fee_signed["hex"]])
+        assert_equal(testres_package_high_fee, self.independent_txns_testres + testres_high_fee)
+
+    def test_chain(self):
+        node = self.nodes[0]
+        first_coin = self.coins.pop()
+
+        self.log.info("Create a chain of 25 transactions")
+        parent_locking_script = None
+        txid = first_coin["txid"]
+        chain_hex = []
+        chain_txns = []
+        value = first_coin["amount"]
+
+        for _ in range(25):
+            value -= Decimal("0.0001") # Deduct reasonable fee
+            (tx, txhex, parent_locking_script) = self.chain_transaction(txid, value, 0, parent_locking_script)
+            txid = tx.rehash()
+            chain_hex.append(txhex)
+            chain_txns.append(tx)
+
+        self.log.info("Check that testmempoolaccept requires packages to be sorted by dependency")
+        testres_multiple_unsorted = node.testmempoolaccept(rawtxs=chain_hex[::-1])
+        assert_equal(testres_multiple_unsorted, [{"txid": chain_txns[-1].rehash(), "wtxid": chain_txns[-1].getwtxid(), "allowed": False, "reject-reason": "missing-inputs"}]
+                                              + [{"txid": tx.rehash(), "wtxid": tx.getwtxid()} for tx in chain_txns[::-1]][1:])
+
+        self.log.info("Testmempoolaccept with entire package")
+        testres_multiple = node.testmempoolaccept(rawtxs=chain_hex)
+
+        testres_single = []
+        self.log.info("Test accept and then submit each one individually, which should be identical to package testaccept")
+        for rawtx in chain_hex:
+            testres = node.testmempoolaccept([rawtx])
+            testres_single.append(testres[0])
+            # Submit the transaction now so its child should have no problem validating
+            node.sendrawtransaction(rawtx)
+        assert_equal(testres_single, testres_multiple)
+
+        # Clean up by clearing the mempool
+        node.generate(1)
+
+    def test_multiple_children(self):
+        node = self.nodes[0]
+
+        self.log.info("Create a package in which a transaction has two children within the package")
+        first_coin = self.coins.pop()
+        value = (first_coin["amount"] - Decimal("0.0002")) / 2 # Deduct reasonable fee and make 2 outputs
+        inputs = [{"txid" : first_coin["txid"], "vout" : 0}]
+        outputs = [{self.address : value}, {ADDRESS_BCRT1_P2WSH_OP_TRUE : value}]
+        rawtx = node.createrawtransaction(inputs, outputs)
+
+        parent_signed = node.signrawtransactionwithkey(hexstring=rawtx, privkeys=self.privkeys)
+        parent_tx = CTransaction()
+        assert parent_signed["complete"]
+        parent_tx.deserialize(BytesIO(hex_str_to_bytes(parent_signed["hex"])))
+        parent_txid = parent_tx.rehash()
+        assert node.testmempoolaccept([parent_signed["hex"]])[0]["allowed"]
+
+        parent_locking_script_a = parent_tx.vout[0].scriptPubKey.hex()
+        child_value = value - Decimal("0.0001")
+
+        # Child A
+        (_, tx_child_a_hex, _) = self.chain_transaction(parent_txid, child_value, 0, parent_locking_script_a)
+        assert not node.testmempoolaccept([tx_child_a_hex])[0]["allowed"]
+
+        # Child B
+        rawtx_b = node.createrawtransaction([{"txid" : parent_txid, "vout" : 1}], {self.address : child_value})
+        tx_child_b = CTransaction()
+        tx_child_b.deserialize(BytesIO(hex_str_to_bytes(rawtx_b)))
+        tx_child_b.wit.vtxinwit = [CTxInWitness()]
+        tx_child_b.wit.vtxinwit[0].scriptWitness.stack = [CScript([OP_TRUE])]
+        tx_child_b_hex = tx_child_b.serialize().hex()
+        assert not node.testmempoolaccept([tx_child_b_hex])[0]["allowed"]
+
+        self.log.info("Testmempoolaccept with entire package, should work with children in either order")
+        testres_multiple_ab = node.testmempoolaccept(rawtxs=[parent_signed["hex"], tx_child_a_hex, tx_child_b_hex])
+        testres_multiple_ba = node.testmempoolaccept(rawtxs=[parent_signed["hex"], tx_child_b_hex, tx_child_a_hex])
+        assert all([testres["allowed"] for testres in testres_multiple_ab + testres_multiple_ba])
+
+        testres_single = []
+        self.log.info("Test accept and then submit each one individually, which should be identical to package testaccept")
+        for rawtx in [parent_signed["hex"], tx_child_a_hex, tx_child_b_hex]:
+            testres = node.testmempoolaccept([rawtx])
+            testres_single.append(testres[0])
+            # Submit the transaction now so its child should have no problem validating
+            node.sendrawtransaction(rawtx)
+        assert_equal(testres_single, testres_multiple_ab)
+
+    def test_multiple_parents(self):
+        node = self.nodes[0]
+
+        self.log.info("Create a package in which a transaction has two parents within the package")
+        # Parent A
+        parent_a_coin = self.coins.pop()
+        parent_a_value = parent_a_coin["amount"] - Decimal("0.0001")
+        (tx_parent_a, hex_parent_a, parent_locking_script_a) = self.chain_transaction(parent_a_coin["txid"], parent_a_value)
+
+        # Parent B
+        parent_b_coin = self.coins.pop()
+        parent_b_value = parent_b_coin["amount"] - Decimal("0.0001")
+        (tx_parent_b, hex_parent_b, parent_locking_script_b) = self.chain_transaction(parent_b_coin["txid"], parent_b_value)
+
+        # Child
+        inputs = [{"txid" : tx_parent_a.rehash(), "vout" : 0}, {"txid" : tx_parent_b.rehash(), "vout" : 0}]
+        outputs = {self.address : parent_a_value + parent_b_value - Decimal("0.0001")}
+        rawtx_child = node.createrawtransaction(inputs, outputs)
+        prevtxs = [{"txid": tx_parent_a.rehash(), "vout": 0, "scriptPubKey": parent_locking_script_a, "amount": parent_a_value},
+                   {"txid": tx_parent_b.rehash(), "vout": 0, "scriptPubKey": parent_locking_script_b, "amount": parent_b_value}]
+        signedtx_child = node.signrawtransactionwithkey(hexstring=rawtx_child, privkeys=self.privkeys, prevtxs=prevtxs)
+        assert signedtx_child["complete"]
+        assert not node.testmempoolaccept([signedtx_child["hex"]])[0]["allowed"]
+
+        self.log.info("Testmempoolaccept with entire package, should work with parents in either order")
+        testres_multiple_ab = node.testmempoolaccept(rawtxs=[hex_parent_a, hex_parent_b, signedtx_child["hex"]])
+        testres_multiple_ba = node.testmempoolaccept(rawtxs=[hex_parent_b, hex_parent_a, signedtx_child["hex"]])
+        assert all([testres["allowed"] for testres in testres_multiple_ab + testres_multiple_ba])
+
+        testres_single = []
+        self.log.info("Test accept and then submit each one individually, which should be identical to package testaccept")
+        for rawtx in [hex_parent_a, hex_parent_b, signedtx_child["hex"]]:
+            testres = node.testmempoolaccept([rawtx])
+            testres_single.append(testres[0])
+            # Submit the transaction now so its child should have no problem validating
+            node.sendrawtransaction(rawtx)
+        assert_equal(testres_single, testres_multiple_ab)
+
+    def test_conflicting(self):
+        node = self.nodes[0]
+        prevtx = self.coins.pop()
+        inputs = [{"txid" : prevtx["txid"], "vout" : 0}]
+        output1 = {node.get_deterministic_priv_key().address: 50 - 0.00125}
+        output2 = {ADDRESS_BCRT1_P2WSH_OP_TRUE: 50 - 0.00125}
+
+        # tx1 and tx2 share the same inputs
+        rawtx1 = node.createrawtransaction(inputs, output1)
+        rawtx2 = node.createrawtransaction(inputs, output2)
+        signedtx1 = node.signrawtransactionwithkey(hexstring=rawtx1, privkeys=self.privkeys)
+        signedtx2 = node.signrawtransactionwithkey(hexstring=rawtx2, privkeys=self.privkeys)
+        tx1 = CTransaction()
+        tx1.deserialize(BytesIO(hex_str_to_bytes(signedtx1["hex"])))
+        tx2 = CTransaction()
+        tx2.deserialize(BytesIO(hex_str_to_bytes(signedtx2["hex"])))
+        assert signedtx1["complete"]
+        assert signedtx2["complete"]
+
+        # Ensure tx1 and tx2 are valid by themselves
+        assert node.testmempoolaccept([signedtx1["hex"]])[0]["allowed"]
+        assert node.testmempoolaccept([signedtx2["hex"]])[0]["allowed"]
+
+        self.log.info("Test duplicate transactions in the same package")
+        testres = node.testmempoolaccept([signedtx1["hex"], signedtx1["hex"]])
+        assert_equal(testres, [
+            {"txid": tx1.rehash(), "wtxid": tx1.getwtxid()},
+            {"txid": tx1.rehash(), "wtxid": tx1.getwtxid(), "allowed": False, "reject-reason": "conflict-in-package"}
+        ])
+
+        self.log.info("Test conflicting transactions in the same package")
+        testres = node.testmempoolaccept([signedtx1["hex"], signedtx2["hex"]])
+        assert_equal(testres, [
+            {"txid": tx1.rehash(), "wtxid": tx1.getwtxid()},
+            {"txid": tx2.rehash(), "wtxid": tx2.getwtxid(), "allowed": False, "reject-reason": "conflict-in-package"}
+        ])
+
+    def test_rbf(self):
+        node = self.nodes[0]
+        coin = self.coins.pop()
+        inputs = [{"txid" : coin["txid"], "vout" : 0, "sequence": BIP125_SEQUENCE_NUMBER}]
+        fee = Decimal('0.00125000')
+        output = {node.get_deterministic_priv_key().address: 50 - fee}
+        raw_replaceable_tx = node.createrawtransaction(inputs, output)
+        signed_replaceable_tx = node.signrawtransactionwithkey(hexstring=raw_replaceable_tx, privkeys=self.privkeys)
+        testres_replaceable = node.testmempoolaccept([signed_replaceable_tx["hex"]])
+        replaceable_tx = CTransaction()
+        replaceable_tx.deserialize(BytesIO(hex_str_to_bytes(signed_replaceable_tx["hex"])))
+        assert_equal(testres_replaceable, [
+            {"txid": replaceable_tx.rehash(), "wtxid": replaceable_tx.getwtxid(),
+            "allowed": True, "vsize": replaceable_tx.get_vsize(), "fees": { "base": fee }}
+        ])
+
+        # Replacement transaction is identical except has double the fee
+        replacement_tx = CTransaction()
+        replacement_tx.deserialize(BytesIO(hex_str_to_bytes(signed_replaceable_tx["hex"])))
+        replacement_tx.vout[0].nValue -= int(fee * COIN)  # Doubled fee
+        signed_replacement_tx = node.signrawtransactionwithkey(replacement_tx.serialize().hex(), self.privkeys)
+        replacement_tx.deserialize(BytesIO(hex_str_to_bytes(signed_replacement_tx["hex"])))
+
+        self.log.info("Test that transactions within a package cannot replace each other")
+        testres_rbf_conflicting = node.testmempoolaccept([signed_replaceable_tx["hex"], signed_replacement_tx["hex"]])
+        assert_equal(testres_rbf_conflicting, [
+            {"txid": replaceable_tx.rehash(), "wtxid": replaceable_tx.getwtxid()},
+            {"txid": replacement_tx.rehash(), "wtxid": replacement_tx.getwtxid(),
+            "allowed": False, "reject-reason": "conflict-in-package"}
+        ])
+
+        self.log.info("Test a package with a transaction replacing a mempool transaction")
+        node.sendrawtransaction(signed_replaceable_tx["hex"])
+        testres_rbf = node.testmempoolaccept(self.independent_txns_hex + [signed_replacement_tx["hex"]])
+        testres_replacement = testres_replaceable[0]
+        testres_replacement["txid"] = replacement_tx.rehash()
+        testres_replacement["wtxid"] = replacement_tx.getwtxid()
+        testres_replacement["fees"]["base"] = Decimal(str(2 * fee))
+        assert_equal(testres_rbf, self.independent_txns_testres + [testres_replacement])
+
+
+if __name__ == "__main__":
+    RPCPackagesTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -210,6 +210,7 @@ BASE_SCRIPTS = [
     'mempool_package_onemore.py',
     'rpc_createmultisig.py --legacy-wallet',
     'rpc_createmultisig.py --descriptors',
+    'rpc_packages.py',
     'feature_versionbits_warning.py',
     'rpc_preciousblock.py',
     'wallet_importprunedfunds.py --legacy-wallet',


### PR DESCRIPTION
Draft because this depends on an open PR and I'm only looking for Concept ACKs for now.

With #20833, we can test transactions chains against validation rules + policy without broadcasting them. There was [discussion](https://github.com/bitcoin/bitcoin/pull/20833#issuecomment-765057102) about how to make it useful by applications which have spending paths that require some delay (e.g. "if Alice doesn't redeem, Bob can get the coins 144 blocks later"). This PR implements a `test_accept`-only flag, `bypass_timelocks`, to skip `CheckFinalTx` and `CheckSequenceLocks`, i.e. that tx nLocktime and nSequence are ok based on the current block height/time. Script checks are still done as-is, so if the transaction itself has an error beyond not being final yet, it still fails.

I've added a few lines here and there in the functional tests just to make sure it works as expected. If people think this is useful, I can write more tests from scratch.