### PR TITLE
doc: add arm macOS depends platform triplet

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -25,7 +25,8 @@ Common `host-platform-triplets` for cross compilation are:
 - `i686-pc-linux-gnu` for Linux 32 bit
 - `x86_64-pc-linux-gnu` for x86 Linux
 - `x86_64-w64-mingw32` for Win64
-- `x86_64-apple-darwin18` for macOS
+- `x86_64-apple-darwin18` for Intel macOS
+- `arm-apple-darwin20` for ARM macOS
 - `arm-linux-gnueabihf` for Linux ARM 32 bit
 - `aarch64-linux-gnu` for Linux ARM 64 bit
 - `powerpc64-linux-gnu` for Linux POWER 64-bit (big endian)


### PR DESCRIPTION
This PR adds a common `host-platform-triplet` example for ARM macOS.

**Master:** [render](https://github.com/bitcoin/bitcoin/blob/master/depends/README.md)

**PR:** [render](https://github.com/bitcoin/bitcoin/blob/2c11d28319d66cb173ce7a425df00796e0801ba7/depends/README.md)