### PR TITLE
Misc external signer improvement and HWI 2 support 

### DIFF
--- a/doc/external-signer.md
+++ b/doc/external-signer.md
@@ -4,7 +4,7 @@ Bitcoin Core can be launched with `-signer=<cmd>` where `<cmd>` is an external t
 
 ## Example usage
 
-The following example is based on the [HWI](https://github.com/bitcoin-core/HWI) tool. Although this tool is hosted under the Bitcoin Core GitHub organization and maintained by Bitcoin Core developers, it should be used with caution. It is considered experimental and has far less review than Bitcoin Core itself. Be particularly careful when running tools such as these on a computer with private keys on it.
+The following example is based on the [HWI](https://github.com/bitcoin-core/HWI) tool. Version 2.0 or newer is required. Although this tool is hosted under the Bitcoin Core GitHub organization and maintained by Bitcoin Core developers, it should be used with caution. It is considered experimental and has far less review than Bitcoin Core itself. Be particularly careful when running tools such as these on a computer with private keys on it.
 
 When using a hardware wallet, consult the manufacturer website for (alternative) software they recommend. As long as their software conforms to the standard below, it should be able to work with Bitcoin Core.
 

--- a/src/wallet/rpcsigner.cpp
+++ b/src/wallet/rpcsigner.cpp
@@ -32,9 +32,6 @@ static RPCHelpMan enumeratesigners()
         },
         RPCExamples{""},
         [](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
-            std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
-            if (!wallet) return NullUniValue;
-
             const std::string command = gArgs.GetArg("-signer", "");
             if (command == "") throw JSONRPCError(RPC_WALLET_ERROR, "Error: restart bitcoind with -signer=<cmd>");
             std::string chain = gArgs.GetChainName();


### PR DESCRIPTION
HWI just released 2.0. See https://github.com/bitcoin-core/HWI/releases/tag/2.0.0

As of #16546 we already rely on features that are in 2.0 and not in the previous 1.* releases:
* `--chain` param

This shouldn't be a problem, because HWI 2.0 has been released before we release v22.

Misc improvements:
* document that HWI 2.0 is required 
* drop wallet requirement for `enumeratesigners`