### PR TITLE
contrib: Make systemd invoke dependencies only when ready

### DIFF
--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -18,7 +18,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-ExecStart=/usr/bin/bitcoind -daemon \
+ExecStart=/usr/bin/bitcoind -daemonwait \
                             -pid=/run/bitcoind/bitcoind.pid \
                             -conf=/etc/bitcoin/bitcoin.conf \
                             -datadir=/var/lib/bitcoind
@@ -33,6 +33,7 @@ ExecStartPre=/bin/chgrp bitcoin /etc/bitcoin
 Type=forking
 PIDFile=/run/bitcoind/bitcoind.pid
 Restart=on-failure
+TimeoutStartSec=infinity
 TimeoutStopSec=600
 
 # Directory creation and permissions


### PR DESCRIPTION
Make systemd invoke dependencies only when ready by using `-daemonwait` in the service file instead of `-daemon`.

Closes #21322 by making bitcoind conform to behavior specified for `type=forking`.

This may need some tuning of timeouts.