### PR TITLE
build: Improve depends/funcs.mk

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -212,7 +212,7 @@ $($(1)_built): | $($(1)_configured)
 	$(AT)touch $$@
 $($(1)_staged): | $($(1)_built)
 	$(AT)echo Staging $(1)...
-	$(AT)mkdir -p $($(1)_staging_dir)/$(host_prefix)
+	$(AT)mkdir -p $($(1)_staging_prefix_dir)
 	$(AT)cd $($(1)_build_dir); $($(1)_stage_env) $(call $(1)_stage_cmds, $(1))
 	$(AT)rm -rf $($(1)_extract_dir)
 	$(AT)touch $$@
@@ -222,7 +222,7 @@ $($(1)_postprocessed): | $($(1)_staged)
 	$(AT)touch $$@
 $($(1)_cached): | $($(1)_dependencies) $($(1)_postprocessed)
 	$(AT)echo Caching $(1)...
-	$(AT)cd $$($(1)_staging_dir)/$(host_prefix); find . | sort | tar --no-recursion -czf $$($(1)_staging_dir)/$$(@F) -T -
+	$(AT)cd $($(1)_staging_prefix_dir); find . | sort | tar --no-recursion -czf $$($(1)_staging_dir)/$$(@F) -T -
 	$(AT)mkdir -p $$(@D)
 	$(AT)rm -rf $$(@D) && mkdir -p $$(@D)
 	$(AT)mv $$($(1)_staging_dir)/$$(@F) $$(@)

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -77,7 +77,7 @@ $(1)_cleaned=$$($(1)_extract_dir)/.stamp_cleaned
 $(1)_built=$$($(1)_build_dir)/.stamp_built
 $(1)_configured=$$($(1)_build_dir)/.stamp_configured
 $(1)_staged=$$($(1)_staging_dir)/.stamp_staged
-$(1)_postprocessed=$$($(1)_staging_prefix_dir)/.stamp_postprocessed
+$(1)_postprocessed=$$($(1)_staging_dir)/.stamp_postprocessed
 $(1)_download_path_fixed=$(subst :,\:,$$($(1)_download_path))
 
 


### PR DESCRIPTION
1) Use the `$(package)_staging_prefix_dir` variable consistently to improves readability, and make it easier to reason about build scripts

2) Do not put the `.stamp_postprocessed` into the cached package archive as it is an unrelated artifact when that archive
is lately used in the `$(package)_configured` target for other packages.

