### PR TITLE
test: Cleanup in test-{security,symbol}-check.py

### DIFF
--- a/contrib/devtools/test-security-check.py
+++ b/contrib/devtools/test-security-check.py
@@ -5,6 +5,7 @@
 '''
 Test script for security-check.py
 '''
+import os
 import subprocess
 import unittest
 
@@ -18,6 +19,10 @@ def write_testcode(filename):
         return 0;
     }
     ''')
+
+def clean_files(source, executable):
+    os.remove(source)
+    os.remove(executable)
 
 def call_security_check(cc, source, executable, options):
     subprocess.run([cc,source,'-o',executable] + options, check=True)
@@ -44,6 +49,8 @@ class TestSecurityChecks(unittest.TestCase):
         self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-znoexecstack','-fstack-protector-all','-Wl,-zrelro','-Wl,-z,now','-pie','-fPIE', '-Wl,-z,separate-code']),
                 (0, ''))
 
+        clean_files(source, executable)
+
     def test_PE(self):
         source = 'test1.c'
         executable = 'test1.exe'
@@ -60,6 +67,8 @@ class TestSecurityChecks(unittest.TestCase):
             (1, executable+': failed RELOC_SECTION'))
         self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--dynamicbase','-Wl,--high-entropy-va','-pie','-fPIE']),
             (0, ''))
+
+        clean_files(source, executable)
 
     def test_MACHO(self):
         source = 'test1.c'
@@ -79,6 +88,8 @@ class TestSecurityChecks(unittest.TestCase):
             (1, executable+': failed PIE'))
         self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-pie','-Wl,-bind_at_load','-fstack-protector-all']),
             (0, ''))
+
+        clean_files(source, executable)
 
 if __name__ == '__main__':
     unittest.main()

--- a/contrib/devtools/test-symbol-check.py
+++ b/contrib/devtools/test-symbol-check.py
@@ -16,10 +16,6 @@ def call_symbol_check(cc, source, executable, options):
     os.remove(executable)
     return (p.returncode, p.stdout.rstrip())
 
-def get_machine(cc):
-    p = subprocess.run([cc,'-dumpmachine'], stdout=subprocess.PIPE, universal_newlines=True)
-    return p.stdout.rstrip()
-
 class TestSymbolChecks(unittest.TestCase):
     def test_ELF(self):
         source = 'test1.c'

--- a/contrib/devtools/test-symbol-check.py
+++ b/contrib/devtools/test-symbol-check.py
@@ -5,12 +5,15 @@
 '''
 Test script for symbol-check.py
 '''
+import os
 import subprocess
 import unittest
 
 def call_symbol_check(cc, source, executable, options):
     subprocess.run([cc,source,'-o',executable] + options, check=True)
     p = subprocess.run(['./contrib/devtools/symbol-check.py',executable], stdout=subprocess.PIPE, universal_newlines=True)
+    os.remove(source)
+    os.remove(executable)
     return (p.returncode, p.stdout.rstrip())
 
 def get_machine(cc):


### PR DESCRIPTION
1) Test source and executable files are neither ignored by `.gitignore` nor removed by `make clean` and `make distclean`.

2) The `get_machine` function is no longer used since #21255.