### PR TITLE
util: check integer overrun in RaiseFileDescriptorLimit

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1152,6 +1152,8 @@ int RaiseFileDescriptorLimit(int nMinFD) {
             setrlimit(RLIMIT_NOFILE, &limitFD);
             getrlimit(RLIMIT_NOFILE, &limitFD);
         }
+        if (limitFD.rlim_cur > INT_MAX)
+            limitFD.rlim_cur = INT_MAX;
         return limitFD.rlim_cur;
     }
     return nMinFD; // getrlimit failed, assume it's fine


### PR DESCRIPTION
The function RaiseFileDescriptorLimit returns an integer, but the returned value limitFD.rlim_cur (rlim_t) can be of type unsigned long long in some systems. This can lead to an overrun and subsequently to an error in the calling functions.
To prevent that, it has to be checked if the value of rlim_cur exceeds the integer boundaries. If so the rlim_cur will be set to the maximum integer value.
