### PR TITLE
Always add -daemonwait to known command line arguments

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -585,6 +585,7 @@ void SetupServerArgs(NodeContext& node)
     argsman.AddArg("-daemonwait", strprintf("Wait for initialization to be finished before exiting. This implies -daemon (default: %d)", DEFAULT_DAEMONWAIT), ArgsManager::ALLOW_BOOL, OptionsCategory::OPTIONS);
 #else
     hidden_args.emplace_back("-daemon");
+    hidden_args.emplace_back("-daemonwait");
 #endif
 
     // Add the hidden options


### PR DESCRIPTION
This is a follow up of #21007.

When `AC_CHECK_DECLS([fork])` fails:

- on master (8e6532053f580003869346510fc1dc20c46c8067):
```
$ src/bitcoind -daemonwait
Error: Error parsing command line arguments: Invalid parameter -daemonwait

```

- with this PR:
```
$ src/bitcoind -daemonwait
Error: -daemon is not supported on this operating system

```