### PR TITLE
Only log time to write coins cache to disk if bench debug enabled

### DIFF
--- a/src/logging/timer.h
+++ b/src/logging/timer.h
@@ -97,6 +97,8 @@ private:
     BCLog::Timer<std::chrono::milliseconds> PASTE2(logging_timer, __COUNTER__)(__func__, end_msg, log_category)
 #define LOG_TIME_SECONDS(end_msg) \
     BCLog::Timer<std::chrono::seconds> PASTE2(logging_timer, __COUNTER__)(__func__, end_msg)
+#define LOG_TIME_SECONDS_WITH_CATEGORY(end_msg, log_category) \
+    BCLog::Timer<std::chrono::seconds> PASTE2(logging_timer, __COUNTER__)(__func__, end_msg, log_category)
 
 
 #endif // BITCOIN_LOGGING_TIMER_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2372,8 +2372,8 @@ bool CChainState::FlushStateToDisk(
         }
         // Flush best chain related state. This can only be done if the blocks / block index write was also done.
         if (fDoFullFlush && !CoinsTip().GetBestBlock().IsNull()) {
-            LOG_TIME_SECONDS(strprintf("write coins cache to disk (%d coins, %.2fkB)",
-                coins_count, coins_mem_usage / 1000));
+            LOG_TIME_SECONDS_WITH_CATEGORY(strprintf("write coins cache to disk (%d coins, %.2fkB)",
+                coins_count, coins_mem_usage / 1000), BCLog::BENCH);
 
             // Typical Coin structures on disk are around 48 bytes in size.
             // Pushing a new one to the database can cause it to be written


### PR DESCRIPTION
Minor debugging change to only log this if bench debugging is enabled.