### PR TITLE
p2p: add time when deserialize file db for ReadAnchors

### DIFF
--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -19,6 +19,7 @@
 #include <util/settings.h>
 #include <util/system.h>
 #include <util/translation.h>
+#include <util/time.h>
 
 namespace {
 
@@ -213,9 +214,11 @@ void DumpAnchors(const fs::path& anchors_db_path, const std::vector<CAddress>& a
 std::vector<CAddress> ReadAnchors(const fs::path& anchors_db_path)
 {
     std::vector<CAddress> anchors;
+    int64_t nStart = GetTimeMillis();
+
     try {
         DeserializeFileDB(anchors_db_path, anchors, CLIENT_VERSION | ADDRV2_FORMAT);
-        LogPrintf("Loaded %i addresses from %s\n", anchors.size(), fs::quoted(fs::PathToString(anchors_db_path.filename())));
+        LogPrintf("Loaded %i addresses from %s %dms\n", anchors.size(), fs::PathToString(anchors_db_path.filename()), GetTimeMillis() - nStart);
     } catch (const std::exception&) {
         anchors.clear();
     }


### PR DESCRIPTION
This PR adds time duration for anchors.dat deserialization (following the same logic that peers.dat). 
Also, it removes the quotes of `"anchors.dat"` in `LogPrintf` to follow the pattern of other logs.