### PR TITLE
build: link against -lsocket if required for *ifaddrs

### DIFF
--- a/build-aux/m4/l_socket.m4
+++ b/build-aux/m4/l_socket.m4
@@ -1,0 +1,36 @@
+# Illumos/SmartOS requires linking with -lsocket if
+# using getifaddrs & freeifaddrs
+
+m4_define([_CHECK_SOCKET_testbody], [[
+  #include <sys/types.h>
+  #include <ifaddrs.h>
+
+  int main() {
+    struct ifaddrs *ifaddr;
+    getifaddrs(&ifaddr);
+    freeifaddrs(ifaddr);
+  }
+]])
+
+AC_DEFUN([CHECK_SOCKET], [
+
+  AC_LANG_PUSH(C++)
+
+  AC_MSG_CHECKING([whether ifaddrs funcs can be used without link library])
+
+  AC_LINK_IFELSE([AC_LANG_SOURCE([_CHECK_SOCKET_testbody])],[
+      AC_MSG_RESULT([yes])
+    ],[
+      AC_MSG_RESULT([no])
+      LIBS="$LIBS -lsocket"
+      AC_MSG_CHECKING([whether getifaddrs needs -lsocket])
+      AC_LINK_IFELSE([AC_LANG_SOURCE([_CHECK_SOCKET_testbody])],[
+          AC_MSG_RESULT([yes])
+        ],[
+          AC_MSG_RESULT([no])
+          AC_MSG_FAILURE([cannot figure out how to use getifaddrs])
+        ])
+    ])
+
+  AC_LANG_POP
+])

--- a/configure.ac
+++ b/configure.ac
@@ -936,7 +936,7 @@ fi
 
 AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h sys/select.h sys/prctl.h sys/sysctl.h vm/vm_param.h sys/vmmeter.h sys/resources.h])
 
-AC_CHECK_DECLS([getifaddrs, freeifaddrs],,,
+AC_CHECK_DECLS([getifaddrs, freeifaddrs],[CHECK_SOCKET],,
     [#include <sys/types.h>
     #include <ifaddrs.h>]
 )

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -31,6 +31,10 @@
 #include <fcntl.h>
 #endif
 
+#if HAVE_DECL_GETIFADDRS && HAVE_DECL_FREEIFADDRS
+#include <ifaddrs.h>
+#endif
+
 #ifdef USE_POLL
 #include <poll.h>
 #endif

--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -38,7 +38,7 @@
 #include <sys/utsname.h>
 #include <unistd.h>
 #endif
-#if HAVE_DECL_GETIFADDRS
+#if HAVE_DECL_GETIFADDRS && HAVE_DECL_FREEIFADDRS
 #include <ifaddrs.h>
 #endif
 #if HAVE_SYSCTL
@@ -361,7 +361,7 @@ void RandAddStaticEnv(CSHA512& hasher)
         hasher.Write((const unsigned char*)hname, strnlen(hname, 256));
     }
 
-#if HAVE_DECL_GETIFADDRS
+#if HAVE_DECL_GETIFADDRS && HAVE_DECL_FREEIFADDRS
     // Network interfaces
     struct ifaddrs *ifad = NULL;
     getifaddrs(&ifad);


### PR DESCRIPTION
Fixes #21485 by linking against `-lsocket` when it's required for using `*ifaddrs` functions.