### PR TITLE
build: Do not opt-in unused CoreWLAN stuff in depends for macOS

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -111,6 +111,7 @@ $(package)_config_opts += -no-feature-xml
 $(package)_config_opts_darwin = -no-dbus
 $(package)_config_opts_darwin += -no-opengl
 $(package)_config_opts_darwin += -pch
+$(package)_config_opts_darwin += -no-feature-corewlan
 $(package)_config_opts_darwin += -device-option QMAKE_MACOSX_DEPLOYMENT_TARGET=$(OSX_MIN_VERSION)
 
 ifneq ($(build_os),darwin)


### PR DESCRIPTION
We [do not use](https://github.com/bitcoin/bitcoin/blob/d2a78ee9288e4d3bace9125bcfae6b7747f85982/contrib/devtools/symbol-check.py#L96-L111) any macOS CoreWLAN Framework stuff.

Changes in Qt Configure summary with `HOST=x86_64-apple-darwin18`:
```diff
--- wlan-master/summary	2021-03-22 00:26:04.377387806 +0200
+++ wlan-pr/summary	2021-03-22 00:37:07.060997990 +0200
@@ -49,7 +49,7 @@
     slog2 ................................ no
   Using system PCRE2 ..................... no
 Qt Network:
-  CoreWLan ............................... yes
+  CoreWLan ............................... no
   getifaddrs() ........................... yes
   IPv6 ifname ............................ yes
   libproxy ............................... no
```