### PR TITLE
doc: add maxuploadtarget to bitcoinf.conf example

### DIFF
--- a/share/examples/bitcoin.conf
+++ b/share/examples/bitcoin.conf
@@ -66,7 +66,7 @@
 # Maximum number of inbound+outbound connections.
 #maxconnections=
 
-#Maximum daily upload target in MiB per day (e.g. 'maxuploadtarget=1024' is 1GiB max throughput per day)
+#Maximum daily upload target in MiB per day (e.g. 'maxuploadtarget=1024' is 1 GiB max throughput per day)
 #Limiting the free-for-all bandwidth uploads for those with bandwidth limits
 #maxuploadtarget=
 

--- a/share/examples/bitcoin.conf
+++ b/share/examples/bitcoin.conf
@@ -66,6 +66,10 @@
 # Maximum number of inbound+outbound connections.
 #maxconnections=
 
+#Maximum daily upload target in MiB per day (e.g. 'maxuploadtarget=1024' is 1GiB max throughput per day)
+#Limiting the free-for-all bandwidth uploads for those with bandwidth limits
+#maxuploadtarget=
+
 #
 # JSON-RPC options (for controlling a running Bitcoin/bitcoind process)
 #

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1450,7 +1450,6 @@ BOOST_AUTO_TEST_CASE(test_ParseInt32)
     BOOST_CHECK(!ParseInt32("1a", &n));
     BOOST_CHECK(!ParseInt32("aap", &n));
     BOOST_CHECK(!ParseInt32("0x1", &n)); // no hex
-    BOOST_CHECK(!ParseInt32("0x1", &n)); // no hex
     BOOST_CHECK(!ParseInt32(STRING_WITH_EMBEDDED_NULL_CHAR, &n));
     // Overflow and underflow
     BOOST_CHECK(!ParseInt32("-2147483649", nullptr));
@@ -1513,7 +1512,6 @@ BOOST_AUTO_TEST_CASE(test_ParseUInt8)
     BOOST_CHECK(!ParseUInt8("1a", &n));
     BOOST_CHECK(!ParseUInt8("aap", &n));
     BOOST_CHECK(!ParseUInt8("0x1", &n)); // no hex
-    BOOST_CHECK(!ParseUInt8("0x1", &n)); // no hex
     BOOST_CHECK(!ParseUInt8(STRING_WITH_EMBEDDED_NULL_CHAR, &n));
     // Overflow and underflow
     BOOST_CHECK(!ParseUInt8("-255", &n));
@@ -1548,7 +1546,6 @@ BOOST_AUTO_TEST_CASE(test_ParseUInt16)
     BOOST_CHECK(!ParseUInt16("1 ", &n));
     BOOST_CHECK(!ParseUInt16("1a", &n));
     BOOST_CHECK(!ParseUInt16("aap", &n));
-    BOOST_CHECK(!ParseUInt16("0x1", &n)); // no hex
     BOOST_CHECK(!ParseUInt16("0x1", &n)); // no hex
     BOOST_CHECK(!ParseUInt16(STRING_WITH_EMBEDDED_NULL_CHAR, &n));
     // Overflow and underflow
@@ -1586,7 +1583,6 @@ BOOST_AUTO_TEST_CASE(test_ParseUInt32)
     BOOST_CHECK(!ParseUInt32("1 ", &n));
     BOOST_CHECK(!ParseUInt32("1a", &n));
     BOOST_CHECK(!ParseUInt32("aap", &n));
-    BOOST_CHECK(!ParseUInt32("0x1", &n)); // no hex
     BOOST_CHECK(!ParseUInt32("0x1", &n)); // no hex
     BOOST_CHECK(!ParseUInt32(STRING_WITH_EMBEDDED_NULL_CHAR, &n));
     // Overflow and underflow


### PR DESCRIPTION
I reduced mine to 10000 since I was seeing about 40GB+ a day being uploaded and need to utilize my bandwidth for other projects. Running bitcoin-qt on a Raspberry Pi 4 with a gig fiber connection. Would be interested if maxconnections is a better use to throttle than upload limits or if this suggested parameter can cause issues. So far throttling looks much better for me. Thank you for the conf file!

