### PR TITLE
test: remove unicode from tmp test_runner dir

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -351,7 +351,8 @@ def main():
     logging.basicConfig(format='%(message)s', level=logging_level)
 
     # Create base test directory
-    tmpdir = "%s/test_runner_₿_🏃_%s" % (args.tmpdirprefix, datetime.datetime.now().strftime("%Y%m%d_%H%M%S"))
+    tmpdir = "%s/test_runner_bitcoincore_%s" % (
+        args.tmpdirprefix, datetime.datetime.now().strftime("%Y%m%d_%H%M%S"))
 
     os.makedirs(tmpdir)
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/73197/111999943-dd55b600-8af3-11eb-8669-f3a3a272b051.png)


The unicode characters in the temporary test directory paths, while cute, cause inconvenience on remote systems which are not configured to display unicode over tty. Specifically this makes debugging functional test failures on some of the bitcoinperf systems difficult.