### PR TITLE
p2p: Don't send FEEFILTER in blocksonly mode.

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4689,7 +4689,10 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
         //
         // Message: feefilter
         //
-        if (pto->m_tx_relay != nullptr && pto->GetCommonVersion() >= FEEFILTER_VERSION && gArgs.GetBoolArg("-feefilter", DEFAULT_FEEFILTER) &&
+        if (pto->m_tx_relay != nullptr &&
+            !m_ignore_incoming_txs &&
+            pto->GetCommonVersion() >= FEEFILTER_VERSION &&
+            gArgs.GetBoolArg("-feefilter", DEFAULT_FEEFILTER) &&
             !pto->HasPermission(PF_FORCERELAY) // peers with the forcerelay permission should not filter txs to us
         ) {
             CAmount currentFilter = m_mempool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK();

--- a/test/functional/p2p_feefilter.py
+++ b/test/functional/p2p_feefilter.py
@@ -61,6 +61,7 @@ class FeeFilterTest(BitcoinTestFramework):
     def run_test(self):
         self.test_feefilter_forcerelay()
         self.test_feefilter()
+        self.test_feefilter_blocksonly()
 
     def test_feefilter_forcerelay(self):
         self.log.info('Check that peers without forcerelay permission (default) get a feefilter message')
@@ -118,6 +119,19 @@ class FeeFilterTest(BitcoinTestFramework):
         txids = [miniwallet.send_self_transfer(fee_rate=Decimal('0.00020000'), from_node=node1)['wtxid'] for _ in range(3)]
         conn.wait_for_invs_to_match(txids)
         conn.clear_invs()
+
+    def test_feefilter_blocksonly(self):
+        """Test that we don't send fee filters to block-relay-only peers and when we're in blocksonly mode."""
+        self.log.info("Check that we don't send fee filters to block-relay-only peers.")
+        feefilter_peer = self.nodes[0].add_outbound_p2p_connection(FeefilterConn(), p2p_idx=0, connection_type="block-relay-only")
+        feefilter_peer.sync_with_ping()
+        feefilter_peer.assert_feefilter_received(False)
+
+        self.log.info("Check that we don't send fee filters when in blocksonly mode.")
+        self.restart_node(0, ["-blocksonly"])
+        feefilter_peer = self.nodes[0].add_p2p_connection(FeefilterConn())
+        feefilter_peer.sync_with_ping()
+        feefilter_peer.assert_feefilter_received(False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The purpose of FEEFILTER messages (BIP 133) is to inform our peers that we do not want transactions below a specified fee rate. 
In blocksonly mode, we do not want our peer to send us any transactions at all (and will disconnect if a peer still sends a transaction INV or TX). 

Therefore, I don't think that it makes sense to send FEEFILTER messages every 10 minutes on average in blocksonly mode - this PR disables it.

Note that on block-relay-only connections, FEEFILTER is already disabled, just not in blocksonly mode.