### PR TITLE
p2p: Ignore ports on I2P addresses

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1694,7 +1694,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     connOptions.m_msgproc = node.peerman.get();
     connOptions.nSendBufferMaxSize = 1000 * args.GetArg("-maxsendbuffer", DEFAULT_MAXSENDBUFFER);
     connOptions.nReceiveFloodSize = 1000 * args.GetArg("-maxreceivebuffer", DEFAULT_MAXRECEIVEBUFFER);
-    connOptions.m_added_nodes = args.GetArgs("-addnode");
+    connOptions.m_added_nodes = RemovePortIfIrrelevant(args.GetArgs("-addnode"));
 
     connOptions.nMaxOutboundLimit = 1024 * 1024 * args.GetArg("-maxuploadtarget", DEFAULT_MAX_UPLOAD_TARGET);
     connOptions.m_peer_connect_timeout = peer_connect_timeout;
@@ -1753,7 +1753,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     if (!connOptions.m_use_addrman_outgoing) {
         const auto connect = args.GetArgs("-connect");
         if (connect.size() != 1 || connect[0] != "0") {
-            connOptions.m_specified_outgoing = connect;
+            connOptions.m_specified_outgoing = RemovePortIfIrrelevant(connect);
         }
     }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -327,9 +327,10 @@ CNode* CConnman::FindNode(const CSubNet& subNet)
 
 CNode* CConnman::FindNode(const std::string& addrName)
 {
+    const std::string& addr = RemovePortIfIrrelevant(addrName);
     LOCK(cs_vNodes);
     for (CNode* pnode : vNodes) {
-        if (pnode->GetAddrName() == addrName) {
+        if (pnode->GetAddrName() == addr) {
             return pnode;
         }
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -411,10 +411,9 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
                 LogPrint(BCLog::NET, "Resolver returned invalid address %s for %s\n", addrConnect.ToString(), pszDest);
                 return nullptr;
             }
-            // It is possible that we already have a connection to the IP/port pszDest resolved to.
-            // In that case, drop the connection that was just created, and return the existing CNode instead.
-            // Also store the name we used to connect in that CNode, so that future FindNode() calls to that
-            // name catch this early.
+            // It is possible that we already have a connection to the addr:port pszDest resolved to.
+            // Don't connect in that case. If the node's name is not set, then set it, so that future
+            // FindNode(std::string) calls to that name catch this early.
             LOCK(cs_vNodes);
             CNode* pnode = FindNode(static_cast<CService>(addrConnect));
             if (pnode)

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -988,11 +988,6 @@ bool operator==(const CService& a, const CService& b)
     return static_cast<CNetAddr>(a) == static_cast<CNetAddr>(b) && a.port == b.port;
 }
 
-bool operator<(const CService& a, const CService& b)
-{
-    return static_cast<CNetAddr>(a) < static_cast<CNetAddr>(b) || (static_cast<CNetAddr>(a) == static_cast<CNetAddr>(b) && a.port < b.port);
-}
-
 /**
  * Obtain the IPv4/6 socket address this represents.
  *

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -985,7 +985,13 @@ uint16_t CService::GetPort() const
 
 bool operator==(const CService& a, const CService& b)
 {
-    return static_cast<CNetAddr>(a) == static_cast<CNetAddr>(b) && a.port == b.port;
+    if (static_cast<CNetAddr>(a) != static_cast<CNetAddr>(b)) {
+        return false;
+    }
+    if (UsesPorts(a.GetNetwork())) {
+        return a.port == b.port;
+    }
+    return true;
 }
 
 /**

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -1054,7 +1054,9 @@ std::string CService::ToStringPort() const
 
 std::string CService::ToStringIPPort() const
 {
-    if (IsIPv4() || IsTor() || IsI2P() || IsInternal()) {
+    if (!UsesPorts(GetNetwork())) {
+        return ToStringIP();
+    } else if (IsIPv4() || IsTor() || IsInternal()) {
         return ToStringIP() + ":" + ToStringPort();
     } else {
         return "[" + ToStringIP() + "]:" + ToStringPort();

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -587,4 +587,13 @@ class CService : public CNetAddr
 
 bool SanityCheckASMap(const std::vector<bool>& asmap);
 
+/**
+ * Check if a given network uses ports in addition to addresses to identify peers.
+ * The familiar concept of "a TCP port 8333 in 1.2.3.4:8333" does not apply to some
+ * networks or at least in the way we use them.
+ * @param[in] net The network to check.
+ * @return true if ports are being used on the given network.
+ */
+static inline bool UsesPorts(Network net) { return net != NET_I2P; }
+
 #endif // BITCOIN_NETADDRESS_H

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -563,7 +563,13 @@ class CService : public CNetAddr
         bool SetSockAddr(const struct sockaddr* paddr);
         friend bool operator==(const CService& a, const CService& b);
         friend bool operator!=(const CService& a, const CService& b) { return !(a == b); }
-        friend bool operator<(const CService& a, const CService& b);
+
+        /**
+         * Avoid silently, unintentionally falling back to comparing CService objects as
+         * CNetAddr objects.
+         */
+        bool operator<(const CService&) = delete;
+
         std::vector<unsigned char> GetKey() const;
         std::string ToString() const;
         std::string ToStringPort() const;

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -754,3 +754,28 @@ void InterruptSocks5(bool interrupt)
 {
     interruptSocks5Recv = interrupt;
 }
+
+std::string RemovePortIfIrrelevant(const std::string& addr)
+{
+    uint16_t port{0};
+    std::string addr_without_port;
+
+    SplitHostPort(addr, port, addr_without_port);
+
+    std::vector<CNetAddr> net_addr;
+    if (port > 0 && LookupIntern(addr_without_port, net_addr, 1, false, g_dns_lookup) &&
+        !UsesPorts(net_addr.at(0).GetNetwork())) {
+        return addr_without_port;
+    }
+    return addr;
+}
+
+std::vector<std::string> RemovePortIfIrrelevant(const std::vector<std::string>& addresses)
+{
+    std::vector<std::string> ret;
+    ret.reserve(addresses.size());
+    for (const auto& addr : addresses) {
+        ret.emplace_back(RemovePortIfIrrelevant(addr));
+    }
+    return ret;
+}

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -246,4 +246,13 @@ void InterruptSocks5(bool interrupt);
  */
 bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* auth, const Sock& socket);
 
+/**
+ * Remove the trailing `:port` (if any) if the network of the address does not use ports.
+ * @param[in] addr Address in human readable form, possibly followed by `:port`.
+ * @return `addr` if ports are relevant or `addr` without the `:port`.
+ */
+std::string RemovePortIfIrrelevant(const std::string& addr);
+
+std::vector<std::string> RemovePortIfIrrelevant(const std::vector<std::string>& addresses);
+
 #endif // BITCOIN_NETBASE_H

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -12,6 +12,7 @@
 #include <net_permissions.h>
 #include <net_processing.h>
 #include <net_types.h> // For banmap_t
+#include <netaddress.h>
 #include <netbase.h>
 #include <node/context.h>
 #include <policy/settings.h>
@@ -304,7 +305,7 @@ static RPCHelpMan addnode()
     NodeContext& node = EnsureAnyNodeContext(request.context);
     CConnman& connman = EnsureConnman(node);
 
-    std::string strNode = request.params[0].get_str();
+    std::string strNode = RemovePortIfIrrelevant(request.params[0].get_str());
 
     if (strCommand == "onetry")
     {
@@ -356,7 +357,7 @@ static RPCHelpMan addconnection()
     }
 
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VSTR});
-    const std::string address = request.params[0].get_str();
+    const std::string address = RemovePortIfIrrelevant(request.params[0].get_str());
     const std::string conn_type_in{TrimString(request.params[1].get_str())};
     ConnectionType conn_type{};
     if (conn_type_in == "outbound-full-relay") {

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -588,4 +588,15 @@ BOOST_AUTO_TEST_CASE(caddress_unserialize_v2)
     BOOST_CHECK(fixture_addresses == addresses_unserialized);
 }
 
+BOOST_AUTO_TEST_CASE(cservice_compare)
+{
+    BOOST_CHECK(LookupNumeric("1.1.1.1:555") == LookupNumeric("1.1.1.1:555"));
+    BOOST_CHECK(LookupNumeric("1.1.1.1:555") != LookupNumeric("1.1.1.1:666"));
+    BOOST_CHECK(LookupNumeric("1.1.1.1:555") != LookupNumeric("2.2.2.2:555"));
+
+    const std::string i2p_addr{"ukeu3k5oycgaauneqgtnvselmt4yemvoilkln7jpvamvfx7dnkdq.b32.i2p"};
+    BOOST_CHECK(LookupNumeric(i2p_addr + ":555") == LookupNumeric(i2p_addr + ":555"));
+    BOOST_CHECK(LookupNumeric(i2p_addr + ":555") == LookupNumeric(i2p_addr + ":666"));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -604,4 +604,29 @@ BOOST_AUTO_TEST_CASE(cservice_compare)
     BOOST_CHECK(LookupNumeric(i2p_addr + ":555") == LookupNumeric(i2p_addr + ":666"));
 }
 
+BOOST_AUTO_TEST_CASE(remove_port_if_irrelevant)
+{
+    const std::string i2p_addr{"ukeu3k5oycgaauneqgtnvselmt4yemvoilkln7jpvamvfx7dnkdq.b32.i2p"};
+    BOOST_CHECK_EQUAL(RemovePortIfIrrelevant(i2p_addr + ":4444"), i2p_addr);
+
+    const std::vector<std::string> addresses{{
+         "1.2.3.4",
+         "1.2.3.4:5678",
+         "[1:2::3:4]:5678",
+         "pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion",
+         "pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion:1111",
+         "ukeu3k5oycgaauneqgtnvselmt4yemvoilkln7jpvamvfx7dnkdq.b32.i2p",
+    }};
+
+    for (const auto& addr : addresses) {
+        BOOST_CHECK_EQUAL(RemovePortIfIrrelevant(addr), addr);
+    }
+
+    const auto& addresses_ports_removed = RemovePortIfIrrelevant(addresses);
+    BOOST_REQUIRE_EQUAL(addresses_ports_removed.size(), addresses.size());
+    for (size_t i = 0; i < addresses.size(); ++i) {
+        BOOST_CHECK_EQUAL(addresses_ports_removed[i], addresses[i]);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -131,6 +131,11 @@ BOOST_AUTO_TEST_CASE(netbase_lookupnumeric)
     BOOST_CHECK(TestParse("[fd6b:88c0:8724:1:2:3:4:5]", "[::]:0"));
     // and that a one-off resolves correctly
     BOOST_CHECK(TestParse("[fd6c:88c0:8724:1:2:3:4:5]", "[fd6c:88c0:8724:1:2:3:4:5]:65535"));
+
+    // I2P skips the port.
+    const std::string i2p_addr{"ukeu3k5oycgaauneqgtnvselmt4yemvoilkln7jpvamvfx7dnkdq.b32.i2p"};
+    BOOST_CHECK(TestParse(i2p_addr, i2p_addr));
+    BOOST_CHECK(TestParse(i2p_addr + ":8333", i2p_addr));
 }
 
 BOOST_AUTO_TEST_CASE(onioncat_test)

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -65,6 +65,13 @@ std::string EncodeBase32(Span<const unsigned char> input, bool pad = true);
  */
 std::string EncodeBase32(const std::string& str, bool pad = true);
 
+/**
+ * Parse and split addr:port.
+ * @param[in] in Address to parse, either `addr`, `addr:port`, `[ip:v:6]` or `[ip:v:6]:port`.
+ * @param[out] portOut The port from the `:port` suffix. Or left unmodified if no such suffix.
+ * @param[out] hostOut The address part, before `:port` (if any). `[` and `]` are removed from
+ * IPv6 addresses.
+ */
 void SplitHostPort(std::string in, uint16_t& portOut, std::string& hostOut);
 int64_t atoi64(const std::string& str);
 int atoi(const std::string& str);

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -215,11 +215,23 @@ class ConfArgsTest(BitcoinTestFramework):
         ]):
             self.nodes[0].setmocktime(start + 65)
 
+    def test_addnode_and_connect_i2p(self):
+        self.log.info('Test ports are removed from I2P addresses passed to -addnode/-connect')
+
+        i2p_addr = "ukeu3k5oycgaauneqgtnvselmt4yemvoilkln7jpvamvfx7dnkdq.b32.i2p"
+        i2p_addr_with_port = i2p_addr + ":3333"
+
+        msg = f"trying connection {i2p_addr} lastseen="
+        for option in ["addnode", "connect"]:
+            with self.nodes[0].assert_debug_log(expected_msgs=[msg]):
+                self.restart_node(0, extra_args=[f"-{option}={i2p_addr_with_port}"])
+
     def run_test(self):
         self.test_log_buffer()
         self.test_args_log()
         self.test_seed_peers()
         self.test_networkactive()
+        self.test_addnode_and_connect_i2p()
 
         self.test_config_file_parser()
         self.test_invalid_command_line_options()


### PR DESCRIPTION
_This is an alternative to #22112. They are mutually exclusive. Just one of them should be merged._

### Background

Listening for incoming connections in I2P does not involve a port - we just listen on an address. Similarly we just connect to an I2P address, without a port (this is in I2P SAM 3.1, what's used in Bitcoin Core).

### Problem

It is possible to connect to the same node multiple times if different ports are used.

### Solution

For I2P addresses:

* Ignore ports when comparing `CService` objects
* Do not print ports in `CService::ToString()`
* Strip ports from user-input addresses - this helps to detect duplicates earlier (by `CConnMan::FindNode(std::string)`) and to print without the ports in the cases where we print the user input without converting it to `CService` object and using its `ToString()` method

Fixes https://github.com/bitcoin/bitcoin/issues/21389