### PR TITLE
fuzz: [refactor] Use PickValue where possible

### DIFF
--- a/src/test/fuzz/pow.cpp
+++ b/src/test/fuzz/pow.cpp
@@ -34,7 +34,7 @@ FUZZ_TARGET_INIT(pow, initialize_pow)
         }
         CBlockIndex current_block{*block_header};
         {
-            CBlockIndex* previous_block = !blocks.empty() ? &blocks[fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, blocks.size() - 1)] : nullptr;
+            CBlockIndex* previous_block = blocks.empty() ? nullptr : &PickValue(fuzzed_data_provider, blocks);
             const int current_height = (previous_block != nullptr && previous_block->nHeight != std::numeric_limits<int>::max()) ? previous_block->nHeight + 1 : 0;
             if (fuzzed_data_provider.ConsumeBool()) {
                 current_block.pprev = previous_block;
@@ -66,9 +66,9 @@ FUZZ_TARGET_INIT(pow, initialize_pow)
             }
         }
         {
-            const CBlockIndex* to = &blocks[fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, blocks.size() - 1)];
-            const CBlockIndex* from = &blocks[fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, blocks.size() - 1)];
-            const CBlockIndex* tip = &blocks[fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, blocks.size() - 1)];
+            const CBlockIndex* to = &PickValue(fuzzed_data_provider, blocks);
+            const CBlockIndex* from = &PickValue(fuzzed_data_provider, blocks);
+            const CBlockIndex* tip = &PickValue(fuzzed_data_provider, blocks);
             try {
                 (void)GetBlockProofEquivalentTime(*to, *from, *tip, consensus_params);
             } catch (const uint_error&) {

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -65,7 +65,7 @@ FUZZ_TARGET_INIT(process_messages, initialize_process_messages)
         net_msg.m_type = random_message_type;
         net_msg.data = ConsumeRandomLengthByteVector(fuzzed_data_provider);
 
-        CNode& random_node = *peers.at(fuzzed_data_provider.ConsumeIntegralInRange<int>(0, peers.size() - 1));
+        CNode& random_node = *PickValue(fuzzed_data_provider, peers);
 
         (void)connman.ReceiveMsgFrom(random_node, net_msg);
         random_node.fPauseSend = false;

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -49,7 +49,7 @@ void CallOneOf(FuzzedDataProvider& fuzzed_data_provider, Callables... callables)
 }
 
 template <typename Collection>
-const auto& PickValue(FuzzedDataProvider& fuzzed_data_provider, const Collection& col)
+auto& PickValue(FuzzedDataProvider& fuzzed_data_provider, Collection& col)
 {
     const auto sz = col.size();
     assert(sz >= 1);


### PR DESCRIPTION
`PickValue` is a bit less typing, so I think it should be used where possible