### PR TITLE
validation: run VerifyDB on all chainstates

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1554,7 +1554,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                         // work when we allow VerifyDB to be parameterized by chainstate.
                         if (&::ChainstateActive() == chainstate &&
                             !CVerifyDB().VerifyDB(
-                                chainparams, *chainstate, &chainstate->CoinsDB(),
+                                *chainstate, chainparams, &chainstate->CoinsDB(),
                                 args.GetArg("-checklevel", DEFAULT_CHECKLEVEL),
                                 args.GetArg("-checkblocks", DEFAULT_CHECKBLOCKS))) {
                             strLoadError = _("Corrupted block database detected");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1550,11 +1550,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                             break;
                         }
 
-                        // Only verify the DB of the active chainstate. This is fixed in later
-                        // work when we allow VerifyDB to be parameterized by chainstate.
-                        if (&::ChainstateActive() == chainstate &&
-                            !CVerifyDB().VerifyDB(
-                                *chainstate, chainparams, &chainstate->CoinsDB(),
+                        if (!CVerifyDB().VerifyDB(
+                                *chainstate, chainparams, chainstate->CoinsDB(),
                                 args.GetArg("-checklevel", DEFAULT_CHECKLEVEL),
                                 args.GetArg("-checkblocks", DEFAULT_CHECKBLOCKS))) {
                             strLoadError = _("Corrupted block database detected");

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1239,7 +1239,8 @@ static RPCHelpMan verifychain()
     LOCK(cs_main);
 
     CChainState& active_chainstate = chainman.ActiveChainstate();
-    return CVerifyDB().VerifyDB(active_chainstate, Params(), &active_chainstate.CoinsTip(), check_level, check_depth);
+    return CVerifyDB().VerifyDB(
+        active_chainstate, Params(), active_chainstate.CoinsTip(), check_level, check_depth);
 },
     };
 }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1239,7 +1239,7 @@ static RPCHelpMan verifychain()
     LOCK(cs_main);
 
     CChainState& active_chainstate = chainman.ActiveChainstate();
-    return CVerifyDB().VerifyDB(Params(), active_chainstate, &active_chainstate.CoinsTip(), check_level, check_depth);
+    return CVerifyDB().VerifyDB(active_chainstate, Params(), &active_chainstate.CoinsTip(), check_level, check_depth);
 },
     };
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -329,7 +329,12 @@ class CVerifyDB {
 public:
     CVerifyDB();
     ~CVerifyDB();
-    bool VerifyDB(const CChainParams& chainparams, CChainState& active_chainstate, CCoinsView *coinsview, int nCheckLevel, int nCheckDepth) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    bool VerifyDB(
+        CChainState& chainstate,
+        const CChainParams& chainparams,
+        CCoinsView* coinsview,
+        int nCheckLevel,
+        int nCheckDepth) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 };
 
 enum DisconnectResult

--- a/src/validation.h
+++ b/src/validation.h
@@ -919,6 +919,8 @@ public:
         return m_blockman.m_block_index;
     }
 
+    //! @returns true if a snapshot-based chainstate is in use. Also implies
+    //!          that a background validation chainstate is also in use.
     bool IsSnapshotActive() const;
 
     std::optional<uint256> SnapshotBlockhash() const;

--- a/src/validation.h
+++ b/src/validation.h
@@ -332,7 +332,7 @@ public:
     bool VerifyDB(
         CChainState& chainstate,
         const CChainParams& chainparams,
-        CCoinsView* coinsview,
+        CCoinsView& coinsview,
         int nCheckLevel,
         int nCheckDepth) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 };


### PR DESCRIPTION
This is part of the [assumeutxo project](https://github.com/bitcoin/bitcoin/projects/11) (parent PR: #15606) 

---

~~Pretty cut and dry; parameterizes `CVerifyDB` methods so that we can run the verify procedure on multiple chainstates.~~ 

Two minor tweaks to ensure that `VerifyDB` can be run on multiple chainstates and a corresponding rename.