### PR TITLE
mining: Remove unused extranonce logic

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -434,14 +434,14 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
     }
 }
 
-void SetCoinbaseScriptSig(CBlock* pblock, const CBlockIndex* pindexPrev)
+void SetCoinbaseScriptSig(CBlock* pblock, int32_t height)
 {
+    assert(height > 0);
     CMutableTransaction txCoinbase(*pblock->vtx[0]);
 
     // Coinbase scriptSig contains height first (required for block.version=2)
     // followed by an extra nonce (1).
-    unsigned int nHeight = pindexPrev->nHeight + 1; 
-    txCoinbase.vin[0].scriptSig = (CScript() << nHeight << CScriptNum(1));
+    txCoinbase.vin[0].scriptSig = (CScript() << height << CScriptNum(1));
     assert(txCoinbase.vin[0].scriptSig.size() <= 100);
 
     pblock->vtx[0] = MakeTransactionRef(std::move(txCoinbase));

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -434,13 +434,12 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
     }
 }
 
-void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned int& nExtraNonce)
+void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev)
 {
-    // Update nExtraNonce
+    unsigned int nExtraNonce{0};
     static uint256 hashPrevBlock;
     if (hashPrevBlock != pblock->hashPrevBlock)
     {
-        nExtraNonce = 0;
         hashPrevBlock = pblock->hashPrevBlock;
     }
     ++nExtraNonce;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -434,7 +434,7 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
     }
 }
 
-void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev)
+void SetCoinbaseScriptSig(CBlock* pblock, const CBlockIndex* pindexPrev)
 {
     CMutableTransaction txCoinbase(*pblock->vtx[0]);
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -436,12 +436,6 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
 
 void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev)
 {
-    static uint256 hashPrevBlock;
-    if (hashPrevBlock != pblock->hashPrevBlock)
-    {
-        hashPrevBlock = pblock->hashPrevBlock;
-    }
-
     CMutableTransaction txCoinbase(*pblock->vtx[0]);
 
     // Coinbase scriptSig contains height first (required for block.version=2)

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -436,16 +436,18 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
 
 void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev)
 {
-    unsigned int nExtraNonce{0};
     static uint256 hashPrevBlock;
     if (hashPrevBlock != pblock->hashPrevBlock)
     {
         hashPrevBlock = pblock->hashPrevBlock;
     }
-    ++nExtraNonce;
-    unsigned int nHeight = pindexPrev->nHeight+1; // Height first in coinbase required for block.version=2
+
     CMutableTransaction txCoinbase(*pblock->vtx[0]);
-    txCoinbase.vin[0].scriptSig = (CScript() << nHeight << CScriptNum(nExtraNonce));
+
+    // Coinbase scriptSig contains height first (required for block.version=2)
+    // followed by an extra nonce (1).
+    unsigned int nHeight = pindexPrev->nHeight + 1; 
+    txCoinbase.vin[0].scriptSig = (CScript() << nHeight << CScriptNum(1));
     assert(txCoinbase.vin[0].scriptSig.size() <= 100);
 
     pblock->vtx[0] = MakeTransactionRef(std::move(txCoinbase));

--- a/src/miner.h
+++ b/src/miner.h
@@ -198,7 +198,7 @@ private:
 };
 
 /** Resets the coinbase scriptSig to be valid according to BIP 30 and recalculates the merkle root. */
-void SetCoinbaseScriptSig(CBlock* pblock, const CBlockIndex* pindexPrev);
+void SetCoinbaseScriptSig(CBlock* pblock, int32_t height);
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
 
 /** Update an old GenerateCoinbaseCommitment from CreateNewBlock after the block txs have changed */

--- a/src/miner.h
+++ b/src/miner.h
@@ -198,7 +198,7 @@ private:
 };
 
 /** Modify the extranonce in a block */
-void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned int& nExtraNonce);
+void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev);
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
 
 /** Update an old GenerateCoinbaseCommitment from CreateNewBlock after the block txs have changed */

--- a/src/miner.h
+++ b/src/miner.h
@@ -197,8 +197,8 @@ private:
     int UpdatePackagesForAdded(const CTxMemPool::setEntries& alreadyAdded, indexed_modified_transaction_set& mapModifiedTx) EXCLUSIVE_LOCKS_REQUIRED(m_mempool.cs);
 };
 
-/** Modify the extranonce in a block */
-void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev);
+/** Resets the coinbase scriptSig to be valid according to BIP 30 and recalculates the merkle root. */
+void SetCoinbaseScriptSig(CBlock* pblock, const CBlockIndex* pindexPrev);
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
 
 /** Update an old GenerateCoinbaseCommitment from CreateNewBlock after the block txs have changed */

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -111,7 +111,7 @@ static bool GenerateBlock(ChainstateManager& chainman, CBlock& block, uint64_t& 
 
     {
         LOCK(cs_main);
-        IncrementExtraNonce(&block, ::ChainActive().Tip());
+        SetCoinbaseScriptSig(&block, ::ChainActive().Tip());
     }
 
     CChainParams chainparams(Params());

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -105,9 +105,10 @@ static RPCHelpMan getnetworkhashps()
     };
 }
 
-static bool GenerateBlock(ChainstateManager& chainman, CBlock& block, uint64_t& max_tries, unsigned int& extra_nonce, uint256& block_hash)
+static bool GenerateBlock(ChainstateManager& chainman, CBlock& block, uint64_t& max_tries, uint256& block_hash)
 {
     block_hash.SetNull();
+    unsigned int extra_nonce{0};
 
     {
         LOCK(cs_main);
@@ -146,7 +147,6 @@ static UniValue generateBlocks(ChainstateManager& chainman, const CTxMemPool& me
         nHeight = ::ChainActive().Height();
         nHeightEnd = nHeight+nGenerate;
     }
-    unsigned int nExtraNonce = 0;
     UniValue blockHashes(UniValue::VARR);
     while (nHeight < nHeightEnd && !ShutdownRequested())
     {
@@ -156,7 +156,7 @@ static UniValue generateBlocks(ChainstateManager& chainman, const CTxMemPool& me
         CBlock *pblock = &pblocktemplate->block;
 
         uint256 block_hash;
-        if (!GenerateBlock(chainman, *pblock, nMaxTries, nExtraNonce, block_hash)) {
+        if (!GenerateBlock(chainman, *pblock, nMaxTries, block_hash)) {
             break;
         }
 
@@ -382,9 +382,8 @@ static RPCHelpMan generateblock()
 
     uint256 block_hash;
     uint64_t max_tries{DEFAULT_MAX_TRIES};
-    unsigned int extra_nonce{0};
 
-    if (!GenerateBlock(EnsureChainman(request.context), block, max_tries, extra_nonce, block_hash) || block_hash.IsNull()) {
+    if (!GenerateBlock(EnsureChainman(request.context), block, max_tries, block_hash) || block_hash.IsNull()) {
         throw JSONRPCError(RPC_MISC_ERROR, "Failed to make block.");
     }
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -109,10 +109,8 @@ static bool GenerateBlock(ChainstateManager& chainman, CBlock& block, uint64_t& 
 {
     block_hash.SetNull();
 
-    {
-        LOCK(cs_main);
-        SetCoinbaseScriptSig(&block, ::ChainActive().Tip());
-    }
+    const int32_t height = chainman.ActiveHeight() + 1;
+    SetCoinbaseScriptSig(&block, height);
 
     CChainParams chainparams(Params());
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -108,11 +108,10 @@ static RPCHelpMan getnetworkhashps()
 static bool GenerateBlock(ChainstateManager& chainman, CBlock& block, uint64_t& max_tries, uint256& block_hash)
 {
     block_hash.SetNull();
-    unsigned int extra_nonce{0};
 
     {
         LOCK(cs_main);
-        IncrementExtraNonce(&block, ::ChainActive().Tip(), extra_nonce);
+        IncrementExtraNonce(&block, ::ChainActive().Tip());
     }
 
     CChainParams chainparams(Params());

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -72,8 +72,8 @@ CBlock BuildChainTestingSetup::CreateBlock(const CBlockIndex* prev,
     for (const CMutableTransaction& tx : txns) {
         block.vtx.push_back(MakeTransactionRef(tx));
     }
-    // IncrementExtraNonce creates a valid coinbase and merkleRoot
-    IncrementExtraNonce(&block, prev);
+    // SetCoinbaseScriptSig creates a valid coinbase and merkleRoot
+    SetCoinbaseScriptSig(&block, prev);
 
     while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
 

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -73,8 +73,7 @@ CBlock BuildChainTestingSetup::CreateBlock(const CBlockIndex* prev,
         block.vtx.push_back(MakeTransactionRef(tx));
     }
     // IncrementExtraNonce creates a valid coinbase and merkleRoot
-    unsigned int extraNonce = 0;
-    IncrementExtraNonce(&block, prev, extraNonce);
+    IncrementExtraNonce(&block, prev);
 
     while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
 

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -73,7 +73,7 @@ CBlock BuildChainTestingSetup::CreateBlock(const CBlockIndex* prev,
         block.vtx.push_back(MakeTransactionRef(tx));
     }
     // SetCoinbaseScriptSig creates a valid coinbase and merkleRoot
-    SetCoinbaseScriptSig(&block, prev);
+    SetCoinbaseScriptSig(&block, prev->nHeight + 1);
 
     while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
 


### PR DESCRIPTION
Since at least #17693, the extra nonce logic has been unused.

Prior to that PR, if the nNonce field rolled, then the while loop inside `generateBlocks()` would iterate, a new block would be generated in `CreateNewBlock()`, and the extra nonce could be incremented. See https://github.com/bitcoin/bitcoin/pull/17693/commits/dcc8332543f8fb6d1bb47cb270fcbb6a814a7d6e#diff-ccc24453c13307f815879738d3bf00eec351417537fbf10dde1468180cacd2f1L132-L133.

After that PR, the extra_nonce can only be set to 0 in the call to `IncrementExtraNonce()`.

I think this is fine and we should just remove the unused code. The generate RPCs are only used for regtest and signet. For regtest, the difficulty is always minimum, so the nNonce field won't roll. If the nNonce field rolls in signet and the rpc fails, then the rpc can just be called again and a new candidate block will be generated.