### PR TITLE
ci: Build depends only once for Android build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -183,6 +183,8 @@ task:
 
 task:
   name: 'ARM64 Android APK [focal]'
+  depends_sources_cache:
+    folder: "/tmp/cirrus-ci-build/depends/sources"
   << : *GLOBAL_TASK_TEMPLATE
   container:
     image: ubuntu:focal

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -182,9 +182,9 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_mac_host.sh"
 
 task:
-  name: 'ARM64 Android APK [bionic]'
+  name: 'ARM64 Android APK [focal]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
-    image: ubuntu:bionic
+    image: ubuntu:focal
   env:
     FILE_ENV: "./ci/test/00_setup_env_android.sh"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,8 +35,6 @@ global_task_template: &GLOBAL_TASK_TEMPLATE
     folder: "/tmp/cirrus-ci-build/depends/built"
   depends_sdk_cache:
     folder: "/tmp/cirrus-ci-build/depends/sdk-sources"
-  depends_releases_cache:
-    folder: "/tmp/cirrus-ci-build/releases"
   ci_script:
     - ./ci/test_run_all.sh
 
@@ -103,6 +101,8 @@ task:
   # For faster CI feedback, immediately schedule a task that compiles most modules
   << : *CREDITS_TEMPLATE
   << : *GLOBAL_TASK_TEMPLATE
+  depends_releases_cache:
+    folder: "/tmp/cirrus-ci-build/releases"
   container:
     image: ubuntu:bionic
   env:

--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -11,6 +11,9 @@ export LC_ALL=C.UTF-8
 # This is where the depends build is done.
 BASE_ROOT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../../ >/dev/null 2>&1 && pwd )
 export BASE_ROOT_DIR
+# The depends dir.
+# This folder exists on the ci host and ci guest. Changes are propagated back and forth.
+export DEPENDS_DIR=${DEPENDS_DIR:-$BASE_ROOT_DIR/depends}
 
 echo "Setting specific values in env"
 if [ -n "${FILE_ENV}" ]; then
@@ -56,9 +59,6 @@ export CCACHE_COMPRESS=${CCACHE_COMPRESS:-1}
 # The cache dir.
 # This folder exists on the ci host and ci guest. Changes are propagated back and forth.
 export CCACHE_DIR=${CCACHE_DIR:-$BASE_SCRATCH_DIR/.ccache}
-# The depends dir.
-# This folder exists on the ci host and ci guest. Changes are propagated back and forth.
-export DEPENDS_DIR=${DEPENDS_DIR:-$BASE_ROOT_DIR/depends}
 # Folder where the build result is put (bin and lib).
 export BASE_OUTDIR=${BASE_OUTDIR:-$BASE_SCRATCH_DIR/out/$HOST}
 # Folder where the build is done (dist and out-of-tree build).

--- a/ci/test/00_setup_env_android.sh
+++ b/ci/test/00_setup_env_android.sh
@@ -6,12 +6,20 @@
 
 export LC_ALL=C.UTF-8
 
-export CONTAINER_NAME=ci_android
+export HOST=aarch64-linux-android
 export PACKAGES="clang llvm unzip openjdk-8-jdk gradle"
+export CONTAINER_NAME=ci_android
+export DOCKER_NAME_TAG="ubuntu:bionic"
+
+export RUN_UNIT_TESTS=false
+export RUN_FUNCTIONAL_TESTS=false
 
 export ANDROID_API_LEVEL=28
 export ANDROID_BUILD_TOOLS_VERSION=28.0.3
 export ANDROID_NDK_VERSION=21.1.6352462
 export ANDROID_TOOLS_URL=https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip
+export ANDROID_HOME="${DEPENDS_DIR}/SDKs/android"
+export ANDROID_NDK_HOME="${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}"
+export DEP_OPTS="ANDROID_SDK=${ANDROID_HOME} ANDROID_NDK=${ANDROID_NDK_HOME} ANDROID_API_LEVEL=${ANDROID_API_LEVEL} ANDROID_TOOLCHAIN_BIN=${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/"
 
 export BITCOIN_CONFIG="--disable-ccache"

--- a/ci/test/00_setup_env_android.sh
+++ b/ci/test/00_setup_env_android.sh
@@ -9,7 +9,7 @@ export LC_ALL=C.UTF-8
 export HOST=aarch64-linux-android
 export PACKAGES="clang llvm unzip openjdk-8-jdk gradle"
 export CONTAINER_NAME=ci_android
-export DOCKER_NAME_TAG="ubuntu:bionic"
+export DOCKER_NAME_TAG="ubuntu:focal"
 
 export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false

--- a/ci/test/05_before_script.sh
+++ b/ci/test/05_before_script.sh
@@ -24,16 +24,11 @@ fi
 
 if [ -n "$ANDROID_TOOLS_URL" ]; then
   ANDROID_TOOLS_PATH=$DEPENDS_DIR/sdk-sources/android-tools.zip
-  ANDROID_HOME="$DEPENDS_DIR"/SDKs/android
-  ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}
 
   DOCKER_EXEC curl --location --fail "${ANDROID_TOOLS_URL}" -o "$ANDROID_TOOLS_PATH"
   DOCKER_EXEC mkdir -p "${ANDROID_HOME}/cmdline-tools"
   DOCKER_EXEC unzip -o "$ANDROID_TOOLS_PATH" -d "${ANDROID_HOME}/cmdline-tools"
   DOCKER_EXEC "yes | ${ANDROID_HOME}/cmdline-tools/tools/bin/sdkmanager --install \"build-tools;${ANDROID_BUILD_TOOLS_VERSION}\" \"platform-tools\" \"platforms;android-${ANDROID_API_LEVEL}\" \"ndk;${ANDROID_NDK_VERSION}\""
-
-  MAKE_COMMAND="ANDROID_SDK=${ANDROID_HOME} ANDROID_NDK=${ANDROID_NDK_HOME} make $MAKEJOBS -C depends HOST=aarch64-linux-android ANDROID_API_LEVEL=${ANDROID_API_LEVEL} ANDROID_TOOLCHAIN_BIN=${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}/toolchains/llvm/prebuilt/linux-x86_64/bin/ $DEP_OPTS"
-  DOCKER_EXEC "$MAKE_COMMAND" HOST=aarch64-linux-android
 fi
 
 if [[ ${USE_MEMORY_SANITIZER} == "true" ]]; then


### PR DESCRIPTION
Currently the Android task has several issues:

* It is missing a cache instruction, thus failing the build on Cirrus CI
* It is running the depends build twice

Fix those issues