### PR TITLE
[net processing] Various tidying up of PeerManagerImpl ctor

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -396,7 +396,8 @@ private:
     /** The height of the best chain */
     std::atomic<int> m_best_height{-1};
 
-    int64_t m_stale_tip_check_time; //!< Next time to check for stale tip
+    /** Next time to check for stale tip */
+    int64_t m_stale_tip_check_time{0};
 
     /** Whether this node is running in blocks only mode */
     const bool m_ignore_incoming_txs;
@@ -1393,7 +1394,6 @@ PeerManagerImpl::PeerManagerImpl(const CChainParams& chainparams, CConnman& conn
       m_banman(banman),
       m_chainman(chainman),
       m_mempool(pool),
-      m_stale_tip_check_time(0),
       m_ignore_incoming_txs(ignore_incoming_txs)
 {
     // Initialize global variables that cannot be constructed at startup.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1194,6 +1194,7 @@ void PeerManagerImpl::FinalizeNode(const CNode& node)
         assert(m_outbound_peers_with_protect_from_disconnect == 0);
         assert(m_wtxid_relay_peers == 0);
         assert(m_txrequest.Size() == 0);
+        assert(m_orphanage.Size() == 0);
     }
     } // cs_main
     if (node.fSuccessfullyConnected && misbehavior == 0 &&

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -47,6 +47,13 @@ public:
      * (ie orphans that may have found their final missing parent, and so should be reconsidered for the mempool) */
     void AddChildrenToWorkSet(const CTransaction& tx, std::set<uint256>& orphan_work_set) const EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans);
 
+    /** Return how many entries exist in the orphange */
+    size_t Size() LOCKS_EXCLUDED(::g_cs_orphans)
+    {
+        LOCK(::g_cs_orphans);
+        return m_orphans.size();
+    }
+
 protected:
     struct OrphanTx {
         CTransactionRef tx;

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -80,7 +80,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         self.log.info("Generate a block")
         last_block = self.nodes[0].generate(1)
         # Sync blocks, so that peer 1 gets the block before timelock_tx
-        # Otherwise, peer 1 would put the timelock_tx in recentRejects
+        # Otherwise, peer 1 would put the timelock_tx in m_recent_rejects
         self.sync_all()
 
         self.log.info("The time-locked transaction can now be spent")

--- a/test/functional/p2p_permissions.py
+++ b/test/functional/p2p_permissions.py
@@ -130,7 +130,7 @@ class P2PPermissionsTests(BitcoinTestFramework):
         tx.vout[0].nValue += 1
         txid = tx.rehash()
         # Send the transaction twice. The first time, it'll be rejected by ATMP because it conflicts
-        # with a mempool transaction. The second time, it'll be in the recentRejects filter.
+        # with a mempool transaction. The second time, it'll be in the m_recent_rejects filter.
         p2p_rebroadcast_wallet.send_txs_and_test(
             [tx],
             self.nodes[1],


### PR DESCRIPTION
- Use default initialization of PeerManagerImpl members where possible
- Remove unique_ptr indirection where it's not needed