### PR TITLE
net: Avoid calling getnameinfo when formatting IPv4 addresses in CNetAddr::ToStringIP

### DIFF
--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -576,6 +576,7 @@ std::string CNetAddr::ToStringIP() const
 {
     switch (m_net) {
     case NET_IPV4:
+        return IPv4ToString(m_addr);
     case NET_IPV6: {
         CService serv(*this, 0);
         struct sockaddr_storage sockaddr;
@@ -585,9 +586,6 @@ std::string CNetAddr::ToStringIP() const
             if (!getnameinfo((const struct sockaddr*)&sockaddr, socklen, name,
                              sizeof(name), nullptr, 0, NI_NUMERICHOST))
                 return std::string(name);
-        }
-        if (m_net == NET_IPV4) {
-            return IPv4ToString(m_addr);
         }
         return IPv6ToString(m_addr);
     }

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -551,6 +551,11 @@ enum Network CNetAddr::GetNetwork() const
     return m_net;
 }
 
+static std::string IPv4ToString(Span<const uint8_t> a)
+{
+    return strprintf("%u.%u.%u.%u", a[0], a[1], a[2], a[3]);
+}
+
 static std::string IPv6ToString(Span<const uint8_t> a)
 {
     assert(a.size() == ADDR_IPV6_SIZE);
@@ -582,7 +587,7 @@ std::string CNetAddr::ToStringIP() const
                 return std::string(name);
         }
         if (m_net == NET_IPV4) {
-            return strprintf("%u.%u.%u.%u", m_addr[0], m_addr[1], m_addr[2], m_addr[3]);
+            return IPv4ToString(m_addr);
         }
         return IPv6ToString(m_addr);
     }


### PR DESCRIPTION
Avoid calling `getnameinfo` when formatting IPv4 addresses in `CNetAddr::ToStringIP`.