### PR TITLE
build, qt: Simplifies checks for `-fPIE` and `-fPIC` compatibility

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -180,17 +180,7 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
     TEMP_CXXFLAGS=$CXXFLAGS
     CPPFLAGS="$QT_INCLUDES $CORE_CPPFLAGS $CPPFLAGS"
     CXXFLAGS="$PIE_FLAGS $CORE_CXXFLAGS $CXXFLAGS"
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-        #include <QtCore/qconfig.h>
-        #ifndef QT_VERSION
-        #  include <QtCore/qglobal.h>
-        #endif
-      ]],
-      [[
-        #if defined(QT_REDUCE_RELOCATIONS)
-        choke
-        #endif
-      ]])],
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[ #include <QtGlobal> ]])],
       [ AC_MSG_RESULT([yes]); QT_PIE_FLAGS=$PIE_FLAGS ],
       [ AC_MSG_RESULT([no]); QT_PIE_FLAGS=$PIC_FLAGS]
     )
@@ -202,17 +192,7 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
     AC_MSG_CHECKING([whether -fPIC is needed with this Qt config])
     TEMP_CPPFLAGS=$CPPFLAGS
     CPPFLAGS="$QT_INCLUDES $CORE_CPPFLAGS $CPPFLAGS"
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-        #include <QtCore/qconfig.h>
-        #ifndef QT_VERSION
-        #  include <QtCore/qglobal.h>
-        #endif
-      ]],
-      [[
-        #if defined(QT_REDUCE_RELOCATIONS)
-        choke
-        #endif
-      ]])],
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[ #include <QtGlobal> ]])],
       [ AC_MSG_RESULT([no])],
       [ AC_MSG_RESULT([yes]); QT_PIE_FLAGS=$PIC_FLAGS]
     )


### PR DESCRIPTION
As noted in [bitcoin/bitcoin#6978](https://github.com/bitcoin/bitcoin/pull/6978#issuecomment-155568770):
> When Qt discovered this issue (somewhere around 5.4), they added the check in qconfig.h so that compilation would fail in this QT_REDUCE_RELOCATIONS+-fPIE case. 

To be precise, since Qt 5.4.2 the `qglobal.h` header implements the correct checks for `-fPIE` and `-fPIC` compatibility:
- https://github.com/qt/qtbase/commit/482d96a0c5d523ace63f56bda6851926b4469dd0 (5.0.0)
- https://github.com/qt/qtbase/commit/36d6eb721e7d5997ade75e289d4088dc48678d0d (5.4.2, [QTBUG-45755](https://bugreports.qt.io/browse/QTBUG-45755))
- https://github.com/qt/qtbase/commit/3eca75de67b3fd2c890715b30c7899cebc096fe9 (5.4.2, [QTBUG-45755](https://bugreports.qt.io/browse/QTBUG-45755))
- https://github.com/qt/qtbase/commit/95b6c4fed6521aa2212cab67cb8a6e5553e86117 (5.4.2)

As now we require GCC 8.1+ and Qt 5.11.3+, it is safe to rely on Qt's checks. The removed lines
```cpp
        #if defined(QT_REDUCE_RELOCATIONS)
        choke
        #endif
```
are redundant now.

One of the easiest way to test this PR is `configure.log` comparison.

No behavior change.