### PR TITLE
Fix wrong wallet RPC context set after #21366

### DIFF
--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -522,7 +522,7 @@ public:
 #ifdef ENABLE_EXTERNAL_SIGNER
         for (const CRPCCommand& command : GetSignerRPCCommands()) {
             m_rpc_commands.emplace_back(command.category, command.name, [this, &command](const JSONRPCRequest& request, UniValue& result, bool last_handler) {
-                return command.actor({request, m_context}, result, last_handler);
+                return command.actor({request, &m_context}, result, last_handler);
             }, command.argNames, command.unique_id);
             m_rpc_handlers.emplace_back(m_context.chain->handleRpc(m_rpc_commands.back()));
         }


### PR DESCRIPTION
This bug doesn't have any effects currently because it only affects
external signer RPCs which aren't currently using the wallet context,
but it does cause an appveyor failure in a upcoming PR:

https://ci.appveyor.com/project/DrahtBot/bitcoin/builds/38512882

This bug is subtle and could have been avoided if JSONRPCRequest didn't
have constructors that were so loose with type checking.  Suggested
change
https://github.com/bitcoin/bitcoin/pull/21366#issuecomment-792044351
eliminates these and would be a good followup for a future PR.

This PR just implements the simplest possible fix.