### PR TITLE
refactor: Remove superfluous "return" from "addUnchecked" in txmempool.cpp

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -980,7 +980,7 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, bool validFeeEstimat
     uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
     std::string dummy;
     CalculateMemPoolAncestors(entry, setAncestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy);
-    return addUnchecked(entry, setAncestors, validFeeEstimate);
+    addUnchecked(entry, setAncestors, validFeeEstimate);
 }
 
 void CTxMemPool::UpdateChild(txiter entry, txiter child, bool add)


### PR DESCRIPTION
Honestly, I'm not sure whether it makes sense to fix it or not. Feel free to close this PR to avoid this being a precedent for "fixing" stuff like this.

Follow-up to #13774.