### PR TITLE
streams: Accept URef obj for VectorReader unserialize

### DIFF
--- a/src/streams.h
+++ b/src/streams.h
@@ -167,7 +167,7 @@ public:
     }
 
     template<typename T>
-    VectorReader& operator>>(T& obj)
+    VectorReader& operator>>(T&& obj)
     {
         // Unserialize from this stream
         ::Unserialize(*this, obj);

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -112,6 +112,17 @@ BOOST_AUTO_TEST_CASE(streams_vector_reader)
     BOOST_CHECK_THROW(new_reader >> d, std::ios_base::failure);
 }
 
+BOOST_AUTO_TEST_CASE(streams_vector_reader_rvalue)
+{
+    std::vector<uint8_t> data{0x82, 0xa7, 0x31};
+    VectorReader reader(SER_NETWORK, INIT_PROTO_VERSION, data, /* pos= */ 0);
+    uint32_t varint = 0;
+    // Deserialize into r-value
+    reader >> VARINT(varint);
+    BOOST_CHECK_EQUAL(varint, 54321);
+    BOOST_CHECK(reader.empty());
+}
+
 BOOST_AUTO_TEST_CASE(bitstream_reader_writer)
 {
     CDataStream data(SER_NETWORK, INIT_PROTO_VERSION);


### PR DESCRIPTION
Missed in commit 172f5fa738d419efda99542e2ad2a0f4db5be580. An URef may collapse into an LRef or RRef depending on context. There is no reason to forbid RRef in `VectorReader::operator>>`, so add it for consistency.