### PR TITLE
Fix assumeutxo crash due to missing base_blockhash

### DIFF
--- a/src/node/coinstats.cpp
+++ b/src/node/coinstats.cpp
@@ -94,7 +94,8 @@ static bool GetUTXOStats(CCoinsView* view, BlockManager& blockman, CCoinsStats& 
     {
         LOCK(cs_main);
         assert(std::addressof(g_chainman.m_blockman) == std::addressof(blockman));
-        stats.nHeight = blockman.LookupBlockIndex(stats.hashBlock)->nHeight;
+        const CBlockIndex* block = blockman.LookupBlockIndex(stats.hashBlock);
+        stats.nHeight = Assert(block)->nHeight;
     }
 
     PrepareHash(hash_obj, stats);

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -259,6 +259,11 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_activate_snapshot, TestChain100Determi
             // Coins count is smaller than coins in file
             metadata.m_coins_count -= 1;
     }));
+    BOOST_REQUIRE(!CreateAndActivateUTXOSnapshot(
+        m_node, m_path_root, [](CAutoFile& auto_infile, SnapshotMetadata& metadata) {
+            // Wrong hash
+            metadata.m_base_blockhash = uint256::ONE;
+    }));
 
     BOOST_REQUIRE(CreateAndActivateUTXOSnapshot(m_node, m_path_root));
 


### PR DESCRIPTION
This fixes an UB (which results in a crash with sanitizers enabled). Can be reproduced by cherry-picking the test without the other code changes. The fix:

* Adds an `Assert` to transform the UB into a clean crash, even when sanitizers are disabled
* Adds an early-fail condition to avoid the crash