### PR TITLE
Remove -feefilter option

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4708,7 +4708,6 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
         if (pto->m_tx_relay != nullptr &&
             !m_ignore_incoming_txs &&
             pto->GetCommonVersion() >= FEEFILTER_VERSION &&
-            gArgs.GetBoolArg("-feefilter", DEFAULT_FEEFILTER) &&
             !pto->HasPermission(PF_FORCERELAY) // peers with the forcerelay permission should not filter txs to us
         ) {
             CAmount currentFilter = m_mempool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK();


### PR DESCRIPTION
Removed the `-feefilter` option from `src/net_processing.cpp`.  #21545 
To make sure everything works, I ran `make check` and then ran `test_runner.py` with [`p2p_feefilter.py`](https://github.com/bitcoin/bitcoin/blob/master/test/functional/p2p_feefilter.py)

```bash
$ test/functional/test_runner.py p2p_feefilter.py
Temporary test directory at /tmp/test_runner_₿_🏃_20210403_190347
Running Unit Tests for Test Framework Modules
..........
----------------------------------------------------------------------
Ran 10 tests in 0.633s

OK
Remaining jobs: [p2p_feefilter.py]
1/1 - p2p_feefilter.py passed, Duration: 15 s

TEST             | STATUS    | DURATION

p2p_feefilter.py | ✓ Passed  | 15 s

ALL              | ✓ Passed  | 15 s (accumulated) 
Runtime: 15 s
```

Regarding splitting up the `feefilter` logic and moving it to a seperate function for better readability, the `g_filter_rounder.round()` function is not thread safe and is currently inside a `LOCK(cs_main);`  called at the begining of [`PeerManagerImpl::SendMessages(CNode* pto)`](https://github.com/AdityaNG/bitcoin/blob/e08f3193b543017702d000c2263bccbefa981c14/src/net_processing.cpp#L4267). Didn't make any changes for this, how would I proceed for this?