### PR TITLE
build, qt: Fix wrong cross-compiling detection on macOS

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -11,6 +11,7 @@ $(package)_patches+= fix_android_qmake_conf.patch fix_android_jni_static.patch d
 $(package)_patches+= drop_lrelease_dependency.patch no_sdk_version_check.patch
 $(package)_patches+= fix_lib_paths.patch fix_android_pch.patch
 $(package)_patches+= qtbase-moc-ignore-gcc-macro.patch
+$(package)_patches += force_bootstrap.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=577b0668a777eb2b451c61e8d026d79285371597ce9df06b6dee6c814164b7c3
@@ -64,6 +65,7 @@ $(package)_config_opts += -no-system-proxies
 $(package)_config_opts += -no-use-gold-linker
 $(package)_config_opts += -nomake examples
 $(package)_config_opts += -nomake tests
+$(package)_config_opts += -nomake tools
 $(package)_config_opts += -opensource
 $(package)_config_opts += -pkg-config
 $(package)_config_opts += -prefix $(host_prefix)
@@ -233,6 +235,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/no_sdk_version_check.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_lib_paths.patch && \
   patch -p1 -i $($(package)_patch_dir)/qtbase-moc-ignore-gcc-macro.patch && \
+  patch -p1 -i $($(package)_patch_dir)/force_bootstrap.patch && \
   sed -i.old "s|updateqm.commands = \$$$$\$$$$LRELEASE|updateqm.commands = $($(package)_extract_dir)/qttools/bin/lrelease|" qttranslations/translations/translations.pro && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -115,14 +115,13 @@ $(package)_config_opts_darwin = -no-dbus
 $(package)_config_opts_darwin += -no-opengl
 $(package)_config_opts_darwin += -pch
 $(package)_config_opts_darwin += -no-feature-corewlan
-$(package)_config_opts_darwin += -device-option QMAKE_MACOSX_DEPLOYMENT_TARGET=$(OSX_MIN_VERSION)
+$(package)_config_opts_darwin += QMAKE_MACOSX_DEPLOYMENT_TARGET=$(OSX_MIN_VERSION)
 
 ifneq ($(build_os),darwin)
 $(package)_config_opts_darwin += -xplatform macx-clang-linux
 $(package)_config_opts_darwin += -device-option MAC_SDK_PATH=$(OSX_SDK)
 $(package)_config_opts_darwin += -device-option MAC_SDK_VERSION=$(OSX_SDK_VERSION)
 $(package)_config_opts_darwin += -device-option CROSS_COMPILE="$(host)-"
-$(package)_config_opts_darwin += -device-option MAC_MIN_VERSION=$(OSX_MIN_VERSION)
 $(package)_config_opts_darwin += -device-option MAC_TARGET=$(host)
 $(package)_config_opts_darwin += -device-option XCODE_VERSION=$(XCODE_VERSION)
 endif

--- a/depends/patches/qt/force_bootstrap.patch
+++ b/depends/patches/qt/force_bootstrap.patch
@@ -1,0 +1,16 @@
+Qt lrelease tool depends on XML features.
+No need to build the libQt5Xml module if tools are
+bootstrapped, even if not cross-compiling.
+
+--- old/qtbase/mkspecs/features/qt_build_config.prf
++++ new/qtbase/mkspecs/features/qt_build_config.prf
+@@ -82,8 +82,7 @@
+ !prefix_build: \
+     CONFIG += qt_clear_installs
+ 
+-cross_compile: \
+-    CONFIG += force_bootstrap
++CONFIG += force_bootstrap
+ 
+ android|uikit|winrt: \
+     CONFIG += builtin_testdata

--- a/depends/patches/qt/mac-qmake.conf
+++ b/depends/patches/qt/mac-qmake.conf
@@ -8,7 +8,6 @@ include(../common/clang-mac.conf)
 QMAKE_MAC_SDK_PATH=$${MAC_SDK_PATH}
 QMAKE_XCODE_VERSION = $${XCODE_VERSION}
 QMAKE_XCODE_DEVELOPER_PATH=/Developer
-QMAKE_MACOSX_DEPLOYMENT_TARGET = $${MAC_MIN_VERSION}
 QMAKE_MAC_SDK=macosx
 QMAKE_MAC_SDK.macosx.Path = $${MAC_SDK_PATH}
 QMAKE_MAC_SDK.macosx.platform_name = macosx


### PR DESCRIPTION
When running `make -C depends qt_configured` it is expected that Qt is configured for a native build. That is not the case on master (ad4bf8a94594e7fe424e409ba9474d91584bb78c) on macOS.

This PR fixes this behavior. The diff for Qt's "Configure summary":
```diff
 Configure summary:
 
-Building on: macx-clang (x86_64, CPU features: cx16 mmx sse sse2 sse3 ssse3 sse4.1)
-Building for: macx-clang (x86_64, CPU features: cx16 mmx sse sse2 sse3 ssse3 sse4.1)
-Target compiler: clang (Apple) 12.0.0
-Configuration: cross_compile sse2 aesni sse3 ssse3 sse4_1 sse4_2 avx avx2 avx512f avx512bw avx512cd avx512dq avx512er avx512ifma avx512pf avx512vbmi avx512vl f16c largefile precompile_header rdrnd shani silent x86SimdAlways release c++11 c++14 c++1z reduce_exports static stl
+Build type: macx-clang (x86_64, CPU features: cx16 mmx sse sse2 sse3 ssse3 sse4.1)
+Compiler: clang (Apple) 12.0.0
+Configuration: sse2 aesni sse3 ssse3 sse4_1 sse4_2 avx avx2 avx512f avx512bw avx512cd avx512dq avx512er avx512ifma avx512pf avx512vbmi avx512vl f16c largefile precompile_header rdrnd shani silent x86SimdAlways release c++11 c++14 c++1z reduce_exports static stl
 Build options:
   Mode ................................... release
   Optimize release build for size ........ no
```

Related to #21588.

Based on #21589, only the last commit belongs to this PR.

#### Guix builds:
```
$ find output -type f -name *$(git rev-parse --short HEAD)*.* -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
fbdc22dc3bd6c7aaf20686504ebf37c5920bef3c2e61d3746f96a450aa3b9c43  output/bitcoin-9d65a3b5a9a1-aarch64-linux-gnu-debug.tar.gz
49610a02028a0bc99b65610c636737a8fe24a6b1d0d02f70fb8a0c25a4f71161  output/bitcoin-9d65a3b5a9a1-aarch64-linux-gnu.tar.gz
5d07460dc2c77b740d40661f6d252da08435b255a8230158b018050c4215f74d  output/bitcoin-9d65a3b5a9a1-arm-linux-gnueabihf-debug.tar.gz
2ce3f97ab7f2ac1198490e1437073662b17b7b8a5b335deccc07d067f4a3794c  output/bitcoin-9d65a3b5a9a1-arm-linux-gnueabihf.tar.gz
8f76ec0227678f101d6477772ff08d74fd761558a714ff5b4b924334407b65ad  output/bitcoin-9d65a3b5a9a1-osx-unsigned.dmg
0b9802d0cf36bc5b79835292880ec26a1fdd6e2203d8a65de345b32a44e7f7a6  output/bitcoin-9d65a3b5a9a1-osx-unsigned.tar.gz
470de76e81243be1cb21e33ddf6d1d1b5535f8b23678ba91a9ac2a8c824eb137  output/bitcoin-9d65a3b5a9a1-osx64.tar.gz
e10ba476bc901c7520b1d45e6fb68abbd13c3e3cf6d7e8edd7a881153b294123  output/bitcoin-9d65a3b5a9a1-powerpc64-linux-gnu-debug.tar.gz
3f9fd8e74d90dc386dcd52f5ac426104d9e319853f9d2e2d796d4b9acb295567  output/bitcoin-9d65a3b5a9a1-powerpc64-linux-gnu.tar.gz
92cef2b232cf111fbf71d4af1e928436234d8fc9030beb1e45c4229e25ae4f7d  output/bitcoin-9d65a3b5a9a1-powerpc64le-linux-gnu-debug.tar.gz
160d6272ddffedd30935070da20fdbb4c610bcf6c9035cff59b66ab9cc0f7b35  output/bitcoin-9d65a3b5a9a1-powerpc64le-linux-gnu.tar.gz
b05248ed798470a292d159a6993f38ef5404c13d145a2cecf671417d4cfe6cf4  output/bitcoin-9d65a3b5a9a1-riscv64-linux-gnu-debug.tar.gz
1507a8033522b5379655a8bbd27f7a56875923953f8882a4877f2c588ac2b9ec  output/bitcoin-9d65a3b5a9a1-riscv64-linux-gnu.tar.gz
64bee253f7c0d9d498b17f00b9249da14331b8d36625ceb6e88c215528ca8536  output/bitcoin-9d65a3b5a9a1-win-unsigned.tar.gz
2596a9bfe47917f45d478a44f61ffe3d6c6b2d2555c20c24914b8ca844af9e60  output/bitcoin-9d65a3b5a9a1-win64-debug.zip
4b9edb6503ce0c87dce5341c37129d4856709f9be981e83ad7bf2c8b2f3f060d  output/bitcoin-9d65a3b5a9a1-win64-setup-unsigned.exe
5388679da7dc8ff95d6f9a42ddee57a0bc67b4f9c561a552a1663501d019b2df  output/bitcoin-9d65a3b5a9a1-win64.zip
d8aeff23e0976287563c175bef1e4f39f90952ed8c14a33d5ef5a8e6b70e2b5c  output/bitcoin-9d65a3b5a9a1-x86_64-linux-gnu-debug.tar.gz
038c216652ceeb3b5a03804976a57637333573d4e4989e720d8212818439a7c5  output/bitcoin-9d65a3b5a9a1-x86_64-linux-gnu.tar.gz
7693757063a6f76d223e6a3aa5e57baa08ba340f12a734dba2e9e7efcbb047e0  output/src/bitcoin-9d65a3b5a9a1.tar.gz
```

#### Gitian builds:
- Linux
```
Generating report
b549df366d96bd73abbc01a683362b74d3ba27ee670bbfb604fa517694751c12  bitcoin-9d65a3b5a9a1-aarch64-linux-gnu-debug.tar.gz
4e562c0be1221457dba6c18b5b9ce80da0bcca7d860569a5d0b14f24e4409783  bitcoin-9d65a3b5a9a1-aarch64-linux-gnu.tar.gz
b9eb7f06e97535622deefd2ba2c4516a48eae70536f26094088b22728d0a951e  bitcoin-9d65a3b5a9a1-arm-linux-gnueabihf-debug.tar.gz
51a69ea11319aad30c3b81399d9e3eb201b3f7173679fe9e182610aed3af16e2  bitcoin-9d65a3b5a9a1-arm-linux-gnueabihf.tar.gz
4c30717d9e6a25202c6c40636febf6c2da2ac271d9f2209a225ec61216bd2964  bitcoin-9d65a3b5a9a1-powerpc64-linux-gnu-debug.tar.gz
0778e7de5d14a2506088f4fb11a85aa3bfc0d7bbfea526ce94bfe9fe4b89c010  bitcoin-9d65a3b5a9a1-powerpc64-linux-gnu.tar.gz
8aedb704c5dad05705e90a57912ca9379cea7785bc4c56457e83fbe6a11d2c49  bitcoin-9d65a3b5a9a1-powerpc64le-linux-gnu-debug.tar.gz
cd126c010227b743327b27aaf2fc649c849ca982fb0462fd18e1ade81553e23c  bitcoin-9d65a3b5a9a1-powerpc64le-linux-gnu.tar.gz
ea16e3de791427275573f5ee6746eafb1a25b3b90a2b2e94ced439fa9dbd0b50  bitcoin-9d65a3b5a9a1-riscv64-linux-gnu-debug.tar.gz
c1019627656c37866861b0fb3caa769732d51f8c84c443883442185d5816b83f  bitcoin-9d65a3b5a9a1-riscv64-linux-gnu.tar.gz
03182ce45d38ebbf315f7281982e2d88ce9812790d861e30deccea4872ba0597  bitcoin-9d65a3b5a9a1-x86_64-linux-gnu-debug.tar.gz
b07d854b297436ceb108d856d664ffaea61db3314e54b8605dcd63c136e47d54  bitcoin-9d65a3b5a9a1-x86_64-linux-gnu.tar.gz
7693757063a6f76d223e6a3aa5e57baa08ba340f12a734dba2e9e7efcbb047e0  src/bitcoin-9d65a3b5a9a1.tar.gz
5ccb335d55e1c2b46254418e9e91011022f04850303275a305aa2778556013d7  bitcoin-core-linux-22-res.yml
Done.
```
- Windows
```
Generating report
94f655b25485715dbbc532f86a0442b3f44eb106059207e35a2db2cb5b1e7a84  bitcoin-9d65a3b5a9a1-win-unsigned.tar.gz
7e64758ce29e8df1436e66aee0da5ff9a1540ea4f8a35dd2e404e6b044345164  bitcoin-9d65a3b5a9a1-win64-debug.zip
7cd351abd2175fb1ea6ef13a982ac48d0f3b7dde7cf062e10eb966bab116f855  bitcoin-9d65a3b5a9a1-win64-setup-unsigned.exe
bd4ebfb03d5704eab832aaf20841d03fec3a16370a84459049020903e98119b0  bitcoin-9d65a3b5a9a1-win64.zip
7693757063a6f76d223e6a3aa5e57baa08ba340f12a734dba2e9e7efcbb047e0  src/bitcoin-9d65a3b5a9a1.tar.gz
45db33e1d761335370081b4dffc1d4ed80a3239366ffb71d76a185c0bc6cc2ee  bitcoin-core-win-22-res.yml
Done.
```
- macOS
```
Generating report
e1103cc5b4237e7d9fbf45c9c0dc3b85c7decc2fb145065cef6a1bb702318aea  bitcoin-9d65a3b5a9a1-osx-unsigned.dmg
4f26998c523612f011d1540364a65bf25f9e0d957d342174334cc2ed2aabe777  bitcoin-9d65a3b5a9a1-osx-unsigned.tar.gz
f033c5fcc46af86b25ed607512e978d9367e543c04a3bc63cb0c2a864dff0edf  bitcoin-9d65a3b5a9a1-osx64.tar.gz
7693757063a6f76d223e6a3aa5e57baa08ba340f12a734dba2e9e7efcbb047e0  src/bitcoin-9d65a3b5a9a1.tar.gz
38c18029c5a270e29e64abc16453fe20b827208fd11577c74519044971c97885  bitcoin-core-osx-22-res.yml
Done.
```