### PR TITLE
rpc: add network field to getnodeaddresses

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -126,6 +126,9 @@ Changes to Wallet or GUI related settings can be found in the GUI or Wallet sect
 
 - Passing an invalid `-rpcauth` argument now cause bitcoind to fail to start.  (#20461)
 
+- The `getnodeaddresses` RPC now returns a "network" field indicating the
+  network type (ipv4, ipv6, onion, or i2p) for each address.  (#21594)
+
 Tools and Utilities
 -------------------
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -848,6 +848,7 @@ static RPCHelpMan getnodeaddresses()
                             {RPCResult::Type::NUM, "services", "The services offered"},
                             {RPCResult::Type::STR, "address", "The address of the node"},
                             {RPCResult::Type::NUM, "port", "The port of the node"},
+                            {RPCResult::Type::STR, "network", "The network (" + Join(GetNetworkNames(), ", ") + ") the node connected through"},
                         }},
                     }
                 },
@@ -879,6 +880,7 @@ static RPCHelpMan getnodeaddresses()
         obj.pushKV("services", (uint64_t)addr.nServices);
         obj.pushKV("address", addr.ToStringIP());
         obj.pushKV("port", addr.GetPort());
+        obj.pushKV("network", GetNetworkName(addr.GetNetClass()));
         ret.push_back(obj);
     }
     return ret;

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -863,15 +863,11 @@ static RPCHelpMan getnodeaddresses()
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
     }
 
-    int count = 1;
-    if (!request.params[0].isNull()) {
-        count = request.params[0].get_int();
-        if (count < 0) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Address count out of range");
-        }
-    }
+    const int count{request.params[0].isNull() ? 1 : request.params[0].get_int()};
+    if (count < 0) throw JSONRPCError(RPC_INVALID_PARAMETER, "Address count out of range");
+
     // returns a shuffled list of CAddress
-    std::vector<CAddress> vAddr = node.connman->GetAddresses(count, /* max_pct */ 0);
+    const std::vector<CAddress> vAddr{node.connman->GetAddresses(count, /* max_pct */ 0)};
     UniValue ret(UniValue::VARR);
 
     for (const CAddress& addr : vAddr) {

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -835,7 +835,7 @@ static RPCHelpMan setnetworkactive()
 static RPCHelpMan getnodeaddresses()
 {
     return RPCHelpMan{"getnodeaddresses",
-                "\nReturn known addresses which can potentially be used to find new nodes in the network\n",
+                "\nReturn known addresses, which can potentially be used to find new nodes in the network.\n",
                 {
                     {"count", RPCArg::Type::NUM, /* default */ "1", "The maximum number of addresses to return. Specify 0 to return all known addresses."},
                 },
@@ -844,10 +844,10 @@ static RPCHelpMan getnodeaddresses()
                     {
                         {RPCResult::Type::OBJ, "", "",
                         {
-                            {RPCResult::Type::NUM_TIME, "time", "The " + UNIX_EPOCH_TIME + " of when the node was last seen"},
-                            {RPCResult::Type::NUM, "services", "The services offered"},
+                            {RPCResult::Type::NUM_TIME, "time", "The " + UNIX_EPOCH_TIME + " when the node was last seen"},
+                            {RPCResult::Type::NUM, "services", "The services offered by the node"},
                             {RPCResult::Type::STR, "address", "The address of the node"},
-                            {RPCResult::Type::NUM, "port", "The port of the node"},
+                            {RPCResult::Type::NUM, "port", "The port number of the node"},
                             {RPCResult::Type::STR, "network", "The network (" + Join(GetNetworkNames(), ", ") + ") the node connected through"},
                         }},
                     }

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -195,7 +195,7 @@ class NetTest(BitcoinTestFramework):
         for i in range(10000):
             first_octet = i >> 8
             second_octet = i % 256
-            a = "{}.{}.1.1".format(first_octet, second_octet)
+            a = "{}.{}.1.1".format(first_octet, second_octet)  # IPV4
             imported_addrs.append(a)
             self.nodes[0].addpeeraddress(a, 8333)
 
@@ -212,6 +212,7 @@ class NetTest(BitcoinTestFramework):
             assert_equal(a["services"], NODE_NETWORK | NODE_WITNESS)
             assert a["address"] in imported_addrs
             assert_equal(a["port"], 8333)
+            assert_equal(a["network"], "ipv4")
 
         node_addresses = self.nodes[0].getnodeaddresses(1)
         assert_equal(len(node_addresses), 1)


### PR DESCRIPTION
This patch adds a network field to RPC `getnodeaddresses`, which is useful on its own, particularly with the addition of new networks like I2P and others in the future, and which I also found helpful for adding a new CLI command as a follow-up to this pull that calls `getnodeaddresses` and needs to know the network of each address.

While here, also improve the `getnodeaddresses` code and help.

```
$ bitcoin-cli -signet getnodeaddresses 3
[
  {
    "time": 1611564659,
    "services": 1033,
    "address": "2600:1702:3c30:734f:8f2e:744b:2a51:dfa5",
    "port": 38333,
    "network": "ipv6"
  },
  {
    "time": 1617531931,
    "services": 1033,
    "address": "153.126.143.201",
    "port": 38333,
    "network": "ipv4"
  },
  {
    "time": 1617473058,
    "services": 1033,
    "address": "nsgyo7begau4yecc46ljfecaykyzszcseapxmtu6adrfagfrrzrlngyd.onion",
    "port": 38333,
    "network": "onion"
  }
]

$ bitcoin-cli help getnodeaddresses 
getnodeaddresses ( count )

Return known addresses, which can potentially be used to find new nodes in the network.

Arguments:
1. count    (numeric, optional, default=1) The maximum number of addresses to return. Specify 0 to return all known addresses.

Result:
[                         (json array)
  {                       (json object)
    "time" : xxx,         (numeric) The UNIX epoch time when the node was last seen
    "services" : n,       (numeric) The services offered by the node
    "address" : "str",    (string) The address of the node
    "port" : n,           (numeric) The port number of the node
    "network" : "str"     (string) The network (ipv4, ipv6, onion, i2p) the node connected through
  },
  ...
]
```
Future idea: allow passing `getnodeaddresses` a network (or networks) as an argument to return only addresses in that network.