### PR TITLE
cli: create -addrinfo

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -132,6 +132,12 @@ Changes to Wallet or GUI related settings can be found in the GUI or Wallet sect
 Tools and Utilities
 -------------------
 
+- A new CLI `-addrinfo` command returns the number of addresses known to the
+  node per network type (including Tor v2 versus v3) and total. This can be
+  useful to see if the node knows enough addresses in a network to use options
+  like `-onlynet=<network>` or to upgrade to current and future Tor releases
+  that support Tor v3 addresses only.  (#21595)
+
 Wallet
 ------
 

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -256,9 +256,14 @@ public:
 
     UniValue ProcessReply(const UniValue& reply) override
     {
+        if (!reply["error"].isNull()) return reply;
+        const std::vector<UniValue>& nodes{reply["result"].getValues()};
+        if (!nodes.empty() && nodes.at(0)["network"].isNull()) {
+            throw std::runtime_error("-addrinfo requires bitcoind server to be running v22.0 and up");
+        }
         // Count the number of peers we know by network, including torv2 versus torv3.
         std::array<uint64_t, m_networks_size> counts{{}};
-        for (const UniValue& node : reply["result"].getValues()) {
+        for (const UniValue& node : nodes) {
             std::string network_name{node["network"].get_str()};
             if (network_name == "onion") {
                 network_name = node["address"].get_str().size() > 22 ? "torv3" : "torv2";

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -60,6 +60,7 @@ static void SetupCliArgs(ArgsManager& argsman)
     argsman.AddArg("-conf=<file>", strprintf("Specify configuration file. Relative paths will be prefixed by datadir location. (default: %s)", BITCOIN_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-datadir=<dir>", "Specify data directory", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-generate", strprintf("Generate blocks immediately, equivalent to RPC getnewaddress followed by RPC generatetoaddress. Optional positional integer arguments are number of blocks to generate (default: %s) and maximum iterations to try (default: %s), equivalent to RPC generatetoaddress nblocks and maxtries arguments. Example: bitcoin-cli -generate 4 1000", DEFAULT_NBLOCKS, DEFAULT_MAX_TRIES), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-addrinfo", "Get the number of addresses known to the node, per network and total.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-getinfo", "Get general information from the remote server. Note that unlike server-side RPC calls, the results of -getinfo is the result of multiple non-atomic requests. Some entries in the result may represent results from different states (e.g. wallet balance may be as of a different block from the chain state reported)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-netinfo", "Get network peer connection information from the remote server. An optional integer argument from 0 to 4 can be passed for different peers listings (default: 0). Pass \"help\" for detailed help documentation.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 
@@ -964,6 +965,8 @@ static int CommandLineRPC(int argc, char *argv[])
             } else {
                 ParseError(error, strPrint, nRet);
             }
+        } else if (gArgs.GetBoolArg("-addrinfo", false)) {
+            rh.reset(new AddrinfoRequestHandler());
         } else {
             rh.reset(new DefaultRequestHandler());
             if (args.size() < 1) {


### PR DESCRIPTION
While looking at issue #21351, it turned out that the problem was a lack of tor v3 addresses known to the node. It became clear (e.g. https://github.com/bitcoin/bitcoin/issues/21351#issuecomment-811004779) that a CLI command returning the number of addresses the node knows per network (with a tor v2 / v3 breakdown) would be very helpful. This patch adds that.

`-addrinfo` is useful to see if your node knows enough addresses in a network to use options like `-onlynet=<network>`, or to upgrade to the upcoming tor release that no longer supports tor v2, for which you'll need to be sure your node knows enough tor v3 peers.

```
$ bitcoin-cli --help | grep -A1 addrinfo
  -addrinfo
       Get the number of addresses known to the node, per network and total.

$ bitcoin-cli -addrinfo
{
  "addresses_known": {
    "ipv4": 14406,
    "ipv6": 2511,
    "torv2": 5563,
    "torv3": 2842,
    "i2p": 8,
    "total": 25330
  }
}

$ bitcoin-cli -addrinfo 1
error: -addrinfo takes no arguments
```

This can be manually tested, for example, with commands like this:
```
$ bitcoin-cli getnodeaddresses 0 | jq '.[] | (select(.address | contains(".onion")) | select(.address | length <= 22)) | .address' | wc -l
5563
$ bitcoin-cli getnodeaddresses 0 | jq '.[] | (select(.address | contains(".onion")) | select(.address | length > 22)) | .address' | wc -l
2842
$ bitcoin-cli getnodeaddresses 0 | jq '.[] | .address' | wc -l
25330
```
