### PR TITLE
test: Replace file level integer overflow suppression with function level suppression

### DIFF
--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -1,6 +1,6 @@
 # -fsanitize=undefined suppressions
 # =================================
-# No suppressions at the moment. Hooray!
+signed-integer-overflow:CTxMemPool::PrioritiseTransaction
 
 # -fsanitize=integer suppressions
 # ===============================
@@ -100,4 +100,3 @@ shift-base:leveldb/
 shift-base:net_processing.cpp
 shift-base:streams.h
 shift-base:util/bip32.cpp
-signed-integer-overflow:txmempool.cpp


### PR DESCRIPTION
Replace file level (`txmempool.cpp`) signed integer overflow suppression with function level suppression (`CTxMemPool::PrioritiseTransaction`). The suppression was added yesterday in #21586.

Rationale: To avoid risk hiding other signed integer overflows in `txmempool.cpp`.

Obviously it would be better if this signed integer overflow fixed instead of suppressed - see details #20626. Any taker? :)

To hit the issue via fuzzing:

```
$ UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:report_error_type=1" FUZZ=validation_load_mempool src/test/fuzz/fuzz
INFO: Seed: 1184244493
INFO: Loaded 1 modules   (634418 inline 8-bit counters): 634418 [0x55a09fdfbf98, 0x55a09fe96dca),
INFO: Loaded 1 PC tables (634418 PCs): 634418 [0x55a09fe96dd0,0x55a0a08450f0),
INFO:     1264 files found in mempool/
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 1040698 bytes
INFO: seed corpus: files: 1264 min: 1b max: 1040698b total: 15997133b rss: 197Mb
txmempool.cpp:847:15: runtime error: signed integer overflow: -7211388903327006720 + -7211353718954917888 cannot be represented in type 'long'
    #0 0x55a09c3ce2d8 in CTxMemPool::PrioritiseTransaction(uint256 const&, long const&) /home/thomas/bitcoin/src/txmempool.cpp:847:15
```