### PR TITLE
rpc: add additional ban time fields to listbanned

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -104,6 +104,10 @@ Updated RPCs
   with the `-json` option set, the following fields: `addresses`, `reqSigs` are no longer
   returned in the tx output of the response. (#20286)
 
+- The `listbanned` RPC now returns two new numeric fields: `ban_duration` and `time_remaining`.
+  Respectively, these new fields indicate the duration of a ban and the time remaining until a ban expires,
+  both in seconds. Additionally, the `ban_created` field is repositioned to come before `banned_until`. (#21602)
+
 Changes to Wallet or GUI related RPCs can be found in the GUI or Wallet section below.
 
 New RPCs

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -750,8 +750,8 @@ static RPCHelpMan listbanned()
                 {RPCResult::Type::OBJ, "", "",
                     {
                         {RPCResult::Type::STR, "address", ""},
-                        {RPCResult::Type::NUM_TIME, "banned_until", ""},
                         {RPCResult::Type::NUM_TIME, "ban_created", ""},
+                        {RPCResult::Type::NUM_TIME, "banned_until", ""},
                     }},
             }},
                 RPCExamples{
@@ -774,8 +774,8 @@ static RPCHelpMan listbanned()
         const CBanEntry& banEntry = entry.second;
         UniValue rec(UniValue::VOBJ);
         rec.pushKV("address", entry.first.ToString());
-        rec.pushKV("banned_until", banEntry.nBanUntil);
         rec.pushKV("ban_created", banEntry.nCreateTime);
+        rec.pushKV("banned_until", banEntry.nBanUntil);
 
         bannedAddresses.push_back(rec);
     }

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -752,6 +752,7 @@ static RPCHelpMan listbanned()
                         {RPCResult::Type::STR, "address", "The IP/Subnet of the banned node"},
                         {RPCResult::Type::NUM_TIME, "ban_created", "The " + UNIX_EPOCH_TIME + " the ban was created"},
                         {RPCResult::Type::NUM_TIME, "banned_until", "The " + UNIX_EPOCH_TIME + " the ban expires"},
+                        {RPCResult::Type::NUM_TIME, "ban_duration", "The ban duration, in seconds"},
                     }},
             }},
                 RPCExamples{
@@ -776,6 +777,7 @@ static RPCHelpMan listbanned()
         rec.pushKV("address", entry.first.ToString());
         rec.pushKV("ban_created", banEntry.nCreateTime);
         rec.pushKV("banned_until", banEntry.nBanUntil);
+        rec.pushKV("ban_duration", (banEntry.nBanUntil - banEntry.nCreateTime));
 
         bannedAddresses.push_back(rec);
     }

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -749,9 +749,9 @@ static RPCHelpMan listbanned()
             {
                 {RPCResult::Type::OBJ, "", "",
                     {
-                        {RPCResult::Type::STR, "address", ""},
-                        {RPCResult::Type::NUM_TIME, "ban_created", ""},
-                        {RPCResult::Type::NUM_TIME, "banned_until", ""},
+                        {RPCResult::Type::STR, "address", "The IP/Subnet of the banned node"},
+                        {RPCResult::Type::NUM_TIME, "ban_created", "The " + UNIX_EPOCH_TIME + " the ban was created"},
+                        {RPCResult::Type::NUM_TIME, "banned_until", "The " + UNIX_EPOCH_TIME + " the ban expires"},
                     }},
             }},
                 RPCExamples{

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -753,6 +753,7 @@ static RPCHelpMan listbanned()
                         {RPCResult::Type::NUM_TIME, "ban_created", "The " + UNIX_EPOCH_TIME + " the ban was created"},
                         {RPCResult::Type::NUM_TIME, "banned_until", "The " + UNIX_EPOCH_TIME + " the ban expires"},
                         {RPCResult::Type::NUM_TIME, "ban_duration", "The ban duration, in seconds"},
+                        {RPCResult::Type::NUM_TIME, "time_remaining", "The time remaining until the ban expires, in seconds"},
                     }},
             }},
                 RPCExamples{
@@ -768,6 +769,7 @@ static RPCHelpMan listbanned()
 
     banmap_t banMap;
     node.banman->GetBanned(banMap);
+    const int64_t current_time{GetTime()};
 
     UniValue bannedAddresses(UniValue::VARR);
     for (const auto& entry : banMap)
@@ -778,6 +780,7 @@ static RPCHelpMan listbanned()
         rec.pushKV("ban_created", banEntry.nCreateTime);
         rec.pushKV("banned_until", banEntry.nBanUntil);
         rec.pushKV("ban_duration", (banEntry.nBanUntil - banEntry.nCreateTime));
+        rec.pushKV("time_remaining", (banEntry.nBanUntil - current_time));
 
         bannedAddresses.push_back(rec);
     }


### PR DESCRIPTION
This PR adds a `ban_duration` and `time_remaining` field to the `listbanned` RPC command. Thanks to jonatack, this PR also expands the `listbanned` test coverage to include these new fields

It's useful to keep track of `ban_duration` as this is another data point on which to sort banned peers. I found this helpful in adding additional context columns to the GUI `bantablemodel` as part of a follow-up PR. As [suggested](https://github.com/bitcoin/bitcoin/pull/21602#issuecomment-813486134) by jonatack, `time_remaining` is another useful user-centric data point.

Since a ban always expires after its created, the `ban_created` field is now placed before the `banned_until` field. This new ordering is more logical.

This PR also improves the `help listbanned` output by providing additional context to the descriptions of the `address`, `ban_created`, and `banned_until` fields.



**Master: listbanned**
```
[
  {
    "address": "1.2.3.4/32",
    "banned_until": 1617691101,
    "ban_created": 1617604701
  },
  {
    "address": "135.181.41.129/32",
    "banned_until": 1649140716,
    "ban_created": 1617604716
  }
]
```

**PR: listbanned**
```
[
  {
    "address": "1.2.3.4/32",
    "ban_created": 1617775773,
    "banned_until": 1617862173,
    "ban_duration": 86400,
    "time_remaining": 86392
  },
  {
    "address": "3.114.211.172/32",
    "ban_created": 1617753165,
    "banned_until": 1618357965,
    "ban_duration": 604800,
    "time_remaining": 582184
  }
]
```