### PR TITLE
log: Mitigate disk filling attacks by rate limiting LogPrintf

### DIFF
--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -81,6 +81,7 @@ void AddLoggingArgs(ArgsManager& argsman)
     argsman.AddArg("-logtimemicros", strprintf("Add microsecond precision to debug timestamps (default: %u)", DEFAULT_LOGTIMEMICROS), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-printtoconsole", "Send trace/debug info to console (default: 1 when no -daemon. To disable logging to file, set -nodebuglogfile)", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-shrinkdebugfile", "Shrink debug.log file on client startup (default: 1 when no -debug)", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
+    argsman.AddArg("-ratelimitlogging", strprintf("Rate limit unconditional logging to disk (default: %u)", DEFAULT_RATELIMITLOGGING), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 }
 
 void SetLoggingOptions(const ArgsManager& args)
@@ -94,6 +95,7 @@ void SetLoggingOptions(const ArgsManager& args)
     LogInstance().m_log_threadnames = args.GetBoolArg("-logthreadnames", DEFAULT_LOGTHREADNAMES);
 #endif
     LogInstance().m_log_sourcelocations = args.GetBoolArg("-logsourcelocations", DEFAULT_LOGSOURCELOCATIONS);
+    LogInstance().m_ratelimit = args.GetBoolArg("-ratelimitlogging", DEFAULT_RATELIMITLOGGING);
 
     fLogIPs = args.GetBoolArg("-logips", DEFAULT_LOGIPS);
 }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -333,7 +333,9 @@ namespace BCLog {
     }
 } // namespace BCLog
 
-void BCLog::Logger::LogPrintStr(const std::string& str, const std::string& logging_function, const std::string& source_file, const int source_line, const BCLog::LogFlags category, const BCLog::Level level)
+void BCLog::Logger::LogPrintStr(const std::string& str, const std::string& logging_function,
+                                const SourceLocation& source_location, const BCLog::LogFlags category,
+                                const BCLog::Level level)
 {
     StdLockGuard scoped_lock(m_cs);
     std::string str_prefixed = LogEscapeMessage(str);
@@ -359,7 +361,7 @@ void BCLog::Logger::LogPrintStr(const std::string& str, const std::string& loggi
     }
 
     if (m_log_sourcelocations && m_started_new_line) {
-        str_prefixed.insert(0, "[" + RemovePrefix(source_file, "./") + ":" + ToString(source_line) + "] [" + logging_function + "] ");
+        str_prefixed.insert(0, "[" + RemovePrefix(source_location.m_file, "./") + ":" + ToString(source_location.m_line) + "] [" + logging_function + "] ");
     }
 
     if (m_log_threadnames && m_started_new_line) {

--- a/src/logging.h
+++ b/src/logging.h
@@ -10,6 +10,7 @@
 #include <tinyformat.h>
 #include <threadsafety.h>
 #include <util/string.h>
+#include <util/time.h>
 
 #include <atomic>
 #include <cstdint>
@@ -73,6 +74,43 @@ namespace BCLog {
         Info = 2,
         Warning = 3,
         Error = 4,
+    };
+
+    //! Fixed window rate limiter for logging.
+    class LogRateLimiter
+    {
+    private:
+        //! Timestamp of the last window reset.
+        std::chrono::time_point<NodeClock> m_last_reset;
+        //! Remaining bytes in the current window interval.
+        uint64_t m_available_bytes{WINDOW_MAX_BYTES};
+        //! Number of bytes that were not consumed within the current window.
+        uint64_t m_dropped_bytes{0};
+        //! Reset the window if the window interval has passed since the last reset.
+        void MaybeReset();
+
+    public:
+        //! Interval after which the window is reset.
+        static constexpr std::chrono::hours WINDOW_SIZE{1};
+        //! The maximum number of bytes that can be logged within one window.
+        static constexpr uint64_t WINDOW_MAX_BYTES{1024 * 1024};
+
+        LogRateLimiter() : m_last_reset{NodeClock::now()} {}
+
+        //! Consume bytes from the window if enough bytes are available.
+        //!
+        //! Returns whether or not enough bytes were available.
+        bool Consume(uint64_t bytes);
+
+        uint64_t GetAvailableBytes() const
+        {
+            return m_available_bytes;
+        }
+
+        uint64_t GetDroppedBytes() const
+        {
+            return m_dropped_bytes;
+        }
     };
 
     class Logger
@@ -161,7 +199,6 @@ namespace BCLog {
 
         bool DefaultShrinkDebugFile() const;
     };
-
 } // namespace BCLog
 
 BCLog::Logger& LogInstance();

--- a/src/logging.h
+++ b/src/logging.h
@@ -19,6 +19,8 @@
 #include <list>
 #include <mutex>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 static const bool DEFAULT_LOGTIMEMICROS = false;
@@ -150,6 +152,11 @@ namespace BCLog {
         FILE* m_fileout GUARDED_BY(m_cs) = nullptr;
         std::list<std::string> m_msgs_before_open GUARDED_BY(m_cs);
         bool m_buffering GUARDED_BY(m_cs) = true; //!< Buffer messages before logging can be started.
+
+        //! Fixed window rate limiters for each source location that has attempted to log something.
+        std::unordered_map<SourceLocation, LogRateLimiter, SourceLocationHasher> m_ratelimiters GUARDED_BY(m_cs);
+        //! Set of source file locations that were dropped on the last log attempt.
+        std::unordered_set<SourceLocation, SourceLocationHasher> m_supressed_locations GUARDED_BY(m_cs);
 
         /**
          * m_started_new_line is a state variable that will suppress printing of

--- a/src/logging.h
+++ b/src/logging.h
@@ -26,6 +26,7 @@ static const bool DEFAULT_LOGIPS        = false;
 static const bool DEFAULT_LOGTIMESTAMPS = true;
 static const bool DEFAULT_LOGTHREADNAMES = false;
 static const bool DEFAULT_LOGSOURCELOCATIONS = false;
+static constexpr bool DEFAULT_RATELIMITLOGGING{true};
 extern const char * const DEFAULT_DEBUGLOGFILE;
 
 extern bool fLogIPs;
@@ -169,6 +170,7 @@ namespace BCLog {
         bool m_log_time_micros = DEFAULT_LOGTIMEMICROS;
         bool m_log_threadnames = DEFAULT_LOGTHREADNAMES;
         bool m_log_sourcelocations = DEFAULT_LOGSOURCELOCATIONS;
+        bool m_ratelimit{DEFAULT_RATELIMITLOGGING};
 
         fs::path m_file_path;
         std::atomic<bool> m_reopen_file{false};

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -311,7 +311,7 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     //
     // Debug view
     //
-    if (node.getLogCategories() != BCLog::NONE)
+    if (node.getLogCategories() != BCLog::DEFAULT_LOG_FLAGS)
     {
         strHTML += "<hr><br>" + tr("Debug information") + "<br><br>";
         for (const CTxIn& txin : wtx.tx->vin)

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -150,4 +150,36 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrintMacros_CategoryName, LogSetup)
     BOOST_CHECK_EQUAL_COLLECTIONS(log_lines.begin(), log_lines.end(), expected.begin(), expected.end());
 }
 
+BOOST_AUTO_TEST_CASE(logging_ratelimit_window)
+{
+    SetMockTime(std::chrono::hours{1});
+    BCLog::LogRateLimiter window;
+
+    // Check that window gets initialised correctly.
+    BOOST_CHECK_EQUAL(window.GetAvailableBytes(), BCLog::LogRateLimiter::WINDOW_MAX_BYTES);
+    BOOST_CHECK_EQUAL(window.GetDroppedBytes(), 0ull);
+
+    const uint64_t MESSAGE_SIZE{512 * 1024};
+    BOOST_CHECK(window.Consume(MESSAGE_SIZE));
+    BOOST_CHECK_EQUAL(window.GetAvailableBytes(), BCLog::LogRateLimiter::WINDOW_MAX_BYTES - MESSAGE_SIZE);
+    BOOST_CHECK_EQUAL(window.GetDroppedBytes(), 0ull);
+
+    BOOST_CHECK(window.Consume(MESSAGE_SIZE));
+    BOOST_CHECK_EQUAL(window.GetAvailableBytes(), BCLog::LogRateLimiter::WINDOW_MAX_BYTES - MESSAGE_SIZE * 2);
+    BOOST_CHECK_EQUAL(window.GetDroppedBytes(), 0ull);
+
+    // Consuming more bytes after already having consumed a 1MB should fail.
+    BOOST_CHECK(!window.Consume(500));
+    BOOST_CHECK_EQUAL(window.GetAvailableBytes(), 0ull);
+    BOOST_CHECK_EQUAL(window.GetDroppedBytes(), 500ull);
+
+    // Advance time by one hour. This should trigger a window reset.
+    SetMockTime(std::chrono::hours{2});
+
+    // Check that the window resets as expected when new bytes are consumed.
+    BOOST_CHECK(window.Consume(MESSAGE_SIZE));
+    BOOST_CHECK_EQUAL(window.GetAvailableBytes(), BCLog::LogRateLimiter::WINDOW_MAX_BYTES - MESSAGE_SIZE);
+    BOOST_CHECK_EQUAL(window.GetDroppedBytes(), 0ull);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -136,10 +136,11 @@ BOOST_FIXTURE_TEST_CASE(logging_LogPrintMacros_CategoryName, LogSetup)
     std::vector<std::string> expected;
     for (const auto& [category, name] : expected_category_names) {
         LogPrint(category, "foo: %s\n", "bar");
-        std::string expected_log = "[";
-        expected_log += name;
-        expected_log += "] foo: bar";
-        expected.push_back(expected_log);
+        if (category == BCLog::UNCONDITIONAL_ALWAYS || category == BCLog::UNCONDITIONAL_RATE_LIMITED) {
+            expected.push_back("foo: bar");
+        } else {
+            expected.push_back("[" + name + "] foo: bar");
+        }
     }
 
     std::ifstream file{tmp_log_path};

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -268,6 +268,19 @@ BOOST_AUTO_TEST_CASE(rate_limiting)
         BOOST_CHECK_MESSAGE(log_file_size < std::filesystem::file_size(LogInstance().m_file_path), "location 3 should be exempt from rate limiting");
     }
 
+    SetMockTime(std::chrono::hours{3});
+
+    // Disable rate limiting.
+    // Source locations should now be able to log without limit.
+    LogInstance().m_ratelimit = false;
+    for (int i = 0; i < 2048; ++i) {
+        log_file_size = std::filesystem::file_size(LogInstance().m_file_path);
+        BOOST_CHECK_THROW(
+            LogFromLocationAndExpect(0, log_message, "Excessive logging detected"), std::runtime_error);
+        BOOST_CHECK_MESSAGE(log_file_size < std::filesystem::file_size(LogInstance().m_file_path), "location 0 should be able to log disk, when rate limiting is disabled");
+    }
+    LogInstance().m_ratelimit = true;
+
     LogInstance().m_log_timestamps = prev_log_timestamps;
     LogInstance().m_log_sourcelocations = prev_log_sourcelocations;
     LogInstance().m_log_threadnames = prev_log_threadnames;

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -216,20 +216,35 @@ BOOST_AUTO_TEST_CASE(rate_limiting)
 
     SetMockTime(std::chrono::hours{1});
 
+    size_t log_file_size = std::filesystem::file_size(LogInstance().m_file_path);
     // Logging 1 MiB should be allowed.
     for (int i = 0; i < 1024; ++i) {
         LogFromLocation(0, log_message);
     }
+    BOOST_CHECK_MESSAGE(log_file_size < std::filesystem::file_size(LogInstance().m_file_path), "should be able to log 1 MiB from location 0");
 
+    log_file_size = std::filesystem::file_size(LogInstance().m_file_path);
     BOOST_CHECK_NO_THROW(
         LogFromLocationAndExpect(0, log_message, "Excessive logging detected"));
+    BOOST_CHECK_MESSAGE(log_file_size < std::filesystem::file_size(LogInstance().m_file_path), "the start of the supression period should be logged");
+
+    log_file_size = std::filesystem::file_size(LogInstance().m_file_path);
+    for (int i = 0; i < 1024; ++i) {
+        LogFromLocation(0, log_message);
+    }
+    BOOST_CHECK_MESSAGE(log_file_size == std::filesystem::file_size(LogInstance().m_file_path), "all further logs from location 0 should be dropped");
+
     BOOST_CHECK_THROW(
         LogFromLocationAndExpect(1, log_message, "Excessive logging detected"), std::runtime_error);
+    BOOST_CHECK_MESSAGE(log_file_size < std::filesystem::file_size(LogInstance().m_file_path), "location 1 should be unaffected by other locations");
 
     SetMockTime(std::chrono::hours{2});
 
+    log_file_size = std::filesystem::file_size(LogInstance().m_file_path);
     BOOST_CHECK_NO_THROW(
         LogFromLocationAndExpect(0, log_message, "Restarting logging"));
+    BOOST_CHECK_MESSAGE(log_file_size < std::filesystem::file_size(LogInstance().m_file_path), "the end of the supression period should be logged");
+
     BOOST_CHECK_THROW(
         LogFromLocationAndExpect(1, log_message, "Restarting logging"), std::runtime_error);
 

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -193,6 +193,12 @@ void LogFromLocation(int location, std::string message)
     case 1:
         LogPrint(BCLog::UNCONDITIONAL_RATE_LIMITED, "%s\n", message);
         break;
+    case 2:
+        LogPrint(BCLog::UNCONDITIONAL_ALWAYS, "%s\n", message);
+        break;
+    case 3:
+        LogPrint(BCLog::ALL, "%s\n", message);
+        break;
     }
 }
 
@@ -247,6 +253,20 @@ BOOST_AUTO_TEST_CASE(rate_limiting)
 
     BOOST_CHECK_THROW(
         LogFromLocationAndExpect(1, log_message, "Restarting logging"), std::runtime_error);
+
+    // Attempt to log 2 MiB to disk.
+    // The exempt locations 2 and 3 should be allowed to log without limit.
+    for (int i = 0; i < 2048; ++i) {
+        log_file_size = std::filesystem::file_size(LogInstance().m_file_path);
+        BOOST_CHECK_THROW(
+            LogFromLocationAndExpect(2, log_message, "Excessive logging detected"), std::runtime_error);
+        BOOST_CHECK_MESSAGE(log_file_size < std::filesystem::file_size(LogInstance().m_file_path), "location 2 should be exempt from rate limiting");
+
+        log_file_size = std::filesystem::file_size(LogInstance().m_file_path);
+        BOOST_CHECK_THROW(
+            LogFromLocationAndExpect(3, log_message, "Excessive logging detected"), std::runtime_error);
+        BOOST_CHECK_MESSAGE(log_file_size < std::filesystem::file_size(LogInstance().m_file_path), "location 3 should be exempt from rate limiting");
+    }
 
     LogInstance().m_log_timestamps = prev_log_timestamps;
     LogInstance().m_log_sourcelocations = prev_log_sourcelocations;

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <logging.h>
 #include <logging/timer.h>
+#include <test/util/logging.h>
 #include <test/util/setup_common.h>
 #include <util/string.h>
 
@@ -181,6 +182,61 @@ BOOST_AUTO_TEST_CASE(logging_ratelimit_window)
     BOOST_CHECK(window.Consume(MESSAGE_SIZE));
     BOOST_CHECK_EQUAL(window.GetAvailableBytes(), BCLog::LogRateLimiter::WINDOW_MAX_BYTES - MESSAGE_SIZE);
     BOOST_CHECK_EQUAL(window.GetDroppedBytes(), 0ull);
+}
+
+void LogFromLocation(int location, std::string message)
+{
+    switch (location) {
+    case 0:
+        LogPrint(BCLog::UNCONDITIONAL_RATE_LIMITED, "%s\n", message);
+        break;
+    case 1:
+        LogPrint(BCLog::UNCONDITIONAL_RATE_LIMITED, "%s\n", message);
+        break;
+    }
+}
+
+void LogFromLocationAndExpect(int location, std::string message, std::string expect)
+{
+    ASSERT_DEBUG_LOG(expect);
+    LogFromLocation(location, message);
+}
+
+BOOST_AUTO_TEST_CASE(rate_limiting)
+{
+    bool prev_log_timestamps = LogInstance().m_log_sourcelocations;
+    LogInstance().m_log_timestamps = false;
+    bool prev_log_sourcelocations = LogInstance().m_log_sourcelocations;
+    LogInstance().m_log_sourcelocations = false;
+    bool prev_log_threadnames = LogInstance().m_log_threadnames;
+    LogInstance().m_log_threadnames = false;
+
+    // Log 1024-character lines (1023 plus newline) to make the math simple.
+    std::string log_message(1023, 'a');
+
+    SetMockTime(std::chrono::hours{1});
+
+    // Logging 1 MiB should be allowed.
+    for (int i = 0; i < 1024; ++i) {
+        LogFromLocation(0, log_message);
+    }
+
+    BOOST_CHECK_NO_THROW(
+        LogFromLocationAndExpect(0, log_message, "Excessive logging detected"));
+    BOOST_CHECK_THROW(
+        LogFromLocationAndExpect(1, log_message, "Excessive logging detected"), std::runtime_error);
+
+    SetMockTime(std::chrono::hours{2});
+
+    BOOST_CHECK_NO_THROW(
+        LogFromLocationAndExpect(0, log_message, "Restarting logging"));
+    BOOST_CHECK_THROW(
+        LogFromLocationAndExpect(1, log_message, "Restarting logging"), std::runtime_error);
+
+    LogInstance().m_log_timestamps = prev_log_timestamps;
+    LogInstance().m_log_sourcelocations = prev_log_sourcelocations;
+    LogInstance().m_log_threadnames = prev_log_threadnames;
+    SetMockTime(std::chrono::seconds{0});
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/logging.h
+++ b/src/test/util/logging.h
@@ -33,7 +33,7 @@ class DebugLogHelper
 
 public:
     explicit DebugLogHelper(std::string message, MatchFn match = [](const std::string*){ return true; });
-    ~DebugLogHelper() { check_found(); }
+    ~DebugLogHelper() noexcept(false) { check_found(); }
 };
 
 #define ASSERT_DEBUG_LOG(message) DebugLogHelper UNIQUE_NAME(debugloghelper)(message)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2515,15 +2515,15 @@ static void UpdateTipLog(
 {
 
     AssertLockHeld(::cs_main);
-    LogPrintf("%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
-        prefix, func_name,
-        tip->GetBlockHash().ToString(), tip->nHeight, tip->nVersion,
-        log(tip->nChainWork.getdouble()) / log(2.0), (unsigned long)tip->nChainTx,
-        FormatISO8601DateTime(tip->GetBlockTime()),
-        GuessVerificationProgress(params.TxData(), tip),
-        coins_tip.DynamicMemoryUsage() * (1.0 / (1 << 20)),
-        coins_tip.GetCacheSize(),
-        !warning_messages.empty() ? strprintf(" warning='%s'", warning_messages) : "");
+    LogPrint(BCLog::UNCONDITIONAL_ALWAYS, "%s%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n",
+             prefix, func_name,
+             tip->GetBlockHash().ToString(), tip->nHeight, tip->nVersion,
+             log(tip->nChainWork.getdouble()) / log(2.0), (unsigned long)tip->nChainTx,
+             FormatISO8601DateTime(tip->GetBlockTime()),
+             GuessVerificationProgress(params.TxData(), tip),
+             coins_tip.DynamicMemoryUsage() * (1.0 / (1 << 20)),
+             coins_tip.GetCacheSize(),
+             !warning_messages.empty() ? strprintf(" warning='%s'", warning_messages) : "");
 }
 
 void CChainState::UpdateTip(const CBlockIndex* pindexNew)


### PR DESCRIPTION
This picks up #19995 in an attempt to solve #21559.

The goal of this PR is to mitigate disk filling attacks by temporarily rate limiting `LogPrintf(…)`.

A disk fill attack is an attack where an untrusted party (such as a peer) is able to cheaply make your node log to disk excessively. The excessive logging may fill your disk and thus make your node crash either cleanly (best case: if disk fill rate is relatively slow) or uncleanly (worst case: if disk fill rate is relatively fast).

## Approach

The hourly logging quota is set **per source location**. Every single source location (say net_processing.cpp:418) gets a quota of 1 MB of logging per hour. Logging is only dropped from source locations that exceed the quota.

- Only logging to disk is rate limited. Logging to console is not rate limited.
- Only `LogPrintf(…)` is rate limited. `LogPrint(category, …)` (`-debug`) is not rate limited.
- `UpdateTip: new best=[…]` is logged using `LogPrintfWithoutRateLimiting(…)` to avoid rate limiting. High log volume is expected for that source location during IBD.
- When logging is restarted a tally of how many messages/bytes were dropped is printed.
- Log rate limiting can be disabled with the `-ratelimitlogging` config option.
- All logs will be prefixed with `[*]` if there is at least one source location that is currently being suppressed.

### Alternatives

In a recent [PR Review Club meeting](https://bitcoincore.reviews/21603) we discussed this PR and evaluated alternative approaches.

<details>
<summary>Global rate limiting </summary>

#### Global rate limiting

There was some discussion around an alternative approach which would be to globally rate limit `LogPrintf(…)`.  This approach was implemented in a competing PR #21706. The main point [1] in favor of global rate limiting is that it could be confusing to have incomplete logs when logs from one source location are dropped but not from others. The main point against global rate limiting is that it opens another attack vector where an attacker could trigger rate limiting and then execute a 2. attack which would then not be document in the logs at all. With regard to the attack vector on the global approach and the overall reviews the two approaches have gotten I have chosen to continue with the approach in this PR. 
(To address the concern of [1] i have chosen to prefix all logs with `[*]` if there is at least one source location that is currently being suppressed.)
</details>

<details>
<summary>logrotate</summary>

#### logrotate

LarryRuane brought up [logrotate](https://linux.die.net/man/8/logrotate) which can be used on linux to monitor log files and perform actions (delete, compress, send somewhere, etc.) on them when a certain size or point in time is reached. `logrotate` could be used to rate limit log but since we would like log rate limiting to be enabled by default it is not the best solution. Also on windows an alternative would have to be used.

</details>

## Testing

I have a written a unit test which is contained in this PR. (Not the greatest test, it currently does not work on windows thanks to `\r\n`. If someone has an idea how to improve the test i would appreciate it)

Further more I made a RPC [here](https://github.com/dergoegge/bitcoin/commit/8e6d15d6be06834d1f634f4a54ea646be8bc3491) that can log excessive amounts of "a"s from different locations which i have found useful during my own testing.
`bitcoin-cli excessivelog <location (1-5)> <num_bytes>`

⚠️One thing to note with that rpc is that the rate limiting logic still prints the last message that triggered the limiting to disk, so something like `bitcoin-cli excessivelog 1 536870912` would still log ~512MiB to disk. Logging to console is also never suppressed (unless -printtoconsole=0)  ⚠️

A simple example to use the rpc:
```bash
bitcoin-cli -regtest setmocktime 1
bitcoin-cli -regtest excessivelog 1 1048500 # log just under 1MiB
bitcoin-cli -regtest excessivelog 1 100 # this should get the total amount logged above 1MiB
                                        # and the rate limiting logic should kick in
bitcoin-cli -regtest setmocktime 3602 # let 1 hour pass (only works in regtest)
bitcoin-cli -regtest excessivelog 1 100 # this should trigger logging to resume
```
