### PR TITLE
ci: increase CPU count of sanitizer job to increase memory limit

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -113,7 +113,7 @@ task:
   << : *GLOBAL_TASK_TEMPLATE
   container:
     image: ubuntu:focal
-    cpu: 4  # Double CPU and increase Memory to avoid timeout
+    cpu: 6  # Increase CPU and Memory to avoid timeout
     memory: 24G
   env:
     MAKEJOBS: "-j8"


### PR DESCRIPTION
According to the [docs](https://cirrus-ci.org/guide/linux/#linux-containers):
> For each CPU you can't get more than 4G of memory.

thus if we want this job to have 24GB of memory, we need to increase the CPU count to 6.

It's currently [failing with](https://github.com/bitcoin/bitcoin/runs/2273962280):
>  Requested memory is too high! You can request at most 4G per CPU