### PR TITLE
Fix a typo in guix-build output

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -262,7 +262,7 @@ INFO: Building ${VERSION:?not set} for platform triple ${HOST:?not set}:
           ...bind-mounted in container to: '/bitcoin'
       ...in build directory: '$(distsrc_for_host "$HOST")'
           ...bind-mounted in container to: '$(DISTSRC_BASE=/distsrc-base && distsrc_for_host "$HOST")'
-      ...outdirting in: '$(outdir_for_host "$HOST")'
+      ...outputting in: '$(outdir_for_host "$HOST")'
           ...bind-mounted in container to: '$(OUTDIR_BASE=/outdir-base && outdir_for_host "$HOST")'
 EOF
 


### PR DESCRIPTION
This was overlooked in #21375.