### PR TITLE
fuzz: Fix uninitialized read in i2p test

### DIFF
--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -7,6 +7,14 @@
 #include <util/rbf.h>
 #include <version.h>
 
+bool FuzzedSock::Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred ) const
+{
+    if (!m_fuzzed_data_provider.ConsumeBool()) {
+        return false;
+    }
+    if (occurred) *occurred = 0;
+    return true;
+}
 
 void FillNode(FuzzedDataProvider& fuzzed_data_provider, CNode& node, bool init_version) noexcept
 {

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -738,12 +738,10 @@ public:
         return 0;
     }
 
-    bool Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred = nullptr) const override
-    {
-        return m_fuzzed_data_provider.ConsumeBool();
-    }
+    bool Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred = nullptr) const override;
 
-    bool IsConnected(std::string& errmsg) const override {
+    bool IsConnected(std::string& errmsg) const override
+    {
         if (m_fuzzed_data_provider.ConsumeBool()) {
             return true;
         }


### PR DESCRIPTION
Can be tested with:

```
./test/fuzz/test_runner.py -l DEBUG --valgrind ../btc_qa_assets/fuzz_seed_corpus/ i2p
```

```
==22582== Conditional jump or move depends on uninitialised value(s)
==22582==    at 0x6BB2D8: __sanitizer_cov_trace_const_cmp1 (in /tmp/bitcoin-core/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/test/fuzz/fuzz)
==22582==    by 0xB305DB: ConnectSocketDirectly(CService const&, Sock const&, int, bool) (netbase.cpp:570)
==22582==    by 0x8AAA5D: i2p::sam::Session::Hello() const (i2p.cpp:284)
==22582==    by 0x8A6FA0: i2p::sam::Session::CreateIfNotCreatedAlready() (i2p.cpp:352)
==22582==    by 0x8A6742: i2p::sam::Session::Listen(i2p::Connection&) (i2p.cpp:134)
==22582==    by 0x7A6C42: i2p_fuzz_target(Span<unsigned char const>) (i2p.cpp:37)