### PR TITLE
WIP: Reduce MinRelayFee slower when Mempool utilised and faster when needed.

### DIFF
--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -24,7 +24,6 @@ struct MockedTxPool : public CTxMemPool {
     void RollingFeeUpdate()
     {
         lastRollingFeeUpdate = GetTime();
-        blockSinceLastRollingFeeBump = true;
     }
 };
 

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -548,29 +548,9 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
 
     std::vector<CTransactionRef> vtx;
     SetMockTime(42);
-    SetMockTime(42 + CTxMemPool::ROLLING_FEE_HALFLIFE);
     BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);
     // ... we should keep the same min fee until we get a block
     pool.removeForBlock(vtx, 1);
-    SetMockTime(42 + 2*CTxMemPool::ROLLING_FEE_HALFLIFE);
-    BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), llround((maxFeeRateRemoved.GetFeePerK() + 1000)/2.0));
-    // ... then feerate should drop 1/2 each halflife
-
-    SetMockTime(42 + 2*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2);
-    BOOST_CHECK_EQUAL(pool.GetMinFee(pool.DynamicMemoryUsage() * 5 / 2).GetFeePerK(), llround((maxFeeRateRemoved.GetFeePerK() + 1000)/4.0));
-    // ... with a 1/2 halflife when mempool is < 1/2 its target size
-
-    SetMockTime(42 + 2*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2 + CTxMemPool::ROLLING_FEE_HALFLIFE/4);
-    BOOST_CHECK_EQUAL(pool.GetMinFee(pool.DynamicMemoryUsage() * 9 / 2).GetFeePerK(), llround((maxFeeRateRemoved.GetFeePerK() + 1000)/8.0));
-    // ... with a 1/4 halflife when mempool is < 1/4 its target size
-
-    SetMockTime(42 + 7*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2 + CTxMemPool::ROLLING_FEE_HALFLIFE/4);
-    BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), 1000);
-    // ... but feerate should never drop below 1000
-
-    SetMockTime(42 + 8*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2 + CTxMemPool::ROLLING_FEE_HALFLIFE/4);
-    BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), 0);
-    // ... unless it has gone all the way to 0 (after getting past 1000/2)
 }
 
 inline CTransactionRef make_tx(std::vector<CAmount>&& output_values, std::vector<CTransactionRef>&& inputs=std::vector<CTransactionRef>(), std::vector<uint32_t>&& input_indices=std::vector<uint32_t>())

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -486,7 +486,6 @@ protected:
     uint64_t cachedInnerUsage GUARDED_BY(cs); //!< sum of dynamic memory usage of all the map elements (NOT the maps themselves)
 
     mutable int64_t lastRollingFeeUpdate;
-    mutable bool blockSinceLastRollingFeeBump;
     mutable double rollingMinimumFeeRate; //!< minimum fee to get into the pool, decreases exponentially
     mutable Epoch m_epoch GUARDED_BY(cs);
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -487,6 +487,7 @@ protected:
 
     mutable int64_t lastRollingFeeUpdate;
     mutable double rollingMinimumFeeRate; //!< minimum fee to get into the pool, decreases exponentially
+    mutable double bumpedMinimumFeeRate; //!< The highest the fee rate got to last time mempool was full
     mutable Epoch m_epoch GUARDED_BY(cs);
 
     // In-memory counter for external mempool tracking purposes.
@@ -499,9 +500,6 @@ protected:
     bool m_is_loaded GUARDED_BY(cs){false};
 
 public:
-
-    static const int ROLLING_FEE_HALFLIFE = 60 * 60 * 12; // public only for testing
-
     typedef boost::multi_index_container<
         CTxMemPoolEntry,
         boost::multi_index::indexed_by<


### PR DESCRIPTION
I'm not sure whether to label this WIP or not. It's a little experimental, and perhaps only needed on nodes with a small maxmempool (tested on 50MB).

It's attempting to address the issue #21558 

Example in action:-
![image](https://user-images.githubusercontent.com/1530283/114637927-0df8cc00-9cfd-11eb-8d14-707010f736e2.png)
