### PR TITLE
ChainstateManager locking improvements

### DIFF
--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -49,14 +49,19 @@ BOOST_AUTO_TEST_CASE(chainstatemanager)
     auto all = manager.GetAll();
     BOOST_CHECK_EQUAL_COLLECTIONS(all.begin(), all.end(), chainstates.begin(), chainstates.end());
 
-    auto& active_chain = manager.ActiveChain();
-    BOOST_CHECK_EQUAL(&active_chain, &c1.m_chain);
+    CBlockIndex* exp_tip;
+    {
+        LOCK(::cs_main);
 
-    BOOST_CHECK_EQUAL(manager.ActiveHeight(), -1);
+        auto& active_chain = manager.ActiveChain();
+        BOOST_CHECK_EQUAL(&active_chain, &c1.m_chain);
 
-    auto active_tip = manager.ActiveTip();
-    auto exp_tip = c1.m_chain.Tip();
-    BOOST_CHECK_EQUAL(active_tip, exp_tip);
+        BOOST_CHECK_EQUAL(manager.ActiveHeight(), -1);
+
+        auto active_tip = manager.ActiveTip();
+        exp_tip = c1.m_chain.Tip();
+        BOOST_CHECK_EQUAL(active_tip, exp_tip);
+    }
 
     auto& validated_cs = manager.ValidatedChainstate();
     BOOST_CHECK_EQUAL(&validated_cs, &c1);
@@ -87,28 +92,31 @@ BOOST_AUTO_TEST_CASE(chainstatemanager)
     auto all2 = manager.GetAll();
     BOOST_CHECK_EQUAL_COLLECTIONS(all2.begin(), all2.end(), chainstates.begin(), chainstates.end());
 
-    auto& active_chain2 = manager.ActiveChain();
-    BOOST_CHECK_EQUAL(&active_chain2, &c2.m_chain);
+    {
+        LOCK(::cs_main);
+        auto& active_chain2 = manager.ActiveChain();
+        BOOST_CHECK_EQUAL(&active_chain2, &c2.m_chain);
 
-    BOOST_CHECK_EQUAL(manager.ActiveHeight(), 0);
+        BOOST_CHECK_EQUAL(manager.ActiveHeight(), 0);
 
-    auto active_tip2 = manager.ActiveTip();
-    auto exp_tip2 = c2.m_chain.Tip();
-    BOOST_CHECK_EQUAL(active_tip2, exp_tip2);
+        auto active_tip2 = manager.ActiveTip();
+        auto exp_tip2 = c2.m_chain.Tip();
+        BOOST_CHECK_EQUAL(active_tip2, exp_tip2);
 
-    // Ensure that these pointers actually correspond to different
-    // CCoinsViewCache instances.
-    BOOST_CHECK(exp_tip != exp_tip2);
+        // Ensure that these pointers actually correspond to different
+        // CCoinsViewCache instances.
+        BOOST_CHECK(exp_tip != exp_tip2);
 
-    auto& validated_cs2 = manager.ValidatedChainstate();
-    BOOST_CHECK_EQUAL(&validated_cs2, &c1);
+        auto& validated_cs2 = manager.ValidatedChainstate();
+        BOOST_CHECK_EQUAL(&validated_cs2, &c1);
 
-    auto& validated_chain = manager.ValidatedChain();
-    BOOST_CHECK_EQUAL(&validated_chain, &c1.m_chain);
+        auto& validated_chain = manager.ValidatedChain();
+        BOOST_CHECK_EQUAL(&validated_chain, &c1.m_chain);
 
-    auto validated_tip = manager.ValidatedTip();
-    exp_tip = c1.m_chain.Tip();
-    BOOST_CHECK_EQUAL(validated_tip, exp_tip);
+        auto validated_tip = manager.ValidatedTip();
+        exp_tip = c1.m_chain.Tip();
+        BOOST_CHECK_EQUAL(validated_tip, exp_tip);
+    }
 
     // Let scheduler events finish running to avoid accessing memory that is going to be unloaded
     SyncWithValidationInterfaceQueue();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -106,7 +106,6 @@ ChainstateManager g_chainman;
 
 CChainState& ChainstateActive()
 {
-    LOCK(::cs_main);
     assert(g_chainman.m_active_chainstate);
     return *g_chainman.m_active_chainstate;
 }
@@ -5181,7 +5180,6 @@ double GuessVerificationProgress(const ChainTxData& data, const CBlockIndex *pin
 }
 
 std::optional<uint256> ChainstateManager::SnapshotBlockhash() const {
-    LOCK(::cs_main);
     CChainState* active_cs = m_active_chainstate.load();
     if (active_cs != nullptr && !active_cs->m_from_snapshot_blockhash.IsNull()) {
         // If a snapshot chainstate exists, it will always be our active.
@@ -5519,7 +5517,6 @@ bool ChainstateManager::PopulateAndValidateSnapshot(
 
 CChainState& ChainstateManager::ActiveChainstate() const
 {
-    LOCK(::cs_main);
     CChainState* active_cs = m_active_chainstate.load();
     assert(active_cs);
     return *active_cs;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5479,10 +5479,10 @@ bool ChainstateManager::PopulateAndValidateSnapshot(
         return false;
     }
 
-    snapshot_chainstate.m_chain.SetTip(snapshot_start_block);
-
     // The remainder of this function requires modifying data protected by cs_main.
     LOCK(::cs_main);
+
+    snapshot_chainstate.m_chain.SetTip(snapshot_start_block);
 
     // Fake various pieces of CBlockIndex state:
     //

--- a/src/validation.h
+++ b/src/validation.h
@@ -815,6 +815,12 @@ private:
 class ChainstateManager
 {
 private:
+    //! Serializes access to the references of all chainstates being
+    //! managed by this object (m_ibd_chainstate, m_snapshot_chainstate).
+    //! Note that this does not manage m_active_chainstate, which is has
+    //! no need for a mutex due to its use of std::atomic.
+    mutable RecursiveMutex m_cs_chainstates;
+
     //! The chainstate used under normal operation (i.e. "regular" IBD) or, if
     //! a snapshot is in use, for background validation.
     //!
@@ -830,7 +836,7 @@ private:
     //! This is especially important when, e.g., calling ActivateBestChain()
     //! on all chainstates because we are not able to hold ::cs_main going into
     //! that call.
-    std::unique_ptr<CChainState> m_ibd_chainstate GUARDED_BY(::cs_main);
+    std::unique_ptr<CChainState> m_ibd_chainstate GUARDED_BY(m_cs_chainstates);
 
     //! A chainstate initialized on the basis of a UTXO snapshot. If this is
     //! non-null, it is always our active chainstate.
@@ -841,7 +847,7 @@ private:
     //! This is especially important when, e.g., calling ActivateBestChain()
     //! on all chainstates because we are not able to hold ::cs_main going into
     //! that call.
-    std::unique_ptr<CChainState> m_snapshot_chainstate GUARDED_BY(::cs_main);
+    std::unique_ptr<CChainState> m_snapshot_chainstate GUARDED_BY(m_cs_chainstates);
 
     //! Points to either the ibd or snapshot chainstate; indicates our
     //! most-work chain.

--- a/src/validation.h
+++ b/src/validation.h
@@ -875,6 +875,8 @@ public:
     //! Instantiate a new chainstate and assign it based upon whether it is
     //! from a snapshot.
     //!
+    //! cs_main only required for access to m_blockman.
+    //!
     //! @param[in] mempool              The mempool to pass to the chainstate
     //                                  constructor
     //! @param[in] snapshot_blockhash   If given, signify that this chainstate

--- a/src/validation.h
+++ b/src/validation.h
@@ -991,7 +991,7 @@ public:
 };
 
 /** DEPRECATED! Please use node.chainman instead. May only be used in validation.cpp internally */
-extern ChainstateManager g_chainman GUARDED_BY(::cs_main);
+extern ChainstateManager g_chainman;
 
 /** Please prefer the identical ChainstateManager::ActiveChainstate */
 CChainState& ChainstateActive();

--- a/src/validation.h
+++ b/src/validation.h
@@ -601,7 +601,7 @@ public:
 
     //! The current chain of blockheaders we consult and build on.
     //! @see CChain, CBlockIndex.
-    CChain m_chain;
+    CChain m_chain GUARDED_BY(::cs_main);
 
     /**
      * The blockhash which is the base of the snapshot this chainstate was created from.
@@ -725,7 +725,7 @@ public:
     /** Ensures we have a genesis block in the block tree, possibly writing one to disk. */
     bool LoadGenesisBlock(const CChainParams& chainparams);
 
-    void PruneBlockIndexCandidates();
+    void PruneBlockIndexCandidates() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     void UnloadBlockIndex();
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -832,10 +832,6 @@ private:
     //!
     //! Once this pointer is set to a corresponding chainstate, it will not
     //! be reset until init.cpp:Shutdown().
-    //!
-    //! This is especially important when, e.g., calling ActivateBestChain()
-    //! on all chainstates because we are not able to hold ::cs_main going into
-    //! that call.
     std::unique_ptr<CChainState> m_ibd_chainstate GUARDED_BY(m_cs_chainstates);
 
     //! A chainstate initialized on the basis of a UTXO snapshot. If this is
@@ -843,21 +839,10 @@ private:
     //!
     //! Once this pointer is set to a corresponding chainstate, it will not
     //! be reset until init.cpp:Shutdown().
-    //!
-    //! This is especially important when, e.g., calling ActivateBestChain()
-    //! on all chainstates because we are not able to hold ::cs_main going into
-    //! that call.
     std::unique_ptr<CChainState> m_snapshot_chainstate GUARDED_BY(m_cs_chainstates);
 
     //! Points to either the ibd or snapshot chainstate; indicates our
     //! most-work chain.
-    //!
-    //! Once this pointer is set to a corresponding chainstate, it will not
-    //! be reset until init.cpp:Shutdown().
-    //!
-    //! This is especially important when, e.g., calling ActivateBestChain()
-    //! on all chainstates because we are not able to hold ::cs_main going into
-    //! that call.
     std::atomic<CChainState*> m_active_chainstate {nullptr};
 
     //! If true, the assumed-valid chainstate has been fully validated

--- a/src/validation.h
+++ b/src/validation.h
@@ -852,7 +852,7 @@ private:
     //! This is especially important when, e.g., calling ActivateBestChain()
     //! on all chainstates because we are not able to hold ::cs_main going into
     //! that call.
-    std::atomic<CChainState*> m_active_chainstate GUARDED_BY(::cs_main) {nullptr};
+    std::atomic<CChainState*> m_active_chainstate {nullptr};
 
     //! If true, the assumed-valid chainstate has been fully validated
     //! by the background validation chainstate.

--- a/src/validation.h
+++ b/src/validation.h
@@ -852,7 +852,7 @@ private:
     //! This is especially important when, e.g., calling ActivateBestChain()
     //! on all chainstates because we are not able to hold ::cs_main going into
     //! that call.
-    CChainState* m_active_chainstate GUARDED_BY(::cs_main) {nullptr};
+    std::atomic<CChainState*> m_active_chainstate GUARDED_BY(::cs_main) {nullptr};
 
     //! If true, the assumed-valid chainstate has been fully validated
     //! by the background validation chainstate.


### PR DESCRIPTION
Hopefully this'll make everyone happy, and clarify some chainstate locking issues going forward.

### Background 

There is some amount of confusion due to my choice to conflate use of `cs_main` between
- its original purpose: guarding legacy data structures related to CChainState-related data (i.e. pre-`ChainstateManager` coverage of `chainActive`), and
- its new purpose: guarding *pointers* to the constituent CChainState instances managed by ChainstateManager, e.g. `m_ibd_chainstate`, `m_active_chainstate`.

I initially thought that reusing cs_main would be a simplification, but it turned out to just be mostly confusing.

As a quick refresher, ChainstateManager manages two constituent CChainState instances (`m_ibd_chainstate`, `m_snapshot_chainstate`) and reveals a pointer to the one that is in active use (`m_active_chainstate`) per the assumeutxo semantics. As [@jnewbery has pointed out](https://github.com/bitcoin/bitcoin/pull/19806#issuecomment-768946522), the active pointer doesn't need to be guarded by a mutex, but can be marked `atomic` to avoid explicit locking.

Throughout the course of [deglobalizing chainstate use](https://github.com/bitcoin/bitcoin/pull/20158), @dongcarl has had to embed `cs_main` acquisitions in the active chainstate accessor functions (e.g. ::ChainstateActive()) to avoid the risk of unserialized access to the `ChainstateManager::m_active_chainstate` state. This is suboptimal because callers are almost always already holding cs_main anyway, so we just end up recursively acquiring the lock in many cases. And fundamentally, cs_main use isn't necessary for that once we decouple chainstate *pointer* management from cs_main.

### These changes

- make `ChainstateManager::m_active_chainstate` atomic to avoid requiring explicit locking (per @jnewbery's suggestion),
- introduce `ChainstateManager::m_cs_chainstates` to relieve cs_main of guarding the internal chainstates managed by ChainstateManager,
- remove the `cs_main` acquisitions in `::ChainstateActive()` and `ChainstateManager::ActiveChainstate()`, which are no longer necessary, and
- annotate `CChainState::m_chain` as guarded by cs_main, which was an implicit requirement that I'm just making explicit here.