### PR TITLE
doc: Fix typos from codespell

### DIFF
--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -295,7 +295,7 @@ rebuild _just_ this derivation in a single-threaded fashion:
 $ guix build --cores=1 /gnu/store/...-foo-3.6.12.drv
 ```
 
-If the single-threaded rebuild stil did not succeed, you may need to dig deeper.
+If the single-threaded rebuild did not succeed, you may need to dig deeper.
 You may view `foo`'s build logs in `less` like so (please replace paths with the
 path you see in the build failure output):
 

--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -15,7 +15,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/libexec/prelude.bash"
 ###################
 
 ################
-# Required non-builtin commands should be invokable
+# Required non-builtin commands should be invocable
 ################
 
 check_tools cat mkdir make git guix

--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -9,7 +9,7 @@ source contrib/shell/realpath.bash
 source contrib/shell/git-utils.bash
 
 ################
-# Required non-builtin commands should be invokable
+# Required non-builtin commands should be invocable
 ################
 
 check_tools() {

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -34,7 +34,7 @@ void initialize_tx_pool()
 
     for (int i = 0; i < 2 * COINBASE_MATURITY; ++i) {
         CTxIn in = MineBlock(g_setup->m_node, P2WSH_OP_TRUE);
-        // Remember the txids to avoid expensive disk acess later on
+        // Remember the txids to avoid expensive disk access later on
         auto& outpoints = i < COINBASE_MATURITY ?
                               g_outpoints_coinbase_init_mature :
                               g_outpoints_coinbase_init_immature;

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -26,7 +26,7 @@ public:
     /** Check if we already have an orphan transaction (by txid or wtxid) */
     bool HaveTx(const GenTxid& gtxid) const LOCKS_EXCLUDED(::g_cs_orphans);
 
-    /** Get an orphan transaction and its orginating peer
+    /** Get an orphan transaction and its originating peer
      * (Transaction ref will be nullptr if not found)
      */
     std::pair<CTransactionRef, NodeId> GetTx(const uint256& txid) const EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans);

--- a/src/txrequest.cpp
+++ b/src/txrequest.cpp
@@ -486,7 +486,7 @@ private:
     }
 
     //! Make the data structure consistent with a given point in time:
-    //! - REQUESTED annoucements with expiry <= now are turned into COMPLETED.
+    //! - REQUESTED announcements with expiry <= now are turned into COMPLETED.
     //! - CANDIDATE_DELAYED announcements with reqtime <= now are turned into CANDIDATE_{READY,BEST}.
     //! - CANDIDATE_{READY,BEST} announcements with reqtime > now are turned into CANDIDATE_DELAYED.
     void SetTimePoint(std::chrono::microseconds now, std::vector<std::pair<NodeId, GenTxid>>* expired)


### PR DESCRIPTION
Typos from codespell linter: https://cirrus-ci.com/task/6677401661865984?logs=lint#L856
- txrequest.cpp: `annoucements` ==> `announcements`
- contrib/guix/README.md:298: `stil` ==> `still`
- contrib/guix/guix-build:18: `invokable` ==> `invocable`
- contrib/guix/libexec/prelude.bash:12: `invokable` ==> `invocable`
- src/test/fuzz/tx_pool.cpp:37: `acess` ==> `access`
- src/txorphanage.h:29: `orginating` ==> `originating`