### PR TITLE
i2p: always check the return value of Sock::Wait()

### DIFF
--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -147,7 +147,9 @@ bool Session::Accept(Connection& conn)
     try {
         while (!*m_interrupt) {
             Sock::Event occurred;
-            conn.sock->Wait(MAX_WAIT_FOR_IO, Sock::RECV, &occurred);
+            if (!conn.sock->Wait(MAX_WAIT_FOR_IO, Sock::RECV, &occurred)) {
+                throw std::runtime_error("wait on socket failed");
+            }
 
             if ((occurred & Sock::RECV) == 0) {
                 // Timeout, no incoming connections within MAX_WAIT_FOR_IO.


### PR DESCRIPTION
If `Sock::Wait()` fails, then cancel the `Accept()` method.

Not checking the return value may cause an uninitialized read a few lines below when we read the `occurred` variable.

[Spotted](https://github.com/bitcoin/bitcoin/pull/21630#issuecomment-814765659) by MarcoFalke, thanks!