### PR TITLE
p2p, bugfix: use NetPermissions::HasFlag() in CConnman::Bind()

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2408,8 +2408,9 @@ NodeId CConnman::GetNewNodeId()
 
 
 bool CConnman::Bind(const CService &addr, unsigned int flags, NetPermissionFlags permissions) {
-    if (!(flags & BF_EXPLICIT) && !IsReachable(addr))
+    if (!(flags & BF_EXPLICIT) && !IsReachable(addr)) {
         return false;
+    }
     bilingual_str strError;
     if (!BindListenPort(addr, strError, permissions)) {
         if ((flags & BF_REPORT_ERROR) && clientInterface) {
@@ -2418,7 +2419,7 @@ bool CConnman::Bind(const CService &addr, unsigned int flags, NetPermissionFlags
         return false;
     }
 
-    if (addr.IsRoutable() && fDiscover && !(flags & BF_DONT_ADVERTISE) && !(permissions & PF_NOBAN)) {
+    if (addr.IsRoutable() && fDiscover && !(flags & BF_DONT_ADVERTISE) && !NetPermissions::HasFlag(permissions, NetPermissionFlags::PF_NOBAN)) {
         AddLocal(addr, LOCAL_BIND);
     }
 

--- a/src/net_permissions.h
+++ b/src/net_permissions.h
@@ -51,8 +51,14 @@ public:
     {
         flags = static_cast<NetPermissionFlags>(flags | f);
     }
+    //! ClearFlag is only called with `f` == NetPermissionFlags::PF_ISIMPLICIT.
+    //! If that should change in the future, be aware that ClearFlag should not
+    //! be called with a subflag of a multiflag, e.g. NetPermissionFlags::PF_RELAY
+    //! or NetPermissionFlags::PF_DOWNLOAD, as that would leave `flags` in an
+    //! invalid state corresponding to none of the existing flags.
     static inline void ClearFlag(NetPermissionFlags& flags, NetPermissionFlags f)
     {
+        assert(f == NetPermissionFlags::PF_ISIMPLICIT);
         flags = static_cast<NetPermissionFlags>(flags & ~f);
     }
 };

--- a/src/test/fuzz/net_permissions.cpp
+++ b/src/test/fuzz/net_permissions.cpp
@@ -25,7 +25,7 @@ FUZZ_TARGET(net_permissions)
         (void)NetPermissions::ToStrings(net_whitebind_permissions.m_flags);
         (void)NetPermissions::AddFlag(net_whitebind_permissions.m_flags, net_permission_flags);
         assert(NetPermissions::HasFlag(net_whitebind_permissions.m_flags, net_permission_flags));
-        (void)NetPermissions::ClearFlag(net_whitebind_permissions.m_flags, net_permission_flags);
+        (void)NetPermissions::ClearFlag(net_whitebind_permissions.m_flags, NetPermissionFlags::PF_ISIMPLICIT);
         (void)NetPermissions::ToStrings(net_whitebind_permissions.m_flags);
     }
 
@@ -35,7 +35,7 @@ FUZZ_TARGET(net_permissions)
         (void)NetPermissions::ToStrings(net_whitelist_permissions.m_flags);
         (void)NetPermissions::AddFlag(net_whitelist_permissions.m_flags, net_permission_flags);
         assert(NetPermissions::HasFlag(net_whitelist_permissions.m_flags, net_permission_flags));
-        (void)NetPermissions::ClearFlag(net_whitelist_permissions.m_flags, net_permission_flags);
+        (void)NetPermissions::ClearFlag(net_whitelist_permissions.m_flags, NetPermissionFlags::PF_ISIMPLICIT);
         (void)NetPermissions::ToStrings(net_whitelist_permissions.m_flags);
     }
 }


### PR DESCRIPTION
This is a bugfix follow-up to #16248 and #19191 that was noticed in #21506. Both v0.21 and master are affected.

Since #19191, noban is a multi-flag that implies download, so the conditional in `CConnman::Bind()` using a bitwise AND on noban will return the same result for both the noban status and the download status. This means that download peers are incorrectly not being added to local addresses because they are mistakenly seen as noban peers.

The second commit adds unit test coverage to illustrate and test the noban/download relationship and the `NetPermissions` operations involving them.

The final commit adds documentation and disallows calling `NetPermissions::ClearFlag()` with any second param other than `NetPermissionFlags` "implicit" -- per current usage in the codebase -- because `ClearFlag()` should not be called with any second param that is a subflag of a multiflag, e.g. "relay" or "download," as that would leave the result in an invalid state corresponding to none of the existing NetPermissionFlags. Thanks to Vasil Dimov for noticing this.