### PR TITLE
-daemonwait change to -daemon

### DIFF
--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -18,7 +18,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-ExecStart=/usr/bin/bitcoind -daemonwait \
+ExecStart=/usr/bin/bitcoind -daemon \
                             -pid=/run/bitcoind/bitcoind.pid \
                             -conf=/etc/bitcoin/bitcoin.conf \
                             -datadir=/var/lib/bitcoind


### PR DESCRIPTION
`-daemonwait change to -daemon`

Bugfix for Ubuntu 20.04 (systemd)

Tested with : /lib/systemd/system/bitcoind.service

`
[Service]
ExecStart=/usr/local/bin/bitcoind -daemon \
                            -pid=/run/bitcoind/bitcoind.pid \
                            -conf=/etc/bitcoin/bitcoin.conf \
                            -datadir=/var/lib/bitcoind
`

sudo systemctl daemon-reload
sudo systemctl start bitcoind

bitcoin has been built by hand which explain the change to /usr/local/bin/bitcoind when I did my test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bitcoin/bitcoin/21646)
<!-- Reviewable:end -->
