### PR TITLE
build, qt: Make Qt rcc output always deterministic

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -56,7 +56,6 @@ script: |
   HOST_CXXFLAGS="-O2 -g"
   HOST_LDFLAGS_BASE="-static-libstdc++ -Wl,-O2"
 
-  export QT_RCC_SOURCE_DATE_OVERRIDE=1
   export TZ="UTC"
   export BUILD_DIR="$PWD"
   mkdir -p ${WRAP_DIR}

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -42,7 +42,6 @@ script: |
   FAKETIME_HOST_PROGS=""
   FAKETIME_PROGS="ar ranlib date dmg xorrisofs"
 
-  export QT_RCC_SOURCE_DATE_OVERRIDE=1
   export TZ="UTC"
   export BUILD_DIR="$PWD"
   mkdir -p ${WRAP_DIR}

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -38,7 +38,6 @@ script: |
   HOST_CFLAGS="-O2 -g -fno-ident"
   HOST_CXXFLAGS="-O2 -g -fno-ident"
 
-  export QT_RCC_SOURCE_DATE_OVERRIDE=1
   export TZ="UTC"
   export BUILD_DIR="$PWD"
   mkdir -p ${WRAP_DIR}

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -175,7 +175,6 @@ case "$HOST" in
 esac
 
 # Environment variables for determinism
-export QT_RCC_SOURCE_DATE_OVERRIDE=1
 export TAR_OPTIONS="--owner=0 --group=0 --numeric-owner --mtime='@${SOURCE_DATE_EPOCH}' --sort=name"
 export TZ="UTC"
 case "$HOST" in

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -172,8 +172,6 @@ $(package)_config_opts_aarch64_android += -android-arch arm64-v8a
 $(package)_config_opts_armv7a_android += -android-arch armeabi-v7a
 $(package)_config_opts_x86_64_android += -android-arch x86_64
 $(package)_config_opts_i686_android += -android-arch i686
-
-$(package)_build_env += QT_RCC_SOURCE_DATE_OVERRIDE=1
 endef
 
 define $(package)_fetch_cmds

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -365,12 +365,12 @@ translate: $(srcdir)/qt/bitcoinstrings.cpp $(QT_FORMS_UI) $(QT_FORMS_UI) $(BITCO
 $(QT_QRC_LOCALE_CPP): $(QT_QRC_LOCALE) $(QT_QM)
 	@test -f $(RCC)
 	@cp -f $< $(@D)/temp_$(<F)
-	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(RCC) -name bitcoin_locale $(@D)/temp_$(<F) > $@
+	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(RCC) -name bitcoin_locale --format-version 1 $(@D)/temp_$(<F) > $@
 	@rm $(@D)/temp_$(<F)
 
 $(QT_QRC_CPP): $(QT_QRC) $(QT_FORMS_H) $(RES_FONTS) $(RES_ICONS) $(RES_ANIMATION)
 	@test -f $(RCC)
-	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(RCC) -name bitcoin $< > $@
+	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(RCC) -name bitcoin --format-version 1 $< > $@
 
 CLEAN_QT = $(nodist_qt_libbitcoinqt_a_SOURCES) $(QT_QM) $(QT_FORMS_H) qt/*.gcda qt/*.gcno qt/temp_bitcoin_locale.qrc
 


### PR DESCRIPTION
The Qt Resource Compiler ([rcc](https://doc.qt.io/qt-5/rcc.html)) has a command-line option `--format-version` which has the [default value](https://code.qt.io/cgit/qt/qtbase.git/tree/src/tools/rcc/main.cpp?h=5.12.10#n172) 2.

The only difference from `--format-version 1` is adding a [last modified timestamp](https://code.qt.io/cgit/qt/qtbase.git/tree/src/tools/rcc/rcc.cpp?h=5.12.10#n207) to the output file ([credits](https://github.com/bitcoin/bitcoin/pull/21654#issuecomment-819198228) to **fanquake**). That, in turn, forces us to use `QT_RCC_SOURCE_DATE_OVERRIDE=1` to get deterministic builds (#13732).

This change makes rcc output always deterministic by using `--format-version 1` option that makes usage of the
`QT_RCC_SOURCE_DATE_OVERRIDE` needless.

---

Also it improves interaction with ccache:

On master (f6c44e999b7d1d9a0de5d678ac8f1679aa271f65):
```
$ make && make clean && ccache --zero-stats && make && ccache --show-stats
...
cache directory                     /home/hebasto/.ccache
primary config                      /home/hebasto/.ccache/ccache.conf
secondary config      (readonly)    /etc/ccache.conf
stats updated                       Sun Apr 11 15:45:43 2021
stats zeroed                        Sun Apr 11 15:45:05 2021
cache hit (direct)                   638
cache hit (preprocessed)               0
cache miss                             1
cache hit rate                     99.84 %
called for link                       10
cleanups performed                     0
files in cache                     20023
cache size                          13.2 GB
max cache size                      15.0 GB
```

The missed file is always `qt/libbitcoinqt_a-qrc_bitcoin_locale.o`.

With this PR:
```
$ make && make clean && ccache --zero-stats && make && ccache --show-stats
...
cache directory                     /home/hebasto/.ccache
primary config                      /home/hebasto/.ccache/ccache.conf
secondary config      (readonly)    /etc/ccache.conf
stats updated                       Sun Apr 11 15:28:46 2021
stats zeroed                        Sun Apr 11 15:28:21 2021
cache hit (direct)                   639
cache hit (preprocessed)               0
cache miss                             0
cache hit rate                    100.00 %
called for link                       10
cleanups performed                     0
files in cache                     20012
cache size                          13.2 GB
max cache size                      15.0 GB
```