### PR TITLE
test: Remove spurious double lock tsan suppressions by bumping to clang-12

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -120,10 +120,10 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_native_qt5.sh"
 
 task:
-  name: '[depends, sanitizers: thread (TSan), no gui] [focal]'
+  name: '[depends, sanitizers: thread (TSan), no gui] [hirsute]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
-    image: ubuntu:focal
+    image: ubuntu:hirsute
     cpu: 6  # Increase CPU and Memory to avoid timeout
     memory: 24G
   env:

--- a/ci/test/00_setup_env_native_tsan.sh
+++ b/ci/test/00_setup_env_native_tsan.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_tsan
-export DOCKER_NAME_TAG=ubuntu:20.04
+export DOCKER_NAME_TAG=ubuntu:hirsute
 export PACKAGES="clang llvm libc++abi-dev libc++-dev python3-zmq"
 export DEP_OPTS="CC=clang CXX='clang++ -stdlib=libc++'"
 export GOAL="install"

--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -3,25 +3,7 @@
 #
 # https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
 
-# double locks (TODO fix)
-mutex:g_genesis_wait_mutex
-mutex:Interrupt
-mutex:CThreadInterrupt
-mutex:CConnman::Interrupt
-mutex:CConnman::WakeMessageHandler
-mutex:CConnman::ThreadOpenConnections
-mutex:CConnman::ThreadOpenAddedConnections
-mutex:CConnman::SocketHandler
-mutex:UpdateTip
-mutex:PeerManagerImpl::UpdatedBlockTip
-mutex:g_best_block_mutex
-
 # race (TODO fix)
-race:CConnman::WakeMessageHandler
-race:CConnman::ThreadMessageHandler
-race:fHaveGenesis
-race:ProcessNewBlock
-race:ThreadImport
 race:LoadWallet
 race:WalletBatch::WriteHDChain
 race:BerkeleyBatch

--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -9,7 +9,6 @@ race:WalletBatch::WriteHDChain
 race:BerkeleyBatch
 race:BerkeleyDatabase
 race:DatabaseBatch
-race:leveldb::DBImpl::DeleteObsoleteFiles
 race:zmq::*
 race:bitcoin-qt
 


### PR DESCRIPTION
The double lock warnings appeared in #19041, but they didn't make any sense. Also, our sync module would detect double locks, if there were any.

Bumping to clang-12 allows us to remove the spurious suppressions needed to run the tests, so do that.