### PR TITLE
doc: remove boostrap info from GUIX_COMMON_FLAGS doc

### DIFF
--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -205,10 +205,7 @@ find output/ -type f -print0 | sort -z | xargs -r0 sha256sum
 
 * _**ADDITIONAL_GUIX_COMMON_FLAGS**_
 
-  Additional flags to be passed to all `guix` commands. For a fully-bootstrapped
-  build, set this to `--bootstrap --no-substitutes` (refer to the [security
-  model section](#choosing-your-security-model) for more details). Note that a
-  fully-bootstrapped build will take quite a long time on the first run.
+  Additional flags to be passed to all `guix` commands.
 
 * _**ADDITIONAL_GUIX_TIMEMACHINE_FLAGS**_
 


### PR DESCRIPTION
Passing `ADDITIONAL_GUIX_COMMON_FLAGS="--no-substitutes --bootstrap"` as suggested doesn't work:
```bash
      ...outputting in: '/bitcoin/guix-build-a1f0b8b62eb8/output/x86_64-linux-gnu'
          ...bind-mounted in container to: '/outdir-base/x86_64-linux-gnu'
guix time-machine: error: bootstrap: unrecognized option
```

and I think bootstrapping is more than covered in the preceding "Choose your security model" section.