### PR TITLE
ci: Only cache depends/sdk-sources for macos/apk task in cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -41,10 +41,12 @@ global_task_template: &GLOBAL_TASK_TEMPLATE
     folder: "/tmp/ccache_dir"
   depends_built_cache:
     folder: "depends/built"
-  depends_sdk_cache:
-    folder: "depends/sdk-sources"
   ci_script:
     - ./ci/test_run_all.sh
+
+depends_sdk_cache_template: &DEPENDS_SDK_CACHE_TEMPLATE
+  depends_sdk_cache:
+    folder: "depends/sdk-sources"
 
 compute_credits_template: &CREDITS_TEMPLATE
   # https://cirrus-ci.org/pricing/#compute-credits
@@ -178,6 +180,7 @@ task:
 
 task:
   name: 'macOS 10.14 [gui, no tests] [focal]'
+  << : *DEPENDS_SDK_CACHE_TEMPLATE
   << : *GLOBAL_TASK_TEMPLATE
   container:
     image: ubuntu:focal
@@ -202,6 +205,7 @@ task:
 
 task:
   name: 'ARM64 Android APK [focal]'
+  << : *DEPENDS_SDK_CACHE_TEMPLATE
   depends_sources_cache:
     folder: "depends/sources"
   << : *GLOBAL_TASK_TEMPLATE


### PR DESCRIPTION
Only macos needs the sdk-sources, so move it there (and remove it from showing up in the other tasks)