### PR TITLE
fuzz: Avoid use of low file descriptor ids (which may be in use) in FuzzedSock

### DIFF
--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -577,15 +577,15 @@ class FuzzedSock : public Sock
 public:
     explicit FuzzedSock(FuzzedDataProvider& fuzzed_data_provider) : m_fuzzed_data_provider{fuzzed_data_provider}
     {
-          m_socket = fuzzed_data_provider.ConsumeIntegral<SOCKET>();
+          m_socket = fuzzed_data_provider.ConsumeIntegralInRange<SOCKET>(INVALID_SOCKET - 1, INVALID_SOCKET);
     }
 
     ~FuzzedSock() override
     {
         // Sock::~Sock() will be called after FuzzedSock::~FuzzedSock() and it will call
         // Sock::Reset() (not FuzzedSock::Reset()!) which will call CloseSocket(m_socket).
-        // Avoid closing an arbitrary file descriptor (m_socket is just a random number which
-        // may concide with a real opened file descriptor).
+        // Avoid closing an arbitrary file descriptor (m_socket is just a random very high number which
+        // theoretically may concide with a real opened file descriptor).
         Reset();
     }
 

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -78,8 +78,7 @@ public:
     explicit StaticContentsSock(const std::string& contents) : m_contents{contents}, m_consumed{0}
     {
         // Just a dummy number that is not INVALID_SOCKET.
-        static_assert(INVALID_SOCKET != 1000);
-        m_socket = 1000;
+        m_socket = INVALID_SOCKET - 1;
     }
 
     ~StaticContentsSock() override { Reset(); }


### PR DESCRIPTION
Avoid use of low file descriptor ids (which may be in use) in `FuzzedSock`.

Context: https://github.com/bitcoin/bitcoin/pull/21630/files#r610694541