### PR TITLE
test: Fix TestPotentialDeadLockDetected suppression

### DIFF
--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -16,7 +16,7 @@ race:bitcoin-qt
 deadlock:CChainState::ConnectTip
 
 # Intentional deadlock in tests
-deadlock:TestPotentialDeadLockDetected
+deadlock:sync_tests::potential_deadlock_detected
 
 # Wildcard for all gui tests, should be replaced with non-wildcard suppressions
 race:src/qt/test/*


### PR DESCRIPTION
This PR is a #21669 follow up, and fixes [locally running `make check`](https://github.com/bitcoin/bitcoin/pull/21669#issuecomment-819403540).