### PR TITLE
test: Use called_from_lib to point uninstrumented libs to TSan

### DIFF
--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -4,11 +4,6 @@
 # https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
 
 # race (TODO fix)
-race:LoadWallet
-race:WalletBatch::WriteHDChain
-race:BerkeleyBatch
-race:BerkeleyDatabase
-race:DatabaseBatch
 race:zmq::*
 race:bitcoin-qt
 
@@ -26,9 +21,8 @@ deadlock:src/qt/test/*
 # Can be removed once upgraded to boost test 1.74 in depends
 race:validation_chainstatemanager_tests
 
-# External libraries
-deadlock:libdb
-race:libzmq
+# Uninstrumented external libraries.
+called_from_lib:libdb
 
 # Intermittent issues
 # -------------------


### PR DESCRIPTION
From [docs](https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions):
> `called_from_lib` suppresses all interceptors in a particular library

Could be an alternative to #20558.