### PR TITLE
p2p: 1 IP per-connection policy

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -1075,12 +1075,15 @@ private:
     CNode* FindNode(const CSubNet& subNet);
     CNode* FindNode(const std::string& addrName);
     CNode* FindNode(const CService& addr);
+    CNode* FindNodeByIP(const CService& addr);
 
     /**
      * Determine whether we're already connected to a given address, in order to
      * avoid initiating duplicate connections.
      */
     bool AlreadyConnectedToAddress(const CAddress& addr);
+    bool AlreadyConnectedToIPAddress(const CAddress& addr);
+
 
     bool AttemptToEvictConnection();
     CNode* ConnectNode(CAddress addrConnect, const char *pszDest, bool fCountFailure, ConnectionType conn_type);


### PR DESCRIPTION
Currently, users can open multiple connections to a reachable node using the same IP address and a different port and request blockchain data at each connection. This behavior has the following impacts.
(1) Overwhelm the reachable node and consume its bandwidth by requesting data and discarding it (see video demonstrations here: https://www.dropbox.com/s/pvasua7lnepdgfq/Occupy_Connections.mp4?dl=0 and https://www.dropbox.com/s/45ld1h7cxi3xzj6/RequestingBlockchain.mp4?dl=0)

(2) Undermine the transaction relaying anonymity since multiple connections to each node increase the probability of mapping a transaction to an IP address (currently, the random delay factor in the trickling effect implicitly assumes the attacker has one connection to each node). By establishing multiple connections, the attacker undermines the anonymity property. 

To address the two concerns above, we enforce 1 incoming connection per IP address. Please note that it will not significantly affect the nodes behind NAT since there are close to 10K reachable nodes and NATed nodes only need 8-10 outbound connections. Assuming 10K reachable nodes, each with default 117 incoming connections, there are 10K*117 incoming slots available out of which (10K*8) are supposedly occupied by the reachable nodes. As a result, the network has 1090000 slots for unreachable nodes. In the worst case, (i.e., the unreachable nodes really exceed in count), a natural equilibrium is self-enforced where some of the unreachable nodes must become reachable and support the rest of the network (altruism in the P2P network). 

We were motivated to apply 1IP per-connection policy since we observed malicious behavior on our node whereby two IP addresses occupied multiple incoming connection slots which led to the bandwidth and privacy concerns.