### PR TITLE
doc: note on SDK for macOS depends cross-compile

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -49,6 +49,11 @@ The paths are automatically configured and no other options are needed unless ta
 
     sudo apt-get install curl librsvg2-bin libtiff-tools bsdmainutils cmake imagemagick libz-dev python3-setuptools libtinfo5 xorriso
 
+Note: You must obtain the macOS SDK before proceeding with a cross-compile.
+Under the depends directory, create a subdirectory named `SDKs`.
+Then, place the extracted SDK under this new directory.
+For more information, see [SDK Extraction](../contrib/macdeploy/README.md#sdk-extraction).
+
 #### For Win64 cross compilation
 
 - see [build-windows.md](../doc/build-windows.md#cross-compilation-for-ubuntu-and-windows-subsystem-for-linux)


### PR DESCRIPTION
This PR adds a friendly note for those who are unfamiliar with our depends build system that an extracted SDK is needed before proceeding with a macOS cross-compile. Additionally, it refers a builder to look at [macdeploy](https://github.com/bitcoin/bitcoin/tree/master/contrib/macdeploy#sdk-extraction) for instructions on obtaining the SDK and provides context to where this SDK should reside.

**Master:** [render](https://github.com/bitcoin/bitcoin/blob/master/depends/README.md#for-macos-cross-compilation)
**PR:** [render](https://github.com/bitcoin/bitcoin/blob/241c4017eddbe33a39073766accf556c2cad90a0/depends/README.md#for-macos-cross-compilation)