### PR TITLE
test: use higher value and per-platform assert in cnetaddr link-local test

### DIFF
--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -307,6 +307,9 @@ BOOST_AUTO_TEST_CASE(cnetaddr_basic)
     BOOST_REQUIRE(addr.IsValid());
     BOOST_REQUIRE(addr.IsIPv6());
     BOOST_CHECK(!addr.IsBindAny());
+    const std::string addr_str{addr.ToString()};
+    BOOST_CHECK(addr_str == scoped_addr || addr_str == "fe80:0:0:0:0:0:0:1");
+    // The fallback case "fe80:0:0:0:0:0:0:1" is needed for macOS 10.14/10.15 and (probably) later.
     // Test that the delimiter "%" and default zone id of 0 can be omitted for the default scope.
     BOOST_REQUIRE(LookupHost(link_local + "%0", addr, false));
     BOOST_REQUIRE(addr.IsValid());

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -308,8 +308,13 @@ BOOST_AUTO_TEST_CASE(cnetaddr_basic)
     BOOST_REQUIRE(addr.IsIPv6());
     BOOST_CHECK(!addr.IsBindAny());
     const std::string addr_str{addr.ToString()};
-    BOOST_CHECK(addr_str == scoped_addr || addr_str == "fe80:0:0:0:0:0:0:1");
-    // The fallback case "fe80:0:0:0:0:0:0:1" is needed for macOS 10.14/10.15 and (probably) later.
+#ifdef MAC_OSX
+    // Expect macOS to return the address in this format, without zone ids.
+    BOOST_CHECK_EQUAL(addr_str, "fe80:0:0:0:0:0:0:1");
+#else
+    // Expect normal scoped address functionality on the other platforms.
+    BOOST_CHECK_EQUAL(addr_str, scoped_addr);
+#endif
     // Test that the delimiter "%" and default zone id of 0 can be omitted for the default scope.
     BOOST_REQUIRE(LookupHost(link_local + "%0", addr, false));
     BOOST_REQUIRE(addr.IsValid());

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -300,9 +300,9 @@ BOOST_AUTO_TEST_CASE(cnetaddr_basic)
 
     // IPv6, scoped/link-local. See https://tools.ietf.org/html/rfc4007
     // We support non-negative decimal integers (uint32_t) as zone id indices.
-    // Test with a fairly-high value, e.g. 32, to avoid locally reserved ids.
+    // Test with a high value, e.g. 4096, to avoid any local ids in use.
     const std::string link_local{"fe80::1"};
-    const std::string scoped_addr{link_local + "%32"};
+    const std::string scoped_addr{link_local + "%4096"};
     BOOST_REQUIRE(LookupHost(scoped_addr, addr, false));
     BOOST_REQUIRE(addr.IsValid());
     BOOST_REQUIRE(addr.IsIPv6());


### PR DESCRIPTION
This patch improves the cnetaddr link-local test in `net_tests` by making it platform-specific and by using a higher scoped id value to alleviate recent CI issues.

Closes #21682.