### PR TITLE
build: Use XLIFF file to provide more context to Transifex translators

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -3,5 +3,5 @@ host = https://www.transifex.com
 
 [bitcoin.qt-translation-021x]
 file_filter = src/qt/locale/bitcoin_<lang>.ts
-source_file = src/qt/locale/bitcoin_en.ts
+source_file = src/qt/locale/bitcoin_en.xlf
 source_lang = en

--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -225,6 +225,7 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
   BITCOIN_QT_PATH_PROGS([RCC], [rcc-qt5 rcc5 rcc], $qt_bin_path)
   BITCOIN_QT_PATH_PROGS([LRELEASE], [lrelease-qt5 lrelease5 lrelease], $qt_bin_path)
   BITCOIN_QT_PATH_PROGS([LUPDATE], [lupdate-qt5 lupdate5 lupdate],$qt_bin_path, yes)
+  BITCOIN_QT_PATH_PROGS([LCONVERT], [lconvert-qt5 lconvert5 lconvert], $qt_bin_path, yes)
 
   MOC_DEFS='-DHAVE_CONFIG_H -I$(srcdir)'
   case $host in
@@ -258,7 +259,10 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
       AC_MSG_ERROR([libQtDBus not found. Install libQtDBus or remove --with-qtdbus.])
     fi
     if test "x$LUPDATE" = x; then
-      AC_MSG_WARN([lupdate is required to update qt translations])
+      AC_MSG_WARN([lupdate tool is required to update Qt translations.])
+    fi
+    if test "x$LCONVERT" = x; then
+      AC_MSG_WARN([lconvert tool is required to update Qt translations.])
     fi
   ],[
     bitcoin_enable_qt=no

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -261,13 +261,15 @@ define $(package)_config_cmds
   qtbase/bin/qmake -o qttranslations/Makefile qttranslations/qttranslations.pro && \
   qtbase/bin/qmake -o qttranslations/translations/Makefile qttranslations/translations/translations.pro && \
   qtbase/bin/qmake -o qttools/src/linguist/lrelease/Makefile qttools/src/linguist/lrelease/lrelease.pro && \
-  qtbase/bin/qmake -o qttools/src/linguist/lupdate/Makefile qttools/src/linguist/lupdate/lupdate.pro
+  qtbase/bin/qmake -o qttools/src/linguist/lupdate/Makefile qttools/src/linguist/lupdate/lupdate.pro && \
+  qtbase/bin/qmake -o qttools/src/linguist/lconvert/Makefile qttools/src/linguist/lconvert/lconvert.pro
 endef
 
 define $(package)_build_cmds
   $(MAKE) -C qtbase/src $(addprefix sub-,$($(package)_qt_libs)) && \
   $(MAKE) -C qttools/src/linguist/lrelease && \
   $(MAKE) -C qttools/src/linguist/lupdate && \
+  $(MAKE) -C qttools/src/linguist/lconvert && \
   $(MAKE) -C qttranslations
 endef
 
@@ -275,6 +277,7 @@ define $(package)_stage_cmds
   $(MAKE) -C qtbase/src INSTALL_ROOT=$($(package)_staging_dir) $(addsuffix -install_subtargets,$(addprefix sub-,$($(package)_qt_libs))) && \
   $(MAKE) -C qttools/src/linguist/lrelease INSTALL_ROOT=$($(package)_staging_dir) install_target && \
   $(MAKE) -C qttools/src/linguist/lupdate INSTALL_ROOT=$($(package)_staging_dir) install_target && \
+  $(MAKE) -C qttools/src/linguist/lconvert INSTALL_ROOT=$($(package)_staging_dir) install_target && \
   $(MAKE) -C qttranslations INSTALL_ROOT=$($(package)_staging_dir) install_subtargets
 endef
 

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -356,6 +356,8 @@ $(srcdir)/qt/bitcoinstrings.cpp: FORCE
 translate: $(srcdir)/qt/bitcoinstrings.cpp $(QT_FORMS_UI) $(QT_FORMS_UI) $(BITCOIN_QT_BASE_CPP) qt/bitcoin.cpp $(BITCOIN_QT_WINDOWS_CPP) $(BITCOIN_QT_WALLET_CPP) $(BITCOIN_QT_H) $(BITCOIN_MM)
 	@test -n $(LUPDATE) || echo "lupdate is required for updating translations"
 	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(LUPDATE) $^ -locations relative -no-obsolete -ts $(srcdir)/qt/locale/bitcoin_en.ts
+	@test -n $(LCONVERT) || echo "lconvert is required for updating translations"
+	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(LCONVERT) -o $(srcdir)/qt/locale/bitcoin_en.xlf -i $(srcdir)/qt/locale/bitcoin_en.ts
 
 $(QT_QRC_LOCALE_CPP): $(QT_QRC_LOCALE) $(QT_QM)
 	@test -f $(RCC)

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -309,7 +309,8 @@ void AddressBookPage::on_exportButton_clicked()
 
     if(!writer.write()) {
         QMessageBox::critical(this, tr("Exporting Failed"),
-            tr("There was an error trying to save the address list to %1. Please try again.").arg(filename));
+            //: %1 is a name of the file (e.g., "addrbook.csv") that the bitcoin addresses were exported to.
+            tr("There was an error trying to save the address list to %1. Please try again.", "An error message.").arg(filename));
     }
 }
 

--- a/src/qt/bitcoinstrings.cpp
+++ b/src/qt/bitcoinstrings.cpp
@@ -17,13 +17,17 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "-maxtxfee is set very high! Fees this large could be paid on a single "
 "transaction."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Cannot downgrade wallet from version %i to version %i. Wallet version "
+"unchanged."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Cannot obtain a lock on data directory %s. %s is probably already running."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Cannot provide specific connections and have addrman find outgoing "
 "connections at the same."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Cannot upgrade a non HD split wallet without upgrading to support pre split "
-"keypool. Please use version 169900 or no version specified."),
+"Cannot upgrade a non HD split wallet from version %i to version %i without "
+"upgrading to support pre-split keypool. Please use version %i or no version "
+"specified."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Distributed under the MIT software license, see the accompanying file %s or "
 "%s"),
@@ -31,16 +35,34 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Error reading %s! All keys read correctly, but transaction data or address "
 "book entries might be missing or incorrect."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Error: Dumpfile format record is incorrect. Got \"%s\", expected \"format\"."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Error: Dumpfile identifier record is incorrect. Got \"%s\", expected \"%s\"."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Error: Dumpfile version is not supported. This version of bitcoin-wallet "
+"only supports version 1 dumpfiles. Got dumpfile with version %s"),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Error: Listening for incoming connections failed (listen returned error %s)"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -"
 "fallbackfee."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"File %s already exists. If you are sure this is what you want, move it out "
+"of the way first."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Invalid amount for -maxtxfee=<amount>: '%s' (must be at least the minrelay "
 "fee of %s to prevent stuck transactions)"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "More than one onion bind address is provided. Using %s for the automatically "
 "created Tor onion service."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"No dump file provided. To use createfromdump, -dumpfile=<filename> must be "
+"provided."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"No dump file provided. To use dump, -dumpfile=<filename> must be provided."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"No wallet file format provided. To use createfromdump, -format=<format> must "
+"be provided."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Please check that your computer's date and time are correct! If your clock "
 "is wrong, %s will not work properly."),
@@ -96,10 +118,13 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Unable to rewind the database to a pre-fork state. You will need to "
 "redownload the blockchain"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Warning: Private keys detected in wallet {%s} with disabled private keys"),
+"Unknown wallet file format \"%s\" provided. Please provide one of \"bdb\" or "
+"\"sqlite\"."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Warning: The network does not appear to fully agree! Some miners appear to "
-"be experiencing issues."),
+"Warning: Dumpfile wallet format \"%s\" does not match command line specified "
+"format \"%s\"."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Warning: Private keys detected in wallet {%s} with disabled private keys"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Warning: We do not appear to fully agree with our peers! You may need to "
 "upgrade, or other nodes may need to upgrade."),
@@ -109,7 +134,6 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 QT_TRANSLATE_NOOP("bitcoin-core", "%s is set very high!"),
 QT_TRANSLATE_NOOP("bitcoin-core", "-maxmempool must be at least %d MB"),
 QT_TRANSLATE_NOOP("bitcoin-core", "A fatal internal error occurred, see debug.log for details"),
-QT_TRANSLATE_NOOP("bitcoin-core", "Cannot downgrade wallet"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Cannot resolve -%s address: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Cannot set -peerblockfilters without -blockfilterindex."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Cannot write to data directory '%s'; check permissions."),
@@ -122,6 +146,8 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Could not parse asmap file %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Disk space is too low!"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Do you want to rebuild the block database now?"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Done loading"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Dump file %s does not exist."),
+QT_TRANSLATE_NOOP("bitcoin-core", "Error creating %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error initializing block database"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error initializing wallet database environment %s!"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error loading %s"),
@@ -131,9 +157,17 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Error loading %s: Wallet requires newer versi
 QT_TRANSLATE_NOOP("bitcoin-core", "Error loading block database"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error opening block database"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error reading from database, shutting down."),
+QT_TRANSLATE_NOOP("bitcoin-core", "Error reading next record from wallet database"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error upgrading chainstate database"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Error: Couldn't create cursor into database"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error: Disk space is low for %s"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Error: Dumpfile checksum does not match. Computed %s, expected %s"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Error: Got key that was not hex: %s"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Error: Got value that was not hex: %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error: Keypool ran out, please call keypoolrefill first"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Error: Missing checksum"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Error: Unable to parse version %u as a uint32_t"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Error: Unable to write record to new wallet"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failed to listen on any port. Use -listen=0 if you want this."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failed to rescan the wallet during initialization"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Failed to verify database"),
@@ -143,6 +177,7 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Importing..."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Incorrect or no genesis block found. Wrong datadir for network?"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Initialization sanity check failed. %s is shutting down."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Insufficient funds"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Invalid -i2psam address or hostname: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid -onion address or hostname: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid -proxy address or hostname: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid P2P permission: '%s'"),
@@ -159,7 +194,6 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Need to specify a port with -whitebind: '%s'"
 QT_TRANSLATE_NOOP("bitcoin-core", "No proxy server specified. Use -proxy=<ip> or -proxy=<ip:port>."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Not enough file descriptors available."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Prune cannot be configured with a negative value."),
-QT_TRANSLATE_NOOP("bitcoin-core", "Prune mode is incompatible with -blockfilterindex."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Prune mode is incompatible with -txindex."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Pruning blockstore..."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Reducing -maxconnections from %d to %d, because of system limitations."),
@@ -180,7 +214,7 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Specified -walletdir \"%s\" is not a director
 QT_TRANSLATE_NOOP("bitcoin-core", "Specified blocks directory \"%s\" does not exist."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Starting network threads..."),
 QT_TRANSLATE_NOOP("bitcoin-core", "The source code is available from %s."),
-QT_TRANSLATE_NOOP("bitcoin-core", "The specified config file %s does not exist\n"),
+QT_TRANSLATE_NOOP("bitcoin-core", "The specified config file %s does not exist"),
 QT_TRANSLATE_NOOP("bitcoin-core", "The transaction amount is too small to pay the fee"),
 QT_TRANSLATE_NOOP("bitcoin-core", "The wallet will avoid paying less than the minimum relay fee."),
 QT_TRANSLATE_NOOP("bitcoin-core", "This is experimental software."),
@@ -197,6 +231,7 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Unable to bind to %s on this computer. %s is 
 QT_TRANSLATE_NOOP("bitcoin-core", "Unable to create the PID file '%s': %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unable to generate initial keys"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unable to generate keys"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Unable to open %s for writing"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unable to start HTTP server. See debug log for details."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unknown -blockfilterindex value %s."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Unknown address type '%s'"),

--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -116,17 +116,20 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     </message>
     <message>
         <location line="+1"/>
-        <source>Comma separated file (*.csv)</source>
+        <source>Comma separated file</source>
+        <comment>Name of CSV file format</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Exporting Failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+15"/>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
+        <comment>An error message.</comment>
+        <extracomment>%1 is a name of the file (e.g., &quot;addrbook.csv&quot;) that the bitcoin addresses were exported to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-2"/>
+        <source>Exporting Failed</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -143,7 +146,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
+        <location line="+38"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -192,16 +195,6 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     </message>
     <message>
         <location line="+3"/>
-        <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Decrypt wallet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation type="unfinished"></translation>
     </message>
@@ -221,18 +214,18 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location line="+57"/>
+        <location line="+18"/>
+        <location line="+44"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-147"/>
+        <location line="-125"/>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+15"/>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -252,7 +245,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+7"/>
         <source>Your wallet is now encrypted. </source>
         <translation type="unfinished"></translation>
     </message>
@@ -262,49 +255,43 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+6"/>
         <location line="+8"/>
-        <location line="+8"/>
-        <location line="+43"/>
+        <location line="+32"/>
         <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-56"/>
+        <location line="-45"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
-        <location line="+49"/>
+        <location line="+38"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
+        <location line="-27"/>
         <location line="+6"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-5"/>
-        <location line="+12"/>
-        <location line="+19"/>
+        <location line="+20"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-20"/>
-        <source>Wallet decryption failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+14"/>
+        <location line="-6"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
+        <location line="+46"/>
         <location line="+33"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"></translation>
@@ -313,7 +300,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
 <context>
     <name>BanTableModel</name>
     <message>
-        <location filename="../bantablemodel.cpp" line="+86"/>
+        <location filename="../bantablemodel.cpp" line="+85"/>
         <source>IP/Netmask</source>
         <translation type="unfinished"></translation>
     </message>
@@ -324,19 +311,42 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    <message>
+        <location filename="../bitcoin.cpp" line="+423"/>
+        <source>Runaway exception</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Internal error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+322"/>
+        <location filename="../bitcoingui.cpp" line="+325"/>
         <source>Sign &amp;message...</source>
         <translation>Sign &amp;message...</translation>
     </message>
     <message>
-        <location line="+669"/>
+        <location line="+668"/>
         <source>Synchronizing with network...</source>
         <translation>Synchronizing with network...</translation>
     </message>
     <message>
-        <location line="-747"/>
+        <location line="-746"/>
         <source>&amp;Overview</source>
         <translation>&amp;Overview</translation>
     </message>
@@ -426,7 +436,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+210"/>
+        <location line="+209"/>
         <source>Wallet:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -461,7 +471,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1065"/>
+        <location line="-1064"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Send coins to a Bitcoin address</translation>
     </message>
@@ -556,7 +566,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="+556"/>
+        <location line="+555"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation>
             <numerusform>%n active connection to Bitcoin network</numerusform>
@@ -617,7 +627,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation>Up to date</translation>
     </message>
     <message>
-        <location line="-695"/>
+        <location line="-694"/>
         <source>&amp;Load PSBT from file...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -737,7 +747,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+246"/>
+        <location line="+245"/>
         <source>%1 client</source>
         <translation type="unfinished"></translation>
     </message>
@@ -833,13 +843,8 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+129"/>
+        <location line="+121"/>
         <source>Original message:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../bitcoin.cpp" line="+418"/>
-        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1036,7 +1041,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <location filename="../walletcontroller.cpp" line="+241"/>
+        <location filename="../walletcontroller.cpp" line="+250"/>
         <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1059,12 +1064,17 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+11"/>
         <source>Wallet Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+13"/>
+        <source>Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
         <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1074,7 +1084,12 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
+        <location line="+26"/>
+        <source>Advanced Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
         <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1084,7 +1099,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+7"/>
         <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1094,7 +1109,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+7"/>
         <source>Use descriptors for scriptPubKey management</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1104,12 +1119,12 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../createwalletdialog.cpp" line="+19"/>
+        <location filename="../createwalletdialog.cpp" line="+21"/>
         <source>Create</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+42"/>
         <source>Compiled without sqlite support (required for descriptor wallets)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1475,7 +1490,12 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+22"/>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+50"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1485,7 +1505,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+161"/>
+        <location line="+171"/>
         <location line="+187"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"></translation>
@@ -1498,17 +1518,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+146"/>
-        <source>Hide the icon from the system tray.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>&amp;Hide tray icon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+17"/>
+        <location line="+169"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1519,7 +1529,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
+        <location line="+179"/>
         <source>Open the %1 configuration file from the working directory.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1539,17 +1549,12 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation>&amp;Reset Options</translation>
     </message>
     <message>
-        <location line="-532"/>
+        <location line="-645"/>
         <source>&amp;Network</source>
         <translation>&amp;Network</translation>
     </message>
     <message>
-        <location line="-191"/>
-        <source>Disables some advanced features but all blocks will still be fully validated. Reverting this setting requires re-downloading the entire blockchain. Actual disk usage may be somewhat higher.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
+        <location line="-188"/>
         <source>Prune &amp;block storage to</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1607,6 +1612,16 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Map port using &amp;UPnP</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Map port using NA&amp;T-PMP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+7"/>
@@ -1672,7 +1687,17 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation>&amp;Window</translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+6"/>
+        <source>Show the icon in the system tray.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Show tray icon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Show only a tray icon after minimizing the window.</translation>
     </message>
@@ -1712,12 +1737,12 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation>Choose the default subdivision unit to show in the interface and when sending coins.</translation>
     </message>
     <message>
-        <location line="-450"/>
+        <location line="-463"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+250"/>
+        <location line="+260"/>
         <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1727,12 +1752,39 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
+        <location line="+214"/>
         <source>&amp;Third party transaction URLs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+22"/>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>embedded &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <location line="+49"/>
+        <source>111.11111111 BTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-42"/>
+        <location line="+49"/>
+        <source>909.09090909 BTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-29"/>
+        <source>closest matching &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+65"/>
         <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1747,28 +1799,28 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation>&amp;Cancel</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+96"/>
+        <location filename="../optionsdialog.cpp" line="+104"/>
         <source>default</source>
         <translation>default</translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+81"/>
         <source>none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+89"/>
+        <location line="+91"/>
         <source>Confirm options reset</source>
         <translation>Confirm options reset</translation>
     </message>
     <message>
         <location line="+1"/>
-        <location line="+60"/>
+        <location line="+57"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-60"/>
+        <location line="-57"/>
         <source>Client will be shut down. Do you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1793,7 +1845,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
+        <location line="+40"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1812,12 +1864,12 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     </message>
     <message>
         <location line="+62"/>
-        <location line="+394"/>
+        <location line="+335"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</translation>
     </message>
     <message>
-        <location line="-141"/>
+        <location line="-127"/>
         <source>Watch-only:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1827,22 +1879,22 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+10"/>
         <source>Your current spendable balance</source>
         <translation>Your current spendable balance</translation>
     </message>
     <message>
-        <location line="+42"/>
+        <location line="+35"/>
         <source>Pending:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-242"/>
+        <location line="-200"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</translation>
     </message>
     <message>
-        <location line="+114"/>
+        <location line="+100"/>
         <source>Immature:</source>
         <translation>Immature:</translation>
     </message>
@@ -1852,22 +1904,22 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation>Mined balance that has not yet matured</translation>
     </message>
     <message>
-        <location line="-181"/>
+        <location line="-150"/>
         <source>Balances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+140"/>
         <source>Total:</source>
         <translation>Total:</translation>
     </message>
     <message>
-        <location line="+63"/>
+        <location line="+49"/>
         <source>Your current total balance</source>
         <translation>Your current total balance</translation>
     </message>
     <message>
-        <location line="+95"/>
+        <location line="+74"/>
         <source>Your current balance in watch-only addresses</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1882,22 +1934,22 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-324"/>
+        <location line="-275"/>
         <source>Unconfirmed transactions to watch-only addresses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+38"/>
         <source>Mined balance in watch-only addresses that has not yet matured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+131"/>
+        <location line="+110"/>
         <source>Current total balance in watch-only addresses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+166"/>
+        <location filename="../overviewpage.cpp" line="+191"/>
         <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1986,7 +2038,8 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     </message>
     <message>
         <location line="+1"/>
-        <source>Partially Signed Transaction (Binary) (*.psbt)</source>
+        <source>Partially Signed Transaction (Binary)</source>
+        <comment>Name of binary PSBT file format</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2058,7 +2111,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+174"/>
+        <location filename="../paymentserver.cpp" line="+173"/>
         <source>Payment request error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2083,23 +2136,13 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     <message>
         <location line="+14"/>
         <location line="+23"/>
-        <source>Cannot process payment request because BIP70 is not supported.</source>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it&apos;s strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-22"/>
-        <location line="+23"/>
-        <source>Due to widespread security flaws in BIP70 it&apos;s strongly recommended that any merchant instructions to switch wallets be ignored.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-22"/>
-        <location line="+23"/>
-        <source>If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-20"/>
+        <location line="-18"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2117,18 +2160,8 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
 <context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+107"/>
+        <location filename="../peertablemodel.h" line="+91"/>
         <source>User Agent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+0"/>
-        <source>Node/Service</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+0"/>
-        <source>NodeId</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2146,21 +2179,86 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <source>Received</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+0"/>
+        <source>Peer Id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Network</source>
+        <translation type="unfinished">Network</translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoinunits.cpp" line="+209"/>
+        <location filename="../bitcoinunits.cpp" line="+213"/>
         <source>Amount</source>
         <translation type="unfinished">Amount</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+108"/>
+        <location filename="../guiutil.cpp" line="+118"/>
         <source>Enter a Bitcoin address (e.g. %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+652"/>
+        <location line="+532"/>
+        <source>Unroutable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Internal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Inbound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Outbound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Full Relay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Block Relay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Feeler</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Address Fetch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
         <source>%1 d</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2176,22 +2274,22 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     </message>
     <message>
         <location line="+2"/>
-        <location line="+26"/>
+        <location line="+28"/>
         <source>%1 s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
+        <location line="-12"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>N/A</source>
         <translation type="unfinished">N/A</translation>
     </message>
     <message>
-        <location line="+0"/>
+        <location line="+1"/>
         <source>%1 ms</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2256,7 +2354,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     </message>
     <message>
         <location line="+2"/>
-        <source>%1 KB</source>
+        <source>%1 kB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2270,7 +2368,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+105"/>
+        <location filename="../bitcoin.cpp" line="+111"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2328,13 +2426,14 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
+        <location line="+30"/>
         <source>Save QR Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <source>PNG Image (*.png)</source>
+        <location line="+1"/>
+        <source>PNG Image</source>
+        <comment>Name of PNG file format</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2342,7 +2441,6 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     <name>RPCConsole</name>
     <message>
         <location filename="../forms/debugwindow.ui" line="+75"/>
-        <location line="+26"/>
         <location line="+26"/>
         <location line="+26"/>
         <location line="+29"/>
@@ -2354,14 +2452,19 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <location line="+36"/>
         <location line="+23"/>
         <location line="+710"/>
+        <location line="+26"/>
+        <location line="+26"/>
+        <location line="+23"/>
+        <location line="+23"/>
+        <location line="+23"/>
+        <location line="+26"/>
+        <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
         <location line="+23"/>
         <location line="+23"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+23"/>
+        <location line="+26"/>
+        <location line="+26"/>
         <location line="+23"/>
         <location line="+23"/>
         <location line="+23"/>
@@ -2371,13 +2474,12 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <location line="+23"/>
         <location line="+23"/>
         <location line="+26"/>
-        <location filename="../rpcconsole.cpp" line="+1127"/>
-        <location line="+8"/>
+        <location filename="../rpcconsole.h" line="+141"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="-1427"/>
+        <location line="-1534"/>
         <source>Client version</source>
         <translation>Client version</translation>
     </message>
@@ -2393,11 +2495,6 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     </message>
     <message>
         <location line="+56"/>
-        <source>Using BerkeleyDB version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+26"/>
         <source>Datadir</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2423,11 +2520,12 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     </message>
     <message>
         <location line="+29"/>
+        <location line="+910"/>
         <source>Network</source>
         <translation>Network</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="-903"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2473,18 +2571,18 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     </message>
     <message>
         <location line="+80"/>
-        <location line="+560"/>
+        <location line="+693"/>
         <source>Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-480"/>
-        <location line="+457"/>
+        <location line="-613"/>
+        <location line="+590"/>
         <source>Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-416"/>
+        <location line="-549"/>
         <source>&amp;Peers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2495,23 +2593,17 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     </message>
     <message>
         <location line="+65"/>
-        <location filename="../rpcconsole.cpp" line="-637"/>
-        <location line="+766"/>
+        <location filename="../rpcconsole.cpp" line="+1104"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
-        <source>Direction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+23"/>
+        <location line="+106"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
+        <location line="+121"/>
         <source>Starting Block</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2526,7 +2618,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+233"/>
+        <location line="+285"/>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2536,18 +2628,18 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1394"/>
-        <location line="+1066"/>
+        <location line="-1501"/>
+        <location line="+1069"/>
         <source>User Agent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1140"/>
+        <location line="-1143"/>
         <source>Node window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+279"/>
+        <location line="+253"/>
         <source>Current block height</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2572,13 +2664,68 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
+        <location line="+23"/>
+        <source>The direction and type of peer connection: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Direction/Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+72"/>
         <source>Services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>High Bandwidth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+92"/>
         <source>Connection Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Last Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Last Tx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2617,7 +2764,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1140"/>
+        <location line="-1273"/>
         <source>Last block time</source>
         <translation>Last block time</translation>
     </message>
@@ -2642,7 +2789,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-416"/>
+        <location filename="../rpcconsole.cpp" line="-242"/>
         <source>In:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2662,7 +2809,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation>Clear console</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-243"/>
+        <location filename="../rpcconsole.cpp" line="-242"/>
         <source>1 &amp;hour</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2687,15 +2834,82 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+1"/>
-        <location line="+1"/>
+        <location filename="../rpcconsole.h" line="-1"/>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>To</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>From</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+1"/>
         <source>Ban for</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+37"/>
+        <source>Never</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../rpcconsole.cpp" line="-155"/>
+        <source>Inbound: initiated by peer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Outbound Full Relay: default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+182"/>
         <source>&amp;Unban</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2735,39 +2949,22 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
+        <location line="+178"/>
+        <source>(peer id: %1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-180"/>
         <source>Executing command using &quot;%1&quot; wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+192"/>
-        <source>(node id: %1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
+        <location line="+182"/>
         <source>via %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+1"/>
-        <source>never</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Inbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+0"/>
-        <source>Outbound</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+20"/>
-        <location line="+6"/>
+        <location filename="../rpcconsole.h" line="-37"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2871,8 +3068,13 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+45"/>
+        <location filename="../receivecoinsdialog.cpp" line="+46"/>
         <source>Copy URI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2891,7 +3093,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+131"/>
+        <location line="+140"/>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2977,7 +3179,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
+        <location line="+41"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3001,7 +3203,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+664"/>
+        <location filename="../sendcoinsdialog.cpp" line="+673"/>
         <source>Send Coins</source>
         <translation>Send Coins</translation>
     </message>
@@ -3188,7 +3390,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 satos
         <translation>S&amp;end</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-572"/>
+        <location filename="../sendcoinsdialog.cpp" line="-581"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3223,12 +3425,12 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 satos
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
+        <location line="+76"/>
         <source>%1 (%2 blocks)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+29"/>
         <source>Cr&amp;eate Unsigned</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3273,12 +3475,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 satos
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Partially Signed Transaction (Binary) (*.psbt)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+8"/>
         <source>PSBT saved</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3338,7 +3535,13 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 satos
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+228"/>
+        <location line="+45"/>
+        <source>Partially Signed Transaction (Binary)</source>
+        <comment>Name of binary PSBT file format</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+183"/>
         <source>Watch-only balance:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3743,7 +3946,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 satos
     <name>TrafficGraphWidget</name>
     <message>
         <location filename="../trafficgraphwidget.cpp" line="+82"/>
-        <source>KB/s</source>
+        <source>kB/s</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3996,7 +4199,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 satos
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+251"/>
+        <location filename="../transactiontablemodel.cpp" line="+252"/>
         <source>Date</source>
         <translation type="unfinished">Date</translation>
     </message>
@@ -4011,7 +4214,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 satos
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="+58"/>
+        <location line="+62"/>
         <source>Open for %n more block(s)</source>
         <translation>
             <numerusform>Open for %n more block</numerusform>
@@ -4094,7 +4297,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 satos
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+208"/>
+        <location line="+210"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4132,7 +4335,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 satos
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+69"/>
+        <location filename="../transactionview.cpp" line="+70"/>
         <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"></translation>
@@ -4203,7 +4406,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 satos
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
+        <location line="+63"/>
         <source>Abandon transaction</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4244,26 +4447,27 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 satos
     </message>
     <message>
         <location line="+1"/>
-        <source>Edit label</source>
+        <source>Edit address label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+186"/>
+        <source>Comma separated file</source>
+        <comment>Name of CSV file format</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-185"/>
         <source>Show transaction details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+194"/>
+        <location line="+184"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Comma separated file (*.csv)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
+        <location line="+10"/>
         <source>Confirmed</source>
         <translation type="unfinished">Confirmed</translation>
     </message>
@@ -4339,7 +4543,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 satos
 <context>
     <name>WalletController</name>
     <message>
-        <location filename="../walletcontroller.cpp" line="-238"/>
+        <location filename="../walletcontroller.cpp" line="-247"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4382,20 +4586,20 @@ Go to File &gt; Open Wallet to load a wallet.
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+214"/>
+        <location filename="../walletmodel.cpp" line="+218"/>
         <source>Send Coins</source>
         <translation type="unfinished">Send Coins</translation>
     </message>
     <message>
-        <location line="+282"/>
-        <location line="+45"/>
+        <location line="+279"/>
+        <location line="+52"/>
         <location line="+13"/>
         <location line="+5"/>
         <source>Fee bump error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-63"/>
+        <location line="-70"/>
         <source>Increasing transaction fee failed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4425,7 +4629,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+8"/>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Confirm fee bump</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4506,7 +4715,8 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <location line="+1"/>
-        <source>Wallet Data (*.dat)</source>
+        <source>Wallet Data</source>
+        <comment>Name of wallet data file format</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4538,12 +4748,12 @@ Go to File &gt; Open Wallet to load a wallet.
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+27"/>
+        <location filename="../bitcoinstrings.cpp" line="+31"/>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+41"/>
         <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4553,22 +4763,22 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+124"/>
         <source>Pruning blockstore...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
+        <location line="+37"/>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-188"/>
+        <location line="-223"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+10"/>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4578,17 +4788,17 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+10"/>
         <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+21"/>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+11"/>
         <source>Please check that your computer&apos;s date and time are correct! If your clock is wrong, %s will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4638,12 +4848,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
+        <location line="+11"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4653,7 +4858,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Cannot resolve -%s address: &apos;%s&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4694,6 +4899,16 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <location line="+2"/>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Error creating %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Error initializing block database</source>
         <translation>Error initializing block database</translation>
     </message>
@@ -4733,7 +4948,47 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Error opening block database</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+2"/>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Error: Couldn&apos;t create cursor into database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Error: Unable to parse version %u as a uint32_t</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Failed to listen on any port. Use -listen=0 if you want this.</translation>
     </message>
@@ -4768,7 +5023,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+2"/>
+        <source>Invalid -i2psam address or hostname: &apos;%s&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Invalid P2P permission: &apos;%s&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4788,7 +5048,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+17"/>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4823,7 +5083,17 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+3"/>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+17"/>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Unknown address type &apos;%s&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4843,7 +5113,62 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-170"/>
+        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Error: Dumpfile format record is incorrect. Got &quot;%s&quot;, expected &quot;format&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Error: Dumpfile identifier record is incorrect. Got &quot;%s&quot;, expected &quot;%s&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+57"/>
+        <source>Unknown wallet file format &quot;%s&quot; provided. Please provide one of &quot;bdb&quot; or &quot;sqlite&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Warning: Dumpfile wallet format &quot;%s&quot; does not match command line specified format &quot;%s&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+67"/>
         <source>Loading banlist...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4858,7 +5183,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Prune mode is incompatible with -txindex.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4893,7 +5218,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4918,27 +5243,22 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-178"/>
+        <location line="-202"/>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-20"/>
+        <location line="-31"/>
         <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
-        <source>Cannot upgrade a non HD split wallet without upgrading to support pre split keypool. Please use version 169900 or no version specified.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+14"/>
+        <location line="+39"/>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
+        <location line="+39"/>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4958,7 +5278,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+20"/>
         <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4968,7 +5288,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+2"/>
         <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4978,32 +5298,32 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+13"/>
         <source>Error reading from database, shutting down.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Error upgrading chainstate database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+4"/>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+7"/>
         <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Invalid -onion address or hostname: &apos;%s&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5033,12 +5353,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Prune mode is incompatible with -blockfilterindex.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
+        <location line="+5"/>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5068,13 +5383,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>The specified config file %s does not exist
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+5"/>
         <source>The transaction amount is too small to pay the fee</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5109,7 +5418,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Unknown -blockfilterindex value %s.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5124,12 +5433,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
+        <location line="-231"/>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
+        <location line="+90"/>
         <source>This is the transaction fee you may pay when fee estimates are not available.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5139,12 +5448,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+26"/>
         <source>%s is set very high!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+81"/>
         <source>Starting network threads...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5179,32 +5488,32 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Unknown network specified in -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-59"/>
+        <location line="-60"/>
         <source>Insufficient funds</source>
         <translation>Insufficient funds</translation>
     </message>
     <message>
-        <location line="-110"/>
+        <location line="-133"/>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
+        <location line="+80"/>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+13"/>
         <source>Cannot write to data directory &apos;%s&apos;; check permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
+        <location line="+52"/>
         <source>Loading block index...</source>
         <translation>Loading block index...</translation>
     </message>
@@ -5214,17 +5523,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation>Loading wallet...</translation>
     </message>
     <message>
-        <location line="-45"/>
-        <source>Cannot downgrade wallet</source>
-        <translation>Cannot downgrade wallet</translation>
-    </message>
-    <message>
-        <location line="+55"/>
+        <location line="+9"/>
         <source>Rescanning...</source>
         <translation>Rescanning...</translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-53"/>
         <source>Done loading</source>
         <translation>Done loading</translation>
     </message>

--- a/src/qt/locale/bitcoin_en.xlf
+++ b/src/qt/locale/bitcoin_en.xlf
@@ -1,0 +1,5688 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:trolltech="urn:trolltech:names:ts:document:1.0">
+  <file original="../forms/addressbookpage.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="AddressBookPage">
+      <trans-unit id="_msg1">
+        <source xml:space="preserve">Right-click to edit address or label</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg2" approved="yes">
+        <source xml:space="preserve">Create a new address</source>
+        <target xml:space="preserve">Create a new address</target>
+        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg3">
+        <source xml:space="preserve">&amp;New</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg4" approved="yes">
+        <source xml:space="preserve">Copy the currently selected address to the system clipboard</source>
+        <target xml:space="preserve">Copy the currently selected address to the system clipboard</target>
+        <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg5">
+        <source xml:space="preserve">&amp;Copy</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg6">
+        <source xml:space="preserve">C&amp;lose</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg7" approved="yes">
+        <source xml:space="preserve">Delete the currently selected address from the list</source>
+        <target xml:space="preserve">Delete the currently selected address from the list</target>
+        <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg8">
+        <source xml:space="preserve">Enter address or label to search</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg9" approved="yes">
+        <source xml:space="preserve">Export the data in the current tab to a file</source>
+        <target xml:space="preserve">Export the data in the current tab to a file</target>
+        <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg10" approved="yes">
+        <source xml:space="preserve">&amp;Export</source>
+        <target xml:space="preserve">&amp;Export</target>
+        <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg11" approved="yes">
+        <source xml:space="preserve">&amp;Delete</source>
+        <target xml:space="preserve">&amp;Delete</target>
+        <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../addressbookpage.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="AddressBookPage">
+      <trans-unit id="_msg12">
+        <source xml:space="preserve">Choose the address to send coins to</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg13">
+        <source xml:space="preserve">Choose the address to receive coins with</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg14">
+        <source xml:space="preserve">C&amp;hoose</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg15">
+        <source xml:space="preserve">Sending addresses</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg16">
+        <source xml:space="preserve">Receiving addresses</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg17">
+        <source xml:space="preserve">These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg18">
+        <source xml:space="preserve">These are your Bitcoin addresses for receiving payments. Use the &apos;Create new receiving address&apos; button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">109</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg19">
+        <source xml:space="preserve">&amp;Copy Address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">116</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg20">
+        <source xml:space="preserve">Copy &amp;Label</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">117</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg21">
+        <source xml:space="preserve">&amp;Edit</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">118</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg22">
+        <source xml:space="preserve">Export Address List</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">297</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg23">
+        <source xml:space="preserve">Comma separated file</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
+        <context-group><context context-type="x-gettext-msgctxt">Name of CSV file format</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg24">
+        <source xml:space="preserve">There was an error trying to save the address list to %1. Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">313</context></context-group>
+        <context-group><context context-type="x-gettext-msgctxt">An error message.</context></context-group>
+        <note annotates="source" from="developer">%1 is a name of the file (e.g., &quot;addrbook.csv&quot;) that the bitcoin addresses were exported to.</note>
+      </trans-unit>
+      <trans-unit id="_msg25">
+        <source xml:space="preserve">Exporting Failed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../addresstablemodel.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="AddressTableModel">
+      <trans-unit id="_msg26">
+        <source xml:space="preserve">Label</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg27">
+        <source xml:space="preserve">Address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg28">
+        <source xml:space="preserve">(no label)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/askpassphrasedialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="AskPassphraseDialog">
+      <trans-unit id="_msg29" approved="yes">
+        <source xml:space="preserve">Passphrase Dialog</source>
+        <target xml:space="preserve">Passphrase Dialog</target>
+        <context-group purpose="location"><context context-type="linenumber">26</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg30" approved="yes">
+        <source xml:space="preserve">Enter passphrase</source>
+        <target xml:space="preserve">Enter passphrase</target>
+        <context-group purpose="location"><context context-type="linenumber">56</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg31" approved="yes">
+        <source xml:space="preserve">New passphrase</source>
+        <target xml:space="preserve">New passphrase</target>
+        <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg32" approved="yes">
+        <source xml:space="preserve">Repeat new passphrase</source>
+        <target xml:space="preserve">Repeat new passphrase</target>
+        <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg33">
+        <source xml:space="preserve">Show passphrase</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../askpassphrasedialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="AskPassphraseDialog">
+      <trans-unit id="_msg34">
+        <source xml:space="preserve">Encrypt wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg35">
+        <source xml:space="preserve">This operation needs your wallet passphrase to unlock the wallet.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">54</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg36">
+        <source xml:space="preserve">Unlock wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">59</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg37">
+        <source xml:space="preserve">Change passphrase</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">62</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg38">
+        <source xml:space="preserve">Confirm wallet encryption</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg39">
+        <source xml:space="preserve">Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg40">
+        <source xml:space="preserve">Are you sure you wish to encrypt your wallet?</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg41">
+        <source xml:space="preserve">Wallet encrypted</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg42">
+        <source xml:space="preserve">Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg43">
+        <source xml:space="preserve">Enter the old passphrase and new passphrase for the wallet.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">63</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg44">
+        <source xml:space="preserve">Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">118</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg45">
+        <source xml:space="preserve">Wallet to be encrypted</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg46">
+        <source xml:space="preserve">Your wallet is about to be encrypted. </source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg47">
+        <source xml:space="preserve">Your wallet is now encrypted. </source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg48">
+        <source xml:space="preserve">IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">133</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg49">
+        <source xml:space="preserve">Wallet encryption failed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">179</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">185</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg50">
+        <source xml:space="preserve">Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg51">
+        <source xml:space="preserve">The supplied passphrases do not match.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">186</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg52">
+        <source xml:space="preserve">Wallet unlock failed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">165</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg53">
+        <source xml:space="preserve">The passphrase entered for the wallet decryption was incorrect.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">160</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg54">
+        <source xml:space="preserve">Wallet passphrase was successfully changed.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">174</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg55">
+        <source xml:space="preserve">Warning: The Caps Lock key is on!</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">253</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../bantablemodel.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="BanTableModel">
+      <trans-unit id="_msg56">
+        <source xml:space="preserve">IP/Netmask</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg57">
+        <source xml:space="preserve">Banned Until</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../bitcoin.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="BitcoinApplication">
+      <trans-unit id="_msg58">
+        <source xml:space="preserve">Runaway exception</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">423</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg59">
+        <source xml:space="preserve">A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">424</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg60">
+        <source xml:space="preserve">Internal error</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">433</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg61">
+        <source xml:space="preserve">An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">434</context></context-group>
+      </trans-unit>
+    </group>
+    <group restype="x-trolltech-linguist-context" resname="QObject">
+      <trans-unit id="_msg62">
+        <source xml:space="preserve">Error: Specified data directory &quot;%1&quot; does not exist.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">545</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg63">
+        <source xml:space="preserve">Error: Cannot parse configuration file: %1.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">551</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg64">
+        <source xml:space="preserve">Error: %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">566</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg65">
+        <source xml:space="preserve">Error initializing settings: %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">575</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg66">
+        <source xml:space="preserve">%1 didn&apos;t yet exit safely...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">638</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../bitcoingui.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="BitcoinGUI">
+      <trans-unit id="_msg67" approved="yes">
+        <source xml:space="preserve">Sign &amp;message...</source>
+        <target xml:space="preserve">Sign &amp;message...</target>
+        <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg68" approved="yes">
+        <source xml:space="preserve">Synchronizing with network...</source>
+        <target xml:space="preserve">Synchronizing with network...</target>
+        <context-group purpose="location"><context context-type="linenumber">993</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg69" approved="yes">
+        <source xml:space="preserve">&amp;Overview</source>
+        <target xml:space="preserve">&amp;Overview</target>
+        <context-group purpose="location"><context context-type="linenumber">247</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg70" approved="yes">
+        <source xml:space="preserve">Show general overview of wallet</source>
+        <target xml:space="preserve">Show general overview of wallet</target>
+        <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg71" approved="yes">
+        <source xml:space="preserve">&amp;Transactions</source>
+        <target xml:space="preserve">&amp;Transactions</target>
+        <context-group purpose="location"><context context-type="linenumber">276</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg72" approved="yes">
+        <source xml:space="preserve">Browse transaction history</source>
+        <target xml:space="preserve">Browse transaction history</target>
+        <context-group purpose="location"><context context-type="linenumber">277</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg73" approved="yes">
+        <source xml:space="preserve">E&amp;xit</source>
+        <target xml:space="preserve">E&amp;xit</target>
+        <context-group purpose="location"><context context-type="linenumber">300</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg74" approved="yes">
+        <source xml:space="preserve">Quit application</source>
+        <target xml:space="preserve">Quit application</target>
+        <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg75">
+        <source xml:space="preserve">&amp;About %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg76">
+        <source xml:space="preserve">Show information about %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg77" approved="yes">
+        <source xml:space="preserve">About &amp;Qt</source>
+        <target xml:space="preserve">About &amp;Qt</target>
+        <context-group purpose="location"><context context-type="linenumber">308</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg78" approved="yes">
+        <source xml:space="preserve">Show information about Qt</source>
+        <target xml:space="preserve">Show information about Qt</target>
+        <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg79" approved="yes">
+        <source xml:space="preserve">&amp;Options...</source>
+        <target xml:space="preserve">&amp;Options...</target>
+        <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg80">
+        <source xml:space="preserve">Modify configuration options for %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">312</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg81" approved="yes">
+        <source xml:space="preserve">&amp;Encrypt Wallet...</source>
+        <target xml:space="preserve">&amp;Encrypt Wallet...</target>
+        <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg82" approved="yes">
+        <source xml:space="preserve">&amp;Backup Wallet...</source>
+        <target xml:space="preserve">&amp;Backup Wallet...</target>
+        <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg83" approved="yes">
+        <source xml:space="preserve">&amp;Change Passphrase...</source>
+        <target xml:space="preserve">&amp;Change Passphrase...</target>
+        <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg84">
+        <source xml:space="preserve">Open &amp;URI...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg85">
+        <source xml:space="preserve">Create Wallet...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg86">
+        <source xml:space="preserve">Create a new wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">358</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg87">
+        <source xml:space="preserve">Wallet:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">567</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg88">
+        <source xml:space="preserve">Click to disable network activity.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">918</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg89">
+        <source xml:space="preserve">Network activity disabled.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">920</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg90">
+        <source xml:space="preserve">Click to enable network activity again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">920</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg91">
+        <source xml:space="preserve">Syncing Headers (%1%)...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">947</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg92" approved="yes">
+        <source xml:space="preserve">Reindexing blocks on disk...</source>
+        <target xml:space="preserve">Reindexing blocks on disk...</target>
+        <context-group purpose="location"><context context-type="linenumber">1004</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg93">
+        <source xml:space="preserve">Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1319</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg94" approved="yes">
+        <source xml:space="preserve">Send coins to a Bitcoin address</source>
+        <target xml:space="preserve">Send coins to a Bitcoin address</target>
+        <context-group purpose="location"><context context-type="linenumber">255</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg95" approved="yes">
+        <source xml:space="preserve">Backup wallet to another location</source>
+        <target xml:space="preserve">Backup wallet to another location</target>
+        <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg96" approved="yes">
+        <source xml:space="preserve">Change the passphrase used for wallet encryption</source>
+        <target xml:space="preserve">Change the passphrase used for wallet encryption</target>
+        <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg97" approved="yes">
+        <source xml:space="preserve">&amp;Verify message...</source>
+        <target xml:space="preserve">&amp;Verify message...</target>
+        <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg98" approved="yes">
+        <source xml:space="preserve">&amp;Send</source>
+        <target xml:space="preserve">&amp;Send</target>
+        <context-group purpose="location"><context context-type="linenumber">254</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg99" approved="yes">
+        <source xml:space="preserve">&amp;Receive</source>
+        <target xml:space="preserve">&amp;Receive</target>
+        <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg100" approved="yes">
+        <source xml:space="preserve">&amp;Show / Hide</source>
+        <target xml:space="preserve">&amp;Show / Hide</target>
+        <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg101" approved="yes">
+        <source xml:space="preserve">Show or hide the main Window</source>
+        <target xml:space="preserve">Show or hide the main Window</target>
+        <context-group purpose="location"><context context-type="linenumber">316</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg102" approved="yes">
+        <source xml:space="preserve">Encrypt the private keys that belong to your wallet</source>
+        <target xml:space="preserve">Encrypt the private keys that belong to your wallet</target>
+        <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg103" approved="yes">
+        <source xml:space="preserve">Sign messages with your Bitcoin addresses to prove you own them</source>
+        <target xml:space="preserve">Sign messages with your Bitcoin addresses to prove you own them</target>
+        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg104" approved="yes">
+        <source xml:space="preserve">Verify messages to ensure they were signed with specified Bitcoin addresses</source>
+        <target xml:space="preserve">Verify messages to ensure they were signed with specified Bitcoin addresses</target>
+        <context-group purpose="location"><context context-type="linenumber">328</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg105" approved="yes">
+        <source xml:space="preserve">&amp;File</source>
+        <target xml:space="preserve">&amp;File</target>
+        <context-group purpose="location"><context context-type="linenumber">457</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg106" approved="yes">
+        <source xml:space="preserve">&amp;Settings</source>
+        <target xml:space="preserve">&amp;Settings</target>
+        <context-group purpose="location"><context context-type="linenumber">475</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg107" approved="yes">
+        <source xml:space="preserve">&amp;Help</source>
+        <target xml:space="preserve">&amp;Help</target>
+        <context-group purpose="location"><context context-type="linenumber">536</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg108" approved="yes">
+        <source xml:space="preserve">Tabs toolbar</source>
+        <target xml:space="preserve">Tabs toolbar</target>
+        <context-group purpose="location"><context context-type="linenumber">547</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg109">
+        <source xml:space="preserve">Request payments (generates QR codes and bitcoin: URIs)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg110">
+        <source xml:space="preserve">Show the list of used sending addresses and labels</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg111">
+        <source xml:space="preserve">Show the list of used receiving addresses and labels</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg112">
+        <source xml:space="preserve">&amp;Command-line options</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
+      </trans-unit>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">918</context></context-group>
+        <trans-unit id="_msg113[0]" approved="yes">
+          <source xml:space="preserve">%n active connection(s) to Bitcoin network</source>
+          <target xml:space="preserve">%n active connection to Bitcoin network</target>
+        </trans-unit>
+        <trans-unit id="_msg113[1]" approved="yes">
+          <source xml:space="preserve">%n active connection(s) to Bitcoin network</source>
+          <target xml:space="preserve">%n active connections to Bitcoin network</target>
+        </trans-unit>
+      </group>
+      <trans-unit id="_msg114">
+        <source xml:space="preserve">Indexing blocks on disk...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">998</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg115">
+        <source xml:space="preserve">Processing blocks on disk...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1000</context></context-group>
+      </trans-unit>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">1019</context></context-group>
+        <trans-unit id="_msg116[0]" approved="yes">
+          <source xml:space="preserve">Processed %n block(s) of transaction history.</source>
+          <target xml:space="preserve">Processed %n block of transaction history.</target>
+        </trans-unit>
+        <trans-unit id="_msg116[1]" approved="yes">
+          <source xml:space="preserve">Processed %n block(s) of transaction history.</source>
+          <target xml:space="preserve">Processed %n blocks of transaction history.</target>
+        </trans-unit>
+      </group>
+      <trans-unit id="_msg117" approved="yes">
+        <source xml:space="preserve">%1 behind</source>
+        <target xml:space="preserve">%1 behind</target>
+        <context-group purpose="location"><context context-type="linenumber">1042</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg118" approved="yes">
+        <source xml:space="preserve">Last received block was generated %1 ago.</source>
+        <target xml:space="preserve">Last received block was generated %1 ago.</target>
+        <context-group purpose="location"><context context-type="linenumber">1066</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg119" approved="yes">
+        <source xml:space="preserve">Transactions after this will not yet be visible.</source>
+        <target xml:space="preserve">Transactions after this will not yet be visible.</target>
+        <context-group purpose="location"><context context-type="linenumber">1068</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg120" approved="yes">
+        <source xml:space="preserve">Error</source>
+        <target xml:space="preserve">Error</target>
+        <context-group purpose="location"><context context-type="linenumber">1093</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg121" approved="yes">
+        <source xml:space="preserve">Warning</source>
+        <target xml:space="preserve">Warning</target>
+        <context-group purpose="location"><context context-type="linenumber">1097</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg122" approved="yes">
+        <source xml:space="preserve">Information</source>
+        <target xml:space="preserve">Information</target>
+        <context-group purpose="location"><context context-type="linenumber">1101</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg123" approved="yes">
+        <source xml:space="preserve">Up to date</source>
+        <target xml:space="preserve">Up to date</target>
+        <context-group purpose="location"><context context-type="linenumber">1023</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg124">
+        <source xml:space="preserve">&amp;Load PSBT from file...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg125">
+        <source xml:space="preserve">Load Partially Signed Bitcoin Transaction</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">330</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg126">
+        <source xml:space="preserve">Load PSBT from clipboard...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">331</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg127">
+        <source xml:space="preserve">Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">332</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg128">
+        <source xml:space="preserve">Node window</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg129">
+        <source xml:space="preserve">Open node debugging and diagnostic console</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg130">
+        <source xml:space="preserve">&amp;Sending addresses</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg131">
+        <source xml:space="preserve">&amp;Receiving addresses</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg132">
+        <source xml:space="preserve">Open a bitcoin: URI</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg133">
+        <source xml:space="preserve">Open Wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg134">
+        <source xml:space="preserve">Open a wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">350</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg135">
+        <source xml:space="preserve">Close Wallet...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg136">
+        <source xml:space="preserve">Close wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">354</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg137">
+        <source xml:space="preserve">Close All Wallets...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">360</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg138">
+        <source xml:space="preserve">Close all wallets</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">361</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg139">
+        <source xml:space="preserve">Show the %1 help message to get a list with possible Bitcoin command-line options</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg140">
+        <source xml:space="preserve">&amp;Mask values</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg141">
+        <source xml:space="preserve">Mask the values in the Overview tab</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">369</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg142">
+        <source xml:space="preserve">default wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">401</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg143">
+        <source xml:space="preserve">No wallets available</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">422</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg144">
+        <source xml:space="preserve">&amp;Window</source>
+        <target xml:space="preserve" state="needs-review-translation">&amp;Window</target>
+        <context-group purpose="location"><context context-type="linenumber">486</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg145">
+        <source xml:space="preserve">Minimize</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">488</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg146">
+        <source xml:space="preserve">Zoom</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">498</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg147">
+        <source xml:space="preserve">Main Window</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">516</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg148">
+        <source xml:space="preserve">%1 client</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">761</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg149">
+        <source xml:space="preserve">Connecting to peers...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1010</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg150" approved="yes">
+        <source xml:space="preserve">Catching up...</source>
+        <target xml:space="preserve">Catching up...</target>
+        <context-group purpose="location"><context context-type="linenumber">1047</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg151">
+        <source xml:space="preserve">Error: %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1094</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg152">
+        <source xml:space="preserve">Warning: %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1098</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg153">
+        <source xml:space="preserve">Date: %1
+</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1198</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg154">
+        <source xml:space="preserve">Amount: %1
+</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1199</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg155">
+        <source xml:space="preserve">Wallet: %1
+</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1201</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg156">
+        <source xml:space="preserve">Type: %1
+</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1203</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg157">
+        <source xml:space="preserve">Label: %1
+</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1205</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg158">
+        <source xml:space="preserve">Address: %1
+</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1207</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg159" approved="yes">
+        <source xml:space="preserve">Sent transaction</source>
+        <target xml:space="preserve">Sent transaction</target>
+        <context-group purpose="location"><context context-type="linenumber">1208</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg160" approved="yes">
+        <source xml:space="preserve">Incoming transaction</source>
+        <target xml:space="preserve">Incoming transaction</target>
+        <context-group purpose="location"><context context-type="linenumber">1208</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg161">
+        <source xml:space="preserve">HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1260</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg162">
+        <source xml:space="preserve">HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1260</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg163">
+        <source xml:space="preserve">Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1260</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg164" approved="yes">
+        <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
+        <target xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</target>
+        <context-group purpose="location"><context context-type="linenumber">1279</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg165" approved="yes">
+        <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
+        <target xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</target>
+        <context-group purpose="location"><context context-type="linenumber">1287</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg166">
+        <source xml:space="preserve">Original message:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1408</context></context-group>
+      </trans-unit>
+    </group>
+    <group restype="x-trolltech-linguist-context" resname="UnitDisplayStatusBarControl">
+      <trans-unit id="_msg167">
+        <source xml:space="preserve">Unit to show amounts in. Click to select another unit.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1448</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/coincontroldialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="CoinControlDialog">
+      <trans-unit id="_msg168">
+        <source xml:space="preserve">Coin Selection</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg169">
+        <source xml:space="preserve">Quantity:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg170">
+        <source xml:space="preserve">Bytes:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg171">
+        <source xml:space="preserve">Amount:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg172">
+        <source xml:space="preserve">Fee:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg173">
+        <source xml:space="preserve">Dust:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg174">
+        <source xml:space="preserve">After Fee:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">247</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg175">
+        <source xml:space="preserve">Change:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg176">
+        <source xml:space="preserve">(un)select all</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg177">
+        <source xml:space="preserve">Tree mode</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg178">
+        <source xml:space="preserve">List mode</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg179">
+        <source xml:space="preserve">Amount</source>
+        <target xml:space="preserve" state="needs-review-translation">Amount</target>
+        <context-group purpose="location"><context context-type="linenumber">420</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg180">
+        <source xml:space="preserve">Received with label</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">425</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg181">
+        <source xml:space="preserve">Received with address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">430</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg182">
+        <source xml:space="preserve">Date</source>
+        <target xml:space="preserve" state="needs-review-translation">Date</target>
+        <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg183">
+        <source xml:space="preserve">Confirmations</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">440</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg184">
+        <source xml:space="preserve">Confirmed</source>
+        <target xml:space="preserve" state="needs-review-translation">Confirmed</target>
+        <context-group purpose="location"><context context-type="linenumber">443</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../coincontroldialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="CoinControlDialog">
+      <trans-unit id="_msg185">
+        <source xml:space="preserve">Copy address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">54</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg186">
+        <source xml:space="preserve">Copy label</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">55</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg187">
+        <source xml:space="preserve">Copy amount</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">56</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">82</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg188">
+        <source xml:space="preserve">Copy transaction ID</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg189">
+        <source xml:space="preserve">Lock unspent</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg190">
+        <source xml:space="preserve">Unlock unspent</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">59</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg191">
+        <source xml:space="preserve">Copy quantity</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg192">
+        <source xml:space="preserve">Copy fee</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg193">
+        <source xml:space="preserve">Copy after fee</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg194">
+        <source xml:space="preserve">Copy bytes</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg195">
+        <source xml:space="preserve">Copy dust</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg196">
+        <source xml:space="preserve">Copy change</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg197">
+        <source xml:space="preserve">(%1 locked)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">389</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg198">
+        <source xml:space="preserve">yes</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">544</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg199">
+        <source xml:space="preserve">no</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">544</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg200">
+        <source xml:space="preserve">This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">558</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg201">
+        <source xml:space="preserve">Can vary +/- %1 satoshi(s) per input.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">563</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg202">
+        <source xml:space="preserve">(no label)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">601</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">655</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg203">
+        <source xml:space="preserve">change from %1 (%2)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">648</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg204">
+        <source xml:space="preserve">(change)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">649</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../walletcontroller.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="CreateWalletActivity">
+      <trans-unit id="_msg205">
+        <source xml:space="preserve">Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg206">
+        <source xml:space="preserve">Create wallet failed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">278</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg207">
+        <source xml:space="preserve">Create wallet warning</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
+      </trans-unit>
+    </group>
+    <group restype="x-trolltech-linguist-context" resname="OpenWalletActivity">
+      <trans-unit id="_msg208">
+        <source xml:space="preserve">Open wallet failed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg209">
+        <source xml:space="preserve">Open wallet warning</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg210">
+        <source xml:space="preserve">default wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">331</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg211">
+        <source xml:space="preserve">Opening Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
+      </trans-unit>
+    </group>
+    <group restype="x-trolltech-linguist-context" resname="WalletController">
+      <trans-unit id="_msg212">
+        <source xml:space="preserve">Close wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg213">
+        <source xml:space="preserve">Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg214">
+        <source xml:space="preserve">Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg215">
+        <source xml:space="preserve">Close all wallets</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg216">
+        <source xml:space="preserve">Are you sure you wish to close all wallets?</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/createwalletdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="CreateWalletDialog">
+      <trans-unit id="_msg217">
+        <source xml:space="preserve">Create Wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg218">
+        <source xml:space="preserve">Wallet Name</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">25</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg219">
+        <source xml:space="preserve">Wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">38</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg220">
+        <source xml:space="preserve">Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg221">
+        <source xml:space="preserve">Encrypt Wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg222">
+        <source xml:space="preserve">Advanced Options</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg223">
+        <source xml:space="preserve">Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg224">
+        <source xml:space="preserve">Disable Private Keys</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg225">
+        <source xml:space="preserve">Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg226">
+        <source xml:space="preserve">Make Blank Wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg227">
+        <source xml:space="preserve">Use descriptors for scriptPubKey management</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">105</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg228">
+        <source xml:space="preserve">Descriptor Wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../createwalletdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="CreateWalletDialog">
+      <trans-unit id="_msg229">
+        <source xml:space="preserve">Create</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">21</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg230">
+        <source xml:space="preserve">Compiled without sqlite support (required for descriptor wallets)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">63</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/editaddressdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="EditAddressDialog">
+      <trans-unit id="_msg231" approved="yes">
+        <source xml:space="preserve">Edit Address</source>
+        <target xml:space="preserve">Edit Address</target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg232" approved="yes">
+        <source xml:space="preserve">&amp;Label</source>
+        <target xml:space="preserve">&amp;Label</target>
+        <context-group purpose="location"><context context-type="linenumber">25</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg233">
+        <source xml:space="preserve">The label associated with this address list entry</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg234">
+        <source xml:space="preserve">The address associated with this address list entry. This can only be modified for sending addresses.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">52</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg235" approved="yes">
+        <source xml:space="preserve">&amp;Address</source>
+        <target xml:space="preserve">&amp;Address</target>
+        <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../editaddressdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="EditAddressDialog">
+      <trans-unit id="_msg236">
+        <source xml:space="preserve">New sending address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg237">
+        <source xml:space="preserve">Edit receiving address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg238">
+        <source xml:space="preserve">Edit sending address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg239">
+        <source xml:space="preserve">The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">113</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg240">
+        <source xml:space="preserve">Address &quot;%1&quot; already exists as a receiving address with label &quot;%2&quot; and so cannot be added as a sending address.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg241">
+        <source xml:space="preserve">The entered address &quot;%1&quot; is already in the address book with label &quot;%2&quot;.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg242">
+        <source xml:space="preserve">Could not unlock wallet.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg243">
+        <source xml:space="preserve">New key generation failed.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../intro.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="FreespaceChecker">
+      <trans-unit id="_msg244" approved="yes">
+        <source xml:space="preserve">A new data directory will be created.</source>
+        <target xml:space="preserve">A new data directory will be created.</target>
+        <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg245" approved="yes">
+        <source xml:space="preserve">name</source>
+        <target xml:space="preserve">name</target>
+        <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg246" approved="yes">
+        <source xml:space="preserve">Directory already exists. Add %1 if you intend to create a new directory here.</source>
+        <target xml:space="preserve">Directory already exists. Add %1 if you intend to create a new directory here.</target>
+        <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg247" approved="yes">
+        <source xml:space="preserve">Path already exists, and is not a directory.</source>
+        <target xml:space="preserve">Path already exists, and is not a directory.</target>
+        <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg248" approved="yes">
+        <source xml:space="preserve">Cannot create data directory here.</source>
+        <target xml:space="preserve">Cannot create data directory here.</target>
+        <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
+      </trans-unit>
+    </group>
+    <group restype="x-trolltech-linguist-context" resname="Intro">
+      <trans-unit id="_msg249">
+        <source xml:space="preserve">Bitcoin</source>
+        <target xml:space="preserve" state="needs-review-translation">Bitcoin</target>
+        <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg250">
+        <source xml:space="preserve">Discard blocks after verification, except most recent %1 GB (prune)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg251">
+        <source xml:space="preserve">At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">358</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg252">
+        <source xml:space="preserve">Approximately %1 GB of data will be stored in this directory.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">361</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg253">
+        <source xml:space="preserve">%1 will download and store a copy of the Bitcoin block chain.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg254">
+        <source xml:space="preserve">The wallet will also be stored in this directory.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg255">
+        <source xml:space="preserve">Error: Specified data directory &quot;%1&quot; cannot be created.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">230</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg256" approved="yes">
+        <source xml:space="preserve">Error</source>
+        <target xml:space="preserve">Error</target>
+        <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
+      </trans-unit>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
+        <trans-unit id="_msg257[0]" approved="yes">
+          <source xml:space="preserve">%n GB of free space available</source>
+          <target xml:space="preserve">%n GB of free space available</target>
+        </trans-unit>
+        <trans-unit id="_msg257[1]" approved="yes">
+          <source xml:space="preserve">%n GB of free space available</source>
+          <target xml:space="preserve">%n GB of free space available</target>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">283</context></context-group>
+        <trans-unit id="_msg258[0]" approved="yes">
+          <source xml:space="preserve">(of %n GB needed)</source>
+          <target xml:space="preserve">(of %n GB needed)</target>
+        </trans-unit>
+        <trans-unit id="_msg258[1]" approved="yes">
+          <source xml:space="preserve">(of %n GB needed)</source>
+          <target xml:space="preserve">(of %n GB needed)</target>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">286</context></context-group>
+        <trans-unit id="_msg259[0]">
+          <source xml:space="preserve">(%n GB needed for full chain)</source>
+          <target xml:space="preserve"></target>
+        </trans-unit>
+        <trans-unit id="_msg259[1]">
+          <source xml:space="preserve">(%n GB needed for full chain)</source>
+          <target xml:space="preserve"></target>
+        </trans-unit>
+      </group>
+    </group>
+  </body></file>
+  <file original="../utilitydialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="HelpMessageDialog">
+      <trans-unit id="_msg260">
+        <source xml:space="preserve">version</source>
+        <target xml:space="preserve" state="needs-review-translation">version</target>
+        <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg261">
+        <source xml:space="preserve">About %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">41</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg262">
+        <source xml:space="preserve">Command-line options</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
+      </trans-unit>
+    </group>
+    <group restype="x-trolltech-linguist-context" resname="ShutdownWindow">
+      <trans-unit id="_msg263">
+        <source xml:space="preserve">%1 is shutting down...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg264">
+        <source xml:space="preserve">Do not shut down the computer until this window disappears.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/intro.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="Intro">
+      <trans-unit id="_msg265" approved="yes">
+        <source xml:space="preserve">Welcome</source>
+        <target xml:space="preserve">Welcome</target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg266">
+        <source xml:space="preserve">Welcome to %1.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">23</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg267">
+        <source xml:space="preserve">As this is the first time the program is launched, you can choose where %1 will store its data.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg268">
+        <source xml:space="preserve">When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg269">
+        <source xml:space="preserve">Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg270">
+        <source xml:space="preserve">This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg271">
+        <source xml:space="preserve">If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">236</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg272" approved="yes">
+        <source xml:space="preserve">Use the default data directory</source>
+        <target xml:space="preserve">Use the default data directory</target>
+        <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg273" approved="yes">
+        <source xml:space="preserve">Use a custom data directory:</source>
+        <target xml:space="preserve">Use a custom data directory:</target>
+        <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/modaloverlay.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="ModalOverlay">
+      <trans-unit id="_msg274">
+        <source xml:space="preserve">Form</source>
+        <target xml:space="preserve" state="needs-review-translation">Form</target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg275">
+        <source xml:space="preserve">Recent transactions may not yet be visible, and therefore your wallet&apos;s balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">133</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg276">
+        <source xml:space="preserve">Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg277">
+        <source xml:space="preserve">Number of blocks left</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg278">
+        <source xml:space="preserve">Unknown...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../modaloverlay.cpp</context><context context-type="linenumber">153</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg279">
+        <source xml:space="preserve">Last block time</source>
+        <target xml:space="preserve" state="needs-review-translation">Last block time</target>
+        <context-group purpose="location"><context context-type="linenumber">235</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg280">
+        <source xml:space="preserve">Progress</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg281">
+        <source xml:space="preserve">Progress increase per hour</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg282">
+        <source xml:space="preserve">calculating...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg283">
+        <source xml:space="preserve">Estimated time left until synced</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg284">
+        <source xml:space="preserve">Hide</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg285">
+        <source xml:space="preserve">Esc</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">355</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../modaloverlay.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="ModalOverlay">
+      <trans-unit id="_msg286">
+        <source xml:space="preserve">%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg287">
+        <source xml:space="preserve">Unknown. Syncing Headers (%1, %2%)...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
+      </trans-unit>
+    </group>
+    <group restype="x-trolltech-linguist-context" resname="QObject">
+      <trans-unit id="_msg288">
+        <source xml:space="preserve">unknown</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/openuridialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="OpenURIDialog">
+      <trans-unit id="_msg289">
+        <source xml:space="preserve">Open bitcoin URI</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg290">
+        <source xml:space="preserve">URI:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">22</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/optionsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="OptionsDialog">
+      <trans-unit id="_msg291" approved="yes">
+        <source xml:space="preserve">Options</source>
+        <target xml:space="preserve">Options</target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg292" approved="yes">
+        <source xml:space="preserve">&amp;Main</source>
+        <target xml:space="preserve">&amp;Main</target>
+        <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg293">
+        <source xml:space="preserve">Automatically start %1 after logging in to the system.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg294">
+        <source xml:space="preserve">&amp;Start %1 on system login</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg295">
+        <source xml:space="preserve">Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg296">
+        <source xml:space="preserve">Size of &amp;database cache</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg297">
+        <source xml:space="preserve">Number of script &amp;verification threads</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg298">
+        <source xml:space="preserve">IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">509</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg299">
+        <source xml:space="preserve">Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">391</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">414</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">437</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg300">
+        <source xml:space="preserve">Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">606</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg301">
+        <source xml:space="preserve">Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">686</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">699</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg302">
+        <source xml:space="preserve">Open the %1 configuration file from the working directory.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">878</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg303">
+        <source xml:space="preserve">Open Configuration File</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">881</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg304" approved="yes">
+        <source xml:space="preserve">Reset all client options to default.</source>
+        <target xml:space="preserve">Reset all client options to default.</target>
+        <context-group purpose="location"><context context-type="linenumber">891</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg305" approved="yes">
+        <source xml:space="preserve">&amp;Reset Options</source>
+        <target xml:space="preserve">&amp;Reset Options</target>
+        <context-group purpose="location"><context context-type="linenumber">894</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg306" approved="yes">
+        <source xml:space="preserve">&amp;Network</source>
+        <target xml:space="preserve">&amp;Network</target>
+        <context-group purpose="location"><context context-type="linenumber">249</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg307">
+        <source xml:space="preserve">Prune &amp;block storage to</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg308">
+        <source xml:space="preserve">GB</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg309">
+        <source xml:space="preserve">Reverting this setting requires re-downloading the entire blockchain.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg310">
+        <source xml:space="preserve">MiB</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg311">
+        <source xml:space="preserve">(0 = auto, &lt;0 = leave that many cores free)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg312">
+        <source xml:space="preserve">W&amp;allet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">200</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg313">
+        <source xml:space="preserve">Expert</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg314">
+        <source xml:space="preserve">Enable coin &amp;control features</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg315">
+        <source xml:space="preserve">If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg316">
+        <source xml:space="preserve">&amp;Spend unconfirmed change</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg317" approved="yes">
+        <source xml:space="preserve">Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
+        <target xml:space="preserve">Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</target>
+        <context-group purpose="location"><context context-type="linenumber">255</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg318" approved="yes">
+        <source xml:space="preserve">Map port using &amp;UPnP</source>
+        <target xml:space="preserve">Map port using &amp;UPnP</target>
+        <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg319">
+        <source xml:space="preserve">Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg320">
+        <source xml:space="preserve">Map port using NA&amp;T-PMP</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg321">
+        <source xml:space="preserve">Accept connections from outside.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg322">
+        <source xml:space="preserve">Allow incomin&amp;g connections</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">278</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg323">
+        <source xml:space="preserve">Connect to the Bitcoin network through a SOCKS5 proxy.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">285</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg324">
+        <source xml:space="preserve">&amp;Connect through SOCKS5 proxy (default proxy):</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">288</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg325" approved="yes">
+        <source xml:space="preserve">Proxy &amp;IP:</source>
+        <target xml:space="preserve">Proxy &amp;IP:</target>
+        <context-group purpose="location"><context context-type="linenumber">297</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">484</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg326" approved="yes">
+        <source xml:space="preserve">&amp;Port:</source>
+        <target xml:space="preserve">&amp;Port:</target>
+        <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">516</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg327" approved="yes">
+        <source xml:space="preserve">Port of the proxy (e.g. 9050)</source>
+        <target xml:space="preserve">Port of the proxy (e.g. 9050)</target>
+        <context-group purpose="location"><context context-type="linenumber">354</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">541</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg328">
+        <source xml:space="preserve">Used for reaching peers via:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg329">
+        <source xml:space="preserve">IPv4</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">401</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg330">
+        <source xml:space="preserve">IPv6</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">424</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg331">
+        <source xml:space="preserve">Tor</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">447</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg332" approved="yes">
+        <source xml:space="preserve">&amp;Window</source>
+        <target xml:space="preserve">&amp;Window</target>
+        <context-group purpose="location"><context context-type="linenumber">577</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg333">
+        <source xml:space="preserve">Show the icon in the system tray.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">583</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg334">
+        <source xml:space="preserve">&amp;Show tray icon</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">586</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg335" approved="yes">
+        <source xml:space="preserve">Show only a tray icon after minimizing the window.</source>
+        <target xml:space="preserve">Show only a tray icon after minimizing the window.</target>
+        <context-group purpose="location"><context context-type="linenumber">596</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg336" approved="yes">
+        <source xml:space="preserve">&amp;Minimize to the tray instead of the taskbar</source>
+        <target xml:space="preserve">&amp;Minimize to the tray instead of the taskbar</target>
+        <context-group purpose="location"><context context-type="linenumber">599</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg337" approved="yes">
+        <source xml:space="preserve">M&amp;inimize on close</source>
+        <target xml:space="preserve">M&amp;inimize on close</target>
+        <context-group purpose="location"><context context-type="linenumber">609</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg338" approved="yes">
+        <source xml:space="preserve">&amp;Display</source>
+        <target xml:space="preserve">&amp;Display</target>
+        <context-group purpose="location"><context context-type="linenumber">630</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg339" approved="yes">
+        <source xml:space="preserve">User Interface &amp;language:</source>
+        <target xml:space="preserve">User Interface &amp;language:</target>
+        <context-group purpose="location"><context context-type="linenumber">638</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg340">
+        <source xml:space="preserve">The user interface language can be set here. This setting will take effect after restarting %1.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">651</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg341" approved="yes">
+        <source xml:space="preserve">&amp;Unit to show amounts in:</source>
+        <target xml:space="preserve">&amp;Unit to show amounts in:</target>
+        <context-group purpose="location"><context context-type="linenumber">662</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg342" approved="yes">
+        <source xml:space="preserve">Choose the default subdivision unit to show in the interface and when sending coins.</source>
+        <target xml:space="preserve">Choose the default subdivision unit to show in the interface and when sending coins.</target>
+        <context-group purpose="location"><context context-type="linenumber">675</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg343">
+        <source xml:space="preserve">Whether to show coin control features or not.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg344">
+        <source xml:space="preserve">Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">472</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg345">
+        <source xml:space="preserve">Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">475</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg346">
+        <source xml:space="preserve">&amp;Third party transaction URLs</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">689</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg347">
+        <source xml:space="preserve">Monospaced font in the Overview tab:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">711</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg348">
+        <source xml:space="preserve">embedded &quot;%1&quot;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">719</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg349">
+        <source xml:space="preserve">111.11111111 BTC</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">741</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">790</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg350">
+        <source xml:space="preserve">909.09090909 BTC</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">748</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">797</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg351">
+        <source xml:space="preserve">closest matching &quot;%1&quot;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">768</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg352">
+        <source xml:space="preserve">Options set in this dialog are overridden by the command line or in the configuration file:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">833</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg353" approved="yes">
+        <source xml:space="preserve">&amp;OK</source>
+        <target xml:space="preserve">&amp;OK</target>
+        <context-group purpose="location"><context context-type="linenumber">974</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg354" approved="yes">
+        <source xml:space="preserve">&amp;Cancel</source>
+        <target xml:space="preserve">&amp;Cancel</target>
+        <context-group purpose="location"><context context-type="linenumber">987</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../optionsdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="OptionsDialog">
+      <trans-unit id="_msg355" approved="yes">
+        <source xml:space="preserve">default</source>
+        <target xml:space="preserve">default</target>
+        <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg356">
+        <source xml:space="preserve">none</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">185</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg357" approved="yes">
+        <source xml:space="preserve">Confirm options reset</source>
+        <target xml:space="preserve">Confirm options reset</target>
+        <context-group purpose="location"><context context-type="linenumber">276</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg358">
+        <source xml:space="preserve">Client restart required to activate changes.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">277</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg359">
+        <source xml:space="preserve">Client will be shut down. Do you want to proceed?</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">277</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg360">
+        <source xml:space="preserve">Configuration options</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg361">
+        <source xml:space="preserve">The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">293</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg362">
+        <source xml:space="preserve">Error</source>
+        <target xml:space="preserve" state="needs-review-translation">Error</target>
+        <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg363">
+        <source xml:space="preserve">The configuration file could not be opened.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg364">
+        <source xml:space="preserve">This change would require a client restart.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg365" approved="yes">
+        <source xml:space="preserve">The supplied proxy address is invalid.</source>
+        <target xml:space="preserve">The supplied proxy address is invalid.</target>
+        <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/overviewpage.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="OverviewPage">
+      <trans-unit id="_msg366" approved="yes">
+        <source xml:space="preserve">Form</source>
+        <target xml:space="preserve">Form</target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg367" approved="yes">
+        <source xml:space="preserve">The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
+        <target xml:space="preserve">The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</target>
+        <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">411</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg368">
+        <source xml:space="preserve">Watch-only:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg369">
+        <source xml:space="preserve">Available:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg370" approved="yes">
+        <source xml:space="preserve">Your current spendable balance</source>
+        <target xml:space="preserve">Your current spendable balance</target>
+        <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg371">
+        <source xml:space="preserve">Pending:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg372" approved="yes">
+        <source xml:space="preserve">Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
+        <target xml:space="preserve">Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</target>
+        <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg373" approved="yes">
+        <source xml:space="preserve">Immature:</source>
+        <target xml:space="preserve">Immature:</target>
+        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg374" approved="yes">
+        <source xml:space="preserve">Mined balance that has not yet matured</source>
+        <target xml:space="preserve">Mined balance that has not yet matured</target>
+        <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg375">
+        <source xml:space="preserve">Balances</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg376" approved="yes">
+        <source xml:space="preserve">Total:</source>
+        <target xml:space="preserve">Total:</target>
+        <context-group purpose="location"><context context-type="linenumber">200</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg377" approved="yes">
+        <source xml:space="preserve">Your current total balance</source>
+        <target xml:space="preserve">Your current total balance</target>
+        <context-group purpose="location"><context context-type="linenumber">249</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg378">
+        <source xml:space="preserve">Your current balance in watch-only addresses</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg379">
+        <source xml:space="preserve">Spendable:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg380">
+        <source xml:space="preserve">Recent transactions</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">395</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg381">
+        <source xml:space="preserve">Unconfirmed transactions to watch-only addresses</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg382">
+        <source xml:space="preserve">Mined balance in watch-only addresses that has not yet matured</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg383">
+        <source xml:space="preserve">Current total balance in watch-only addresses</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../overviewpage.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="OverviewPage">
+      <trans-unit id="_msg384">
+        <source xml:space="preserve">Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">191</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/psbtoperationsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="PSBTOperationsDialog">
+      <trans-unit id="_msg385">
+        <source xml:space="preserve">Dialog</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg386">
+        <source xml:space="preserve">Sign Tx</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg387">
+        <source xml:space="preserve">Broadcast Tx</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg388">
+        <source xml:space="preserve">Copy to Clipboard</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg389">
+        <source xml:space="preserve">Save...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg390">
+        <source xml:space="preserve">Close</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../psbtoperationsdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="PSBTOperationsDialog">
+      <trans-unit id="_msg391">
+        <source xml:space="preserve">Failed to load transaction: %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">55</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg392">
+        <source xml:space="preserve">Failed to sign transaction: %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg393">
+        <source xml:space="preserve">Could not sign any more inputs.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg394">
+        <source xml:space="preserve">Signed %1 inputs, but more signatures are still required.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg395">
+        <source xml:space="preserve">Signed transaction successfully. Transaction is ready to broadcast.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg396">
+        <source xml:space="preserve">Unknown error processing transaction.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg397">
+        <source xml:space="preserve">Transaction broadcast successfully! Transaction ID: %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg398">
+        <source xml:space="preserve">Transaction broadcast failed: %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg399">
+        <source xml:space="preserve">PSBT copied to clipboard.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg400">
+        <source xml:space="preserve">Save Transaction Data</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg401">
+        <source xml:space="preserve">Partially Signed Transaction (Binary)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
+        <context-group><context context-type="x-gettext-msgctxt">Name of binary PSBT file format</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg402">
+        <source xml:space="preserve">PSBT saved to disk.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg403">
+        <source xml:space="preserve"> * Sends %1 to %2</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg404">
+        <source xml:space="preserve">Unable to calculate transaction fee or total transaction amount.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">177</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg405">
+        <source xml:space="preserve">Pays transaction fee: </source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">179</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg406">
+        <source xml:space="preserve">Total Amount</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">191</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg407">
+        <source xml:space="preserve">or</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg408">
+        <source xml:space="preserve">Transaction has %1 unsigned inputs.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">200</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg409">
+        <source xml:space="preserve">Transaction is missing some information about inputs.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">242</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg410">
+        <source xml:space="preserve">Transaction still needs signature(s).</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg411">
+        <source xml:space="preserve">(But this wallet cannot sign transactions.)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">249</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg412">
+        <source xml:space="preserve">(But this wallet does not have the right keys.)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">252</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg413">
+        <source xml:space="preserve">Transaction is fully signed and ready for broadcast.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg414">
+        <source xml:space="preserve">Transaction status is unknown.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../paymentserver.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="PaymentServer">
+      <trans-unit id="_msg415">
+        <source xml:space="preserve">Payment request error</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg416">
+        <source xml:space="preserve">Cannot start bitcoin: click-to-pay handler</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">174</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg417">
+        <source xml:space="preserve">URI handling</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">224</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">237</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg418">
+        <source xml:space="preserve">&apos;bitcoin://&apos; is not a valid URI. Use &apos;bitcoin:&apos; instead.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">224</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg419">
+        <source xml:space="preserve">Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it&apos;s strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg420">
+        <source xml:space="preserve">Invalid payment address %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg421">
+        <source xml:space="preserve">URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">251</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg422">
+        <source xml:space="preserve">Payment request file handling</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../peertablemodel.h" datatype="c" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="PeerTableModel">
+      <trans-unit id="_msg423">
+        <source xml:space="preserve">User Agent</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg424">
+        <source xml:space="preserve">Ping</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg425">
+        <source xml:space="preserve">Sent</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg426">
+        <source xml:space="preserve">Received</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg427">
+        <source xml:space="preserve">Peer Id</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg428">
+        <source xml:space="preserve">Address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg429">
+        <source xml:space="preserve">Type</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg430">
+        <source xml:space="preserve">Network</source>
+        <target xml:space="preserve" state="needs-review-translation">Network</target>
+        <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../bitcoinunits.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="QObject">
+      <trans-unit id="_msg431">
+        <source xml:space="preserve">Amount</source>
+        <target xml:space="preserve" state="needs-review-translation">Amount</target>
+        <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../guiutil.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="QObject">
+      <trans-unit id="_msg432">
+        <source xml:space="preserve">Enter a Bitcoin address (e.g. %1)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">118</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg433">
+        <source xml:space="preserve">Unroutable</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">650</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg434">
+        <source xml:space="preserve">Internal</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">656</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg435">
+        <source xml:space="preserve">Inbound</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">666</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg436">
+        <source xml:space="preserve">Outbound</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">666</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg437">
+        <source xml:space="preserve">Full Relay</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">670</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg438">
+        <source xml:space="preserve">Block Relay</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">671</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg439">
+        <source xml:space="preserve">Manual</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">672</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg440">
+        <source xml:space="preserve">Feeler</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">673</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg441">
+        <source xml:space="preserve">Address Fetch</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">674</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg442">
+        <source xml:space="preserve">%1 d</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">688</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg443">
+        <source xml:space="preserve">%1 h</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">690</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg444">
+        <source xml:space="preserve">%1 m</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">692</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg445">
+        <source xml:space="preserve">%1 s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">694</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">722</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg446">
+        <source xml:space="preserve">None</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">710</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg447">
+        <source xml:space="preserve">N/A</source>
+        <target xml:space="preserve" state="needs-review-translation">N/A</target>
+        <context-group purpose="location"><context context-type="linenumber">716</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg448">
+        <source xml:space="preserve">%1 ms</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">717</context></context-group>
+      </trans-unit>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">735</context></context-group>
+        <trans-unit id="_msg449[0]" approved="yes">
+          <source xml:space="preserve">%n second(s)</source>
+          <target xml:space="preserve">%n second</target>
+        </trans-unit>
+        <trans-unit id="_msg449[1]" approved="yes">
+          <source xml:space="preserve">%n second(s)</source>
+          <target xml:space="preserve">%n seconds</target>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">739</context></context-group>
+        <trans-unit id="_msg450[0]" approved="yes">
+          <source xml:space="preserve">%n minute(s)</source>
+          <target xml:space="preserve">%n minute</target>
+        </trans-unit>
+        <trans-unit id="_msg450[1]" approved="yes">
+          <source xml:space="preserve">%n minute(s)</source>
+          <target xml:space="preserve">%n minutes</target>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">743</context></context-group>
+        <trans-unit id="_msg451[0]">
+          <source xml:space="preserve">%n hour(s)</source>
+          <target xml:space="preserve" state="needs-review-translation">%n hour</target>
+        </trans-unit>
+        <trans-unit id="_msg451[1]">
+          <source xml:space="preserve">%n hour(s)</source>
+          <target xml:space="preserve" state="needs-review-translation">%n hours</target>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">747</context></context-group>
+        <trans-unit id="_msg452[0]">
+          <source xml:space="preserve">%n day(s)</source>
+          <target xml:space="preserve" state="needs-review-translation">%n day</target>
+        </trans-unit>
+        <trans-unit id="_msg452[1]">
+          <source xml:space="preserve">%n day(s)</source>
+          <target xml:space="preserve" state="needs-review-translation">%n days</target>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">751</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">757</context></context-group>
+        <trans-unit id="_msg453[0]">
+          <source xml:space="preserve">%n week(s)</source>
+          <target xml:space="preserve" state="needs-review-translation">%n week</target>
+        </trans-unit>
+        <trans-unit id="_msg453[1]">
+          <source xml:space="preserve">%n week(s)</source>
+          <target xml:space="preserve" state="needs-review-translation">%n weeks</target>
+        </trans-unit>
+      </group>
+      <trans-unit id="_msg454">
+        <source xml:space="preserve">%1 and %2</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">757</context></context-group>
+      </trans-unit>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">757</context></context-group>
+        <trans-unit id="_msg455[0]">
+          <source xml:space="preserve">%n year(s)</source>
+          <target xml:space="preserve" state="needs-review-translation">%n year</target>
+        </trans-unit>
+        <trans-unit id="_msg455[1]">
+          <source xml:space="preserve">%n year(s)</source>
+          <target xml:space="preserve" state="needs-review-translation">%n years</target>
+        </trans-unit>
+      </group>
+      <trans-unit id="_msg456">
+        <source xml:space="preserve">%1 B</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">765</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg457">
+        <source xml:space="preserve">%1 kB</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">767</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg458">
+        <source xml:space="preserve">%1 MB</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">769</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg459">
+        <source xml:space="preserve">%1 GB</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">771</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../qrimagewidget.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="QRImageWidget">
+      <trans-unit id="_msg460">
+        <source xml:space="preserve">&amp;Save Image...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">30</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg461">
+        <source xml:space="preserve">&amp;Copy Image</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg462">
+        <source xml:space="preserve">Resulting URI too long, try to reduce the text for label / message.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg463">
+        <source xml:space="preserve">Error encoding URI into QR Code.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg464">
+        <source xml:space="preserve">QR code support not available.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg465">
+        <source xml:space="preserve">Save QR Code</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg466">
+        <source xml:space="preserve">PNG Image</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
+        <context-group><context context-type="x-gettext-msgctxt">Name of PNG file format</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/debugwindow.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="RPCConsole">
+      <trans-unit id="_msg467" approved="yes">
+        <source xml:space="preserve">N/A</source>
+        <target xml:space="preserve">N/A</target>
+        <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">156</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">182</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">277</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">300</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">336</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">359</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1069</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1095</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1121</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1144</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1167</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1190</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1216</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1242</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1265</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1288</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1311</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1334</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1360</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1386</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1409</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1432</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1455</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1478</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1501</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1527</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1550</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1573</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1599</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.h</context><context context-type="linenumber">141</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg468" approved="yes">
+        <source xml:space="preserve">Client version</source>
+        <target xml:space="preserve">Client version</target>
+        <context-group purpose="location"><context context-type="linenumber">65</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg469" approved="yes">
+        <source xml:space="preserve">&amp;Information</source>
+        <target xml:space="preserve">&amp;Information</target>
+        <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg470">
+        <source xml:space="preserve">General</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg471">
+        <source xml:space="preserve">Datadir</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">114</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg472">
+        <source xml:space="preserve">To specify a non-default location of the data directory use the &apos;%1&apos; option.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg473">
+        <source xml:space="preserve">Blocksdir</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg474">
+        <source xml:space="preserve">To specify a non-default location of the blocks directory use the &apos;%1&apos; option.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg475" approved="yes">
+        <source xml:space="preserve">Startup time</source>
+        <target xml:space="preserve">Startup time</target>
+        <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg476" approved="yes">
+        <source xml:space="preserve">Network</source>
+        <target xml:space="preserve">Network</target>
+        <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1111</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg477">
+        <source xml:space="preserve">Name</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg478" approved="yes">
+        <source xml:space="preserve">Number of connections</source>
+        <target xml:space="preserve">Number of connections</target>
+        <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg479" approved="yes">
+        <source xml:space="preserve">Block chain</source>
+        <target xml:space="preserve">Block chain</target>
+        <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg480">
+        <source xml:space="preserve">Memory Pool</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg481">
+        <source xml:space="preserve">Current number of transactions</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg482">
+        <source xml:space="preserve">Memory usage</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">349</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg483">
+        <source xml:space="preserve">Wallet: </source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">443</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg484">
+        <source xml:space="preserve">(none)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">454</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg485">
+        <source xml:space="preserve">&amp;Reset</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">695</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg486">
+        <source xml:space="preserve">Received</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">775</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1468</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg487">
+        <source xml:space="preserve">Sent</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">855</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1445</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg488">
+        <source xml:space="preserve">&amp;Peers</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">896</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg489">
+        <source xml:space="preserve">Banned peers</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">963</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg490">
+        <source xml:space="preserve">Select a peer to view detailed information.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1028</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1104</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg491">
+        <source xml:space="preserve">Version</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1134</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg492">
+        <source xml:space="preserve">Starting Block</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1255</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg493">
+        <source xml:space="preserve">Synced Headers</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1278</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg494">
+        <source xml:space="preserve">Synced Blocks</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1301</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg495">
+        <source xml:space="preserve">The mapped Autonomous System used for diversifying peer selection.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1586</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg496">
+        <source xml:space="preserve">Mapped AS</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1589</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg497">
+        <source xml:space="preserve">User Agent</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1157</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg498">
+        <source xml:space="preserve">Node window</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg499">
+        <source xml:space="preserve">Current block height</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg500">
+        <source xml:space="preserve">Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">397</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg501">
+        <source xml:space="preserve">Decrease font size</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">481</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg502">
+        <source xml:space="preserve">Increase font size</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">513</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg503">
+        <source xml:space="preserve">Permissions</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1059</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg504">
+        <source xml:space="preserve">The direction and type of peer connection: %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1082</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg505">
+        <source xml:space="preserve">Direction/Type</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1085</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg506">
+        <source xml:space="preserve">The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1108</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg507">
+        <source xml:space="preserve">Services</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1180</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg508">
+        <source xml:space="preserve">Whether the peer requested us to relay transactions.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1203</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg509">
+        <source xml:space="preserve">Wants Tx Relay</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1206</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg510">
+        <source xml:space="preserve">High bandwidth BIP152 compact block relay: %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1229</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg511">
+        <source xml:space="preserve">High Bandwidth</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1232</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg512">
+        <source xml:space="preserve">Connection Time</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1324</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg513">
+        <source xml:space="preserve">Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1347</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg514">
+        <source xml:space="preserve">Last Block</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1350</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg515">
+        <source xml:space="preserve">Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1373</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg516">
+        <source xml:space="preserve">Last Tx</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1376</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg517">
+        <source xml:space="preserve">Last Send</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1399</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg518">
+        <source xml:space="preserve">Last Receive</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1422</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg519">
+        <source xml:space="preserve">Ping Time</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1491</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg520">
+        <source xml:space="preserve">The duration of a currently outstanding ping.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1514</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg521">
+        <source xml:space="preserve">Ping Wait</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1517</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg522">
+        <source xml:space="preserve">Min Ping</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1540</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg523">
+        <source xml:space="preserve">Time Offset</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1563</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg524" approved="yes">
+        <source xml:space="preserve">Last block time</source>
+        <target xml:space="preserve">Last block time</target>
+        <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg525" approved="yes">
+        <source xml:space="preserve">&amp;Open</source>
+        <target xml:space="preserve">&amp;Open</target>
+        <context-group purpose="location"><context context-type="linenumber">400</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg526" approved="yes">
+        <source xml:space="preserve">&amp;Console</source>
+        <target xml:space="preserve">&amp;Console</target>
+        <context-group purpose="location"><context context-type="linenumber">426</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg527">
+        <source xml:space="preserve">&amp;Network Traffic</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">643</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg528">
+        <source xml:space="preserve">Totals</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">711</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg529" approved="yes">
+        <source xml:space="preserve">Debug log file</source>
+        <target xml:space="preserve">Debug log file</target>
+        <context-group purpose="location"><context context-type="linenumber">390</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg530" approved="yes">
+        <source xml:space="preserve">Clear console</source>
+        <target xml:space="preserve">Clear console</target>
+        <context-group purpose="location"><context context-type="linenumber">545</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../rpcconsole.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="RPCConsole">
+      <trans-unit id="_msg531">
+        <source xml:space="preserve">In:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">862</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg532">
+        <source xml:space="preserve">Out:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">863</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg533">
+        <source xml:space="preserve">1 &amp;hour</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">621</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg534">
+        <source xml:space="preserve">1 &amp;day</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">622</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg535">
+        <source xml:space="preserve">1 &amp;week</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">623</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg536">
+        <source xml:space="preserve">1 &amp;year</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">624</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg537">
+        <source xml:space="preserve">&amp;Disconnect</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">620</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg538">
+        <source xml:space="preserve">Inbound: initiated by peer</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">465</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg539">
+        <source xml:space="preserve">Outbound Full Relay: default</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">466</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg540">
+        <source xml:space="preserve">Outbound Block Relay: does not relay transactions or addresses</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">467</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg541">
+        <source xml:space="preserve">Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">468</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg542">
+        <source xml:space="preserve">Outbound Feeler: short-lived, for testing addresses</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">472</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg543">
+        <source xml:space="preserve">Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">473</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg544">
+        <source xml:space="preserve">we selected the peer for high bandwidth relay</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">477</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg545">
+        <source xml:space="preserve">the peer selected us for high bandwidth relay</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">478</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg546">
+        <source xml:space="preserve">no high bandwidth relay selected</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">479</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg547">
+        <source xml:space="preserve">&amp;Unban</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">661</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg548">
+        <source xml:space="preserve">Welcome to the %1 RPC console.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">825</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg549">
+        <source xml:space="preserve">Use up and down arrows to navigate history, and %1 to clear screen.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">826</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg550">
+        <source xml:space="preserve">Type %1 for an overview of available commands.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">827</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg551">
+        <source xml:space="preserve">For more information on using this console type %1.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">828</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg552">
+        <source xml:space="preserve">WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">830</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg553">
+        <source xml:space="preserve">Network activity disabled</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">866</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg554">
+        <source xml:space="preserve">Executing command without any wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">932</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg555">
+        <source xml:space="preserve">(peer id: %1)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1110</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg556">
+        <source xml:space="preserve">Executing command using &quot;%1&quot; wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">930</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg557">
+        <source xml:space="preserve">via %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1112</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../rpcconsole.h" datatype="c" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="RPCConsole">
+      <trans-unit id="_msg558">
+        <source xml:space="preserve">Yes</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg559">
+        <source xml:space="preserve">No</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg560">
+        <source xml:space="preserve">To</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg561">
+        <source xml:space="preserve">From</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg562">
+        <source xml:space="preserve">Ban for</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">141</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg563">
+        <source xml:space="preserve">Never</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">178</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg564">
+        <source xml:space="preserve">Unknown</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">141</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/receivecoinsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="ReceiveCoinsDialog">
+      <trans-unit id="_msg565">
+        <source xml:space="preserve">&amp;Amount:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg566">
+        <source xml:space="preserve">&amp;Label:</source>
+        <target xml:space="preserve" state="needs-review-translation">&amp;Label:</target>
+        <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg567">
+        <source xml:space="preserve">&amp;Message:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg568">
+        <source xml:space="preserve">An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg569">
+        <source xml:space="preserve">An optional label to associate with the new receiving address.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg570">
+        <source xml:space="preserve">Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg571">
+        <source xml:space="preserve">An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg572">
+        <source xml:space="preserve">An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg573">
+        <source xml:space="preserve">An optional message that is attached to the payment request and may be displayed to the sender.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg574">
+        <source xml:space="preserve">&amp;Create new receiving address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg575">
+        <source xml:space="preserve">Clear all fields of the form.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">134</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg576">
+        <source xml:space="preserve">Clear</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg577">
+        <source xml:space="preserve">Native segwit addresses (aka Bech32 or BIP-173) reduce your transaction fees later on and offer better protection against typos, but old wallets don&apos;t support them. When unchecked, an address compatible with older wallets will be created instead.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg578">
+        <source xml:space="preserve">Generate native segwit (Bech32) address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg579">
+        <source xml:space="preserve">Requested payments history</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg580">
+        <source xml:space="preserve">Show the selected request (does the same as double clicking an entry)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg581">
+        <source xml:space="preserve">Show</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">307</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg582">
+        <source xml:space="preserve">Remove the selected entries from the list</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg583">
+        <source xml:space="preserve">Remove</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../receivecoinsdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="ReceiveCoinsDialog">
+      <trans-unit id="_msg584">
+        <source xml:space="preserve">Copy URI</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg585">
+        <source xml:space="preserve">Copy address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg586">
+        <source xml:space="preserve">Copy label</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg587">
+        <source xml:space="preserve">Copy message</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg588">
+        <source xml:space="preserve">Copy amount</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg589">
+        <source xml:space="preserve">Could not unlock wallet.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">190</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg590">
+        <source xml:space="preserve">Could not generate new %1 address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/receiverequestdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="ReceiveRequestDialog">
+      <trans-unit id="_msg591">
+        <source xml:space="preserve">Request payment to ...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg592">
+        <source xml:space="preserve">Address:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg593">
+        <source xml:space="preserve">Amount:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg594">
+        <source xml:space="preserve">Label:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg595">
+        <source xml:space="preserve">Message:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg596">
+        <source xml:space="preserve">Wallet:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg597">
+        <source xml:space="preserve">Copy &amp;URI</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg598">
+        <source xml:space="preserve">Copy &amp;Address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg599">
+        <source xml:space="preserve">&amp;Save Image...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg600">
+        <source xml:space="preserve">Payment information</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">39</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../receiverequestdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="ReceiveRequestDialog">
+      <trans-unit id="_msg601">
+        <source xml:space="preserve">Request payment to %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../recentrequeststablemodel.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="RecentRequestsTableModel">
+      <trans-unit id="_msg602">
+        <source xml:space="preserve">Date</source>
+        <target xml:space="preserve" state="needs-review-translation">Date</target>
+        <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg603">
+        <source xml:space="preserve">Label</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg604">
+        <source xml:space="preserve">Message</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg605">
+        <source xml:space="preserve">(no label)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg606">
+        <source xml:space="preserve">(no message)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg607">
+        <source xml:space="preserve">(no amount requested)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg608">
+        <source xml:space="preserve">Requested</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/sendcoinsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="SendCoinsDialog">
+      <trans-unit id="_msg609" approved="yes">
+        <source xml:space="preserve">Send Coins</source>
+        <target xml:space="preserve">Send Coins</target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../sendcoinsdialog.cpp</context><context context-type="linenumber">673</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg610">
+        <source xml:space="preserve">Coin Control Features</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg611">
+        <source xml:space="preserve">Inputs...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg612">
+        <source xml:space="preserve">automatically selected</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg613">
+        <source xml:space="preserve">Insufficient funds!</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg614">
+        <source xml:space="preserve">Quantity:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">228</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg615">
+        <source xml:space="preserve">Bytes:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg616">
+        <source xml:space="preserve">Amount:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg617">
+        <source xml:space="preserve">Fee:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">391</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg618">
+        <source xml:space="preserve">After Fee:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">442</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg619">
+        <source xml:space="preserve">Change:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">474</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg620">
+        <source xml:space="preserve">If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">518</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg621">
+        <source xml:space="preserve">Custom change address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">521</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg622">
+        <source xml:space="preserve">Transaction Fee:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">727</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg623">
+        <source xml:space="preserve">Choose...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">741</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg624">
+        <source xml:space="preserve">Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">765</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg625">
+        <source xml:space="preserve">Warning: Fee estimation is currently not possible.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">774</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg626">
+        <source xml:space="preserve">Specify a custom fee per kB (1,000 bytes) of the transaction&apos;s virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 satoshis per kB&quot; for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">851</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg627">
+        <source xml:space="preserve">per kilobyte</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">856</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg628">
+        <source xml:space="preserve">Hide</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">803</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg629">
+        <source xml:space="preserve">Recommended:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">915</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg630">
+        <source xml:space="preserve">Custom:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">945</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg631">
+        <source xml:space="preserve">(Smart fee not initialized yet. This usually takes a few blocks...)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">994</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg632" approved="yes">
+        <source xml:space="preserve">Send to multiple recipients at once</source>
+        <target xml:space="preserve">Send to multiple recipients at once</target>
+        <context-group purpose="location"><context context-type="linenumber">1160</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg633" approved="yes">
+        <source xml:space="preserve">Add &amp;Recipient</source>
+        <target xml:space="preserve">Add &amp;Recipient</target>
+        <context-group purpose="location"><context context-type="linenumber">1163</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg634">
+        <source xml:space="preserve">Clear all fields of the form.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1143</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg635">
+        <source xml:space="preserve">Dust:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg636">
+        <source xml:space="preserve">Hide transaction fee settings</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">800</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg637">
+        <source xml:space="preserve">When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">886</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg638">
+        <source xml:space="preserve">A too low fee might result in a never confirming transaction (read the tooltip)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">889</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg639">
+        <source xml:space="preserve">Confirmation time target:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1020</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg640">
+        <source xml:space="preserve">Enable Replace-By-Fee</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1078</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg641">
+        <source xml:space="preserve">With Replace-By-Fee (BIP-125) you can increase a transaction&apos;s fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1081</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg642" approved="yes">
+        <source xml:space="preserve">Clear &amp;All</source>
+        <target xml:space="preserve">Clear &amp;All</target>
+        <context-group purpose="location"><context context-type="linenumber">1146</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg643" approved="yes">
+        <source xml:space="preserve">Balance:</source>
+        <target xml:space="preserve">Balance:</target>
+        <context-group purpose="location"><context context-type="linenumber">1201</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg644" approved="yes">
+        <source xml:space="preserve">Confirm the send action</source>
+        <target xml:space="preserve">Confirm the send action</target>
+        <context-group purpose="location"><context context-type="linenumber">1117</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg645" approved="yes">
+        <source xml:space="preserve">S&amp;end</source>
+        <target xml:space="preserve">S&amp;end</target>
+        <context-group purpose="location"><context context-type="linenumber">1120</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../sendcoinsdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="SendCoinsDialog">
+      <trans-unit id="_msg646">
+        <source xml:space="preserve">Copy quantity</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg647">
+        <source xml:space="preserve">Copy amount</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">93</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg648">
+        <source xml:space="preserve">Copy fee</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg649">
+        <source xml:space="preserve">Copy after fee</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg650">
+        <source xml:space="preserve">Copy bytes</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg651">
+        <source xml:space="preserve">Copy dust</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg652">
+        <source xml:space="preserve">Copy change</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg653">
+        <source xml:space="preserve">%1 (%2 blocks)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">174</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg654">
+        <source xml:space="preserve">Cr&amp;eate Unsigned</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">203</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg655">
+        <source xml:space="preserve">Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">204</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg656">
+        <source xml:space="preserve"> from wallet &apos;%1&apos;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg657">
+        <source xml:space="preserve">%1 to &apos;%2&apos;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg658">
+        <source xml:space="preserve">%1 to %2</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg659">
+        <source xml:space="preserve">Do you want to draft this transaction?</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">317</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg660">
+        <source xml:space="preserve">Are you sure you want to send?</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg661">
+        <source xml:space="preserve">Create Unsigned</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">390</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg662">
+        <source xml:space="preserve">Save Transaction Data</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">434</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg663">
+        <source xml:space="preserve">PSBT saved</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">442</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg664">
+        <source xml:space="preserve">or</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg665">
+        <source xml:space="preserve">You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg666">
+        <source xml:space="preserve">Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg667">
+        <source xml:space="preserve">Please, review your transaction.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg668">
+        <source xml:space="preserve">Transaction fee</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg669">
+        <source xml:space="preserve">Not signalling Replace-By-Fee, BIP-125.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">350</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg670">
+        <source xml:space="preserve">Total Amount</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg671">
+        <source xml:space="preserve">To review recipient list click &quot;Show Details...&quot;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">371</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg672">
+        <source xml:space="preserve">Confirm send coins</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">389</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg673">
+        <source xml:space="preserve">Confirm transaction proposal</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">389</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg674">
+        <source xml:space="preserve">Send</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">390</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg675">
+        <source xml:space="preserve">Partially Signed Transaction (Binary)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
+        <context-group><context context-type="x-gettext-msgctxt">Name of binary PSBT file format</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg676">
+        <source xml:space="preserve">Watch-only balance:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">618</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg677">
+        <source xml:space="preserve">The recipient address is not valid. Please recheck.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">642</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg678">
+        <source xml:space="preserve">The amount to pay must be larger than 0.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">645</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg679">
+        <source xml:space="preserve">The amount exceeds your balance.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">648</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg680">
+        <source xml:space="preserve">The total exceeds your balance when the %1 transaction fee is included.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">651</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg681">
+        <source xml:space="preserve">Duplicate address found: addresses should only be used once each.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">654</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg682">
+        <source xml:space="preserve">Transaction creation failed!</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">657</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg683">
+        <source xml:space="preserve">A fee higher than %1 is considered an absurdly high fee.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">661</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg684">
+        <source xml:space="preserve">Payment request expired.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">664</context></context-group>
+      </trans-unit>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">788</context></context-group>
+        <trans-unit id="_msg685[0]" approved="yes">
+          <source xml:space="preserve">Estimated to begin confirmation within %n block(s).</source>
+          <target xml:space="preserve">Estimated to begin confirmation within %n block.</target>
+        </trans-unit>
+        <trans-unit id="_msg685[1]" approved="yes">
+          <source xml:space="preserve">Estimated to begin confirmation within %n block(s).</source>
+          <target xml:space="preserve">Estimated to begin confirmation within %n blocks.</target>
+        </trans-unit>
+      </group>
+      <trans-unit id="_msg686">
+        <source xml:space="preserve">Warning: Invalid Bitcoin address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">888</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg687">
+        <source xml:space="preserve">Warning: Unknown change address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">893</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg688">
+        <source xml:space="preserve">Confirm custom change address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">896</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg689">
+        <source xml:space="preserve">The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">896</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg690">
+        <source xml:space="preserve">(no label)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">917</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/sendcoinsentry.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="SendCoinsEntry">
+      <trans-unit id="_msg691" approved="yes">
+        <source xml:space="preserve">A&amp;mount:</source>
+        <target xml:space="preserve">A&amp;mount:</target>
+        <context-group purpose="location"><context context-type="linenumber">155</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">705</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1238</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg692" approved="yes">
+        <source xml:space="preserve">Pay &amp;To:</source>
+        <target xml:space="preserve">Pay &amp;To:</target>
+        <context-group purpose="location"><context context-type="linenumber">39</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg693" approved="yes">
+        <source xml:space="preserve">&amp;Label:</source>
+        <target xml:space="preserve">&amp;Label:</target>
+        <context-group purpose="location"><context context-type="linenumber">132</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg694">
+        <source xml:space="preserve">Choose previously used address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg695">
+        <source xml:space="preserve">The Bitcoin address to send the payment to</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg696" approved="yes">
+        <source xml:space="preserve">Alt+A</source>
+        <target xml:space="preserve">Alt+A</target>
+        <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg697" approved="yes">
+        <source xml:space="preserve">Paste address from clipboard</source>
+        <target xml:space="preserve">Paste address from clipboard</target>
+        <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg698" approved="yes">
+        <source xml:space="preserve">Alt+P</source>
+        <target xml:space="preserve">Alt+P</target>
+        <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg699">
+        <source xml:space="preserve">Remove this entry</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">672</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1205</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg700">
+        <source xml:space="preserve">The amount to send in the selected unit</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg701">
+        <source xml:space="preserve">The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">177</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg702">
+        <source xml:space="preserve">S&amp;ubtract fee from amount</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg703">
+        <source xml:space="preserve">Use available balance</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg704">
+        <source xml:space="preserve">Message:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">196</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg705">
+        <source xml:space="preserve">This is an unauthenticated payment request.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">639</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg706">
+        <source xml:space="preserve">This is an authenticated payment request.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1168</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg707">
+        <source xml:space="preserve">Enter a label for this address to add it to the list of used addresses</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg708">
+        <source xml:space="preserve">A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg709">
+        <source xml:space="preserve">Pay To:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">654</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1183</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg710">
+        <source xml:space="preserve">Memo:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">688</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1221</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/signverifymessagedialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="SignVerifyMessageDialog">
+      <trans-unit id="_msg711" approved="yes">
+        <source xml:space="preserve">Signatures - Sign / Verify a Message</source>
+        <target xml:space="preserve">Signatures - Sign / Verify a Message</target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg712" approved="yes">
+        <source xml:space="preserve">&amp;Sign Message</source>
+        <target xml:space="preserve">&amp;Sign Message</target>
+        <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg713">
+        <source xml:space="preserve">You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg714">
+        <source xml:space="preserve">The Bitcoin address to sign the message with</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg715">
+        <source xml:space="preserve">Choose previously used address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg716" approved="yes">
+        <source xml:space="preserve">Alt+A</source>
+        <target xml:space="preserve">Alt+A</target>
+        <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg717" approved="yes">
+        <source xml:space="preserve">Paste address from clipboard</source>
+        <target xml:space="preserve">Paste address from clipboard</target>
+        <context-group purpose="location"><context context-type="linenumber">78</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg718" approved="yes">
+        <source xml:space="preserve">Alt+P</source>
+        <target xml:space="preserve">Alt+P</target>
+        <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg719" approved="yes">
+        <source xml:space="preserve">Enter the message you want to sign here</source>
+        <target xml:space="preserve">Enter the message you want to sign here</target>
+        <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg720" approved="yes">
+        <source xml:space="preserve">Signature</source>
+        <target xml:space="preserve">Signature</target>
+        <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg721" approved="yes">
+        <source xml:space="preserve">Copy the current signature to the system clipboard</source>
+        <target xml:space="preserve">Copy the current signature to the system clipboard</target>
+        <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg722" approved="yes">
+        <source xml:space="preserve">Sign the message to prove you own this Bitcoin address</source>
+        <target xml:space="preserve">Sign the message to prove you own this Bitcoin address</target>
+        <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg723" approved="yes">
+        <source xml:space="preserve">Sign &amp;Message</source>
+        <target xml:space="preserve">Sign &amp;Message</target>
+        <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg724" approved="yes">
+        <source xml:space="preserve">Reset all sign message fields</source>
+        <target xml:space="preserve">Reset all sign message fields</target>
+        <context-group purpose="location"><context context-type="linenumber">178</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg725" approved="yes">
+        <source xml:space="preserve">Clear &amp;All</source>
+        <target xml:space="preserve">Clear &amp;All</target>
+        <context-group purpose="location"><context context-type="linenumber">181</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg726" approved="yes">
+        <source xml:space="preserve">&amp;Verify Message</source>
+        <target xml:space="preserve">&amp;Verify Message</target>
+        <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg727">
+        <source xml:space="preserve">Enter the receiver&apos;s address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg728">
+        <source xml:space="preserve">The Bitcoin address the message was signed with</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg729">
+        <source xml:space="preserve">The signed message to verify</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg730">
+        <source xml:space="preserve">The signature given when the message was signed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg731" approved="yes">
+        <source xml:space="preserve">Verify the message to ensure it was signed with the specified Bitcoin address</source>
+        <target xml:space="preserve">Verify the message to ensure it was signed with the specified Bitcoin address</target>
+        <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg732" approved="yes">
+        <source xml:space="preserve">Verify &amp;Message</source>
+        <target xml:space="preserve">Verify &amp;Message</target>
+        <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg733" approved="yes">
+        <source xml:space="preserve">Reset all verify message fields</source>
+        <target xml:space="preserve">Reset all verify message fields</target>
+        <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg734">
+        <source xml:space="preserve">Click &quot;Sign Message&quot; to generate signature</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../signverifymessagedialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="SignVerifyMessageDialog">
+      <trans-unit id="_msg735">
+        <source xml:space="preserve">The entered address is invalid.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg736">
+        <source xml:space="preserve">Please check the address and try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">227</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg737">
+        <source xml:space="preserve">The entered address does not refer to a key.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg738">
+        <source xml:space="preserve">Wallet unlock was cancelled.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg739">
+        <source xml:space="preserve">No error</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg740">
+        <source xml:space="preserve">Private key for the entered address is not available.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg741">
+        <source xml:space="preserve">Message signing failed.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg742">
+        <source xml:space="preserve">Message signed.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg743">
+        <source xml:space="preserve">The signature could not be decoded.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg744">
+        <source xml:space="preserve">Please check the signature and try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg745">
+        <source xml:space="preserve">The signature did not match the message digest.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg746">
+        <source xml:space="preserve">Message verification failed.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg747">
+        <source xml:space="preserve">Message verified.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">214</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../trafficgraphwidget.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="TrafficGraphWidget">
+      <trans-unit id="_msg748">
+        <source xml:space="preserve">kB/s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">82</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../transactiondesc.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="TransactionDesc">
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
+        <trans-unit id="_msg749[0]" approved="yes">
+          <source xml:space="preserve">Open for %n more block(s)</source>
+          <target xml:space="preserve">Open for %n more block</target>
+        </trans-unit>
+        <trans-unit id="_msg749[1]" approved="yes">
+          <source xml:space="preserve">Open for %n more block(s)</source>
+          <target xml:space="preserve">Open for %n more blocks</target>
+        </trans-unit>
+      </group>
+      <trans-unit id="_msg750">
+        <source xml:space="preserve">Open until %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg751">
+        <source xml:space="preserve">conflicted with a transaction with %1 confirmations</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg752">
+        <source xml:space="preserve">0/unconfirmed, %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">44</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg753">
+        <source xml:space="preserve">in memory pool</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">44</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg754">
+        <source xml:space="preserve">not in memory pool</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">44</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg755">
+        <source xml:space="preserve">abandoned</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">44</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg756">
+        <source xml:space="preserve">%1/unconfirmed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg757">
+        <source xml:space="preserve">%1 confirmations</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg758">
+        <source xml:space="preserve">Status</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg759">
+        <source xml:space="preserve">Date</source>
+        <target xml:space="preserve" state="needs-review-translation">Date</target>
+        <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg760">
+        <source xml:space="preserve">Source</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg761">
+        <source xml:space="preserve">Generated</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg762">
+        <source xml:space="preserve">From</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">113</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">199</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg763">
+        <source xml:space="preserve">unknown</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg764">
+        <source xml:space="preserve">To</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg765">
+        <source xml:space="preserve">own address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg766">
+        <source xml:space="preserve">watch-only</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">199</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg767">
+        <source xml:space="preserve">label</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">132</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg768">
+        <source xml:space="preserve">Credit</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
+      </trans-unit>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
+        <trans-unit id="_msg769[0]" approved="yes">
+          <source xml:space="preserve">matures in %n more block(s)</source>
+          <target xml:space="preserve">matures in %n more block</target>
+        </trans-unit>
+        <trans-unit id="_msg769[1]" approved="yes">
+          <source xml:space="preserve">matures in %n more block(s)</source>
+          <target xml:space="preserve">matures in %n more blocks</target>
+        </trans-unit>
+      </group>
+      <trans-unit id="_msg770">
+        <source xml:space="preserve">not accepted</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg771">
+        <source xml:space="preserve">Debit</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg772">
+        <source xml:space="preserve">Total debit</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">242</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg773">
+        <source xml:space="preserve">Total credit</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg774">
+        <source xml:space="preserve">Transaction fee</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg775">
+        <source xml:space="preserve">Net amount</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">270</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg776">
+        <source xml:space="preserve">Message</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">276</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">288</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg777">
+        <source xml:space="preserve">Comment</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">278</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg778">
+        <source xml:space="preserve">Transaction ID</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg779">
+        <source xml:space="preserve">Transaction total size</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg780">
+        <source xml:space="preserve">Transaction virtual size</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg781">
+        <source xml:space="preserve">Output index</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">283</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg782">
+        <source xml:space="preserve"> (Certificate was not verified)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg783">
+        <source xml:space="preserve">Merchant</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg784">
+        <source xml:space="preserve">Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg785">
+        <source xml:space="preserve">Debug information</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg786">
+        <source xml:space="preserve">Transaction</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg787">
+        <source xml:space="preserve">Inputs</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg788">
+        <source xml:space="preserve">Amount</source>
+        <target xml:space="preserve" state="needs-review-translation">Amount</target>
+        <context-group purpose="location"><context context-type="linenumber">350</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg789">
+        <source xml:space="preserve">true</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg790">
+        <source xml:space="preserve">false</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/transactiondescdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="TransactionDescDialog">
+      <trans-unit id="_msg791" approved="yes">
+        <source xml:space="preserve">This pane shows a detailed description of the transaction</source>
+        <target xml:space="preserve">This pane shows a detailed description of the transaction</target>
+        <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../transactiondescdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="TransactionDescDialog">
+      <trans-unit id="_msg792">
+        <source xml:space="preserve">Details for %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">18</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../transactiontablemodel.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="TransactionTableModel">
+      <trans-unit id="_msg793">
+        <source xml:space="preserve">Date</source>
+        <target xml:space="preserve" state="needs-review-translation">Date</target>
+        <context-group purpose="location"><context context-type="linenumber">252</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg794">
+        <source xml:space="preserve">Type</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">252</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg795">
+        <source xml:space="preserve">Label</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">252</context></context-group>
+      </trans-unit>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">314</context></context-group>
+        <trans-unit id="_msg796[0]" approved="yes">
+          <source xml:space="preserve">Open for %n more block(s)</source>
+          <target xml:space="preserve">Open for %n more block</target>
+        </trans-unit>
+        <trans-unit id="_msg796[1]" approved="yes">
+          <source xml:space="preserve">Open for %n more block(s)</source>
+          <target xml:space="preserve">Open for %n more blocks</target>
+        </trans-unit>
+      </group>
+      <trans-unit id="_msg797">
+        <source xml:space="preserve">Open until %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">317</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg798">
+        <source xml:space="preserve">Unconfirmed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">320</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg799">
+        <source xml:space="preserve">Abandoned</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg800">
+        <source xml:space="preserve">Confirming (%1 of %2 recommended confirmations)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg801">
+        <source xml:space="preserve">Confirmed (%1 confirmations)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg802">
+        <source xml:space="preserve">Conflicted</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">332</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg803">
+        <source xml:space="preserve">Immature (%1 confirmations, will be available after %2)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg804">
+        <source xml:space="preserve">Generated but not accepted</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg805">
+        <source xml:space="preserve">Received with</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">377</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg806">
+        <source xml:space="preserve">Received from</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">379</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg807">
+        <source xml:space="preserve">Sent to</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">382</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg808">
+        <source xml:space="preserve">Payment to yourself</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">384</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg809">
+        <source xml:space="preserve">Mined</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">386</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg810">
+        <source xml:space="preserve">watch-only</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">414</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg811">
+        <source xml:space="preserve">(n/a)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">430</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg812">
+        <source xml:space="preserve">(no label)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">640</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg813">
+        <source xml:space="preserve">Transaction status. Hover over this field to show number of confirmations.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">679</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg814">
+        <source xml:space="preserve">Date and time that the transaction was received.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">681</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg815">
+        <source xml:space="preserve">Type of transaction.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">683</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg816">
+        <source xml:space="preserve">Whether or not a watch-only address is involved in this transaction.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">685</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg817">
+        <source xml:space="preserve">User-defined intent/purpose of the transaction.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">687</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg818">
+        <source xml:space="preserve">Amount removed from or added to balance.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">689</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../transactionview.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="TransactionView">
+      <trans-unit id="_msg819">
+        <source xml:space="preserve">All</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg820">
+        <source xml:space="preserve">Today</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg821">
+        <source xml:space="preserve">This week</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg822">
+        <source xml:space="preserve">This month</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg823">
+        <source xml:space="preserve">Last month</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg824">
+        <source xml:space="preserve">This year</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg825">
+        <source xml:space="preserve">Range...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg826">
+        <source xml:space="preserve">Received with</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg827">
+        <source xml:space="preserve">Sent to</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg828">
+        <source xml:space="preserve">To yourself</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg829">
+        <source xml:space="preserve">Mined</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg830">
+        <source xml:space="preserve">Other</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">93</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg831">
+        <source xml:space="preserve">Enter address, transaction id, or label to search</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg832">
+        <source xml:space="preserve">Min amount</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg833">
+        <source xml:space="preserve">Abandon transaction</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">165</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg834">
+        <source xml:space="preserve">Increase transaction fee</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg835">
+        <source xml:space="preserve">Copy address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg836">
+        <source xml:space="preserve">Copy label</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">169</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg837">
+        <source xml:space="preserve">Copy amount</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg838">
+        <source xml:space="preserve">Copy transaction ID</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">171</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg839">
+        <source xml:space="preserve">Copy raw transaction</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg840">
+        <source xml:space="preserve">Copy full transaction details</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg841">
+        <source xml:space="preserve">Edit address label</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">174</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg842">
+        <source xml:space="preserve">Comma separated file</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">360</context></context-group>
+        <context-group><context context-type="x-gettext-msgctxt">Name of CSV file format</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg843">
+        <source xml:space="preserve">Show transaction details</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">175</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg844">
+        <source xml:space="preserve">Export Transaction History</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">359</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg845">
+        <source xml:space="preserve">Confirmed</source>
+        <target xml:space="preserve" state="needs-review-translation">Confirmed</target>
+        <context-group purpose="location"><context context-type="linenumber">369</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg846">
+        <source xml:space="preserve">Watch-only</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">371</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg847">
+        <source xml:space="preserve">Date</source>
+        <target xml:space="preserve" state="needs-review-translation">Date</target>
+        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg848">
+        <source xml:space="preserve">Type</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg849">
+        <source xml:space="preserve">Label</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">374</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg850">
+        <source xml:space="preserve">Address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg851">
+        <source xml:space="preserve">ID</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">377</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg852">
+        <source xml:space="preserve">Exporting Failed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg853">
+        <source xml:space="preserve">There was an error trying to save the transaction history to %1.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg854">
+        <source xml:space="preserve">Exporting Successful</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">384</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg855">
+        <source xml:space="preserve">The transaction history was successfully saved to %1.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">384</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg856">
+        <source xml:space="preserve">Range:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">556</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg857">
+        <source xml:space="preserve">to</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">564</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../walletframe.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="WalletFrame">
+      <trans-unit id="_msg858">
+        <source xml:space="preserve">No wallet has been loaded.
+Go to File &gt; Open Wallet to load a wallet.
+- OR -</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">39</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg859">
+        <source xml:space="preserve">Create a new wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">44</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../walletmodel.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="WalletModel">
+      <trans-unit id="_msg860">
+        <source xml:space="preserve">Send Coins</source>
+        <target xml:space="preserve" state="needs-review-translation">Send Coins</target>
+        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg861">
+        <source xml:space="preserve">Fee bump error</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">497</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">549</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">562</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">567</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg862">
+        <source xml:space="preserve">Increasing transaction fee failed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">497</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg863">
+        <source xml:space="preserve">Do you want to increase the fee?</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">505</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg864">
+        <source xml:space="preserve">Do you want to draft a transaction with fee increase?</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">505</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg865">
+        <source xml:space="preserve">Current fee:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">509</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg866">
+        <source xml:space="preserve">Increase:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">513</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg867">
+        <source xml:space="preserve">New fee:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">517</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg868">
+        <source xml:space="preserve">Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">525</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg869">
+        <source xml:space="preserve">Confirm fee bump</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">528</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg870">
+        <source xml:space="preserve">Can&apos;t draft transaction.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">549</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg871">
+        <source xml:space="preserve">PSBT copied</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">556</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg872">
+        <source xml:space="preserve">Can&apos;t sign transaction.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">562</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg873">
+        <source xml:space="preserve">Could not commit transaction</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">567</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg874">
+        <source xml:space="preserve">default wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">587</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../walletview.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="WalletView">
+      <trans-unit id="_msg875">
+        <source xml:space="preserve">&amp;Export</source>
+        <target xml:space="preserve" state="needs-review-translation">&amp;Export</target>
+        <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg876">
+        <source xml:space="preserve">Export the data in the current tab to a file</source>
+        <target xml:space="preserve" state="needs-review-translation">Export the data in the current tab to a file</target>
+        <context-group purpose="location"><context context-type="linenumber">52</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg877">
+        <source xml:space="preserve">Error</source>
+        <target xml:space="preserve" state="needs-review-translation">Error</target>
+        <context-group purpose="location"><context context-type="linenumber">217</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">236</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg878">
+        <source xml:space="preserve">Unable to decode PSBT from clipboard (invalid base64)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">217</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg879">
+        <source xml:space="preserve">Load Transaction Data</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg880">
+        <source xml:space="preserve">Partially Signed Transaction (*.psbt)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">223</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg881">
+        <source xml:space="preserve">PSBT file must be smaller than 100 MiB</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg882">
+        <source xml:space="preserve">Unable to decode PSBT</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">236</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg883">
+        <source xml:space="preserve">Backup Wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg884">
+        <source xml:space="preserve">Wallet Data</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">276</context></context-group>
+        <context-group><context context-type="x-gettext-msgctxt">Name of wallet data file format</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg885">
+        <source xml:space="preserve">Backup Failed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg886">
+        <source xml:space="preserve">There was an error trying to save the wallet data to %1.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg887">
+        <source xml:space="preserve">Backup Successful</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">286</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg888">
+        <source xml:space="preserve">The wallet data was successfully saved to %1.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">286</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg889">
+        <source xml:space="preserve">Cancel</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">330</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../bitcoinstrings.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="bitcoin-core">
+      <trans-unit id="_msg890">
+        <source xml:space="preserve">Distributed under the MIT software license, see the accompanying file %s or %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">31</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg891">
+        <source xml:space="preserve">Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg892">
+        <source xml:space="preserve">Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg893">
+        <source xml:space="preserve">Pruning blockstore...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">198</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg894">
+        <source xml:space="preserve">Unable to start HTTP server. See debug log for details.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">235</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg895">
+        <source xml:space="preserve">The %s developers</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">12</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg896">
+        <source xml:space="preserve">Cannot obtain a lock on data directory %s. %s is probably already running.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">22</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg897">
+        <source xml:space="preserve">Cannot provide specific connections and have addrman find outgoing connections at the same.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">24</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg898">
+        <source xml:space="preserve">Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg899">
+        <source xml:space="preserve">More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">55</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg900">
+        <source xml:space="preserve">Please check that your computer&apos;s date and time are correct! If your clock is wrong, %s will not work properly.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg901">
+        <source xml:space="preserve">Please contribute if you find %s useful. Visit %s for further information about the software.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg902">
+        <source xml:space="preserve">SQLiteDatabase: Failed to prepare the statement to fetch sqlite wallet schema version: %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg903">
+        <source xml:space="preserve">SQLiteDatabase: Failed to prepare the statement to fetch the application id: %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg904">
+        <source xml:space="preserve">SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg905">
+        <source xml:space="preserve">The block database contains a block which appears to be from the future. This may be due to your computer&apos;s date and time being set incorrectly. Only rebuild the block database if you are sure that your computer&apos;s date and time are correct</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg906">
+        <source xml:space="preserve">This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg907">
+        <source xml:space="preserve">This is the transaction fee you may discard if change is smaller than dust at this level</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg908">
+        <source xml:space="preserve">Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">114</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg909">
+        <source xml:space="preserve">Unable to rewind the database to a pre-fork state. You will need to redownload the blockchain</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">117</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg910">
+        <source xml:space="preserve">Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg911">
+        <source xml:space="preserve">-maxmempool must be at least %d MB</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg912">
+        <source xml:space="preserve">Cannot resolve -%s address: &apos;%s&apos;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg913">
+        <source xml:space="preserve">Change index out of range</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg914">
+        <source xml:space="preserve">Config setting for %s only applied on %s network when in [%s] section.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">141</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg915">
+        <source xml:space="preserve">Copyright (C) %i-%i</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">142</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg916" approved="yes">
+        <source xml:space="preserve">Corrupted block database detected</source>
+        <target xml:space="preserve">Corrupted block database detected</target>
+        <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg917">
+        <source xml:space="preserve">Could not find asmap file %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg918">
+        <source xml:space="preserve">Could not parse asmap file %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg919" approved="yes">
+        <source xml:space="preserve">Do you want to rebuild the block database now?</source>
+        <target xml:space="preserve">Do you want to rebuild the block database now?</target>
+        <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg920">
+        <source xml:space="preserve">Dump file %s does not exist.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg921">
+        <source xml:space="preserve">Error creating %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">150</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg922" approved="yes">
+        <source xml:space="preserve">Error initializing block database</source>
+        <target xml:space="preserve">Error initializing block database</target>
+        <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg923" approved="yes">
+        <source xml:space="preserve">Error initializing wallet database environment %s!</source>
+        <target xml:space="preserve">Error initializing wallet database environment %s!</target>
+        <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg924">
+        <source xml:space="preserve">Error loading %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg925">
+        <source xml:space="preserve">Error loading %s: Private keys can only be disabled during creation</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg926">
+        <source xml:space="preserve">Error loading %s: Wallet corrupted</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">155</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg927">
+        <source xml:space="preserve">Error loading %s: Wallet requires newer version of %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">156</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg928" approved="yes">
+        <source xml:space="preserve">Error loading block database</source>
+        <target xml:space="preserve">Error loading block database</target>
+        <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg929" approved="yes">
+        <source xml:space="preserve">Error opening block database</source>
+        <target xml:space="preserve">Error opening block database</target>
+        <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg930">
+        <source xml:space="preserve">Error reading next record from wallet database</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">160</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg931">
+        <source xml:space="preserve">Error: Couldn&apos;t create cursor into database</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">162</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg932">
+        <source xml:space="preserve">Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg933">
+        <source xml:space="preserve">Error: Got key that was not hex: %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">165</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg934">
+        <source xml:space="preserve">Error: Got value that was not hex: %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg935">
+        <source xml:space="preserve">Error: Missing checksum</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg936">
+        <source xml:space="preserve">Error: Unable to parse version %u as a uint32_t</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">169</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg937">
+        <source xml:space="preserve">Error: Unable to write record to new wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg938" approved="yes">
+        <source xml:space="preserve">Failed to listen on any port. Use -listen=0 if you want this.</source>
+        <target xml:space="preserve">Failed to listen on any port. Use -listen=0 if you want this.</target>
+        <context-group purpose="location"><context context-type="linenumber">171</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg939">
+        <source xml:space="preserve">Failed to rescan the wallet during initialization</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg940">
+        <source xml:space="preserve">Failed to verify database</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg941">
+        <source xml:space="preserve">Ignoring duplicate -wallet %s.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">175</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg942">
+        <source xml:space="preserve">Importing...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg943" approved="yes">
+        <source xml:space="preserve">Incorrect or no genesis block found. Wrong datadir for network?</source>
+        <target xml:space="preserve">Incorrect or no genesis block found. Wrong datadir for network?</target>
+        <context-group purpose="location"><context context-type="linenumber">177</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg944">
+        <source xml:space="preserve">Initialization sanity check failed. %s is shutting down.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">178</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg945">
+        <source xml:space="preserve">Invalid -i2psam address or hostname: &apos;%s&apos;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg946">
+        <source xml:space="preserve">Invalid P2P permission: &apos;%s&apos;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg947">
+        <source xml:space="preserve">Invalid amount for -%s=&lt;amount&gt;: &apos;%s&apos;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">184</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg948">
+        <source xml:space="preserve">Invalid amount for -discardfee=&lt;amount&gt;: &apos;%s&apos;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">185</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg949">
+        <source xml:space="preserve">Invalid amount for -fallbackfee=&lt;amount&gt;: &apos;%s&apos;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">186</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg950">
+        <source xml:space="preserve">SQLiteDatabase: Failed to execute statement to verify database: %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">203</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg951">
+        <source xml:space="preserve">SQLiteDatabase: Failed to fetch sqlite wallet schema version: %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">204</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg952">
+        <source xml:space="preserve">SQLiteDatabase: Failed to fetch the application id: %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg953">
+        <source xml:space="preserve">SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg954">
+        <source xml:space="preserve">SQLiteDatabase: Failed to read database verification error: %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg955">
+        <source xml:space="preserve">SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg956">
+        <source xml:space="preserve">Specified blocks directory &quot;%s&quot; does not exist.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">214</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg957">
+        <source xml:space="preserve">The specified config file %s does not exist</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">217</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg958">
+        <source xml:space="preserve">Unable to open %s for writing</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg959">
+        <source xml:space="preserve">Unknown address type &apos;%s&apos;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">237</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg960">
+        <source xml:space="preserve">Unknown change type &apos;%s&apos;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg961">
+        <source xml:space="preserve">Upgrading txindex database</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">242</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg962">
+        <source xml:space="preserve">Loading P2P addresses...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">189</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg963">
+        <source xml:space="preserve">Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">19</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg964">
+        <source xml:space="preserve">Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg965">
+        <source xml:space="preserve">Error: Dumpfile format record is incorrect. Got &quot;%s&quot;, expected &quot;format&quot;.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg966">
+        <source xml:space="preserve">Error: Dumpfile identifier record is incorrect. Got &quot;%s&quot;, expected &quot;%s&quot;.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">39</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg967">
+        <source xml:space="preserve">Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">41</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg968">
+        <source xml:space="preserve">File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg969">
+        <source xml:space="preserve">No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg970">
+        <source xml:space="preserve">No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg971">
+        <source xml:space="preserve">No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">63</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg972">
+        <source xml:space="preserve">Unknown wallet file format &quot;%s&quot; provided. Please provide one of &quot;bdb&quot; or &quot;sqlite&quot;.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg973">
+        <source xml:space="preserve">Warning: Dumpfile wallet format &quot;%s&quot; does not match command line specified format &quot;%s&quot;.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg974">
+        <source xml:space="preserve">Loading banlist...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">190</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg975" approved="yes">
+        <source xml:space="preserve">Not enough file descriptors available.</source>
+        <target xml:space="preserve">Not enough file descriptors available.</target>
+        <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg976">
+        <source xml:space="preserve">Prune cannot be configured with a negative value.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">196</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg977">
+        <source xml:space="preserve">Prune mode is incompatible with -txindex.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">197</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg978">
+        <source xml:space="preserve">Replaying blocks...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">200</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg979">
+        <source xml:space="preserve">Rewinding blocks...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg980">
+        <source xml:space="preserve">The source code is available from %s.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg981">
+        <source xml:space="preserve">Transaction fee and change calculation failed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg982">
+        <source xml:space="preserve">Unable to bind to %s on this computer. %s is probably already running.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">230</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg983">
+        <source xml:space="preserve">Unable to generate keys</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg984">
+        <source xml:space="preserve">Unsupported logging category %s=%s.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg985">
+        <source xml:space="preserve">Upgrading UTXO database</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg986">
+        <source xml:space="preserve">User Agent comment (%s) contains unsafe characters.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg987" approved="yes">
+        <source xml:space="preserve">Verifying blocks...</source>
+        <target xml:space="preserve">Verifying blocks...</target>
+        <context-group purpose="location"><context context-type="linenumber">244</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg988">
+        <source xml:space="preserve">Wallet needed to be rewritten: restart %s to complete</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg989">
+        <source xml:space="preserve">Error: Listening for incoming connections failed (listen returned error %s)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">44</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg990">
+        <source xml:space="preserve">%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">13</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg991">
+        <source xml:space="preserve">Invalid amount for -maxtxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">52</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg992">
+        <source xml:space="preserve">The transaction amount is too small to send after the fee has been deducted</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg993">
+        <source xml:space="preserve">This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">93</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg994">
+        <source xml:space="preserve">This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg995">
+        <source xml:space="preserve">Transaction needs a change address, but we can&apos;t generate it. Please call keypoolrefill first.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg996">
+        <source xml:space="preserve">You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg997">
+        <source xml:space="preserve">A fatal internal error occurred, see debug.log for details</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg998">
+        <source xml:space="preserve">Cannot set -peerblockfilters without -blockfilterindex.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg999">
+        <source xml:space="preserve">Disk space is too low!</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1000">
+        <source xml:space="preserve">Error reading from database, shutting down.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1001">
+        <source xml:space="preserve">Error upgrading chainstate database</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1002">
+        <source xml:space="preserve">Error: Disk space is low for %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">163</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1003">
+        <source xml:space="preserve">Error: Keypool ran out, please call keypoolrefill first</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1004">
+        <source xml:space="preserve">Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">174</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1005">
+        <source xml:space="preserve">Invalid -onion address or hostname: &apos;%s&apos;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">181</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1006">
+        <source xml:space="preserve">Invalid -proxy address or hostname: &apos;%s&apos;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">182</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1007">
+        <source xml:space="preserve">Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least %s)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1008">
+        <source xml:space="preserve">Invalid netmask specified in -whitelist: &apos;%s&apos;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">188</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1009">
+        <source xml:space="preserve">Need to specify a port with -whitebind: &apos;%s&apos;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1010">
+        <source xml:space="preserve">No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1011">
+        <source xml:space="preserve">Reducing -maxconnections from %d to %d, because of system limitations.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">199</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1012">
+        <source xml:space="preserve">Section [%s] is not recognized.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">209</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1013" approved="yes">
+        <source xml:space="preserve">Signing transaction failed</source>
+        <target xml:space="preserve">Signing transaction failed</target>
+        <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1014">
+        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; does not exist</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1015">
+        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is a relative path</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1016">
+        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is not a directory</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1017">
+        <source xml:space="preserve">The transaction amount is too small to pay the fee</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1018">
+        <source xml:space="preserve">This is experimental software.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1019" approved="yes">
+        <source xml:space="preserve">Transaction amount too small</source>
+        <target xml:space="preserve">Transaction amount too small</target>
+        <context-group purpose="location"><context context-type="linenumber">223</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1020" approved="yes">
+        <source xml:space="preserve">Transaction too large</source>
+        <target xml:space="preserve">Transaction too large</target>
+        <context-group purpose="location"><context context-type="linenumber">228</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1021">
+        <source xml:space="preserve">Unable to bind to %s on this computer (bind returned error %s)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1022">
+        <source xml:space="preserve">Unable to create the PID file &apos;%s&apos;: %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1023">
+        <source xml:space="preserve">Unable to generate initial keys</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1024">
+        <source xml:space="preserve">Unknown -blockfilterindex value %s.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">236</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1025">
+        <source xml:space="preserve">Verifying wallet(s)...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">245</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1026">
+        <source xml:space="preserve">Warning: unknown new rules activated (versionbit %i)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">247</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1027">
+        <source xml:space="preserve">-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">16</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1028">
+        <source xml:space="preserve">This is the transaction fee you may pay when fee estimates are not available.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1029">
+        <source xml:space="preserve">Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1030">
+        <source xml:space="preserve">%s is set very high!</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">134</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1031">
+        <source xml:space="preserve">Starting network threads...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1032">
+        <source xml:space="preserve">The wallet will avoid paying less than the minimum relay fee.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1033">
+        <source xml:space="preserve">This is the minimum transaction fee you pay on every transaction.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">221</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1034">
+        <source xml:space="preserve">This is the transaction fee you will pay if you send a transaction.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1035">
+        <source xml:space="preserve">Transaction amounts must not be negative</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">224</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1036">
+        <source xml:space="preserve">Transaction has too long of a mempool chain</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1037">
+        <source xml:space="preserve">Transaction must have at least one recipient</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">227</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1038" approved="yes">
+        <source xml:space="preserve">Unknown network specified in -onlynet: &apos;%s&apos;</source>
+        <target xml:space="preserve">Unknown network specified in -onlynet: &apos;%s&apos;</target>
+        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1039" approved="yes">
+        <source xml:space="preserve">Insufficient funds</source>
+        <target xml:space="preserve">Insufficient funds</target>
+        <context-group purpose="location"><context context-type="linenumber">179</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1040">
+        <source xml:space="preserve">Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1041">
+        <source xml:space="preserve">Warning: Private keys detected in wallet {%s} with disabled private keys</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1042">
+        <source xml:space="preserve">Cannot write to data directory &apos;%s&apos;; check permissions.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1043" approved="yes">
+        <source xml:space="preserve">Loading block index...</source>
+        <target xml:space="preserve">Loading block index...</target>
+        <context-group purpose="location"><context context-type="linenumber">191</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1044" approved="yes">
+        <source xml:space="preserve">Loading wallet...</source>
+        <target xml:space="preserve">Loading wallet...</target>
+        <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1045" approved="yes">
+        <source xml:space="preserve">Rescanning...</source>
+        <target xml:space="preserve">Rescanning...</target>
+        <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1046" approved="yes">
+        <source xml:space="preserve">Done loading</source>
+        <target xml:space="preserve">Done loading</target>
+        <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+</xliff>


### PR DESCRIPTION
Currently, only a class name is provided to the Transifex translators as a context. Neither `disambiguation` parameter of the `tr()` function nor [translator comments](https://doc.qt.io/qt-5/i18n-source-translation.html#translator-comments), being included as XML elements to `*.ts` translation files, are not parsed by the Transifex due to its [limited support](https://docs.transifex.com/formats/qt-ts) of such files.

This PR makes possible to provide all of the context details via an intermediate [XLIFF](https://docs.transifex.com/formats/xliff) translation file.

With this PR `make -C src translate` produces the `src/qt/locale/bitcoin_en.xlf` file which must be provided to the Transifex as a translation source instead of `src/qt/locale/bitcoin_en.ts`.

Closes #21465.

An example translatable string with additional `<context>` and `<note>` XML elements: https://github.com/bitcoin/bitcoin/blob/35d52397e72f3ab96a7797148666b501d50b445d/src/qt/locale/bitcoin_en.xlf#L126-L132