### PR TITLE
DONOTMERGE test: drop cnetaddr link-local assert for macOS 10.14 to re-verify CI

### DIFF
--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -300,15 +300,15 @@ BOOST_AUTO_TEST_CASE(cnetaddr_basic)
 
     // IPv6, scoped/link-local. See https://tools.ietf.org/html/rfc4007
     // We support non-negative decimal integers (uint32_t) as zone id indices.
-    // Test with a fairly-high value, e.g. 32, to avoid locally reserved ids.
+    // Test with a high value, e.g. 4096, to avoid any local ids in use.
     const std::string link_local{"fe80::1"};
-    const std::string scoped_addr{link_local + "%32"};
+    const std::string scoped_addr{link_local + "%4096"};
     BOOST_REQUIRE(LookupHost(scoped_addr, addr, false));
     BOOST_REQUIRE(addr.IsValid());
     BOOST_REQUIRE(addr.IsIPv6());
     BOOST_CHECK(!addr.IsBindAny());
     const std::string addr_str{addr.ToString()};
-    BOOST_CHECK(addr_str == scoped_addr || addr_str == "fe80:0:0:0:0:0:0:1");
+    BOOST_CHECK(addr_str == "fe80:0:0:0:0:0:0:1");
     // The fallback case "fe80:0:0:0:0:0:0:1" is needed for macOS 10.14/10.15 and (probably) later.
     // Test that the delimiter "%" and default zone id of 0 can be omitted for the default scope.
     BOOST_REQUIRE(LookupHost(link_local + "%0", addr, false));


### PR DESCRIPTION
Seven months ago this passed all CI checks except the macOS 10.14 one. Re-verifying this is true in the current context.