### PR TITLE
net: expand Sock and fuzz-test more of CConnman

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -97,14 +97,6 @@ typedef char* sockopt_arg_type;
 #define USE_POLL
 #endif
 
-bool static inline IsSelectableSocket(const SOCKET& s) {
-#if defined(USE_POLL) || defined(WIN32)
-    return true;
-#else
-    return (s < FD_SETSIZE);
-#endif
-}
-
 // MSG_NOSIGNAL is not available on some platforms, if it doesn't exist define it as 0
 #if !defined(MSG_NOSIGNAL)
 #define MSG_NOSIGNAL 0

--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -397,7 +397,7 @@ std::unique_ptr<Sock> Session::StreamAccept()
 
 void Session::Disconnect()
 {
-    if (m_control_sock->Get() != INVALID_SOCKET) {
+    if (*m_control_sock) {
         if (m_session_id.empty()) {
             Log("Destroying incomplete session");
         } else {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1106,7 +1106,10 @@ void CConnman::CreateNodeFromAcceptedSocket(std::unique_ptr<Sock> sock,
 
     // According to the internet TCP_NODELAY is not carried into accepted sockets
     // on all platforms.  Set it again here just to be sure.
-    SetSocketNoDelay(sock->Get());
+    if (!sock->SetNoDelay()) {
+        LogPrint(BCLog::NET, "connection from %s: unable to set TCP_NODELAY, continuing anyway\n",
+                 addr.ToString());
+    }
 
     // Don't accept connections from banned peers.
     bool banned = m_banman && m_banman->IsBanned(addr);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2302,8 +2302,7 @@ bool CConnman::BindListenPort(const CService& addrBind, bilingual_str& strError,
 #endif
     }
 
-    if (::bind(sock->Get(), (struct sockaddr*)&sockaddr, len) == SOCKET_ERROR)
-    {
+    if (sock->Bind(reinterpret_cast<struct sockaddr*>(&sockaddr), len) == SOCKET_ERROR) {
         int nErr = WSAGetLastError();
         if (nErr == WSAEADDRINUSE)
             strError = strprintf(_("Unable to bind to %s on this computer. %s is probably already running."), addrBind.ToString(), PACKAGE_NAME);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1098,8 +1098,7 @@ void CConnman::CreateNodeFromAcceptedSocket(std::unique_ptr<Sock> sock,
         return;
     }
 
-    if (!IsSelectableSocket(sock->Get()))
-    {
+    if (!sock->IsSelectable()) {
         LogPrintf("connection from %s dropped: non-selectable socket\n", addr.ToString());
         return;
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2289,17 +2289,17 @@ bool CConnman::BindListenPort(const CService& addrBind, bilingual_str& strError,
 
     // Allow binding if the port is still in TIME_WAIT state after
     // the program was closed and restarted.
-    setsockopt(sock->Get(), SOL_SOCKET, SO_REUSEADDR, (sockopt_arg_type)&nOne, sizeof(int));
+    sock->SetSockOpt(SOL_SOCKET, SO_REUSEADDR, (sockopt_arg_type)&nOne, sizeof(int));
 
     // some systems don't have IPV6_V6ONLY but are always v6only; others do have the option
     // and enable it by default or not. Try to enable it, if possible.
     if (addrBind.IsIPv6()) {
 #ifdef IPV6_V6ONLY
-        setsockopt(sock->Get(), IPPROTO_IPV6, IPV6_V6ONLY, (sockopt_arg_type)&nOne, sizeof(int));
+        sock->SetSockOpt(IPPROTO_IPV6, IPV6_V6ONLY, (sockopt_arg_type)&nOne, sizeof(int));
 #endif
 #ifdef WIN32
         int nProtLevel = PROTECTION_LEVEL_UNRESTRICTED;
-        setsockopt(sock->Get(), IPPROTO_IPV6, IPV6_PROTECTION_LEVEL, (const char*)&nProtLevel, sizeof(int));
+        sock->SetSockOpt(IPPROTO_IPV6, IPV6_PROTECTION_LEVEL, (const char*)&nProtLevel, sizeof(int));
 #endif
     }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2314,7 +2314,7 @@ bool CConnman::BindListenPort(const CService& addrBind, bilingual_str& strError,
     LogPrintf("Bound to %s\n", addrBind.ToString());
 
     // Listen for incoming connections
-    if (listen(sock->Get(), SOMAXCONN) == SOCKET_ERROR)
+    if (sock->Listen(SOMAXCONN) == SOCKET_ERROR)
     {
         strError = strprintf(_("Error: Listening for incoming connections failed (listen returned error %s)"), NetworkErrorString(WSAGetLastError()));
         LogPrintf("%s\n", strError.original);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -361,13 +361,13 @@ bool CConnman::CheckIncomingNonce(uint64_t nonce)
 }
 
 /** Get the bind address for a socket as CAddress */
-static CAddress GetBindAddress(SOCKET sock)
+static CAddress GetBindAddress(const Sock& sock)
 {
     CAddress addr_bind;
     struct sockaddr_storage sockaddr_bind;
     socklen_t sockaddr_bind_len = sizeof(sockaddr_bind);
-    if (sock != INVALID_SOCKET) {
-        if (!getsockname(sock, (struct sockaddr*)&sockaddr_bind, &sockaddr_bind_len)) {
+    if (sock) {
+        if (!sock.GetSockName((struct sockaddr*)&sockaddr_bind, &sockaddr_bind_len)) {
             addr_bind.SetSockAddr((const struct sockaddr*)&sockaddr_bind);
         } else {
             LogPrint(BCLog::NET, "Warning: getsockname failed\n");
@@ -481,7 +481,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
     NodeId id = GetNewNodeId();
     uint64_t nonce = GetDeterministicRandomizer(RANDOMIZER_ID_LOCALHOSTNONCE).Write(id).Finalize();
     if (!addr_bind.IsValid()) {
-        addr_bind = GetBindAddress(sock->Get());
+        addr_bind = GetBindAddress(*sock);
     }
     CNode* pnode = new CNode(id, nLocalServices, sock->Release(), addrConnect, CalculateKeyedNetGroup(addrConnect), nonce, addr_bind, pszDest ? pszDest : "", conn_type, /* inbound_onion */ false);
     pnode->AddRef();
@@ -1061,7 +1061,7 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
 
     auto sock = std::make_unique<Sock>(hSocket);
 
-    const CAddress addr_bind = GetBindAddress(hSocket);
+    const CAddress addr_bind = GetBindAddress(*sock);
 
     NetPermissionFlags permissionFlags = NetPermissionFlags::PF_NONE;
     hListenSocket.AddSocketPermissionFlags(permissionFlags);

--- a/src/net.h
+++ b/src/net.h
@@ -27,6 +27,7 @@
 #include <threadinterrupt.h>
 #include <uint256.h>
 #include <util/check.h>
+#include <util/sock.h>
 
 #include <atomic>
 #include <condition_variable>
@@ -1049,12 +1050,12 @@ private:
     /**
      * Create a `CNode` object from a socket that has just been accepted and add the node to
      * the `vNodes` member.
-     * @param[in] hSocket Connected socket to communicate with the peer.
+     * @param[in] sock Connected socket to communicate with the peer.
      * @param[in] permissionFlags The peer's permissions.
      * @param[in] addr_bind The address and port at our side of the connection.
      * @param[in] addr The address and port at the peer's side of the connection.
      */
-    void CreateNodeFromAcceptedSocket(SOCKET hSocket,
+    void CreateNodeFromAcceptedSocket(std::unique_ptr<Sock> sock,
                                       NetPermissionFlags permissionFlags,
                                       const CAddress& addr_bind,
                                       const CAddress& addr);

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -303,8 +303,7 @@ enum class IntrRecvError {
  *          read.
  *
  * @see This function can be interrupted by calling InterruptSocks5(bool).
- *      Sockets can be made non-blocking with SetSocketNonBlocking(const
- *      SOCKET&, bool).
+ *      Sockets can be made non-blocking with Sock::SetNonBlocking().
  */
 static IntrRecvError InterruptibleRecv(uint8_t* data, size_t len, int timeout, const Sock& sock)
 {
@@ -520,7 +519,7 @@ std::unique_ptr<Sock> CreateSockTCP(const CService& address_family)
     }
 
     // Set the non-blocking option on the socket.
-    if (!SetSocketNonBlocking(sock->Get(), true)) {
+    if (!sock->SetNonBlocking()) {
         LogPrintf("Error setting socket to non-blocking: %s\n", NetworkErrorString(WSAGetLastError()));
         return nullptr;
     }
@@ -716,33 +715,6 @@ bool LookupSubNet(const std::string& strSubnet, CSubNet& ret, DNSLookupFn dns_lo
         }
     }
     return false;
-}
-
-bool SetSocketNonBlocking(const SOCKET& hSocket, bool fNonBlocking)
-{
-    if (fNonBlocking) {
-#ifdef WIN32
-        u_long nOne = 1;
-        if (ioctlsocket(hSocket, FIONBIO, &nOne) == SOCKET_ERROR) {
-#else
-        int fFlags = fcntl(hSocket, F_GETFL, 0);
-        if (fcntl(hSocket, F_SETFL, fFlags | O_NONBLOCK) == SOCKET_ERROR) {
-#endif
-            return false;
-        }
-    } else {
-#ifdef WIN32
-        u_long nZero = 0;
-        if (ioctlsocket(hSocket, FIONBIO, &nZero) == SOCKET_ERROR) {
-#else
-        int fFlags = fcntl(hSocket, F_GETFL, 0);
-        if (fcntl(hSocket, F_SETFL, fFlags & ~O_NONBLOCK) == SOCKET_ERROR) {
-#endif
-            return false;
-        }
-    }
-
-    return true;
 }
 
 void InterruptSocks5(bool interrupt)

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -502,7 +502,7 @@ std::unique_ptr<Sock> CreateSockTCP(const CService& address_family)
 
     // Ensure that waiting for I/O on this socket won't result in undefined
     // behavior.
-    if (!IsSelectableSocket(sock->Get())) {
+    if (!sock->IsSelectable()) {
         LogPrintf("Cannot create connection: non-selectable socket created (fd >= FD_SETSIZE ?)\n");
         return nullptr;
     }

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -544,7 +544,7 @@ bool ConnectSocketDirectly(const CService &addrConnect, const Sock& sock, int nT
     // Create a sockaddr from the specified service.
     struct sockaddr_storage sockaddr;
     socklen_t len = sizeof(sockaddr);
-    if (sock.Get() == INVALID_SOCKET) {
+    if (!sock) {
         LogPrintf("Cannot connect to %s: invalid socket\n", addrConnect.ToString());
         return false;
     }

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -515,7 +515,9 @@ std::unique_ptr<Sock> CreateSockTCP(const CService& address_family)
 #endif
 
     // Set the no-delay option (disable Nagle's algorithm) on the TCP socket.
-    SetSocketNoDelay(sock->Get());
+    if (!sock->SetNoDelay()) {
+        LogPrint(BCLog::NET, "Unable to set TCP_NODELAY on a newly created socket, continuing anyway\n");
+    }
 
     // Set the non-blocking option on the socket.
     if (!SetSocketNonBlocking(sock->Get(), true)) {
@@ -741,13 +743,6 @@ bool SetSocketNonBlocking(const SOCKET& hSocket, bool fNonBlocking)
     }
 
     return true;
-}
-
-bool SetSocketNoDelay(const SOCKET& hSocket)
-{
-    int set = 1;
-    int rc = setsockopt(hSocket, IPPROTO_TCP, TCP_NODELAY, (const char*)&set, sizeof(int));
-    return rc == 0;
 }
 
 void InterruptSocks5(bool interrupt)

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -221,7 +221,6 @@ bool ConnectSocketDirectly(const CService &addrConnect, const Sock& sock, int nT
 bool ConnectThroughProxy(const proxyType& proxy, const std::string& strDest, uint16_t port, const Sock& sock, int nTimeout, bool& outProxyConnectionFailed);
 
 /** Disable or enable blocking-mode for a socket */
-bool SetSocketNonBlocking(const SOCKET& hSocket, bool fNonBlocking);
 void InterruptSocks5(bool interrupt);
 
 /**

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -222,8 +222,6 @@ bool ConnectThroughProxy(const proxyType& proxy, const std::string& strDest, uin
 
 /** Disable or enable blocking-mode for a socket */
 bool SetSocketNonBlocking(const SOCKET& hSocket, bool fNonBlocking);
-/** Set the TCP_NODELAY flag on a socket */
-bool SetSocketNoDelay(const SOCKET& hSocket);
 void InterruptSocks5(bool interrupt);
 
 /**

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -167,6 +167,19 @@ int FuzzedSock::Bind(const sockaddr*, socklen_t) const
     return 0;
 }
 
+int FuzzedSock::Listen(int) const
+{
+    constexpr std::array listen_errnos{
+        EINVAL,
+        EOPNOTSUPP,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, listen_errnos);
+        return -1;
+    }
+    return 0;
+}
+
 int FuzzedSock::GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const
 {
     constexpr std::array getsockopt_errnos{

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -8,7 +8,7 @@
 #include <version.h>
 
 FuzzedSock::FuzzedSock(FuzzedDataProvider& fuzzed_data_provider)
-    : m_fuzzed_data_provider{fuzzed_data_provider}
+    : m_fuzzed_data_provider{fuzzed_data_provider}, m_selectable{fuzzed_data_provider.ConsumeBool()}
 {
     m_socket = fuzzed_data_provider.ConsumeIntegralInRange<SOCKET>(INVALID_SOCKET - 1, INVALID_SOCKET);
 }
@@ -182,6 +182,11 @@ int FuzzedSock::SetSockOpt(int, int, const void*, socklen_t) const
         return -1;
     }
     return 0;
+}
+
+bool FuzzedSock::IsSelectable() const
+{
+    return m_selectable;
 }
 
 bool FuzzedSock::Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred) const

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -184,6 +184,20 @@ int FuzzedSock::SetSockOpt(int, int, const void*, socklen_t) const
     return 0;
 }
 
+int FuzzedSock::GetSockName(sockaddr* name, socklen_t* name_len) const
+{
+    constexpr std::array getsockname_errnos{
+        ECONNRESET,
+        ENOBUFS,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, getsockname_errnos);
+        return -1;
+    }
+    *name_len = m_fuzzed_data_provider.ConsumeData(name, *name_len);
+    return 0;
+}
+
 bool FuzzedSock::IsSelectable() const
 {
     return m_selectable;

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -226,6 +226,19 @@ int FuzzedSock::GetSockName(sockaddr* name, socklen_t* name_len) const
     return 0;
 }
 
+bool FuzzedSock::SetNonBlocking() const
+{
+    constexpr std::array setnonblocking_errnos{
+        EBADF,
+        EPERM,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, setnonblocking_errnos);
+        return false;
+    }
+    return true;
+}
+
 bool FuzzedSock::IsSelectable() const
 {
     return m_selectable;

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -171,6 +171,19 @@ int FuzzedSock::GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* op
     return 0;
 }
 
+int FuzzedSock::SetSockOpt(int, int, const void*, socklen_t) const
+{
+    constexpr std::array setsockopt_errnos{
+        ENOMEM,
+        ENOBUFS,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, setsockopt_errnos);
+        return -1;
+    }
+    return 0;
+}
+
 bool FuzzedSock::Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred) const
 {
     constexpr std::array wait_errnos{

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -152,6 +152,21 @@ int FuzzedSock::Connect(const sockaddr*, socklen_t) const
     return 0;
 }
 
+int FuzzedSock::Bind(const sockaddr*, socklen_t) const
+{
+    constexpr std::array bind_errnos{
+        EACCES,
+        EADDRINUSE,
+        EADDRNOTAVAIL,
+        EAGAIN,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, bind_errnos);
+        return -1;
+    }
+    return 0;
+}
+
 int FuzzedSock::GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const
 {
     constexpr std::array getsockopt_errnos{

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -598,6 +598,8 @@ public:
 
     int Bind(const sockaddr*, socklen_t) const override;
 
+    int Listen(int backlog) const override;
+
     int GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const override;
 
     int SetSockOpt(int level, int opt_name, const void* opt_val, socklen_t opt_len) const override;

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -574,6 +574,13 @@ class FuzzedSock : public Sock
      */
     mutable std::optional<uint8_t> m_peek_data;
 
+    /**
+     * Whether to pretend that the socket is select(2)-able. This is randomly set in the
+     * constructor. It should remain constant so that repeated calls to `IsSelectable()`
+     * return the same value.
+     */
+    const bool m_selectable;
+
 public:
     explicit FuzzedSock(FuzzedDataProvider& fuzzed_data_provider);
 
@@ -592,6 +599,8 @@ public:
     int GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const override;
 
     int SetSockOpt(int level, int opt_name, const void* opt_val, socklen_t opt_len) const override;
+
+    bool IsSelectable() const override;
 
     bool Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred = nullptr) const override;
 

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -600,6 +600,8 @@ public:
 
     int SetSockOpt(int level, int opt_name, const void* opt_val, socklen_t opt_len) const override;
 
+    int GetSockName(sockaddr* name, socklen_t* name_len) const override;
+
     bool IsSelectable() const override;
 
     bool Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred = nullptr) const override;

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -596,6 +596,8 @@ public:
 
     int Connect(const sockaddr*, socklen_t) const override;
 
+    int Bind(const sockaddr*, socklen_t) const override;
+
     int GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const override;
 
     int SetSockOpt(int level, int opt_name, const void* opt_val, socklen_t opt_len) const override;

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -606,6 +606,8 @@ public:
 
     int GetSockName(sockaddr* name, socklen_t* name_len) const override;
 
+    bool SetNonBlocking() const override;
+
     bool IsSelectable() const override;
 
     bool Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred = nullptr) const override;

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -591,6 +591,8 @@ public:
 
     int GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const override;
 
+    int SetSockOpt(int level, int opt_name, const void* opt_val, socklen_t opt_len) const override;
+
     bool Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred = nullptr) const override;
 
     bool IsConnected(std::string& errmsg) const override;

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -126,6 +126,8 @@ public:
         return 0;
     }
 
+    bool SetNonBlocking() const override { return true; }
+
     bool IsSelectable() const override { return true; }
 
     bool Wait(std::chrono::milliseconds timeout,

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -116,6 +116,12 @@ public:
 
     int SetSockOpt(int, int, const void*, socklen_t) const override { return 0; }
 
+    int GetSockName(sockaddr* name, socklen_t* name_len) const override
+    {
+        std::memset(name, 0x0, *name_len);
+        return 0;
+    }
+
     bool IsSelectable() const override { return true; }
 
     bool Wait(std::chrono::milliseconds timeout,

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -116,6 +116,8 @@ public:
 
     int SetSockOpt(int, int, const void*, socklen_t) const override { return 0; }
 
+    bool IsSelectable() const override { return true; }
+
     bool Wait(std::chrono::milliseconds timeout,
               Event requested,
               Event* occurred = nullptr) const override

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -108,6 +108,8 @@ public:
 
     int Connect(const sockaddr*, socklen_t) const override { return 0; }
 
+    int Bind(const sockaddr*, socklen_t) const override { return 0; }
+
     int GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const override
     {
         std::memset(opt_val, 0x0, *opt_len);

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -114,6 +114,8 @@ public:
         return 0;
     }
 
+    int SetSockOpt(int, int, const void*, socklen_t) const override { return 0; }
+
     bool Wait(std::chrono::milliseconds timeout,
               Event requested,
               Event* occurred = nullptr) const override

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -110,6 +110,8 @@ public:
 
     int Bind(const sockaddr*, socklen_t) const override { return 0; }
 
+    int Listen(int) const override { return 0; }
+
     int GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const override
     {
         std::memset(opt_val, 0x0, *opt_len);

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -76,6 +76,11 @@ int Sock::GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len)
     return getsockopt(m_socket, level, opt_name, static_cast<char*>(opt_val), opt_len);
 }
 
+int Sock::SetSockOpt(int level, int opt_name, const void* opt_val, socklen_t opt_len) const
+{
+    return setsockopt(m_socket, level, opt_name, static_cast<const char*>(opt_val), opt_len);
+}
+
 bool Sock::Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred) const
 {
 #ifdef USE_POLL

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -81,6 +81,11 @@ int Sock::Bind(const sockaddr* addr, socklen_t addr_len) const
     return bind(m_socket, addr, addr_len);
 }
 
+int Sock::Listen(int backlog) const
+{
+    return listen(m_socket, backlog);
+}
+
 int Sock::GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const
 {
     return getsockopt(m_socket, level, opt_name, static_cast<char*>(opt_val), opt_len);

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -81,6 +81,11 @@ int Sock::SetSockOpt(int level, int opt_name, const void* opt_val, socklen_t opt
     return setsockopt(m_socket, level, opt_name, static_cast<const char*>(opt_val), opt_len);
 }
 
+int Sock::GetSockName(sockaddr* name, socklen_t* name_len) const
+{
+    return getsockname(m_socket, name, name_len);
+}
+
 bool Sock::SetNoDelay() const
 {
     const int on{1};

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -81,6 +81,12 @@ int Sock::SetSockOpt(int level, int opt_name, const void* opt_val, socklen_t opt
     return setsockopt(m_socket, level, opt_name, static_cast<const char*>(opt_val), opt_len);
 }
 
+bool Sock::SetNoDelay() const
+{
+    const int on{1};
+    return SetSockOpt(IPPROTO_TCP, TCP_NODELAY, &on, sizeof(on)) == 0;
+}
+
 bool Sock::Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred) const
 {
 #ifdef USE_POLL

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -107,6 +107,25 @@ bool Sock::SetNoDelay() const
     return SetSockOpt(IPPROTO_TCP, TCP_NODELAY, &on, sizeof(on)) == 0;
 }
 
+bool Sock::SetNonBlocking() const
+{
+#ifdef WIN32
+    u_long on{1};
+    if (ioctlsocket(m_socket, FIONBIO, &on) == SOCKET_ERROR) {
+        return false;
+    }
+#else
+    const int flags{fcntl(m_socket, F_GETFL, 0)};
+    if (flags == SOCKET_ERROR) {
+        return false;
+    }
+    if (fcntl(m_socket, F_SETFL, flags | O_NONBLOCK) == SOCKET_ERROR) {
+        return false;
+    }
+#endif
+    return true;
+}
+
 bool Sock::IsSelectable() const
 {
 #if defined(USE_POLL) || defined(WIN32)

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -45,6 +45,11 @@ Sock& Sock::operator=(Sock&& other)
     return *this;
 }
 
+Sock::operator bool() const
+{
+    return m_socket != INVALID_SOCKET;
+}
+
 SOCKET Sock::Get() const { return m_socket; }
 
 SOCKET Sock::Release()

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -76,6 +76,11 @@ int Sock::Connect(const sockaddr* addr, socklen_t addr_len) const
     return connect(m_socket, addr, addr_len);
 }
 
+int Sock::Bind(const sockaddr* addr, socklen_t addr_len) const
+{
+    return bind(m_socket, addr, addr_len);
+}
+
 int Sock::GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const
 {
     return getsockopt(m_socket, level, opt_name, static_cast<char*>(opt_val), opt_len);

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -87,6 +87,15 @@ bool Sock::SetNoDelay() const
     return SetSockOpt(IPPROTO_TCP, TCP_NODELAY, &on, sizeof(on)) == 0;
 }
 
+bool Sock::IsSelectable() const
+{
+#if defined(USE_POLL) || defined(WIN32)
+    return true;
+#else
+    return m_socket < FD_SETSIZE;
+#endif
+}
+
 bool Sock::Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred) const
 {
 #ifdef USE_POLL
@@ -116,7 +125,7 @@ bool Sock::Wait(std::chrono::milliseconds timeout, Event requested, Event* occur
 
     return true;
 #else
-    if (!IsSelectableSocket(m_socket)) {
+    if (!IsSelectable()) {
         return false;
     }
 

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -141,6 +141,12 @@ public:
     [[nodiscard]] virtual bool SetNoDelay() const;
 
     /**
+     * Set the non-blocking option on the socket.
+     * @return true if set successfully
+     */
+    [[nodiscard]] virtual bool SetNonBlocking() const;
+
+    /**
      * Check if the underlying socket can be used for `select(2)` (or the `Wait()` method).
      * @return true if selectable
      */

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -103,6 +103,13 @@ public:
      */
     virtual int GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const;
 
+    /**
+     * setsockopt(2) wrapper. Equivalent to
+     * `setsockopt(this->Get(), level, opt_name, opt_val, opt_len)`. Code that uses this
+     * wrapper can be unit tested if this method is overridden by a mock Sock implementation.
+     */
+    virtual int SetSockOpt(int level, int opt_name, const void* opt_val, socklen_t opt_len) const;
+
     using Event = uint8_t;
 
     /**

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -110,6 +110,12 @@ public:
      */
     virtual int SetSockOpt(int level, int opt_name, const void* opt_val, socklen_t opt_len) const;
 
+    /**
+     * Shortcut to set the TCP_NODELAY option with SetSockOpt().
+     * @return true if set successfully
+     */
+    [[nodiscard]] virtual bool SetNoDelay() const;
+
     using Event = uint8_t;
 
     /**

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -116,6 +116,12 @@ public:
      */
     [[nodiscard]] virtual bool SetNoDelay() const;
 
+    /**
+     * Check if the underlying socket can be used for `select(2)` (or the `Wait()` method).
+     * @return true if selectable
+     */
+    [[nodiscard]] virtual bool IsSelectable() const;
+
     using Event = uint8_t;
 
     /**

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -61,6 +61,11 @@ public:
     virtual Sock& operator=(Sock&& other);
 
     /**
+     * Check whether *this owns a socket.
+     */
+    virtual explicit operator bool() const;
+
+    /**
      * Get the value of the contained socket.
      * @return socket or INVALID_SOCKET if empty
      */

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -108,6 +108,12 @@ public:
     virtual int Bind(const sockaddr* addr, socklen_t addr_len) const;
 
     /**
+     * listen(2) wrapper. Equivalent to `listen(this->Get(), backlog)`. Code that uses this
+     * wrapper can be unit tested if this method is overridden by a mock Sock implementation.
+     */
+    virtual int Listen(int backlog) const;
+
+    /**
      * getsockopt(2) wrapper. Equivalent to
      * `getsockopt(this->Get(), level, opt_name, opt_val, opt_len)`. Code that uses this
      * wrapper can be unit tested if this method is overridden by a mock Sock implementation.

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -102,6 +102,12 @@ public:
     virtual int Connect(const sockaddr* addr, socklen_t addr_len) const;
 
     /**
+     * bind(2) wrapper. Equivalent to `bind(this->Get(), addr, addr_len)`. Code that uses this
+     * wrapper can be unit tested if this method is overridden by a mock Sock implementation.
+     */
+    virtual int Bind(const sockaddr* addr, socklen_t addr_len) const;
+
+    /**
      * getsockopt(2) wrapper. Equivalent to
      * `getsockopt(this->Get(), level, opt_name, opt_val, opt_len)`. Code that uses this
      * wrapper can be unit tested if this method is overridden by a mock Sock implementation.

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -111,6 +111,13 @@ public:
     virtual int SetSockOpt(int level, int opt_name, const void* opt_val, socklen_t opt_len) const;
 
     /**
+     * getsockname(2) wrapper. Equivalent to
+     * `getsockname(this->Get(), name, name_len)`. Code that uses this
+     * wrapper can be unit tested if this method is overridden by a mock Sock implementation.
+     */
+    virtual int GetSockName(sockaddr* name, socklen_t* name_len) const;
+
+    /**
      * Shortcut to set the TCP_NODELAY option with SetSockOpt().
      * @return true if set successfully
      */


### PR DESCRIPTION
* Expand the `Sock` class
  * Add wrapper methods for `setsockopt()`, `getsockname()`, `bind()` and `listen()`
  * Convert the standalone functions `SetSocketNoDelay()` and `IsSelectableSocket()` to `Sock` methods
* Expand the usage of `Sock`: `CConnman::CreateNodeFromAcceptedSocket()` and `GetBindAddress()` changed to take `Sock` as an argument instead of `SOCKET`
* Add fuzz tests for `OpenNetworkConnection()`, `CreateNodeFromAcceptedSocket()` and `InitBinds()` `CConnman` methods.