### PR TITLE
 log: Mitigate disk filling attacks by globally rate limiting LogPrintf(…)

### DIFF
--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -76,6 +76,7 @@ void AddLoggingArgs(ArgsManager& argsman)
     argsman.AddArg("-logtimemicros", strprintf("Add microsecond precision to debug timestamps (default: %u)", DEFAULT_LOGTIMEMICROS), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-printtoconsole", "Send trace/debug info to console (default: 1 when no -daemon. To disable logging to file, set -nodebuglogfile)", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-shrinkdebugfile", "Shrink debug.log file on client startup (default: 1 when no -debug)", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
+    argsman.AddArg("-logratelimiting", strprintf("Rate limit debug logging to disk (default: %u)", DEFAULT_LOGRATELIMITING), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 }
 
 void SetLoggingOptions(const ArgsManager& args)
@@ -89,6 +90,7 @@ void SetLoggingOptions(const ArgsManager& args)
     LogInstance().m_log_threadnames = args.GetBoolArg("-logthreadnames", DEFAULT_LOGTHREADNAMES);
 #endif
     LogInstance().m_log_sourcelocations = args.GetBoolArg("-logsourcelocations", DEFAULT_LOGSOURCELOCATIONS);
+    LogInstance().m_rate_limiting = args.GetBoolArg("-logratelimiting", DEFAULT_LOGRATELIMITING);
 
     fLogIPs = args.GetBoolArg("-logips", DEFAULT_LOGIPS);
 }

--- a/src/logging.h
+++ b/src/logging.h
@@ -6,16 +6,21 @@
 #ifndef BITCOIN_LOGGING_H
 #define BITCOIN_LOGGING_H
 
+#include <crypto/siphash.h>
 #include <fs.h>
 #include <tinyformat.h>
 #include <threadsafety.h>
 #include <util/string.h>
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
+#include <functional>
 #include <list>
 #include <mutex>
 #include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 static const bool DEFAULT_LOGTIMEMICROS = false;
@@ -23,6 +28,7 @@ static const bool DEFAULT_LOGIPS        = false;
 static const bool DEFAULT_LOGTIMESTAMPS = true;
 static const bool DEFAULT_LOGTHREADNAMES = false;
 static const bool DEFAULT_LOGSOURCELOCATIONS = false;
+static const bool DEFAULT_LOGRATELIMITING = true;
 extern const char * const DEFAULT_DEBUGLOGFILE;
 
 extern bool fLogIPs;
@@ -30,6 +36,22 @@ extern bool fLogIPs;
 struct LogCategory {
     std::string category;
     bool active;
+};
+
+// Replace with std::source_location when switching to C++20.
+using SourceLocation = std::pair<const char*, int>;
+struct SourceLocationHasher {
+    size_t operator()(const SourceLocation& source_location) const noexcept
+    {
+        // Use CSipHasher(0, 0) as a simple way to get uniform distribution.
+        return static_cast<size_t>(CSipHasher(0, 0).Write(std::hash<const char*>{}(source_location.first)).Write(std::hash<int>{}(source_location.second)).Finalize());
+    }
+};
+
+struct QuotaUsage {
+    uint64_t m_bytes_logged{0};
+    uint64_t m_bytes_dropped{0};
+    uint64_t m_messages_dropped{0};
 };
 
 namespace BCLog {
@@ -71,6 +93,14 @@ namespace BCLog {
         std::list<std::string> m_msgs_before_open GUARDED_BY(m_cs);
         bool m_buffering GUARDED_BY(m_cs) = true; //!< Buffer messages before logging can be started.
 
+        // Number of source locations that have exceeded the log rate limits for a single location.
+        // If there is 1 or more of these locations, we skip logging to disk until the next quota usage reset.
+        uint32_t m_num_excessive_locations GUARDED_BY(m_cs){0};
+        // Time of last quota usage reset.
+        std::chrono::seconds m_last_quota_usage_reset GUARDED_BY(m_cs){0};
+        // Track quota usage for rate limiting per source location.
+        std::unordered_map<SourceLocation, QuotaUsage, SourceLocationHasher> m_quota_usage_per_source_location GUARDED_BY(m_cs);
+
         /**
          * m_started_new_line is a state variable that will suppress printing of
          * the timestamp when multiple calls are made that don't end in a
@@ -94,12 +124,13 @@ namespace BCLog {
         bool m_log_time_micros = DEFAULT_LOGTIMEMICROS;
         bool m_log_threadnames = DEFAULT_LOGTHREADNAMES;
         bool m_log_sourcelocations = DEFAULT_LOGSOURCELOCATIONS;
+        bool m_rate_limiting = DEFAULT_LOGRATELIMITING;
 
         fs::path m_file_path;
         std::atomic<bool> m_reopen_file{false};
 
         /** Send a string to the log output */
-        void LogPrintStr(const std::string& str, const std::string& logging_function, const std::string& source_file, const int source_line);
+        void LogPrintStr(const std::string& str, const std::string& logging_function, const SourceLocation& source_location, const bool skip_disk_usage_rate_limiting);
 
         /** Returns whether logs will be written to any output */
         bool Enabled() const
@@ -147,6 +178,13 @@ namespace BCLog {
         };
 
         bool DefaultShrinkDebugFile() const;
+
+        // Only for testing to help with mocked time.
+        void ResetRateLimitingTime()
+        {
+            StdLockGuard scoped_lock(m_cs);
+            m_last_quota_usage_reset = std::chrono::seconds{0};
+        }
     };
 
 } // namespace BCLog
@@ -165,9 +203,11 @@ bool GetLogCategory(BCLog::LogFlags& flag, const std::string& str);
 // Be conservative when using LogPrintf/error or other things which
 // unconditionally log to debug.log! It should not be the case that an inbound
 // peer can fill up a user's disk with debug.log entries.
-
+//
+// An attempt to mitigate disk filling attacks is made unless skip_disk_usage_rate_limiting
+// is set to true.
 template <typename... Args>
-static inline void LogPrintf_(const std::string& logging_function, const std::string& source_file, const int source_line, const char* fmt, const Args&... args)
+static inline void LogPrintf_(const std::string& logging_function, const char* source_file, const int source_line, const bool skip_disk_usage_rate_limiting, const char* fmt, const Args&... args)
 {
     if (LogInstance().Enabled()) {
         std::string log_msg;
@@ -177,19 +217,32 @@ static inline void LogPrintf_(const std::string& logging_function, const std::st
             /* Original format string will have newline so don't add one here */
             log_msg = "Error \"" + std::string(fmterr.what()) + "\" while formatting log message: " + fmt;
         }
-        LogInstance().LogPrintStr(log_msg, logging_function, source_file, source_line);
+
+        const SourceLocation source_location = std::make_pair(source_file, source_line);
+        LogInstance().LogPrintStr(log_msg, logging_function, source_location, skip_disk_usage_rate_limiting);
     }
 }
 
-#define LogPrintf(...) LogPrintf_(__func__, __FILE__, __LINE__, __VA_ARGS__)
+// Unconditional logging. Uses basic rate limiting to mitigate disk filling attacks.
+#define LogPrintf(...) LogPrintf_(__func__, __FILE__, __LINE__, /* skip_disk_usage_rate_limiting */ false, __VA_ARGS__)
+
+// Unconditional logging WITHOUT rate limiting. Use only for log messages that
+// MUST NOT be rate limited no matter how often they are logged. That requirement
+// should be extremely rare, so please use with care. Prefer LogPrintf(...) if
+// possible.
+#define LogPrintfWithoutRateLimiting(...) LogPrintf_(__func__, __FILE__, __LINE__, /* skip_disk_usage_rate_limiting */ true, __VA_ARGS__)
 
 // Use a macro instead of a function for conditional logging to prevent
 // evaluating arguments when logging for the category is not enabled.
-#define LogPrint(category, ...)              \
-    do {                                     \
-        if (LogAcceptCategory((category))) { \
-            LogPrintf(__VA_ARGS__);          \
-        }                                    \
+//
+// Note that conditional logging is performed WITHOUT rate limiting. Users
+// specifying -debug are assumed to be developers or power users who are aware
+// that -debug may cause excessive disk usage due to logging.
+#define LogPrint(category, ...)                                                                              \
+    do {                                                                                                     \
+        if (LogAcceptCategory((category))) {                                                                 \
+            LogPrintf_(__func__, __FILE__, __LINE__, /* skip_disk_usage_rate_limiting */ true, __VA_ARGS__); \
+        }                                                                                                    \
     } while (0)
 
 #endif // BITCOIN_LOGGING_H

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -30,4 +30,101 @@ BOOST_AUTO_TEST_CASE(logging_timer)
     BOOST_CHECK_EQUAL(micro_timer.LogMsg("test micros"), "tests: test micros (1000000.00μs)");
 }
 
+void GetLogFileSize(size_t& size)
+{
+    boost::system::error_code ec;
+    size = fs::file_size(LogInstance().m_file_path, ec);
+    if (ec) LogPrintf("%s: %s %s\n", __func__, ec.message(), LogInstance().m_file_path);
+    BOOST_CHECK(!ec);
+}
+
+void LogFromFixedLocation(const std::string& str)
+{
+    LogPrintf("%s\n", str);
+}
+
+BOOST_AUTO_TEST_CASE(rate_limiting)
+{
+#if defined(_WIN32)
+    // TODO
+    // Since windows prints \r\n to file instead of \n, the log file size
+    // does not match up with the internal "bytes logged" count.
+    // This test relies on matching file sizes with expected values.
+    return;
+#endif
+
+    // This allows us to check for exact size differences in the log file.
+    bool prev_log_timestamps = LogInstance().m_log_sourcelocations;
+    LogInstance().m_log_timestamps = false;
+    bool prev_log_sourcelocations = LogInstance().m_log_sourcelocations;
+    LogInstance().m_log_sourcelocations = false;
+    bool prev_log_threadnames = LogInstance().m_log_threadnames;
+    LogInstance().m_log_threadnames = false;
+
+    std::string log_message(1023, 'a');
+
+    SetMockTime(std::chrono::seconds{1});
+
+    LogInstance().ResetRateLimitingTime();
+
+    size_t prev_log_file_size, curr_log_file_size;
+    GetLogFileSize(prev_log_file_size);
+
+    // Log 1 MiB, this should be allowed.
+    for (int i = 0; i < 1024; ++i) {
+        LogFromFixedLocation(log_message);
+    }
+    GetLogFileSize(curr_log_file_size);
+    BOOST_CHECK(curr_log_file_size - prev_log_file_size == 1024 * 1024);
+
+    LogFromFixedLocation("This should trigger rate limiting");
+    GetLogFileSize(prev_log_file_size);
+
+    // Log 0.5 MiB, this should not be allowed and all messages should be dropped.
+    for (int i = 0; i < 512; ++i) {
+        LogFromFixedLocation(log_message);
+    }
+    GetLogFileSize(curr_log_file_size);
+    BOOST_CHECK(curr_log_file_size - prev_log_file_size == 0);
+
+    // Let one hour pass.
+    SetMockTime(std::chrono::seconds{60 * 60 + 2});
+    LogFromFixedLocation("This should trigger the quota usage reset");
+    GetLogFileSize(prev_log_file_size);
+
+    // Log 1 MiB, this should be allowed since the usage was reset.
+    for (int i = 0; i < 1024; ++i) {
+        LogFromFixedLocation(log_message);
+    }
+    GetLogFileSize(curr_log_file_size);
+    BOOST_CHECK(curr_log_file_size - prev_log_file_size == 1024 * 1024);
+
+    LogFromFixedLocation("This should trigger rate limiting");
+    GetLogFileSize(prev_log_file_size);
+
+    // Log 1 MiB, this should not be allowed and all messages should be dropped.
+    for (int i = 0; i < 1024; ++i) {
+        LogFromFixedLocation(log_message);
+    }
+    GetLogFileSize(curr_log_file_size);
+    BOOST_CHECK(curr_log_file_size - prev_log_file_size == 0);
+
+    // Let another hour pass
+    SetMockTime(std::chrono::seconds{2 * 60 * 60 + 3});
+    LogFromFixedLocation("This should trigger the quota usage reset");
+    GetLogFileSize(prev_log_file_size);
+
+    // Log 1 MiB, this should be allowed since the usage was reset.
+    for (int i = 0; i < 1024; ++i) {
+        LogFromFixedLocation(log_message);
+    }
+    GetLogFileSize(curr_log_file_size);
+    BOOST_CHECK(curr_log_file_size - prev_log_file_size == 1024 * 1024);
+
+    LogInstance().m_log_timestamps = prev_log_timestamps;
+    LogInstance().m_log_sourcelocations = prev_log_sourcelocations;
+    LogInstance().m_log_threadnames = prev_log_threadnames;
+    SetMockTime(std::chrono::seconds{0});
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2260,7 +2260,7 @@ static void UpdateTip(CTxMemPool& mempool, const CBlockIndex* pindexNew, const C
             }
         }
     }
-    LogPrintf("%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n", __func__,
+    LogPrintfWithoutRateLimiting("%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n", __func__,
       pindexNew->GetBlockHash().ToString(), pindexNew->nHeight, pindexNew->nVersion,
       log(pindexNew->nChainWork.getdouble())/log(2.0), (unsigned long)pindexNew->nChainTx,
       FormatISO8601DateTime(pindexNew->GetBlockTime()),


### PR DESCRIPTION
This is an alternative to #21603 in an attempt to solve #21559.

Example for the approach in this PR: Location A logs excessively and logging gets suppressed for up to one hour. All logs from any other location will also be dropped during the suppression period. After ~one hour logging restarts and a message with a report on which locations have been suppressed is printed to the log.

The key difference to #21603 is that logging is suppressed globally instead of "per source location" when at least one source location is logging excessively. 

Approach review is probably the best next step to determine which of the two PRs to move forward with.