### PR TITLE
test: Extend functional tests for addr relay

### DIFF
--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -58,6 +58,14 @@ class AddrTest(BitcoinTestFramework):
         msg.addrs = addrs
         return msg
 
+    def send_addr_msg(self, source, msg, receivers):
+        source.send_and_ping(msg)
+        # pop m_next_addr_send timer
+        self.mocktime += 5 * 60
+        self.nodes[0].setmocktime(self.mocktime)
+        for peer in receivers:
+            peer.sync_with_ping()
+
     def oversized_addr_test(self):
         self.log.info('Send an addr message that is too large')
         addr_source = self.nodes[0].add_p2p_connection(P2PInterface())
@@ -86,11 +94,7 @@ class AddrTest(BitcoinTestFramework):
                 'received: addr (301 bytes) peer=1',
             ]
         ):
-            addr_source.send_and_ping(msg)
-            self.mocktime += 30 * 60
-            self.nodes[0].setmocktime(self.mocktime)
-            for receiver in receivers:
-                receiver.sync_with_ping()
+            self.send_addr_msg(addr_source, msg, receivers)
 
         total_ipv4_received = sum(r.num_ipv4_received for r in receivers)
 


### PR DESCRIPTION
This extends the functional test `p2p_addr_relay.py`.
It adds test coverage for address relay involving outbound peers, tests for both outgoing and incoming `GETADDR` requests and tests for `-blocksonly` mode.

The initial refactors and some of the new tests were taken from Amiti Uttarwar's PR #21528 - they are general test improvements not directly tied to the change proposed there.