### PR TITLE
doc: update reduce-memory.md and bitcoin.conf -maxconnections info

### DIFF
--- a/doc/reduce-memory.md
+++ b/doc/reduce-memory.md
@@ -24,9 +24,13 @@ The size of some in-memory caches can be reduced. As caches trade off memory usa
 
 ## Number of peers
 
-- `-maxconnections=<n>` - the maximum number of connections, this defaults to 125. Each active connection takes up some
-  memory. This option applies only if incoming connections are enabled, otherwise the number of connections will never
-  be more than 10. Of the 10 outbound peers, there can be 8 full-relay connections and 2 block-relay-only ones.
+- `-maxconnections=<n>` - the maximum number of connections, which defaults to 125. Each active connection takes up some
+  memory. This option applies only if inbound connections are enabled; otherwise, the number of connections will not
+  be more than 11. Of the 11 outbound peers, there can be 8 full-relay connections, 2 block-relay-only ones,
+  and occasionally 1 short-lived feeler or extra outbound block-relay-only connection.
+
+- These limits do not apply to connections added manually with the `-addnode` configuration option or
+  the `addnode` RPC, which have a separate limit of 8 connections.
 
 ## Thread configuration
 

--- a/share/examples/bitcoin.conf
+++ b/share/examples/bitcoin.conf
@@ -63,7 +63,12 @@
 # Port on which to listen for connections (default: 8333, testnet: 18333, signet: 38333, regtest: 18444)
 #port=
 
-# Maximum number of inbound+outbound connections.
+# Maximum number of inbound + outbound connections (default: 125). This option
+# applies only if inbound connections are enabled; otherwise, the number of connections
+# will not be more than 11: 8 full-relay connections, 2 block-relay-only ones, and
+# occasionally 1 short-lived feeler or extra outbound block-relay-only connection.
+# These limits do not apply to connections added manually with the -addnode
+# configuration option or the addnode RPC, which have a separate limit of 8 connections.
 #maxconnections=
 
 #


### PR DESCRIPTION
This patch updates the documentation in `doc/reduce-memory.md` and `share/examples/bitcoin.conf` regarding the peer connections limits and `-maxconnections`