### PR TITLE
refactor: Drop CCoinControl::SetNull

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -839,8 +839,9 @@ void SendCoinsDialog::coinControlFeatureChanged(bool checked)
 {
     ui->frameCoinControl->setVisible(checked);
 
-    if (!checked && model) // coin control features disabled
-        m_coin_control->SetNull();
+    if (!checked && model) { // coin control features disabled
+        m_coin_control = std::make_unique<CCoinControl>();
+    }
 
     coinControlUpdateLabels();
 }

--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -6,21 +6,7 @@
 
 #include <util/system.h>
 
-void CCoinControl::SetNull()
+CCoinControl::CCoinControl()
 {
-    destChange = CNoDestination();
-    m_change_type.reset();
-    m_add_inputs = true;
-    fAllowOtherInputs = false;
-    fAllowWatchOnly = false;
     m_avoid_partial_spends = gArgs.GetBoolArg("-avoidpartialspends", DEFAULT_AVOIDPARTIALSPENDS);
-    m_avoid_address_reuse = false;
-    setSelected.clear();
-    m_feerate.reset();
-    fOverrideFeeRate = false;
-    m_confirm_target.reset();
-    m_signal_bip125_rbf.reset();
-    m_fee_mode = FeeEstimateMode::UNSET;
-    m_min_depth = DEFAULT_MIN_DEPTH;
-    m_max_depth = DEFAULT_MAX_DEPTH;
 }

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -24,17 +24,17 @@ class CCoinControl
 {
 public:
     //! Custom change destination, if not set an address is generated
-    CTxDestination destChange;
+    CTxDestination destChange = CNoDestination();
     //! Override the default change type if set, ignored if destChange is set
     std::optional<OutputType> m_change_type;
     //! If false, only selected inputs are used
-    bool m_add_inputs;
+    bool m_add_inputs = true;
     //! If false, allows unselected inputs, but requires all selected inputs be used
-    bool fAllowOtherInputs;
+    bool fAllowOtherInputs = false;
     //! Includes watch only addresses which are solvable
-    bool fAllowWatchOnly;
+    bool fAllowWatchOnly = false;
     //! Override automatic min/max checks on fee, m_feerate must be set if true
-    bool fOverrideFeeRate;
+    bool fOverrideFeeRate = false;
     //! Override the wallet's m_pay_tx_fee if set
     std::optional<CFeeRate> m_feerate;
     //! Override the default confirmation target if set
@@ -42,22 +42,17 @@ public:
     //! Override the wallet's m_signal_rbf if set
     std::optional<bool> m_signal_bip125_rbf;
     //! Avoid partial use of funds sent to a given address
-    bool m_avoid_partial_spends;
+    bool m_avoid_partial_spends = DEFAULT_AVOIDPARTIALSPENDS;
     //! Forbids inclusion of dirty (previously used) addresses
-    bool m_avoid_address_reuse;
+    bool m_avoid_address_reuse = false;
     //! Fee estimation mode to control arguments to estimateSmartFee
-    FeeEstimateMode m_fee_mode;
+    FeeEstimateMode m_fee_mode = FeeEstimateMode::UNSET;
     //! Minimum chain depth value for coin availability
     int m_min_depth = DEFAULT_MIN_DEPTH;
     //! Maximum chain depth value for coin availability
     int m_max_depth = DEFAULT_MAX_DEPTH;
 
-    CCoinControl()
-    {
-        SetNull();
-    }
-
-    void SetNull();
+    CCoinControl();
 
     bool HasSelected() const
     {


### PR DESCRIPTION
The only external call to `SetNull` is changed as follow

```diff
- m_coin_control->SetNull();
+ m_coin_control = std::make_unique<CCoinControl>();
```