### PR TITLE
rpc: Improve error message for getblock invalid datatype.

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -936,10 +936,11 @@ static RPCHelpMan getblock()
 
     int verbosity = 1;
     if (!request.params[1].isNull()) {
-        if(request.params[1].isNum())
-            verbosity = request.params[1].get_int();
-        else
+        if (request.params[1].isBool()) {
             verbosity = request.params[1].get_bool() ? 1 : 0;
+        } else {
+            verbosity = request.params[1].get_int();
+        }
     }
 
     CBlock block;

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -410,6 +410,9 @@ class BlockchainTest(BitcoinTestFramework):
         self.log.info("Test that getblock with verbosity 2 still works with pruned Undo data")
         datadir = get_datadir_path(self.options.tmpdir, 0)
 
+        self.log.info("Test that getblock with invalid verbosity type returns proper error message")
+        assert_raises_rpc_error(-1, "JSON value is not an integer as expected", node.getblock, blockhash, "2")
+
         def move_block_file(old, new):
             old_path = os.path.join(datadir, self.chain, 'blocks', old)
             new_path = os.path.join(datadir, self.chain, 'blocks', new)


### PR DESCRIPTION
Improve error messages for getblock invalid datatype. 

fixes: #21717