### PR TITLE
[WIP][POC][DONOTMERGE] Flag Day ST Compatible Logic w/ Optional Mandatory Signalling

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -35,6 +35,11 @@ struct BIP9Deployment {
      */
     int min_activation_height{0};
 
+    /** If the timeout is reached, should the deployment proceed to LOCKED_IN (true) or FAILED
+     * (false).
+     */
+    bool flag_day_on_timeout{false};
+
     /** Constant for nTimeout very far in the future. */
     static constexpr int64_t NO_TIMEOUT = std::numeric_limits<int64_t>::max();
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -40,6 +40,10 @@ struct BIP9Deployment {
      */
     bool flag_day_on_timeout{false};
 
+    /** When we are locked in does signaling become required until we are ACTIVE
+     */
+    bool mandatory_signaling_during_locked_in{false};
+
     /** Constant for nTimeout very far in the future. */
     static constexpr int64_t NO_TIMEOUT = std::numeric_limits<int64_t>::max();
 

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -75,7 +75,7 @@ ThresholdState AbstractThresholdConditionChecker::GetStateFor(const CBlockIndex*
                 if (count >= nThreshold) {
                     stateNext = ThresholdState::LOCKED_IN;
                 } else if (pindexPrev->GetMedianTimePast() >= nTimeTimeout) {
-                    stateNext = ThresholdState::FAILED;
+                    stateNext = OnTimeout(params);
                 }
                 break;
             }
@@ -174,6 +174,7 @@ private:
 protected:
     int64_t BeginTime(const Consensus::Params& params) const override { return params.vDeployments[id].nStartTime; }
     int64_t EndTime(const Consensus::Params& params) const override { return params.vDeployments[id].nTimeout; }
+    ThresholdState OnTimeout(const Consensus::Params& params) const override { return params.vDeployments[id].flag_day_on_timeout ? ThresholdState::LOCKED_IN : ThresholdState::FAILED; }
     int MinActivationHeight(const Consensus::Params& params) const override { return params.vDeployments[id].min_activation_height; }
     int Period(const Consensus::Params& params) const override { return params.nMinerConfirmationWindow; }
     int Threshold(const Consensus::Params& params) const override { return params.nRuleChangeActivationThreshold; }

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -57,6 +57,7 @@ protected:
     virtual bool Condition(const CBlockIndex* pindex, const Consensus::Params& params) const =0;
     virtual int64_t BeginTime(const Consensus::Params& params) const =0;
     virtual int64_t EndTime(const Consensus::Params& params) const =0;
+    virtual ThresholdState OnTimeout(const Consensus::Params& params) const { return ThresholdState::FAILED; }
     virtual int MinActivationHeight(const Consensus::Params& params) const { return 0; }
     virtual int Period(const Consensus::Params& params) const =0;
     virtual int Threshold(const Consensus::Params& params) const =0;


### PR DESCRIPTION
Just posting this here for discussion to show ST/MTP compatibility with flag days. This shows 2 patches for deployment params that enable lock in on timeout and optional mandatory signalling in a manner compatible with the existing ST logic.

This is quite similar to how a LAST_CHANCE state could work, but I think a little simpler.

Note that the lock in on timeout in this case would likely not activate the current ST parameters, unless one were to choose a timeout period that was earlier that the existing deployment (otherwise the original clients transition to FAILED and the flag_day_on_timeout proceed to true). In most cases what we see suggested for use, however, is a UASF client with a much further out date than a ST client, so concern of overlap for drag along is minimal.

One difference with prior mandatory signalling proposals is that this requires mandatory signaling until the transition becomes active. Changing the state machine so that signaling is required only sometimes is additional complexity for uncertain benefit. During any LOCKED_IN period, thus we require signalling.

The main drawback for not having LAST_CHANCE window is that clients with otherwise identical params except flag_day_on_timeout + mando won't activate the rule. However, supposing that because of the mandatory signalling and following the most work chain that the flag_day_on_timeout clients must have a hashrate supermajority anyways for these clients, it seems safe and simple that they can just switch to a buried deployment client after the fact. The LAST_CHANCE state transition would only be relevant for clients which are flag_day_on_timeout = false and mandaotry_signalling= false, I chose not to implement it so that this can serve as a reference for what could be deployed against Core's Taproot RC1.

The mandatory signalling during LOCKED_IN rule is compatible with BIP9 by policy, which suggests miners continue to signal till ACTIVE.

| flag day on timeout | mandatory signalling | description |
|---------------------------|-----------------------------|----------------|
| no                           | no                              | requires 90% signalling before timeout to activate, identical to current behavior |
| no                           | yes                            |  Essentially invalid combo since you can be Failed and require signalling after. |
| yes                          | yes                            | always locks in after last signalling period, signals unconditionally in the period after timeout or when LOCKED_IN until Active|
| yes                          | no                             | always locks in after last signalling period, does not require signalling afterwards | 

I don't intend to personally deploy or use anything like this until it is clear that Taproot might not activate and there is no discernible reason why, but I thought this should post this now just for the sake of demonstrating the existence of possible alternative UASF plans in the future. I think I'd be most likely to run yesflag nomando in the future if I felt I needed a flag day client.

