### PR TITLE
refactor: Add missing includes in pubkey.cpp/pubkey.h

### DIFF
--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -5,9 +5,16 @@
 
 #include <pubkey.h>
 
+#include <hash.h>
 #include <secp256k1.h>
+#include <secp256k1_extrakeys.h>
 #include <secp256k1_recovery.h>
 #include <secp256k1_schnorrsig.h>
+#include <span.h>
+#include <uint256.h>
+
+#include <algorithm>
+#include <cassert>
 
 namespace
 {

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -12,7 +12,7 @@
 #include <span.h>
 #include <uint256.h>
 
-#include <stdexcept>
+#include <cstring>
 #include <vector>
 
 const unsigned int BIP32_EXTKEY_SIZE = 74;


### PR DESCRIPTION
#### Problem:
Many symbols in the files were undefined and causing issues when I was working on building independent sections of the codebase. The hidden imports from the "secp256k1" library was a particular pain point.

The other standard and missing includes are following best practices and will help with refactoring, build process and others. 

#### Changes:
Clean up and declared imports/include for `pubkey.cpp` and `pubkey.h`
