### PR TITLE
test: Bump shellcheck version

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -17,6 +17,6 @@ ${CI_RETRY_EXE} pip3 install yq
 ${CI_RETRY_EXE} pip3 install mypy==0.781
 ${CI_RETRY_EXE} pip3 install vulture==2.3
 
-SHELLCHECK_VERSION=v0.7.1
+SHELLCHECK_VERSION=v0.7.2
 curl -sL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar --xz -xf - --directory /tmp/
 export PATH="/tmp/shellcheck-${SHELLCHECK_VERSION}:${PATH}"

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -62,7 +62,7 @@ if test -z "$enable_zmq" && test -n "@no_zmq@"; then
   enable_zmq=no
 fi
 
-if test "x@host_os@" = xdarwin; then
+if test "@host_os@" = darwin; then
   BREW=no
   PORT=no
 fi

--- a/test/README.md
+++ b/test/README.md
@@ -262,7 +262,7 @@ Use the `-v` option for verbose output.
 |-----------|:----------:|:-------------------------------------------:|--------------
 | [`lint-python.sh`](lint/lint-python.sh) | [flake8](https://gitlab.com/pycqa/flake8) | [3.8.3](https://github.com/bitcoin/bitcoin/pull/19348) | `pip3 install flake8==3.8.3`
 | [`lint-python.sh`](lint/lint-python.sh) | [mypy](https://github.com/python/mypy) | [0.781](https://github.com/bitcoin/bitcoin/pull/19348) | `pip3 install mypy==0.781`
-| [`lint-shell.sh`](lint/lint-shell.sh) | [ShellCheck](https://github.com/koalaman/shellcheck) | [0.7.1](https://github.com/bitcoin/bitcoin/pull/19348) | [details...](https://github.com/koalaman/shellcheck#installing)
+| [`lint-shell.sh`](lint/lint-shell.sh) | [ShellCheck](https://github.com/koalaman/shellcheck) | [0.7.2](https://github.com/bitcoin/bitcoin/pull/21749) | [details...](https://github.com/koalaman/shellcheck#installing)
 | [`lint-shell.sh`](lint/lint-shell.sh) | [yq](https://github.com/kislyuk/yq) | default | `pip3 install yq`
 | [`lint-spelling.sh`](lint/lint-spelling.sh) | [codespell](https://github.com/codespell-project/codespell) | [2.0.0](https://github.com/bitcoin/bitcoin/pull/20817) | `pip3 install codespell==2.0.0`
 

--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -12,7 +12,7 @@
 # one. Any remaining diff signals an error.
 
 export LC_ALL=C
-if test "x$1" = "x"; then
+if test -z $1; then
     echo "Usage: $0 <commit>..."
     exit 1
 fi
@@ -24,7 +24,7 @@ for commit in $(git rev-list --reverse $1); do
     if git rev-list -n 1 --pretty="%s" $commit | grep -q "^scripted-diff:"; then
         git checkout --quiet $commit^ || exit
         SCRIPT="$(git rev-list --format=%b -n1 $commit | sed '/^-BEGIN VERIFY SCRIPT-$/,/^-END VERIFY SCRIPT-$/{//!b};d')"
-        if test "x$SCRIPT" = "x"; then
+        if test -z "$SCRIPT"; then
             echo "Error: missing script for: $commit"
             echo "Failed"
             RET=1


### PR DESCRIPTION
The changelog for v0.7.2 is available [here](https://github.com/koalaman/shellcheck/blob/v0.7.2/CHANGELOG.md).

Only [SC2268](https://github.com/koalaman/shellcheck/wiki/SC2268) requires to update our code.