### PR TITLE
Add -flushwalletinterval command line arg

### DIFF
--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -48,6 +48,7 @@ void DummyWalletInit::AddWalletOptions(ArgsManager& argsman) const
         "-walletrbf",
         "-dblogsize=<n>",
         "-flushwallet",
+        "-flushwalletinterval=<n>",
         "-privdb",
         "-walletrejectlongchains",
         "-unsafesqlitesync",

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -77,9 +77,10 @@ void WalletInit::AddWalletOptions(ArgsManager& argsman) const
 #ifdef USE_BDB
     argsman.AddArg("-dblogsize=<n>", strprintf("Flush wallet database activity from memory to disk log every <n> megabytes (default: %u)", DEFAULT_WALLET_DBLOGSIZE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
     argsman.AddArg("-flushwallet", strprintf("Run a thread to flush wallet periodically (default: %u)", DEFAULT_FLUSHWALLET), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
+    argsman.AddArg("-flushwalletinterval", strprintf("Interval of how often to flush wallet, in milliseconds (default: %u)", DEFAULT_FLUSHWALLETINTERVAL), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
     argsman.AddArg("-privdb", strprintf("Sets the DB_PRIVATE flag in the wallet db environment (default: %u)", DEFAULT_WALLET_PRIVDB), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
 #else
-    argsman.AddHiddenArgs({"-dblogsize", "-flushwallet", "-privdb"});
+    argsman.AddHiddenArgs({"-dblogsize", "-flushwallet", "-flushwalletinterval", "-privdb"});
 #endif
 
 #ifdef USE_SQLITE

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -128,7 +128,7 @@ void StartWallets(CScheduler& scheduler, const ArgsManager& args)
 
     // Schedule periodic wallet flushes and tx rebroadcasts
     if (args.GetBoolArg("-flushwallet", DEFAULT_FLUSHWALLET)) {
-        scheduler.scheduleEvery(MaybeCompactWalletDB, std::chrono::milliseconds{gArgs.GetArg("-flushwalletinterval", DEFAULT_FLUSHWALLETINTERVAL});
+        scheduler.scheduleEvery(MaybeCompactWalletDB, std::chrono::milliseconds{gArgs.GetArg("-flushwalletinterval", DEFAULT_FLUSHWALLETINTERVAL)});
     }
     scheduler.scheduleEvery(MaybeResendWalletTxs, std::chrono::milliseconds{1000});
 }

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -128,7 +128,7 @@ void StartWallets(CScheduler& scheduler, const ArgsManager& args)
 
     // Schedule periodic wallet flushes and tx rebroadcasts
     if (args.GetBoolArg("-flushwallet", DEFAULT_FLUSHWALLET)) {
-        scheduler.scheduleEvery(MaybeCompactWalletDB, std::chrono::milliseconds{500});
+        scheduler.scheduleEvery(MaybeCompactWalletDB, std::chrono::milliseconds{DEFAULT_FLUSHWALLETINTERVAL});
     }
     scheduler.scheduleEvery(MaybeResendWalletTxs, std::chrono::milliseconds{1000});
 }

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -128,7 +128,8 @@ void StartWallets(CScheduler& scheduler, const ArgsManager& args)
 
     // Schedule periodic wallet flushes and tx rebroadcasts
     if (args.GetBoolArg("-flushwallet", DEFAULT_FLUSHWALLET)) {
-        scheduler.scheduleEvery(MaybeCompactWalletDB, std::chrono::milliseconds{DEFAULT_FLUSHWALLETINTERVAL});
+        flushwalletinterval = gArgs.GetArg("-flushwalletinterval", DEFAULT_FLUSHWALLETINTERVAL)
+        scheduler.scheduleEvery(MaybeCompactWalletDB, std::chrono::milliseconds{flushwalletinterval});
     }
     scheduler.scheduleEvery(MaybeResendWalletTxs, std::chrono::milliseconds{1000});
 }

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -128,7 +128,7 @@ void StartWallets(CScheduler& scheduler, const ArgsManager& args)
 
     // Schedule periodic wallet flushes and tx rebroadcasts
     if (args.GetBoolArg("-flushwallet", DEFAULT_FLUSHWALLET)) {
-        scheduler.scheduleEvery(MaybeCompactWalletDB, std::chrono::milliseconds{DEFAULT_FLUSHWALLETINTERVAL});
+        scheduler.scheduleEvery(MaybeCompactWalletDB, std::chrono::milliseconds{gArgs.GetArg("-flushwalletinterval", DEFAULT_FLUSHWALLETINTERVAL});
     }
     scheduler.scheduleEvery(MaybeResendWalletTxs, std::chrono::milliseconds{1000});
 }

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -29,7 +29,7 @@
  */
 
 static const bool DEFAULT_FLUSHWALLET = true;
-static const int DEFAULT_FLUSHWALLET = 500;
+static const int DEFAULT_FLUSHWALLETINTERVAL = 500;
 
 struct CBlockLocator;
 class CKeyPool;

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -29,6 +29,7 @@
  */
 
 static const bool DEFAULT_FLUSHWALLET = true;
+static const int DEFAULT_FLUSHWALLET = 500;
 
 struct CBlockLocator;
 class CKeyPool;


### PR DESCRIPTION
Dear sirs or ladies. I'm experiencing issue with large BDB wallet: it's hammering disk io heavily (when wallet is flushing to disk every 500ms) and node requires a fast filesystem to keep working normally. To avoid situations like that, flushing can be turned off using `-flushwallet=0`, however it looks like walking on thin ice from point of wallet consistency in case of possible power/hardware outage.

I believe issue can be resolved less radically, if there will be a possibility to increase flush interval - this would relax disk usage significantly and at same time let us to still have some guarantees