### PR TITLE
WIP - Add maxmempool RPC

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -552,6 +552,32 @@ UniValue MempoolToJSON(const CTxMemPool& pool, bool verbose, bool include_mempoo
     }
 }
 
+static RPCHelpMan maxmempool()
+{
+    return RPCHelpMan{"maxmempool",
+                "\nSets the allocated memory for the memory pool.\n",
+                {
+                    {"megabytes", RPCArg::Type::NUM, RPCArg::Optional::NO, "The memory allocated in MB"},
+                },
+                RPCResult{
+                    RPCResult::Type::NONE, "", ""},
+                RPCExamples{
+                    HelpExampleCli("maxmempool", "150") + HelpExampleRpc("maxmempool", "150")
+                },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    int nSize = request.params[0].get_int();
+    int64_t nMempoolSizeMax = nSize * 1000000;
+    int64_t nMempoolSizeMin = gArgs.GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT) * 1000 * 40;
+    if (nMempoolSizeMax < 0 || nMempoolSizeMax < nMempoolSizeMin)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("MaxMempool size %d is too small", nSize));
+    gArgs.ForceSetArg("-maxmempool", strprintf("%d", nSize));
+
+    return NullUniValue;
+}
+    };
+}
+
 static RPCHelpMan getrawmempool()
 {
     return RPCHelpMan{"getrawmempool",
@@ -2574,6 +2600,7 @@ static const CRPCCommand commands[] =
     { "blockchain",         &gettxoutsetinfo,                    },
     { "blockchain",         &pruneblockchain,                    },
     { "blockchain",         &savemempool,                        },
+    { "blockchain",         &maxmempool,                         },
     { "blockchain",         &verifychain,                        },
 
     { "blockchain",         &preciousblock,                      },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -57,6 +57,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getbalance", 2, "include_watchonly" },
     { "getbalance", 3, "avoid_reuse" },
     { "getblockhash", 0, "height" },
+    { "maxmempool", 0, "megabytes" },
     { "waitforblockheight", 0, "height" },
     { "waitforblockheight", 1, "timeout" },
     { "waitforblock", 1, "timeout" },


### PR DESCRIPTION
Not entirely sure how useful this is given that currently when the mempool is reduced in size, the memory is not yet freed - perhaps this can come in a later pull request.

It's WIP as currently it doesn't work from bitcoin-cli - and I don't quite know why! (can someone help please? it works from within the console of the GUI though).
