### PR TITLE
Security enhancements to ChaCha20::SetKey and CSignatureCache::ComputeEntryECDSA

### DIFF
--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -8,7 +8,7 @@
 #include <crypto/common.h>
 #include <crypto/chacha20.h>
 
-#include <stdexcept>
+#include <cassert>
 #include <string.h>
 
 constexpr static inline uint32_t rotl32(uint32_t v, int c) { return (v << c) | (v >> (32 - c)); }
@@ -24,9 +24,7 @@ static const unsigned char tau[] = "expand 16-byte k";
 
 void ChaCha20::SetKey(const unsigned char* k, size_t keylen)
 {
-    if (keylen != 16 && keylen != 32) {
-        throw std::invalid_argument("ChaCha20 key size must be 16 or 32");
-    }
+    assert(keylen == 16 || keylen == 32);
 
     const unsigned char *constants;
 

--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -8,6 +8,7 @@
 #include <crypto/common.h>
 #include <crypto/chacha20.h>
 
+#include <stdexcept>
 #include <string.h>
 
 constexpr static inline uint32_t rotl32(uint32_t v, int c) { return (v << c) | (v >> (32 - c)); }
@@ -23,6 +24,10 @@ static const unsigned char tau[] = "expand 16-byte k";
 
 void ChaCha20::SetKey(const unsigned char* k, size_t keylen)
 {
+    if (keylen != 16 && keylen != 32) {
+        throw std::invalid_argument("ChaCha20 key size must be 16 or 32");
+    }
+
     const unsigned char *constants;
 
     input[4] = ReadLE32(k + 0);

--- a/src/crypto/chacha20.h
+++ b/src/crypto/chacha20.h
@@ -17,8 +17,8 @@ private:
 
 public:
     ChaCha20();
-    ChaCha20(const unsigned char* key, size_t keylen);
-    void SetKey(const unsigned char* key, size_t keylen); //!< set key with flexible keylength; 256bit recommended */
+    ChaCha20(const unsigned char* key, size_t keylen); //!< set key of 128 or 256 bits; 256 bits recommended */
+    void SetKey(const unsigned char* key, size_t keylen); //!< set key of 128 or 256 bits; 256 bits recommended */
     void SetIV(uint64_t iv); // set the 64bit nonce
     void Seek(uint64_t pos); // set the 64bit block counter
 

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -53,7 +53,7 @@ public:
     ComputeEntryECDSA(uint256& entry, const uint256 &hash, const std::vector<unsigned char>& vchSig, const CPubKey& pubkey) const
     {
         CSHA256 hasher = m_salted_hasher_ecdsa;
-        hasher.Write(hash.begin(), 32).Write(&pubkey[0], pubkey.size()).Write(&vchSig[0], vchSig.size()).Finalize(entry.begin());
+        hasher.Write(hash.begin(), 32).Write(&pubkey[0], pubkey.size()).Write(vchSig.data(), vchSig.size()).Finalize(entry.begin());
     }
 
     void


### PR DESCRIPTION
- Add a check to ChaCha20::SetKey which asserts that the specified key size is valid. This is an inexpensive check that guards against (accidental) misuse, which could result in out-of-bound reads.
- In CSignatureCache::ComputeEntryECDSA, change the way a vector pointer is resolved to prevent invoking undefined behavior if the vector is empty.