### PR TITLE
build: Fix static Darwin builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -734,6 +734,9 @@ case $host in
        esac
      fi
 
+     if test "x$DARWIN_FLAGS" != x; then
+       AX_CHECK_LINK_FLAG([$DARWIN_FLAGS], [LDFLAGS="$LDFLAGS $DARWIN_FLAGS"])
+     fi
      AX_CHECK_LINK_FLAG([[-Wl,-headerpad_max_install_names]], [LDFLAGS="$LDFLAGS -Wl,-headerpad_max_install_names"],, [[$LDFLAG_WERROR]])
      CPPFLAGS="$CPPFLAGS -DMAC_OSX -DOBJC_OLD_DISPATCH_PROTOTYPES=0"
      OBJCXXFLAGS="$CXXFLAGS"

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -228,6 +228,7 @@ $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_
             -e 's|@CXXFLAGS@|$(strip $(host_CXXFLAGS) $(host_$(release_type)_CXXFLAGS))|' \
             -e 's|@CPPFLAGS@|$(strip $(host_CPPFLAGS) $(host_$(release_type)_CPPFLAGS))|' \
             -e 's|@LDFLAGS@|$(strip $(host_LDFLAGS) $(host_$(release_type)_LDFLAGS))|' \
+            -e 's|@DARWIN_FLAGS@|$(darwin_FLAGS)|' \
             -e 's|@allow_host_packages@|$(ALLOW_HOST_PACKAGES)|' \
             -e 's|@no_qt@|$(NO_QT)|' \
             -e 's|@no_qr@|$(NO_QR)|' \

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -120,3 +120,6 @@ fi
 if test -n "@LDFLAGS@"; then
   LDFLAGS="@LDFLAGS@ ${LDFLAGS}"
 fi
+if test -n "@DARWIN_FLAGS@"; then
+  DARWIN_FLAGS="@DARWIN_FLAGS@"
+fi

--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -1,5 +1,11 @@
 OSX_MIN_VERSION=10.14
-OSX_SDK_VERSION=10.15.1
+
+ifeq ($(build_os),darwin)
+OSX_SDK_VERSION := $(shell xcrun --show-sdk-version)
+else
+OSX_SDK_VERSION := 10.15.1
+endif
+
 XCODE_VERSION=11.3.1
 XCODE_BUILD_ID=11C505
 LD64_VERSION=530
@@ -122,5 +128,7 @@ darwin_release_CXXFLAGS=$(darwin_release_CFLAGS)
 
 darwin_debug_CFLAGS=-O1
 darwin_debug_CXXFLAGS=$(darwin_debug_CFLAGS)
+
+darwin_FLAGS := -Wl,-platform_version -Wl,macos -Wl,$(OSX_MIN_VERSION) -Wl,$(OSX_SDK_VERSION)
 
 darwin_cmake_system=Darwin


### PR DESCRIPTION
From `##bitcoin-core-gui` IRC channel:

> \<fanquake> hebasto: I think I might have solved the darkmode issue, or at least some of the macOS qt problems. Will PR shortly
> \<hebasto> was I on the right way?
> \<fanquake> Yes I think it's related to how the SDK is being setup
> \<hebasto> fanquake: expecting of adding `-Wl,-sdk_version` to linker flags :)
> \<fanquake> hebasto: heh. That may be added at some point, however I think the solution here will be even simpler

Assuming, that **fanquake**'s solution does not involve linker flags, I'm suggesting an alternative one that does use them.

When doing static builds, for some reasons, SDK version is not handled correctly when Darwin Driver [passes](https://github.com/llvm/llvm-project/commit/25ce33a6e4f3b13732c0f851e68390dc2acb9123) it to a linker via the
`-platform_version` option.

With this PR we pass the `-platform_version` option to a linker explicitly.

Fix #21771.

This change causes harmless [warnings](https://github.com/tpoechtrager/cctools-port/blob/6c438753d2252274678d3e0839270045698c159b/cctools/ld64/src/ld/Options.cpp#L3213-L3214):
```
ld: warning: passed two min versions (10.14.0, 10.14) for platform macOS. Using 10.14.
```

---

Building with depends on macOS Big Sur 11.2.3 (20D91):
```
% ld -v
@(#)PROGRAM:ld  PROJECT:ld64-609.8
BUILD 15:07:46 Dec 18 2020
configured to support archs: armv6 armv7 armv7s arm64 arm64e arm64_32 i386 x86_64 x86_64h armv6m armv7k armv7m armv7em
LTO support using: LLVM version 12.0.0, (clang-1200.0.32.29) (static support for 27, runtime is 27)
TAPI support using: Apple TAPI version 12.0.0 (tapi-1200.0.23.5)
```
- on master (683dda2a70e7a210996fa34be23bd0c563971ba9)
```
% otool -l src/qt/bitcoin-qt | grep -A 7 -B 1 BUILD_VERSION
Load command 9
      cmd LC_BUILD_VERSION
  cmdsize 32
 platform 1
    minos 10.14
      sdk n/a
   ntools 1
     tool 3
  version 609.8
```
- with this PR
```
% otool -l src/qt/bitcoin-qt | grep -A 7 -B 1 BUILD_VERSION                       
Load command 9
      cmd LC_BUILD_VERSION
  cmdsize 32
 platform 1
    minos 10.14
      sdk 11.1
   ntools 1
     tool 3
  version 609.8
```