### PR TITLE
refactor: Make MempoolAcceptResult members const

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -195,14 +195,14 @@ struct MempoolAcceptResult {
         VALID, //!> Fully validated, valid.
         INVALID, //!> Invalid.
     };
-    ResultType m_result_type;
-    TxValidationState m_state;
+    const ResultType m_result_type;
+    const TxValidationState m_state;
 
     // The following fields are only present when m_result_type = ResultType::VALID
     /** Mempool transactions replaced by the tx per BIP 125 rules. */
-    std::optional<std::list<CTransactionRef>> m_replaced_transactions;
-    /** Raw base fees. */
-    std::optional<CAmount> m_base_fees;
+    const std::optional<std::list<CTransactionRef>> m_replaced_transactions;
+    /** Raw base fees in satoshis. */
+    const std::optional<CAmount> m_base_fees;
 
     /** Constructor for failure case */
     explicit MempoolAcceptResult(TxValidationState state)
@@ -212,7 +212,7 @@ struct MempoolAcceptResult {
 
     /** Constructor for success case */
     explicit MempoolAcceptResult(std::list<CTransactionRef>&& replaced_txns, CAmount fees)
-        : m_result_type(ResultType::VALID), m_state(TxValidationState{}),
+        : m_result_type(ResultType::VALID),
         m_replaced_transactions(std::move(replaced_txns)), m_base_fees(fees) {}
 };
 


### PR DESCRIPTION
Follow up to #21062. Was going to be a part of #20833 but I'm trying to break it down as much as possible. 

- Make members const (https://github.com/bitcoin/bitcoin/pull/21062#discussion_r573659273)
- List fee units (https://github.com/bitcoin/bitcoin/pull/21062#discussion_r569329362)
- Use default value for `TxValidationState` in the success case (https://github.com/bitcoin/bitcoin/pull/21062#discussion_r573659801).