### PR TITLE
doc: note that brew install qt6 is not supported

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -142,11 +142,10 @@ Note: Building with Qt binaries downloaded from the Qt website is not officially
 See the notes in [#7714](https://github.com/bitcoin/bitcoin/issues/7714).
 
 Note: Ensure that the `qt@5` package is installed, not the `qt` package.
-If 'qt' (v6.x) is installed in macOS the build process will fail with a "unknown type name 'QStringRef'; did you mean 'CFStringRef'?" error. 
-You can use the following two commands to verify if 'qt' (version 6.x) is installed and remove it:
+If 'qt' is installed, the build process will fail. 
+if installed, remove the `qt` package with the following command:
 
 ``` bash
-brew info qt
 brew uninstall qt
 ```
 

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -142,7 +142,7 @@ Note: Building with Qt binaries downloaded from the Qt website is not officially
 See the notes in [#7714](https://github.com/bitcoin/bitcoin/issues/7714).
 
 Note: Ensure that the `qt@5` package is installed, not the `qt` package.
-If 'qt' is installed, the build process will fail. 
+If 'qt' is installed, the build process will fail.
 if installed, remove the `qt` package with the following command:
 
 ``` bash

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -141,7 +141,7 @@ brew install qt@5
 Note: Building with Qt binaries downloaded from the Qt website is not officially supported.
 See the notes in [#7714](https://github.com/bitcoin/bitcoin/issues/7714).
 
-Note: Be sure 'qt' (version 6.x) is not installed in brew together with 'qt@5'. Only 'qt@5' is required.
+Note: Ensure that the `qt@5` package is installed, not the `qt` package.
 If 'qt' (v6.x) is installed in macOS the build process will fail with a "unknown type name 'QStringRef'; did you mean 'CFStringRef'?" error. 
 You can use the following two commands to verify if 'qt' (version 6.x) is installed and remove it:
 

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -141,6 +141,15 @@ brew install qt@5
 Note: Building with Qt binaries downloaded from the Qt website is not officially supported.
 See the notes in [#7714](https://github.com/bitcoin/bitcoin/issues/7714).
 
+Note: Be sure 'qt' (version 6.x) is not installed in brew together with 'qt@5'. Only 'qt@5' is required.
+If 'qt' (v6.x) is installed in macOS the build process will fail with a "unknown type name 'QStringRef'; did you mean 'CFStringRef'?" error. 
+You can use the following two commands to verify if 'qt' (version 6.x) is installed and remove it:
+
+``` bash
+brew info qt
+brew uninstall qt
+```
+
 ###### qrencode
 
 The GUI can encode addresses in a QR Code. To build in QR support for the GUI, install `qrencode`.


### PR DESCRIPTION
Ensure 'qt' v6.x is not installed in brew to force the use to 'qt@5'.
