### PR TITLE
test: Fix intermittent issue in p2p_segwit.py

### DIFF
--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -1966,9 +1966,10 @@ class SegWitTest(BitcoinTestFramework):
         # Restarting node 2 should result in a shutdown because the blockchain consists of
         # insufficiently validated blocks per segwit consensus rules.
         self.stop_node(2)
-        with self.nodes[2].assert_debug_log(expected_msgs=[
-                f"Witness data for blocks after height {SEGWIT_HEIGHT} requires validation. Please restart with -reindex."], timeout=10):
-            self.nodes[2].start([f"-segwitheight={SEGWIT_HEIGHT}"])
+        self.nodes[2].assert_start_raises_init_error(
+            extra_args=[f"-segwitheight={SEGWIT_HEIGHT}"],
+            expected_msg=f": Witness data for blocks after height {SEGWIT_HEIGHT} requires validation. Please restart with -reindex..\nPlease restart with -reindex or -reindex-chainstate to recover.",
+        )
 
         # As directed, the user restarts the node with -reindex
         self.start_node(2, extra_args=["-reindex", f"-segwitheight={SEGWIT_HEIGHT}"])

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -491,6 +491,7 @@ class TestNode():
                 self.start(extra_args, stdout=log_stdout, stderr=log_stderr, *args, **kwargs)
                 ret = self.process.wait(timeout=self.rpc_timeout)
                 self.log.debug(self._node_msg(f'bitcoind exited with status {ret} during initialization'))
+                assert ret != 0  # Exit code must indicate failure
                 self.running = False
                 self.process = None
                 # Check stderr for expected message


### PR DESCRIPTION
Calling `start_node` might call `wait_for_rpc_connection`, which will fail.

https://cirrus-ci.com/task/5669555591708672?logs=ci#L3504

```
  File "/tmp/cirrus-ci-build/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/test/functional/p2p_segwit.py", line 1974, in test_upgrade_after_activation
    self.start_node(2, extra_args=["-reindex", f"-segwitheight={SEGWIT_HEIGHT}"])
  File "/tmp/cirrus-ci-build/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/test/functional/test_framework/test_framework.py", line 508, in start_node
    node.wait_for_rpc_connection()
  File "/tmp/cirrus-ci-build/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/test/functional/test_framework/test_node.py", line 224, in wait_for_rpc_connection
    raise FailedToStartError(self._node_msg(
test_framework.test_node.FailedToStartError: [node 2] bitcoind exited with status 1 during initialization