### PR TITLE
fuzz: Terminate immediately if a fuzzing harness tries to perform a DNS lookup (belt and suspenders)

### DIFF
--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <exception>
 #include <memory>
+#include <string>
 #include <unistd.h>
 #include <vector>
 
@@ -36,6 +37,14 @@ void initialize()
 {
     // Terminate immediately if a fuzzing harness ever tries to create a TCP socket.
     CreateSock = [](const CService&) -> std::unique_ptr<Sock> { std::terminate(); };
+
+    // Terminate immediately if a fuzzing harness ever tries to perform a DNS lookup.
+    g_dns_lookup = [](const std::string& name, bool allow_lookup) {
+        if (allow_lookup) {
+            std::terminate();
+        }
+        return WrappedGetAddrInfo(name, false);
+    };
 
     bool should_abort{false};
     if (std::getenv("PRINT_ALL_FUZZ_TARGETS_AND_ABORT")) {


### PR DESCRIPTION
Terminate immediately if a fuzzing harness tries to perform a DNS lookup (belt and suspenders).

Obviously this _should_ never happen, but if it _does_ happen we want immediate termination instead of a DNS lookup :)