### PR TITLE
guix: Use `gcc-8` across the board

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -255,7 +255,7 @@ case "$HOST" in
 esac
 
 case "$HOST" in
-    powerpc64-linux-*) HOST_LDFLAGS="${HOST_LDFLAGS} -Wl,-z,noexecstack" ;;
+    powerpc64-linux-*|riscv64-linux-*) HOST_LDFLAGS="${HOST_LDFLAGS} -Wl,-z,noexecstack" ;;
 esac
 
 # Make $HOST-specific native binaries from depends available in $PATH

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -129,7 +129,7 @@ chain for " target " development."))
                                   (base-gcc-for-libc gcc-7)
                                   (base-kernel-headers linux-libre-headers-5.4)
                                   (base-libc glibc)  ; glibc 2.31
-                                  (base-gcc (make-gcc-rpath-link gcc-9)))
+                                  (base-gcc (make-gcc-rpath-link gcc-8)))
   "Convenience wrapper around MAKE-CROSS-TOOLCHAIN with default values
 desirable for building Bitcoin Core release binaries."
   (make-cross-toolchain target
@@ -147,7 +147,7 @@ desirable for building Bitcoin Core release binaries."
          (pthreads-xlibc mingw-w64-x86_64-winpthreads)
          (pthreads-xgcc (make-gcc-with-pthreads
                          (cross-gcc target
-                                    #:xgcc (make-ssp-fixed-gcc gcc-9)
+                                    #:xgcc (make-ssp-fixed-gcc gcc-8)
                                     #:xbinutils xbinutils
                                     #:libc pthreads-xlibc))))
     ;; Define a meta-package that propagates the resulting XBINUTILS, XLIBC, and


### PR DESCRIPTION
Only non-base commit is the last commit: https://github.com/bitcoin/bitcoin/commit/b5abb07d0d8051f337df2e7981d42a60e0140ee3

Right now, here's what we use in Gitian:
- Linux: Focal's [`g++-8-<arch>-linux-gnu`](https://packages.ubuntu.com/focal/g++-8-aarch64-linux-gnu) (`8.4.0-3ubuntu1cross1`)
- MinGW-w64: Focal's [`g++-mingw-w64`](https://packages.ubuntu.com/focal/g++-mingw-w64) (`9.3.0-7ubuntu1+22~exp1ubuntu4`)

In Guix right now we use `gcc-9` across the board.

I think it makes more sense to use `gcc-8` across the board, as it doesn't suffer from the `memcmp` bug, and is what debian buster (stable) does, meaning it will be well tested ([`g++-mingw-w64`](https://packages.debian.org/buster/g++-mingw-w64), [`g++-aarch64-linux-gnu`](https://packages.debian.org/buster/g++-aarch64-linux-gnu)).

We can accomplish this somewhat easily using Guix as we have tighter control over the toolchain (see: https://github.com/bitcoin/bitcoin/commit/b5abb07d0d8051f337df2e7981d42a60e0140ee3).

Let me know your thoughts!