### PR TITLE
refactor: Avoid UB in util/asmap (advance a dereferenceable iterator outside its valid range)

### DIFF
--- a/src/util/asmap.cpp
+++ b/src/util/asmap.cpp
@@ -93,8 +93,7 @@ uint32_t Interpret(const std::vector<bool> &asmap, const std::vector<bool> &ip)
             jump = DecodeJump(pos, endpos);
             if (jump == INVALID) break; // Jump offset straddles EOF
             if (bits == 0) break; // No input bits left
-            if (pos + jump < pos) break; // overflow
-            if (pos + jump >= endpos) break; // Jumping past EOF
+            if (int64_t{jump} >= int64_t{endpos - pos}) break; // Jumping past EOF
             if (ip[ip.size() - bits]) {
                 pos += jump;
             }
@@ -156,8 +155,7 @@ bool SanityCheckASMap(const std::vector<bool>& asmap, int bits)
         } else if (opcode == Instruction::JUMP) {
             uint32_t jump = DecodeJump(pos, endpos);
             if (jump == INVALID) return false; // Jump offset straddles EOF
-            if (pos + jump < pos) return false; // overflow
-            if (pos + jump > endpos) return false; // Jump out of range
+            if (int64_t{jump} > int64_t{endpos - pos}) return false; // Jump out of range
             if (bits == 0) return false; // Consuming bits past the end of the input
             --bits;
             uint32_t jump_offset = pos - begin + jump;


### PR DESCRIPTION
Can be reproduced on current master with `D_GLIBCXX_DEBUG`:

```
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/debug/safe_iterator.h:883:
In function:
    __gnu_debug::_Safe_iterator<type-parameter-0-0, type-parameter-0-1, 
    std::random_access_iterator_tag>::_Self __gnu_debug::operator+(const 
    __gnu_debug::_Safe_iterator<type-parameter-0-0, type-parameter-0-1, 
    std::random_access_iterator_tag>::_Self &, 
    __gnu_debug::_Safe_iterator<type-parameter-0-0, type-parameter-0-1, 
    std::random_access_iterator_tag>::difference_type)

Error: attempt to advance a dereferenceable iterator 369 steps, which falls 
outside its valid range.

Objects involved in the operation:
    iterator @ 0x0x7ffd3d613138 {
      type = std::__cxx1998::_Bit_const_iterator (constant iterator);
      state = dereferenceable;
      references sequence with type 'std::__debug::vector<bool, std::allocator<bool> >' @ 0x0x7ffd3d663590
    }
==65050== ERROR: libFuzzer: deadly signal
    #0 0x559ab9787690 in __sanitizer_print_stack_trace (/bitcoin/src/test/fuzz/fuzz+0x5a1690)
    #1 0x559ab9733998 in fuzzer::PrintStackTrace() (/bitcoin/src/test/fuzz/fuzz+0x54d998)
    #2 0x559ab9718ae3 in fuzzer::Fuzzer::CrashCallback() (/bitcoin/src/test/fuzz/fuzz+0x532ae3)
    #3 0x7f70a0e723bf  (/lib/x86_64-linux-gnu/libpthread.so.0+0x153bf)
    #4 0x7f70a0b3418a in raise (/lib/x86_64-linux-gnu/libc.so.6+0x4618a)
    #5 0x7f70a0b13858 in abort (/lib/x86_64-linux-gnu/libc.so.6+0x25858)
    #6 0x7f70a0f21148  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xa1148)
    #7 0x559ab9f60a96 in __gnu_debug::operator+(__gnu_debug::_Safe_iterator<std::__cxx1998::_Bit_const_iterator, std::__debug::vector<bool, std::allocator<bool> >, std::random_access_iterator_tag> const&, long) /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/debug/safe_iterator.h:881:2
    #8 0x559ab9f61062 in SanityCheckASMap(std::__debug::vector<bool, std::allocator<bool> > const&, int) util/asmap.cpp:159:21
    #9 0x559ab9e4fdfa in SanityCheckASMap(std::__debug::vector<bool, std::allocator<bool> > const&) netaddress.cpp:1242:12
    #10 0x559ab9793fcb in addrman_fuzz_target(Span<unsigned char const>) test/fuzz/addrman.cpp:43:14
    #11 0x559ab978a03c in std::_Function_handler<void (Span<unsigned char const>), void (*)(Span<unsigned char const>)>::_M_invoke(std::_Any_data const&, Span<unsigned char const>&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/std_function.h:300:2
    #12 0x559aba2692c7 in std::function<void (Span<unsigned char const>)>::operator()(Span<unsigned char const>) const /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/std_function.h:688:14
    #13 0x559aba269132 in LLVMFuzzerTestOneInput test/fuzz/fuzz.cpp:63:5
    #14 0x559ab971a1a1 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/bitcoin/src/test/fuzz/fuzz+0x5341a1)
    #15 0x559ab97198e5 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool*) (/bitcoin/src/test/fuzz/fuzz+0x5338e5)
    #16 0x559ab971bb87 in fuzzer::Fuzzer::MutateAndTestOne() (/bitcoin/src/test/fuzz/fuzz+0x535b87)
    #17 0x559ab971c885 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) (/bitcoin/src/test/fuzz/fuzz+0x536885)
    #18 0x559ab970b23e in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/bitcoin/src/test/fuzz/fuzz+0x52523e)
    #19 0x559ab9734082 in main (/bitcoin/src/test/fuzz/fuzz+0x54e082)
    #20 0x7f70a0b150b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #21 0x559ab96dffdd in _start (/bitcoin/src/test/fuzz/fuzz+0x4f9fdd)
