### PR TITLE
Display send/recv in Bps instead of totals in the debug window

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -774,6 +774,20 @@ QString formatBytes(uint64_t bytes)
     return QObject::tr("%1 GB").arg(bytes / 1'000'000'000);
 }
 
+QString formatBps(uint64_t bytes)
+{
+    if (bytes < 1'000)
+        return QObject::tr("%1 B/s").arg(bytes);
+    if (bytes < 1'000'000)
+        return QObject::tr("%1 kB/s").arg(bytes / 1'000);
+    if (bytes < 1'000'000'000)
+        return QObject::tr("%1 MB/s").arg(bytes / 1'000'000);
+
+    return QObject::tr("%1 GB/s").arg(bytes / 1'000'000'000);
+}
+
+qreal calculateIdealFontSize(int width, const QString& text, QFont font, qreal minPointSize, qreal font_size) {
+
 qreal calculateIdealFontSize(int width, const QString& text, QFont font, qreal minPointSize, qreal font_size) {
     while(font_size >= minPointSize) {
         font.setPointSizeF(font_size);

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -218,6 +218,7 @@ namespace GUIUtil
     QString formatNiceTimeOffset(qint64 secs);
 
     QString formatBytes(uint64_t bytes);
+    QString formatBps(uint64_t bytes);
 
     qreal calculateIdealFontSize(int width, const QString& text, QFont font, qreal minPointSize = 4, qreal startPointSize = 14);
 

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -170,9 +170,9 @@ QVariant PeerTableModel::data(const QModelIndex &index, int role) const
         case Ping:
             return GUIUtil::formatPingTime(rec->nodeStats.m_min_ping_time);
         case Sent:
-            return GUIUtil::formatBytes(rec->nodeStats.nSendBytes);
+            return GUIUtil::formatBps(rec->nodeStats.nSendBytes / (GetSystemTimeInSeconds() + 1 - rec->nodeStats.nTimeConnected));
         case Received:
-            return GUIUtil::formatBytes(rec->nodeStats.nRecvBytes);
+            return GUIUtil::formatBps(rec->nodeStats.nRecvBytes / (GetSystemTimeInSeconds() + 1 - rec->nodeStats.nTimeConnected));
         case Subversion:
             return QString::fromStdString(rec->nodeStats.cleanSubVer);
         } // no default case, so the compiler can warn about missing cases


### PR DESCRIPTION
I find this far more useful for than the totals. For example, I can easily see which nodes are not really talking with this metric, and not so much with the totals (as is current functionality).

Example:-

![image](https://user-images.githubusercontent.com/1530283/116594398-be4d0e00-a954-11eb-923b-cb1c651c8cb6.png)
