### PR TITLE
test: resolve bug in interface_bitcoin_cli.py

### DIFF
--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -151,7 +151,7 @@ class TestBitcoinCli(BitcoinTestFramework):
             assert_equal(cli_get_info['balance'], amounts[1])
 
             self.log.info("Test -getinfo with -rpcwallet=unloaded wallet returns no balances")
-            cli_get_info = self.nodes[0].cli('-getinfo', rpcwallet3).send_cli()
+            cli_get_info_keys = self.nodes[0].cli('-getinfo', rpcwallet3).send_cli().keys()
             assert 'balance' not in cli_get_info_keys
             assert 'balances' not in cli_get_info_keys
 


### PR DESCRIPTION
I think there is a bug in this test case where the new value of `cli_get_info` is not asserted. 