### PR TITLE
script: update REVIEWERS

### DIFF
--- a/REVIEWERS
+++ b/REVIEWERS
@@ -19,6 +19,7 @@
 
 # Maintainers
 #   @fanquake
+#   @hebasto
 #   @jonasschnelli
 #   @laanwj
 #   @marcofalke
@@ -59,11 +60,16 @@
 /src/test/fuzz/                             @practicalswift
 /doc/fuzzing.md                             @practicalswift
 
-# Test framework
+# Tests
+/src/test/net_peer_eviction_tests.cpp       @jonatack
 /test/functional/mempool_updatefromblock.py @hebasto
 /test/functional/feature_asmap.py           @jonatack
 /test/functional/interface_bitcoin_cli.py   @jonatack
-/test/functional/tool_wallet.py             @jonatack
+
+# Backwards compatibility tests
+*_compatibility.py                          @sjors
+/test/functional/wallet_upgradewallet.py    @sjors @achow101
+/test/get_previous_releases.py              @sjors
 
 # Translations
 /src/util/translation.h                     @hebasto
@@ -98,6 +104,11 @@
 # Descriptors
 *descriptor*                                @achow101 @sipa
 
+# External signer
+*external_signer*                           @sjors
+/doc/external-signer.md                     @sjors
+*signer.py                                  @sjors
+
 # Interfaces
 /src/interfaces/                            @ryanofsky
 
@@ -105,8 +116,7 @@
 /src/txdb.*                                 @jamesob
 /src/dbwrapper.*                            @jamesob
 
-# Scripts/Linter
-*.sh                                        @practicalswift
+# Linter
 /test/lint/                                 @practicalswift
 /test/lint/lint-shell.sh                    @hebasto
 


### PR DESCRIPTION
Meta: `git show a06eb03` indicates the commit was first made one year ago and the PR was merged in September 2020. 

It might be time for an update, if automated review requests via DrahtBot are operational.

"Regular contributors are free to add their names to specific directories or files provided that they are willing to provide a review." 

Perhaps we can compile and squash suggested updates here, per that guideline.
