### PR TITLE
refactor: [index] Replace deprecated char with uint8_t in serialization

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -13,7 +13,7 @@
 #include <validation.h> // For g_chainman
 #include <warnings.h>
 
-constexpr char DB_BEST_BLOCK = 'B';
+constexpr uint8_t DB_BEST_BLOCK{'B'};
 
 constexpr int64_t SYNC_LOG_INTERVAL = 30; // seconds
 constexpr int64_t SYNC_LOCATOR_WRITE_INTERVAL = 30; // seconds

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -24,9 +24,9 @@
  * as big-endian so that sequential reads of filters by height are fast.
  * Keys for the hash index have the type [DB_BLOCK_HASH, uint256].
  */
-constexpr char DB_BLOCK_HASH = 's';
-constexpr char DB_BLOCK_HEIGHT = 't';
-constexpr char DB_FILTER_POS = 'P';
+constexpr uint8_t DB_BLOCK_HASH{'s'};
+constexpr uint8_t DB_BLOCK_HEIGHT{'t'};
+constexpr uint8_t DB_FILTER_POS{'P'};
 
 constexpr unsigned int MAX_FLTR_FILE_SIZE = 0x1000000; // 16 MiB
 /** The pre-allocation chunk size for fltr?????.dat files */
@@ -63,7 +63,7 @@ struct DBHeightKey {
     template<typename Stream>
     void Unserialize(Stream& s)
     {
-        char prefix = ser_readdata8(s);
+        const uint8_t prefix{ser_readdata8(s)};
         if (prefix != DB_BLOCK_HEIGHT) {
             throw std::ios_base::failure("Invalid format for block filter index DB height key");
         }
@@ -77,7 +77,7 @@ struct DBHashKey {
     explicit DBHashKey(const uint256& hash_in) : hash(hash_in) {}
 
     SERIALIZE_METHODS(DBHashKey, obj) {
-        char prefix = DB_BLOCK_HASH;
+        uint8_t prefix{DB_BLOCK_HASH};
         READWRITE(prefix);
         if (prefix != DB_BLOCK_HASH) {
             throw std::ios_base::failure("Invalid format for block filter index DB hash key");
@@ -149,7 +149,7 @@ bool BlockFilterIndex::ReadFilterFromDisk(const FlatFilePos& pos, BlockFilter& f
     }
 
     uint256 block_hash;
-    std::vector<unsigned char> encoded_filter;
+    std::vector<uint8_t> encoded_filter;
     try {
         filein >> block_hash >> encoded_filter;
         filter = BlockFilter(GetFilterType(), block_hash, std::move(encoded_filter));

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -12,9 +12,9 @@
 #include <undo.h>
 #include <validation.h>
 
-static constexpr char DB_BLOCK_HASH = 's';
-static constexpr char DB_BLOCK_HEIGHT = 't';
-static constexpr char DB_MUHASH = 'M';
+static constexpr uint8_t DB_BLOCK_HASH{'s'};
+static constexpr uint8_t DB_BLOCK_HEIGHT{'t'};
+static constexpr uint8_t DB_MUHASH{'M'};
 
 namespace {
 
@@ -66,7 +66,7 @@ struct DBHeightKey {
     template <typename Stream>
     void Unserialize(Stream& s)
     {
-        char prefix{static_cast<char>(ser_readdata8(s))};
+        const uint8_t prefix{ser_readdata8(s)};
         if (prefix != DB_BLOCK_HEIGHT) {
             throw std::ios_base::failure("Invalid format for coinstatsindex DB height key");
         }
@@ -81,7 +81,7 @@ struct DBHashKey {
 
     SERIALIZE_METHODS(DBHashKey, obj)
     {
-        char prefix{DB_BLOCK_HASH};
+        uint8_t prefix{DB_BLOCK_HASH};
         READWRITE(prefix);
         if (prefix != DB_BLOCK_HASH) {
             throw std::ios_base::failure("Invalid format for coinstatsindex DB hash key");

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -10,12 +10,11 @@
 #include <util/translation.h>
 #include <validation.h>
 
-constexpr char DB_BEST_BLOCK = 'B';
-constexpr char DB_TXINDEX = 't';
-constexpr char DB_TXINDEX_BLOCK = 'T';
+constexpr uint8_t DB_BEST_BLOCK{'B'};
+constexpr uint8_t DB_TXINDEX{'t'};
+constexpr uint8_t DB_TXINDEX_BLOCK{'T'};
 
 std::unique_ptr<TxIndex> g_txindex;
-
 
 
 /** Access to the txindex database (indexes/txindex/) */
@@ -60,8 +59,8 @@ bool TxIndex::DB::WriteTxs(const std::vector<std::pair<uint256, CDiskTxPos>>& v_
  */
 static void WriteTxIndexMigrationBatches(CDBWrapper& newdb, CDBWrapper& olddb,
                                          CDBBatch& batch_newdb, CDBBatch& batch_olddb,
-                                         const std::pair<unsigned char, uint256>& begin_key,
-                                         const std::pair<unsigned char, uint256>& end_key)
+                                         const std::pair<uint8_t, uint256>& begin_key,
+                                         const std::pair<uint8_t, uint256>& end_key)
 {
     // Sync new DB changes to disk before deleting from old DB.
     newdb.WriteBatch(batch_newdb, /*fSync=*/ true);
@@ -113,9 +112,9 @@ bool TxIndex::DB::MigrateData(CBlockTreeDB& block_tree_db, const CBlockLocator& 
     CDBBatch batch_newdb(*this);
     CDBBatch batch_olddb(block_tree_db);
 
-    std::pair<unsigned char, uint256> key;
-    std::pair<unsigned char, uint256> begin_key{DB_TXINDEX, uint256()};
-    std::pair<unsigned char, uint256> prev_key = begin_key;
+    std::pair<uint8_t, uint256> key;
+    std::pair<uint8_t, uint256> begin_key{DB_TXINDEX, uint256()};
+    std::pair<uint8_t, uint256> prev_key = begin_key;
 
     bool interrupted = false;
     std::unique_ptr<CDBIterator> cursor(block_tree_db.NewIterator());


### PR DESCRIPTION
All char representations are serialized in the same way, however the `char` one is deprecated according to https://github.com/bitcoin/bitcoin/blob/d22e7ee93313b13365bd14a5fffeb055cff4dcd2/src/serialize.h#L227 . Also, using `uint8_t` directly avoids casts.