### PR TITLE
Display progress of LoadBlockDB() on splash screen

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1387,8 +1387,6 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         };
         bilingual_str strLoadError;
 
-        uiInterface.InitMessage(_("Loading block index...").translated);
-
         do {
             const int64_t load_block_index_start_time = GetTimeMillis();
             try {

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -105,7 +105,7 @@ public:
     void ReadReindexing(bool &fReindexing);
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
-    bool LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex);
+    bool LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex, int& nHighest);
 };
 
 #endif // BITCOIN_TXDB_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3937,7 +3937,8 @@ bool BlockManager::LoadBlockIndex(
     CBlockTreeDB& blocktree,
     std::set<CBlockIndex*, CBlockIndexWorkComparator>& block_index_candidates)
 {
-    if (!blocktree.LoadBlockIndexGuts(consensus_params, [this](const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return this->InsertBlockIndex(hash); }))
+    int nHighest = 1;
+    if (!blocktree.LoadBlockIndexGuts(consensus_params, [this](const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return this->InsertBlockIndex(hash); }, nHighest))
         return false;
 
     // Calculate nChainWork
@@ -3949,10 +3950,24 @@ bool BlockManager::LoadBlockIndex(
         vSortedByHeight.push_back(std::make_pair(pindex->nHeight, pindex));
     }
     sort(vSortedByHeight.begin(), vSortedByHeight.end());
+    int64_t nNow;
+    int64_t nLastNow = 0;
+    int nHeight = 0;
+    int nLastPercent = -1;
     for (const std::pair<int, CBlockIndex*>& item : vSortedByHeight)
     {
+        nNow = GetTime();
+        if (nNow >= nLastNow + 5) {
+            int nPercent = 100 * nHeight / nHighest;
+            if (nPercent > nLastPercent) {
+                uiInterface.InitMessage(strprintf(_("Indexing blocks... %d%%").translated, (100 * nHeight) / nHighest));
+                nLastPercent = nPercent;
+            }
+            nLastNow = nNow;
+        }
         if (ShutdownRequested()) return false;
         CBlockIndex* pindex = item.second;
+        nHeight = pindex->nHeight;
         pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + GetBlockProof(*pindex);
         pindex->nTimeMax = (pindex->pprev ? std::max(pindex->pprev->nTimeMax, pindex->nTime) : pindex->nTime);
         // We can link the chain of blocks for which we've received transactions at some point.


### PR DESCRIPTION
On some relatively slow computers the splash screen can be displaying the message "Loading block index..." for more than a couple of minutes, causing some users to panic thinking the software has crashed or frozen.

This pull request makes it clear that the loading is progressing by showing a percentage that updates per second (although limited to no more updates than per 1 percent so as to reduce logging).