### PR TITLE
Send fewer feefilter messages (avoid the wobbling number issue)

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4732,7 +4732,7 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                 CAmount filterToSend = g_filter_rounder.round(currentFilter);
                 // We always have a fee filter of at least minRelayTxFee
                 filterToSend = std::max(filterToSend, ::minRelayTxFee.GetFeePerK());
-                if (filterToSend != pto->m_tx_relay->lastSentFeeFilter) {
+                if (abs(filterToSend - currentFilter) < abs(pto->m_tx_relay->lastSentFeeFilter - currentFilter)) {
                     m_connman.PushMessage(pto, msgMaker.Make(NetMsgType::FEEFILTER, filterToSend));
                     pto->m_tx_relay->lastSentFeeFilter = filterToSend;
                 }


### PR DESCRIPTION
This is a simpler replacement for #21805. The only change now to the current functionality is that it requires that the actual (i.e. not rounded up or down) minrelayfee has changed since the last sent feefilter message.

This helps increase privacy (by not sending repeated messages above and below the actual, thereby revealing the actual), and reduces network traffic (due to fewer messages).

This pull will make almost no functional changes without #21618 given that it's extremely rare that the actual minrelayfee will remain constant, so it's safe to merge, and will be there for privacy safety in the event that a pull is later merged which encourages the minrelayfee to remain constant.

TODO - need to fix the test that is failing as soon as I work out how to run the test - can someone comment with this info please?