### PR TITLE
Update reviewers file: Remove too broad (`*.sh`) entry. Keep narrower entries.

### DIFF
--- a/REVIEWERS
+++ b/REVIEWERS
@@ -105,8 +105,7 @@
 /src/txdb.*                                 @jamesob
 /src/dbwrapper.*                            @jamesob
 
-# Scripts/Linter
-*.sh                                        @practicalswift
+# Linter
 /test/lint/                                 @practicalswift
 /test/lint/lint-shell.sh                    @hebasto
 


### PR DESCRIPTION
Update reviewers file: Remove too broad (`*.sh`) entry.

Keep narrower entries (such as `/test/lint/`).

I've found the `*.sh` wildcard a bit too broad for me to keep up with :)