### PR TITLE
fuzz: Add `-fsanitize=integer` suppression needed for RPC fuzzer (`generateblock`)

### DIFF
--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -85,6 +85,7 @@ implicit-signed-integer-truncation:chain.h
 implicit-signed-integer-truncation:crypto/
 implicit-signed-integer-truncation:cuckoocache.h
 implicit-signed-integer-truncation:leveldb/
+implicit-signed-integer-truncation:miner.cpp
 implicit-signed-integer-truncation:net.cpp
 implicit-signed-integer-truncation:net_processing.cpp
 implicit-signed-integer-truncation:streams.h


### PR DESCRIPTION
Add `-fsanitize=integer` suppression needed for RPC fuzzer (`generateblock`).

Context: https://github.com/bitcoin-core/qa-assets/pull/59/checks?check_run_id=2494624259

```
miner.cpp:130:21: runtime error: implicit conversion from type 'int64_t' (aka 'long') of value 244763573890 (64-bit, signed) to type 'uint32_t' (aka 'unsigned int') changed the value to 4245405314 (32-bit, unsigned)
    #0 0x56143974eaf3 in BlockAssembler::CreateNewBlock(CScript const&) miner.cpp:130:21
    #1 0x56143993690d in generateblock()::$_4::operator()(RPCHelpMan const&, JSONRPCRequest const&) const rpc/mining.cpp:370:127
```