### PR TITLE
[0.21] Backport update to Boost download URL

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,6 +1,6 @@
 package=boost
 $(package)_version=1_70_0
-$(package)_download_path=https://dl.bintray.com/boostorg/release/1.70.0/source/
+$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/1.70.0/source/
 $(package)_file_name=boost_$($(package)_version).tar.bz2
 $(package)_sha256_hash=430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778
 $(package)_patches=unused_var_in_process.patch


### PR DESCRIPTION
Backports #21662 to the 0.21 branch. Boost has migrated it's download URLs due to bintrays imminent closure. The Boost site has also been updated to point to the new URLs. i.e: https://www.boost.org/users/history/version_1_70_0.html.

Github-Pull: #21662
Rebased-From: 36c10b9f4b181db6afa2f8cb7d4872b158768c16