### PR TITLE
depends: Add missing -D_LIBCPP_DEBUG=1 to debug flags

### DIFF
--- a/depends/hosts/linux.mk
+++ b/depends/hosts/linux.mk
@@ -7,7 +7,7 @@ linux_release_CXXFLAGS=$(linux_release_CFLAGS)
 linux_debug_CFLAGS=-O1
 linux_debug_CXXFLAGS=$(linux_debug_CFLAGS)
 
-linux_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC
+linux_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC -D_LIBCPP_DEBUG=1
 
 ifeq (86,$(findstring 86,$(build_arch)))
 i686_linux_CC=gcc -m32


### PR DESCRIPTION
Commands that can be used for testing:

```
$ cat 1.cpp 
#include <vector>

int main() {
  std::vector<int> foo;
  foo.begin() + 7;
}
```

```
clang++ -stdlib=libc++ -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC -D_LIBCPP_DEBUG=1 -Wall 1.cpp -o exe && ./exe  
g++                    -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC -D_LIBCPP_DEBUG=1 -Wall 1.cpp -o exe && ./exe 
