### PR TITLE
Make all networking code mockable

### DIFF
--- a/src/i2p.h
+++ b/src/i2p.h
@@ -261,6 +261,7 @@ private:
      * ("SESSION CREATE"). With the established session id we later open
      * other connections to the SAM service to accept incoming I2P
      * connections and make outgoing ones.
+     * If not connected then this unique_ptr will be empty.
      * See https://geti2p.net/en/docs/api/samv3
      */
     std::unique_ptr<Sock> m_control_sock GUARDED_BY(m_mutex);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -427,12 +427,10 @@ static CAddress GetBindAddress(const Sock& sock)
     CAddress addr_bind;
     struct sockaddr_storage sockaddr_bind;
     socklen_t sockaddr_bind_len = sizeof(sockaddr_bind);
-    if (sock.Get() != INVALID_SOCKET) {
-        if (!sock.GetSockName((struct sockaddr*)&sockaddr_bind, &sockaddr_bind_len)) {
-            addr_bind.SetSockAddr((const struct sockaddr*)&sockaddr_bind);
-        } else {
-            LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "getsockname failed\n");
-        }
+    if (!sock.GetSockName((struct sockaddr*)&sockaddr_bind, &sockaddr_bind_len)) {
+        addr_bind.SetSockAddr((const struct sockaddr*)&sockaddr_bind);
+    } else {
+        LogPrintLevel(BCLog::NET, BCLog::Level::Warning, "getsockname failed\n");
     }
     return addr_bind;
 }

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -514,10 +514,6 @@ bool ConnectSocketDirectly(const CService &addrConnect, const Sock& sock, int nT
     // Create a sockaddr from the specified service.
     struct sockaddr_storage sockaddr;
     socklen_t len = sizeof(sockaddr);
-    if (sock.Get() == INVALID_SOCKET) {
-        LogPrintf("Cannot connect to %s: invalid socket\n", addrConnect.ToStringAddrPort());
-        return false;
-    }
     if (!addrConnect.GetSockAddr((struct sockaddr*)&sockaddr, &len)) {
         LogPrintf("Cannot connect to %s: unsupported network\n", addrConnect.ToStringAddrPort());
         return false;

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -170,6 +170,25 @@ FUZZ_TARGET(connman, .init = initialize_connman)
                 auto sock = CreateSock(peer);
 
                 connman.CreateNodeFromAcceptedSocketPublic(std::move(sock), permissions, me, peer);
+            },
+            [&] {
+                CConnman::Options options;
+
+                options.vBinds = ConsumeServiceVector(fuzzed_data_provider, 5);
+
+                options.vWhiteBinds = std::vector<NetWhitebindPermissions>{
+                    fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 5)};
+                for (auto& wb : options.vWhiteBinds) {
+                    wb.m_flags = ConsumeWeakEnum(fuzzed_data_provider, ALL_NET_PERMISSION_FLAGS);
+                    wb.m_service = ConsumeService(fuzzed_data_provider);
+                }
+
+                options.onion_binds = ConsumeServiceVector(fuzzed_data_provider, 5);
+
+                options.bind_on_any = options.vBinds.empty() && options.vWhiteBinds.empty() &&
+                                      options.onion_binds.empty();
+
+                connman.InitBindsPublic(options);
             });
     }
     (void)connman.GetAddedNodeInfo();

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -189,6 +189,9 @@ FUZZ_TARGET(connman, .init = initialize_connman)
                                       options.onion_binds.empty();
 
                 connman.InitBindsPublic(options);
+            },
+            [&] {
+                connman.SocketHandlerPublic();
             });
     }
     (void)connman.GetAddedNodeInfo();

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -17,6 +17,7 @@
 #include <util/translation.h>
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 namespace {
@@ -158,6 +159,17 @@ FUZZ_TARGET(connman, .init = initialize_connman)
                 }
 
                 connman.OpenNetworkConnection(to_addr, count_failure, grant_ptr, to_str, conn_type);
+            },
+            [&] {
+                connman.SetNetworkActive(true);
+
+                NetPermissionFlags permissions{
+                    ConsumeWeakEnum(fuzzed_data_provider, ALL_NET_PERMISSION_FLAGS)};
+                auto me = ConsumeAddress(fuzzed_data_provider);
+                auto peer = ConsumeAddress(fuzzed_data_provider);
+                auto sock = CreateSock(peer);
+
+                connman.CreateNodeFromAcceptedSocketPublic(std::move(sock), permissions, me, peer);
             });
     }
     (void)connman.GetAddedNodeInfo();

--- a/src/test/fuzz/util/net.cpp
+++ b/src/test/fuzz/util/net.cpp
@@ -56,9 +56,10 @@ CAddress ConsumeAddress(FuzzedDataProvider& fuzzed_data_provider) noexcept
 }
 
 FuzzedSock::FuzzedSock(FuzzedDataProvider& fuzzed_data_provider)
-    : m_fuzzed_data_provider{fuzzed_data_provider}, m_selectable{fuzzed_data_provider.ConsumeBool()}
+    : Sock{fuzzed_data_provider.ConsumeIntegralInRange<SOCKET>(INVALID_SOCKET - 1, INVALID_SOCKET)},
+      m_fuzzed_data_provider{fuzzed_data_provider},
+      m_selectable{fuzzed_data_provider.ConsumeBool()}
 {
-    m_socket = fuzzed_data_provider.ConsumeIntegralInRange<SOCKET>(INVALID_SOCKET - 1, INVALID_SOCKET);
 }
 
 FuzzedSock::~FuzzedSock()

--- a/src/test/fuzz/util/net.h
+++ b/src/test/fuzz/util/net.h
@@ -95,6 +95,19 @@ inline CService ConsumeService(FuzzedDataProvider& fuzzed_data_provider) noexcep
     return {ConsumeNetAddr(fuzzed_data_provider), fuzzed_data_provider.ConsumeIntegral<uint16_t>()};
 }
 
+inline std::vector<CService> ConsumeServiceVector(FuzzedDataProvider& fuzzed_data_provider,
+                                                  size_t max_vector_size) noexcept
+{
+    std::vector<CService> ret;
+    const size_t size = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, max_vector_size);
+    ret.reserve(size);
+    for (size_t i = 0; i < size; ++i) {
+        ret.emplace_back(ConsumeNetAddr(fuzzed_data_provider),
+                         fuzzed_data_provider.ConsumeIntegral<uint16_t>());
+    }
+    return ret;
+}
+
 CAddress ConsumeAddress(FuzzedDataProvider& fuzzed_data_provider) noexcept;
 
 template <bool ReturnUniquePtr = false>

--- a/src/test/sock_tests.cpp
+++ b/src/test/sock_tests.cpp
@@ -56,14 +56,25 @@ BOOST_AUTO_TEST_CASE(move_constructor)
 
 BOOST_AUTO_TEST_CASE(move_assignment)
 {
-    const SOCKET s = CreateSocket();
-    Sock* sock1 = new Sock(s);
-    Sock* sock2 = new Sock();
+    const SOCKET s1 = CreateSocket();
+    const SOCKET s2 = CreateSocket();
+    Sock* sock1 = new Sock(s1);
+    Sock* sock2 = new Sock(s2);
+
+    BOOST_CHECK(!SocketIsClosed(s1));
+    BOOST_CHECK(!SocketIsClosed(s2));
+
     *sock2 = std::move(*sock1);
+    BOOST_CHECK(!SocketIsClosed(s1));
+    BOOST_CHECK(SocketIsClosed(s2));
+
     delete sock1;
-    BOOST_CHECK(!SocketIsClosed(s));
+    BOOST_CHECK(!SocketIsClosed(s1));
+    BOOST_CHECK(SocketIsClosed(s2));
+
     delete sock2;
-    BOOST_CHECK(SocketIsClosed(s));
+    BOOST_CHECK(SocketIsClosed(s1));
+    BOOST_CHECK(SocketIsClosed(s2));
 }
 
 #ifndef WIN32 // Windows does not have socketpair(2).
@@ -95,7 +106,7 @@ BOOST_AUTO_TEST_CASE(send_and_receive)
     SendAndRecvMessage(*sock0, *sock1);
 
     Sock* sock0moved = new Sock(std::move(*sock0));
-    Sock* sock1moved = new Sock();
+    Sock* sock1moved = new Sock(INVALID_SOCKET);
     *sock1moved = std::move(*sock1);
 
     delete sock0;

--- a/src/test/sock_tests.cpp
+++ b/src/test/sock_tests.cpp
@@ -38,7 +38,6 @@ BOOST_AUTO_TEST_CASE(constructor_and_destructor)
 {
     const SOCKET s = CreateSocket();
     Sock* sock = new Sock(s);
-    BOOST_CHECK_EQUAL(sock->Get(), s);
     BOOST_CHECK(!SocketIsClosed(s));
     delete sock;
     BOOST_CHECK(SocketIsClosed(s));
@@ -51,7 +50,6 @@ BOOST_AUTO_TEST_CASE(move_constructor)
     Sock* sock2 = new Sock(std::move(*sock1));
     delete sock1;
     BOOST_CHECK(!SocketIsClosed(s));
-    BOOST_CHECK_EQUAL(sock2->Get(), s);
     delete sock2;
     BOOST_CHECK(SocketIsClosed(s));
 }
@@ -64,7 +62,6 @@ BOOST_AUTO_TEST_CASE(move_assignment)
     *sock2 = std::move(*sock1);
     delete sock1;
     BOOST_CHECK(!SocketIsClosed(s));
-    BOOST_CHECK_EQUAL(sock2->Get(), s);
     delete sock2;
     BOOST_CHECK(SocketIsClosed(s));
 }

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -106,10 +106,10 @@ constexpr auto ALL_NETWORKS = std::array{
 class StaticContentsSock : public Sock
 {
 public:
-    explicit StaticContentsSock(const std::string& contents) : m_contents{contents}
+    explicit StaticContentsSock(const std::string& contents)
+        : Sock{INVALID_SOCKET},
+          m_contents{contents}
     {
-        // Just a dummy number that is not INVALID_SOCKET.
-        m_socket = INVALID_SOCKET - 1;
     }
 
     ~StaticContentsSock() override { m_socket = INVALID_SOCKET; }
@@ -189,6 +189,11 @@ public:
             (void)sock;
             events.occurred = events.requested;
         }
+        return true;
+    }
+
+    bool IsConnected(std::string&) const override
+    {
         return true;
     }
 

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -42,6 +42,14 @@ struct ConnmanTestMsg : public CConnman {
         m_nodes.clear();
     }
 
+    void CreateNodeFromAcceptedSocketPublic(std::unique_ptr<Sock> sock,
+                                            NetPermissionFlags permissions,
+                                            const CAddress& addr_bind,
+                                            const CAddress& addr_peer)
+    {
+        CreateNodeFromAcceptedSocket(std::move(sock), permissions, addr_bind, addr_peer);
+    }
+
     void Handshake(CNode& node,
                    bool successfully_connected,
                    ServiceFlags remote_services,

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -55,6 +55,11 @@ struct ConnmanTestMsg : public CConnman {
         return InitBinds(options);
     }
 
+    void SocketHandlerPublic()
+    {
+        SocketHandler();
+    }
+
     void Handshake(CNode& node,
                    bool successfully_connected,
                    ServiceFlags remote_services,

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -50,6 +50,11 @@ struct ConnmanTestMsg : public CConnman {
         CreateNodeFromAcceptedSocket(std::move(sock), permissions, addr_bind, addr_peer);
     }
 
+    bool InitBindsPublic(const CConnman::Options& options)
+    {
+        return InitBinds(options);
+    }
+
     void Handshake(CNode& node,
                    bool successfully_connected,
                    ServiceFlags remote_services,

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -24,8 +24,6 @@ static inline bool IOErrorIsPermanent(int err)
     return err != WSAEAGAIN && err != WSAEINTR && err != WSAEWOULDBLOCK && err != WSAEINPROGRESS;
 }
 
-Sock::Sock() : m_socket(INVALID_SOCKET) {}
-
 Sock::Sock(SOCKET s) : m_socket(s) {}
 
 Sock::Sock(Sock&& other)

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -44,8 +44,6 @@ Sock& Sock::operator=(Sock&& other)
     return *this;
 }
 
-SOCKET Sock::Get() const { return m_socket; }
-
 ssize_t Sock::Send(const void* data, size_t len, int flags) const
 {
     return send(m_socket, static_cast<const char*>(data), len, flags);

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -21,8 +21,7 @@
 static constexpr auto MAX_WAIT_FOR_IO = 1s;
 
 /**
- * RAII helper class that manages a socket. Mimics `std::unique_ptr`, but instead of a pointer it
- * contains a socket and closes it automatically when it goes out of scope.
+ * RAII helper class that manages a socket and closes it automatically when it goes out of scope.
  */
 class Sock
 {
@@ -61,12 +60,6 @@ public:
      * Move assignment operator, grab the socket from another object and close ours (if set).
      */
     virtual Sock& operator=(Sock&& other);
-
-    /**
-     * Get the value of the contained socket.
-     * @return socket or INVALID_SOCKET if empty
-     */
-    [[nodiscard]] virtual SOCKET Get() const;
 
     /**
      * send(2) wrapper. Equivalent to `send(this->Get(), data, len, flags);`. Code that uses this

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -27,11 +27,6 @@ class Sock
 {
 public:
     /**
-     * Default constructor, creates an empty object that does nothing when destroyed.
-     */
-    Sock();
-
-    /**
      * Take ownership of an existent socket.
      */
     explicit Sock(SOCKET s);


### PR DESCRIPTION
_This is a roadmap PR. It can be merged, but it can also be split into separate PRs and to get proper thorough review it is split._

Add wrapper methods to the syscalls `accept()`, `setsockopt()`, `getsockname()`, `bind()`, `listen()`  in the [`Sock`](https://github.com/bitcoin/bitcoin/blob/eb9a1fe03779bf05062b70f14190cb23ff42b46f/src/util/sock.h#L25) class (e.g. `Sock::Accept()`). Those methods can be overriden (mocked) by unit tests ([existent example in `master`](https://github.com/bitcoin/bitcoin/blob/eb9a1fe03779bf05062b70f14190cb23ff42b46f/src/test/util/net.h#L75)) and by fuzz tests ([existent example in `master`](https://github.com/bitcoin/bitcoin/blob/eb9a1fe03779bf05062b70f14190cb23ff42b46f/src/test/fuzz/util.h#L561)).

Change everybody to use [`Sock`](https://github.com/bitcoin/bitcoin/blob/eb9a1fe03779bf05062b70f14190cb23ff42b46f/src/util/sock.h#L25) instead of [`SOCKET`](https://github.com/bitcoin/bitcoin/blob/eb9a1fe03779bf05062b70f14190cb23ff42b46f/src/compat.h#L41).

Move the functionality of [`CConnman::SocketEvents()`](https://github.com/bitcoin/bitcoin/blob/eb9a1fe03779bf05062b70f14190cb23ff42b46f/src/net.cpp#L1334) to a mockable method of the [`Sock`](https://github.com/bitcoin/bitcoin/blob/eb9a1fe03779bf05062b70f14190cb23ff42b46f/src/util/sock.h#L25) class.

### Already merged pieces of this PR
* [x] https://github.com/bitcoin/bitcoin/pull/21943
* [x] https://github.com/bitcoin/bitcoin/pull/23601
* [x] https://github.com/bitcoin/bitcoin/pull/21879
* [x] https://github.com/bitcoin/bitcoin/pull/23604
* [x] https://github.com/bitcoin/bitcoin/pull/24357
* [x] https://github.com/bitcoin/bitcoin/pull/24356
* [x] https://github.com/bitcoin/bitcoin/pull/25428
* [x] https://github.com/bitcoin/bitcoin/pull/25426
* [x] https://github.com/bitcoin/bitcoin/pull/24378
* [x] https://github.com/bitcoin/bitcoin/pull/25421
* [x] https://github.com/bitcoin/bitcoin/pull/26312

### Current pieces of this for review

* [ ] https://github.com/bitcoin/bitcoin/pull/28584