### PR TITLE
build: Fix undefined reference to __mulodi4

### DIFF
--- a/build-aux/m4/bitcoin_runtime_lib.m4
+++ b/build-aux/m4/bitcoin_runtime_lib.m4
@@ -1,0 +1,42 @@
+# On some platforms clang builtin implementations
+# require compiler-rt as a runtime library to use.
+#
+# See:
+# - https://bugs.llvm.org/show_bug.cgi?id=28629
+
+m4_define([_CHECK_RUNTIME_testbody], [[
+  bool f(long long x, long long y, long long* p)
+  {
+    return __builtin_mul_overflow(x, y, p);
+  }
+  int main() { return 0; }
+]])
+
+AC_DEFUN([CHECK_RUNTIME_LIB], [
+
+  AC_LANG_PUSH([C++])
+
+  AC_MSG_CHECKING([for __builtin_mul_overflow])
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([_CHECK_RUNTIME_testbody])],
+    [
+      AC_MSG_RESULT([yes])
+      AC_DEFINE([HAVE_BUILTIN_MUL_OVERFLOW], [1], [Define if you have a working __builtin_mul_overflow])
+    ],
+    [
+      ax_check_save_flags="$LDFLAGS"
+      LDFLAGS="$LDFLAGS --rtlib=compiler-rt -lgcc_s"
+      AC_LINK_IFELSE(
+        [AC_LANG_SOURCE([_CHECK_RUNTIME_testbody])],
+        [
+          AC_MSG_RESULT([yes, with additional linker flags])
+          RUNTIME_LDFLAGS="--rtlib=compiler-rt -lgcc_s"
+          AC_DEFINE([HAVE_BUILTIN_MUL_OVERFLOW], [1], [Define if you have a working __builtin_mul_overflow])
+        ],
+        [AC_MSG_RESULT([no])])
+      LDFLAGS="$ax_check_save_flags"
+    ])
+
+  AC_LANG_POP
+  AC_SUBST([RUNTIME_LDFLAGS])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -1773,6 +1773,10 @@ if test x$build_bitcoin_wallet$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_
   AC_MSG_ERROR([No targets! Please specify at least one of: --with-utils --with-libs --with-daemon --with-gui --enable-bench or --enable-tests])
 fi
 
+if test x$enable_fuzz_binary = xyes; then
+  CHECK_RUNTIME_LIB
+fi
+
 AM_CONDITIONAL([TARGET_DARWIN], [test x$TARGET_OS = xdarwin])
 AM_CONDITIONAL([BUILD_DARWIN], [test x$BUILD_OS = xdarwin])
 AM_CONDITIONAL([TARGET_LINUX], [test x$TARGET_OS = xlinux])

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -200,7 +200,7 @@ if ENABLE_FUZZ_BINARY
 test_fuzz_fuzz_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_fuzz_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_fuzz_LDADD = $(FUZZ_SUITE_LD_COMMON)
-test_fuzz_fuzz_LDFLAGS = $(FUZZ_SUITE_LDFLAGS_COMMON)
+test_fuzz_fuzz_LDFLAGS = $(FUZZ_SUITE_LDFLAGS_COMMON) $(RUNTIME_LDFLAGS)
 test_fuzz_fuzz_SOURCES = \
  test/fuzz/addition_overflow.cpp \
  test/fuzz/addrdb.cpp \

--- a/src/test/fuzz/multiplication_overflow.cpp
+++ b/src/test/fuzz/multiplication_overflow.cpp
@@ -2,6 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
@@ -9,14 +13,6 @@
 #include <cstdint>
 #include <string>
 #include <vector>
-
-#if defined(__has_builtin)
-#if __has_builtin(__builtin_mul_overflow)
-#define HAVE_BUILTIN_MUL_OVERFLOW
-#endif
-#elif defined(__GNUC__)
-#define HAVE_BUILTIN_MUL_OVERFLOW
-#endif
 
 namespace {
 template <typename T>


### PR DESCRIPTION
When compiling with clang on 32-bit systems the `__mulodi4` symbol is defined in compiler-rt only.

Fixes #21294.

See more:
- https://bugs.llvm.org/show_bug.cgi?id=16404
- https://bugs.llvm.org/show_bug.cgi?id=28629