### PR TITLE
fuzz: Limit ParseISO8601DateTime fuzzing to 32-bit

### DIFF
--- a/src/test/fuzz/parse_iso8601.cpp
+++ b/src/test/fuzz/parse_iso8601.cpp
@@ -15,7 +15,7 @@ FUZZ_TARGET(parse_iso8601)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
 
-    const int64_t random_time = fuzzed_data_provider.ConsumeIntegral<int64_t>();
+    const int64_t random_time = fuzzed_data_provider.ConsumeIntegral<int32_t>();
     const std::string random_string = fuzzed_data_provider.ConsumeRemainingBytesAsString();
 
     const std::string iso8601_datetime = FormatISO8601DateTime(random_time);


### PR DESCRIPTION
2038 is more than 10 years in the future, so no need for us to waste time fuzzing a 3rd party lib that will be EOL by then.


Hopefully fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34092