### PR TITLE
gitignore: Add JetBrains CLion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,9 @@ background.tiff*
 # Qt Creator
 Makefile.am.user
 
+# CLion
+.idea/
+
 # Unit-tests
 Makefile.test
 bitcoin-qt_test


### PR DESCRIPTION
Some good news, JetBrains has added makefile support to their excellent CLion IDE. This PR adds the .idea folder to gitignore so PRs do not end up with IDE related files added accidentally.