### PR TITLE
refactor: Remove useless extern keyword

### DIFF
--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -72,10 +72,10 @@ void RPCTypeCheckObj(const UniValue& o,
  * Utilities: convert hex-encoded Values
  * (throws error if not hex).
  */
-extern uint256 ParseHashV(const UniValue& v, std::string strName);
-extern uint256 ParseHashO(const UniValue& o, std::string strKey);
-extern std::vector<unsigned char> ParseHexV(const UniValue& v, std::string strName);
-extern std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKey);
+uint256 ParseHashV(const UniValue& v, std::string strName);
+uint256 ParseHashO(const UniValue& o, std::string strKey);
+std::vector<unsigned char> ParseHexV(const UniValue& v, std::string strName);
+std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKey);
 
 /**
  * Validate and return a CAmount from a UniValue number or string.
@@ -84,13 +84,13 @@ extern std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKe
  * @param[in] decimals  Number of significant digits (default: 8).
  * @returns a CAmount if the various checks pass.
  */
-extern CAmount AmountFromValue(const UniValue& value, int decimals = 8);
+CAmount AmountFromValue(const UniValue& value, int decimals = 8);
 
 using RPCArgList = std::vector<std::pair<std::string, UniValue>>;
-extern std::string HelpExampleCli(const std::string& methodname, const std::string& args);
-extern std::string HelpExampleCliNamed(const std::string& methodname, const RPCArgList& args);
-extern std::string HelpExampleRpc(const std::string& methodname, const std::string& args);
-extern std::string HelpExampleRpcNamed(const std::string& methodname, const RPCArgList& args);
+std::string HelpExampleCli(const std::string& methodname, const std::string& args);
+std::string HelpExampleCliNamed(const std::string& methodname, const RPCArgList& args);
+std::string HelpExampleRpc(const std::string& methodname, const std::string& args);
+std::string HelpExampleRpcNamed(const std::string& methodname, const RPCArgList& args);
 
 CPubKey HexToPubKey(const std::string& hex_in);
 CPubKey AddrToPubKey(const FillableSigningProvider& keystore, const std::string& addr_in);

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -16,7 +16,7 @@
 
 using namespace std::literals;
 
-extern UniValue read_json(const std::string& jsondata);
+UniValue read_json(const std::string& jsondata);
 
 BOOST_FIXTURE_TEST_SUITE(base58_tests, BasicTestingSetup)
 

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -15,7 +15,7 @@
 
 #include <univalue.h>
 
-extern UniValue read_json(const std::string& jsondata);
+UniValue read_json(const std::string& jsondata);
 
 BOOST_FIXTURE_TEST_SUITE(key_io_tests, BasicTestingSetup)
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -39,8 +39,7 @@ static const unsigned int gFlags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC;
 unsigned int ParseScriptFlags(std::string strFlags);
 std::string FormatScriptFlags(unsigned int flags);
 
-UniValue
-read_json(const std::string& jsondata)
+UniValue read_json(const std::string& jsondata)
 {
     UniValue v;
 

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -21,7 +21,7 @@
 
 #include <univalue.h>
 
-extern UniValue read_json(const std::string& jsondata);
+UniValue read_json(const std::string& jsondata);
 
 // Old script.cpp SignatureHash function
 uint256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -39,7 +39,7 @@
 typedef std::vector<unsigned char> valtype;
 
 // In script_tests.cpp
-extern UniValue read_json(const std::string& jsondata);
+UniValue read_json(const std::string& jsondata);
 
 static std::map<std::string, unsigned int> mapFlagNames = {
     {std::string("P2SH"), (unsigned int)SCRIPT_VERIFY_P2SH},


### PR DESCRIPTION
It is redundant, confusing and useless.

https://en.cppreference.com/w/cpp/language/storage_duration#external_linkage