### PR TITLE
net: initialize nMessageSize to uint32_t max

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -91,7 +91,6 @@ CMessageHeader::CMessageHeader()
 {
     memset(pchMessageStart, 0, MESSAGE_START_SIZE);
     memset(pchCommand, 0, sizeof(pchCommand));
-    nMessageSize = -1;
     memset(pchChecksum, 0, CHECKSUM_SIZE);
 }
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -16,6 +16,7 @@
 #include <uint256.h>
 #include <version.h>
 
+#include <limits>
 #include <stdint.h>
 #include <string>
 
@@ -51,7 +52,7 @@ public:
 
     char pchMessageStart[MESSAGE_START_SIZE];
     char pchCommand[COMMAND_SIZE];
-    uint32_t nMessageSize;
+    uint32_t nMessageSize{std::numeric_limits<uint32_t>::max()};
     uint8_t pchChecksum[CHECKSUM_SIZE];
 };
 

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -62,7 +62,6 @@ implicit-integer-sign-change:key.cpp
 implicit-integer-sign-change:noui.cpp
 implicit-integer-sign-change:policy/fees.cpp
 implicit-integer-sign-change:prevector.h
-implicit-integer-sign-change:protocol.cpp
 implicit-integer-sign-change:script/bitcoinconsensus.cpp
 implicit-integer-sign-change:script/interpreter.cpp
 implicit-integer-sign-change:serialize.h


### PR DESCRIPTION
nMessageSize is uint32_t and is set to -1. This will warn with `-fsanitize=implicit-integer-sign-change` when V1TransportDeserializer calls into the ctor.  This pull initializes nMessageSize to `numeric_limits<uint32_t>::max()` instead and removes the ubsan suppression.