### PR TITLE
refactor: Preserve const in cast on CTransactionSignatureSerializer

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1303,12 +1303,12 @@ public:
         it = itBegin;
         while (scriptCode.GetOp(it, opcode)) {
             if (opcode == OP_CODESEPARATOR) {
-                s.write((char*)&itBegin[0], it-itBegin-1);
+                s.write(reinterpret_cast<const char*>(&itBegin[0]), it-itBegin-1);
                 itBegin = it;
             }
         }
         if (itBegin != scriptCode.end())
-            s.write((char*)&itBegin[0], it-itBegin);
+            s.write(reinterpret_cast<const char*>(&itBegin[0]), it-itBegin);
     }
 
     /** Serialize an input of txTo */


### PR DESCRIPTION
It was casting from `const unsigned char*` to `char*`.