### PR TITLE
wallet: Do not iterate a directory if having an error while accessing it 

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -18,7 +18,12 @@ std::vector<fs::path> ListDatabases(const fs::path& wallet_dir)
 
     for (auto it = fs::recursive_directory_iterator(wallet_dir, ec); it != fs::recursive_directory_iterator(); it.increment(ec)) {
         if (ec) {
-            LogPrintf("%s: %s %s\n", __func__, ec.message(), it->path().string());
+            if (fs::is_directory(*it)) {
+                it.no_push();
+                LogPrintf("%s: %s %s -- skipping.\n", __func__, ec.message(), it->path().string());
+            } else {
+                LogPrintf("%s: %s %s\n", __func__, ec.message(), it->path().string());
+            }
             continue;
         }
 


### PR DESCRIPTION
On Windows when `ListDatabases` tries to iterate any system folder, e.g., "System Volume Information", it falls into an infinite loop.

This PR fixes this bug. Now the `debug.log` contains:
```
2021-05-12T09:07:53Z ListDatabases: Access is denied D:/System Volume Information -- skipping.
```

An easy way to reproduce the bug and test this PR is to pass the `-walletdir=D:\` command-line option, and run the `listwalletdir` RPC, or File -> Open Wallet in the GUI menu.

Fixes #20081.
Fixes #21136.
Fixes #21904.

Also https://bitcoin.stackexchange.com/questions/99243/listwalletdir-access-is-denied-d-system-volume-information