### PR TITLE
fuzz: Limit max insertions in timedata fuzz test

### DIFF
--- a/src/test/fuzz/timedata.cpp
+++ b/src/test/fuzz/timedata.cpp
@@ -15,10 +15,12 @@ FUZZ_TARGET(timedata)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const unsigned int max_size = fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(0, 1000);
+    // A max_size of 0 implies no limit, so cap the max number of insertions to avoid timeouts
+    auto max_to_insert = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 4000);
     // Divide by 2 to avoid signed integer overflow in .median()
     const int64_t initial_value = fuzzed_data_provider.ConsumeIntegral<int64_t>() / 2;
     CMedianFilter<int64_t> median_filter{max_size, initial_value};
-    while (fuzzed_data_provider.remaining_bytes() > 0) {
+    while (fuzzed_data_provider.remaining_bytes() > 0 && --max_to_insert >= 0) {
         (void)median_filter.median();
         assert(median_filter.size() > 0);
         assert(static_cast<size_t>(median_filter.size()) == median_filter.sorted().size());


### PR DESCRIPTION
It is debatable whether a size of the median filter other than `200` (the only size used in production) should be fuzzed. For now add a minimal patch to cap the max insertions. Otherwise the complexity is N^2 log(N), where N is the size of the fuzz input.

Hopefully fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34167