### PR TITLE
build: add configure~ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ src/qt/bitcoin-qt.includes
 .dirstamp
 .libs
 .*.swp
-*.*~*
+*~
 *.bak
 *.rej
 *.orig


### PR DESCRIPTION
The file `configure~` recently started appearing for me on macOS (11.3.1) whenever configure is (re)run.