### PR TITLE
net: use stronger AddLocal() for our I2P address

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2244,7 +2244,7 @@ void CConnman::ThreadI2PAcceptIncoming()
         }
 
         if (!advertising_listen_addr) {
-            AddLocal(conn.me, LOCAL_BIND);
+            AddLocal(conn.me, LOCAL_MANUAL);
             advertising_listen_addr = true;
         }
 


### PR DESCRIPTION
There are two issues:

### 1. Our I2P address not added to local addresses.

* `externalip=` is used with an IPv4 address (this sets automatically `discover=0`)
* No `discover=1` is used
* `i2psam=` is used
* No `externalip=` is used for our I2P address
* `listenonion=1 torcontrol=` are used

In this case `AddLocal(LOCAL_MANUAL)` [is used](https://github.com/bitcoin/bitcoin/blob/94f83534e4b771944af7d9ed0f40746f392eb75e/src/torcontrol.cpp#L354) for our `.onion` address and `AddLocal(LOCAL_BIND)` [for our](https://github.com/bitcoin/bitcoin/blob/94f83534e4b771944af7d9ed0f40746f392eb75e/src/net.cpp#L2247) `.b32.i2p` address, the latter being [ignored](https://github.com/bitcoin/bitcoin/blob/94f83534e4b771944af7d9ed0f40746f392eb75e/src/net.cpp#L232-L233) due to `discover=0`.

### 2. Our I2P address removed from local addresses even if specified with `externalip=` on I2P proxy restart.

* `externalip=` is used with our I2P address (this sets automatically `discover=0`)
* No `discover=1` is used
* `i2psam=` is used

In this case, initially `externalip=` causes our I2P address to be [added](https://github.com/bitcoin/bitcoin/blob/94f83534e4b771944af7d9ed0f40746f392eb75e/src/init.cpp#L1266) with `AddLocal(LOCAL_MANUAL)` which overrides `discover=0` and works as expected. However, if later the I2P proxy is shut down [we do](https://github.com/bitcoin/bitcoin/blob/94f83534e4b771944af7d9ed0f40746f392eb75e/src/net.cpp#L2234) `RemoveLocal()` in order to stop advertising our I2P address (since we have lost I2P connectivity). When the I2P proxy is started and we reconnect to it, restoring the I2P connectivity, [we do](https://github.com/bitcoin/bitcoin/blob/94f83534e4b771944af7d9ed0f40746f392eb75e/src/net.cpp#L2247) `AddLocal(LOCAL_BIND)` which does nothing due to `discover=0`.

To resolve those two issues, use `AddLocal(LOCAL_MANUAL)` for I2P which is also what we do with Tor.
