### PR TITLE
build: improve macro for testing -latomic requirement

### DIFF
--- a/build-aux/m4/l_atomic.m4
+++ b/build-aux/m4/l_atomic.m4
@@ -12,10 +12,16 @@ dnl warranty.
 m4_define([_CHECK_ATOMIC_testbody], [[
   #include <atomic>
   #include <cstdint>
+  #include <chrono>
+
+  using namespace std::chrono_literals;
 
   int main() {
     std::atomic<bool> lock{true};
     std::atomic_exchange(&lock, false);
+
+    std::atomic<std::chrono::seconds> t{0s};
+    t.store(2s);
 
     std::atomic<int64_t> a{};
 


### PR DESCRIPTION
This fixes the issue where `-latomic` is incorrectly omitted from the linker flags.

Steps to reproduce on vanilla Ubuntu Focal:

```
export DEBIAN_FRONTEND=noninteractive && apt update && apt install curl wget htop git vim ccache -y && git clone https://github.com/bitcoin/bitcoin.git && cd bitcoin && apt install build-essential libtool autotools-dev automake pkg-config bsdmainutils python3-zmq make automake cmake curl clang llvm g++-multilib libtool binutils-gold bsdmainutils pkg-config python3 patch bison -y  && ( cd depends && make DEBUG=1 HOST=i686-pc-linux-gnu NO_QT=1 NO_WALLET=1 NO_ZMQ=1 NO_UPNP=1 NO_NATPMP=1 -j $(nproc) ) && ./autogen.sh && CONFIG_SITE="$PWD/depends/i686-pc-linux-gnu/share/config.site" ./configure CC='clang -m32' CXX='clang++ -m32' --enable-fuzz --with-sanitizers=fuzzer && make  -j $(nproc)
```

Before:
```
/usr/bin/ld: libbitcoin_server.a(libbitcoin_server_a-net.o): in function `std::atomic<std::chrono::duration<long long, std::ratio<1ll, 1000000ll> > >::load(std::memory_order) const':
net.cpp:(.text._ZNKSt6atomicINSt6chrono8durationIxSt5ratioILx1ELx1000000EEEEE4loadESt12memory_order[_ZNKSt6atomicINSt6chrono8durationIxSt5ratioILx1ELx1000000EEEEE4loadESt12memory_order]+0x51): undefined reference to `__atomic_load'
/usr/bin/ld: libbitcoin_server.a(libbitcoin_server_a-net.o): in function `std::atomic<std::chrono::duration<long long, std::ratio<1ll, 1000000ll> > >::store(std::chrono::duration<long long, std::ratio<1ll, 1000000ll> >, std::memory_order)':
net.cpp:(.text._ZNSt6atomicINSt6chrono8durationIxSt5ratioILx1ELx1000000EEEEE5storeES4_St12memory_order[_ZNSt6atomicINSt6chrono8durationIxSt5ratioILx1ELx1000000EEEEE5storeES4_St12memory_order]+0x5f): undefined reference to `__atomic_store'
/usr/bin/ld: libbitcoin_server.a(libbitcoin_server_a-net.o): in function `std::atomic<ServiceFlags>::load(std::memory_order) const':
net.cpp:(.text._ZNKSt6atomicI12ServiceFlagsE4loadESt12memory_order[_ZNKSt6atomicI12ServiceFlagsE4loadESt12memory_order]+0x51): undefined reference to `__atomic_load'
/usr/bin/ld: libbitcoin_server.a(libbitcoin_server_a-net_processing.o): in function `std::atomic<ServiceFlags>::store(ServiceFlags, std::memory_order)':
net_processing.cpp:(.text._ZNSt6atomicI12ServiceFlagsE5storeES0_St12memory_order[_ZNSt6atomicI12ServiceFlagsE5storeES0_St12memory_order]+0x6c): undefined reference to `__atomic_store'
/usr/bin/ld: libbitcoin_server.a(libbitcoin_server_a-net_processing.o): in function `std::atomic<std::chrono::duration<long long, std::ratio<1ll, 1ll> > >::load(std::memory_order) const':
net_processing.cpp:(.text._ZNKSt6atomicINSt6chrono8durationIxSt5ratioILx1ELx1EEEEE4loadESt12memory_order[_ZNKSt6atomicINSt6chrono8durationIxSt5ratioILx1ELx1EEEEE4loadESt12memory_order]+0x51): undefined reference to `__atomic_load'
/usr/bin/ld: libbitcoin_server.a(libbitcoin_server_a-net_processing.o): in function `std::atomic<std::chrono::duration<long long, std::ratio<1ll, 1ll> > >::store(std::chrono::duration<long long, std::ratio<1ll, 1ll> >, std::memory_order)':
net_processing.cpp:(.text._ZNSt6atomicINSt6chrono8durationIxSt5ratioILx1ELx1EEEEE5storeES4_St12memory_order[_ZNSt6atomicINSt6chrono8durationIxSt5ratioILx1ELx1EEEEE5storeES4_St12memory_order]+0x5f): undefined reference to `__atomic_store'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

After:

Clean