### PR TITLE
fuzz: Run const CScript member functions only once

### DIFF
--- a/src/test/fuzz/script_ops.cpp
+++ b/src/test/fuzz/script_ops.cpp
@@ -14,55 +14,54 @@
 FUZZ_TARGET(script_ops)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    CScript script = ConsumeScript(fuzzed_data_provider);
+    CScript script_mut = ConsumeScript(fuzzed_data_provider);
     while (fuzzed_data_provider.remaining_bytes() > 0) {
         CallOneOf(
             fuzzed_data_provider,
             [&] {
                 CScript s = ConsumeScript(fuzzed_data_provider);
-                script = std::move(s);
+                script_mut = std::move(s);
             },
             [&] {
                 const CScript& s = ConsumeScript(fuzzed_data_provider);
-                script = s;
+                script_mut = s;
             },
             [&] {
-                script << fuzzed_data_provider.ConsumeIntegral<int64_t>();
+                script_mut << fuzzed_data_provider.ConsumeIntegral<int64_t>();
             },
             [&] {
-                script << ConsumeOpcodeType(fuzzed_data_provider);
+                script_mut << ConsumeOpcodeType(fuzzed_data_provider);
             },
             [&] {
-                script << ConsumeScriptNum(fuzzed_data_provider);
+                script_mut << ConsumeScriptNum(fuzzed_data_provider);
             },
             [&] {
-                script << ConsumeRandomLengthByteVector(fuzzed_data_provider);
+                script_mut << ConsumeRandomLengthByteVector(fuzzed_data_provider);
             },
             [&] {
-                script.clear();
-            },
-            [&] {
-                (void)script.GetSigOpCount(false);
-                (void)script.GetSigOpCount(true);
-                (void)script.GetSigOpCount(script);
-                (void)script.HasValidOps();
-                (void)script.IsPayToScriptHash();
-                (void)script.IsPayToWitnessScriptHash();
-                (void)script.IsPushOnly();
-                (void)script.IsUnspendable();
-                {
-                    CScript::const_iterator pc = script.begin();
-                    opcodetype opcode;
-                    (void)script.GetOp(pc, opcode);
-                    std::vector<uint8_t> data;
-                    (void)script.GetOp(pc, opcode, data);
-                    (void)script.IsPushOnly(pc);
-                }
-                {
-                    int version;
-                    std::vector<uint8_t> program;
-                    (void)script.IsWitnessProgram(version, program);
-                }
+                script_mut.clear();
             });
+    }
+    const CScript& script = script_mut;
+    (void)script.GetSigOpCount(false);
+    (void)script.GetSigOpCount(true);
+    (void)script.GetSigOpCount(script);
+    (void)script.HasValidOps();
+    (void)script.IsPayToScriptHash();
+    (void)script.IsPayToWitnessScriptHash();
+    (void)script.IsPushOnly();
+    (void)script.IsUnspendable();
+    {
+        CScript::const_iterator pc = script.begin();
+        opcodetype opcode;
+        (void)script.GetOp(pc, opcode);
+        std::vector<uint8_t> data;
+        (void)script.GetOp(pc, opcode, data);
+        (void)script.IsPushOnly(pc);
+    }
+    {
+        int version;
+        std::vector<uint8_t> program;
+        (void)script.IsWitnessProgram(version, program);
     }
 }


### PR DESCRIPTION
Those functions should be O(N) in the input size (or maybe worse, I didn't check), so if the fuzz input dictates to run them N times, the complexity is N^2.

Fix this by calling them only once.

Can be reviewed with: `--ignore-all-space  --word-diff-regex=.`

Input: https://github.com/bitcoin/bitcoin/files/6464685/clusterfuzz-testcase-minimized-input.log


Hopefully fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34101