### PR TITLE
wallet: allow toggling external_signer flag

### DIFF
--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -276,6 +276,16 @@ static RPCHelpMan setwalletflag()
 
     auto flag = WALLET_FLAG_MAP.at(flag_str);
 
+    if (flag == WALLET_FLAG_EXTERNAL_SIGNER) {
+ #ifdef ENABLE_EXTERNAL_SIGNER
+         if (!pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) || !pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
+             throw JSONRPCError(RPC_WALLET_ERROR, "This flag can only be set on a watch-only descriptor wallet");
+         }
+ #else
+         throw JSONRPCError(RPC_WALLET_ERROR, "Compiled without external signing support (required for external signing)");
+ #endif
+     }
+
     if (!(flag & MUTABLE_WALLET_FLAGS)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Wallet flag is immutable: %s", flag_str));
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -55,6 +55,9 @@ const std::map<uint64_t,std::string> WALLET_FLAG_CAVEATS{
         "destinations in the past. Until this is done, some destinations may "
         "be considered unused, even if the opposite is the case."
     },
+    {WALLET_FLAG_EXTERNAL_SIGNER,
+        "The ability to toggle this flag may be removed in a future update."
+    },
 };
 
 bool AddWalletSetting(interfaces::Chain& chain, const std::string& wallet_name)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -129,7 +129,8 @@ static constexpr uint64_t KNOWN_WALLET_FLAGS =
     |   WALLET_FLAG_EXTERNAL_SIGNER;
 
 static constexpr uint64_t MUTABLE_WALLET_FLAGS =
-        WALLET_FLAG_AVOID_REUSE;
+        WALLET_FLAG_EXTERNAL_SIGNER
+    |   WALLET_FLAG_AVOID_REUSE;
 
 static const std::map<std::string,WalletFlags> WALLET_FLAG_MAP{
     {"avoid_reuse", WALLET_FLAG_AVOID_REUSE},

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -78,7 +78,14 @@ class WalletSignerTest(BitcoinTestFramework):
         self.nodes[1].createwallet(wallet_name='not_hww', disable_private_keys=True, descriptors=True, external_signer=False)
         not_hww = self.nodes[1].get_wallet_rpc('not_hww')
         assert_equal(not_hww.getwalletinfo()["external_signer"], False)
-        assert_raises_rpc_error(-8, "Wallet flag is immutable: external_signer", not_hww.setwalletflag, "external_signer", True)
+
+        # Flag can be set
+        not_hww.setwalletflag("external_signer", True)
+        assert_equal(not_hww.getwalletinfo()["external_signer"], True)
+
+        # Flag can be unset
+        not_hww.setwalletflag("external_signer", False)
+        assert_equal(not_hww.getwalletinfo()["external_signer"], False)
 
         # assert_raises_rpc_error(-4, "Multiple signers found, please specify which to use", wallet_name='not_hww', disable_private_keys=True, descriptors=True, external_signer=True)
 


### PR DESCRIPTION
Currently `WALLET_FLAG_EXTERNAL_SIGNER` is just a precaution. This PR makes the flag mutable so it can be toggled with `setwalletflag`. There's a warning that in the future it may no longer be possible to toggle. This might be the case if we need to store additional device specific data in the wallet payload.

Rationale for this PR is to make it a bit easier to switch between tooling, e.g. to "upgrade" a regular watch-only wallet created by Specter to work with Core hardware wallet support directly.