### PR TITLE
fuzz: Remove incorrect float round-trip serialization test

### DIFF
--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -122,10 +122,6 @@ FUZZ_TARGET_INIT(integer, initialize_integer)
         assert(dynamic_usage == incremental_dynamic_usage * i64s.size());
     }
     (void)MillisToTimeval(i64);
-    const double d = ser_uint64_to_double(u64);
-    assert(ser_double_to_uint64(d) == u64);
-    const float f = ser_uint32_to_float(u32);
-    assert(ser_float_to_uint32(f) == u32);
     (void)SighashToStr(uch);
     (void)SipHashUint256(u64, u64, u256);
     (void)SipHashUint256Extra(u64, u64, u256, u32);


### PR DESCRIPTION
It tests the wrong way of the round-trip: `int -> float -> int`, but only `float -> int -> float` is allowed and used. See also `src/test/fuzz/float.cpp`.

Hopefully fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34118