### PR TITLE
doc: update enumerator naming in developer notes

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -89,6 +89,10 @@ code.
     - Class member variables have a `m_` prefix.
     - Global variables have a `g_` prefix.
   - Constant names are all uppercase, and use `_` to separate words.
+  - Enumerator constants may be `snake_case`, `PascalCase` or `ALL_CAPS`.
+    This is a more tolerant policy than the [C++ Core
+    Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Renum-caps),
+    which recommend using `snake_case`.  Please use what seems appropriate.
   - Class names, function names, and method names are UpperCamelCase
     (PascalCase). Do not prefix class names with `C`.
   - Test suite naming convention: The Boost test suite in file
@@ -669,19 +673,19 @@ Foo(vec);
 
 ```cpp
 enum class Tabs {
-    INFO,
-    CONSOLE,
-    GRAPH,
-    PEERS
+    info,
+    console,
+    network_graph,
+    peers
 };
 
 int GetInt(Tabs tab)
 {
     switch (tab) {
-    case Tabs::INFO: return 0;
-    case Tabs::CONSOLE: return 1;
-    case Tabs::GRAPH: return 2;
-    case Tabs::PEERS: return 3;
+    case Tabs::info: return 0;
+    case Tabs::console: return 1;
+    case Tabs::network_graph: return 2;
+    case Tabs::peers: return 3;
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }


### PR DESCRIPTION
Per our current doc, the general rule is we follow the C++ Core Guidelines, which for enumerator naming stipulate:

https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Renum-caps
```
Don’t use ALL_CAPS for enumerators
Reason: Avoid clashes with macros.
```

but our examples (and often, codebase) are contradictory to it (and perhaps to common usage), which can be confusing when a contributor needs to choose a style to use. This patch:

- updates the enumerator examples to snake_case per CPP Core Guidelines
- clarifies for contributors that in this project enumerators may be snake_case, PascalCase or ALL_CAPS, and to use what seems appropriate.
