### PR TITLE
docs: improve make with parallel jobs description.

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -124,6 +124,6 @@ This explicitly enables the GUI and disables legacy wallet support. If `qt5` is 
 **Important**: Use `gmake` (the non-GNU `make` will exit with an error).
 
 ```bash
-gmake # use -jX here for parallelism
+gmake # use "-j N" for N parallel jobs
 gmake check # Run tests if Python 3 is available
 ```

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -76,6 +76,6 @@ Without wallet:
 
 Build and run the tests:
 ```bash
-gmake # use -jX here for parallelism
+gmake # use "-j N" here for N parallel jobs
 gmake check
 ```

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -90,7 +90,7 @@ To configure with GUI:
 
 Build and run the tests:
 ```bash
-gmake # use -jX here for parallelism
+gmake # use "-j N" here for N parallel jobs
 gmake check
 ```
 

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -270,7 +270,7 @@ After configuration, you are ready to compile.
 Run the following in your terminal to compile Bitcoin Core:
 
 ``` bash
-make -jx    # use -jX here for parallelism
+make        # use "-j N" here for N parallel jobs
 make check  # Run tests if Python 3 is available
 ```
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -20,7 +20,7 @@ To Build
 ```bash
 ./autogen.sh
 ./configure
-make
+make # use "-j N" for N parallel jobs
 make install # optional
 ```
 

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -105,7 +105,7 @@ Build using:
     cd ..
     ./autogen.sh
     CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/
-    make
+    make # use "-j N" for N parallel jobs
     sudo bash -c "echo 1 > /proc/sys/fs/binfmt_misc/status" # Enable WSL support for Win32 applications.
 
 ## Depends system


### PR DESCRIPTION
Changed `use -jX here for parallelism` to `use "-j N" for N parallel jobs`

**Rationale**: In my opinion `use -jX here for parallelism` is quite ambiguous as it could be perceived as a single option without any argument. Ie running: 
```sh
make -jX
```

Embarrassingly this caused me to be stuck for quite a long time until I opened the help menu for `make` but if I am the only one who faced this issue I would be happy to close this PR.