### PR TITLE
 fuzz: Add missing CheckTransaction before CheckTxInputs 

### DIFF
--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -6,6 +6,7 @@
 #include <chainparams.h>
 #include <chainparamsbase.h>
 #include <coins.h>
+#include <consensus/tx_check.h>
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <key.h>
@@ -228,6 +229,11 @@ FUZZ_TARGET_INIT(coins_view, initialize_coins_view)
                 if (ContainsSpentInput(transaction, coins_view_cache)) {
                     // Avoid:
                     // consensus/tx_verify.cpp:171: bool Consensus::CheckTxInputs(const CTransaction &, TxValidationState &, const CCoinsViewCache &, int, CAmount &): Assertion `!coin.IsSpent()' failed.
+                    return;
+                }
+                TxValidationState dummy;
+                if (!CheckTransaction(transaction, dummy)) {
+                    // It is not allowed to call CheckTxInputs if CheckTransaction failed
                     return;
                 }
                 (void)Consensus::CheckTxInputs(transaction, state, coins_view_cache, fuzzed_data_provider.ConsumeIntegralInRange<int>(0, std::numeric_limits<int>::max()), tx_fee_out);

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -61,8 +61,11 @@ FUZZ_TARGET_INIT(transaction, initialize_transaction)
         return;
     }
 
-    TxValidationState state_with_dupe_check;
-    (void)CheckTransaction(tx, state_with_dupe_check);
+    {
+        TxValidationState state_with_dupe_check;
+        const bool res{CheckTransaction(tx, state_with_dupe_check)};
+        Assert(res == state_with_dupe_check.IsValid());
+    }
 
     const CFeeRate dust_relay_fee{DUST_RELAY_TX_FEE};
     std::string reason;


### PR DESCRIPTION
This bug was introduced by myself in commit eeee8f5be1d4ccfb7e237248be5c6bef45b0fbb8 (https://github.com/bitcoin/bitcoin/pull/21553)

Reproducer: https://github.com/bitcoin/bitcoin/files/6492249/clusterfuzz-testcase-minimized-coins_view-6109460079706112.log

Hopefully fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34301