### PR TITLE
build: Silence lupdate "unknown namespace/class" warnings

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -358,7 +358,7 @@ $(srcdir)/qt/bitcoinstrings.cpp: FORCE
 
 translate: $(srcdir)/qt/bitcoinstrings.cpp $(QT_FORMS_UI) $(QT_FORMS_UI) $(BITCOIN_QT_BASE_CPP) qt/bitcoin.cpp $(BITCOIN_QT_WINDOWS_CPP) $(BITCOIN_QT_WALLET_CPP) $(BITCOIN_QT_H) $(BITCOIN_MM)
 	@test -n $(LUPDATE) || echo "lupdate is required for updating translations"
-	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(LUPDATE) $^ -locations relative -no-obsolete -ts $(srcdir)/qt/locale/bitcoin_en.ts
+	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(LUPDATE) -no-obsolete -I $(srcdir) -locations relative $^ -ts $(srcdir)/qt/locale/bitcoin_en.ts
 	@test -n $(LCONVERT) || echo "lconvert is required for updating translations"
 	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(LCONVERT) -o $(srcdir)/qt/locale/bitcoin_en.xlf -i $(srcdir)/qt/locale/bitcoin_en.ts
 


### PR DESCRIPTION
This PR removes multiple _"Qualifying with unknown namespace/class"_ warnings in `make -C src translate` output.
Also all of the `lupdate` options are moved before input files (as documented).

The remaining warnings are fixed in Qt 5.12.2 (see [QTBUG-42736](https://bugreports.qt.io/browse/QTBUG-42736)).