### PR TITLE
net: Return IPv6 scope id in `CNetAddr::ToStringIP()`

### DIFF
--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -558,7 +558,7 @@ static std::string IPv4ToString(Span<const uint8_t> a)
 
 // Return an IPv6 address text representation with zero compression as described in RFC 5952
 // ("A Recommendation for IPv6 Address Text Representation").
-static std::string IPv6ToString(Span<const uint8_t> a)
+static std::string IPv6ToString(Span<const uint8_t> a, uint32_t scope_id)
 {
     assert(a.size() == ADDR_IPV6_SIZE);
     const std::array groups{
@@ -606,6 +606,10 @@ static std::string IPv6ToString(Span<const uint8_t> a)
         r += strprintf("%s%x", ((!r.empty() && r.back() != ':') ? ":" : ""), groups[i]);
     }
 
+    if (scope_id != 0) {
+        r += strprintf("%%%u", scope_id);
+    }
+
     return r;
 }
 
@@ -615,7 +619,7 @@ std::string CNetAddr::ToStringIP() const
     case NET_IPV4:
         return IPv4ToString(m_addr);
     case NET_IPV6: {
-        return IPv6ToString(m_addr);
+        return IPv6ToString(m_addr, m_scope_id);
     }
     case NET_ONION:
         switch (m_addr.size()) {
@@ -639,7 +643,7 @@ std::string CNetAddr::ToStringIP() const
     case NET_I2P:
         return EncodeBase32(m_addr, false /* don't pad with = */) + ".b32.i2p";
     case NET_CJDNS:
-        return IPv6ToString(m_addr);
+        return IPv6ToString(m_addr, 0);
     case NET_INTERNAL:
         return EncodeBase32(m_addr) + ".internal";
     case NET_UNROUTABLE: // m_net is never and should not be set to NET_UNROUTABLE

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -300,13 +300,17 @@ BOOST_AUTO_TEST_CASE(cnetaddr_basic)
 
     // IPv6, scoped/link-local. See https://tools.ietf.org/html/rfc4007
     // We support non-negative decimal integers (uint32_t) as zone id indices.
-    // Test with a fairly-high value, e.g. 32, to avoid locally reserved ids.
+    // Normal link-local scoped address functionality is to append "%" plus the
+    // zone id, for example, given a link-local address of "fe80::1" and a zone
+    // id of "32", return the address as "fe80::1%32".
     const std::string link_local{"fe80::1"};
     const std::string scoped_addr{link_local + "%32"};
     BOOST_REQUIRE(LookupHost(scoped_addr, addr, false));
     BOOST_REQUIRE(addr.IsValid());
     BOOST_REQUIRE(addr.IsIPv6());
     BOOST_CHECK(!addr.IsBindAny());
+    BOOST_CHECK_EQUAL(addr.ToString(), scoped_addr);
+
     // Test that the delimiter "%" and default zone id of 0 can be omitted for the default scope.
     BOOST_REQUIRE(LookupHost(link_local + "%0", addr, false));
     BOOST_REQUIRE(addr.IsValid());


### PR DESCRIPTION
If a scope id is provided, return it back in the string representation. Also bring back the test (now in platform independent fashion). Closes #21982. Includes #21961 (apart from the MacOS remark).
