### PR TITLE
doc: note that brew installed qt is not supported

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -138,6 +138,14 @@ Skip if you don't intend to use the GUI.
 brew install qt@5
 ```
 
+Ensure that the `qt@5` package is installed, not the `qt` package.
+If 'qt' is installed, the build process will fail.
+if installed, remove the `qt` package with the following command:
+
+``` bash
+brew uninstall qt
+```
+
 Note: Building with Qt binaries downloaded from the Qt website is not officially supported.
 See the notes in [#7714](https://github.com/bitcoin/bitcoin/issues/7714).
 


### PR DESCRIPTION
picking up #21791, the author has stated they [cannot squash](https://github.com/bitcoin/bitcoin/pull/21791#issuecomment-828770283).

This is a useful note to prevent any issues from being opened up about this. The reason that both cannot co-exist and build bitcoin is stated [here](https://github.com/bitcoin/bitcoin/pull/21791#issuecomment-837278123):
> ... the reason is sharing /usr/local/include/ and /usr/local/lib/ directories by both qt5 and qt6 installations.

Changes from original PR:
- slightly move the note up in this section, this placement seems more appropriate to me
- drop "Note:"

[PR Render](https://github.com/jarolrod/bitcoin/blob/33b0b26a03a401bd39b88931b69d162c3c538d31/doc/build-osx.md#qt)
