### PR TITLE
p2p: pass strings to NetPermissions::TryParse functions by const ref

### DIFF
--- a/src/net_permissions.cpp
+++ b/src/net_permissions.cpp
@@ -20,8 +20,8 @@ const std::vector<std::string> NET_PERMISSIONS_DOC{
 
 namespace {
 
-// The parse the following format "perm1,perm2@xxxxxx"
-bool TryParsePermissionFlags(const std::string str, NetPermissionFlags& output, size_t& readen, bilingual_str& error)
+// Parse the following format: "perm1,perm2@xxxxxx"
+bool TryParsePermissionFlags(const std::string& str, NetPermissionFlags& output, size_t& readen, bilingual_str& error)
 {
     NetPermissionFlags flags = NetPermissionFlags::None;
     const auto atSeparator = str.find('@');
@@ -81,7 +81,7 @@ std::vector<std::string> NetPermissions::ToStrings(NetPermissionFlags flags)
     return strings;
 }
 
-bool NetWhitebindPermissions::TryParse(const std::string str, NetWhitebindPermissions& output, bilingual_str& error)
+bool NetWhitebindPermissions::TryParse(const std::string& str, NetWhitebindPermissions& output, bilingual_str& error)
 {
     NetPermissionFlags flags;
     size_t offset;
@@ -104,7 +104,7 @@ bool NetWhitebindPermissions::TryParse(const std::string str, NetWhitebindPermis
     return true;
 }
 
-bool NetWhitelistPermissions::TryParse(const std::string str, NetWhitelistPermissions& output, bilingual_str& error)
+bool NetWhitelistPermissions::TryParse(const std::string& str, NetWhitelistPermissions& output, bilingual_str& error)
 {
     NetPermissionFlags flags;
     size_t offset;

--- a/src/net_permissions.h
+++ b/src/net_permissions.h
@@ -74,14 +74,14 @@ public:
 class NetWhitebindPermissions : public NetPermissions
 {
 public:
-    static bool TryParse(const std::string str, NetWhitebindPermissions& output, bilingual_str& error);
+    static bool TryParse(const std::string& str, NetWhitebindPermissions& output, bilingual_str& error);
     CService m_service;
 };
 
 class NetWhitelistPermissions : public NetPermissions
 {
 public:
-    static bool TryParse(const std::string str, NetWhitelistPermissions& output, bilingual_str& error);
+    static bool TryParse(const std::string& str, NetWhitelistPermissions& output, bilingual_str& error);
     CSubNet m_subnet;
 };
 


### PR DESCRIPTION
instead of by value, as these are "in" params that are not cheap to copy.

Reference: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f16-for-in-parameters-pass-cheaply-copied-types-by-value-and-others-by-reference-to-const