### PR TITLE
doc: Generate doxygen documentation for test sources

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -863,9 +863,7 @@ RECURSIVE              = YES
 
 EXCLUDE                = src/crc32c \
                          src/leveldb \
-                         src/json \
-                         src/test \
-                         src/qt/test
+                         src/json
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded


### PR DESCRIPTION
Fixes #19248

While searching for the documentation of the test utilities I realized they were excluded from doxygen. I agree with the statement in #19248. It's also helpful for new contributors to gain a broader understanding of the class dependencies visually (see BasicTestSetup)