### PR TITLE
Fix crash when parsing command line with -noincludeconf=0

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -366,14 +366,12 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
     }
 
     // we do not allow -includeconf from command line
-    bool success = true;
     if (auto* includes = util::FindKey(m_settings.command_line_options, "includeconf")) {
-        for (const auto& include : util::SettingsSpan(*includes)) {
-            error += "-includeconf cannot be used from commandline; -includeconf=" + include.write() + "\n";
-            success = false;
-        }
+        const auto& include{*util::SettingsSpan(*includes).begin()}; // pick first value as example
+        error = "-includeconf cannot be used from commandline; -includeconf=" + include.write();
+        return false;
     }
-    return success;
+    return true;
 }
 
 std::optional<unsigned int> ArgsManager::GetArgFlags(const std::string& name) const

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -369,7 +369,7 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
     bool success = true;
     if (auto* includes = util::FindKey(m_settings.command_line_options, "includeconf")) {
         for (const auto& include : util::SettingsSpan(*includes)) {
-            error += "-includeconf cannot be used from commandline; -includeconf=" + include.get_str() + "\n";
+            error += "-includeconf cannot be used from commandline; -includeconf=" + include.write() + "\n";
             success = false;
         }
     }

--- a/test/functional/feature_includeconf.py
+++ b/test/functional/feature_includeconf.py
@@ -42,7 +42,14 @@ class IncludeConfTest(BitcoinTestFramework):
 
         self.log.info("-includeconf cannot be used as command-line arg")
         self.stop_node(0)
-        self.nodes[0].assert_start_raises_init_error(extra_args=["-includeconf=relative2.conf"], expected_msg="Error: Error parsing command line arguments: -includeconf cannot be used from commandline; -includeconf=relative2.conf")
+        self.nodes[0].assert_start_raises_init_error(
+            extra_args=['-noincludeconf=0'],
+            expected_msg='Error: Error parsing command line arguments: -includeconf cannot be used from commandline; -includeconf=true',
+        )
+        self.nodes[0].assert_start_raises_init_error(
+            extra_args=['-includeconf=relative2.conf'],
+            expected_msg='Error: Error parsing command line arguments: -includeconf cannot be used from commandline; -includeconf="relative2.conf"',
+        )
 
         self.log.info("-includeconf cannot be used recursively. subversion should end with 'main; relative)/'")
         with open(os.path.join(self.options.tmpdir, "node0", "relative.conf"), "a", encoding="utf8") as f:

--- a/test/functional/feature_includeconf.py
+++ b/test/functional/feature_includeconf.py
@@ -47,7 +47,7 @@ class IncludeConfTest(BitcoinTestFramework):
             expected_msg='Error: Error parsing command line arguments: -includeconf cannot be used from commandline; -includeconf=true',
         )
         self.nodes[0].assert_start_raises_init_error(
-            extra_args=['-includeconf=relative2.conf'],
+            extra_args=['-includeconf=relative2.conf', '-includeconf=no_warn.conf'],
             expected_msg='Error: Error parsing command line arguments: -includeconf cannot be used from commandline; -includeconf="relative2.conf"',
         )
 


### PR DESCRIPTION
The error message has several issues:

* It may crash instead of cleanly shutting down, when `-noincludeconf=0` is passed
* It doesn't quote the value 
* It includes an erroneous trailing `\n`
* It is redundantly mentioning `"-includeconf cannot be used from commandline;"` several times, when once should be more than sufficient

Fix all issues by:
* Replacing `get_str()` with `write()` to fix the crash and quoting issue
* Remove the `\n` and only print the first value to fix the other issues

Before:

```
$ ./src/bitcoind -noincludeconf=0
terminate called after throwing an instance of 'std::runtime_error'
  what():  JSON value is not a string as expected
Aborted (core dumped)

$ ./src/bitcoind -includeconf='a b' -includeconf=c
Error: Error parsing command line arguments: -includeconf cannot be used from commandline; -includeconf=a b
-includeconf cannot be used from commandline; -includeconf=c
```

After:


```
$ ./src/bitcoind -noincludeconf=0
Error: Error parsing command line arguments: -includeconf cannot be used from commandline; -includeconf=true

$ ./src/bitcoind -includeconf='a b' -includeconf=c
Error: Error parsing command line arguments: -includeconf cannot be used from commandline; -includeconf="a b"
```


Hopefully fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34493

Testcase: https://github.com/bitcoin/bitcoin/files/6515429/clusterfuzz-testcase-minimized-system-6328535926046720.log

```
FUZZ=system ./src/test/fuzz/fuzz ./clusterfuzz-testcase-minimized-system-6328535926046720.log
```

See https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md