### PR TITLE
rpc: add period_start to version bits statistics

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1434,6 +1434,7 @@ static void SoftForkDescPushBack(const CBlockIndex* active_chain_tip, UniValue& 
         UniValue statsUV(UniValue::VOBJ);
         BIP9Stats statsStruct = g_versionbitscache.Statistics(active_chain_tip, consensusParams, id);
         statsUV.pushKV("period", statsStruct.period);
+        statsUV.pushKV("period_start", active_chain_tip->nHeight + 1 - statsStruct.elapsed);
         statsUV.pushKV("elapsed", statsStruct.elapsed);
         statsUV.pushKV("count", statsStruct.count);
         if (ThresholdState::LOCKED_IN != thresholdState) {
@@ -1494,6 +1495,7 @@ RPCHelpMan getblockchaininfo()
                                     {RPCResult::Type::OBJ, "statistics", /*optional=*/true, "numeric statistics about signalling for a softfork (only for \"started\" and \"locked_in\" status)",
                                     {
                                         {RPCResult::Type::NUM, "period", "the length in blocks of the signalling period"},
+                                        {RPCResult::Type::NUM, "period_start", "height of the first block of this signalling period"},
                                         {RPCResult::Type::NUM, "threshold", /*optional=*/true, "the number of blocks with the version bit set required to activate the feature (only for \"started\" status)"},
                                         {RPCResult::Type::NUM, "elapsed", "the number of blocks elapsed since the beginning of the current period"},
                                         {RPCResult::Type::NUM, "count", "the number of blocks with the version bit set in the current period"},

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -193,6 +193,7 @@ class BlockchainTest(BitcoinTestFramework):
                     'since': 144,
                     'statistics': {
                         'period': 144,
+                        'period_start': 144,
                         'threshold': 108,
                         'elapsed': HEIGHT - 143,
                         'count': HEIGHT - 143,


### PR DESCRIPTION
This PR adds `period_start` to the softfork statistics.

This makes it easier to draw [green squares](https://gist.github.com/mutatrum/264cfa84af5fc3dc0b107bcb3ba10893#gistcomment-3752162). 

Admittedly this is trivial to calculate: `$height - ($height mod $period)`