### PR TITLE
wallet: Introduce SelectionResult for encapsulating a coin selection solution

### DIFF
--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -54,12 +54,10 @@ static void CoinSelection(benchmark::Bench& bench)
                                                     /* long_term_feerate= */ CFeeRate(0), /* discard_feerate= */ CFeeRate(0),
                                                     /* tx_noinputs_size= */ 0, /* avoid_partial= */ false);
     bench.run([&] {
-        std::set<CInputCoin> setCoinsRet;
-        CAmount nValueRet;
-        bool success = AttemptSelection(wallet, 1003 * COIN, filter_standard, coins, setCoinsRet, nValueRet, coin_selection_params);
-        assert(success);
-        assert(nValueRet == 1003 * COIN);
-        assert(setCoinsRet.size() == 2);
+        auto result = AttemptSelection(wallet, 1003 * COIN, filter_standard, coins, coin_selection_params);
+        assert(result);
+        assert(result->GetSelectedValue() == 1003 * COIN);
+        assert(result->GetInputSet().size() == 2);
     });
 }
 

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -92,17 +92,14 @@ static void BnBExhaustion(benchmark::Bench& bench)
 {
     // Setup
     std::vector<OutputGroup> utxo_pool;
-    CoinSet selection;
-    CAmount value_ret = 0;
 
     bench.run([&] {
         // Benchmark
         CAmount target = make_hard_case(17, utxo_pool);
-        SelectCoinsBnB(utxo_pool, target, 0, selection, value_ret); // Should exhaust
+        SelectCoinsBnB(utxo_pool, target, 0); // Should exhaust
 
         // Cleanup
         utxo_pool.clear();
-        selection.clear();
     });
 }
 

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -166,10 +166,9 @@ std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_poo
     return result;
 }
 
-std::optional<std::pair<std::set<CInputCoin>, CAmount>> SelectCoinsSRD(const std::vector<OutputGroup>& utxo_pool, CAmount target_value)
+std::optional<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& utxo_pool, CAmount target_value)
 {
-    std::set<CInputCoin> out_set;
-    CAmount value_ret = 0;
+    SelectionResult result(target_value);
 
     std::vector<size_t> indexes;
     indexes.resize(utxo_pool.size());
@@ -181,10 +180,9 @@ std::optional<std::pair<std::set<CInputCoin>, CAmount>> SelectCoinsSRD(const std
         const OutputGroup& group = utxo_pool.at(i);
         Assume(group.GetSelectionAmount() > 0);
         selected_eff_value += group.GetSelectionAmount();
-        value_ret += group.m_value;
-        util::insert(out_set, group.m_outputs);
+        result.AddInput(group);
         if (selected_eff_value >= target_value) {
-            return std::make_pair(out_set, value_ret);
+            return result;
         }
     }
     return std::nullopt;

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -199,6 +199,7 @@ struct OutputGroup
 
 struct SelectionResult
 {
+private:
     /** Set of inputs selected by the algorithm to use in the transaction */
     std::set<CInputCoin> m_selected_inputs;
     /** The target the algorithm selected for. Note that this may not be equal to the recipient amount as it can include non-input fees */
@@ -208,6 +209,7 @@ struct SelectionResult
     /** The computed waste */
     std::optional<CAmount> m_waste;
 
+public:
     explicit SelectionResult(const CAmount target)
         : m_target(target) {}
 

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -241,9 +241,9 @@ std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_poo
  *
  * @param[in]  utxo_pool    The positive effective value OutputGroups eligible for selection
  * @param[in]  target_value The target value to select for
- * @returns If successful, a pair of set of outputs and total selected value, otherwise, std::nullopt
+ * @returns If successful, a SelectionResult, otherwise, std::nullopt
  */
-std::optional<std::pair<std::set<CInputCoin>, CAmount>> SelectCoinsSRD(const std::vector<OutputGroup>& utxo_pool, CAmount target_value);
+std::optional<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& utxo_pool, CAmount target_value);
 
 // Original coin selection algorithm as a fallback
 std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, const CAmount& nTargetValue);

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -234,7 +234,7 @@ public:
     bool operator<(SelectionResult other) const;
 };
 
-bool SelectCoinsBnB(std::vector<OutputGroup>& utxo_pool, const CAmount& selection_target, const CAmount& cost_of_change, std::set<CInputCoin>& out_set, CAmount& value_ret);
+std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_pool, const CAmount& selection_target, const CAmount& cost_of_change);
 
 /** Select coins by Single Random Draw. OutputGroups are selected randomly from the eligible
  * outputs until the target is satisfied

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -187,6 +187,8 @@ struct OutputGroup
  * where excess = selected_effective_value - target
  * change_cost = effective_feerate * change_output_size + long_term_feerate * change_spend_size
  *
+ * Note this function is separate from SelectionResult for the tests.
+ *
  * @param[in] inputs The selected inputs
  * @param[in] change_cost The cost of creating change and spending it in the future.
  *                        Only used if there is change, in which case it must be positive.

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -246,6 +246,6 @@ std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_poo
 std::optional<std::pair<std::set<CInputCoin>, CAmount>> SelectCoinsSRD(const std::vector<OutputGroup>& utxo_pool, CAmount target_value);
 
 // Original coin selection algorithm as a fallback
-bool KnapsackSolver(const CAmount& nTargetValue, std::vector<OutputGroup>& groups, std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet);
+std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, const CAmount& nTargetValue);
 
 #endif // BITCOIN_WALLET_COINSELECTION_H

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -197,6 +197,41 @@ struct OutputGroup
  */
 [[nodiscard]] CAmount GetSelectionWaste(const std::set<CInputCoin>& inputs, CAmount change_cost, CAmount target, bool use_effective_value = true);
 
+struct SelectionResult
+{
+    /** Set of inputs selected by the algorithm to use in the transaction */
+    std::set<CInputCoin> m_selected_inputs;
+    /** The target the algorithm selected for. Note that this may not be equal to the recipient amount as it can include non-input fees */
+    const CAmount m_target;
+    /** Whether the input values for calculations should be the effective value (true) or normal value (false) */
+    bool m_use_effective{false};
+    /** The computed waste */
+    std::optional<CAmount> m_waste;
+
+    explicit SelectionResult(const CAmount target)
+        : m_target(target) {}
+
+    SelectionResult() = delete;
+
+    /** Get the sum of the input values */
+    [[nodiscard]] CAmount GetSelectedValue() const;
+
+    void Clear();
+
+    void AddInput(const OutputGroup& group);
+
+    /** Calculates and stores the waste for this selection via GetSelectionWaste */
+    void ComputeAndSetWaste(CAmount change_cost);
+    [[nodiscard]] CAmount GetWaste() const;
+
+    /** Get m_selected_inputs */
+    const std::set<CInputCoin>& GetInputSet() const;
+    /** Get the vector of CInputCoins that will be used to fill in a CTransaction's vin */
+    std::vector<CInputCoin> GetShuffledInputVector() const;
+
+    bool operator<(SelectionResult other) const;
+};
+
 bool SelectCoinsBnB(std::vector<OutputGroup>& utxo_pool, const CAmount& selection_target, const CAmount& cost_of_change, std::set<CInputCoin>& out_set, CAmount& value_ret);
 
 /** Select coins by Single Random Draw. OutputGroups are selected randomly from the eligible

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -443,6 +443,7 @@ bool SelectCoins(const CWallet& wallet, const std::vector<COutput>& vAvailableCo
     // calculate value from preset inputs and store them
     std::set<CInputCoin> setPresetCoins;
     CAmount nValueFromPresetInputs = 0;
+    OutputGroup preset_inputs(coin_selection_params);
 
     std::vector<COutPoint> vPresetInputs;
     coin_control.ListSelected(vPresetInputs);
@@ -480,6 +481,10 @@ bool SelectCoins(const CWallet& wallet, const std::vector<COutput>& vAvailableCo
             value_to_select -= coin.effective_value;
         }
         setPresetCoins.insert(coin);
+        /* Set depth, from_me, ancestors, and descendants to 0 or false as don't matter for preset inputs as no actual selection is being done.
+         * positive_only is set to false because we want to include all preset inputs, even if they are dust.
+         */
+        preset_inputs.Insert(coin, 0, false, 0, 0, false);
     }
 
     // remove preset inputs from vCoins so that Coin Selection doesn't pick them.

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -402,10 +402,9 @@ bool AttemptSelection(const CWallet& wallet, const CAmount& nTargetValue, const 
     // We include the minimum final change for SRD as we do want to avoid making really small change.
     // KnapsackSolver does not need this because it includes MIN_CHANGE internally.
     const CAmount srd_target = nTargetValue + coin_selection_params.m_change_fee + MIN_FINAL_CHANGE;
-    auto srd_result = SelectCoinsSRD(positive_groups, srd_target);
-    if (srd_result != std::nullopt) {
-        const auto waste = GetSelectionWaste(srd_result->first, coin_selection_params.m_cost_of_change, srd_target, !coin_selection_params.m_subtract_fee_outputs);
-        results.emplace_back(std::make_tuple(waste, std::move(srd_result->first), srd_result->second));
+    if (auto srd_result{SelectCoinsSRD(positive_groups, srd_target)}) {
+        srd_result->ComputeAndSetWaste(coin_selection_params.m_cost_of_change);
+        results.emplace_back(std::make_tuple(srd_result->GetWaste(), srd_result->GetInputSet(), srd_result->GetSelectedValue()));
     }
 
     if (results.size() == 0) {

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -101,18 +101,20 @@ std::map<CTxDestination, std::vector<COutput>> ListCoins(const CWallet& wallet) 
 std::vector<OutputGroup> GroupOutputs(const CWallet& wallet, const std::vector<COutput>& outputs, const CoinSelectionParams& coin_sel_params, const CoinEligibilityFilter& filter, bool positive_only);
 
 /**
- * Shuffle and select coins until nTargetValue is reached while avoiding
- * small change; This method is stochastic for some inputs and upon
- * completion the coin set and corresponding actual target value is
- * assembled
- * param@[in]   coins           Set of UTXOs to consider. These will be categorized into
- *                              OutputGroups and filtered using eligibility_filter before
- *                              selecting coins.
- * param@[out]  setCoinsRet     Populated with the coins selected if successful.
- * param@[out]  nValueRet       Used to return the total value of selected coins.
+ * Attempt to find a valid input set that meets the provided eligibility filter and target.
+ * Multiple coin selection algorithms will be run and the input set that produces the least waste
+ * (according to the waste metric) will be chosen.
+ *
+ * param@[in]  wallet                 The wallet which provides solving data for the coins
+ * param@[in]  nTargetValue           The target value
+ * param@[in]  eligilibity_filter     A filter containing rules for which coins are allowed to be included in this selection
+ * param@[in]  coins                  The vector of coins available for selection prior to filtering
+ * param@[in]  coin_selection_params  Parameters for the coin selection
+ * returns                            If successful, a SelectionResult containing the input set
+ *                                    If failed, a nullopt
  */
-bool AttemptSelection(const CWallet& wallet, const CAmount& nTargetValue, const CoinEligibilityFilter& eligibility_filter, std::vector<COutput> coins,
-                        std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet, const CoinSelectionParams& coin_selection_params);
+std::optional<SelectionResult> AttemptSelection(const CWallet& wallet, const CAmount& nTargetValue, const CoinEligibilityFilter& eligibility_filter, std::vector<COutput> coins,
+                        const CoinSelectionParams& coin_selection_params);
 
 /**
  * Select a set of coins such that nValueRet >= nTargetValue and at least

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -117,15 +117,18 @@ std::optional<SelectionResult> AttemptSelection(const CWallet& wallet, const CAm
                         const CoinSelectionParams& coin_selection_params);
 
 /**
- * Select a set of coins such that nValueRet >= nTargetValue and at least
+ * Select a set of coins such that nTargetValue is met and at least
  * all coins from coin_control are selected; never select unconfirmed coins if they are not ours
- * param@[out]  setCoinsRet         Populated with inputs including pre-selected inputs from
- *                                  coin_control and Coin Selection if successful.
- * param@[out]  nValueRet           Total value of selected coins including pre-selected ones
- *                                  from coin_control and Coin Selection if successful.
+ * param@[in]   wallet                 The wallet which provides data necessary to spend the selected coins
+ * param@[in]   vAvailableCoins        The vector of coins available to be spent
+ * param@[in]   nTargetValue           The target value
+ * param@[in]   coin_selection_params  Parameters for this coin selection such as feerates, whether to avoid partial spends,
+ *                                     and whether to subtract the fee from the outputs.
+ * returns                             If successful, a SelectionResult containing the selected coins
+ *                                     If failed, a nullopt.
  */
-bool SelectCoins(const CWallet& wallet, const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet,
-                 const CCoinControl& coin_control, CoinSelectionParams& coin_selection_params) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+std::optional<SelectionResult> SelectCoins(const CWallet& wallet, const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, const CCoinControl& coin_control,
+                 const CoinSelectionParams& coin_selection_params) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 
 /**
  * Create a new transaction paying the recipients with a set of coins

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -42,6 +42,18 @@ static void add_coin(const CAmount& nValue, int nInput, std::vector<CInputCoin>&
     set.emplace_back(MakeTransactionRef(tx), nInput);
 }
 
+static void add_coin(const CAmount& nValue, int nInput, SelectionResult& result)
+{
+    CMutableTransaction tx;
+    tx.vout.resize(nInput + 1);
+    tx.vout[nInput].nValue = nValue;
+    tx.nLockTime = nextLockTime++;        // so all transactions get different hashes
+    CInputCoin coin(MakeTransactionRef(tx), nInput);
+    OutputGroup group;
+    group.Insert(coin, 1, false, 0, 0, true);
+    result.AddInput(group);
+}
+
 static void add_coin(const CAmount& nValue, int nInput, CoinSet& set, CAmount fee = 0, CAmount long_term_fee = 0)
 {
     CMutableTransaction tx;
@@ -175,26 +187,26 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     add_coin(4 * CENT, 4, utxo_pool);
 
     // Select 1 Cent
-    add_coin(1 * CENT, 1, expected_result.m_selected_inputs);
+    add_coin(1 * CENT, 1, expected_result);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 1 * CENT, 0.5 * CENT, selection, value_ret));
-    BOOST_CHECK(equivalent_sets(selection, expected_result.m_selected_inputs));
+    BOOST_CHECK(equivalent_sets(selection, expected_result.GetInputSet()));
     BOOST_CHECK_EQUAL(value_ret, 1 * CENT);
     expected_result.Clear();
     selection.clear();
 
     // Select 2 Cent
-    add_coin(2 * CENT, 2, expected_result.m_selected_inputs);
+    add_coin(2 * CENT, 2, expected_result);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 2 * CENT, 0.5 * CENT, selection, value_ret));
-    BOOST_CHECK(equivalent_sets(selection, expected_result.m_selected_inputs));
+    BOOST_CHECK(equivalent_sets(selection, expected_result.GetInputSet()));
     BOOST_CHECK_EQUAL(value_ret, 2 * CENT);
     expected_result.Clear();
     selection.clear();
 
     // Select 5 Cent
-    add_coin(4 * CENT, 4, expected_result.m_selected_inputs);
-    add_coin(1 * CENT, 1, expected_result.m_selected_inputs);
+    add_coin(4 * CENT, 4, expected_result);
+    add_coin(1 * CENT, 1, expected_result);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 5 * CENT, 0.5 * CENT, selection, value_ret));
-    BOOST_CHECK(equivalent_sets(selection, expected_result.m_selected_inputs));
+    BOOST_CHECK(equivalent_sets(selection, expected_result.GetInputSet()));
     BOOST_CHECK_EQUAL(value_ret, 5 * CENT);
     expected_result.Clear();
     selection.clear();
@@ -205,10 +217,10 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     selection.clear();
 
     // Cost of change is greater than the difference between target value and utxo sum
-    add_coin(1 * CENT, 1, expected_result.m_selected_inputs);
+    add_coin(1 * CENT, 1, expected_result);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 0.9 * CENT, 0.5 * CENT, selection, value_ret));
     BOOST_CHECK_EQUAL(value_ret, 1 * CENT);
-    BOOST_CHECK(equivalent_sets(selection, expected_result.m_selected_inputs));
+    BOOST_CHECK(equivalent_sets(selection, expected_result.GetInputSet()));
     expected_result.Clear();
     selection.clear();
 
@@ -219,24 +231,24 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
 
     // Select 10 Cent
     add_coin(5 * CENT, 5, utxo_pool);
-    add_coin(5 * CENT, 5, expected_result.m_selected_inputs);
-    add_coin(4 * CENT, 4, expected_result.m_selected_inputs);
-    add_coin(1 * CENT, 1, expected_result.m_selected_inputs);
+    add_coin(5 * CENT, 5, expected_result);
+    add_coin(4 * CENT, 4, expected_result);
+    add_coin(1 * CENT, 1, expected_result);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 10 * CENT, 0.5 * CENT, selection, value_ret));
-    BOOST_CHECK(equivalent_sets(selection, expected_result.m_selected_inputs));
+    BOOST_CHECK(equivalent_sets(selection, expected_result.GetInputSet()));
     BOOST_CHECK_EQUAL(value_ret, 10 * CENT);
     expected_result.Clear();
     selection.clear();
 
     // Negative effective value
     // Select 10 Cent but have 1 Cent not be possible because too small
-    add_coin(5 * CENT, 5, expected_result.m_selected_inputs);
-    add_coin(3 * CENT, 3, expected_result.m_selected_inputs);
-    add_coin(2 * CENT, 2, expected_result.m_selected_inputs);
+    add_coin(5 * CENT, 5, expected_result);
+    add_coin(3 * CENT, 3, expected_result);
+    add_coin(2 * CENT, 2, expected_result);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 10 * CENT, 5000, selection, value_ret));
     BOOST_CHECK_EQUAL(value_ret, 10 * CENT);
     // FIXME: this test is redundant with the above, because 1 Cent is selected, not "too small"
-    // BOOST_CHECK(equivalent_sets(selection, expected_result.m_selected_inputs));
+    // BOOST_CHECK(equivalent_sets(selection, expected_result.GetInputSet()));
 
     // Select 0.25 Cent, not possible
     BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 0.25 * CENT, 0.5 * CENT, selection, value_ret));
@@ -251,11 +263,11 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
 
     // Test same value early bailout optimization
     utxo_pool.clear();
-    add_coin(7 * CENT, 7, expected_result.m_selected_inputs);
-    add_coin(7 * CENT, 7, expected_result.m_selected_inputs);
-    add_coin(7 * CENT, 7, expected_result.m_selected_inputs);
-    add_coin(7 * CENT, 7, expected_result.m_selected_inputs);
-    add_coin(2 * CENT, 7, expected_result.m_selected_inputs);
+    add_coin(7 * CENT, 7, expected_result);
+    add_coin(7 * CENT, 7, expected_result);
+    add_coin(7 * CENT, 7, expected_result);
+    add_coin(7 * CENT, 7, expected_result);
+    add_coin(2 * CENT, 7, expected_result);
     add_coin(7 * CENT, 7, utxo_pool);
     add_coin(7 * CENT, 7, utxo_pool);
     add_coin(7 * CENT, 7, utxo_pool);
@@ -266,7 +278,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     }
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 30 * CENT, 5000, selection, value_ret));
     BOOST_CHECK_EQUAL(value_ret, 30 * CENT);
-    BOOST_CHECK(equivalent_sets(selection, expected_result.m_selected_inputs));
+    BOOST_CHECK(equivalent_sets(selection, expected_result.GetInputSet()));
 
     ////////////////////
     // Behavior tests //

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -31,12 +31,14 @@ typedef std::set<CInputCoin> CoinSet;
 static const CoinEligibilityFilter filter_standard(1, 6, 0);
 static const CoinEligibilityFilter filter_confirmed(1, 1, 0);
 static const CoinEligibilityFilter filter_standard_extra(6, 6, 0);
+static int nextLockTime = 0;
 
 static void add_coin(const CAmount& nValue, int nInput, std::vector<CInputCoin>& set)
 {
     CMutableTransaction tx;
     tx.vout.resize(nInput + 1);
     tx.vout[nInput].nValue = nValue;
+    tx.nLockTime = nextLockTime++;        // so all transactions get different hashes
     set.emplace_back(MakeTransactionRef(tx), nInput);
 }
 
@@ -45,6 +47,7 @@ static void add_coin(const CAmount& nValue, int nInput, CoinSet& set, CAmount fe
     CMutableTransaction tx;
     tx.vout.resize(nInput + 1);
     tx.vout[nInput].nValue = nValue;
+    tx.nLockTime = nextLockTime++;        // so all transactions get different hashes
     CInputCoin coin(MakeTransactionRef(tx), nInput);
     coin.effective_value = nValue - fee;
     coin.m_fee = fee;
@@ -54,7 +57,6 @@ static void add_coin(const CAmount& nValue, int nInput, CoinSet& set, CAmount fe
 
 static void add_coin(std::vector<COutput>& coins, CWallet& wallet, const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = false, int nInput=0, bool spendable = false)
 {
-    static int nextLockTime = 0;
     CMutableTransaction tx;
     tx.nLockTime = nextLockTime++;        // so all transactions get different hashes
     tx.vout.resize(nInput + 1);
@@ -79,6 +81,23 @@ static void add_coin(std::vector<COutput>& coins, CWallet& wallet, const CAmount
     }
     COutput output(wallet, *wtx, nInput, nAge, true /* spendable */, true /* solvable */, true /* safe */);
     coins.push_back(output);
+}
+
+static bool equivalent_sets(CoinSet a, CoinSet b)
+{
+    std::vector<CAmount> a_amts;
+    std::vector<CAmount> b_amts;
+    for (const auto& coin : a) {
+        a_amts.push_back(coin.txout.nValue);
+    }
+    for (const auto& coin : b) {
+        b_amts.push_back(coin.txout.nValue);
+    }
+    std::sort(a_amts.begin(), a_amts.end());
+    std::sort(b_amts.begin(), b_amts.end());
+
+    std::pair<std::vector<CAmount>::iterator, std::vector<CAmount>::iterator> ret = mismatch(a_amts.begin(), a_amts.end(), b_amts.begin());
+    return ret.first == a_amts.end() && ret.second == b_amts.end();
 }
 
 static bool equal_sets(CoinSet a, CoinSet b)
@@ -158,7 +177,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     // Select 1 Cent
     add_coin(1 * CENT, 1, actual_selection);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 1 * CENT, 0.5 * CENT, selection, value_ret));
-    BOOST_CHECK(equal_sets(selection, actual_selection));
+    BOOST_CHECK(equivalent_sets(selection, actual_selection));
     BOOST_CHECK_EQUAL(value_ret, 1 * CENT);
     actual_selection.clear();
     selection.clear();
@@ -166,7 +185,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     // Select 2 Cent
     add_coin(2 * CENT, 2, actual_selection);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 2 * CENT, 0.5 * CENT, selection, value_ret));
-    BOOST_CHECK(equal_sets(selection, actual_selection));
+    BOOST_CHECK(equivalent_sets(selection, actual_selection));
     BOOST_CHECK_EQUAL(value_ret, 2 * CENT);
     actual_selection.clear();
     selection.clear();
@@ -175,7 +194,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     add_coin(4 * CENT, 4, actual_selection);
     add_coin(1 * CENT, 1, actual_selection);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 5 * CENT, 0.5 * CENT, selection, value_ret));
-    BOOST_CHECK(equal_sets(selection, actual_selection));
+    BOOST_CHECK(equivalent_sets(selection, actual_selection));
     BOOST_CHECK_EQUAL(value_ret, 5 * CENT);
     actual_selection.clear();
     selection.clear();
@@ -189,7 +208,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     add_coin(1 * CENT, 1, actual_selection);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 0.9 * CENT, 0.5 * CENT, selection, value_ret));
     BOOST_CHECK_EQUAL(value_ret, 1 * CENT);
-    BOOST_CHECK(equal_sets(selection, actual_selection));
+    BOOST_CHECK(equivalent_sets(selection, actual_selection));
     actual_selection.clear();
     selection.clear();
 
@@ -204,7 +223,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     add_coin(4 * CENT, 4, actual_selection);
     add_coin(1 * CENT, 1, actual_selection);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 10 * CENT, 0.5 * CENT, selection, value_ret));
-    BOOST_CHECK(equal_sets(selection, actual_selection));
+    BOOST_CHECK(equivalent_sets(selection, actual_selection));
     BOOST_CHECK_EQUAL(value_ret, 10 * CENT);
     actual_selection.clear();
     selection.clear();
@@ -217,7 +236,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 10 * CENT, 5000, selection, value_ret));
     BOOST_CHECK_EQUAL(value_ret, 10 * CENT);
     // FIXME: this test is redundant with the above, because 1 Cent is selected, not "too small"
-    // BOOST_CHECK(equal_sets(selection, actual_selection));
+    // BOOST_CHECK(equivalent_sets(selection, actual_selection));
 
     // Select 0.25 Cent, not possible
     BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 0.25 * CENT, 0.5 * CENT, selection, value_ret));
@@ -247,7 +266,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     }
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 30 * CENT, 5000, selection, value_ret));
     BOOST_CHECK_EQUAL(value_ret, 30 * CENT);
-    BOOST_CHECK(equal_sets(selection, actual_selection));
+    BOOST_CHECK(equivalent_sets(selection, actual_selection));
 
     ////////////////////
     // Behavior tests //

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -330,8 +330,6 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
         wallet->SetupDescriptorScriptPubKeyMans();
 
         std::vector<COutput> coins;
-        CoinSet setCoinsRet;
-        CAmount nValueRet;
 
         add_coin(coins, *wallet, 5 * CENT, 6 * 24, false, 0, true);
         add_coin(coins, *wallet, 3 * CENT, 6 * 24, false, 0, true);
@@ -340,7 +338,8 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
         coin_control.fAllowOtherInputs = true;
         coin_control.Select(COutPoint(coins.at(0).tx->GetHash(), coins.at(0).i));
         coin_selection_params_bnb.m_effective_feerate = CFeeRate(0);
-        BOOST_CHECK(SelectCoins(*wallet, coins, 10 * CENT, setCoinsRet, nValueRet, coin_control, coin_selection_params_bnb));
+        const auto result10 = SelectCoins(*wallet, coins, 10 * CENT, coin_control, coin_selection_params_bnb);
+        BOOST_CHECK(result10);
     }
 }
 
@@ -713,11 +712,10 @@ BOOST_AUTO_TEST_CASE(SelectCoins_test)
                                       /* change_spend_size= */ 148, /* effective_feerate= */ CFeeRate(0),
                                       /* long_term_feerate= */ CFeeRate(0), /* discard_feerate= */ CFeeRate(0),
                                       /* tx_noinputs_size= */ 0, /* avoid_partial= */ false);
-        CoinSet out_set;
-        CAmount out_value = 0;
         CCoinControl cc;
-        BOOST_CHECK(SelectCoins(*wallet, coins, target, out_set, out_value, cc, cs_params));
-        BOOST_CHECK_GE(out_value, target);
+        const auto result = SelectCoins(*wallet, coins, target, cc, cs_params);
+        BOOST_CHECK(result);
+        BOOST_CHECK_GE(result->GetSelectedValue(), target);
     }
 }
 

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     // Setup
     std::vector<CInputCoin> utxo_pool;
     CoinSet selection;
-    CoinSet actual_selection;
+    SelectionResult expected_result(CAmount(0));
     CAmount value_ret = 0;
 
     /////////////////////////
@@ -175,72 +175,72 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     add_coin(4 * CENT, 4, utxo_pool);
 
     // Select 1 Cent
-    add_coin(1 * CENT, 1, actual_selection);
+    add_coin(1 * CENT, 1, expected_result.m_selected_inputs);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 1 * CENT, 0.5 * CENT, selection, value_ret));
-    BOOST_CHECK(equivalent_sets(selection, actual_selection));
+    BOOST_CHECK(equivalent_sets(selection, expected_result.m_selected_inputs));
     BOOST_CHECK_EQUAL(value_ret, 1 * CENT);
-    actual_selection.clear();
+    expected_result.Clear();
     selection.clear();
 
     // Select 2 Cent
-    add_coin(2 * CENT, 2, actual_selection);
+    add_coin(2 * CENT, 2, expected_result.m_selected_inputs);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 2 * CENT, 0.5 * CENT, selection, value_ret));
-    BOOST_CHECK(equivalent_sets(selection, actual_selection));
+    BOOST_CHECK(equivalent_sets(selection, expected_result.m_selected_inputs));
     BOOST_CHECK_EQUAL(value_ret, 2 * CENT);
-    actual_selection.clear();
+    expected_result.Clear();
     selection.clear();
 
     // Select 5 Cent
-    add_coin(4 * CENT, 4, actual_selection);
-    add_coin(1 * CENT, 1, actual_selection);
+    add_coin(4 * CENT, 4, expected_result.m_selected_inputs);
+    add_coin(1 * CENT, 1, expected_result.m_selected_inputs);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 5 * CENT, 0.5 * CENT, selection, value_ret));
-    BOOST_CHECK(equivalent_sets(selection, actual_selection));
+    BOOST_CHECK(equivalent_sets(selection, expected_result.m_selected_inputs));
     BOOST_CHECK_EQUAL(value_ret, 5 * CENT);
-    actual_selection.clear();
+    expected_result.Clear();
     selection.clear();
 
     // Select 11 Cent, not possible
     BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 11 * CENT, 0.5 * CENT, selection, value_ret));
-    actual_selection.clear();
+    expected_result.Clear();
     selection.clear();
 
     // Cost of change is greater than the difference between target value and utxo sum
-    add_coin(1 * CENT, 1, actual_selection);
+    add_coin(1 * CENT, 1, expected_result.m_selected_inputs);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 0.9 * CENT, 0.5 * CENT, selection, value_ret));
     BOOST_CHECK_EQUAL(value_ret, 1 * CENT);
-    BOOST_CHECK(equivalent_sets(selection, actual_selection));
-    actual_selection.clear();
+    BOOST_CHECK(equivalent_sets(selection, expected_result.m_selected_inputs));
+    expected_result.Clear();
     selection.clear();
 
     // Cost of change is less than the difference between target value and utxo sum
     BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 0.9 * CENT, 0, selection, value_ret));
-    actual_selection.clear();
+    expected_result.Clear();
     selection.clear();
 
     // Select 10 Cent
     add_coin(5 * CENT, 5, utxo_pool);
-    add_coin(5 * CENT, 5, actual_selection);
-    add_coin(4 * CENT, 4, actual_selection);
-    add_coin(1 * CENT, 1, actual_selection);
+    add_coin(5 * CENT, 5, expected_result.m_selected_inputs);
+    add_coin(4 * CENT, 4, expected_result.m_selected_inputs);
+    add_coin(1 * CENT, 1, expected_result.m_selected_inputs);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 10 * CENT, 0.5 * CENT, selection, value_ret));
-    BOOST_CHECK(equivalent_sets(selection, actual_selection));
+    BOOST_CHECK(equivalent_sets(selection, expected_result.m_selected_inputs));
     BOOST_CHECK_EQUAL(value_ret, 10 * CENT);
-    actual_selection.clear();
+    expected_result.Clear();
     selection.clear();
 
     // Negative effective value
     // Select 10 Cent but have 1 Cent not be possible because too small
-    add_coin(5 * CENT, 5, actual_selection);
-    add_coin(3 * CENT, 3, actual_selection);
-    add_coin(2 * CENT, 2, actual_selection);
+    add_coin(5 * CENT, 5, expected_result.m_selected_inputs);
+    add_coin(3 * CENT, 3, expected_result.m_selected_inputs);
+    add_coin(2 * CENT, 2, expected_result.m_selected_inputs);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 10 * CENT, 5000, selection, value_ret));
     BOOST_CHECK_EQUAL(value_ret, 10 * CENT);
     // FIXME: this test is redundant with the above, because 1 Cent is selected, not "too small"
-    // BOOST_CHECK(equivalent_sets(selection, actual_selection));
+    // BOOST_CHECK(equivalent_sets(selection, expected_result.m_selected_inputs));
 
     // Select 0.25 Cent, not possible
     BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 0.25 * CENT, 0.5 * CENT, selection, value_ret));
-    actual_selection.clear();
+    expected_result.Clear();
     selection.clear();
 
     // Iteration exhaustion test
@@ -251,11 +251,11 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
 
     // Test same value early bailout optimization
     utxo_pool.clear();
-    add_coin(7 * CENT, 7, actual_selection);
-    add_coin(7 * CENT, 7, actual_selection);
-    add_coin(7 * CENT, 7, actual_selection);
-    add_coin(7 * CENT, 7, actual_selection);
-    add_coin(2 * CENT, 7, actual_selection);
+    add_coin(7 * CENT, 7, expected_result.m_selected_inputs);
+    add_coin(7 * CENT, 7, expected_result.m_selected_inputs);
+    add_coin(7 * CENT, 7, expected_result.m_selected_inputs);
+    add_coin(7 * CENT, 7, expected_result.m_selected_inputs);
+    add_coin(2 * CENT, 7, expected_result.m_selected_inputs);
     add_coin(7 * CENT, 7, utxo_pool);
     add_coin(7 * CENT, 7, utxo_pool);
     add_coin(7 * CENT, 7, utxo_pool);
@@ -266,7 +266,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     }
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 30 * CENT, 5000, selection, value_ret));
     BOOST_CHECK_EQUAL(value_ret, 30 * CENT);
-    BOOST_CHECK(equivalent_sets(selection, actual_selection));
+    BOOST_CHECK(equivalent_sets(selection, expected_result.m_selected_inputs));
 
     ////////////////////
     // Behavior tests //

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -14,6 +14,7 @@
 #include <wallet/test/wallet_test_fixture.h>
 #include <wallet/wallet.h>
 
+#include <algorithm>
 #include <boost/test/unit_test.hpp>
 #include <random>
 
@@ -95,20 +96,22 @@ static void add_coin(std::vector<COutput>& coins, CWallet& wallet, const CAmount
     coins.push_back(output);
 }
 
-static bool equivalent_sets(CoinSet a, CoinSet b)
+/** Check if SelectionResult a is equivalent to SelectionResult b.
+ * Equivalent means same input values, but maybe different inputs (i.e. same value, different prevout) */
+static bool EquivalentResult(const SelectionResult& a, const SelectionResult& b)
 {
     std::vector<CAmount> a_amts;
     std::vector<CAmount> b_amts;
-    for (const auto& coin : a) {
+    for (const auto& coin : a.GetInputSet()) {
         a_amts.push_back(coin.txout.nValue);
     }
-    for (const auto& coin : b) {
+    for (const auto& coin : b.GetInputSet()) {
         b_amts.push_back(coin.txout.nValue);
     }
     std::sort(a_amts.begin(), a_amts.end());
     std::sort(b_amts.begin(), b_amts.end());
 
-    std::pair<std::vector<CAmount>::iterator, std::vector<CAmount>::iterator> ret = mismatch(a_amts.begin(), a_amts.end(), b_amts.begin());
+    std::pair<std::vector<CAmount>::iterator, std::vector<CAmount>::iterator> ret = std::mismatch(a_amts.begin(), a_amts.end(), b_amts.begin());
     return ret.first == a_amts.end() && ret.second == b_amts.end();
 }
 
@@ -168,17 +171,14 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
 {
     // Setup
     std::vector<CInputCoin> utxo_pool;
-    CoinSet selection;
     SelectionResult expected_result(CAmount(0));
-    CAmount value_ret = 0;
 
     /////////////////////////
     // Known Outcome tests //
     /////////////////////////
 
     // Empty utxo pool
-    BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 1 * CENT, 0.5 * CENT, selection, value_ret));
-    selection.clear();
+    BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 1 * CENT, 0.5 * CENT));
 
     // Add utxos
     add_coin(1 * CENT, 1, utxo_pool);
@@ -188,78 +188,77 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
 
     // Select 1 Cent
     add_coin(1 * CENT, 1, expected_result);
-    BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 1 * CENT, 0.5 * CENT, selection, value_ret));
-    BOOST_CHECK(equivalent_sets(selection, expected_result.GetInputSet()));
-    BOOST_CHECK_EQUAL(value_ret, 1 * CENT);
+    const auto result1 = SelectCoinsBnB(GroupCoins(utxo_pool), 1 * CENT, 0.5 * CENT);
+    BOOST_CHECK(result1);
+    BOOST_CHECK(EquivalentResult(expected_result, *result1));
+    BOOST_CHECK_EQUAL(result1->GetSelectedValue(), 1 * CENT);
     expected_result.Clear();
-    selection.clear();
 
     // Select 2 Cent
     add_coin(2 * CENT, 2, expected_result);
-    BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 2 * CENT, 0.5 * CENT, selection, value_ret));
-    BOOST_CHECK(equivalent_sets(selection, expected_result.GetInputSet()));
-    BOOST_CHECK_EQUAL(value_ret, 2 * CENT);
+    const auto result2 = SelectCoinsBnB(GroupCoins(utxo_pool), 2 * CENT, 0.5 * CENT);
+    BOOST_CHECK(result2);
+    BOOST_CHECK(EquivalentResult(expected_result, *result2));
+    BOOST_CHECK_EQUAL(result2->GetSelectedValue(), 2 * CENT);
     expected_result.Clear();
-    selection.clear();
 
     // Select 5 Cent
     add_coin(4 * CENT, 4, expected_result);
     add_coin(1 * CENT, 1, expected_result);
-    BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 5 * CENT, 0.5 * CENT, selection, value_ret));
-    BOOST_CHECK(equivalent_sets(selection, expected_result.GetInputSet()));
-    BOOST_CHECK_EQUAL(value_ret, 5 * CENT);
+    const auto result3 = SelectCoinsBnB(GroupCoins(utxo_pool), 5 * CENT, 0.5 * CENT);
+    BOOST_CHECK(result3);
+    BOOST_CHECK(EquivalentResult(expected_result, *result3));
+    BOOST_CHECK_EQUAL(result3->GetSelectedValue(), 5 * CENT);
     expected_result.Clear();
-    selection.clear();
 
     // Select 11 Cent, not possible
-    BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 11 * CENT, 0.5 * CENT, selection, value_ret));
+    BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 11 * CENT, 0.5 * CENT));
     expected_result.Clear();
-    selection.clear();
 
     // Cost of change is greater than the difference between target value and utxo sum
     add_coin(1 * CENT, 1, expected_result);
-    BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 0.9 * CENT, 0.5 * CENT, selection, value_ret));
-    BOOST_CHECK_EQUAL(value_ret, 1 * CENT);
-    BOOST_CHECK(equivalent_sets(selection, expected_result.GetInputSet()));
+    const auto result4 = SelectCoinsBnB(GroupCoins(utxo_pool), 0.9 * CENT, 0.5 * CENT);
+    BOOST_CHECK(result4);
+    BOOST_CHECK_EQUAL(result4->GetSelectedValue(), 1 * CENT);
+    BOOST_CHECK(EquivalentResult(expected_result, *result4));
     expected_result.Clear();
-    selection.clear();
 
     // Cost of change is less than the difference between target value and utxo sum
-    BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 0.9 * CENT, 0, selection, value_ret));
+    BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 0.9 * CENT, 0));
     expected_result.Clear();
-    selection.clear();
 
     // Select 10 Cent
     add_coin(5 * CENT, 5, utxo_pool);
     add_coin(5 * CENT, 5, expected_result);
     add_coin(4 * CENT, 4, expected_result);
     add_coin(1 * CENT, 1, expected_result);
-    BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 10 * CENT, 0.5 * CENT, selection, value_ret));
-    BOOST_CHECK(equivalent_sets(selection, expected_result.GetInputSet()));
-    BOOST_CHECK_EQUAL(value_ret, 10 * CENT);
+    const auto result5 = SelectCoinsBnB(GroupCoins(utxo_pool), 10 * CENT, 0.5 * CENT);
+    BOOST_CHECK(result5);
+    BOOST_CHECK(EquivalentResult(expected_result, *result5));
+    BOOST_CHECK_EQUAL(result5->GetSelectedValue(), 10 * CENT);
     expected_result.Clear();
-    selection.clear();
 
     // Negative effective value
     // Select 10 Cent but have 1 Cent not be possible because too small
     add_coin(5 * CENT, 5, expected_result);
     add_coin(3 * CENT, 3, expected_result);
     add_coin(2 * CENT, 2, expected_result);
-    BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 10 * CENT, 5000, selection, value_ret));
-    BOOST_CHECK_EQUAL(value_ret, 10 * CENT);
+    const auto result6 = SelectCoinsBnB(GroupCoins(utxo_pool), 10 * CENT, 5000);
+    BOOST_CHECK(result6);
+    BOOST_CHECK_EQUAL(result6->GetSelectedValue(), 10 * CENT);
     // FIXME: this test is redundant with the above, because 1 Cent is selected, not "too small"
-    // BOOST_CHECK(equivalent_sets(selection, expected_result.GetInputSet()));
+    // BOOST_CHECK(EquivalentResult(expected_result, *result));
 
     // Select 0.25 Cent, not possible
-    BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 0.25 * CENT, 0.5 * CENT, selection, value_ret));
+    BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 0.25 * CENT, 0.5 * CENT));
     expected_result.Clear();
-    selection.clear();
 
     // Iteration exhaustion test
     CAmount target = make_hard_case(17, utxo_pool);
-    BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), target, 0, selection, value_ret)); // Should exhaust
+    BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), target, 0)); // Should exhaust
     target = make_hard_case(14, utxo_pool);
-    BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), target, 0, selection, value_ret)); // Should not exhaust
+    const auto result7 = SelectCoinsBnB(GroupCoins(utxo_pool), target, 0); // Should not exhaust
+    BOOST_CHECK(result7);
 
     // Test same value early bailout optimization
     utxo_pool.clear();
@@ -276,9 +275,10 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     for (int i = 0; i < 50000; ++i) {
         add_coin(5 * CENT, 7, utxo_pool);
     }
-    BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 30 * CENT, 5000, selection, value_ret));
-    BOOST_CHECK_EQUAL(value_ret, 30 * CENT);
-    BOOST_CHECK(equivalent_sets(selection, expected_result.GetInputSet()));
+    const auto result8 = SelectCoinsBnB(GroupCoins(utxo_pool), 30 * CENT, 5000);
+    BOOST_CHECK(result8);
+    BOOST_CHECK_EQUAL(result8->GetSelectedValue(), 30 * CENT);
+    BOOST_CHECK(EquivalentResult(expected_result, *result8));
 
     ////////////////////
     // Behavior tests //
@@ -290,7 +290,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     }
     // Run 100 times, to make sure it is never finding a solution
     for (int i = 0; i < 100; ++i) {
-        BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 1 * CENT, 2 * CENT, selection, value_ret));
+        BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 1 * CENT, 2 * CENT));
     }
 
     // Make sure that effective value is working in AttemptSelection when BnB is used
@@ -306,20 +306,19 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
         wallet->SetupDescriptorScriptPubKeyMans();
 
         std::vector<COutput> coins;
-        CoinSet setCoinsRet;
-        CAmount nValueRet;
 
         add_coin(coins, *wallet, 1);
         coins.at(0).nInputBytes = 40; // Make sure that it has a negative effective value. The next check should assert if this somehow got through. Otherwise it will fail
-        BOOST_CHECK(!SelectCoinsBnB(GroupCoins(coins), 1 * CENT, coin_selection_params_bnb.m_cost_of_change, setCoinsRet, nValueRet));
+        BOOST_CHECK(!SelectCoinsBnB(GroupCoins(coins), 1 * CENT, coin_selection_params_bnb.m_cost_of_change));
 
         // Test fees subtracted from output:
         coins.clear();
         add_coin(coins, *wallet, 1 * CENT);
         coins.at(0).nInputBytes = 40;
         coin_selection_params_bnb.m_subtract_fee_outputs = true;
-        BOOST_CHECK(SelectCoinsBnB(GroupCoins(coins), 1 * CENT, coin_selection_params_bnb.m_cost_of_change, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 1 * CENT);
+        const auto result9 = SelectCoinsBnB(GroupCoins(coins), 1 * CENT, coin_selection_params_bnb.m_cost_of_change);
+        BOOST_CHECK(result9);
+        BOOST_CHECK_EQUAL(result9->GetSelectedValue(), 1 * CENT);
     }
 
     {


### PR DESCRIPTION
Instead of returning a set of selected coins and their total value as separate items, encapsulate both of these, and other variables, into a new `SelectionResult` struct. This allows us to have all of the things relevant to a coin selection solution be in a single object. `SelectionResult` enables us to implement the waste calculation in a cleaner way.

All of the coin selection functions (`SelectCoinsBnB`, `KnapsackSolver`, `AttemptSelection`, and `SelectCoins`) are changed to use a `SelectionResult` as the output parameter.

Based on #22009