### PR TITLE
build: Make --enable-suppress-external-warnings the default 

### DIFF
--- a/ci/test/06_script_a.sh
+++ b/ci/test/06_script_a.sh
@@ -14,7 +14,7 @@ if [ -n "$ANDROID_TOOLS_URL" ]; then
   exit 0
 fi
 
-BITCOIN_CONFIG_ALL="--enable-suppress-external-warnings --disable-dependency-tracking --prefix=$DEPENDS_DIR/$HOST --bindir=$BASE_OUTDIR/bin --libdir=$BASE_OUTDIR/lib"
+BITCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$DEPENDS_DIR/$HOST --bindir=$BASE_OUTDIR/bin --libdir=$BASE_OUTDIR/lib"
 if [ -z "$NO_WERROR" ]; then
   BITCOIN_CONFIG_ALL="${BITCOIN_CONFIG_ALL} --enable-werror"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1801,6 +1801,7 @@ AM_CONDITIONAL([USE_ASM],[test x$use_asm = xyes])
 AM_CONDITIONAL([WORDS_BIGENDIAN],[test x$ac_cv_c_bigendian = xyes])
 AM_CONDITIONAL([USE_NATPMP],[test x$use_natpmp = xyes])
 AM_CONDITIONAL([USE_UPNP],[test x$use_upnp = xyes])
+AM_CONDITIONAL([SUPPRESS_EXTERNAL_WARNINGS], [test x$suppress_external_warnings = xyes])
 
 AC_DEFINE(CLIENT_VERSION_MAJOR, _CLIENT_VERSION_MAJOR, [Major version])
 AC_DEFINE(CLIENT_VERSION_MINOR, _CLIENT_VERSION_MINOR, [Minor version])

--- a/configure.ac
+++ b/configure.ac
@@ -224,9 +224,9 @@ dnl too much, so that it becomes difficult to spot Bitcoin Core warnings
 dnl or if they cause a build failure with --enable-werror.
 AC_ARG_ENABLE([suppress-external-warnings],
   [AS_HELP_STRING([--enable-suppress-external-warnings],
-                  [Suppress warnings from external headers (default is no)])],
+                  [Suppress warnings from external headers (default is yes)])],
   [suppress_external_warnings=$enableval],
-  [suppress_external_warnings=no])
+  [suppress_external_warnings=yes])
 
 AC_ARG_ENABLE([lcov],
   [AS_HELP_STRING([--enable-lcov],

--- a/src/Makefile.leveldb.include
+++ b/src/Makefile.leveldb.include
@@ -36,7 +36,11 @@ LEVELDB_CPPFLAGS_INT += -DLEVELDB_PLATFORM_POSIX
 endif
 
 leveldb_libleveldb_a_CPPFLAGS = $(AM_CPPFLAGS) $(LEVELDB_CPPFLAGS_INT) $(LEVELDB_CPPFLAGS)
+if SUPPRESS_EXTERNAL_WARNINGS
 leveldb_libleveldb_a_CXXFLAGS = $(filter-out -Wconditional-uninitialized -Werror=conditional-uninitialized -Wsuggest-override -Werror=suggest-override, $(AM_CXXFLAGS)) $(PIE_FLAGS)
+else
+leveldb_libleveldb_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+endif
 
 leveldb_libleveldb_a_SOURCES=
 leveldb_libleveldb_a_SOURCES += leveldb/port/port_stdcxx.h


### PR DESCRIPTION
This is split from #21667.

For users, one of the preferred ways to use the Bitcoin Core client is compiling from source, either downloaded as a part of release or acquired via git.

Only basic knowledge about terminal is required to run:
```
$ cd bitcoin
$ ./autogen.sh
$ ./configure
$ make check
```

Also, it is natural to expect that number of users that have such knowledge is higher than the number of advanced users or developers.

Assuming the basic knowledge level of users it seems unwise to allow compiler and linker warnings because they could undermine the users' trust in the Bitcoin Core quality/security/reliability.

Of course, warnings could be emitted by different parts of code: either the code we are responsible for, or third parties code, including sub-trees in our repo:
- https://github.com/google/crc32c
- https://github.com/google/leveldb

and other dependencies:
- https://github.com/libevent/libevent
- https://github.com/boostorg/boost
- https://github.com/qt/qtbase
- ...

Currently, warnings from `leveldb` are suppressed _unconditionally_: https://github.com/bitcoin/bitcoin/blob/599000903e09e5ae3784d15ae078a2e1ed89ab12/src/Makefile.leveldb.include#L39

OTOH, warnings from Qt and Boost code could be suppressed with the `--enable-suppress-external-warnings` configure option.

Making the `--enable-suppress-external-warnings` the default has the following benefits:
- don't alarm users who compile from source
- increase signal/noise ratio for developers when a new warning appears in our code (as an example, Qt warnings on macOS, where Homebrew's Qt is pretty fresh)
- allows to apply more `-W` and `-Werror` options by default (for example, `-Wdocumentation` and `-Werror=documentation` introduced in #21613)

There was an [objection](https://github.com/bitcoin/bitcoin/pull/21667#issuecomment-820185228): 
> I don't think we should make `--enable-suppress-external-warnings` the default, but it should be better documented. Someone needs to be motivated to fix things upstream and/or notice problems when we update dependencies.

The answer to this objection is that fixing "things upstream" is not the top priority for developers. It is always possible to build with the `--disable-suppress-external-warnings`. Even more, with this PR the `--disable-suppress-external-warnings` will reveal `leveldb` warning as well.