### PR TITLE
Sanitize fee options

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -922,6 +922,9 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     // and the amount the mempool min fee increases above the feerate of txs evicted due to mempool limiting.
     if (args.IsArgSet("-incrementalrelayfee")) {
         if (std::optional<CAmount> inc_relay_fee = ParseMoney(args.GetArg("-incrementalrelayfee", ""))) {
+            // High fee check
+            if (inc_relay_fee > MAX_FEE_PER_KVB)
+                return InitError(AmountHighWarn("-incrementalrelayfee"));
             ::incrementalRelayFee = CFeeRate{inc_relay_fee.value()};
         } else {
             return InitError(AmountErrMsg("incrementalrelayfee", args.GetArg("-incrementalrelayfee", "")));
@@ -958,7 +961,9 @@ bool AppInitParameterInteraction(const ArgsManager& args)
 
     if (args.IsArgSet("-minrelaytxfee")) {
         if (std::optional<CAmount> min_relay_fee = ParseMoney(args.GetArg("-minrelaytxfee", ""))) {
-            // High fee check is done afterward in CWallet::Create()
+            // High fee check
+            if (min_relay_fee > MAX_FEE_PER_KVB)
+                return InitError(AmountHighWarn("-minrelaytxfee"));
             ::minRelayTxFee = CFeeRate{min_relay_fee.value()};
         } else {
             return InitError(AmountErrMsg("minrelaytxfee", args.GetArg("-minrelaytxfee", "")));
@@ -972,7 +977,11 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     // Sanity check argument for min fee for including tx in block
     // TODO: Harmonize which arguments need sanity checking and where that happens
     if (args.IsArgSet("-blockmintxfee")) {
-        if (!ParseMoney(args.GetArg("-blockmintxfee", ""))) {
+        if (std::optional<CAmount> block_min_tx_fee = ParseMoney(args.GetArg("-blockmintxfee", ""))) {
+            // High fee check
+            if (block_min_tx_fee > MAX_FEE_PER_KVB)
+                return InitError(AmountHighWarn("-blockmintxfee"));
+        }else{
             return InitError(AmountErrMsg("blockmintxfee", args.GetArg("-blockmintxfee", "")));
         }
     }
@@ -981,6 +990,9 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     // implementations may inadvertently create non-standard transactions
     if (args.IsArgSet("-dustrelayfee")) {
         if (std::optional<CAmount> parsed = ParseMoney(args.GetArg("-dustrelayfee", ""))) {
+            // High fee check
+            if (parsed > MAX_FEE_PER_KVB)
+                return InitError(AmountHighWarn("-dustrelayfee"));
             dustRelayFee = CFeeRate{parsed.value()};
         } else {
             return InitError(AmountErrMsg("dustrelayfee", args.GetArg("-dustrelayfee", "")));

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -20,6 +20,8 @@ class CTxOut;
 static const unsigned int DEFAULT_BLOCK_MAX_WEIGHT = MAX_BLOCK_WEIGHT - 4000;
 /** Default for -blockmintxfee, which sets the minimum feerate for a transaction in blocks created by mining code **/
 static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = 1000;
+/** The maximum fee rate value **/
+static const unsigned int MAX_FEE_PER_KVB = COIN;
 /** The maximum weight for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_WEIGHT = 400000;
 /** The minimum non-witness size for transactions we're willing to relay/mine (1 segwit input + 1 P2WPKH output = 82 bytes) */


### PR DESCRIPTION
rpc: Sanitize fee option inputs. refs #21893

Checks -blockmintxfee, -incrementalrelayfee, -dustrelayfee and -minrelaytxfee values.
Fees are parsed as int64_t, and as a fee is being multiplied by the package size, too large a value might lead to an overflow.

Max value set to 1 BTC as @MarcoFalke states in #21893: 
> Assuming a maximum transaction size of at most 4MvB, this would give an upper bound for the fee rate of ~46116 BTC/kvB. Though, any fee rate larger than 1 BTC/kvB is probably nonsense and should be rejected early on startup.
