### PR TITLE
[WIP] ci: Do not cache depends/sources directory

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -209,8 +209,6 @@ task:
 task:
   name: 'ARM64 Android APK [focal]'
   << : *DEPENDS_SDK_CACHE_TEMPLATE
-  depends_sources_cache:
-    folder: "depends/sources"
   << : *GLOBAL_TASK_TEMPLATE
   container:
     image: ubuntu:focal


### PR DESCRIPTION
Caching the `depends/sources` directory does not handle a source file update well, and it causes CI job failure.

See https://cirrus-ci.com/task/5975797421834240:
```
  CXXLD    qt/bitcoin-qt
  CXXLD    qt/test/test_bitcoin-qt
make[1]: Leaving directory '/tmp/cirrus-ci-build/src'
make -C .. bitcoin_qt_apk
make[1]: Entering directory '/tmp/cirrus-ci-build/src'
tar: ../depends/sources/qtbase-everywhere-src-5.12.11.tar.xz: Not found in archive
tar: Exiting with failure status due to previous errors
tar: ../depends/sources/qtbase-everywhere-src-5.12.11.tar.xz: Not found in archive
tar: Exiting with failure status due to previous errors
tar: ../depends/sources/qtbase-everywhere-src-5.12.11.tar.xz: Not found in archive
tar: Exiting with failure status due to previous errors
mkdir -p qt/android/libs/arm64-v8a
cp /tmp/cirrus-ci-build/depends/SDKs/android/ndk/21.1.6352462/toolchains/llvm/prebuilt/linux-x86_64/bin//../sysroot/usr/lib/aarch64-linux-android/libc++_shared.so qt/android/libs/arm64-v8a
tar xf ../depends/sources/qtbase-everywhere-src-5.12.10.tar.xz ../depends/sources/qtbase-everywhere-src-5.12.11.tar.xz -C qt/android/src/ src/android/jar/src --strip-components=5
tar: ../depends/sources/qtbase-everywhere-src-5.12.11.tar.xz: Not found in archive
tar: src/android/jar/src: Not found in archive
tar: Exiting with failure status due to previous errors
make[1]: *** [Makefile:17975: bitcoin_qt_apk] Error 2
make[1]: Leaving directory '/tmp/cirrus-ci-build/src'
make: *** [Makefile:11: apk] Error 2
```