### PR TITLE
build: Use Qt archive of the same version as the compiled binaries

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -382,7 +382,8 @@ bitcoin_qt_clean: FORCE
 bitcoin_qt : qt/bitcoin-qt$(EXEEXT)
 
 APK_LIB_DIR = qt/android/libs/$(ANDROID_ARCH)
-QT_BASE_PATH = $(shell find ../depends/sources/ -maxdepth 1 -type f -regex ".*qtbase.*\.tar.xz")
+QT_BASE_VERSION = $(lastword $(shell $(MOC) --version))
+QT_BASE_PATH = $(shell find ../depends/sources/ -maxdepth 1 -type f -regex ".*qtbase.*$(QT_BASE_VERSION)\.tar.xz")
 QT_BASE_TLD = $(shell tar tf $(QT_BASE_PATH) --exclude='*/*')
 
 bitcoin_qt_apk: FORCE


### PR DESCRIPTION
This PR fixes broken Android APK build when the `depends/sources` directory contains Qt source archives of different versions (e.g., Qt version update [pull request](https://github.com/bitcoin/bitcoin/pull/22054) in CI with the cached `depends/sources` directory).

This is an alternative to #22058.