### PR TITLE
Mark `CheckTxInputs` `[[nodiscard]]`. Avoid UUM in fuzzing harness `coins_view`.

### DIFF
--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -24,7 +24,7 @@ namespace Consensus {
  * @param[out] txfee Set to the transaction fee if successful.
  * Preconditions: tx.IsCoinBase() is false.
  */
-bool CheckTxInputs(const CTransaction& tx, TxValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmount& txfee);
+[[nodiscard]] bool CheckTxInputs(const CTransaction& tx, TxValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmount& txfee);
 } // namespace Consensus
 
 /** Auxiliary functions for transaction validation (ideally should not be exposed) */

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -236,8 +236,9 @@ FUZZ_TARGET_INIT(coins_view, initialize_coins_view)
                     // It is not allowed to call CheckTxInputs if CheckTransaction failed
                     return;
                 }
-                (void)Consensus::CheckTxInputs(transaction, state, coins_view_cache, fuzzed_data_provider.ConsumeIntegralInRange<int>(0, std::numeric_limits<int>::max()), tx_fee_out);
-                assert(MoneyRange(tx_fee_out));
+                if (Consensus::CheckTxInputs(transaction, state, coins_view_cache, fuzzed_data_provider.ConsumeIntegralInRange<int>(0, std::numeric_limits<int>::max()), tx_fee_out)) {
+                    assert(MoneyRange(tx_fee_out));
+                }
             },
             [&] {
                 const CTransaction transaction{random_mutable_transaction};


### PR DESCRIPTION
Mark `CheckTxInputs` `[[nodiscard]]` (out-param `txfee` only set if call is successful).

Avoid use of uninitialised memory (UUM) in fuzzing harness `coins_view`.