### PR TITLE
build: don't use cf-protection when targeting arm-apple-darwin

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -26,7 +26,7 @@ $(package)_config_libraries=filesystem,system,test
 $(package)_cxxflags=-std=c++17 -fvisibility=hidden
 $(package)_cxxflags_linux=-fPIC
 $(package)_cxxflags_android=-fPIC
-$(package)_cxxflags_darwin=-fcf-protection=full
+$(package)_cxxflags_x86_64_darwin=-fcf-protection=full
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
After two reports on IRC of issues building depends on an Apple M1 machine, this option (obviously) can't be used when targeting `arm-apple-darwin`.  For now, just use it for `x86_64-apple-darwin`.

```bash
Apple clang version 12.0.5 (clang-1205.0.22.9)
Target: x86_64-apple-darwin20.4.0

error: option 'cf-protection=return' cannot be specified on this target
error: option 'cf-protection=branch' cannot be specified on this target
2 errors generated.
```