### PR TITLE
doc: add maxuploadtarget to bitcoin.conf example

### DIFF
--- a/share/examples/bitcoin.conf
+++ b/share/examples/bitcoin.conf
@@ -71,6 +71,12 @@
 # configuration option or the addnode RPC, which have a separate limit of 8 connections.
 #maxconnections=
 
+# Maximum upload bandwidth target in MiB per day (e.g. 'maxuploadtarget=1024' is 1 GiB per day).
+# This limits the upload bandwidth for those with bandwidth limits. 0 = no limit (default: 0).
+# -maxuploadtarget does not apply to peers with 'download' permission.
+# For more information on reducing bandwidth utilization, see: doc/reduce-traffic.md.
+#maxuploadtarget=
+
 #
 # JSON-RPC options (for controlling a running Bitcoin/bitcoind process)
 #


### PR DESCRIPTION
picking up #21499, author has stated they [can't squash](https://github.com/bitcoin/bitcoin/pull/21499#issuecomment-849277632).

This adds the maxuploadtarget option to the `bitcoin.conf` example file. This is useful for those looking to configure their bandwidth utilization.

**Changes from Original PR:**
- squash commits
- fix typo in commit message + reword commit message to be more appropriate
- Implement review suggestions ([1](https://github.com/bitcoin/bitcoin/pull/21499#discussion_r615409982), [2](https://github.com/bitcoin/bitcoin/pull/21499#discussion_r615410337), [3](https://github.com/bitcoin/bitcoin/pull/21499#pullrequestreview-659357756))
- Fix spacing