### PR TITLE
test: remove BasicTestingSetup from unit tests that don't need it

### DIFF
--- a/src/test/allocator_tests.cpp
+++ b/src/test/allocator_tests.cpp
@@ -2,15 +2,18 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <support/lockedpool.h>
 #include <util/system.h>
 
-#include <test/util/setup_common.h>
-
+#include <limits>
 #include <memory>
+#include <stdexcept>
+#include <utility>
+#include <vector>
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(allocator_tests, BasicTestingSetup)
+BOOST_AUTO_TEST_SUITE(allocator_tests)
 
 BOOST_AUTO_TEST_CASE(arena_tests)
 {

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -4,11 +4,12 @@
 
 #include <amount.h>
 #include <policy/feerate.h>
-#include <test/util/setup_common.h>
+
+#include <limits>
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(amount_tests, BasicTestingSetup)
+BOOST_AUTO_TEST_SUITE(amount_tests)
 
 BOOST_AUTO_TEST_CASE(MoneyRangeTest)
 {

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -3,19 +3,19 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <arith_uint256.h>
-#include <test/util/setup_common.h>
 #include <uint256.h>
 
 #include <boost/test/unit_test.hpp>
 
 #include <cmath>
+#include <cstdint>
 #include <iomanip>
 #include <limits>
 #include <sstream>
-#include <stdint.h>
 #include <string>
+#include <vector>
 
-BOOST_FIXTURE_TEST_SUITE(arith_uint256_tests, BasicTestingSetup)
+BOOST_AUTO_TEST_SUITE(arith_uint256_tests)
 
 /// Convert vector to arith_uint256, via uint256 blob
 static inline arith_uint256 arith_uint256V(const std::vector<unsigned char>& vch)

--- a/src/test/base32_tests.cpp
+++ b/src/test/base32_tests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <test/util/setup_common.h>
 #include <util/strencodings.h>
 
 #include <boost/test/unit_test.hpp>
@@ -10,7 +9,7 @@
 
 using namespace std::literals;
 
-BOOST_FIXTURE_TEST_SUITE(base32_tests, BasicTestingSetup)
+BOOST_AUTO_TEST_SUITE(base32_tests)
 
 BOOST_AUTO_TEST_CASE(base32_testvectors)
 {

--- a/src/test/base64_tests.cpp
+++ b/src/test/base64_tests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <test/util/setup_common.h>
 #include <util/strencodings.h>
 
 #include <boost/test/unit_test.hpp>
@@ -10,7 +9,7 @@
 
 using namespace std::literals;
 
-BOOST_FIXTURE_TEST_SUITE(base64_tests, BasicTestingSetup)
+BOOST_AUTO_TEST_SUITE(base64_tests)
 
 BOOST_AUTO_TEST_CASE(base64_testvectors)
 {

--- a/src/test/bech32_tests.cpp
+++ b/src/test/bech32_tests.cpp
@@ -3,12 +3,13 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bech32.h>
-#include <test/util/setup_common.h>
 #include <test/util/str.h>
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(bech32_tests, BasicTestingSetup)
+#include <string>
+
+BOOST_AUTO_TEST_SUITE(bech32_tests)
 
 BOOST_AUTO_TEST_CASE(bech32_testvectors_valid)
 {

--- a/src/test/bswap_tests.cpp
+++ b/src/test/bswap_tests.cpp
@@ -3,11 +3,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <compat/byteswap.h>
-#include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(bswap_tests, BasicTestingSetup)
+BOOST_AUTO_TEST_SUITE(bswap_tests)
 
 BOOST_AUTO_TEST_CASE(bswap_tests)
 {

--- a/src/test/compilerbug_tests.cpp
+++ b/src/test/compilerbug_tests.cpp
@@ -3,9 +3,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <boost/test/unit_test.hpp>
-#include <test/util/setup_common.h>
 
-BOOST_FIXTURE_TEST_SUITE(compilerbug_tests, BasicTestingSetup)
+BOOST_AUTO_TEST_SUITE(compilerbug_tests)
 
 #if defined(__GNUC__)
 // This block will also be built under clang, which is fine (as it supports noinline)

--- a/src/test/hash_tests.cpp
+++ b/src/test/hash_tests.cpp
@@ -10,7 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(hash_tests, BasicTestingSetup)
+BOOST_AUTO_TEST_SUITE(hash_tests)
 
 BOOST_AUTO_TEST_CASE(murmurhash3)
 {

--- a/src/test/merkleblock_tests.cpp
+++ b/src/test/merkleblock_tests.cpp
@@ -8,8 +8,10 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <set>
+#include <vector>
 
-BOOST_FIXTURE_TEST_SUITE(merkleblock_tests, BasicTestingSetup)
+BOOST_AUTO_TEST_SUITE(merkleblock_tests)
 
 /**
  * Create a CMerkleBlock using a list of txids which will be found in the

--- a/src/test/policy_fee_tests.cpp
+++ b/src/test/policy_fee_tests.cpp
@@ -5,11 +5,11 @@
 #include <amount.h>
 #include <policy/fees.h>
 
-#include <test/util/setup_common.h>
-
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(policy_fee_tests, BasicTestingSetup)
+#include <set>
+
+BOOST_AUTO_TEST_SUITE(policy_fee_tests)
 
 BOOST_AUTO_TEST_CASE(FeeRounder)
 {

--- a/src/test/reverselock_tests.cpp
+++ b/src/test/reverselock_tests.cpp
@@ -7,7 +7,9 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(reverselock_tests, BasicTestingSetup)
+#include <stdexcept>
+
+BOOST_AUTO_TEST_SUITE(reverselock_tests)
 
 BOOST_AUTO_TEST_CASE(reverselock_basics)
 {

--- a/src/test/sync_tests.cpp
+++ b/src/test/sync_tests.cpp
@@ -8,6 +8,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <mutex>
+#include <stdexcept>
 
 namespace {
 template <typename MutexType>
@@ -76,7 +77,7 @@ void TestInconsistentLockOrderDetected(MutexType& mutex1, MutexType& mutex2) NO_
 }
 } // namespace
 
-BOOST_FIXTURE_TEST_SUITE(sync_tests, BasicTestingSetup)
+BOOST_AUTO_TEST_SUITE(sync_tests)
 
 BOOST_AUTO_TEST_CASE(potential_deadlock_detected)
 {

--- a/src/test/torcontrol_tests.cpp
+++ b/src/test/torcontrol_tests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 //
-#include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -15,7 +14,7 @@ std::pair<std::string, std::string> SplitTorReplyLine(const std::string& s);
 std::map<std::string, std::string> ParseTorReplyMapping(const std::string& s);
 
 
-BOOST_FIXTURE_TEST_SUITE(torcontrol_tests, BasicTestingSetup)
+BOOST_AUTO_TEST_SUITE(torcontrol_tests)
 
 static void CheckSplitTorReplyLine(std::string input, std::string command, std::string args)
 {

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -13,8 +13,9 @@
 #include <iomanip>
 #include <sstream>
 #include <string>
+#include <vector>
 
-BOOST_FIXTURE_TEST_SUITE(uint256_tests, BasicTestingSetup)
+BOOST_AUTO_TEST_SUITE(uint256_tests)
 
 const unsigned char R1Array[] =
     "\x9c\x52\x4a\xdb\xcf\x56\x11\x12\x2b\x29\x12\x5e\x5d\x35\xd2\xd2"

--- a/src/test/util_threadnames_tests.cpp
+++ b/src/test/util_threadnames_tests.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <test/util/setup_common.h>
 #include <util/string.h>
 #include <util/threadnames.h>
 
 #include <mutex>
 #include <set>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -17,7 +17,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(util_threadnames_tests, BasicTestingSetup)
+BOOST_AUTO_TEST_SUITE(util_threadnames_tests)
 
 const std::string TEST_THREAD_NAME_BASE = "test_thread.";
 


### PR DESCRIPTION
* Less setup/overhead for tests that don't need it. Some naive bench-marking would suggest that a full `test_bitcoin` run is a few % faster after this change.
* Tests which don't need the BasicTestingSetup can't accidentally end up depending on it somehow.
* Already the case in at least the scheduler and block_filter tests.

This adds missing includes, but more significant is the removal of `setup_common.h` from tests where it isn't needed. This saves recompiling those tests when changes are made in the header.