### PR TITLE
p2p: fix ubsan addrman errors, make nTime truncation conversion explicit

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -573,7 +573,7 @@ void CAddrMan::GetAddr_(std::vector<CAddress>& vAddr, size_t max_addresses, size
     }
 }
 
-void CAddrMan::Connected_(const CService& addr, int64_t nTime)
+void CAddrMan::Connected_(const CService& addr)
 {
     AssertLockHeld(cs);
 
@@ -590,9 +590,11 @@ void CAddrMan::Connected_(const CService& addr, int64_t nTime)
         return;
 
     // update info
-    int64_t nUpdateInterval = 20 * 60;
-    if (nTime - info.nTime > nUpdateInterval)
-        info.nTime = nTime;
+    const int64_t nUpdateInterval{20 * 60};
+    const int64_t now{GetAdjustedTime()};
+    if (now - info.nTime > nUpdateInterval) {
+        info.nTime = now;
+    }
 }
 
 void CAddrMan::SetServices_(const CService& addr, ServiceFlags nServices)

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -329,11 +329,12 @@ bool CAddrMan::Add_(const CAddress& addr, const CNetAddr& source, int64_t nTimeP
 
     if (pinfo) {
         // periodically update nTime
-        bool fCurrentlyOnline = (GetAdjustedTime() - addr.nTime < 24 * 60 * 60);
+        // TODO: change CAddress::nTime from uint32 to int64 before the Year 2106.
+        bool fCurrentlyOnline = (GetAdjustedTime() - static_cast<int64_t>(addr.nTime) < 24 * 60 * 60);
         int64_t nUpdateInterval = (fCurrentlyOnline ? 60 * 60 : 24 * 60 * 60);
-        if (addr.nTime && (!pinfo->nTime || pinfo->nTime < addr.nTime - nUpdateInterval - nTimePenalty))
-            pinfo->nTime = std::max((int64_t)0, addr.nTime - nTimePenalty);
-
+        if (addr.nTime && (!pinfo->nTime || pinfo->nTime < static_cast<int64_t>(addr.nTime) - nUpdateInterval - nTimePenalty)) {
+            pinfo->nTime = std::max<uint32_t>(0, static_cast<int64_t>(addr.nTime) - nTimePenalty);
+        }
         // add services
         pinfo->nServices = ServiceFlags(pinfo->nServices | addr.nServices);
 
@@ -357,7 +358,8 @@ bool CAddrMan::Add_(const CAddress& addr, const CNetAddr& source, int64_t nTimeP
             return false;
     } else {
         pinfo = Create(addr, source, &nId);
-        pinfo->nTime = std::max((int64_t)0, (int64_t)pinfo->nTime - nTimePenalty);
+        // TODO: change CAddress::nTime from uint32 to int64 before the Year 2106.
+        pinfo->nTime = std::max<uint32_t>(0, static_cast<int64_t>(pinfo->nTime) - nTimePenalty);
         nNew++;
         fNew = true;
     }

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -592,8 +592,9 @@ void CAddrMan::Connected_(const CService& addr)
     // update info
     const int64_t nUpdateInterval{20 * 60};
     const int64_t now{GetAdjustedTime()};
-    if (now - info.nTime > nUpdateInterval) {
-        info.nTime = now;
+    // TODO: change CAddress::nTime from uint32 to int64 before the Year 2106.
+    if (now - static_cast<int64_t>(info.nTime) > nUpdateInterval) {
+        info.nTime = static_cast<uint32_t>(now);
     }
 }
 

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -317,6 +317,12 @@ public:
 
         uint8_t compat;
         s >> compat;
+        if (compat < INCOMPATIBILITY_BASE) {
+            throw std::ios_base::failure(strprintf(
+                "Corrupt addrman database file header; its compatibility base is %u "
+                "but the minimum supported by this version of %s is %u.",
+                compat, PACKAGE_NAME, INCOMPATIBILITY_BASE));
+        }
         const uint8_t lowest_compatible = compat - INCOMPATIBILITY_BASE;
         if (lowest_compatible > FILE_FORMAT) {
             throw std::ios_base::failure(strprintf(

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -608,12 +608,12 @@ public:
     }
 
     //! Outer function for Connected_()
-    void Connected(const CService &addr, int64_t nTime = GetAdjustedTime())
+    void Connected(const CService &addr)
         EXCLUSIVE_LOCKS_REQUIRED(!cs)
     {
         LOCK(cs);
         Check();
-        Connected_(addr, nTime);
+        Connected_(addr);
         Check();
     }
 
@@ -763,9 +763,8 @@ private:
      *  not leak information about currently connected peers.
      *
      * @param[in]   addr     The address of the peer we were connected to
-     * @param[in]   nTime    The time that we were last connected to this peer
      */
-    void Connected_(const CService& addr, int64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void Connected_(const CService& addr) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     //! Update an entry's service bits.
     void SetServices_(const CService &addr, ServiceFlags nServices) EXCLUSIVE_LOCKS_REQUIRED(cs);

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -103,7 +103,7 @@ FUZZ_TARGET_INIT(addrman, initialize_addrman)
             [&] {
                 const std::optional<CService> opt_service = ConsumeDeserializable<CService>(fuzzed_data_provider);
                 if (opt_service) {
-                    addr_man.Connected(*opt_service, ConsumeTime(fuzzed_data_provider));
+                    addr_man.Connected(*opt_service);
                 }
             },
             [&] {

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -17,7 +17,6 @@ signed-integer-overflow:policy/feerate.cpp
 # list is used to suppress -fsanitize=integer warnings when running our CI UBSan
 # job.
 unsigned-integer-overflow:*/include/c++/
-unsigned-integer-overflow:addrman.cpp
 unsigned-integer-overflow:arith_uint256.h
 unsigned-integer-overflow:basic_string.h
 unsigned-integer-overflow:bench/bench.h
@@ -45,7 +44,6 @@ unsigned-integer-overflow:validation.cpp
 implicit-integer-sign-change:*/include/boost/
 implicit-integer-sign-change:*/include/c++/
 implicit-integer-sign-change:*/new_allocator.h
-implicit-integer-sign-change:addrman.h
 implicit-integer-sign-change:arith_uint256.cpp
 implicit-integer-sign-change:bech32.cpp
 implicit-integer-sign-change:bloom.cpp
@@ -80,8 +78,6 @@ implicit-integer-sign-change:validation.cpp
 implicit-integer-sign-change:zmq/zmqpublishnotifier.cpp
 implicit-signed-integer-truncation,implicit-integer-sign-change:chain.h
 implicit-signed-integer-truncation,implicit-integer-sign-change:test/skiplist_tests.cpp
-implicit-signed-integer-truncation:addrman.cpp
-implicit-signed-integer-truncation:addrman.h
 implicit-signed-integer-truncation:chain.h
 implicit-signed-integer-truncation:crypto/
 implicit-signed-integer-truncation:cuckoocache.h


### PR DESCRIPTION
This patch

1. drops an unused `nTime` param from `CAddrMan::Connected_()` and `CAddrMan::Connected()`

2. makes an `nTime` integer truncations explicit, as `CAddress::nTime` is declared in src/protocol.h as uint32 but int64 values can be written to it in `CAddrMan::Connected_()`. This also fixes the following non-suppressed UBSan error in `addrman.cpp`:

```bash
SUMMARY: UndefinedBehaviorSanitizer
addrman.cpp:535:22: runtime error: implicit conversion
  from type 'int64_t' (aka 'long') of value 68719478016 (64-bit, signed)
  to type 'uint32_t' (aka 'unsigned int') changed the value to 1280 (32-bit, unsigned)
```

(According to https://en.cppreference.com/w/cpp/language/implicit_conversion, if the destination type is unsigned, the resulting value is the smallest unsigned value equal to the source value modulo (2 exponent n), where n is the number of bits used to represent the destination type. So it seems this is defined behavior and the signed integer is being truncated correctly. However, using a named cast makes the truncation conversion explicit and reduces the warnings by the UBSan integer sanitizer.)

3. does the same for two similar UBSan errors in `CAddrMan::Add_()` that were suppressed

4. fixes the following UBSan error in `CAddrMan::Unserialize()` that was suppressed

```bash
SUMMARY: UndefinedBehaviorSanitizer
addrman.h:320:43: runtime error: implicit conversion
  from type 'int' of value -32 (32-bit, signed)
  to type 'const uint8_t' (aka 'const unsigned char')
  changed the value to 224 (8-bit, unsigned)
```

5. removes the four addrman UBSan suppressions

6. adds TODO documentation for updates needed by the Year 2106

To test
```
$ ./autogen.sh && ./configure --enable-fuzz --with-sanitizers=fuzzer,address,undefined,integer CC=clang CXX=clang++ && make clean && make
$ FUZZ=addrman src/test/fuzz/fuzz ../qa-assets/fuzz_seed_corpus/addrman
```
