### PR TITLE
[test, init] DNS seed querying logic 

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -435,7 +435,8 @@ public:
         assert(genesis.hashMerkleRoot == uint256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 
         vFixedSeeds.clear(); //!< Regtest mode doesn't have any fixed seeds.
-        vSeeds.clear();      //!< Regtest mode doesn't have any DNS seeds.
+        vSeeds.clear();
+        vSeeds.emplace_back("dummySeed.invalid.");
 
         fDefaultConsistencyChecks = true;
         fRequireStandard = true;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -431,7 +431,7 @@ void SetupServerArgs(NodeContext& node)
     argsman.AddArg("-dnsseed", strprintf("Query for peer addresses via DNS lookup, if low on addresses (default: %u unless -connect used)", DEFAULT_DNSSEED), ArgsManager::ALLOW_BOOL, OptionsCategory::CONNECTION);
     argsman.AddArg("-externalip=<ip>", "Specify your own public address", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-fixedseeds", strprintf("Allow fixed seeds if DNS seeds don't provide peers (default: %u)", DEFAULT_FIXEDSEEDS), ArgsManager::ALLOW_BOOL, OptionsCategory::CONNECTION);
-    argsman.AddArg("-forcednsseed", strprintf("Always query for peer addresses via DNS lookup (default: %u)", DEFAULT_FORCEDNSSEED), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-forcednsseed", strprintf("Always query for peer addresses via DNS lookup (default: %u)", DEFAULT_FORCEDNSSEED), ArgsManager::ALLOW_BOOL, OptionsCategory::CONNECTION);
     argsman.AddArg("-listen", "Accept connections from outside (default: 1 if no -proxy or -connect)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-listenonion", strprintf("Automatically create Tor onion service (default: %d)", DEFAULT_LISTEN_ONION), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-maxconnections=<n>", strprintf("Maintain at most <n> connections to peers (default: %u). This limit does not apply to connections manually added via -addnode or the addnode RPC, which have a separate limit of %u.", DEFAULT_MAX_PEER_CONNECTIONS, MAX_ADDNODE_CONNECTIONS), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -853,6 +853,11 @@ bool AppInitParameterInteraction(const ArgsManager& args)
             return InitError(_("Prune mode is incompatible with -coinstatsindex."));
     }
 
+    // If -forcednsseed is set to true, ensure -dnsseed has not been set to false
+    if (args.GetBoolArg("-forcednsseed", DEFAULT_FORCEDNSSEED) && !args.GetBoolArg("-dnsseed", DEFAULT_DNSSEED)){
+        return InitError(_("Cannot set -forcednsseed to true when setting -dnsseed to false."));
+    }
+
     // -bind and -whitebind can't be set when not listening
     size_t nUserBind = args.GetArgs("-bind").size() + args.GetArgs("-whitebind").size();
     if (nUserBind != 0 && !args.GetBoolArg("-listen", DEFAULT_LISTEN)) {

--- a/src/net.h
+++ b/src/net.h
@@ -79,9 +79,9 @@ static const int64_t DEFAULT_PEER_CONNECT_TIMEOUT = 60;
 /** Number of file descriptors required for message capture **/
 static const int NUM_FDS_MESSAGE_CAPTURE = 1;
 
-static const bool DEFAULT_FORCEDNSSEED = false;
-static const bool DEFAULT_DNSSEED = true;
-static const bool DEFAULT_FIXEDSEEDS = true;
+static constexpr bool DEFAULT_FORCEDNSSEED{false};
+static constexpr bool DEFAULT_DNSSEED{true};
+static constexpr bool DEFAULT_FIXEDSEEDS{true};
 static const size_t DEFAULT_MAXRECEIVEBUFFER = 5 * 1000;
 static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;
 

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -158,8 +158,9 @@ class ConfArgsTest(BitcoinTestFramework):
         self.stop_node(0)
 
         # No peers.dat exists and -dnsseed=1
-        # We expect the node will use DNS Seeds, but Regtest mode has 0 DNS seeds
-        # So after 60 seconds, the node should fallback to fixed seeds (this is a slow test)
+        # We expect the node will use DNS Seeds, but Regtest mode does not have
+        # any valid DNS seeds. So after 60 seconds, the node should fallback to
+        # fixed seeds
         assert not os.path.exists(os.path.join(default_data_dir, "peers.dat"))
         start = int(time.time())
         with self.nodes[0].assert_debug_log(expected_msgs=[

--- a/test/functional/p2p_dns_seeds.py
+++ b/test/functional/p2p_dns_seeds.py
@@ -18,6 +18,7 @@ class P2PDNSSeeds(BitcoinTestFramework):
         self.init_arg_tests()
         self.existing_outbound_connections_test()
         self.existing_block_relay_connections_test()
+        self.force_dns_test()
 
     def init_arg_tests(self):
         fakeaddr = "fakenodeaddr.fakedomain.invalid."
@@ -59,6 +60,17 @@ class P2PDNSSeeds(BitcoinTestFramework):
             # we still want to query the DNS seeds.
             for i in range(2):
                 self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=i, connection_type="block-relay-only")
+
+    def force_dns_test(self):
+        self.log.info("Check that we query DNS seeds if -forcednsseed param is set")
+
+        with self.nodes[0].assert_debug_log(expected_msgs=["Loading addresses from DNS seed"], timeout=12):
+            # -dnsseed defaults to 1 in bitcoind, but 0 in the test framework,
+            # so pass it explicitly here
+            self.restart_node(0, ["-forcednsseed", "-dnsseed=1"])
+
+        # Restore default for subsequent tests
+        self.restart_node(0)
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_dns_seeds.py
+++ b/test/functional/p2p_dns_seeds.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test ThreadDNSAddressSeed logic for querying DNS seeds."""
+
+from test_framework.p2p import P2PInterface
+from test_framework.test_framework import BitcoinTestFramework
+
+
+class P2PDNSSeeds(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [["-dnsseed=1"]]
+
+    def run_test(self):
+        self.existing_outbound_connections_test()
+
+    def existing_outbound_connections_test(self):
+        # Make sure addrman is populated to enter the conditional where we
+        # delay and potentially skip DNS seeding.
+        self.nodes[0].addpeeraddress("192.0.0.8", 8333)
+
+        self.log.info("Check that we *do not* query DNS seeds if we have 2 outbound connections")
+
+        self.restart_node(0)
+        with self.nodes[0].assert_debug_log(expected_msgs=["P2P peers available. Skipped DNS seeding."], timeout=12):
+            for i in range(2):
+                self.nodes[0].add_outbound_p2p_connection(P2PInterface(), p2p_idx=i, connection_type="outbound-full-relay")
+
+
+if __name__ == '__main__':
+    P2PDNSSeeds().main()

--- a/test/functional/p2p_dns_seeds.py
+++ b/test/functional/p2p_dns_seeds.py
@@ -32,6 +32,24 @@ class P2PDNSSeeds(BitcoinTestFramework):
         with self.nodes[0].assert_debug_log(expected_msgs=["Loading addresses from DNS seed"], timeout=12):
             self.restart_node(0, [f"-connect={fakeaddr}", "-dnsseed=1"])
 
+        self.log.info("Check that running -forcednsseed and -dnsseed=0 throws an error.")
+        self.nodes[0].stop_node()
+        self.nodes[0].assert_start_raises_init_error(
+            expected_msg="Error: Cannot set -forcednsseed to true when setting -dnsseed to false.",
+            extra_args=["-forcednsseed=1", "-dnsseed=0"],
+        )
+
+        self.log.info("Check that running -forcednsseed and -connect throws an error.")
+        # -connect soft sets -dnsseed to false, so throws the same error
+        self.nodes[0].stop_node()
+        self.nodes[0].assert_start_raises_init_error(
+            expected_msg="Error: Cannot set -forcednsseed to true when setting -dnsseed to false.",
+            extra_args=["-forcednsseed=1", f"-connect={fakeaddr}"],
+        )
+
+        # Restore default bitcoind settings
+        self.restart_node(0)
+
     def existing_outbound_connections_test(self):
         # Make sure addrman is populated to enter the conditional where we
         # delay and potentially skip DNS seeding.

--- a/test/functional/p2p_dns_seeds.py
+++ b/test/functional/p2p_dns_seeds.py
@@ -15,8 +15,21 @@ class P2PDNSSeeds(BitcoinTestFramework):
         self.extra_args = [["-dnsseed=1"]]
 
     def run_test(self):
+        self.init_arg_tests()
         self.existing_outbound_connections_test()
         self.existing_block_relay_connections_test()
+
+    def init_arg_tests(self):
+        fakeaddr = "fakenodeaddr.fakedomain.invalid."
+
+        self.log.info("Check that setting -connect disables -dnsseed by default")
+        self.nodes[0].stop_node()
+        with self.nodes[0].assert_debug_log(expected_msgs=["DNS seeding disabled"]):
+            self.start_node(0, [f"-connect={fakeaddr}"])
+
+        self.log.info("Check that running -connect and -dnsseed means DNS logic runs.")
+        with self.nodes[0].assert_debug_log(expected_msgs=["Loading addresses from DNS seed"], timeout=12):
+            self.restart_node(0, [f"-connect={fakeaddr}", "-dnsseed=1"])
 
     def existing_outbound_connections_test(self):
         # Make sure addrman is populated to enter the conditional where we

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -121,6 +121,7 @@ BASE_SCRIPTS = [
     'wallet_listreceivedby.py --legacy-wallet',
     'wallet_listreceivedby.py --descriptors',
     'wallet_abandonconflict.py --legacy-wallet',
+    'p2p_dns_seeds.py',
     'wallet_abandonconflict.py --descriptors',
     'feature_csv_activation.py',
     'rpc_rawtransaction.py --legacy-wallet',


### PR DESCRIPTION
This PR adds a DNS seed to the regtest chain params to enable testing the DNS seed querying logic of `CConnman::ThreadDNSAddressSeed` and relevant startup parameters. Adds coverage for the changes in #22013 (and then some).

The main behavioral change to bitcoind is that this PR disallows starting up with conflicting parameters for `-dnsseed` and `-forcednsseed`. 

The tests include:
* parameter interactions of different combinations of `-connect`, `-dnsseed` and `-forcednsseed`
* the delay before querying DNS seeds depending on how many addresses are in the addrman 
* the behavior of `-forcednsseed` 
* skipping DNS querying if we have outbound full relay connections & not block-relay-only connections 

Huge props to mzumsande for identifying the timing technique for testing successful connections before running `ThreadDNSAddressSeed` 🙌🏽