### PR TITLE
doc: add link to bitcoin whitepaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ with no central authority: managing transactions and issuing money are carried
 out collectively by the network. Bitcoin Core is the name of open source
 software which enables the use of this currency.
 
-For more information read the original Bitcoin whitepaper.
+For more information read the original Bitcoin [whitepaper](https://bitcoin.org/bitcoin.pdf).
 
 License
 -------


### PR DESCRIPTION
This change adds a direct link to the Bitcoin whitepaper in the README.