### PR TITLE
test: Fix IPv6 check on BSD systems

### DIFF
--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -151,7 +151,7 @@ def test_ipv6_local():
     have_ipv6 = True
     try:
         s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-        s.connect(('::1', 0))
+        s.connect(('::1', 1))
     except socket.error:
         have_ipv6 = False
     return have_ipv6


### PR DESCRIPTION
I noticed that `test_ipv6_local()` always returns `False` on macOS or FreeBSD, even though IPv6 is working perfectly fine. This causes `test/functional/rpc_bind.py --ipv6` and `test/functional/feature_proxy.py` to skip their run.
Apparently, there's a check if the port number is `0` (see [here](https://github.com/freebsd/freebsd-src/blob/64881da478071431a2d9e62613997a5772c56cdf/sys/netinet6/udp6_usrreq.c#L248) or [here](https://github.com/apple/darwin-xnu/blob/8f02f2a044b9bb1ad951987ef5bab20ec9486310/bsd/netinet6/udp6_usrreq.c#L282)), while Linux has no problem with this.
This is fixed by specifying any other port number than `0`, e.g. `1`. Still, because of `SOCK_DGRAM`, no actual connection is made.