### PR TITLE
test: minor cleanups in feature_cltv.py

### DIFF
--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -111,17 +111,17 @@ class BIP65Test(BitcoinTestFramework):
         self.log.info("Test that invalid-according-to-CLTV transactions can still appear in a block")
 
         # create one invalid tx per CLTV failure reason (5 in total) and collect them
-        invalid_ctlv_txs = []
+        invalid_cltv_txs = []
         for i in range(5):
             spendtx = wallet.create_self_transfer(from_node=self.nodes[0])['tx']
             spendtx = cltv_invalidate(self.nodes[0], spendtx, i)
-            invalid_ctlv_txs.append(spendtx)
+            invalid_cltv_txs.append(spendtx)
 
         tip = self.nodes[0].getbestblockhash()
         block_time = self.nodes[0].getblockheader(tip)['mediantime'] + 1
         block = create_block(int(tip, 16), create_coinbase(CLTV_HEIGHT - 1), block_time)
         block.nVersion = 3
-        block.vtx.extend(invalid_ctlv_txs)
+        block.vtx.extend(invalid_cltv_txs)
         block.hashMerkleRoot = block.calc_merkle_root()
         block.solve()
 

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -45,7 +45,6 @@ def cltv_modify_tx(tx, prepend_scriptsig, nsequence=None, nlocktime=None):
 
     tx.vin[0].scriptSig = CScript(prepend_scriptsig + list(CScript(tx.vin[0].scriptSig)))
     tx.rehash()
-    return tx
 
 
 def cltv_invalidate(tx, failure_reason):
@@ -69,14 +68,14 @@ def cltv_invalidate(tx, failure_reason):
         [[CScriptNum(500),  OP_CHECKLOCKTIMEVERIFY, OP_DROP], 0xffffffff, 500],
     ][failure_reason]
 
-    return cltv_modify_tx(tx, prepend_scriptsig=scheme[0], nsequence=scheme[1], nlocktime=scheme[2])
+    cltv_modify_tx(tx, prepend_scriptsig=scheme[0], nsequence=scheme[1], nlocktime=scheme[2])
 
 
 def cltv_validate(tx, height):
     # Modify the signature in vin 0 and nSequence/nLockTime of the tx to pass CLTV
     scheme = [[CScriptNum(height), OP_CHECKLOCKTIMEVERIFY, OP_DROP], 0, height]
 
-    return cltv_modify_tx(tx, prepend_scriptsig=scheme[0], nsequence=scheme[1], nlocktime=scheme[2])
+    cltv_modify_tx(tx, prepend_scriptsig=scheme[0], nsequence=scheme[1], nlocktime=scheme[2])
 
 
 class BIP65Test(BitcoinTestFramework):
@@ -114,7 +113,7 @@ class BIP65Test(BitcoinTestFramework):
         invalid_cltv_txs = []
         for i in range(5):
             spendtx = wallet.create_self_transfer(from_node=self.nodes[0])['tx']
-            spendtx = cltv_invalidate(spendtx, i)
+            cltv_invalidate(spendtx, i)
             invalid_cltv_txs.append(spendtx)
 
         tip = self.nodes[0].getbestblockhash()
@@ -149,7 +148,7 @@ class BIP65Test(BitcoinTestFramework):
         # create and test one invalid tx per CLTV failure reason (5 in total)
         for i in range(5):
             spendtx = wallet.create_self_transfer(from_node=self.nodes[0])['tx']
-            spendtx = cltv_invalidate(spendtx, i)
+            cltv_invalidate(spendtx, i)
 
             expected_cltv_reject_reason = [
                 "non-mandatory-script-verify-flag (Operation not valid with the current stack size)",
@@ -182,7 +181,7 @@ class BIP65Test(BitcoinTestFramework):
                 peer.sync_with_ping()
 
         self.log.info("Test that a version 4 block with a valid-according-to-CLTV transaction is accepted")
-        spendtx = cltv_validate(spendtx, CLTV_HEIGHT - 1)
+        cltv_validate(spendtx, CLTV_HEIGHT - 1)
 
         block.vtx.pop(1)
         block.vtx.append(spendtx)


### PR DESCRIPTION
This tiny PR cleans up the test `feature_cltv.py` in the following ways:
* fixes a typo (s/ctlv/cltv/); compared to CHECKLOCKTIMEVERIFY, CHECKTIMELOCKVERIFY probably also sounds good and you [even get some search results for it](https://www.google.com/search?q=%22CHECKTIMELOCKVERIFY%22), but it's still wrong ;)
* drops the unused "node" parameters from the tx modification functions
* don't return a copy from the tx modification functions; it's modified in-place, hence a copy is not needed and `cltv_validate(tx, ...)` looks more natural than `tx = cltv_validate(tx, ...)`