### PR TITLE
doc: fix GitHub links

### DIFF
--- a/doc/release-notes/release-notes-0.8.6.md
+++ b/doc/release-notes/release-notes-0.8.6.md
@@ -63,4 +63,4 @@ Warning
   Hence it is recommended to use a 64-bit executable if possible.
   A 64-bit executable for Windows is planned for 0.9.
 
-Note: Gavin Andresen's GPG signing key for SHA256SUMS.asc has been changed from  key id 1FC730C1 to sub key 7BF6E212 (see https://github.com/bitcoin/bitcoin.org/pull/279).
+Note: Gavin Andresen's GPG signing key for SHA256SUMS.asc has been changed from  key id 1FC730C1 to sub key 7BF6E212 (see https://github.com/bitcoin-dot-org/Bitcoin.org/pull/279).

--- a/src/bench/nanobench.h
+++ b/src/bench/nanobench.h
@@ -1889,7 +1889,7 @@ void gatherStabilityInformation(std::vector<std::string>& warnings, std::vector<
         recommendations.emplace_back("Make sure you compile for Release");
     }
     if (recommendPyPerf) {
-        recommendations.emplace_back("Use 'pyperf system tune' before benchmarking. See https://github.com/vstinner/pyperf");
+        recommendations.emplace_back("Use 'pyperf system tune' before benchmarking. See https://github.com/psf/pyperf");
     }
 }
 

--- a/src/crc32c/.ycm_extra_conf.py
+++ b/src/crc32c/.ycm_extra_conf.py
@@ -4,10 +4,10 @@
 """YouCompleteMe configuration that interprets a .clang_complete file.
 
 This module implementes the YouCompleteMe configuration API documented at:
-https://github.com/Valloric/ycmd#ycm_extra_confpy-specification
+https://github.com/ycm-core/ycmd#ycm_extra_confpy-specification
 
 The implementation loads and processes a .clang_complete file, documented at:
-https://github.com/Rip-Rip/clang_complete/blob/master/README.md
+https://github.com/xavierd/clang_complete/blob/master/README.md
 """
 
 import os

--- a/src/crc32c/README.md
+++ b/src/crc32c/README.md
@@ -65,7 +65,7 @@ apm install autocomplete-clang build build-cmake clang-format language-cmake \
 
 If you don't mind more setup in return for more speed, replace
 `autocomplete-clang` and `linter-clang` with `you-complete-me`. This requires
-[setting up ycmd](https://github.com/Valloric/ycmd#building).
+[setting up ycmd](https://github.com/ycm-core/ycmd#building).
 
 ```bash
 apm install autocomplete-plus build build-cmake clang-format language-cmake \

--- a/src/univalue/configure.ac
+++ b/src/univalue/configure.ac
@@ -15,7 +15,7 @@ m4_define([libunivalue_version], [libunivalue_major_version().libunivalue_minor_
 
 
 AC_INIT([univalue], [1.0.3],
-        [http://github.com/jgarzik/univalue/])
+        [https://github.com/jgarzik/univalue/])
 
 dnl make the compilation flags quiet unless V=1 is used
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])


### PR DESCRIPTION
All of these links now redirect to a new GitHub user.

While the links still work, the fact that they rely on a 301 redirection means that it's possible that some of these repos could be [hijacked](https://blog.securityinnovation.com/repo-jacking-exploiting-the-dependency-supply-chain) by someone in the future.