### PR TITLE
depends: Fix qt.mk for mac arm64

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -126,7 +126,7 @@ $(package)_config_opts_darwin += -device-option XCODE_VERSION=$(XCODE_VERSION)
 endif
 
 # for macOS on Apple Silicon (ARM) see https://bugreports.qt.io/browse/QTBUG-85279
-$(package)_config_opts_arm_darwin += -device-option QMAKE_APPLE_DEVICE_ARCHS=arm64
+$(package)_config_opts_aarch64_darwin += -device-option QMAKE_APPLE_DEVICE_ARCHS=arm64
 
 $(package)_config_opts_linux = -qt-xcb
 $(package)_config_opts_linux += -no-xcb-xlib


### PR DESCRIPTION
With f16d4cd8c5412890ee0b73f4ef142b59d130e5d5 `depends/config.guess` gives `aarch64-apple-darwin20.3.0` where before would give `arm-apple-darwin20.3.0`. Fix `qt.mk` accordingly.