### PR TITLE
build: Disable make builtin rules.

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -28,6 +28,21 @@ print-%: FORCE
 # this means that sub-makes will be invoked as if:
 #   $(MAKE) A=1 blah blah
 MAKEOVERRIDES := $(filter V=%,$(MAKEOVERRIDES))
+
+# Disable builtin rules and suffixes.
+# Construct mflags to ensure -r is not passed down to children. Some packages
+# use builtin rules.
+# Long options which have no short form (--trace, ---warn-undefined-variables)
+# are present in MAKEFLAGS with both dashes. Filter them out here, to avoid
+# benign duplication when these options are added again when mflags is
+# constructed.
+# After expansion in the recipe mflags will contain all user specified options
+# and command line variable definitions, but it won't contain the change
+# introduced here.
+oldmflags := $(filter-out -%,$(MAKEFLAGS))
+MAKEFLAGS += -r
+mflags = MAKEFLAGS="$(oldmflags) $(filter -%,$(MAKEFLAGS)) $(MAKEOVERRIDES)"
+
 SOURCES_PATH ?= $(BASEDIR)/sources
 WORK_PATH = $(BASEDIR)/work
 BASE_CACHE ?= $(BASEDIR)/built

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -209,17 +209,17 @@ $($(1)_configured): | $($(1)_dependencies) $($(1)_preprocessed)
 	echo Configuring $(1)...
 	rm -rf $(host_prefix); mkdir -p $(host_prefix)/lib; cd $(host_prefix); $(foreach package,$($(1)_all_dependencies), tar --no-same-owner -xf $($(package)_cached); )
 	mkdir -p $$(@D)
-	+cd $$(@D); $($(1)_config_env) $(call $(1)_config_cmds, $(1))
+	+cd $$(@D); $$(mflags) $($(1)_config_env) $(call $(1)_config_cmds, $(1))
 	touch $$@
 $($(1)_built): | $($(1)_configured)
 	echo Building $(1)...
 	mkdir -p $$(@D)
-	+cd $$(@D); $($(1)_build_env) $(call $(1)_build_cmds, $(1))
+	+cd $$(@D); $$(mflags) $($(1)_build_env) $(call $(1)_build_cmds, $(1))
 	touch $$@
 $($(1)_staged): | $($(1)_built)
 	echo Staging $(1)...
 	mkdir -p $($(1)_staging_dir)/$(host_prefix)
-	cd $($(1)_build_dir); $($(1)_stage_env) $(call $(1)_stage_cmds, $(1))
+	cd $($(1)_build_dir); $$(mflags) $($(1)_stage_env) $(call $(1)_stage_cmds, $(1))
 	rm -rf $($(1)_extract_dir)
 	touch $$@
 $($(1)_postprocessed): | $($(1)_staged)


### PR DESCRIPTION
Disable make builtin rules.

When there is no rule to build a target in the makefile, make looks
for a builtin rule.
When -r is specified make no longer performs this lookup.

E.g. the following in an excerpt from make -d output.
Here, make looks for a rule to build 'all'.

Considering target file 'all'.
 File 'all' does not exist.
 Looking for an implicit rule for 'all'.
 Trying pattern rule with stem 'all'.
 Trying implicit prerequisite 'all.o'.
 Trying pattern rule with stem 'all'.
 Trying implicit prerequisite 'all.c'.
 Trying pattern rule with stem 'all'.
 Trying implicit prerequisite 'all.cc'.
 Trying pattern rule with stem 'all'.
 Trying implicit prerequisite 'all.C'.
 Trying pattern rule with stem 'all'.
 Trying implicit prerequisite 'all.cpp'.
 Trying pattern rule with stem 'all'.
 Trying implicit prerequisite 'all.p'.
 Trying pattern rule with stem 'all'.
 Trying implicit prerequisite 'all.f'.
...
Many more lines like this are omitted.

Because this build system does not use make builtin rules or suffixes,
there is no benefit in having builtin rules enabled.

There are 2 benefits in having builtin rules disabled.

1. Improves performance by eliminating redundant lookups.
2. Simplifies troubleshooting by reducing the output of make -d or
make -p.