### PR TITLE
test: refactor: dedup utility function chain_transaction()

### DIFF
--- a/test/functional/mempool_package_onemore.py
+++ b/test/functional/mempool_package_onemore.py
@@ -11,7 +11,11 @@ from decimal import Decimal
 
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_raises_rpc_error, satoshi_round
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+    chain_transaction,
+)
 
 MAX_ANCESTORS = 25
 MAX_DESCENDANTS = 25
@@ -23,23 +27,6 @@ class MempoolPackagesTest(BitcoinTestFramework):
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
-
-    # Build a transaction that spends parent_txid:vout
-    # Return amount sent
-    def chain_transaction(self, node, parent_txids, vouts, value, fee, num_outputs):
-        send_value = satoshi_round((value - fee)/num_outputs)
-        inputs = []
-        for (txid, vout) in zip(parent_txids, vouts):
-            inputs.append({'txid' : txid, 'vout' : vout})
-        outputs = {}
-        for _ in range(num_outputs):
-            outputs[node.getnewaddress()] = send_value
-        rawtx = node.createrawtransaction(inputs, outputs, 0, True)
-        signedtx = node.signrawtransactionwithwallet(rawtx)
-        txid = node.sendrawtransaction(signedtx['hex'])
-        fulltx = node.getrawtransaction(txid, 1)
-        assert len(fulltx['vout']) == num_outputs  # make sure we didn't generate a change output
-        return (txid, send_value)
 
     def run_test(self):
         # Mine some blocks and have them mature.
@@ -53,32 +40,32 @@ class MempoolPackagesTest(BitcoinTestFramework):
         # MAX_ANCESTORS transactions off a confirmed tx should be fine
         chain = []
         for _ in range(4):
-            (txid, sent_value) = self.chain_transaction(self.nodes[0], [txid], [vout], value, fee, 2)
+            (txid, sent_value) = chain_transaction(self.nodes[0], [txid], [vout], value, fee, 2)
             vout = 0
             value = sent_value
             chain.append([txid, value])
         for _ in range(MAX_ANCESTORS - 4):
-            (txid, sent_value) = self.chain_transaction(self.nodes[0], [txid], [0], value, fee, 1)
+            (txid, sent_value) = chain_transaction(self.nodes[0], [txid], [0], value, fee, 1)
             value = sent_value
             chain.append([txid, value])
-        (second_chain, second_chain_value) = self.chain_transaction(self.nodes[0], [utxo[1]['txid']], [utxo[1]['vout']], utxo[1]['amount'], fee, 1)
+        (second_chain, second_chain_value) = chain_transaction(self.nodes[0], [utxo[1]['txid']], [utxo[1]['vout']], utxo[1]['amount'], fee, 1)
 
         # Check mempool has MAX_ANCESTORS + 1 transactions in it
         assert_equal(len(self.nodes[0].getrawmempool(True)), MAX_ANCESTORS + 1)
 
         # Adding one more transaction on to the chain should fail.
-        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many unconfirmed ancestors [limit: 25]", self.chain_transaction, self.nodes[0], [txid], [0], value, fee, 1)
+        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many unconfirmed ancestors [limit: 25]", chain_transaction, self.nodes[0], [txid], [0], value, fee, 1)
         # ...even if it chains on from some point in the middle of the chain.
-        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many descendants", self.chain_transaction, self.nodes[0], [chain[2][0]], [1], chain[2][1], fee, 1)
-        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many descendants", self.chain_transaction, self.nodes[0], [chain[1][0]], [1], chain[1][1], fee, 1)
+        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many descendants", chain_transaction, self.nodes[0], [chain[2][0]], [1], chain[2][1], fee, 1)
+        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many descendants", chain_transaction, self.nodes[0], [chain[1][0]], [1], chain[1][1], fee, 1)
         # ...even if it chains on to two parent transactions with one in the chain.
-        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many descendants", self.chain_transaction, self.nodes[0], [chain[0][0], second_chain], [1, 0], chain[0][1] + second_chain_value, fee, 1)
+        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many descendants", chain_transaction, self.nodes[0], [chain[0][0], second_chain], [1, 0], chain[0][1] + second_chain_value, fee, 1)
         # ...especially if its > 40k weight
-        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many descendants", self.chain_transaction, self.nodes[0], [chain[0][0]], [1], chain[0][1], fee, 350)
+        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many descendants", chain_transaction, self.nodes[0], [chain[0][0]], [1], chain[0][1], fee, 350)
         # But not if it chains directly off the first transaction
-        (replacable_txid, replacable_orig_value) = self.chain_transaction(self.nodes[0], [chain[0][0]], [1], chain[0][1], fee, 1)
+        (replacable_txid, replacable_orig_value) = chain_transaction(self.nodes[0], [chain[0][0]], [1], chain[0][1], fee, 1)
         # and the second chain should work just fine
-        self.chain_transaction(self.nodes[0], [second_chain], [0], second_chain_value, fee, 1)
+        chain_transaction(self.nodes[0], [second_chain], [0], second_chain_value, fee, 1)
 
         # Make sure we can RBF the chain which used our carve-out rule
         second_tx_outputs = {self.nodes[0].getrawtransaction(replacable_txid, True)["vout"][0]['scriptPubKey']['address']: replacable_orig_value - (Decimal(1) / Decimal(100))}

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -13,6 +13,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
+    chain_transaction,
     satoshi_round,
 )
 
@@ -42,21 +43,6 @@ class MempoolPackagesTest(BitcoinTestFramework):
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
 
-    # Build a transaction that spends parent_txid:vout
-    # Return amount sent
-    def chain_transaction(self, node, parent_txid, vout, value, fee, num_outputs):
-        send_value = satoshi_round((value - fee)/num_outputs)
-        inputs = [ {'txid' : parent_txid, 'vout' : vout} ]
-        outputs = {}
-        for _ in range(num_outputs):
-            outputs[node.getnewaddress()] = send_value
-        rawtx = node.createrawtransaction(inputs, outputs)
-        signedtx = node.signrawtransactionwithwallet(rawtx)
-        txid = node.sendrawtransaction(signedtx['hex'])
-        fulltx = node.getrawtransaction(txid, 1)
-        assert len(fulltx['vout']) == num_outputs  # make sure we didn't generate a change output
-        return (txid, send_value)
-
     def run_test(self):
         # Mine some blocks and have them mature.
         peer_inv_store = self.nodes[0].add_p2p_connection(P2PTxInvStore()) # keep track of invs
@@ -71,7 +57,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         chain = []
         witness_chain = []
         for _ in range(MAX_ANCESTORS):
-            (txid, sent_value) = self.chain_transaction(self.nodes[0], txid, 0, value, fee, 1)
+            (txid, sent_value) = chain_transaction(self.nodes[0], [txid], [0], value, fee, 1)
             value = sent_value
             chain.append(txid)
             # We need the wtxids to check P2P announcements
@@ -189,7 +175,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
             assert_equal(mempool[x]['descendantfees'], descendant_fees * COIN + 1000)
 
         # Adding one more transaction on to the chain should fail.
-        assert_raises_rpc_error(-26, "too-long-mempool-chain", self.chain_transaction, self.nodes[0], txid, vout, value, fee, 1)
+        assert_raises_rpc_error(-26, "too-long-mempool-chain", chain_transaction, self.nodes[0], [txid], [vout], value, fee, 1)
 
         # Check that prioritising a tx before it's added to the mempool works
         # First clear the mempool by mining a block.
@@ -238,7 +224,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         transaction_package = []
         tx_children = []
         # First create one parent tx with 10 children
-        (txid, sent_value) = self.chain_transaction(self.nodes[0], txid, vout, value, fee, 10)
+        (txid, sent_value) = chain_transaction(self.nodes[0], [txid], [vout], value, fee, 10)
         parent_transaction = txid
         for i in range(10):
             transaction_package.append({'txid': txid, 'vout': i, 'amount': sent_value})
@@ -247,7 +233,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         chain = [] # save sent txs for the purpose of checking node1's mempool later (see below)
         for _ in range(MAX_DESCENDANTS - 1):
             utxo = transaction_package.pop(0)
-            (txid, sent_value) = self.chain_transaction(self.nodes[0], utxo['txid'], utxo['vout'], utxo['amount'], fee, 10)
+            (txid, sent_value) = chain_transaction(self.nodes[0], [utxo['txid']], [utxo['vout']], utxo['amount'], fee, 10)
             chain.append(txid)
             if utxo['txid'] is parent_transaction:
                 tx_children.append(txid)
@@ -263,7 +249,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
 
         # Sending one more chained transaction will fail
         utxo = transaction_package.pop(0)
-        assert_raises_rpc_error(-26, "too-long-mempool-chain", self.chain_transaction, self.nodes[0], utxo['txid'], utxo['vout'], utxo['amount'], fee, 10)
+        assert_raises_rpc_error(-26, "too-long-mempool-chain", chain_transaction, self.nodes[0], [utxo['txid']], [utxo['vout']], utxo['amount'], fee, 10)
 
         # Check that node1's mempool is as expected, containing:
         # - txs from previous ancestor test (-> custom ancestor limit)
@@ -321,13 +307,13 @@ class MempoolPackagesTest(BitcoinTestFramework):
         value = send_value
 
         # Create tx1
-        tx1_id, _ = self.chain_transaction(self.nodes[0], tx0_id, 0, value, fee, 1)
+        tx1_id, _ = chain_transaction(self.nodes[0], [tx0_id], [0], value, fee, 1)
 
         # Create tx2-7
         vout = 1
         txid = tx0_id
         for _ in range(6):
-            (txid, sent_value) = self.chain_transaction(self.nodes[0], txid, vout, value, fee, 1)
+            (txid, sent_value) = chain_transaction(self.nodes[0], [txid], [vout], value, fee, 1)
             vout = 0
             value = sent_value
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -481,9 +481,13 @@ def create_confirmed_utxos(fee, node, count):
     return utxos
 
 
-# Build a transaction that spends parent_txid:vout
-# Return amount sent
 def chain_transaction(node, parent_txids, vouts, value, fee, num_outputs):
+    """Build and send a transaction that spends the given inputs (specified
+    by lists of parent_txid:vout each), with the desired total value and fee,
+    equally divided up to the desired number of outputs.
+
+    Returns a tuple with the txid and the amount sent per output.
+    """
     send_value = satoshi_round((value - fee)/num_outputs)
     inputs = []
     for (txid, vout) in zip(parent_txids, vouts):


### PR DESCRIPTION
Both tests `mempool_packages.py` and `mempool_package_onemore.py` define a utility function `chain_transaction` with a similar implementation. This PR deduplicates it by moving it into the util package and keeping the more general properties:
* pass a list of parent_txids/vouts instead of single values
* always mark the BIP125-replaceable flag for txs, created via `createrawtransaction` (this is needed by the `mempool_package_onemore.py` test, but doesn't hurt the other one)

This is a low-hanging fruit; as a potential follow-up one could probably also deduplicate the function `chain_transaction` in `rpc_packages.py`, which looks a bit different, as it also takes the parent locking script into account and doesn't send the tx.