### PR TITLE
CRegTestParams: Use `args` instead of `gArgs`.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -423,7 +423,7 @@ public:
         pchMessageStart[2] = 0xb5;
         pchMessageStart[3] = 0xda;
         nDefaultPort = 18444;
-        nPruneAfterHeight = gArgs.GetBoolArg("-fastprune", false) ? 100 : 1000;
+        nPruneAfterHeight = args.GetBoolArg("-fastprune", false) ? 100 : 1000;
         m_assumed_blockchain_size = 0;
         m_assumed_chain_state_size = 0;
 


### PR DESCRIPTION
This PR is a very minor follow-up to #13311.

I believe that `gArgs` was just overlooked at the modified line.