### PR TITLE
Add --disable-rpc configure option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -114,6 +114,12 @@ AM_CONDITIONAL([HAVE_DOXYGEN], [test -n "$DOXYGEN"])
 
 AC_ARG_VAR(PYTHONPATH, Augments the default search path for python module files)
 
+AC_ARG_ENABLE([rpc],
+  [AS_HELP_STRING([--disable-rpc],
+  [disable rpc (enabled by default)])],
+  [enable_rpc=$enableval],
+  [enable_rpc=yes])
+
 AC_ARG_ENABLE([wallet],
   [AS_HELP_STRING([--disable-wallet],
   [disable wallet (enabled by default)])],
@@ -1777,6 +1783,7 @@ AM_CONDITIONAL([TARGET_DARWIN], [test x$TARGET_OS = xdarwin])
 AM_CONDITIONAL([BUILD_DARWIN], [test x$BUILD_OS = xdarwin])
 AM_CONDITIONAL([TARGET_LINUX], [test x$TARGET_OS = xlinux])
 AM_CONDITIONAL([TARGET_WINDOWS], [test x$TARGET_OS = xwindows])
+AM_CONDITIONAL([ENABLE_RPC],[test x$enable_rpc = xyes])
 AM_CONDITIONAL([ENABLE_WALLET],[test x$enable_wallet = xyes])
 AM_CONDITIONAL([USE_SQLITE], [test "x$use_sqlite" = "xyes"])
 AM_CONDITIONAL([USE_BDB], [test "x$use_bdb" = "xyes"])
@@ -1933,6 +1940,7 @@ echo "Options used to compile and link:"
 echo "  external signer = $use_external_signer"
 echo "  multiprocess    = $build_multiprocess"
 echo "  with libs       = $build_bitcoin_libs"
+echo "  with rpc        = $enable_rpc"
 echo "  with wallet     = $enable_wallet"
 if test "x$enable_wallet" != "xno"; then
     echo "    with sqlite   = $use_sqlite"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -355,12 +355,6 @@ libbitcoin_server_a_SOURCES = \
   policy/settings.cpp \
   pow.cpp \
   rest.cpp \
-  rpc/blockchain.cpp \
-  rpc/mining.cpp \
-  rpc/misc.cpp \
-  rpc/net.cpp \
-  rpc/rawtransaction.cpp \
-  rpc/server.cpp \
   script/sigcache.cpp \
   shutdown.cpp \
   signet.cpp \
@@ -374,6 +368,16 @@ libbitcoin_server_a_SOURCES = \
   validationinterface.cpp \
   versionbits.cpp \
   $(BITCOIN_CORE_H)
+
+if ENABLE_RPC
+libbitcoin_server_a_SOURCES += \
+	rpc/blockchain.cpp \
+	rpc/mining.cpp \
+	rpc/misc.cpp \
+	rpc/net.cpp \
+	rpc/rawtransaction.cpp \
+	rpc/server.cpp
+endif
 
 if ENABLE_WALLET
 libbitcoin_server_a_SOURCES += wallet/init.cpp
@@ -389,8 +393,10 @@ libbitcoin_zmq_a_SOURCES = \
   zmq/zmqabstractnotifier.cpp \
   zmq/zmqnotificationinterface.cpp \
   zmq/zmqpublishnotifier.cpp \
-  zmq/zmqrpc.cpp \
   zmq/zmqutil.cpp
+if ENABLE_RPC
+libbitcoin_zmq_a_SOURCES += zmq/zmqrpc.cpp
+endif
 endif
 
 
@@ -410,8 +416,6 @@ libbitcoin_wallet_a_SOURCES = \
   wallet/interfaces.cpp \
   wallet/load.cpp \
   wallet/receive.cpp \
-  wallet/rpcdump.cpp \
-  wallet/rpcwallet.cpp \
   wallet/scriptpubkeyman.cpp \
   wallet/spend.cpp \
   wallet/transaction.cpp \
@@ -420,6 +424,12 @@ libbitcoin_wallet_a_SOURCES = \
   wallet/walletutil.cpp \
   wallet/coinselection.cpp \
   $(BITCOIN_CORE_H)
+
+if ENABLE_RPC
+libbitcoin_wallet_a_SOURCES += \
+	wallet/rpcdump.cpp \
+	wallet/rpcwallet.cpp
+endif
 
 if USE_SQLITE
 libbitcoin_wallet_a_SOURCES += wallet/sqlite.cpp


### PR DESCRIPTION
Seeking feedback before going further.

The goal is to have a build without RPC support just by passing `--disable-rpc`. An alternative would be `--disable-http` if we want to also disable REST and RPC in one shot. 

Follow ups would be:
 - add `--disable-rest`.
 - add `--without-libevent` configure option that would allow `auto` value for `--disable-rpc` and `--disable-rest`.