### PR TITLE
script: fix spelling linter raising spuriously on "invokable"

### DIFF
--- a/test/lint/lint-spelling.ignore-words.txt
+++ b/test/lint/lint-spelling.ignore-words.txt
@@ -6,6 +6,7 @@ fpr
 hights
 hist
 inout
+invokable
 mor
 nin
 ser


### PR DESCRIPTION
"invokable" is a valid word that means to be callable, but the linter is raising on it:
```
$ test/lint/lint-spelling.sh 
contrib/guix/guix-attest:18: invokable ==> invocable
contrib/guix/guix-clean:18: invokable ==> invocable
contrib/guix/guix-verify:18: invokable ==> invocable
^ Warning: codespell identified likely spelling errors. Any false positives? Add them to the list of ignored words in test/lint/lint-spelling.ignore-words.txt
```
