### PR TITLE
test: add type annotations to util.get_rpc_proxy

### DIFF
--- a/test/functional/test_framework/coverage.py
+++ b/test/functional/test_framework/coverage.py
@@ -10,6 +10,7 @@ testing.
 
 import os
 
+from .authproxy import AuthServiceProxy
 
 REFERENCE_FILENAME = 'rpc_interface.txt'
 
@@ -19,16 +20,17 @@ class AuthServiceProxyWrapper():
     An object that wraps AuthServiceProxy to record specific RPC calls.
 
     """
-    def __init__(self, auth_service_proxy_instance, coverage_logfile=None):
+    def __init__(self, auth_service_proxy_instance: AuthServiceProxy, rpc_url: str, coverage_logfile: str=None):
         """
         Kwargs:
-            auth_service_proxy_instance (AuthServiceProxy): the instance
-                being wrapped.
-            coverage_logfile (str): if specified, write each service_name
+            auth_service_proxy_instance: the instance being wrapped.
+            rpc_url: url of the RPC instance being wrapped
+            coverage_logfile: if specified, write each service_name
                 out to a file when called.
 
         """
         self.auth_service_proxy_instance = auth_service_proxy_instance
+        self.rpc_url = rpc_url
         self.coverage_logfile = coverage_logfile
 
     def __getattr__(self, name):
@@ -36,7 +38,7 @@ class AuthServiceProxyWrapper():
         if not isinstance(return_val, type(self.auth_service_proxy_instance)):
             # If proxy getattr returned an unwrapped value, do the same here.
             return return_val
-        return AuthServiceProxyWrapper(return_val, self.coverage_logfile)
+        return AuthServiceProxyWrapper(return_val, self.rpc_url, self.coverage_logfile)
 
     def __call__(self, *args, **kwargs):
         """
@@ -57,6 +59,7 @@ class AuthServiceProxyWrapper():
 
     def __truediv__(self, relative_uri):
         return AuthServiceProxyWrapper(self.auth_service_proxy_instance / relative_uri,
+                                       self.rpc_url,
                                        self.coverage_logfile)
 
     def get_request(self, *args, **kwargs):
@@ -74,18 +77,18 @@ def get_filename(dirname, n_node):
         dirname, "coverage.pid%s.node%s.txt" % (pid, str(n_node)))
 
 
-def write_all_rpc_commands(dirname, node):
+def write_all_rpc_commands(dirname: str, node: AuthServiceProxy) -> bool:
     """
     Write out a list of all RPC functions available in `bitcoin-cli` for
     coverage comparison. This will only happen once per coverage
     directory.
 
     Args:
-        dirname (str): temporary test dir
-        node (AuthServiceProxy): client
+        dirname: temporary test dir
+        node: client
 
     Returns:
-        bool. if the RPC interface file was written.
+        if the RPC interface file was written.
 
     """
     filename = os.path.join(dirname, REFERENCE_FILENAME)

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -258,7 +258,7 @@ class TestNode():
                     return
                 self.rpc = rpc
                 self.rpc_connected = True
-                self.url = self.rpc.url
+                self.url = self.rpc.rpc_url
                 return
             except JSONRPCException as e:  # Initialization phase
                 # -28 RPC in warmup

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -286,15 +286,15 @@ class PortSeed:
     n = None
 
 
-def get_rpc_proxy(url, node_number, *, timeout=None, coveragedir=None):
+def get_rpc_proxy(url: str, node_number: int, *, timeout: int=None, coveragedir: str=None) -> coverage.AuthServiceProxyWrapper:
     """
     Args:
-        url (str): URL of the RPC server to call
-        node_number (int): the node number (or id) that this calls to
+        url: URL of the RPC server to call
+        node_number: the node number (or id) that this calls to
 
     Kwargs:
-        timeout (int): HTTP timeout in seconds
-        coveragedir (str): Directory
+        timeout: HTTP timeout in seconds
+        coveragedir: Directory
 
     Returns:
         AuthServiceProxy. convenience object for making RPC calls.
@@ -305,11 +305,10 @@ def get_rpc_proxy(url, node_number, *, timeout=None, coveragedir=None):
         proxy_kwargs['timeout'] = int(timeout)
 
     proxy = AuthServiceProxy(url, **proxy_kwargs)
-    proxy.url = url  # store URL on proxy for info
 
     coverage_logfile = coverage.get_filename(coveragedir, node_number) if coveragedir else None
 
-    return coverage.AuthServiceProxyWrapper(proxy, coverage_logfile)
+    return coverage.AuthServiceProxyWrapper(proxy, url, coverage_logfile)
 
 
 def p2p_port(n):


### PR DESCRIPTION
Split out from #22092 while we address the functional test failure.