### PR TITLE
Randomize message processing peer order

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2173,6 +2173,7 @@ void CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
 
 void CConnman::ThreadMessageHandler()
 {
+    FastRandomContext rng;
     while (!flagInterruptMsgProc)
     {
         std::vector<CNode*> vNodesCopy;
@@ -2185,6 +2186,11 @@ void CConnman::ThreadMessageHandler()
         }
 
         bool fMoreWork = false;
+
+        // Randomize the order in which we process messages from/to our peers.
+        // This prevents attacks in which an attacker exploits having multiple
+        // consecutive connections in the vNodes list.
+        Shuffle(vNodesCopy.begin(), vNodesCopy.end(), rng);
 
         for (CNode* pnode : vNodesCopy)
         {


### PR DESCRIPTION
Right now, the message handling loop iterates the list of nodes always in the same order: the order they were connected in (see the `vNodes` vector). For some parts of the net processing logic, this order matters. Transaction requests are assigned explicitly to peers since #19988, but many other parts of processing work on a "first-served-by-loop-first" basis, such as block downloading. If peers can predict this ordering, it may be exploited to cause delays.

As there isn't anything particularly optimal about the current ordering, just make it unpredictable by randomizing.

Reported by Crypt-iQ.




