### PR TITLE
test: Remove unused node from feature_nulldummy

### DIFF
--- a/test/functional/feature_nulldummy.py
+++ b/test/functional/feature_nulldummy.py
@@ -28,6 +28,7 @@ from test_framework.util import assert_equal, assert_raises_rpc_error
 
 NULLDUMMY_ERROR = "non-mandatory-script-verify-flag (Dummy CHECKMULTISIG argument must be zero)"
 
+
 def trueDummy(tx):
     scriptSig = CScript(tx.vin[0].scriptSig)
     newscript = []
@@ -40,18 +41,17 @@ def trueDummy(tx):
     tx.vin[0].scriptSig = CScript(newscript)
     tx.rehash()
 
-class NULLDUMMYTest(BitcoinTestFramework):
 
+class NULLDUMMYTest(BitcoinTestFramework):
     def set_test_params(self):
-        # Need two nodes so GBT (getblocktemplate) doesn't complain that it's not connected.
-        self.num_nodes = 2
+        self.num_nodes = 1
         self.setup_clean_chain = True
         # This script tests NULLDUMMY activation, which is part of the 'segwit' deployment, so we go through
         # normal segwit activation here (and don't use the default always-on behaviour).
         self.extra_args = [[
             f'-segwitheight={COINBASE_MATURITY + 5}',
             '-addresstype=legacy',
-        ]] * 2
+        ]]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()


### PR DESCRIPTION
This is confusing and might even slow down the test.

This reverts a change that was added a year ago in d438d60 and then the need for it was removed by 95d5d5e six months ago.