### PR TITLE
test: Fix p2p_leak.py intermittent failure

### DIFF
--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -29,6 +29,8 @@ from test_framework.util import (
     assert_greater_than_or_equal,
 )
 
+PEER_TIMEOUT = 3
+
 
 class LazyPeer(P2PInterface):
     def __init__(self):
@@ -98,7 +100,7 @@ class P2PVersionStore(P2PInterface):
 class P2PLeakTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.extra_args = [['-peertimeout=4']]
+        self.extra_args = [[f"-peertimeout={PEER_TIMEOUT}"]]
 
     def create_old_version(self, nversion):
         old_version_msg = msg_version()
@@ -134,7 +136,7 @@ class P2PLeakTest(BitcoinTestFramework):
         self.nodes[0].generate(nblocks=1)
 
         # Give the node enough time to possibly leak out a message
-        time.sleep(5)
+        time.sleep(PEER_TIMEOUT + 2)
 
         # Make sure only expected messages came in
         assert not no_version_idle_peer.unexpected_msg


### PR DESCRIPTION
Fixes #22085 

Root cause: There was just 1 second between the wait (5 seconds) and the `-peertimeout=4`.
Since `ShouldRunInactivityChecks` in `net.cpp` measures the timeout in seconds, its result can only change once per second, even though it is called more often.
So in situations when the connection is established early in a given second like [here](https://bitcoinbuilds.org/index.php?ansilog=d7b3e075-683a-45cc-94d4-9645fc17e0b6.log#l3117) (2021-05-27T12:28:04.**001**913Z ), the 1 second leeway was not be sufficient, leading to the intermittent failures.

Fix this by lowering the timeout by one second.