### PR TITLE
[wip] rng: adds support for x86 rdrand/rdseed instructions when building using MSVC

### DIFF
--- a/src/compat/cpuid.h
+++ b/src/compat/cpuid.h
@@ -21,4 +21,20 @@ void static inline GetCPUID(uint32_t leaf, uint32_t subleaf, uint32_t& a, uint32
 }
 
 #endif // defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
+
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
+#define HAVE_GETCPUID
+
+#include <intrin.h>
+void static inline GetCPUID(uint32_t leaf, uint32_t subleaf, uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d)
+{
+  int regs[4];
+  __cpuidex(regs, leaf, subleaf);
+  a = regs[0];
+  b = regs[1];
+  c = regs[2];
+  d = regs[3];
+}
+
+#endif  // defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
 #endif // BITCOIN_COMPAT_CPUID_H

--- a/src/test/hwrand_tests.cpp
+++ b/src/test/hwrand_tests.cpp
@@ -1,0 +1,86 @@
+// Copyright (c) 2011-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+#include <test/util/setup_common.h>
+#include <boost/test/unit_test.hpp>
+
+#include <random.cpp>
+
+using namespace std;
+
+BOOST_FIXTURE_TEST_SUITE(hwrand_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(rdx86seedhwslow_test)
+{
+    const size_t DIGEST_LEN = 512/8; // 512 bits = 64 bytes
+
+    unsigned char emptyoutput[DIGEST_LEN];
+    memset(emptyoutput, 0, DIGEST_LEN);
+    CSHA512 emptyhasher;
+    emptyhasher.Finalize(emptyoutput);
+
+    for (int i = 0; i < 5; i++)
+    {
+        CSHA512 hasher;
+        unsigned char output[DIGEST_LEN];
+        memset(output, 0, DIGEST_LEN);
+
+        SeedHardwareSlow(hasher);
+        hasher.Finalize(output);
+
+        #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__) || (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64)))
+            bool isNotEqual = (memcmp(output, emptyoutput, DIGEST_LEN) != 0);
+            if (g_rdseed_supported)
+            {
+                BOOST_CHECK(isNotEqual);
+            }
+            else
+            {
+                BOOST_CHECK(!isNotEqual);
+            }
+        #else
+            // RDRand not supported on this platform so the hasher should have no data written to it
+            bool isEqual = (memcmp(output, emptyoutput, DIGEST_LEN) == 0);
+            BOOST_CHECK(isEqual);
+        #endif
+    }
+}
+
+BOOST_AUTO_TEST_CASE(rdx86seedhwfast_test)
+{
+    const size_t DIGEST_LEN = 512/8; // 512 bits = 64 bytes
+
+    unsigned char emptyoutput[DIGEST_LEN];
+    memset(emptyoutput, 0, DIGEST_LEN);
+    CSHA512 emptyhasher;
+    emptyhasher.Finalize(emptyoutput);
+
+    for (int i = 0; i < 5; i++)
+    {
+        CSHA512 hasher;
+        unsigned char output[DIGEST_LEN];
+        memset(output, 0, DIGEST_LEN);
+
+        SeedHardwareFast(hasher);
+        hasher.Finalize(output);
+
+        #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__) || (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64)))
+            bool isNotEqual = (memcmp(output, emptyoutput, DIGEST_LEN) != 0);
+            if (g_rdrand_supported)
+            {
+                BOOST_CHECK(isNotEqual);
+            }
+            else
+            {
+                BOOST_CHECK(!isNotEqual);
+            }
+        #else
+            // RDRand not supported on this platform so the hasher should have no data written to it
+            bool isEqual = (memcmp(output, emptyoutput, DIGEST_LEN) == 0);
+            BOOST_CHECK(isEqual);
+        #endif
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The bitcoin-core RNG uses the x86 RDSeed and RDRand instructions as an additional source of entropy. However RDSeed and RDRand are not used as an additional source of entropy even if the CPU supports them *if* the bitcoind binary was built using the the Microsoft C++ compiler, MSVC. This results from the fact that: 

1. The bitcoin-core code base uses the GCC macros such as `__x86_64__` to detect the CPU architecture. Thus on platforms that do not support the GCC macros the compiler will make the incorrect assumption that the underlying system does not support RDRand and RDSeed.
2. The bitcoin-core code base uses the GCC keyword `__asm__` for inline assembly. This keyword is not supported for MSVC.

This PR adds support for RDRand/RDSeed to bitcoind when built with MSVC by adding MSVC supported macros to correctly determine the target architecture and by adding MSVC supported keywords for the HDSeed and HDRand x86 instructions. This PR includes hwrand_tests to validate this behavior.