### PR TITLE
build: Add --with-append-cxxflags option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -212,6 +212,11 @@ AC_ARG_ENABLE([reduce-exports],
   [use_reduce_exports=$enableval],
   [use_reduce_exports=no])
 
+AC_ARG_WITH([append-cxxflags],
+  [AS_HELP_STRING([--with-append-cxxflags],
+  [append given cxxflags without checking them (default is empty string)])],
+  [append_cxxflags=$withval])
+
 AC_ARG_ENABLE([ccache],
   [AS_HELP_STRING([--disable-ccache],
   [do not use ccache for building (default is to use if found)])],
@@ -1427,6 +1432,8 @@ if test x$use_reduce_exports = xyes; then
   [AC_MSG_ERROR([Cannot set hidden symbol visibility. Use --disable-reduce-exports.])],[[$CXXFLAG_WERROR]])
   AX_CHECK_LINK_FLAG([[-Wl,--exclude-libs,ALL]],[RELDFLAGS="-Wl,--exclude-libs,ALL"],,[[$LDFLAG_WERROR]])
 fi
+
+CXXFLAGS="$CXXFLAGS $append_cxxflags"
 
 if test x$use_tests = xyes; then
 


### PR DESCRIPTION
This can be useful for testing. For example https://github.com/bitcoin/bitcoin/issues/22064#issuecomment-855199561 could use `--with-append-cxxflags="-ftrivial-auto-var-init=pattern"` without having to specify the default arguments again (-g -O2).