### PR TITLE
refactor: Remove char serialize

### DIFF
--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -17,7 +17,7 @@
 static void DeserializeBlockTest(benchmark::Bench& bench)
 {
     CDataStream stream(benchmark::data::block413567, SER_NETWORK, PROTOCOL_VERSION);
-    char a = '\0';
+    uint8_t a{'\0'};
     stream.write(&a, 1); // Prevent compaction
 
     bench.unit("block").run([&] {
@@ -31,7 +31,7 @@ static void DeserializeBlockTest(benchmark::Bench& bench)
 static void DeserializeAndCheckBlockTest(benchmark::Bench& bench)
 {
     CDataStream stream(benchmark::data::block413567, SER_NETWORK, PROTOCOL_VERSION);
-    char a = '\0';
+    uint8_t a{'\0'};
     stream.write(&a, 1); // Prevent compaction
 
     ArgsManager bench_args;

--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -23,7 +23,7 @@ struct TestBlockAndIndex {
     TestBlockAndIndex()
     {
         CDataStream stream(benchmark::data::block413567, SER_NETWORK, PROTOCOL_VERSION);
-        char a = '\0';
+        uint8_t a{'\0'};
         stream.write(&a, 1); // Prevent compaction
 
         stream >> block;

--- a/src/hash.h
+++ b/src/hash.h
@@ -111,8 +111,9 @@ public:
     int GetType() const { return nType; }
     int GetVersion() const { return nVersion; }
 
-    void write(const char *pch, size_t size) {
-        ctx.Write((const unsigned char*)pch, size);
+    void write(const uint8_t* pch, size_t size)
+    {
+        ctx.Write(pch, size);
     }
 
     /** Compute the double-SHA256 hash of all data written to this object.
@@ -162,7 +163,7 @@ private:
 public:
     explicit CHashVerifier(Source* source_) : CHashWriter(source_->GetType(), source_->GetVersion()), source(source_) {}
 
-    void read(char* pch, size_t nSize)
+    void read(uint8_t* pch, size_t nSize)
     {
         source->read(pch, nSize);
         this->write(pch, nSize);
@@ -170,7 +171,7 @@ public:
 
     void ignore(size_t nSize)
     {
-        char data[1024];
+        uint8_t data[1024];
         while (nSize > 0) {
             size_t now = std::min<size_t>(nSize, 1024);
             read(data, now);

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -158,7 +158,7 @@ bool CoinStatsIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
                     continue;
                 }
 
-                m_muhash.Insert(MakeUCharSpan(TxOutSer(outpoint, coin)));
+                m_muhash.Insert(TxOutSer(outpoint, coin));
 
                 if (tx->IsCoinBase()) {
                     m_total_coinbase_amount += coin.out.nValue;
@@ -179,7 +179,7 @@ bool CoinStatsIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
                     Coin coin{tx_undo.vprevout[j]};
                     COutPoint outpoint{tx->vin[j].prevout.hash, tx->vin[j].prevout.n};
 
-                    m_muhash.Remove(MakeUCharSpan(TxOutSer(outpoint, coin)));
+                    m_muhash.Remove(TxOutSer(outpoint, coin));
 
                     m_total_prevout_spent_amount += coin.out.nValue;
 
@@ -421,7 +421,7 @@ bool CoinStatsIndex::ReverseBlock(const CBlock& block, const CBlockIndex* pindex
                 continue;
             }
 
-            m_muhash.Remove(MakeUCharSpan(TxOutSer(outpoint, coin)));
+            m_muhash.Remove(TxOutSer(outpoint, coin));
 
             if (tx->IsCoinBase()) {
                 m_total_coinbase_amount -= coin.out.nValue;
@@ -442,7 +442,7 @@ bool CoinStatsIndex::ReverseBlock(const CBlock& block, const CBlockIndex* pindex
                 Coin coin{tx_undo.vprevout[j]};
                 COutPoint outpoint{tx->vin[j].prevout.hash, tx->vin[j].prevout.n};
 
-                m_muhash.Insert(MakeUCharSpan(TxOutSer(outpoint, coin)));
+                m_muhash.Insert(TxOutSer(outpoint, coin));
 
                 m_total_prevout_spent_amount -= coin.out.nValue;
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3097,11 +3097,11 @@ void CaptureMessage(const CAddress& addr, const std::string& msg_type, const Spa
     CAutoFile f(fsbridge::fopen(path, "ab"), SER_DISK, CLIENT_VERSION);
 
     ser_writedata64(f, now.count());
-    f.write(msg_type.data(), msg_type.length());
+    f.write(Uint8Ptr(msg_type.data()), msg_type.length());
     for (auto i = msg_type.length(); i < CMessageHeader::COMMAND_SIZE; ++i) {
         f << uint8_t{'\0'};
     }
     uint32_t size = data.size();
     ser_writedata32(f, size);
-    f.write((const char*)data.data(), data.size());
+    f.write(data.data(), data.size());
 }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4108,7 +4108,7 @@ bool PeerManagerImpl::ProcessMessages(CNode* pfrom, std::atomic<bool>& interrupt
     );
 
     if (gArgs.GetBoolArg("-capturemessages", false)) {
-        CaptureMessage(pfrom->addr, msg.m_command, MakeUCharSpan(msg.m_recv), /* incoming */ true);
+        CaptureMessage(pfrom->addr, msg.m_command, msg.m_recv, /* incoming */ true);
     }
 
     msg.SetVersion(pfrom->GetCommonVersion());

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -435,7 +435,7 @@ bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, c
         }
 
         block.resize(blk_size); // Zeroing of memory is intentional here
-        filein.read((char*)block.data(), blk_size);
+        filein.read(block.data(), blk_size);
     } catch (const std::exception& e) {
         return error("%s: Read from block file failed: %s for %s", __func__, e.what(), pos.ToString());
     }

--- a/src/node/coinstats.cpp
+++ b/src/node/coinstats.cpp
@@ -72,7 +72,7 @@ static void ApplyHash(MuHash3072& muhash, const uint256& hash, const std::map<ui
     for (auto it = outputs.begin(); it != outputs.end(); ++it) {
         COutPoint outpoint = COutPoint(hash, it->first);
         Coin coin = it->second;
-        muhash.Insert(MakeUCharSpan(TxOutSer(outpoint, coin)));
+        muhash.Insert(TxOutSer(outpoint, coin));
     }
 }
 

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -136,20 +136,20 @@ public:
     {
         unsigned int len = size();
         ::WriteCompactSize(s, len);
-        s.write((char*)vch, len);
+        s.write(vch, len);
     }
     template <typename Stream>
     void Unserialize(Stream& s)
     {
         unsigned int len = ::ReadCompactSize(s);
         if (len <= SIZE) {
-            s.read((char*)vch, len);
+            s.read(vch, len);
             if (len != size()) {
                 Invalidate();
             }
         } else {
             // invalid pubkey, skip available data
-            char dummy;
+            uint8_t dummy;
             while (len--)
                 s.read(&dummy, 1);
             Invalidate();

--- a/src/script/bitcoinconsensus.cpp
+++ b/src/script/bitcoinconsensus.cpp
@@ -22,7 +22,7 @@ public:
     m_remaining(txToLen)
     {}
 
-    void read(char* pch, size_t nSize)
+    void read(uint8_t* pch, size_t nSize)
     {
         if (nSize > m_remaining)
             throw std::ios_base::failure(std::string(__func__) + ": end of data");

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1303,12 +1303,12 @@ public:
         it = itBegin;
         while (scriptCode.GetOp(it, opcode)) {
             if (opcode == OP_CODESEPARATOR) {
-                s.write((char*)&itBegin[0], it-itBegin-1);
+                s.write(&itBegin[0], it - itBegin - 1);
                 itBegin = it;
             }
         }
         if (itBegin != scriptCode.end())
-            s.write((char*)&itBegin[0], it-itBegin);
+            s.write(&itBegin[0], it - itBegin);
     }
 
     /** Serialize an input of txTo */

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -23,6 +23,7 @@
 
 #include <prevector.h>
 #include <span.h>
+#include <util/types.h>
 
 /**
  * The maximum size of a serialized object in bytes or number of elements
@@ -47,11 +48,9 @@ static const unsigned int MAX_VECTOR_ALLOCATE = 5000000;
 struct deserialize_type {};
 constexpr deserialize_type deserialize {};
 
-//! Safely convert odd char pointer types to standard ones.
-inline char* CharCast(char* c) { return c; }
-inline char* CharCast(unsigned char* c) { return (char*)c; }
-inline const char* CharCast(const char* c) { return c; }
-inline const char* CharCast(const unsigned char* c) { return (const char*)c; }
+//! Safely convert a data pointer to a uint8_t data pointer.
+inline uint8_t* Uint8Ptr(void* data) { return reinterpret_cast<uint8_t*>(data); }
+inline const uint8_t* Uint8Ptr(const void* data) { return reinterpret_cast<const uint8_t*>(data); }
 
 /*
  * Lowest-level serialization and conversion.
@@ -59,67 +58,67 @@ inline const char* CharCast(const unsigned char* c) { return (const char*)c; }
  */
 template<typename Stream> inline void ser_writedata8(Stream &s, uint8_t obj)
 {
-    s.write((char*)&obj, 1);
+    s.write(Uint8Ptr(&obj), 1);
 }
 template<typename Stream> inline void ser_writedata16(Stream &s, uint16_t obj)
 {
     obj = htole16(obj);
-    s.write((char*)&obj, 2);
+    s.write(Uint8Ptr(&obj), 2);
 }
 template<typename Stream> inline void ser_writedata16be(Stream &s, uint16_t obj)
 {
     obj = htobe16(obj);
-    s.write((char*)&obj, 2);
+    s.write(Uint8Ptr(&obj), 2);
 }
 template<typename Stream> inline void ser_writedata32(Stream &s, uint32_t obj)
 {
     obj = htole32(obj);
-    s.write((char*)&obj, 4);
+    s.write(Uint8Ptr(&obj), 4);
 }
 template<typename Stream> inline void ser_writedata32be(Stream &s, uint32_t obj)
 {
     obj = htobe32(obj);
-    s.write((char*)&obj, 4);
+    s.write(Uint8Ptr(&obj), 4);
 }
 template<typename Stream> inline void ser_writedata64(Stream &s, uint64_t obj)
 {
     obj = htole64(obj);
-    s.write((char*)&obj, 8);
+    s.write(Uint8Ptr(&obj), 8);
 }
 template<typename Stream> inline uint8_t ser_readdata8(Stream &s)
 {
     uint8_t obj;
-    s.read((char*)&obj, 1);
+    s.read(Uint8Ptr(&obj), 1);
     return obj;
 }
 template<typename Stream> inline uint16_t ser_readdata16(Stream &s)
 {
     uint16_t obj;
-    s.read((char*)&obj, 2);
+    s.read(Uint8Ptr(&obj), 2);
     return le16toh(obj);
 }
 template<typename Stream> inline uint16_t ser_readdata16be(Stream &s)
 {
     uint16_t obj;
-    s.read((char*)&obj, 2);
+    s.read(Uint8Ptr(&obj), 2);
     return be16toh(obj);
 }
 template<typename Stream> inline uint32_t ser_readdata32(Stream &s)
 {
     uint32_t obj;
-    s.read((char*)&obj, 4);
+    s.read(Uint8Ptr(&obj), 4);
     return le32toh(obj);
 }
 template<typename Stream> inline uint32_t ser_readdata32be(Stream &s)
 {
     uint32_t obj;
-    s.read((char*)&obj, 4);
+    s.read(Uint8Ptr(&obj), 4);
     return be32toh(obj);
 }
 template<typename Stream> inline uint64_t ser_readdata64(Stream &s)
 {
     uint64_t obj;
-    s.read((char*)&obj, 8);
+    s.read(Uint8Ptr(&obj), 8);
     return le64toh(obj);
 }
 
@@ -127,7 +126,7 @@ template<typename Stream> inline uint64_t ser_readdata64(Stream &s)
 /////////////////////////////////////////////////////////////////
 //
 // Templates for serializing to anything that looks like a stream,
-// i.e. anything that supports .read(char*, size_t) and .write(char*, size_t)
+// i.e. anything that supports .read(uint8_t*, size_t) and .write(uint8_t*, size_t)
 //
 
 class CSizeComputer;
@@ -196,7 +195,7 @@ template<typename X> const X& ReadWriteAsHelper(const X& x) { return x; }
     FORMATTER_METHODS(cls, obj)
 
 #ifndef CHAR_EQUALS_INT8
-template<typename Stream> inline void Serialize(Stream& s, char a    ) { ser_writedata8(s, a); } // TODO Get rid of bare char
+template<typename Stream> void Serialize(Stream&, char) { static_assert(ALWAYS_FALSE<Stream>, "char serialization forbidden use uint8_t or int8_t"); }
 #endif
 template<typename Stream> inline void Serialize(Stream& s, int8_t a  ) { ser_writedata8(s, a); }
 template<typename Stream> inline void Serialize(Stream& s, uint8_t a ) { ser_writedata8(s, a); }
@@ -206,13 +205,13 @@ template<typename Stream> inline void Serialize(Stream& s, int32_t a ) { ser_wri
 template<typename Stream> inline void Serialize(Stream& s, uint32_t a) { ser_writedata32(s, a); }
 template<typename Stream> inline void Serialize(Stream& s, int64_t a ) { ser_writedata64(s, a); }
 template<typename Stream> inline void Serialize(Stream& s, uint64_t a) { ser_writedata64(s, a); }
-template<typename Stream, int N> inline void Serialize(Stream& s, const char (&a)[N]) { s.write(a, N); }
-template<typename Stream, int N> inline void Serialize(Stream& s, const unsigned char (&a)[N]) { s.write(CharCast(a), N); }
-template<typename Stream> inline void Serialize(Stream& s, const Span<const unsigned char>& span) { s.write(CharCast(span.data()), span.size()); }
-template<typename Stream> inline void Serialize(Stream& s, const Span<unsigned char>& span) { s.write(CharCast(span.data()), span.size()); }
+template<typename Stream, int N> inline void Serialize(Stream& s, const char (&a)[N]) { s.write(Uint8Ptr(a), N); }
+template<typename Stream, int N> inline void Serialize(Stream& s, const unsigned char (&a)[N]) { s.write(a, N); }
+template<typename Stream> inline void Serialize(Stream& s, const Span<const unsigned char>& span) { s.write(span.data(), span.size()); }
+template<typename Stream> inline void Serialize(Stream& s, const Span<unsigned char>& span) { s.write(span.data(), span.size()); }
 
 #ifndef CHAR_EQUALS_INT8
-template<typename Stream> inline void Unserialize(Stream& s, char& a    ) { a = ser_readdata8(s); } // TODO Get rid of bare char
+template<typename Stream> void Unserialize(Stream&, char) { static_assert(ALWAYS_FALSE<Stream>, "char serialization forbidden use uint8_t or int8_t"); }
 #endif
 template<typename Stream> inline void Unserialize(Stream& s, int8_t& a  ) { a = ser_readdata8(s); }
 template<typename Stream> inline void Unserialize(Stream& s, uint8_t& a ) { a = ser_readdata8(s); }
@@ -222,9 +221,9 @@ template<typename Stream> inline void Unserialize(Stream& s, int32_t& a ) { a = 
 template<typename Stream> inline void Unserialize(Stream& s, uint32_t& a) { a = ser_readdata32(s); }
 template<typename Stream> inline void Unserialize(Stream& s, int64_t& a ) { a = ser_readdata64(s); }
 template<typename Stream> inline void Unserialize(Stream& s, uint64_t& a) { a = ser_readdata64(s); }
-template<typename Stream, int N> inline void Unserialize(Stream& s, char (&a)[N]) { s.read(a, N); }
-template<typename Stream, int N> inline void Unserialize(Stream& s, unsigned char (&a)[N]) { s.read(CharCast(a), N); }
-template<typename Stream> inline void Unserialize(Stream& s, Span<unsigned char>& span) { s.read(CharCast(span.data()), span.size()); }
+template<typename Stream, int N> inline void Unserialize(Stream& s, char (&a)[N]) { s.read(Uint8Ptr(a), N); }
+template<typename Stream, int N> inline void Unserialize(Stream& s, unsigned char (&a)[N]) { s.read(a, N); }
+template<typename Stream> inline void Unserialize(Stream& s, Span<unsigned char>& span) { s.read(span.data(), span.size()); }
 
 template <typename Stream> inline void Serialize(Stream& s, bool a) { uint8_t f = a; ser_writedata8(s, f); }
 template <typename Stream> inline void Unserialize(Stream& s, bool& a) { uint8_t f = ser_readdata8(s); a = f; }
@@ -479,10 +478,10 @@ struct CustomUintFormatter
         if (v < 0 || v > MAX) throw std::ios_base::failure("CustomUintFormatter value out of range");
         if (BigEndian) {
             uint64_t raw = htobe64(v);
-            s.write(((const char*)&raw) + 8 - Bytes, Bytes);
+            s.write(Uint8Ptr(&raw) + 8 - Bytes, Bytes);
         } else {
             uint64_t raw = htole64(v);
-            s.write((const char*)&raw, Bytes);
+            s.write(Uint8Ptr(&raw), Bytes);
         }
     }
 
@@ -492,10 +491,10 @@ struct CustomUintFormatter
         static_assert(std::numeric_limits<U>::max() >= MAX && std::numeric_limits<U>::min() <= 0, "Assigned type too small");
         uint64_t raw = 0;
         if (BigEndian) {
-            s.read(((char*)&raw) + 8 - Bytes, Bytes);
+            s.read(Uint8Ptr(&raw) + 8 - Bytes, Bytes);
             v = static_cast<I>(be64toh(raw));
         } else {
-            s.read((char*)&raw, Bytes);
+            s.read(Uint8Ptr(&raw), Bytes);
             v = static_cast<I>(le64toh(raw));
         }
     }
@@ -538,7 +537,7 @@ struct LimitedStringFormatter
             throw std::ios_base::failure("String length limit exceeded");
         }
         v.resize(size);
-        if (size != 0) s.read((char*)v.data(), size);
+        if (size != 0) s.read(Uint8Ptr(v.data()), size);
     }
 
     template<typename Stream>
@@ -702,7 +701,7 @@ void Serialize(Stream& os, const std::basic_string<C>& str)
 {
     WriteCompactSize(os, str.size());
     if (!str.empty())
-        os.write((char*)str.data(), str.size() * sizeof(C));
+        os.write(Uint8Ptr(str.data()), str.size() * sizeof(C));
 }
 
 template<typename Stream, typename C>
@@ -711,7 +710,7 @@ void Unserialize(Stream& is, std::basic_string<C>& str)
     unsigned int nSize = ReadCompactSize(is);
     str.resize(nSize);
     if (nSize != 0)
-        is.read((char*)str.data(), nSize * sizeof(C));
+        is.read(Uint8Ptr(str.data()), nSize * sizeof(C));
 }
 
 
@@ -724,7 +723,7 @@ void Serialize_impl(Stream& os, const prevector<N, T>& v, const unsigned char&)
 {
     WriteCompactSize(os, v.size());
     if (!v.empty())
-        os.write((char*)v.data(), v.size() * sizeof(T));
+        os.write(Uint8Ptr(v.data()), v.size() * sizeof(T));
 }
 
 template<typename Stream, unsigned int N, typename T, typename V>
@@ -751,7 +750,7 @@ void Unserialize_impl(Stream& is, prevector<N, T>& v, const unsigned char&)
     {
         unsigned int blk = std::min(nSize - i, (unsigned int)(1 + 4999999 / sizeof(T)));
         v.resize_uninitialized(i + blk);
-        is.read((char*)&v[i], blk * sizeof(T));
+        is.read(Uint8Ptr(&v[i]), blk * sizeof(T));
         i += blk;
     }
 }
@@ -778,7 +777,7 @@ void Serialize_impl(Stream& os, const std::vector<T, A>& v, const unsigned char&
 {
     WriteCompactSize(os, v.size());
     if (!v.empty())
-        os.write((char*)v.data(), v.size() * sizeof(T));
+        os.write(Uint8Ptr(v.data()), v.size() * sizeof(T));
 }
 
 template<typename Stream, typename T, typename A>
@@ -817,7 +816,7 @@ void Unserialize_impl(Stream& is, std::vector<T, A>& v, const unsigned char&)
     {
         unsigned int blk = std::min(nSize - i, (unsigned int)(1 + 4999999 / sizeof(T)));
         v.resize(i + blk);
-        is.read((char*)&v[i], blk * sizeof(T));
+        is.read(Uint8Ptr(&v[i]), blk * sizeof(T));
         i += blk;
     }
 }
@@ -982,7 +981,7 @@ protected:
 public:
     explicit CSizeComputer(int nVersionIn) : nSize(0), nVersion(nVersionIn) {}
 
-    void write(const char *psz, size_t _nSize)
+    void write(const uint8_t* psz, size_t _nSize)
     {
         this->nSize += _nSize;
     }

--- a/src/streams.h
+++ b/src/streams.h
@@ -49,12 +49,12 @@ public:
         return (*this);
     }
 
-    void write(const char* pch, size_t nSize)
+    void write(const uint8_t* pch, size_t nSize)
     {
         stream->write(pch, nSize);
     }
 
-    void read(char* pch, size_t nSize)
+    void read(uint8_t* pch, size_t nSize)
     {
         stream->read(pch, nSize);
     }
@@ -94,15 +94,15 @@ class CVectorWriter
     {
         ::SerializeMany(*this, std::forward<Args>(args)...);
     }
-    void write(const char* pch, size_t nSize)
+    void write(const uint8_t* pch, size_t nSize)
     {
         assert(nPos <= vchData.size());
         size_t nOverwrite = std::min(nSize, vchData.size() - nPos);
         if (nOverwrite) {
-            memcpy(vchData.data() + nPos, reinterpret_cast<const unsigned char*>(pch), nOverwrite);
+            memcpy(vchData.data() + nPos, pch, nOverwrite);
         }
         if (nOverwrite < nSize) {
-            vchData.insert(vchData.end(), reinterpret_cast<const unsigned char*>(pch) + nOverwrite, reinterpret_cast<const unsigned char*>(pch) + nSize);
+            vchData.insert(vchData.end(), pch + nOverwrite, pch + nSize);
         }
         nPos += nSize;
     }
@@ -180,7 +180,7 @@ public:
     size_t size() const { return m_data.size() - m_pos; }
     bool empty() const { return m_data.size() == m_pos; }
 
-    void read(char* dst, size_t n)
+    void read(uint8_t* dst, size_t n)
     {
         if (n == 0) {
             return;
@@ -278,7 +278,7 @@ public:
             vch.insert(it, first, last);
     }
 
-    void insert(iterator it, const char* first, const char* last)
+    void insert(iterator it, const uint8_t* first, const uint8_t* last)
     {
         if (last == first) return;
         assert(last - first > 0);
@@ -362,7 +362,7 @@ public:
     void SetVersion(int n)       { nVersion = n; }
     int GetVersion() const       { return nVersion; }
 
-    void read(char* pch, size_t nSize)
+    void read(uint8_t* pch, size_t nSize)
     {
         if (nSize == 0) return;
 
@@ -399,7 +399,7 @@ public:
         nReadPos = nReadPosNext;
     }
 
-    void write(const char* pch, size_t nSize)
+    void write(const uint8_t* pch, size_t nSize)
     {
         // Write to the end of the buffer
         vch.insert(vch.end(), pch, pch + nSize);
@@ -410,7 +410,7 @@ public:
     {
         // Special case: stream << stream concatenates like stream += stream
         if (!vch.empty())
-            s.write((char*)vch.data(), vch.size() * sizeof(value_type));
+            s.write(vch.data(), vch.size() * sizeof(value_type));
     }
 
     template<typename T>
@@ -614,7 +614,7 @@ public:
     int GetType() const          { return nType; }
     int GetVersion() const       { return nVersion; }
 
-    void read(char* pch, size_t nSize)
+    void read(uint8_t* pch, size_t nSize)
     {
         if (!file)
             throw std::ios_base::failure("CAutoFile::read: file handle is nullptr");
@@ -635,7 +635,7 @@ public:
         }
     }
 
-    void write(const char* pch, size_t nSize)
+    void write(const uint8_t* pch, size_t nSize)
     {
         if (!file)
             throw std::ios_base::failure("CAutoFile::write: file handle is nullptr");
@@ -681,7 +681,7 @@ private:
     uint64_t nReadPos;    //!< how many bytes have been read from this
     uint64_t nReadLimit;  //!< up to which position we're allowed to read
     uint64_t nRewind;     //!< how many bytes we guarantee to rewind
-    std::vector<char> vchBuf; //!< the buffer
+    std::vector<uint8_t> vchBuf; //!< the buffer
 
 protected:
     //! read data from the source to fill the buffer
@@ -736,7 +736,8 @@ public:
     }
 
     //! read a number of bytes
-    void read(char *pch, size_t nSize) {
+    void read(uint8_t* pch, size_t nSize)
+    {
         if (nSize + nReadPos > nReadLimit)
             throw std::ios_base::failure("Read attempted past buffer limit");
         while (nSize > 0) {
@@ -794,7 +795,8 @@ public:
     }
 
     //! search for a given byte in the stream, and remain positioned on it
-    void FindByte(char ch) {
+    void FindByte(uint8_t ch)
+    {
         while (true) {
             if (nReadPos == nSrcPos)
                 Fill();

--- a/src/test/fuzz/autofile.cpp
+++ b/src/test/fuzz/autofile.cpp
@@ -25,14 +25,14 @@ FUZZ_TARGET(autofile)
             [&] {
                 std::array<uint8_t, 4096> arr{};
                 try {
-                    auto_file.read((char*)arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
+                    auto_file.read(arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
                 } catch (const std::ios_base::failure&) {
                 }
             },
             [&] {
                 const std::array<uint8_t, 4096> arr{};
                 try {
-                    auto_file.write((const char*)arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
+                    auto_file.write(arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
                 } catch (const std::ios_base::failure&) {
                 }
             },

--- a/src/test/fuzz/buffered_file.cpp
+++ b/src/test/fuzz/buffered_file.cpp
@@ -35,7 +35,7 @@ FUZZ_TARGET(buffered_file)
                 [&] {
                     std::array<uint8_t, 4096> arr{};
                     try {
-                        opt_buffered_file->read((char*)arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
+                        opt_buffered_file->read(arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
                     } catch (const std::ios_base::failure&) {
                     }
                 },
@@ -53,7 +53,7 @@ FUZZ_TARGET(buffered_file)
                         return;
                     }
                     try {
-                        opt_buffered_file->FindByte(fuzzed_data_provider.ConsumeIntegral<char>());
+                        opt_buffered_file->FindByte(fuzzed_data_provider.ConsumeIntegral<uint8_t>());
                     } catch (const std::ios_base::failure&) {
                     }
                 },

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -209,11 +209,6 @@ FUZZ_TARGET_INIT(integer, initialize_integer)
         stream >> deserialized_i8;
         assert(i8 == deserialized_i8 && stream.empty());
 
-        char deserialized_ch;
-        stream << ch;
-        stream >> deserialized_ch;
-        assert(ch == deserialized_ch && stream.empty());
-
         bool deserialized_b;
         stream << b;
         stream >> deserialized_b;

--- a/src/test/fuzz/p2p_transport_serialization.cpp
+++ b/src/test/fuzz/p2p_transport_serialization.cpp
@@ -76,7 +76,7 @@ FUZZ_TARGET_INIT(p2p_transport_serialization, initialize_p2p_transport_serializa
             assert(msg.m_time == m_time);
 
             std::vector<unsigned char> header;
-            auto msg2 = CNetMsgMaker{msg.m_recv.GetVersion()}.Make(msg.m_command, MakeUCharSpan(msg.m_recv));
+            auto msg2 = CNetMsgMaker{msg.m_recv.GetVersion()}.Make(msg.m_command, msg.m_recv);
             serializer.prepareForTransport(msg2, header);
         }
     }

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -337,7 +337,6 @@ void WriteToStream(FuzzedDataProvider& fuzzed_data_provider, Stream& stream) noe
             CallOneOf(
                 fuzzed_data_provider,
                 WRITE_TO_STREAM_CASE(bool, fuzzed_data_provider.ConsumeBool()),
-                WRITE_TO_STREAM_CASE(char, fuzzed_data_provider.ConsumeIntegral<char>()),
                 WRITE_TO_STREAM_CASE(int8_t, fuzzed_data_provider.ConsumeIntegral<int8_t>()),
                 WRITE_TO_STREAM_CASE(uint8_t, fuzzed_data_provider.ConsumeIntegral<uint8_t>()),
                 WRITE_TO_STREAM_CASE(int16_t, fuzzed_data_provider.ConsumeIntegral<int16_t>()),
@@ -347,7 +346,7 @@ void WriteToStream(FuzzedDataProvider& fuzzed_data_provider, Stream& stream) noe
                 WRITE_TO_STREAM_CASE(int64_t, fuzzed_data_provider.ConsumeIntegral<int64_t>()),
                 WRITE_TO_STREAM_CASE(uint64_t, fuzzed_data_provider.ConsumeIntegral<uint64_t>()),
                 WRITE_TO_STREAM_CASE(std::string, fuzzed_data_provider.ConsumeRandomLengthString(32)),
-                WRITE_TO_STREAM_CASE(std::vector<char>, ConsumeRandomLengthIntegralVector<char>(fuzzed_data_provider)));
+                WRITE_TO_STREAM_CASE(std::vector<uint8_t>, ConsumeRandomLengthIntegralVector<uint8_t>(fuzzed_data_provider)));
         } catch (const std::ios_base::failure&) {
             break;
         }
@@ -367,7 +366,6 @@ void ReadFromStream(FuzzedDataProvider& fuzzed_data_provider, Stream& stream) no
             CallOneOf(
                 fuzzed_data_provider,
                 READ_FROM_STREAM_CASE(bool),
-                READ_FROM_STREAM_CASE(char),
                 READ_FROM_STREAM_CASE(int8_t),
                 READ_FROM_STREAM_CASE(uint8_t),
                 READ_FROM_STREAM_CASE(int16_t),
@@ -377,7 +375,7 @@ void ReadFromStream(FuzzedDataProvider& fuzzed_data_provider, Stream& stream) no
                 READ_FROM_STREAM_CASE(int64_t),
                 READ_FROM_STREAM_CASE(uint64_t),
                 READ_FROM_STREAM_CASE(std::string),
-                READ_FROM_STREAM_CASE(std::vector<char>));
+                READ_FROM_STREAM_CASE(std::vector<uint8_t>));
         } catch (const std::ios_base::failure&) {
             break;
         }

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -61,7 +61,7 @@ public:
 
 BOOST_AUTO_TEST_CASE(sizes)
 {
-    BOOST_CHECK_EQUAL(sizeof(char), GetSerializeSize(char(0), 0));
+    BOOST_CHECK_EQUAL(sizeof(unsigned char), GetSerializeSize((unsigned char)0, 0));
     BOOST_CHECK_EQUAL(sizeof(int8_t), GetSerializeSize(int8_t(0), 0));
     BOOST_CHECK_EQUAL(sizeof(uint8_t), GetSerializeSize(uint8_t(0), 0));
     BOOST_CHECK_EQUAL(sizeof(int16_t), GetSerializeSize(int16_t(0), 0));
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(sizes)
     BOOST_CHECK_EQUAL(sizeof(uint8_t), GetSerializeSize(bool(0), 0));
 
     // Sanity-check GetSerializeSize and c++ type matching
-    BOOST_CHECK_EQUAL(GetSerializeSize(char(0), 0), 1U);
+    BOOST_CHECK_EQUAL(GetSerializeSize((unsigned char)0, 0), 1U);
     BOOST_CHECK_EQUAL(GetSerializeSize(int8_t(0), 0), 1U);
     BOOST_CHECK_EQUAL(GetSerializeSize(uint8_t(0), 0), 1U);
     BOOST_CHECK_EQUAL(GetSerializeSize(int16_t(0), 0), 2U);
@@ -186,32 +186,32 @@ BOOST_AUTO_TEST_CASE(noncanonical)
     std::vector<char>::size_type n;
 
     // zero encoded with three bytes:
-    ss.write("\xfd\x00\x00", 3);
+    ss.write(Uint8Ptr("\xfd\x00\x00"), 3);
     BOOST_CHECK_EXCEPTION(ReadCompactSize(ss), std::ios_base::failure, isCanonicalException);
 
     // 0xfc encoded with three bytes:
-    ss.write("\xfd\xfc\x00", 3);
+    ss.write(Uint8Ptr("\xfd\xfc\x00"), 3);
     BOOST_CHECK_EXCEPTION(ReadCompactSize(ss), std::ios_base::failure, isCanonicalException);
 
     // 0xfd encoded with three bytes is OK:
-    ss.write("\xfd\xfd\x00", 3);
+    ss.write(Uint8Ptr("\xfd\xfd\x00"), 3);
     n = ReadCompactSize(ss);
     BOOST_CHECK(n == 0xfd);
 
     // zero encoded with five bytes:
-    ss.write("\xfe\x00\x00\x00\x00", 5);
+    ss.write(Uint8Ptr("\xfe\x00\x00\x00\x00"), 5);
     BOOST_CHECK_EXCEPTION(ReadCompactSize(ss), std::ios_base::failure, isCanonicalException);
 
     // 0xffff encoded with five bytes:
-    ss.write("\xfe\xff\xff\x00\x00", 5);
+    ss.write(Uint8Ptr("\xfe\xff\xff\x00\x00"), 5);
     BOOST_CHECK_EXCEPTION(ReadCompactSize(ss), std::ios_base::failure, isCanonicalException);
 
     // zero encoded with nine bytes:
-    ss.write("\xff\x00\x00\x00\x00\x00\x00\x00\x00", 9);
+    ss.write(Uint8Ptr("\xff\x00\x00\x00\x00\x00\x00\x00\x00"), 9);
     BOOST_CHECK_EXCEPTION(ReadCompactSize(ss), std::ios_base::failure, isCanonicalException);
 
     // 0x01ffffff encoded with nine bytes:
-    ss.write("\xff\xff\xff\xff\x01\x00\x00\x00\x00", 9);
+    ss.write(Uint8Ptr("\xff\xff\xff\xff\x01\x00\x00\x00\x00"), 9);
     BOOST_CHECK_EXCEPTION(ReadCompactSize(ss), std::ios_base::failure, isCanonicalException);
 }
 
@@ -221,7 +221,7 @@ BOOST_AUTO_TEST_CASE(insert_delete)
     CDataStream ss(SER_DISK, 0);
     BOOST_CHECK_EQUAL(ss.size(), 0U);
 
-    ss.write("\x00\x01\x02\xff", 4);
+    ss.write(Uint8Ptr("\x00\x01\x02\xff"), 4);
     BOOST_CHECK_EQUAL(ss.size(), 4U);
 
     char c = (char)11;

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -96,13 +96,13 @@ public:
     template<typename Stream>
     void Serialize(Stream& s) const
     {
-        s.write((char*)m_data, sizeof(m_data));
+        s.write(m_data, sizeof(m_data));
     }
 
     template<typename Stream>
     void Unserialize(Stream& s)
     {
-        s.read((char*)m_data, sizeof(m_data));
+        s.read(m_data, sizeof(m_data));
     }
 };
 

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -680,10 +680,10 @@ bool BerkeleyBatch::ReadAtCursor(CDataStream& ssKey, CDataStream& ssValue, bool&
     // Convert to streams
     ssKey.SetType(SER_DISK);
     ssKey.clear();
-    ssKey.write((char*)datKey.get_data(), datKey.get_size());
+    ssKey.write(Uint8Ptr(datKey.get_data()), datKey.get_size());
     ssValue.SetType(SER_DISK);
     ssValue.clear();
-    ssValue.write((char*)datValue.get_data(), datValue.get_size());
+    ssValue.write(Uint8Ptr(datValue.get_data()), datValue.get_size());
     return true;
 }
 
@@ -755,7 +755,7 @@ bool BerkeleyBatch::ReadKey(CDataStream&& key, CDataStream& value)
     SafeDbt datValue;
     int ret = pdb->get(activeTxn, datKey, datValue, 0);
     if (ret == 0 && datValue.get_data() != nullptr) {
-        value.write((char*)datValue.get_data(), datValue.get_size());
+        value.write(Uint8Ptr(datValue.get_data()), datValue.get_size());
         return true;
     }
     return false;

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -46,12 +46,12 @@ bool DumpWallet(CWallet& wallet, bilingual_str& error)
     // Write out a magic string with version
     std::string line = strprintf("%s,%u\n", DUMP_MAGIC, DUMP_VERSION);
     dump_file.write(line.data(), line.size());
-    hasher.write(line.data(), line.size());
+    hasher.write(Uint8Ptr(line.data()), line.size());
 
     // Write out the file format
     line = strprintf("%s,%s\n", "format", db.Format());
     dump_file.write(line.data(), line.size());
-    hasher.write(line.data(), line.size());
+    hasher.write(Uint8Ptr(line.data()), line.size());
 
     if (ret) {
 
@@ -72,7 +72,7 @@ bool DumpWallet(CWallet& wallet, bilingual_str& error)
             std::string value_str = HexStr(ss_value);
             line = strprintf("%s,%s\n", key_str, value_str);
             dump_file.write(line.data(), line.size());
-            hasher.write(line.data(), line.size());
+            hasher.write(Uint8Ptr(line.data()), line.size());
         }
     }
 
@@ -149,7 +149,7 @@ bool CreateFromDump(const std::string& name, const fs::path& wallet_path, biling
         return false;
     }
     std::string magic_hasher_line = strprintf("%s,%s\n", magic_key, version_value);
-    hasher.write(magic_hasher_line.data(), magic_hasher_line.size());
+    hasher.write(Uint8Ptr(magic_hasher_line.data()), magic_hasher_line.size());
 
     // Get the stored file format
     std::string format_key;
@@ -180,7 +180,7 @@ bool CreateFromDump(const std::string& name, const fs::path& wallet_path, biling
         warnings.push_back(strprintf(_("Warning: Dumpfile wallet format \"%s\" does not match command line specified format \"%s\"."), format_value, file_format));
     }
     std::string format_hasher_line = strprintf("%s,%s\n", format_key, format_value);
-    hasher.write(format_hasher_line.data(), format_hasher_line.size());
+    hasher.write(Uint8Ptr(format_hasher_line.data()), format_hasher_line.size());
 
     DatabaseOptions options;
     DatabaseStatus status;
@@ -219,7 +219,7 @@ bool CreateFromDump(const std::string& name, const fs::path& wallet_path, biling
             }
 
             std::string line = strprintf("%s,%s\n", key, value);
-            hasher.write(line.data(), line.size());
+            hasher.write(Uint8Ptr(line.data()), line.size());
 
             if (key.empty() || value.empty()) {
                 continue;

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -394,7 +394,7 @@ bool SQLiteBatch::ReadKey(CDataStream&& key, CDataStream& value)
         return false;
     }
     // Leftmost column in result is index 0
-    const char* data = reinterpret_cast<const char*>(sqlite3_column_blob(m_read_stmt, 0));
+    const uint8_t* data{Uint8Ptr(sqlite3_column_blob(m_read_stmt, 0))};
     int data_size = sqlite3_column_bytes(m_read_stmt, 0);
     value.write(data, data_size);
 
@@ -511,10 +511,10 @@ bool SQLiteBatch::ReadAtCursor(CDataStream& key, CDataStream& value, bool& compl
     }
 
     // Leftmost column in result is index 0
-    const char* key_data = reinterpret_cast<const char*>(sqlite3_column_blob(m_cursor_stmt, 0));
+    const uint8_t* key_data{Uint8Ptr(sqlite3_column_blob(m_cursor_stmt, 0))};
     int key_data_size = sqlite3_column_bytes(m_cursor_stmt, 0);
     key.write(key_data, key_data_size);
-    const char* value_data = reinterpret_cast<const char*>(sqlite3_column_blob(m_cursor_stmt, 1));
+    const uint8_t* value_data{Uint8Ptr(sqlite3_column_blob(m_cursor_stmt, 1))};
     int value_data_size = sqlite3_column_bytes(m_cursor_stmt, 1);
     value.write(value_data, value_data_size);
     return true;


### PR DESCRIPTION
Follow-up to #21969.

Serialize doesn't care whether one of the bits in a `char` is a sign bit or not, but having the possibility is slightly confusing to calling code. `int8_t` and `uint8_t` can be used as replacement to `char`.