### PR TITLE
wallet: Avoid exception when loading with unsupported external signer

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3153,6 +3153,14 @@ void CWallet::AddActiveScriptPubKeyMan(uint256 id, OutputType type, bool interna
 void CWallet::LoadActiveScriptPubKeyMan(uint256 id, OutputType type, bool internal)
 {
     WalletLogPrintf("Setting spkMan to active: id = %s, type = %d, internal = %d\n", id.ToString(), static_cast<int>(type), static_cast<int>(internal));
+#ifdef ENABLE_EXTERNAL_SIGNER
+    assert(m_spk_managers.count(id));
+#else
+    if (m_spk_managers.count(id) == 0) {
+        assert(!internal);
+        throw std::runtime_error(std::string(__func__) + ": Compiled without external signing support (required for external signing)");
+    }
+#endif
     auto& spk_mans = internal ? m_internal_spk_managers : m_external_spk_managers;
     auto spk_man = m_spk_managers.at(id).get();
     spk_man->SetInternal(internal);


### PR DESCRIPTION
To reproduce the exception:
 - build with `--enable-external-signer`
 - create a wallet, lets say `ledger_nano_s`
 - now build with `--disable-external-signer`
 - running daemon with `-wallet=ledger_nano_s` fails
 - running daemon with `-nowallet` and calling `cli loadwallet ledger_nano_s` fails
 - repeating `loadwallet` after the above gives "wallet already loaded"

The exception is `std::out_of_range` from `std::map::at` raised by `auto spk_man = m_spk_managers.at(id).get()`.

Fix this by early checking for `ENABLE_EXTERNAL_SIGNER`.