### PR TITLE
p2p, rpc, fuzz: various tiny follow-ups

### DIFF
--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -594,7 +594,7 @@ static std::string IPv6ToString(Span<const uint8_t> a, uint32_t scope_id)
     return r;
 }
 
-static std::string OnionToString(const Span<const uint8_t>& addr)
+static std::string OnionToString(Span<const uint8_t> addr)
 {
     uint8_t checksum[torv3::CHECKSUM_LEN];
     torv3::Checksum(addr, checksum);

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -939,7 +939,7 @@ static RPCHelpMan addpeeraddress()
     bool success{false};
 
     if (LookupHost(addr_string, net_addr, false)) {
-        CAddress address{CAddress({net_addr, port}, ServiceFlags(NODE_NETWORK | NODE_WITNESS))};
+        CAddress address{{net_addr, port}, ServiceFlags{NODE_NETWORK | NODE_WITNESS}};
         address.nTime = GetAdjustedTime();
         // The source address is set equal to the address. This is equivalent to the peer
         // announcing itself.

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -143,7 +143,7 @@ FUZZ_TARGET_DESERIALIZE(script_deserialize, {
         CScript script;
         DeserializeFromFuzzingInput(buffer, script);
 })
-FUZZ_TARGET_DESERIALIZE(subnet_deserialize, {
+FUZZ_TARGET_DESERIALIZE(sub_net_deserialize, {
         CSubNet sub_net_1;
         DeserializeFromFuzzingInput(buffer, sub_net_1, INIT_PROTO_VERSION);
         AssertEqualAfterSerializeDeserialize(sub_net_1, INIT_PROTO_VERSION);
@@ -223,7 +223,7 @@ FUZZ_TARGET_DESERIALIZE(coins_deserialize, {
         Coin coin;
         DeserializeFromFuzzingInput(buffer, coin);
 })
-FUZZ_TARGET_DESERIALIZE(net_address_deserialize, {
+FUZZ_TARGET_DESERIALIZE(netaddr_deserialize, {
         CNetAddr na;
         DeserializeFromFuzzingInput(buffer, na);
         if (na.IsAddrV1Compatible()) {
@@ -231,7 +231,7 @@ FUZZ_TARGET_DESERIALIZE(net_address_deserialize, {
         }
         AssertEqualAfterSerializeDeserialize(na, INIT_PROTO_VERSION | ADDRV2_FORMAT);
 })
-FUZZ_TARGET_DESERIALIZE(net_service_deserialize, {
+FUZZ_TARGET_DESERIALIZE(service_deserialize, {
         CService s;
         DeserializeFromFuzzingInput(buffer, s);
         if (s.IsAddrV1Compatible()) {


### PR DESCRIPTION
- p2p: pass `Span` by value per https://github.com/bitcoin/bitcoin/pull/22143#issuecomment-853953438 as a follow-up to 8be56f0f8ecc54744
- rpc: remove duplicate `CAddress` constructor per https://github.com/bitcoin/bitcoin/pull/22043#discussion_r638535703
- fuzz: rename 3 fuzz targets changed in eba9a94b9f56be2fda623e77f19b960425ea1eb5 back to their original names per https://github.com/bitcoin-core/qa-assets/pull/63#issuecomment-855281865
