### PR TITLE
doc: update tor.md, release notes with removal of tor v2 support

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -59,6 +59,13 @@ Notable changes
 P2P and network changes
 -----------------------
 
+- This release removes support for Tor version 2 hidden services in favor of Tor
+  v3 only, as the Tor network [dropped support for Tor
+  v2](https://blog.torproject.org/v2-deprecation-timeline) with the release of
+  Tor version 0.4.6.  Henceforth, Bitcoin Core ignores Tor v2 addresses; it
+  neither rumors them over the network to other peers, nor stores them in memory
+  or to `peers.dat`.  (#22050)
+
 - Added NAT-PMP port mapping support via
   [`libnatpmp`](https://miniupnp.tuxfamily.org/libnatpmp.html). (#18077)
 
@@ -142,8 +149,8 @@ Tools and Utilities
 - A new CLI `-addrinfo` command returns the number of addresses known to the
   node per network type (including Tor v2 versus v3) and total. This can be
   useful to see if the node knows enough addresses in a network to use options
-  like `-onlynet=<network>` or to upgrade to current and future Tor releases
-  that support Tor v3 addresses only.  (#21595)
+  like `-onlynet=<network>` or to upgrade to this release of Bitcoin Core 22.0
+  that supports Tor v3 only.  (#21595)
 
 Wallet
 ------

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -5,6 +5,14 @@ It is possible to run Bitcoin Core as a Tor onion service, and connect to such s
 The following directions assume you have a Tor proxy running on port 9050. Many distributions default to having a SOCKS proxy listening on port 9050, but others may not. In particular, the Tor Browser Bundle defaults to listening on port 9150. See [Tor Project FAQ:TBBSocksPort](https://www.torproject.org/docs/faq.html.en#TBBSocksPort) for how to properly
 configure Tor.
 
+## Compatibility
+
+- Starting with version 22.0, Bitcoin Core only supports Tor version 3 hidden
+  services (Tor v3). Tor v2 addresses are ignored by Bitcoin Core and neither
+  relayed nor stored.
+
+- Tor removed v2 support beginning with version 0.4.6.
+
 ## How to see information about your Tor configuration via Bitcoin Core
 
 There are several ways to see your local onion address in Bitcoin Core:
@@ -18,7 +26,7 @@ information in the debug log about your Tor configuration.
 CLI `-addrinfo` returns the number of addresses known to your node per network
 type, including Tor v2 and v3. This is useful to see how many onion addresses
 are known to your node for `-onlynet=onion` and how many Tor v3 addresses it
-knows when upgrading to current and future Tor releases that support Tor v3 only.
+knows when upgrading to Bitcoin Core v22.0 and up that supports Tor v3 only.
 
 ## 1. Run Bitcoin Core behind a Tor proxy
 


### PR DESCRIPTION
Follow-up documentation to #22050 that removed support for Tor version 2 hidden services from Bitcoin Core.
