### PR TITLE
wallet: Do not load external signers wallets when unsupported

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -712,6 +712,13 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
             }
         }
 
+#ifndef ENABLE_EXTERNAL_SIGNER
+        if (pwallet->IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER)) {
+            pwallet->WalletLogPrintf("Error: External signer wallet being loaded without external signer support compiled\n");
+            return DBErrors::TOO_NEW;
+        }
+#endif
+
         // Get cursor
         if (!m_batch->StartCursor())
         {


### PR DESCRIPTION
When external signer support is not compiled, do not load external signer wallets.

Alternative to #22168.