### PR TITLE
fuzz: Increase branch coverage of the float fuzz target

### DIFF
--- a/src/test/fuzz/float.cpp
+++ b/src/test/fuzz/float.cpp
@@ -5,6 +5,7 @@
 #include <memusage.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
 #include <util/serfloat.h>
 #include <version.h>
 
@@ -17,7 +18,33 @@ FUZZ_TARGET(float)
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
 
     {
-        const double d = fuzzed_data_provider.ConsumeFloatingPoint<double>();
+        const double d{[&] {
+            double tmp;
+            CallOneOf(
+                fuzzed_data_provider,
+                // an actual number
+                [&] { tmp = fuzzed_data_provider.ConsumeFloatingPoint<double>(); },
+                // special numbers and NANs
+                [&] { tmp = fuzzed_data_provider.PickValueInArray({
+                          std::numeric_limits<double>::infinity(),
+                          -std::numeric_limits<double>::infinity(),
+                          std::numeric_limits<double>::min(),
+                          -std::numeric_limits<double>::min(),
+                          std::numeric_limits<double>::max(),
+                          -std::numeric_limits<double>::max(),
+                          std::numeric_limits<double>::lowest(),
+                          -std::numeric_limits<double>::lowest(),
+                          std::numeric_limits<double>::quiet_NaN(),
+                          -std::numeric_limits<double>::quiet_NaN(),
+                          std::numeric_limits<double>::signaling_NaN(),
+                          -std::numeric_limits<double>::signaling_NaN(),
+                          std::numeric_limits<double>::denorm_min(),
+                          -std::numeric_limits<double>::denorm_min(),
+                      }); },
+                // Anything from raw memory (also checks that DecodeDouble doesn't crash on any input)
+                [&] { tmp = DecodeDouble(fuzzed_data_provider.ConsumeIntegral<uint64_t>()); });
+            return tmp;
+        }()};
         (void)memusage::DynamicUsage(d);
 
         uint64_t encoded = EncodeDouble(d);

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -44,7 +44,7 @@ void CallOneOf(FuzzedDataProvider& fuzzed_data_provider, Callables... callables)
     const size_t call_index{fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, call_size - 1)};
 
     size_t i{0};
-    return ((i++ == call_index ? callables() : void()), ...);
+    ((i++ == call_index ? callables() : void()), ...);
 }
 
 template <typename Collection>


### PR DESCRIPTION
Currently the branch coverage for the float fuzz target is only 50% : https://marcofalke.github.io/btc_cov/fuzz.coverage/src/test/fuzz/float.cpp.gcov.html

This is caused by the Fuzzed Data Provider only picking "nice" floats.