### PR TITLE
test: Add sync_blocks in wallet_orphanedreward.py

### DIFF
--- a/test/functional/wallet_orphanedreward.py
+++ b/test/functional/wallet_orphanedreward.py
@@ -31,6 +31,7 @@ class OrphanedBlockRewardTest(BitcoinTestFramework):
         # Let the block reward mature and send coins including both
         # the existing balance and the block reward.
         self.nodes[0].generate(150)
+        self.sync_blocks()
         assert_equal(self.nodes[1].getbalance(), 10 + 25)
         txid = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 30)
 


### PR DESCRIPTION
Add an explicit `sync_blocks` call in `wallet_orphanedreward.py`, which was missing and could lead to intermittent failures of the test due to race conditions.

This will presumably fix #22181.