### PR TITLE
bitcoin-tx: validate range of parsed output amount

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -191,6 +191,8 @@ static CAmount ExtractAndValidateValue(const std::string& strValue)
     CAmount value;
     if (!ParseMoney(strValue, value))
         throw std::runtime_error("invalid TX output value");
+    if (!MoneyRange(value))
+        throw std::runtime_error("TX output value out of range");
     return value;
 }
 


### PR DESCRIPTION
This tiny PR adds a sanity check to the `bitcoin-tx` tool w.r.t. to tx output values specified by the user: the parsing function `ExtractAndValidateValue` is extended to throw if the amount is not in range [0, MAX_MONEY].

master:
```
$ bitcoin-tx -create outdata=21000001:affe
0200000000010021fd5ff0750700046a02affe00000000
```

PR branch:
```
$ bitcoin-tx -create outdata=21000001:affe
error: TX output value out of range
```