### PR TITLE
zmq: use std::string in zmqError()

### DIFF
--- a/src/zmq/zmqutil.cpp
+++ b/src/zmq/zmqutil.cpp
@@ -12,5 +12,5 @@
 
 void zmqError(const std::string& str)
 {
-    LogPrint(BCLog::ZMQ, "zmq: Error: %s, errno=%s\n", str, zmq_strerror(errno));
+    LogPrint(BCLog::ZMQ, "zmq: Error: %s, msg: %s\n", str, zmq_strerror(errno));
 }

--- a/src/zmq/zmqutil.cpp
+++ b/src/zmq/zmqutil.cpp
@@ -5,10 +5,12 @@
 #include <zmq/zmqutil.h>
 
 #include <logging.h>
-
 #include <zmq.h>
 
-void zmqError(const char* str)
+#include <cerrno>
+#include <string>
+
+void zmqError(const std::string& str)
 {
     LogPrint(BCLog::ZMQ, "zmq: Error: %s, errno=%s\n", str, zmq_strerror(errno));
 }

--- a/src/zmq/zmqutil.h
+++ b/src/zmq/zmqutil.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_ZMQ_ZMQUTIL_H
 #define BITCOIN_ZMQ_ZMQUTIL_H
 
-void zmqError(const char* str);
+#include <string>
+
+void zmqError(const std::string& str);
 
 #endif // BITCOIN_ZMQ_ZMQUTIL_H


### PR DESCRIPTION
This is two minor changes. The first is to change `zmqError` to take a `const std::string&` instead of a `const char*`. The second is to change the second portion of `zmqError` to print `msg: message` rather than `errno=message`, given that `zmq_strerror` returns a message. To me, this seems more readable / useful than output like: `Error: Unable to initialize context errno=No such file or directory`.