### PR TITLE
Guard `fHavePruned` to avoid potential data race

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1352,6 +1352,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             const int64_t load_block_index_start_time = GetTimeMillis();
             try {
                 LOCK(cs_main);
+                LOCK(cs_HavePruned);
                 chainman.InitializeChainstate(*Assert(node.mempool));
                 chainman.m_total_coinstip_cache = nCoinCacheUsage;
                 chainman.m_total_coinsdb_cache = nCoinDBCache;
@@ -1476,6 +1477,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
             try {
                 LOCK(cs_main);
+                LOCK(cs_HavePruned);
 
                 for (CChainState* chainstate : chainman.GetAll()) {
                     if (!is_coinsview_empty(chainstate)) {

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -17,7 +17,6 @@
 #include <streams.h>
 #include <undo.h>
 #include <util/system.h>
-#include <validation.h>
 
 std::atomic_bool fImporting(false);
 std::atomic_bool fReindex(false);
@@ -48,6 +47,7 @@ static FlatFileSeq UndoFileSeq();
 
 bool IsBlockPruned(const CBlockIndex* pblockindex)
 {
+    LOCK(cs_main);
     return (fHavePruned && !(pblockindex->nStatus & BLOCK_HAVE_DATA) && pblockindex->nTx > 0);
 }
 

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -17,6 +17,7 @@
 #include <streams.h>
 #include <undo.h>
 #include <util/system.h>
+#include <validation.h>
 
 std::atomic_bool fImporting(false);
 std::atomic_bool fReindex(false);
@@ -25,6 +26,7 @@ bool fPruneMode = false;
 uint64_t nPruneTarget = 0;
 
 // TODO make namespace {
+Mutex cs_HavePruned;
 RecursiveMutex cs_LastBlockFile;
 std::vector<CBlockFileInfo> vinfoBlockFile;
 int nLastBlockFile = 0;
@@ -47,7 +49,7 @@ static FlatFileSeq UndoFileSeq();
 
 bool IsBlockPruned(const CBlockIndex* pblockindex)
 {
-    LOCK(cs_main);
+    LOCK(cs_HavePruned);
     return (fHavePruned && !(pblockindex->nStatus & BLOCK_HAVE_DATA) && pblockindex->nTx > 0);
 }
 

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -10,6 +10,8 @@
 
 #include <fs.h>
 #include <protocol.h> // For CMessageHeader::MessageStartChars
+#include <sync.h>
+#include <validation.h> // For cs_main
 
 class ArgsManager;
 class BlockValidationState;
@@ -38,7 +40,7 @@ extern std::atomic_bool fImporting;
 extern std::atomic_bool fReindex;
 /** Pruning-related variables and constants */
 /** True if any block files have ever been pruned. */
-extern bool fHavePruned;
+extern bool fHavePruned GUARDED_BY(cs_main);
 /** True if we're running in -prune mode. */
 extern bool fPruneMode;
 /** Number of MiB of block files that we're trying to stay below. */

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -11,7 +11,6 @@
 #include <fs.h>
 #include <protocol.h> // For CMessageHeader::MessageStartChars
 #include <sync.h>
-#include <validation.h> // For cs_main
 
 class ArgsManager;
 class BlockValidationState;
@@ -36,11 +35,12 @@ static const unsigned int UNDOFILE_CHUNK_SIZE = 0x100000; // 1 MiB
 /** The maximum size of a blk?????.dat file (since 0.8) */
 static const unsigned int MAX_BLOCKFILE_SIZE = 0x8000000; // 128 MiB
 
+extern Mutex cs_HavePruned;
 extern std::atomic_bool fImporting;
 extern std::atomic_bool fReindex;
 /** Pruning-related variables and constants */
 /** True if any block files have ever been pruned. */
-extern bool fHavePruned GUARDED_BY(cs_main);
+extern bool fHavePruned GUARDED_BY(cs_HavePruned);
 /** True if we're running in -prune mode. */
 extern bool fPruneMode;
 /** Number of MiB of block files that we're trying to stay below. */

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -632,7 +632,7 @@ public:
     CFeeRate relayDustFee() override { return ::dustRelayFee; }
     bool havePruned() override
     {
-        LOCK(cs_main);
+        LOCK(cs_HavePruned);
         return ::fHavePruned;
     }
     bool isReadyToBroadcast() override { return !::fImporting && !::fReindex && !isInitialBlockDownload(); }


### PR DESCRIPTION
As detailed in #21627, there is a potential data race on `fHavePruned` as one thread could be reading it while another one is writing to it.

Guard `fHavePruned`, lock in `IsBlockPruned` (`FlushStateToDisk` is holding `cs_main` while writing to the variable, so this ensures that the data race cannot occur).
