### PR TITLE
refactor: Avoid wallet code writing node settings file

### DIFF
--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -262,11 +262,18 @@ public:
     //! Current RPC serialization flags.
     virtual int rpcSerializationFlags() = 0;
 
+    //! Get settings value.
+    virtual util::SettingsValue getSetting(const std::string& arg) = 0;
+
+    //! Get list of settings values.
+    virtual std::vector<util::SettingsValue> getSettingsList(const std::string& arg) = 0;
+
     //! Return <datadir>/settings.json setting value.
     virtual util::SettingsValue getRwSetting(const std::string& name) = 0;
 
-    //! Write a setting to <datadir>/settings.json.
-    virtual bool updateRwSetting(const std::string& name, const util::SettingsValue& value) = 0;
+    //! Write a setting to <datadir>/settings.json. Optionally just update the
+    //! setting in memory and do not write the file.
+    virtual bool updateRwSetting(const std::string& name, const util::SettingsValue& value, bool write=true) = 0;
 
     //! Synchronously send transactionAddedToMempool notifications about all
     //! current mempool transactions to the specified handler and return after

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -690,6 +690,14 @@ public:
         RPCRunLater(name, std::move(fn), seconds);
     }
     int rpcSerializationFlags() override { return RPCSerializationFlags(); }
+    util::SettingsValue getSetting(const std::string& name) override
+    {
+        return gArgs.GetSetting(name);
+    }
+    std::vector<util::SettingsValue> getSettingsList(const std::string& name) override
+    {
+        return gArgs.GetSettingsList(name);
+    }
     util::SettingsValue getRwSetting(const std::string& name) override
     {
         util::SettingsValue result;
@@ -700,7 +708,7 @@ public:
         });
         return result;
     }
-    bool updateRwSetting(const std::string& name, const util::SettingsValue& value) override
+    bool updateRwSetting(const std::string& name, const util::SettingsValue& value, bool write) override
     {
         gArgs.LockSettings([&](util::Settings& settings) {
             if (value.isNull()) {
@@ -709,7 +717,7 @@ public:
                 settings.rw_settings[name] = value;
             }
         });
-        return gArgs.WriteSettingsFile();
+        return !write || gArgs.WriteSettingsFile();
     }
     void requestMempoolTransactions(Notifications& notifications) override
     {

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -207,6 +207,7 @@ protected:
      */
     bool UseDefaultSection(const std::string& arg) const EXCLUSIVE_LOCKS_REQUIRED(cs_args);
 
+ public:
     /**
      * Get setting value.
      *
@@ -221,7 +222,6 @@ protected:
      */
     std::vector<util::SettingsValue> GetSettingsList(const std::string& arg) const;
 
-public:
     ArgsManager();
     ~ArgsManager();
 

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -50,18 +50,20 @@ bool VerifyWallets(interfaces::Chain& chain)
         options.require_existing = true;
         options.verify = false;
         if (MakeWalletDatabase("", options, status, error_string)) {
-            gArgs.LockSettings([&](util::Settings& settings) {
-                util::SettingsValue wallets(util::SettingsValue::VARR);
-                wallets.push_back(""); // Default wallet name is ""
-                settings.rw_settings["wallet"] = wallets;
-            });
+            util::SettingsValue wallets(util::SettingsValue::VARR);
+            wallets.push_back(""); // Default wallet name is ""
+            // Pass write=false because no need to write file and probably
+            // better not to. If unnamed wallet needs to be added next startup
+            // and the setting is empty, this code will just run again.
+            chain.updateRwSetting("wallet", wallets, /* write= */ false);
         }
     }
 
     // Keep track of each wallet absolute path to detect duplicates.
     std::set<fs::path> wallet_paths;
 
-    for (const auto& wallet_file : gArgs.GetArgs("-wallet")) {
+    for (const auto& wallet : chain.getSettingsList("wallet")) {
+        const auto& wallet_file = wallet.get_str();
         const fs::path path = fsbridge::AbsPathJoin(GetWalletDir(), wallet_file);
 
         if (!wallet_paths.insert(path).second) {
@@ -91,7 +93,8 @@ bool LoadWallets(interfaces::Chain& chain)
 {
     try {
         std::set<fs::path> wallet_paths;
-        for (const std::string& name : gArgs.GetArgs("-wallet")) {
+        for (const auto& wallet : chain.getSettingsList("wallet")) {
+            const auto& name = wallet.get_str();
             if (!wallet_paths.insert(name).second) {
                 continue;
             }


### PR DESCRIPTION
Change wallet loading code to access settings through the Chain interface instead of writing settings.json directly. This is for running wallet and node in separate processes, since multiprocess code wouldn't easily work with different processes updating the same file.

---

This PR is part of the [process separation project](https://github.com/bitcoin/bitcoin/projects/10). The commit was first part of larger PR #10102.