### PR TITLE
Update msvc and appveyor builds to use Qt5.12.11 binaries

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,15 +1,15 @@
 version: '{branch}.{build}'
 skip_tags: true
-image: Visual Studio 2019
+image: Visual Studio 2019 Preview
 configuration: Release
 platform: x64
 clone_depth: 5
 environment:
   PATH: 'C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%'
   PYTHONUTF8: 1
-  QT_DOWNLOAD_URL: 'https://github.com/sipsorcery/qt_win_binary/releases/download/qt51210x64_vs2019_1694/Qt5.12.10_x64_static_vs2019_1694.zip'
-  QT_DOWNLOAD_HASH: '3035a1307e8302bb3a76eba9bb3102979f945ab4022cc3bc2e1583edd44bdc99'
-  QT_LOCAL_PATH: 'C:\Qt5.12.10_x64_static_vs2019_1694'
+  QT_DOWNLOAD_URL: 'https://github.com/sipsorcery/qt_win_binary/releases/download/qt51211x64_static_vs2019_16101/Qt5.12.11_x64_static_vs2019_16101.zip'
+  QT_DOWNLOAD_HASH: 'cf1b58107fadbf0d9a957d14dab16cde6b6eb6936a1908472da1f967dda34a3a'
+  QT_LOCAL_PATH: 'C:\Qt5.12.11_x64_static_vs2019_16101'
   VCPKG_TAG: '75522bb1f2e7d863078bcd06322348f053a9e33f'
 install:
 # Disable zmq test for now since python zmq library on Windows would cause Access violation sometimes.

--- a/build_msvc/common.qt.init.vcxproj
+++ b/build_msvc/common.qt.init.vcxproj
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="QtGlobals">
-    <QtBaseDir>C:\Qt5.12.10_x64_static_vs2019_1694</QtBaseDir>
+    <QtBaseDir>C:\Qt5.12.11_x64_static_vs2019_16101</QtBaseDir>
     <QtPluginsLibraryDir>$(QtBaseDir)\plugins</QtPluginsLibraryDir>
     <QtLibraryDir>$(QtBaseDir)\lib</QtLibraryDir>
     <QtIncludeDir>$(QtBaseDir)\include</QtIncludeDir>


### PR DESCRIPTION
Synchronises the Qt version used in the msvc and Appveyor builds with #22054.

I needed to use switch to the `Visual Studio 2019 Preview` Appveyor image because the compiler version on the non-preview image is too far behind and I had difficulty building a compatible Qt version for it. Once the main Appveyor `Visual Studio 2019` image reaches version `16.10.1` it can be used.
