### PR TITLE
build: Fix MSVC linker /SubSystem option for bitcoin-qt.exe

### DIFF
--- a/build_msvc/bitcoin-qt/bitcoin-qt.vcxproj
+++ b/build_msvc/bitcoin-qt/bitcoin-qt.vcxproj
@@ -55,6 +55,7 @@
       <AdditionalIncludeDirectories>$(QtIncludes);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
+      <SubSystem>Windows</SubSystem>
       <AdditionalDependencies>$(QtReleaseLibraries);%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/ignore:4206 /LTCG:OFF</AdditionalOptions>
     </Link>


### PR DESCRIPTION
On master (6f3fbc062f97183f19a8551177371cc74a33351d), running `bitcoin-qt.exe`, which was built with MSVC, causes a terminal window open along with the GUI.

This PR fixes such behavior. See Microsoft [docs](https://docs.microsoft.com/en-us/cpp/build/reference/subsystem-specify-subsystem?view=msvc-160).

It is still possible to use the `-printtoconsole` option for debug builds.