### PR TITLE
Separate AppInitStartClients from AppInitMain

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -224,6 +224,9 @@ static bool AppInit(NodeContext& node, int argc, char* argv[])
             return false;
         }
         fRet = AppInitInterfaces(node) && AppInitMain(node);
+        if (fRet) {
+            AppInitStartClients(node);
+        }
     }
     catch (const std::exception& e) {
         PrintExceptionContinue(&e, "AppInit()");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1780,10 +1780,6 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     SetRPCWarmupFinished();
     uiInterface.InitMessage(_("Done loading").translated);
 
-    for (const auto& client : node.chain_clients) {
-        client->start(*node.scheduler);
-    }
-
     BanMan* banman = node.banman.get();
     node.scheduler->scheduleEvery([banman]{
         banman->DumpBanlist();
@@ -1794,4 +1790,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 #endif
 
     return true;
+}
+
+void AppInitStartClients(NodeContext& node)
+{
+    for (const auto& client : node.chain_clients) {
+        client->start(*node.scheduler);
+    }
 }

--- a/src/init.h
+++ b/src/init.h
@@ -64,6 +64,11 @@ bool AppInitInterfaces(NodeContext& node);
 bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info = nullptr);
 
 /**
+ * Start execution of chain clients (e.g., wallets).
+ */
+void AppInitStartClients(NodeContext& node);
+
+/**
  * Register all arguments with the ArgsManager
  */
 void SetupServerArgs(ArgsManager& argsman);

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -74,6 +74,9 @@ public:
     //! Start node.
     virtual bool appInitMain(interfaces::BlockAndHeaderTipInfo* tip_info = nullptr) = 0;
 
+    //! Start execution of chain clients (e.g., wallets).
+    virtual void appInitStartClients() = 0;
+
     //! Stop node.
     virtual void appShutdown() = 0;
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -86,6 +86,12 @@ public:
     {
         return AppInitMain(*m_context, tip_info);
     }
+
+    void appInitStartClients() override
+    {
+        AppInitStartClients(*m_context);
+    }
+
     void appShutdown() override
     {
         Interrupt(*m_context);

--- a/src/qt/initexecutor.cpp
+++ b/src/qt/initexecutor.cpp
@@ -43,6 +43,9 @@ void InitExecutor::initialize()
         qDebug() << __func__ << ": Running initialization in thread";
         interfaces::BlockAndHeaderTipInfo tip_info;
         bool rv = m_node.appInitMain(&tip_info);
+        if (rv) {
+            m_node.appInitStartClients();
+        }
         Q_EMIT initializeResult(rv, tip_info);
     } catch (const std::exception& e) {
         handleRunawayException(&e);


### PR DESCRIPTION
This change allows to make the GUI startup process more granular, and, eventually, to move the `appInitStartClients` call from
`BitcoinCore::initialize` into `LoadWalletsActivity` (see https://github.com/bitcoin-core/gui/pull/342) and fix https://github.com/bitcoin-core/gui/issues/247.

~No behavior change.~