### PR TITLE
build: improve detection of eBPF support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1357,13 +1357,15 @@ if test x$enable_wallet != xno; then
 fi
 
 if test x$use_ebpf != xno; then
-  AC_CHECK_HEADER([sys/sdt.h], [have_sdt=yes], [have_sdt=no])
-else
-  have_sdt=no
-fi
-
-if test x$have_sdt = xyes; then
-  AC_DEFINE([ENABLE_TRACING], [1], [Define to 1 to enable eBPF user static defined tracepoints])
+  AC_MSG_CHECKING([whether eBPF tracepoints are supported])
+  AC_COMPILE_IFELSE([
+    AC_LANG_PROGRAM(
+      [#include <sys/sdt.h>],
+      [DTRACE_PROBE("context", "event");]
+    )],
+    [AC_MSG_RESULT(yes); have_sdt=yes; AC_DEFINE([ENABLE_TRACING], [1], [Define to 1 to enable eBPF user static defined tracepoints])],
+    [AC_MSG_RESULT(no); have_sdt=no;]
+  )
 fi
 
 dnl Check for libminiupnpc (optional)


### PR DESCRIPTION
Just checking for the `sys/sdt.h` header isn't enough, as systems like macOS have the header, but it doesn't actually have the `DTRACE_PROBE*` probes, which leads to [compile failures](https://github.com/bitcoin/bitcoin/pull/22006#issuecomment-859559004). The contents of `sys/sdt.h` in the macOS SDK is:
```bash
#ifndef _SYS_SDT_H
#define _SYS_SDT_H

/*
 * This is a wrapper header that wraps the mach visible sdt.h header so that
 * the header file ends up visible where software expects it to be.  We also
 * do the C/C++ symbol wrapping here, since Mach headers are technically C
 * interfaces.
 *
 * Note:  The process of adding USDT probes to code is slightly different
 * than documented in the "Solaris Dynamic Tracing Guide".
 * The DTRACE_PROBE*() macros are not supported on Mac OS X -- instead see
 * "BUILDING CODE CONTAINING USDT PROBES" in the dtrace(1) manpage
 *
 */
#include <sys/cdefs.h>
__BEGIN_DECLS
#include <mach/sdt.h>
__END_DECLS

#endif  /* _SYS_SDT_H */
```

The `BUILDING CODE CONTAINING USDT PROBES` section from the dtrace manpage is available [here](https://gist.github.com/fanquake/e56c9866d53b326646d04ab43a8df9e2), and outlines the more involved process of using USDT probes on macOS.