### PR TITLE
build: Re-enable -Wdeprecated-copy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -475,7 +475,6 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wself-assign],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-self-assign"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wunused-local-typedef],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-unused-local-typedef"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-implicit-fallthrough"],,[[$CXXFLAG_WERROR]])
-  AX_CHECK_COMPILE_FLAG([-Wdeprecated-copy],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-deprecated-copy"],,[[$CXXFLAG_WERROR]])
 fi
 
 dnl Don't allow extended (non-ASCII) symbols in identifiers. This is easier for code review.


### PR DESCRIPTION
This PR reverts commit 0c63f808542ba02fc41aa90b1d96e9123f16d8ad (#18738), because the initial issue is no longer a thing.

Tested on the following systems:
- Ubuntu Focal + Qt 5.12.8:
  - ~gcc 9.3.0~ test is wrong
  - clang 10.0.0
  - clang 11.0.0
- Fedora 34 + Qt 5.15.2
  - gcc 11.1.1
  - clang 12.0.0

Although, did not test [this](https://github.com/bitcoin/bitcoin/pull/18738#issuecomment-622956100) configuration.

Closes #18967.