### PR TITLE
devtools: Correctly extract symbol versions in symbol-check

### DIFF
--- a/contrib/devtools/pixie.py
+++ b/contrib/devtools/pixie.py
@@ -217,7 +217,7 @@ def _parse_verneed(section: Section, strings: bytes, eh: ELFHeader) -> Dict[int,
     result = {}
     while True:
         verneed = Verneed(data, ofs, eh)
-        aofs = verneed.vn_aux
+        aofs = ofs + verneed.vn_aux
         while True:
             vernaux = Vernaux(data, aofs, eh, strings)
             result[vernaux.vna_other] = vernaux.name

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -41,7 +41,14 @@ import pixie
 #
 MAX_VERSIONS = {
 'GCC':       (4,8,0),
-'GLIBC':     (2,17),
+'GLIBC': {
+    pixie.EM_386:    (2,17),
+    pixie.EM_X86_64: (2,17),
+    pixie.EM_ARM:    (2,17),
+    pixie.EM_AARCH64:(2,17),
+    pixie.EM_PPC64:  (2,17),
+    pixie.EM_RISCV:  (2,27),
+},
 'LIBATOMIC': (1,0),
 'V':         (0,5,0),  # xkb (bitcoin-qt only)
 }
@@ -78,14 +85,6 @@ ELF_ALLOWED_LIBRARIES = {
 'libfontconfig.so.1', # font support
 'libfreetype.so.6', # font parsing
 'libdl.so.2' # programming interface to dynamic linker
-}
-ARCH_MIN_GLIBC_VER = {
-pixie.EM_386:    (2,1),
-pixie.EM_X86_64: (2,2,5),
-pixie.EM_ARM:    (2,4),
-pixie.EM_AARCH64:(2,17),
-pixie.EM_PPC64:  (2,17),
-pixie.EM_RISCV:  (2,27)
 }
 
 MACHO_ALLOWED_LIBRARIES = {
@@ -162,7 +161,10 @@ def check_version(max_versions, version, arch) -> bool:
     ver = tuple([int(x) for x in ver.split('.')])
     if not lib in max_versions:
         return False
-    return ver <= max_versions[lib] or lib == 'GLIBC' and ver <= ARCH_MIN_GLIBC_VER[arch]
+    if isinstance(max_versions[lib], tuple):
+        return ver <= max_versions[lib]
+    else:
+        return ver <= max_versions[lib][arch]
 
 def check_imported_symbols(filename) -> bool:
     elf = pixie.load(filename)

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -42,7 +42,8 @@ import pixie
 MAX_VERSIONS = {
 'GCC':       (4,8,0),
 'GLIBC':     (2,17),
-'LIBATOMIC': (1,0)
+'LIBATOMIC': (1,0),
+'V':         (0,5,0),  # xkb (bitcoin-qt only)
 }
 # See here for a description of _IO_stdin_used:
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=634261#109


### PR DESCRIPTION
I misunderstood the ELF specification for version symbols (verneed): The `vn_aux` pointer is relative to the main verneed record, not the start of the section.

This caused many symbols to not be versioned properly in the return value of `elf.dyn_symbols`. This was discovered in #21454.

Fix it by correcting the offset computation.

- xkb versions symbols (using the prefix `V`), as this library is used by bitcoin-qt, add it to the valid versions in `symbol-check.py`

This unfortunately brings to light some symbols that have been introduced since and weren't caught (from a gitian compile of master):

```
bitcoin-cli: symbol getrandom from unsupported version GLIBC_2.25
bitcoin-cli: failed IMPORTED_SYMBOLS
bitcoind: symbol getrandom from unsupported version GLIBC_2.25
bitcoind: symbol log from unsupported version GLIBC_2.29
bitcoind: symbol fcntl64 from unsupported version GLIBC_2.28
bitcoind: symbol pow from unsupported version GLIBC_2.29
bitcoind: symbol exp from unsupported version GLIBC_2.29
bitcoind: failed IMPORTED_SYMBOLS
bitcoin-qt: symbol exp from unsupported version GLIBC_2.29
bitcoin-qt: symbol fcntl64 from unsupported version GLIBC_2.28
bitcoin-qt: symbol log from unsupported version GLIBC_2.29
bitcoin-qt: symbol pow from unsupported version GLIBC_2.29
bitcoin-qt: symbol statx from unsupported version GLIBC_2.28
bitcoin-qt: symbol getrandom from unsupported version GLIBC_2.25
bitcoin-qt: symbol renameat2 from unsupported version GLIBC_2.28
bitcoin-qt: symbol getentropy from unsupported version GLIBC_2.25
bitcoin-qt: failed IMPORTED_SYMBOLS
bitcoin-wallet: symbol exp from unsupported version GLIBC_2.29
bitcoin-wallet: symbol log from unsupported version GLIBC_2.29
bitcoin-wallet: symbol fcntl64 from unsupported version GLIBC_2.28
bitcoin-wallet: failed IMPORTED_SYMBOLS
test_bitcoin: symbol getrandom from unsupported version GLIBC_2.25
test_bitcoin: symbol log from unsupported version GLIBC_2.29
test_bitcoin: symbol fcntl64 from unsupported version GLIBC_2.28
test_bitcoin: symbol pow from unsupported version GLIBC_2.29
test_bitcoin: symbol exp from unsupported version GLIBC_2.29
test_bitcoin: failed IMPORTED_SYMBOLS
```