### PR TITLE
[p2p] Stop sending SENDADDRV2 message to block-relay-only peers

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2498,7 +2498,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         }
 
         // Signal ADDRv2 support (BIP155).
-        if (greatest_common_version >= 70016) {
+        if (greatest_common_version >= 70016 && !pfrom.IsBlockOnlyConn()) {
             // BIP155 defines addrv2 and sendaddrv2 for all protocol versions, but some
             // implementations reject messages they don't know. As a courtesy, don't send
             // it to nodes with a version before 70016, as no software is known to support


### PR DESCRIPTION
Came up when working on #21528. 

Currently, sending a `SENDADDRV2` message to an outbound block-relay-only peer is harmless but misleading. However, if we move forward with the approached proposed in that PR, this would mistakenly indicate that the node is interested in participating in addr relay.

Would be great to include this in v22.0 so only v0.21 peers will have this misleading behavior. 