### PR TITLE
policy: Trim Packages when transaction with same txid exists in mempool

### DIFF
--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -50,7 +50,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
         // So if the output does exist, then this transaction exists in the chain.
         if (!existingCoin.IsSpent()) return TransactionError::ALREADY_IN_CHAIN;
     }
-    if (!node.mempool->exists(hashTx)) {
+    if (!node.mempool->exists(GenTxid(false, tx->GetHash()))) {
         // Transaction is not already in the mempool.
         if (max_tx_fee > 0) {
             // First, call ATMP with test_accept and check the fee. If ATMP

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -905,7 +905,7 @@ static RPCHelpMan testmempoolaccept()
                 RPCResult{
                     RPCResult::Type::ARR, "", "The result of the mempool acceptance test for each raw transaction in the input array.\n"
                         "Returns results for each transaction in the same order they were passed in.\n"
-                        "It is possible for transactions to not be fully validated ('allowed' unset) if another transaction failed.\n",
+                        "Transactions that cannot be fully validated due to failures in other transactions will not contain an 'allowed' result.\n",
                     {
                         {RPCResult::Type::OBJ, "", "",
                         {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -993,8 +993,7 @@ static RPCHelpMan testmempoolaccept()
         if (tx_result.m_result_type == MempoolAcceptResult::ResultType::VALID) {
             const CAmount fee = tx_result.m_base_fees.value();
             // Check that fee does not exceed maximum fee
-            const int64_t virtual_size = GetVirtualTransactionSize(*tx);
-            const CAmount max_raw_tx_fee = max_raw_tx_fee_rate.GetFee(virtual_size);
+            const CAmount max_raw_tx_fee = max_raw_tx_fee_rate.GetFee(tx_result.m_vsize.value());
             if (max_raw_tx_fee && fee > max_raw_tx_fee) {
                 result_inner.pushKV("allowed", false);
                 result_inner.pushKV("reject-reason", "max-fee-exceeded");
@@ -1003,7 +1002,7 @@ static RPCHelpMan testmempoolaccept()
                 // Only return the fee and vsize if the transaction would pass ATMP.
                 // These can be used to calculate the feerate.
                 result_inner.pushKV("allowed", true);
-                result_inner.pushKV("vsize", virtual_size);
+                result_inner.pushKV("vsize", tx_result.m_vsize.value());
                 UniValue fees(UniValue::VOBJ);
                 fees.pushKV("base", ValueFromAmount(fee));
                 result_inner.pushKV("fees", fees);

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -199,6 +199,9 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     std::string dummy;
     BOOST_CHECK_EQUAL(pool.CalculateMemPoolAncestors(entry.Fee(2000000LL).FromTx(tx7), setAncestorsCalculated, 100, 1000000, 1000, 1000000, dummy), true);
     BOOST_CHECK(setAncestorsCalculated == setAncestors);
+    setAncestorsCalculated.clear();
+    BOOST_CHECK(pool.CalculateMemPoolAncestors({entry.Fee(2000000LL).FromTx(tx7)}, setAncestorsCalculated, 100, 1000000, 1000, 1000000, dummy));
+    BOOST_CHECK(setAncestorsCalculated == setAncestors);
 
     pool.addUnchecked(entry.FromTx(tx7), setAncestors);
     BOOST_CHECK_EQUAL(pool.size(), 7U);
@@ -256,6 +259,9 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
 
     setAncestorsCalculated.clear();
     BOOST_CHECK_EQUAL(pool.CalculateMemPoolAncestors(entry.Fee(200000LL).Time(4).FromTx(tx10), setAncestorsCalculated, 100, 1000000, 1000, 1000000, dummy), true);
+    BOOST_CHECK(setAncestorsCalculated == setAncestors);
+    setAncestorsCalculated.clear();
+    BOOST_CHECK(pool.CalculateMemPoolAncestors({entry.Fee(200000LL).Time(4).FromTx(tx10)}, setAncestorsCalculated, 100, 1000000, 1000, 1000000, dummy));
     BOOST_CHECK(setAncestorsCalculated == setAncestors);
 
     pool.addUnchecked(entry.FromTx(tx10), setAncestors);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -19,6 +19,7 @@
 #include <validationinterface.h>
 
 #include <cmath>
+#include <numeric>
 #include <optional>
 
 CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFee,
@@ -151,33 +152,47 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashes
     }
 }
 
-bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntries &setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string &errString, bool fSearchForParents /* = true */) const
+bool CTxMemPool::CalculateMemPoolAncestors(const std::vector<CTxMemPoolEntry::CTxMemPoolEntryRef>& entries,
+                                           setEntries& setAncestors,
+                                           const uint64_t limitAncestorCount,
+                                           const uint64_t limitAncestorSize,
+                                           const uint64_t limitDescendantCount,
+                                           const uint64_t limitDescendantSize,
+                                           std::string &errString,
+                                           const bool fSearchForParents /*=true*/) const
 {
-    CTxMemPoolEntry::Parents staged_ancestors;
-    const CTransaction &tx = entry.GetTx();
+    const size_t total_virtual_size = std::accumulate(entries.cbegin(), entries.cend(), 0,
+                                      [](int64_t sum, const auto& entry)
+                                      { return sum + GetVirtualTransactionSize(entry.get().GetTx()); });
+    const size_t total_count = entries.size();
 
+    CTxMemPoolEntry::Parents staged_ancestors;
     if (fSearchForParents) {
-        // Get parents of this transaction that are in the mempool
-        // GetMemPoolParents() is only valid for entries in the mempool, so we
-        // iterate mapTx to find parents.
-        for (unsigned int i = 0; i < tx.vin.size(); i++) {
-            std::optional<txiter> piter = GetIter(tx.vin[i].prevout.hash);
-            if (piter) {
-                staged_ancestors.insert(**piter);
-                if (staged_ancestors.size() + 1 > limitAncestorCount) {
-                    errString = strprintf("too many unconfirmed parents [limit: %u]", limitAncestorCount);
-                    return false;
+        for (const auto& entry : entries) {
+            // Get parents of this transaction that are in the mempool
+            // GetMemPoolParents() is only valid for entries in the mempool, so we
+            // iterate mapTx to find parents.
+            for (const auto& input : entry.get().GetTx().vin) {
+                std::optional<txiter> piter = GetIter(input.prevout.hash);
+                if (piter) {
+                    staged_ancestors.insert(**piter);
+                    if (staged_ancestors.size() + total_count > limitAncestorCount) {
+                        errString = strprintf("too many unconfirmed parents [limit: %u]", limitAncestorCount);
+                        return false;
+                    }
                 }
             }
         }
     } else {
-        // If we're not searching for parents, we require this to be an
-        // entry in the mempool already.
-        txiter it = mapTx.iterator_to(entry);
-        staged_ancestors = it->GetMemPoolParentsConst();
+        // If we're not searching for parents, we require all entries to be in the mempool already.
+        // We should never use CalculateMemPoolAncestors on a set of transactions that are already
+        // in the mempool.
+        assert(entries.size() == 1);
+        txiter it = mapTx.iterator_to(entries[0].get());
+        staged_ancestors = it->GetMemPoolParents();
     }
 
-    size_t totalSizeWithAncestors = entry.GetTxSize();
+    size_t totalSizeWithAncestors = total_virtual_size;
 
     while (!staged_ancestors.empty()) {
         const CTxMemPoolEntry& stage = staged_ancestors.begin()->get();
@@ -187,14 +202,22 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntr
         staged_ancestors.erase(stage);
         totalSizeWithAncestors += stageit->GetTxSize();
 
-        if (stageit->GetSizeWithDescendants() + entry.GetTxSize() > limitDescendantSize) {
-            errString = strprintf("exceeds descendant size limit for tx %s [limit: %u]", stageit->GetTx().GetHash().ToString(), limitDescendantSize);
+        // When multiple transactions are passed in, the ancestors and descendants of all transactions
+        // considered together must be within limits even if they are not interdependent. This may be
+        // stricter than the limits for each individual transaction.
+        if (stageit->GetSizeWithDescendants() + total_virtual_size > limitDescendantSize) {
+            errString = strprintf("%sexceeds descendant size limit for tx %s [limit: %u]",
+                                  total_count > 1 ? "possibly" : "",
+                                  stageit->GetTx().GetHash().ToString(), limitDescendantSize);
             return false;
-        } else if (stageit->GetCountWithDescendants() + 1 > limitDescendantCount) {
-            errString = strprintf("too many descendants for tx %s [limit: %u]", stageit->GetTx().GetHash().ToString(), limitDescendantCount);
+        } else if (stageit->GetCountWithDescendants() + total_count > limitDescendantCount) {
+            errString = strprintf("%stoo many descendants for tx %s [limit: %u]",
+                                  total_count > 1 ? "possibly" : "",
+                                  stageit->GetTx().GetHash().ToString(), limitDescendantCount);
             return false;
         } else if (totalSizeWithAncestors > limitAncestorSize) {
-            errString = strprintf("exceeds ancestor size limit [limit: %u]", limitAncestorSize);
+            errString = strprintf("%sexceeds ancestor size limit [limit: %u]",
+                                  total_count > 1 ? "possibly" : "", limitAncestorSize);
             return false;
         }
 
@@ -206,14 +229,26 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntr
             if (setAncestors.count(parent_it) == 0) {
                 staged_ancestors.insert(parent);
             }
-            if (staged_ancestors.size() + setAncestors.size() + 1 > limitAncestorCount) {
-                errString = strprintf("too many unconfirmed ancestors [limit: %u]", limitAncestorCount);
+            if (staged_ancestors.size() + setAncestors.size() + total_count > limitAncestorCount) {
+                errString = strprintf("%stoo many unconfirmed ancestors [limit: %u]",
+                                      total_count > 1 ? "possibly" : "", limitAncestorCount);
                 return false;
             }
         }
     }
 
     return true;
+}
+
+bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntries &setAncestors,
+                                           uint64_t limitAncestorCount, uint64_t limitAncestorSize,
+                                           uint64_t limitDescendantCount, uint64_t limitDescendantSize,
+                                           std::string &errString, bool fSearchForParents /* = true */) const
+{
+    std::vector<CTxMemPoolEntry::CTxMemPoolEntryRef> entry_vec{std::cref(entry)};
+    return CalculateMemPoolAncestors(entry_vec,
+                                     setAncestors, limitAncestorCount, limitAncestorSize, limitDescendantCount,
+                                     limitDescendantSize, errString, fSearchForParents);
 }
 
 void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, setEntries &setAncestors)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -681,6 +681,34 @@ public:
      */
     bool CalculateMemPoolAncestors(const CTxMemPoolEntry& entry, setEntries& setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, bool fSearchForParents = true) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
+    /** Try to calculate all in-mempool ancestors of a set of entries, and check for ancestor and
+     * descendant limits (all are inclusive of the transactions in entries). The same limits are
+     * used no matter how many transactions are passed in. For example, if entries.size() = 3 and
+     * the limit is 25, the union of all 3 sets of ancestors must be <= 22.
+     * @param[in]       entries                 Entries corresponding to transaction(s) being
+     *                                          evaluated for acceptance to mempool. If there are
+     *                                          multiple, they must not already be in the mempool.
+     *                                          They need not be direct ancestors/descendants of
+     *                                          each other, though they will be treated as such.
+     * @param[in,out]   setAncestors            Set of in-mempool ancestors. Updated to include
+     *                                          any new ancestors found.
+     * @param[in]       limitAncestorCount      Max number of txns including ancestors.
+     * @param[in]       limitAncestorSize       Max virtual size including ancestors.
+     * @param[in]       limitDescendantCount    Max number of txns including descendants.
+     * @param[in]       limitDescendantSize     Max virtual size including descendants.
+     * @param[out]      errString               Populated with error reason if a limit is hit.
+     * @param[in]       fSearchForParents       Whether to search for entries' in-mempool parents.
+     *                                          Must be true if any entries are not already in mempool.
+     */
+    bool CalculateMemPoolAncestors(const std::vector<CTxMemPoolEntry::CTxMemPoolEntryRef>& entries,
+                                   setEntries& setAncestors,
+                                   const uint64_t limitAncestorCount,
+                                   const uint64_t limitAncestorSize,
+                                   const uint64_t limitDescendantCount,
+                                   const uint64_t limitDescendantSize,
+                                   std::string &errString,
+                                   const bool fSearchForParents = true) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+
     /** Populate setDescendants with all in-mempool descendants of hash.
      *  Assumes that setDescendants includes all in-mempool descendants of anything
      *  already in it.  */

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1076,14 +1076,16 @@ MempoolAcceptResult MemPoolAccept::AcceptSingleTransaction(const CTransactionRef
 
     // Tx was accepted, but not added
     if (args.m_test_accept) {
-        return MempoolAcceptResult::Success(std::move(ws.m_replaced_transactions), ws.m_base_fees);
+        return MempoolAcceptResult::Success(std::move(ws.m_replaced_transactions), ws.m_base_fees,
+                                            GetVirtualTransactionSize(*ws.m_ptx));
     }
 
     if (!Finalize(args, ws)) return MempoolAcceptResult::Failure(ws.m_state);
 
     GetMainSignals().TransactionAddedToMempool(ptx, m_pool.GetAndIncrementSequence());
 
-    return MempoolAcceptResult::Success(std::move(ws.m_replaced_transactions), ws.m_base_fees);
+    return MempoolAcceptResult::Success(std::move(ws.m_replaced_transactions), ws.m_base_fees,
+                                        GetVirtualTransactionSize(*ws.m_ptx));
 }
 
 PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::vector<CTransactionRef>& txns, ATMPArgs& args)
@@ -1158,7 +1160,8 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
             // When test_accept=true, transactions that pass PolicyScriptChecks are valid because there are
             // no further mempool checks (passing PolicyScriptChecks implies passing ConsensusScriptChecks).
             results.emplace(ws.m_ptx->GetWitnessHash(),
-                            MempoolAcceptResult::Success(std::move(ws.m_replaced_transactions), ws.m_base_fees));
+                            MempoolAcceptResult::Success(std::move(ws.m_replaced_transactions), ws.m_base_fees,
+                                                         GetVirtualTransactionSize(*ws.m_ptx)));
         }
     }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -181,12 +181,15 @@ struct MempoolAcceptResult {
     const std::optional<std::list<CTransactionRef>> m_replaced_transactions;
     /** Raw base fees in satoshis. */
     const std::optional<CAmount> m_base_fees;
+    /** Size in virtual bytes. */
+    const std::optional<int64_t> m_vsize;
     static MempoolAcceptResult Failure(TxValidationState state) {
         return MempoolAcceptResult(state);
     }
 
-    static MempoolAcceptResult Success(std::list<CTransactionRef>&& replaced_txns, CAmount fees) {
-        return MempoolAcceptResult(std::move(replaced_txns), fees);
+    static MempoolAcceptResult Success(std::list<CTransactionRef>&& replaced_txns, CAmount fees,
+                                       int64_t vsize) {
+        return MempoolAcceptResult(std::move(replaced_txns), fees, vsize);
     }
 
 // Private constructors. Use static methods MempoolAcceptResult::Success, etc. to construct.
@@ -198,9 +201,9 @@ private:
         }
 
     /** Constructor for success case */
-    explicit MempoolAcceptResult(std::list<CTransactionRef>&& replaced_txns, CAmount fees)
+    explicit MempoolAcceptResult(std::list<CTransactionRef>&& replaced_txns, CAmount fees, int64_t vsize)
         : m_result_type(ResultType::VALID),
-        m_replaced_transactions(std::move(replaced_txns)), m_base_fees(fees) {}
+        m_replaced_transactions(std::move(replaced_txns)), m_base_fees(fees), m_vsize{vsize} {}
 };
 
 /**
@@ -240,8 +243,7 @@ MempoolAcceptResult AcceptToMemoryPool(CChainState& active_chainstate, CTxMemPoo
 * @param[in]    txns                Group of transactions which may be independent or contain
 *                                   parent-child dependencies. The transactions must not conflict
 *                                   with each other, i.e., must not spend the same inputs. If any
-*                                   dependencies exist, parents must appear anywhere in the list
-*                                   before their children.
+*                                   dependencies exist, parents must appear before children.
 * @returns a PackageMempoolAcceptResult which includes a MempoolAcceptResult for each transaction.
 * If a transaction fails, validation will exit early and some results may be missing.
 */

--- a/src/validation.h
+++ b/src/validation.h
@@ -240,7 +240,8 @@ MempoolAcceptResult AcceptToMemoryPool(CChainState& active_chainstate, CTxMemPoo
 * @param[in]    txns                Group of transactions which may be independent or contain
 *                                   parent-child dependencies. The transactions must not conflict
 *                                   with each other, i.e., must not spend the same inputs. If any
-*                                   dependencies exist, parents must appear before children.
+*                                   dependencies exist, parents must appear anywhere in the list
+*                                   before their children.
 * @returns a PackageMempoolAcceptResult which includes a MempoolAcceptResult for each transaction.
 * If a transaction fails, validation will exit early and some results may be missing.
 */

--- a/test/functional/mempool_wtxid.py
+++ b/test/functional/mempool_wtxid.py
@@ -6,6 +6,7 @@
 Test mempool acceptance in case of an already known transaction
 with identical non-witness data different witness.
 """
+from decimal import Decimal
 
 from test_framework.script import (
     CScript,
@@ -99,6 +100,7 @@ class MempoolWtxidTest(BitcoinTestFramework):
         assert child_one_wtxid != child_two_wtxid
 
         self.log.info("Submit one child to the mempool")
+        testres_child_one = node.testmempoolaccept([ToHex(child_one)])[0]
         txid_submitted = node.sendrawtransaction(ToHex(child_one))
         assert_equal(node.getrawmempool(True)[txid_submitted]['wtxid'], child_one_wtxid)
 
@@ -117,6 +119,32 @@ class MempoolWtxidTest(BitcoinTestFramework):
         node.sendrawtransaction(ToHex(child_one))
         # sendrawtransaction will not throw but quits early when a transaction with the same nonwitness data is already in mempool
         node.sendrawtransaction(ToHex(child_two))
+
+        self.log.info("Simulate an attack attempting to prevent package from being accepted")
+        # This grandchild is valid with either child_one or child_two; it shouldn't matter which one.
+        grandchild = CTransaction()
+        grandchild.vin.append(CTxIn(COutPoint(int(child_two_txid, 16), 0), b""))
+        # Deduct 0.00001 BTC as fee, and use the same scriptPubKey (OP_TRUE script)
+        grandchild.vout.append(CTxOut(int(9.99995 * COIN), child_script_pubkey))
+        grandchild.wit.vtxinwit.append(CTxInWitness())
+        grandchild.wit.vtxinwit[0].scriptWitness.stack = [child_witness_script]
+        grandchild_txid = grandchild.rehash()
+        grandchild_wtxid = grandchild.getwtxid()
+
+        # Submit the package { child_two, grandchild }. MemPoolAccept should detect that child_two
+        # "matches" (by txid) child_one which is already in the mempool, and trim child_two from the
+        # package. The RPC result should include this information: the full result for child_one
+        # from its mempool entry, along with a "txn-same-nonwitness-data-in-mempool" for child_two.
+        testres_full = node.testmempoolaccept([ToHex(child_two), ToHex(grandchild)])
+        assert_equal(testres_full[0], testres_child_one)
+        assert_equal(testres_full[1], testres_child_two)
+        assert_equal(testres_full[2], {
+                "txid": grandchild_txid,
+                "wtxid": grandchild_wtxid,
+                "allowed": True,
+                "vsize": grandchild.get_vsize(),
+                "fees": { "base": Decimal("0.00001")}
+        })
 
 
 if __name__ == '__main__':

--- a/test/functional/mempool_wtxid.py
+++ b/test/functional/mempool_wtxid.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Test mempool acceptance in case of an already known transaction
+with identical non-witness data different witness.
+"""
+
+from test_framework.script import (
+    CScript,
+    OP_0,
+    OP_TRUE,
+    OP_IF,
+    OP_HASH160,
+    OP_EQUAL,
+    OP_ELSE,
+    OP_ENDIF,
+    hash160,
+)
+from test_framework.messages import (
+    CTransaction,
+    CTxIn,
+    CTxInWitness,
+    CTxOut,
+    COutPoint,
+    sha256,
+    COIN,
+    ToHex,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+
+class MempoolWtxidTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [["-incrementalrelayfee=0"]]
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        self.log.info('Start with empty mempool, and 200 blocks')
+        self.privkeys = [node.get_deterministic_priv_key().key]
+        self.address = node.get_deterministic_priv_key().address
+        self.coins = []
+        # The last 100 coinbase transactions are premature
+        for b in node.generatetoaddress(110, self.address)[:-100]:
+            coinbase = node.getblock(blockhash=b, verbosity=2)["tx"][0]
+            self.coins.append({
+                "txid": coinbase["txid"],
+                "amount": coinbase["vout"][0]["value"],
+                "scriptPubKey": coinbase["vout"][0]["scriptPubKey"],
+            })
+        assert_equal(node.getmempoolinfo()['size'], 0)
+
+        txid = self.coins.pop()["txid"]
+
+        self.log.info("Submit parent with multiple script branches to mempool")
+        hashlock = hash160(b'Preimage')
+        witness_script = CScript([OP_IF, OP_HASH160, hashlock, OP_EQUAL, OP_ELSE, OP_TRUE, OP_ENDIF])
+        witness_program = sha256(witness_script)
+        script_pubkey = CScript([OP_0, witness_program])
+
+        parent = CTransaction()
+        parent.vin.append(CTxIn(COutPoint(int(txid, 16), 0), b""))
+        parent.vout.append(CTxOut(int(9.99998 * COIN), script_pubkey))
+        parent.rehash()
+
+        raw_parent = node.signrawtransactionwithkey(hexstring=parent.serialize().hex(), privkeys=self.privkeys)['hex']
+        parent_txid = node.sendrawtransaction(hexstring=raw_parent, maxfeerate=0)
+        node.generate(1)
+
+        # Create a new segwit transaction with witness solving first branch
+        child_witness_script = CScript([OP_TRUE])
+        child_witness_program = sha256(child_witness_script)
+        child_script_pubkey = CScript([OP_0, child_witness_program])
+
+        child_one = CTransaction()
+        child_one.vin.append(CTxIn(COutPoint(int(parent_txid, 16), 0), b""))
+        child_one.vout.append(CTxOut(int(9.99996 * COIN), child_script_pubkey))
+        child_one.wit.vtxinwit.append(CTxInWitness())
+        child_one.wit.vtxinwit[0].scriptWitness.stack = [b'Preimage', b'\x01', witness_script]
+        child_one_wtxid = child_one.getwtxid()
+        child_one_txid = child_one.rehash()
+
+        # Create another identical segwit transaction with witness solving second branch
+        child_two = CTransaction()
+        child_two.vin.append(CTxIn(COutPoint(int(parent_txid, 16), 0), b""))
+        child_two.vout.append(CTxOut(int(9.99996 * COIN), child_script_pubkey))
+        child_two.wit.vtxinwit.append(CTxInWitness())
+        child_two.wit.vtxinwit[0].scriptWitness.stack = [b'', witness_script]
+        child_two_wtxid = child_two.getwtxid()
+        child_two_txid = child_two.rehash()
+
+        assert_equal(child_one_txid, child_two_txid)
+        assert child_one_wtxid != child_two_wtxid
+
+        self.log.info("Submit one child to the mempool")
+        txid_submitted = node.sendrawtransaction(ToHex(child_one))
+        assert_equal(node.getrawmempool(True)[txid_submitted]['wtxid'], child_one_wtxid)
+
+        # testmempoolaccept reports the "already in mempool" error
+        assert_equal(node.testmempoolaccept([ToHex(child_one)]),
+                     [{"txid": child_one_txid, "wtxid": child_one_wtxid, "allowed": False, "reject-reason": "txn-already-in-mempool"}])
+        testres_child_two = node.testmempoolaccept([ToHex(child_two)])[0]
+        assert_equal(testres_child_two, {
+            "txid": child_two_txid,
+            "wtxid": child_two_wtxid,
+            "allowed": False,
+            "reject-reason": "txn-same-nonwitness-data-in-mempool"
+        })
+
+        # sendrawtransaction will not throw but quits early when the exact same transaction is already in mempool
+        node.sendrawtransaction(ToHex(child_one))
+        # sendrawtransaction will not throw but quits early when a transaction with the same nonwitness data is already in mempool
+        node.sendrawtransaction(ToHex(child_two))
+
+
+if __name__ == '__main__':
+    MempoolWtxidTest().main()

--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -75,6 +75,9 @@ class RPCPackagesTest(BitcoinTestFramework):
 
         self.test_independent()
         self.test_chain()
+        self.test_chain_limits()
+        self.test_descendant_limits()
+        self.test_ancestor_limits()
         self.test_multiple_children()
         self.test_multiple_parents()
         self.test_conflicting()
@@ -186,6 +189,178 @@ class RPCPackagesTest(BitcoinTestFramework):
 
         # Clean up by clearing the mempool
         node.generate(1)
+
+    def test_chain_limits_helper(self, mempool_count, package_count):
+        node = self.nodes[0]
+        first_coin = self.coins.pop()
+        parent_locking_script = None
+        txid = first_coin["txid"]
+        chain_hex = []
+        chain_txns = []
+        value = first_coin["amount"]
+
+        for i in range(mempool_count + package_count):
+            (tx, txhex, value, parent_locking_script) = self.chain_transaction(txid, value, 0, parent_locking_script)
+            txid = tx.rehash()
+            if i < mempool_count:
+                node.sendrawtransaction(txhex)
+                assert_equal(node.getrawmempool(verbose=True)[txid]["ancestorcount"], i + 1)
+            else:
+                chain_hex.append(txhex)
+                chain_txns.append(tx)
+        testres_too_long = node.testmempoolaccept(rawtxs=chain_hex)
+        for txres in testres_too_long:
+            assert_equal(txres["reject-reason"], "exceeds-ancestor-descendant-limits")
+            assert_equal(txres["package-error"], "package-mempool-limits")
+
+        # Clear mempool and check that the package passes now
+        node.generate(1)
+        assert all([res["allowed"] for res in node.testmempoolaccept(rawtxs=chain_hex)])
+
+    def test_chain_limits(self):
+        """Create chains from mempool and package transactions that are longer than 25,
+        but only if both in-mempool and in-package transactions are considered together.
+        This checks that both mempool and in-package transactions are taken into account when
+        calculating ancestors/descendant limits.
+        """
+        self.log.info("Check that in-package ancestors count for mempool ancestor limits")
+
+        # 24 transactions in the mempool and 2 in the package. The parent in the package has
+        # 24 in-mempool ancestors and 1 in-package descendant. The child has 0 direct parents
+        # in the mempool, but 25 in-mempool and in-package ancestors in total.
+        self.test_chain_limits_helper(24, 2)
+        # 2 transactions in the mempool and 24 in the package.
+        self.test_chain_limits_helper(2, 24)
+        # 13 transactions in the mempool and 13 in the package.
+        self.test_chain_limits_helper(13, 13)
+
+    def test_descendant_limits(self):
+        """Create an 'A' shaped package with 25 transactions in the mempool and 2 in the package:
+                    M1
+                   ^  ^
+                 M2a  M2b
+                .       .
+               .         .
+              .           .
+             M11a          ^
+            ^              M12b
+           ^                 ^
+          Pa                  Pb
+        The top ancestor in the package exceeds descendant limits but only if the in-mempool and in-package
+        descendants are all considered together (24 including in-mempool descendants and 26 including both
+        package transactions).
+        """
+        node = self.nodes[0]
+        self.log.info("Check that in-mempool and in-package descendants are calculated properly in packages")
+        # Top parent in mempool, M1
+        first_coin = self.coins.pop()
+        parent_value = (first_coin["amount"] - Decimal("0.0002")) / 2 # Deduct reasonable fee and make 2 outputs
+        inputs = [{"txid": first_coin["txid"], "vout": 0}]
+        outputs = [{self.address : parent_value}, {ADDRESS_BCRT1_P2WSH_OP_TRUE : parent_value}]
+        rawtx = node.createrawtransaction(inputs, outputs)
+
+        parent_signed = node.signrawtransactionwithkey(hexstring=rawtx, privkeys=self.privkeys)
+        parent_tx = CTransaction()
+        assert parent_signed["complete"]
+        parent_tx.deserialize(BytesIO(hex_str_to_bytes(parent_signed["hex"])))
+        parent_txid = parent_tx.rehash()
+        node.sendrawtransaction(parent_signed["hex"])
+
+        package_hex = []
+
+        # Chain A
+        parent_locking_script = parent_tx.vout[0].scriptPubKey.hex()
+        value = parent_value
+        txid = parent_txid
+        for i in range(12):
+            (tx, txhex, value, parent_locking_script) = self.chain_transaction(txid, value, 0, parent_locking_script)
+            txid = tx.rehash()
+            if i < 11: # M2a... M12a
+                node.sendrawtransaction(txhex)
+            else: # Pa
+                package_hex.append(txhex)
+
+        # Chain B
+        value = parent_value - Decimal("0.0001")
+        rawtx_b = node.createrawtransaction([{"txid": parent_txid, "vout": 1}], {self.address : value})
+        tx_child_b = CTransaction() # M2b
+        tx_child_b.deserialize(BytesIO(hex_str_to_bytes(rawtx_b)))
+        tx_child_b.wit.vtxinwit = [CTxInWitness()]
+        tx_child_b.wit.vtxinwit[0].scriptWitness.stack = [CScript([OP_TRUE])]
+        tx_child_b_hex = tx_child_b.serialize().hex()
+        node.sendrawtransaction(tx_child_b_hex)
+        parent_locking_script = tx_child_b.vout[0].scriptPubKey.hex()
+        txid = tx_child_b.rehash()
+        for i in range(12):
+            (tx, txhex, value, parent_locking_script) = self.chain_transaction(txid, value, 0, parent_locking_script)
+            txid = tx.rehash()
+            if i < 11: # M3b... M13b
+                node.sendrawtransaction(txhex)
+            else: # Pb
+                package_hex.append(txhex)
+
+        testres_too_long = node.testmempoolaccept(rawtxs=package_hex)
+        for txres in testres_too_long:
+            assert_equal(txres["reject-reason"], "exceeds-ancestor-descendant-limits")
+            assert_equal(txres["package-error"], "package-mempool-limits")
+
+        # Clear mempool and check that the package passes now
+        node.generate(1)
+        assert all([res["allowed"] for res in node.testmempoolaccept(rawtxs=package_hex)])
+
+    def test_ancestor_limits(self):
+        """Create a 'V' shaped chain with 24 transactions in the mempool and 3 in the package:
+        M1a                    M1b
+         ^                     ^
+          M2a                M2b
+           .                 .
+            .               .
+             .             .
+             M12a        M12b
+               ^         ^
+                Pa     Pb
+                 ^    ^
+                   Pc
+        The lowest descendant, Pc, exceeds ancestor limits, but only if the in-mempool
+        and in-package ancestors are all considered together.
+        """
+        node = self.nodes[0]
+        package_hex = []
+        parents_tx = []
+        values = []
+        parent_locking_scripts = []
+
+        self.log.info("Check that in-mempool and in-package ancestors are calculated properly in packages")
+
+        # Two chains of 13 transactions each
+        for _ in range(2):
+            parent_locking_script = None
+            top_coin = self.coins.pop()
+            txid = top_coin["txid"]
+            value = top_coin["amount"]
+            for i in range(13):
+                (tx, txhex, value, parent_locking_script) = self.chain_transaction(txid, value, 0, parent_locking_script)
+                txid = tx.rehash()
+                if i < 12:
+                    node.sendrawtransaction(txhex)
+                else: # Save the 13th transaction for the package
+                    package_hex.append(txhex)
+                    parents_tx.append(tx)
+                    parent_locking_scripts.append(parent_locking_script)
+                    values.append(value)
+
+        # Child Pc
+        child_hex = self.create_child_with_parents(parents_tx, values, parent_locking_scripts)
+        package_hex.append(child_hex)
+
+        testres_too_long = node.testmempoolaccept(rawtxs=package_hex)
+        for txres in testres_too_long:
+            assert_equal(txres["reject-reason"], "exceeds-ancestor-descendant-limits")
+            assert_equal(txres["package-error"], "package-mempool-limits")
+
+        # Clear mempool and check that the package passes now
+        node.generate(1)
+        assert all([res["allowed"] for res in node.testmempoolaccept(rawtxs=package_hex)])
 
     def test_multiple_children(self):
         node = self.nodes[0]

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -277,6 +277,7 @@ BASE_SCRIPTS = [
     'feature_asmap.py',
     'mempool_unbroadcast.py',
     'mempool_compatibility.py',
+    'mempool_wtxid.py',
     'rpc_deriveaddresses.py',
     'rpc_deriveaddresses.py --usecli',
     'p2p_ping.py',


### PR DESCRIPTION
[WIP] This requires #22253 and is built on top of #21800, please review them first.

This PR implements deduplication of package transactions that have the same txid as transaction(s) in the mempool. In that sense, our policy changes because it is no longer all-or-nothing. I would still call it "atomic" because it either decides (1) all transactions may be submitted to mempool or (2) there should be no change to the mempool. Importantly, we deduplicate by txid rather than wtxid - a transaction with the same nonwitness data should be sufficient to validate the descendants in the package.

I consider this a prerequisite to _submission_ of packages to mempool, because it would be a rather annoying limitation if we couldn't tell that the package was already partially in the mempool. It could also be problematic if someone could submit the transaction with a different witness to cause the package to be rejected.