### PR TITLE
[0.21] wallet: Do not iterate a directory if having an error while accessing it

### DIFF
--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -63,7 +63,12 @@ std::vector<fs::path> ListWalletDir()
 
     for (auto it = fs::recursive_directory_iterator(wallet_dir, ec); it != fs::recursive_directory_iterator(); it.increment(ec)) {
         if (ec) {
-            LogPrintf("%s: %s %s\n", __func__, ec.message(), it->path().string());
+            if (fs::is_directory(*it)) {
+                it.no_push();
+                LogPrintf("%s: %s %s -- skipping.\n", __func__, ec.message(), it->path().string());
+            } else {
+                LogPrintf("%s: %s %s\n", __func__, ec.message(), it->path().string());
+            }
             continue;
         }
 


### PR DESCRIPTION
This change prevents infinite looping for, for example, system folders
on Windows.

Github-Pull: #21907
Rebased-From: 29c9e2c2d2015ade47ed4497926363dea3f9c59b

Note: Trivial backport, but in a differently-named function in another file