### PR TITLE
Make bech32m the default for RPC, opt-in for GUI

### DIFF
--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -87,7 +87,7 @@ void ReceiveCoinsDialog::setModel(WalletModel *_model)
             &QItemSelectionModel::selectionChanged, this,
             &ReceiveCoinsDialog::recentRequestsView_selectionChanged);
 
-        if (model->wallet().getDefaultAddressType() == OutputType::BECH32) {
+        if (model->wallet().getDefaultAddressType() == OutputType::BECH32 || model->wallet().getDefaultAddressType() == OutputType::BECH32M) {
             ui->useBech32->setCheckState(Qt::Checked);
         } else {
             ui->useBech32->setCheckState(Qt::Unchecked);
@@ -144,12 +144,14 @@ void ReceiveCoinsDialog::on_receiveButton_clicked()
     QString address;
     QString label = ui->reqLabel->text();
     /* Generate new receiving address */
-    OutputType address_type;
+    OutputType address_type = model->wallet().getDefaultAddressType();
+
     if (ui->useBech32->isChecked()) {
-        address_type = OutputType::BECH32;
+        if (address_type != OutputType::BECH32 && address_type != OutputType::BECH32M) {
+            address_type = OutputType::BECH32;
+        }
     } else {
-        address_type = model->wallet().getDefaultAddressType();
-        if (address_type == OutputType::BECH32) {
+        if (address_type == OutputType::BECH32 || address_type == OutputType::BECH32M) {
             address_type = OutputType::P2SH_SEGWIT;
         }
     }

--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -64,6 +64,7 @@ void TestAddAddressesToSendBook(interfaces::Node& node)
     test.m_node.wallet_client = wallet_client.get();
     node.setContext(&test.m_node);
     std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(node.context()->chain.get(), "", CreateMockWalletDatabase());
+    wallet->m_default_address_type = OutputType::BECH32;
     wallet->LoadWallet();
     wallet->SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
     {

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -142,6 +142,7 @@ void TestGUI(interfaces::Node& node)
     test.m_node.wallet_client = wallet_client.get();
     node.setContext(&test.m_node);
     std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(node.context()->chain.get(), "", CreateMockWalletDatabase());
+    wallet->m_default_address_type = OutputType::BECH32;
     wallet->LoadWallet();
     wallet->SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
     {

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -1555,6 +1555,10 @@ static UniValue ProcessDescriptorImport(CWallet& wallet, const UniValue& data, c
                 // Taproot is not active, raise an error
                 throw JSONRPCError(RPC_WALLET_ERROR, "Cannot import tr() descriptor when Taproot is not active");
             }
+            // When importing an active taproot descriptor, change the default address type to bech32m
+            if (active && wallet.m_default_address_type == OutputType::BECH32) {
+                wallet.m_default_address_type = OutputType::BECH32M;
+            }
         }
 
         // If private keys are enabled, check some things.

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -18,6 +18,7 @@
 std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, CChain& cchain, const CKey& key)
 {
     auto wallet = std::make_unique<CWallet>(&chain, "", CreateMockWalletDatabase());
+    wallet->m_default_address_type = OutputType::BECH32;
     {
         LOCK2(wallet->cs_wallet, ::cs_main);
         wallet->SetLastBlockProcessed(cchain.Height(), cchain.Tip()->GetBlockHash());

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -275,6 +275,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         WalletContext context;
         context.args = &gArgs;
         std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(m_node.chain.get(), "", CreateDummyWalletDatabase());
+        wallet->m_default_address_type = OutputType::BECH32;
         {
             auto spk_man = wallet->GetOrCreateLegacyScriptPubKeyMan();
             LOCK2(wallet->cs_wallet, spk_man->cs_KeyStore);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2628,6 +2628,12 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
             return nullptr;
         }
         walletInstance->m_default_address_type = parsed.value();
+    } else {
+        // Set default type to bech32 for legacy wallets and descriptor wallets without taproot
+        auto spk_man = walletInstance->GetScriptPubKeyMan(OutputType::BECH32M, false);
+        if (walletInstance->IsLegacy() || spk_man == nullptr) {
+            walletInstance->m_default_address_type = OutputType::BECH32;
+        }
     }
 
     if (!args.GetArg("-changetype", "").empty()) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -113,7 +113,7 @@ enum class FeeEstimateMode;
 class ReserveDestination;
 
 //! Default for -addresstype
-constexpr OutputType DEFAULT_ADDRESS_TYPE{OutputType::BECH32};
+constexpr OutputType DEFAULT_ADDRESS_TYPE{OutputType::BECH32M};
 
 static constexpr uint64_t KNOWN_WALLET_FLAGS =
         WALLET_FLAG_AVOID_REUSE


### PR DESCRIPTION
**RPC**
This makes bech32m the default whenever possible. For legacy wallets the default remains bech32. Same for descriptor wallets without an active Taproot descriptor.

**GUI**
A new wallet setting allows users to opt-in to Taproot. If they opt in, the GUI bech32 checkbox now produces either bech32 or bech32m depending on the wallet. This avoids having to explain the difference.

<img width="591" alt="Schermafbeelding 2021-10-20 om 20 13 17" src="https://user-images.githubusercontent.com/10217/138150773-353bd519-56b2-4b24-a2a0-998778cc56ab.png">

**Considerations**
This lets users and developers experiment with taproot wallets. When merged before #22364, the user will have to manually import a taproot descriptor. After that PR, taproot descriptors will be present for all new wallets.

It is better to stick to bech32 addresses for the time being, because:
1. It is expected that it will take a while for enough wallets and exchanges to correctly handle sending to bech32m addresses
2. Taproot savings for a single signature wallet are not huge
3. Explaining the difference between bech32 and bech32m is not great UX

But we don't want to prevent users and developers who _do_ understand the difference to use Taproot. Without this PR they can only do this via the RPC (`getnewaddress some_label bech32m`). With this PR it's a simple checkbox.

Changing the RPC default to bech32m seems acceptable to me, since those users will have a better understanding of the wallet. Though I can see the case against it because it might be a breaking change, e.g. if someone has an automated setup that creates new wallets (existing wallets currently don't auto upgrade to taproot, so their behavior is not changed). 

**Suggested testing**
* call `getnewaddress` without type and `getnewaddress Test bech32` / `bech32m`
* create a receive address in the GUI with and without the bech32 checkbox
1. Legacy wallet
2. Default descriptor wallet (current does not have taproot descriptor)
3. Wallet with taproot descriptor:
   * build #22364 
   * create new descriptor wallet
   * build this PR again