### PR TITLE
refactor: call GetBestBlock() before NewIterator()

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -194,8 +194,9 @@ private:
 
 std::unique_ptr<CCoinsViewCursor> CCoinsViewDB::Cursor() const
 {
+    uint256 hashBestChain = GetBestBlock();
     auto i = std::make_unique<CCoinsViewDBCursor>(
-        const_cast<CDBWrapper&>(*m_db).NewIterator(), GetBestBlock());
+        const_cast<CDBWrapper&>(*m_db).NewIterator(), hashBestChain);
     /* It seems that there are no "const iterators" for LevelDB.  Since we
        only need read operations on it, use a const-cast to get around
        that restriction.  */


### PR DESCRIPTION
This fixes the potential memory leak caused by `NewIterator()`  when `GetBestBlock()` throws an exception. (When compiled with clang, the parameters are evaluated from left to right)