### PR TITLE
fuzz: Assert roundtrip equality for `CPubKey`

### DIFF
--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -136,8 +136,7 @@ FUZZ_TARGET_DESERIALIZE(partial_merkle_tree_deserialize, {
 FUZZ_TARGET_DESERIALIZE(pub_key_deserialize, {
         CPubKey pub_key;
         DeserializeFromFuzzingInput(buffer, pub_key);
-        // TODO: The following equivalence should hold for CPubKey? Fix.
-        // AssertEqualAfterSerializeDeserialize(pub_key);
+        AssertEqualAfterSerializeDeserialize(pub_key);
 })
 FUZZ_TARGET_DESERIALIZE(script_deserialize, {
         CScript script;


### PR DESCRIPTION
This PR is a (quite late) follow-up to #19237 (https://github.com/bitcoin/bitcoin/pull/19237#issuecomment-642203251). Looking at `CPubKey::Serialize` and `CPubKey::Unserialize` I can't think of a scenario where the roundtrip (serialization/deserialization) equality wouldn't hold. 