### PR TITLE
Add LIFETIMEBOUND to CScript where needed

### DIFF
--- a/src/script/script.h
+++ b/src/script/script.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_SCRIPT_SCRIPT_H
 #define BITCOIN_SCRIPT_SCRIPT_H
 
+#include <attributes.h>
 #include <crypto/common.h>
 #include <prevector.h>
 #include <serialize.h>
@@ -438,9 +439,9 @@ public:
     /** Delete non-existent operator to defend against future introduction */
     CScript& operator<<(const CScript& b) = delete;
 
-    CScript& operator<<(int64_t b) { return push_int64(b); }
+    CScript& operator<<(int64_t b) LIFETIMEBOUND { return push_int64(b); }
 
-    CScript& operator<<(opcodetype opcode)
+    CScript& operator<<(opcodetype opcode) LIFETIMEBOUND
     {
         if (opcode < 0 || opcode > 0xff)
             throw std::runtime_error("CScript::operator<<(): invalid opcode");
@@ -448,13 +449,13 @@ public:
         return *this;
     }
 
-    CScript& operator<<(const CScriptNum& b)
+    CScript& operator<<(const CScriptNum& b) LIFETIMEBOUND
     {
         *this << b.getvch();
         return *this;
     }
 
-    CScript& operator<<(const std::vector<unsigned char>& b)
+    CScript& operator<<(const std::vector<unsigned char>& b) LIFETIMEBOUND
     {
         if (b.size() < OP_PUSHDATA1)
         {

--- a/src/validation.h
+++ b/src/validation.h
@@ -929,7 +929,7 @@ public:
     CChainState& InitializeChainstate(
         CTxMemPool* mempool,
         const std::optional<uint256>& snapshot_blockhash = std::nullopt)
-        EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+        LIFETIMEBOUND EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     //! Get all chainstates currently being used.
     std::vector<CChainState*> GetAll();


### PR DESCRIPTION
Without this, stack-use-after-scope can only be detected at runtime with ASan or code review, both of which are expensive.

Use `LIFETIMEBOUND` to turn this error into a compile warning.

See https://releases.llvm.org/12.0.0/tools/clang/docs/AttributeReference.html#lifetimebound

Example:

```cpp
const CScript a{WITH_LOCK(::cs_main, return CScript{} << OP_0 << OP_1)};
```

Before: (no warning)
After:

```
warning: returning reference to local temporary object [-Wreturn-stack-address]
    const CScript a{WITH_LOCK(::cs_main, return CScript{} << OP_0 << OP_1)};
                                                ^~~~~~~~~
./sync.h:276:65: note: expanded from macro 'WITH_LOCK'
#define WITH_LOCK(cs, code) [&]() -> decltype(auto) { LOCK(cs); code; }()
                                                                ^~~~
