### PR TITLE
build: Avoid @GLIBC_2.29 libm symbols when --enable-glibc-back-compat

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -838,7 +838,10 @@ fi
 
 if test x$use_glibc_compat != xno; then
   AX_CHECK_LINK_FLAG([[-Wl,--wrap=__divmoddi4]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=__divmoddi4"])
+  AX_CHECK_LINK_FLAG([-Wl,--wrap=exp], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=exp"])
+  AX_CHECK_LINK_FLAG([-Wl,--wrap=log], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=log"])
   AX_CHECK_LINK_FLAG([[-Wl,--wrap=log2f]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=log2f"])
+  AX_CHECK_LINK_FLAG([-Wl,--wrap=pow], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=pow"])
   case $host in
     powerpc64* | ppc64*)
       AX_CHECK_LINK_FLAG([[-Wl,--no-tls-get-addr-optimize]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--no-tls-get-addr-optimize"])

--- a/src/compat/glibc_compat.cpp
+++ b/src/compat/glibc_compat.cpp
@@ -38,25 +38,61 @@ extern "C" int64_t __wrap___divmoddi4(int64_t u, int64_t v, int64_t* rp)
 }
 #endif
 
+extern "C" double exp_old(double x);
+extern "C" double log_old(double x);
 extern "C" float log2f_old(float x);
+extern "C" double pow_old(double base, double power);
 #ifdef __i386__
+__asm(".symver exp_old,exp@GLIBC_2.1");
+__asm(".symver log_old,log@GLIBC_2.1");
 __asm(".symver log2f_old,log2f@GLIBC_2.1");
+__asm(".symver pow_old,pow@GLIBC_2.1");
 #elif defined(__amd64__)
+__asm(".symver exp_old,exp@GLIBC_2.2.5");
+__asm(".symver log_old,log@GLIBC_2.2.5");
 __asm(".symver log2f_old,log2f@GLIBC_2.2.5");
+__asm(".symver pow_old,pow@GLIBC_2.2.5");
 #elif defined(__arm__)
+__asm(".symver exp_old,exp@GLIBC_2.4");
+__asm(".symver log_old,log@GLIBC_2.4");
 __asm(".symver log2f_old,log2f@GLIBC_2.4");
+__asm(".symver pow_old,pow@GLIBC_2.4");
 #elif defined(__aarch64__)
+__asm(".symver exp_old,exp@GLIBC_2.17");
+__asm(".symver log_old,log@GLIBC_2.17");
 __asm(".symver log2f_old,log2f@GLIBC_2.17");
+__asm(".symver pow_old,pow@GLIBC_2.17");
 #elif defined(__powerpc64__)
 #  ifdef WORDS_BIGENDIAN
+__asm(".symver exp_old,exp@GLIBC_2.3");
+__asm(".symver log_old,log@GLIBC_2.3");
 __asm(".symver log2f_old,log2f@GLIBC_2.3");
+__asm(".symver pow_old,pow@GLIBC_2.3");
 #  else
+__asm(".symver exp_old,exp@GLIBC_2.17");
+__asm(".symver log_old,log@GLIBC_2.17");
 __asm(".symver log2f_old,log2f@GLIBC_2.17");
+__asm(".symver pow_old,pow@GLIBC_2.17");
 #  endif
 #elif defined(__riscv)
+__asm(".symver exp_old,exp@GLIBC_2.27");
+__asm(".symver log_old,log@GLIBC_2.27");
 __asm(".symver log2f_old,log2f@GLIBC_2.27");
+__asm(".symver pow_old,pow@GLIBC_2.27");
 #endif
+extern "C" double __wrap_exp(double x)
+{
+    return exp_old(x);
+}
+extern "C" double __wrap_log(double x)
+{
+    return log_old(x);
+}
 extern "C" float __wrap_log2f(float x)
 {
     return log2f_old(x);
+}
+extern "C" double __wrap_pow(double base, double power)
+{
+    return pow_old(base, power);
 }


### PR DESCRIPTION
This PR is a partial fix for #21454 (see #22287 for the complete fix for the `bitcoind` compatibility).

#### Gitian builds:
```
Generating report
28c2e625cc23ab3c306565df6b49e8883518ad478d93fec13ef72c5e4904c476  bitcoin-9922cda0823a-aarch64-linux-gnu-debug.tar.gz
69aabc323eb1b6d243ab0b786f61056dcd5be5bb938b93ec3890de5c1aec9141  bitcoin-9922cda0823a-aarch64-linux-gnu.tar.gz
22df86a8e77f2f8472871067baa09b31ed932ada335584df42a4398743989c54  bitcoin-9922cda0823a-arm-linux-gnueabihf-debug.tar.gz
4ee9ae9c384efca953feca92149009909ff3ba653a0fb03b2712670526350018  bitcoin-9922cda0823a-arm-linux-gnueabihf.tar.gz
d377f8e6d4d9243ceafa1cf016837b3c1796d85926165333497d2b33155a1bac  bitcoin-9922cda0823a-powerpc64-linux-gnu-debug.tar.gz
68af39d9bcfabc6c00de82d222930dfc070d7051836e469505811256eb03ca3e  bitcoin-9922cda0823a-powerpc64-linux-gnu.tar.gz
0ebe6f51b21e4fc6f6329c823da7937385832a44b950208a3406be00866586cd  bitcoin-9922cda0823a-powerpc64le-linux-gnu-debug.tar.gz
5754d69beb6359c9bb1a01c98c71bfa1f49460759646375c02de6f05af3258b4  bitcoin-9922cda0823a-powerpc64le-linux-gnu.tar.gz
3f68d9da14da0db4a79528673fc8c4cd2f37c6fa51778d3027f2ba3d031f4c98  bitcoin-9922cda0823a-riscv64-linux-gnu-debug.tar.gz
0ef6587d65400498aeb167bc6a098ab58c38df00faa85e8d1fc1530fca30f300  bitcoin-9922cda0823a-riscv64-linux-gnu.tar.gz
8c0eaf703216eda1d4325921d741904a139150518ddd58143147513e527b24d9  bitcoin-9922cda0823a-x86_64-linux-gnu-debug.tar.gz
fad8a676153efe0106661211fe632c4e6a7d4c28e9db6b665f12e9db578238fb  bitcoin-9922cda0823a-x86_64-linux-gnu.tar.gz
c5c0368207e7f00dda5f13eca94f73d8b67fa930b5dd225deb9848f4c2872ab0  src/bitcoin-9922cda0823a.tar.gz
08171dcfe016b4b14bd242a9ded01557791fe27b57486352fabedb040c96a739  bitcoin-core-linux-22-res.yml
Done.
```