### PR TITLE
contrib/init: (OpenRC) use -startupnotify to wait for startup completion

### DIFF
--- a/contrib/init/bitcoind.openrc
+++ b/contrib/init/bitcoind.openrc
@@ -17,14 +17,20 @@ BITCOIND_GROUP=${BITCOIND_GROUP:-bitcoin}
 BITCOIND_BIN=${BITCOIND_BIN:-/usr/bin/bitcoind}
 BITCOIND_NICE=${BITCOIND_NICE:-${NICELEVEL:-0}}
 BITCOIND_OPTS="${BITCOIND_OPTS:-${BITCOIN_OPTS}}"
+: ${BITCOIND_STARTUPFILE:=${BITCOIND_PIDFILE%.pid}.startup}
 
 name="Bitcoin Core Daemon"
 description="Bitcoin cryptocurrency P2P network daemon"
 
-command="/usr/bin/bitcoind"
-command_args="-pid=\"${BITCOIND_PIDFILE}\" \
-		-conf=\"${BITCOIND_CONFIGFILE}\" \
-		-datadir=\"${BITCOIND_DATADIR}\" \
+command="/usr/bin/flock"
+command_args="--no-fork
+		$(/usr/bin/printf '%q' "${BITCOIND_STARTUPFILE}") \
+		/usr/bin/bitcoind
+		$(/usr/bin/printf '%s=%q ' \
+			-pid "${BITCOIND_PIDFILE}" \
+			-conf "${BITCOIND_CONFIGFILE}" \
+			-datadir "${BITCOIND_DATADIR}" \
+			-startupnotify "flock -u 3") \
 		-daemon \
 		${BITCOIND_OPTS}"
 
@@ -65,6 +71,16 @@ start_pre() {
 	${BITCOIND_CONFIGFILE}
 
 	checkconfig || return 1
+}
+
+start_post() {
+	# continue only after -startupnotify or daemon failure
+	if ! flock -n "${BITCOIND_STARTUPFILE}" true ; then
+		ebegin "Waiting for Bitcoin Core startup to finish"
+		flock "${BITCOIND_STARTUPFILE}" true
+		[ -e "${BITCOIND_PIDFILE}" ]
+		eend $?
+	fi
 }
 
 checkconfig()


### PR DESCRIPTION
When other initscripts depend on bitcoind, it's because their daemons want to be able to invoke `bitcoin-cli` or to communicate with bitcoind via RPC. That can't happen until some time after bitcoind has forked into the background. The `-startupnotify` option was added in 090530cc24 (#15367) to support exactly this use case, so let's use it.

The ideal OpenRC mechanism of marking the service inactive at startup and later calling back into the `start()` function with `IN_BACKGROUND=yes` won't work here because bitcoind runs as an unprivileged user that is not allowed to call `rc-service ${SVCNAME} start`, and OpenRC has no mechanism like `systemd-notify`, so instead we make `start-stop-daemon` lock a startup dummy file with `flock(1)` before exec'ing `bitcoind`, and then we use `-startupnotify` to release the lock when bitcoind is ready to service RPC requests. In the initscript's `start_post()` function we lock the startup file briefly, which forces that function to wait until bitcoind has released its lock on the file, which will happen when bitcoind either executes the `-startupnotify` command or dies. After acquiring and releasing the lock, `start_post()` performs one final check that the pid file still exists, which allows the service to be marked as started or stopped appropriately.

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
