### PR TITLE
build: Avoid fcntl64@GLIBC_2.28 symbol when --enable-glibc-back-compat

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -837,6 +837,7 @@ if test x$ac_cv_sys_large_files != x &&
 fi
 
 if test x$use_glibc_compat != xno; then
+  AX_CHECK_LINK_FLAG([-Wl,--wrap=fcntl64], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=fcntl64"])
   AX_CHECK_LINK_FLAG([[-Wl,--wrap=__divmoddi4]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=__divmoddi4"])
   AX_CHECK_LINK_FLAG([[-Wl,--wrap=log2f]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=log2f"])
   case $host in

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -645,7 +645,6 @@ endif
 bitcoin_bin_ldadd = \
   $(LIBBITCOIN_WALLET) \
   $(LIBBITCOIN_COMMON) \
-  $(LIBBITCOIN_UTIL) \
   $(LIBUNIVALUE) \
   $(LIBBITCOIN_ZMQ) \
   $(LIBBITCOIN_CONSENSUS) \
@@ -656,6 +655,7 @@ bitcoin_bin_ldadd = \
   $(LIBSECP256K1)
 
 bitcoin_bin_ldadd += $(BOOST_LIBS) $(BDB_LIBS) $(MINIUPNPC_LIBS) $(NATPMP_LIBS) $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS) $(ZMQ_LIBS) $(SQLITE_LIBS)
+bitcoin_bin_ldadd += $(LIBBITCOIN_UTIL)
 
 bitcoind_SOURCES = $(bitcoin_daemon_sources) init/bitcoind.cpp
 bitcoind_CPPFLAGS = $(bitcoin_bin_cppflags)

--- a/src/compat/glibc_compat.cpp
+++ b/src/compat/glibc_compat.cpp
@@ -9,6 +9,126 @@
 #include <cstddef>
 #include <cstdint>
 
+// See https://stackoverflow.com/a/58472959
+#if defined(__GLIBC__) && (__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 28)
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <fcntl.h>
+
+#ifdef __i386__
+__asm(".symver fcntl64,fcntl@GLIBC_2.1");
+#elif defined(__amd64__)
+__asm(".symver fcntl64,fcntl@GLIBC_2.2.5");
+#elif defined(__arm__)
+__asm(".symver fcntl64,fcntl@GLIBC_2.4");
+#elif defined(__aarch64__)
+__asm(".symver fcntl64,fcntl@GLIBC_2.17");
+#elif defined(__powerpc64__)
+#  ifdef WORDS_BIGENDIAN
+__asm(".symver fcntl64,fcntl@GLIBC_2.3");
+#  else
+__asm(".symver fcntl64,fcntl@GLIBC_2.17");
+#  endif
+#elif defined(__riscv)
+__asm(".symver fcntl64,fcntl@GLIBC_2.27");
+#endif
+extern "C" int __wrap_fcntl64(int fd, int cmd, ...)
+{
+    int result;
+    va_list va;
+    va_start(va, cmd);
+
+    switch (cmd) {
+    //
+    // File descriptor flags
+    //
+    case F_GETFD: goto takes_void;
+    case F_SETFD: goto takes_int;
+
+    // File status flags
+    //
+    case F_GETFL: goto takes_void;
+    case F_SETFL: goto takes_int;
+
+    // File byte range locking, not held across fork() or clone()
+    //
+    case F_SETLK: goto takes_flock_ptr;
+    case F_SETLKW: goto takes_flock_ptr;
+    case F_GETLK: goto takes_flock_ptr;
+
+    // File byte range locking, held across fork()/clone() -- Not POSIX
+    //
+    case F_OFD_SETLK: goto takes_flock_ptr;
+    case F_OFD_SETLKW: goto takes_flock_ptr;
+    case F_OFD_GETLK: goto takes_flock_ptr;
+
+    // Managing I/O availability signals
+    //
+    case F_GETOWN: goto takes_void;
+    case F_SETOWN: goto takes_int;
+    case F_GETOWN_EX: goto takes_f_owner_ex_ptr;
+    case F_SETOWN_EX: goto takes_f_owner_ex_ptr;
+    case F_GETSIG: goto takes_void;
+    case F_SETSIG: goto takes_int;
+
+    // Notified when process tries to open or truncate file (Linux 2.4+)
+    //
+    case F_SETLEASE: goto takes_int;
+    case F_GETLEASE: goto takes_void;
+
+    // File and directory change notification
+    //
+    case F_NOTIFY: goto takes_int;
+
+    // Changing pipe capacity (Linux 2.6.35+)
+    //
+    case F_SETPIPE_SZ: goto takes_int;
+    case F_GETPIPE_SZ: goto takes_void;
+
+    // File sealing (Linux 3.17+)
+    //
+    case F_ADD_SEALS: goto takes_int;
+    case F_GET_SEALS: goto takes_void;
+
+    // File read/write hints (Linux 4.13+)
+    //
+    case F_GET_RW_HINT: goto takes_uint64_t_ptr;
+    case F_SET_RW_HINT: goto takes_uint64_t_ptr;
+    case F_GET_FILE_RW_HINT: goto takes_uint64_t_ptr;
+    case F_SET_FILE_RW_HINT: goto takes_uint64_t_ptr;
+
+    default:
+        fprintf(stderr, "fcntl64 workaround got unknown F_XXX constant: %d\n", cmd);
+        exit(1);
+    }
+
+takes_void:
+    va_end(va);
+    return fcntl64(fd, cmd);
+
+takes_int:
+    result = fcntl64(fd, cmd, va_arg(va, int));
+    va_end(va);
+    return result;
+
+takes_flock_ptr:
+    result = fcntl64(fd, cmd, va_arg(va, struct flock*));
+    va_end(va);
+    return result;
+
+takes_f_owner_ex_ptr:
+    result = fcntl64(fd, cmd, va_arg(va, struct f_owner_ex*));
+    va_end(va);
+    return result;
+
+takes_uint64_t_ptr:
+    result = fcntl64(fd, cmd, va_arg(va, uint64_t*));
+    va_end(va);
+    return result;
+}
+#endif
+
 #if defined(__i386__) || defined(__arm__)
 
 extern "C" int64_t __udivmoddi4(uint64_t u, uint64_t v, uint64_t* rp);

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -40,6 +40,7 @@ export LC_ALL=C
 KNOWN_VIOLATIONS=(
     "src/bitcoin-tx.cpp.*stoul"
     "src/bitcoin-tx.cpp.*trim_right"
+    "src/compat/glibc_compat.cpp:.*fprintf"
     "src/dbwrapper.cpp.*stoul"
     "src/dbwrapper.cpp:.*vsnprintf"
     "src/httprpc.cpp.*trim"


### PR DESCRIPTION
This PR is a partial fix for #21454 (see #22281 for the complete fix for the `bitcoind` compatibility).

#### Gitian builds:
```
Generating report
5d2b1cf6c0a59796e0e087877faff290a252f79bae1a61aeceeda15e5c316186  bitcoin-530bc278b9fa-aarch64-linux-gnu-debug.tar.gz
a67a2a8a160d289fabe786e00715eeccf800e418a305d35a774721a74f738a4a  bitcoin-530bc278b9fa-aarch64-linux-gnu.tar.gz
315f787b8f77b55a37bf56201c747f77c5641c6eab1779049fdc65ef6e3aa162  bitcoin-530bc278b9fa-arm-linux-gnueabihf-debug.tar.gz
58d1b886f10b9a6011645bb65795ed0d418433c44b83fe8359ed4b31f501c167  bitcoin-530bc278b9fa-arm-linux-gnueabihf.tar.gz
31eedc8531fca0b4bd76c5b0cbc8799f6621a758e5fe9abda3aef3f264832c89  bitcoin-530bc278b9fa-powerpc64-linux-gnu-debug.tar.gz
79b8ca4bee6fc24a5c3216fed95f341510f15cdaaf04e2b6d4db991a3d077450  bitcoin-530bc278b9fa-powerpc64-linux-gnu.tar.gz
0fcd01009aa80b9c4b567a241d0d56b579756d9f70a1a78e0fa8c015b99d9bfa  bitcoin-530bc278b9fa-powerpc64le-linux-gnu-debug.tar.gz
af63f25b3de98cf2f25b6592dec9c3b4f95021fcc11396fb345c592979b9e4b7  bitcoin-530bc278b9fa-powerpc64le-linux-gnu.tar.gz
539d6317a7c2cfe6cbecb07eb82ef9b039010ef544cc9a74984a7cb23c03b58a  bitcoin-530bc278b9fa-riscv64-linux-gnu-debug.tar.gz
75ce0a0eabb4555589e632676b2e44df8365f320dea28d9edcd54ec78b4038d1  bitcoin-530bc278b9fa-riscv64-linux-gnu.tar.gz
9dc543d3b0c9ea39e153616132b0c41205a639d0129b752e7151712b8eda54b7  bitcoin-530bc278b9fa-x86_64-linux-gnu-debug.tar.gz
ba5452615ebd1c1398916837ee1a36233721819c08f48ea12ac7c03ac67526c7  bitcoin-530bc278b9fa-x86_64-linux-gnu.tar.gz
2b618a7b6e99bffc15522ca9f4bc0bfb1187a9bb0b005cc32d23127289644cc1  src/bitcoin-530bc278b9fa.tar.gz
9db429d8b661e2d7a48be8b8f9bcbb3df4e8a6b8cce0bd0660d54c1422c0d696  bitcoin-core-linux-22-res.yml
Done.
```

I tested only:
- `bitcoin-530bc278b9fa-arm-linux-gnueabihf.tar.gz`
- `bitcoin-530bc278b9fa-x86_64-linux-gnu.tar.gz`