### PR TITLE
Package Mempool Submission with Package Fee-Bumping

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -137,6 +137,7 @@ BITCOIN_TESTS =\
   test/torcontrol_tests.cpp \
   test/transaction_tests.cpp \
   test/txindex_tests.cpp \
+  test/txpackage_tests.cpp \
   test/txrequest_tests.cpp \
   test/txvalidation_tests.cpp \
   test/txvalidationcache_tests.cpp \

--- a/src/policy/packages.h
+++ b/src/policy/packages.h
@@ -18,13 +18,15 @@ static constexpr uint32_t MAX_PACKAGE_SIZE{101};
 static_assert(MAX_PACKAGE_SIZE * WITNESS_SCALE_FACTOR * 1000 >= MAX_STANDARD_TX_WEIGHT);
 
 /** A "reason" why a package was invalid. It may be that one or more of the included
- * transactions is invalid or the package itself violates our rules.
- * We don't distinguish between consensus and policy violations right now.
+ * transactions is invalid or the package itself fails. It's possible for failures to arise from
+ * rule violations or mempool policy.
  */
 enum class PackageValidationResult {
     PCKG_RESULT_UNSET = 0,        //!< Initial value. The package has not yet been rejected.
-    PCKG_POLICY,                  //!< The package itself is invalid (e.g. too many transactions).
-    PCKG_TX,                      //!< At least one tx is invalid.
+    PCKG_BAD,                     //!< The package itself is invalid or malformed.
+    PCKG_POLICY,                  //!< The package failed due to package-related mempool policy.
+    PCKG_TX_CONSENSUS,            //!< At least one tx is invalid for consensus reasons.
+    PCKG_TX_POLICY,               //!< At least one tx is invalid for non-consensus reasons.
 };
 
 /** A package is an ordered list of transactions. The transactions cannot conflict with (spend the
@@ -33,7 +35,7 @@ using Package = std::vector<CTransactionRef>;
 
 class PackageValidationState : public ValidationState<PackageValidationResult> {};
 
-/** Context-free package policy checks:
+/** Context-free package sanitization. A package is not well-formed if it fails any of these checks:
  * 1. The number of transactions cannot exceed MAX_PACKAGE_COUNT.
  * 2. The total virtual size cannot exceed MAX_PACKAGE_SIZE.
  * 3. If any dependencies exist between transactions, parents must appear before children.

--- a/src/policy/packages.h
+++ b/src/policy/packages.h
@@ -43,4 +43,12 @@ class PackageValidationState : public ValidationState<PackageValidationResult> {
  */
 bool CheckPackage(const Package& txns, PackageValidationState& state);
 
+/** Context-free check that a package is exactly one child and at least one of its parents. It is
+ * expected to be sorted, which means the last transaction must be the child. The package cannot
+ * contain any transactions that are not the child's parents.
+ * @param[in]   exact   When true, return whether this package is exactly one child and all of its
+ *                      parents. Otherwise, only require that non-child transactions are parents.
+ */
+bool IsChildWithParents(const Package& package, bool exact);
+
 #endif // BITCOIN_POLICY_PACKAGES_H

--- a/src/policy/rbf.h
+++ b/src/policy/rbf.h
@@ -99,4 +99,10 @@ std::optional<std::string> PaysForRBF(CAmount original_fees,
                                       CFeeRate relay_fee,
                                       const uint256& txid);
 
+/** Check that the ancestor score of replacement transaction(s) is at least as high as the ancestor
+ * scores of every mempool transaction it conflicts with. */
+std::optional<std::string> CheckAncestorScores(CAmount replacement_fees,
+                                               int64_t replacement_vsize,
+                                               const CTxMemPool::setEntries& ancestors,
+                                               const CTxMemPool::setEntries& all_conflicts);
 #endif // BITCOIN_POLICY_RBF_H

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -105,6 +105,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendrawtransaction", 1, "maxfeerate" },
     { "testmempoolaccept", 0, "rawtxs" },
     { "testmempoolaccept", 1, "maxfeerate" },
+    { "submitrawpackage", 0, "package" },
     { "combinerawtransaction", 0, "txs" },
     { "fundrawtransaction", 1, "options" },
     { "fundrawtransaction", 2, "iswitness" },

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -997,7 +997,7 @@ static RPCHelpMan testmempoolaccept()
         if (tx_result.m_result_type == MempoolAcceptResult::ResultType::VALID) {
             const CAmount fee = tx_result.m_base_fees.value();
             // Check that fee does not exceed maximum fee
-            const int64_t virtual_size = GetVirtualTransactionSize(*tx);
+            const int64_t virtual_size = tx_result.m_vsize.value();
             const CAmount max_raw_tx_fee = max_raw_tx_fee_rate.GetFee(virtual_size);
             if (max_raw_tx_fee && fee > max_raw_tx_fee) {
                 result_inner.pushKV("allowed", false);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -983,7 +983,8 @@ static RPCHelpMan testmempoolaccept()
         UniValue result_inner(UniValue::VOBJ);
         result_inner.pushKV("txid", tx->GetHash().GetHex());
         result_inner.pushKV("wtxid", tx->GetWitnessHash().GetHex());
-        if (package_result.m_state.GetResult() == PackageValidationResult::PCKG_POLICY) {
+        if (package_result.m_state.GetResult() == PackageValidationResult::PCKG_BAD ||
+            package_result.m_state.GetResult() == PackageValidationResult::PCKG_POLICY) {
             result_inner.pushKV("package-error", package_result.m_state.GetRejectReason());
         }
         auto it = package_result.m_tx_results.find(tx->GetWitnessHash());

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1044,6 +1044,7 @@ static RPCHelpMan submitrawpackage()
         RPCResult{
             RPCResult::Type::OBJ, "", "",
             {
+                {RPCResult::Type::STR_AMOUNT, "package-feerate", "package feerate in " + CURRENCY_UNIT + "/KvB, the total modified fees divided by the total virtual size of all transactions in the package."},
                 {RPCResult::Type::OBJ_DYN, "tx-results", "transaction results keyed by wtxid",
                 {
                     {RPCResult::Type::OBJ, "xxxx", "transaction wtxid", {
@@ -1103,6 +1104,9 @@ static RPCHelpMan submitrawpackage()
     }
 
     UniValue rpc_result{UniValue::VOBJ};
+    if (const auto package_feerate{package_result.m_package_feerate}) {
+        rpc_result.pushKV("package-feerate", ValueFromAmount(package_feerate.value().GetFeePerK()));
+    }
     if (package_result.m_state.IsInvalid()) {
         switch(package_result.m_state.GetResult()) {
             case PackageValidationResult::PCKG_RESULT_UNSET: break;

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -152,6 +152,7 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "signrawtransactionwithkey",
     "submitblock",
     "submitheader",
+    "submitrawpackage",
     "syncwithvalidationinterfacequeue",
     "testmempoolaccept",
     "uptime",

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying file COPYING or
+// http://www.opensource.org/licenses/mit-license.php.
+
+#include <consensus/validation.h>
+#include <key_io.h>
+#include <policy/packages.h>
+#include <policy/policy.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <script/standard.h>
+#include <test/util/setup_common.h>
+#include <validation.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(txpackage_tests)
+
+BOOST_FIXTURE_TEST_CASE(static_package_tests, TestChain100Setup)
+{
+    // The signatures won't be verified so we can just use a placeholder
+    CKey placeholder_key;
+    placeholder_key.MakeNewKey(true);
+    CScript spk = GetScriptForDestination(PKHash(placeholder_key.GetPubKey()));
+    CKey placeholder_key_2;
+    placeholder_key_2.MakeNewKey(true);
+    CScript spk2 = GetScriptForDestination(PKHash(placeholder_key_2.GetPubKey()));
+
+    // Parent and Child Package
+    {
+        auto mtx_parent = CreateValidMempoolTransaction(m_coinbase_txns[0], 0, 0, coinbaseKey, spk,
+                                                        CAmount(49 * COIN), /* submit */ false);
+        CTransactionRef tx_parent = MakeTransactionRef(mtx_parent);
+
+        auto mtx_child = CreateValidMempoolTransaction(tx_parent, 0, 101, placeholder_key, spk2,
+                                                       CAmount(48 * COIN), /* submit */ false);
+        CTransactionRef tx_child = MakeTransactionRef(mtx_child);
+
+        PackageValidationState state;
+        BOOST_CHECK(CheckPackage({tx_parent, tx_child}, state));
+        BOOST_CHECK(!CheckPackage({tx_child, tx_parent}, state));
+        BOOST_CHECK(IsChildWithParents({tx_parent, tx_child}, /* exact */ false));
+        BOOST_CHECK(IsChildWithParents({tx_parent, tx_child}, /* exact */ true));
+    }
+
+    // 24 Parents and 1 Child
+    {
+        std::vector<CTransactionRef> package;
+        CMutableTransaction child;
+        for (int i{0}; i < 24; ++i) {
+            auto parent = MakeTransactionRef(CreateValidMempoolTransaction(m_coinbase_txns[i + 1],
+                                             0, 0, coinbaseKey, spk, CAmount(48 * COIN), false));
+            package.emplace_back(parent);
+            child.vin.push_back(CTxIn(COutPoint(parent->GetHash(), 0)));
+        }
+        child.vout.push_back(CTxOut(47 * COIN, spk2));
+
+        // The child must be in the package.
+        BOOST_CHECK(!IsChildWithParents(package, /* exact */ false));
+        BOOST_CHECK(!IsChildWithParents(package, /* exact */ true));
+
+        // The parents can be in any order.
+        FastRandomContext rng;
+        Shuffle(package.begin(), package.end(), rng);
+        package.push_back(MakeTransactionRef(child));
+
+        PackageValidationState state;
+        BOOST_CHECK(CheckPackage(package, state));
+        BOOST_CHECK(IsChildWithParents(package, /* exact */ false));
+        BOOST_CHECK(IsChildWithParents(package, /* exact */ true));
+
+        // Not all of the parents need to be in the package if exact = false.
+        package.erase(package.begin());
+        BOOST_CHECK(IsChildWithParents(package, /* exact */ false));
+        BOOST_CHECK(!IsChildWithParents(package, /* exact */ true));
+
+        // The package cannot have unrelated transactions.
+        package.insert(package.begin(), m_coinbase_txns[0]);
+        BOOST_CHECK(!IsChildWithParents(package, /* exact */ false));
+        BOOST_CHECK(!IsChildWithParents(package, /* exact */ true));
+    }
+
+    // 2 Parents and 1 Child where one parent depends on the other.
+    {
+        CMutableTransaction mtx_parent;
+        mtx_parent.vin.push_back(CTxIn(COutPoint(m_coinbase_txns[0]->GetHash(), 0)));
+        mtx_parent.vout.push_back(CTxOut(20 * COIN, spk));
+        mtx_parent.vout.push_back(CTxOut(20 * COIN, spk2));
+        CTransactionRef tx_parent = MakeTransactionRef(mtx_parent);
+
+        CMutableTransaction mtx_parent2;
+        mtx_parent2.vin.push_back(CTxIn(COutPoint(tx_parent->GetHash(), 0)));
+        mtx_parent2.vout.push_back(CTxOut(20 * COIN, spk));
+        CTransactionRef tx_parent_also_child = MakeTransactionRef(mtx_parent2);
+
+        CMutableTransaction mtx_child;
+        mtx_child.vin.push_back(CTxIn(COutPoint(tx_parent->GetHash(), 1)));
+        mtx_child.vin.push_back(CTxIn(COutPoint(tx_parent_also_child->GetHash(), 0)));
+        mtx_child.vout.push_back(CTxOut(49 * COIN, spk));
+        CTransactionRef tx_child = MakeTransactionRef(mtx_child);
+
+        PackageValidationState state;
+        BOOST_CHECK(CheckPackage({tx_parent, tx_parent_also_child, tx_child}, state));
+        BOOST_CHECK(IsChildWithParents({tx_parent, tx_parent_also_child, tx_child}, /* exact */ false));
+        BOOST_CHECK(IsChildWithParents({tx_parent, tx_parent_also_child, tx_child}, /* exact */ true));
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -113,7 +113,7 @@ BOOST_FIXTURE_TEST_CASE(package_tests, TestChain100Setup)
     }
     auto result_too_many = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_too_many, /* test_accept */ true);
     BOOST_CHECK(result_too_many.m_state.IsInvalid());
-    BOOST_CHECK_EQUAL(result_too_many.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
+    BOOST_CHECK_EQUAL(result_too_many.m_state.GetResult(), PackageValidationResult::PCKG_BAD);
     BOOST_CHECK_EQUAL(result_too_many.m_state.GetRejectReason(), "package-too-many-transactions");
 
     // Packages can't have a total size of more than 101KvB.
@@ -128,7 +128,7 @@ BOOST_FIXTURE_TEST_CASE(package_tests, TestChain100Setup)
     BOOST_CHECK(package_too_large.size() <= MAX_PACKAGE_COUNT);
     auto result_too_large = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_too_large, /* test_accept */ true);
     BOOST_CHECK(result_too_large.m_state.IsInvalid());
-    BOOST_CHECK_EQUAL(result_too_large.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
+    BOOST_CHECK_EQUAL(result_too_large.m_state.GetResult(), PackageValidationResult::PCKG_BAD);
     BOOST_CHECK_EQUAL(result_too_large.m_state.GetRejectReason(), "package-too-large");
 
     // A single, giant transaction submitted through ProcessNewPackage fails on single tx policy.
@@ -136,7 +136,7 @@ BOOST_FIXTURE_TEST_CASE(package_tests, TestChain100Setup)
     BOOST_CHECK(GetVirtualTransactionSize(*giant_ptx) > MAX_PACKAGE_SIZE * 1000);
     auto result_single_large = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, {giant_ptx}, /* test_accept */ true);
     BOOST_CHECK(result_single_large.m_state.IsInvalid());
-    BOOST_CHECK_EQUAL(result_single_large.m_state.GetResult(), PackageValidationResult::PCKG_TX);
+    BOOST_CHECK_EQUAL(result_single_large.m_state.GetResult(), PackageValidationResult::PCKG_TX_POLICY);
     BOOST_CHECK_EQUAL(result_single_large.m_state.GetRejectReason(), "transaction failed");
     auto it_giant_tx = result_single_large.m_tx_results.find(giant_ptx->GetWitnessHash());
     BOOST_CHECK(it_giant_tx != result_single_large.m_tx_results.end());

--- a/src/util/error.cpp
+++ b/src/util/error.cpp
@@ -35,6 +35,8 @@ bilingual_str TransactionErrorString(const TransactionError err)
             return Untranslated("External signer not found");
         case TransactionError::EXTERNAL_SIGNER_FAILED:
             return Untranslated("External signer failed to sign");
+        case TransactionError::INVALID_PACKAGE:
+            return Untranslated("Transaction rejected due to invalid package");
         // no default case, so the compiler can warn about missing cases
     }
     assert(false);

--- a/src/util/error.h
+++ b/src/util/error.h
@@ -32,6 +32,7 @@ enum class TransactionError {
     MAX_FEE_EXCEEDED,
     EXTERNAL_SIGNER_NOT_FOUND,
     EXTERNAL_SIGNER_FAILED,
+    INVALID_PACKAGE,
 };
 
 bilingual_str TransactionErrorString(const TransactionError error);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -503,6 +503,9 @@ private:
         std::list<CTransactionRef> m_replaced_transactions;
 
         bool m_replacement_transaction;
+        /** Virtual size of the transaction as used by the mempool, calculated using serialized size
+         * of the transaction and sigops. */
+        int64_t m_vsize;
         CAmount m_base_fees;
         CAmount m_modified_fees;
         /** Total modified fees of all transactions being replaced. */
@@ -727,7 +730,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     entry.reset(new CTxMemPoolEntry(ptx, ws.m_base_fees, nAcceptTime, m_active_chainstate.m_chain.Height(),
             fSpendsCoinbase, nSigOpsCost, lp));
-    unsigned int nSize = entry->GetTxSize();
+    ws.m_vsize = entry->GetTxSize();
 
     if (nSigOpsCost > MAX_STANDARD_TX_SIGOPS_COST)
         return state.Invalid(TxValidationResult::TX_NOT_STANDARD, "bad-txns-too-many-sigops",
@@ -735,7 +738,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     // No transactions are allowed below minRelayTxFee except from disconnected
     // blocks
-    if (!bypass_limits && !CheckFeeRate(nSize, nModifiedFees, state)) return false;
+    if (!bypass_limits && !CheckFeeRate(ws.m_vsize, nModifiedFees, state)) return false;
 
     const CTxMemPool::setEntries setIterConflicting = m_pool.GetIterSet(setConflicts);
     // Calculate in-mempool ancestors, up to a limit.
@@ -790,7 +793,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         // to be secure by simply only having two immediately-spendable
         // outputs - one for each counterparty. For more info on the uses for
         // this, see https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-November/016518.html
-        if (nSize >  EXTRA_DESCENDANT_TX_SIZE_LIMIT ||
+        if (ws.m_vsize > EXTRA_DESCENDANT_TX_SIZE_LIMIT ||
                 !m_pool.CalculateMemPoolAncestors(*entry, setAncestors, 2, m_limit_ancestor_size, m_limit_descendants + 1, m_limit_descendant_size + EXTRA_DESCENDANT_TX_SIZE_LIMIT, dummy_err_string)) {
             return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "too-long-mempool-chain", errString);
         }
@@ -808,8 +811,9 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
 
     fReplacementTransaction = setConflicts.size();
-    if (fReplacementTransaction) {
-        CFeeRate newFeeRate(nModifiedFees, nSize);
+    if (fReplacementTransaction)
+    {
+        CFeeRate newFeeRate(nModifiedFees, ws.m_vsize);
         // It's possible that the replacement pays more fees than its direct conflicts but not more
         // than all conflicts (i.e. the direct conflicts have high-fee descendants). However, if the
         // replacement doesn't pay more fees than its direct conflicts, then we can be sure it's not
@@ -837,7 +841,8 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
             nConflictingFees += it->GetModifiedFee();
             nConflictingSize += it->GetTxSize();
         }
-        if (const auto err_string{PaysForRBF(nConflictingFees, nModifiedFees, nSize, ::incrementalRelayFee, hash)}) {
+        if (const auto err_string{PaysForRBF(nConflictingFees, nModifiedFees, ws.m_vsize,
+                                             ::incrementalRelayFee, hash)}) {
             return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "insufficient fee", *err_string);
         }
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -973,14 +973,14 @@ MempoolAcceptResult MemPoolAccept::AcceptSingleTransaction(const CTransactionRef
 
     // Tx was accepted, but not added
     if (args.m_test_accept) {
-        return MempoolAcceptResult::Success(std::move(ws.m_replaced_transactions), ws.m_base_fees);
+        return MempoolAcceptResult::Success(std::move(ws.m_replaced_transactions), ws.m_vsize, ws.m_base_fees);
     }
 
     if (!Finalize(args, ws)) return MempoolAcceptResult::Failure(ws.m_state);
 
     GetMainSignals().TransactionAddedToMempool(ptx, m_pool.GetAndIncrementSequence());
 
-    return MempoolAcceptResult::Success(std::move(ws.m_replaced_transactions), ws.m_base_fees);
+    return MempoolAcceptResult::Success(std::move(ws.m_replaced_transactions), ws.m_vsize, ws.m_base_fees);
 }
 
 PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::vector<CTransactionRef>& txns, ATMPArgs& args)
@@ -1050,7 +1050,8 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
             // When test_accept=true, transactions that pass PolicyScriptChecks are valid because there are
             // no further mempool checks (passing PolicyScriptChecks implies passing ConsensusScriptChecks).
             results.emplace(ws.m_ptx->GetWitnessHash(),
-                            MempoolAcceptResult::Success(std::move(ws.m_replaced_transactions), ws.m_base_fees));
+                            MempoolAcceptResult::Success(std::move(ws.m_replaced_transactions),
+                                                         ws.m_vsize, ws.m_base_fees));
         }
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -449,7 +449,36 @@ public:
         /** Whether we allow transactions to replace mempool transactions by BIP125 rules. If false,
          * any transaction spending the same inputs as a transaction in the mempool is considered
          * a conflict. */
-        const bool m_allow_bip125_replacement{true};
+        const bool m_allow_bip125_replacement;
+
+        /** Parameters for single transaction mempool validation. */
+        static ATMPArgs SingleAccept(const CChainParams& chainparams, int64_t accept_time,
+                                     bool bypass_limits, bool test_accept,
+                                     std::vector<COutPoint>& coins_to_uncache) {
+            return ATMPArgs{/* m_chainparams */ chainparams,
+                            /* m_accept_time */ accept_time,
+                            /* m_bypass_limits */ bypass_limits,
+                            /* m_coins_to_uncache */ coins_to_uncache,
+                            /* m_test_accept */ test_accept,
+                            /* m_allow_bip125_replacement */ true,
+            };
+        }
+
+        /** Parameters for test package mempool validation through. */
+        static ATMPArgs PackageTestAccept(const CChainParams& chainparams, int64_t accept_time,
+                                          std::vector<COutPoint>& coins_to_uncache) {
+            return ATMPArgs{/* m_chainparams */ chainparams,
+                            /* m_accept_time */ accept_time,
+                            /* m_bypass_limits */ false,
+                            /* m_coins_to_uncache */ coins_to_uncache,
+                            /* m_test_accept */ true,
+                            /* m_allow_bip125_replacement */ false,
+            };
+        }
+
+        // No default ctor to avoid exposing details to clients and allowing the possibility of
+        // mixing up the order of the arguments. Use static functions above instead.
+        ATMPArgs() = delete;
     };
 
     // Single transaction acceptance
@@ -1033,9 +1062,7 @@ static MempoolAcceptResult AcceptToMemoryPoolWithTime(const CChainParams& chainp
                                                       EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     std::vector<COutPoint> coins_to_uncache;
-    MemPoolAccept::ATMPArgs args { chainparams, nAcceptTime, bypass_limits, coins_to_uncache,
-                                   test_accept, /* m_allow_bip125_replacement */ true };
-
+    auto args = MemPoolAccept::ATMPArgs::SingleAccept(chainparams, nAcceptTime, bypass_limits, test_accept, coins_to_uncache);
     const MempoolAcceptResult result = MemPoolAccept(pool, active_chainstate).AcceptSingleTransaction(tx, args);
     if (result.m_result_type != MempoolAcceptResult::ResultType::VALID) {
         // Remove coins that were not present in the coins cache before calling
@@ -1068,8 +1095,7 @@ PackageMempoolAcceptResult ProcessNewPackage(CChainState& active_chainstate, CTx
 
     std::vector<COutPoint> coins_to_uncache;
     const CChainParams& chainparams = Params();
-    MemPoolAccept::ATMPArgs args { chainparams, GetTime(), /* bypass_limits */ false, coins_to_uncache,
-                                   test_accept, /* m_allow_bip125_replacement */ false };
+    auto args = MemPoolAccept::ATMPArgs::PackageTestAccept(chainparams, GetTime(), coins_to_uncache);
     const PackageMempoolAcceptResult result = MemPoolAccept(pool, active_chainstate).AcceptMultipleTransactions(package, args);
 
     // Uncache coins pertaining to transactions that were not submitted to the mempool.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -504,7 +504,7 @@ public:
                             /* m_allow_bip125_replacement */ true,
                             /* m_package_submission */ true,
                             /* m_package_feerates */ true,
-                            /* m_enforce_bip125_rule2 */ true,
+                            /* m_enforce_bip125_rule2 */ false,
             };
         }
 
@@ -926,7 +926,7 @@ bool MemPoolAccept::MempoolChecks(const ATMPArgs& args, Workspace& ws)
                                                                      ws.m_ancestors, m_all_conflicts)}) {
                 // Bypass BIP125 Rule #2 under the condition that the replacement transaction has a higher
                 // ancestor score than that of all mempool transactions it is trying to replace.
-                return state.Invalid(TxValidationResult::TX_LOW_FEE, "insufficient fee", *err_string_anc);
+                return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "insufficient fee", *err_string_anc);
             }
         }
 
@@ -1014,7 +1014,7 @@ bool MemPoolAccept::PackageMempoolChecks(const ATMPArgs& args,
                 // inputs = inputs of parents, outputs = outputs of child + UTXOs of parents.
                 // Bypass BIP125 Rule #2 under the condition that the package has a higher ancestor
                 // score than that of all mempool transactions it is trying to replace.
-                return ws.m_state.Invalid(TxValidationResult::TX_LOW_FEE,
+                return ws.m_state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY,
                                           "package RBF failed: insufficient fee", *err_string_anc);
             }
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -593,14 +593,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     // Alias what we need out of ws
     TxValidationState& state = ws.m_state;
-    std::set<uint256>& setConflicts = ws.m_conflicts;
-    CTxMemPool::setEntries& allConflicting = ws.m_all_conflicting;
-    CTxMemPool::setEntries& setAncestors = ws.m_ancestors;
     std::unique_ptr<CTxMemPoolEntry>& entry = ws.m_entry;
-    bool& fReplacementTransaction = ws.m_replacement_transaction;
-    CAmount& nModifiedFees = ws.m_modified_fees;
-    CAmount& nConflictingFees = ws.m_conflicting_fees;
-    size_t& nConflictingSize = ws.m_conflicting_size;
 
     if (!CheckTransaction(tx, state)) {
         return false; // state filled in by CheckTransaction
@@ -646,7 +639,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
                 // Transaction conflicts with a mempool tx, but we're not allowing replacements.
                 return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "bip125-replacement-disallowed");
             }
-            if (!setConflicts.count(ptxConflicting->GetHash()))
+            if (!ws.m_conflicts.count(ptxConflicting->GetHash()))
             {
                 // Transactions that don't explicitly signal replaceability are
                 // *not* replaceable with the current logic, even if one of their
@@ -659,7 +652,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
                     return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "txn-mempool-conflict");
                 }
 
-                setConflicts.insert(ptxConflicting->GetHash());
+                ws.m_conflicts.insert(ptxConflicting->GetHash());
             }
         }
     }
@@ -723,9 +716,9 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     int64_t nSigOpsCost = GetTransactionSigOpCost(tx, m_view, STANDARD_SCRIPT_VERIFY_FLAGS);
 
-    // nModifiedFees includes any fee deltas from PrioritiseTransaction
-    nModifiedFees = ws.m_base_fees;
-    m_pool.ApplyDelta(hash, nModifiedFees);
+    // ws.m_modified_fees includes any fee deltas from PrioritiseTransaction
+    ws.m_modified_fees = ws.m_base_fees;
+    m_pool.ApplyDelta(hash, ws.m_modified_fees);
 
     // Keep track of transactions that spend a coinbase, which we re-scan
     // during reorgs to ensure COINBASE_MATURITY is still met.
@@ -748,11 +741,11 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     // No transactions are allowed below minRelayTxFee except from disconnected
     // blocks
-    if (!bypass_limits && !CheckFeeRate(ws.m_vsize, nModifiedFees, state)) return false;
+    if (!bypass_limits && !CheckFeeRate(ws.m_vsize, ws.m_modified_fees, state)) return false;
 
-    const CTxMemPool::setEntries setIterConflicting = m_pool.GetIterSet(setConflicts);
+    const CTxMemPool::setEntries setIterConflicting = m_pool.GetIterSet(ws.m_conflicts);
     // Calculate in-mempool ancestors, up to a limit.
-    if (setConflicts.size() == 1) {
+    if (ws.m_conflicts.size() == 1) {
         // In general, when we receive an RBF transaction with mempool conflicts, we want to know whether we
         // would meet the chain limits after the conflicts have been removed. However, there isn't a practical
         // way to do this short of calculating the ancestor and descendant sets with an overlay cache of
@@ -788,9 +781,9 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     }
 
     std::string errString;
-    if (!m_pool.CalculateMemPoolAncestors(*entry, setAncestors, m_limit_ancestors, m_limit_ancestor_size,
+    if (!m_pool.CalculateMemPoolAncestors(*entry, ws.m_ancestors, m_limit_ancestors, m_limit_ancestor_size,
             ws.m_tx_limit_descendants, ws.m_tx_limit_descendant_size, errString)) {
-        setAncestors.clear();
+        ws.m_ancestors.clear();
         // If CalculateMemPoolAncestors fails second time, we want the original error string.
         std::string dummy_err_string;
         // Contracting/payment channels CPFP carve-out:
@@ -805,7 +798,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         // outputs - one for each counterparty. For more info on the uses for
         // this, see https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-November/016518.html
         if (ws.m_vsize >  EXTRA_DESCENDANT_TX_SIZE_LIMIT ||
-            !m_pool.CalculateMemPoolAncestors(*entry, setAncestors, /* limitancestors */ 2,
+            !m_pool.CalculateMemPoolAncestors(*entry, ws.m_ancestors, /* limitancestors */ 2,
                 m_limit_ancestor_size, ws.m_tx_limit_descendants + 1,
                 ws.m_tx_limit_descendant_size + EXTRA_DESCENDANT_TX_SIZE_LIMIT, dummy_err_string)) {
             return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "too-long-mempool-chain", errString);
@@ -814,19 +807,19 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     // A transaction that spends outputs that would be replaced by it is invalid. Now
     // that we have the set of all ancestors we can detect this
-    // pathological case by making sure setConflicts and setAncestors don't
+    // pathological case by making sure ws.m_conflicts and ws.m_ancestors don't
     // intersect.
-    if (const auto err_string{EntriesAndTxidsDisjoint(setAncestors, setConflicts, hash)}) {
+    if (const auto err_string{EntriesAndTxidsDisjoint(ws.m_ancestors, ws.m_conflicts, hash)}) {
         // We classify this as a consensus error because a transaction depending on something it
         // conflicts with would be inconsistent.
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-spends-conflicting-tx", *err_string);
     }
 
 
-    fReplacementTransaction = setConflicts.size();
-    if (fReplacementTransaction)
+    ws.m_replacement_transaction = ws.m_conflicts.size();
+    if (ws.m_replacement_transaction)
     {
-        CFeeRate newFeeRate(nModifiedFees, ws.m_vsize);
+        CFeeRate newFeeRate(ws.m_modified_fees, ws.m_vsize);
         // It's possible that the replacement pays more fees than its direct conflicts but not more
         // than all conflicts (i.e. the direct conflicts have high-fee descendants). However, if the
         // replacement doesn't pay more fees than its direct conflicts, then we can be sure it's not
@@ -838,7 +831,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         }
 
         // Calculate all conflicting entries and enforce BIP125 Rule #5.
-        if (const auto err_string{GetEntriesForConflicts(tx, m_pool, setIterConflicting, allConflicting)}) {
+        if (const auto err_string{GetEntriesForConflicts(tx, m_pool, setIterConflicting, ws.m_all_conflicting)}) {
             return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY,
                                  "too many potential replacements", *err_string);
         }
@@ -850,11 +843,11 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
         // Check if it's economically rational to mine this transaction rather than the ones it
         // replaces and pays for its own relay fees. Enforce BIP125 Rules #3 and #4.
-        for (CTxMemPool::txiter it : allConflicting) {
-            nConflictingFees += it->GetModifiedFee();
-            nConflictingSize += it->GetTxSize();
+        for (CTxMemPool::txiter it : ws.m_all_conflicting) {
+            ws.m_conflicting_fees += it->GetModifiedFee();
+            ws.m_conflicting_size += it->GetTxSize();
         }
-        if (const auto err_string{PaysForRBF(nConflictingFees, nModifiedFees, ws.m_vsize,
+        if (const auto err_string{PaysForRBF(ws.m_conflicting_fees, ws.m_modified_fees, ws.m_vsize,
                                              ::incrementalRelayFee, hash)}) {
             return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "insufficient fee", *err_string);
         }
@@ -926,35 +919,29 @@ bool MemPoolAccept::Finalize(const ATMPArgs& args, Workspace& ws)
     TxValidationState& state = ws.m_state;
     const bool bypass_limits = args.m_bypass_limits;
 
-    CTxMemPool::setEntries& allConflicting = ws.m_all_conflicting;
-    CTxMemPool::setEntries& setAncestors = ws.m_ancestors;
-    const CAmount& nModifiedFees = ws.m_modified_fees;
-    const CAmount& nConflictingFees = ws.m_conflicting_fees;
-    const size_t& nConflictingSize = ws.m_conflicting_size;
-    const bool fReplacementTransaction = ws.m_replacement_transaction;
     std::unique_ptr<CTxMemPoolEntry>& entry = ws.m_entry;
 
     // Remove conflicting transactions from the mempool
-    for (CTxMemPool::txiter it : allConflicting)
+    for (CTxMemPool::txiter it : ws.m_all_conflicting)
     {
         LogPrint(BCLog::MEMPOOL, "replacing tx %s with %s for %s additional fees, %d delta bytes\n",
                 it->GetTx().GetHash().ToString(),
                 hash.ToString(),
-                FormatMoney(nModifiedFees - nConflictingFees),
-                (int)entry->GetTxSize() - (int)nConflictingSize);
+                FormatMoney(ws.m_modified_fees - ws.m_conflicting_fees),
+                (int)entry->GetTxSize() - (int)ws.m_conflicting_size);
         ws.m_replaced_transactions.push_back(it->GetSharedTx());
     }
-    m_pool.RemoveStaged(allConflicting, false, MemPoolRemovalReason::REPLACED);
+    m_pool.RemoveStaged(ws.m_all_conflicting, false, MemPoolRemovalReason::REPLACED);
 
     // This transaction should only count for fee estimation if:
     // - it isn't a BIP 125 replacement transaction (may not be widely supported)
     // - it's not being re-added during a reorg which bypasses typical mempool fee limits
     // - the node is not behind
     // - the transaction is not dependent on any other transactions in the mempool
-    bool validForFeeEstimation = !fReplacementTransaction && !bypass_limits && IsCurrentForFeeEstimation(m_active_chainstate) && m_pool.HasNoInputsOf(tx);
+    bool validForFeeEstimation = !ws.m_replacement_transaction && !bypass_limits && IsCurrentForFeeEstimation(m_active_chainstate) && m_pool.HasNoInputsOf(tx);
 
     // Store transaction in memory
-    m_pool.addUnchecked(*entry, setAncestors, validForFeeEstimation);
+    m_pool.addUnchecked(*entry, ws.m_ancestors, validForFeeEstimation);
 
     // trim mempool and check if tx was trimmed
     if (!bypass_limits) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -953,6 +953,10 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
 {
     AssertLockHeld(cs_main);
 
+    // TODO: handle the case where the user has configured their mempool limits to be more
+    // restrictive than package limits. Make this check parameterizable but avoid introducing more
+    // globals. We might need to distinguish between mempool and network-wide package limits or
+    // just do limited package validation.
     // These context-free package limits can be done before taking the mempool lock.
     PackageValidationState package_state;
     if (!CheckPackage(txns, package_state)) return PackageMempoolAcceptResult(package_state, {});

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -972,7 +972,10 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
     // Do all PreChecks first and fail fast to avoid running expensive script checks when unnecessary.
     for (Workspace& ws : workspaces) {
         if (!PreChecks(args, ws)) {
-            package_state.Invalid(PackageValidationResult::PCKG_TX, "transaction failed");
+            package_state.Invalid(ws.m_state.GetResult() == TxValidationResult::TX_CONSENSUS
+                                  ? PackageValidationResult::PCKG_TX_CONSENSUS
+                                  : PackageValidationResult::PCKG_TX_POLICY,
+                                  "transaction failed");
             // Exit early to avoid doing pointless work. Update the failed tx result; the rest are unfinished.
             results.emplace(ws.m_ptx->GetWitnessHash(), MempoolAcceptResult::Failure(ws.m_state));
             return PackageMempoolAcceptResult(package_state, std::move(results));
@@ -1002,7 +1005,10 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
         PrecomputedTransactionData txdata;
         if (!PolicyScriptChecks(args, ws, txdata)) {
             // Exit early to avoid doing pointless work. Update the failed tx result; the rest are unfinished.
-            package_state.Invalid(PackageValidationResult::PCKG_TX, "transaction failed");
+            package_state.Invalid(ws.m_state.GetResult() == TxValidationResult::TX_CONSENSUS
+                                  ? PackageValidationResult::PCKG_TX_CONSENSUS
+                                  : PackageValidationResult::PCKG_TX_POLICY,
+                                  "transaction failed");
             results.emplace(ws.m_ptx->GetWitnessHash(), MempoolAcceptResult::Failure(ws.m_state));
             return PackageMempoolAcceptResult(package_state, std::move(results));
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -455,6 +455,10 @@ public:
          * partially submitted.
          */
         const bool m_package_submission;
+        /** When true, use package feerates instead of individual transaction feerates for fee-based
+         * policies such as mempool min fee and min relay fee.
+         */
+        const bool m_package_feerates;
 
         /** Parameters for single transaction mempool validation. */
         static ATMPArgs SingleAccept(const CChainParams& chainparams, int64_t accept_time,
@@ -467,6 +471,7 @@ public:
                             /* m_test_accept */ test_accept,
                             /* m_allow_bip125_replacement */ true,
                             /* m_package_submission */ false,
+                            /* m_package_feerates */ false,
             };
         }
 
@@ -480,6 +485,7 @@ public:
                             /* m_test_accept */ true,
                             /* m_allow_bip125_replacement */ false,
                             /* m_package_submission */ false,
+                            /* m_package_feerates */ true,
             };
         }
 
@@ -492,6 +498,7 @@ public:
                             /* m_test_accept */ false,
                             /* m_allow_bip125_replacement */ false,
                             /* m_package_submission */ true,
+                            /* m_package_feerates */ true,
             };
         }
 
@@ -610,6 +617,10 @@ private:
     CCoinsView m_dummy;
 
     CChainState& m_active_chainstate;
+
+    // Used to calculate package feerate.
+    CAmount m_total_modified_fees;
+    int64_t m_total_vsize;
 
     // The package limits in effect at the time of invocation.
     // The same ancestor limits are applied for every transaction.
@@ -780,9 +791,10 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         return state.Invalid(TxValidationResult::TX_NOT_STANDARD, "bad-txns-too-many-sigops",
                 strprintf("%d", nSigOpsCost));
 
-    // No transactions are allowed below minRelayTxFee except from disconnected
-    // blocks
-    if (!bypass_limits && !CheckFeeRate(ws.m_vsize, ws.m_modified_fees, state)) return false;
+    // No individual transactions are allowed below minRelayTxFee and mempool min fee except from
+    // disconnected blocks and transactions in a package. Package transactions will be checked using
+    // descendant feerates later.
+    if (!bypass_limits && !args.m_package_feerates && !CheckFeeRate(ws.m_vsize, ws.m_modified_fees, state)) return false;
 
     const CTxMemPool::setEntries setIterConflicting = m_pool.GetIterSet(ws.m_conflicts);
     // Calculate in-mempool ancestors, up to a limit.
@@ -1159,6 +1171,21 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
         m_viewmempool.PackageAddTransaction(ws.m_ptx);
     }
 
+    // Transactions must meet two minimum feerates: the mempool minimum fee and min relay fee.
+    // For transactions consisting of exactly one child and its parents, it suffices to use the
+    // package feerate (total modified fees / total virtual size) to check this requirement.
+    m_total_vsize = std::accumulate(workspaces.cbegin(), workspaces.cend(), 0,
+        [](int64_t sum, auto& ws) { return sum + ws.m_vsize; });
+    m_total_modified_fees = std::accumulate(workspaces.cbegin(), workspaces.cend(), 0,
+        [](CAmount sum, auto& ws) { return sum + ws.m_modified_fees; });
+    const CFeeRate package_feerate(m_total_modified_fees, m_total_vsize);
+    TxValidationState placeholder_state;
+    if (args.m_package_feerates && IsChildWithParents(txns, /* exact */ false) &&
+        !CheckFeeRate(m_total_vsize, m_total_modified_fees, placeholder_state)) {
+        package_state.Invalid(PackageValidationResult::PCKG_POLICY, "package-fee-too-low");
+        return PackageMempoolAcceptResult(package_state, package_feerate, {});
+    }
+
     // Apply package mempool ancestor/descendant limits. Skip if there is only one transaction,
     // because it's unnecessary. Also, CPFP carve out can increase the limit for individual
     // transactions, but this exemption is not extended to packages in CheckPackageLimits().
@@ -1193,7 +1220,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
         return PackageMempoolAcceptResult(package_state, std::move(results));
     }
 
-    return PackageMempoolAcceptResult(package_state, std::move(results));
+    return PackageMempoolAcceptResult(package_state, package_feerate, std::move(results));
 }
 
 PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, ATMPArgs& args)

--- a/src/validation.h
+++ b/src/validation.h
@@ -60,6 +60,13 @@ static const unsigned int DEFAULT_ANCESTOR_SIZE_LIMIT = 101;
 static const unsigned int DEFAULT_DESCENDANT_LIMIT = 25;
 /** Default for -limitdescendantsize, maximum kilobytes of in-mempool descendants */
 static const unsigned int DEFAULT_DESCENDANT_SIZE_LIMIT = 101;
+
+// It doesn't make sense for package limits to exceed default mempool ancestor/descendant limits.
+static_assert(DEFAULT_DESCENDANT_LIMIT >= MAX_PACKAGE_COUNT);
+static_assert(DEFAULT_ANCESTOR_LIMIT >= MAX_PACKAGE_COUNT);
+static_assert(DEFAULT_ANCESTOR_SIZE_LIMIT >= MAX_PACKAGE_SIZE);
+static_assert(DEFAULT_DESCENDANT_SIZE_LIMIT >= MAX_PACKAGE_SIZE);
+
 /** Default for -mempoolexpiry, expiration time for mempool transactions in hours */
 static const unsigned int DEFAULT_MEMPOOL_EXPIRY = 336;
 /** Maximum number of dedicated script-checking threads allowed */

--- a/src/validation.h
+++ b/src/validation.h
@@ -164,14 +164,16 @@ struct MempoolAcceptResult {
     // The following fields are only present when m_result_type = ResultType::VALID
     /** Mempool transactions replaced by the tx per BIP 125 rules. */
     const std::optional<std::list<CTransactionRef>> m_replaced_transactions;
+    /** Virtual size as used by the mempool, calculated using serialized size and sigops. */
+    const std::optional<int64_t> m_vsize;
     /** Raw base fees in satoshis. */
     const std::optional<CAmount> m_base_fees;
     static MempoolAcceptResult Failure(TxValidationState state) {
         return MempoolAcceptResult(state);
     }
 
-    static MempoolAcceptResult Success(std::list<CTransactionRef>&& replaced_txns, CAmount fees) {
-        return MempoolAcceptResult(std::move(replaced_txns), fees);
+    static MempoolAcceptResult Success(std::list<CTransactionRef>&& replaced_txns, int64_t vsize, CAmount fees) {
+        return MempoolAcceptResult(std::move(replaced_txns), vsize, fees);
     }
 
 // Private constructors. Use static methods MempoolAcceptResult::Success, etc. to construct.
@@ -183,9 +185,9 @@ private:
         }
 
     /** Constructor for success case */
-    explicit MempoolAcceptResult(std::list<CTransactionRef>&& replaced_txns, CAmount fees)
+    explicit MempoolAcceptResult(std::list<CTransactionRef>&& replaced_txns, int64_t vsize, CAmount fees)
         : m_result_type(ResultType::VALID),
-        m_replaced_transactions(std::move(replaced_txns)), m_base_fees(fees) {}
+        m_replaced_transactions(std::move(replaced_txns)), m_vsize{vsize}, m_base_fees(fees) {}
 };
 
 /**

--- a/src/validation.h
+++ b/src/validation.h
@@ -247,7 +247,8 @@ MempoolAcceptResult AcceptToMemoryPool(CChainState& active_chainstate, CTxMemPoo
 *    true (analogous but not identical to BIP125 RBF):
 *    - No package transaction replaces the dependency of another package transaction.
 *    - All original transactions signal replaceability.
-*    - None of the transactions in the package have any unconfirmed inputs.
+*    - If any of the transactions have unconfirmed inputs, the child's ancestor score must be at
+*      least as high as the ancestor scores of every mempool transaction being replaced.
 *    - The package total modified fees >= the modified fees of the original transactions.
 *    - The package pays for its own bandwidth: its feerate is >= incrementalRelayFee higher than the
 *      original transactions.

--- a/src/validation.h
+++ b/src/validation.h
@@ -157,23 +157,29 @@ struct MempoolAcceptResult {
     enum class ResultType {
         VALID, //!> Fully validated, valid.
         INVALID, //!> Invalid.
+        MEMPOOL_ENTRY, //!> Valid, transaction was already in the mempool.
     };
     const ResultType m_result_type;
     const TxValidationState m_state;
 
-    // The following fields are only present when m_result_type = ResultType::VALID
+    // The following fields are only present when m_result_type = ResultType::VALID or MEMPOOL_ENTRY
     /** Mempool transactions replaced by the tx per BIP 125 rules. */
     const std::optional<std::list<CTransactionRef>> m_replaced_transactions;
     /** Virtual size as used by the mempool, calculated using serialized size and sigops. */
     const std::optional<int64_t> m_vsize;
     /** Raw base fees in satoshis. */
     const std::optional<CAmount> m_base_fees;
+
     static MempoolAcceptResult Failure(TxValidationState state) {
         return MempoolAcceptResult(state);
     }
 
     static MempoolAcceptResult Success(std::list<CTransactionRef>&& replaced_txns, int64_t vsize, CAmount fees) {
         return MempoolAcceptResult(std::move(replaced_txns), vsize, fees);
+    }
+
+    static MempoolAcceptResult MempoolTx(int64_t vsize, CAmount fees) {
+        return MempoolAcceptResult(vsize, fees);
     }
 
 // Private constructors. Use static methods MempoolAcceptResult::Success, etc. to construct.
@@ -188,6 +194,10 @@ private:
     explicit MempoolAcceptResult(std::list<CTransactionRef>&& replaced_txns, int64_t vsize, CAmount fees)
         : m_result_type(ResultType::VALID),
         m_replaced_transactions(std::move(replaced_txns)), m_vsize{vsize}, m_base_fees(fees) {}
+
+    /** Constructor for already-in-mempool case. It wouldn't replace any transactions. */
+    explicit MempoolAcceptResult(int64_t vsize, CAmount fees)
+        : m_result_type(ResultType::MEMPOOL_ENTRY), m_vsize{vsize}, m_base_fees(fees) {}
 };
 
 /**
@@ -197,7 +207,7 @@ struct PackageMempoolAcceptResult
 {
     const PackageValidationState m_state;
     /**
-    * Map from wtxid to finished MempoolAcceptResults. The client is responsible
+    * Map from (w)txid to finished MempoolAcceptResults. The client is responsible
     * for keeping track of the transaction objects themselves. If a result is not
     * present, it means validation was unfinished for that transaction. If there
     * was a package-wide error (see result in m_state), m_tx_results will be empty.

--- a/test/functional/feature_package_relay.py
+++ b/test/functional/feature_package_relay.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from decimal import Decimal
+
+from test_framework.address import (
+    ADDRESS_BCRT1_P2WSH_OP_TRUE,
+    ADDRESS_BCRT1_UNSPENDABLE,
+)
+from test_framework.messages import (
+    BIP125_SEQUENCE_NUMBER,
+    tx_from_hex,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_greater_than_or_equal,
+    assert_raises_rpc_error,
+)
+from test_framework.wallet import (
+    create_child_with_parents,
+    DEFAULT_FEE,
+    make_chain,
+)
+
+class PackageRelayTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def assert_mempool_contents(self, expected=None, unexpected=None):
+        """Assert that all transactions in expected are in the mempool,
+        and all transactions in unexpected are not in the mempool.
+        """
+        if not expected:
+            expected = []
+        if not unexpected:
+            unexpected = []
+        assert set(unexpected).isdisjoint(expected)
+        mempool = self.nodes[0].getrawmempool(verbose=True)
+        for tx in expected:
+            assert tx.rehash() in mempool
+        for tx in unexpected:
+            assert tx.rehash() not in mempool
+
+    def create_simple_package(self, parent_coins, parent_fee=0, child_fee=DEFAULT_FEE):
+        """Create a child-with-parents package using the parent_coins passed in.
+        Each coin in parent_coins will be used to fund one parent transaction.
+        Thus, the package will contain len(parent_coins) parents and 1 child.
+        Default fee for the parent transactions is 0.
+        The child will have a fee of 0.0001BTC*len(parent_coins) unless otherwise specified.
+
+        returns tuple (hex serialized txns, CTransaction objects)
+        """
+        node = self.nodes[0]
+        package_hex = []
+        package_txns = []
+        values = []
+        scripts = []
+        # Create the parents
+        for coin in parent_coins:
+            value = coin["amount"]
+            txid = coin["txid"]
+            (tx, txhex, value, spk) = make_chain(node, self.address, self.privkeys, txid, value, 0, None, parent_fee)
+            package_hex.append(txhex)
+            package_txns.append(tx)
+            values.append(value)
+            scripts.append(spk)
+        # Subtract the fee that will automatically be applied. Pass in the fee difference.
+        child_hex = create_child_with_parents(node, self.address, self.privkeys, package_txns, values, scripts, child_fee)
+        package_hex.append(child_hex)
+        package_txns.append(tx_from_hex(child_hex))
+        return package_hex, package_txns
+
+    def create_package_heavy(self, parent_coins):
+        """Create a package with a parent for each coin in parent_coins as inputs.
+        Each parent will have 3 outputs and slightly higher fees.
+        There will be 1 child of all the parent transactions (a package can only have 1 child).
+        Default fee for each parent transaction is 0.0001001
+        Default fee for the child transaction is 0.0001BTC*num_parents
+
+        returns tuple (package_hex, package_txns)
+        """
+        node = self.nodes[0]
+        package_hex = []
+        package_txns = []
+        values = []
+        scripts = []
+        # Create the parents
+        for coin in parent_coins:
+            value = coin["amount"]
+            txid = coin["txid"]
+            # Subtract a tiny additional amount to increase the absolute fee
+            amount_each = (value - Decimal("0.0001001")) / 3
+            inputs = [{"txid": txid, "vout": 0, "sequence": BIP125_SEQUENCE_NUMBER}]
+            outputs = {
+                self.address : amount_each,
+                ADDRESS_BCRT1_P2WSH_OP_TRUE: amount_each,
+                ADDRESS_BCRT1_UNSPENDABLE: amount_each,
+            }
+            rawtx = node.createrawtransaction(inputs, outputs)
+            txhex = node.signrawtransactionwithkey(rawtx, self.privkeys)["hex"]
+            package_hex.append(txhex)
+            tx = tx_from_hex(txhex)
+            package_txns.append(tx)
+            values.append(amount_each)
+            scripts.append(tx.vout[0].scriptPubKey.hex())
+        # This function will use the first output of each parent
+        child_hex = create_child_with_parents(node, self.address, self.privkeys, package_txns, values, scripts)
+        package_hex.append(child_hex)
+        package_txns.append(tx_from_hex(child_hex))
+        return package_hex, package_txns
+
+    def create_package_many_conflicts(self, parent_coins):
+        """Create a family of transactions using the parent_coins passed in (should have > 100).
+        The goal here is to have more than 100 dependencies so we hit the BIP125 Rule 5 limit.
+        Every 10 coins will be used to fund 1 parent transaction, so num_parents = parent_coins/10
+        There will be 1 child of all the parent transactions.
+        Default fee for each transaction is 0.0001BTC.
+
+        returns tuple (package_hex, package_txns)
+        """
+        assert_greater_than_or_equal(len(parent_coins), 100)
+        node = self.nodes[0]
+
+        # Create a package that spends 10 coins per parent
+        package_hex = []
+        package_txns = []
+        values = []
+        scripts = []
+        # Create the parents
+        for i in range(len(parent_coins) // 10):
+            my_coins = parent_coins[10*i : 10*i+10]
+            inputs = [{"txid": coin["txid"], "vout": 0} for coin in my_coins]
+            my_value = sum([coin["amount"] for coin in my_coins]) - DEFAULT_FEE
+            outputs = {self.address: my_value}
+            raw_parent = node.createrawtransaction(inputs, outputs)
+            signed_parent = node.signrawtransactionwithkey(raw_parent, self.privkeys)
+            assert signed_parent["complete"]
+            package_hex.append(signed_parent["hex"])
+            parent_tx = tx_from_hex(signed_parent["hex"])
+            package_txns.append(parent_tx)
+            values.append(my_value)
+            scripts.append(parent_tx.vout[0].scriptPubKey.hex())
+        # Subtract the fee that will automatically be applied. Pass in the fee difference.
+        child_hex = create_child_with_parents(node, self.address, self.privkeys, package_txns, values, scripts)
+        package_hex.append(child_hex)
+        package_txns.append(tx_from_hex(child_hex))
+        return package_hex, package_txns
+
+    def run_test(self):
+        self.log.info("Generate blocks to create UTXOs")
+        node = self.nodes[0]
+        self.privkeys = [node.get_deterministic_priv_key().key]
+        self.address = node.get_deterministic_priv_key().address
+        self.coins = []
+        # The last 100 coinbase transactions are premature
+        for b in node.generatetoaddress(260, self.address)[:-100]:
+            coinbase = node.getblock(blockhash=b, verbosity=2)["tx"][0]
+            self.coins.append({
+                "txid": coinbase["txid"],
+                "amount": coinbase["vout"][0]["value"],
+                "scriptPubKey": coinbase["vout"][0]["scriptPubKey"],
+            })
+
+        self.test_package_rbf_basic()
+        self.test_package_rbf_rule1()
+        self.test_package_rbf_rule2()
+        self.test_package_rbf_rule3()
+        self.test_package_rbf_rule4()
+        self.test_package_rbf_rule5()
+        self.test_package_rbf_conflicting_conflicts()
+
+    def test_package_rbf_basic(self):
+        self.log.info("Test that packages can RBF")
+        node = self.nodes[0]
+        # Reuse the same coins so that the transactions conflict with one another.
+        num_parents = 2
+        parent_coins = self.coins[:num_parents]
+        del self.coins[:num_parents]
+        (package_hex1, package_txns1) = self.create_simple_package(parent_coins, DEFAULT_FEE)
+        (package_hex2, package_txns2) = self.create_simple_package(parent_coins, DEFAULT_FEE * 2)
+        node.submitrawpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=package_txns2)
+        node.submitrawpackage(package_hex2)
+        self.assert_mempool_contents(expected=package_txns2, unexpected=package_txns1)
+        node.generate(1)
+
+    def test_package_rbf_rule1(self):
+        self.log.info("Test that all replacement candidates in package RBF must signal BIP125 replaceability")
+        node = self.nodes[0]
+        num_parents = 20
+        parent_coins = self.coins[:num_parents]
+        del self.coins[:num_parents]
+        (package_hex, package_txns) = self.create_simple_package(parent_coins, DEFAULT_FEE * 3)
+
+        # Submit transactions to the mempool be replaced
+        singleton_txns = []
+        # Create 1 transaction per coin and submit to mempool.
+        for coin in parent_coins[1:]:
+            txid = coin["txid"]
+            value = coin["amount"]
+            (tx, txhex, _, _) = make_chain(node, self.address, self.privkeys, txid, value)
+            node.sendrawtransaction(txhex)
+            singleton_txns.append(tx)
+
+        # Create single transaction that doesn't signal replaceability
+        coin = parent_coins[0]
+        txid = coin["txid"]
+        value = coin["amount"]
+        inputs = [{"txid": txid, "vout": 0, "sequence": BIP125_SEQUENCE_NUMBER + 1}]
+        outputs = {self.address: value - DEFAULT_FEE}
+        rawtx = node.createrawtransaction(inputs, outputs)
+        txhex = node.signrawtransactionwithkey(rawtx, self.privkeys)["hex"]
+        node.sendrawtransaction(txhex)
+
+        assert_raises_rpc_error(-26, "txn-mempool-conflict", node.submitrawpackage, package_hex)
+        self.assert_mempool_contents(expected=[tx_from_hex(txhex)] + singleton_txns, unexpected=package_txns)
+        node.generate(1)
+
+    def test_package_rbf_rule2(self):
+        self.log.info("Test that packages cannot RBF if they introduce other unconfirmed inputs")
+        node = self.nodes[0]
+        num_parents = 2
+        parent_coins = self.coins[:num_parents]
+        del self.coins[:num_parents]
+        (package_hex1, package_txns1) = self.create_simple_package(parent_coins, DEFAULT_FEE)
+        node.submitrawpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1)
+
+        # Create a mempool transaction for additional unconfirmed input
+        coin = self.coins.pop()
+        value = coin["amount"]
+        (tx, txhex, _, _) = make_chain(node, self.address, self.privkeys, coin["txid"], value)
+        node.sendrawtransaction(txhex)
+        parent_coins.append({
+            "txid": tx.rehash(),
+            "amount": value - DEFAULT_FEE,
+            "scriptPubKey": tx.vout[0].scriptPubKey.hex(),
+        })
+        (package_hex2, package_txns2) = self.create_simple_package(parent_coins, DEFAULT_FEE * 2)
+        assert_raises_rpc_error(-25, "package RBF failed: replacement adds unconfirmed", node.submitrawpackage, package_hex2)
+        node.generate(1)
+
+    def test_package_rbf_rule3(self):
+        self.log.info("Check Package RBF must increase the absolute fee")
+        node = self.nodes[0]
+        num_parents = 10
+        parent_coins = self.coins[:num_parents]
+        del self.coins[:num_parents]
+        (package_hex1, package_txns1) = self.create_package_heavy(parent_coins)
+        node.submitrawpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1)
+        # Package 2 has a higher feerate but lower absolute fee
+        package2_parent_fee = Decimal("0.00010005")
+        package2_absolute_fee = package2_parent_fee * 10 + DEFAULT_FEE
+        (package_hex2, package_txns2) = self.create_simple_package(parent_coins, package2_parent_fee)
+        assert_greater_than_or_equal(node.getmempoolinfo()["total_fee"], package2_absolute_fee)
+        assert_raises_rpc_error(-25, "package RBF failed: insufficient fee", node.submitrawpackage, package_hex2)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=package_txns2)
+        # Package 3 has a higher feerate and absolute fee
+        (package_hex3, package_txns3) = self.create_simple_package(parent_coins, Decimal("0.0002"))
+        node.submitrawpackage(package_hex3)
+        self.assert_mempool_contents(expected=package_txns3, unexpected=package_txns1 + package_txns2)
+        node.generate(1)
+
+    def test_package_rbf_rule4(self):
+        node = self.nodes[0]
+        self.log.info("Check Package RBF must pay for the entire package's bandwidth")
+        num_parents = 2
+        parent_coins = self.coins[:num_parents]
+        del self.coins[:num_parents]
+        (package_hex1, package_txns1) = self.create_simple_package(parent_coins, Decimal("0.0001"))
+        (package_hex2, package_txns2) = self.create_simple_package(parent_coins, Decimal("0.0001001"))
+        node.submitrawpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=package_txns2)
+        assert_raises_rpc_error(-25, "package RBF failed: insufficient fee", node.submitrawpackage, package_hex2)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=package_txns2)
+        node.generate(1)
+
+    def test_package_rbf_rule5(self):
+        node = self.nodes[0]
+        self.log.info("Check Package RBF cannot replace more than 100 transactions")
+        num_parents = 110
+        parent_coins = self.coins[:num_parents]
+        del self.coins[:num_parents]
+        (package_hex, package_txns) = self.create_package_many_conflicts(parent_coins)
+        singleton_txns = []
+        # Create 1 transaction per coin and submit to mempool.
+        for coin in parent_coins:
+            txid = coin["txid"]
+            value = coin["amount"]
+            # Low fee
+            (tx, txhex, _, _) = make_chain(node, ADDRESS_BCRT1_P2WSH_OP_TRUE, self.privkeys, txid, value, 0, None, Decimal("0.00001"))
+            node.sendrawtransaction(txhex)
+            singleton_txns.append(tx)
+        self.assert_mempool_contents(expected=singleton_txns, unexpected=package_txns)
+        assert_raises_rpc_error(-25, "package RBF failed: too many potential replacements", node.submitrawpackage, package_hex)
+        node.generate(1)
+
+    def test_package_rbf_conflicting_conflicts(self):
+        node = self.nodes[0]
+        self.log.info("Check that different package transactions cannot share the same conflicts")
+        num_parents = 5
+        parent_coins = self.coins[:num_parents]
+        del self.coins[:num_parents]
+        (package_hex1, package_txns1) = self.create_simple_package(parent_coins, DEFAULT_FEE)
+        (package_hex2, package_txns2) = self.create_simple_package(parent_coins, DEFAULT_FEE * 2)
+        (package_hex3, package_txns3) = self.create_simple_package(parent_coins, DEFAULT_FEE * 4)
+        node.submitrawpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1)
+        # The first two transactions have the same conflicts
+        package_duplicate_conflicts_hex = [package_hex2[0]] + package_hex3
+        # Note that this won't actually go into the RBF logic, because static package checks will
+        # detect that two package transactions conflict with each other. Either way, this must fail.
+        assert_raises_rpc_error(-25, "conflict-in-package", node.submitrawpackage, package_duplicate_conflicts_hex)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=package_txns2 + package_txns3)
+        # The RBFs should otherwise work.
+        node.submitrawpackage(package_hex2)
+        self.assert_mempool_contents(expected=package_txns2, unexpected=package_txns1)
+        node.submitrawpackage(package_hex3)
+        self.assert_mempool_contents(expected=package_txns3, unexpected=package_txns2)
+
+if __name__ == "__main__":
+    PackageRelayTest().main()

--- a/test/functional/feature_package_relay.py
+++ b/test/functional/feature_package_relay.py
@@ -241,7 +241,8 @@ class PackageRelayTest(BitcoinTestFramework):
             "scriptPubKey": tx.vout[0].scriptPubKey.hex(),
         })
         (package_hex2, package_txns2) = self.create_simple_package(parent_coins, DEFAULT_FEE * 2)
-        assert_raises_rpc_error(-25, "package RBF failed: replacement adds unconfirmed", node.submitrawpackage, package_hex2)
+        node.submitrawpackage(package_hex2)
+        self.assert_mempool_contents(expected=package_txns2, unexpected=package_txns1)
         node.generate(1)
 
     def test_package_rbf_rule3(self):

--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -318,7 +318,7 @@ class RPCPackagesTest(BitcoinTestFramework):
                 assert_equal(submitres_tx["vsize"], testres_tx["vsize"])
                 assert_equal(submitres_tx["fees"]["base"], testres_tx["fees"]["base"])
 
-    def test_submit_child_with_parents(self, num_parents):
+    def test_submit_child_with_parents(self, num_parents, partial_submit=False):
         node = self.nodes[0]
         # Test a package with num_parents parents and 1 child transaction.
         package_hex = []
@@ -333,6 +333,8 @@ class RPCPackagesTest(BitcoinTestFramework):
             package_txns.append(tx)
             values.append(value)
             scripts.append(spk)
+            if partial_submit and random.choice([True, False]):
+                node.sendrawtransaction(txhex)
         child_hex = create_child_with_parents(node, self.address, self.privkeys, package_txns, values, scripts)
         package_hex.append(child_hex)
         package_txns.append(tx_from_hex(child_hex))
@@ -365,6 +367,7 @@ class RPCPackagesTest(BitcoinTestFramework):
         self.log.info("Submitrawpackage valid packages with 1 child and some number of parents")
         for num_parents in [1, 2, 10, 24]:
             self.test_submit_child_with_parents(num_parents)
+            self.test_submit_child_with_parents(num_parents, partial_submit=True)
 
         self.log.info("Submitrawpackage only allows packages of 1 child with its parents")
         # Chain of 3 transactions has too many generations

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -12,6 +12,7 @@ from typing import Optional
 from test_framework.address import ADDRESS_BCRT1_P2WSH_OP_TRUE
 from test_framework.key import ECKey
 from test_framework.messages import (
+    BIP125_SEQUENCE_NUMBER,
     COIN,
     COutPoint,
     CTransaction,
@@ -190,7 +191,7 @@ def make_chain(node, address, privkeys, parent_txid, parent_value, n=0, parent_l
     amount = parent_value with a fee deducted.
     Return tuple (CTransaction object, raw hex, nValue, scriptPubKey of the output created).
     """
-    inputs = [{"txid": parent_txid, "vout": n}]
+    inputs = [{"txid": parent_txid, "vout": n, "sequence": BIP125_SEQUENCE_NUMBER}]
     my_value = parent_value - fee
     outputs = {address : my_value}
     rawtx = node.createrawtransaction(inputs, outputs)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -219,6 +219,7 @@ BASE_SCRIPTS = [
     'rpc_createmultisig.py --descriptors',
     'rpc_packages.py',
     'mempool_package_limits.py',
+    'feature_package_relay.py',
     'feature_versionbits_warning.py',
     'rpc_preciousblock.py',
     'wallet_importprunedfunds.py --legacy-wallet',


### PR DESCRIPTION
This implements mempool validation logic for fee-bumping transactions using CPFP and RBFing mempool transactions within a package, and the combination of both (i.e. a child in a package can pay to RBF its parents' conflicts). This does not implement package relay; there are no P2P changes.

For more info, see full proposal [gist](https://gist.github.com/glozow/dc4e9d5c5b14ade7cdfac40f43adb18a).

**Package Mempool Accept Progress**:
- [x] #21062
- [x] #20833
- [x] #21800
- [x] #22675 
- [x] #23381
- [x] #22674
- [x] #23804
- [x] #24152
- [x] #24836 
- [ ] #25038

Note that, until package relay exists, fee-bumped package transactions that are otherwise too-low-fee won't go any further than the user's mempool. This PR doesn't expose the package validation codepath to users because it would be misleading.