### PR TITLE
Added comment about narrow contract for Span(T* begin, T* end) ctor

### DIFF
--- a/src/span.h
+++ b/src/span.h
@@ -117,6 +117,8 @@ public:
      *
      * This implements a subset of the iterator-based std::span constructor in C++20,
      * which is hard to implement without std::address_of.
+     *
+     * The behavior is undefined if [begin, end) is not a valid range
      */
     template <typename T, typename std::enable_if<std::is_convertible<T (*)[], C (*)[]>::value, int>::type = 0>
     CONSTEXPR_IF_NOT_DEBUG Span(T* begin, T* end) noexcept : m_data(begin), m_size(end - begin)


### PR DESCRIPTION
Hi, 
Following issue: #22289
It's completely overkill, even though it's just a comment. But it's what it'll take for me to sleep tonight. 
I've only added a comment to clarrify that this constructor comes with a narrow contract. 
