### PR TITLE
build: Perform boost::process detection with BOOST_CPPFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1425,6 +1425,8 @@ if test x$use_boost = xyes; then
   dnl Opt-in to Boost Process if external signer support is requested
   if test "x$use_external_signer" != xno; then
     AC_MSG_CHECKING(for Boost Process)
+    TEMP_CPPFLAGS="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <boost/process.hpp>]],
      [[ boost::process::child* child = new boost::process::child; delete child; ]])],
      [ AC_MSG_RESULT(yes)
@@ -1432,6 +1434,7 @@ if test x$use_boost = xyes; then
      ],
      [ AC_MSG_ERROR([Boost::Process is required for external signer support, but not available!])]
     )
+    CPPFLAGS="$TEMP_CPPFLAGS"
   fi
 
   if test x$suppress_external_warnings != xno; then


### PR DESCRIPTION
Pass boost's build settings to boost-specific library detection. As boost::process is header-only, setting the CPPFLAGS is enough, there is no need to set LIBS.

Closes #22269.