### PR TITLE
build: Avoid fcntl64@GLIBC_2.28 in libsqlite3.a

### DIFF
--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -39,12 +39,17 @@ import pixie
 #   GCC 4.8.5: GCC_4.8.0
 #   (glibc)    GLIBC_2_17
 #
+# For 32-bit systems the minimum libc version is 2.28 to embrace new fcntl{64} symbols.
+# It is safer than handling them in the glibc_compat.cpp due to their variadic arguments
+# with possible different sizes.
+# See: https://stackoverflow.com/a/58472959
+#
 MAX_VERSIONS = {
 'GCC':       (4,8,0),
 'GLIBC': {
-    pixie.EM_386:    (2,17),
+    pixie.EM_386:    (2,28),
     pixie.EM_X86_64: (2,17),
-    pixie.EM_ARM:    (2,17),
+    pixie.EM_ARM:    (2,28),
     pixie.EM_AARCH64:(2,17),
     pixie.EM_PPC64:  (2,17),
     pixie.EM_RISCV:  (2,27),

--- a/depends/packages/sqlite.mk
+++ b/depends/packages/sqlite.mk
@@ -7,6 +7,7 @@ $(package)_sha256_hash=486748abfb16abd8af664e3a5f03b228e5f124682b0c942e157644bf6
 define $(package)_set_vars
 $(package)_config_opts=--disable-shared --disable-readline --disable-dynamic-extensions --enable-option-checking
 $(package)_config_opts_linux=--with-pic
+$(package)_cppflags_linux = -DSQLITE_DISABLE_LFS
 endef
 
 define $(package)_config_cmds


### PR DESCRIPTION
This PR is:
- a partial fix for #21454 (see #22281 for the complete fix of the `bitcoind` compatibility)
- a well [documented](https://www.sqlite.org/compile.html#_options_to_disable_features_normally_turned_on) alternative to the hackish #22287

As noted in https://github.com/bitcoin/bitcoin/pull/22244#issuecomment-860932169:
>     * `fcntl64` has a data reference, it's not ever called in the code (`objdump -d bitcoin-qt|grep fcntl64@plt` shows nothing)

but on 64-bit systems the only offender is `libsqlite3.a`.

From glibc [docs](https://sourceware.org/legacy-ml/libc-alpha/2018-08/msg00003.html):
> * The `fcntl` function now have a Long File Support variant named `fcntl64`.  It
  is added to fix some Linux Open File Description (OFD) locks usage on non
  LFS mode.  As for others *64 functions, `fcntl64` semantics are analogous with
  `fcntl` and LFS support is handled transparently.  Also for Linux, the OFD
  locks act as a cancellation entrypoint.

From SQLite [docs](https://www.sqlite.org/compile.html#_options_to_disable_features_normally_turned_on):
> `SQLITE_DISABLE_LFS`
>
>    If this C-preprocessor macro is defined, large file support is disabled.

Due to peculiarities in glibc Large File Support implementation for 32-bit systems it looks safer to bump the minimum libc version to 2.28 for them.

Could be reverted back after bumping minimum glibc version to 2.28+.