### PR TITLE
[test] Improvements to p2p_addr_relay.py

### DIFF
--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -40,6 +40,12 @@ class AddrReceiver(P2PInterface):
                     raise AssertionError("Invalid addr.port of {} (8333-8342 expected)".format(addr.port))
                 assert addr.ip.startswith('123.123.123.')
 
+    def addr_received(self):
+        return self.num_ipv4_received != 0
+
+    def getaddr_received(self):
+        return self.message_count['getaddr'] > 0
+
 
 class GetAddrStore(P2PInterface):
     getaddr_received = False

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -47,21 +47,6 @@ class AddrReceiver(P2PInterface):
         return self.message_count['getaddr'] > 0
 
 
-class GetAddrStore(P2PInterface):
-    getaddr_received = False
-    num_ipv4_received = 0
-
-    def on_getaddr(self, message):
-        self.getaddr_received = True
-
-    def on_addr(self, message):
-        for addr in message.addrs:
-            self.num_ipv4_received += 1
-
-    def addr_received(self):
-        return self.num_ipv4_received != 0
-
-
 class AddrTest(BitcoinTestFramework):
     counter = 0
     mocktime = int(time.time())

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -140,7 +140,7 @@ class AddrTest(BitcoinTestFramework):
 
         self.log.info('Check relay of addresses received from outbound peers')
         inbound_peer = self.nodes[0].add_p2p_connection(AddrReceiver(test_addr_contents=True))
-        full_outbound_peer = self.nodes[0].add_outbound_p2p_connection(GetAddrStore(), p2p_idx=0, connection_type="outbound-full-relay")
+        full_outbound_peer = self.nodes[0].add_outbound_p2p_connection(AddrReceiver(), p2p_idx=0, connection_type="outbound-full-relay")
         msg = self.setup_addr_msg(2)
         self.send_addr_msg(full_outbound_peer, msg, [inbound_peer])
         self.log.info('Check that the first addr message received from an outbound peer is not relayed')
@@ -156,7 +156,7 @@ class AddrTest(BitcoinTestFramework):
         assert_equal(inbound_peer.num_ipv4_received, 2)
 
         self.log.info('Check address relay to outbound peers')
-        block_relay_peer = self.nodes[0].add_outbound_p2p_connection(GetAddrStore(), p2p_idx=1, connection_type="block-relay-only")
+        block_relay_peer = self.nodes[0].add_outbound_p2p_connection(AddrReceiver(), p2p_idx=1, connection_type="block-relay-only")
         msg3 = self.setup_addr_msg(2)
         self.send_addr_msg(inbound_peer, msg3, [full_outbound_peer, block_relay_peer])
 
@@ -170,17 +170,17 @@ class AddrTest(BitcoinTestFramework):
     def getaddr_tests(self):
         self.log.info('Test getaddr behavior')
         self.log.info('Check that we send a getaddr message upon connecting to an outbound-full-relay peer')
-        full_outbound_peer = self.nodes[0].add_outbound_p2p_connection(GetAddrStore(), p2p_idx=0, connection_type="outbound-full-relay")
+        full_outbound_peer = self.nodes[0].add_outbound_p2p_connection(AddrReceiver(), p2p_idx=0, connection_type="outbound-full-relay")
         full_outbound_peer.sync_with_ping()
-        assert full_outbound_peer.getaddr_received
+        assert full_outbound_peer.getaddr_received()
 
         self.log.info('Check that we do not send a getaddr message upon connecting to a block-relay-only peer')
-        block_relay_peer = self.nodes[0].add_outbound_p2p_connection(GetAddrStore(), p2p_idx=1, connection_type="block-relay-only")
+        block_relay_peer = self.nodes[0].add_outbound_p2p_connection(AddrReceiver(), p2p_idx=1, connection_type="block-relay-only")
         block_relay_peer.sync_with_ping()
-        assert_equal(block_relay_peer.getaddr_received, False)
+        assert_equal(block_relay_peer.getaddr_received(), False)
 
         self.log.info('Check that we answer getaddr messages only from inbound peers')
-        inbound_peer = self.nodes[0].add_p2p_connection(GetAddrStore())
+        inbound_peer = self.nodes[0].add_p2p_connection(AddrReceiver())
         inbound_peer.sync_with_ping()
 
         # Add some addresses to addrman
@@ -196,7 +196,7 @@ class AddrTest(BitcoinTestFramework):
 
         self.mocktime += 5 * 60
         self.nodes[0].setmocktime(self.mocktime)
-        inbound_peer.wait_until(inbound_peer.addr_received)
+        inbound_peer.wait_until(lambda: inbound_peer.addr_received() is True)
 
         assert_equal(full_outbound_peer.num_ipv4_received, 0)
         assert_equal(block_relay_peer.num_ipv4_received, 0)
@@ -210,9 +210,9 @@ class AddrTest(BitcoinTestFramework):
         self.mocktime = int(time.time())
 
         self.log.info('Check that we send getaddr messages')
-        full_outbound_peer = self.nodes[0].add_outbound_p2p_connection(GetAddrStore(), p2p_idx=0, connection_type="outbound-full-relay")
+        full_outbound_peer = self.nodes[0].add_outbound_p2p_connection(AddrReceiver(), p2p_idx=0, connection_type="outbound-full-relay")
         full_outbound_peer.sync_with_ping()
-        assert full_outbound_peer.getaddr_received
+        assert full_outbound_peer.getaddr_received()
 
         self.log.info('Check that we relay address messages')
         addr_source = self.nodes[0].add_p2p_connection(P2PInterface())

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -78,7 +78,7 @@ class AddrTest(BitcoinTestFramework):
     def send_addr_msg(self, source, msg, receivers):
         source.send_and_ping(msg)
         # pop m_next_addr_send timer
-        self.mocktime += 5 * 60
+        self.mocktime += 10 * 60
         self.nodes[0].setmocktime(self.mocktime)
         for peer in receivers:
             peer.sync_send_with_ping()


### PR DESCRIPTION
A test refactor broken out from #21528 & a fix to #22243.

This PR: 
1. consolidates the two helper classes into one, with the intent of making the test logic more clear & usable as we add more subtests to the file 

2. hopefully fixes the test flakiness by bumping up the mocktime interval to ensure `m_next_addr_send` timer triggers