### PR TITLE
test: Add functional test for replacement relay fee check 

### DIFF
--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -122,6 +122,9 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         self.log.info("Running test no inherited signaling...")
         self.test_no_inherited_signaling()
 
+        self.log.info("Running test replacement relay fee...")
+        self.test_replacement_relay_fee()
+
         self.log.info("Passed")
 
     def test_simple_doublespend(self):
@@ -627,6 +630,15 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         assert_equal(True, self.nodes[0].getmempoolentry(optin_parent_tx['txid'])['bip125-replaceable'])
         assert_raises_rpc_error(-26, 'txn-mempool-conflict', self.nodes[0].sendrawtransaction, replacement_child_tx["hex"], 0)
 
+    def test_replacement_relay_fee(self):
+        wallet = MiniWallet(self.nodes[0])
+        wallet.scan_blocks(start=77, num=1)
+        tx = wallet.send_self_transfer(from_node=self.nodes[0])['tx']
+
+        # Higher fee, higher feerate, different txid, but the replacement does not provide a relay
+        # fee conforming to node's `incrementalrelayfee` policy of 1000 sat per KB.
+        tx.vout[0].nValue -= 1
+        assert_raises_rpc_error(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx.serialize().hex())
 
 if __name__ == '__main__':
     ReplaceByFeeTest().main()


### PR DESCRIPTION
This PR adds rename the `reject_reason` of our implementation of BIP125 rule 4 and adds missing functional test coverage. Note, `insufficient fee` is already the `reject_reason` of few others `PreChecks` replacement checks and as such might be confusing.


> The replacement transaction must also pay for its own bandwidth at or above the rate set by the node's minimum relay fee setting. For example, if the minimum relay fee is 1 satoshi/byte and the replacement transaction is 500 bytes total, then the replacement must pay a fee at least 500 satoshis higher than the sum of the originals.

```
        // Finally in addition to paying more fees than the conflicts the
        // new transaction must pay for its own bandwidth.
        CAmount nDeltaFees = nModifiedFees - nConflictingFees;
        if (nDeltaFees < ::incrementalRelayFee.GetFee(nSize))
        {
            return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "insufficient fee",
                    strprintf("rejecting replacement %s, not enough additional fees to relay; %s < %s",
                        hash.ToString(),
                        FormatMoney(nDeltaFees),
                        FormatMoney(::incrementalRelayFee.GetFee(nSize))));
        }
```