### PR TITLE
build: Avoid @GLIBC_2.25 symbols for compatibility

### DIFF
--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -3,6 +3,7 @@ $(package)_version=2.1.12-stable
 $(package)_download_path=https://github.com/libevent/libevent/releases/download/release-$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
+$(package)_patches = glibc_compatibility.patch
 
 # When building for Windows, we set _WIN32_WINNT to target the same Windows
 # version as we do in configure. Due to quirks in libevents build system, this
@@ -14,6 +15,10 @@ define $(package)_set_vars
   $(package)_config_opts_linux=--with-pic
   $(package)_config_opts_android=--with-pic
   $(package)_cppflags_mingw32=-D_WIN32_WINNT=0x0601
+endef
+
+define $(package)_preprocess_cmds
+  patch -p1 -i $($(package)_patch_dir)/glibc_compatibility.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -136,6 +136,7 @@ $(package)_config_opts_linux += -fontconfig
 $(package)_config_opts_linux += -no-opengl
 $(package)_config_opts_linux += -no-feature-vulkan
 $(package)_config_opts_linux += -dbus-runtime
+$(package)_config_opts_linux += -no-feature-getentropy
 $(package)_config_opts_arm_linux += -platform linux-g++ -xplatform bitcoin-linux-g++
 $(package)_config_opts_i686_linux  = -xplatform linux-g++-32
 $(package)_config_opts_x86_64_linux = -xplatform linux-g++-64

--- a/depends/patches/libevent/glibc_compatibility.patch
+++ b/depends/patches/libevent/glibc_compatibility.patch
@@ -1,0 +1,14 @@
+Avoid getrandom@GLIBC_2.25 symbol.
+
+--- old/config.h.in
++++ new/config.h.in
+@@ -101,9 +101,6 @@
+ /* Define to 1 if you have the `getprotobynumber' function. */
+ #undef HAVE_GETPROTOBYNUMBER
+ 
+-/* Define to 1 if you have the `getrandom' function. */
+-#undef HAVE_GETRANDOM
+-
+ /* Define to 1 if you have the `getservbyname' function. */
+ #undef HAVE_GETSERVBYNAME
+ 


### PR DESCRIPTION
As noted in #22244, new symbols were introduced in the current release cycle, particularly:
- `getrandom@GLIBC_2.25`
- `getentropy@GLIBC_2.25`

This PR gets rid of them.

On master (c93e123dc72bfc1bd2c637fdcd032e570d53a7bd):
```
$ objdump -T src/bitcoind src/bitcoin-cli src/bitcoin-tx src/bitcoin-util src/bitcoin-wallet src/test/test_bitcoin src/qt/bitcoin-qt | grep 2.25 | wc -l
5
```

With this PR:
```
$ objdump -T src/bitcoind src/bitcoin-cli src/bitcoin-tx src/bitcoin-util src/bitcoin-wallet src/test/test_bitcoin src/qt/bitcoin-qt | grep 2.25 | wc -l
0
```