### PR TITLE
build: Avoid qt-specific @GLIBC_2.28 symbols for compatibility

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -11,6 +11,7 @@ $(package)_patches+= fix_android_qmake_conf.patch fix_android_jni_static.patch d
 $(package)_patches+= drop_lrelease_dependency.patch no_sdk_version_check.patch
 $(package)_patches+= fix_lib_paths.patch fix_android_pch.patch
 $(package)_patches+= qtbase-moc-ignore-gcc-macro.patch fix_limits_header.patch
+$(package)_patches += glibc_compatibility.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=577b0668a777eb2b451c61e8d026d79285371597ce9df06b6dee6c814164b7c3
@@ -232,6 +233,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/fix_lib_paths.patch && \
   patch -p1 -i $($(package)_patch_dir)/qtbase-moc-ignore-gcc-macro.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_limits_header.patch && \
+  patch -p1 -i $($(package)_patch_dir)/glibc_compatibility.patch && \
   sed -i.old "s|updateqm.commands = \$$$$\$$$$LRELEASE|updateqm.commands = $($(package)_extract_dir)/qttools/bin/lrelease|" qttranslations/translations/translations.pro && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -137,6 +137,7 @@ $(package)_config_opts_linux += -fontconfig
 $(package)_config_opts_linux += -no-opengl
 $(package)_config_opts_linux += -no-feature-vulkan
 $(package)_config_opts_linux += -dbus-runtime
+$(package)_config_opts_linux += -no-feature-renameat2
 $(package)_config_opts_arm_linux += -platform linux-g++ -xplatform bitcoin-linux-g++
 $(package)_config_opts_i686_linux  = -xplatform linux-g++-32
 $(package)_config_opts_x86_64_linux = -xplatform linux-g++-64

--- a/depends/patches/qt/glibc_compatibility.patch
+++ b/depends/patches/qt/glibc_compatibility.patch
@@ -1,0 +1,17 @@
+Avoid statx@GLIBC_2.28 symbol.
+
+--- old/qtbase/src/corelib/io/qfilesystemengine_unix.cpp
++++ new/qtbase/src/corelib/io/qfilesystemengine_unix.cpp
+@@ -95,12 +95,7 @@
+ #endif
+ #endif
+ 
+-#if defined(Q_OS_ANDROID)
+-// statx() is disabled on Android because quite a few systems
+-// come with sandboxes that kill applications that make system calls outside a
+-// whitelist and several Android vendors can't be bothered to update the list.
+ #  undef STATX_BASIC_STATS
+-#endif
+ 
+ #ifndef STATX_ALL
+ struct statx { mode_t stx_mode; };      // dummy


### PR DESCRIPTION
As noted in #22244, new symbols were introduced in `bitcoin-qt` during the current release cycle, particularly:
- `statx@GLIBC_2.28`
- `renameat2@GLIBC_2.28`

This PR gets rid of them.

Removing of `statx` is pretty hacky because it is integrated into Qt code tightly, and just passing `-no-feature-statx` don't work.

See:
- [QTBUG-64490](https://bugreports.qt.io/browse/QTBUG-64490)
- [QTBUG-68205](https://bugreports.qt.io/browse/QTBUG-68205)
- [QTBUG-74526](https://bugreports.qt.io/browse/QTBUG-74526)

Closes #22280.

---

**Note for reviewers.** While testing please post kernel and glib versions of systems you run tested binaries on.

It would be nice to test systems with pretty old ones (e.g., pre-4.11 kernel).