### PR TITLE
doc: spelling update

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -467,7 +467,7 @@ private:
     bool IsBlockRequested(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /** Remove this block from our tracked requested blocks. Called if:
-     *  - the block has been recieved from a peer
+     *  - the block has been received from a peer
      *  - the request for the block has timed out
      */
     void RemoveBlockRequest(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -180,7 +180,7 @@ public:
         ExternalSigner::Enumerate(command, signers, Params().NetworkIDString());
         return signers;
 #else
-        // This result is undistinguisable from a succesful call that returns
+        // This result is indistinguishable from a successful call that returns
         // no signers. For the current GUI this doesn't matter, because the wallet
         // creation dialog disables the external signer checkbox in both
         // cases. The return type could be changed to std::optional<std::vector>

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -530,9 +530,9 @@ std::optional<std::vector<std::tuple<int, CScript, int>>> InferTaprootTree(const
     std::vector<std::tuple<int, CScript, int>> ret;
     if (spenddata.merkle_root.IsNull()) return ret;
 
-    /** Data structure to represent the nodes of the tree we're going to be build. */
+    /** Data structure to represent the nodes of the tree we're going to build. */
     struct TreeNode {
-        /** Hash of this none, if known; 0 otherwise. */
+        /** Hash of this node, if known; 0 otherwise. */
         uint256 hash;
         /** The left and right subtrees (note that their order is irrelevant). */
         std::unique_ptr<TreeNode> sub[2];
@@ -547,7 +547,7 @@ std::optional<std::vector<std::tuple<int, CScript, int>>> InferTaprootTree(const
         bool done = false;
     };
 
-    // Build tree from the provides branches.
+    // Build tree from the provided branches.
     TreeNode root;
     root.hash = spenddata.merkle_root;
     for (const auto& [key, control_blocks] : spenddata.scripts) {

--- a/test/lint/lint-spelling.ignore-words.txt
+++ b/test/lint/lint-spelling.ignore-words.txt
@@ -7,6 +7,7 @@ hights
 hist
 inout
 invokable
+keypair
 mor
 nin
 ser


### PR DESCRIPTION
Clears out the report from `test/lint/lint-spelling.sh` and touches up the leftover nits in https://github.com/bitcoin/bitcoin/pull/22166#pullrequestreview-690454669. Happy to add any others people are aware of.