### PR TITLE
test: use MiniWallet for simple doublespend sub-test in feature_rbf.py

### DIFF
--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -84,11 +84,6 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         self.skip_if_no_wallet()
 
     def run_test(self):
-        make_utxo(self.nodes[0], 1 * COIN)
-
-        # Ensure nodes are synced
-        self.sync_all()
-
         self.log.info("Running test simple doublespend...")
         self.test_simple_doublespend()
 


### PR DESCRIPTION
This PR's goal is to prepare the functional test `feature_rbf.py` for more MiniWallet usage. It first gets rid of unused initialization code (I guess that was needed at times when the nodes were still in IBD at the start of tests?), then makes the MiniWallet instance introduced in #22210 available for all sub-tests, and finally, uses that instance in the first sub-test `test_simple_doublespend`.

Note that the same idea of replacing the `make_utxo` calls with MiniWallet can be also applied to other sub-tests too; this just serves as a first proof-of-concept.