### PR TITLE
doc: recommend `--disable-external-signer` in OpenBSD build guide

### DIFF
--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,6 +1,6 @@
 OpenBSD build guide
 ======================
-(updated for OpenBSD 6.7)
+(updated for OpenBSD 6.9)
 
 This guide describes how to build bitcoind, bitcoin-qt, and command-line utilities on OpenBSD.
 
@@ -67,9 +67,16 @@ export AUTOMAKE_VERSION=1.16
 ```
 Make sure `BDB_PREFIX` is set to the appropriate path from the above steps.
 
+Note that building with external signer support currently fails on OpenBSD,
+hence you have to explicitely disable it by passing the parameter
+`--disable-external-signer` to the configure script.
+(Background: the feature requires the header-only library boost::process, which
+is available on OpenBSD 6.9 via Boost 1.72.0, but contains certain system calls
+and preprocessor defines like `waitid()` and `WEXITED` that are not available.)
+
 To configure with wallet:
 ```bash
-./configure --with-gui=no CC=cc CXX=c++ \
+./configure --with-gui=no --disable-external-signer CC=cc CXX=c++ \
     BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
     BDB_CFLAGS="-I${BDB_PREFIX}/include" \
     MAKE=gmake
@@ -77,12 +84,12 @@ To configure with wallet:
 
 To configure without wallet:
 ```bash
-./configure --disable-wallet --with-gui=no CC=cc CC_FOR_BUILD=cc CXX=c++ MAKE=gmake
+./configure --disable-wallet --with-gui=no --disable-external-signer CC=cc CC_FOR_BUILD=cc CXX=c++ MAKE=gmake
 ```
 
 To configure with GUI:
 ```bash
-./configure --with-gui=yes CC=cc CXX=c++ \
+./configure --with-gui=yes --disable-external-signer CC=cc CXX=c++ \
     BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
     BDB_CFLAGS="-I${BDB_PREFIX}/include" \
     MAKE=gmake


### PR DESCRIPTION
Building the master branch with the default build settings (i.e. with external signer support enabled) leads to the following errors on my OpenBSD 6.9 machine:

```
In file included from util/system.cpp:9:
In file included from /usr/local/include/boost/process.hpp:25:
In file included from /usr/local/include/boost/process/group.hpp:32:
/usr/local/include/boost/process/detail/posix/wait_group.hpp:38:17: error: no member named 'waitid' in the global namespace
        ret = ::waitid(P_PGID, p.grp, &status, WEXITED | WNOHANG);
              ~~^
/usr/local/include/boost/process/detail/posix/wait_group.hpp:38:24: error: use of undeclared identifier 'P_PGID'
        ret = ::waitid(P_PGID, p.grp, &status, WEXITED | WNOHANG);
                       ^
/usr/local/include/boost/process/detail/posix/wait_group.hpp:38:48: error: use of undeclared identifier 'WEXITED'
        ret = ::waitid(P_PGID, p.grp, &status, WEXITED | WNOHANG);
                                               ^
/usr/local/include/boost/process/detail/posix/wait_group.hpp:144:17: error: no member named 'waitid' in the global namespace
        ret = ::waitid(P_PGID, p.grp, &siginfo, WEXITED | WSTOPPED | WNOHANG);
              ~~^
/usr/local/include/boost/process/detail/posix/wait_group.hpp:144:24: error: use of undeclared identifier 'P_PGID'
        ret = ::waitid(P_PGID, p.grp, &siginfo, WEXITED | WSTOPPED | WNOHANG);
                       ^
/usr/local/include/boost/process/detail/posix/wait_group.hpp:144:49: error: use of undeclared identifier 'WEXITED'
        ret = ::waitid(P_PGID, p.grp, &siginfo, WEXITED | WSTOPPED | WNOHANG);
                                                ^
/usr/local/include/boost/process/detail/posix/wait_group.hpp:144:59: error: use of undeclared identifier 'WSTOPPED'
        ret = ::waitid(P_PGID, p.grp, &siginfo, WEXITED | WSTOPPED | WNOHANG);
                                                          ^
7 errors generated.
```

This PR recommends passing `--disable-external-signer` in the OpenBSD build guide ([as suggested by laanwj](https://github.com/bitcoin/bitcoin/pull/22294#issuecomment-867452411)). The same commit also bumps the OpenBSD version mentioned in the header to 6.9 -- I recently used this document to setup a Bitcoin Core build on 6.9 and the description and all mentioned versions were still valid (before external signer support was enabled by default).

Would be nice if another OpenBSD user could confirm the build error.