### PR TITLE
[Refactor]: Rename Script methods that only work on PreTapScript scripts

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -463,7 +463,7 @@ static void MutateTxAddOutScript(CMutableTransaction& tx, const std::string& str
 
     // extract and validate script
     std::string strScript = vStrInputParts[1];
-    CScript scriptPubKey = ParseScript(strScript);
+    CScript scriptPubKey = ParseScriptPreTapScript(strScript);
 
     // Extract FLAGS
     bool bSegWit = false;

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -30,7 +30,7 @@ enum class TxVerbosity {
 };
 
 // core_read.cpp
-CScript ParseScript(const std::string& s);
+CScript ParseScriptPreTapScript(const std::string& s);
 std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDecode = false);
 [[nodiscard]] bool DecodeHexTx(CMutableTransaction& tx, const std::string& hex_tx, bool try_no_witness = false, bool try_witness = true);
 [[nodiscard]] bool DecodeHexBlk(CBlock&, const std::string& strHexBlk);

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -18,15 +18,15 @@
 #include <string>
 
 namespace {
-class OpCodeParser
+class PreTapScriptOpCodeParser
 {
 private:
     std::map<std::string, opcodetype> mapOpNames;
 
 public:
-    OpCodeParser()
+    PreTapScriptOpCodeParser()
     {
-        for (unsigned int op = 0; op <= MAX_OPCODE; ++op) {
+        for (unsigned int op = 0; op <= MAX_OPCODE_PRE_TAPSCRIPT; ++op) {
             // Allow OP_RESERVED to get into mapOpNames
             if (op < OP_NOP && op != OP_RESERVED) {
                 continue;
@@ -51,15 +51,15 @@ public:
     }
 };
 
-opcodetype ParseOpCode(const std::string& s)
+opcodetype ParseOpCodePreTapScript(const std::string& s)
 {
-    static const OpCodeParser ocp;
+    static const PreTapScriptOpCodeParser ocp;
     return ocp.Parse(s);
 }
 
 } // namespace
 
-CScript ParseScript(const std::string& s)
+CScript ParseScriptPreTapScript(const std::string& s)
 {
     CScript result;
 
@@ -93,7 +93,7 @@ CScript ParseScript(const std::string& s)
             result << value;
         } else {
             // opcode, e.g. OP_ADD or ADD:
-            result << ParseOpCode(w);
+            result << ParseOpCodePreTapScript(w);
         }
     }
 
@@ -106,14 +106,14 @@ static bool CheckTxScriptsSanity(const CMutableTransaction& tx)
     // Check input scripts for non-coinbase txs
     if (!CTransaction(tx).IsCoinBase()) {
         for (unsigned int i = 0; i < tx.vin.size(); i++) {
-            if (!tx.vin[i].scriptSig.HasValidOps() || tx.vin[i].scriptSig.size() > MAX_SCRIPT_SIZE) {
+            if (!tx.vin[i].scriptSig.HasValidOpsPreTapScript() || tx.vin[i].scriptSig.size() > MAX_SCRIPT_SIZE) {
                 return false;
             }
         }
     }
     // Check output scripts
     for (unsigned int i = 0; i < tx.vout.size(); i++) {
-        if (!tx.vout[i].scriptPubKey.HasValidOps() || tx.vout[i].scriptPubKey.size() > MAX_SCRIPT_SIZE) {
+        if (!tx.vout[i].scriptPubKey.HasValidOpsPreTapScript() || tx.vout[i].scriptPubKey.size() > MAX_SCRIPT_SIZE) {
             return false;
         }
     }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -425,7 +425,7 @@ static RPCHelpMan decodescript()
             // Should not be wrapped
             return false;
         } // no default case, so the compiler can warn about missing cases
-        if (!script.HasValidOps() || script.IsUnspendable()) {
+        if (!script.HasValidOpsPreTapScript() || script.IsUnspendable()) {
             return false;
         }
         for (CScript::const_iterator it{script.begin()}; it != script.end();) {

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -267,13 +267,13 @@ std::string CScriptWitness::ToString() const
     return ret + ")";
 }
 
-bool CScript::HasValidOps() const
+bool CScript::HasValidOpsPreTapScript() const
 {
     CScript::const_iterator it = begin();
     while (it < end()) {
         opcodetype opcode;
         std::vector<unsigned char> item;
-        if (!GetOp(it, opcode, item) || opcode > MAX_OPCODE || item.size() > MAX_SCRIPT_ELEMENT_SIZE) {
+        if (!GetOp(it, opcode, item) || opcode > MAX_OPCODE_PRE_TAPSCRIPT || item.size() > MAX_SCRIPT_ELEMENT_SIZE) {
             return false;
         }
     }

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -209,7 +209,7 @@ enum opcodetype
 };
 
 // Maximum value that an opcode can be
-static const unsigned int MAX_OPCODE = OP_NOP10;
+static const unsigned int MAX_OPCODE_PRE_TAPSCRIPT = OP_NOP10;
 
 std::string GetOpName(opcodetype opcode);
 
@@ -539,7 +539,7 @@ public:
     bool IsPushOnly() const;
 
     /** Check if the script contains valid OP_CODES */
-    bool HasValidOps() const;
+    bool HasValidOpsPreTapScript() const;
 
     /**
      * Returns whether the script is guaranteed to fail at execution,

--- a/src/test/data/script_tests.json
+++ b/src/test/data/script_tests.json
@@ -252,7 +252,7 @@
 ["0", "IF NOP10 ENDIF 1", "P2SH,STRICTENC,DISCOURAGE_UPGRADABLE_NOPS", "OK",
  "Discouraged NOPs are allowed if not executed"],
 
-["0", "IF 0xba ELSE 1 ENDIF", "P2SH,STRICTENC", "OK", "opcodes above MAX_OPCODE invalid if executed"],
+["0", "IF 0xba ELSE 1 ENDIF", "P2SH,STRICTENC", "OK", "opcodes above MAX_OPCODE_PRE_TAPSCRIPT invalid if executed"],
 ["0", "IF 0xbb ELSE 1 ENDIF", "P2SH,STRICTENC", "OK"],
 ["0", "IF 0xbc ELSE 1 ENDIF", "P2SH,STRICTENC", "OK"],
 ["0", "IF 0xbd ELSE 1 ENDIF", "P2SH,STRICTENC", "OK"],
@@ -889,7 +889,7 @@
  "P2SH,DISCOURAGE_UPGRADABLE_NOPS", "DISCOURAGE_UPGRADABLE_NOPS", "Discouraged NOP10 in redeemScript"],
 
 ["0x50","1", "P2SH,STRICTENC", "BAD_OPCODE", "opcode 0x50 is reserved"],
-["1", "IF 0xba ELSE 1 ENDIF", "P2SH,STRICTENC", "BAD_OPCODE", "opcodes above MAX_OPCODE invalid if executed"],
+["1", "IF 0xba ELSE 1 ENDIF", "P2SH,STRICTENC", "BAD_OPCODE", "opcodes above MAX_OPCODE_PRE_TAPSCRIPT invalid if executed"],
 ["1", "IF 0xbb ELSE 1 ENDIF", "P2SH,STRICTENC", "BAD_OPCODE"],
 ["1", "IF 0xbc ELSE 1 ENDIF", "P2SH,STRICTENC", "BAD_OPCODE"],
 ["1", "IF 0xbd ELSE 1 ENDIF", "P2SH,STRICTENC", "BAD_OPCODE"],
@@ -1012,7 +1012,7 @@
 ["1","RESERVED", "P2SH,STRICTENC", "BAD_OPCODE", "OP_RESERVED is reserved"],
 ["1","RESERVED1", "P2SH,STRICTENC", "BAD_OPCODE", "OP_RESERVED1 is reserved"],
 ["1","RESERVED2", "P2SH,STRICTENC", "BAD_OPCODE", "OP_RESERVED2 is reserved"],
-["1","0xba", "P2SH,STRICTENC", "BAD_OPCODE", "0xba == MAX_OPCODE + 1"],
+["1","0xba", "P2SH,STRICTENC", "BAD_OPCODE", "0xba == MAX_OPCODE_PRE_TAPSCRIPT + 1"],
 
 ["2147483648", "1ADD 1", "P2SH,STRICTENC", "UNKNOWN_ERROR", "We cannot do math on 5-byte integers"],
 ["2147483648", "NEGATE 1", "P2SH,STRICTENC", "UNKNOWN_ERROR", "We cannot do math on 5-byte integers"],

--- a/src/test/fuzz/key.cpp
+++ b/src/test/fuzz/key.cpp
@@ -126,7 +126,7 @@ FUZZ_TARGET_INIT(key, initialize_key)
         assert(!tx_pubkey_script.IsPayToWitnessScriptHash());
         assert(!tx_pubkey_script.IsPushOnly());
         assert(!tx_pubkey_script.IsUnspendable());
-        assert(tx_pubkey_script.HasValidOps());
+        assert(tx_pubkey_script.HasValidOpsPreTapScript());
         assert(tx_pubkey_script.size() == 35);
 
         const CScript tx_multisig_script = GetScriptForMultisig(1, {pubkey});
@@ -134,7 +134,7 @@ FUZZ_TARGET_INIT(key, initialize_key)
         assert(!tx_multisig_script.IsPayToWitnessScriptHash());
         assert(!tx_multisig_script.IsPushOnly());
         assert(!tx_multisig_script.IsUnspendable());
-        assert(tx_multisig_script.HasValidOps());
+        assert(tx_multisig_script.HasValidOpsPreTapScript());
         assert(tx_multisig_script.size() == 37);
 
         FillableSigningProvider fillable_signing_provider;

--- a/src/test/fuzz/parse_script.cpp
+++ b/src/test/fuzz/parse_script.cpp
@@ -10,7 +10,7 @@ FUZZ_TARGET(parse_script)
 {
     const std::string script_string(buffer.begin(), buffer.end());
     try {
-        (void)ParseScript(script_string);
+        (void)ParseScriptPreTapScript(script_string);
     } catch (const std::runtime_error&) {
     }
 }

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -96,7 +96,7 @@ FUZZ_TARGET_INIT(script, initialize_script)
     std::vector<std::vector<unsigned char>> solutions;
     (void)Solver(script, solutions);
 
-    (void)script.HasValidOps();
+    (void)script.HasValidOpsPreTapScript();
     (void)script.IsPayToScriptHash();
     (void)script.IsPayToWitnessScriptHash();
     (void)script.IsPushOnly();

--- a/src/test/fuzz/script_ops.cpp
+++ b/src/test/fuzz/script_ops.cpp
@@ -46,7 +46,7 @@ FUZZ_TARGET(script_ops)
     (void)script.GetSigOpCount(false);
     (void)script.GetSigOpCount(true);
     (void)script.GetSigOpCount(script);
-    (void)script.HasValidOps();
+    (void)script.HasValidOpsPreTapScript();
     (void)script.IsPayToScriptHash();
     (void)script.IsPayToWitnessScriptHash();
     (void)script.IsPushOnly();

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -165,7 +165,7 @@ template <typename WeakEnumType, size_t size>
 
 [[nodiscard]] inline opcodetype ConsumeOpcodeType(FuzzedDataProvider& fuzzed_data_provider) noexcept
 {
-    return static_cast<opcodetype>(fuzzed_data_provider.ConsumeIntegralInRange<uint32_t>(0, MAX_OPCODE));
+    return static_cast<opcodetype>(fuzzed_data_provider.ConsumeIntegralInRange<uint32_t>(0, MAX_OPCODE_PRE_TAPSCRIPT));
 }
 
 [[nodiscard]] CAmount ConsumeMoney(FuzzedDataProvider& fuzzed_data_provider, const std::optional<CAmount>& max = std::nullopt) noexcept;

--- a/src/test/script_parse_tests.cpp
+++ b/src/test/script_parse_tests.cpp
@@ -42,14 +42,14 @@ BOOST_AUTO_TEST_CASE(parse_script)
     std::string all_in;
     std::string all_out;
     for (const auto& [in, out] : IN_OUT) {
-        BOOST_CHECK_EQUAL(HexStr(ParseScript(in)), out);
+        BOOST_CHECK_EQUAL(HexStr(ParseScriptPreTapScript(in)), out);
         all_in += " " + in + " ";
         all_out += out;
     }
-    BOOST_CHECK_EQUAL(HexStr(ParseScript(all_in)), all_out);
+    BOOST_CHECK_EQUAL(HexStr(ParseScriptPreTapScript(all_in)), all_out);
 
-    BOOST_CHECK_EXCEPTION(ParseScript("11111111111111111111"), std::runtime_error, HasReason("script parse error: decimal numeric value only allowed in the range -0xFFFFFFFF...0xFFFFFFFF"));
-    BOOST_CHECK_EXCEPTION(ParseScript("11111111111"), std::runtime_error, HasReason("script parse error: decimal numeric value only allowed in the range -0xFFFFFFFF...0xFFFFFFFF"));
-    BOOST_CHECK_EXCEPTION(ParseScript("OP_CHECKSIGADD"), std::runtime_error, HasReason("script parse error: unknown opcode"));
+    BOOST_CHECK_EXCEPTION(ParseScriptPreTapScript("11111111111111111111"), std::runtime_error, HasReason("script parse error: decimal numeric value only allowed in the range -0xFFFFFFFF...0xFFFFFFFF"));
+    BOOST_CHECK_EXCEPTION(ParseScriptPreTapScript("11111111111"), std::runtime_error, HasReason("script parse error: decimal numeric value only allowed in the range -0xFFFFFFFF...0xFFFFFFFF"));
+    BOOST_CHECK_EXCEPTION(ParseScriptPreTapScript("OP_CHECKSIGADD"), std::runtime_error, HasReason("script parse error: unknown opcode"));
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -963,9 +963,9 @@ BOOST_AUTO_TEST_CASE(script_json_test)
             continue;
         }
         std::string scriptSigString = test[pos++].get_str();
-        CScript scriptSig = ParseScript(scriptSigString);
+        CScript scriptSig = ParseScriptPreTapScript(scriptSigString);
         std::string scriptPubKeyString = test[pos++].get_str();
-        CScript scriptPubKey = ParseScript(scriptPubKeyString);
+        CScript scriptPubKey = ParseScriptPreTapScript(scriptPubKeyString);
         unsigned int scriptflags = ParseScriptFlags(test[pos++].get_str());
         int scriptError = ParseScriptError(test[pos++].get_str());
 
@@ -1457,18 +1457,18 @@ BOOST_AUTO_TEST_CASE(script_FindAndDelete)
     BOOST_CHECK(s == expect);
 }
 
-BOOST_AUTO_TEST_CASE(script_HasValidOps)
+BOOST_AUTO_TEST_CASE(script_HasValidOpsPreTapScript)
 {
-    // Exercise the HasValidOps functionality
+    // Exercise the HasValidOpsPreTapScript functionality
     CScript script;
     script = ScriptFromHex("76a9141234567890abcdefa1a2a3a4a5a6a7a8a9a0aaab88ac"); // Normal script
-    BOOST_CHECK(script.HasValidOps());
+    BOOST_CHECK(script.HasValidOpsPreTapScript());
     script = ScriptFromHex("76a914ff34567890abcdefa1a2a3a4a5a6a7a8a9a0aaab88ac");
-    BOOST_CHECK(script.HasValidOps());
+    BOOST_CHECK(script.HasValidOpsPreTapScript());
     script = ScriptFromHex("ff88ac"); // Script with OP_INVALIDOPCODE explicit
-    BOOST_CHECK(!script.HasValidOps());
+    BOOST_CHECK(!script.HasValidOpsPreTapScript());
     script = ScriptFromHex("88acc0"); // Script with undefined opcode
-    BOOST_CHECK(!script.HasValidOps());
+    BOOST_CHECK(!script.HasValidOpsPreTapScript());
 }
 
 static CMutableTransaction TxFromHex(const std::string& str)

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -217,8 +217,13 @@ BOOST_AUTO_TEST_CASE(tx_valid)
                     fValid = false;
                     break;
                 }
+<<<<<<< HEAD
                 COutPoint outpoint{uint256S(vinput[0].get_str()), uint32_t(vinput[1].getInt<int>())};
                 mapprevOutScriptPubKeys[outpoint] = ParseScript(vinput[2].get_str());
+=======
+                COutPoint outpoint{uint256S(vinput[0].get_str()), uint32_t(vinput[1].get_int())};
+                mapprevOutScriptPubKeys[outpoint] = ParseScriptPreTapScript(vinput[2].get_str());
+>>>>>>> 2cee051b1... Rename script operations that only work on pretapscripts
                 if (vinput.size() >= 4)
                 {
                     mapprevOutValues[outpoint] = vinput[3].getInt<int64_t>();
@@ -306,7 +311,7 @@ BOOST_AUTO_TEST_CASE(tx_invalid)
                     break;
                 }
                 COutPoint outpoint{uint256S(vinput[0].get_str()), uint32_t(vinput[1].getInt<int>())};
-                mapprevOutScriptPubKeys[outpoint] = ParseScript(vinput[2].get_str());
+                mapprevOutScriptPubKeys[outpoint] = ParseScriptPreTapScript(vinput[2].get_str());
                 if (vinput.size() >= 4)
                 {
                     mapprevOutValues[outpoint] = vinput[3].getInt<int64_t>();


### PR DESCRIPTION
<s>
- This change is not really necessary as MAX_OPCODE check is only really
used while decoding transactions, but makes the code more consistent(and correct)

- The tests that use MAX_OPCODE are not failing because they are under P2SH context(where the OP_CHECKSIGADD is invalid anyways). The comment in the test has been updated to accurately reflect what is going on.</s>

Based on Aj's comment, I have changed the PR so that it renames the constants/functions that operate on PreTapScript Scripts. 

I don't know if this is the ideal way to separate pre-tapscripts and tapscripts.  If the new PR is not useful, feel free to close it. 