### PR TITLE
Avoid the use of P0083R3 std::set::merge

### DIFF
--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -407,7 +407,13 @@ void TaprootSpendData::Merge(TaprootSpendData other)
         merkle_root = other.merkle_root;
     }
     for (auto& [key, control_blocks] : other.scripts) {
-        scripts[key].merge(std::move(control_blocks));
+        // Once P0083R3 is supported by all our targeted platforms,
+        // this loop body can be replaced with:
+        // scripts[key].merge(std::move(control_blocks));
+        auto& target = scripts[key];
+        for (auto& control_block: control_blocks) {
+            target.insert(std::move(control_block));
+        }
     }
 }
 


### PR DESCRIPTION
This use was introduced in #21365, but as pointed out in #22339, this causes compatibility problems.

Just avoid its use for now.