### PR TITLE
Rotate debug.log file

### DIFF
--- a/doc/release-notes-22350.md
+++ b/doc/release-notes-22350.md
@@ -1,0 +1,5 @@
+New settings
+------------
+
+- Add the option to rotate the `debug.log` file so it doesn't
+  grow without limit, consuming too much local disk space. (#22350)

--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -126,9 +126,11 @@ bool StartLogging(const ArgsManager& args)
             LogInstance().ShrinkDebugFile();
         }
     }
-    if (!LogInstance().StartLogging()) {
-            return InitError(strprintf(Untranslated("Could not open debug log file %s"),
-                LogInstance().m_file_path.string()));
+    {
+        const std::string err_msg = LogInstance().StartLogging();
+        if (!err_msg.empty()) {
+            return InitError(Untranslated(err_msg));
+        }
     }
 
     if (!LogInstance().m_log_timestamps)

--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -61,6 +61,8 @@ bool SanityChecks()
 void AddLoggingArgs(ArgsManager& argsman)
 {
     argsman.AddArg("-debuglogfile=<file>", strprintf("Specify location of debug log file. Relative paths will be prefixed by a net-specific datadir location. (-nodebuglogfile to disable; default: %s)", DEFAULT_DEBUGLOGFILE), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-debuglogrotatekeep=count", strprintf("The number of rotated (old) debug log files (0 to disable; default: %d)", DEFAULT_DEBUGLOG_ROTATE_KEEP), ArgsManager::ALLOW_INT, OptionsCategory::OPTIONS);
+    argsman.AddArg("-debugloglimit=size", strprintf("The (approximate) size (integer MB) debug log reaches before log rotation; default: %d)", DEFAULT_DEBUGLOG_SIZE_LIMIT_MB), ArgsManager::ALLOW_INT, OptionsCategory::OPTIONS);
     argsman.AddArg("-debug=<category>", "Output debugging information (default: -nodebug, supplying <category> is optional). "
         "If <category> is not supplied or if <category> = 1, output all debugging information. <category> can be: " + LogInstance().LogCategoriesString() + ". This option can be specified multiple times to output multiple categories.",
         ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
@@ -89,6 +91,8 @@ void SetLoggingOptions(const ArgsManager& args)
     LogInstance().m_log_threadnames = args.GetBoolArg("-logthreadnames", DEFAULT_LOGTHREADNAMES);
 #endif
     LogInstance().m_log_sourcelocations = args.GetBoolArg("-logsourcelocations", DEFAULT_LOGSOURCELOCATIONS);
+    LogInstance().m_rotate_keep = args.GetArg("-debuglogrotatekeep", DEFAULT_DEBUGLOG_ROTATE_KEEP);
+    LogInstance().m_file_size_limit = args.GetArg("-debugloglimit", DEFAULT_DEBUGLOG_SIZE_LIMIT_MB);
 
     fLogIPs = args.GetBoolArg("-logips", DEFAULT_LOGIPS);
 }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -40,7 +40,7 @@ static int FileWriteStr(const std::string &str, FILE *fp)
     return fwrite(str.data(), 1, str.size(), fp);
 }
 
-bool BCLog::Logger::StartLogging()
+std::string BCLog::Logger::StartLogging()
 {
     StdLockGuard scoped_lock(m_cs);
 
@@ -51,7 +51,7 @@ bool BCLog::Logger::StartLogging()
         assert(!m_file_path.empty());
         m_fileout = fsbridge::fopen(m_file_path, "a");
         if (!m_fileout) {
-            return false;
+            return strprintf("Could not open debug log file %s", m_file_path.string());
         }
 
         setbuf(m_fileout, nullptr); // unbuffered
@@ -76,7 +76,7 @@ bool BCLog::Logger::StartLogging()
     }
     if (m_print_to_console) fflush(stdout);
 
-    return true;
+    return {};
 }
 
 void BCLog::Logger::DisconnectTestLogger()

--- a/src/logging.h
+++ b/src/logging.h
@@ -123,8 +123,8 @@ namespace BCLog {
             m_print_callbacks.erase(it);
         }
 
-        /** Start logging (and flush all buffered messages) */
-        bool StartLogging();
+        /** Start logging (and flush all buffered messages), return error string (empty if none) */
+        std::string StartLogging();
         /** Only for testing */
         void DisconnectTestLogger();
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -24,6 +24,8 @@ static const bool DEFAULT_LOGTIMESTAMPS = true;
 static const bool DEFAULT_LOGTHREADNAMES = false;
 static const bool DEFAULT_LOGSOURCELOCATIONS = false;
 extern const char * const DEFAULT_DEBUGLOGFILE;
+static const int DEFAULT_DEBUGLOG_ROTATE_KEEP = 0; // log file rotation must be explicitly enabled
+static const int DEFAULT_DEBUGLOG_SIZE_LIMIT_MB = 10;
 
 extern bool fLogIPs;
 
@@ -96,6 +98,10 @@ namespace BCLog {
         bool m_log_sourcelocations = DEFAULT_LOGSOURCELOCATIONS;
 
         fs::path m_file_path;
+        /** debug.log file size before being rotated (units are MB) */
+        int m_file_size_limit;
+        /** The number of old (rotated) debug.log files to retain */
+        int m_rotate_keep;
         std::atomic<bool> m_reopen_file{false};
 
         /** Send a string to the log output */

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -142,6 +142,19 @@ std::string FormatISO8601DateTime(int64_t nTime) {
     return strprintf("%04i-%02i-%02iT%02i:%02i:%02iZ", ts.tm_year + 1900, ts.tm_mon + 1, ts.tm_mday, ts.tm_hour, ts.tm_min, ts.tm_sec);
 }
 
+std::string FormatISO8601DateTimeBasic(int64_t nTime) {
+    struct tm ts;
+    time_t time_val = nTime;
+#ifdef HAVE_GMTIME_R
+    if (gmtime_r(&time_val, &ts) == nullptr) {
+#else
+    if (gmtime_s(&ts, &time_val) != 0) {
+#endif
+        return {};
+    }
+    return strprintf("%04i-%02i-%02iT%02i%02i%02iZ", ts.tm_year + 1900, ts.tm_mon + 1, ts.tm_mday, ts.tm_hour, ts.tm_min, ts.tm_sec);
+}
+
 std::string FormatISO8601Date(int64_t nTime) {
     struct tm ts;
     time_t time_val = nTime;

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -73,6 +73,7 @@ T GetTime();
  * helper functions if possible.
  */
 std::string FormatISO8601DateTime(int64_t nTime);
+std::string FormatISO8601DateTimeBasic(int64_t nTime);
 std::string FormatISO8601Date(int64_t nTime);
 int64_t ParseISO8601DateTime(const std::string& str);
 


### PR DESCRIPTION
*EDIT*: Change the default behavior to be that log rotation is _not_ enabled.

This PR will mitigate a disk-fill DoS attack (although such an attack is not known to exist today).

If log rotation is enabled, then when the `debug.log` file reaches a certain size (default, 10 MB), rename it to a similar name that includes the current time, and reset (truncate) `debug.log`. Keep a limited number of rotated files. This provides a sliding window of debug messages so that disk space isn't consumed without limit. 

This is similar to Unix `logrotate(8)` but requires no external tools and complex configuration, and works on Windows (which doesn't have `logrotate`).