### PR TITLE
ci: Upgrading pip version in macos environment

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -11,6 +11,7 @@ if [[ $QEMU_USER_CMD == qemu-s390* ]]; then
 fi
 
 if [ "$CI_OS_NAME" == "macos" ]; then
+  sudo -H pip3 install --upgrade pip
   IN_GETOPT_BIN="/usr/local/opt/gnu-getopt/bin/getopt" ${CI_RETRY_EXE} pip3 install --user $PIP_PACKAGES
 fi
 


### PR DESCRIPTION
During each CI run, in macos native environment, python packages lief and zmq are rebuilt everytime which wastes a lot of resources and time and fixes #22206. The latest version of pip directly fetches pre-built binaries. Through this commit pip version is upgraded in macos environment before installation of these packages.