### PR TITLE
Drop only invalid entries when reading banlist.json

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -69,6 +69,7 @@ BITCOIN_TESTS =\
   test/allocator_tests.cpp \
   test/amount_tests.cpp \
   test/arith_uint256_tests.cpp \
+  test/banman_tests.cpp \
   test/base32_tests.cpp \
   test/base58_tests.cpp \
   test/base64_tests.cpp \

--- a/src/test/banman_tests.cpp
+++ b/src/test/banman_tests.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <banman.h>
+#include <chainparams.h>
+#include <netbase.h>
+#include <streams.h>
+#include <test/util/logging.h>
+#include <test/util/setup_common.h>
+#include <util/readwritefile.h>
+
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(banman_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(file)
+{
+    SetMockTime(777s);
+    const fs::path banlist_path{m_args.GetDataDirBase() / "banlist_test"};
+    {
+        const std::string entries_write{
+            "{ \"banned_nets\": ["
+            "  { \"version\": 1, \"ban_created\": 0, \"banned_until\": 778, \"address\": \"aaaaaaaaa\" },"
+            "  { \"version\": 2, \"ban_created\": 0, \"banned_until\": 778, \"address\": \"bbbbbbbbb\" },"
+            "  { \"version\": 1, \"ban_created\": 0, \"banned_until\": 778, \"address\": \"1.0.0.0/8\" }"
+            "] }",
+        };
+        assert(WriteBinaryFile(banlist_path + ".json", entries_write));
+        {
+            // The invalid entries will be dropped, but the valid one remains
+            ASSERT_DEBUG_LOG("Dropping entry with unparseable address or subnet (aaaaaaaaa) from ban list");
+            ASSERT_DEBUG_LOG("Dropping entry with unknown version (2) from ban list");
+            BanMan banman{banlist_path, /*client_interface=*/nullptr, /*default_ban_time=*/0};
+            banmap_t entries_read;
+            banman.GetBanned(entries_read);
+            assert(entries_read.size() == 1);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
All entries will be dropped when there is at least one invalid one in `banlist.json`. Fix this by only dropping invalid ones.

Also suggested in https://github.com/bitcoin/bitcoin/pull/20966#issuecomment-861150204