### PR TITLE
test: refactor: use `script_util` helpers for creating P2{PKH,SH,WPKH,WSH} scripts

### DIFF
--- a/test/functional/data/invalid_txs.py
+++ b/test/functional/data/invalid_txs.py
@@ -29,27 +29,32 @@ from test_framework.messages import (
     CTxOut,
     MAX_MONEY,
 )
-from test_framework import script as sc
 from test_framework.blocktools import create_tx_with_script, MAX_BLOCK_SIGOPS
 from test_framework.script import (
     CScript,
-    OP_CAT,
-    OP_SUBSTR,
-    OP_LEFT,
-    OP_RIGHT,
-    OP_INVERT,
-    OP_AND,
-    OP_OR,
-    OP_XOR,
-    OP_2MUL,
+    OP_0,
     OP_2DIV,
-    OP_MUL,
+    OP_2MUL,
+    OP_AND,
+    OP_CAT,
+    OP_CHECKSIG,
     OP_DIV,
-    OP_MOD,
+    OP_INVERT,
+    OP_LEFT,
     OP_LSHIFT,
-    OP_RSHIFT
+    OP_MOD,
+    OP_MUL,
+    OP_OR,
+    OP_RIGHT,
+    OP_RSHIFT,
+    OP_SUBSTR,
+    OP_TRUE,
+    OP_XOR,
 )
-basic_p2sh = sc.CScript([sc.OP_HASH160, sc.hash160(sc.CScript([sc.OP_0])), sc.OP_EQUAL])
+from test_framework.script_util import (
+    script_to_p2sh_script,
+)
+basic_p2sh = script_to_p2sh_script(CScript([OP_0]))
 
 
 class BadTxTemplate:
@@ -116,7 +121,7 @@ class SizeTooSmall(BadTxTemplate):
     def get_tx(self):
         tx = CTransaction()
         tx.vin.append(self.valid_txin)
-        tx.vout.append(CTxOut(0, sc.CScript([sc.OP_TRUE])))
+        tx.vout.append(CTxOut(0, CScript([OP_TRUE])))
         tx.calc_sha256()
         return tx
 
@@ -217,7 +222,7 @@ class TooManySigops(BadTxTemplate):
     expect_disconnect = False
 
     def get_tx(self):
-        lotsa_checksigs = sc.CScript([sc.OP_CHECKSIG] * (MAX_BLOCK_SIGOPS))
+        lotsa_checksigs = CScript([OP_CHECKSIG] * (MAX_BLOCK_SIGOPS))
         return create_tx_with_script(
             self.spend_tx, 0,
             script_pub_key=lotsa_checksigs,

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -37,17 +37,17 @@ from test_framework.script import (
     OP_CHECKSIGVERIFY,
     OP_ELSE,
     OP_ENDIF,
-    OP_EQUAL,
     OP_DROP,
     OP_FALSE,
-    OP_HASH160,
     OP_IF,
     OP_INVALIDOPCODE,
     OP_RETURN,
     OP_TRUE,
     SIGHASH_ALL,
     LegacySignatureHash,
-    hash160,
+)
+from test_framework.script_util import (
+    script_to_p2sh_script,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
@@ -469,8 +469,7 @@ class FullBlockTest(BitcoinTestFramework):
 
         # Build the redeem script, hash it, use hash to create the p2sh script
         redeem_script = CScript([self.coinbase_pubkey] + [OP_2DUP, OP_CHECKSIGVERIFY] * 5 + [OP_CHECKSIG])
-        redeem_script_hash = hash160(redeem_script)
-        p2sh_script = CScript([OP_HASH160, redeem_script_hash, OP_EQUAL])
+        p2sh_script = script_to_p2sh_script(redeem_script)
 
         # Create a transaction that spends one satoshi to the p2sh_script, the rest to OP_TRUE
         # This must be signed because it is spending a coinbase

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -18,10 +18,10 @@ from test_framework.script import (
     OP_1,
     OP_2,
     OP_DROP,
-    OP_EQUAL,
-    OP_HASH160,
     OP_TRUE,
-    hash160,
+)
+from test_framework.script_util import (
+    script_to_p2sh_script,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -37,8 +37,8 @@ from test_framework.util import (
 # time signing.
 REDEEM_SCRIPT_1 = CScript([OP_1, OP_DROP])
 REDEEM_SCRIPT_2 = CScript([OP_2, OP_DROP])
-P2SH_1 = CScript([OP_HASH160, hash160(REDEEM_SCRIPT_1), OP_EQUAL])
-P2SH_2 = CScript([OP_HASH160, hash160(REDEEM_SCRIPT_2), OP_EQUAL])
+P2SH_1 = script_to_p2sh_script(REDEEM_SCRIPT_1)
+P2SH_2 = script_to_p2sh_script(REDEEM_SCRIPT_2)
 
 # Associated ScriptSig's to spend satisfy P2SH_1 and P2SH_2
 SCRIPT_SIG = [CScript([OP_TRUE, REDEEM_SCRIPT_1]), CScript([OP_TRUE, REDEEM_SCRIPT_2])]

--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -34,12 +34,13 @@ from test_framework.script import (
     OP_CHECKMULTISIG,
     OP_CHECKSIG,
     OP_DROP,
-    OP_DUP,
     OP_EQUAL,
-    OP_EQUALVERIFY,
     OP_HASH160,
     OP_TRUE,
     hash160,
+)
+from test_framework.script_util import (
+    key_to_p2pkh_script,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -427,7 +428,7 @@ class SegWitTest(BitcoinTestFramework):
         op0 = CScript([OP_0])
         # 2N7MGY19ti4KDMSzRfPAssP6Pxyuxoi6jLe is the P2SH(P2PKH) version of mjoE3sSrb8ByYEvgnC3Aox86u1CHnfJA4V
         unsolvable_address_key = hex_str_to_bytes("02341AEC7587A51CDE5279E0630A531AEA2615A9F80B17E8D9376327BAEAA59E3D")
-        unsolvablep2pkh = CScript([OP_DUP, OP_HASH160, hash160(unsolvable_address_key), OP_EQUALVERIFY, OP_CHECKSIG])
+        unsolvablep2pkh = key_to_p2pkh_script(unsolvable_address_key)
         unsolvablep2wshp2pkh = CScript([OP_0, sha256(unsolvablep2pkh)])
         p2shop0 = CScript([OP_HASH160, hash160(op0), OP_EQUAL])
         p2wshop1 = CScript([OP_0, sha256(op1)])
@@ -454,7 +455,7 @@ class SegWitTest(BitcoinTestFramework):
             else:
                 pubkey = hex_str_to_bytes(v['pubkey'])
                 p2pk = CScript([pubkey, OP_CHECKSIG])
-                p2pkh = CScript([OP_DUP, OP_HASH160, hash160(pubkey), OP_EQUALVERIFY, OP_CHECKSIG])
+                p2pkh = key_to_p2pkh_script(pubkey)
                 importlist.append(p2pk.hex())
                 importlist.append(p2pkh.hex())
                 importlist.append(CScript([OP_0, hash160(pubkey)]).hex())

--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -34,13 +34,12 @@ from test_framework.script import (
     OP_CHECKMULTISIG,
     OP_CHECKSIG,
     OP_DROP,
-    OP_EQUAL,
-    OP_HASH160,
     OP_TRUE,
     hash160,
 )
 from test_framework.script_util import (
     key_to_p2pkh_script,
+    script_to_p2sh_script,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -354,7 +353,7 @@ class SegWitTest(BitcoinTestFramework):
 
         multisig_without_privkey_address = self.nodes[0].addmultisigaddress(2, [pubkeys[3], pubkeys[4]])['address']
         script = CScript([OP_2, hex_str_to_bytes(pubkeys[3]), hex_str_to_bytes(pubkeys[4]), OP_2, OP_CHECKMULTISIG])
-        solvable_after_importaddress.append(CScript([OP_HASH160, hash160(script), OP_EQUAL]))
+        solvable_after_importaddress.append(script_to_p2sh_script(script))
 
         for i in compressed_spendable_address:
             v = self.nodes[0].getaddressinfo(i)
@@ -430,7 +429,7 @@ class SegWitTest(BitcoinTestFramework):
         unsolvable_address_key = hex_str_to_bytes("02341AEC7587A51CDE5279E0630A531AEA2615A9F80B17E8D9376327BAEAA59E3D")
         unsolvablep2pkh = key_to_p2pkh_script(unsolvable_address_key)
         unsolvablep2wshp2pkh = CScript([OP_0, sha256(unsolvablep2pkh)])
-        p2shop0 = CScript([OP_HASH160, hash160(op0), OP_EQUAL])
+        p2shop0 = script_to_p2sh_script(op0)
         p2wshop1 = CScript([OP_0, sha256(op1)])
         unsolvable_after_importaddress.append(unsolvablep2pkh)
         unsolvable_after_importaddress.append(unsolvablep2wshp2pkh)
@@ -616,21 +615,21 @@ class SegWitTest(BitcoinTestFramework):
         bare = CScript(hex_str_to_bytes(v['hex']))
         p2sh = CScript(hex_str_to_bytes(v['scriptPubKey']))
         p2wsh = CScript([OP_0, sha256(bare)])
-        p2sh_p2wsh = CScript([OP_HASH160, hash160(p2wsh), OP_EQUAL])
+        p2sh_p2wsh = script_to_p2sh_script(p2wsh)
         return([bare, p2sh, p2wsh, p2sh_p2wsh])
 
     def p2pkh_address_to_script(self, v):
         pubkey = hex_str_to_bytes(v['pubkey'])
         p2wpkh = CScript([OP_0, hash160(pubkey)])
-        p2sh_p2wpkh = CScript([OP_HASH160, hash160(p2wpkh), OP_EQUAL])
+        p2sh_p2wpkh = script_to_p2sh_script(p2wpkh)
         p2pk = CScript([pubkey, OP_CHECKSIG])
         p2pkh = CScript(hex_str_to_bytes(v['scriptPubKey']))
-        p2sh_p2pk = CScript([OP_HASH160, hash160(p2pk), OP_EQUAL])
-        p2sh_p2pkh = CScript([OP_HASH160, hash160(p2pkh), OP_EQUAL])
+        p2sh_p2pk = script_to_p2sh_script(p2pk)
+        p2sh_p2pkh = script_to_p2sh_script(p2pkh)
         p2wsh_p2pk = CScript([OP_0, sha256(p2pk)])
         p2wsh_p2pkh = CScript([OP_0, sha256(p2pkh)])
-        p2sh_p2wsh_p2pk = CScript([OP_HASH160, hash160(p2wsh_p2pk), OP_EQUAL])
-        p2sh_p2wsh_p2pkh = CScript([OP_HASH160, hash160(p2wsh_p2pkh), OP_EQUAL])
+        p2sh_p2wsh_p2pk = script_to_p2sh_script(p2wsh_p2pk)
+        p2sh_p2wsh_p2pkh = script_to_p2sh_script(p2wsh_p2pkh)
         return [p2wpkh, p2sh_p2wpkh, p2pk, p2pkh, p2sh_p2pk, p2sh_p2pkh, p2wsh_p2pk, p2wsh_p2pkh, p2sh_p2wsh_p2pk, p2sh_p2wsh_p2pkh]
 
     def create_and_mine_tx_from_txids(self, txids, success=True):

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -76,15 +76,16 @@ from test_framework.script import (
     taproot_construct,
 )
 from test_framework.script_util import (
+    key_to_p2wpkh_script,
     keyhash_to_p2pkh_script,
     script_to_p2sh_script,
+    script_to_p2wsh_script,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_raises_rpc_error, assert_equal
 from test_framework.key import generate_privkey, compute_xonly_pubkey, sign_schnorr, tweak_add_privkey, ECKey
 from test_framework.address import (
     hash160,
-    sha256,
 )
 from collections import OrderedDict, namedtuple
 from io import BytesIO
@@ -461,13 +462,13 @@ def make_spender(comment, *, tap=None, witv0=False, script=None, pkh=None, p2sh=
             # P2WPKH
             assert script is None
             pubkeyhash = hash160(pkh)
-            spk = CScript([OP_0, pubkeyhash])
+            spk = key_to_p2wpkh_script(pkh)
             conf["scriptcode"] = keyhash_to_p2pkh_script(pubkeyhash)
             conf["script_witv0"] = None
             conf["inputs"] = [getter("sign"), pkh]
         elif script is not None:
             # P2WSH
-            spk = CScript([OP_0, sha256(script)])
+            spk = script_to_p2wsh_script(script)
             conf["scriptcode"] = script
             conf["script_witv0"] = script
         else:

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -76,6 +76,9 @@ from test_framework.script import (
     is_op_success,
     taproot_construct,
 )
+from test_framework.script_util import (
+    keyhash_to_p2pkh_script,
+)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_raises_rpc_error, assert_equal
 from test_framework.key import generate_privkey, compute_xonly_pubkey, sign_schnorr, tweak_add_privkey, ECKey
@@ -459,7 +462,7 @@ def make_spender(comment, *, tap=None, witv0=False, script=None, pkh=None, p2sh=
             assert script is None
             pubkeyhash = hash160(pkh)
             spk = CScript([OP_0, pubkeyhash])
-            conf["scriptcode"] = CScript([OP_DUP, OP_HASH160, pubkeyhash, OP_EQUALVERIFY, OP_CHECKSIG])
+            conf["scriptcode"] = keyhash_to_p2pkh_script(pubkeyhash)
             conf["script_witv0"] = None
             conf["inputs"] = [getter("sign"), pkh]
         elif script is not None:
@@ -475,7 +478,7 @@ def make_spender(comment, *, tap=None, witv0=False, script=None, pkh=None, p2sh=
             # P2PKH
             assert script is None
             pubkeyhash = hash160(pkh)
-            spk = CScript([OP_DUP, OP_HASH160, pubkeyhash, OP_EQUALVERIFY, OP_CHECKSIG])
+            spk = keyhash_to_p2pkh_script(pubkeyhash)
             conf["scriptcode"] = spk
             conf["inputs"] = [getter("sign"), pkh]
         elif script is not None:

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -57,7 +57,6 @@ from test_framework.script import (
     OP_ENDIF,
     OP_EQUAL,
     OP_EQUALVERIFY,
-    OP_HASH160,
     OP_IF,
     OP_NOP,
     OP_NOT,
@@ -78,6 +77,7 @@ from test_framework.script import (
 )
 from test_framework.script_util import (
     keyhash_to_p2pkh_script,
+    script_to_p2sh_script,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_raises_rpc_error, assert_equal
@@ -499,7 +499,7 @@ def make_spender(comment, *, tap=None, witv0=False, script=None, pkh=None, p2sh=
     if p2sh:
         # P2SH wrapper can be combined with anything else
         conf["script_p2sh"] = spk
-        spk = CScript([OP_HASH160, hash160(spk), OP_EQUAL])
+        spk = script_to_p2sh_script(spk)
 
     conf = {**conf, **kwargs}
 

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -19,15 +19,16 @@ from test_framework.messages import (
     tx_from_hex,
 )
 from test_framework.script import (
-    hash160,
     CScript,
     OP_0,
     OP_2,
     OP_3,
     OP_CHECKMULTISIG,
-    OP_EQUAL,
     OP_HASH160,
     OP_RETURN,
+)
+from test_framework.script_util import (
+    script_to_p2sh_script,
 )
 from test_framework.util import (
     assert_equal,
@@ -291,7 +292,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
             rawtxs=[tx.serialize().hex()],
         )
         tx = tx_from_hex(raw_tx_reference)
-        output_p2sh_burn = CTxOut(nValue=540, scriptPubKey=CScript([OP_HASH160, hash160(b'burn'), OP_EQUAL]))
+        output_p2sh_burn = CTxOut(nValue=540, scriptPubKey=script_to_p2sh_script(b'burn'))
         num_scripts = 100000 // len(output_p2sh_burn.serialize())  # Use enough outputs to make the tx too large for our policy
         tx.vout = [output_p2sh_burn] * num_scripts
         self.check_mempool_result(

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -60,11 +60,9 @@ from test_framework.script import (
     OP_CHECKMULTISIG,
     OP_CHECKSIG,
     OP_DROP,
-    OP_DUP,
     OP_ELSE,
     OP_ENDIF,
     OP_EQUAL,
-    OP_EQUALVERIFY,
     OP_HASH160,
     OP_IF,
     OP_RETURN,
@@ -76,6 +74,9 @@ from test_framework.script import (
     SegwitV0SignatureHash,
     LegacySignatureHash,
     hash160,
+)
+from test_framework.script_util import (
+    keyhash_to_p2pkh_script,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -99,10 +100,6 @@ class UTXO():
         self.sha256 = sha256
         self.n = n
         self.nValue = value
-
-def get_p2pkh_script(pubkeyhash):
-    """Get the script associated with a P2PKH."""
-    return CScript([CScriptOp(OP_DUP), CScriptOp(OP_HASH160), pubkeyhash, CScriptOp(OP_EQUALVERIFY), CScriptOp(OP_CHECKSIG)])
 
 def sign_p2pk_witness_input(script, tx_to, in_idx, hashtype, value, key):
     """Add signature for a P2PK witness program."""
@@ -1550,7 +1547,7 @@ class SegWitTest(BitcoinTestFramework):
         tx2 = CTransaction()
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
         tx2.vout.append(CTxOut(tx.vout[0].nValue - 1000, script_wsh))
-        script = get_p2pkh_script(pubkeyhash)
+        script = keyhash_to_p2pkh_script(pubkeyhash)
         sig_hash = SegwitV0SignatureHash(script, tx2, 0, SIGHASH_ALL, tx.vout[0].nValue)
         signature = key.sign_ecdsa(sig_hash) + b'\x01'  # 0x1 is SIGHASH_ALL
         tx2.wit.vtxinwit.append(CTxInWitness())
@@ -1587,7 +1584,7 @@ class SegWitTest(BitcoinTestFramework):
         # Test 3: P2SH(P2WSH)
         # Try to spend the P2SH output created in the last test.
         # Send it to a P2PKH output, which we'll use in the next test.
-        script_pubkey = get_p2pkh_script(pubkeyhash)
+        script_pubkey = keyhash_to_p2pkh_script(pubkeyhash)
         tx4 = CTransaction()
         tx4.vin.append(CTxIn(COutPoint(tx3.sha256, 0), script_sig))
         tx4.vout.append(CTxOut(tx3.vout[0].nValue - 1000, script_pubkey))
@@ -1754,7 +1751,7 @@ class SegWitTest(BitcoinTestFramework):
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
         tx2.vout.append(CTxOut(tx.vout[0].nValue, CScript([OP_TRUE])))
 
-        script = get_p2pkh_script(pubkeyhash)
+        script = keyhash_to_p2pkh_script(pubkeyhash)
         sig_hash = SegwitV0SignatureHash(script, tx2, 0, SIGHASH_ALL, tx.vout[0].nValue)
         signature = key.sign_ecdsa(sig_hash) + b'\x01'  # 0x1 is SIGHASH_ALL
 

--- a/test/functional/rpc_signrawtransaction.py
+++ b/test/functional/rpc_signrawtransaction.py
@@ -6,7 +6,6 @@
 
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.address import (
-    check_script,
     script_to_p2sh,
     script_to_p2wsh,
 )
@@ -20,12 +19,10 @@ from test_framework.util import (
 )
 from test_framework.messages import (
     CTxInWitness,
-    sha256,
     tx_from_hex,
 )
 from test_framework.script import (
     CScript,
-    OP_0,
     OP_CHECKLOCKTIMEVERIFY,
     OP_CHECKSIG,
     OP_CHECKSEQUENCEVERIFY,
@@ -233,7 +230,7 @@ class SignRawTransactionsTest(BitcoinTestFramework):
             'P2PKH': key_to_p2pkh_script(embedded_pubkey).hex(),
             'P2PK': CScript([hex_str_to_bytes(embedded_pubkey), OP_CHECKSIG]).hex()
         }.get(tx_type, "Invalid tx_type")
-        redeem_script = CScript([OP_0, sha256(check_script(witness_script))]).hex()
+        redeem_script = script_to_p2wsh_script(witness_script).hex()
         addr = script_to_p2sh(redeem_script)
         script_pub_key = self.nodes[1].validateaddress(addr)['scriptPubKey']
         # Fund that address

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -26,7 +26,6 @@ from .messages import (
     hash256,
     hex_str_to_bytes,
     ser_uint256,
-    sha256,
     tx_from_hex,
     uint256_from_str,
 )
@@ -34,13 +33,15 @@ from .script import (
     CScript,
     CScriptNum,
     CScriptOp,
-    OP_0,
     OP_1,
     OP_CHECKMULTISIG,
     OP_CHECKSIG,
     OP_RETURN,
     OP_TRUE,
-    hash160,
+)
+from .script_util import (
+    key_to_p2wpkh_script,
+    script_to_p2wsh_script,
 )
 from .util import assert_equal
 
@@ -206,13 +207,11 @@ def witness_script(use_p2wsh, pubkey):
     scriptPubKey."""
     if not use_p2wsh:
         # P2WPKH instead
-        pubkeyhash = hash160(hex_str_to_bytes(pubkey))
-        pkscript = CScript([OP_0, pubkeyhash])
+        pkscript = key_to_p2wpkh_script(pubkey)
     else:
         # 1-of-1 multisig
         witness_program = CScript([OP_1, hex_str_to_bytes(pubkey), OP_1, OP_CHECKMULTISIG])
-        scripthash = sha256(witness_program)
-        pkscript = CScript([OP_0, scripthash])
+        pkscript = script_to_p2wsh_script(witness_program)
     return pkscript.hex()
 
 def create_witness_tx(node, use_p2wsh, utxo, pubkey, encode_p2sh, amount):

--- a/test/functional/test_framework/wallet_util.py
+++ b/test/functional/test_framework/wallet_util.py
@@ -106,7 +106,7 @@ def get_multisig(node):
                     redeem_script=script_code.hex(),
                     p2wsh_script=witness_script.hex(),
                     p2wsh_addr=script_to_p2wsh(script_code),
-                    p2sh_p2wsh_script=CScript([OP_HASH160, witness_script, OP_EQUAL]).hex(),
+                    p2sh_p2wsh_script=CScript([OP_HASH160, hash160(witness_script), OP_EQUAL]).hex(),
                     p2sh_p2wsh_addr=script_to_p2sh_p2wsh(script_code))
 
 def test_address(node, address, **kwargs):

--- a/test/functional/test_framework/wallet_util.py
+++ b/test/functional/test_framework/wallet_util.py
@@ -21,13 +21,12 @@ from test_framework.script import (
     OP_2,
     OP_3,
     OP_CHECKMULTISIG,
-    OP_EQUAL,
-    OP_HASH160,
     hash160,
     sha256,
 )
 from test_framework.script_util import (
     key_to_p2pkh_script,
+    script_to_p2sh_script,
 )
 from test_framework.util import hex_str_to_bytes
 
@@ -64,7 +63,7 @@ def get_key(node):
                p2pkh_addr=key_to_p2pkh(pubkey),
                p2wpkh_script=CScript([OP_0, pkh]).hex(),
                p2wpkh_addr=key_to_p2wpkh(pubkey),
-               p2sh_p2wpkh_script=CScript([OP_HASH160, hash160(CScript([OP_0, pkh])), OP_EQUAL]).hex(),
+               p2sh_p2wpkh_script=script_to_p2sh_script(CScript([OP_0, pkh])).hex(),
                p2sh_p2wpkh_redeem_script=CScript([OP_0, pkh]).hex(),
                p2sh_p2wpkh_addr=key_to_p2sh_p2wpkh(pubkey))
 
@@ -83,7 +82,7 @@ def get_generate_key():
                p2pkh_addr=key_to_p2pkh(pubkey),
                p2wpkh_script=CScript([OP_0, pkh]).hex(),
                p2wpkh_addr=key_to_p2wpkh(pubkey),
-               p2sh_p2wpkh_script=CScript([OP_HASH160, hash160(CScript([OP_0, pkh])), OP_EQUAL]).hex(),
+               p2sh_p2wpkh_script=script_to_p2sh_script(CScript([OP_0, pkh])).hex(),
                p2sh_p2wpkh_redeem_script=CScript([OP_0, pkh]).hex(),
                p2sh_p2wpkh_addr=key_to_p2sh_p2wpkh(pubkey))
 
@@ -101,12 +100,12 @@ def get_multisig(node):
     witness_script = CScript([OP_0, sha256(script_code)])
     return Multisig(privkeys=[node.dumpprivkey(addr) for addr in addrs],
                     pubkeys=pubkeys,
-                    p2sh_script=CScript([OP_HASH160, hash160(script_code), OP_EQUAL]).hex(),
+                    p2sh_script=script_to_p2sh_script(script_code).hex(),
                     p2sh_addr=script_to_p2sh(script_code),
                     redeem_script=script_code.hex(),
                     p2wsh_script=witness_script.hex(),
                     p2wsh_addr=script_to_p2wsh(script_code),
-                    p2sh_p2wsh_script=CScript([OP_HASH160, hash160(witness_script), OP_EQUAL]).hex(),
+                    p2sh_p2wsh_script=script_to_p2sh_script(witness_script).hex(),
                     p2sh_p2wsh_addr=script_to_p2sh_p2wsh(script_code))
 
 def test_address(node, address, **kwargs):

--- a/test/functional/test_framework/wallet_util.py
+++ b/test/functional/test_framework/wallet_util.py
@@ -21,13 +21,13 @@ from test_framework.script import (
     OP_2,
     OP_3,
     OP_CHECKMULTISIG,
-    OP_CHECKSIG,
-    OP_DUP,
     OP_EQUAL,
-    OP_EQUALVERIFY,
     OP_HASH160,
     hash160,
     sha256,
+)
+from test_framework.script_util import (
+    key_to_p2pkh_script,
 )
 from test_framework.util import hex_str_to_bytes
 
@@ -60,7 +60,7 @@ def get_key(node):
     pkh = hash160(hex_str_to_bytes(pubkey))
     return Key(privkey=node.dumpprivkey(addr),
                pubkey=pubkey,
-               p2pkh_script=CScript([OP_DUP, OP_HASH160, pkh, OP_EQUALVERIFY, OP_CHECKSIG]).hex(),
+               p2pkh_script=key_to_p2pkh_script(pubkey).hex(),
                p2pkh_addr=key_to_p2pkh(pubkey),
                p2wpkh_script=CScript([OP_0, pkh]).hex(),
                p2wpkh_addr=key_to_p2wpkh(pubkey),
@@ -79,7 +79,7 @@ def get_generate_key():
     pkh = hash160(hex_str_to_bytes(pubkey))
     return Key(privkey=privkey,
                pubkey=pubkey,
-               p2pkh_script=CScript([OP_DUP, OP_HASH160, pkh, OP_EQUALVERIFY, OP_CHECKSIG]).hex(),
+               p2pkh_script=key_to_p2pkh_script(pubkey).hex(),
                p2pkh_addr=key_to_p2pkh(pubkey),
                p2wpkh_script=CScript([OP_0, pkh]).hex(),
                p2wpkh_addr=key_to_p2wpkh(pubkey),


### PR DESCRIPTION
PR #18788 (commit 08067aebfd7e838e6ce6b030c31a69422260fc6f) introduced functions to generate output scripts for various types. This PR replaces all manual CScript creations in the P2PKH, P2SH, P2WPKH, P2WSH formats with those helpers in order to increase readability and maintainability over the functional test codebase. The first commit fixes a bug in the wallet_util helper module w.r.t. to P2SH-P2WSH script creation (the result is not used in any test so far, hence it can still be seen as refactoring).

The following table shows a summary of the output script patterns tackled in this PR:

| Type | master branch  | PR branch |
| ---------- | ------------- | ------------- |
| P2PKH | `CScript([OP_DUP, OP_HASH160, hash160(key), OP_EQUALVERIFY, OP_CHECKSIG])` | `key_to_p2pkh_script(key)`  |
|             | `CScript([OP_DUP, OP_HASH160, keyhash, OP_EQUALVERIFY, OP_CHECKSIG])` | `keyhash_to_p2pkh_script(keyhash)` |
| P2SH  | `CScript([OP_HASH160, hash160(script), OP_EQUAL])`  | `script_to_p2sh_script(script)` |
| P2WPKH | `CScript([OP_0, hash160(key)])` | `key_to_p2wpkh_script(key)` |
| P2WSH | `CScript([OP_0, sha256(script)])` | `script_to_p2wsh_script(script)` |

Note that the `key_to_...` helpers can't be used if an invalid key size (not 33 or 65 bytes) is passed, which is the case in some rare instances where the scripts still have to be created manually.

Possible follow-up ideas:
* further simplify by identifying P2SH-wrapped scripts and using `key_to_p2sh_p2wpkh_script()` and `script_to_p2sh_p2wsh_script()` helpers
* introduce and use `key_to_p2pk_script()` helper for P2PK scripts