### PR TITLE
[0.21] fuzz: add missing ECCVerifyHandle to base_encode_decode

### DIFF
--- a/src/test/fuzz/base_encode_decode.cpp
+++ b/src/test/fuzz/base_encode_decode.cpp
@@ -14,6 +14,11 @@
 #include <string>
 #include <vector>
 
+void initialize()
+{
+    static const ECCVerifyHandle verify_handle;
+}
+
 void test_one_input(const std::vector<uint8_t>& buffer)
 {
     const std::string random_encoded_string(buffer.begin(), buffer.end());

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -318,6 +318,25 @@ BOOST_FIXTURE_TEST_CASE(util_CheckValue, CheckValueTest)
     CheckValue(M::ALLOW_ANY, "-value=abc", Expect{"abc"}.String("abc").Int(0).Bool(false).List({"abc"}));
 }
 
+struct NoIncludeConfTest {
+    std::string Parse(const char* arg)
+    {
+        TestArgsManager test;
+        test.SetupArgs({{"-includeconf", ArgsManager::ALLOW_ANY}});
+        std::array<const char*, 2> argv{"ignored", arg};
+        std::string error;
+        (void)test.ParseParameters(argv.size(), argv.data(), error);
+        return error;
+    }
+};
+
+BOOST_FIXTURE_TEST_CASE(util_NoIncludeConf, NoIncludeConfTest)
+{
+    BOOST_CHECK_EQUAL(Parse("-noincludeconf"), "");
+    BOOST_CHECK_EQUAL(Parse("-includeconf"), "-includeconf cannot be used from commandline; -includeconf=\"\"");
+    BOOST_CHECK_EQUAL(Parse("-includeconf=file"), "-includeconf cannot be used from commandline; -includeconf=\"file\"");
+}
+
 BOOST_AUTO_TEST_CASE(util_ParseParameters)
 {
     TestArgsManager testArgs;

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -337,14 +337,12 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
     }
 
     // we do not allow -includeconf from command line
-    bool success = true;
     if (auto* includes = util::FindKey(m_settings.command_line_options, "includeconf")) {
-        for (const auto& include : util::SettingsSpan(*includes)) {
-            error += "-includeconf cannot be used from commandline; -includeconf=" + include.write() + "\n";
-            success = false;
-        }
+        const auto& include{*util::SettingsSpan(*includes).begin()}; // pick first value as example
+        error = "-includeconf cannot be used from commandline; -includeconf=" + include.write();
+        return false;
     }
-    return success;
+    return true;
 }
 
 Optional<unsigned int> ArgsManager::GetArgFlags(const std::string& name) const

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -336,11 +336,14 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
         m_settings.command_line_options[key].push_back(value);
     }
 
-    // we do not allow -includeconf from command line
+    // we do not allow -includeconf from command line, only -noincludeconf
     if (auto* includes = util::FindKey(m_settings.command_line_options, "includeconf")) {
-        const auto& include{*util::SettingsSpan(*includes).begin()}; // pick first value as example
-        error = "-includeconf cannot be used from commandline; -includeconf=" + include.write();
-        return false;
+        const util::SettingsSpan values{*includes};
+        // Range may be empty if -noincludeconf was passed
+        if (!values.empty()) {
+            error = "-includeconf cannot be used from commandline; -includeconf=" + values.begin()->write();
+            return false; // pick first value as example
+        }
     }
     return true;
 }

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -340,7 +340,7 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
     bool success = true;
     if (auto* includes = util::FindKey(m_settings.command_line_options, "includeconf")) {
         for (const auto& include : util::SettingsSpan(*includes)) {
-            error += "-includeconf cannot be used from commandline; -includeconf=" + include.get_str() + "\n";
+            error += "-includeconf cannot be used from commandline; -includeconf=" + include.write() + "\n";
             success = false;
         }
     }

--- a/test/functional/feature_includeconf.py
+++ b/test/functional/feature_includeconf.py
@@ -48,7 +48,7 @@ class IncludeConfTest(BitcoinTestFramework):
             expected_msg='Error: Error parsing command line arguments: -includeconf cannot be used from commandline; -includeconf=true',
         )
         self.nodes[0].assert_start_raises_init_error(
-            extra_args=['-includeconf=relative2.conf'],
+            extra_args=['-includeconf=relative2.conf', '-includeconf=no_warn.conf'],
             expected_msg='Error: Error parsing command line arguments: -includeconf cannot be used from commandline; -includeconf="relative2.conf"',
         )
 

--- a/test/functional/feature_includeconf.py
+++ b/test/functional/feature_includeconf.py
@@ -43,7 +43,14 @@ class IncludeConfTest(BitcoinTestFramework):
 
         self.log.info("-includeconf cannot be used as command-line arg")
         self.stop_node(0)
-        self.nodes[0].assert_start_raises_init_error(extra_args=["-includeconf=relative2.conf"], expected_msg="Error: Error parsing command line arguments: -includeconf cannot be used from commandline; -includeconf=relative2.conf")
+        self.nodes[0].assert_start_raises_init_error(
+            extra_args=['-noincludeconf=0'],
+            expected_msg='Error: Error parsing command line arguments: -includeconf cannot be used from commandline; -includeconf=true',
+        )
+        self.nodes[0].assert_start_raises_init_error(
+            extra_args=['-includeconf=relative2.conf'],
+            expected_msg='Error: Error parsing command line arguments: -includeconf cannot be used from commandline; -includeconf="relative2.conf"',
+        )
 
         self.log.info("-includeconf cannot be used recursively. subversion should end with 'main; relative)/'")
         with open(os.path.join(self.options.tmpdir, "node0", "relative.conf"), "a", encoding="utf8") as f:


### PR DESCRIPTION
Backports #22279, #22002 and #22137 to fix fuzzing issues in the 0.21 branch: https://github.com/bitcoin/bitcoin/runs/2864012729.