### PR TITLE
Remove unused CSubNet serialize code

### DIFF
--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -534,22 +534,23 @@ class CSubNet
         friend bool operator!=(const CSubNet& a, const CSubNet& b) { return !(a == b); }
         friend bool operator<(const CSubNet& a, const CSubNet& b);
 
-        SERIALIZE_METHODS(CSubNet, obj)
+        template <typename Stream>
+        void Unserialize(Stream& s)
         {
-            READWRITE(obj.network);
-            if (obj.network.IsIPv4()) {
+            s >> network;
+            if (network.IsIPv4()) {
                 // Before commit 102867c587f5f7954232fb8ed8e85cda78bb4d32, CSubNet used the last 4 bytes of netmask
                 // to store the relevant bytes for an IPv4 mask. For compatibility reasons, keep doing so in
                 // serialized form.
                 unsigned char dummy[12] = {0};
-                READWRITE(dummy);
-                READWRITE(MakeSpan(obj.netmask).first(4));
+                s >> dummy;
+                s >> MakeSpan(netmask).first(4);
             } else {
-                READWRITE(obj.netmask);
+                s >> netmask;
             }
-            READWRITE(obj.valid);
+            s >> valid;
             // Mark invalid if the result doesn't pass sanity checking.
-            SER_READ(obj, if (obj.valid) obj.valid = obj.SanityCheck());
+            if (valid) valid = SanityCheck();
         }
 };
 

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -143,15 +143,16 @@ FUZZ_TARGET_DESERIALIZE(script_deserialize, {
         DeserializeFromFuzzingInput(buffer, script);
 })
 FUZZ_TARGET_DESERIALIZE(sub_net_deserialize, {
-        CSubNet sub_net_1;
-        DeserializeFromFuzzingInput(buffer, sub_net_1, INIT_PROTO_VERSION);
-        AssertEqualAfterSerializeDeserialize(sub_net_1, INIT_PROTO_VERSION);
-        CSubNet sub_net_2;
-        DeserializeFromFuzzingInput(buffer, sub_net_2, INIT_PROTO_VERSION | ADDRV2_FORMAT);
-        AssertEqualAfterSerializeDeserialize(sub_net_2, INIT_PROTO_VERSION | ADDRV2_FORMAT);
-        CSubNet sub_net_3;
-        DeserializeFromFuzzingInput(buffer, sub_net_3);
-        AssertEqualAfterSerializeDeserialize(sub_net_3, INIT_PROTO_VERSION | ADDRV2_FORMAT);
+    CDataStream ds(buffer, 0, 0);
+    try {
+        {
+            int version;
+            ds >> version;
+            ds.SetVersion(version);
+        }
+        ds >> CSubNet{};
+    } catch (const std::ios_base::failure&) {
+    }
 })
 FUZZ_TARGET_DESERIALIZE(tx_in_deserialize, {
         CTxIn tx_in;


### PR DESCRIPTION
The code is complicated and confusing. Now that it is unused, remove it to avoid the risk of using it later.