### PR TITLE
ci: Do not clone `bitcoin-core/qa-assets` git repository if not necessary

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -84,11 +84,14 @@ fi
 DOCKER_EXEC echo "Free disk space:"
 DOCKER_EXEC df -h
 
-if [ ! -d ${DIR_QA_ASSETS} ]; then
-  DOCKER_EXEC git clone --depth=1 https://github.com/bitcoin-core/qa-assets ${DIR_QA_ASSETS}
+if [ "$RUN_FUZZ_TESTS" = "true" ] || [ "$RUN_UNIT_TESTS" = "true" ] || [ "$RUN_UNIT_TESTS_SEQUENTIAL" = "true" ]; then
+  if [ ! -d ${DIR_QA_ASSETS} ]; then
+    DOCKER_EXEC git clone --depth=1 https://github.com/bitcoin-core/qa-assets ${DIR_QA_ASSETS}
+  fi
+
+  export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/
+  export DIR_UNIT_TEST_DATA=${DIR_QA_ASSETS}/unit_test_data/
 fi
-export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/
-export DIR_UNIT_TEST_DATA=${DIR_QA_ASSETS}/unit_test_data/
 
 DOCKER_EXEC mkdir -p "${BASE_SCRATCH_DIR}/sanitizer-output/"
 


### PR DESCRIPTION
This PR attempts to remove an unnecessary step when CI runs.

The main motivation for the change is that I locally use `MAKEJOBS="-j15" FILE_ENV="./ci/test/00_setup_env_android.sh" ./ci/test_run_all.sh` to find out if a patch of mine works or not. Cloning `bitcoin-core/qa-assets` is slow on my machine (which is by no means slow).