### PR TITLE
wallet: erase spkmans rather than setting to nullptr

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3184,7 +3184,7 @@ void CWallet::LoadActiveScriptPubKeyMan(uint256 id, OutputType type, bool intern
     spk_mans[type] = spk_man;
 
     if (spk_mans_other[type] == spk_man) {
-        spk_mans_other[type] = nullptr;
+        spk_mans_other.erase(type);
     }
 
     NotifyCanGetAddressesChanged();
@@ -3201,7 +3201,7 @@ void CWallet::DeactivateScriptPubKeyMan(uint256 id, OutputType type, bool intern
         }
 
         auto& spk_mans = internal ? m_internal_spk_managers : m_external_spk_managers;
-        spk_mans[type] = nullptr;
+        spk_mans.erase(type);
     }
 
     NotifyCanGetAddressesChanged();


### PR DESCRIPTION
In many places in ScriptPubKeyMan managing code, we assume that the ScriptPubKeyMan being retrieved actually exists and is not a nullptr. Thus removing a ScriptPubKeyMan requires erasing the object from the map rather than setting it to a nullptr.

This fixes a segmentation fault that can be reached with `test/functional/wallet_descriptors.py --descriptors`