### PR TITLE
system: skip trying to set the locale on NetBSD

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1301,7 +1301,7 @@ void SetupEnvironment()
 #endif
     // On most POSIX systems (e.g. Linux, but not BSD) the environment's locale
     // may be invalid, in which case the "C.UTF-8" locale is used as fallback.
-#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__NetBSD__)
     try {
         std::locale(""); // Raises a runtime error if current locale is invalid
     } catch (const std::runtime_error&) {


### PR DESCRIPTION
Just treat it the same as the other BSDs.

Fixes #17379.