### PR TITLE
doc: added info to bitcoin.conf doc

### DIFF
--- a/doc/bitcoin-conf.md
+++ b/doc/bitcoin-conf.md
@@ -4,6 +4,8 @@ The configuration file is used by `bitcoind`, `bitcoin-qt` and `bitcoin-cli`.
 
 All command-line options (except for `-?`, `-help`, `-version` and `-conf`) may be specified in a configuration file, and all configuration file options (except for `includeconf`) may also be specified on the command line. Command-line options override values set in the configuration file and configuration file options override values set in the GUI.
 
+Changes to the configuration file while `bitcoind` or `bitcoin-qt` is running only take effect after restarting.
+
 ## Configuration File Format
 
 The configuration file is a plain text file and consists of `option=value` entries, one per line. Leading and trailing whitespaces are removed.


### PR DESCRIPTION
Should probably be explicitly stated to not make modifications to the conf file while daemon is running. ref #11586



For example, if rpc credentials are modified while bitcoind is running, `bitcoin-cli stop` is unable to stop bitcoind until the original credentials are restored in `bitcoin.conf`