### PR TITLE
doc: Install Rosetta on M1-macOS for qt in depends

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -87,6 +87,14 @@ For linux S390X cross compilation:
 
     sudo apt-get install g++-s390x-linux-gnu binutils-s390x-linux-gnu
 
+### Install the required dependencies: M1-based macOS
+
+To be able to build the `qt` package, ensure that Rosetta 2 is installed:
+
+```
+softwareupdate --install-rosetta
+```
+
 ### Dependency Options
 
 The following can be set when running make: `make FOO=bar`


### PR DESCRIPTION
On master (c609e10545492aba480ff17aff7eefc13a0b5cd8) `make -C depends qt` on Apple Silicon based macOS 11.4 ends with an error:
```
/bin/sh: /Users/hebasto/bitcoin/depends/work/build/aarch64-apple-darwin20.5.0/qt/5.12.11-6c4d47a8f8f/qtbase/bin/moc: Bad CPU type in executable
```

Installing Rosetta 2 fixes it.

Explanation. On Apple Silicon macOS the `qt` package in depends actually is cross compiled. All native tools (including `moc`) are x86_64 binaries, that require Rosetta 2 to run.