### PR TITLE
test: add tests for `bad-txns-prevout-null` reject reason

### DIFF
--- a/test/functional/data/invalid_txs.py
+++ b/test/functional/data/invalid_txs.py
@@ -151,6 +151,19 @@ class DuplicateInput(BadTxTemplate):
         return tx
 
 
+class PrevoutNullInput(BadTxTemplate):
+    reject_reason = 'bad-txns-prevout-null'
+    expect_disconnect = True
+
+    def get_tx(self):
+        tx = CTransaction()
+        tx.vin.append(self.valid_txin)
+        tx.vin.append(CTxIn(COutPoint(hash=0, n=0xffffffff)))
+        tx.vout.append(CTxOut(1, basic_p2sh))
+        tx.calc_sha256()
+        return tx
+
+
 class NonexistentInput(BadTxTemplate):
     reject_reason = None  # Added as an orphan tx.
     expect_disconnect = False

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -13,6 +13,7 @@ from test_framework.messages import (
     BIP125_SEQUENCE_NUMBER,
     COIN,
     COutPoint,
+    CTxIn,
     CTxOut,
     MAX_BLOCK_BASE_SIZE,
     MAX_MONEY,
@@ -244,6 +245,14 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         tx.vin = [tx.vin[0]] * 2
         self.check_mempool_result(
             result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'bad-txns-inputs-duplicate'}],
+            rawtxs=[tx.serialize().hex()],
+        )
+
+        self.log.info('A non-coinbase transaction with coinbase-like outpoint')
+        tx = tx_from_hex(raw_tx_reference)
+        tx.vin.append(CTxIn(COutPoint(hash=0, n=0xffffffff)))
+        self.check_mempool_result(
+            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'bad-txns-prevout-null'}],
             rawtxs=[tx.serialize().hex()],
         )
 


### PR DESCRIPTION
This simple PR adds missing tests for the reject reason `bad-txns-prevout-null`, which is thrown in the function `CheckTransaction()`: https://github.com/bitcoin/bitcoin/blob/a62fc35a150da584d39d7cd01ade14bbb5002fb9/src/consensus/tx_check.cpp#L52-L54

Basically this condition is met for non-coinbase transactions (the code snippet above only hits if `!tx.IsCoinBase()`) with coinbase-like outpoints, i.e. hash=0, n=0xffffffff.

Can be tested by running the functional tests `feature_block.py`, `p2p_invalid_tx.py` and `mempool_accept.py`. Not sure if the redundancy in the tests is desired (I guess it would make sense if the mempool acceptance test also makes use of the invalid_txs templates?).