### PR TITLE
Bugfix: Workaround UniValue push_back(bool) limitation with push_back(UniValue(bool))

### DIFF
--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -23,6 +23,7 @@ These are the dependencies currently used by Bitcoin Core. You can find instruct
 | qrencode | [3.4.4](https://fukuchi.org/works/qrencode) |  | No |  |  |
 | Qt | [5.9.8](https://download.qt.io/official_releases/qt/) | [5.5.1](https://github.com/bitcoin/bitcoin/issues/13478) | No |  |  |
 | SQLite | [3.32.1](https://sqlite.org/download.html) | [3.7.17](https://github.com/bitcoin/bitcoin/pull/19077) |  |  |  |
+| UniValue | non-standard | [1.0.4](https://github.com/jgarzik/univalue/tags) | No |  |  |
 | XCB |  |  |  |  | [Yes](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/qt.mk) (Linux only) |
 | xkbcommon |  |  |  |  | [Yes](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/qt.mk) (Linux only) |
 | ZeroMQ | [4.3.1](https://github.com/zeromq/libzmq/releases) | 4.0.0 | No |  |  |
@@ -39,6 +40,7 @@ Some dependencies are not needed in all configurations. The following are some f
 * SQLite is not needed with `--disable-wallet` or `--without-sqlite`.
 * Qt is not needed with `--without-gui`.
 * If the qrencode dependency is absent, QR support won't be added. To force an error when that happens, pass `--with-qrencode`.
+* UniValue is needed only with the `--with-system-univalue` option. Otherwise, a non-standard bundled copy is staticly linked.
 * ZeroMQ is needed only with the `--with-zmq` option.
 
 #### Other

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -606,8 +606,9 @@ void RPCHelpMan::AppendArgMap(UniValue& arr) const
             map.push_back(m_name);
             map.push_back(i);
             map.push_back(arg_name);
-            map.push_back(arg.m_type == RPCArg::Type::STR ||
-                          arg.m_type == RPCArg::Type::STR_HEX);
+            // NOTE: push_back(bool) converts the bool to Number, so explicitly make a boolean UniValue first
+            map.push_back(UniValue(arg.m_type == RPCArg::Type::STR ||
+                          arg.m_type == RPCArg::Type::STR_HEX));
             arr.push_back(map);
         }
     }

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -444,7 +444,8 @@ BOOST_AUTO_TEST_CASE(help_example)
     // test array params
     UniValue arr_value(UniValue::VARR);
     arr_value.push_back("bar");
-    arr_value.push_back(false);
+    // NOTE: push_back(bool) converts the bool to Number, so explicitly make a boolean UniValue first
+    arr_value.push_back(UniValue(false));
     arr_value.push_back(1);
     BOOST_CHECK_EQUAL(HelpExampleCliNamed("test", {{"name", arr_value}}), "> bitcoin-cli -named test name='[\"bar\",false,1]'\n");
     BOOST_CHECK_EQUAL(HelpExampleRpcNamed("test", {{"name", arr_value}}), "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\": \"curltest\", \"method\": \"test\", \"params\": {\"name\":[\"bar\",false,1]}}' -H 'content-type: text/plain;' http://127.0.0.1:8332/\n");


### PR DESCRIPTION
UniValue doesn't define push_back(bool), so C++ silently converts the bool to int and we end up with a Number of 0/1 instead
Explicitly passing a bool UniValue, however, works fine.

Fixes regressions introduced by #20012 and #21302