### PR TITLE
doc: Specify how to set the value of TORGROUP

### DIFF
--- a/doc/tor.md
+++ b/doc/tor.md
@@ -134,7 +134,7 @@ You can also check the group of the cookie file. On most Linux systems, the Tor
 auth cookie will usually be `/run/tor/control.authcookie`:
 
 ```
-stat -c '%G' /run/tor/control.authcookie
+TORGROUP=$(stat -c '%G' /run/tor/control.authcookie)
 ```
 
 Once you have determined the `${TORGROUP}` and selected the `${USER}` that will


### PR DESCRIPTION
This change just makes it more explicit how to assign the value to the TORGROUP variable.