### PR TITLE
init: remove straggling boost thread_group related code

### DIFF
--- a/src/init.h
+++ b/src/init.h
@@ -20,9 +20,6 @@ struct NodeContext;
 namespace interfaces {
 struct BlockAndHeaderTipInfo;
 }
-namespace boost {
-class thread_group;
-} // namespace boost
 
 /** Interrupt threads */
 void Interrupt(NodeContext& node);


### PR DESCRIPTION
`boost::thread_group` was removed in #21016.