### PR TITLE
build: use aarch64 Clang if cross-compiling for darwin on aarch64

### DIFF
--- a/depends/packages/native_clang.mk
+++ b/depends/packages/native_clang.mk
@@ -1,9 +1,15 @@
 package=native_clang
 $(package)_version=10.0.1
 $(package)_download_path=https://github.com/llvm/llvm-project/releases/download/llvmorg-$($(package)_version)
+ifneq (,$(findstring aarch64,$(BUILD)))
+$(package)_download_file=clang+llvm-$($(package)_version)-aarch64-linux-gnu.tar.xz
+$(package)_file_name=clang+llvm-$($(package)_version)-aarch64-linux-gnu.tar.xz
+$(package)_sha256_hash=90dc69a4758ca15cd0ffa45d07fbf5bf4309d47d2c7745a9f0735ecffde9c31f
+else
 $(package)_download_file=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 $(package)_file_name=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 $(package)_sha256_hash=48b83ef827ac2c213d5b64f5ad7ed082c8bcb712b46644e0dc5045c6f462c231
+endif
 
 define $(package)_preprocess_cmds
   rm -f $($(package)_extract_dir)/lib/libc++abi.so*


### PR DESCRIPTION
If we're cross-compiling for darwin on aarch64 hardware, we need to
use a Clang that will run on that hardware.

Only tested in a Linux Docker container (aarch64-unknown-linux-gnu),
running on an Apple M1 mac-mini (aarch64-apple-darwin20.5.0).