### PR TITLE
build: Use guix within gitian

### DIFF
--- a/contrib/gitian-descriptors/README.md
+++ b/contrib/gitian-descriptors/README.md
@@ -1,0 +1,80 @@
+# Gitian
+
+Prior to Bitcoin Core 22.0, gitian was the build system used to create reproducible builds.
+Guix has been used since 22.0.
+In order to ease the transition to guix, the gitian descriptors have been replaced with ones which setup and run guix inside of the gitian virtual machines.
+This is not the recommended method for making Bitcoin Core release builds; new builders should setup and use guix directly.
+
+## Security Model
+
+Guix allows users to select their own security model, but these gitian descriptors do not give builders that option.
+The security model implemented is the most trusting one - the guix installation script is used (which uses the prebuilt binaries) and packages are installed from the substitute servers when available.
+Note that this security model is largely the same as the previous gitian builds as required packages are downloaded from third parties.
+If this security model is insufficient, then we recommend that you install and use guix directly rather than these gitian descriptors.
+
+## Usage
+
+As these gitian descriptors are intended for existing gitian builders, we assume that the necessary repos have already been cloned at that builders are already familiar with the setup and build process.
+However because the actual build system used is guix, the process is slightly different.
+
+### Virtualization Notes
+
+Guix uses some kernel features which are not always available with all of the virtualization methods supported by gitian.
+These have been tested only with the Docker and KVM virtualization methods.
+No changes are necessary to work with KVM.
+For builders using Docker, [gitian-builder#251](https://github.com/devrandom/gitian-builder/pull/251) is required and the `GITIAN_ALLOW_PRIVILEGED=1` must be set:
+```
+export GITIAN_ALLOW_PRIVILEGED=1
+```
+
+### Prepare gitian-builder
+
+1. Checkout [`guix.sigs`](https://github.com/bitcoin-core/guix.sigs)
+2. Checkout [`gitian-builder`](https://github.com/devrandom/gitian-builder) and make sure it contains commit `9e97a4d5038cd61215f5243a37c06fa1734a276e`.
+3. Install all of the prerequisites as per gitian's instructions.
+4. Create a Ubuntu 18.04 base vm with `bin/make-base-vm --suite bionic --arch amd64` (include virtualization arguments as needed)
+
+### Build
+
+A build can be performed with (from the gitian-builder root):
+
+```
+bin/gbuild --commit bitcoin=<version> --allow-sudo ../bitcoin/guix-in-gitian/contrib/gitian-descriptors/gitian-guix-linux-win.yml
+bin/gbuild --commit bitcoin=<version> --allow-sudo ../bitcoin/guix-in-gitian/contrib/gitian-descriptors/gitian-guix-mac.yml
+```
+
+Note that this comamnd includes `--allow-sudo`.
+This is required in order for guix to work inside of the container.
+
+### Attesting (signing)
+
+With gitian, the binaries would be commited to (signed) using `gsign`.
+However this is no longer necessary with guix.
+The `guix-attest` script is used for making and signing the sha256 hashes of the build results.
+This script does not require guix, and should be run on the build host.
+
+1. Copy the build results to a safe location. This is necessary as these binaries are needed for attestation after codesigning and gitian will delete them if they remain in gitian's output directory (from the gitian-builder root):
+```
+mv build/out/* ../bitcoin-binaries/<version>/
+```
+2. Make the attestation (from bitcoin repo root):
+```
+env GUIX_SIGS_REPO=<path/to/sigs/repo> SIGNER=<name> OUTDIR_BASE=../bitcoin-binaries/<version> contrib/guix/guix-attest
+```
+
+### Codesign
+
+Once detached code signatures have been pushed to the `bitcoin-detached-sigs` repo, the code signature can be attached.
+
+1. Copy unsigned tarballs to gitian builder inputs (from the gitian-builder root):
+```
+cp build/out/x86_64-w64-mingw32/bitcoin-<version>-win-unsigned.tar.gz inputs/bitcoin-win-unsigned.tar.gz
+cp build/out/x86_64-apple-darwin18/bitcoin-<version>-osx-unsigned.tar.gz inputs/bitcoin-osx-unsigned.tar.gz
+```
+2. Run the code signature builds (from the gitian-builder root):
+```
+bin/gbuild --commit bitcoin=<version>,signature=<version> --allow-sudo ../bitcoin/guix-in-gitian/contrib/gitian-descriptors/gitian-guix-win-signer.yml
+bin/gbuild --commit bitcoin=<version>,signature=<version> --allow-sudo ../bitcoin/guix-in-gitian/contrib/gitian-descriptors/gitian-guix-mac-signer.yml
+```
+3. Copy the results to the same safe location as done previously.
+4. Attest the results as done previously.

--- a/contrib/gitian-descriptors/gitian-guix-linux-win.yml
+++ b/contrib/gitian-descriptors/gitian-guix-linux-win.yml
@@ -1,0 +1,113 @@
+---
+name: "bitcoin-core-guix-linux-win"
+enable_cache: true
+sudo: true
+distro: "ubuntu"
+suites:
+- "bionic"
+architectures:
+- "amd64"
+packages:
+- "ca-certificates"
+- "curl"
+- "gnupg"
+- "netbase"
+- "wget"
+remotes:
+- "url": "https://github.com/bitcoin/bitcoin.git"
+  "dir": "bitcoin"
+files: []
+script: |
+  set -e -o pipefail
+
+  export TZ="UTC"
+  export BUILD_DIR="$PWD"
+  if test -n "$GBUILD_CACHE_ENABLED"; then
+    export SOURCES_PATH=${GBUILD_COMMON_CACHE}
+    export BASE_CACHE=${GBUILD_PACKAGE_CACHE}
+    mkdir -p "${BASE_CACHE}" "${SOURCES_PATH}"
+    GUIX_CACHE="${GBUILD_COMMON_CACHE}/guix"
+
+    GUIX_SCRIPT="${GUIX_CACHE}/guix-install.sh"
+    if [[ -f "${GUIX_SCRIPT}" ]]; then
+      cp "${GUIX_SCRIPT}" "${BUILD_DIR}"
+    fi
+    GUIX_TARBALL="${GUIX_CACHE}/guix-install-tarball-x86_64-linux.tar.gz"
+    if [[ -f "${GUIX_TARBALL}" ]]; then
+      export GUIX_BINARY_FILE_NAME=${GUIX_TARBALL}
+    fi
+    GUIX_CACHE_TARBALL="${GUIX_CACHE}/cache-guix.tar.gz"
+    if [[ -f "${GUIX_CACHE_TARBALL}" ]]; then
+      mkdir -p ~/.cache/guix
+      tar -xf "${GUIX_CACHE_TARBALL}" -C ~/.cache/guix/
+    fi
+  fi
+  export JOBS=${NUM_PROCS}
+
+  # Install guix with the installer script
+  if [[ ! -f "guix-install.sh" ]]; then
+    wget -nc -O "guix-install.sh" "https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh?h=version-1.3.0&id=aa34d4d28dfe25ba47d5800d05000fb7221788c0"
+  fi
+  echo "bcdeaa757cd42d2c9de4791272737e9ee0d518398403955f113611f4a893380a  guix-install.sh" | sha256sum -c -
+  # Remove /tmp cleanup from guix-install.sh
+  # shellcheck disable=SC2016
+  sed 's/rm -r "${tmp_path}"//g' guix-install.sh > our-guix-install.sh
+  chmod +x our-guix-install.sh
+  # We don't want SIGPIPE from running `yes`, so temporarily remove pipefail
+  set +o pipefail
+  yes | sudo -E ./our-guix-install.sh
+  set -o pipefail
+  if [[ -z "${GUIX_BINARY_FILE_NAME}" ]]; then
+    cp guix-install.sh "${GUIX_SCRIPT}"
+    GUIX_ORIG_TARBALL=$(sudo find /tmp -name "guix-binary-*.x86_64-linux.tar.xz")
+    sudo mv "${GUIX_ORIG_TARBALL}" "${GUIX_TARBALL}"
+  fi
+
+  # Check guix-daemon is running
+  if ! guix gc --list-failures > /dev/null; then
+    # Not running, try starting it
+    # Not all virtualization methods have systemd available, so start guix-daemon manually
+    sudo /var/guix/profiles/per-user/root/current-guix/bin/guix-daemon --build-users-group=guixbuild --substitute-urls="https://guix.carldong.io https://ci.guix.gnu.org"&
+  fi
+
+  # Import guix cache
+  if test -n "$GBUILD_CACHE_ENABLED"; then
+    mkdir -p "${GUIX_CACHE}"
+    KEYFILE="${GUIX_CACHE}/signing-key.pub"
+    STORE_FILE="${GUIX_CACHE}/guix_store.nar"
+    if [[ -f "$KEYFILE" && -f "$STORE_FILE" ]]; then
+      # shellcheck disable=SC2024
+      sudo -i guix archive --authorize < "${KEYFILE}"
+      guix archive --import < "${STORE_FILE}"
+    fi
+  fi
+
+  # Prep for build
+  cd bitcoin
+
+  # Define DISTNAME variable.
+  # shellcheck source=contrib/gitian-descriptors/assign_DISTNAME
+  # shellcheck disable=SC2034
+  source contrib/gitian-descriptors/assign_DISTNAME
+
+  # Do the build
+  export HOSTS="x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu powerpc64-linux-gnu powerpc64le-linux-gnu x86_64-w64-mingw32"
+  ./contrib/guix/guix-build
+
+  # Move all of the guix output to our output dir
+  mv "guix-build-${VERSION}/output/"* "${OUTDIR}"
+
+  if test -n "$GBUILD_CACHE_ENABLED"; then
+    cd "${BUILD_DIR}"
+
+    # Find all of the items in the guix store and export them to the cache
+    STORE_FILES=$(find /gnu/store -maxdepth 1 -mindepth 1 -type d -not -name ".links" | sort)
+    sudo -i guix archive --generate-key
+    sudo cp /etc/guix/signing-key.pub "${KEYFILE}"
+    guix archive --export --recursive $STORE_FILES > "${STORE_FILE}"
+
+    # Cache guix cache
+    pushd ~/.cache/guix
+    tar -czf "${GUIX_CACHE_TARBALL}" ./*
+    popd
+  fi

--- a/contrib/gitian-descriptors/gitian-guix-mac-signer.yml
+++ b/contrib/gitian-descriptors/gitian-guix-mac-signer.yml
@@ -1,0 +1,122 @@
+---
+name: "bitcoin-core-guix-mac-signer"
+enable_cache: true
+sudo: true
+distro: "ubuntu"
+suites:
+- "bionic"
+architectures:
+- "amd64"
+packages:
+- "ca-certificates"
+- "curl"
+- "gnupg"
+- "netbase"
+- "wget"
+remotes:
+- "url": "https://github.com/bitcoin/bitcoin.git"
+  "dir": "bitcoin"
+- "url": "https://github.com/bitcoin-core/bitcoin-detached-sigs.git"
+  "dir": "signature"
+files:
+- "bitcoin-osx-unsigned.tar.gz"
+script: |
+  set -e -o pipefail
+
+  export TZ="UTC"
+  export BUILD_DIR="$PWD"
+  if test -n "$GBUILD_CACHE_ENABLED"; then
+    export SOURCES_PATH=${GBUILD_COMMON_CACHE}
+    export BASE_CACHE=${GBUILD_PACKAGE_CACHE}
+    mkdir -p "${BASE_CACHE}" "${SOURCES_PATH}"
+    GUIX_CACHE="${GBUILD_COMMON_CACHE}/guix"
+
+    GUIX_SCRIPT="${GUIX_CACHE}/guix-install.sh"
+    if [[ -f "${GUIX_SCRIPT}" ]]; then
+      cp "${GUIX_SCRIPT}" "${BUILD_DIR}"
+    fi
+    GUIX_TARBALL="${GUIX_CACHE}/guix-install-tarball-x86_64-linux.tar.gz"
+    if [[ -f "${GUIX_TARBALL}" ]]; then
+      export GUIX_BINARY_FILE_NAME=${GUIX_TARBALL}
+    fi
+    GUIX_CACHE_TARBALL="${GUIX_CACHE}/cache-guix.tar.gz"
+    if [[ -f "${GUIX_CACHE_TARBALL}" ]]; then
+      mkdir -p ~/.cache/guix
+      tar -xf "${GUIX_CACHE_TARBALL}" -C ~/.cache/guix/
+    fi
+  fi
+  export JOBS=${NUM_PROCS}
+
+  # Install guix with the installer script
+  if [[ ! -f "guix-install.sh" ]]; then
+    wget -nc -O "guix-install.sh" "https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh?h=version-1.3.0&id=aa34d4d28dfe25ba47d5800d05000fb7221788c0"
+  fi
+  echo "bcdeaa757cd42d2c9de4791272737e9ee0d518398403955f113611f4a893380a  guix-install.sh" | sha256sum -c -
+  # Remove /tmp cleanup from guix-install.sh
+  # shellcheck disable=SC2016
+  sed 's/rm -r "${tmp_path}"//g' guix-install.sh > our-guix-install.sh
+  chmod +x our-guix-install.sh
+  # We don't want SIGPIPE from running `yes`, so temporarily remove pipefail
+  set +o pipefail
+  yes | sudo -E ./our-guix-install.sh
+  set -o pipefail
+  if [[ -z "${GUIX_BINARY_FILE_NAME}" ]]; then
+    cp guix-install.sh "${GUIX_SCRIPT}"
+    GUIX_ORIG_TARBALL=$(sudo find /tmp -name "guix-binary-*.x86_64-linux.tar.xz")
+    sudo mv "${GUIX_ORIG_TARBALL}" "${GUIX_TARBALL}"
+  fi
+
+  # Check guix-daemon is running
+  if ! guix gc --list-failures > /dev/null; then
+    # Not running, try starting it
+    # Not all virtualization methods have systemd available, so start guix-daemon manually
+    sudo /var/guix/profiles/per-user/root/current-guix/bin/guix-daemon --build-users-group=guixbuild --substitute-urls="https://guix.carldong.io https://ci.guix.gnu.org"&
+  fi
+
+  # Import guix cache
+  if test -n "$GBUILD_CACHE_ENABLED"; then
+    mkdir -p "${GUIX_CACHE}"
+    KEYFILE="${GUIX_CACHE}/signing-key.pub"
+    STORE_FILE="${GUIX_CACHE}/guix_store.nar"
+    if [[ -f "$KEYFILE" && -f "$STORE_FILE" ]]; then
+      # shellcheck disable=SC2024
+      sudo -i guix archive --authorize < "${KEYFILE}"
+      guix archive --import < "${STORE_FILE}"
+    fi
+  fi
+
+  # Prep for build
+  cd bitcoin
+  export HOSTS="x86_64-apple-darwin18"
+
+  # Define DISTNAME variable.
+  # shellcheck source=contrib/gitian-descriptors/assign_DISTNAME
+  # shellcheck disable=SC2034
+  source contrib/gitian-descriptors/assign_DISTNAME
+
+  # Prepare the unsigned tarball for codesigning
+  mkdir -p "guix-build-${VERSION}/output/${HOSTS}"
+  mkdir -p "guix-build-${VERSION}/var/profiles"
+  mv "${BUILD_DIR}/bitcoin-osx-unsigned.tar.gz" "guix-build-${VERSION}/output/${HOSTS}/bitcoin-${VERSION}-osx-unsigned.tar.gz"
+
+  # Do the build
+  export DETACHED_SIGS_REPO="${BUILD_DIR}/signature"
+  ./contrib/guix/guix-codesign
+
+  # Move all of the guix output to our output dir
+  mv "guix-build-${VERSION}/output/${HOSTS}-codesigned" "${OUTDIR}"
+
+  if test -n "$GBUILD_CACHE_ENABLED"; then
+    cd "${BUILD_DIR}"
+
+    # Find all of the items in the guix store and export them to the cache
+    STORE_FILES=$(find /gnu/store -maxdepth 1 -mindepth 1 -type d -not -name ".links" | sort)
+    sudo -i guix archive --generate-key
+    sudo cp /etc/guix/signing-key.pub "${KEYFILE}"
+    guix archive --export --recursive $STORE_FILES > "${STORE_FILE}"
+
+    # Cache guix cache
+    pushd ~/.cache/guix
+    tar -czf "${GUIX_CACHE_TARBALL}" ./*
+    popd
+  fi

--- a/contrib/gitian-descriptors/gitian-guix-mac.yml
+++ b/contrib/gitian-descriptors/gitian-guix-mac.yml
@@ -1,0 +1,118 @@
+---
+name: "bitcoin-core-guix-mac"
+enable_cache: true
+sudo: true
+distro: "ubuntu"
+suites:
+- "bionic"
+architectures:
+- "amd64"
+packages:
+- "ca-certificates"
+- "curl"
+- "gnupg"
+- "netbase"
+- "wget"
+remotes:
+- "url": "https://github.com/bitcoin/bitcoin.git"
+  "dir": "bitcoin"
+files:
+- "Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz"
+script: |
+  set -e -o pipefail
+
+  export TZ="UTC"
+  export BUILD_DIR="$PWD"
+  if test -n "$GBUILD_CACHE_ENABLED"; then
+    export SOURCES_PATH=${GBUILD_COMMON_CACHE}
+    export BASE_CACHE=${GBUILD_PACKAGE_CACHE}
+    mkdir -p "${BASE_CACHE}" "${SOURCES_PATH}"
+    GUIX_CACHE="${GBUILD_COMMON_CACHE}/guix"
+
+    GUIX_SCRIPT=${GUIX_CACHE}/guix-install.sh
+    if [[ -f "${GUIX_SCRIPT}" ]]; then
+      cp "${GUIX_SCRIPT}" "${BUILD_DIR}"
+    fi
+    GUIX_TARBALL="${GUIX_CACHE}/guix-install-tarball-x86_64-linux.tar.gz"
+    if [[ -f "${GUIX_TARBALL}" ]]; then
+      export GUIX_BINARY_FILE_NAME=${GUIX_TARBALL}
+    fi
+    GUIX_CACHE_TARBALL="${GUIX_CACHE}/cache-guix.tar.gz"
+    if [[ -f "${GUIX_CACHE_TARBALL}" ]]; then
+      mkdir -p ~/.cache/guix
+      tar -xf "${GUIX_CACHE_TARBALL}" -C ~/.cache/guix/
+    fi
+  fi
+  export JOBS=${NUM_PROCS}
+
+  # Install guix with the installer script
+  if [[ ! -f "guix-install.sh" ]]; then
+    wget -nc -O "guix-install.sh" "https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh?h=version-1.3.0&id=aa34d4d28dfe25ba47d5800d05000fb7221788c0"
+  fi
+  echo "bcdeaa757cd42d2c9de4791272737e9ee0d518398403955f113611f4a893380a  guix-install.sh" | sha256sum -c -
+  # Remove /tmp cleanup from guix-install.sh
+  # shellcheck disable=SC2016
+  sed 's/rm -r "${tmp_path}"//g' guix-install.sh > our-guix-install.sh
+  chmod +x our-guix-install.sh
+  # We don't want SIGPIPE from running `yes`, so temporarily remove pipefail
+  set +o pipefail
+  yes | sudo -E ./our-guix-install.sh
+  set -o pipefail
+  if [[ -z "${GUIX_BINARY_FILE_NAME}" ]]; then
+    cp guix-install.sh "${GUIX_SCRIPT}"
+    GUIX_ORIG_TARBALL=$(sudo find /tmp -name "guix-binary-*.x86_64-linux.tar.xz")
+    sudo mv "${GUIX_ORIG_TARBALL}" "${GUIX_TARBALL}"
+  fi
+
+  # Check guix-daemon is running
+  if ! guix gc --list-failures > /dev/null; then
+    # Not running, try starting it
+    # Not all virtualization methods have systemd available, so start guix-daemon manually
+    sudo /var/guix/profiles/per-user/root/current-guix/bin/guix-daemon --build-users-group=guixbuild --substitute-urls="https://guix.carldong.io https://ci.guix.gnu.org"&
+  fi
+
+  # Import guix cache
+  if test -n "$GBUILD_CACHE_ENABLED"; then
+    mkdir -p "${GUIX_CACHE}"
+    KEYFILE="${GUIX_CACHE}/signing-key.pub"
+    STORE_FILE="${GUIX_CACHE}/guix_store.nar"
+    if [[ -f "$KEYFILE" && -f "$STORE_FILE" ]]; then
+      # shellcheck disable=SC2024
+      sudo -i guix archive --authorize < "${KEYFILE}"
+      guix archive --import < "${STORE_FILE}"
+    fi
+  fi
+
+  # Prep for build
+  cd bitcoin
+  BASEPREFIX="${PWD}/depends"
+
+  mkdir -p "${BASEPREFIX}/SDKs"
+  tar -C "${BASEPREFIX}/SDKs" -xf "${BUILD_DIR}/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz"
+  export HOSTS="x86_64-apple-darwin18"
+
+  # Define DISTNAME variable.
+  # shellcheck source=contrib/gitian-descriptors/assign_DISTNAME
+  # shellcheck disable=SC2034
+  source contrib/gitian-descriptors/assign_DISTNAME
+
+  # Do the build
+  ./contrib/guix/guix-build
+
+  # Move all of the guix output to our output dir
+  mv "guix-build-${VERSION}/output/${HOSTS}" "${OUTDIR}"
+
+  if test -n "$GBUILD_CACHE_ENABLED"; then
+    cd "${BUILD_DIR}"
+
+    # Find all of the items in the guix store and export them to the cache
+    STORE_FILES=$(find /gnu/store -maxdepth 1 -mindepth 1 -type d -not -name ".links" | sort)
+    sudo -i guix archive --generate-key
+    sudo cp /etc/guix/signing-key.pub "${KEYFILE}"
+    guix archive --export --recursive $STORE_FILES > "${STORE_FILE}"
+
+    # Cache guix cache
+    pushd ~/.cache/guix
+    tar -czf "${GUIX_CACHE_TARBALL}" ./*
+    popd
+  fi

--- a/contrib/gitian-descriptors/gitian-guix-win-signer.yml
+++ b/contrib/gitian-descriptors/gitian-guix-win-signer.yml
@@ -1,0 +1,122 @@
+---
+name: "bitcoin-core-guix-win-signer"
+enable_cache: true
+sudo: true
+distro: "ubuntu"
+suites:
+- "bionic"
+architectures:
+- "amd64"
+packages:
+- "ca-certificates"
+- "curl"
+- "gnupg"
+- "netbase"
+- "wget"
+remotes:
+- "url": "https://github.com/bitcoin/bitcoin.git"
+  "dir": "bitcoin"
+- "url": "https://github.com/bitcoin-core/bitcoin-detached-sigs.git"
+  "dir": "signature"
+files:
+- "bitcoin-win-unsigned.tar.gz"
+script: |
+  set -e -o pipefail
+
+  export TZ="UTC"
+  export BUILD_DIR="$PWD"
+  if test -n "$GBUILD_CACHE_ENABLED"; then
+    export SOURCES_PATH=${GBUILD_COMMON_CACHE}
+    export BASE_CACHE=${GBUILD_PACKAGE_CACHE}
+    mkdir -p "${BASE_CACHE}" "${SOURCES_PATH}"
+    GUIX_CACHE="${GBUILD_COMMON_CACHE}/guix"
+
+    GUIX_SCRIPT="${GUIX_CACHE}/guix-install.sh"
+    if [[ -f "${GUIX_SCRIPT}" ]]; then
+      cp "${GUIX_SCRIPT}" "${BUILD_DIR}"
+    fi
+    GUIX_TARBALL="${GUIX_CACHE}/guix-install-tarball-x86_64-linux.tar.gz"
+    if [[ -f "${GUIX_TARBALL}" ]]; then
+      export GUIX_BINARY_FILE_NAME=${GUIX_TARBALL}
+    fi
+    GUIX_CACHE_TARBALL="${GUIX_CACHE}/cache-guix.tar.gz"
+    if [[ -f "${GUIX_CACHE_TARBALL}" ]]; then
+      mkdir -p ~/.cache/guix
+      tar -xf "${GUIX_CACHE_TARBALL}" -C ~/.cache/guix/
+    fi
+  fi
+  export JOBS=${NUM_PROCS}
+
+  # Install guix with the installer script
+  if [[ ! -f "guix-install.sh" ]]; then
+    wget -nc -O "guix-install.sh" "https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh?h=version-1.3.0&id=aa34d4d28dfe25ba47d5800d05000fb7221788c0"
+  fi
+  echo "bcdeaa757cd42d2c9de4791272737e9ee0d518398403955f113611f4a893380a  guix-install.sh" | sha256sum -c -
+  # Remove /tmp cleanup from guix-install.sh
+  # shellcheck disable=SC2016
+  sed 's/rm -r "${tmp_path}"//g' guix-install.sh > our-guix-install.sh
+  chmod +x our-guix-install.sh
+  # We don't want SIGPIPE from running `yes`, so temporarily remove pipefail
+  set +o pipefail
+  yes | sudo -E ./our-guix-install.sh
+  set -o pipefail
+  if [[ -z "${GUIX_BINARY_FILE_NAME}" ]]; then
+    cp guix-install.sh "${GUIX_SCRIPT}"
+    GUIX_ORIG_TARBALL=$(sudo find /tmp -name "guix-binary-*.x86_64-linux.tar.xz")
+    sudo mv "${GUIX_ORIG_TARBALL}" "${GUIX_TARBALL}"
+  fi
+
+  # Check guix-daemon is running
+  if ! guix gc --list-failures > /dev/null; then
+    # Not running, try starting it
+    # Not all virtualization methods have systemd available, so start guix-daemon manually
+    sudo /var/guix/profiles/per-user/root/current-guix/bin/guix-daemon --build-users-group=guixbuild --substitute-urls="https://guix.carldong.io https://ci.guix.gnu.org"&
+  fi
+
+  # Import guix cache
+  if test -n "$GBUILD_CACHE_ENABLED"; then
+    mkdir -p "${GUIX_CACHE}"
+    KEYFILE="${GUIX_CACHE}/signing-key.pub"
+    STORE_FILE="${GUIX_CACHE}/guix_store.nar"
+    if [[ -f "$KEYFILE" && -f "$STORE_FILE" ]]; then
+      # shellcheck disable=SC2024
+      sudo guix archive --authorize < "${KEYFILE}"
+      guix archive --import < "${STORE_FILE}"
+    fi
+  fi
+
+  # Prep for build
+  cd bitcoin
+  export HOSTS="x86_64-w64-mingw32"
+
+  # Define DISTNAME variable.
+  # shellcheck source=contrib/gitian-descriptors/assign_DISTNAME
+  # shellcheck disable=SC2034
+  source contrib/gitian-descriptors/assign_DISTNAME
+
+  # Prepare the unsigned tarball for codesigning
+  mkdir -p "guix-build-${VERSION}/output/${HOSTS}"
+  mkdir -p "guix-build-${VERSION}/var/profiles"
+  mv "${BUILD_DIR}/bitcoin-win-unsigned.tar.gz" "guix-build-${VERSION}/output/${HOSTS}/bitcoin-${VERSION}-win-unsigned.tar.gz"
+
+  # Do the build
+  export DETACHED_SIGS_REPO="${BUILD_DIR}/signature"
+  ./contrib/guix/guix-codesign
+
+  # Move all of the guix output to our output dir
+  mv "guix-build-${VERSION}/output/${HOSTS}-codesigned" "${OUTDIR}"
+
+  if test -n "$GBUILD_CACHE_ENABLED"; then
+    cd "${BUILD_DIR}"
+
+    # Find all of the items in the guix store and export them to the cache
+    STORE_FILES=$(find /gnu/store -maxdepth 1 -mindepth 1 -type d -not -name ".links" | sort)
+    sudo -i guix archive --generate-key
+    sudo cp /etc/guix/signing-key.pub "${KEYFILE}"
+    guix archive --export --recursive $STORE_FILES > "${STORE_FILE}"
+
+    # Cache guix cache
+    pushd ~/.cache/guix
+    tar -czf "${GUIX_CACHE_TARBALL}" ./*
+    popd
+  fi


### PR DESCRIPTION
To somewhat ease the transition from gitian to guix, this PR replaces the previous gitian descriptors with ones that perform the guix build.

Due to the way guix works, some changes were needed to gitian itself, so builders must make sure that their gitian is up to date before trying this. Additionally, the base gitian images may need to be rebuilt.

I have only tested this using docker (with some changes to gitian: https://github.com/devrandom/gitian-builder/pull/251). It is my understanding that @luke-jr has been able to get these to work using kvm. I have tried with lxc but was unable to make it work.

The previous gitian descriptors used Ubuntu Focal as the image base. However because gitian is unable to make such images for lxc and kvm, the base image used here is Bionic.