### PR TITLE
util: improves error messages on get_previous_releases script

### DIFF
--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -104,7 +104,11 @@ def download_binary(tag, args) -> int:
     tarballHash = hasher.hexdigest()
 
     if tarballHash not in SHA256_SUMS or SHA256_SUMS[tarballHash] != tarball:
-        print("Checksum did not match")
+        if tarball in SHA256_SUMS.values():
+            print("Checksum did not match")
+            return 1
+
+        print("Checksum for given version doesn't exist")
         return 1
     print("Checksum matched")
 


### PR DESCRIPTION
When previous releases are fetched and the specified version wasn't added to the checksum list we used to get a "Checksum did not match" which isn't true (https://github.com/bitcoin-core/bitcoincore.org/issues/753#issuecomment-879546719). 

If the specified version number is not on the list, it now logs cannot do the comparison instead.