### PR TITLE
fuzz: Limit max ops in prevector fuzz target

### DIFF
--- a/src/test/fuzz/prevector.cpp
+++ b/src/test/fuzz/prevector.cpp
@@ -206,10 +206,14 @@ public:
 
 FUZZ_TARGET(prevector)
 {
+    // Pick an arbitrary upper bound to limit the runtime and avoid timeouts on
+    // inputs.
+    int limit_max_ops{3000};
+
     FuzzedDataProvider prov(buffer.data(), buffer.size());
     prevector_tester<8, int> test;
 
-    while (prov.remaining_bytes()) {
+    while (--limit_max_ops >= 0 && prov.remaining_bytes()) {
         switch (prov.ConsumeIntegralInRange<int>(0, 13 + 3 * (test.size() > 0))) {
         case 0:
             test.insert(prov.ConsumeIntegralInRange<size_t>(0, test.size()), prov.ConsumeIntegral<int>());


### PR DESCRIPTION
Without a size limit on the input data, the runtime is unbounded. Fix this by picking an upper bound on the maximum number of fuzz operations.

Should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=35981