### PR TITLE
[WIP] build: Use specific cross-compilers instead of multilib one

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -20,6 +20,10 @@ created. To use it during compilation:
 
     CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure
 
+For the current arch+OS:
+
+    CONFIG_SITE=$PWD/depends/$(depends/config.guess)/share/config.site ./configure
+
 The default install prefix when using `config.site` is `--prefix=depends/<host-platform-triplet>`,
 so depends build outputs will be installed in that location.
 

--- a/depends/README.md
+++ b/depends/README.md
@@ -25,8 +25,8 @@ so depends build outputs will be installed in that location.
 
 Common `host-platform-triplet`s for cross compilation are:
 
-- `i686-pc-linux-gnu` for Linux 32 bit
-- `x86_64-pc-linux-gnu` for x86 Linux
+- `i686-linux-gnu` for Linux 32 bit
+- `x86_64-linux-gnu` for x86 Linux
 - `x86_64-w64-mingw32` for Win64
 - `x86_64-apple-darwin18` for macOS
 - `arm-linux-gnueabihf` for Linux ARM 32 bit
@@ -58,11 +58,21 @@ For more information, see [SDK Extraction](../contrib/macdeploy/README.md#sdk-ex
 
 - see [build-windows.md](../doc/build-windows.md#cross-compilation-for-ubuntu-and-windows-subsystem-for-linux)
 
-#### For linux (including i386, ARM) cross compilation
+#### For linux cross compilation
 
 Common linux dependencies:
 
-    sudo apt-get install make automake cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config python3 patch bison
+    sudo apt-get install automake binutils bison bsdmainutils build-essential cmake curl libtool patch pkg-config python3
+
+No more dependencies are required to build dependencies for the current architecture.
+
+For linux 32 bit (i386 architecture) cross compilation:
+
+    sudo apt-get install g++-i686-linux-gnu binutils-i686-linux-gnu
+
+For x86 linux cross compilation:
+
+    sudo apt-get install g++-x86-64-linux-gnu binutils-x86-64-linux-gnu
 
 For linux ARM cross compilation:
 

--- a/depends/hosts/linux.mk
+++ b/depends/hosts/linux.mk
@@ -9,24 +9,10 @@ linux_debug_CXXFLAGS=$(linux_debug_CFLAGS)
 
 linux_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC -D_LIBCPP_DEBUG=1
 
-ifeq (86,$(findstring 86,$(build_arch)))
-i686_linux_CC=gcc -m32
-i686_linux_CXX=g++ -m32
-i686_linux_AR=ar
-i686_linux_RANLIB=ranlib
-i686_linux_NM=nm
-i686_linux_STRIP=strip
+i686_linux_CC = $(default_host_CC) -m32
+i686_linux_CXX = $(default_host_CXX) -m32
 
-x86_64_linux_CC=gcc -m64
-x86_64_linux_CXX=g++ -m64
-x86_64_linux_AR=ar
-x86_64_linux_RANLIB=ranlib
-x86_64_linux_NM=nm
-x86_64_linux_STRIP=strip
-else
-i686_linux_CC=$(default_host_CC) -m32
-i686_linux_CXX=$(default_host_CXX) -m32
-x86_64_linux_CC=$(default_host_CC) -m64
-x86_64_linux_CXX=$(default_host_CXX) -m64
-endif
+x86_64_linux_CC = $(default_host_CC) -m64
+x86_64_linux_CXX = $(default_host_CXX) -m64
+
 linux_cmake_system=Linux

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -137,13 +137,19 @@ $(package)_config_opts_linux += -no-opengl
 $(package)_config_opts_linux += -no-feature-vulkan
 $(package)_config_opts_linux += -dbus-runtime
 $(package)_config_opts_arm_linux += -platform linux-g++ -xplatform bitcoin-linux-g++
-$(package)_config_opts_i686_linux  = -xplatform linux-g++-32
-$(package)_config_opts_x86_64_linux = -xplatform linux-g++-64
 $(package)_config_opts_aarch64_linux = -xplatform linux-aarch64-gnu-g++
 $(package)_config_opts_powerpc64_linux = -platform linux-g++ -xplatform bitcoin-linux-g++
 $(package)_config_opts_powerpc64le_linux = -platform linux-g++ -xplatform bitcoin-linux-g++
 $(package)_config_opts_riscv64_linux = -platform linux-g++ -xplatform bitcoin-linux-g++
 $(package)_config_opts_s390x_linux = -platform linux-g++ -xplatform bitcoin-linux-g++
+
+ifneq ($(build_os),$(host_os))
+$(package)_config_opts_i686_linux = -platform linux-g++ -xplatform bitcoin-linux-g++
+$(package)_config_opts_x86_64_linux = -platform linux-g++ -xplatform bitcoin-linux-g++
+else
+$(package)_config_opts_i686_linux = -xplatform linux-g++-32
+$(package)_config_opts_x86_64_linux = -xplatform linux-g++-64
+endif
 
 $(package)_config_opts_mingw32 = -no-opengl
 $(package)_config_opts_mingw32 += -no-dbus


### PR DESCRIPTION
This PR replaces the [`g++-multilib`](https://packages.ubuntu.com/focal/g++-multilib) compiler with arch-specific cross-compilers for x86_64 and i386 hosts.

Motivation:
1. The [`g++-multilib`](https://packages.ubuntu.com/focal/g++-multilib) package conflicts with arch-specific cross-compiler packages. That means it is not possible to cross compile for i386 _and_ other platforms on x86_64 system with the same set of installed packages.
2. The [`g++-multilib`](https://packages.ubuntu.com/focal/g++-multilib) package is not available for the **aarch64** arch. That means it is not possible to cross-compile for x86_64 in a Docker container on Apple Silicon based systems.