### PR TITLE
refactor: Remove unused "disconnectpool is nullptr" feature

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -732,8 +732,8 @@ public:
     bool ConnectBlock(const CBlock& block, BlockValidationState& state, CBlockIndex* pindex,
                       CCoinsViewCache& view, bool fJustCheck = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-    // Apply the effects of a block disconnection on the UTXO set.
-    bool DisconnectTip(BlockValidationState& state, DisconnectedBlockTransactions* disconnectpool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
+    /** Apply the effects of a block disconnection on the UTXO set. */
+    bool DisconnectTip(BlockValidationState& state, DisconnectedBlockTransactions& disconnectpool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
 
     // Manual block validity manipulation:
     /** Mark a block as precious and reorganize.


### PR DESCRIPTION
No need to keep an unused feature. If this is ever needed again, it can be added back trivially.