### PR TITLE
guix: Pin kernel-header version, time-machine to upstream 1.3.0 commit

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -215,8 +215,8 @@ SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log --format=%at -1)}"
 # across time.
 time-machine() {
     # shellcheck disable=SC2086
-    guix time-machine --url=https://github.com/dongcarl/guix.git \
-                      --commit=490e39ff303f4f6873a04bfb8253755bdae1b29c \
+    guix time-machine --url=https://git.savannah.gnu.org/git/guix.git \
+                      --commit=aa34d4d28dfe25ba47d5800d05000fb7221788c0 \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \

--- a/contrib/guix/guix-codesign
+++ b/contrib/guix/guix-codesign
@@ -226,14 +226,14 @@ SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log --format=%at -1)}"
 # across time.
 time-machine() {
     # shellcheck disable=SC2086
-    guix time-machine --url=https://github.com/dongcarl/guix.git \
-         --commit=490e39ff303f4f6873a04bfb8253755bdae1b29c \
-         --cores="$JOBS" \
-         --keep-failed \
-         --fallback \
-         ${SUBSTITUTE_URLS:+--substitute-urls="$SUBSTITUTE_URLS"} \
-         ${ADDITIONAL_GUIX_COMMON_FLAGS} ${ADDITIONAL_GUIX_TIMEMACHINE_FLAGS} \
-         -- "$@"
+    guix time-machine --url=https://git.savannah.gnu.org/git/guix.git \
+                      --commit=aa34d4d28dfe25ba47d5800d05000fb7221788c0 \
+                      --cores="$JOBS" \
+                      --keep-failed \
+                      --fallback \
+                      ${SUBSTITUTE_URLS:+--substitute-urls="$SUBSTITUTE_URLS"} \
+                      ${ADDITIONAL_GUIX_COMMON_FLAGS} ${ADDITIONAL_GUIX_TIMEMACHINE_FLAGS} \
+                      -- "$@"
 }
 
 # Make sure an output directory exists for our builds

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -156,7 +156,7 @@ chain for " target " development."))
 (define* (make-bitcoin-cross-toolchain target
                                        #:key
                                        (base-gcc-for-libc gcc-7)
-                                       (base-kernel-headers linux-libre-headers-5.4)
+                                       (base-kernel-headers linux-libre-headers-4.9)
                                        (base-libc (make-glibc-without-ssp glibc-2.24))
                                        (base-gcc (make-gcc-rpath-link base-gcc)))
   "Convenience wrapper around MAKE-CROSS-TOOLCHAIN with default values
@@ -647,7 +647,9 @@ inspecting signatures in Mach-O binaries.")
                  osslsigncode))
           ((string-contains target "-linux-")
            (list (cond ((string-contains target "riscv64-")
-                        (make-bitcoin-cross-toolchain target #:base-libc glibc-2.27/bitcoin-patched))
+                        (make-bitcoin-cross-toolchain target
+                                                      #:base-libc glibc-2.27/bitcoin-patched
+                                                      #:base-kernel-headers linux-libre-headers-4.19))
                        (else
                         (make-bitcoin-cross-toolchain target)))))
           ((string-contains target "darwin")


### PR DESCRIPTION
```
- Use 4.19 for riscv64 (earliest LTS release w/ riscv64 support)
- Use 4.9 for all others (second-oldest LTS release, released in
  combination with glibc glibc 2.24 in Debian stretch)
```

```
The chosen commit is the HEAD of Guix's version-1.3.0 branch as of July
15th, 2021.

Also fix visual indenting.
```

-----

This + the documentation PR should make our Guix system ready for release!