### PR TITLE
addrman: reset I2P ports in all "new" buckets

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -746,7 +746,7 @@ void CAddrMan::ResetI2PPorts()
                 return;
             }
             auto& addr_info = it->second;
-            if (!addr_info.IsI2P() || addr_info.GetPort() == I2P_SAM31_PORT) {
+            if (!addr_info.IsI2P()) {
                 continue;
             }
 


### PR DESCRIPTION
In `CAddrMan::ResetI2PPorts()`, if an I2P address is found in two or
more "new" buckets, our first encounter of it would change the port to
0 and re-position it within that "new" bucket. The `CAddrInfo` object is
shared between all occurrences of an address in all "new" buckets. So
subsequent encounters of that address will see the `CAddrInfo` already
with port 0 and will skip re-positioning.

To fix that, check and re-position if necessary even for I2P entries
with port 0.

Fixes https://github.com/bitcoin/bitcoin/issues/22470

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
