### PR TITLE
p2p, doc: log DEBUG_ADDRMAN consistency checks, add developer notes info

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -16,6 +16,7 @@ Developer Notes
         - [`debug.log`](#debuglog)
         - [Signet, testnet, and regtest modes](#signet-testnet-and-regtest-modes)
         - [DEBUG_LOCKORDER](#debug_lockorder)
+        - [DEBUG_ADDRMAN](#debug_addrman)
         - [Valgrind suppressions file](#valgrind-suppressions-file)
         - [Compiling for test coverage](#compiling-for-test-coverage)
         - [Performance profiling with perf](#performance-profiling-with-perf)
@@ -281,6 +282,21 @@ multi-threading bugs can be very difficult to track down. The `--enable-debug`
 configure option adds `-DDEBUG_LOCKORDER` to the compiler flags. This inserts
 run-time checks to keep track of which locks are held and adds warnings to the
 `debug.log` file if inconsistencies are detected.
+
+### DEBUG_ADDRMAN
+
+Defining `DEBUG_ADDRMAN` performs frequent (and expensive) consistency checks on
+the entire addrman data structure. To enable it, either run configure with
+`-DDEBUG_ADDRMAN` added to your CPPFLAGS, e.g. `CPPFLAGS="-DDEBUG_ADDRMAN"`, or
+add this line in `src/addrman.h` before `void Check()`
+
+```cpp
+#define DEBUG_ADDRMAN
+```
+
+and then in both cases build and run bitcoind. You can use the `-debug=addrman`
+configuration option or `bitcoin-cli logging '["addrman"]'` to see the
+consistency checks in the debug log.
 
 ### Assertions and Checks
 

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -732,6 +732,7 @@ private:
     {
 #ifdef DEBUG_ADDRMAN
         AssertLockHeld(cs);
+        LogPrint(BCLog::ADDRMAN, "Check addrman\n");
         const int err = Check_();
         if (err) {
             LogPrintf("ADDRMAN CONSISTENCY CHECK FAILED!!! err=%i\n", err);


### PR DESCRIPTION
Provide logging and info to help people
- use the `DEBUG_ADDRMAN` consistency checks
- verify the checks are running
- see when and how often they are being performed