### PR TITLE
build: fix -Wreturn-type compiler warnings (Win64)

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -710,6 +710,8 @@ unsigned int CBlockPolicyEstimator::HighestTargetTracked(FeeEstimateHorizon hori
     }
     } // no default case, so the compiler can warn about missing cases
     assert(false);
+
+    return 0; // -Wreturn-type
 }
 
 unsigned int CBlockPolicyEstimator::BlockSpan() const

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -667,6 +667,8 @@ QString NetworkToQString(Network net)
     case NET_MAX: assert(false);
     } // no default case, so the compiler can warn about missing cases
     assert(false);
+
+    return ""; // -Wreturn-type
 }
 
 QString ConnectionTypeToQString(ConnectionType conn_type, bool prepend_direction)

--- a/src/qt/peertablesortproxy.cpp
+++ b/src/qt/peertablesortproxy.cpp
@@ -40,4 +40,6 @@ bool PeerTableSortProxy::lessThan(const QModelIndex& left_index, const QModelInd
         return left_stats.cleanSubVer.compare(right_stats.cleanSubVer) < 0;
     } // no default case, so the compiler can warn about missing cases
     assert(false);
+
+    return false;
 }

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -322,6 +322,8 @@ static bool SignStep(const SigningProvider& provider, const BaseSignatureCreator
         return SignTaproot(provider, creator, WitnessV1Taproot(XOnlyPubKey{vSolutions[0]}), sigdata, ret);
     } // no default case, so the compiler can warn about missing cases
     assert(false);
+
+    return false;
 }
 
 static CScript PushAll(const std::vector<valtype>& values)

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -264,6 +264,8 @@ bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
         return false;
     } // no default case, so the compiler can warn about missing cases
     assert(false);
+
+    return false;
 }
 
 // TODO: from v23 ("addresses" and "reqSigs" deprecated) "ExtractDestinations" should be removed


### PR DESCRIPTION
This should silence the Win64 warnings (example https://cirrus-ci.com/task/5328746770071552?logs=ci#L3750) that don't consider `assert(false)` as an end of control flow:

```bash
script/sign.cpp: In function ‘bool SignStep(const SigningProvider&, const BaseSignatureCreator&, const CScript&, std::vector<std::vector<unsigned char> >&, TxoutType&, SigVersion, SignatureData&)’:
script/sign.cpp:247:13: warning: control reaches end of non-void function [-Wreturn-type]
```

```bash
script/standard.cpp: In function ‘bool ExtractDestination(const CScript&, CTxDestination&)’:
script/standard.cpp:215:26: warning: control reaches end of non-void function [-Wreturn-type]
```

```bash
policy/fees.cpp: In member function ‘unsigned int CBlockPolicyEstimator::HighestTargetTracked(FeeEstimateHorizon) const’:
./sync.h:232:104: warning: control reaches end of non-void function [-Wreturn-type]
```

```bash
qt/guiutil.cpp: In function ‘QString GUIUtil::ConnectionTypeToQString(ConnectionType, bool)’:
qt/guiutil.cpp:674:13: warning: control reaches end of non-void function [-Wreturn-type]
```

```bash
qt/peertablesortproxy.cpp: In member function ‘virtual bool PeerTableSortProxy::lessThan(const QModelIndex&, const QModelIndex&) const’:
qt/peertablesortproxy.cpp:21:132: warning: control reaches end of non-void function [-Wreturn-type]
```


Added a comment in the small functions where it seemed helpful.
