### PR TITLE
doc: BaseIndex sync behavior with empty datadir

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -69,6 +69,10 @@ bool BaseIndex::Init()
     } else {
         SetBestBlockIndex(m_chainstate->FindForkInGlobalIndex(locator));
     }
+
+    // Note: this will latch to true immediately if the user starts up with an empty
+    // datadir and an index enabled. If this is the case, indexation will happen solely
+    // via `BlockConnected` signals until, possibly, the next restart.
     m_synced = m_best_block_index.load() == active_chain.Tip();
     if (!m_synced) {
         bool prune_violation = false;

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -51,6 +51,10 @@ private:
     /// Whether the index is in sync with the main chain. The flag is flipped
     /// from false to true once, after which point this starts processing
     /// ValidationInterface notifications to stay in sync.
+    ///
+    /// Note that this will latch to true *immediately* upon startup if
+    /// `m_chainstate->m_chain` is empty, which will be the case upon startup
+    /// with an empty datadir if, e.g., `-txindex=1` is specified.
     std::atomic<bool> m_synced{false};
 
     /// The last block in the chain that the index is in sync with.


### PR DESCRIPTION
Make a note about a potentially confusing behavior with `BaseIndex::m_synced`;
if the user starts bitcoind with an empty datadir and an index enabled,
BaseIndex will consider itself synced (as a degenerate case). This affects
how indices are built during IBD (relying solely on BlockConnected signals vs.
using ThreadSync()).