### PR TITLE
build, qt: Fix cross-compiling detection on M1-based macOS (aarch64)

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -87,14 +87,6 @@ For linux S390X cross compilation:
 
     sudo apt-get install g++-s390x-linux-gnu binutils-s390x-linux-gnu
 
-### Install the required dependencies: M1-based macOS
-
-To be able to build the `qt` package, ensure that Rosetta 2 is installed:
-
-```
-softwareupdate --install-rosetta
-```
-
 ### Dependency Options
 
 The following can be set when running make: `make FOO=bar`

--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -10,8 +10,15 @@ build_darwin_SHA256SUM=shasum -a 256
 build_darwin_DOWNLOAD=curl --location --fail --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -o
 
 #darwin host on darwin builder. overrides darwin host preferences.
+ifneq ($(host_arch),$(build_arch))
+x86_64_darwin_CC=$(shell xcrun -f clang) -arch x86_64 -mmacosx-version-min=$(OSX_MIN_VERSION) -isysroot$(shell xcrun --show-sdk-path)
+x86_64_darwin_CXX:=$(shell xcrun -f clang++) -arch x86_64 -mmacosx-version-min=$(OSX_MIN_VERSION) -stdlib=libc++ -isysroot$(shell xcrun --show-sdk-path)
+aarch64_darwin_CC=$(shell xcrun -f clang) -arch arm64 -mmacosx-version-min=$(OSX_MIN_VERSION) -isysroot$(shell xcrun --show-sdk-path)
+aarch64_darwin_CXX:=$(shell xcrun -f clang++) -arch arm64 -mmacosx-version-min=$(OSX_MIN_VERSION) -stdlib=libc++ -isysroot$(shell xcrun --show-sdk-path)
+else
 darwin_CC=$(shell xcrun -f clang) -mmacosx-version-min=$(OSX_MIN_VERSION) -isysroot$(shell xcrun --show-sdk-path)
 darwin_CXX:=$(shell xcrun -f clang++) -mmacosx-version-min=$(OSX_MIN_VERSION) -stdlib=libc++ -isysroot$(shell xcrun --show-sdk-path)
+endif
 darwin_AR:=$(shell xcrun -f ar)
 darwin_RANLIB:=$(shell xcrun -f ranlib)
 darwin_STRIP:=$(shell xcrun -f strip)

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -13,6 +13,7 @@ $(package)_patches += support_new_android_ndks.patch fix_android_jni_static.patc
 $(package)_patches+= no_sdk_version_check.patch
 $(package)_patches+= fix_lib_paths.patch fix_android_pch.patch
 $(package)_patches+= qtbase-moc-ignore-gcc-macro.patch fix_limits_header.patch
+$(package)_patches += fix_darwin_archs.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=577b0668a777eb2b451c61e8d026d79285371597ce9df06b6dee6c814164b7c3
@@ -129,11 +130,10 @@ else
 ifneq ($(host_arch),$(build_arch))
 $(package)_cc = $(build_darwin_CC)
 $(package)_cxx = $(build_darwin_CXX)
-endif
-endif
-
-# for macOS on Apple Silicon (ARM) see https://bugreports.qt.io/browse/QTBUG-85279
+$(package)_config_opts_x86_64_darwin += -device-option QMAKE_APPLE_DEVICE_ARCHS=x86_64
 $(package)_config_opts_aarch64_darwin += -device-option QMAKE_APPLE_DEVICE_ARCHS=arm64
+endif
+endif
 
 $(package)_config_opts_linux = -qt-xcb
 $(package)_config_opts_linux += -no-xcb-xlib
@@ -237,6 +237,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/fix_lib_paths.patch && \
   patch -p1 -i $($(package)_patch_dir)/qtbase-moc-ignore-gcc-macro.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_limits_header.patch && \
+  patch -p1 -i $($(package)_patch_dir)/fix_darwin_archs.patch && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f $($(package)_patch_dir)/mac-qmake.conf qtbase/mkspecs/macx-clang-linux/qmake.conf && \

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -125,6 +125,11 @@ $(package)_config_opts_darwin += -device-option MAC_SDK_VERSION=$(OSX_SDK_VERSIO
 $(package)_config_opts_darwin += -device-option CROSS_COMPILE="$(host)-"
 $(package)_config_opts_darwin += -device-option MAC_TARGET=$(host)
 $(package)_config_opts_darwin += -device-option XCODE_VERSION=$(XCODE_VERSION)
+else
+ifneq ($(host_arch),$(build_arch))
+$(package)_cc = $(build_darwin_CC)
+$(package)_cxx = $(build_darwin_CXX)
+endif
 endif
 
 # for macOS on Apple Silicon (ARM) see https://bugreports.qt.io/browse/QTBUG-85279

--- a/depends/patches/qt/fix_darwin_archs.patch
+++ b/depends/patches/qt/fix_darwin_archs.patch
@@ -1,0 +1,16 @@
+To cross compile for the x86_64-darwin host on aarch64-darwin,
+passing QMAKE_APPLE_DEVICE_ARCHS=arm64 to the configure script
+does not work for some reasons.
+This is a simpliest workaround for this issue.
+
+--- old/qtbase/mkspecs/common/macx.conf
++++ new/qtbase/mkspecs/common/macx.conf
+@@ -6,7 +6,7 @@
+ QMAKE_MAC_SDK           = macosx
+ 
+ QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.12
+-QMAKE_APPLE_DEVICE_ARCHS = x86_64
++QMAKE_APPLE_DEVICE_ARCHS = $$system("uname -m")
+ 
+ QT_MAC_SDK_VERSION_MIN = 10.13
+ QT_MAC_SDK_VERSION_MAX = 11.0


### PR DESCRIPTION
#20641 made building of the `qt` package in depends more structured, and, particularly, fixed cross-compiling detection on Intel-based macOS (x86_64).

However, a similar issue still present on M1-based macOS (arm64):

```
% make -C depends qt_configured
...
Configure summary:

Building on: macx-clang (x86_64, CPU features: cx16 mmx sse sse2 sse3 ssse3 sse4.1)
Building for: macx-clang (arm64, CPU features: neon crc32)
Target compiler: clang (Apple) 12.0.5
Configuration: cross_compile largefile neon precompile_header silent release c++11 c++14 c++1z reduce_exports static stl
...
```

Note an unexpected `cross_compile`.

```
% make -C depends qt_configured HOST=x86_64-apple-darwin18
...
Configure summary:

Build type: macx-clang (x86_64, CPU features: cx16 mmx sse sse2 sse3 ssse3 sse4.1)
Compiler: clang (Apple) 12.0.5
Configuration: sse2 aesni sse3 ssse3 sse4_1 sse4_2 avx avx2 avx512f avx512bw avx512cd avx512dq avx512er avx512ifma avx512pf avx512vbmi avx512vl f16c largefile precompile_header rdrnd shani silent x86SimdAlways release c++11 c++14 c++1z reduce_exports static stl
...
```

Note that the build system failed to detect cross compiling.

In both cases building the configured `qt` package fails without installed Rosetta 2 (see #22402).

This PR:
- fixes both cases above
- makes #22402 no longer required, and reverts it
- does not change the build system behavior on Intel-based macOS (x86_64)
- does not touch the code for cross-compiling on Linux builder, see a dedicated #21851

With this PR:
```
% make -j 9 -C depends qt_configured
...
Configure summary:

Build type: macx-clang (arm64, CPU features: neon crc32)
Compiler: clang (Apple) 12.0.5
Configuration: largefile neon precompile_header silent release c++11 c++14 c++1z reduce_exports static stl
...
```

```
% make -j 9 -C depends qt_configured HOST=x86_64-apple-darwin18
...
Configure summary:

Building on: macx-clang (arm64, CPU features: neon crc32)
Building for: macx-clang (x86_64, CPU features: cx16 mmx sse sse2 sse3 ssse3 sse4.1)
Target compiler: clang (Apple) 12.0.5
Configuration: cross_compile sse2 aesni sse3 ssse3 sse4_1 sse4_2 avx avx2 avx512f avx512bw avx512cd avx512dq avx512er avx512ifma avx512pf avx512vbmi avx512vl f16c largefile precompile_header rdrnd shani silent x86SimdAlways release c++11 c++14 c++1z reduce_exports static stl
...
```

This PR is based on #22506.