### PR TITLE
Check that CAddrMan::nKey is not null after deserialize

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -334,6 +334,9 @@ public:
         }
 
         s >> nKey;
+        if (nKey.IsNull()) {
+            throw std::ios_base::failure("Corrupt CAddrMan serialization, nKey is all zeros.");
+        }
         s >> nNew;
         s >> nTried;
         int nUBuckets = 0;


### PR DESCRIPTION
Otherwise `CAddrMan::_Check()` will complain.

An alternative would be to remove the check from `CAddrMan::_Check()`.