### PR TITLE
Assert in CAddrMan::Check()

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -492,12 +492,12 @@ void CAddrMan::Check()
 
     for (int n = 0; n < ADDRMAN_TRIED_BUCKET_COUNT; n++) {
         for (int i = 0; i < ADDRMAN_BUCKET_SIZE; i++) {
-             if (vvTried[n][i] != -1) {
+            if (vvTried[n][i] != -1) {
                 assert(setTried.count(vvTried[n][i]));
                 assert(mapInfo[vvTried[n][i]].GetTriedBucket(nKey, m_asmap) == n);
                 assert(mapInfo[vvTried[n][i]].GetBucketPosition(nKey, false, n) == i);
                 setTried.erase(vvTried[n][i]);
-             }
+            }
         }
     }
 

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -722,21 +722,7 @@ private:
 
     //! Consistency check
     void Check()
-        EXCLUSIVE_LOCKS_REQUIRED(cs)
-    {
-#ifdef DEBUG_ADDRMAN
-        AssertLockHeld(cs);
-        const int err = Check_();
-        if (err) {
-            LogPrintf("ADDRMAN CONSISTENCY CHECK FAILED!!! err=%i\n", err);
-        }
-#endif
-    }
-
-#ifdef DEBUG_ADDRMAN
-    //! Perform consistency check. Returns an error code or zero.
-    int Check_() EXCLUSIVE_LOCKS_REQUIRED(cs);
-#endif
+        EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /**
      * Return all or many randomly selected addresses, optionally by network.


### PR DESCRIPTION
Just writing to a log will be easily missed.

The same is done in CTxMemPool::check() and other debug checks for
developers, like lock order debugging.

Can be reviewed with https://en.wikipedia.org/wiki/De_Morgan%27s_laws and
`git difftool --tool=meld cccc47b0ef~ cccc47b0ef`