### PR TITLE
netinfo: display addr_{processed, rate_limited, relay_enabled} and relaytxes data

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -532,10 +532,10 @@ public:
                     peer.network,
                     PingTimeToString(peer.min_ping),
                     PingTimeToString(peer.ping),
-                    peer.last_send == 0 ? "" : ToString(m_time_now - peer.last_send),
-                    peer.last_recv == 0 ? "" : ToString(m_time_now - peer.last_recv),
-                    peer.last_trxn == 0 ? "" : ToString((m_time_now - peer.last_trxn) / 60),
-                    peer.last_blck == 0 ? "" : ToString((m_time_now - peer.last_blck) / 60),
+                    peer.last_send ? ToString(m_time_now - peer.last_send) : "",
+                    peer.last_recv ? ToString(m_time_now - peer.last_recv) : "",
+                    peer.last_trxn ? ToString((m_time_now - peer.last_trxn) / 60) : "",
+                    peer.last_blck ? ToString((m_time_now - peer.last_blck) / 60) : "",
                     strprintf("%s%s", peer.is_bip152_hb_to ? "." : " ", peer.is_bip152_hb_from ? "*" : " "),
                     m_max_addr_processed_length, // variable spacing
                     peer.addr_processed ? ToString(peer.addr_processed) : "",
@@ -544,7 +544,7 @@ public:
                     m_max_age_length, // variable spacing
                     peer.age,
                     m_is_asmap_on ? 7 : 0, // variable spacing
-                    m_is_asmap_on && peer.mapped_as != 0 ? ToString(peer.mapped_as) : "",
+                    m_is_asmap_on && peer.mapped_as ? ToString(peer.mapped_as) : "",
                     m_max_id_length, // variable spacing
                     peer.id,
                     IsAddressSelected() ? m_max_addr_length : 0, // variable spacing

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -534,7 +534,7 @@ public:
                     PingTimeToString(peer.ping),
                     peer.last_send ? ToString(m_time_now - peer.last_send) : "",
                     peer.last_recv ? ToString(m_time_now - peer.last_recv) : "",
-                    peer.last_trxn ? ToString((m_time_now - peer.last_trxn) / 60) : "",
+                    peer.last_trxn ? ToString((m_time_now - peer.last_trxn) / 60) : peer.is_block_relay ? "*" : "",
                     peer.last_blck ? ToString((m_time_now - peer.last_blck) / 60) : "",
                     strprintf("%s%s", peer.is_bip152_hb_to ? "." : " ", peer.is_bip152_hb_from ? "*" : " "),
                     m_max_addr_processed_length, // variable spacing
@@ -625,6 +625,7 @@ public:
         "  send     Time since last message sent to the peer, in seconds\n"
         "  recv     Time since last message received from the peer, in seconds\n"
         "  txn      Time since last novel transaction received from the peer and accepted into our mempool, in minutes\n"
+        "           \"*\" - the peer requested we not relay transactions to it (relaytxes is false)\n"
         "  blk      Time since last novel block passing initial validity checks received from the peer, in minutes\n"
         "  hb       High-bandwidth BIP152 compact block relay\n"
         "           \".\" (to)   - we selected the peer as a high-bandwidth peer\n"

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -407,6 +407,7 @@ private:
         int id;
         int mapped_as;
         int version;
+        bool is_addr_relay_enabled;
         bool is_bip152_hb_from;
         bool is_bip152_hb_to;
         bool is_block_relay;
@@ -499,9 +500,10 @@ public:
                 const std::string addr{peer["addr"].get_str()};
                 const std::string age{conn_time == 0 ? "" : ToString((m_time_now - conn_time) / 60)};
                 const std::string sub_version{peer["subver"].get_str()};
+                const bool is_addr_relay_enabled{peer["addr_relay_enabled"].isNull() ? false : peer["addr_relay_enabled"].get_bool()};
                 const bool is_bip152_hb_from{peer["bip152_hb_from"].get_bool()};
                 const bool is_bip152_hb_to{peer["bip152_hb_to"].get_bool()};
-                m_peers.push_back({addr, sub_version, conn_type, network, age, min_ping, ping, addr_processed, addr_rate_limited, last_blck, last_recv, last_send, last_trxn, peer_id, mapped_as, version, is_bip152_hb_from, is_bip152_hb_to, is_block_relay, is_outbound});
+                m_peers.push_back({addr, sub_version, conn_type, network, age, min_ping, ping, addr_processed, addr_rate_limited, last_blck, last_recv, last_send, last_trxn, peer_id, mapped_as, version, is_addr_relay_enabled, is_bip152_hb_from, is_bip152_hb_to, is_block_relay, is_outbound});
                 m_max_addr_length = std::max(addr.length() + 1, m_max_addr_length);
                 m_max_addr_processed_length = std::max(ToString(addr_processed).length(), m_max_addr_processed_length);
                 m_max_addr_rate_limited_length = std::max(ToString(addr_rate_limited).length(), m_max_addr_rate_limited_length);
@@ -538,7 +540,7 @@ public:
                     peer.last_blck ? ToString((m_time_now - peer.last_blck) / 60) : "",
                     strprintf("%s%s", peer.is_bip152_hb_to ? "." : " ", peer.is_bip152_hb_from ? "*" : " "),
                     m_max_addr_processed_length, // variable spacing
-                    peer.addr_processed ? ToString(peer.addr_processed) : "",
+                    peer.addr_processed ? ToString(peer.addr_processed) : peer.is_addr_relay_enabled ? "" : ".",
                     m_max_addr_rate_limited_length, // variable spacing
                     peer.addr_rate_limited ? ToString(peer.addr_rate_limited) : "",
                     m_max_age_length, // variable spacing
@@ -631,6 +633,7 @@ public:
         "           \".\" (to)   - we selected the peer as a high-bandwidth peer\n"
         "           \"*\" (from) - the peer selected us as a high-bandwidth peer\n"
         "  addrp    Total number of addresses processed, excluding those dropped due to rate limiting\n"
+        "           \".\" - we do not relay addresses to this peer (addr_relay_enabled is false)\n"
         "  addrl    Total number of addresses dropped due to rate limiting\n"
         "  age      Duration of connection to the peer, in minutes\n"
         "  asmap    Mapped AS (Autonomous System) number in the BGP route to the peer, used for diversifying\n"


### PR DESCRIPTION
Update CLI -netinfo to display the getpeerinfo `addr_processed`, `addr_rate_limited`, `addr_relay_enabled` and `relaytxes` data with auto-adjusting column widths.

```
$ ./src/bitcoin-cli -netinfo help

  txn      Time since last novel transaction received from the peer and accepted into our mempool, in minutes
           "*" - the peer requested we not relay transactions to it (relaytxes is false)

  addrp    Total number of addresses processed, excluding those dropped due to rate limiting
           "." - we do not relay addresses to this peer (addr_relay_enabled is false)

  addrl    Total number of addresses dropped due to rate limiting
```

![Screenshot from 2021-08-22 14-31-40](https://user-images.githubusercontent.com/2415484/130355514-f6fd4f21-79d6-463b-9791-de01ebef20b1.png)
