### PR TITLE
scripted-diff: Revert "fuzz: Add Temporary debug assert for oss-fuzz issue"

### DIFF
--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -58,19 +58,7 @@ void initialize_process_message()
 
     static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
     g_setup = testing_setup.get();
-
-    // Temporary debug for https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=35027
-    {
-        LOCK(::cs_main);
-        assert(CheckDiskSpace(gArgs.GetDataDirNet()));
-        assert(CheckDiskSpace(gArgs.GetDataDirNet(), 48 * 2 * 2 * g_setup->m_node.chainman->ActiveChainstate().CoinsTip().GetCacheSize()));
-    }
     for (int i = 0; i < 2 * COINBASE_MATURITY; i++) {
-        {
-            LOCK(::cs_main);
-            assert(CheckDiskSpace(gArgs.GetDataDirNet()));
-            assert(CheckDiskSpace(gArgs.GetDataDirNet(), 48 * 2 * 2 * g_setup->m_node.chainman->ActiveChainstate().CoinsTip().GetCacheSize()));
-        }
         MineBlock(g_setup->m_node, CScript() << OP_TRUE);
     }
     SyncWithValidationInterfaceQueue();


### PR DESCRIPTION
No longer needed, as it wouldn't help to debug this issue. See https://github.com/bitcoin/bitcoin/pull/22472#issuecomment-882692900