### PR TITLE
addrman: Remove unused test_before_evict argument from Good()

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -536,12 +536,12 @@ public:
     }
 
     //! Mark an entry as accessible.
-    void Good(const CService &addr, bool test_before_evict = true, int64_t nTime = GetAdjustedTime())
+    void Good(const CService &addr, int64_t nTime = GetAdjustedTime())
         EXCLUSIVE_LOCKS_REQUIRED(!cs)
     {
         LOCK(cs);
         Check();
-        Good_(addr, test_before_evict, nTime);
+        Good_(addr, /* test_before_evict */ true, nTime);
         Check();
     }
 

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -76,7 +76,7 @@ public:
     {
          int64_t nLastSuccess = 1;
          // Set last good connection in the deep past.
-         Good(addr, true, nLastSuccess);
+         Good(addr, nLastSuccess);
 
          bool count_failure = false;
          int64_t nLastTry = GetAdjustedTime()-61;

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -80,7 +80,7 @@ FUZZ_TARGET_INIT(addrman, initialize_addrman)
             [&] {
                 const std::optional<CService> opt_service = ConsumeDeserializable<CService>(fuzzed_data_provider);
                 if (opt_service) {
-                    addr_man.Good(*opt_service, fuzzed_data_provider.ConsumeBool(), ConsumeTime(fuzzed_data_provider));
+                    addr_man.Good(*opt_service, ConsumeTime(fuzzed_data_provider));
                 }
             },
             [&] {


### PR DESCRIPTION
This has never been used in the public interface method since it was
introduced in #9037.