### PR TITLE
build: Support x86_64 <-> arm64 cross-compiling for macOS

### DIFF
--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -10,8 +10,8 @@ build_darwin_SHA256SUM=shasum -a 256
 build_darwin_DOWNLOAD=curl --location --fail --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -o
 
 #darwin host on darwin builder. overrides darwin host preferences.
-darwin_CC=$(shell xcrun -f clang) -mmacosx-version-min=$(OSX_MIN_VERSION) -isysroot$(shell xcrun --show-sdk-path)
-darwin_CXX:=$(shell xcrun -f clang++) -mmacosx-version-min=$(OSX_MIN_VERSION) -stdlib=libc++ -isysroot$(shell xcrun --show-sdk-path)
+darwin_CC := $(build_darwin_CC) -mmacosx-version-min=$(OSX_MIN_VERSION)
+darwin_CXX := $(build_darwin_CXX) -mmacosx-version-min=$(OSX_MIN_VERSION) -stdlib=libc++
 darwin_AR:=$(shell xcrun -f ar)
 darwin_RANLIB:=$(shell xcrun -f ranlib)
 darwin_STRIP:=$(shell xcrun -f strip)

--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -10,8 +10,10 @@ build_darwin_SHA256SUM=shasum -a 256
 build_darwin_DOWNLOAD=curl --location --fail --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -o
 
 #darwin host on darwin builder. overrides darwin host preferences.
-darwin_CC := $(build_darwin_CC) -mmacosx-version-min=$(OSX_MIN_VERSION)
-darwin_CXX := $(build_darwin_CXX) -mmacosx-version-min=$(OSX_MIN_VERSION) -stdlib=libc++
+x86_64_darwin_CC := $(build_darwin_CC) -arch x86_64 -mmacosx-version-min=$(OSX_MIN_VERSION)
+x86_64_darwin_CXX := $(build_darwin_CXX) -arch x86_64 -mmacosx-version-min=$(OSX_MIN_VERSION) -stdlib=libc++
+aarch64_darwin_CC := $(build_darwin_CC) -arch arm64 -mmacosx-version-min=$(OSX_MIN_VERSION)
+aarch64_darwin_CXX := $(build_darwin_CXX) -arch arm64 -mmacosx-version-min=$(OSX_MIN_VERSION) -stdlib=libc++
 darwin_AR:=$(shell xcrun -f ar)
 darwin_RANLIB:=$(shell xcrun -f ranlib)
 darwin_STRIP:=$(shell xcrun -f strip)

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -24,6 +24,22 @@ $(package)_qttools_sha256_hash=98b2aaca230458f65996f3534fd471d2ffd038dd58ac997c0
 $(package)_extra_sources  = $($(package)_qttranslations_file_name)
 $(package)_extra_sources += $($(package)_qttools_file_name)
 
+# Qt has its own deeply integrated build system which during cross compiling builds some tools,
+# including qmake, for a build platform (internally, such tools depend on the `host_build`
+# variable). For a host platform qmake constructs tool invocations based on the provided mkspec.
+# That is why we should provide Qt with build tools rather host ones, as we do for native packages.
+# Otherwise, a compiler targeted, for instance, for a host with the arm64 architecture builds
+# the qmake tool, which in turn will fail to run on a build platform with the x86_64 architecture.
+ifneq ($(build),$(host))
+ifneq ($(build_os),darwin)
+$(package)_cc := $(clang_prog)
+$(package)_cxx := $(clangxx_prog)
+else
+$(package)_cc := $(build_CC)
+$(package)_cxx := $(build_CXX)
+endif
+endif
+
 define $(package)_set_vars
 $(package)_config_opts_release = -release
 $(package)_config_opts_release += -silent


### PR DESCRIPTION
Currently, on master (681b25e3cd7d084f642693152322ed9a40f33ba0), dependencies are built for the build system architecture, not the provided host.

On Intel-based macOS Big Sur 11.6.1 (20G224):
```
% make -C depends HOST=arm64-apple-darwin20
% lipo -info depends/arm64-apple-darwin20/lib/libsqlite3.a 
Non-fat file: depends/arm64-apple-darwin20/lib/libsqlite3.a is architecture: x86_64
```

On M1-based macOS Monterey 12.0.1 (21A559) the `boost` package building fails with multiple errors like that:
```
% make -C depends boost HOST=x86_64-apple-darwin19
...
error: option 'cf-protection=return' cannot be specified on this target
error: option 'cf-protection=branch' cannot be specified on this target
2 errors generated.
```

This PR allows to cross-compile as follows:
- on Intel-based macOS Big Sur 11.6.1 (20G224):
```
% make -C depends HOST=arm64-apple-darwin20
% lipo -info depends/arm64-apple-darwin20/lib/libsqlite3.a 
Non-fat file: depends/arm64-apple-darwin20/lib/libsqlite3.a is architecture: arm64
% CONFIG_SITE=$PWD/depends/arm64-apple-darwin20/share/config.site ./configure
% make
% lipo -info src/qt/bitcoin-qt 
Non-fat file: src/qt/bitcoin-qt is architecture: arm64
```

- on M1-based macOS Monterey 12.0.1 (21A559):
```
% make -C depends HOST=x86_64-apple-darwin19
% CONFIG_SITE=$PWD/depends/x86_64-apple-darwin19/share/config.site ./configure
% make
% lipo -info src/qt/bitcoin-qt
Non-fat file: src/qt/bitcoin-qt is architecture: x86_64
```

No behavior change for other builder-host pairs.