### PR TITLE
docs: Update the explainer text for the listunspent RPC

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2882,7 +2882,7 @@ static RPCHelpMan listunspent()
                             {RPCResult::Type::NUM, "confirmations", "The number of confirmations"},
                             {RPCResult::Type::STR_HEX, "redeemScript", "The redeemScript if scriptPubKey is P2SH"},
                             {RPCResult::Type::STR, "witnessScript", "witnessScript if the scriptPubKey is P2WSH or P2SH-P2WSH"},
-                            {RPCResult::Type::BOOL, "spendable", "Whether we have the private keys to spend this output"},
+                            {RPCResult::Type::BOOL, "spendable", "Whether we have the private keys to spend this output. Native descriptor wallets will always return true regardless of the wallet having private keys for the output."},
                             {RPCResult::Type::BOOL, "solvable", "Whether we know how to spend this output, ignoring the lack of keys"},
                             {RPCResult::Type::BOOL, "reused", "(only present if avoid_reuse is set) Whether this output is reused/dirty (sent to an address that was previously spent from)"},
                             {RPCResult::Type::STR, "desc", "(only when solvable) A descriptor for spending this output"},


### PR DESCRIPTION
Users may find it confusing to see that their utxo is labelled as `spendable` when they know for certain their wallet does not hold private keys.

This is a minor documentation fix for `bitcoin-cli listunspent` to clarify that native descriptor wallets always consider utxos to be `spendable`.

Fixes #22518.