### PR TITLE
build: use newer config.guess & config.sub in depends

### DIFF
--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -221,10 +221,10 @@ EOF
 # The packaged config.guess and config.sub are ancient (2009) and can cause build issues.
 # Replace them with modern versions.
 # See https://github.com/bitcoin/bitcoin/issues/16064
-CONFIG_GUESS_URL='https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=55eaf3e779455c4e5cc9f82efb5278be8f8f900b'
-CONFIG_GUESS_HASH='2d1ff7bca773d2ec3c6217118129220fa72d8adda67c7d2bf79994b3129232c1'
-CONFIG_SUB_URL='https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=55eaf3e779455c4e5cc9f82efb5278be8f8f900b'
-CONFIG_SUB_HASH='3a4befde9bcdf0fdb2763fc1bfa74e8696df94e1ad7aac8042d133c8ff1d2e32'
+CONFIG_GUESS_URL='https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=4550d2f15b3a7ce2451c1f29500b9339430c877f'
+CONFIG_GUESS_HASH='c8f530e01840719871748a8071113435bdfdf75b74c57e78e47898edea8754ae'
+CONFIG_SUB_URL='https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=4550d2f15b3a7ce2451c1f29500b9339430c877f'
+CONFIG_SUB_HASH='3969f7d5f6967ccc6f792401b8ef3916a1d1b1d0f0de5a4e354c95addb8b800e'
 
 rm -f "dist/config.guess"
 rm -f "dist/config.sub"

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -16,6 +16,10 @@ define $(package)_set_vars
   $(package)_cppflags_mingw32=-D_WIN32_WINNT=0x0601
 endef
 
+define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub build-aux
+endef
+
 define $(package)_config_cmds
   $($(package)_autoconf)
 endef

--- a/depends/packages/native_cctools.mk
+++ b/depends/packages/native_cctools.mk
@@ -16,6 +16,10 @@ define $(package)_set_vars
   $(package)_cxx=$(clangxx_prog)
 endef
 
+define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub cctools
+endef
+
 define $(package)_config_cmds
   $($(package)_autoconf)
 endef

--- a/depends/packages/sqlite.mk
+++ b/depends/packages/sqlite.mk
@@ -9,6 +9,10 @@ $(package)_config_opts=--disable-shared --disable-readline --disable-dynamic-ext
 $(package)_config_opts_linux=--with-pic
 endef
 
+define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub .
+endef
+
 define $(package)_config_cmds
   $($(package)_autoconf)
 endef


### PR DESCRIPTION
Hebasto asked for these to be split out of #21851. Using the newer config.guess and config.sub is needed when wanting to cross-compile for newer targets, like `arm64-apple-darwin`. I did Guix builds for 5985f098eaa3f9eff0b2fd580a0ef51e8aebc4e0, and then added another commit for `install_db4.sh`, to use a smilar version to what we have in depends, although that isn't used in Guix.

Guix builds for 5985f098eaa3f9eff0b2fd580a0ef51e8aebc4e0:
```bash
5b1d280764cacefba42e8002cb6cdcdd353b4cd6f5b84f60505eca6a3814ea29  guix-build-5985f098eaa3/output/aarch64-linux-gnu/SHA256SUMS.part
a4bfcfc91cc7acaa7d1eb039c9715f930faef0def819eaf476a69976dc86f8c9  guix-build-5985f098eaa3/output/aarch64-linux-gnu/bitcoin-5985f098eaa3-aarch64-linux-gnu-debug.tar.gz
e8175aa11b7f46af364e40015de497c4585eb7307375bb4c1a9d8e94cd992359  guix-build-5985f098eaa3/output/aarch64-linux-gnu/bitcoin-5985f098eaa3-aarch64-linux-gnu.tar.gz
2ec5d3d85979e7334c03761649655e1b384049d634be99d8e96e7d1e4dbca2e7  guix-build-5985f098eaa3/output/arm-linux-gnueabihf/SHA256SUMS.part
ccb73b187cc91b65bd1f74a63019162ef1186a69e1f9e7415847e4a50b9df35f  guix-build-5985f098eaa3/output/arm-linux-gnueabihf/bitcoin-5985f098eaa3-arm-linux-gnueabihf-debug.tar.gz
8d645022560b46f109c6de0c1a320eed2e348300274f3a5fcc78c911ec6e4338  guix-build-5985f098eaa3/output/arm-linux-gnueabihf/bitcoin-5985f098eaa3-arm-linux-gnueabihf.tar.gz
e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  guix-build-5985f098eaa3/output/dist-archive/SKIPATTEST.TAG
5189568f1db5539d955f762f0c15ff2a03f9551663239f3a25e2b9832b223081  guix-build-5985f098eaa3/output/dist-archive/bitcoin-5985f098eaa3.tar.gz
bd07c1ccb512501ed18498d2a7f7d3f9d370fdb624e34514a3acea7457d137e7  guix-build-5985f098eaa3/output/powerpc64-linux-gnu/SHA256SUMS.part
3f989fcb6dcccc82ebed9d316944ce2be2f75a4735a2cfb0d0298655f9491852  guix-build-5985f098eaa3/output/powerpc64-linux-gnu/bitcoin-5985f098eaa3-powerpc64-linux-gnu-debug.tar.gz
77badf255903a23cb60b8468c9c233da7253d866c47adc39e27c49a95640722f  guix-build-5985f098eaa3/output/powerpc64-linux-gnu/bitcoin-5985f098eaa3-powerpc64-linux-gnu.tar.gz
75d5481a909951055af8fb3812ec315d2aeaba6cc0d2310dde08b5cacfa27d75  guix-build-5985f098eaa3/output/powerpc64le-linux-gnu/SHA256SUMS.part
bfb090300af5acee297f139df4a9163fed3a5715cddb1fd3fdf99b4922790a62  guix-build-5985f098eaa3/output/powerpc64le-linux-gnu/bitcoin-5985f098eaa3-powerpc64le-linux-gnu-debug.tar.gz
d6e78a56cbb967840f881e630fe42d4add000dfb442e90120ca541a16caabb57  guix-build-5985f098eaa3/output/powerpc64le-linux-gnu/bitcoin-5985f098eaa3-powerpc64le-linux-gnu.tar.gz
ccfee2f4cb1134356cd607a9f7687bd4f5cf4e4e1121fd98a32c9c74aad19110  guix-build-5985f098eaa3/output/riscv64-linux-gnu/SHA256SUMS.part
3cc9eb93c1143e565a68f57633c1932c84638ff40f3286ef59c3dddde514e97b  guix-build-5985f098eaa3/output/riscv64-linux-gnu/bitcoin-5985f098eaa3-riscv64-linux-gnu-debug.tar.gz
7d6d9c68afc29f39e2dce74fcb36555638c99cce5168d1daecd97e598ce5ac50  guix-build-5985f098eaa3/output/riscv64-linux-gnu/bitcoin-5985f098eaa3-riscv64-linux-gnu.tar.gz
3d3437db545b0ab0111bf0f017c589b136a68f77d7525ed17597a0482493fe5d  guix-build-5985f098eaa3/output/x86_64-apple-darwin18/SHA256SUMS.part
0b51cf6a9338036a6f4505232a3b0eeb6265182261b588da8ed90ffc3bd702c7  guix-build-5985f098eaa3/output/x86_64-apple-darwin18/bitcoin-5985f098eaa3-osx-unsigned.dmg
2cb20c994777bc2e3747e8ed19209e98c614448f231c8906f4a99a93be9df5c9  guix-build-5985f098eaa3/output/x86_64-apple-darwin18/bitcoin-5985f098eaa3-osx-unsigned.tar.gz
85fa4e6de567d515b36bd81edc28743507878fefb64c3ca3bb4509f0f9ffab88  guix-build-5985f098eaa3/output/x86_64-apple-darwin18/bitcoin-5985f098eaa3-osx64.tar.gz
09ab1a4d1e8743fba66766b077ac3e0316a161e9aaf238de5d418a5d4ed0adde  guix-build-5985f098eaa3/output/x86_64-linux-gnu/SHA256SUMS.part
eb18a31f088188fdd54e82c9cdb96751d271f67b4beba29dfb0c1ce2964b0e5c  guix-build-5985f098eaa3/output/x86_64-linux-gnu/bitcoin-5985f098eaa3-x86_64-linux-gnu-debug.tar.gz
45b91caad1e09f80d43b0a577f210596214d08bdc795c4f9e191caa7c3f494b9  guix-build-5985f098eaa3/output/x86_64-linux-gnu/bitcoin-5985f098eaa3-x86_64-linux-gnu.tar.gz
96c8a07bd58d5fe3b38a797cca254999646d6af102d3bdf2495c71f1c641f798  guix-build-5985f098eaa3/output/x86_64-w64-mingw32/SHA256SUMS.part
fe79ba07cd834f842ffa4e11cbea91f026e9f2cda2d05dde565d0da6caad61dd  guix-build-5985f098eaa3/output/x86_64-w64-mingw32/bitcoin-5985f098eaa3-win-unsigned.tar.gz
22d6a2c7b66b6a3d1693235c9ee3b3a3686c3417164a40bc6d83eefda533eb93  guix-build-5985f098eaa3/output/x86_64-w64-mingw32/bitcoin-5985f098eaa3-win64-debug.zip
bdef5d3a7c6d9e180fbbb870ac210c26e53fcf73cced84297a0ee42339e3970f  guix-build-5985f098eaa3/output/x86_64-w64-mingw32/bitcoin-5985f098eaa3-win64-setup-unsigned.exe
af24796889ebd671003a1e139a07b440bc28c97ab19bdd5ae9bd3d6fbfa2095a  guix-build-5985f098eaa3/output/x86_64-w64-mingw32/bitcoin-5985f098eaa3-win64.zip
```