### PR TITLE
log: sort logging categories alphabetically

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -8,6 +8,8 @@
 #include <util/string.h>
 #include <util/time.h>
 
+#include <algorithm>
+#include <array>
 #include <mutex>
 
 const char * const DEFAULT_DEBUGLOGFILE = "debug.log";
@@ -179,8 +181,13 @@ bool GetLogCategory(BCLog::LogFlags& flag, const std::string& str)
 
 std::vector<LogCategory> BCLog::Logger::LogCategoriesList() const
 {
+    // Sort log categories by alphabetical order.
+    std::array<CLogCategoryDesc, std::size(LogCategories)> categories;
+    std::copy(std::begin(LogCategories), std::end(LogCategories), categories.begin());
+    std::sort(categories.begin(), categories.end(), [](auto a, auto b) { return a.category < b.category; });
+
     std::vector<LogCategory> ret;
-    for (const CLogCategoryDesc& category_desc : LogCategories) {
+    for (const CLogCategoryDesc& category_desc : categories) {
         // Omit the special cases.
         if (category_desc.flag != BCLog::NONE && category_desc.flag != BCLog::ALL) {
             LogCategory catActive;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -126,8 +126,7 @@ bool BCLog::Logger::DefaultShrinkDebugFile() const
     return m_categories == BCLog::NONE;
 }
 
-struct CLogCategoryDesc
-{
+struct CLogCategoryDesc {
     BCLog::LogFlags flag;
     std::string category;
 };
@@ -188,13 +187,11 @@ std::vector<LogCategory> BCLog::Logger::LogCategoriesList() const
 
     std::vector<LogCategory> ret;
     for (const CLogCategoryDesc& category_desc : categories) {
-        // Omit the special cases.
-        if (category_desc.flag != BCLog::NONE && category_desc.flag != BCLog::ALL) {
-            LogCategory catActive;
-            catActive.category = category_desc.category;
-            catActive.active = WillLogCategory(category_desc.flag);
-            ret.push_back(catActive);
-        }
+        if (category_desc.flag == BCLog::NONE || category_desc.flag == BCLog::ALL) continue;
+        LogCategory catActive;
+        catActive.category = category_desc.category;
+        catActive.active = WillLogCategory(category_desc.flag);
+        ret.push_back(catActive);
     }
     return ret;
 }
@@ -244,7 +241,7 @@ namespace BCLog {
         }
         return ret;
     }
-}
+} // namespace BCLog
 
 void BCLog::Logger::LogPrintStr(const std::string& str, const std::string& logging_function, const std::string& source_file, const int source_line)
 {

--- a/src/logging.h
+++ b/src/logging.h
@@ -138,9 +138,9 @@ namespace BCLog {
         bool DisableCategory(const std::string& str);
 
         bool WillLogCategory(LogFlags category) const;
-        /** Returns a vector of the log categories */
+        /** Returns a vector of the log categories in alphabetical order. */
         std::vector<LogCategory> LogCategoriesList() const;
-        /** Returns a string with the log categories */
+        /** Returns a string with the log categories in alphabetical order. */
         std::string LogCategoriesString() const
         {
             return Join(LogCategoriesList(), ", ", [&](const LogCategory& i) { return i.category; });

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -54,7 +54,7 @@ class RpcMiscTest(BitcoinTestFramework):
 
         assert_raises_rpc_error(-8, "unknown mode foobar", node.getmemoryinfo, mode="foobar")
 
-        self.log.info("test logging rpc")
+        self.log.info("test logging rpc and help")
 
         # Test logging RPC returns the expected number of logging categories.
         assert_equal(len(node.logging()), 24)
@@ -65,6 +65,15 @@ class RpcMiscTest(BitcoinTestFramework):
         assert_equal(node.logging()['qt'], False)
         node.logging(include=['qt'])
         assert_equal(node.logging()['qt'], True)
+
+        # Test logging RPC returns the logging categories in alphabetical order.
+        sorted_logging_categories = sorted(node.logging())
+        assert_equal(list(node.logging()), sorted_logging_categories)
+
+        # Test logging help returns the logging categories string in alphabetical order.
+        categories = ', '.join(sorted_logging_categories)
+        logging_help = self.nodes[0].help('logging')
+        assert f"valid logging categories are: {categories}" in logging_help
 
         self.log.info("test echoipc (testing spawned process in multiprocess build)")
         assert_equal(node.echoipc("hello"), "hello")

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -54,7 +54,12 @@ class RpcMiscTest(BitcoinTestFramework):
 
         assert_raises_rpc_error(-8, "unknown mode foobar", node.getmemoryinfo, mode="foobar")
 
-        self.log.info("test logging")
+        self.log.info("test logging rpc")
+
+        # Test logging RPC returns the expected number of logging categories.
+        assert_equal(len(node.logging()), 24)
+
+        # Test toggling a logging category on/off/on with the logging RPC.
         assert_equal(node.logging()['qt'], True)
         node.logging(exclude=['qt'])
         assert_equal(node.logging()['qt'], False)


### PR DESCRIPTION
Sorting the logging categories seems more user-friendly with the number of categories we now have, allowing CLI users to more quickly find a particular category.

before
```
$ bitcoin-cli help logging
...
The valid logging categories are: net, tor, mempool, http, bench, zmq, walletdb, rpc, estimatefee, addrman, selectcoins, reindex, cmpctblock, rand, prune, proxy, mempoolrej, libevent, coindb, qt, leveldb, validation, i2p, ipc

$ bitcoind -h | grep -A8 "debug=<category>"
  -debug=<category>
       ...
       output all debugging information. <category> can be: net, tor,
       mempool, http, bench, zmq, walletdb, rpc, estimatefee, addrman,
       selectcoins, reindex, cmpctblock, rand, prune, proxy, mempoolrej,
       libevent, coindb, qt, leveldb, validation, i2p, ipc.

$ bitcoin-cli logging [] '["addrman"]'
{
  "net": false,
  "tor": true,
  "mempool": false,
  "http": false,
  "bench": false,
  "zmq": false,
  "walletdb": false,
  "rpc": false,
  "estimatefee": false,
  "addrman": false,
  "selectcoins": false,
  "reindex": false,
  "cmpctblock": false,
  "rand": false,
  "prune": false,
  "proxy": true,
  "mempoolrej": false,
  "libevent": false,
  "coindb": false,
  "qt": false,
  "leveldb": false,
  "validation": false,
  "i2p": true,
  "ipc": false
}
```

after

```
$ bitcoin-cli help logging
...
The valid logging categories are: addrman, bench, cmpctblock, coindb, estimatefee, http, i2p, ipc, leveldb, libevent, mempool, mempoolrej, net, proxy, prune, qt, rand, reindex, rpc, selectcoins, tor, validation, walletdb, zmq

$ bitcoind -h | grep -A8 "debug=<category>"
  -debug=<category>
       ...
       output all debugging information. <category> can be: addrman,
       bench, cmpctblock, coindb, estimatefee, http, i2p, ipc, leveldb,
       libevent, mempool, mempoolrej, net, proxy, prune, qt, rand,
       reindex, rpc, selectcoins, tor, validation, walletdb, zmq.

$ bitcoin-cli logging [] '["addrman"]'
{
  "addrman": false,
  "bench": false,
  "cmpctblock": false,
  "coindb": false,
  "estimatefee": false,
  "http": false,
  "i2p": false,
  "ipc": false,
  "leveldb": false,
  "libevent": false,
  "mempool": false,
  "mempoolrej": false,
  "net": false,
  "proxy": false,
  "prune": false,
  "qt": false,
  "rand": false,
  "reindex": false,
  "rpc": false,
  "selectcoins": false,
  "tor": false,
  "validation": false,
  "walletdb": false,
  "zmq": false
}
```
