### PR TITLE
guix: Fixes to guix-{attest,verify}

### DIFF
--- a/contrib/guix/guix-attest
+++ b/contrib/guix/guix-attest
@@ -207,8 +207,8 @@ mkdir -p "$outsigdir"
         exit 1
     fi
 
-    temp_codesigned="$(mktemp)"
-    trap 'rm -rf -- "$temp_codesigned"' EXIT
+    temp_all="$(mktemp)"
+    trap 'rm -rf -- "$temp_all"' EXIT
 
     if (( ${#codesigned_fragments[@]} )); then
         # Note: all.SHA256SUMS attests to all of $sha256sum_fragments, but is
@@ -218,18 +218,18 @@ mkdir -p "$outsigdir"
             | sort -k2 \
             | sed 's/$/\r/' \
             | rfc4880_normalize_document \
-                > "$temp_codesigned"
-        if [ -e codesigned.SHA256SUMS ]; then
+                > "$temp_all"
+        if [ -e all.SHA256SUMS ]; then
             # The SHA256SUMS already exists, make sure it's exactly what we
             # expect, error out if not
-            if diff -u all.SHA256SUMS "$temp_codesigned"; then
+            if diff -u all.SHA256SUMS "$temp_all"; then
                 echo "An all.SHA256SUMS file already exists for '${VERSION}' and is up-to-date."
             else
                 shasum_already_exists all.SHA256SUMS
                 exit 1
             fi
         else
-            mv "$temp_codesigned" codesigned.SHA256SUMS
+            mv "$temp_all" all.SHA256SUMS
         fi
     else
         # It is fine to have the codesigned outputs be missing (perhaps the

--- a/contrib/guix/guix-attest
+++ b/contrib/guix/guix-attest
@@ -216,7 +216,6 @@ mkdir -p "$outsigdir"
         cat "${sha256sum_fragments[@]}" \
             | sort -u \
             | sort -k2 \
-            | sed 's/$/\r/' \
             | rfc4880_normalize_document \
                 > "$temp_all"
         if [ -e all.SHA256SUMS ]; then

--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -232,7 +232,7 @@ host_to_commonname() {
 }
 
 # Determine the reference time used for determinism (overridable by environment)
-SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log --format=%at -1)}"
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git -c log.showSignature=false log --format=%at -1)}"
 
 # Execute "$@" in a pinned, possibly older version of Guix, for reproducibility
 # across time.

--- a/contrib/guix/guix-codesign
+++ b/contrib/guix/guix-codesign
@@ -220,7 +220,7 @@ fi
 JOBS="${JOBS:-$(nproc)}"
 
 # Determine the reference time used for determinism (overridable by environment)
-SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log --format=%at -1)}"
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git -c log.showSignature=false log --format=%at -1)}"
 
 # Execute "$@" in a pinned, possibly older version of Guix, for reproducibility
 # across time.

--- a/contrib/guix/guix-verify
+++ b/contrib/guix/guix-verify
@@ -28,7 +28,11 @@ cmd_usage() {
 cat <<EOF
 Synopsis:
 
-    env GUIX_SIGS_REPO=<path/to/guix.sigs> ./contrib/guix/guix-verify
+    env GUIX_SIGS_REPO=<path/to/guix.sigs> [ SIGNER=<signer> ] ./contrib/guix/guix-verify
+
+Example overriding signer's manifest to use as base
+
+    env GUIX_SIGS_REPO=/home/dongcarl/guix.sigs SIGNER=achow101 ./contrib/guix/guix-verify
 
 EOF
 }
@@ -92,6 +96,17 @@ echo "--------------------"
 echo ""
 if (( ${#all_noncodesigned[@]} )); then
     compare_noncodesigned="${all_noncodesigned[0]}"
+    if [[ -n "$SIGNER" ]]; then
+        signer_noncodesigned="$OUTSIGDIR_BASE/$SIGNER/noncodesigned.SHA256SUMS"
+        if [[ -f "$signer_noncodesigned" ]]; then
+            echo "Using $SIGNER's manifest as the base to compare against"
+            compare_noncodesigned="$signer_noncodesigned"
+        else
+            echo "Unable to find $SIGNER's manifest, using the first one found"
+        fi
+    else
+        echo "No SIGNER provided, using the first manifest found"
+    fi
 
     for current_manifest in "${all_noncodesigned[@]}"; do
         verify "$compare_noncodesigned" "$current_manifest"
@@ -112,6 +127,17 @@ echo "--------------------"
 echo ""
 if (( ${#all_all[@]} )); then
     compare_all="${all_all[0]}"
+    if [[ -n "$SIGNER" ]]; then
+        signer_all="$OUTSIGDIR_BASE/$SIGNER/all.SHA256SUMS"
+        if [[ -f "$signer_all" ]]; then
+            echo "Using $SIGNER's manifest as the base to compare against"
+            compare_all="$signer_all"
+        else
+            echo "Unable to find $SIGNER's manifest, using the first one found"
+        fi
+    else
+        echo "No SIGNER provided, using the first manifest found"
+    fi
 
     for current_manifest in "${all_all[@]}"; do
         verify "$compare_all" "$current_manifest"

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -160,6 +160,9 @@ Codesigner only: Sign the windows binaries:
     Enter the passphrase for the key when prompted
     signature-win.tar.gz will be created
 
+Code-signer only: It is advised to test that the code signature attaches properly prior to tagging by performing the `guix-codesign` step.
+However if this is done, once the release has been tagged in the bitcoin-detached-sigs repo, the `guix-codesign` step must be performed again in order for the guix attestation to be valid when compared against the attestations of non-codesigner builds.
+
 Codesigner only: Commit the detached codesign payloads:
 
 ```sh


### PR DESCRIPTION
`guix-verify` expects `all.SHA256SUMS` but `guix-attest` produces `codesigned.SHA256SUMS`. Since `all.SHA256SUMS` makes more sense (as the file contains all the sha256sums, not just the codesigned ones), `guix-attest` has been changed to output a file of that name.

As a quality of life improvement, `guix-verify` can take `SIGNER` and use the signer's manifest as the base to compare against. This makes it easier to compare a single person's attestations with everyone else's and can make it more obvious when one builder is clearly mismatching with everyone else.

Lastly `release-process.md` is updated with a note about a gotcha that can cause a mismatch in the codesigned attestation.