### PR TITLE
test: Reduce number of blocks generated in rpc_signrawtransaction

### DIFF
--- a/test/functional/rpc_signrawtransaction.py
+++ b/test/functional/rpc_signrawtransaction.py
@@ -305,7 +305,7 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         getcontext().prec = 8
 
         # Make sure CSV is active
-        self.nodes[0].generate(1500)
+        self.nodes[0].generate(500)
 
         # Create a P2WSH script with CLTV
         script = CScript([1000, OP_CHECKLOCKTIMEVERIFY, OP_DROP])


### PR DESCRIPTION
Reduce the number of blocks generated to make sure CSV is activated in `test_signing_with_cltv` from 1500 to 500. This makes it consistent with the test above it, `test_signing_with_csv`.

Also, generating 1500 blocks in one go takes longer than the alotted 30 seconds and times out consistently on Sifive Unmatched.