### PR TITLE
test: Use MiniWallet in mempool_limit.py

### DIFF
--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -36,7 +36,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         miniwallet = MiniWallet(node)
         relayfee = node.getnetworkinfo()['relayfee']
 
-        self.log.info('Check that mempoolminfee is minrelytxfee')
+        self.log.info('Check that mempoolminfee is minrelaytxfee')
         assert_equal(node.getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
         assert_equal(node.getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
 
@@ -68,7 +68,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         # Initial tx created should not be present in the mempool anymore as it had a lower fee rate
         assert tx_to_be_evicted_id not in node.getrawmempool()
 
-        self.log.info('Check that mempoolminfee is larger than minrelytxfee')
+        self.log.info('Check that mempoolminfee is larger than minrelaytxfee')
         assert_equal(node.getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
         assert_greater_than(node.getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
 

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -6,8 +6,11 @@
 
 from decimal import Decimal
 
+from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_greater_than, assert_raises_rpc_error, create_confirmed_utxos, create_lots_of_big_transactions, gen_return_txouts
+from test_framework.util import assert_equal, assert_greater_than, assert_raises_rpc_error, gen_return_txouts
+from test_framework.wallet import MiniWallet
+
 
 class MempoolLimitTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -20,55 +23,58 @@ class MempoolLimitTest(BitcoinTestFramework):
         ]]
         self.supports_cli = False
 
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
+    def send_large_txs(self, miniwallet, txouts, fee_rate, tx_batch_size):
+        for _ in range(tx_batch_size):
+            tx = miniwallet.create_self_transfer(from_node=self.nodes[0], fee_rate=fee_rate)['tx']
+            for txout in txouts:
+                tx.vout.append(txout)
+            miniwallet.sendrawtransaction(from_node=self.nodes[0], tx_hex=tx.serialize().hex())
 
     def run_test(self):
         txouts = gen_return_txouts()
+        miniwallet = MiniWallet(self.nodes[0])
         relayfee = self.nodes[0].getnetworkinfo()['relayfee']
 
         self.log.info('Check that mempoolminfee is minrelytxfee')
         assert_equal(self.nodes[0].getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
         assert_equal(self.nodes[0].getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
 
-        txids = []
-        utxos = create_confirmed_utxos(self, relayfee, self.nodes[0], 91)
+        tx_batch_size = 25
+        num_of_batches = 3
+        # Generate UTXOs to flood the mempool
+        # 1 to create a tx initially that will be evicted from the mempool later
+        # 3 batches of multiple transactions with a fee rate much higher than the previous UTXO
+        # And 1 more to verify that this tx does not get added to the mempool with a fee rate less than the mempoolminfee
+        self.generate(miniwallet, 1 + (num_of_batches * tx_batch_size) + 1)
+
+        # Mine 99 blocks so that the UTXOs are allowed to be spent
+        self.generate(self.nodes[0], COINBASE_MATURITY - 1)
 
         self.log.info('Create a mempool tx that will be evicted')
-        us0 = utxos.pop()
-        inputs = [{ "txid" : us0["txid"], "vout" : us0["vout"]}]
-        outputs = {self.nodes[0].getnewaddress() : 0.0001}
-        tx = self.nodes[0].createrawtransaction(inputs, outputs)
-        self.nodes[0].settxfee(relayfee) # specifically fund this tx with low fee
-        txF = self.nodes[0].fundrawtransaction(tx)
-        self.nodes[0].settxfee(0) # return to automatic fee selection
-        txFS = self.nodes[0].signrawtransactionwithwallet(txF['hex'])
-        txid = self.nodes[0].sendrawtransaction(txFS['hex'])
+        tx_to_be_evicted_id = miniwallet.send_self_transfer(from_node=self.nodes[0], fee_rate=relayfee)["txid"]
 
-        relayfee = self.nodes[0].getnetworkinfo()['relayfee']
-        base_fee = relayfee*100
-        for i in range (3):
-            txids.append([])
-            txids[i] = create_lots_of_big_transactions(self.nodes[0], txouts, utxos[30*i:30*i+30], 30, (i+1)*base_fee)
+        # Increase the tx fee rate massively to give the subsequent transactions a higher priority in the mempool
+        base_fee = relayfee * 1000
+
+        self.log.info("Fill up the mempool with txs with higher fee rate")
+        for batch_of_txid in range(num_of_batches):
+            fee_rate=(batch_of_txid + 1) * base_fee
+            self.send_large_txs(miniwallet, txouts, fee_rate, tx_batch_size)
 
         self.log.info('The tx should be evicted by now')
-        assert txid not in self.nodes[0].getrawmempool()
-        txdata = self.nodes[0].gettransaction(txid)
-        assert txdata['confirmations'] ==  0  #confirmation should still be 0
+        # The number of transactions created should be greater than the ones present in the mempool
+        assert_greater_than(tx_batch_size * num_of_batches, len(self.nodes[0].getrawmempool()))
+        # Initial tx created should not be present in the mempool anymore as it had a lower fee rate
+        assert tx_to_be_evicted_id not in self.nodes[0].getrawmempool()
 
         self.log.info('Check that mempoolminfee is larger than minrelytxfee')
         assert_equal(self.nodes[0].getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
         assert_greater_than(self.nodes[0].getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
 
+        # Deliberately try to create a tx with a fee less than the minimum mempool fee to assert that it does not get added to the mempool
         self.log.info('Create a mempool tx that will not pass mempoolminfee')
-        us0 = utxos.pop()
-        inputs = [{ "txid" : us0["txid"], "vout" : us0["vout"]}]
-        outputs = {self.nodes[0].getnewaddress() : 0.0001}
-        tx = self.nodes[0].createrawtransaction(inputs, outputs)
-        # specifically fund this tx with a fee < mempoolminfee, >= than minrelaytxfee
-        txF = self.nodes[0].fundrawtransaction(tx, {'feeRate': relayfee})
-        txFS = self.nodes[0].signrawtransactionwithwallet(txF['hex'])
-        assert_raises_rpc_error(-26, "mempool min fee not met", self.nodes[0].sendrawtransaction, txFS['hex'])
+        assert_raises_rpc_error(-26, "mempool min fee not met", miniwallet.send_self_transfer, from_node=self.nodes[0], fee_rate=relayfee, mempool_valid=False)
+
 
 if __name__ == '__main__':
     MempoolLimitTest().main()


### PR DESCRIPTION
This is a PR proposed in #20078

This PR enables running another non-wallet functional test even when the wallet is disabled thanks to the MiniWallet, i.e. it can be run even when bitcoin-core is compiled with --disable-wallet.

It also includes changes in wallet.py in the form of a new method, `create_large_transactions()` for the MiniWallet to create large transactions.

Efforts for this feature started in #20874 but were not continued and that PR was closed hence I picked this up.

To test this PR locally, compile and build bitcoin-core without the wallet and run:
```
$ test/functional/mempool_limit.py
```