### PR TITLE
cli -addrinfo: drop torv2; torv3 becomes onion per GetNetworkName()

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -77,6 +77,10 @@ Tools and Utilities
 
 - Update `-getinfo` to return data in a user-friendly format that also reduces vertical space. (#21832)
 
+- CLI `-addrinfo` now returns a single field for the number of `onion` addresses
+  known to the node instead of separate `torv2` and `torv3` fields, as support
+  for Tor V2 addresses was removed from Bitcoin Core in 22.0. (#22544)
+
 Wallet
 ------
 

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -23,10 +23,9 @@ There are several ways to see your local onion address in Bitcoin Core:
 You may set the `-debug=tor` config logging option to have additional
 information in the debug log about your Tor configuration.
 
-CLI `-addrinfo` returns the number of addresses known to your node per network
-type, including Tor v2 and v3. This is useful to see how many onion addresses
-are known to your node for `-onlynet=onion` and how many Tor v3 addresses it
-knows when upgrading to Bitcoin Core v22.0 and up that supports Tor v3 only.
+CLI `-addrinfo` returns the number of addresses known to your node per
+network. This can be useful to see how many onion peers your node knows,
+e.g. for `-onlynet=onion`.
 
 ## 1. Run Bitcoin Core behind a Tor proxy
 

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -245,7 +245,7 @@ public:
 class AddrinfoRequestHandler : public BaseRequestHandler
 {
 private:
-    static constexpr std::array m_networks{"ipv4", "ipv6", "torv2", "torv3", "i2p"};
+    static constexpr std::array m_networks{"ipv4", "ipv6", "onion", "i2p"};
     int8_t NetworkStringToId(const std::string& str) const
     {
         for (size_t i = 0; i < m_networks.size(); ++i) {
@@ -271,13 +271,10 @@ public:
         if (!nodes.empty() && nodes.at(0)["network"].isNull()) {
             throw std::runtime_error("-addrinfo requires bitcoind server to be running v22.0 and up");
         }
-        // Count the number of peers we know by network, including torv2 versus torv3.
+        // Count the number of peers known to our node, by network.
         std::array<uint64_t, m_networks.size()> counts{{}};
         for (const UniValue& node : nodes) {
             std::string network_name{node["network"].get_str()};
-            if (network_name == "onion") {
-                network_name = node["address"].get_str().size() > 22 ? "torv3" : "torv2";
-            }
             const int8_t network_id{NetworkStringToId(network_name)};
             if (network_id == UNKNOWN_NETWORK) continue;
             ++counts.at(network_id);


### PR DESCRIPTION
#22050 removed torv2 support from 22.0. For 23.0 and subsequent releases, we can probably remove torv2 from -addrinfo.

before
```
  "addresses_known": {
    "ipv4": 58305,
    "ipv6": 5138,
    "torv2": 0,
    "torv3": 5441,
    "i2p": 14,
    "total": 68898
  }
```
after
```
  "addresses_known": {
    "ipv4": 58305,
    "ipv6": 5138,
    "onion": 5441,
    "i2p": 14,
    "total": 68898
  }
```
Per the naming of `netbase.{h, cpp}::GetNetworkName()`, torv3 becomes onion, which is what is printed in the output of getpeerinfo, getnetworkinfo and getnodeaddresses.