### PR TITLE
test: improve `test_signing_with_{csv,cltv}` subtests (speed, prevent timeout)

### DIFF
--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -9,6 +9,7 @@ Test that the CHECKLOCKTIMEVERIFY soft-fork activates at (regtest) block height
 """
 
 from test_framework.blocktools import (
+    CLTV_HEIGHT,
     create_block,
     create_coinbase,
 )
@@ -30,8 +31,6 @@ from test_framework.wallet import (
     MiniWallet,
     MiniWalletMode,
 )
-
-CLTV_HEIGHT = 1351
 
 
 # Helper function to modify a transaction by

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -41,6 +41,7 @@ from itertools import product
 import time
 
 from test_framework.blocktools import (
+    CSV_ACTIVATION_HEIGHT,
     create_block,
     create_coinbase,
 )
@@ -63,7 +64,6 @@ from test_framework.wallet import (
 TESTING_TX_COUNT = 83  # Number of testing transactions: 1 BIP113 tx, 16 BIP68 txs, 66 BIP112 txs (see comments above)
 COINBASE_BLOCK_COUNT = TESTING_TX_COUNT  # Number of coinbase blocks we need to generate as inputs for our txs
 BASE_RELATIVE_LOCKTIME = 10
-CSV_ACTIVATION_HEIGHT = 432
 SEQ_DISABLE_FLAG = 1 << 31
 SEQ_RANDOM_HIGH_BIT = 1 << 25
 SEQ_TYPE_FLAG = 1 << 22

--- a/test/functional/rpc_signrawtransaction.py
+++ b/test/functional/rpc_signrawtransaction.py
@@ -4,7 +4,11 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test transaction signing using the signrawtransaction* RPCs."""
 
-from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.blocktools import (
+    CLTV_HEIGHT,
+    COINBASE_MATURITY,
+    CSV_ACTIVATION_HEIGHT,
+)
 from test_framework.address import (
     script_to_p2sh,
     script_to_p2wsh,
@@ -271,7 +275,7 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         getcontext().prec = 8
 
         # Make sure CSV is active
-        generate_to_height(self.nodes[0], 500)
+        generate_to_height(self.nodes[0], CSV_ACTIVATION_HEIGHT)
         assert self.nodes[0].getblockchaininfo()['softforks']['csv']['active']
 
         # Create a P2WSH script with CSV
@@ -307,7 +311,7 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         getcontext().prec = 8
 
         # Make sure CLTV is active
-        generate_to_height(self.nodes[0], 1500)
+        generate_to_height(self.nodes[0], CLTV_HEIGHT)
         assert self.nodes[0].getblockchaininfo()['softforks']['bip65']['active']
 
         # Create a P2WSH script with CLTV

--- a/test/functional/rpc_signrawtransaction.py
+++ b/test/functional/rpc_signrawtransaction.py
@@ -15,6 +15,7 @@ from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
     find_vout_for_address,
+    generate_to_height,
     hex_str_to_bytes,
 )
 from test_framework.messages import (
@@ -270,7 +271,7 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         getcontext().prec = 8
 
         # Make sure CSV is active
-        self.nodes[0].generate(500)
+        generate_to_height(self.nodes[0], 500)
         assert self.nodes[0].getblockchaininfo()['softforks']['csv']['active']
 
         # Create a P2WSH script with CSV
@@ -306,7 +307,7 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         getcontext().prec = 8
 
         # Make sure CLTV is active
-        self.nodes[0].generate(1500)
+        generate_to_height(self.nodes[0], 1500)
         assert self.nodes[0].getblockchaininfo()['softforks']['bip65']['active']
 
         # Create a P2WSH script with CLTV

--- a/test/functional/rpc_signrawtransaction.py
+++ b/test/functional/rpc_signrawtransaction.py
@@ -271,6 +271,7 @@ class SignRawTransactionsTest(BitcoinTestFramework):
 
         # Make sure CSV is active
         self.nodes[0].generate(500)
+        assert self.nodes[0].getblockchaininfo()['softforks']['csv']['active']
 
         # Create a P2WSH script with CSV
         script = CScript([1, OP_CHECKSEQUENCEVERIFY, OP_DROP])
@@ -304,8 +305,9 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         self.nodes[0].walletpassphrase("password", 9999)
         getcontext().prec = 8
 
-        # Make sure CSV is active
+        # Make sure CLTV is active
         self.nodes[0].generate(1500)
+        assert self.nodes[0].getblockchaininfo()['softforks']['bip65']['active']
 
         # Create a P2WSH script with CLTV
         script = CScript([1000, OP_CHECKLOCKTIMEVERIFY, OP_DROP])

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -55,6 +55,10 @@ TIME_GENESIS_BLOCK = 1296688602
 # Coinbase transaction outputs can only be spent after this number of new blocks (network rule)
 COINBASE_MATURITY = 100
 
+# Soft-fork activation heights
+CLTV_HEIGHT = 1351
+CSV_ACTIVATION_HEIGHT = 432
+
 # From BIP141
 WITNESS_COMMITMENT_HEADER = b"\xaa\x21\xa9\xed"
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -559,6 +559,17 @@ def mine_large_block(node, utxos=None):
     node.generate(1)
 
 
+def generate_to_height(node, target_height):
+    """Generates blocks until a given target block height has been reached.
+       To prevent timeouts, only up to 200 blocks are generated per RPC call.
+       Can be used to activate certain soft-forks (e.g. CSV, CLTV)."""
+    current_height = node.getblockcount()
+    while current_height < target_height:
+        nblocks = min(200, target_height - current_height)
+        current_height += len(node.generate(nblocks))
+    assert_equal(node.getblockcount(), target_height)
+
+
 def find_vout_for_address(node, txid, addr):
     """
     Locate the vout index of the given transaction sending to the


### PR DESCRIPTION
This PR primarily aims to solve the current RPC timeout problem for test rpc_signrawtransaction.py, as described in #22542. In the course of that the test is also improved in other ways (see https://github.com/bitcoin/bitcoin/pull/22542#pullrequestreview-714297804).

Reviewers guideline:
* In `test_signing_with_cltv()`, a comment is fixed -- it wrongly referred to CSV, it should be CLTV.
* As preparation, assertions are added that ensure that CSV and CLTV have been really activated after generating blocks by checking the 'softforks' output of the getblockchaininfo() RPC. Right now in master, one could remove (or decrease, like in #22542) the generate calls and the test would still pass, when it shouldn't.
* A helper `generate_to_height()` is introduced which improves the previous way of reaching a block height in two ways:
    - instead of blindly generating TH blocks to reach target block height >= TH, the current block height CH is taken into account, and only (TH - CH) are generated in total
    - to avoid potential RPC timeouts, the block generation is split up into multiple generatetoaddress RPC calls ([as suggested by laanwj](https://github.com/bitcoin/bitcoin/pull/22542#issuecomment-886237866)); here chunks of 200 blocks have been chosen
 * The helper is used in the affected sub-tests, which should both speed-up the test (from ~18s to ~12s on my machine) and avoid potential timeouts
 * Finally, the activation constants for CSV and CLTV are used instead of using magic numbers 500 and 1500

Open questions:
* Any good naming alternatives for `generate_to_height()`? Not really happy with the name, happy to hear suggestions
* Where to put the CSV and CLTV activation height constants in the test_framewor folder? I guess importing constants from other tests isn't really the desired way to go