### PR TITLE
build: Improve depends build system robustness

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -1,21 +1,21 @@
-package=bdb
-$(package)_version=4.8.30
-$(package)_download_path=https://download.oracle.com/berkeley-db
-$(package)_file_name=db-$($(package)_version).NC.tar.gz
-$(package)_sha256_hash=12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef
-$(package)_build_subdir=build_unix
-$(package)_patches=clang_cxx_11.patch
+package := bdb
+$(package)_version := 4.8.30
+$(package)_download_path := https://download.oracle.com/berkeley-db
+$(package)_file_name := db-$($(package)_version).NC.tar.gz
+$(package)_sha256_hash := 12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef
+$(package)_build_subdir := build_unix
+$(package)_patches := clang_cxx_11.patch
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-shared --enable-cxx --disable-replication --enable-option-checking
-$(package)_config_opts_mingw32=--enable-mingw
-$(package)_config_opts_linux=--with-pic
-$(package)_config_opts_freebsd=--with-pic
-$(package)_config_opts_netbsd=--with-pic
-$(package)_config_opts_openbsd=--with-pic
-$(package)_config_opts_android=--with-pic
+$(package)_config_opts := --disable-shared --enable-cxx --disable-replication --enable-option-checking
+$(package)_config_opts_mingw32 := --enable-mingw
+$(package)_config_opts_linux := --with-pic
+$(package)_config_opts_freebsd := --with-pic
+$(package)_config_opts_netbsd := --with-pic
+$(package)_config_opts_openbsd := --with-pic
+$(package)_config_opts_android := --with-pic
 $(package)_cflags+=-Wno-error=implicit-function-declaration
-$(package)_cppflags_mingw32=-DUNICODE -D_UNICODE
+$(package)_cppflags_mingw32 := -DUNICODE -D_UNICODE
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,8 +1,8 @@
-package=boost
-$(package)_version=1.77.0
-$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/$($(package)_version)/source/
-$(package)_file_name=boost_$(subst .,_,$($(package)_version)).tar.bz2
-$(package)_sha256_hash=fc9f85fc030e233142908241af7a846e60630aa7388de9a5fafb1f3a26840854
+package := boost
+$(package)_version := 1.77.0
+$(package)_download_path := https://boostorg.jfrog.io/artifactory/main/release/$($(package)_version)/source/
+$(package)_file_name := boost_$(subst .,_,$($(package)_version)).tar.bz2
+$(package)_sha256_hash := fc9f85fc030e233142908241af7a846e60630aa7388de9a5fafb1f3a26840854
 
 define $(package)_stage_cmds
   mkdir -p $($(package)_staging_prefix_dir)/include && \

--- a/depends/packages/capnp.mk
+++ b/depends/packages/capnp.mk
@@ -1,10 +1,10 @@
-package=capnp
-$(package)_version=$(native_$(package)_version)
-$(package)_download_path=$(native_$(package)_download_path)
-$(package)_download_file=$(native_$(package)_download_file)
-$(package)_file_name=$(native_$(package)_file_name)
-$(package)_sha256_hash=$(native_$(package)_sha256_hash)
-$(package)_dependencies=native_$(package)
+package := capnp
+$(package)_version := $(native_$(package)_version)
+$(package)_download_path := $(native_$(package)_download_path)
+$(package)_download_file := $(native_$(package)_download_file)
+$(package)_file_name := $(native_$(package)_file_name)
+$(package)_sha256_hash := $(native_$(package)_sha256_hash)
+$(package)_dependencies := native_$(package)
 
 define $(package)_config_cmds
   $($(package)_autoconf) --with-external-capnp

--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -1,14 +1,14 @@
-package=expat
-$(package)_version=2.4.1
-$(package)_download_path=https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$($(package)_version))/
-$(package)_file_name=$(package)-$($(package)_version).tar.xz
-$(package)_sha256_hash=cf032d0dba9b928636548e32b327a2d66b1aab63c4f4a13dd132c2d1d2f2fb6a
+package := expat
+$(package)_version := 2.4.1
+$(package)_download_path := https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$($(package)_version))/
+$(package)_file_name := $(package)-$($(package)_version).tar.xz
+$(package)_sha256_hash := cf032d0dba9b928636548e32b327a2d66b1aab63c4f4a13dd132c2d1d2f2fb6a
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared --without-docbook --without-tests --without-examples
+  $(package)_config_opts := --disable-shared --without-docbook --without-tests --without-examples
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
   $(package)_config_opts += --without-xmlwf
-  $(package)_config_opts_linux=--with-pic
+  $(package)_config_opts_linux := --with-pic
   $(package)_cflags += -fno-lto
 endef
 

--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -1,13 +1,13 @@
-package=fontconfig
-$(package)_version=2.12.6
-$(package)_download_path=https://www.freedesktop.org/software/fontconfig/release/
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=cf0c30807d08f6a28ab46c61b8dbd55c97d2f292cf88f3a07d3384687f31f017
-$(package)_dependencies=freetype expat
-$(package)_patches=gperf_header_regen.patch
+package := fontconfig
+$(package)_version := 2.12.6
+$(package)_download_path := https://www.freedesktop.org/software/fontconfig/release/
+$(package)_file_name := $(package)-$($(package)_version).tar.bz2
+$(package)_sha256_hash := cf0c30807d08f6a28ab46c61b8dbd55c97d2f292cf88f3a07d3384687f31f017
+$(package)_dependencies := freetype expat
+$(package)_patches := gperf_header_regen.patch
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-docs --disable-static --disable-libxml2 --disable-iconv
+  $(package)_config_opts := --disable-docs --disable-static --disable-libxml2 --disable-iconv
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 endef
 

--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -1,13 +1,13 @@
-package=freetype
-$(package)_version=2.11.0
-$(package)_download_path=https://download.savannah.gnu.org/releases/$(package)
-$(package)_file_name=$(package)-$($(package)_version).tar.xz
-$(package)_sha256_hash=8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7
+package := freetype
+$(package)_version := 2.11.0
+$(package)_download_path := https://download.savannah.gnu.org/releases/$(package)
+$(package)_file_name := $(package)-$($(package)_version).tar.xz
+$(package)_sha256_hash := 8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7
 
 define $(package)_set_vars
-  $(package)_config_opts=--without-zlib --without-png --without-harfbuzz --without-bzip2 --disable-static
+  $(package)_config_opts := --without-zlib --without-png --without-harfbuzz --without-bzip2 --disable-static
   $(package)_config_opts += --enable-option-checking --without-brotli
-  $(package)_config_opts_linux=--with-pic
+  $(package)_config_opts_linux := --with-pic
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/libXau.mk
+++ b/depends/packages/libXau.mk
@@ -1,16 +1,16 @@
-package=libXau
-$(package)_version=1.0.9
-$(package)_download_path=https://xorg.freedesktop.org/releases/individual/lib/
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=ccf8cbf0dbf676faa2ea0a6d64bcc3b6746064722b606c8c52917ed00dcb73ec
-$(package)_dependencies=xproto
+package := libXau
+$(package)_version := 1.0.9
+$(package)_download_path := https://xorg.freedesktop.org/releases/individual/lib/
+$(package)_file_name := $(package)-$($(package)_version).tar.bz2
+$(package)_sha256_hash := ccf8cbf0dbf676faa2ea0a6d64bcc3b6746064722b606c8c52917ed00dcb73ec
+$(package)_dependencies := xproto
 
 # When updating this package, check the default value of
 # --disable-xthreads. It is currently enabled.
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared --disable-lint-library --without-lint
+  $(package)_config_opts := --disable-shared --disable-lint-library --without-lint
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
-  $(package)_config_opts_linux=--with-pic
+  $(package)_config_opts_linux := --with-pic
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -1,22 +1,22 @@
-package=libevent
-$(package)_version=2.1.12-stable
-$(package)_download_path=https://github.com/libevent/libevent/releases/download/release-$($(package)_version)/
-$(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
+package := libevent
+$(package)_version := 2.1.12-stable
+$(package)_download_path := https://github.com/libevent/libevent/releases/download/release-$($(package)_version)/
+$(package)_file_name := $(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash := 92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
 
 # When building for Windows, we set _WIN32_WINNT to target the same Windows
 # version as we do in configure. Due to quirks in libevents build system, this
 # is also required to enable support for ipv6. See #19375.
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared --disable-openssl --disable-libevent-regress --disable-samples
+  $(package)_config_opts := --disable-shared --disable-openssl --disable-libevent-regress --disable-samples
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
-  $(package)_config_opts_release=--disable-debug-mode
-  $(package)_config_opts_linux=--with-pic
-  $(package)_config_opts_freebsd=--with-pic
-  $(package)_config_opts_netbsd=--with-pic
-  $(package)_config_opts_openbsd=--with-pic
-  $(package)_config_opts_android=--with-pic
-  $(package)_cppflags_mingw32=-D_WIN32_WINNT=0x0601
+  $(package)_config_opts_release := --disable-debug-mode
+  $(package)_config_opts_linux := --with-pic
+  $(package)_config_opts_freebsd := --with-pic
+  $(package)_config_opts_netbsd := --with-pic
+  $(package)_config_opts_openbsd := --with-pic
+  $(package)_config_opts_android := --with-pic
+  $(package)_cppflags_mingw32 := -D_WIN32_WINNT=0x0601
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/libmultiprocess.mk
+++ b/depends/packages/libmultiprocess.mk
@@ -1,9 +1,9 @@
-package=libmultiprocess
-$(package)_version=$(native_$(package)_version)
-$(package)_download_path=$(native_$(package)_download_path)
-$(package)_file_name=$(native_$(package)_file_name)
-$(package)_sha256_hash=$(native_$(package)_sha256_hash)
-$(package)_dependencies=native_$(package) capnp
+package := libmultiprocess
+$(package)_version := $(native_$(package)_version)
+$(package)_download_path := $(native_$(package)_download_path)
+$(package)_file_name := $(native_$(package)_file_name)
+$(package)_sha256_hash := $(native_$(package)_sha256_hash)
+$(package)_dependencies := native_$(package) capnp
 ifneq ($(host),$(build))
 $(package)_dependencies += native_capnp
 endif

--- a/depends/packages/libnatpmp.mk
+++ b/depends/packages/libnatpmp.mk
@@ -1,13 +1,13 @@
-package=libnatpmp
-$(package)_version=4536032ae32268a45c073a4d5e91bbab4534773a
-$(package)_download_path=https://github.com/miniupnp/libnatpmp/archive
-$(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=543b460aab26acf91e11d15e17d8798f845304199eea2d76c2f444ec749c5383
+package := libnatpmp
+$(package)_version := 4536032ae32268a45c073a4d5e91bbab4534773a
+$(package)_download_path := https://github.com/miniupnp/libnatpmp/archive
+$(package)_file_name := $($(package)_version).tar.gz
+$(package)_sha256_hash := 543b460aab26acf91e11d15e17d8798f845304199eea2d76c2f444ec749c5383
 
 define $(package)_set_vars
-  $(package)_build_opts=CC="$($(package)_cc)"
-  $(package)_build_opts_mingw32=CPPFLAGS=-DNATPMP_STATICLIB
-  $(package)_build_opts_darwin=LIBTOOL="$($(package)_libtool)"
+  $(package)_build_opts := CC="$($(package)_cc)"
+  $(package)_build_opts_mingw32 := CPPFLAGS=-DNATPMP_STATICLIB
+  $(package)_build_opts_darwin := LIBTOOL="$($(package)_libtool)"
   $(package)_build_env+=CFLAGS="$($(package)_cflags) $($(package)_cppflags)" AR="$($(package)_ar)"
 endef
 

--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -1,12 +1,12 @@
-package=libxcb
-$(package)_version=1.14
-$(package)_download_path=https://xcb.freedesktop.org/dist
-$(package)_file_name=$(package)-$($(package)_version).tar.xz
-$(package)_sha256_hash=a55ed6db98d43469801262d81dc2572ed124edc3db31059d4e9916eb9f844c34
-$(package)_dependencies=xcb_proto libXau
+package := libxcb
+$(package)_version := 1.14
+$(package)_download_path := https://xcb.freedesktop.org/dist
+$(package)_file_name := $(package)-$($(package)_version).tar.xz
+$(package)_sha256_hash := a55ed6db98d43469801262d81dc2572ed124edc3db31059d4e9916eb9f844c34
+$(package)_dependencies := xcb_proto libXau
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-static --disable-devel-docs --without-doxygen --without-launchd
+$(package)_config_opts := --disable-static --disable-devel-docs --without-doxygen --without-launchd
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 # Disable unneeded extensions.
 # More info is available from: https://doc.qt.io/qt-5.15/linux-requirements.html

--- a/depends/packages/libxcb_util.mk
+++ b/depends/packages/libxcb_util.mk
@@ -1,9 +1,9 @@
-package=libxcb_util
-$(package)_version=0.4.0
-$(package)_download_path=https://xcb.freedesktop.org/dist
-$(package)_file_name=xcb-util-$($(package)_version).tar.bz2
-$(package)_sha256_hash=46e49469cb3b594af1d33176cd7565def2be3fa8be4371d62271fabb5eae50e9
-$(package)_dependencies=libxcb
+package := libxcb_util
+$(package)_version := 0.4.0
+$(package)_download_path := https://xcb.freedesktop.org/dist
+$(package)_file_name := xcb-util-$($(package)_version).tar.bz2
+$(package)_sha256_hash := 46e49469cb3b594af1d33176cd7565def2be3fa8be4371d62271fabb5eae50e9
+$(package)_dependencies := libxcb
 
 define $(package)_set_vars
 $(package)_config_opts = --disable-shared --disable-devel-docs --without-doxygen

--- a/depends/packages/libxcb_util_image.mk
+++ b/depends/packages/libxcb_util_image.mk
@@ -1,12 +1,12 @@
-package=libxcb_util_image
-$(package)_version=0.4.0
-$(package)_download_path=https://xcb.freedesktop.org/dist
-$(package)_file_name=xcb-util-image-$($(package)_version).tar.bz2
-$(package)_sha256_hash=2db96a37d78831d643538dd1b595d7d712e04bdccf8896a5e18ce0f398ea2ffc
-$(package)_dependencies=libxcb libxcb_util
+package := libxcb_util_image
+$(package)_version := 0.4.0
+$(package)_download_path := https://xcb.freedesktop.org/dist
+$(package)_file_name := xcb-util-image-$($(package)_version).tar.bz2
+$(package)_sha256_hash := 2db96a37d78831d643538dd1b595d7d712e04bdccf8896a5e18ce0f398ea2ffc
+$(package)_dependencies := libxcb libxcb_util
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-static --disable-devel-docs --without-doxygen
+$(package)_config_opts := --disable-static --disable-devel-docs --without-doxygen
 $(package)_config_opts+= --disable-dependency-tracking --enable-option-checking
 endef
 

--- a/depends/packages/libxcb_util_keysyms.mk
+++ b/depends/packages/libxcb_util_keysyms.mk
@@ -1,12 +1,12 @@
-package=libxcb_util_keysyms
-$(package)_version=0.4.0
-$(package)_download_path=https://xcb.freedesktop.org/dist
-$(package)_file_name=xcb-util-keysyms-$($(package)_version).tar.bz2
-$(package)_sha256_hash=0ef8490ff1dede52b7de533158547f8b454b241aa3e4dcca369507f66f216dd9
-$(package)_dependencies=libxcb xproto
+package := libxcb_util_keysyms
+$(package)_version := 0.4.0
+$(package)_download_path := https://xcb.freedesktop.org/dist
+$(package)_file_name := xcb-util-keysyms-$($(package)_version).tar.bz2
+$(package)_sha256_hash := 0ef8490ff1dede52b7de533158547f8b454b241aa3e4dcca369507f66f216dd9
+$(package)_dependencies := libxcb xproto
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-static --disable-devel-docs --without-doxygen
+$(package)_config_opts := --disable-static --disable-devel-docs --without-doxygen
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 endef
 

--- a/depends/packages/libxcb_util_render.mk
+++ b/depends/packages/libxcb_util_render.mk
@@ -1,12 +1,12 @@
-package=libxcb_util_render
-$(package)_version=0.3.9
-$(package)_download_path=https://xcb.freedesktop.org/dist
-$(package)_file_name=xcb-util-renderutil-$($(package)_version).tar.bz2
-$(package)_sha256_hash=c6e97e48fb1286d6394dddb1c1732f00227c70bd1bedb7d1acabefdd340bea5b
-$(package)_dependencies=libxcb
+package := libxcb_util_render
+$(package)_version := 0.3.9
+$(package)_download_path := https://xcb.freedesktop.org/dist
+$(package)_file_name := xcb-util-renderutil-$($(package)_version).tar.bz2
+$(package)_sha256_hash := c6e97e48fb1286d6394dddb1c1732f00227c70bd1bedb7d1acabefdd340bea5b
+$(package)_dependencies := libxcb
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-static --disable-devel-docs --without-doxygen
+$(package)_config_opts := --disable-static --disable-devel-docs --without-doxygen
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 endef
 

--- a/depends/packages/libxcb_util_wm.mk
+++ b/depends/packages/libxcb_util_wm.mk
@@ -1,12 +1,12 @@
-package=libxcb_util_wm
-$(package)_version=0.4.1
-$(package)_download_path=https://xcb.freedesktop.org/dist
-$(package)_file_name=xcb-util-wm-$($(package)_version).tar.bz2
-$(package)_sha256_hash=28bf8179640eaa89276d2b0f1ce4285103d136be6c98262b6151aaee1d3c2a3f
-$(package)_dependencies=libxcb
+package := libxcb_util_wm
+$(package)_version := 0.4.1
+$(package)_download_path := https://xcb.freedesktop.org/dist
+$(package)_file_name := xcb-util-wm-$($(package)_version).tar.bz2
+$(package)_sha256_hash := 28bf8179640eaa89276d2b0f1ce4285103d136be6c98262b6151aaee1d3c2a3f
+$(package)_dependencies := libxcb
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-static --disable-devel-docs --without-doxygen
+$(package)_config_opts := --disable-static --disable-devel-docs --without-doxygen
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 endef
 

--- a/depends/packages/libxkbcommon.mk
+++ b/depends/packages/libxkbcommon.mk
@@ -1,9 +1,9 @@
-package=libxkbcommon
-$(package)_version=0.8.4
-$(package)_download_path=https://xkbcommon.org/download/
-$(package)_file_name=$(package)-$($(package)_version).tar.xz
-$(package)_sha256_hash=60ddcff932b7fd352752d51a5c4f04f3d0403230a584df9a2e0d5ed87c486c8b
-$(package)_dependencies=libxcb
+package := libxkbcommon
+$(package)_version := 0.8.4
+$(package)_download_path := https://xkbcommon.org/download/
+$(package)_file_name := $(package)-$($(package)_version).tar.xz
+$(package)_sha256_hash := 60ddcff932b7fd352752d51a5c4f04f3d0403230a584df9a2e0d5ed87c486c8b
+$(package)_dependencies := libxcb
 
 # This package explicitly enables -Werror=array-bounds, which causes build failures
 # with GCC 12.1+. Work around that by turning errors back into warnings.

--- a/depends/packages/miniupnpc.mk
+++ b/depends/packages/miniupnpc.mk
@@ -1,14 +1,14 @@
-package=miniupnpc
-$(package)_version=2.2.2
-$(package)_download_path=https://miniupnp.tuxfamily.org/files/
-$(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=888fb0976ba61518276fe1eda988589c700a3f2a69d71089260d75562afd3687
-$(package)_patches=dont_leak_info.patch
+package := miniupnpc
+$(package)_version := 2.2.2
+$(package)_download_path := https://miniupnp.tuxfamily.org/files/
+$(package)_file_name := $(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash := 888fb0976ba61518276fe1eda988589c700a3f2a69d71089260d75562afd3687
+$(package)_patches := dont_leak_info.patch
 
 define $(package)_set_vars
-$(package)_build_opts=CC="$($(package)_cc)"
-$(package)_build_opts_darwin=LIBTOOL="$($(package)_libtool)"
-$(package)_build_opts_mingw32=-f Makefile.mingw
+$(package)_build_opts := CC="$($(package)_cc)"
+$(package)_build_opts_darwin := LIBTOOL="$($(package)_libtool)"
+$(package)_build_opts_mingw32 := -f Makefile.mingw
 $(package)_build_env+=CFLAGS="$($(package)_cflags) $($(package)_cppflags)" AR="$($(package)_ar)"
 endef
 

--- a/depends/packages/native_capnp.mk
+++ b/depends/packages/native_capnp.mk
@@ -1,9 +1,9 @@
-package=native_capnp
-$(package)_version=0.7.0
-$(package)_download_path=https://capnproto.org/
-$(package)_download_file=capnproto-c++-$($(package)_version).tar.gz
-$(package)_file_name=capnproto-cxx-$($(package)_version).tar.gz
-$(package)_sha256_hash=c9a4c0bd88123064d483ab46ecee777f14d933359e23bff6fb4f4dbd28b4cd41
+package := native_capnp
+$(package)_version := 0.7.0
+$(package)_download_path := https://capnproto.org/
+$(package)_download_file := capnproto-c++-$($(package)_version).tar.gz
+$(package)_file_name := capnproto-cxx-$($(package)_version).tar.gz
+$(package)_sha256_hash := c9a4c0bd88123064d483ab46ecee777f14d933359e23bff6fb4f4dbd28b4cd41
 
 define $(package)_config_cmds
   $($(package)_autoconf)

--- a/depends/packages/native_cctools.mk
+++ b/depends/packages/native_cctools.mk
@@ -1,19 +1,19 @@
-package=native_cctools
-$(package)_version=2ef2e931cf641547eb8a68cfebde61003587c9fd
-$(package)_download_path=https://github.com/tpoechtrager/cctools-port/archive
-$(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=6b73269efdf5c58a070e7357b66ee760501388549d6a12b423723f45888b074b
-$(package)_build_subdir=cctools
-$(package)_dependencies=native_libtapi
+package := native_cctools
+$(package)_version := 2ef2e931cf641547eb8a68cfebde61003587c9fd
+$(package)_download_path := https://github.com/tpoechtrager/cctools-port/archive
+$(package)_file_name := $($(package)_version).tar.gz
+$(package)_sha256_hash := 6b73269efdf5c58a070e7357b66ee760501388549d6a12b423723f45888b074b
+$(package)_build_subdir := cctools
+$(package)_dependencies := native_libtapi
 
 define $(package)_set_vars
-  $(package)_config_opts=--target=$(host)
+  $(package)_config_opts := --target=$(host)
   $(package)_ldflags+=-Wl,-rpath=\\$$$$$$$$\$$$$$$$$ORIGIN/../lib
   ifeq ($(strip $(FORCE_USE_SYSTEM_CLANG)),)
   $(package)_config_opts+=--enable-lto-support --with-llvm-config=$(build_prefix)/bin/llvm-config
   endif
-  $(package)_cc=$(clang_prog)
-  $(package)_cxx=$(clangxx_prog)
+  $(package)_cc := $(clang_prog)
+  $(package)_cxx := $(clangxx_prog)
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/native_clang.mk
+++ b/depends/packages/native_clang.mk
@@ -1,12 +1,12 @@
-package=native_clang
-$(package)_version=10.0.1
-$(package)_download_path=https://github.com/llvm/llvm-project/releases/download/llvmorg-$($(package)_version)
+package := native_clang
+$(package)_version := 10.0.1
+$(package)_download_path := https://github.com/llvm/llvm-project/releases/download/llvmorg-$($(package)_version)
 ifneq (,$(findstring aarch64,$(BUILD)))
-$(package)_file_name=clang+llvm-$($(package)_version)-aarch64-linux-gnu.tar.xz
-$(package)_sha256_hash=90dc69a4758ca15cd0ffa45d07fbf5bf4309d47d2c7745a9f0735ecffde9c31f
+$(package)_file_name := clang+llvm-$($(package)_version)-aarch64-linux-gnu.tar.xz
+$(package)_sha256_hash := 90dc69a4758ca15cd0ffa45d07fbf5bf4309d47d2c7745a9f0735ecffde9c31f
 else
-$(package)_file_name=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
-$(package)_sha256_hash=48b83ef827ac2c213d5b64f5ad7ed082c8bcb712b46644e0dc5045c6f462c231
+$(package)_file_name := clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+$(package)_sha256_hash := 48b83ef827ac2c213d5b64f5ad7ed082c8bcb712b46644e0dc5045c6f462c231
 endif
 
 define $(package)_preprocess_cmds

--- a/depends/packages/native_ds_store.mk
+++ b/depends/packages/native_ds_store.mk
@@ -1,9 +1,9 @@
-package=native_ds_store
-$(package)_version=1.3.0
-$(package)_download_path=https://github.com/dmgbuild/ds_store/archive/
-$(package)_file_name=v$($(package)_version).tar.gz
-$(package)_sha256_hash=76b3280cd4e19e5179defa23fb594a9dd32643b0c80d774bd3108361d94fb46d
-$(package)_install_libdir=$(build_prefix)/lib/python3/dist-packages
+package := native_ds_store
+$(package)_version := 1.3.0
+$(package)_download_path := https://github.com/dmgbuild/ds_store/archive/
+$(package)_file_name := v$($(package)_version).tar.gz
+$(package)_sha256_hash := 76b3280cd4e19e5179defa23fb594a9dd32643b0c80d774bd3108361d94fb46d
+$(package)_install_libdir := $(build_prefix)/lib/python3/dist-packages
 
 define $(package)_build_cmds
     python3 setup.py build

--- a/depends/packages/native_libmultiprocess.mk
+++ b/depends/packages/native_libmultiprocess.mk
@@ -1,9 +1,9 @@
-package=native_libmultiprocess
-$(package)_version=d576d975debdc9090bd2582f83f49c76c0061698
-$(package)_download_path=https://github.com/chaincodelabs/libmultiprocess/archive
-$(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=9f8b055c8bba755dc32fe799b67c20b91e7b13e67cadafbc54c0f1def057a370
-$(package)_dependencies=native_capnp
+package := native_libmultiprocess
+$(package)_version := d576d975debdc9090bd2582f83f49c76c0061698
+$(package)_download_path := https://github.com/chaincodelabs/libmultiprocess/archive
+$(package)_file_name := $($(package)_version).tar.gz
+$(package)_sha256_hash := 9f8b055c8bba755dc32fe799b67c20b91e7b13e67cadafbc54c0f1def057a370
+$(package)_dependencies := native_capnp
 
 define $(package)_config_cmds
   $($(package)_cmake) .

--- a/depends/packages/native_libtapi.mk
+++ b/depends/packages/native_libtapi.mk
@@ -1,11 +1,11 @@
-package=native_libtapi
-$(package)_version=664b8414f89612f2dfd35a9b679c345aa5389026
-$(package)_download_path=https://github.com/tpoechtrager/apple-libtapi/archive
-$(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=62e419c12d1c9fad67cc1cd523132bc00db050998337c734c15bc8d73cc02b61
+package := native_libtapi
+$(package)_version := 664b8414f89612f2dfd35a9b679c345aa5389026
+$(package)_download_path := https://github.com/tpoechtrager/apple-libtapi/archive
+$(package)_file_name := $($(package)_version).tar.gz
+$(package)_sha256_hash := 62e419c12d1c9fad67cc1cd523132bc00db050998337c734c15bc8d73cc02b61
 
 ifeq ($(strip $(FORCE_USE_SYSTEM_CLANG)),)
-$(package)_dependencies=native_clang
+$(package)_dependencies := native_clang
 endif
 
 define $(package)_build_cmds

--- a/depends/packages/native_mac_alias.mk
+++ b/depends/packages/native_mac_alias.mk
@@ -1,9 +1,9 @@
-package=native_mac_alias
-$(package)_version=2.2.0
-$(package)_download_path=https://github.com/dmgbuild/mac_alias/archive/
-$(package)_file_name=v$($(package)_version).tar.gz
-$(package)_sha256_hash=421e6d7586d1f155c7db3e7da01ca0dacc9649a509a253ad7077b70174426499
-$(package)_install_libdir=$(build_prefix)/lib/python3/dist-packages
+package := native_mac_alias
+$(package)_version := 2.2.0
+$(package)_download_path := https://github.com/dmgbuild/mac_alias/archive/
+$(package)_file_name := v$($(package)_version).tar.gz
+$(package)_sha256_hash := 421e6d7586d1f155c7db3e7da01ca0dacc9649a509a253ad7077b70174426499
+$(package)_install_libdir := $(build_prefix)/lib/python3/dist-packages
 
 define $(package)_build_cmds
     python3 setup.py build

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,29 +1,29 @@
-packages:=boost libevent
+packages := boost libevent
 
-qrencode_linux_packages = qrencode
-qrencode_android_packages = qrencode
-qrencode_darwin_packages = qrencode
-qrencode_mingw32_packages = qrencode
+qrencode_linux_packages := qrencode
+qrencode_android_packages := qrencode
+qrencode_darwin_packages := qrencode
+qrencode_mingw32_packages := qrencode
 
-qt_linux_packages:=qt expat libxcb xcb_proto libXau xproto freetype fontconfig libxkbcommon libxcb_util libxcb_util_render libxcb_util_keysyms libxcb_util_image libxcb_util_wm
-qt_android_packages=qt
-qt_darwin_packages=qt
-qt_mingw32_packages=qt
+qt_linux_packages := qt expat libxcb xcb_proto libXau xproto freetype fontconfig libxkbcommon libxcb_util libxcb_util_render libxcb_util_keysyms libxcb_util_image libxcb_util_wm
+qt_android_packages := qt
+qt_darwin_packages := qt
+qt_mingw32_packages := qt
 
-bdb_packages=bdb
-sqlite_packages=sqlite
+bdb_packages := bdb
+sqlite_packages := sqlite
 
-zmq_packages=zeromq
+zmq_packages := zeromq
 
-upnp_packages=miniupnpc
-natpmp_packages=libnatpmp
+upnp_packages := miniupnpc
+natpmp_packages := libnatpmp
 
-multiprocess_packages = libmultiprocess capnp
-multiprocess_native_packages = native_libmultiprocess native_capnp
+multiprocess_packages := libmultiprocess capnp
+multiprocess_native_packages := native_libmultiprocess native_capnp
 
-usdt_linux_packages=systemtap
+usdt_linux_packages := systemtap
 
-darwin_native_packages = native_ds_store native_mac_alias
+darwin_native_packages := native_ds_store native_mac_alias
 
 ifneq ($(build_os),darwin)
 darwin_native_packages += native_cctools native_libtapi

--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -1,15 +1,15 @@
-package=qrencode
-$(package)_version=3.4.4
-$(package)_download_path=https://fukuchi.org/works/qrencode/
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=efe5188b1ddbcbf98763b819b146be6a90481aac30cfc8d858ab78a19cde1fa5
+package := qrencode
+$(package)_version := 3.4.4
+$(package)_download_path := https://fukuchi.org/works/qrencode/
+$(package)_file_name := $(package)-$($(package)_version).tar.bz2
+$(package)_sha256_hash := efe5188b1ddbcbf98763b819b146be6a90481aac30cfc8d858ab78a19cde1fa5
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-shared --without-tools --without-tests --disable-sdltest
+$(package)_config_opts := --disable-shared --without-tools --without-tests --disable-sdltest
 $(package)_config_opts += --disable-gprof --disable-gcov --disable-mudflap
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
-$(package)_config_opts_linux=--with-pic
-$(package)_config_opts_android=--with-pic
+$(package)_config_opts_linux := --with-pic
+$(package)_config_opts_android := --with-pic
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -6,8 +6,8 @@ $(package)_file_name := qtbase-$($(package)_suffix)
 $(package)_sha256_hash := 26394ec9375d52c1592bd7b689b1619c6b8dbe9b6f91fdd5c355589787f3a0b6
 $(package)_linux_dependencies := freetype fontconfig libxcb libxkbcommon libxcb_util libxcb_util_render libxcb_util_keysyms libxcb_util_image libxcb_util_wm
 $(package)_qt_libs := corelib network widgets gui plugins testlib
-$(package)_linguist_tools = lrelease lupdate lconvert
-$(package)_patches = qt.pro
+$(package)_linguist_tools := lrelease lupdate lconvert
+$(package)_patches := qt.pro
 $(package)_patches += qttools_src.pro
 $(package)_patches += mac-qmake.conf
 $(package)_patches += fix_qt_pkgconfig.patch
@@ -29,7 +29,7 @@ $(package)_qttranslations_sha256_hash := 5d7869f670a135ad0986e266813b9dd5bbae2b0
 $(package)_qttools_file_name := qttools-$($(package)_suffix)
 $(package)_qttools_sha256_hash := 463b2fe71a085e7ab4e39333ae360ab0ec857b966d7a08f752c427e5df55f90d
 
-$(package)_extra_sources  = $($(package)_qttranslations_file_name)
+$(package)_extra_sources := $($(package)_qttranslations_file_name)
 $(package)_extra_sources += $($(package)_qttools_file_name)
 
 define $(package)_set_vars

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -1,11 +1,11 @@
-package=qt
-$(package)_version=5.15.3
-$(package)_download_path=https://download.qt.io/official_releases/qt/5.15/$($(package)_version)/submodules
-$(package)_suffix=everywhere-opensource-src-$($(package)_version).tar.xz
-$(package)_file_name=qtbase-$($(package)_suffix)
-$(package)_sha256_hash=26394ec9375d52c1592bd7b689b1619c6b8dbe9b6f91fdd5c355589787f3a0b6
-$(package)_linux_dependencies=freetype fontconfig libxcb libxkbcommon libxcb_util libxcb_util_render libxcb_util_keysyms libxcb_util_image libxcb_util_wm
-$(package)_qt_libs=corelib network widgets gui plugins testlib
+package := qt
+$(package)_version := 5.15.3
+$(package)_download_path := https://download.qt.io/official_releases/qt/5.15/$($(package)_version)/submodules
+$(package)_suffix := everywhere-opensource-src-$($(package)_version).tar.xz
+$(package)_file_name := qtbase-$($(package)_suffix)
+$(package)_sha256_hash := 26394ec9375d52c1592bd7b689b1619c6b8dbe9b6f91fdd5c355589787f3a0b6
+$(package)_linux_dependencies := freetype fontconfig libxcb libxkbcommon libxcb_util libxcb_util_render libxcb_util_keysyms libxcb_util_image libxcb_util_wm
+$(package)_qt_libs := corelib network widgets gui plugins testlib
 $(package)_linguist_tools = lrelease lupdate lconvert
 $(package)_patches = qt.pro
 $(package)_patches += qttools_src.pro
@@ -23,11 +23,11 @@ $(package)_patches += rcc_hardcode_timestamp.patch
 $(package)_patches += duplicate_lcqpafonts.patch
 $(package)_patches += fast_fixed_dtoa_no_optimize.patch
 
-$(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
-$(package)_qttranslations_sha256_hash=5d7869f670a135ad0986e266813b9dd5bbae2b09577338f9cdf8904d4af52db0
+$(package)_qttranslations_file_name := qttranslations-$($(package)_suffix)
+$(package)_qttranslations_sha256_hash := 5d7869f670a135ad0986e266813b9dd5bbae2b09577338f9cdf8904d4af52db0
 
-$(package)_qttools_file_name=qttools-$($(package)_suffix)
-$(package)_qttools_sha256_hash=463b2fe71a085e7ab4e39333ae360ab0ec857b966d7a08f752c427e5df55f90d
+$(package)_qttools_file_name := qttools-$($(package)_suffix)
+$(package)_qttools_sha256_hash := 463b2fe71a085e7ab4e39333ae360ab0ec857b966d7a08f752c427e5df55f90d
 
 $(package)_extra_sources  = $($(package)_qttranslations_file_name)
 $(package)_extra_sources += $($(package)_qttools_file_name)

--- a/depends/packages/sqlite.mk
+++ b/depends/packages/sqlite.mk
@@ -1,15 +1,15 @@
-package=sqlite
-$(package)_version=3380500
-$(package)_download_path=https://sqlite.org/2022/
-$(package)_file_name=sqlite-autoconf-$($(package)_version).tar.gz
-$(package)_sha256_hash=5af07de982ba658fd91a03170c945f99c971f6955bc79df3266544373e39869c
+package := sqlite
+$(package)_version := 3380500
+$(package)_download_path := https://sqlite.org/2022/
+$(package)_file_name := sqlite-autoconf-$($(package)_version).tar.gz
+$(package)_sha256_hash := 5af07de982ba658fd91a03170c945f99c971f6955bc79df3266544373e39869c
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-shared --disable-readline --disable-dynamic-extensions --enable-option-checking
-$(package)_config_opts_linux=--with-pic
-$(package)_config_opts_freebsd=--with-pic
-$(package)_config_opts_netbsd=--with-pic
-$(package)_config_opts_openbsd=--with-pic
+$(package)_config_opts := --disable-shared --disable-readline --disable-dynamic-extensions --enable-option-checking
+$(package)_config_opts_linux := --with-pic
+$(package)_config_opts_freebsd := --with-pic
+$(package)_config_opts_netbsd := --with-pic
+$(package)_config_opts_openbsd := --with-pic
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/systemtap.mk
+++ b/depends/packages/systemtap.mk
@@ -1,9 +1,9 @@
-package=systemtap
-$(package)_version=4.7
-$(package)_download_path=https://sourceware.org/systemtap/ftp/releases/
-$(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=43a0a3db91aa4d41e28015b39a65e62059551f3cc7377ebf3a3a5ca7339e7b1f
-$(package)_patches=remove_SDT_ASM_SECTION_AUTOGROUP_SUPPORT_check.patch
+package := systemtap
+$(package)_version := 4.7
+$(package)_download_path := https://sourceware.org/systemtap/ftp/releases/
+$(package)_file_name := $(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash := 43a0a3db91aa4d41e28015b39a65e62059551f3cc7377ebf3a3a5ca7339e7b1f
+$(package)_patches := remove_SDT_ASM_SECTION_AUTOGROUP_SUPPORT_check.patch
 
 define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/remove_SDT_ASM_SECTION_AUTOGROUP_SUPPORT_check.patch && \

--- a/depends/packages/xcb_proto.mk
+++ b/depends/packages/xcb_proto.mk
@@ -1,8 +1,8 @@
-package=xcb_proto
-$(package)_version=1.14.1
-$(package)_download_path=https://xorg.freedesktop.org/archive/individual/proto
-$(package)_file_name=xcb-proto-$($(package)_version).tar.xz
-$(package)_sha256_hash=f04add9a972ac334ea11d9d7eb4fc7f8883835da3e4859c9afa971efdf57fcc3
+package := xcb_proto
+$(package)_version := 1.14.1
+$(package)_download_path := https://xorg.freedesktop.org/archive/individual/proto
+$(package)_file_name := xcb-proto-$($(package)_version).tar.xz
+$(package)_sha256_hash := f04add9a972ac334ea11d9d7eb4fc7f8883835da3e4859c9afa971efdf57fcc3
 
 define $(package)_config_cmds
   $($(package)_autoconf)

--- a/depends/packages/xproto.mk
+++ b/depends/packages/xproto.mk
@@ -1,11 +1,11 @@
-package=xproto
-$(package)_version=7.0.31
-$(package)_download_path=https://xorg.freedesktop.org/releases/individual/proto
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=c6f9747da0bd3a95f86b17fb8dd5e717c8f3ab7f0ece3ba1b247899ec1ef7747
+package := xproto
+$(package)_version := 7.0.31
+$(package)_download_path := https://xorg.freedesktop.org/releases/individual/proto
+$(package)_file_name := $(package)-$($(package)_version).tar.bz2
+$(package)_sha256_hash := c6f9747da0bd3a95f86b17fb8dd5e717c8f3ab7f0ece3ba1b247899ec1ef7747
 
 define $(package)_set_vars
-$(package)_config_opts=--without-fop --without-xmlto --without-xsltproc --disable-specs
+$(package)_config_opts := --without-fop --without-xmlto --without-xsltproc --disable-specs
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 endef
 

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -1,9 +1,9 @@
-package=zeromq
-$(package)_version=4.3.4
-$(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
-$(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5
-$(package)_patches=remove_libstd_link.patch netbsd_kevent_void.patch
+package := zeromq
+$(package)_version := 4.3.4
+$(package)_download_path := https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
+$(package)_file_name := $(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash := c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5
+$(package)_patches := remove_libstd_link.patch netbsd_kevent_void.patch
 
 define $(package)_set_vars
   $(package)_config_opts = --without-docs --disable-shared --disable-valgrind
@@ -11,11 +11,11 @@ define $(package)_set_vars
   $(package)_config_opts += --without-libsodium --without-libgssapi_krb5 --without-pgm --without-norm --without-vmci
   $(package)_config_opts += --disable-libunwind --disable-radix-tree --without-gcov --disable-dependency-tracking
   $(package)_config_opts += --disable-Werror --disable-drafts --enable-option-checking
-  $(package)_config_opts_linux=--with-pic
-  $(package)_config_opts_freebsd=--with-pic
-  $(package)_config_opts_netbsd=--with-pic
-  $(package)_config_opts_openbsd=--with-pic
-  $(package)_config_opts_android=--with-pic
+  $(package)_config_opts_linux := --with-pic
+  $(package)_config_opts_freebsd := --with-pic
+  $(package)_config_opts_netbsd := --with-pic
+  $(package)_config_opts_openbsd := --with-pic
+  $(package)_config_opts_android := --with-pic
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
The depends build system looks fragile in its current state. For example, on master (346e780442f91fc155dcc9c44eedf23ac0bb15a7):
```
$ make --no-print-directory -C depends print-qt_suffix
qt_suffix=everywhere-opensource-src-4.3.4.tar.xz
```

With this PR:
```
$ make --no-print-directory -C depends print-qt_suffix
qt_suffix=everywhere-opensource-src-5.15.3.tar.xz
```

Required for bitcoin/bitcoin#22555.