### PR TITLE
fuzz: silence a compiler warning about unused CBanEntry comparator

### DIFF
--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -109,8 +109,9 @@ FUZZ_TARGET_INIT(banman, initialize_banman)
             BanMan ban_man_read{banlist_file, /* client_interface */ nullptr, /* default_ban_time */ 0};
             banmap_t banmap_read;
             ban_man_read.GetBanned(banmap_read);
-            // Temporarily disabled to allow the remainder of the fuzz test to run while a fix is being worked on:
-            // assert(banmap == banmap_read);
+            // Assert temporarily disabled to allow the remainder of the fuzz test to run while a
+            // fix is being worked on. See https://github.com/bitcoin/bitcoin/pull/22517
+            (void)(banmap == banmap_read);
         }
     }
     fs::remove(banlist_file.string() + ".dat");


### PR DESCRIPTION
```
test/fuzz/banman.cpp:35:13: warning: unused function 'operator==' [-Wunused-function]
static bool operator==(const CBanEntry& lhs, const CBanEntry& rhs)
            ^
1 warning generated.
```

See https://github.com/bitcoin/bitcoin/pull/22517#issuecomment-886177699