### PR TITLE
addrman: treat Tor/I2P/CJDNS as a single group

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -53,6 +53,11 @@ int AddrInfo::GetTriedBucket(const uint256& nKey, const NetGroupManager& netgrou
 int AddrInfo::GetNewBucket(const uint256& nKey, const CNetAddr& src, const NetGroupManager& netgroupman) const
 {
     std::vector<unsigned char> vchSourceGroupKey = netgroupman.GetGroup(src);
+    if (src.IsTor() || src.IsI2P() || src.IsCJDNS()) {
+        // For the purposes of new-bucketing, treat the entire Tor network as a single source (same
+        // for I2P and CJDNS).
+        vchSourceGroupKey.resize(1);
+    }
     uint64_t hash1 = (HashWriter{} << nKey << netgroupman.GetGroup(*this) << vchSourceGroupKey).GetCheapHash();
     uint64_t hash2 = (HashWriter{} << nKey << vchSourceGroupKey << (hash1 % ADDRMAN_NEW_BUCKETS_PER_SOURCE_GROUP)).GetCheapHash();
     return hash2 % ADDRMAN_NEW_BUCKET_COUNT;


### PR DESCRIPTION
Sub-netting does not exist in Tor/I2P/CJDNS. Obtaining such addresses
is easier compared to obtaining IP addresses. Also, obtaining
Tor/I2P/CJDNS addresses that do not have a common prefix is not harder
than obtaining ones with common prefix.