### PR TITLE
fuzz: document faster throughput configuration

### DIFF
--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -83,6 +83,10 @@ INFO: seed corpus: files: 991 min: 1b max: 1858b total: 288291b rss: 150Mb
 …
 ```
 
+## Run without sanitizers for increased throughput
+
+Fuzzing on a harness compiled with `--with-sanitizers=address,fuzzer,undefined` is good for finding bugs. However, the very slow execution even under libFuzzer will limit the ability to find new coverage. A good approach is to perform occasional long runs without the additional bug-detectors (configure `--with-sanitizers=fuzzer`) and then merge new inputs into a corpus as described in the qa-assets repo (https://github.com/bitcoin-core/qa-assets/blob/main/.github/PULL_REQUEST_TEMPLATE.md).  Patience is useful; even with improved throughput, libFuzzer may need days and 10s of millions of executions to reach deep/hard targets.
+
 ## Reproduce a fuzzer crash reported by the CI
 
 - `cd` into the `qa-assets` directory and update it with `git pull qa-assets`


### PR DESCRIPTION
This is a small change to the fuzzing doc that I think might help more people improve the corpus coverage, which I think is low partly just due to lack of long, low-overhead, runs, in addition to the need to apply a more diverse set of fuzzers and coverage notions.