### PR TITLE
test: Add temporary sanitizer suppression implicit-signed-integer-truncation:netaddress.cpp

### DIFF
--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -89,6 +89,7 @@ implicit-signed-integer-truncation:leveldb/
 implicit-signed-integer-truncation:miner.cpp
 implicit-signed-integer-truncation:net.cpp
 implicit-signed-integer-truncation:net_processing.cpp
+implicit-signed-integer-truncation:netaddress.cpp
 implicit-signed-integer-truncation:streams.h
 implicit-signed-integer-truncation:test/arith_uint256_tests.cpp
 implicit-signed-integer-truncation:test/skiplist_tests.cpp


### PR DESCRIPTION
This is required to unbreak the fuzzers while a fix is being worked on.

https://cirrus-ci.com/task/4787303177519104?logs=ci#L3020

```
netaddress.cpp:1190:18: runtime error: implicit conversion from type 'int' of value -1 (32-bit, signed) to type 'uint8_t' (aka 'unsigned char') changed the value to 255 (8-bit, unsigned)