### PR TITLE
p2p: fix ubsan implicit conversion error in CSubNet::ToString()

### DIFF
--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -1187,7 +1187,12 @@ std::string CSubNet::ToString() const
             if (netmask[i] == 0x00) {
                 break;
             }
-            cidr += NetmaskBits(netmask[i]);
+            const int num_bits{NetmaskBits(netmask[i])};
+            if (num_bits == -1) {
+                // Invalid subnet mask
+                break;
+            }
+            cidr += num_bits;
         }
 
         suffix = strprintf("/%u", cidr);

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -89,7 +89,6 @@ implicit-signed-integer-truncation:leveldb/
 implicit-signed-integer-truncation:miner.cpp
 implicit-signed-integer-truncation:net.cpp
 implicit-signed-integer-truncation:net_processing.cpp
-implicit-signed-integer-truncation:netaddress.cpp
 implicit-signed-integer-truncation:streams.h
 implicit-signed-integer-truncation:test/arith_uint256_tests.cpp
 implicit-signed-integer-truncation:test/skiplist_tests.cpp


### PR DESCRIPTION
Resolves https://cirrus-ci.com/task/4787303177519104?logs=ci#L3020 related to #22584.

```
UndefinedBehaviorSanitizer: implicit-signed-integer-truncation

netaddress.cpp:1190:18: runtime error: implicit conversion
  from type 'int' of value -1 (32-bit, signed)
  to type 'uint8_t' (aka 'unsigned char')
  changed the value to 255 (8-bit, unsigned)
```

`NetmaskBits()` returns -1 if the subnet mask is invalid, which can be incompatible with `uint8_t cidr` and should probably be exited from.

This allows removing the netaddress UBSan suppression (implicit-signed-integer-truncation).