### PR TITLE
test: refactor: remove `hex_str_to_bytes` helper

### DIFF
--- a/test/functional/feature_dbcrash.py
+++ b/test/functional/feature_dbcrash.py
@@ -41,7 +41,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     create_confirmed_utxos,
-    hex_str_to_bytes,
 )
 
 
@@ -204,7 +203,7 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
                 continue
 
             for _ in range(3):
-                tx.vout.append(CTxOut(output_amount, hex_str_to_bytes(utxo['scriptPubKey'])))
+                tx.vout.append(CTxOut(output_amount, bytes.fromhex(utxo['scriptPubKey'])))
 
             # Sign and send the transaction to get into the mempool
             tx_signed_hex = node.signrawtransactionwithwallet(tx.serialize().hex())['hex']

--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -46,7 +46,6 @@ from test_framework.util import (
     assert_equal,
     assert_is_hex_string,
     assert_raises_rpc_error,
-    hex_str_to_bytes,
     try_rpc,
 )
 
@@ -140,7 +139,7 @@ class SegWitTest(BitcoinTestFramework):
         for i in range(3):
             newaddress = self.nodes[i].getnewaddress()
             self.pubkey.append(self.nodes[i].getaddressinfo(newaddress)["pubkey"])
-            multiscript = CScript([OP_1, hex_str_to_bytes(self.pubkey[-1]), OP_1, OP_CHECKMULTISIG])
+            multiscript = CScript([OP_1, bytes.fromhex(self.pubkey[-1]), OP_1, OP_CHECKMULTISIG])
             p2sh_ms_addr = self.nodes[i].addmultisigaddress(1, [self.pubkey[-1]], '', 'p2sh-segwit')['address']
             bip173_ms_addr = self.nodes[i].addmultisigaddress(1, [self.pubkey[-1]], '', 'bech32')['address']
             assert_equal(p2sh_ms_addr, script_to_p2sh_p2wsh(multiscript))
@@ -352,7 +351,7 @@ class SegWitTest(BitcoinTestFramework):
         # Money sent to P2SH of multisig of this should only be seen after importaddress with the BASE58 P2SH address.
 
         multisig_without_privkey_address = self.nodes[0].addmultisigaddress(2, [pubkeys[3], pubkeys[4]])['address']
-        script = CScript([OP_2, hex_str_to_bytes(pubkeys[3]), hex_str_to_bytes(pubkeys[4]), OP_2, OP_CHECKMULTISIG])
+        script = CScript([OP_2, bytes.fromhex(pubkeys[3]), bytes.fromhex(pubkeys[4]), OP_2, OP_CHECKMULTISIG])
         solvable_after_importaddress.append(script_to_p2sh_script(script))
 
         for i in compressed_spendable_address:
@@ -426,7 +425,7 @@ class SegWitTest(BitcoinTestFramework):
         op1 = CScript([OP_1])
         op0 = CScript([OP_0])
         # 2N7MGY19ti4KDMSzRfPAssP6Pxyuxoi6jLe is the P2SH(P2PKH) version of mjoE3sSrb8ByYEvgnC3Aox86u1CHnfJA4V
-        unsolvable_address_key = hex_str_to_bytes("02341AEC7587A51CDE5279E0630A531AEA2615A9F80B17E8D9376327BAEAA59E3D")
+        unsolvable_address_key = bytes.fromhex("02341AEC7587A51CDE5279E0630A531AEA2615A9F80B17E8D9376327BAEAA59E3D")
         unsolvablep2pkh = key_to_p2pkh_script(unsolvable_address_key)
         unsolvablep2wshp2pkh = script_to_p2wsh_script(unsolvablep2pkh)
         p2shop0 = script_to_p2sh_script(op0)
@@ -448,11 +447,11 @@ class SegWitTest(BitcoinTestFramework):
         for i in compressed_spendable_address + uncompressed_spendable_address + compressed_solvable_address + uncompressed_solvable_address:
             v = self.nodes[0].getaddressinfo(i)
             if (v['isscript']):
-                bare = hex_str_to_bytes(v['hex'])
+                bare = bytes.fromhex(v['hex'])
                 importlist.append(bare.hex())
                 importlist.append(script_to_p2wsh_script(bare).hex())
             else:
-                pubkey = hex_str_to_bytes(v['pubkey'])
+                pubkey = bytes.fromhex(v['pubkey'])
                 p2pk = CScript([pubkey, OP_CHECKSIG])
                 p2pkh = key_to_p2pkh_script(pubkey)
                 importlist.append(p2pk.hex())
@@ -612,18 +611,18 @@ class SegWitTest(BitcoinTestFramework):
         return txid
 
     def p2sh_address_to_script(self, v):
-        bare = CScript(hex_str_to_bytes(v['hex']))
-        p2sh = CScript(hex_str_to_bytes(v['scriptPubKey']))
+        bare = CScript(bytes.fromhex(v['hex']))
+        p2sh = CScript(bytes.fromhex(v['scriptPubKey']))
         p2wsh = script_to_p2wsh_script(bare)
         p2sh_p2wsh = script_to_p2sh_script(p2wsh)
         return([bare, p2sh, p2wsh, p2sh_p2wsh])
 
     def p2pkh_address_to_script(self, v):
-        pubkey = hex_str_to_bytes(v['pubkey'])
+        pubkey = bytes.fromhex(v['pubkey'])
         p2wpkh = key_to_p2wpkh_script(pubkey)
         p2sh_p2wpkh = script_to_p2sh_script(p2wpkh)
         p2pk = CScript([pubkey, OP_CHECKSIG])
-        p2pkh = CScript(hex_str_to_bytes(v['scriptPubKey']))
+        p2pkh = CScript(bytes.fromhex(v['scriptPubKey']))
         p2sh_p2pk = script_to_p2sh_script(p2pk)
         p2sh_p2pkh = script_to_p2sh_script(p2pkh)
         p2wsh_p2pk = script_to_p2wsh_script(p2pk)

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -19,7 +19,6 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than,
     assert_greater_than_or_equal,
-    hex_str_to_bytes,
 )
 
 from test_framework.messages import BLOCK_HEADER_SIZE
@@ -147,7 +146,7 @@ class RESTTest (BitcoinTestFramework):
 
         bin_request = b'\x01\x02'
         for txid, n in [spending, spent]:
-            bin_request += hex_str_to_bytes(txid)
+            bin_request += bytes.fromhex(txid)
             bin_request += pack("i", n)
 
         bin_response = self.test_rest_request("/getutxos", http_method='POST', req_type=ReqType.BIN, body=bin_request, ret_type=RetType.BYTES)

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -28,7 +28,6 @@ from test_framework.p2p import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    hex_str_to_bytes,
 )
 
 VALID_DATA_LIMIT = MAX_PROTOCOL_MESSAGE_LENGTH - 5  # Account for the 5-byte length prefix
@@ -187,7 +186,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
             [
                 'received: addrv2 (1 bytes)',
             ],
-            hex_str_to_bytes('00'))
+            bytes.fromhex('00'))
 
     def test_addrv2_too_long_address(self):
         self.test_addrv2('too long address',
@@ -196,7 +195,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
                 'ProcessMessages(addrv2, 525 bytes): Exception',
                 'Address too long: 513 > 512',
             ],
-            hex_str_to_bytes(
+            bytes.fromhex(
                 '01' +       # number of entries
                 '61bc6649' + # time, Fri Jan  9 02:54:25 UTC 2009
                 '00' +       # service flags, COMPACTSIZE(NODE_NONE)
@@ -213,7 +212,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
                 'IP 9.9.9.9 mapped',
                 'Added 1 addresses',
             ],
-            hex_str_to_bytes(
+            bytes.fromhex(
                 '02' +     # number of entries
                 # this should be ignored without impeding acceptance of subsequent ones
                 now_hex +  # time

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -81,7 +81,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     softfork_active,
-    hex_str_to_bytes,
     assert_raises_rpc_error,
 )
 
@@ -415,7 +414,7 @@ class SegWitTest(BitcoinTestFramework):
                 block = self.test_node.request_block(block_hash, 2)
                 wit_block = self.test_node.request_block(block_hash, 2 | MSG_WITNESS_FLAG)
                 assert_equal(block.serialize(), wit_block.serialize())
-                assert_equal(block.serialize(), hex_str_to_bytes(rpc_block))
+                assert_equal(block.serialize(), bytes.fromhex(rpc_block))
         else:
             # After activation, witness blocks and non-witness blocks should
             # be different.  Verify rpc getblock() returns witness blocks, while
@@ -430,7 +429,7 @@ class SegWitTest(BitcoinTestFramework):
             rpc_block = self.nodes[0].getblock(block.hash, False)
             non_wit_block = self.test_node.request_block(block.sha256, 2)
             wit_block = self.test_node.request_block(block.sha256, 2 | MSG_WITNESS_FLAG)
-            assert_equal(wit_block.serialize(), hex_str_to_bytes(rpc_block))
+            assert_equal(wit_block.serialize(), bytes.fromhex(rpc_block))
             assert_equal(wit_block.serialize(False), non_wit_block.serialize())
             assert_equal(wit_block.serialize(), block.serialize())
 

--- a/test/functional/rpc_addresses_deprecation.py
+++ b/test/functional/rpc_addresses_deprecation.py
@@ -10,7 +10,6 @@ from test_framework.messages import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    hex_str_to_bytes
 )
 
 
@@ -36,7 +35,7 @@ class AddressesDeprecationTest(BitcoinTestFramework):
 
         # This transaction is derived from test/util/data/txcreatemultisig1.json
         tx = tx_from_hex(signed)
-        tx.vout[0].scriptPubKey = hex_str_to_bytes("522102a5613bd857b7048924264d1e70e08fb2a7e6527d32b7ab1bb993ac59964ff39721021ac43c7ff740014c3b33737ede99c967e4764553d1b2b83db77c83b8715fa72d2102df2089105c77f266fa11a9d33f05c735234075f2e8780824c6b709415f9fb48553ae")
+        tx.vout[0].scriptPubKey = bytes.fromhex("522102a5613bd857b7048924264d1e70e08fb2a7e6527d32b7ab1bb993ac59964ff39721021ac43c7ff740014c3b33737ede99c967e4764553d1b2b83db77c83b8715fa72d2102df2089105c77f266fa11a9d33f05c735234075f2e8780824c6b709415f9fb48553ae")
         tx_signed = node.signrawtransactionwithwallet(tx.serialize().hex())['hex']
         txid = node.sendrawtransaction(hexstring=tx_signed, maxfeerate=0)
 

--- a/test/functional/rpc_decodescript.py
+++ b/test/functional/rpc_decodescript.py
@@ -11,7 +11,6 @@ from test_framework.messages import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    hex_str_to_bytes,
 )
 
 
@@ -86,7 +85,7 @@ class DecodeScriptTest(BitcoinTestFramework):
         rpc_result = self.nodes[0].decodescript(multisig_script)
         assert_equal('2 ' + public_key + ' ' + public_key + ' ' + public_key +  ' 3 OP_CHECKMULTISIG', rpc_result['asm'])
         # multisig in P2WSH
-        multisig_script_hash = sha256(hex_str_to_bytes(multisig_script)).hex()
+        multisig_script_hash = sha256(bytes.fromhex(multisig_script)).hex()
         assert_equal('0 ' + multisig_script_hash, rpc_result['segwit']['asm'])
 
         # 4) P2SH scriptPubKey
@@ -124,7 +123,7 @@ class DecodeScriptTest(BitcoinTestFramework):
         rpc_result = self.nodes[0].decodescript(cltv_script)
         assert_equal('OP_IF ' + public_key + ' OP_CHECKSIGVERIFY OP_ELSE 500000 OP_CHECKLOCKTIMEVERIFY OP_DROP OP_ENDIF ' + public_key + ' OP_CHECKSIG', rpc_result['asm'])
         # CLTV script in P2WSH
-        cltv_script_hash = sha256(hex_str_to_bytes(cltv_script)).hex()
+        cltv_script_hash = sha256(bytes.fromhex(cltv_script)).hex()
         assert_equal('0 ' + cltv_script_hash, rpc_result['segwit']['asm'])
 
         # 7) P2PK scriptPubKey
@@ -209,23 +208,23 @@ class DecodeScriptTest(BitcoinTestFramework):
         signature_2_sighash_decoded = der_signature + '[NONE|ANYONECANPAY]'
 
         # 1) P2PK scriptSig
-        txSave.vin[0].scriptSig = hex_str_to_bytes(push_signature)
+        txSave.vin[0].scriptSig = bytes.fromhex(push_signature)
         rpc_result = self.nodes[0].decoderawtransaction(txSave.serialize().hex())
         assert_equal(signature_sighash_decoded, rpc_result['vin'][0]['scriptSig']['asm'])
 
         # make sure that the sighash decodes come out correctly for a more complex / lesser used case.
-        txSave.vin[0].scriptSig = hex_str_to_bytes(push_signature_2)
+        txSave.vin[0].scriptSig = bytes.fromhex(push_signature_2)
         rpc_result = self.nodes[0].decoderawtransaction(txSave.serialize().hex())
         assert_equal(signature_2_sighash_decoded, rpc_result['vin'][0]['scriptSig']['asm'])
 
         # 2) multisig scriptSig
-        txSave.vin[0].scriptSig = hex_str_to_bytes('00' + push_signature + push_signature_2)
+        txSave.vin[0].scriptSig = bytes.fromhex('00' + push_signature + push_signature_2)
         rpc_result = self.nodes[0].decoderawtransaction(txSave.serialize().hex())
         assert_equal('0 ' + signature_sighash_decoded + ' ' + signature_2_sighash_decoded, rpc_result['vin'][0]['scriptSig']['asm'])
 
         # 3) test a scriptSig that contains more than push operations.
         # in fact, it contains an OP_RETURN with data specially crafted to cause improper decode if the code does not catch it.
-        txSave.vin[0].scriptSig = hex_str_to_bytes('6a143011020701010101010101020601010101010101')
+        txSave.vin[0].scriptSig = bytes.fromhex('6a143011020701010101010101020601010101010101')
         rpc_result = self.nodes[0].decoderawtransaction(txSave.serialize().hex())
         assert_equal('OP_RETURN 3011020701010101010101020601010101010101', rpc_result['vin'][0]['scriptSig']['asm'])
 

--- a/test/functional/rpc_signrawtransaction.py
+++ b/test/functional/rpc_signrawtransaction.py
@@ -20,7 +20,6 @@ from test_framework.util import (
     assert_raises_rpc_error,
     find_vout_for_address,
     generate_to_height,
-    hex_str_to_bytes,
 )
 from test_framework.messages import (
     CTxInWitness,
@@ -233,7 +232,7 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         embedded_pubkey = eckey.get_pubkey().get_bytes().hex()
         witness_script = {
             'P2PKH': key_to_p2pkh_script(embedded_pubkey).hex(),
-            'P2PK': CScript([hex_str_to_bytes(embedded_pubkey), OP_CHECKSIG]).hex()
+            'P2PK': CScript([bytes.fromhex(embedded_pubkey), OP_CHECKSIG]).hex()
         }.get(tx_type, "Invalid tx_type")
         redeem_script = script_to_p2wsh_script(witness_script).hex()
         addr = script_to_p2sh(redeem_script)

--- a/test/functional/test_framework/address.py
+++ b/test/functional/test_framework/address.py
@@ -12,7 +12,7 @@ import unittest
 
 from .script import hash256, hash160, sha256, CScript, OP_0
 from .segwit_addr import encode_segwit_address
-from .util import assert_equal, hex_str_to_bytes
+from .util import assert_equal
 
 ADDRESS_BCRT1_UNSPENDABLE = 'bcrt1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3xueyj'
 ADDRESS_BCRT1_UNSPENDABLE_DESCRIPTOR = 'addr(bcrt1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3xueyj)#juyq9d97'
@@ -33,7 +33,7 @@ def byte_to_base58(b, version):
     result = ''
     str = b.hex()
     str = chr(version).encode('latin-1').hex() + str
-    checksum = hash256(hex_str_to_bytes(str)).hex()
+    checksum = hash256(bytes.fromhex(str)).hex()
     str += checksum[:8]
     value = int('0x' + str, 0)
     while value > 0:
@@ -100,7 +100,7 @@ def key_to_p2sh_p2wpkh(key, main=False):
 
 def program_to_witness(version, program, main=False):
     if (type(program) is str):
-        program = hex_str_to_bytes(program)
+        program = bytes.fromhex(program)
     assert 0 <= version <= 16
     assert 2 <= len(program) <= 40
     assert version > 0 or len(program) in [20, 32]
@@ -121,14 +121,14 @@ def script_to_p2sh_p2wsh(script, main=False):
 
 def check_key(key):
     if (type(key) is str):
-        key = hex_str_to_bytes(key)  # Assuming this is hex string
+        key = bytes.fromhex(key)  # Assuming this is hex string
     if (type(key) is bytes and (len(key) == 33 or len(key) == 65)):
         return key
     assert False
 
 def check_script(script):
     if (type(script) is str):
-        script = hex_str_to_bytes(script)  # Assuming this is hex string
+        script = bytes.fromhex(script)  # Assuming this is hex string
     if (type(script) is bytes or type(script) is CScript):
         return script
     assert False

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -24,7 +24,6 @@ from .messages import (
     CTxInWitness,
     CTxOut,
     hash256,
-    hex_str_to_bytes,
     ser_uint256,
     tx_from_hex,
     uint256_from_str,
@@ -214,7 +213,7 @@ def witness_script(use_p2wsh, pubkey):
         pkscript = key_to_p2wpkh_script(pubkey)
     else:
         # 1-of-1 multisig
-        witness_script = CScript([OP_1, hex_str_to_bytes(pubkey), OP_1, OP_CHECKMULTISIG])
+        witness_script = CScript([OP_1, bytes.fromhex(pubkey), OP_1, OP_CHECKMULTISIG])
         pkscript = script_to_p2wsh_script(witness_script)
     return pkscript.hex()
 
@@ -223,7 +222,7 @@ def create_witness_tx(node, use_p2wsh, utxo, pubkey, encode_p2sh, amount):
 
     Optionally wrap the segwit output using P2SH."""
     if use_p2wsh:
-        program = CScript([OP_1, hex_str_to_bytes(pubkey), OP_1, OP_CHECKMULTISIG])
+        program = CScript([OP_1, bytes.fromhex(pubkey), OP_1, OP_CHECKMULTISIG])
         addr = script_to_p2sh_p2wsh(program) if encode_p2sh else script_to_p2wsh(program)
     else:
         addr = key_to_p2sh_p2wpkh(pubkey) if encode_p2sh else key_to_p2wpkh(pubkey)
@@ -246,7 +245,7 @@ def send_to_witness(use_p2wsh, node, utxo, pubkey, encode_p2sh, amount, sign=Tru
     else:
         if (insert_redeem_script):
             tx = tx_from_hex(tx_to_witness)
-            tx.vin[0].scriptSig += CScript([hex_str_to_bytes(insert_redeem_script)])
+            tx.vin[0].scriptSig += CScript([bytes.fromhex(insert_redeem_script)])
             tx_to_witness = tx.serialize().hex()
 
     return node.sendrawtransaction(tx_to_witness)

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -30,7 +30,7 @@ import struct
 import time
 
 from test_framework.siphash import siphash256
-from test_framework.util import hex_str_to_bytes, assert_equal
+from test_framework.util import assert_equal
 
 MAX_LOCATOR_SZ = 101
 MAX_BLOCK_BASE_SIZE = 1000000
@@ -197,7 +197,7 @@ def from_hex(obj, hex_string):
     Note that there is no complementary helper like e.g. `to_hex` for the
     inverse operation. To serialize a message object to a hex string, simply
     use obj.serialize().hex()"""
-    obj.deserialize(BytesIO(hex_str_to_bytes(hex_string)))
+    obj.deserialize(BytesIO(bytes.fromhex(hex_string)))
     return obj
 
 

--- a/test/functional/test_framework/script_util.py
+++ b/test/functional/test_framework/script_util.py
@@ -4,7 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Useful Script constants and utils."""
 from test_framework.script import CScript, hash160, sha256, OP_0, OP_DUP, OP_HASH160, OP_CHECKSIG, OP_EQUAL, OP_EQUALVERIFY
-from test_framework.util import hex_str_to_bytes
 
 # To prevent a "tx-size-small" policy rule error, a transaction has to have a
 # non-witness size of at least 82 bytes (MIN_STANDARD_TX_NONWITNESS_SIZE in
@@ -49,7 +48,7 @@ def key_to_p2sh_p2wpkh_script(key, main = False):
 
 def program_to_witness_script(version, program, main = False):
     if isinstance(program, str):
-        program = hex_str_to_bytes(program)
+        program = bytes.fromhex(program)
     assert 0 <= version <= 16
     assert 2 <= len(program) <= 40
     assert version > 0 or len(program) in [20, 32]
@@ -70,14 +69,14 @@ def script_to_p2sh_p2wsh_script(script, main = False):
 
 def check_key(key):
     if isinstance(key, str):
-        key = hex_str_to_bytes(key) # Assuming this is hex string
+        key = bytes.fromhex(key) # Assuming this is hex string
     if isinstance(key, bytes) and (len(key) == 33 or len(key) == 65):
         return key
     assert False
 
 def check_script(script):
     if isinstance(script, str):
-        script = hex_str_to_bytes(script) # Assuming this is hex string
+        script = bytes.fromhex(script) # Assuming this is hex string
     if isinstance(script, bytes) or isinstance(script, CScript):
         return script
     assert False

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -5,7 +5,6 @@
 """Helpful routines for regression testing."""
 
 from base64 import b64encode
-from binascii import unhexlify
 from decimal import Decimal, ROUND_DOWN
 from subprocess import CalledProcessError
 import hashlib
@@ -212,10 +211,6 @@ def EncodeDecimal(o):
 
 def count_bytes(hex_string):
     return len(bytearray.fromhex(hex_string))
-
-
-def hex_str_to_bytes(hex_str):
-    return unhexlify(hex_str.encode('ascii'))
 
 
 def str_to_b64str(string):
@@ -517,7 +512,7 @@ def gen_return_txouts():
     from .messages import CTxOut
     txout = CTxOut()
     txout.nValue = 0
-    txout.scriptPubKey = hex_str_to_bytes(script_pubkey)
+    txout.scriptPubKey = bytes.fromhex(script_pubkey)
     for _ in range(128):
         txouts.append(txout)
     return txouts

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -27,7 +27,6 @@ from test_framework.script import (
 )
 from test_framework.util import (
     assert_equal,
-    hex_str_to_bytes,
     satoshi_round,
 )
 
@@ -73,7 +72,7 @@ class MiniWallet:
             self._scriptPubKey = bytes(CScript([pub_key.get_bytes(), OP_CHECKSIG]))
         elif mode == MiniWalletMode.ADDRESS_OP_TRUE:
             self._address = ADDRESS_BCRT1_P2WSH_OP_TRUE
-            self._scriptPubKey = hex_str_to_bytes(self._test_node.validateaddress(self._address)['scriptPubKey'])
+            self._scriptPubKey = bytes.fromhex(self._test_node.validateaddress(self._address)['scriptPubKey'])
 
     def scan_blocks(self, *, start=1, num):
         """Scan the blocks for self._address outputs and add them to self._utxos"""

--- a/test/functional/test_framework/wallet_util.py
+++ b/test/functional/test_framework/wallet_util.py
@@ -27,7 +27,6 @@ from test_framework.script_util import (
     script_to_p2sh_script,
     script_to_p2wsh_script,
 )
-from test_framework.util import hex_str_to_bytes
 
 Key = namedtuple('Key', ['privkey',
                          'pubkey',
@@ -93,7 +92,7 @@ def get_multisig(node):
         addr = node.getaddressinfo(node.getnewaddress())
         addrs.append(addr['address'])
         pubkeys.append(addr['pubkey'])
-    script_code = CScript([OP_2] + [hex_str_to_bytes(pubkey) for pubkey in pubkeys] + [OP_3, OP_CHECKMULTISIG])
+    script_code = CScript([OP_2] + [bytes.fromhex(pubkey) for pubkey in pubkeys] + [OP_3, OP_CHECKMULTISIG])
     witness_script = script_to_p2wsh_script(script_code)
     return Multisig(privkeys=[node.dumpprivkey(addr) for addr in addrs],
                     pubkeys=pubkeys,


### PR DESCRIPTION
Use the built-in class method `bytes.fromhex()` instead, which is available since Python 3.0 (https://docs.python.org/3.0/library/stdtypes.html?highlight=fromhex#bytes.fromhex).

This would be nice to solve with a scripted-diff, but it's tricky to also tackle the imports (which need to be removed in the same commit, otherwise the linter would complain).