### PR TITLE
p2p, rpc, test: address rate-limiting follow-ups

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -161,7 +161,7 @@ static constexpr size_t MAX_ADDR_TO_SEND{1000};
 static constexpr double MAX_ADDR_RATE_PER_SECOND{0.1};
 /** The soft limit of the address processing token bucket (the regular MAX_ADDR_RATE_PER_SECOND
  *  based increments won't go above this, but the MAX_ADDR_TO_SEND increment following GETADDR
- *  is exempt from this limit. */
+ *  is exempt from this limit). */
 static constexpr size_t MAX_ADDR_PROCESSING_TOKEN_BUCKET{MAX_ADDR_TO_SEND};
 
 // Internal stuff
@@ -263,14 +263,14 @@ struct Peer {
     std::atomic_bool m_wants_addrv2{false};
     /** Whether this peer has already sent us a getaddr message. */
     bool m_getaddr_recvd{false};
-    /** Number of addr messages that can be processed from this peer. Start at 1 to
+    /** Number of addresses that can be processed from this peer. Start at 1 to
      *  permit self-announcement. */
     double m_addr_token_bucket{1.0};
     /** When m_addr_token_bucket was last updated */
     std::chrono::microseconds m_addr_token_timestamp{GetTime<std::chrono::microseconds>()};
     /** Total number of addresses that were dropped due to rate limiting. */
     std::atomic<uint64_t> m_addr_rate_limited{0};
-    /** Total number of addresses that were processed (excludes rate limited ones). */
+    /** Total number of addresses that were processed (excludes rate-limited ones). */
     std::atomic<uint64_t> m_addr_processed{0};
 
     /** Set of txids to reconsider once their parent transactions have been accepted **/
@@ -2848,11 +2848,12 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                 return;
 
             // Apply rate limiting.
-            if (rate_limited) {
-                if (peer->m_addr_token_bucket < 1.0) {
+            if (peer->m_addr_token_bucket < 1.0) {
+                if (rate_limited) {
                     ++num_rate_limit;
                     continue;
                 }
+            } else {
                 peer->m_addr_token_bucket -= 1.0;
             }
             // We only bother storing full nodes, though this may include
@@ -2880,12 +2881,8 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         }
         peer->m_addr_processed += num_proc;
         peer->m_addr_rate_limited += num_rate_limit;
-        LogPrint(BCLog::NET, "Received addr: %u addresses (%u processed, %u rate-limited) from peer=%d%s\n",
-                 vAddr.size(),
-                 num_proc,
-                 num_rate_limit,
-                 pfrom.GetId(),
-                 fLogIPs ? ", peeraddr=" + pfrom.addr.ToString() : "");
+        LogPrint(BCLog::NET, "Received addr: %u addresses (%u processed, %u rate-limited) from peer=%d\n",
+                 vAddr.size(), num_proc, num_rate_limit, pfrom.GetId());
 
         m_addrman.Add(vAddrOk, pfrom.addr, 2 * 60 * 60);
         if (vAddr.size() < 1000) peer->m_getaddr_sent = false;

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -151,6 +151,8 @@ static RPCHelpMan getpeerinfo()
                                 {RPCResult::Type::NUM, "n", "The heights of blocks we're currently asking from this peer"},
                             }},
                             {RPCResult::Type::BOOL, "addr_relay_enabled", "Whether we participate in address relay with this peer"},
+                            {RPCResult::Type::NUM, "addr_processed", "The total number of addresses processed, excluding those dropped due to rate limiting"},
+                            {RPCResult::Type::NUM, "addr_rate_limited", "The total number of addresses dropped due to rate limiting"},
                             {RPCResult::Type::ARR, "permissions", "Any special permissions that have been granted to this peer",
                             {
                                 {RPCResult::Type::STR, "permission_type", Join(NET_PERMISSIONS_DOC, ",\n") + ".\n"},

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -311,7 +311,7 @@ class AddrTest(BitcoinTestFramework):
 
         self.nodes[0].disconnect_p2ps()
 
-    def send_addrs_and_test_rate_limiting(self, peer, no_relay, new_addrs, total_addrs):
+    def send_addrs_and_test_rate_limiting(self, peer, no_relay, *, new_addrs, total_addrs):
         """Send an addr message and check that the number of addresses processed and rate-limited is as expected"""
 
         peer.send_and_ping(self.setup_rand_addr_msg(new_addrs))
@@ -329,27 +329,26 @@ class AddrTest(BitcoinTestFramework):
             assert_equal(addrs_rate_limited, max(0, total_addrs - peer.tokens))
 
     def rate_limit_tests(self):
-
         self.mocktime = int(time.time())
         self.restart_node(0, [])
         self.nodes[0].setmocktime(self.mocktime)
 
-        for contype, no_relay in [("outbound-full-relay", False), ("block-relay-only", True), ("inbound", False)]:
-            self.log.info(f'Test rate limiting of addr processing for {contype} peers')
-            if contype == "inbound":
+        for conn_type, no_relay in [("outbound-full-relay", False), ("block-relay-only", True), ("inbound", False)]:
+            self.log.info(f'Test rate limiting of addr processing for {conn_type} peers')
+            if conn_type == "inbound":
                 peer = self.nodes[0].add_p2p_connection(AddrReceiver())
             else:
-                peer = self.nodes[0].add_outbound_p2p_connection(AddrReceiver(), p2p_idx=0, connection_type=contype)
+                peer = self.nodes[0].add_outbound_p2p_connection(AddrReceiver(), p2p_idx=0, connection_type=conn_type)
 
             # Send 600 addresses. For all but the block-relay-only peer this should result in addresses being processed.
-            self.send_addrs_and_test_rate_limiting(peer, no_relay, 600, 600)
+            self.send_addrs_and_test_rate_limiting(peer, no_relay, new_addrs=600, total_addrs=600)
 
             # Send 600 more addresses. For the outbound-full-relay peer (which we send a GETADDR, and thus will
             # process up to 1001 incoming addresses), this means more addresses will be processed.
-            self.send_addrs_and_test_rate_limiting(peer, no_relay, 600, 1200)
+            self.send_addrs_and_test_rate_limiting(peer, no_relay, new_addrs=600, total_addrs=1200)
 
             # Send 10 more. As we reached the processing limit for all nodes, no more addresses should be procesesd.
-            self.send_addrs_and_test_rate_limiting(peer, no_relay, 10, 1210)
+            self.send_addrs_and_test_rate_limiting(peer, no_relay, new_addrs=10, total_addrs=1210)
 
             # Advance the time by 100 seconds, permitting the processing of 10 more addresses.
             # Send 200 and verify that 10 are processed.
@@ -357,7 +356,7 @@ class AddrTest(BitcoinTestFramework):
             self.nodes[0].setmocktime(self.mocktime)
             peer.increment_tokens(10)
 
-            self.send_addrs_and_test_rate_limiting(peer, no_relay, 200, 1410)
+            self.send_addrs_and_test_rate_limiting(peer, no_relay, new_addrs=200, total_addrs=1410)
 
             # Advance the time by 1000 seconds, permitting the processing of 100 more addresses.
             # Send 200 and verify that 100 are processed.
@@ -365,9 +364,10 @@ class AddrTest(BitcoinTestFramework):
             self.nodes[0].setmocktime(self.mocktime)
             peer.increment_tokens(100)
 
-            self.send_addrs_and_test_rate_limiting(peer, no_relay, 200, 1610)
+            self.send_addrs_and_test_rate_limiting(peer, no_relay, new_addrs=200, total_addrs=1610)
 
             self.nodes[0].disconnect_p2ps()
+
 
 if __name__ == '__main__':
     AddrTest().main()


### PR DESCRIPTION
Incorporates review feedback in #22387.

Edit, could be considered separately: should a release note (or two) be added for 22.0? e.g. the new getpeerinfo fields in `Updated RPCs` and the rate-limiting itself in `P2P and network changes`.