### PR TITLE
Updated the conversion of bytes<-> hex-string

### DIFF
--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -66,7 +66,7 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
 
         # decompress pk2
         pk_obj = ECPubKey()
-        pk_obj.set(binascii.unhexlify(pk2))
+        pk_obj.set(bytes.fromhex(pk2))
         pk_obj.compressed = False
         pk2 = binascii.hexlify(pk_obj.get_bytes()).decode()
 

--- a/test/util/bitcoin-util-test.py
+++ b/test/util/bitcoin-util-test.py
@@ -10,7 +10,6 @@ Runs automatically during `make check`.
 Can also be run manually."""
 
 import argparse
-import binascii
 import configparser
 import difflib
 import json
@@ -167,7 +166,7 @@ def parse_output(a, fmt):
     if fmt == 'json':  # json: compare parsed data
         return json.loads(a)
     elif fmt == 'hex':  # hex: parse and compare binary data
-        return binascii.a2b_hex(a.strip())
+        return bytes.fromhex(a.strip())
     else:
         raise NotImplementedError("Don't know how to compare %s" % fmt)
 


### PR DESCRIPTION
Regarding issue #22605 
The functional test framework uses binascii in the following files:
- test/functional/interface_rest.py
- test/functional/rpc_createmultisig.py
- test/functional/test_framework/bdb.py
- test/functional/test_framework/blocktools.py
- test/functional/test_framework/netutil.py

The rpc_createmultisig.py and bitcoin-util-test.py don't require the binascii functions and could be run using the builtin and consistent <code>bytes</code> (class) methods. 
I have tested the other files and tried to replace binascii functions but wasn't able to replace them, they are the legitimate use cases of binascii. 