### PR TITLE
build: Treat obj/build.h as an intermediate file

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -306,7 +306,8 @@ BITCOIN_CORE_H = \
   zmq/zmqutil.h
 
 
-obj/build.h: FORCE
+.INTERMEDIATE: obj/build.h
+obj/build.h:
 	@$(MKDIR_P) $(builddir)/obj
 	@$(top_srcdir)/share/genbuild.sh "$(abs_top_builddir)/src/obj/build.h" \
 	  "$(abs_top_srcdir)"
@@ -787,7 +788,6 @@ CLEANFILES += util/*.gcda util/*.gcno
 CLEANFILES += wallet/*.gcda wallet/*.gcno
 CLEANFILES += wallet/test/*.gcda wallet/test/*.gcno
 CLEANFILES += zmq/*.gcda zmq/*.gcno
-CLEANFILES += obj/build.h
 
 EXTRA_DIST = $(CTAES_DIST)
 


### PR DESCRIPTION
This PR prevents unneeded calls of the `share/genbuild.sh` script, e.g., while `make install`.

**Note for reviewers.** Before testing this PR make sure your git tree is clean.

#### Guix builds:
```
$ find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
672c0aa39773c6a8cf73cf882d629f3b341c6e27826e76408aa4a206e97e5549  guix-build-b621730d3324/output/aarch64-linux-gnu/SHA256SUMS.part
b525150eff7c83ac048fa66d57cd0a329a5d535aac079db63a56e801478172de  guix-build-b621730d3324/output/aarch64-linux-gnu/bitcoin-b621730d3324-aarch64-linux-gnu-debug.tar.gz
94db3e1511a0c964f4938e19761e5530b0eba6c64decb8079ea74bb044f646af  guix-build-b621730d3324/output/aarch64-linux-gnu/bitcoin-b621730d3324-aarch64-linux-gnu.tar.gz
b2fc8e0f6961bc7cd7aa83cc78c7ee85c3a7c66b55074bac590fc74ef04b36cd  guix-build-b621730d3324/output/arm-linux-gnueabihf/SHA256SUMS.part
e10eb07a360ac7569d3715145d7872d6e47d0a53ee7c5d0d55f1e5a183e3102f  guix-build-b621730d3324/output/arm-linux-gnueabihf/bitcoin-b621730d3324-arm-linux-gnueabihf-debug.tar.gz
c3805d554ca0ac8069d8bac4dfdd5c5157db8f99ef39d622d333e3acd11ea05f  guix-build-b621730d3324/output/arm-linux-gnueabihf/bitcoin-b621730d3324-arm-linux-gnueabihf.tar.gz
59e58f8f5f142decc2e65ec6537437c0fa4d3ce6d748f5653a0c14f5dd05848a  guix-build-b621730d3324/output/dist-archive/bitcoin-b621730d3324.tar.gz
b6988c6b6f3f54a7a5954a79b8d698cddfdd0c1bea9d38c19258ac0939e9aa8c  guix-build-b621730d3324/output/powerpc64-linux-gnu/SHA256SUMS.part
9b9a836110ffb9e6ec70deac8b7e309420245215343fdcf0a53ae8bc0c2baf2a  guix-build-b621730d3324/output/powerpc64-linux-gnu/bitcoin-b621730d3324-powerpc64-linux-gnu-debug.tar.gz
b35c0bc90cecb93bf7bc4975a82dbb571a5c8f3751513dd9c5f98fd3726c0a17  guix-build-b621730d3324/output/powerpc64-linux-gnu/bitcoin-b621730d3324-powerpc64-linux-gnu.tar.gz
6c877d3fd4788ff1566198eb902bb2f44320e4d0a19cb8c50cfb2870b32aeb1f  guix-build-b621730d3324/output/powerpc64le-linux-gnu/SHA256SUMS.part
a899353e89daa6755089d3c1c9e80c4e0e736e020d21c88fa5fbae375b713b21  guix-build-b621730d3324/output/powerpc64le-linux-gnu/bitcoin-b621730d3324-powerpc64le-linux-gnu-debug.tar.gz
5c736d8a873063cc2c8e167a1d2603da1d5ff2c69f65212c4f993fa2521e8342  guix-build-b621730d3324/output/powerpc64le-linux-gnu/bitcoin-b621730d3324-powerpc64le-linux-gnu.tar.gz
6e3dcf47764429d7b5ec1834873f2ecf8cfe700e707a637dac279598867d0445  guix-build-b621730d3324/output/riscv64-linux-gnu/SHA256SUMS.part
23a088edb241a3734e2c9bec04aeff777dba9f931ab81d18d4cac5c0bd5d3b93  guix-build-b621730d3324/output/riscv64-linux-gnu/bitcoin-b621730d3324-riscv64-linux-gnu-debug.tar.gz
b7b916cc8b45852b75088cd8f3d19c8db92d9283d957d0c4094b14fc79656672  guix-build-b621730d3324/output/riscv64-linux-gnu/bitcoin-b621730d3324-riscv64-linux-gnu.tar.gz
c09b70368ae96e16a05b2d3fe1c3bbaea7c67d036892138be5bf1da62aefff11  guix-build-b621730d3324/output/x86_64-apple-darwin18/SHA256SUMS.part
43d0ae4a1104fa5d0b0a439f94f9df4fba27467d75bb8a20a9ea56047cbf5ea2  guix-build-b621730d3324/output/x86_64-apple-darwin18/bitcoin-b621730d3324-osx-unsigned.dmg
1a603cef65c0d99a162a1f0636c76f53c94dc0a36f9ee208db2343563575f06b  guix-build-b621730d3324/output/x86_64-apple-darwin18/bitcoin-b621730d3324-osx-unsigned.tar.gz
999bfd7fc9f4690766d661213b9999feb0c268983c3940c5cb3d456c92f78966  guix-build-b621730d3324/output/x86_64-apple-darwin18/bitcoin-b621730d3324-osx64.tar.gz
a47b5aff04f1ad7b2719a71791c189d0e3fa275e9f2aca7f6477f808c3103df2  guix-build-b621730d3324/output/x86_64-linux-gnu/SHA256SUMS.part
f1a9c9a5bee6ecc0cbc4ea49076c4e6e8dee151c94b44bcbd31e970b77315d23  guix-build-b621730d3324/output/x86_64-linux-gnu/bitcoin-b621730d3324-x86_64-linux-gnu-debug.tar.gz
b3c6863b06d80d5abb98ff40c7b54f26a679242640a34d81c66edb3a6c03d257  guix-build-b621730d3324/output/x86_64-linux-gnu/bitcoin-b621730d3324-x86_64-linux-gnu.tar.gz
d2204b42f767a19e811bf9d5d43cf9e230641d4fc877eeae6aca0a8dc8191921  guix-build-b621730d3324/output/x86_64-w64-mingw32/SHA256SUMS.part
ee96b0862ce0e24230da05658e8ef5134b57fccd4e27fac987a450396a64e3dc  guix-build-b621730d3324/output/x86_64-w64-mingw32/bitcoin-b621730d3324-win-unsigned.tar.gz
7293b713b52d3add8c54e378dc2b67712d26d36f094e904a87f0bc17778dc7b7  guix-build-b621730d3324/output/x86_64-w64-mingw32/bitcoin-b621730d3324-win64-debug.zip
77960bb2ac7f16e5daaf99428617bd839b1351c638aab3f74006bd81ea81999b  guix-build-b621730d3324/output/x86_64-w64-mingw32/bitcoin-b621730d3324-win64-setup-unsigned.exe
2de0cbe14e5cd9f243458489de685c496ba2110782cf9ba26500c9422e8af43c  guix-build-b621730d3324/output/x86_64-w64-mingw32/bitcoin-b621730d3324-win64.zip
```