### PR TITLE
doc: Add packages that provide Qt Wayland plugin for Linux

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -122,6 +122,10 @@ To build with Qt 5 you need the following:
 
     sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools
 
+Additionally, to support Wayland protocol for modern desktop environments:
+
+    sudo apt install qtwayland5
+
 libqrencode (optional) can be installed with:
 
     sudo apt-get install libqrencode-dev
@@ -180,6 +184,10 @@ To build without GUI pass `--without-gui`.
 To build with Qt 5 you need the following:
 
     sudo dnf install qt5-qttools-devel qt5-qtbase-devel
+
+Additionally, to support Wayland protocol for modern desktop environments:
+
+    sudo dnf install qt5-qtwayland
 
 libqrencode (optional) can be installed with:
 


### PR DESCRIPTION
When building on Linux using system packages (without depends) the support of Wayland protocol for modern desktop environments (e.g., GNOME, KDE Plasma) depends on the presence of the installed Qt Wayland plugin which is loaded dynamically at the GUI startup.

1. On Debian/Ubuntu, the [`qtwayland5`](https://packages.ubuntu.com/focal/qtwayland5) package is required (also see this [patch](https://codereview.qt-project.org/c/qt/qtbase/+/231227), and this [doc](https://wiki.debian.org/Wayland#Qt_.28supported_since_5.29)):
- with `qtwayland5` installed:
```
$ QT_QPA_PLATFORM="wayland;xcb" ./src/qt/bitcoin-qt -printtoconsole
Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway.
2021-08-05T09:51:31Z Bitcoin Core version v22.99.0-c4b42aa4ffa1 (release build)
2021-08-05T09:51:31Z Qt 5.11.3 (dynamic), plugin=wayland (dynamic)
2021-08-05T09:51:31Z No static plugins.
2021-08-05T09:51:31Z Style: fusion / QFusionStyle
2021-08-05T09:51:31Z System: Debian GNU/Linux 10 (buster), x86_64-little_endian-lp64
...
```

- without `qtwayland5`:
```
$ QT_QPA_PLATFORM="wayland;xcb" ./src/qt/bitcoin-qt -printtoconsole
Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway.
qt.qpa.plugin: Could not find the Qt platform plugin "wayland" in ""
2021-08-05T09:48:55Z Bitcoin Core version v22.99.0-c4b42aa4ffa1 (release build)
2021-08-05T09:48:55Z Qt 5.11.3 (dynamic), plugin=xcb (dynamic)
2021-08-05T09:48:55Z No static plugins.
2021-08-05T09:48:55Z Style: fusion / QFusionStyle
2021-08-05T09:48:55Z System: Debian GNU/Linux 10 (buster), x86_64-little_endian-lp64
2021-08-05T09:48:55Z Screen: XWAYLAND0 1920x1200, pixel ratio=1.0
...
```

2. On Fedora, the [`qt5-qtwayland`](https://fedora.pkgs.org/34/fedora-x86_64/qt5-qtwayland-5.15.2-4.fc34.x86_64.rpm.html) package is required:
- with `qt5-qtwayland` installed:
```
$ ./src/qt/bitcoin-qt -printtoconsole
QSocketNotifier: Can only be used with threads started with QThread
2021-08-05T08:41:03Z Bitcoin Core version v22.99.0-c4b42aa4ffa1 (release build)
2021-08-05T08:41:03Z Qt 5.15.2 (dynamic), plugin=wayland (dynamic)
2021-08-05T08:41:03Z No static plugins.
2021-08-05T08:41:03Z Style: fusion / QFusionStyle
2021-08-05T08:41:03Z System: Fedora 34 (Workstation Edition), x86_64-little_endian-lp64
...
```
- without `qt5-qtwayland`:
```
$ ./src/qt/bitcoin-qt -printtoconsole
qt.qpa.plugin: Could not find the Qt platform plugin "wayland" in ""
2021-08-05T07:50:41Z Bitcoin Core version v22.99.0-c4b42aa4ffa1 (release build)
2021-08-05T07:50:41Z Qt 5.15.2 (dynamic), plugin=xcb (dynamic)
2021-08-05T07:50:41Z No static plugins.
2021-08-05T07:50:41Z Style: fusion / QFusionStyle
2021-08-05T07:50:41Z System: Fedora 34 (Workstation Edition), x86_64-little_endian-lp64
2021-08-05T07:50:41Z Screen: XWAYLAND0 1920x1200, pixel ratio=1.0
...
```