### PR TITLE
refactor: Replace remaining binascii method calls

### DIFF
--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -17,7 +17,6 @@ import datetime
 import time
 import glob
 from collections import namedtuple
-from binascii import unhexlify
 
 settings = {}
 
@@ -332,7 +331,7 @@ if __name__ == '__main__':
     settings['max_out_sz'] = int(settings['max_out_sz'])
     settings['split_timestamp'] = int(settings['split_timestamp'])
     settings['file_timestamp'] = int(settings['file_timestamp'])
-    settings['netmagic'] = unhexlify(settings['netmagic'].encode('utf-8'))
+    settings['netmagic'] = bytes.fromhex(settings['netmagic'])
     settings['out_of_order_cache_sz'] = int(settings['out_of_order_cache_sz'])
     settings['debug_output'] = settings['debug_output'].lower()
 

--- a/contrib/signet/miner
+++ b/contrib/signet/miner
@@ -15,7 +15,6 @@ import sys
 import time
 import subprocess
 
-from binascii import unhexlify
 from io import BytesIO
 
 PATH_BASE_CONTRIB_SIGNET = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
@@ -202,7 +201,7 @@ def finish_block(block, signet_solution, grind_cmd):
 
 def generate_psbt(tmpl, reward_spk, *, blocktime=None):
     signet_spk = tmpl["signet_challenge"]
-    signet_spk_bin = unhexlify(signet_spk)
+    signet_spk_bin = bytes.fromhex(signet_spk)
 
     cbtx = create_coinbase(height=tmpl["height"], value=tmpl["coinbasevalue"], spk=reward_spk)
     cbtx.vin[0].nSequence = 2**32-2
@@ -258,7 +257,7 @@ def get_reward_addr_spk(args, height):
         return args.address, args.reward_spk
 
     reward_addr = get_reward_address(args, height)
-    reward_spk = unhexlify(json.loads(args.bcli("getaddressinfo", reward_addr))["scriptPubKey"])
+    reward_spk = bytes.fromhex(json.loads(args.bcli("getaddressinfo", reward_addr))["scriptPubKey"])
     if args.address is not None:
         # will always be the same, so cache
         args.reward_spk = reward_spk

--- a/contrib/zmq/zmq_sub.py
+++ b/contrib/zmq/zmq_sub.py
@@ -23,7 +23,6 @@
     https://github.com/bitcoin/bitcoin/blob/37a7fe9e440b83e2364d5498931253937abe9294/contrib/zmq/zmq_sub.py
 """
 
-import binascii
 import asyncio
 import zmq
 import zmq.asyncio
@@ -58,18 +57,18 @@ class ZMQHandler():
             sequence = str(struct.unpack('<I', seq)[-1])
         if topic == b"hashblock":
             print('- HASH BLOCK ('+sequence+') -')
-            print(binascii.hexlify(body))
+            print(body.hex())
         elif topic == b"hashtx":
             print('- HASH TX  ('+sequence+') -')
-            print(binascii.hexlify(body))
+            print(body.hex())
         elif topic == b"rawblock":
             print('- RAW BLOCK HEADER ('+sequence+') -')
-            print(binascii.hexlify(body[:80]))
+            print(body[:80].hex())
         elif topic == b"rawtx":
             print('- RAW TX ('+sequence+') -')
-            print(binascii.hexlify(body))
+            print(body.hex())
         elif topic == b"sequence":
-            hash = binascii.hexlify(body[:32])
+            hash = body[:32].hex()
             label = chr(body[32])
             mempool_sequence = None if len(body) != 32+1+8 else struct.unpack("<Q", body[32+1:])[0]
             print('- SEQUENCE ('+sequence+') -')

--- a/share/rpcauth/rpcauth.py
+++ b/share/rpcauth/rpcauth.py
@@ -5,7 +5,6 @@
 
 from argparse import ArgumentParser
 from base64 import urlsafe_b64encode
-from binascii import hexlify
 from getpass import getpass
 from os import urandom
 
@@ -13,7 +12,7 @@ import hmac
 
 def generate_salt(size):
     """Create size byte hex salt"""
-    return hexlify(urandom(size)).decode()
+    return urandom(size).hex()
 
 def generate_password():
     """Create 32 byte b64 password"""

--- a/src/test/serfloat_tests.cpp
+++ b/src/test/serfloat_tests.cpp
@@ -102,11 +102,12 @@ BOOST_AUTO_TEST_CASE(double_serfloat_tests) {
 Python code to generate the below hashes:
 
     def reversed_hex(x):
-        return binascii.hexlify(''.join(reversed(x)))
+        return bytes(reversed(x)).hex()
+
     def dsha256(x):
         return hashlib.sha256(hashlib.sha256(x).digest()).digest()
 
-    reversed_hex(dsha256(''.join(struct.pack('<d', x) for x in range(0,1000)))) == '43d0c82591953c4eafe114590d392676a01585d25b25d433557f0d7878b23f96'
+    reversed_hex(dsha256(b''.join(struct.pack('<d', x) for x in range(0,1000)))) == '43d0c82591953c4eafe114590d392676a01585d25b25d433557f0d7878b23f96'
 */
 BOOST_AUTO_TEST_CASE(doubles)
 {

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -19,7 +19,6 @@ Classes use __slots__ to ensure extraneous attributes aren't accidentally added
 by tests, compromising their intended effect.
 """
 from base64 import b32decode, b32encode
-from codecs import encode
 import copy
 import hashlib
 from io import BytesIO
@@ -681,7 +680,7 @@ class CBlockHeader:
             r += struct.pack("<I", self.nBits)
             r += struct.pack("<I", self.nNonce)
             self.sha256 = uint256_from_str(hash256(r))
-            self.hash = encode(hash256(r)[::-1], 'hex_codec').decode('ascii')
+            self.hash = hash256(r)[::-1].hex()
 
     def rehash(self):
         self.sha256 = None

--- a/test/util/bitcoin-util-test.py
+++ b/test/util/bitcoin-util-test.py
@@ -10,7 +10,6 @@ Runs automatically during `make check`.
 Can also be run manually."""
 
 import argparse
-import binascii
 import configparser
 import difflib
 import json
@@ -167,7 +166,7 @@ def parse_output(a, fmt):
     if fmt == 'json':  # json: compare parsed data
         return json.loads(a)
     elif fmt == 'hex':  # hex: parse and compare binary data
-        return binascii.a2b_hex(a.strip())
+        return bytes.fromhex(a.strip())
     else:
         raise NotImplementedError("Don't know how to compare %s" % fmt)
 


### PR DESCRIPTION
This PR removes the remaining `binascii` method calls outside `test/functional` and `test_framework`, as pointed out here  https://github.com/bitcoin/bitcoin/pull/22619#pullrequestreview-722153458.

Follow-up to #22593 and #22619
Closes #22605