### PR TITLE
release: Release with separate SHA256SUMS and sig files

### DIFF
--- a/contrib/guix/guix-attest
+++ b/contrib/guix/guix-attest
@@ -159,20 +159,6 @@ Hint: You may wish to remove the existing attestations and their signatures by
 EOF
 }
 
-# Given a document with unix line endings (just <LF>) in stdin, make all lines
-# end in <CR><LF> and make sure there's no trailing <LF> at the end of the file.
-#
-# This is necessary as cleartext signatures are calculated on text after their
-# line endings are canonicalized.
-#
-# For more information:
-#     1. https://security.stackexchange.com/a/104261
-#     2. https://datatracker.ietf.org/doc/html/rfc4880#section-7.1
-#
-rfc4880_normalize_document() {
-    sed 's/$/\r/' | head -c -2
-}
-
 echo "Attesting to build outputs for version: '${VERSION}'"
 echo ""
 
@@ -188,7 +174,6 @@ mkdir -p "$outsigdir"
         cat "${noncodesigned_fragments[@]}" \
             | sort -u \
             | sort -k2 \
-            | rfc4880_normalize_document \
                 > "$temp_noncodesigned"
         if [ -e noncodesigned.SHA256SUMS ]; then
             # The SHA256SUMS already exists, make sure it's exactly what we
@@ -216,7 +201,6 @@ mkdir -p "$outsigdir"
         cat "${sha256sum_fragments[@]}" \
             | sort -u \
             | sort -k2 \
-            | rfc4880_normalize_document \
                 > "$temp_all"
         if [ -e all.SHA256SUMS ]; then
             # The SHA256SUMS already exists, make sure it's exactly what we

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -199,25 +199,12 @@ popd
 
 ### After 3 or more people have guix-built and their results match:
 
-Combine `all.SHA256SUMS` and `all.SHA256SUMS.asc` into a clear-signed
-`SHA256SUMS.asc` message:
-
-```sh
-echo -e "-----BEGIN PGP SIGNED MESSAGE-----\nHash: SHA256\n\n$(cat all.SHA256SUMS)\n$(cat filename.txt.asc)" > SHA256SUMS.asc
-```
-
-Here's an equivalent, more readable command if you're confident that you won't
-mess up whitespaces when copy-pasting:
+Combine the `all.SHA256SUMS.asc` file from all signers into `SHA256SUMS.asc`:
 
 ```bash
-cat << EOF > SHA256SUMS.asc
------BEGIN PGP SIGNED MESSAGE-----
-Hash: SHA256
-
-$(cat all.SHA256SUMS)
-$(cat all.SHA256SUMS.asc)
-EOF
+cat "$VERSION"/*/all.SHA256SUMS.asc > SHA256SUMS.asc
 ```
+
 
 - Upload to the bitcoincore.org server (`/var/www/bin/bitcoin-core-${VERSION}`):
     1. The contents of `./bitcoin/guix-build-${VERSION}/output`, except for
@@ -230,7 +217,9 @@ EOF
        as save storage space *do not upload these to the bitcoincore.org server,
        nor put them in the torrent*.
 
-    2. The combined clear-signed message you just created `SHA256SUMS.asc`
+    2. The `SHA256SUMS` file
+
+    3. The `SHA256SUMS.asc` combined signature file you just created
 
 - Create a torrent of the `/var/www/bin/bitcoin-core-${VERSION}` directory such
   that at the top level there is only one file: the `bitcoin-core-${VERSION}`


### PR DESCRIPTION
This allows us to:
- remove the rfc4880 EOL hacks, and
- release with a SHA256SUMS.asc file that's a combination of all signer signatures