### PR TITLE
scripts: prevent GCC optimising test symbols in test-symbol-check

### DIFF
--- a/contrib/devtools/test-symbol-check.py
+++ b/contrib/devtools/test-symbol-check.py
@@ -73,20 +73,21 @@ class TestSymbolChecks(unittest.TestCase):
                 (1, executable + ': NEEDED library libutil.so.1 is not allowed\n' +
                     executable + ': failed LIBRARY_DEPENDENCIES'))
 
-        # finally, check a conforming file that simply uses a math function
+        # finally, check a simple conforming binary
         source = 'test3.c'
         executable = 'test3'
         with open(source, 'w', encoding="utf8") as f:
             f.write('''
-                #include <math.h>
+                #include <stdio.h>
 
                 int main()
                 {
-                    return (int)pow(2.0, 4.0);
+                    printf("42");
+                    return 0;
                 }
         ''')
 
-        self.assertEqual(call_symbol_check(cc, source, executable, ['-lm']),
+        self.assertEqual(call_symbol_check(cc, source, executable, []),
                 (0, ''))
 
     def test_MACHO(self):


### PR DESCRIPTION
I noticed in #22381 that when the test-symbol-check target was being built with Clang and run in the CI it would fail due to using a too-new version of `pow` (used [here](https://github.com/bitcoin/bitcoin/blob/d67330d11245b11fbdd5e2dd5343ee451186931e/contrib/devtools/test-symbol-check.py#L85)). Our CIs use Focal (glibc 2.31) and the version of `pow` was the optimized version introduced in [glibc 2.29](https://lwn.net/Articles/778286/):
```bash
* Optimized generic exp, exp2, log, log2, pow, sinf, cosf, sincosf and tanf.
```
This made sense, except for that if it was failing when built using Clang, why hadn't it also been failing when being built with GCC?

Turns out GCC is optimizing away that call to `pow` at all optimization levels, including `-O0`, see: https://godbolt.org/z/53MhzMxT7, and this has been the case forever, or at least since GCC 5.x. Clang on the other hand, will only optimize away the `pow` call at `-O1` and `-O2`, not `-O0`: https://godbolt.org/z/Wbnqj3q6c. Thus when this test was built with Clang (we don't pass `-O` so we default to `-O0`) it was failing in the CI environment, because it would actually have a call to the "new" `pow`.

Avoid this issue by using a symbol that won't be optimized away, or that we are unlikely to ever have versioning issues with.