### PR TITLE
doc, test: improve i2p/tor docs and i2p reachable unit tests

### DIFF
--- a/doc/i2p.md
+++ b/doc/i2p.md
@@ -10,11 +10,22 @@ started with I2P terminology.
 ## Run Bitcoin Core with an I2P router (proxy)
 
 A running I2P router (proxy) with [SAM](https://geti2p.net/en/docs/api/samv3)
-enabled is required (there is an [official one](https://geti2p.net) and
-[a few alternatives](https://en.wikipedia.org/wiki/I2P#Routers)). Notice the IP
-address and port the SAM proxy is listening to; usually, it is
-`127.0.0.1:7656`. Once it is up and running with SAM enabled, use the following
-Bitcoin Core options:
+enabled is required. Options include:
+
+- [i2prouter (I2P Router)](https://geti2p.net), the official implementation in
+  Java
+- [i2pd (I2P Daemon)](https://github.com/PurpleI2P/i2pd)
+  ([documentation](https://i2pd.readthedocs.io/en/latest)), a lighter
+  alternative in C++ (successfully tested with version 2.23 and up; version 2.36
+  or later recommended)
+- [i2p-zero](https://github.com/i2p-zero/i2p-zero)
+- [other alternatives](https://en.wikipedia.org/wiki/I2P#Routers)
+
+Note the IP address and port the SAM proxy is listening to; usually, it is
+`127.0.0.1:7656`.
+
+Once an I2P router with SAM enabled is up and running, use the following Bitcoin
+Core configuration options:
 
 ```
 -i2psam=<ip:port>

--- a/doc/i2p.md
+++ b/doc/i2p.md
@@ -42,15 +42,30 @@ named `i2p_private_key` in the Bitcoin Core data directory.
 
 ## Additional configuration options related to I2P
 
-You may set the `debug=i2p` config logging option to have additional
-information in the debug log about your I2P configuration and connections. Run
-`bitcoin-cli help logging` for more information.
+```
+-debug=i2p
+```
 
-It is possible to restrict outgoing connections in the usual way with
-`onlynet=i2p`. I2P support was added to Bitcoin Core in version 22.0 (mid-2021)
-and there may be fewer I2P peers than Tor or IP ones. Therefore, using
-`onlynet=i2p` alone (without other `onlynet=`) may make a node more susceptible
-to [Sybil attacks](https://en.bitcoin.it/wiki/Weaknesses#Sybil_attack). Use
+Set the `debug=i2p` config logging option to see additional information in the
+debug log about your I2P configuration and connections. Run `bitcoin-cli help
+logging` for more information.
+
+```
+-onlynet=i2p
+```
+
+Make outgoing connections only to I2P addresses. Incoming connections are not
+affected by this option. It can be specified multiple times to allow multiple
+network types, e.g. onlynet=ipv4, onlynet=ipv6, onlynet=onion, onlynet=i2p.
+
+Warning: if you use -onlynet with values other than onion, and the -onion or
+-proxy option is set, then outgoing onion connections will still be made; use
+-noonion or -onion=0 to disable outbound onion connections in this case.
+
+I2P support was added to Bitcoin Core in version 22.0 and there may be fewer I2P
+peers than Tor or IP ones. Therefore, using I2P alone without other networks may
+make a node more susceptible to [Sybil
+attacks](https://en.bitcoin.it/wiki/Weaknesses#Sybil_attack). You can use
 `bitcoin-cli -addrinfo` to see the number of I2P addresses known to your node.
 
 Another consideration with `onlynet=i2p` is that the initial blocks download

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -57,11 +57,11 @@ outgoing connections, but more is possible.
     -onlynet=onion  Make outgoing connections only to .onion addresses. Incoming
                     connections are not affected by this option. This option can be
                     specified multiple times to allow multiple network types, e.g.
-                    ipv4, ipv6 or onion. If you use this option with values other
-                    than onion you *cannot* disable onion connections; outgoing onion
-                    connections will be enabled when you use -proxy or -onion. Use
-                    -noonion or -onion=0 if you want to be sure there are no outbound
-                    onion connections over the default proxy or your defined -proxy.
+                    onlynet=ipv4, onlynet=ipv6, onlynet=onion, onlynet=i2p.
+                    Warning: if you use -onlynet with values other than onion, and
+                    the -onion or -proxy option is set, then outgoing onion
+                    connections will still be made; use -noonion or -onion=0 to
+                    disable outbound onion connections in this case.
 
 In a typical situation, this suffices to run behind a Tor proxy:
 

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -764,37 +764,42 @@ BOOST_AUTO_TEST_CASE(ipv4_peer_with_ipv6_addrMe_test)
 
 BOOST_AUTO_TEST_CASE(LimitedAndReachable_Network)
 {
-    BOOST_CHECK_EQUAL(IsReachable(NET_IPV4), true);
-    BOOST_CHECK_EQUAL(IsReachable(NET_IPV6), true);
-    BOOST_CHECK_EQUAL(IsReachable(NET_ONION), true);
+    BOOST_CHECK(IsReachable(NET_IPV4));
+    BOOST_CHECK(IsReachable(NET_IPV6));
+    BOOST_CHECK(IsReachable(NET_ONION));
+    BOOST_CHECK(IsReachable(NET_I2P));
 
     SetReachable(NET_IPV4, false);
     SetReachable(NET_IPV6, false);
     SetReachable(NET_ONION, false);
+    SetReachable(NET_I2P, false);
 
-    BOOST_CHECK_EQUAL(IsReachable(NET_IPV4), false);
-    BOOST_CHECK_EQUAL(IsReachable(NET_IPV6), false);
-    BOOST_CHECK_EQUAL(IsReachable(NET_ONION), false);
+    BOOST_CHECK(!IsReachable(NET_IPV4));
+    BOOST_CHECK(!IsReachable(NET_IPV6));
+    BOOST_CHECK(!IsReachable(NET_ONION));
+    BOOST_CHECK(!IsReachable(NET_I2P));
 
     SetReachable(NET_IPV4, true);
     SetReachable(NET_IPV6, true);
     SetReachable(NET_ONION, true);
+    SetReachable(NET_I2P, true);
 
-    BOOST_CHECK_EQUAL(IsReachable(NET_IPV4), true);
-    BOOST_CHECK_EQUAL(IsReachable(NET_IPV6), true);
-    BOOST_CHECK_EQUAL(IsReachable(NET_ONION), true);
+    BOOST_CHECK(IsReachable(NET_IPV4));
+    BOOST_CHECK(IsReachable(NET_IPV6));
+    BOOST_CHECK(IsReachable(NET_ONION));
+    BOOST_CHECK(IsReachable(NET_I2P));
 }
 
 BOOST_AUTO_TEST_CASE(LimitedAndReachable_NetworkCaseUnroutableAndInternal)
 {
-    BOOST_CHECK_EQUAL(IsReachable(NET_UNROUTABLE), true);
-    BOOST_CHECK_EQUAL(IsReachable(NET_INTERNAL), true);
+    BOOST_CHECK(IsReachable(NET_UNROUTABLE));
+    BOOST_CHECK(IsReachable(NET_INTERNAL));
 
     SetReachable(NET_UNROUTABLE, false);
     SetReachable(NET_INTERNAL, false);
 
-    BOOST_CHECK_EQUAL(IsReachable(NET_UNROUTABLE), true); // Ignored for both networks
-    BOOST_CHECK_EQUAL(IsReachable(NET_INTERNAL), true);
+    BOOST_CHECK(IsReachable(NET_UNROUTABLE)); // Ignored for both networks
+    BOOST_CHECK(IsReachable(NET_INTERNAL));
 }
 
 CNetAddr UtilBuildAddress(unsigned char p1, unsigned char p2, unsigned char p3, unsigned char p4)
@@ -813,10 +818,10 @@ BOOST_AUTO_TEST_CASE(LimitedAndReachable_CNetAddr)
     CNetAddr addr = UtilBuildAddress(0x001, 0x001, 0x001, 0x001); // 1.1.1.1
 
     SetReachable(NET_IPV4, true);
-    BOOST_CHECK_EQUAL(IsReachable(addr), true);
+    BOOST_CHECK(IsReachable(addr));
 
     SetReachable(NET_IPV4, false);
-    BOOST_CHECK_EQUAL(IsReachable(addr), false);
+    BOOST_CHECK(!IsReachable(addr));
 
     SetReachable(NET_IPV4, true); // have to reset this, because this is stateful.
 }
@@ -828,12 +833,12 @@ BOOST_AUTO_TEST_CASE(LocalAddress_BasicLifecycle)
 
     SetReachable(NET_IPV4, true);
 
-    BOOST_CHECK_EQUAL(IsLocal(addr), false);
-    BOOST_CHECK_EQUAL(AddLocal(addr, 1000), true);
-    BOOST_CHECK_EQUAL(IsLocal(addr), true);
+    BOOST_CHECK(!IsLocal(addr));
+    BOOST_CHECK(AddLocal(addr, 1000));
+    BOOST_CHECK(IsLocal(addr));
 
     RemoveLocal(addr);
-    BOOST_CHECK_EQUAL(IsLocal(addr), false);
+    BOOST_CHECK(!IsLocal(addr));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This pull addresses https://github.com/bitcoin/bitcoin/issues/22634#issuecomment-894104681 and various user feedback/questions, updates the -onlynet documentation in doc/i2p.md and doc/tor.md per #22651 (src/init.cpp is already fine) and fills in some missing I2P unit test coverage.

Note: this PR depends in part on whether #22651 is merged in order to propose the correct -onlynet documentation (it is currently aligned with the change in #22651), so that PR should be decided or merged first.
