### PR TITLE
fuzz: Avoid OOM in system fuzz target

### DIFF
--- a/src/test/fuzz/fuzz.h
+++ b/src/test/fuzz/fuzz.h
@@ -11,6 +11,9 @@
 #include <functional>
 #include <string_view>
 
+#define LIMITED_WHILE(condition, limit) \
+    for (unsigned _count{limit}; (condition) && _count; --_count)
+
 using FuzzBufferType = Span<const uint8_t>;
 
 using TypeTestOneInput = std::function<void(FuzzBufferType)>;

--- a/src/test/fuzz/system.cpp
+++ b/src/test/fuzz/system.cpp
@@ -31,7 +31,8 @@ FUZZ_TARGET(system)
         SetupHelpOptions(args_manager);
     }
 
-    while (fuzzed_data_provider.ConsumeBool()) {
+    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 3000)
+    {
         CallOneOf(
             fuzzed_data_provider,
             [&] {


### PR DESCRIPTION
If the inputs size is unlimited, the target may consume unlimited memory, because the argsmanager stores the argument names. Limiting the size should fix this issue.


Should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=36906