### PR TITLE
fuzz: Re-enable assert in banman again

### DIFF
--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -108,9 +108,7 @@ FUZZ_TARGET_INIT(banman, initialize_banman)
             BanMan ban_man_read{banlist_file, /* client_interface */ nullptr, /* default_ban_time */ 0};
             banmap_t banmap_read;
             ban_man_read.GetBanned(banmap_read);
-            // Assert temporarily disabled to allow the remainder of the fuzz test to run while a
-            // fix is being worked on. See https://github.com/bitcoin/bitcoin/pull/22517
-            (void)(banmap == banmap_read);
+            assert(banmap == banmap_read);
         }
     }
     fs::remove(banlist_file.string() + ".json");


### PR DESCRIPTION
Looks like this was accidentally fixed by removing the buggy code in commit efd6f904c78769ad2e93c1f1de43014d284e7561