### PR TITLE
contrib: catch bitcoin-cli RPC call errors in getcoins.py

### DIFF
--- a/contrib/signet/getcoins.py
+++ b/contrib/signet/getcoins.py
@@ -31,6 +31,10 @@ def bitcoin_cli(rpc_command_and_params):
     except FileNotFoundError:
         print('The binary', args.cmd, 'could not be found.')
         exit()
+    except subprocess.CalledProcessError:
+        cmdline = ' '.join(argv)
+        print(f'-----\nError while calling "{cmdline}" (see output above).')
+        exit()
 
 
 if args.faucet.lower() == DEFAULT_GLOBAL_FAUCET:

--- a/contrib/signet/getcoins.py
+++ b/contrib/signet/getcoins.py
@@ -23,24 +23,26 @@ args = parser.parse_args()
 if args.bitcoin_cli_args == []:
     args.bitcoin_cli_args = ['-signet']
 
-if args.faucet.lower() == DEFAULT_GLOBAL_FAUCET:
-    # Get the hash of the block at height 1 of the currently active signet chain
+
+def bitcoin_cli(rpc_command_and_params):
+    argv = [args.cmd] + args.bitcoin_cli_args + rpc_command_and_params
     try:
-        curr_signet_hash = subprocess.check_output([args.cmd] + args.bitcoin_cli_args + ['getblockhash', '1']).strip().decode()
+        return subprocess.check_output(argv).strip().decode()
     except FileNotFoundError:
         print('The binary', args.cmd, 'could not be found.')
         exit()
+
+
+if args.faucet.lower() == DEFAULT_GLOBAL_FAUCET:
+    # Get the hash of the block at height 1 of the currently active signet chain
+    curr_signet_hash = bitcoin_cli(['getblockhash', '1'])
     if curr_signet_hash != GLOBAL_FIRST_BLOCK_HASH:
         print('The global faucet cannot be used with a custom Signet network. Please use the global signet or setup your custom faucet to use this functionality.\n')
         exit()
 
 if args.addr == '':
     # get address for receiving coins
-    try:
-        args.addr = subprocess.check_output([args.cmd] + args.bitcoin_cli_args + ['getnewaddress', 'faucet', 'bech32']).strip()
-    except FileNotFoundError:
-        print('The binary', args.cmd, 'could not be found.')
-        exit()
+    args.addr = bitcoin_cli(['getnewaddress', 'faucet', 'bech32'])
 
 data = {'address': args.addr, 'password': args.password}
 try:

--- a/contrib/signet/getcoins.py
+++ b/contrib/signet/getcoins.py
@@ -30,11 +30,11 @@ def bitcoin_cli(rpc_command_and_params):
         return subprocess.check_output(argv).strip().decode()
     except FileNotFoundError:
         print('The binary', args.cmd, 'could not be found.')
-        exit()
+        exit(1)
     except subprocess.CalledProcessError:
         cmdline = ' '.join(argv)
         print(f'-----\nError while calling "{cmdline}" (see output above).')
-        exit()
+        exit(1)
 
 
 if args.faucet.lower() == DEFAULT_GLOBAL_FAUCET:
@@ -42,7 +42,7 @@ if args.faucet.lower() == DEFAULT_GLOBAL_FAUCET:
     curr_signet_hash = bitcoin_cli(['getblockhash', '1'])
     if curr_signet_hash != GLOBAL_FIRST_BLOCK_HASH:
         print('The global faucet cannot be used with a custom Signet network. Please use the global signet or setup your custom faucet to use this functionality.\n')
-        exit()
+        exit(1)
 
 if args.addr == '':
     # get address for receiving coins
@@ -53,7 +53,7 @@ try:
     res = requests.post(args.faucet, data=data)
 except:
     print('Unexpected error when contacting faucet:', sys.exc_info()[0])
-    exit()
+    exit(1)
 
 # Display the output as per the returned status code
 if res:


### PR DESCRIPTION
This PR is based on #22565 ("[script] signet's getcoins.py improvements"), which should be reviewed first.

The signet faucet script `contrib/signet/getcoins.py` currently issues bitcoin-cli RPC calls without catching errors -- the only case tackled is if there is no `bitcoin-cli` file found. Instead of crashing with a stack-trace on a failed RPC call, the changes in this PR aim to produce a more user-friendly output (see also https://github.com/bitcoin/bitcoin/pull/22565#discussion_r683754875). Additionally, in case of any error, a non-zero status is now returned (instead of 0, indicating success), which could be useful for other scripts taking use of signet faucet script.

The most straight-forward way to test this is invoking the script without a `bitcoind` running on signet:

PR22565 branch:
```
$ ./contrib/signet/getcoins.py
error: Could not connect to the server 127.0.0.1:8332

Make sure the bitcoind server is running and that you are connecting to the correct RPC port.
Traceback (most recent call last):
  File "./contrib/signet/getcoins.py", line 26, in <module>
    curr_signet_hash = subprocess.check_output([args.cmd] + args.bitcoin_cli_args + ['getblockhash', '1']).strip().decode()
  File "/usr/local/lib/python3.8/subprocess.py", line 415, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/local/lib/python3.8/subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['bitcoin-cli', 'getblockhash', '1']' returned non-zero exit status 1.
```

this PR branch:
```
$ ./contrib/signet/getcoins.py
error: Could not connect to the server 127.0.0.1:38332

Make sure the bitcoind server is running and that you are connecting to the correct RPC port.
-----
Error while calling "bitcoin-cli -signet getblockhash 1" (see output above).
```