### PR TITLE
dbwrapper: properly destroy objects in case CDBWrapper ctor throws

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -123,14 +123,13 @@ LevelDbOptions::~LevelDbOptions()
 CDBWrapper::CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory, bool fWipe, bool obfuscate)
     : options(nCacheSize), m_name{fs::PathToString(path.stem())}
 {
-    penv = nullptr;
     readoptions.verify_checksums = true;
     iteroptions.verify_checksums = true;
     iteroptions.fill_cache = false;
     syncoptions.sync = true;
     if (fMemory) {
-        penv = leveldb::NewMemEnv(leveldb::Env::Default());
-        options.env = penv;
+        m_env = std::unique_ptr<leveldb::Env>{leveldb::NewMemEnv(leveldb::Env::Default())};
+        options.env = m_env.get();
     } else {
         if (fWipe) {
             LogPrintf("Wiping LevelDB in %s\n", fs::PathToString(path));
@@ -178,8 +177,6 @@ CDBWrapper::~CDBWrapper()
 {
     delete pdb;
     pdb = nullptr;
-    delete penv;
-    options.env = nullptr;
 }
 
 bool CDBWrapper::WriteBatch(CDBBatch& batch, bool fSync)

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -184,7 +184,7 @@ class CDBWrapper
     friend const std::vector<unsigned char>& dbwrapper_private::GetObfuscateKey(const CDBWrapper &w);
 private:
     //! custom environment this database is using (may be nullptr in case of default environment)
-    leveldb::Env* penv;
+    std::unique_ptr<leveldb::Env> m_env;
 
     //! database options used
     LevelDbOptions options;

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -19,6 +19,12 @@
 static const size_t DBWRAPPER_PREALLOC_KEY_SIZE = 64;
 static const size_t DBWRAPPER_PREALLOC_VALUE_SIZE = 1024;
 
+struct LevelDbOptions : public leveldb::Options {
+    LevelDbOptions(size_t nCacheSize);
+
+    ~LevelDbOptions();
+};
+
 class dbwrapper_error : public std::runtime_error
 {
 public:
@@ -181,7 +187,7 @@ private:
     leveldb::Env* penv;
 
     //! database options used
-    leveldb::Options options;
+    LevelDbOptions options;
 
     //! options used when reading from the database
     leveldb::ReadOptions readoptions;


### PR DESCRIPTION
There are two main changes: introduce LevelDbOptions to manage the leveldb::Options struct and changing CDBWrapper's penv member to a unique_ptr. The first allows LevelDbOptions to destroy leveldb::Options members without CDBWrapper having to directly. The second change allows the leveldb::Env to be managed by penv. Both of these changes prevent a LeakSanitizer exception if the CDBWrapper ctor throws.

Fixes https://github.com/bitcoin/bitcoin/issues/22592
