### PR TITLE
rpc: Add function walletestimatefee

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -115,6 +115,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "walletcreatefundedpsbt", 4, "bip32derivs" },
     { "walletprocesspsbt", 1, "sign" },
     { "walletprocesspsbt", 3, "bip32derivs" },
+    { "walletestimatefee", 0, "conf_target" },
     { "createpsbt", 0, "inputs" },
     { "createpsbt", 1, "outputs" },
     { "createpsbt", 2, "locktime" },


### PR DESCRIPTION
This PR is in response to the issue [#19699](https://github.com/bitcoin/bitcoin/issues/19699).

`walletestimatefee` uses the function `GetMinimumFeeRate` which takes into account `fallbackfee`, `estimateSmartFee`, `mempoolMinFee`, `relayMinFee` . Hence it provides a fee estimate that is most likely to be paid by the user in an actual transaction, preventing issues such as [#16072](https://github.com/bitcoin/bitcoin/issues/16072).

It takes Confirmation Target (in blocks) and fee estimate mode as input and returns the expected fee rate, reason for estimation, and the block number at which estimate was found (only when the reason is estimatesmartfee) as output.

Test for this function has been added in `test/functional/feature_fee_estimation.py`