### PR TITLE
guix: make git tag and commit known prior to building

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -236,6 +236,16 @@ mkdir -p "$OUTDIR"
 # Binary Tarball Building #
 ###########################
 
+# The build will use the extracted git archive in a build directory not under the git work tree.
+# This will result in genbuild.sh being unable to determine the actual git tag for the version
+# string reported by the binary. By exporting GIT_TAG and GIT_COMMIT now, genbuild.sh will know
+# what tag and commit to use.
+# We want "git describe" to not cause an exit on failure and just be set to ""
+# shellcheck disable=SC2155
+export GIT_TAG=$(git describe --exact-match 2> /dev/null)
+git_commit=$(git rev-parse --short=12 HEAD)
+export GIT_COMMIT=${git_commit}
+
 # CONFIGFLAGS
 CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests --disable-fuzz-binary"
 case "$HOST" in

--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -18,17 +18,14 @@ else
     exit 1
 fi
 
-GIT_TAG=""
-GIT_COMMIT=""
+GIT_TAG="${GIT_TAG:-}"
+GIT_COMMIT="${GIT_COMMIT:-}"
 if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$(command -v git)" ] && [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; then
     # clean 'dirty' status of touched files that haven't been modified
     git diff >/dev/null 2>/dev/null
 
     # if latest commit is tagged and not dirty, then override using the tag name
-    RAWDESC=$(git describe --abbrev=0 2>/dev/null)
-    if [ "$(git rev-parse HEAD)" = "$(git rev-list -1 $RAWDESC 2>/dev/null)" ]; then
-        git diff-index --quiet HEAD -- && GIT_TAG=$RAWDESC
-    fi
+    git diff-index --quiet HEAD -- && GIT_TAG=$(git describe --exact-match 2>/dev/null)
 
     # otherwise generate suffix from git, i.e. string like "59887e8-dirty"
     GIT_COMMIT=$(git rev-parse --short=12 HEAD)


### PR DESCRIPTION
Guix currently builds from the source archive produced by `git archive` in a location outside of the git tree. This means that `share/genbuild.sh` will be unable to determine the version number from git because there is no git information available to it during the build. In order for the correct version to be set, `share/genbuild.sh` will now fallback to `GIT_TAG` and `GIT_COMMIT` environment variables if they are set. Guix makes use of this by setting `GIT_TAG` and `GIT_COMMIT` before leaving the git tree so that during the build, `share/genbuild.sh` will create a `build.h` file containing the correct values for the version string.

Fixes #22623