### PR TITLE
test: check for invalid `-prune` parameters

### DIFF
--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -127,6 +127,24 @@ class PruneTest(BitcoinTestFramework):
 
         self.sync_blocks(self.nodes[0:5])
 
+    def test_invalid_command_line_options(self):
+        self.nodes[0].assert_start_raises_init_error(
+            expected_msg='Error: Prune cannot be configured with a negative value.',
+            extra_args=['-prune=-1'],
+        )
+        self.nodes[0].assert_start_raises_init_error(
+            expected_msg='Error: Prune configured below the minimum of 550 MiB.  Please use a higher number.',
+            extra_args=['-prune=549'],
+        )
+        self.nodes[0].assert_start_raises_init_error(
+            expected_msg='Error: Prune mode is incompatible with -txindex.',
+            extra_args=['-prune=550', '-txindex'],
+        )
+        self.nodes[0].assert_start_raises_init_error(
+            expected_msg='Error: Prune mode is incompatible with -coinstatsindex.',
+            extra_args=['-prune=550', '-coinstatsindex'],
+        )
+
     def test_height_min(self):
         assert os.path.isfile(os.path.join(self.prunedir, "blk00000.dat")), "blk00000.dat is missing, pruning too early"
         self.log.info("Success")
@@ -452,6 +470,9 @@ class PruneTest(BitcoinTestFramework):
 
         self.log.info("Test wallet re-scan")
         self.wallet_test()
+
+        self.log.info("Test invalid pruning command line options")
+        self.test_invalid_command_line_options()
 
         self.log.info("Done")
 


### PR DESCRIPTION
This small PR adds missing test coverage for invalid `-prune` parameter values / combinations:

https://github.com/bitcoin/bitcoin/blob/77e23ca945030d557559a7391cb8bd368693548c/src/init.cpp#L926-L928

https://github.com/bitcoin/bitcoin/blob/77e23ca945030d557559a7391cb8bd368693548c/src/init.cpp#L935-L937

https://github.com/bitcoin/bitcoin/blob/77e23ca945030d557559a7391cb8bd368693548c/src/init.cpp#L844-L849

Not sure if the tests fit into `feature_config_args.py` or should rather be moved into `feature_pruning.py`; the latter though seems to be run less often due to being very memory-hungry.