### PR TITLE
clientversion: No suffix #if CLIENT_VERSION_IS_RELEASE

### DIFF
--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -30,8 +30,10 @@ const std::string CLIENT_NAME("Satoshi");
     #define BUILD_DESC BUILD_GIT_TAG
     #define BUILD_SUFFIX ""
 #else
-    #define BUILD_DESC "v" STRINGIZE(CLIENT_VERSION_MAJOR) "." STRINGIZE(CLIENT_VERSION_MINOR) "." STRINGIZE(CLIENT_VERSION_BUILD)
-    #ifdef BUILD_GIT_COMMIT
+    #define BUILD_DESC "v" PACKAGE_VERSION
+    #if CLIENT_VERSION_IS_RELEASE
+        #define BUILD_SUFFIX ""
+    #elif defined(BUILD_GIT_COMMIT)
         #define BUILD_SUFFIX "-" BUILD_GIT_COMMIT
     #elif defined(GIT_COMMIT_ID)
         #define BUILD_SUFFIX "-g" GIT_COMMIT_ID


### PR DESCRIPTION
```
Previously, building from a release source tarball would result in a
version string like v22.0.0-<commithash>, but we expect just v22.0.0.
This commit solves this problem.

Also use PACKAGE_VERSION instead of reconstructing it.
```

Fixes the underlying problem of #22623