### PR TITLE
build: enable SC2046 and SC2086 in lint-shell

### DIFF
--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -10,8 +10,6 @@ export LC_ALL=C
 
 # Disabled warnings:
 disabled=(
-    SC2046 # Quote this to prevent word splitting.
-    SC2086 # Double quote to prevent globbing and word splitting.
     SC2162 # read without -r will mangle backslashes.
 )
 disabled_gitian=(


### PR DESCRIPTION
> **Update**: Closing this in favour of Hebasto's [replacement PR](https://github.com/bitcoin/bitcoin/pull/23462).

As per https://github.com/bitcoin/bitcoin/issues/20879, this PR enables the `shellcheck` rules **SC2046** and **SC2086** respectfully in the lint-shell.sh script to, amongst other things, prevent unintentional word-splitting, and make the shell scripts "*conformant and therefore more robust*", as dongcarl [stated here](https://github.com/bitcoin/bitcoin/issues/20879#issue-781584404).

- [x] Enable **SC2046** & **SC2086** rules (7f1fc5ef5b3cc5a34ac709db1fe64fdf7665d62a)
- [ ] Fix all **SC2046** warnings
- [ ] Fix all **SC2086** warnings

Closes #20879