### PR TITLE
p2p: log addrman consistency checks

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -439,6 +439,8 @@ int CAddrMan::Check_() const
     if (m_consistency_check_ratio == 0) return 0;
     if (insecure_rand.randrange(m_consistency_check_ratio) >= 1) return 0;
 
+    LogPrint(BCLog::ADDRMAN, "Addrman checks started: new %i, tried %i, total %u\n", nNew, nTried, vRandom.size());
+
     std::unordered_set<int> setTried;
     std::unordered_map<int, int> mapNew;
 
@@ -517,6 +519,7 @@ int CAddrMan::Check_() const
     if (nKey.IsNull())
         return -16;
 
+    LogPrint(BCLog::ADDRMAN, "Addrman checks completed successfully\n");
     return 0;
 }
 


### PR DESCRIPTION
This mini-patch picks up #22479 to log addrman consistency checks in the `BCLOG::ADDRMAN` category when they are enabled with the `-checkaddrman=<n>` configuration option for values of n greater than 0.

```
$ ./src/bitcoind -signet -checkaddrman=20 -debug=addrman
...
2021-08-13T11:14:45Z Addrman checks started: new 3352, tried 89, total 3441
2021-08-13T11:14:45Z Addrman checks completed successfully
```

This allows people to
- verify the checks are running
- see when and how often they are being performed
- see the number of new/tried/total addrman entries per check
- see the start/end of the checks

Thanks to John Newbery for ideas to improve this logging.
 