### PR TITLE
Implement RBF inherited signaling and fix getmempoolentry returned bip125-replaceable status

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -54,6 +54,12 @@ unsupported systems.
 Notable changes
 ===============
 
+Mempool policy changed such that now RBF inherited signaling is supported (transactions
+that don't explicitly signal replaceability are replaceable for as long as any one
+of their ancestors signals replaceability and remains unconfirmed). Previously
+the mempool only accepted replacements for transactions that themselves opted-in
+to RBF. See `getmempoolentry` in the "Updated RPCs" section below for more details. (#22698)
+
 P2P and network changes
 -----------------------
 
@@ -98,6 +104,17 @@ Updated RPCs
 - `lockunspent` now optionally takes a third parameter, `persistent`, which
   causes the lock to be written persistently to the wallet database. This
   allows UTXOs to remain locked even after node restarts or crashes. (#23065)
+
+- `getmempoolentry` now returns the "correct" bip125-replaceable status,
+  resolving issue #22209. This status is now consistent with what the mempool
+  treats as replaceable. Before, `getmempoolentry` would show replaceability due
+  to inherited signaling, but the mempool only accepted replacements for
+  transactions that themselves opted-in to RBF (ie the mempool did not support
+  inherited signaling). Some other discrepancies b/w how `getmempoolentry`
+  signals, and what the mempool accepts were also made consistent. As well as
+  more closely adhering to the rules outlined in BIP125 (specifically Rule #5).
+  The result is increased confidence that the bip125-replaceable status returned
+  by `getmempoolentry` is accurate. (#22698)
 
 New RPCs
 --------

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -573,7 +573,7 @@ public:
     }
     RBFTransactionState isRBFOptIn(const CTransaction& tx) override
     {
-        if (!m_node.mempool) return IsRBFOptInEmptyMempool(tx);
+        if (!m_node.mempool) return RBFTransactionState::UNKNOWN;
         LOCK(m_node.mempool->cs);
         return IsRBFOptIn(tx, *m_node.mempool);
     }

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -48,24 +48,18 @@ std::optional<std::string> GetEntriesForConflicts(const CTransaction& tx,
                                                   CTxMemPool::setEntries& all_conflicts)
 {
     AssertLockHeld(pool.cs);
-    const uint256 txid = tx.GetHash();
-    uint64_t nConflictingCount = 0;
-    for (const auto& mi : iters_conflicting) {
-        nConflictingCount += mi->GetCountWithDescendants();
-        // BIP125 Rule #5: don't consider replacing more than MAX_BIP125_REPLACEMENT_CANDIDATES
-        // entries from the mempool. This potentially overestimates the number of actual
-        // descendants (i.e. if multiple conflicts share a descendant, it will be counted multiple
-        // times), but we just want to be conservative to avoid doing too much work.
-        if (nConflictingCount > MAX_BIP125_REPLACEMENT_CANDIDATES) {
-            return strprintf("rejecting replacement %s; too many potential replacements (%d > %d)\n",
-                             txid.ToString(),
-                             nConflictingCount,
-                             MAX_BIP125_REPLACEMENT_CANDIDATES);
-        }
-    }
+
     // Calculate the set of all transactions that would have to be evicted.
     for (CTxMemPool::txiter it : iters_conflicting) {
         pool.CalculateDescendants(it, all_conflicts);
+    }
+
+    // BIP125 Rule #5: don't consider replacing more than MAX_BIP125_REPLACEMENT_CANDIDATES entries from the mempool.
+    if (all_conflicts.size() > MAX_BIP125_REPLACEMENT_CANDIDATES) {
+        return strprintf("rejecting replacement %s; too many potential replacements (%d > %d)\n",
+                         tx.GetHash().ToString(),
+                         all_conflicts.size(),
+                         MAX_BIP125_REPLACEMENT_CANDIDATES);
     }
     return std::nullopt;
 }

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -15,15 +15,15 @@ RBFTransactionState IsRBFOptIn(const CTransaction& tx, const CTxMemPool& pool)
 
     CTxMemPool::setEntries ancestors;
 
-    // First check the transaction itself.
-    if (SignalsOptInRBF(tx)) {
-        return RBFTransactionState::REPLACEABLE_BIP125;
-    }
-
     // If this transaction is not in our mempool, then we can't be sure
     // we will know about all its inputs.
     if (!pool.exists(GenTxid::Txid(tx.GetHash()))) {
         return RBFTransactionState::UNKNOWN;
+    }
+
+    // First check the transaction itself.
+    if (SignalsOptInRBF(tx)) {
+        return RBFTransactionState::REPLACEABLE_BIP125;
     }
 
     // If all the inputs have nSequence >= maxint-1, it still might be
@@ -39,12 +39,6 @@ RBFTransactionState IsRBFOptIn(const CTransaction& tx, const CTxMemPool& pool)
         }
     }
     return RBFTransactionState::FINAL;
-}
-
-RBFTransactionState IsRBFOptInEmptyMempool(const CTransaction& tx)
-{
-    // If we don't have a local mempool we can only check the transaction itself.
-    return SignalsOptInRBF(tx) ? RBFTransactionState::REPLACEABLE_BIP125 : RBFTransactionState::UNKNOWN;
 }
 
 std::optional<std::string> GetEntriesForConflicts(const CTransaction& tx,

--- a/src/policy/rbf.h
+++ b/src/policy/rbf.h
@@ -38,7 +38,6 @@ enum class RBFTransactionState {
  * @return     The rbf state
  */
 RBFTransactionState IsRBFOptIn(const CTransaction& tx, const CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(pool.cs);
-RBFTransactionState IsRBFOptInEmptyMempool(const CTransaction& tx);
 
 /** Get all descendants of iters_conflicting. Also enforce BIP125 Rule #5, "The number of original
  * transactions to be replaced and their descendant transactions which will be evicted from the

--- a/src/policy/rbf.h
+++ b/src/policy/rbf.h
@@ -30,7 +30,10 @@ enum class RBFTransactionState {
  * Determine whether an unconfirmed transaction is signaling opt-in to RBF
  * according to BIP 125
  * This involves checking sequence numbers of the transaction, as well
- * as the sequence numbers of all in-mempool ancestors.
+ * as the sequence numbers of all in-mempool ancestors for inherited signaling.
+ * This also takes the number of original transactions to be replaced and their
+ * descendant transactions into consideration as according to BIP125 RBF (Rule #5)
+ * this must not exceed `MAX_BIP125_REPLACEMENT_CANDIDATES`.
  *
  * @param tx   The unconfirmed transaction
  * @param pool The mempool, which may contain the tx

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -740,24 +740,24 @@ class ReplaceByFeeTest(BitcoinTestFramework):
 
         # Create a chain the size of `MAX_REPLACEMENT_LIMIT` spending `joined_tx` - the BIP125 Rule #5 imposed limit
         tx = None
-        for _ in range(MAX_REPLACEMENT_LIMIT - 1):
+        for i in range(MAX_REPLACEMENT_LIMIT - 1):
             tx = self.wallet.send_self_transfer(
                 from_node=self.nodes[0],
                 utxo_to_spend=joined_utxo if tx is None else self.wallet.get_utxo(txid=tx['txid']),  # a straight line of descendants
                 sequence=0xffffffff,
                 fee_rate=Decimal('0.0001'),
             )
-            assert_equal(True, self.nodes[0].getmempoolentry(tx['txid'])['bip125-replaceable'])  # inherited
+            assert_equal(i < MAX_REPLACEMENT_LIMIT - 2, self.nodes[0].getmempoolentry(tx['txid'])['bip125-replaceable'])  # inherited
         # Now we have a chain of: `optin_parent_tx`, `joined_tx`, and 99 txs. The last tx in the loop exceeded `MAX_REPLACEMENT_LIMIT`
 
         # Attempting to replace the opt-in parent transaction will now result in more than `MAX_REPLACEMENT_LIMIT`
-        # conflicting txns being evicted from the mempool. However, it (and all of its descendants) are still signaling replaceability.
-        # We would've expected that once `MAX_REPLACEMENT_LIMIT` is exceeded, the opt-in parent txn stops signaling
+        # conflicting txns being evicted from the mempool. Therefore, it (and all of its descendants) no longer signal replaceability.
+        # Since `MAX_REPLACEMENT_LIMIT` is exceeded, the opt-in parent txn stops signaling
         # replaceability, along with _all_ of its descendants.
         entry = self.nodes[0].getmempoolentry(optin_parent_tx["txid"])
         assert_greater_than(entry['descendantcount'], MAX_REPLACEMENT_LIMIT)
-        assert_equal(True, entry['bip125-replaceable'])
-        assert_equal(True, self.nodes[0].getmempoolentry(tx["txid"])['bip125-replaceable'])
+        assert_equal(False, entry['bip125-replaceable'])
+        assert_equal(False, self.nodes[0].getmempoolentry(tx["txid"])['bip125-replaceable'])
 
         # Case in point, we can't actually replace `optin_parent_tx` once it has `MAX_REPLACEMENT_LIMIT` descendants
         self.wallet.create_self_transfer(

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -198,7 +198,7 @@ class ListTransactionsTest(BitcoinTestFramework):
         for n in self.nodes[0:2]:
             assert_equal(n.gettransaction(txid_1)["bip125-replaceable"], "no")
             assert_equal(n.gettransaction(txid_2)["bip125-replaceable"], "no")
-            assert_equal(n.gettransaction(txid_3)["bip125-replaceable"], "yes")
+            assert_equal(n.gettransaction(txid_3)["bip125-replaceable"], "unknown")
             assert_equal(n.gettransaction(txid_3b)["bip125-replaceable"], "yes")
             assert_equal(n.gettransaction(txid_4)["bip125-replaceable"], "unknown")
 
@@ -207,7 +207,7 @@ class ListTransactionsTest(BitcoinTestFramework):
             txs = {tx['txid']: tx['bip125-replaceable'] for tx in n.listsinceblock()['transactions']}
             assert_equal(txs[txid_1], "no")
             assert_equal(txs[txid_2], "no")
-            assert_equal(txs[txid_3], "yes")
+            assert_equal(txs[txid_3], "unknown")
             assert_equal(txs[txid_3b], "yes")
             assert_equal(txs[txid_4], "unknown")
 


### PR DESCRIPTION
This PR is on top of #22867 which adds test coverage relevant to this PR, and motivates it by highlighting some of the behavior this improves upon.

It aims to resolve issue #22209 as well as [CVE-2021-31876](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-31876)
> Bitcoin Core 0.12.0 through 0.21.1 does not properly implement the replacement policy specified in BIP125, which makes it easier for attackers to trigger a loss of funds, or a denial of service attack against downstream projects such as Lightning network nodes.

---

- As a followup to this PR I think some fuzz testing would be useful.
- Also an optimization followup can be done, putting some stricter bounds on `IsRBFOptIn` when it invokes `CalculateMemPoolAncestors`. However, I don't do that in this PR to keep it as simple as possible, and I don't think it's necessary. a) default mempool limits are much stricter than BIP125 Rule 5's `MAX_BIP125_REPLACEMENT_CANDIDATES{100}`, because `DEFAULT_DESCENDANT_LIMIT == 25`. b) I don't see a major performance tradeoff (please double check me). I think https://github.com/bitcoin/bitcoin/blob/master/test/functional/mempool_updatefromblock.py is a good worst-case scenario stress test for additional runtime required to check for inherited signaling, and this test seems to run in approx the same amount of time after this PR. Which seems acceptable to me, and not a risk for a DOS vector. But again, please be critical of this in the review. I also noticed #23621 when testing, and would like to see where that lands before I try any optimization.