### PR TITLE
doc: add libboost-thread-dev to build-unix

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -83,7 +83,7 @@ Build requirements:
 
 Now, you can either build from self-compiled [depends](/depends/README.md) or install the required dependencies:
 
-    sudo apt-get install libevent-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev
+    sudo apt-get install libevent-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-thread-dev libboost-test-dev
 
 Berkeley DB is required for the wallet.
 


### PR DESCRIPTION
The `apt-get install` line as-written no longer suffices to install the
required boost dependencies on a debian sid machine.