### PR TITLE
Add allocator for node based containers

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -231,6 +231,10 @@ BITCOIN_CORE_H = \
   shutdown.h \
   signet.h \
   streams.h \
+  support/allocators/node_allocator/allocator_fwd.h \
+  support/allocators/node_allocator/allocator.h \
+  support/allocators/node_allocator/factory.h \
+  support/allocators/node_allocator/memory_resource.h \
   support/allocators/node_allocator/node_size.h \
   support/allocators/secure.h \
   support/allocators/zeroafterfree.h \
@@ -609,6 +613,7 @@ libbitcoin_util_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libbitcoin_util_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_util_a_SOURCES = \
   support/lockedpool.cpp \
+  support/allocators/node_allocator/memory_resource.cpp \
   chainparamsbase.cpp \
   clientversion.cpp \
   compat/glibcxx_sanity.cpp \
@@ -835,6 +840,7 @@ bitcoin_chainstate_SOURCES = \
   script/standard.cpp \
   shutdown.cpp \
   signet.cpp \
+  support/allocators/node_allocator/memory_resource.cpp \
   support/cleanse.cpp \
   support/lockedpool.cpp \
   sync.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -231,6 +231,7 @@ BITCOIN_CORE_H = \
   shutdown.h \
   signet.h \
   streams.h \
+  support/allocators/node_allocator/node_size.h \
   support/allocators/secure.h \
   support/allocators/zeroafterfree.h \
   support/cleanse.h \

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -38,6 +38,7 @@ bench_bench_bitcoin_SOURCES = \
   bench/merkle_root.cpp \
   bench/nanobench.cpp \
   bench/nanobench.h \
+  bench/node_allocator.cpp \
   bench/peer_eviction.cpp \
   bench/poly1305.cpp \
   bench/prevector.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -110,6 +110,8 @@ BITCOIN_TESTS =\
   test/net_peer_eviction_tests.cpp \
   test/net_tests.cpp \
   test/netbase_tests.cpp \
+  test/node_allocator_helpers.h \
+  test/node_size_tests.cpp \
   test/orphanage_tests.cpp \
   test/pmt_tests.cpp \
   test/policy_fee_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -111,6 +111,7 @@ BITCOIN_TESTS =\
   test/net_tests.cpp \
   test/netbase_tests.cpp \
   test/node_allocator_helpers.h \
+  test/node_allocator_tests.cpp \
   test/node_size_tests.cpp \
   test/orphanage_tests.cpp \
   test/pmt_tests.cpp \

--- a/src/bench/node_allocator.cpp
+++ b/src/bench/node_allocator.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2019-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <support/allocators/node_allocator/factory.h>
+
+#include <cstring>
+#include <unordered_map>
+
+template <typename Map>
+void BenchFillClearMap(benchmark::Bench& bench, Map& map)
+{
+    size_t batch_size = 5000;
+
+    // make sure each iteration of the benchmark contains exactly 5000 inserts and one clear.
+    // do this at least 10 times so we get reasonable accurate results
+
+    bench.batch(batch_size).minEpochIterations(10).run([&] {
+        uint64_t key = 0;
+        for (size_t i = 0; i < batch_size; ++i) {
+            // add a random number for better spread in the map
+            key += 0x967f29d1;
+            map[key];
+        }
+        map.clear();
+    });
+}
+
+static void NodeAllocator_StdUnorderedMap(benchmark::Bench& bench)
+{
+    auto map = std::unordered_map<uint64_t, uint64_t>();
+    BenchFillClearMap(bench, map);
+}
+
+static void NodeAllocator_StdUnorderedMapWithNodeAllocator(benchmark::Bench& bench)
+{
+    using Factory = node_allocator::Factory<std::unordered_map<uint64_t, uint64_t>>;
+    Factory::MemoryResourceType memory_resource{};
+    auto map = Factory::CreateContainer(&memory_resource);
+    BenchFillClearMap(bench, map);
+}
+
+BENCHMARK(NodeAllocator_StdUnorderedMap);
+BENCHMARK(NodeAllocator_StdUnorderedMapWithNodeAllocator);

--- a/src/coins.h
+++ b/src/coins.h
@@ -11,6 +11,7 @@
 #include <memusage.h>
 #include <primitives/transaction.h>
 #include <serialize.h>
+#include <support/allocators/node_allocator/factory.h>
 #include <uint256.h>
 #include <util/hasher.h>
 
@@ -131,7 +132,8 @@ struct CCoinsCacheEntry
     CCoinsCacheEntry(Coin&& coin_, unsigned char flag) : coin(std::move(coin_)), flags(flag) {}
 };
 
-typedef std::unordered_map<COutPoint, CCoinsCacheEntry, SaltedOutpointHasher> CCoinsMap;
+using CCoinsMapFactory = node_allocator::Factory<std::unordered_map<COutPoint, CCoinsCacheEntry, SaltedOutpointHasher>>;
+using CCoinsMap = CCoinsMapFactory::ContainerType;
 
 /** Cursor for iterating over CoinsView state */
 class CCoinsViewCursor
@@ -218,10 +220,11 @@ protected:
      * declared as "const".
      */
     mutable uint256 hashBlock;
-    mutable CCoinsMap cacheCoins;
+    mutable CCoinsMapFactory::MemoryResourceType cacheCoinsMemoryResource{};
+    mutable CCoinsMap cacheCoins = CCoinsMapFactory::CreateContainer(&cacheCoinsMemoryResource);
 
     /* Cached dynamic memory usage for the inner Coin objects. */
-    mutable size_t cachedCoinsUsage;
+    mutable size_t cachedCoinsUsage{0};
 
 public:
     CCoinsViewCache(CCoinsView *baseIn);

--- a/src/coins.h
+++ b/src/coins.h
@@ -307,6 +307,7 @@ public:
     //! Check whether all prevouts of the transaction are present in the UTXO set represented by this view
     bool HaveInputs(const CTransaction& tx) const;
 
+private:
     //! Force a reallocation of the cache map. This is required when downsizing
     //! the cache because the map's allocator may be hanging onto a lot of
     //! memory despite having called .clear().
@@ -314,7 +315,6 @@ public:
     //! See: https://stackoverflow.com/questions/42114044/how-to-release-unordered-map-memory
     void ReallocateCache();
 
-private:
     /**
      * @note this is marked const, but may actually append to `cacheCoins`, increasing
      * memory usage.

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -7,6 +7,7 @@
 
 #include <indirectmap.h>
 #include <prevector.h>
+#include <support/allocators/node_allocator/node_size.h>
 
 #include <stdlib.h>
 
@@ -161,10 +162,11 @@ static inline size_t DynamicUsage(const std::unordered_set<X, Y>& s)
     return MallocUsage(sizeof(unordered_node<X>)) * s.size() + MallocUsage(sizeof(void*) * s.bucket_count());
 }
 
-template<typename X, typename Y, typename Z>
-static inline size_t DynamicUsage(const std::unordered_map<X, Y, Z>& m)
+template <typename Key, typename Value, typename Hash, typename Equals>
+static inline size_t DynamicUsage(const std::unordered_map<Key, Value, Hash, Equals>& m)
 {
-    return MallocUsage(sizeof(unordered_node<std::pair<const X, Y> >)) * m.size() + MallocUsage(sizeof(void*) * m.bucket_count());
+    static constexpr auto node_size = node_allocator::NodeSize<std::unordered_map<Key, Value, Hash, Equals>>::VALUE;
+    return MallocUsage(node_size) * m.size() + MallocUsage(sizeof(void*) * m.bucket_count());
 }
 
 }

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -7,6 +7,7 @@
 
 #include <indirectmap.h>
 #include <prevector.h>
+#include <support/allocators/node_allocator/allocator_fwd.h>
 #include <support/allocators/node_allocator/node_size.h>
 
 #include <stdlib.h>
@@ -167,6 +168,14 @@ static inline size_t DynamicUsage(const std::unordered_map<Key, Value, Hash, Equ
 {
     static constexpr auto node_size = node_allocator::NodeSize<std::unordered_map<Key, Value, Hash, Equals>>::VALUE;
     return MallocUsage(node_size) * m.size() + MallocUsage(sizeof(void*) * m.bucket_count());
+}
+
+template <typename Key, typename Value, typename Hash, typename Equals, typename AllocT, size_t AllocS>
+static inline size_t DynamicUsage(const std::unordered_map<Key, Value, Hash, Equals, node_allocator::Allocator<AllocT, AllocS>>& m)
+{
+    // Since node_allocator is used, the memory of the nodes are the MemoryResource's responsibility and
+    // won't be added here. Also multiple maps could use the same MemoryResource.
+    return MallocUsage(sizeof(void*) * m.bucket_count());
 }
 
 }

--- a/src/support/allocators/node_allocator/allocator.h
+++ b/src/support/allocators/node_allocator/allocator.h
@@ -1,0 +1,222 @@
+// Copyright (c) 2019-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SUPPORT_ALLOCATORS_NODE_ALLOCATOR_ALLOCATOR_H
+#define BITCOIN_SUPPORT_ALLOCATORS_NODE_ALLOCATOR_ALLOCATOR_H
+
+#include <support/allocators/node_allocator/allocator_fwd.h>
+#include <support/allocators/node_allocator/memory_resource.h>
+
+#include <cstdint>
+#include <new>
+
+/**
+ * @brief Efficient allocator for node-based containers.
+ *
+ * The combination of Allocator and MemoryResource can be used as an optimization for node-based
+ * containers that experience heavy load.
+ *
+ * ## Behavior
+ *
+ * MemoryResource mallocs pools of memory and uses these to carve out memory for the nodes. Nodes
+ * that are freed by the Allocator are actually put back into a free list for further use. This
+ * behavior has two main advantages:
+ *
+ * - Memory: no malloc control structure is required for each node memory; the free list is stored
+ * in-place. This typically saves about 16 bytes per node.
+ *
+ * - Performance: much fewer calls to malloc/free. Accessing / putting back entries are O(1) with
+ * low constant overhead.
+ *
+ * There's no free lunch, so there are also disadvantages:
+ *
+ * - It is necessary to know the exact size of the container internally used nodes beforehand, but
+ * there is no standard way to get this.
+ *
+ * - Memory that's been used for nodes is always put back into a free list and never given back to
+ * the system. Memory is only freed when the MemoryResource is destructed.
+ *
+ * - The free list is a simple last-in-first-out linked list, it doesn't reorder elements based on
+ * proximity. So freeing and malloc'ing again can become a random access pattern which can lead to
+ * more cache misses.
+ *
+ * ## Design & Implementation
+ *
+ * Allocator is a cheaply copyable, `std::allocator`-compatible type used for the containers.
+ * Similar to `std::pmr::polymorphic_allocator`, it holds a pointer to a memory resource.
+ *
+ * MemoryResource is an immobile object that actually allocates, holds and manages memory. Currently
+ * it is only able to provide optimized alloc/free for a single fixed allocation size. Only allocations
+ * that match this size will be provided from the preallocated pools of memory; all other requests
+ * simply use `::operator new()`. Using node_allocator with a standard container types like std::list,
+ * std::unordered_map requires knowing node sizes of those containers which are non-standard
+ * implementation details. The \ref memusage::NodeSize trait and \ref node_allocator::Factory class can
+ * be used to help with this.
+ *
+ * Node size is determined by memusage::NodeSize and verified to work in various alignment scenarios
+ * in `node_allocator_tests/test_allocations_are_used`.
+ *
+ * ## Further Links
+ *
+ * @see CppCon 2017: Bob Steagall “How to Write a Custom Allocator”
+ *   https://www.youtube.com/watch?v=kSWfushlvB8
+ * @see C++Now 2018: Arthur O'Dwyer “An Allocator is a Handle to a Heap”
+ *   https://www.youtube.com/watch?v=0MdSJsCTRkY
+ * @see AllocatorAwareContainer: Introduction and pitfalls of propagate_on_container_XXX defaults
+ *   https://www.foonathan.net/2015/10/allocatorawarecontainer-propagation-pitfalls/
+ */
+namespace node_allocator {
+
+/**
+ * Allocator that's usable for node-based containers like std::unordered_map or std::list.
+ *
+ * The allocator is stateful, and can be cheaply copied. Its state is an immobile MemoryResource,
+ * which actually does all the allocation/deallocations. So this class is just a simple wrapper that
+ * conforms to the required STL interface to be usable for the node-based containers.
+ */
+template <typename T, size_t ALLOCATION_SIZE_BYTES>
+class Allocator
+{
+    template <typename U, size_t AS>
+    friend class Allocator;
+
+    template <typename X, typename Y, size_t AS>
+    friend bool operator==(const Allocator<X, AS>& a, const Allocator<Y, AS>& b) noexcept;
+
+public:
+    using value_type = T;
+
+    /**
+     * The allocator is stateful so we can't use the compile time `is_always_equal` optimization and
+     * have to use the runtime operator==.
+     */
+    using is_always_equal = std::false_type;
+
+    /**
+     * Move assignment should be a fast operation. In the case of a = std::move(b), we want
+     * a to be able to use b's allocator, otherwise all elements would have to be recreated with a's
+     * old allocator.
+     */
+    using propagate_on_container_move_assignment = std::true_type;
+
+    /**
+     * The default for propagate_on_container_swap is std::false_type. This is bad,because swapping
+     * two containers with unequal allocators but not propagating the allocator is undefined
+     * behavior! Obviously, we want so swap the allocator as well, so we set that to true.
+     *
+     * see https://www.foonathan.net/2015/10/allocatorawarecontainer-propagation-pitfalls/
+     */
+    using propagate_on_container_swap = std::true_type; // to avoid the undefined behavior
+
+    /**
+     * Move and swap have to propagate the allocator, so for consistency we do the same for copy
+     * assignment.
+     */
+    using propagate_on_container_copy_assignment = std::true_type;
+
+    /**
+     * Construct a new Allocator object which will delegate all allocations/deallocations to the
+     * memory resource.
+     */
+    explicit Allocator(MemoryResource<ALLOCATION_SIZE_BYTES>* memory_resource) noexcept
+        : m_memory_resource(memory_resource)
+    {
+    }
+
+    /**
+     * Conversion constructor for rebinding. All Allocators use the same memory_resource.
+     *
+     * The rebound type is determined with the `struct rebind`. The rebind is necessary feature
+     * for standard allocators, and it happens when the allocator shall be used for different types.
+     * E.g. for std::unordered_map this happens for allocation of the internally used nodes, for the
+     * underlying index array, and possibly for some control structure. In fact the type required by
+     * the standard `std::pair<const Key, Value>` type is never actually used for any allocation
+     * (which is therefore a stupid requirement, but that's just C++ being C++).
+     */
+    template <typename U>
+    Allocator(const Allocator<U, ALLOCATION_SIZE_BYTES>& other) noexcept
+        : m_memory_resource(other.m_memory_resource)
+    {
+    }
+
+    /**
+     * From the standard: rebind is only optional (provided by std::allocator_traits) if this
+     * allocator is a template of the form SomeAllocator<T, Args>, where Args is zero or more
+     * additional template type parameters.
+     *
+     * Since we use a size_t as additional argument, it's *not* optional.
+     * @see https://en.cppreference.com/w/cpp/named_req/Allocator#cite_note-2
+     */
+    template <typename U>
+    struct rebind {
+        using other = Allocator<U, ALLOCATION_SIZE_BYTES>;
+    };
+
+    /**
+     * Allocates n entries of the given type.
+     */
+    T* allocate(size_t n)
+    {
+        if constexpr (ALLOCATION_SIZE_BYTES == detail::RequiredAllocationSizeBytes<T>()) {
+            if (n != 1) {
+                // pool is not used so forward to operator new.
+                return static_cast<T*>(::operator new(n * sizeof(T)));
+            }
+
+            // Forward all allocations to the memory_resource
+            return m_memory_resource->template Allocate<T>();
+        } else {
+            // pool is not used so forward to operator new.
+            return static_cast<T*>(::operator new(n * sizeof(T)));
+        }
+    }
+
+    /**
+     * Deallocates n entries of the given type.
+     */
+    void deallocate(T* p, size_t n)
+    {
+        if constexpr (ALLOCATION_SIZE_BYTES == detail::RequiredAllocationSizeBytes<T>()) {
+            if (n != 1) {
+                // allocation didn't happen with the pool
+                ::operator delete(p);
+                return;
+            }
+            m_memory_resource->template Deallocate<T>(p);
+        } else {
+            // allocation didn't happen with the pool
+            ::operator delete(p);
+        }
+    }
+
+private:
+    //! Stateful allocator, where the state is a simple pointer that can be cheaply copied.
+    MemoryResource<ALLOCATION_SIZE_BYTES>* m_memory_resource;
+};
+
+
+/**
+ * Since Allocator is stateful, comparison with another one only returns true if it uses the same
+ * memory_resource.
+ */
+template <typename T, typename U, size_t CS>
+bool operator==(const Allocator<T, CS>& a, const Allocator<U, CS>& b) noexcept
+{
+    // "Equality of an allocator is determined through the ability of allocating memory with one
+    // allocator and deallocating it with another." - Jonathan Müller
+    // See https://www.foonathan.net/2015/10/allocatorawarecontainer-propagation-pitfalls/
+    //
+    // For us that is the case when both allocators use the same memory resource.
+    return a.m_memory_resource == b.m_memory_resource;
+}
+
+template <typename T, typename U, size_t CS>
+bool operator!=(const Allocator<T, CS>& a, const Allocator<U, CS>& b) noexcept
+{
+    return !(a == b);
+}
+
+} // namespace node_allocator
+
+#endif // BITCOIN_SUPPORT_ALLOCATORS_NODE_ALLOCATOR_ALLOCATOR_H

--- a/src/support/allocators/node_allocator/allocator_fwd.h
+++ b/src/support/allocators/node_allocator/allocator_fwd.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SUPPORT_ALLOCATORS_NODE_ALLOCATOR_ALLOCATOR_FWD_H
+#define BITCOIN_SUPPORT_ALLOCATORS_NODE_ALLOCATOR_ALLOCATOR_FWD_H
+
+#include <cstddef>
+
+namespace node_allocator {
+
+template <typename T, size_t ALLOCATION_SIZE_BYTES>
+class Allocator;
+
+} // namespace node_allocator
+
+#endif // BITCOIN_SUPPORT_ALLOCATORS_NODE_ALLOCATOR_ALLOCATOR_FWD_H

--- a/src/support/allocators/node_allocator/factory.h
+++ b/src/support/allocators/node_allocator/factory.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2019-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SUPPORT_ALLOCATORS_NODE_ALLOCATOR_FACTORY_H
+#define BITCOIN_SUPPORT_ALLOCATORS_NODE_ALLOCATOR_FACTORY_H
+
+#include <support/allocators/node_allocator/allocator.h>
+#include <support/allocators/node_allocator/node_size.h>
+
+#include <cassert>
+#include <unordered_map>
+
+namespace node_allocator {
+
+/**
+ * Generic factory to create node_allocator based containers.
+ */
+template <typename Container>
+class Factory;
+
+/**
+ * Helper to create std::unordered_map which uses the node_allocator.
+ *
+ * This calculates the size of the container's internally used node correctly for all supported
+ * platforms, which is also asserted by the unit tests.
+ */
+template <typename Key, typename Value, typename Hash, typename Equals>
+class Factory<std::unordered_map<Key, Value, Hash, Equals>>
+{
+    using BaseContainerType = std::unordered_map<Key, Value, Hash, Equals>;
+    using ValueType = typename BaseContainerType::value_type;
+    static constexpr size_t ALLOCATION_SIZE_BYTES = detail::RequiredAllocationSizeBytes<typename NodeSize<BaseContainerType>::SimulatedNodeType>();
+
+public:
+    using MemoryResourceType = MemoryResource<ALLOCATION_SIZE_BYTES>;
+    using AllocatorType = Allocator<std::pair<const Key, Value>, ALLOCATION_SIZE_BYTES>;
+    using ContainerType = std::unordered_map<Key, Value, Hash, Equals, AllocatorType>;
+
+    /**
+     * Creates the std::unordered_map container, and asserts that the specified memory_resource is correct.
+     */
+    [[nodiscard]] static ContainerType CreateContainer(MemoryResourceType* memory_resource)
+    {
+        assert(memory_resource != nullptr);
+        return ContainerType{0, Hash{}, Equals{}, AllocatorType{memory_resource}};
+    }
+};
+
+} // namespace node_allocator
+
+#endif // BITCOIN_SUPPORT_ALLOCATORS_NODE_ALLOCATOR_FACTORY_H

--- a/src/support/allocators/node_allocator/memory_resource.cpp
+++ b/src/support/allocators/node_allocator/memory_resource.cpp
@@ -1,0 +1,12 @@
+#include <support/allocators/node_allocator/memory_resource.h>
+
+#include <memusage.h>
+
+namespace node_allocator::detail {
+
+size_t DynamicMemoryUsage(size_t pool_size_bytes, std::vector<std::unique_ptr<char[]>> const& allocated_pools)
+{
+    return memusage::MallocUsage(pool_size_bytes) * allocated_pools.size() + memusage::DynamicUsage(allocated_pools);
+}
+
+} // namespace node_allocator::detail

--- a/src/support/allocators/node_allocator/memory_resource.h
+++ b/src/support/allocators/node_allocator/memory_resource.h
@@ -1,0 +1,196 @@
+// Copyright (c) 2019-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#ifndef BITCOIN_SUPPORT_ALLOCATORS_NODE_ALLOCATOR_MEMORY_RESOURCE_H
+#define BITCOIN_SUPPORT_ALLOCATORS_NODE_ALLOCATOR_MEMORY_RESOURCE_H
+
+namespace node_allocator {
+
+namespace detail {
+
+/**
+ * In-place linked list of the allocations, used for the free list.
+ */
+struct FreeList {
+    FreeList* next;
+};
+
+static_assert(std::is_trivially_destructible_v<FreeList>, "make sure we don't need to manually destruct the FreeList");
+
+/**
+ * Calculates the required allocation size for the given type.
+ * The memory needs to be correctly aligned and large enough for both both T and FreeList.
+ */
+template <typename T>
+[[nodiscard]] constexpr size_t RequiredAllocationSizeBytes() noexcept
+{
+    const auto alignment_max = std::max(std::alignment_of_v<T>, std::alignment_of_v<FreeList>);
+    const auto size_max = std::max(sizeof(T), sizeof(FreeList));
+
+    // find closest multiple of alignment_max that holds size_max
+    return ((size_max + alignment_max - 1U) / alignment_max) * alignment_max;
+}
+
+/**
+ * Calculates dynamic memory usage of a MemoryResource. Not a member of MemoryResource so we can implement this
+ * in a cpp and don't depend on memusage.h in the header.
+ */
+[[nodiscard]] size_t DynamicMemoryUsage(size_t pool_size_bytes, std::vector<std::unique_ptr<char[]>> const& allocated_pools);
+
+} // namespace detail
+
+/**
+ * Actually holds and provides memory to an allocator. MemoryResource is an immobile object. It
+ * stores a number of memory pools which are used to quickly give out memory of a fixed allocation
+ * size. The class is purposely kept very simple. It only knows about "Allocations" and "Pools".
+ *
+ * - Pool: MemoryResource allocates one memory pool at a time. These pools are kept around until the
+ * memory resource is destroyed.
+ *
+ * - Allocations: Node-based containers allocate one node at a time. Whenever that happens, the
+ * MemoryResource's Allocate() gives out memory for one node. These are carved out from a previously
+ * allocated memory pool, or from a free list if it contains entries. Whenever a node is given back
+ * with Deallocate(), it is put into that free list.
+ */
+template <size_t ALLOCATION_SIZE_BYTES>
+class MemoryResource
+{
+    /**
+     * Size in bytes to allocate per pool, currently hardcoded to multiple of ALLOCATION_SIZE_BYTES
+     * that comes closest to 256 KiB.
+     */
+    static constexpr size_t POOL_SIZE_BYTES = (262144 / ALLOCATION_SIZE_BYTES) * ALLOCATION_SIZE_BYTES;
+
+public:
+    /**
+     * Construct a new MemoryResource object that uses the specified allocation size to optimize for.
+     */
+    MemoryResource() = default;
+
+    /**
+     * Copying/moving a memory resource is not allowed; it is an immobile object.
+     */
+    MemoryResource(const MemoryResource&) = delete;
+    MemoryResource& operator=(const MemoryResource&) = delete;
+    MemoryResource(MemoryResource&&) = delete;
+    MemoryResource& operator=(MemoryResource&&) = delete;
+
+    /**
+     * Deallocates all allocated pools.
+     *
+     * There's no Clear() method on purpose, because it would be dangerous. E.g. when calling
+     * clear() on an unordered_map, it is not certain that all allocated nodes are given back to the
+     * MemoryResource. Microsoft's STL still uses a control structure that might have the same size
+     * as the nodes, and therefore needs to be kept around until the map is actually destroyed.
+     */
+    ~MemoryResource() = default;
+
+    /**
+     * Allocates memory for sizeof(T).
+     *
+     * @tparam T Object to allocate memory for.
+     */
+    template <typename T>
+    [[nodiscard]] T* Allocate()
+    {
+        static_assert(ALLOCATION_SIZE_BYTES == detail::RequiredAllocationSizeBytes<T>());
+        static_assert(__STDCPP_DEFAULT_NEW_ALIGNMENT__ >= std::alignment_of_v<T>, "make sure AllocatePool() aligns correctly");
+
+        if (m_free_allocations) {
+            // we've already got data in the free list, unlink one element
+            auto old_head = m_free_allocations;
+            m_free_allocations = m_free_allocations->next;
+            return reinterpret_cast<T*>(old_head);
+        }
+
+        // free list is empty: get one allocation from allocated pool memory.
+        // It makes sense to not create the fully linked list of an allocated pool up-front, for
+        // several reasons. On the one hand, the latency is higher when we need to iterate and
+        // update pointers for the whole pool at once. More importantly, most systems lazily
+        // allocate data. So when we allocate a big pool of memory the memory for a page is only
+        // actually made available to the program when it is first touched. So when we allocate
+        // a big pool and only use very little memory from it, the total memory usage is lower
+        // than what has been malloc'ed.
+        if (m_untouched_memory_iterator == m_untouched_memory_end) {
+            // slow path, only happens when a new pool needs to be allocated
+            AllocatePool();
+        }
+
+        // peel off one allocation from the untouched memory. The next pointer of in-use
+        // elements doesn't matter until it is deallocated, only then it is used to form the
+        // free list.
+        char* tmp = m_untouched_memory_iterator;
+        m_untouched_memory_iterator = tmp + ALLOCATION_SIZE_BYTES;
+        return reinterpret_cast<T*>(tmp);
+    }
+
+    /**
+     * Puts p back into the free list.
+     */
+    template <typename T>
+    void Deallocate(void* p) noexcept
+    {
+        static_assert(ALLOCATION_SIZE_BYTES == detail::RequiredAllocationSizeBytes<T>());
+
+        // put it into the linked list.
+        //
+        // Note: We can't just static_cast<detail::FreeList*>(p) because this is technically
+        // undefined behavior. But we can use placement new instead. Correct alignment is
+        // guaranteed by the static_asserts in Allocate().
+        auto* const allocation = new (p) detail::FreeList;
+        allocation->next = m_free_allocations;
+        m_free_allocations = allocation;
+    }
+
+    /**
+     * Calculates bytes allocated by the memory resource.
+     */
+    [[nodiscard]] size_t DynamicMemoryUsage() const noexcept
+    {
+        return detail::DynamicMemoryUsage(POOL_SIZE_BYTES, m_allocated_pools);
+    }
+
+private:
+    //! Access to internals for testing purpose only
+    friend class MemoryResourceTester;
+
+    /**
+     * Allocate one full memory pool which is used to carve out allocations.
+     */
+    void AllocatePool()
+    {
+        m_allocated_pools.emplace_back(new char[POOL_SIZE_BYTES]);
+        m_untouched_memory_iterator = m_allocated_pools.back().get();
+        m_untouched_memory_end = m_untouched_memory_iterator + POOL_SIZE_BYTES;
+    }
+
+    //! Contains all allocated pools of memory, used to free the data in the destructor.
+    std::vector<std::unique_ptr<char[]>> m_allocated_pools{};
+
+    //! A single linked list of all data available in the MemoryResource. This list is used for
+    //! allocations of single elements.
+    detail::FreeList* m_free_allocations = nullptr;
+
+    //! Points to the beginning of available memory for carving out allocations.
+    char* m_untouched_memory_iterator = nullptr;
+
+    /**
+     * Points to the end of available memory for carving out allocations.
+     *
+     * That member variable is redundant, and is always equal to
+     * `m_allocated_pools.back().get() + POOL_SIZE_BYTES` whenever it is accessed, but
+     * `m_untouched_memory_end` caches this for clarity and efficiency.
+     */
+    char* m_untouched_memory_end = nullptr;
+};
+
+} // namespace node_allocator
+
+#endif // BITCOIN_SUPPORT_ALLOCATORS_NODE_ALLOCATOR_MEMORY_RESOURCE_H

--- a/src/support/allocators/node_allocator/node_size.h
+++ b/src/support/allocators/node_allocator/node_size.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2019-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SUPPORT_ALLOCATORS_NODE_ALLOCATOR_NODE_SIZE_H
+#define BITCOIN_SUPPORT_ALLOCATORS_NODE_ALLOCATOR_NODE_SIZE_H
+
+#include <cstddef>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+namespace node_allocator {
+
+/**
+ * Calculates memory usage of nodes for different containers.
+ */
+template <typename T>
+struct NodeSize;
+
+/**
+ * It is important that the calculation here matches exactly the behavior of std::unordered_map
+ * so the node_allocator actually works. This is tested in node_allocator_tests/test_allocations_are_used
+ * with multiple configurations (alignments, noexcept hash, node sizes).
+ */
+template <typename Key, typename V, typename Hash, typename Equals, typename Allocator>
+struct NodeSize<std::unordered_map<Key, V, Hash, Equals, Allocator>> {
+    using ContainerType = std::unordered_map<Key, V, Hash, Equals, Allocator>;
+    using ValueType = typename ContainerType::value_type;
+
+#if defined(_MSC_VER)
+    // libstdc++, libc++, and MSVC implement the nodes differently. To get the correct size with
+    // the correct alignment, we can simulate the memory layouts with accordingly nested std::pairs.
+    //
+    // list node contains 2 pointers and no hash; see
+    // https://github.com/microsoft/STL/blob/main/stl/inc/unordered_map and
+    // https://github.com/microsoft/STL/blob/main/stl/inc/list
+    using SimulatedNodeType = std::pair<std::pair<void*, void*>, ValueType>;
+#elif defined(_LIBCPP_VERSION) // defined in any C++ header from libc++
+    // libc++ always stores hash and pointer in the node
+    // see https://github.com/llvm/llvm-project/blob/release/13.x/libcxx/include/__hash_table#L92
+    using SimulatedNodeType = std::pair<ValueType, std::pair<size_t, void*>>;
+#else
+    // libstdc++ doesn't store hash when its operator() is noexcept;
+    // see hashtable_policy.h, struct _Hash_node
+    // https://gcc.gnu.org/onlinedocs/libstdc++/latest-doxygen/a05689.html
+    using SimulatedNodeType = std::conditional_t<noexcept(std::declval<Hash>()(std::declval<const Key&>())),
+                                                 std::pair<void*, ValueType>,                     // no hash stored
+                                                 std::pair<void*, std::pair<ValueType, size_t>>>; // hash stored along ValueType, and that is wrapped with the pointer.
+#endif
+
+    static constexpr size_t VALUE = sizeof(SimulatedNodeType);
+};
+
+} // namespace node_allocator
+
+#endif // BITCOIN_SUPPORT_ALLOCATORS_NODE_ALLOCATOR_NODE_SIZE_H

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -81,7 +81,7 @@ public:
     void SelfTest() const
     {
         // Manually recompute the dynamic usage of the whole data, and compare it.
-        size_t ret = memusage::DynamicUsage(cacheCoins);
+        size_t ret = memusage::DynamicUsage(cacheCoins) + cacheCoinsMemoryResource.DynamicMemoryUsage();
         size_t count = 0;
         for (const auto& entry : cacheCoins) {
             ret += entry.second.coin.DynamicMemoryUsage();
@@ -609,7 +609,8 @@ void GetCoinsMapEntry(const CCoinsMap& map, CAmount& value, char& flags)
 
 void WriteCoinsViewEntry(CCoinsView& view, CAmount value, char flags)
 {
-    CCoinsMap map;
+    CCoinsMapFactory::MemoryResourceType memory_resource{};
+    auto map = CCoinsMapFactory::CreateContainer(&memory_resource);
     InsertCoinsMapEntry(map, value, flags);
     BOOST_CHECK(view.BatchWrite(map, {}));
 }

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -117,7 +117,8 @@ FUZZ_TARGET_INIT(coins_view, initialize_coins_view)
                 random_mutable_transaction = *opt_mutable_transaction;
             },
             [&] {
-                CCoinsMap coins_map;
+                CCoinsMapFactory::MemoryResourceType cacheCoinsMemoryResource{};
+                auto coins_map = CCoinsMapFactory::CreateContainer(&cacheCoinsMemoryResource);
                 LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000) {
                     CCoinsCacheEntry coins_cache_entry;
                     coins_cache_entry.flags = fuzzed_data_provider.ConsumeIntegral<unsigned char>();

--- a/src/test/node_allocator_helpers.h
+++ b/src/test/node_allocator_helpers.h
@@ -1,0 +1,27 @@
+#ifndef BITCOIN_TEST_NODE_ALLOCATOR_HELPERS_H
+#define BITCOIN_TEST_NODE_ALLOCATOR_HELPERS_H
+
+#include <cstddef>
+#include <utility>
+
+/**
+ * Wrapper around std::hash, but without noexcept. Useful for testing unordered containers
+ * because they potentially behave differently with/without a noexcept hash.
+ */
+template <typename T>
+struct NotNoexceptHash {
+    size_t operator()(const T& x) const /* not noexcept */
+    {
+        return std::hash<T>{}(x);
+    }
+};
+
+/**
+ * Generic struct with customizeable size and alignment.
+ */
+template <size_t ALIGNMENT, size_t SIZE>
+struct alignas(ALIGNMENT) AlignedSize {
+    char data[SIZE];
+};
+
+#endif // BITCOIN_TEST_NODE_ALLOCATOR_HELPERS_H

--- a/src/test/node_allocator_tests.cpp
+++ b/src/test/node_allocator_tests.cpp
@@ -1,0 +1,361 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <support/allocators/node_allocator/factory.h>
+#include <test/node_allocator_helpers.h>
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstddef>
+#include <list>
+#include <map>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+
+namespace node_allocator {
+
+class MemoryResourceTester
+{
+public:
+    /**
+     * Counts number of free entries in the free list. This is an O(n) operation
+     */
+    template <size_t ALLOCATION_SIZE_BYTES>
+    [[nodiscard]] static size_t NumFreeAllocations(
+        MemoryResource<ALLOCATION_SIZE_BYTES> const& mr) noexcept
+    {
+        size_t length = 0;
+        auto allocation = mr.m_free_allocations;
+        while (allocation) {
+            allocation = static_cast<detail::FreeList const*>(allocation)->next;
+            ++length;
+        }
+        return length;
+    }
+
+    /**
+     * Number of memory pools that have been allocated
+     */
+    template <size_t ALLOCATION_SIZE_BYTES>
+    [[nodiscard]] static size_t NumPools(MemoryResource<ALLOCATION_SIZE_BYTES> const& mr) noexcept
+    {
+        return mr.m_allocated_pools.size();
+    }
+
+
+    /**
+     * Extracts allocation size from the type
+     */
+    template <size_t ALLOCATION_SIZE_BYTES>
+    [[nodiscard]] static constexpr size_t AllocationSizeBytes(MemoryResource<ALLOCATION_SIZE_BYTES> const&) noexcept
+    {
+        return ALLOCATION_SIZE_BYTES;
+    }
+};
+
+} // namespace node_allocator
+
+#define CHECK_IN_RANGE(what, lower_inclusive, upper_inclusive) \
+    BOOST_TEST(what >= lower_inclusive);                       \
+    BOOST_TEST(what <= upper_inclusive);
+
+namespace {
+
+struct TwoMapsSetup {
+    using Factory = node_allocator::Factory<std::unordered_map<uint64_t, uint64_t>>;
+    Factory::MemoryResourceType mr_a{};
+    Factory::MemoryResourceType mr_b{};
+
+    std::optional<Factory::ContainerType> map_a{};
+    std::optional<Factory::ContainerType> map_b{};
+
+    TwoMapsSetup()
+    {
+        map_a = Factory::CreateContainer(&mr_a);
+        for (int i = 0; i < 100; ++i) {
+            (*map_a)[i] = i;
+        }
+
+        map_b = Factory::CreateContainer(&mr_b);
+        (*map_b)[123] = 321;
+
+        BOOST_CHECK(map_a->get_allocator() != map_b->get_allocator());
+        BOOST_CHECK_EQUAL(node_allocator::MemoryResourceTester::NumFreeAllocations(mr_b), 0);
+        BOOST_CHECK_EQUAL(node_allocator::MemoryResourceTester::NumPools(mr_b), 1);
+    }
+
+    void DestroyMapBAndCheckAfterAssignment()
+    {
+        // map_a now uses mr_b, since propagate_on_container_copy_assignment is std::true_type
+        BOOST_CHECK(map_a->get_allocator() == map_b->get_allocator());
+
+        // With MSVC there might be an additional allocation used for a control structure, so we
+        // can't just use BOOST_CHECK_EQUAL.
+        CHECK_IN_RANGE(node_allocator::MemoryResourceTester::NumFreeAllocations(mr_b), 1U, 2U);
+        BOOST_CHECK_EQUAL(node_allocator::MemoryResourceTester::NumPools(mr_b), 1);
+
+        // map_b was now recreated with data from map_a, using mr_a as the memory resource.
+        map_b.reset();
+
+        // map_b destroyed, should not have any effect on mr_b
+        CHECK_IN_RANGE(node_allocator::MemoryResourceTester::NumFreeAllocations(mr_b), 1U, 2U);
+        BOOST_CHECK_EQUAL(node_allocator::MemoryResourceTester::NumPools(mr_b), 1);
+
+        // but we'll get more free allocations in mr_a
+        CHECK_IN_RANGE(node_allocator::MemoryResourceTester::NumFreeAllocations(mr_a), 100U, 101U);
+    }
+};
+
+template <typename Key, typename Value, typename Hash = std::hash<Key>>
+void TestAllocationsAreUsed()
+{
+    using Factory = node_allocator::Factory<std::unordered_map<Key, Value, Hash>>;
+    typename Factory::MemoryResourceType mr{};
+    BOOST_TEST_MESSAGE(
+        strprintf("%u sizeof(void*), %u/%u/%u sizeof Key/Value/Pair, %u ALLOCATION_SIZE_BYTES",
+                  sizeof(void*), sizeof(Key), sizeof(Value), sizeof(std::pair<const Key, Value>),
+                  node_allocator::MemoryResourceTester::AllocationSizeBytes(mr)));
+    {
+        auto map = Factory::CreateContainer(&mr);
+        for (size_t i = 0; i < 5; ++i) {
+            map[i];
+        }
+        BOOST_CHECK_EQUAL(node_allocator::MemoryResourceTester::NumFreeAllocations(mr), 0);
+        map.clear();
+        BOOST_CHECK_EQUAL(node_allocator::MemoryResourceTester::NumFreeAllocations(mr), 5);
+
+        for (size_t i = 0; i < 5; ++i) {
+            map[i];
+        }
+        BOOST_CHECK_EQUAL(node_allocator::MemoryResourceTester::NumFreeAllocations(mr), 0);
+        map.clear();
+        BOOST_CHECK_EQUAL(node_allocator::MemoryResourceTester::NumFreeAllocations(mr), 5);
+    }
+
+    CHECK_IN_RANGE(node_allocator::MemoryResourceTester::NumFreeAllocations(mr), 5, 6);
+}
+
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(node_allocator_tests, BasicTestingSetup)
+
+#define CHECK_NUMS_FREES_POOLS(mr, num_free_allocations, num_pools)                  \
+    BOOST_CHECK_EQUAL(num_free_allocations,                                          \
+                      node_allocator::MemoryResourceTester::NumFreeAllocations(mr)); \
+    BOOST_CHECK_EQUAL(num_pools, node_allocator::MemoryResourceTester::NumPools(mr));
+
+BOOST_AUTO_TEST_CASE(too_small)
+{
+    // Verify that MemoryResource specialized for a larger char pair type will do smaller single char allocations as well
+    using T = std::pair<char, char>;
+    node_allocator::MemoryResource<node_allocator::detail::RequiredAllocationSizeBytes<T>()> mr{};
+    void* ptr{mr.Allocate<char>()};
+    BOOST_CHECK(ptr != nullptr);
+
+    // mr is used
+    CHECK_NUMS_FREES_POOLS(mr, 0, 1);
+    mr.Deallocate<char>(ptr);
+    CHECK_NUMS_FREES_POOLS(mr, 1, 1);
+
+    // freelist is used
+    ptr = mr.Allocate<T>();
+    BOOST_CHECK(ptr != nullptr);
+    CHECK_NUMS_FREES_POOLS(mr, 0, 1);
+    mr.Deallocate<char>(ptr);
+    CHECK_NUMS_FREES_POOLS(mr, 1, 1);
+}
+
+BOOST_AUTO_TEST_CASE(std_unordered_map)
+{
+    using Factory = node_allocator::Factory<std::unordered_map<uint64_t, uint64_t>>;
+
+    Factory::MemoryResourceType mr{};
+    auto m = Factory::CreateContainer(&mr);
+    size_t num_free_allocations = 0;
+    {
+        auto a = Factory::CreateContainer(&mr);
+
+        // Allocator compares equal because the same memory resource is used
+        BOOST_CHECK(a.get_allocator() == m.get_allocator());
+        for (uint64_t i = 0; i < 1000; ++i) {
+            a[i] = i;
+        }
+
+        num_free_allocations = node_allocator::MemoryResourceTester::NumFreeAllocations(mr);
+
+        // create a copy of the map, destroy the map => now a lot more free allocations should be
+        // available
+        {
+            auto b = a;
+        }
+
+        BOOST_CHECK(node_allocator::MemoryResourceTester::NumFreeAllocations(mr) >=
+                    num_free_allocations + 1000);
+        num_free_allocations = node_allocator::MemoryResourceTester::NumFreeAllocations(mr);
+
+        // creating another copy, and then destroying everything should reuse all the allocations
+        {
+            auto b = a;
+        }
+        BOOST_CHECK_EQUAL(node_allocator::MemoryResourceTester::NumFreeAllocations(mr),
+                          num_free_allocations);
+
+        // moving the map should not create new nodes
+        m = std::move(a);
+        BOOST_CHECK_EQUAL(node_allocator::MemoryResourceTester::NumFreeAllocations(mr),
+                          num_free_allocations);
+    }
+
+    // a is destroyed, still all allocations should stay roughly the same because its contents were
+    // moved to m which is still alive
+    BOOST_CHECK(node_allocator::MemoryResourceTester::NumFreeAllocations(mr) <=
+                num_free_allocations + 5);
+
+    num_free_allocations = node_allocator::MemoryResourceTester::NumFreeAllocations(mr);
+    m = Factory::CreateContainer(&mr);
+
+    // now that m is replaced its content is freed
+    BOOST_CHECK(node_allocator::MemoryResourceTester::NumFreeAllocations(mr) >=
+                num_free_allocations + 1000);
+}
+
+BOOST_FIXTURE_TEST_CASE(different_memoryresource_assignment, TwoMapsSetup)
+{
+    map_b = map_a;
+
+    DestroyMapBAndCheckAfterAssignment();
+
+    // finally map_a is destroyed, getting more free allocations.
+    map_a.reset();
+    CHECK_IN_RANGE(node_allocator::MemoryResourceTester::NumFreeAllocations(mr_a), 200U, 202U);
+}
+
+BOOST_FIXTURE_TEST_CASE(different_memoryresource_move, TwoMapsSetup)
+{
+    map_b = std::move(map_a);
+
+    DestroyMapBAndCheckAfterAssignment();
+
+    // finally map_a is destroyed, but since it was moved, no more free allocations.
+    map_a.reset();
+    CHECK_IN_RANGE(node_allocator::MemoryResourceTester::NumFreeAllocations(mr_a), 100U, 102U);
+}
+
+
+BOOST_FIXTURE_TEST_CASE(different_memoryresource_swap, TwoMapsSetup)
+{
+    auto alloc_a = map_a->get_allocator();
+    auto alloc_b = map_b->get_allocator();
+
+    std::swap(map_a, map_b);
+
+    // The maps have swapped, so their allocators have swapped, too.
+    // No additional allocations have occurred!
+    BOOST_CHECK(map_a->get_allocator() != map_b->get_allocator());
+    BOOST_CHECK(alloc_a == map_b->get_allocator());
+    BOOST_CHECK(alloc_b == map_a->get_allocator());
+    map_b.reset();
+
+    // map_b destroyed, so mr_a must have plenty of free allocations now
+    CHECK_IN_RANGE(node_allocator::MemoryResourceTester::NumFreeAllocations(mr_a), 100U, 101U);
+
+    // nothing happened to map_a, so mr_b still has no free allocations
+    BOOST_CHECK_EQUAL(node_allocator::MemoryResourceTester::NumFreeAllocations(mr_b), 0);
+    map_a.reset();
+
+    // finally map_a is destroyed, so we got an entry back for mr_b.
+    CHECK_IN_RANGE(node_allocator::MemoryResourceTester::NumFreeAllocations(mr_a), 100U, 101U);
+    CHECK_IN_RANGE(node_allocator::MemoryResourceTester::NumFreeAllocations(mr_b), 1U, 2U);
+}
+
+BOOST_AUTO_TEST_CASE(calc_required_allocation_size)
+{
+    static_assert(sizeof(AlignedSize<1, 1>) == 1U);
+    static_assert(std::alignment_of_v<AlignedSize<1, 1>> == 1U);
+
+    static_assert(sizeof(AlignedSize<16, 1>) == 16U);
+    static_assert(std::alignment_of_v<AlignedSize<16, 1>> == 16U);
+    static_assert(sizeof(AlignedSize<16, 16>) == 16U);
+    static_assert(std::alignment_of_v<AlignedSize<16, 16>> == 16U);
+    static_assert(sizeof(AlignedSize<16, 24>) == 32U);
+    static_assert(std::alignment_of_v<AlignedSize<16, 24>> == 16U);
+
+#if UINTPTR_MAX == 0xFFFFFFFFFFFFFFFF
+    static_assert(8U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<1, 1>>());
+    static_assert(8U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<1, 7>>());
+    static_assert(8U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<1, 8>>());
+    static_assert(16U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<1, 9>>());
+    static_assert(16U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<1, 15>>());
+    static_assert(16U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<1, 16>>());
+    static_assert(24U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<1, 17>>());
+    static_assert(104U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<1, 100>>());
+
+    static_assert(8U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<4, 4>>());
+    static_assert(8U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<4, 7>>());
+    static_assert(104U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<4, 100>>());
+#elif UINTPTR_MAX == 0xFFFFFFFF
+    static_assert(4U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<1, 1>>());
+    static_assert(8U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<1, 7>>());
+    static_assert(8U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<1, 8>>());
+    static_assert(12U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<1, 9>>());
+    static_assert(16U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<1, 15>>());
+    static_assert(16U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<1, 16>>());
+    static_assert(20U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<1, 17>>());
+    static_assert(100U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<1, 100>>());
+
+    static_assert(4U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<4, 4>>());
+    static_assert(8U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<4, 7>>());
+    static_assert(100U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<4, 100>>());
+#else
+#error "Invalid sizeof(void*)"
+#endif
+
+    // Anything with alignment >= 8 is the same in both 32bit and 64bit
+
+    static_assert(104U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<8, 100>>());
+
+    static_assert(8U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<8, 1>>());
+    static_assert(8U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<8, 8>>());
+    static_assert(16U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<8, 16>>());
+
+    static_assert(16U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<16, 1>>());
+    static_assert(16U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<16, 8>>());
+    static_assert(16U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<16, 16>>());
+    static_assert(32U == node_allocator::detail::RequiredAllocationSizeBytes<AlignedSize<16, 17>>());
+}
+
+using MappedTypes = std::tuple<
+    uint8_t,
+    uint16_t,
+    uint32_t,
+    uint64_t,
+    std::string,
+    AlignedSize<__STDCPP_DEFAULT_NEW_ALIGNMENT__, 1> // Biggest allowed alignment is __STDCPP_DEFAULT_NEW_ALIGNMENT__
+    >;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(allocations_are_used, T, MappedTypes)
+{
+#if defined(_LIBCPP_VERSION) // defined in any C++ header from libc++
+    BOOST_TEST_MESSAGE("_LIBCPP_VERSION is defined");
+#endif
+#if defined(__GLIBCXX__) || defined(__GLIBCPP__)
+    BOOST_TEST_MESSAGE("__GLIBCXX__ or __GLIBCPP__ is defined");
+#endif
+
+    TestAllocationsAreUsed<uint8_t, T>();
+    TestAllocationsAreUsed<uint8_t, T, NotNoexceptHash<uint8_t>>();
+
+    TestAllocationsAreUsed<uint16_t, T>();
+    TestAllocationsAreUsed<uint16_t, T, NotNoexceptHash<uint16_t>>();
+
+    TestAllocationsAreUsed<uint32_t, T>();
+    TestAllocationsAreUsed<uint32_t, T, NotNoexceptHash<uint32_t>>();
+
+    TestAllocationsAreUsed<uint64_t, T>();
+    TestAllocationsAreUsed<uint64_t, T, NotNoexceptHash<uint64_t>>();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/node_size_tests.cpp
+++ b/src/test/node_size_tests.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <support/allocators/node_allocator/node_size.h>
+#include <test/node_allocator_helpers.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstddef>
+#include <tuple>
+#include <typeindex>
+#include <unordered_map>
+
+namespace {
+
+struct AllocationInfo {
+    AllocationInfo(size_t size) : size(size) {}
+
+    const size_t size{};
+    size_t num_allocations{};
+};
+
+/**
+ * Singleton used by CountSingleAllocationsAllocator to record allocations for each type
+ */
+std::unordered_map<std::type_index, AllocationInfo>& SingletonAllocationInfo()
+{
+    static std::unordered_map<std::type_index, AllocationInfo> map{};
+    return map;
+}
+
+/**
+ * A minimal allocator that records all n==1 allocations into SingletonAllocationInfo().
+ * That way we can actually find out the size of the allocated nodes.
+ */
+template <typename T>
+struct CountSingleAllocationsAllocator {
+public:
+    using value_type = T;
+    using propagate_on_container_move_assignment = std::true_type;
+    using is_always_equal = std::true_type;
+
+    CountSingleAllocationsAllocator() = default;
+    CountSingleAllocationsAllocator(const CountSingleAllocationsAllocator&) noexcept = default;
+
+    template <typename U>
+    CountSingleAllocationsAllocator(CountSingleAllocationsAllocator<U> const&) noexcept
+    {
+    }
+
+    T* allocate(size_t n)
+    {
+        if (n == 1) {
+            auto [it, isInserted] = SingletonAllocationInfo().try_emplace(std::type_index(typeid(T)), sizeof(T));
+            it->second.num_allocations += 1;
+        }
+        return static_cast<T*>(::operator new(n * sizeof(T)));
+    }
+
+    void deallocate(T* p, size_t n)
+    {
+        ::operator delete(p);
+    }
+};
+
+template <typename Key, typename Value, typename Hash = std::hash<Key>>
+void TestCorrectNodeSize()
+{
+    std::unordered_map<Key, Value, Hash, std::equal_to<Key>, CountSingleAllocationsAllocator<std::pair<const Key, Value>>> map;
+
+    SingletonAllocationInfo().clear();
+
+    const size_t num_entries = 123;
+    for (size_t i = 0; i < num_entries; ++i) {
+        map[i];
+    }
+
+    // there should be a entry with exactly 123 allocations
+    auto it = std::find_if(SingletonAllocationInfo().begin(), SingletonAllocationInfo().end(), [](const auto& kv) {
+        return kv.second.num_allocations == 123;
+    });
+    BOOST_CHECK(it != SingletonAllocationInfo().end());
+
+    static constexpr auto node_size = node_allocator::NodeSize<std::unordered_map<Key, Value, Hash>>::VALUE;
+    BOOST_CHECK_EQUAL(it->second.size, node_size);
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(node_size_tests)
+
+using MappedTypes = std::tuple<uint8_t, uint16_t, uint32_t, uint64_t, std::string, AlignedSize<16, 16>>;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(node_sizes, T, MappedTypes)
+{
+    TestCorrectNodeSize<uint8_t, T>();
+    TestCorrectNodeSize<uint8_t, T, NotNoexceptHash<uint8_t>>();
+
+    TestCorrectNodeSize<uint16_t, T>();
+    TestCorrectNodeSize<uint16_t, T, NotNoexceptHash<uint16_t>>();
+
+    TestCorrectNodeSize<uint32_t, T>();
+    TestCorrectNodeSize<uint32_t, T, NotNoexceptHash<uint32_t>>();
+
+    TestCorrectNodeSize<uint64_t, T>();
+    TestCorrectNodeSize<uint64_t, T, NotNoexceptHash<uint64_t>>();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4622,7 +4622,6 @@ bool CChainState::ResizeCoinsCaches(size_t coinstip_size, size_t coinsdb_size)
     } else {
         // Otherwise, flush state to disk and deallocate the in-memory coins map.
         ret = FlushStateToDisk(state, FlushStateMode::ALWAYS);
-        CoinsTip().ReallocateCache();
     }
     return ret;
 }


### PR DESCRIPTION
jamesob has benchmarked my rebased branch (see https://github.com/bitcoin/bitcoin/pull/16801#issuecomment-895348607) concerning the allocator for node based containers, and has seen a 9% speedup along with 8% reduction in memory. That's why I had another good look at my previously closed PR https://github.com/bitcoin/bitcoin/pull/16801 and updated the code. I've updated the code quite a bit, mostly trying to simplify it and improve correctness:

* Renamed classes to be more in line with naming used for the`std::pmr` allocators (see https://en.cppreference.com/w/cpp/memory/polymorphic_allocator)
* Simplified `Allocator` thanks to being able to use C++17 behavior (`std::allocator_traits`)
* Simpler allocation: only allocate blocks of the same size and just keep them in a `std::vector`.
* Only access memory when actually needed. E.g. Linux uses optimistic memory allocation, so memory pages from malloc are only actually made available to the program when accessed
* Correctly handle alignment for the inplace linked list.

jamesob it would be great if you could run your benchmarks again with the updated code. 

edit laanwj: removed @ signs and html comments from message