### PR TITLE
ci: Invalidate depends caches when sources have been changed

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,8 +29,7 @@ base_template: &BASE_TEMPLATE
     - git merge FETCH_HEAD  # Merge base to detect silent merge conflicts
   stateful: false  # https://cirrus-ci.org/guide/writing-tasks/#stateful-tasks
 
-global_task_template: &GLOBAL_TASK_TEMPLATE
-  << : *BASE_TEMPLATE
+task_template: &TASK_TEMPLATE
   timeout_in: 120m  # https://cirrus-ci.org/faq/#instance-timed-out
   container:
     # https://cirrus-ci.org/faq/#are-there-any-limits
@@ -43,6 +42,10 @@ global_task_template: &GLOBAL_TASK_TEMPLATE
     folder: "depends/built"
   ci_script:
     - ./ci/test_run_all.sh
+
+global_task_template: &GLOBAL_TASK_TEMPLATE
+  << : *BASE_TEMPLATE
+  << : *TASK_TEMPLATE
 
 depends_sdk_cache_template: &DEPENDS_SDK_CACHE_TEMPLATE
   depends_sdk_cache:
@@ -211,9 +214,10 @@ task:
 task:
   name: 'ARM64 Android APK [focal]'
   << : *DEPENDS_SDK_CACHE_TEMPLATE
+  << : *BASE_TEMPLATE
   depends_sources_cache:
     folder: "depends/sources"
-  << : *GLOBAL_TASK_TEMPLATE
+  << : *TASK_TEMPLATE
   container:
     image: ubuntu:focal
   env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,6 +40,7 @@ task_template: &TASK_TEMPLATE
     folder: "/tmp/ccache_dir"
   depends_built_cache:
     folder: "depends/built"
+    fingerprint_script: echo $CIRRUS_TASK_NAME $(git rev-list -1 HEAD ./depends)
   ci_script:
     - ./ci/test_run_all.sh
 
@@ -217,6 +218,7 @@ task:
   << : *BASE_TEMPLATE
   depends_sources_cache:
     folder: "depends/sources"
+    fingerprint_script: git rev-list -1 HEAD ./depends
   << : *TASK_TEMPLATE
   container:
     image: ubuntu:focal


### PR DESCRIPTION
On master (502d22ceed1f90ed41336260f8eb428d3acaf514) the Cirrus CI do _not_ invalidate depends caches when their sources has been changed, i.e. source version updates, a new dependency etc.

This behavior causes:
- breaking CI build for Android APK  (see #22708)
- the cache sizes growing

It is assumed that caches could be invalidated via Cirrus CI API/GUI, but it is inconvenient and it does not work as expected in all cases.

The common part of `fingerprint_key`s for both `depends_sources_cache` and `depends_built_cache` is the recent commit that changes sources in the `src/depends` sub-directory. 

For `depends_built_cache` additionally `CIRRUS_TASK_NAME` is used to avoid sharing of the same cache between tasks with different OSes and different `DEP_OPTS`.

---

The `depends_sources` cache:
- in master (502d22ceed1f90ed41336260f8eb428d3acaf514)

![Screenshot from 2021-08-16 11-10-17](https://user-images.githubusercontent.com/32963518/129532207-56c09e06-c8d0-4f1e-a692-f198da011b20.png)

- with this PR

![Screenshot from 2021-08-16 11-10-42](https://user-images.githubusercontent.com/32963518/129532253-f5426814-4f58-448f-ad52-da26cc312af7.png)