### PR TITLE
rpc: update estimatesmartfee to return max of CBlockPolicyEstimator::estimateSmartFee, mempoolMinFee and minRelayTxFee

### DIFF
--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -132,9 +132,13 @@ def check_smart_estimates(node, fees_seen):
     delta = 1.0e-6  # account for rounding error
     last_feerate = float(max(fees_seen))
     all_smart_estimates = [node.estimatesmartfee(i) for i in range(1, 26)]
+    mempoolMinFee = node.getmempoolinfo()['mempoolminfee']
+    minRelaytxFee = node.getmempoolinfo()['minrelaytxfee']
     for i, e in enumerate(all_smart_estimates):  # estimate is for i+1
         feerate = float(e["feerate"])
         assert_greater_than(feerate, 0)
+        assert_greater_than_or_equal(feerate, float(mempoolMinFee))
+        assert_greater_than_or_equal(feerate, float(minRelaytxFee))
 
         if feerate + delta < min(fees_seen) or feerate - delta > max(fees_seen):
             raise AssertionError(f"Estimated fee ({feerate}) out of range ({min(fees_seen)},{max(fees_seen)})")
@@ -273,6 +277,12 @@ class EstimateFeeTest(BitcoinTestFramework):
 
         self.sync_blocks(self.nodes[0:3], wait=.1)
         self.log.info("Final estimates after emptying mempools")
+        check_estimates(self.nodes[1], self.fees_per_kb)
+
+        # check that the effective feerate is greater than or equal to the mempoolminfee even for high mempoolminfee
+        self.log.info("Test fee rate estimation after restarting node with high MempoolMinFee")
+        high_val = 3*self.nodes[1].estimatesmartfee(1)['feerate']
+        self.restart_node(1, extra_args=[f'-minrelaytxfee={high_val}'])
         check_estimates(self.nodes[1], self.fees_per_kb)
 
         self.log.info("Testing that fee estimation is disabled in blocksonly.")


### PR DESCRIPTION
This PR is in response to the issue [#19699](https://github.com/bitcoin/bitcoin/issues/19699).

Based on the discussion in the comments of PR [#22673](https://github.com/bitcoin/bitcoin/pull/22673) changes have been made in the `estimatesmartfee` itself such that it takes into account `mempoolMinFee` and `relayMinFee` . Hence it provides a fee estimate that is most likely to be paid by the user in an actual transaction, preventing issues such as [#16072](https://github.com/bitcoin/bitcoin/issues/16072).

The test file test/functional/feature_fee_estimation.py has also been updated to check this functionality.