### PR TITLE
windres: use PACKAGE_VERSION rather than building more version numbers

### DIFF
--- a/src/bitcoin-cli-res.rc
+++ b/src/bitcoin-cli-res.rc
@@ -2,9 +2,7 @@
 #include "clientversion.h"       // holds the needed client version information
 
 #define VER_PRODUCTVERSION     CLIENT_VERSION_MAJOR,CLIENT_VERSION_MINOR,CLIENT_VERSION_BUILD
-#define VER_PRODUCTVERSION_STR STRINGIZE(CLIENT_VERSION_MAJOR) "." STRINGIZE(CLIENT_VERSION_MINOR) "." STRINGIZE(CLIENT_VERSION_BUILD)
 #define VER_FILEVERSION        VER_PRODUCTVERSION
-#define VER_FILEVERSION_STR    VER_PRODUCTVERSION_STR
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     VER_FILEVERSION
@@ -18,13 +16,13 @@ BEGIN
         BEGIN
             VALUE "CompanyName",        "Bitcoin"
             VALUE "FileDescription",    "bitcoin-cli (JSON-RPC client for " PACKAGE_NAME ")"
-            VALUE "FileVersion",        VER_FILEVERSION_STR
+            VALUE "FileVersion",        PACKAGE_VERSION
             VALUE "InternalName",       "bitcoin-cli"
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
             VALUE "OriginalFilename",   "bitcoin-cli.exe"
             VALUE "ProductName",        "bitcoin-cli"
-            VALUE "ProductVersion",     VER_PRODUCTVERSION_STR
+            VALUE "ProductVersion",     PACKAGE_VERSION
         END
     END
 

--- a/src/bitcoin-tx-res.rc
+++ b/src/bitcoin-tx-res.rc
@@ -2,9 +2,7 @@
 #include "clientversion.h"       // holds the needed client version information
 
 #define VER_PRODUCTVERSION     CLIENT_VERSION_MAJOR,CLIENT_VERSION_MINOR,CLIENT_VERSION_BUILD
-#define VER_PRODUCTVERSION_STR STRINGIZE(CLIENT_VERSION_MAJOR) "." STRINGIZE(CLIENT_VERSION_MINOR) "." STRINGIZE(CLIENT_VERSION_BUILD)
 #define VER_FILEVERSION        VER_PRODUCTVERSION
-#define VER_FILEVERSION_STR    VER_PRODUCTVERSION_STR
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     VER_FILEVERSION
@@ -18,13 +16,13 @@ BEGIN
         BEGIN
             VALUE "CompanyName",        "Bitcoin"
             VALUE "FileDescription",    "bitcoin-tx (CLI Bitcoin transaction editor utility)"
-            VALUE "FileVersion",        VER_FILEVERSION_STR
+            VALUE "FileVersion",        PACKAGE_VERSION
             VALUE "InternalName",       "bitcoin-tx"
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
             VALUE "OriginalFilename",   "bitcoin-tx.exe"
             VALUE "ProductName",        "bitcoin-tx"
-            VALUE "ProductVersion",     VER_PRODUCTVERSION_STR
+            VALUE "ProductVersion",     PACKAGE_VERSION
         END
     END
 

--- a/src/bitcoin-util-res.rc
+++ b/src/bitcoin-util-res.rc
@@ -2,9 +2,7 @@
 #include "clientversion.h"       // holds the needed client version information
 
 #define VER_PRODUCTVERSION     CLIENT_VERSION_MAJOR,CLIENT_VERSION_MINOR,CLIENT_VERSION_BUILD
-#define VER_PRODUCTVERSION_STR STRINGIZE(CLIENT_VERSION_MAJOR) "." STRINGIZE(CLIENT_VERSION_MINOR) "." STRINGIZE(CLIENT_VERSION_BUILD)
 #define VER_FILEVERSION        VER_PRODUCTVERSION
-#define VER_FILEVERSION_STR    VER_PRODUCTVERSION_STR
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     VER_FILEVERSION
@@ -18,13 +16,13 @@ BEGIN
         BEGIN
             VALUE "CompanyName",        "Bitcoin"
             VALUE "FileDescription",    "bitcoin-util (CLI Bitcoin utility)"
-            VALUE "FileVersion",        VER_FILEVERSION_STR
+            VALUE "FileVersion",        PACKAGE_VERSION
             VALUE "InternalName",       "bitcoin-util"
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
             VALUE "OriginalFilename",   "bitcoin-util.exe"
             VALUE "ProductName",        "bitcoin-util"
-            VALUE "ProductVersion",     VER_PRODUCTVERSION_STR
+            VALUE "ProductVersion",     PACKAGE_VERSION
         END
     END
 

--- a/src/bitcoin-wallet-res.rc
+++ b/src/bitcoin-wallet-res.rc
@@ -2,9 +2,7 @@
 #include "clientversion.h"       // holds the needed client version information
 
 #define VER_PRODUCTVERSION     CLIENT_VERSION_MAJOR,CLIENT_VERSION_MINOR,CLIENT_VERSION_BUILD
-#define VER_PRODUCTVERSION_STR STRINGIZE(CLIENT_VERSION_MAJOR) "." STRINGIZE(CLIENT_VERSION_MINOR) "." STRINGIZE(CLIENT_VERSION_BUILD)
 #define VER_FILEVERSION        VER_PRODUCTVERSION
-#define VER_FILEVERSION_STR    VER_PRODUCTVERSION_STR
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     VER_FILEVERSION
@@ -18,13 +16,13 @@ BEGIN
         BEGIN
             VALUE "CompanyName",        "Bitcoin"
             VALUE "FileDescription",    "bitcoin-wallet (CLI tool for " PACKAGE_NAME " wallets)"
-            VALUE "FileVersion",        VER_FILEVERSION_STR
+            VALUE "FileVersion",        PACKAGE_VERSION
             VALUE "InternalName",       "bitcoin-wallet"
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
             VALUE "OriginalFilename",   "bitcoin-wallet.exe"
             VALUE "ProductName",        "bitcoin-wallet"
-            VALUE "ProductVersion",     VER_PRODUCTVERSION_STR
+            VALUE "ProductVersion",     PACKAGE_VERSION
         END
     END
 

--- a/src/bitcoind-res.rc
+++ b/src/bitcoind-res.rc
@@ -2,9 +2,7 @@
 #include "clientversion.h"       // holds the needed client version information
 
 #define VER_PRODUCTVERSION     CLIENT_VERSION_MAJOR,CLIENT_VERSION_MINOR,CLIENT_VERSION_BUILD
-#define VER_PRODUCTVERSION_STR STRINGIZE(CLIENT_VERSION_MAJOR) "." STRINGIZE(CLIENT_VERSION_MINOR) "." STRINGIZE(CLIENT_VERSION_BUILD)
 #define VER_FILEVERSION        VER_PRODUCTVERSION
-#define VER_FILEVERSION_STR    VER_PRODUCTVERSION_STR
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     VER_FILEVERSION
@@ -18,13 +16,13 @@ BEGIN
         BEGIN
             VALUE "CompanyName",        "Bitcoin"
             VALUE "FileDescription",    "bitcoind (Bitcoin node with a JSON-RPC server)"
-            VALUE "FileVersion",        VER_FILEVERSION_STR
+            VALUE "FileVersion",        PACKAGE_VERSION
             VALUE "InternalName",       "bitcoind"
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
             VALUE "OriginalFilename",   "bitcoind.exe"
             VALUE "ProductName",        "bitcoind"
-            VALUE "ProductVersion",     VER_PRODUCTVERSION_STR
+            VALUE "ProductVersion",     PACKAGE_VERSION
         END
     END
 


### PR DESCRIPTION
Rather than defining more strings, reuse PACKAGE_VERSION, which is already available.

We also already use PACKAGE_VERSION for `ProductVersion` and `FileVersion` in setup.nsi.