### PR TITLE
ci: Run fuzzer task for the master branch only

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -153,6 +153,7 @@ task:
 
 task:
   name: '[no depends, sanitizers: fuzzer,address,undefined,integer] [focal]'
+  only_if: $CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH || $CIRRUS_BASE_BRANCH == $CIRRUS_DEFAULT_BRANCH
   << : *GLOBAL_TASK_TEMPLATE
   container:
     image: ubuntu:focal


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/pull/22629#issuecomment-896454270:
> I think we need to decide whether running the fuzzer CI in any branch other than master is something we want to be doing / maintaining. This seems pretty unsustainable unless we at least make changes in regards to the fuzz inputs being used by the different branches. I'm pretty sure Marco has mentioned this before.

This PR makes CI ignore fuzz tests by forcing `RUN_FUZZ_TESTS=false` for all cases when it is not the master branch or a PR based on it.

See #22731 as a demo for the 22.x branch.