### PR TITLE
test: Use proper target in do_fund_send 

### DIFF
--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -1006,7 +1006,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_greater_than(fees, 0.01)
 
         def do_fund_send(target):
-            create_tx = tester.createrawtransaction([], [{funds.getnewaddress(): lower_bound}])
+            create_tx = tester.createrawtransaction([], [{funds.getnewaddress(): target}])
             funded_tx = tester.fundrawtransaction(create_tx)
             signed_tx = tester.signrawtransactionwithwallet(funded_tx["hex"])
             assert signed_tx["complete"]


### PR DESCRIPTION
It seems there is a bug in the test in #22686, the code behaviour itself looks correct. 

Instead of verifying the scenario from #22670 with both `upper_bound` and `lower_bound` for the transaction amount, the tests verified `lower_bound` two times. This fix is to properly use function parameter instead of a variable from the scope. The test still passes with both values, so no code changes are required.