### PR TITLE
ci: Re-enable verify-commits.py check

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,11 +21,13 @@ persistent_worker_template: &PERSISTENT_WORKER_TEMPLATE
 base_template: &BASE_TEMPLATE
   skip: $CIRRUS_REPO_FULL_NAME == "bitcoin-core/gui" && $CIRRUS_PR == ""  # No need to run on the read-only mirror, unless it is a PR. https://cirrus-ci.org/guide/writing-tasks/#conditional-task-execution
   merge_base_script:
+    # Unconditionally install git (used in fingerprint_script) and set the
+    # default git author name (used in verify-commits.py)
     - bash -c "$PACKAGE_MANAGER_INSTALL git"
-    - if [ "$CIRRUS_PR" = "" ]; then exit 0; fi
-    - git fetch $CIRRUS_REPO_CLONE_URL $CIRRUS_BASE_BRANCH
     - git config --global user.email "ci@ci.ci"
     - git config --global user.name "ci"
+    - if [ "$CIRRUS_PR" = "" ]; then exit 0; fi
+    - git fetch $CIRRUS_REPO_CLONE_URL $CIRRUS_BASE_BRANCH
     - git merge FETCH_HEAD  # Merge base to detect silent merge conflicts
   stateful: false  # https://cirrus-ci.org/guide/writing-tasks/#stateful-tasks
 

--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -23,10 +23,15 @@ test/lint/git-subtree-check.sh src/crc32c
 test/lint/check-doc.py
 test/lint/lint-all.sh
 
-if [ "$CIRRUS_REPO_FULL_NAME" = "bitcoin/bitcoin" ] && [ -n "$CIRRUS_CRON" ]; then
-    git log --merges --before="2 days ago" -1 --format='%H' > ./contrib/verify-commits/trusted-sha512-root-commit
+if [ "$CIRRUS_REPO_FULL_NAME" = "bitcoin/bitcoin" ] && [ "$CIRRUS_PR" = "" ] ; then
+    # Sanity check only the last few commits to get notified of missing sigs,
+    # missing keys, or expired keys. Usually there is only one new merge commit
+    # per push on the master branch and a few commits on release branches, so
+    # sanity checking only a few (10) commits seems sufficient and cheap.
+    git log HEAD~10 -1 --format='%H' > ./contrib/verify-commits/trusted-sha512-root-commit
+    git log HEAD~10 -1 --format='%H' > ./contrib/verify-commits/trusted-git-root
     ${CI_RETRY_EXE}  gpg --keyserver hkps://keys.openpgp.org --recv-keys $(<contrib/verify-commits/trusted-keys) &&
-    ./contrib/verify-commits/verify-commits.py --clean-merge=2;
+    ./contrib/verify-commits/verify-commits.py;
 fi
 
 echo


### PR DESCRIPTION
Might be useful to detect bugs in the script itself or an accidentally missed signature.