### PR TITLE
ci: Run arm task on arm64 hardware

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -90,11 +90,14 @@ task:
 task:
   name: 'ARM [unit tests, no functional tests] [buster]'
   << : *GLOBAL_TASK_TEMPLATE
-  container:
+  arm_container:
     image: debian:buster
+    cpu: 2
+    memory: 8G
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
     FILE_ENV: "./ci/test/00_setup_env_arm.sh"
+    QEMU_USER_CMD: ""  # Disable qemu and run the test natively
 
 task:
   name: 'Win64 [unit tests, no gui tests, no boost::process, no functional tests] [focal]'


### PR DESCRIPTION
It will still run cross-compilation to armhf, but run the binaries on the hardware itself, not qemu.

There shouldn't be any significant difference, other than maybe a slight speedup.