### PR TITLE
ci: Followups for #22710

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,7 +29,7 @@ base_template: &BASE_TEMPLATE
     - git merge FETCH_HEAD  # Merge base to detect silent merge conflicts
   stateful: false  # https://cirrus-ci.org/guide/writing-tasks/#stateful-tasks
 
-task_template: &TASK_TEMPLATE
+main_template: &MAIN_TEMPLATE
   timeout_in: 120m  # https://cirrus-ci.org/faq/#instance-timed-out
   container:
     # https://cirrus-ci.org/faq/#are-there-any-limits
@@ -46,7 +46,7 @@ task_template: &TASK_TEMPLATE
 
 global_task_template: &GLOBAL_TASK_TEMPLATE
   << : *BASE_TEMPLATE
-  << : *TASK_TEMPLATE
+  << : *MAIN_TEMPLATE
 
 depends_sdk_cache_template: &DEPENDS_SDK_CACHE_TEMPLATE
   depends_sdk_cache:
@@ -219,7 +219,7 @@ task:
   depends_sources_cache:
     folder: "depends/sources"
     fingerprint_script: git rev-list -1 HEAD ./depends
-  << : *TASK_TEMPLATE
+  << : *MAIN_TEMPLATE
   container:
     image: ubuntu:focal
   env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,8 +21,8 @@ persistent_worker_template: &PERSISTENT_WORKER_TEMPLATE
 base_template: &BASE_TEMPLATE
   skip: $CIRRUS_REPO_FULL_NAME == "bitcoin-core/gui" && $CIRRUS_PR == ""  # No need to run on the read-only mirror, unless it is a PR. https://cirrus-ci.org/guide/writing-tasks/#conditional-task-execution
   merge_base_script:
-    - if [ "$CIRRUS_PR" = "" ]; then exit 0; fi
     - bash -c "$PACKAGE_MANAGER_INSTALL git"
+    - if [ "$CIRRUS_PR" = "" ]; then exit 0; fi
     - git fetch $CIRRUS_REPO_CLONE_URL $CIRRUS_BASE_BRANCH
     - git config --global user.email "ci@ci.ci"
     - git config --global user.name "ci"


### PR DESCRIPTION
1) Remove Cirrus CI configuration parsing warning:
![Screenshot from 2021-08-20 01-13-57](https://user-images.githubusercontent.com/32963518/130151265-551873cb-6670-48a6-b0c4-687cb341a342.png)
![Screenshot from 2021-08-20 01-13-41](https://user-images.githubusercontent.com/32963518/130151273-920fb316-e7e1-457b-8933-2ac31e9c605f.png)

2) Make `git` available for merge commits, because it is now required for `depends_sources_cache` and `depends_built_cache`.