### PR TITLE
fuzz: Avoid timeout in blockfilter fuzz target

### DIFF
--- a/src/test/fuzz/blockfilter.cpp
+++ b/src/test/fuzz/blockfilter.cpp
@@ -36,9 +36,10 @@ FUZZ_TARGET(blockfilter)
         (void)gcs_filter.GetEncoded();
         (void)gcs_filter.Match(ConsumeRandomLengthByteVector(fuzzed_data_provider));
         GCSFilter::ElementSet element_set;
-        while (fuzzed_data_provider.ConsumeBool()) {
+        LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 30000)
+        {
             element_set.insert(ConsumeRandomLengthByteVector(fuzzed_data_provider));
-            gcs_filter.MatchAny(element_set);
         }
+        gcs_filter.MatchAny(element_set);
     }
 }


### PR DESCRIPTION
Previously it would take 10 seconds to run this input, now it takes 10ms: [clusterfuzz-testcase-blockfilter-5022838196142080.log](https://github.com/bitcoin/bitcoin/files/7021883/clusterfuzz-testcase-blockfilter-5022838196142080.log)

The fix is moving the `MatchAny` out of the hot loop.

Also, to avoid unlimited runtime, cap the hot loop at 30k iterations.