### PR TITLE
Raise InitError when peers.dat is invalid or corrupted

### DIFF
--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -177,12 +177,6 @@ bool DumpPeerAddresses(const ArgsManager& args, const CAddrMan& addr)
     return SerializeFileDB("peers", pathAddr, addr, CLIENT_VERSION);
 }
 
-bool ReadPeerAddresses(const ArgsManager& args, CAddrMan& addr)
-{
-    const auto pathAddr = args.GetDataDirNet() / "peers.dat";
-    return DeserializeFileDB(pathAddr, addr, CLIENT_VERSION);
-}
-
 bool ReadFromStream(CAddrMan& addr, CDataStream& ssPeers)
 {
     return DeserializeDB(ssPeers, addr, false);
@@ -194,7 +188,8 @@ std::optional<bilingual_str> LoadAddrman(const std::vector<bool>& asmap, const A
     addrman = std::make_unique<CAddrMan>(asmap, /* deterministic */ false, /* consistency_check_ratio */ check_addrman);
 
     int64_t nStart = GetTimeMillis();
-    if (ReadPeerAddresses(args, *addrman)) {
+    const auto path_addr{args.GetDataDirNet() / "peers.dat"};
+    if (DeserializeFileDB(path_addr, *addrman, CLIENT_VERSION)) {
         LogPrintf("Loaded %i addresses from peers.dat  %dms\n", addrman->size(), GetTimeMillis() - nStart);
     } else {
         // Addrman can be in an inconsistent state after failure, reset it

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -18,6 +18,7 @@
 #include <univalue.h>
 #include <util/settings.h>
 #include <util/system.h>
+#include <util/translation.h>
 
 namespace {
 template <typename Stream, typename Data>
@@ -185,6 +186,23 @@ bool ReadPeerAddresses(const ArgsManager& args, CAddrMan& addr)
 bool ReadFromStream(CAddrMan& addr, CDataStream& ssPeers)
 {
     return DeserializeDB(ssPeers, addr, false);
+}
+
+std::optional<bilingual_str> LoadAddrman(const std::vector<bool>& asmap, const ArgsManager& args, std::unique_ptr<CAddrMan>& addrman)
+{
+    auto check_addrman = std::clamp<int32_t>(args.GetArg("-checkaddrman", DEFAULT_ADDRMAN_CONSISTENCY_CHECKS), 0, 1000000);
+    addrman = std::make_unique<CAddrMan>(asmap, /* deterministic */ false, /* consistency_check_ratio */ check_addrman);
+
+    int64_t nStart = GetTimeMillis();
+    if (ReadPeerAddresses(args, *addrman)) {
+        LogPrintf("Loaded %i addresses from peers.dat  %dms\n", addrman->size(), GetTimeMillis() - nStart);
+    } else {
+        // Addrman can be in an inconsistent state after failure, reset it
+        addrman = std::make_unique<CAddrMan>(asmap, /* deterministic */ false, /* consistency_check_ratio */ check_addrman);
+        LogPrintf("Recreating peers.dat\n");
+        DumpPeerAddresses(args, *addrman);
+    }
+    return std::nullopt;
 }
 
 void DumpAnchors(const fs::path& anchors_db_path, const std::vector<CAddress>& anchors)

--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -20,7 +20,6 @@ class CDataStream;
 struct bilingual_str;
 
 bool DumpPeerAddresses(const ArgsManager& args, const CAddrMan& addr);
-bool ReadPeerAddresses(const ArgsManager& args, CAddrMan& addr);
 /** Only used by tests. */
 bool ReadFromStream(CAddrMan& addr, CDataStream& ssPeers);
 

--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -21,7 +21,7 @@ struct bilingual_str;
 
 bool DumpPeerAddresses(const ArgsManager& args, const CAddrMan& addr);
 /** Only used by tests. */
-bool ReadFromStream(CAddrMan& addr, CDataStream& ssPeers);
+void ReadFromStream(CAddrMan& addr, CDataStream& ssPeers);
 
 /** Access to the banlist database (banlist.json) */
 class CBanDB

--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -10,12 +10,14 @@
 #include <net_types.h> // For banmap_t
 #include <univalue.h>
 
+#include <optional>
 #include <vector>
 
 class ArgsManager;
 class CAddrMan;
 class CAddress;
 class CDataStream;
+struct bilingual_str;
 
 bool DumpPeerAddresses(const ArgsManager& args, const CAddrMan& addr);
 bool ReadPeerAddresses(const ArgsManager& args, CAddrMan& addr);
@@ -45,6 +47,9 @@ public:
      */
     bool Read(banmap_t& banSet);
 };
+
+/** Returns an error string on failure */
+std::optional<bilingual_str> LoadAddrman(const std::vector<bool>& asmap, const ArgsManager& args, std::unique_ptr<CAddrMan>& addrman);
 
 /**
  * Dump the anchor IP address database (anchors.dat)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1200,19 +1200,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             LogPrintf("Using /16 prefix for IP bucketing\n");
         }
 
-        auto check_addrman = std::clamp<int32_t>(args.GetArg("-checkaddrman", DEFAULT_ADDRMAN_CONSISTENCY_CHECKS), 0, 1000000);
-        node.addrman = std::make_unique<CAddrMan>(asmap, /* deterministic */ false, /* consistency_check_ratio */ check_addrman);
-
-        // Load addresses from peers.dat
         uiInterface.InitMessage(_("Loading P2P addresses…").translated);
-        int64_t nStart = GetTimeMillis();
-        if (ReadPeerAddresses(args, *node.addrman)) {
-            LogPrintf("Loaded %i addresses from peers.dat  %dms\n", node.addrman->size(), GetTimeMillis() - nStart);
-        } else {
-            // Addrman can be in an inconsistent state after failure, reset it
-            node.addrman = std::make_unique<CAddrMan>(asmap, /* deterministic */ false, /* consistency_check_ratio */ check_addrman);
-            LogPrintf("Recreating peers.dat\n");
-            DumpPeerAddresses(args, *node.addrman);
+        if (const auto error{LoadAddrman(asmap, args, node.addrman)}) {
+            return InitError(*error);
         }
     }
 

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -1043,7 +1043,7 @@ BOOST_AUTO_TEST_CASE(load_addrman)
 
     CAddrMan addrman2(/* asmap */ std::vector<bool>(), /* deterministic */ false, /* consistency_check_ratio */ 100);
     BOOST_CHECK(addrman2.size() == 0);
-    BOOST_CHECK(ReadFromStream(addrman2, ssPeers2));
+    ReadFromStream(addrman2, ssPeers2);
     BOOST_CHECK(addrman2.size() == 3);
 }
 
@@ -1073,7 +1073,7 @@ BOOST_AUTO_TEST_CASE(load_addrman_corrupted)
 
     CAddrMan addrman2(/* asmap */ std::vector<bool>(), /* deterministic */ false, /* consistency_check_ratio */ 100);
     BOOST_CHECK(addrman2.size() == 0);
-    BOOST_CHECK(!ReadFromStream(addrman2, ssPeers2));
+    BOOST_CHECK_THROW(ReadFromStream(addrman2, ssPeers2), std::ios_base::failure);
 }
 
 

--- a/src/test/fuzz/data_stream.cpp
+++ b/src/test/fuzz/data_stream.cpp
@@ -23,5 +23,8 @@ FUZZ_TARGET_INIT(data_stream_addr_man, initialize_data_stream_addr_man)
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     CDataStream data_stream = ConsumeDataStream(fuzzed_data_provider);
     CAddrMan addr_man(/* asmap */ std::vector<bool>(), /* deterministic */ false, /* consistency_check_ratio */ 0);
-    ReadFromStream(addr_man, data_stream);
+    try {
+        ReadFromStream(addr_man, data_stream);
+    } catch (const std::exception&) {
+    }
 }


### PR DESCRIPTION
peers.dat is silently erased when it can not be parsed or when it appears corrupted. Fix that by notifying the user. This might help in the following examples:

* The user provided the database, but picked the wrong one.
* A future version of Bitcoin Core wrote the file and it can't be read.
* The file was corrupted by a logic bug in Bitcoin Core.
* The file was corrupted by a disk failure.