### PR TITLE
fuzz: execute each file in dir without fuzz engine

### DIFF
--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -14,7 +14,7 @@
 #include <exception>
 #include <memory>
 #include <string>
-#include <filesystem>
+#include <signal.h>
 #include <unistd.h>
 #include <vector>
 
@@ -85,20 +85,32 @@ static bool read_stdin(std::vector<uint8_t>& data)
 }
 #endif
 
-#if defined(PROVIDE_FUZZ_MAIN_FUNCTION)
-static bool read_file(std::filesystem::path p, std::vector<uint8_t>& data)
+#if defined(PROVIDE_FUZZ_MAIN_FUNCTION) && !defined(__AFL_LOOP)
+static bool read_file(fs::path p, std::vector<uint8_t>& data)
 {
     uint8_t buffer[1024];
-    FILE *f = fsbridge::fopen(p.string(), "rb");
-    if (f == nullptr)
-        return false;
+    FILE* f = fsbridge::fopen(p.string(), "rb");
+    if (f == nullptr) return false;
     do {
         const size_t length = fread(buffer, sizeof(uint8_t), sizeof(buffer), f);
-        Assert(!ferror(f));
+        if (ferror(f)) return false;
         data.insert(data.end(), buffer, buffer + length);
     } while (!feof(f));
     fclose(f);
     return true;
+}
+#endif
+
+#if defined(PROVIDE_FUZZ_MAIN_FUNCTION) && !defined(__AFL_LOOP)
+fs::path g_seed_path;
+void signal_handler(int signal)
+{
+    if (signal == SIGABRT) {
+        std::cerr << "Error processing seed " << g_seed_path << std::endl;
+    } else {
+        std::cerr << "Unexpected signal " << signal << " received\n";
+    }
+    std::_Exit(EXIT_FAILURE);
 }
 #endif
 
@@ -139,33 +151,36 @@ int main(int argc, char** argv)
         test_one_input(buffer);
     }
 #else
-    char* seed_path{nullptr};
-    if (argc > 1) {
-        seed_path = *(argv+1);
-    }
-
     std::vector<uint8_t> buffer;
-    if (seed_path == nullptr) {
+    if (argc <= 1) {
         if (!read_stdin(buffer)) {
             return 0;
         }
         test_one_input(buffer);
-    } else {
-        if(std::filesystem::is_directory(seed_path)) {
-            for (auto& file : std::filesystem::directory_iterator{seed_path}) {
-                if (!read_file(file, buffer)) {
-                    return 0;
-                }
+        return 0;
+    }
+    signal(SIGABRT, signal_handler);
+    int tested = 0;
+    for (int i = 1; i < argc; ++i) {
+        fs::path seed_path(*(argv + i));
+        if (fs::is_directory(seed_path)) {
+            for (fs::directory_iterator it(seed_path); it != fs::directory_iterator(); ++it) {
+                if (!fs::is_regular_file(it->path())) continue;
+                g_seed_path = it->path();
+                Assert(read_file(it->path(), buffer));
                 test_one_input(buffer);
+                ++tested;
                 buffer.clear();
             }
         } else {
-            if (!read_file(seed_path, buffer)) {
-                return 0;
-            }
+            g_seed_path = seed_path;
+            Assert(read_file(seed_path, buffer));
             test_one_input(buffer);
+            ++tested;
+            buffer.clear();
         }
     }
+    std::cout << "tested " << tested << " files\n";
 #endif
     return 0;
 }

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -14,6 +14,7 @@
 #include <exception>
 #include <memory>
 #include <string>
+#include <filesystem>
 #include <unistd.h>
 #include <vector>
 
@@ -84,6 +85,23 @@ static bool read_stdin(std::vector<uint8_t>& data)
 }
 #endif
 
+#if defined(PROVIDE_FUZZ_MAIN_FUNCTION)
+static bool read_file(std::filesystem::path p, std::vector<uint8_t>& data)
+{
+    uint8_t buffer[1024];
+    FILE *f = fsbridge::fopen(p.string(), "rb");
+    if (f == nullptr)
+        return false;
+    do {
+        const size_t length = fread(buffer, sizeof(uint8_t), sizeof(buffer), f);
+        Assert(!ferror(f));
+        data.insert(data.end(), buffer, buffer + length);
+    } while (!feof(f));
+    fclose(f);
+    return true;
+}
+#endif
+
 // This function is used by libFuzzer
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
@@ -121,11 +139,33 @@ int main(int argc, char** argv)
         test_one_input(buffer);
     }
 #else
-    std::vector<uint8_t> buffer;
-    if (!read_stdin(buffer)) {
-        return 0;
+    char* seed_path{nullptr};
+    if (argc > 1) {
+        seed_path = *(argv+1);
     }
-    test_one_input(buffer);
+
+    std::vector<uint8_t> buffer;
+    if (seed_path == nullptr) {
+        if (!read_stdin(buffer)) {
+            return 0;
+        }
+        test_one_input(buffer);
+    } else {
+        if(std::filesystem::is_directory(seed_path)) {
+            for (auto& file : std::filesystem::directory_iterator{seed_path}) {
+                if (!read_file(file, buffer)) {
+                    return 0;
+                }
+                test_one_input(buffer);
+                buffer.clear();
+            }
+        } else {
+            if (!read_file(seed_path, buffer)) {
+                return 0;
+            }
+            test_one_input(buffer);
+        }
+    }
 #endif
     return 0;
 }


### PR DESCRIPTION
Rebased PR #21496

Fixes #21461
 
This supports whole directory runs of the fuzzing seeds without needing a fuzzing library.

Reviewers are  also requested look at the issue [#76](https://github.com/bitcoin-core/qa-assets/issues/76) in `bitcoin-core/qa-assets`.

Testing instructions:
To build without libFuzzer, exclude the sanitizers.
```
CC=clang CXX=clang++ ./configure BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include" --without-gui --with-zmq --enable-fuzz
```

Tests:
```
# clean and build
make clean
make -j "$(($(nproc)+1))"

# get qa-assets if you don't have already
git clone https://github.com/bitcoin-core/qa-assets

# existing way to feed 1 at a time, still supported
FUZZ=process_message src/test/fuzz/fuzz < qa-assets/fuzz_seed_corpus/process_message/1258dd51f2a5f3221b33a306279ef7290c5fca6d

# new with this PR: one at a time
FUZZ=process_message src/test/fuzz/fuzz qa-assets/fuzz_seed_corpus/process_message/1258dd51f2a5f3221b33a306279ef7290c5fca6d

# or multiple files at the same time
FUZZ=process_message src/test/fuzz/fuzz qa-assets/fuzz_seed_corpus/process_message/1258dd51f2a5f3221b33a306279ef7290c5fca6d qa-assets/fuzz_seed_corpus/process_message/322a92239d967fba9ef3035aca3cb3090da344b2 qa-assets/fuzz_seed_corpus/process_message/32c460293ac230ebe269a92c7941518d8b76c95a

# new with this PR: whole directory at a time
FUZZ=process_message src/test/fuzz/fuzz qa-assets/fuzz_seed_corpus/process_message

# or mix of files and directories at the same time
FUZZ=process_message src/test/fuzz/fuzz qa-assets/fuzz_seed_corpus/process_message/1258dd51f2a5f3221b33a306279ef7290c5fca6d qa-assets/fuzz_seed_corpus/process_message/322a92239d967fba9ef3035aca3cb3090da344b2 qa-assets/fuzz_seed_corpus/process_message/32c460293ac230ebe269a92c7941518d8b76c95a qa-assets/fuzz_seed_corpus/process_message/

# new with this PR: wildcard support
FUZZ=process_messages src/test/fuzz/fuzz qa-assets/fuzz_seed_corpus/process_messages/* 

# new with this PR: run all seeds in all targets, one target/directory at a time 
for D in qa-assets/fuzz_seed_corpus/*; do [ -d "${D}" ] && echo "${D##*/}" && FUZZ="${D##*/}" src/test/fuzz/fuzz qa-assets/fuzz_seed_corpus/"${D##*/}"; done
```