### PR TITLE
refactor: hasher cleanup (follow-up to 19935)

### DIFF
--- a/src/util/hasher.h
+++ b/src/util/hasher.h
@@ -33,10 +33,6 @@ public:
     SaltedOutpointHasher();
 
     /**
-     * This *must* return size_t. With Boost 1.46 on 32-bit systems the
-     * unordered_map will behave unpredictably if the custom hasher returns a
-     * uint64_t, resulting in failures when syncing the chain (#4634).
-     *
      * Having the hash noexcept allows libstdc++'s unordered_map to recalculate
      * the hash during rehash, so it does not have to cache the value. This
      * reduces node's memory by sizeof(size_t). The required recalculation has

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -148,17 +148,6 @@ public:
     }
 };
 
-class KeyIDHasher
-{
-public:
-    KeyIDHasher() {}
-
-    size_t operator()(const CKeyID& id) const
-    {
-        return id.GetUint64(0);
-    }
-};
-
 /*
  * A class implementing ScriptPubKeyMan manages some (or all) scriptPubKeys used in a wallet.
  * It contains the scripts and keys related to the scriptPubKeys it manages.


### PR DESCRIPTION
Small follow-ups to  #19935:

- Removal of unused `KeyIDHasher`  class ([comment in 19935](https://github.com/bitcoin/bitcoin/pull/19935#discussion_r544464524))
- Removal of an outdated comment, which referred to an old problem with the no longer supported Boost 1.46 and `boost::unordered_map`, now replaced by `std::unordered_map`. ([comment in 19935](https://github.com/bitcoin/bitcoin/pull/19935#discussion_r540911134))
 