### PR TITLE
rpc: Add option to list transactions from oldest to newest in `listtransactions` RPC command

### DIFF
--- a/doc/release-notes-22775.md
+++ b/doc/release-notes-22775.md
@@ -1,0 +1,5 @@
+New RPCs
+--------
+- A new optional ascending_order flag in the `listtransactions` RPC
+will allow to go through the transactions list from the oldest to
+the newest in addition to the current newest to oldest behavior. (#22775)

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -64,6 +64,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listtransactions", 1, "count" },
     { "listtransactions", 2, "skip" },
     { "listtransactions", 3, "include_watchonly" },
+    { "listtransactions", 4, "ascending_order" },
     { "walletpassphrase", 1, "timeout" },
     { "getblocktemplate", 0, "template_request" },
     { "listsinceblock", 1, "target_confirmations" },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1414,6 +1414,7 @@ static RPCHelpMan listtransactions()
                     {"count", RPCArg::Type::NUM, RPCArg::Default{10}, "The number of transactions to return"},
                     {"skip", RPCArg::Type::NUM, RPCArg::Default{0}, "The number of transactions to skip"},
                     {"include_watchonly", RPCArg::Type::BOOL, RPCArg::DefaultHint{"true for watch-only wallets, otherwise false"}, "Include transactions to watch-only addresses (see 'importaddress')"},
+                    {"ascending_order", RPCArg::Type::BOOL, RPCArg::DefaultHint{"true for ascending order (newest to oldest), false for descending order (oldest to newest), default is true"}, "The direction from which to start getting transactions"},
                 },
                 RPCResult{
                     RPCResult::Type::ARR, "", "",
@@ -1483,6 +1484,13 @@ static RPCHelpMan listtransactions()
     if (nFrom < 0)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative from");
 
+    // Default ascending_order to true if no value has been specified
+    bool ascending_order = true;
+
+    if (!request.params[4].isNull()) {
+        ascending_order = request.params[4].get_bool();
+    }
+
     UniValue ret(UniValue::VARR);
 
     {
@@ -1490,12 +1498,23 @@ static RPCHelpMan listtransactions()
 
         const CWallet::TxItems & txOrdered = pwallet->wtxOrdered;
 
-        // iterate backwards until we have nCount items to return:
-        for (CWallet::TxItems::const_reverse_iterator it = txOrdered.rbegin(); it != txOrdered.rend(); ++it)
-        {
+        // Returns true when enough transactions have been accumulated.
+        auto AccumulateTxns = [&](auto it) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet) {
             CWalletTx *const pwtx = (*it).second;
             ListTransactions(*pwallet, *pwtx, 0, true, ret, filter, filter_label);
-            if ((int)ret.size() >= (nCount+nFrom)) break;
+            return ((int)ret.size() >= (nCount + nFrom));
+        };
+
+        // iterate until we have nCount items to return:
+        // iterate backwards if ascending order or forwards if descending order
+        if (ascending_order) {
+            for (auto it = txOrdered.rbegin(); it != txOrdered.rend(); ++it) {
+                if (AccumulateTxns(it)) break;
+            }
+        } else {
+            for (auto it = txOrdered.cbegin(); it != txOrdered.cend(); ++it) {
+                if (AccumulateTxns(it)) break;
+            }
         }
     }
 
@@ -1508,7 +1527,11 @@ static RPCHelpMan listtransactions()
 
     const std::vector<UniValue>& txs = ret.getValues();
     UniValue result{UniValue::VARR};
-    result.push_backV({ txs.rend() - nFrom - nCount, txs.rend() - nFrom }); // Return oldest to newest
+    if (ascending_order) {
+        result.push_backV({ txs.rend() - nFrom - nCount, txs.rend() - nFrom }); // Return oldest to newest
+    } else {
+        result.push_backV({ txs.cbegin() + nFrom, txs.cbegin() + nFrom + nCount }); // Return oldest to newest
+    }
     return result;
 },
     };

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -103,6 +103,14 @@ class ListTransactionsTest(BitcoinTestFramework):
                                 {"category": "receive", "amount": Decimal("0.1")},
                                 {"txid": txid, "label": "watchonly"})
 
+        self.log.info("Test 'ascending_order' feature")
+        # The first transaction counting from the oldest (descending order) should be the last transaction counting from the newest (ascending order)
+        assert_equal(self.nodes[0].listtransactions(count=1, ascending_order=False),
+                     self.nodes[0].listtransactions(count=1, skip=len(self.nodes[0].listtransactions(count=10000)) - 1, ascending_order=True))
+        # The second and third transactions counting from the oldest (descending order) should be the 2 before the last transaction counting from the newest (ascending order)
+        assert_equal(self.nodes[0].listtransactions(count=2, skip=1, ascending_order=False),
+                     self.nodes[0].listtransactions(count=2, skip=len(self.nodes[0].listtransactions(count=10000)) - 3, ascending_order=True))
+
         self.run_rbf_opt_in_test()
 
 


### PR DESCRIPTION
Currently, the RPC `listtransactions` command returns the latest X transactions of the wallet starting from Y. This means that to get the X oldest transacions would require first to call `getwalletinfo` command to get the total transactions count, and then use that to know what count to pass the `listtransactions` command.

This PR adds an optional flag to allow instead to start going through the transactions list from the oldest to the newest, so it will be possible to get the oldest X transactions of the wallet starting from Y.

For example, this will return the oldest transaction of the wallet:
```
bitcoin-cli -rpcuser=bitcoin -rpcpassword=secret -rpcwallet= listtransactions "*" 1 0 true false
```

This will return the 2nd and 3rd oldest transactions of the wallet:
```
bitcoin-cli -rpcuser=bitcoin -rpcpassword=secret -rpcwallet= listtransactions "*" 2 1 true false
```

Not including the new flag or setting it to true will not change the current behavior.