### PR TITLE
policy: correct (lower) the dust threshold for Taproot outputs

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -37,7 +37,13 @@ CAmount GetDustThreshold(const CTxOut& txout, const CFeeRate& dustRelayFeeIn)
     if (txout.scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram)) {
         // sum the sizes of the parts of a transaction input
         // with 75% segwit discount applied to the script size.
-        nSize += (32 + 4 + 1 + (107 / WITNESS_SCALE_FACTOR) + 4);
+        if (witnessversion == 0) {
+            // P2WPKH spend, a compressed public key + a DER-encoded ECDSA signature
+            nSize += (32 + 4 + 1 + (107 / WITNESS_SCALE_FACTOR) + 4);
+        } else {
+            // Taproot key spend, a single BIP340 signature
+            nSize += (32 + 4 + 1 + (66 / WITNESS_SCALE_FACTOR) + 4);
+        }
     } else {
         nSize += (32 + 4 + 1 + 107 + 4); // the 148 mentioned above
     }

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -971,6 +971,25 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[0].nValue = 329;
     BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
     BOOST_CHECK_EQUAL(reason, "dust");
+
+    // Check Taproot outputs dust threshold
+    t.vout[0].scriptPubKey = CScript() << OP_1 << ParseHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    t.vout[0].nValue = 300;
+    BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
+    t.vout[0].nValue = 299;
+    BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
+    BOOST_CHECK_EQUAL(reason, "dust");
+
+    // Check future Witness Program versions dust threshold
+    for (int op = OP_2; op <= OP_16; op += 1) {
+        t.vout[0].scriptPubKey = CScript() << (opcodetype)op << ParseHex("ffff");
+        t.vout[0].nValue = 210;
+        BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
+
+        t.vout[0].nValue = 209;
+        BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
+        BOOST_CHECK_EQUAL(reason, "dust");
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -955,6 +955,22 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
     BOOST_CHECK_EQUAL(reason, "bare-multisig");
     fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
+
+    // Check P2WPKH outputs dust threshold
+    t.vout[0].scriptPubKey = CScript() << OP_0 << ParseHex("ffffffffffffffffffffffffffffffffffffffff");
+    t.vout[0].nValue = 294;
+    BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
+    t.vout[0].nValue = 293;
+    BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
+    BOOST_CHECK_EQUAL(reason, "dust");
+
+    // Check P2WSH outputs dust threshold
+    t.vout[0].scriptPubKey = CScript() << OP_0 << ParseHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    t.vout[0].nValue = 330;
+    BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
+    t.vout[0].nValue = 329;
+    BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
+    BOOST_CHECK_EQUAL(reason, "dust");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
It was calculated as if it needed a compressed pubkey + a DER encoded
ECDSA signature.

Eventually i believe it would be good to prevent future overlooks by not applying the dust check to unknown witness versions and aborting if `witness_version > current_version`. Had a commit that starts doing that but removed it as it made this simple fix PR needlessly more complex.