### PR TITLE
wallet: fix the behavior of IsHDEnabled, return false in case of a blank hd wallet.

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1364,9 +1364,10 @@ CAmount CWallet::GetDebit(const CTransaction& tx, const isminefilter& filter) co
 bool CWallet::IsHDEnabled() const
 {
     // All Active ScriptPubKeyMans must be HD for this to be true
-    bool result = true;
+    bool result = false;
     for (const auto& spk_man : GetActiveScriptPubKeyMans()) {
-        result &= spk_man->IsHDEnabled();
+        if (!spk_man->IsHDEnabled()) return false;
+        result = true;
     }
     return result;
 }


### PR DESCRIPTION
the result of CWallet::IsHDEnabled() was initialized with true.

But in case of no keys or a blank hd wallet the iterator would be skipped
and not set to false but true, since the loop would be not entered.

That had resulted in a wrong return and subsequent false HD and watch-only
icon display in GUi when reloading a wallet after closing.