### PR TITLE
scripted-diff: Use generate* from TestFramework

### DIFF
--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -141,7 +141,7 @@ class ExampleTest(BitcoinTestFramework):
         peer_messaging = self.nodes[0].add_p2p_connection(BaseNode())
 
         # Generating a block on one of the nodes will get us out of IBD
-        blocks = [int(self.nodes[0].generate(nblocks=1)[0], 16)]
+        blocks = [int(self.generate(self.nodes[0], nblocks=1)[0], 16)]
         self.sync_all(self.nodes[0:2])
 
         # Notice above how we called an RPC by calling a method with the same

--- a/test/functional/feature_abortnode.py
+++ b/test/functional/feature_abortnode.py
@@ -26,7 +26,7 @@ class AbortNodeTest(BitcoinTestFramework):
         # We'll connect the nodes later
 
     def run_test(self):
-        self.nodes[0].generate(3)
+        self.generate(self.nodes[0], 3)
         datadir = get_datadir_path(self.options.tmpdir, 0)
 
         # Deleting the undo file will result in reorg failure
@@ -34,10 +34,10 @@ class AbortNodeTest(BitcoinTestFramework):
 
         # Connecting to a node with a more work chain will trigger a reorg
         # attempt.
-        self.nodes[1].generate(3)
+        self.generate(self.nodes[1], 3)
         with self.nodes[0].assert_debug_log(["Failed to disconnect block"]):
             self.connect_nodes(0, 1)
-            self.nodes[1].generate(1)
+            self.generate(self.nodes[1], 1)
 
             # Check that node0 aborted
             self.log.info("Waiting for crash")

--- a/test/functional/feature_backwards_compatibility.py
+++ b/test/functional/feature_backwards_compatibility.py
@@ -64,7 +64,7 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
         self.import_deterministic_coinbase_privkeys()
 
     def run_test(self):
-        self.nodes[0].generatetoaddress(COINBASE_MATURITY + 1, self.nodes[0].getnewaddress())
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 1, self.nodes[0].getnewaddress())
 
         self.sync_blocks()
 
@@ -92,7 +92,7 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
         address = wallet.getnewaddress()
         self.nodes[0].sendtoaddress(address, 10)
         self.sync_mempools()
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_blocks()
         # Create a conflicting transaction using RBF
         return_address = self.nodes[0].getnewaddress()
@@ -100,7 +100,7 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
         tx2_id = self.nodes[1].bumpfee(tx1_id)["txid"]
         # Confirm the transaction
         self.sync_mempools()
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_blocks()
         # Create another conflicting transaction using RBF
         tx3_id = self.nodes[1].sendtoaddress(return_address, 1)

--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -55,7 +55,7 @@ class BIP68Test(BitcoinTestFramework):
         self.relayfee = self.nodes[0].getnetworkinfo()["relayfee"]
 
         # Generate some coins
-        self.nodes[0].generate(110)
+        self.generate(self.nodes[0], 110)
 
         self.log.info("Running test disable flag")
         self.test_disable_flag()
@@ -143,7 +143,7 @@ class BIP68Test(BitcoinTestFramework):
             for i in range(num_outputs):
                 outputs[addresses[i]] = random.randint(1, 20)*0.01
             self.nodes[0].sendmany("", outputs)
-            self.nodes[0].generate(1)
+            self.generate(self.nodes[0], 1)
 
         utxos = self.nodes[0].listunspent()
 
@@ -273,7 +273,7 @@ class BIP68Test(BitcoinTestFramework):
         cur_time = int(time.time())
         for _ in range(10):
             self.nodes[0].setmocktime(cur_time + 600)
-            self.nodes[0].generate(1)
+            self.generate(self.nodes[0], 1)
             cur_time += 600
 
         assert tx2.hash in self.nodes[0].getrawmempool()
@@ -288,7 +288,7 @@ class BIP68Test(BitcoinTestFramework):
         self.nodes[0].setmocktime(cur_time+600)
         # Save block template now to use for the reorg later
         tmpl = self.nodes[0].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         assert tx2.hash not in self.nodes[0].getrawmempool()
 
         # Now that tx2 is not in the mempool, a sequence locked spend should
@@ -296,7 +296,7 @@ class BIP68Test(BitcoinTestFramework):
         tx3 = test_nonzero_locks(tx2, self.nodes[0], self.relayfee, use_height_lock=False)
         assert tx3.hash in self.nodes[0].getrawmempool()
 
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         assert tx3.hash not in self.nodes[0].getrawmempool()
 
         # One more test, this time using height locks
@@ -349,7 +349,7 @@ class BIP68Test(BitcoinTestFramework):
         # Reset the chain and get rid of the mocktimed-blocks
         self.nodes[0].setmocktime(0)
         self.nodes[0].invalidateblock(self.nodes[0].getblockhash(cur_height+1))
-        self.nodes[0].generate(10)
+        self.generate(self.nodes[0], 10)
 
     # Make sure that BIP68 isn't being used to validate blocks prior to
     # activation height.  If more blocks are mined prior to this test
@@ -403,9 +403,9 @@ class BIP68Test(BitcoinTestFramework):
         min_activation_height = 432
         height = self.nodes[0].getblockcount()
         assert_greater_than(min_activation_height - height, 2)
-        self.nodes[0].generate(min_activation_height - height - 2)
+        self.generate(self.nodes[0], min_activation_height - height - 2)
         assert not softfork_active(self.nodes[0], 'csv')
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         assert softfork_active(self.nodes[0], 'csv')
         self.sync_blocks()
 

--- a/test/functional/feature_blockfilterindex_prune.py
+++ b/test/functional/feature_blockfilterindex_prune.py
@@ -25,9 +25,9 @@ class FeatureBlockfilterindexPruneTest(BitcoinTestFramework):
         self.sync_index(height=200)
         assert_greater_than(len(self.nodes[0].getblockfilter(self.nodes[0].getbestblockhash())['filter']), 0)
         # Mine two batches of blocks to avoid hitting NODE_NETWORK_LIMITED_MIN_BLOCKS disconnection
-        self.nodes[0].generate(250)
+        self.generate(self.nodes[0], 250)
         self.sync_all()
-        self.nodes[0].generate(250)
+        self.generate(self.nodes[0], 250)
         self.sync_all()
         self.sync_index(height=700)
 
@@ -46,7 +46,7 @@ class FeatureBlockfilterindexPruneTest(BitcoinTestFramework):
 
         self.log.info("make sure accessing the blockfilters throws an error")
         assert_raises_rpc_error(-1, "Index is not enabled for filtertype basic", self.nodes[0].getblockfilter, self.nodes[0].getblockhash(2))
-        self.nodes[0].generate(1000)
+        self.generate(self.nodes[0], 1000)
 
         self.log.info("prune below the blockfilterindexes best block while blockfilters are disabled")
         pruneheight_new = self.nodes[0].pruneblockchain(1000)

--- a/test/functional/feature_blocksdir.py
+++ b/test/functional/feature_blocksdir.py
@@ -29,7 +29,7 @@ class BlocksdirTest(BitcoinTestFramework):
         self.log.info("Starting with existing blocksdir ...")
         self.start_node(0, [f"-blocksdir={blocksdir_path}"])
         self.log.info("mining blocks..")
-        self.nodes[0].generatetoaddress(10, self.nodes[0].get_deterministic_priv_key().address)
+        self.generatetoaddress(self.nodes[0], 10, self.nodes[0].get_deterministic_priv_key().address)
         assert os.path.isfile(os.path.join(blocksdir_path, self.chain, "blocks", "blk00000.dat"))
         assert os.path.isdir(os.path.join(self.nodes[0].datadir, self.chain, "blocks", "index"))
 

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -102,8 +102,8 @@ class BIP65Test(BitcoinTestFramework):
         self.test_cltv_info(is_active=False)
 
         self.log.info("Mining %d blocks", CLTV_HEIGHT - 2)
-        wallet.generate(10)
-        self.nodes[0].generate(CLTV_HEIGHT - 2 - 10)
+        self.generate(wallet, 10)
+        self.generate(self.nodes[0], CLTV_HEIGHT - 2 - 10)
         assert_equal(self.nodes[0].getblockcount(), CLTV_HEIGHT - 2)
 
         self.log.info("Test that invalid-according-to-CLTV transactions can still appear in a block")

--- a/test/functional/feature_coinstatsindex.py
+++ b/test/functional/feature_coinstatsindex.py
@@ -67,10 +67,10 @@ class CoinStatsIndexTest(BitcoinTestFramework):
         index_hash_options = ['none', 'muhash']
 
         # Generate a normal transaction and mine it
-        node.generate(COINBASE_MATURITY + 1)
+        self.generate(node, COINBASE_MATURITY + 1)
         address = self.nodes[0].get_deterministic_priv_key().address
         node.sendtoaddress(address=address, amount=10, subtractfeefromamount=True)
-        node.generate(1)
+        self.generate(node, 1)
 
         self.sync_blocks(timeout=120)
 
@@ -92,7 +92,7 @@ class CoinStatsIndexTest(BitcoinTestFramework):
         self.log.info("Test that gettxoutsetinfo() can get fetch data on specific heights with index")
 
         # Generate a new tip
-        node.generate(5)
+        self.generate(node, 5)
 
         for hash_option in index_hash_options:
             # Fetch old stats by height
@@ -169,7 +169,7 @@ class CoinStatsIndexTest(BitcoinTestFramework):
         self.nodes[0].sendrawtransaction(tx2_hex)
 
         # Include both txs in a block
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         for hash_option in index_hash_options:
@@ -228,7 +228,7 @@ class CoinStatsIndexTest(BitcoinTestFramework):
         res9 = index_node.gettxoutsetinfo('muhash')
         assert_equal(res8, res9)
 
-        index_node.generate(1)
+        self.generate(index_node, 1)
         res10 = index_node.gettxoutsetinfo('muhash')
         assert(res8['txouts'] < res10['txouts'])
 
@@ -247,14 +247,14 @@ class CoinStatsIndexTest(BitcoinTestFramework):
 
         # Generate two block, let the index catch up, then invalidate the blocks
         index_node = self.nodes[1]
-        reorg_blocks = index_node.generatetoaddress(2, index_node.getnewaddress())
+        reorg_blocks = self.generatetoaddress(index_node, 2, index_node.getnewaddress())
         reorg_block = reorg_blocks[1]
         res_invalid = index_node.gettxoutsetinfo('muhash')
         index_node.invalidateblock(reorg_blocks[0])
         assert_equal(index_node.gettxoutsetinfo('muhash')['height'], 110)
 
         # Add two new blocks
-        block = index_node.generate(2)[1]
+        block = self.generate(index_node, 2)[1]
         res = index_node.gettxoutsetinfo(hash_type='muhash', hash_or_height=None, use_index=False)
 
         # Test that the result of the reorged block is not returned for its old block height
@@ -270,7 +270,7 @@ class CoinStatsIndexTest(BitcoinTestFramework):
 
         # Add another block, so we don't depend on reconsiderblock remembering which
         # blocks were touched by invalidateblock
-        index_node.generate(1)
+        self.generate(index_node, 1)
         self.sync_all()
 
         # Ensure that removing and re-adding blocks yields consistent results

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -189,7 +189,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
         self.log.info("Generate blocks in the past for coinbase outputs.")
         long_past_time = int(time.time()) - 600 * 1000  # enough to build up to 1000 blocks 10 minutes apart without worrying about getting into the future
         self.nodes[0].setmocktime(long_past_time - 100)  # enough so that the generated blocks will still all be before long_past_time
-        self.coinbase_blocks = self.miniwallet.generate(COINBASE_BLOCK_COUNT)  # blocks generated for inputs
+        self.coinbase_blocks = self.generate(self.miniwallet, COINBASE_BLOCK_COUNT)  # blocks generated for inputs
         self.nodes[0].setmocktime(0)  # set time back to present so yielded blocks aren't in the future as we advance last_block_time
         self.tipheight = COINBASE_BLOCK_COUNT  # height of the next block to build
         self.last_block_time = long_past_time
@@ -235,7 +235,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
         bip113input = self.send_generic_input_tx(self.coinbase_blocks)
 
         self.nodes[0].setmocktime(self.last_block_time + 600)
-        inputblockhash = self.nodes[0].generate(1)[0]  # 1 block generated for inputs to be in chain at height 431
+        inputblockhash = self.generate(self.nodes[0], 1)[0]  # 1 block generated for inputs to be in chain at height 431
         self.nodes[0].setmocktime(0)
         self.tip = int(inputblockhash, 16)
         self.tipheight += 1

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -72,7 +72,7 @@ class BIP66Test(BitcoinTestFramework):
         self.test_dersig_info(is_active=False)
 
         self.log.info("Mining %d blocks", DERSIG_HEIGHT - 2)
-        self.coinbase_txids = [self.nodes[0].getblock(b)['tx'][0] for b in self.miniwallet.generate(DERSIG_HEIGHT - 2)]
+        self.coinbase_txids = [self.nodes[0].getblock(b)['tx'][0] for b in self.generate(self.miniwallet, DERSIG_HEIGHT - 2)]
 
         self.log.info("Test that a transaction with non-DER signature can still appear in a block")
 

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -197,7 +197,7 @@ class EstimateFeeTest(BitcoinTestFramework):
                 tx_kbytes = (len(txhex) // 2) / 1000.0
                 self.fees_per_kb.append(float(fee) / tx_kbytes)
             self.sync_mempools(wait=.1)
-            mined = mining_node.getblock(mining_node.generate(1)[0], True)["tx"]
+            mined = mining_node.getblock(self.generate(mining_node, 1)[0], True)["tx"]
             self.sync_blocks(wait=.1)
             # update which txouts are confirmed
             newmem = []
@@ -221,7 +221,7 @@ class EstimateFeeTest(BitcoinTestFramework):
 
         # Mine
         while len(self.nodes[0].getrawmempool()) > 0:
-            self.nodes[0].generate(1)
+            self.generate(self.nodes[0], 1)
 
         # Repeatedly split those 2 outputs, doubling twice for each rep
         # Use txouts to monitor the available utxo, since these won't be tracked in wallet
@@ -231,12 +231,12 @@ class EstimateFeeTest(BitcoinTestFramework):
             while len(self.txouts) > 0:
                 split_inputs(self.nodes[0], self.txouts, self.txouts2)
             while len(self.nodes[0].getrawmempool()) > 0:
-                self.nodes[0].generate(1)
+                self.generate(self.nodes[0], 1)
             # Double txouts2 to txouts
             while len(self.txouts2) > 0:
                 split_inputs(self.nodes[0], self.txouts2, self.txouts)
             while len(self.nodes[0].getrawmempool()) > 0:
-                self.nodes[0].generate(1)
+                self.generate(self.nodes[0], 1)
             reps += 1
         self.log.info("Finished splitting")
 
@@ -269,7 +269,7 @@ class EstimateFeeTest(BitcoinTestFramework):
 
         # Finish by mining a normal-sized block:
         while len(self.nodes[1].getrawmempool()) > 0:
-            self.nodes[1].generate(1)
+            self.generate(self.nodes[1], 1)
 
         self.sync_blocks(self.nodes[0:3], wait=.1)
         self.log.info("Final estimates after emptying mempools")

--- a/test/functional/feature_loadblock.py
+++ b/test/functional/feature_loadblock.py
@@ -29,7 +29,7 @@ class LoadblockTest(BitcoinTestFramework):
 
     def run_test(self):
         self.nodes[1].setnetworkactive(state=False)
-        self.nodes[0].generate(COINBASE_MATURITY)
+        self.generate(self.nodes[0], COINBASE_MATURITY)
 
         # Parsing the url of our node to get settings for config file
         data_dir = self.nodes[0].datadir

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -56,7 +56,7 @@ class MaxUploadTest(BitcoinTestFramework):
         self.nodes[0].setmocktime(old_time)
 
         # Generate some old blocks
-        self.nodes[0].generate(130)
+        self.generate(self.nodes[0], 130)
 
         # p2p_conns[0] will only request old blocks
         # p2p_conns[1] will only request new blocks

--- a/test/functional/feature_minchainwork.py
+++ b/test/functional/feature_minchainwork.py
@@ -51,7 +51,7 @@ class MinimumChainWorkTest(BitcoinTestFramework):
 
         num_blocks_to_generate = int((self.node_min_work[1] - starting_chain_work) / REGTEST_WORK_PER_BLOCK)
         self.log.info(f"Generating {num_blocks_to_generate} blocks on node0")
-        hashes = self.nodes[0].generatetoaddress(num_blocks_to_generate,
+        hashes = self.generatetoaddress(self.nodes[0], num_blocks_to_generate,
                                                  self.nodes[0].get_deterministic_priv_key().address)
 
         self.log.info(f"Node0 current chain work: {self.nodes[0].getblockheader(hashes[-1])['chainwork']}")
@@ -73,7 +73,7 @@ class MinimumChainWorkTest(BitcoinTestFramework):
         assert_equal(self.nodes[2].getblockcount(), starting_blockcount)
 
         self.log.info("Generating one more block")
-        self.nodes[0].generatetoaddress(1, self.nodes[0].get_deterministic_priv_key().address)
+        self.generatetoaddress(self.nodes[0], 1, self.nodes[0].get_deterministic_priv_key().address)
 
         self.log.info("Verifying nodes are all synced")
 

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -76,7 +76,7 @@ class NotificationsTest(BitcoinTestFramework):
 
         self.log.info("test -blocknotify")
         block_count = 10
-        blocks = self.nodes[1].generatetoaddress(block_count, self.nodes[1].getnewaddress() if self.is_wallet_compiled() else ADDRESS_BCRT1_UNSPENDABLE)
+        blocks = self.generatetoaddress(self.nodes[1], block_count, self.nodes[1].getnewaddress() if self.is_wallet_compiled() else ADDRESS_BCRT1_UNSPENDABLE)
 
         # wait at most 10 seconds for expected number of files before reading the content
         self.wait_until(lambda: len(os.listdir(self.blocknotify_dir)) == block_count, timeout=10)
@@ -110,7 +110,7 @@ class NotificationsTest(BitcoinTestFramework):
             # triggered by node 1
             self.log.info("test -walletnotify with conflicting transactions")
             self.nodes[0].rescanblockchain()
-            self.nodes[0].generatetoaddress(100, ADDRESS_BCRT1_UNSPENDABLE)
+            self.generatetoaddress(self.nodes[0], 100, ADDRESS_BCRT1_UNSPENDABLE)
             self.sync_blocks()
 
             # Generate transaction on node 0, sync mempools, and check for
@@ -131,7 +131,7 @@ class NotificationsTest(BitcoinTestFramework):
 
             # Add bump1 transaction to new block, checking for a notification
             # and the correct number of confirmations.
-            blockhash1 = self.nodes[0].generatetoaddress(1, ADDRESS_BCRT1_UNSPENDABLE)[0]
+            blockhash1 = self.generatetoaddress(self.nodes[0], 1, ADDRESS_BCRT1_UNSPENDABLE)[0]
             blockheight1 = self.nodes[0].getblockcount()
             self.sync_blocks()
             self.expect_wallet_notify([(bump1, blockheight1, blockhash1)])
@@ -148,7 +148,7 @@ class NotificationsTest(BitcoinTestFramework):
             # about newly confirmed bump2 and newly conflicted tx2.
             self.disconnect_nodes(0, 1)
             bump2 = self.nodes[0].bumpfee(tx2)["txid"]
-            blockhash2 = self.nodes[0].generatetoaddress(1, ADDRESS_BCRT1_UNSPENDABLE)[0]
+            blockhash2 = self.generatetoaddress(self.nodes[0], 1, ADDRESS_BCRT1_UNSPENDABLE)[0]
             blockheight2 = self.nodes[0].getblockcount()
             assert_equal(self.nodes[0].gettransaction(bump2)["confirmations"], 1)
             assert_equal(tx2 in self.nodes[1].getrawmempool(), True)

--- a/test/functional/feature_nulldummy.py
+++ b/test/functional/feature_nulldummy.py
@@ -74,11 +74,11 @@ class NULLDUMMYTest(BitcoinTestFramework):
             wmulti.importaddress(self.ms_address)
             wmulti.importaddress(self.wit_ms_address)
 
-        self.coinbase_blocks = self.nodes[0].generate(2)  # block height = 2
+        self.coinbase_blocks = self.generate(self.nodes[0], 2)  # block height = 2
         coinbase_txid = []
         for i in self.coinbase_blocks:
             coinbase_txid.append(self.nodes[0].getblock(i)['tx'][0])
-        self.nodes[0].generate(COINBASE_MATURITY)  # block height = COINBASE_MATURITY + 2
+        self.generate(self.nodes[0], COINBASE_MATURITY)  # block height = COINBASE_MATURITY + 2
         self.lastblockhash = self.nodes[0].getbestblockhash()
         self.lastblockheight = COINBASE_MATURITY + 2
         self.lastblocktime = int(time.time()) + self.lastblockheight

--- a/test/functional/feature_presegwit_node_upgrade.py
+++ b/test/functional/feature_presegwit_node_upgrade.py
@@ -28,7 +28,7 @@ class SegwitUpgradeTest(BitcoinTestFramework):
         assert not softfork_active(node, "segwit")
 
         # Generate 8 blocks without witness data
-        node.generate(8)
+        self.generate(node, 8)
         assert_equal(node.getblockcount(), 8)
 
         self.stop_node(0)

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -118,9 +118,9 @@ class PruneTest(BitcoinTestFramework):
 
     def create_big_chain(self):
         # Start by creating some coinbases we can spend later
-        self.nodes[1].generate(200)
+        self.generate(self.nodes[1], 200)
         self.sync_blocks(self.nodes[0:2])
-        self.nodes[0].generate(150)
+        self.generate(self.nodes[0], 150)
 
         # Then mine enough full blocks to create more than 550MiB of data
         mine_large_blocks(self.nodes[0], 645)
@@ -211,7 +211,7 @@ class PruneTest(BitcoinTestFramework):
         self.disconnect_nodes(1, 2)
 
         self.log.info("Generating new longer chain of 300 more blocks")
-        self.nodes[1].generate(300)
+        self.generate(self.nodes[1], 300)
 
         self.log.info("Reconnect nodes")
         self.connect_nodes(0, 1)
@@ -263,7 +263,7 @@ class PruneTest(BitcoinTestFramework):
             self.nodes[0].invalidateblock(curchainhash)
             assert_equal(self.nodes[0].getblockcount(), self.mainchainheight)
             assert_equal(self.nodes[0].getbestblockhash(), self.mainchainhash2)
-            goalbesthash = self.nodes[0].generate(blocks_to_mine)[-1]
+            goalbesthash = self.generate(self.nodes[0], blocks_to_mine)[-1]
             goalbestheight = first_reorg_height + 1
 
         self.log.info("Verify node 2 reorged back to the main chain, some blocks of which it had to redownload")
@@ -306,7 +306,7 @@ class PruneTest(BitcoinTestFramework):
         assert_equal(block1_details["nTx"], len(block1_details["tx"]))
 
         # mine 6 blocks so we are at height 1001 (i.e., above PruneAfterHeight)
-        node.generate(6)
+        self.generate(node, 6)
         assert_equal(node.getblockchaininfo()["blocks"], 1001)
 
         # Pruned block should still know the number of transactions
@@ -337,7 +337,7 @@ class PruneTest(BitcoinTestFramework):
         assert has_block(2), "blk00002.dat is still there, should be pruned by now"
 
         # advance the tip so blk00002.dat and blk00003.dat can be pruned (the last 288 blocks should now be in blk00004.dat)
-        node.generate(288)
+        self.generate(node, 288)
         prune(1000)
         assert not has_block(2), "blk00002.dat is still there, should be pruned by now"
         assert not has_block(3), "blk00003.dat is still there, should be pruned by now"

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -19,7 +19,7 @@ class ReindexTest(BitcoinTestFramework):
         self.num_nodes = 1
 
     def reindex(self, justchainstate=False):
-        self.nodes[0].generatetoaddress(3, self.nodes[0].get_deterministic_priv_key().address)
+        self.generatetoaddress(self.nodes[0], 3, self.nodes[0].get_deterministic_priv_key().address)
         blockcount = self.nodes[0].getblockcount()
         self.stop_nodes()
         extra_args = [["-reindex-chainstate" if justchainstate else "-reindex"]]

--- a/test/functional/feature_signet.py
+++ b/test/functional/feature_signet.py
@@ -51,7 +51,7 @@ class SignetBasicTest(BitcoinTestFramework):
         assert_equal(mining_info['networkhashps'], Decimal('0'))
         assert_equal(mining_info['pooledtx'], 0)
 
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
 
         self.log.info("pregenerated signet blocks check")
 

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1461,7 +1461,7 @@ class TaprootTest(BitcoinTestFramework):
     def run_test(self):
         # Post-taproot activation tests go first (pre-taproot tests' blocks are invalid post-taproot).
         self.log.info("Post-activation tests...")
-        self.nodes[1].generate(COINBASE_MATURITY + 1)
+        self.generate(self.nodes[1], COINBASE_MATURITY + 1)
         self.test_spenders(self.nodes[1], spenders_taproot_active(), input_counts=[1, 2, 2, 2, 2, 3])
 
         # Re-connect nodes in case they have been disconnected

--- a/test/functional/feature_utxo_set_hash.py
+++ b/test/functional/feature_utxo_set_hash.py
@@ -31,13 +31,13 @@ class UTXOSetHashTest(BitcoinTestFramework):
 
         # Generate 100 blocks and remove the first since we plan to spend its
         # coinbase
-        block_hashes = wallet.generate(1) + node.generate(99)
+        block_hashes = self.generate(wallet, 1) + self.generate(node, 99)
         blocks = list(map(lambda block: from_hex(CBlock(), node.getblock(block, False)), block_hashes))
         blocks.pop(0)
 
         # Create a spending transaction and mine a block which includes it
         txid = wallet.send_self_transfer(from_node=node)['txid']
-        tx_block = node.generateblock(output=wallet.get_address(), transactions=[txid])
+        tx_block = self.generateblock(node, output=wallet.get_address(), transactions=[txid])
         blocks.append(from_hex(CBlock(), node.getblock(tx_block['hash'], False)))
 
         # Serialize the outputs that should be in the UTXO set and add them to

--- a/test/functional/feature_versionbits_warning.py
+++ b/test/functional/feature_versionbits_warning.py
@@ -65,12 +65,12 @@ class VersionBitsWarningTest(BitcoinTestFramework):
 
         node_deterministic_address = node.get_deterministic_priv_key().address
         # Mine one period worth of blocks
-        node.generatetoaddress(VB_PERIOD, node_deterministic_address)
+        self.generatetoaddress(node, VB_PERIOD, node_deterministic_address)
 
         self.log.info("Check that there is no warning if previous VB_BLOCKS have <VB_THRESHOLD blocks with unknown versionbits version.")
         # Build one period of blocks with < VB_THRESHOLD blocks signaling some unknown bit
         self.send_blocks_with_version(peer, VB_THRESHOLD - 1, VB_UNKNOWN_VERSION)
-        node.generatetoaddress(VB_PERIOD - VB_THRESHOLD + 1, node_deterministic_address)
+        self.generatetoaddress(node, VB_PERIOD - VB_THRESHOLD + 1, node_deterministic_address)
 
         # Check that we're not getting any versionbit-related errors in get*info()
         assert not VB_PATTERN.match(node.getmininginfo()["warnings"])
@@ -78,21 +78,21 @@ class VersionBitsWarningTest(BitcoinTestFramework):
 
         # Build one period of blocks with VB_THRESHOLD blocks signaling some unknown bit
         self.send_blocks_with_version(peer, VB_THRESHOLD, VB_UNKNOWN_VERSION)
-        node.generatetoaddress(VB_PERIOD - VB_THRESHOLD, node_deterministic_address)
+        self.generatetoaddress(node, VB_PERIOD - VB_THRESHOLD, node_deterministic_address)
 
         self.log.info("Check that there is a warning if previous VB_BLOCKS have >=VB_THRESHOLD blocks with unknown versionbits version.")
         # Mine a period worth of expected blocks so the generic block-version warning
         # is cleared. This will move the versionbit state to ACTIVE.
-        node.generatetoaddress(VB_PERIOD, node_deterministic_address)
+        self.generatetoaddress(node, VB_PERIOD, node_deterministic_address)
 
         # Stop-start the node. This is required because bitcoind will only warn once about unknown versions or unknown rules activating.
         self.restart_node(0)
 
         # Generating one block guarantees that we'll get out of IBD
-        node.generatetoaddress(1, node_deterministic_address)
+        self.generatetoaddress(node, 1, node_deterministic_address)
         self.wait_until(lambda: not node.getblockchaininfo()['initialblockdownload'])
         # Generating one more block will be enough to generate an error.
-        node.generatetoaddress(1, node_deterministic_address)
+        self.generatetoaddress(node, 1, node_deterministic_address)
         # Check that get*info() shows the versionbits unknown rules warning
         assert WARN_UNKNOWN_RULES_ACTIVE in node.getmininginfo()["warnings"]
         assert WARN_UNKNOWN_RULES_ACTIVE in node.getnetworkinfo()["warnings"]

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -77,7 +77,7 @@ class TestBitcoinCli(BitcoinTestFramework):
 
     def run_test(self):
         """Main test logic"""
-        self.nodes[0].generate(BLOCKS)
+        self.generate(self.nodes[0], BLOCKS)
 
         self.log.info("Compare responses from getblockchaininfo RPC and `bitcoin-cli getblockchaininfo`")
         cli_response = self.nodes[0].cli.getblockchaininfo()
@@ -158,7 +158,7 @@ class TestBitcoinCli(BitcoinTestFramework):
             w1.sendtoaddress(w3.getnewaddress(), amounts[2])
 
             # Mine a block to confirm; adds a block reward (50 BTC) to the default wallet.
-            self.nodes[0].generate(1)
+            self.generate(self.nodes[0], 1)
 
             self.log.info("Test -getinfo with multiple wallets and -rpcwallet returns specified wallet balance")
             for i in range(len(wallets)):
@@ -291,7 +291,7 @@ class TestBitcoinCli(BitcoinTestFramework):
             assert_raises_rpc_error(-19, WALLET_NOT_SPECIFIED, self.nodes[0].cli('-generate', 1, 2, 3).echo)
         else:
             self.log.info("*** Wallet not compiled; cli getwalletinfo and -getinfo wallet tests skipped")
-            self.nodes[0].generate(25)  # maintain block parity with the wallet_compiled conditional branch
+            self.generate(self.nodes[0], 25)  # maintain block parity with the wallet_compiled conditional branch
 
         self.log.info("Test -version with node stopped")
         self.stop_node(0)

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -80,9 +80,9 @@ class RESTTest (BitcoinTestFramework):
         # Random address so node1's balance doesn't increase
         not_related_address = "2MxqoHEdNQTyYeX1mHcbrrpzgojbosTpCvJ"
 
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
-        self.nodes[1].generatetoaddress(100, not_related_address)
+        self.generatetoaddress(self.nodes[1], 100, not_related_address)
         self.sync_all()
 
         assert_equal(self.nodes[0].getbalance(), 50)
@@ -107,7 +107,7 @@ class RESTTest (BitcoinTestFramework):
 
         self.log.info("Query an unspent TXO using the /getutxos URI")
 
-        self.nodes[1].generatetoaddress(1, not_related_address)
+        self.generatetoaddress(self.nodes[1], 1, not_related_address)
         self.sync_all()
         bb_hash = self.nodes[0].getbestblockhash()
 
@@ -182,7 +182,7 @@ class RESTTest (BitcoinTestFramework):
         json_obj = self.test_rest_request(f"/getutxos/checkmempool/{spent[0]}-{spent[1]}")
         assert_equal(len(json_obj['utxos']), 0)
 
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         json_obj = self.test_rest_request(f"/getutxos/{spending[0]}-{spending[1]}")
@@ -203,7 +203,7 @@ class RESTTest (BitcoinTestFramework):
         long_uri = '/'.join([f'{txid}-{n_}' for n_ in range(15)])
         self.test_rest_request(f"/getutxos/checkmempool/{long_uri}", http_method='POST', status=200)
 
-        self.nodes[0].generate(1)  # generate block to not affect upcoming tests
+        self.generate(self.nodes[0], 1)  # generate block to not affect upcoming tests
         self.sync_all()
 
         self.log.info("Test the /block, /blockhashbyheight and /headers URIs")
@@ -274,7 +274,7 @@ class RESTTest (BitcoinTestFramework):
             assert_equal(json_obj[0][key], rpc_block_json[key])
 
         # See if we can get 5 headers in one response
-        self.nodes[1].generate(5)
+        self.generate(self.nodes[1], 5)
         self.sync_all()
         json_obj = self.test_rest_request(f"/headers/5/{bb_hash}")
         assert_equal(len(json_obj), 5)  # now we should have 5 header objects
@@ -302,7 +302,7 @@ class RESTTest (BitcoinTestFramework):
             assert_equal(json_obj[tx]['depends'], txs[i - 1:i])
 
         # Now mine the transactions
-        newblockhash = self.nodes[1].generate(1)
+        newblockhash = self.generate(self.nodes[1], 1)
         self.sync_all()
 
         # Check if the 3 tx show up in the new block

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -78,7 +78,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
             outputs=[{node.getnewaddress(): 0.3}, {node.getnewaddress(): 49}],
         ))['hex']
         txid_in_block = node.sendrawtransaction(hexstring=raw_tx_in_block, maxfeerate=0)
-        node.generate(1)
+        self.generate(node, 1)
         self.mempool_size = 0
         self.check_mempool_result(
             result_expected=[{'txid': txid_in_block, 'allowed': False, 'reject-reason': 'txn-already-known'}],
@@ -172,7 +172,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
             outputs=[{node.getnewaddress(): 0.1}]
         ))['hex']
         txid_spend_both = node.sendrawtransaction(hexstring=raw_tx_spend_both, maxfeerate=0)
-        node.generate(1)
+        self.generate(node, 1)
         self.mempool_size = 0
         # Now see if we can add the coins back to the utxo set by sending the exact txs again
         self.check_mempool_result(

--- a/test/functional/mempool_accept_wtxid.py
+++ b/test/functional/mempool_accept_wtxid.py
@@ -44,7 +44,7 @@ class MempoolWtxidTest(BitcoinTestFramework):
 
         self.log.info('Start with empty mempool and 101 blocks')
         # The last 100 coinbase transactions are premature
-        blockhash = node.generate(101)[0]
+        blockhash = self.generate(node, 101)[0]
         txid = node.getblock(blockhash=blockhash, verbosity=2)["tx"][0]["txid"]
         assert_equal(node.getmempoolinfo()['size'], 0)
 
@@ -62,7 +62,7 @@ class MempoolWtxidTest(BitcoinTestFramework):
         privkeys = [node.get_deterministic_priv_key().key]
         raw_parent = node.signrawtransactionwithkey(hexstring=parent.serialize().hex(), privkeys=privkeys)['hex']
         parent_txid = node.sendrawtransaction(hexstring=raw_parent, maxfeerate=0)
-        node.generate(1)
+        self.generate(node, 1)
 
         peer_wtxid_relay = node.add_p2p_connection(P2PTxInvStore())
 

--- a/test/functional/mempool_compatibility.py
+++ b/test/functional/mempool_compatibility.py
@@ -38,8 +38,8 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
 
         old_node, new_node = self.nodes
         new_wallet = MiniWallet(new_node)
-        new_wallet.generate(1)
-        new_node.generate(COINBASE_MATURITY)
+        self.generate(new_wallet, 1)
+        self.generate(new_node, COINBASE_MATURITY)
         # Sync the nodes to ensure old_node has the block that contains the coinbase that new_wallet will spend.
         # Otherwise, because coinbases are only valid in a block and not as loose txns, if the nodes aren't synced
         # unbroadcasted_tx won't pass old_node's `MemPoolAccept::PreChecks`.

--- a/test/functional/mempool_expiry.py
+++ b/test/functional/mempool_expiry.py
@@ -36,8 +36,8 @@ class MempoolExpiryTest(BitcoinTestFramework):
         self.wallet = MiniWallet(node)
 
         # Add enough mature utxos to the wallet so that all txs spend confirmed coins.
-        self.wallet.generate(4)
-        node.generate(COINBASE_MATURITY)
+        self.generate(self.wallet, 4)
+        self.generate(node, COINBASE_MATURITY)
 
         # Send a parent transaction that will expire.
         parent_txid = self.wallet.send_self_transfer(from_node=node)['txid']

--- a/test/functional/mempool_package_limits.py
+++ b/test/functional/mempool_package_limits.py
@@ -40,7 +40,7 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
         self.address = node.get_deterministic_priv_key().address
         self.coins = []
         # The last 100 coinbase transactions are premature
-        for b in node.generatetoaddress(200, self.address)[:100]:
+        for b in self.generatetoaddress(node, 200, self.address)[:100]:
             coinbase = node.getblock(blockhash=b, verbosity=2)["tx"][0]
             self.coins.append({
                 "txid": coinbase["txid"],
@@ -83,7 +83,7 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
             assert_equal(txres["package-error"], "package-mempool-limits")
 
         # Clear mempool and check that the package passes now
-        node.generate(1)
+        self.generate(node, 1)
         assert all([res["allowed"] for res in node.testmempoolaccept(rawtxs=chain_hex)])
 
     def test_chain_limits(self):
@@ -174,7 +174,7 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
             assert_equal(txres["package-error"], "package-mempool-limits")
 
         # Clear mempool and check that the package passes now
-        node.generate(1)
+        self.generate(node, 1)
         assert all([res["allowed"] for res in node.testmempoolaccept(rawtxs=package_hex)])
 
     def test_anc_count_limits(self):
@@ -230,7 +230,7 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
             assert_equal(txres["package-error"], "package-mempool-limits")
 
         # Clear mempool and check that the package passes now
-        node.generate(1)
+        self.generate(node, 1)
         assert all([res["allowed"] for res in node.testmempoolaccept(rawtxs=package_hex)])
 
     def test_anc_count_limits_2(self):
@@ -288,7 +288,7 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
             assert_equal(txres["package-error"], "package-mempool-limits")
 
         # Clear mempool and check that the package passes now
-        node.generate(1)
+        self.generate(node, 1)
         assert all([res["allowed"] for res in node.testmempoolaccept(rawtxs=[pc_hex, pd_hex])])
 
     def test_anc_count_limits_bushy(self):
@@ -338,7 +338,7 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
             assert_equal(txres["package-error"], "package-mempool-limits")
 
         # Clear mempool and check that the package passes now
-        node.generate(1)
+        self.generate(node, 1)
         assert all([res["allowed"] for res in node.testmempoolaccept(rawtxs=package_hex)])
 
     def test_anc_size_limits(self):
@@ -397,7 +397,7 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
             assert_equal(txres["package-error"], "package-mempool-limits")
 
         # Clear mempool and check that the package passes now
-        node.generate(1)
+        self.generate(node, 1)
         assert all([res["allowed"] for res in node.testmempoolaccept(rawtxs=[pc_hex, pd_hex])])
 
     def test_desc_size_limits(self):
@@ -468,7 +468,7 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
             assert_equal(txres["package-error"], "package-mempool-limits")
 
         # Clear mempool and check that the package passes now
-        node.generate(1)
+        self.generate(node, 1)
         assert all([res["allowed"] for res in node.testmempoolaccept(rawtxs=package_hex)])
 
 if __name__ == "__main__":

--- a/test/functional/mempool_package_onemore.py
+++ b/test/functional/mempool_package_onemore.py
@@ -30,7 +30,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
 
     def run_test(self):
         # Mine some blocks and have them mature.
-        self.nodes[0].generate(COINBASE_MATURITY + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
         utxo = self.nodes[0].listunspent(10)
         txid = utxo[0]['txid']
         vout = utxo[0]['vout']

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -46,7 +46,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
     def run_test(self):
         # Mine some blocks and have them mature.
         peer_inv_store = self.nodes[0].add_p2p_connection(P2PTxInvStore()) # keep track of invs
-        self.nodes[0].generate(COINBASE_MATURITY + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
         utxo = self.nodes[0].listunspent(10)
         txid = utxo[0]['txid']
         vout = utxo[0]['vout']
@@ -179,7 +179,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
 
         # Check that prioritising a tx before it's added to the mempool works
         # First clear the mempool by mining a block.
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_blocks()
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
         # Prioritise a transaction that has been mined, then add it back to the
@@ -270,7 +270,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
 
         # Test reorg handling
         # First, the basics:
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_blocks()
         self.nodes[1].invalidateblock(self.nodes[0].getbestblockhash())
         self.nodes[1].reconsiderblock(self.nodes[0].getbestblockhash())
@@ -317,7 +317,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
             value = sent_value
 
         # Mine these in a block
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         # Now generate tx8, with a big fee

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -160,7 +160,7 @@ class MempoolPersistTest(BitcoinTestFramework):
         self.start_node(0)
 
         # clear out mempool
-        node0.generate(1)
+        self.generate(node0, 1)
 
         # ensure node0 doesn't have any connections
         # make a transaction that will remain in the unbroadcast set

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -65,7 +65,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         wallet.sendrawtransaction(from_node=self.nodes[0], tx_hex=spend_2['hex'])
         wallet.sendrawtransaction(from_node=self.nodes[0], tx_hex=spend_3['hex'])
         self.log.info("Generate a block")
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.log.info("Check that time-locked transaction is still too immature to spend")
         assert_raises_rpc_error(-26, 'non-final', self.nodes[0].sendrawtransaction, timelock_tx)
 
@@ -78,7 +78,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         self.log.info("Broadcast and mine spend_3_1")
         spend_3_1_id = self.nodes[0].sendrawtransaction(spend_3_1['hex'])
         self.log.info("Generate a block")
-        last_block = self.nodes[0].generate(1)
+        last_block = self.generate(self.nodes[0], 1)
         # Sync blocks, so that peer 1 gets the block before timelock_tx
         # Otherwise, peer 1 would put the timelock_tx in m_recent_rejects
         self.sync_all()

--- a/test/functional/mempool_resurrect.py
+++ b/test/functional/mempool_resurrect.py
@@ -20,8 +20,8 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         wallet = MiniWallet(node)
 
         # Add enough mature utxos to the wallet so that all txs spend confirmed coins
-        wallet.generate(3)
-        node.generate(COINBASE_MATURITY)
+        self.generate(wallet, 3)
+        self.generate(node, COINBASE_MATURITY)
 
         # Spend block 1/2/3's coinbase transactions
         # Mine a block
@@ -34,9 +34,9 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         # ... make sure all the transactions are confirmed again
         blocks = []
         spends1_ids = [wallet.send_self_transfer(from_node=node)['txid'] for _ in range(3)]
-        blocks.extend(node.generate(1))
+        blocks.extend(self.generate(node, 1))
         spends2_ids = [wallet.send_self_transfer(from_node=node)['txid'] for _ in range(3)]
-        blocks.extend(node.generate(1))
+        blocks.extend(self.generate(node, 1))
 
         spends_ids = set(spends1_ids + spends2_ids)
 
@@ -53,7 +53,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         assert_equal(set(node.getrawmempool()), spends_ids)
 
         # Generate another block, they should all get mined
-        blocks = node.generate(1)
+        blocks = self.generate(node, 1)
         # mempool should be empty, all txns confirmed
         assert_equal(set(node.getrawmempool()), set())
         confirmed_txns = set(node.getblock(blocks[0])['tx'])

--- a/test/functional/mempool_spend_coinbase.py
+++ b/test/functional/mempool_spend_coinbase.py
@@ -49,7 +49,7 @@ class MempoolSpendCoinbaseTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getrawmempool(), [spend_mature_id])
 
         # mine a block, mature one should get confirmed
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         assert_equal(set(self.nodes[0].getrawmempool()), set())
 
         # ... and now previously immature can be spent:

--- a/test/functional/mempool_unbroadcast.py
+++ b/test/functional/mempool_unbroadcast.py
@@ -109,7 +109,7 @@ class MempoolUnbroadcastTest(BitcoinTestFramework):
         # a block
         removal_reason = "Removed {} from set of unbroadcast txns before confirmation that txn was sent out".format(txhsh)
         with node.assert_debug_log([removal_reason]):
-            node.generate(1)
+            self.generate(node, 1)
 
 if __name__ == "__main__":
     MempoolUnbroadcastTest().main()

--- a/test/functional/mempool_updatefromblock.py
+++ b/test/functional/mempool_updatefromblock.py
@@ -91,7 +91,7 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
             if tx_count in n_tx_to_mine:
                 # The created transactions are mined into blocks by batches.
                 self.log.info('The batch of {} transactions has been accepted into the mempool.'.format(len(self.nodes[0].getrawmempool())))
-                block_hash = self.nodes[0].generate(1)[0]
+                block_hash = self.generate(self.nodes[0], 1)[0]
                 if not first_block_hash:
                     first_block_hash = block_hash
                 assert_equal(len(self.nodes[0].getrawmempool()), 0)

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -58,7 +58,7 @@ class MiningTest(BitcoinTestFramework):
         self.log.info('Create some old blocks')
         for t in range(TIME_GENESIS_BLOCK, TIME_GENESIS_BLOCK + 200 * 600, 600):
             self.nodes[0].setmocktime(t)
-            self.nodes[0].generate(1)
+            self.generate(self.nodes[0], 1)
         mining_info = self.nodes[0].getmininginfo()
         assert_equal(mining_info['blocks'], 200)
         assert_equal(mining_info['currentblocktx'], 0)
@@ -109,7 +109,7 @@ class MiningTest(BitcoinTestFramework):
         assert_equal(witness_commitment, script.hex())
 
         # Mine a block to leave initial block download and clear the mempool
-        node.generatetoaddress(1, node.get_deterministic_priv_key().address)
+        self.generatetoaddress(node, 1, node.get_deterministic_priv_key().address)
         tmpl = node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
         self.log.info("getblocktemplate: Test capability advertised")
         assert 'proposal' in tmpl['capabilities']
@@ -271,7 +271,7 @@ class MiningTest(BitcoinTestFramework):
         assert chain_tip(block.hash, status='active', branchlen=0) in node.getchaintips()
 
         # Building a few blocks should give the same results
-        node.generatetoaddress(10, node.get_deterministic_priv_key().address)
+        self.generatetoaddress(node, 10, node.get_deterministic_priv_key().address)
         assert_raises_rpc_error(-25, 'time-too-old', lambda: node.submitheader(hexdata=CBlockHeader(bad_block_time).serialize().hex()))
         assert_raises_rpc_error(-25, 'bad-prevblk', lambda: node.submitheader(hexdata=CBlockHeader(bad_block2).serialize().hex()))
         node.submitheader(hexdata=CBlockHeader(block).serialize().hex())

--- a/test/functional/mining_getblocktemplate_longpoll.py
+++ b/test/functional/mining_getblocktemplate_longpoll.py
@@ -35,7 +35,7 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
     def run_test(self):
         self.log.info("Warning: this test will take about 70 seconds in the best case. Be patient.")
         self.log.info("Test that longpollid doesn't change between successive getblocktemplate() invocations if nothing else happens")
-        self.nodes[0].generate(10)
+        self.generate(self.nodes[0], 10)
         template = self.nodes[0].getblocktemplate({'rules': ['segwit']})
         longpollid = template['longpollid']
         template2 = self.nodes[0].getblocktemplate({'rules': ['segwit']})
@@ -63,7 +63,7 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
         assert not thr.is_alive()
 
         # Add enough mature utxos to the wallets, so that all txs spend confirmed coins
-        self.nodes[0].generate(COINBASE_MATURITY)
+        self.generate(self.nodes[0], COINBASE_MATURITY)
         self.sync_blocks()
 
         self.log.info("Test that introducing a new transaction into the mempool will terminate the longpoll")

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -75,7 +75,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         # also check that a different entry in the cheapest bucket is NOT mined
         self.nodes[0].prioritisetransaction(txid=txids[0][0], fee_delta=int(3*base_fee*COIN))
 
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
 
         mempool = self.nodes[0].getrawmempool()
         self.log.info("Assert that prioritised transaction was mined")
@@ -105,7 +105,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         # the other high fee transactions. Keep mining until our mempool has
         # decreased by all the high fee size that we calculated above.
         while (self.nodes[0].getmempoolinfo()['bytes'] > sizes[0] + sizes[1]):
-            self.nodes[0].generate(1)
+            self.generate(self.nodes[0], 1)
 
         # High fee transaction should not have been mined, but other high fee rate
         # transactions should have been.

--- a/test/functional/p2p_blockfilters.py
+++ b/test/functional/p2p_blockfilters.py
@@ -56,17 +56,17 @@ class CompactFiltersTest(BitcoinTestFramework):
         peer_1 = self.nodes[1].add_p2p_connection(FiltersClient())
 
         # Nodes 0 & 1 share the same first 999 blocks in the chain.
-        self.nodes[0].generate(999)
+        self.generate(self.nodes[0], 999)
         self.sync_blocks(timeout=600)
 
         # Stale blocks by disconnecting nodes 0 & 1, mining, then reconnecting
         self.disconnect_nodes(0, 1)
 
-        stale_block_hash = self.nodes[0].generate(1)[0]
+        stale_block_hash = self.generate(self.nodes[0], 1)[0]
         self.nodes[0].syncwithvalidationinterfacequeue()
         assert_equal(self.nodes[0].getblockcount(), 1000)
 
-        self.nodes[1].generate(1001)
+        self.generate(self.nodes[1], 1001)
         assert_equal(self.nodes[1].getblockcount(), 2000)
 
         # Check that nodes have signalled NODE_COMPACT_FILTERS correctly.

--- a/test/functional/p2p_blocksonly.py
+++ b/test/functional/p2p_blocksonly.py
@@ -23,8 +23,8 @@ class P2PBlocksOnly(BitcoinTestFramework):
     def run_test(self):
         self.miniwallet = MiniWallet(self.nodes[0])
         # Add enough mature utxos to the wallet, so that all txs spend confirmed coins
-        self.miniwallet.generate(2)
-        self.nodes[0].generate(COINBASE_MATURITY)
+        self.generate(self.miniwallet, 2)
+        self.generate(self.nodes[0], COINBASE_MATURITY)
 
         self.blocksonly_mode_tests()
         self.blocks_relay_conn_tests()
@@ -73,7 +73,7 @@ class P2PBlocksOnly(BitcoinTestFramework):
         self.log.info("Relay-permission peer's transaction is accepted and relayed")
 
         self.nodes[0].disconnect_p2ps()
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
 
     def blocks_relay_conn_tests(self):
         self.log.info('Tests with node in normal mode with block-relay-only connections')

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -165,7 +165,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         block = self.build_block_on_tip(self.nodes[0])
         self.segwit_node.send_and_ping(msg_no_witness_block(block))
         assert int(self.nodes[0].getbestblockhash(), 16) == block.sha256
-        self.nodes[0].generatetoaddress(COINBASE_MATURITY, self.nodes[0].getnewaddress(address_type="bech32"))
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY, self.nodes[0].getnewaddress(address_type="bech32"))
 
         total_value = block.vtx[0].vout[0].nValue
         out_value = total_value // 10
@@ -212,7 +212,7 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         def check_announcement_of_new_block(node, peer, predicate):
             peer.clear_block_announcement()
-            block_hash = int(node.generate(1)[0], 16)
+            block_hash = int(self.generate(node, 1)[0], 16)
             peer.wait_for_block_announcement(block_hash, timeout=30)
             assert peer.block_announced
 
@@ -276,7 +276,7 @@ class CompactBlocksTest(BitcoinTestFramework):
 
     # This test actually causes bitcoind to (reasonably!) disconnect us, so do this last.
     def test_invalid_cmpctblock_message(self):
-        self.nodes[0].generate(COINBASE_MATURITY + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
         block = self.build_block_on_tip(self.nodes[0])
 
         cmpct_block = P2PHeaderAndShortIDs()
@@ -294,7 +294,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         version = test_node.cmpct_version
         node = self.nodes[0]
         # Generate a bunch of transactions.
-        node.generate(COINBASE_MATURITY + 1)
+        self.generate(node, COINBASE_MATURITY + 1)
         num_transactions = 25
         address = node.getnewaddress()
 
@@ -318,7 +318,7 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         # Now mine a block, and look at the resulting compact block.
         test_node.clear_block_announcement()
-        block_hash = int(node.generate(1)[0], 16)
+        block_hash = int(self.generate(node, 1)[0], 16)
 
         # Store the raw block in our internal format.
         block = from_hex(CBlock(), node.getblock("%064x" % block_hash, False))
@@ -660,7 +660,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         new_blocks = []
         for _ in range(MAX_CMPCTBLOCK_DEPTH + 1):
             test_node.clear_block_announcement()
-            new_blocks.append(node.generate(1)[0])
+            new_blocks.append(self.generate(node, 1)[0])
             test_node.wait_until(test_node.received_block_announcement, timeout=30)
 
         test_node.clear_block_announcement()
@@ -668,7 +668,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         test_node.wait_until(lambda: "cmpctblock" in test_node.last_message, timeout=30)
 
         test_node.clear_block_announcement()
-        node.generate(1)
+        self.generate(node, 1)
         test_node.wait_until(test_node.received_block_announcement, timeout=30)
         test_node.clear_block_announcement()
         with p2p_lock:
@@ -844,7 +844,7 @@ class CompactBlocksTest(BitcoinTestFramework):
 
     def run_test(self):
         # Get the nodes out of IBD
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
 
         # Setup the p2p connections
         self.segwit_node = self.nodes[0].add_p2p_connection(TestP2PConn(cmpct_version=2))

--- a/test/functional/p2p_compactblocks_hb.py
+++ b/test/functional/p2p_compactblocks_hb.py
@@ -30,7 +30,7 @@ class CompactBlocksConnectionTest(BitcoinTestFramework):
     def relay_block_through(self, peer):
         """Relay a new block through peer peer, and return HB status between 1 and [2,3,4,5]."""
         self.connect_nodes(peer, 0)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_blocks()
         self.disconnect_nodes(peer, 0)
         status_to = [self.peer_info(1, i)['bip152_hb_to'] for i in range(2, 6)]
@@ -44,7 +44,7 @@ class CompactBlocksConnectionTest(BitcoinTestFramework):
         # Connect everyone to node 0, and mine some blocks to get all nodes out of IBD.
         for i in range(1, 6):
             self.connect_nodes(i, 0)
-        self.nodes[0].generate(2)
+        self.generate(self.nodes[0], 2)
         self.sync_blocks()
         for i in range(1, 6):
             self.disconnect_nodes(i, 0)

--- a/test/functional/p2p_eviction.py
+++ b/test/functional/p2p_eviction.py
@@ -53,7 +53,7 @@ class P2PEvict(BitcoinTestFramework):
         protected_peers = set()  # peers that we expect to be protected from eviction
         current_peer = -1
         node = self.nodes[0]
-        node.generatetoaddress(COINBASE_MATURITY + 1, node.get_deterministic_priv_key().address)
+        self.generatetoaddress(node, COINBASE_MATURITY + 1, node.get_deterministic_priv_key().address)
 
         self.log.info("Create 4 peers and protect them from eviction by sending us a block")
         for _ in range(4):

--- a/test/functional/p2p_feefilter.py
+++ b/test/functional/p2p_feefilter.py
@@ -81,8 +81,8 @@ class FeeFilterTest(BitcoinTestFramework):
         node0 = self.nodes[0]
         miniwallet = MiniWallet(node1)
         # Add enough mature utxos to the wallet, so that all txs spend confirmed coins
-        miniwallet.generate(5)
-        node1.generate(COINBASE_MATURITY)
+        self.generate(miniwallet, 5)
+        self.generate(node1, COINBASE_MATURITY)
 
         conn = self.nodes[0].add_p2p_connection(TestP2PConn())
 

--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -149,7 +149,7 @@ class FilterTest(BitcoinTestFramework):
         assert not filter_peer.tx_received
 
         # Clear the mempool so that this transaction does not impact subsequent tests
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
 
     def test_filter(self, filter_peer):
         # Set the bloomfilter using filterload
@@ -159,14 +159,14 @@ class FilterTest(BitcoinTestFramework):
         filter_address = self.nodes[0].decodescript(filter_peer.watch_script_pubkey)['address']
 
         self.log.info('Check that we receive merkleblock and tx if the filter matches a tx in a block')
-        block_hash = self.nodes[0].generatetoaddress(1, filter_address)[0]
+        block_hash = self.generatetoaddress(self.nodes[0], 1, filter_address)[0]
         txid = self.nodes[0].getblock(block_hash)['tx'][0]
         filter_peer.wait_for_merkleblock(block_hash)
         filter_peer.wait_for_tx(txid)
 
         self.log.info('Check that we only receive a merkleblock if the filter does not match a tx in a block')
         filter_peer.tx_received = False
-        block_hash = self.nodes[0].generatetoaddress(1, self.nodes[0].getnewaddress())[0]
+        block_hash = self.generatetoaddress(self.nodes[0], 1, self.nodes[0].getnewaddress())[0]
         filter_peer.wait_for_merkleblock(block_hash)
         assert not filter_peer.tx_received
 
@@ -194,7 +194,7 @@ class FilterTest(BitcoinTestFramework):
         filter_peer.merkleblock_received = False
         filter_peer.tx_received = False
         with self.nodes[0].assert_debug_log(expected_msgs=['received getdata']):
-            block_hash = self.nodes[0].generatetoaddress(1, self.nodes[0].getnewaddress())[0]
+            block_hash = self.generatetoaddress(self.nodes[0], 1, self.nodes[0].getnewaddress())[0]
             filter_peer.wait_for_inv([CInv(MSG_BLOCK, int(block_hash, 16))])
             filter_peer.sync_with_ping()
             assert not filter_peer.merkleblock_received

--- a/test/functional/p2p_fingerprint.py
+++ b/test/functional/p2p_fingerprint.py
@@ -69,7 +69,7 @@ class P2PFingerprintTest(BitcoinTestFramework):
         self.nodes[0].setmocktime(int(time.time()) - 60 * 24 * 60 * 60)
 
         # Generating a chain of 10 blocks
-        block_hashes = self.nodes[0].generatetoaddress(10, self.nodes[0].get_deterministic_priv_key().address)
+        block_hashes = self.generatetoaddress(self.nodes[0], 10, self.nodes[0].get_deterministic_priv_key().address)
 
         # Create longer chain starting 2 blocks before current tip
         height = len(block_hashes) - 2
@@ -98,7 +98,7 @@ class P2PFingerprintTest(BitcoinTestFramework):
 
         # Longest chain is extended so stale is much older than chain tip
         self.nodes[0].setmocktime(0)
-        block_hash = int(self.nodes[0].generatetoaddress(1, self.nodes[0].get_deterministic_priv_key().address)[-1], 16)
+        block_hash = int(self.generatetoaddress(self.nodes[0], 1, self.nodes[0].get_deterministic_priv_key().address)[-1], 16)
         assert_equal(self.nodes[0].getblockcount(), 14)
         node0.wait_for_block(block_hash, timeout=3)
 

--- a/test/functional/p2p_ibd_txrelay.py
+++ b/test/functional/p2p_ibd_txrelay.py
@@ -29,7 +29,7 @@ class P2PIBDTxRelayTest(BitcoinTestFramework):
             self.wait_until(lambda: all(peer['minfeefilter'] == MAX_FEE_FILTER for peer in node.getpeerinfo()))
 
         # Come out of IBD by generating a block
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         self.log.info("Check that nodes reset minfilter after coming out of IBD")

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -51,7 +51,7 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
         peer.send_blocks_and_test([block1], node, success=True)
 
         self.log.info("Mature the block.")
-        node.generatetoaddress(100, node.get_deterministic_priv_key().address)
+        self.generatetoaddress(node, 100, node.get_deterministic_priv_key().address)
 
         best_block = node.getblock(node.getbestblockhash())
         tip = int(node.getbestblockhash(), 16)

--- a/test/functional/p2p_invalid_locator.py
+++ b/test/functional/p2p_invalid_locator.py
@@ -16,7 +16,7 @@ class InvalidLocatorTest(BitcoinTestFramework):
 
     def run_test(self):
         node = self.nodes[0]  # convenience reference to the node
-        node.generatetoaddress(1, node.get_deterministic_priv_key().address)  # Get node out of IBD
+        self.generatetoaddress(node, 1, node.get_deterministic_priv_key().address)  # Get node out of IBD
 
         self.log.info('Test max locator size')
         block_count = node.getblockcount()

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -64,7 +64,7 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         node.p2ps[0].send_blocks_and_test([block], node, success=True)
 
         self.log.info("Mature the block.")
-        self.nodes[0].generatetoaddress(100, self.nodes[0].get_deterministic_priv_key().address)
+        self.generatetoaddress(self.nodes[0], 100, self.nodes[0].get_deterministic_priv_key().address)
 
         # Iterate through a list of known invalid transaction types, ensuring each is
         # rejected. Some are consensus invalid and some just violate policy.

--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -133,7 +133,7 @@ class P2PLeakTest(BitcoinTestFramework):
         pre_wtxidrelay_peer.wait_until(lambda: pre_wtxidrelay_peer.version_received)
 
         # Mine a block and make sure that it's not sent to the connected peers
-        self.nodes[0].generate(nblocks=1)
+        self.generate(self.nodes[0], nblocks=1)
 
         # Give the node enough time to possibly leak out a message
         time.sleep(PEER_TIMEOUT + 2)

--- a/test/functional/p2p_leak_tx.py
+++ b/test/functional/p2p_leak_tx.py
@@ -27,8 +27,8 @@ class P2PLeakTxTest(BitcoinTestFramework):
         gen_node = self.nodes[0]  # The block and tx generating node
         miniwallet = MiniWallet(gen_node)
         # Add enough mature utxos to the wallet, so that all txs spend confirmed coins
-        miniwallet.generate(1)
-        gen_node.generate(COINBASE_MATURITY)
+        self.generate(miniwallet, 1)
+        self.generate(gen_node, COINBASE_MATURITY)
 
         inbound_peer = self.nodes[0].add_p2p_connection(P2PNode())  # An "attacking" inbound peer
 

--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -59,7 +59,7 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
 
         self.log.info("Mine enough blocks to reach the NODE_NETWORK_LIMITED range.")
         self.connect_nodes(0, 1)
-        blocks = self.nodes[1].generatetoaddress(292, self.nodes[1].get_deterministic_priv_key().address)
+        blocks = self.generatetoaddress(self.nodes[1], 292, self.nodes[1].get_deterministic_priv_key().address)
         self.sync_blocks([self.nodes[0], self.nodes[1]])
 
         self.log.info("Make sure we can max retrieve block at tip-288.")
@@ -101,7 +101,7 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
         self.disconnect_all()
 
         # mine 10 blocks on node 0 (pruned node)
-        self.nodes[0].generatetoaddress(10, self.nodes[0].get_deterministic_priv_key().address)
+        self.generatetoaddress(self.nodes[0], 10, self.nodes[0].get_deterministic_priv_key().address)
 
         # connect node1 (non pruned) with node0 (pruned) and check if the can sync
         self.connect_nodes(0, 1)

--- a/test/functional/p2p_permissions.py
+++ b/test/functional/p2p_permissions.py
@@ -93,7 +93,7 @@ class P2PPermissionsTests(BitcoinTestFramework):
         self.nodes[1].assert_start_raises_init_error(["-whitebind=noban@127.0.0.1/10"], "Cannot resolve -whitebind address", match=ErrorMatch.PARTIAL_REGEX)
 
     def check_tx_relay(self):
-        block_op_true = self.nodes[0].getblock(self.nodes[0].generatetoaddress(100, ADDRESS_BCRT1_P2WSH_OP_TRUE)[0])
+        block_op_true = self.nodes[0].getblock(self.generatetoaddress(self.nodes[0], 100, ADDRESS_BCRT1_P2WSH_OP_TRUE)[0])
         self.sync_all()
 
         self.log.debug("Create a connection from a forcerelay peer that rebroadcasts raw txs")

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -303,7 +303,7 @@ class SegWitTest(BitcoinTestFramework):
         self.test_node.send_and_ping(msg_no_witness_block(block))  # make sure the block was processed
         txid = block.vtx[0].sha256
 
-        self.nodes[0].generate(99)  # let the block mature
+        self.generate(self.nodes[0], 99)  # let the block mature
 
         # Create a transaction that spends the coinbase
         tx = CTransaction()
@@ -319,7 +319,7 @@ class SegWitTest(BitcoinTestFramework):
         assert tx.hash in self.nodes[0].getrawmempool()
         # Save this transaction for later
         self.utxo.append(UTXO(tx.sha256, 0, 49 * 100000000))
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
 
     @subtest  # type: ignore
     def test_unnecessary_witness_before_segwit_activation(self):
@@ -555,7 +555,7 @@ class SegWitTest(BitcoinTestFramework):
         test_transaction_acceptance(self.nodes[0], self.test_node, tx, with_witness=False, accepted=True)
 
         # Cleanup: mine the first transaction and update utxo
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
 
         self.utxo.pop(0)
@@ -580,7 +580,7 @@ class SegWitTest(BitcoinTestFramework):
 
         # Mine it on test_node to create the confirmed output.
         test_transaction_acceptance(self.nodes[0], self.test_node, p2sh_tx, with_witness=True, accepted=True)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_blocks()
 
         # Now test standardness of v0 P2WSH outputs.
@@ -653,7 +653,7 @@ class SegWitTest(BitcoinTestFramework):
             )
         test_transaction_acceptance(self.nodes[0], self.test_node, tx3, with_witness=True, accepted=True)
 
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_blocks()
         self.utxo.pop(0)
         self.utxo.append(UTXO(tx3.sha256, 0, tx3.vout[0].nValue))
@@ -664,9 +664,9 @@ class SegWitTest(BitcoinTestFramework):
         """Mine enough blocks to activate segwit."""
         assert not softfork_active(self.nodes[0], 'segwit')
         height = self.nodes[0].getblockcount()
-        self.nodes[0].generate(SEGWIT_HEIGHT - height - 2)
+        self.generate(self.nodes[0], SEGWIT_HEIGHT - height - 2)
         assert not softfork_active(self.nodes[0], 'segwit')
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         assert softfork_active(self.nodes[0], 'segwit')
         self.segwit_active = True
 
@@ -1298,7 +1298,7 @@ class SegWitTest(BitcoinTestFramework):
         assert vsize != raw_tx["size"]
 
         # Cleanup: mine the transactions and update utxo for next test
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
 
         self.utxo.pop(0)
@@ -1348,7 +1348,7 @@ class SegWitTest(BitcoinTestFramework):
             self.utxo.pop(0)
             temp_utxo.append(UTXO(tx.sha256, 0, tx.vout[0].nValue))
 
-        self.nodes[0].generate(1)  # Mine all the transactions
+        self.generate(self.nodes[0], 1)  # Mine all the transactions
         self.sync_blocks()
         assert len(self.nodes[0].getrawmempool()) == 0
 
@@ -1419,14 +1419,14 @@ class SegWitTest(BitcoinTestFramework):
         spend_tx.rehash()
 
         # Now test a premature spend.
-        self.nodes[0].generate(98)
+        self.generate(self.nodes[0], 98)
         self.sync_blocks()
         block2 = self.build_next_block()
         self.update_witness_block_with_transactions(block2, [spend_tx])
         test_witness_block(self.nodes[0], self.test_node, block2, accepted=False)
 
         # Advancing one more block should allow the spend.
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         block2 = self.build_next_block()
         self.update_witness_block_with_transactions(block2, [spend_tx])
         test_witness_block(self.nodes[0], self.test_node, block2, accepted=True)
@@ -1733,7 +1733,7 @@ class SegWitTest(BitcoinTestFramework):
         tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, script_pubkey))
         tx.rehash()
         test_transaction_acceptance(self.nodes[0], self.test_node, tx, False, True)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_blocks()
 
         # We'll add an unnecessary witness to this transaction that would cause
@@ -1762,7 +1762,7 @@ class SegWitTest(BitcoinTestFramework):
         test_transaction_acceptance(self.nodes[0], self.test_node, tx2, False, True)
         test_transaction_acceptance(self.nodes[0], self.test_node, tx3, False, True)
 
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_blocks()
 
         # Update our utxo list; we spent the first entry.
@@ -1797,7 +1797,7 @@ class SegWitTest(BitcoinTestFramework):
         txid = tx.sha256
         test_transaction_acceptance(self.nodes[0], self.test_node, tx, with_witness=False, accepted=True)
 
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_blocks()
 
         # Creating transactions for tests
@@ -1860,7 +1860,7 @@ class SegWitTest(BitcoinTestFramework):
         test_transaction_acceptance(self.nodes[1], self.std_node, p2sh_txs[3], True, False, 'bad-witness-nonstandard')
         test_transaction_acceptance(self.nodes[0], self.test_node, p2sh_txs[3], True, True)
 
-        self.nodes[0].generate(1)  # Mine and clean up the mempool of non-standard node
+        self.generate(self.nodes[0], 1)  # Mine and clean up the mempool of non-standard node
         # Valid but non-standard transactions in a block should be accepted by standard node
         self.sync_blocks()
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
@@ -1998,7 +1998,7 @@ class SegWitTest(BitcoinTestFramework):
                 return serialize_with_bogus_witness(self.tx)
 
         self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(address_type='bech32'), 5)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         unspent = next(u for u in self.nodes[0].listunspent() if u['spendable'] and u['address'].startswith('bcrt'))
 
         raw = self.nodes[0].createrawtransaction([{"txid": unspent['txid'], "vout": unspent['vout']}], {self.nodes[0].getnewaddress(): 1})

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -205,7 +205,7 @@ class SendHeadersTest(BitcoinTestFramework):
 
         # Clear out block announcements from each p2p listener
         [x.clear_block_announcements() for x in self.nodes[0].p2ps]
-        self.nodes[0].generatetoaddress(count, self.nodes[0].get_deterministic_priv_key().address)
+        self.generatetoaddress(self.nodes[0], count, self.nodes[0].get_deterministic_priv_key().address)
         return int(self.nodes[0].getbestblockhash(), 16)
 
     def mine_reorg(self, length):
@@ -216,7 +216,7 @@ class SendHeadersTest(BitcoinTestFramework):
         return the list of block hashes newly mined."""
 
         # make sure all invalidated blocks are node0's
-        self.nodes[0].generatetoaddress(length, self.nodes[0].get_deterministic_priv_key().address)
+        self.generatetoaddress(self.nodes[0], length, self.nodes[0].get_deterministic_priv_key().address)
         self.sync_blocks(self.nodes, wait=0.1)
         for x in self.nodes[0].p2ps:
             x.wait_for_block_announcement(int(self.nodes[0].getbestblockhash(), 16))
@@ -225,7 +225,7 @@ class SendHeadersTest(BitcoinTestFramework):
         tip_height = self.nodes[1].getblockcount()
         hash_to_invalidate = self.nodes[1].getblockhash(tip_height - (length - 1))
         self.nodes[1].invalidateblock(hash_to_invalidate)
-        all_hashes = self.nodes[1].generatetoaddress(length + 1, self.nodes[1].get_deterministic_priv_key().address)  # Must be longer than the orig chain
+        all_hashes = self.generatetoaddress(self.nodes[1], length + 1, self.nodes[1].get_deterministic_priv_key().address)  # Must be longer than the orig chain
         self.sync_blocks(self.nodes, wait=0.1)
         return [int(x, 16) for x in all_hashes]
 
@@ -240,7 +240,7 @@ class SendHeadersTest(BitcoinTestFramework):
         self.test_nonnull_locators(test_node, inv_node)
 
     def test_null_locators(self, test_node, inv_node):
-        tip = self.nodes[0].getblockheader(self.nodes[0].generatetoaddress(1, self.nodes[0].get_deterministic_priv_key().address)[0])
+        tip = self.nodes[0].getblockheader(self.generatetoaddress(self.nodes[0], 1, self.nodes[0].get_deterministic_priv_key().address)[0])
         tip_hash = int(tip["hash"], 16)
 
         inv_node.check_last_inv_announcement(inv=[tip_hash])

--- a/test/functional/rpc_addresses_deprecation.py
+++ b/test/functional/rpc_addresses_deprecation.py
@@ -40,7 +40,7 @@ class AddressesDeprecationTest(BitcoinTestFramework):
         txid = node.sendrawtransaction(hexstring=tx_signed, maxfeerate=0)
 
         self.log.info("Test RPCResult scriptPubKey no longer returns the fields addresses or reqSigs by default")
-        hash = node.generateblock(output=node.getnewaddress(), transactions=[txid])['hash']
+        hash = self.generateblock(node, output=node.getnewaddress(), transactions=[txid])['hash']
         # Ensure both nodes have the newly generated block on disk.
         self.sync_blocks()
         script_pub_key = node.getblock(blockhash=hash, verbose=2)['tx'][-1]['vout'][0]['scriptPubKey']

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -84,7 +84,7 @@ class BlockchainTest(BitcoinTestFramework):
         self.log.info(f"Generate {HEIGHT} blocks after the genesis block in ten-minute steps")
         for t in range(TIME_GENESIS_BLOCK, TIME_RANGE_END, TIME_RANGE_STEP):
             self.nodes[0].setmocktime(t)
-            self.nodes[0].generatetoaddress(1, ADDRESS_BCRT1_P2WSH_OP_TRUE)
+            self.generatetoaddress(self.nodes[0], 1, ADDRESS_BCRT1_P2WSH_OP_TRUE)
         assert_equal(self.nodes[0].getblockchaininfo()['blocks'], HEIGHT)
 
     def _test_getblockchaininfo(self):
@@ -351,12 +351,12 @@ class BlockchainTest(BitcoinTestFramework):
     def _test_stopatheight(self):
         self.log.info("Test stopping at height")
         assert_equal(self.nodes[0].getblockcount(), HEIGHT)
-        self.nodes[0].generatetoaddress(6, ADDRESS_BCRT1_P2WSH_OP_TRUE)
+        self.generatetoaddress(self.nodes[0], 6, ADDRESS_BCRT1_P2WSH_OP_TRUE)
         assert_equal(self.nodes[0].getblockcount(), HEIGHT + 6)
         self.log.debug('Node should not stop at this height')
         assert_raises(subprocess.TimeoutExpired, lambda: self.nodes[0].process.wait(timeout=3))
         try:
-            self.nodes[0].generatetoaddress(1, ADDRESS_BCRT1_P2WSH_OP_TRUE)
+            self.generatetoaddress(self.nodes[0], 1, ADDRESS_BCRT1_P2WSH_OP_TRUE)
         except (ConnectionError, http.client.BadStatusLine):
             pass  # The node already shut down before response
         self.log.debug('Node should stop at this height...')
@@ -412,7 +412,7 @@ class BlockchainTest(BitcoinTestFramework):
         fee_per_kb = 1000 * fee_per_byte
 
         miniwallet.send_self_transfer(fee_rate=fee_per_kb, from_node=node)
-        blockhash = node.generate(1)[0]
+        blockhash = self.generate(node, 1)[0]
 
         self.log.info("Test getblock with verbosity 1 doesn't include fee")
         block = node.getblock(blockhash, 1)

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -45,7 +45,7 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
         self.check_addmultisigaddress_errors()
 
         self.log.info('Generating blocks ...')
-        node0.generate(149)
+        self.generate(node0, 149)
         self.sync_all()
 
         self.moved = 0
@@ -116,7 +116,7 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
 
     def checkbalances(self):
         node0, node1, node2 = self.nodes
-        node0.generate(COINBASE_MATURITY)
+        self.generate(node0, COINBASE_MATURITY)
         self.sync_all()
 
         bal0 = node0.getbalance()
@@ -179,7 +179,7 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
         value = tx["vout"][vout]["value"]
         prevtxs = [{"txid": txid, "vout": vout, "scriptPubKey": scriptPubKey, "redeemScript": mredeem, "amount": value}]
 
-        node0.generate(1)
+        self.generate(node0, 1)
 
         outval = value - decimal.Decimal("0.00001000")
         rawtx = node2.createrawtransaction([{"txid": txid, "vout": vout}], [{self.final: outval}])
@@ -215,7 +215,7 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
 
         self.moved += outval
         tx = node0.sendrawtransaction(rawtx3["hex"], 0)
-        blk = node0.generate(1)[0]
+        blk = self.generate(node0, 1)[0]
         assert tx in node0.getblock(blk)["tx"]
 
         txinfo = node0.getrawtransaction(tx, True, blk)

--- a/test/functional/rpc_deprecated.py
+++ b/test/functional/rpc_deprecated.py
@@ -21,7 +21,7 @@ class DeprecatedRpcTest(BitcoinTestFramework):
         # In run_test:
         # self.log.info("Test generate RPC")
         # assert_raises_rpc_error(-32, 'The wallet generate rpc method is deprecated', self.nodes[0].rpc.generate, 1)
-        # self.nodes[1].generate(1)
+        # self.generate(self.nodes[1], 1)
 
         self.log.info("No tested deprecated RPC methods")
 

--- a/test/functional/rpc_dumptxoutset.py
+++ b/test/functional/rpc_dumptxoutset.py
@@ -23,7 +23,7 @@ class DumptxoutsetTest(BitcoinTestFramework):
         node = self.nodes[0]
         mocktime = node.getblockheader(node.getblockhash(0))['time'] + 1
         node.setmocktime(mocktime)
-        node.generate(COINBASE_MATURITY)
+        self.generate(node, COINBASE_MATURITY)
 
         FILENAME = 'txoutset.dat'
         out = node.dumptxoutset(FILENAME)

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -63,9 +63,9 @@ class RawTransactionsTest(BitcoinTestFramework):
         #            = 2 bytes * minRelayTxFeePerByte
         self.fee_tolerance = 2 * self.min_relay_tx_fee / 1000
 
-        self.nodes[2].generate(1)
+        self.generate(self.nodes[2], 1)
         self.sync_all()
-        self.nodes[0].generate(121)
+        self.generate(self.nodes[0], 121)
         self.sync_all()
 
         self.test_change_position()
@@ -126,7 +126,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 1.0)
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 5.0)
 
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         wwatch.unloadwallet()
@@ -500,7 +500,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # Send 1.2 BTC to msig addr.
         self.nodes[0].sendtoaddress(mSigObj, 1.2)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         oldBalance = self.nodes[1].getbalance()
@@ -511,7 +511,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         signed_psbt = w2.walletprocesspsbt(funded_psbt)
         final_psbt = w2.finalizepsbt(signed_psbt['psbt'])
         self.nodes[2].sendrawtransaction(final_psbt['hex'])
-        self.nodes[2].generate(1)
+        self.generate(self.nodes[2], 1)
         self.sync_all()
 
         # Make sure funds are received at node1.
@@ -572,7 +572,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[1].walletpassphrase("test", 600)
         signedTx = self.nodes[1].signrawtransactionwithwallet(fundedTx['hex'])
         self.nodes[1].sendrawtransaction(signedTx['hex'])
-        self.nodes[1].generate(1)
+        self.generate(self.nodes[1], 1)
         self.sync_all()
 
         # Make sure funds are received at node1.
@@ -584,12 +584,12 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # Empty node1, send some small coins from node0 to node1.
         self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), self.nodes[1].getbalance(), "", "", True)
-        self.nodes[1].generate(1)
+        self.generate(self.nodes[1], 1)
         self.sync_all()
 
         for _ in range(20):
             self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.01)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         # Fund a tx with ~20 small inputs.
@@ -612,12 +612,12 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # Again, empty node1, send some small coins from node0 to node1.
         self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), self.nodes[1].getbalance(), "", "", True)
-        self.nodes[1].generate(1)
+        self.generate(self.nodes[1], 1)
         self.sync_all()
 
         for _ in range(20):
             self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.01)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         # Fund a tx with ~20 small inputs.
@@ -629,7 +629,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         fundedTx = self.nodes[1].fundrawtransaction(rawtx)
         fundedAndSignedTx = self.nodes[1].signrawtransactionwithwallet(fundedTx['hex'])
         self.nodes[1].sendrawtransaction(fundedAndSignedTx['hex'])
-        self.nodes[1].generate(1)
+        self.generate(self.nodes[1], 1)
         self.sync_all()
         assert_equal(oldBalance+Decimal('50.19000000'), self.nodes[0].getbalance()) #0.19+block reward
 
@@ -707,7 +707,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         signedtx = self.nodes[0].signrawtransactionwithwallet(signedtx["hex"])
         assert signedtx["complete"]
         self.nodes[0].sendrawtransaction(signedtx["hex"])
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         wwatch.unloadwallet()
@@ -933,7 +933,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         for _ in range(1500):
             outputs[recipient.getnewaddress()] = 0.1
         wallet.sendmany("", outputs)
-        self.nodes[0].generate(10)
+        self.generate(self.nodes[0], 10)
         assert_raises_rpc_error(-4, "Transaction too large", recipient.fundrawtransaction, rawtx)
 
     def test_include_unsafe(self):
@@ -962,7 +962,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         wallet.sendrawtransaction(signedtx['hex'])
 
         # And we can also use them once they're confirmed.
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         rawtx = wallet.createrawtransaction([], [{self.nodes[2].getnewaddress(): 3}])
         fundedtx = wallet.fundrawtransaction(rawtx, {"include_unsafe": True})
         tx_dec = wallet.decoderawtransaction(fundedtx['hex'])
@@ -993,7 +993,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # than any single input available, and require more than 1 input. So we make 3 outputs
         for i in range(0, 3):
             funds.sendtoaddress(tester.getnewaddress(address_type="bech32"), 1)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
 
         # Create transactions in order to calculate fees for the target bounds that can trigger this bug
         change_tx = tester.fundrawtransaction(tester.createrawtransaction([], [{funds.getnewaddress(): 1.5}]))

--- a/test/functional/rpc_generateblock.py
+++ b/test/functional/rpc_generateblock.py
@@ -24,13 +24,13 @@ class GenerateBlockTest(BitcoinTestFramework):
 
         self.log.info('Generate an empty block to address')
         address = node.getnewaddress()
-        hash = node.generateblock(output=address, transactions=[])['hash']
+        hash = self.generateblock(node, output=address, transactions=[])['hash']
         block = node.getblock(blockhash=hash, verbose=2)
         assert_equal(len(block['tx']), 1)
         assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['address'], address)
 
         self.log.info('Generate an empty block to a descriptor')
-        hash = node.generateblock('addr(' + address + ')', [])['hash']
+        hash = self.generateblock(node, 'addr(' + address + ')', [])['hash']
         block = node.getblock(blockhash=hash, verbosity=2)
         assert_equal(len(block['tx']), 1)
         assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['address'], address)
@@ -38,7 +38,7 @@ class GenerateBlockTest(BitcoinTestFramework):
         self.log.info('Generate an empty block to a combo descriptor with compressed pubkey')
         combo_key = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
         combo_address = 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080'
-        hash = node.generateblock('combo(' + combo_key + ')', [])['hash']
+        hash = self.generateblock(node, 'combo(' + combo_key + ')', [])['hash']
         block = node.getblock(hash, 2)
         assert_equal(len(block['tx']), 1)
         assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['address'], combo_address)
@@ -46,13 +46,13 @@ class GenerateBlockTest(BitcoinTestFramework):
         self.log.info('Generate an empty block to a combo descriptor with uncompressed pubkey')
         combo_key = '0408ef68c46d20596cc3f6ddf7c8794f71913add807f1dc55949fa805d764d191c0b7ce6894c126fce0babc6663042f3dde9b0cf76467ea315514e5a6731149c67'
         combo_address = 'mkc9STceoCcjoXEXe6cm66iJbmjM6zR9B2'
-        hash = node.generateblock('combo(' + combo_key + ')', [])['hash']
+        hash = self.generateblock(node, 'combo(' + combo_key + ')', [])['hash']
         block = node.getblock(hash, 2)
         assert_equal(len(block['tx']), 1)
         assert_equal(block['tx'][0]['vout'][0]['scriptPubKey']['address'], combo_address)
 
         # Generate 110 blocks to spend
-        node.generatetoaddress(110, address)
+        self.generatetoaddress(node, 110, address)
 
         # Generate some extra mempool transactions to verify they don't get mined
         for _ in range(10):
@@ -60,7 +60,7 @@ class GenerateBlockTest(BitcoinTestFramework):
 
         self.log.info('Generate block with txid')
         txid = node.sendtoaddress(address, 1)
-        hash = node.generateblock(address, [txid])['hash']
+        hash = self.generateblock(node, address, [txid])['hash']
         block = node.getblock(hash, 1)
         assert_equal(len(block['tx']), 2)
         assert_equal(block['tx'][1], txid)
@@ -69,7 +69,7 @@ class GenerateBlockTest(BitcoinTestFramework):
         utxos = node.listunspent(addresses=[address])
         raw = node.createrawtransaction([{'txid':utxos[0]['txid'], 'vout':utxos[0]['vout']}],[{address:1}])
         signed_raw = node.signrawtransactionwithwallet(raw)['hex']
-        hash = node.generateblock(address, [signed_raw])['hash']
+        hash = self.generateblock(node, address, [signed_raw])['hash']
         block = node.getblock(hash, 1)
         assert_equal(len(block['tx']), 2)
         txid = block['tx'][1]
@@ -81,26 +81,26 @@ class GenerateBlockTest(BitcoinTestFramework):
         txid1 = node.sendrawtransaction(signed_raw1)
         raw2 = node.createrawtransaction([{'txid':txid1, 'vout':0}],[{address:0.999}])
         signed_raw2 = node.signrawtransactionwithwallet(raw2)['hex']
-        assert_raises_rpc_error(-25, 'TestBlockValidity failed: bad-txns-inputs-missingorspent', node.generateblock, address, [signed_raw2, txid1])
+        assert_raises_rpc_error(-25, 'TestBlockValidity failed: bad-txns-inputs-missingorspent', self.generateblock, node, address, [signed_raw2, txid1])
 
         self.log.info('Fail to generate block with txid not in mempool')
         missing_txid = '0000000000000000000000000000000000000000000000000000000000000000'
-        assert_raises_rpc_error(-5, 'Transaction ' + missing_txid + ' not in mempool.', node.generateblock, address, [missing_txid])
+        assert_raises_rpc_error(-5, 'Transaction ' + missing_txid + ' not in mempool.', self.generateblock, node, address, [missing_txid])
 
         self.log.info('Fail to generate block with invalid raw tx')
         invalid_raw_tx = '0000'
-        assert_raises_rpc_error(-22, 'Transaction decode failed for ' + invalid_raw_tx, node.generateblock, address, [invalid_raw_tx])
+        assert_raises_rpc_error(-22, 'Transaction decode failed for ' + invalid_raw_tx, self.generateblock, node, address, [invalid_raw_tx])
 
         self.log.info('Fail to generate block with invalid address/descriptor')
-        assert_raises_rpc_error(-5, 'Invalid address or descriptor', node.generateblock, '1234', [])
+        assert_raises_rpc_error(-5, 'Invalid address or descriptor', self.generateblock, node, '1234', [])
 
         self.log.info('Fail to generate block with a ranged descriptor')
         ranged_descriptor = 'pkh(tpubD6NzVbkrYhZ4XgiXtGrdW5XDAPFCL9h7we1vwNCpn8tGbBcgfVYjXyhWo4E1xkh56hjod1RhGjxbaTLV3X4FyWuejifB9jusQ46QzG87VKp/0/*)'
-        assert_raises_rpc_error(-8, 'Ranged descriptor not accepted. Maybe pass through deriveaddresses first?', node.generateblock, ranged_descriptor, [])
+        assert_raises_rpc_error(-8, 'Ranged descriptor not accepted. Maybe pass through deriveaddresses first?', self.generateblock, node, ranged_descriptor, [])
 
         self.log.info('Fail to generate block with a descriptor missing a private key')
         child_descriptor = 'pkh(tpubD6NzVbkrYhZ4XgiXtGrdW5XDAPFCL9h7we1vwNCpn8tGbBcgfVYjXyhWo4E1xkh56hjod1RhGjxbaTLV3X4FyWuejifB9jusQ46QzG87VKp/0\'/0)'
-        assert_raises_rpc_error(-5, 'Cannot derive script without private keys', node.generateblock, child_descriptor, [])
+        assert_raises_rpc_error(-5, 'Cannot derive script without private keys', self.generateblock, node, child_descriptor, [])
 
 if __name__ == '__main__':
     GenerateBlockTest().main()

--- a/test/functional/rpc_getblockfilter.py
+++ b/test/functional/rpc_getblockfilter.py
@@ -21,8 +21,8 @@ class GetBlockFilterTest(BitcoinTestFramework):
         # Create two chains by disconnecting nodes 0 & 1, mining, then reconnecting
         self.disconnect_nodes(0, 1)
 
-        self.nodes[0].generate(3)
-        self.nodes[1].generate(4)
+        self.generate(self.nodes[0], 3)
+        self.generate(self.nodes[1], 4)
 
         assert_equal(self.nodes[0].getblockcount(), 3)
         chain0_hashes = [self.nodes[0].getblockhash(block_height) for block_height in range(4)]

--- a/test/functional/rpc_getblockstats.py
+++ b/test/functional/rpc_getblockstats.py
@@ -43,11 +43,11 @@ class GetblockstatsTest(BitcoinTestFramework):
     def generate_test_data(self, filename):
         mocktime = 1525107225
         self.nodes[0].setmocktime(mocktime)
-        self.nodes[0].generate(COINBASE_MATURITY + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
 
         address = self.nodes[0].get_deterministic_priv_key().address
         self.nodes[0].sendtoaddress(address=address, amount=10, subtractfeefromamount=True)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         self.nodes[0].sendtoaddress(address=address, amount=10, subtractfeefromamount=True)
@@ -55,7 +55,7 @@ class GetblockstatsTest(BitcoinTestFramework):
         self.nodes[0].settxfee(amount=0.003)
         self.nodes[0].sendtoaddress(address=address, amount=1, subtractfeefromamount=True)
         self.sync_all()
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
 
         self.expected_stats = self.get_stats()
 

--- a/test/functional/rpc_getchaintips.py
+++ b/test/functional/rpc_getchaintips.py
@@ -26,8 +26,8 @@ class GetChainTipsTest (BitcoinTestFramework):
 
         # Split the network and build two chains of different lengths.
         self.split_network()
-        self.nodes[0].generatetoaddress(10, self.nodes[0].get_deterministic_priv_key().address)
-        self.nodes[2].generatetoaddress(20, self.nodes[2].get_deterministic_priv_key().address)
+        self.generatetoaddress(self.nodes[0], 10, self.nodes[0].get_deterministic_priv_key().address)
+        self.generatetoaddress(self.nodes[2], 20, self.nodes[2].get_deterministic_priv_key().address)
         self.sync_all(self.nodes[:2])
         self.sync_all(self.nodes[2:])
 

--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -22,12 +22,12 @@ class InvalidateTest(BitcoinTestFramework):
     def run_test(self):
         self.log.info("Make sure we repopulate setBlockIndexCandidates after InvalidateBlock:")
         self.log.info("Mine 4 blocks on Node 0")
-        self.nodes[0].generatetoaddress(4, self.nodes[0].get_deterministic_priv_key().address)
+        self.generatetoaddress(self.nodes[0], 4, self.nodes[0].get_deterministic_priv_key().address)
         assert_equal(self.nodes[0].getblockcount(), 4)
         besthash_n0 = self.nodes[0].getbestblockhash()
 
         self.log.info("Mine competing 6 blocks on Node 1")
-        self.nodes[1].generatetoaddress(6, self.nodes[1].get_deterministic_priv_key().address)
+        self.generatetoaddress(self.nodes[1], 6, self.nodes[1].get_deterministic_priv_key().address)
         assert_equal(self.nodes[1].getblockcount(), 6)
 
         self.log.info("Connect nodes to force a reorg")
@@ -53,14 +53,14 @@ class InvalidateTest(BitcoinTestFramework):
         self.nodes[2].invalidateblock(self.nodes[2].getblockhash(3))
         assert_equal(self.nodes[2].getblockcount(), 2)
         self.log.info("..and then mine a block")
-        self.nodes[2].generatetoaddress(1, self.nodes[2].get_deterministic_priv_key().address)
+        self.generatetoaddress(self.nodes[2], 1, self.nodes[2].get_deterministic_priv_key().address)
         self.log.info("Verify all nodes are at the right height")
         self.wait_until(lambda: self.nodes[2].getblockcount() == 3, timeout=5)
         self.wait_until(lambda: self.nodes[0].getblockcount() == 4, timeout=5)
         self.wait_until(lambda: self.nodes[1].getblockcount() == 4, timeout=5)
 
         self.log.info("Verify that we reconsider all ancestors as well")
-        blocks = self.nodes[1].generatetodescriptor(10, ADDRESS_BCRT1_UNSPENDABLE_DESCRIPTOR)
+        blocks = self.generatetodescriptor(self.nodes[1], 10, ADDRESS_BCRT1_UNSPENDABLE_DESCRIPTOR)
         assert_equal(self.nodes[1].getbestblockhash(), blocks[-1])
         # Invalidate the two blocks at the tip
         self.nodes[1].invalidateblock(blocks[-1])
@@ -72,7 +72,7 @@ class InvalidateTest(BitcoinTestFramework):
         assert_equal(self.nodes[1].getbestblockhash(), blocks[-1])
 
         self.log.info("Verify that we reconsider all descendants")
-        blocks = self.nodes[1].generatetodescriptor(10, ADDRESS_BCRT1_UNSPENDABLE_DESCRIPTOR)
+        blocks = self.generatetodescriptor(self.nodes[1], 10, ADDRESS_BCRT1_UNSPENDABLE_DESCRIPTOR)
         assert_equal(self.nodes[1].getbestblockhash(), blocks[-1])
         # Invalidate the two blocks at the tip
         self.nodes[1].invalidateblock(blocks[-2])

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -52,9 +52,9 @@ class NetTest(BitcoinTestFramework):
     def run_test(self):
         # We need miniwallet to make a transaction
         self.wallet = MiniWallet(self.nodes[0])
-        self.wallet.generate(1)
+        self.generate(self.wallet, 1)
         # Get out of IBD for the minfeefilter and getpeerinfo tests.
-        self.nodes[0].generate(COINBASE_MATURITY + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
 
         # By default, the test framework sets up an addnode connection from
         # node 1 --> node0. By connecting node0 --> node 1, we're left with
@@ -81,7 +81,7 @@ class NetTest(BitcoinTestFramework):
         self.log.info("Test getpeerinfo")
         # Create a few getpeerinfo last_block/last_transaction values.
         self.wallet.send_self_transfer(from_node=self.nodes[0]) # Make a transaction so we can see it in the getpeerinfo results
-        self.nodes[1].generate(1)
+        self.generate(self.nodes[1], 1)
         self.sync_all()
         time_now = int(time.time())
         peer_info = [x.getpeerinfo() for x in self.nodes]

--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -51,7 +51,7 @@ class RPCPackagesTest(BitcoinTestFramework):
         self.address = node.get_deterministic_priv_key().address
         self.coins = []
         # The last 100 coinbase transactions are premature
-        for b in node.generatetoaddress(200, self.address)[:100]:
+        for b in self.generatetoaddress(node, 200, self.address)[:100]:
             coinbase = node.getblock(blockhash=b, verbosity=2)["tx"][0]
             self.coins.append({
                 "txid": coinbase["txid"],
@@ -151,7 +151,7 @@ class RPCPackagesTest(BitcoinTestFramework):
         assert_equal(testres_single, testres_multiple)
 
         # Clean up by clearing the mempool
-        node.generate(1)
+        self.generate(node, 1)
 
     def test_multiple_children(self):
         node = self.nodes[0]

--- a/test/functional/rpc_preciousblock.py
+++ b/test/functional/rpc_preciousblock.py
@@ -43,18 +43,18 @@ class PreciousTest(BitcoinTestFramework):
     def run_test(self):
         self.log.info("Ensure submitblock can in principle reorg to a competing chain")
         gen_address = lambda i: self.nodes[i].get_deterministic_priv_key().address  # A non-wallet address to mine to
-        self.nodes[0].generatetoaddress(1, gen_address(0))
+        self.generatetoaddress(self.nodes[0], 1, gen_address(0))
         assert_equal(self.nodes[0].getblockcount(), 1)
-        hashZ = self.nodes[1].generatetoaddress(2, gen_address(1))[-1]
+        hashZ = self.generatetoaddress(self.nodes[1], 2, gen_address(1))[-1]
         assert_equal(self.nodes[1].getblockcount(), 2)
         node_sync_via_rpc(self.nodes[0:3])
         assert_equal(self.nodes[0].getbestblockhash(), hashZ)
 
         self.log.info("Mine blocks A-B-C on Node 0")
-        hashC = self.nodes[0].generatetoaddress(3, gen_address(0))[-1]
+        hashC = self.generatetoaddress(self.nodes[0], 3, gen_address(0))[-1]
         assert_equal(self.nodes[0].getblockcount(), 5)
         self.log.info("Mine competing blocks E-F-G on Node 1")
-        hashG = self.nodes[1].generatetoaddress(3, gen_address(1))[-1]
+        hashG = self.generatetoaddress(self.nodes[1], 3, gen_address(1))[-1]
         assert_equal(self.nodes[1].getblockcount(), 5)
         assert hashC != hashG
         self.log.info("Connect nodes and check no reorg occurs")
@@ -83,7 +83,7 @@ class PreciousTest(BitcoinTestFramework):
         self.nodes[1].preciousblock(hashC)
         assert_equal(self.nodes[1].getbestblockhash(), hashC)
         self.log.info("Mine another block (E-F-G-)H on Node 0 and reorg Node 1")
-        self.nodes[0].generatetoaddress(1, gen_address(0))
+        self.generatetoaddress(self.nodes[0], 1, gen_address(0))
         assert_equal(self.nodes[0].getblockcount(), 6)
         self.sync_blocks(self.nodes[0:2])
         hashH = self.nodes[0].getbestblockhash()
@@ -92,7 +92,7 @@ class PreciousTest(BitcoinTestFramework):
         self.nodes[1].preciousblock(hashC)
         assert_equal(self.nodes[1].getbestblockhash(), hashH)
         self.log.info("Mine competing blocks I-J-K-L on Node 2")
-        self.nodes[2].generatetoaddress(4, gen_address(2))
+        self.generatetoaddress(self.nodes[2], 4, gen_address(2))
         assert_equal(self.nodes[2].getblockcount(), 6)
         hashL = self.nodes[2].getbestblockhash()
         self.log.info("Connect nodes and check no reorg occurs")

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -57,7 +57,7 @@ class PSBTTest(BitcoinTestFramework):
         online_addr = w2.getnewaddress(address_type="p2sh-segwit")
         wonline.importaddress(offline_addr, "", False)
         mining_node.sendtoaddress(address=offline_addr, amount=1.0)
-        mining_node.generate(nblocks=1)
+        self.generate(mining_node, nblocks=1)
         self.sync_blocks([mining_node, online_node])
 
         # Construct an unsigned PSBT on the online node (who doesn't know the output is Segwit, so will include a non-witness UTXO)
@@ -72,7 +72,7 @@ class PSBTTest(BitcoinTestFramework):
 
         # Make sure we can mine the resulting transaction
         txid = mining_node.sendrawtransaction(mining_node.finalizepsbt(signed_psbt)["hex"])
-        mining_node.generate(1)
+        self.generate(mining_node, 1)
         self.sync_blocks([mining_node, online_node])
         assert_equal(online_node.gettxout(txid,0)["confirmations"], 1)
 
@@ -148,7 +148,7 @@ class PSBTTest(BitcoinTestFramework):
         rawtx = self.nodes[0].fundrawtransaction(rawtx, {"changePosition":3})
         signed_tx = self.nodes[0].signrawtransactionwithwallet(rawtx['hex'])['hex']
         txid = self.nodes[0].sendrawtransaction(signed_tx)
-        self.nodes[0].generate(6)
+        self.generate(self.nodes[0], 6)
         self.sync_all()
 
         # Find the output pos
@@ -307,7 +307,7 @@ class PSBTTest(BitcoinTestFramework):
         node2_addr = self.nodes[2].getnewaddress()
         txid1 = self.nodes[0].sendtoaddress(node1_addr, 13)
         txid2 = self.nodes[0].sendtoaddress(node2_addr, 13)
-        blockhash = self.nodes[0].generate(6)[0]
+        blockhash = self.generate(self.nodes[0], 6)[0]
         self.sync_all()
         vout1 = find_output(self.nodes[1], txid1, 13, blockhash=blockhash)
         vout2 = find_output(self.nodes[2], txid2, 13, blockhash=blockhash)
@@ -335,7 +335,7 @@ class PSBTTest(BitcoinTestFramework):
         combined = self.nodes[0].combinepsbt([psbt1, psbt2])
         finalized = self.nodes[0].finalizepsbt(combined)['hex']
         self.nodes[0].sendrawtransaction(finalized)
-        self.nodes[0].generate(6)
+        self.generate(self.nodes[0], 6)
         self.sync_all()
 
         # Test additional args in walletcreatepsbt
@@ -530,7 +530,7 @@ class PSBTTest(BitcoinTestFramework):
         addr4 = self.nodes[1].getnewaddress("", "p2sh-segwit")
         txid4 = self.nodes[0].sendtoaddress(addr4, 5)
         vout4 = find_output(self.nodes[0], txid4, 5)
-        self.nodes[0].generate(6)
+        self.generate(self.nodes[0], 6)
         self.sync_all()
         psbt2 = self.nodes[1].createpsbt([{"txid":txid4, "vout":vout4}], {self.nodes[0].getnewaddress():Decimal('4.999')})
         psbt2 = self.nodes[1].walletprocesspsbt(psbt2)['psbt']
@@ -554,7 +554,7 @@ class PSBTTest(BitcoinTestFramework):
         addr = self.nodes[1].getnewaddress("", "p2sh-segwit")
         txid = self.nodes[0].sendtoaddress(addr, 7)
         addrinfo = self.nodes[1].getaddressinfo(addr)
-        blockhash = self.nodes[0].generate(6)[0]
+        blockhash = self.generate(self.nodes[0], 6)[0]
         self.sync_all()
         vout = find_output(self.nodes[0], txid, 7, blockhash=blockhash)
         psbt = self.nodes[1].createpsbt([{"txid":txid, "vout":vout}], {self.nodes[0].getnewaddress("", "p2sh-segwit"):Decimal('6.999')})

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -74,14 +74,14 @@ class RawTransactionsTest(BitcoinTestFramework):
 
     def run_test(self):
         self.log.info("Prepare some coins for multiple *rawtransaction commands")
-        self.nodes[2].generate(1)
+        self.generate(self.nodes[2], 1)
         self.sync_all()
-        self.nodes[0].generate(COINBASE_MATURITY + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
         self.sync_all()
         for amount in [1.5, 1.0, 5.0]:
             self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), amount)
         self.sync_all()
-        self.nodes[0].generate(5)
+        self.generate(self.nodes[0], 5)
         self.sync_all()
 
         self.getrawtransaction_tests()
@@ -97,13 +97,13 @@ class RawTransactionsTest(BitcoinTestFramework):
     def getrawtransaction_tests(self):
         addr = self.nodes[1].getnewaddress()
         txid = self.nodes[0].sendtoaddress(addr, 10)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
         vout = find_vout_for_address(self.nodes[1], txid, addr)
         rawTx = self.nodes[1].createrawtransaction([{'txid': txid, 'vout': vout}], {self.nodes[1].getnewaddress(): 9.999})
         rawTxSigned = self.nodes[1].signrawtransactionwithwallet(rawTx)
         txId = self.nodes[1].sendrawtransaction(rawTxSigned['hex'])
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         for n in [0, 3]:
@@ -136,7 +136,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # Make a tx by sending, then generate 2 blocks; block1 has the tx in it
         tx = self.nodes[2].sendtoaddress(self.nodes[1].getnewaddress(), 1)
-        block1, block2 = self.nodes[2].generate(2)
+        block1, block2 = self.generate(self.nodes[2], 2)
         self.sync_all()
         for n in [0, 3]:
             self.log.info(f"Test getrawtransaction {'with' if n == 0 else 'without'} -txindex, with blockhash")
@@ -368,7 +368,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[2].sendrawtransaction(hexstring=rawTxSigned['hex'], maxfeerate='0.20000000')
 
         self.log.info("Test sendrawtransaction/testmempoolaccept with tx already in the chain")
-        self.nodes[2].generate(1)
+        self.generate(self.nodes[2], 1)
         self.sync_blocks()
         for node in self.nodes:
             testres = node.testmempoolaccept([rawTxSigned['hex']])[0]
@@ -442,7 +442,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # send 1.2 BTC to msig adr
         txId = self.nodes[0].sendtoaddress(mSigObj, 1.2)
         self.sync_all()
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
         # node2 has both keys of the 2of2 ms addr, tx should affect the balance
         assert_equal(self.nodes[2].getbalance(), bal + Decimal('1.20000000'))
@@ -464,7 +464,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         decTx = self.nodes[0].gettransaction(txId)
         rawTx = self.nodes[0].decoderawtransaction(decTx['hex'])
         self.sync_all()
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         # THIS IS AN INCOMPLETE FEATURE
@@ -487,7 +487,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[2].sendrawtransaction(rawTxSigned['hex'])
         rawTx = self.nodes[0].decoderawtransaction(rawTxSigned['hex'])
         self.sync_all()
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
         assert_equal(self.nodes[0].getbalance(), bal + Decimal('50.00000000') + Decimal('2.19000000'))  # block reward + tx
 
@@ -507,7 +507,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         decTx = self.nodes[0].gettransaction(txId)
         rawTx2 = self.nodes[0].decoderawtransaction(decTx['hex'])
         self.sync_all()
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         assert_equal(self.nodes[2].getbalance(), bal)  # the funds of a 2of2 multisig tx should not be marked as spendable
@@ -532,7 +532,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[2].sendrawtransaction(rawTxComb)
         rawTx2 = self.nodes[0].decoderawtransaction(rawTxComb)
         self.sync_all()
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
         assert_equal(self.nodes[0].getbalance(), bal + Decimal('50.00000000') + Decimal('2.19000000'))  # block reward + tx
 

--- a/test/functional/rpc_scantxoutset.py
+++ b/test/functional/rpc_scantxoutset.py
@@ -23,7 +23,7 @@ class ScantxoutsetTest(BitcoinTestFramework):
 
     def run_test(self):
         self.log.info("Mining blocks...")
-        self.nodes[0].generate(110)
+        self.generate(self.nodes[0], 110)
 
         addr_P2SH_SEGWIT = self.nodes[0].getnewaddress("", "p2sh-segwit")
         pubk1 = self.nodes[0].getaddressinfo(addr_P2SH_SEGWIT)['pubkey']
@@ -50,14 +50,14 @@ class ScantxoutsetTest(BitcoinTestFramework):
         self.nodes[0].sendtoaddress("mpQ8rokAhp1TAtJQR6F6TaUmjAWkAWYYBq", 16.384) # (m/1/1/1500)
 
 
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
 
         self.log.info("Stop node, remove wallet, mine again some blocks...")
         self.stop_node(0)
         shutil.rmtree(os.path.join(self.nodes[0].datadir, self.chain, 'wallets'))
         self.start_node(0, ['-nowallet'])
         self.import_deterministic_coinbase_privkeys()
-        self.nodes[0].generate(110)
+        self.generate(self.nodes[0], 110)
 
         scan = self.nodes[0].scantxoutset("start", [])
         info = self.nodes[0].gettxoutsetinfo()

--- a/test/functional/rpc_signrawtransaction.py
+++ b/test/functional/rpc_signrawtransaction.py
@@ -183,7 +183,7 @@ class SignRawTransactionsTest(BitcoinTestFramework):
     def test_fully_signed_tx(self):
         self.log.info("Test signing a fully signed transaction does nothing")
         self.nodes[0].walletpassphrase("password", 9999)
-        self.nodes[0].generate(COINBASE_MATURITY + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
         rawtx = self.nodes[0].createrawtransaction([], [{self.nodes[0].getnewaddress(): 10}])
         fundedtx = self.nodes[0].fundrawtransaction(rawtx)
         signedtx = self.nodes[0].signrawtransactionwithwallet(fundedtx["hex"])
@@ -202,9 +202,9 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         embedded_pubkey = eckey.get_pubkey().get_bytes().hex()
         p2sh_p2wsh_address = self.nodes[1].createmultisig(1, [embedded_pubkey], "p2sh-segwit")
         # send transaction to P2SH-P2WSH 1-of-1 multisig address
-        self.nodes[0].generate(COINBASE_MATURITY + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
         self.nodes[0].sendtoaddress(p2sh_p2wsh_address["address"], 49.999)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
         # Get the UTXO info from scantxoutset
         unspent_output = self.nodes[1].scantxoutset('start', [p2sh_p2wsh_address['descriptor']])['unspents'][0]
@@ -239,7 +239,7 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         # Fund that address
         txid = self.nodes[0].sendtoaddress(addr, 10)
         vout = find_vout_for_address(self.nodes[0], txid, addr)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         # Now create and sign a transaction spending that output on node[0], which doesn't know the scripts or keys
         spending_tx = self.nodes[0].createrawtransaction([{'txid': txid, 'vout': vout}], {self.nodes[1].getnewaddress(): Decimal("9.999")})
         spending_tx_signed = self.nodes[0].signrawtransactionwithkey(spending_tx, [embedded_privkey], [{'txid': txid, 'vout': vout, 'scriptPubKey': script_pub_key, 'redeemScript': redeem_script, 'witnessScript': witness_script, 'amount': 10}])
@@ -283,7 +283,7 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         # Fund that address and make the spend
         txid = self.nodes[0].sendtoaddress(address, 1)
         vout = find_vout_for_address(self.nodes[0], txid, address)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         utxo = self.nodes[0].listunspent()[0]
         amt = Decimal(1) + utxo["amount"] - Decimal(0.00001)
         tx = self.nodes[0].createrawtransaction(
@@ -318,7 +318,7 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         # Fund that address and make the spend
         txid = self.nodes[0].sendtoaddress(address, 1)
         vout = find_vout_for_address(self.nodes[0], txid, address)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         utxo = self.nodes[0].listunspent()[0]
         amt = Decimal(1) + utxo["amount"] - Decimal(0.00001)
         tx = self.nodes[0].createrawtransaction(

--- a/test/functional/rpc_txoutproof.py
+++ b/test/functional/rpc_txoutproof.py
@@ -29,8 +29,8 @@ class MerkleBlockTest(BitcoinTestFramework):
     def run_test(self):
         miniwallet = MiniWallet(self.nodes[0])
         # Add enough mature utxos to the wallet, so that all txs spend confirmed coins
-        miniwallet.generate(5)
-        self.nodes[0].generate(COINBASE_MATURITY)
+        self.generate(miniwallet, 5)
+        self.generate(self.nodes[0], COINBASE_MATURITY)
         self.sync_all()
 
         chain_height = self.nodes[1].getblockcount()
@@ -41,7 +41,7 @@ class MerkleBlockTest(BitcoinTestFramework):
         # This will raise an exception because the transaction is not yet in a block
         assert_raises_rpc_error(-5, "Transaction not yet in block", self.nodes[0].gettxoutproof, [txid1])
 
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         blockhash = self.nodes[0].getblockhash(chain_height + 1)
         self.sync_all()
 
@@ -57,7 +57,7 @@ class MerkleBlockTest(BitcoinTestFramework):
         txin_spent = miniwallet.get_utxo()  # Get the change from txid2
         tx3 = miniwallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=txin_spent)
         txid3 = tx3['txid']
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         txid_spent = txin_spent["txid"]

--- a/test/functional/test-shell.md
+++ b/test/functional/test-shell.md
@@ -94,7 +94,7 @@ rewards to a wallet address owned by the mining node.
 
 ```
 >>> address = test.nodes[0].getnewaddress()
->>> test.nodes[0].generatetoaddress(101, address)
+>>> test.self.generatetoaddress(nodes[0], 101, address)
 ['2b98dd0044aae6f1cca7f88a0acf366a4bfe053c7f7b00da3c0d115f03d67efb', ...
 ```
 Since the two nodes are both initialized by default to establish an outbound

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -242,7 +242,7 @@ class ToolWalletTest(BitcoinTestFramework):
         """
         self.start_node(0)
         self.log.info('Generating transaction to mutate wallet')
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.stop_node(0)
 
         self.log.info('Calling wallet tool info after generating a transaction, testing output')

--- a/test/functional/wallet_abandonconflict.py
+++ b/test/functional/wallet_abandonconflict.py
@@ -29,14 +29,14 @@ class AbandonConflictTest(BitcoinTestFramework):
         self.skip_if_no_wallet()
 
     def run_test(self):
-        self.nodes[1].generate(COINBASE_MATURITY)
+        self.generate(self.nodes[1], COINBASE_MATURITY)
         self.sync_blocks()
         balance = self.nodes[0].getbalance()
         txA = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
         txB = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
         txC = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
         self.sync_mempools()
-        self.nodes[1].generate(1)
+        self.generate(self.nodes[1], 1)
 
         # Can not abandon non-wallet transaction
         assert_raises_rpc_error(-5, 'Invalid or non-wallet transaction id', lambda: self.nodes[0].abandontransaction(txid='ff' * 32))
@@ -158,7 +158,7 @@ class AbandonConflictTest(BitcoinTestFramework):
         tx = self.nodes[0].createrawtransaction(inputs, outputs)
         signed = self.nodes[0].signrawtransactionwithwallet(tx)
         self.nodes[1].sendrawtransaction(signed["hex"])
-        self.nodes[1].generate(1)
+        self.generate(self.nodes[1], 1)
 
         self.connect_nodes(0, 1)
         self.sync_blocks()

--- a/test/functional/wallet_address_types.py
+++ b/test/functional/wallet_address_types.py
@@ -221,7 +221,7 @@ class AddressTypeTest(BitcoinTestFramework):
     def run_test(self):
         # Mine 101 blocks on node5 to bring nodes out of IBD and make sure that
         # no coinbases are maturing for the nodes-under-test during the test
-        self.nodes[5].generate(COINBASE_MATURITY + 1)
+        self.generate(self.nodes[5], COINBASE_MATURITY + 1)
         self.sync_blocks()
 
         uncompressed_1 = "0496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858ee"
@@ -306,7 +306,7 @@ class AddressTypeTest(BitcoinTestFramework):
                 assert_equal(unconf_balances[to_node], to_send * 10 * (2 + n))
 
             # node5 collects fee and block subsidy to keep accounting simple
-            self.nodes[5].generate(1)
+            self.generate(self.nodes[5], 1)
             self.sync_blocks()
 
             # Verify that the receiving wallet contains a UTXO with the expected address, and expected descriptor
@@ -336,7 +336,7 @@ class AddressTypeTest(BitcoinTestFramework):
 
         # Fund node 4:
         self.nodes[5].sendtoaddress(self.nodes[4].getnewaddress(), Decimal("1"))
-        self.nodes[5].generate(1)
+        self.generate(self.nodes[5], 1)
         self.sync_blocks()
         assert_equal(self.nodes[4].getbalance(), 1)
 

--- a/test/functional/wallet_avoidreuse.py
+++ b/test/functional/wallet_avoidreuse.py
@@ -79,7 +79,7 @@ class AvoidReuseTest(BitcoinTestFramework):
         self.test_persistence()
         self.test_immutable()
 
-        self.nodes[0].generate(110)
+        self.generate(self.nodes[0], 110)
         self.sync_all()
         self.test_change_remains_change(self.nodes[1])
         reset_balance(self.nodes[1], self.nodes[0].getnewaddress())
@@ -174,7 +174,7 @@ class AvoidReuseTest(BitcoinTestFramework):
         retaddr = self.nodes[0].getnewaddress()
 
         self.nodes[0].sendtoaddress(fundaddr, 10)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         # listunspent should show 1 single, unused 10 btc output
@@ -185,7 +185,7 @@ class AvoidReuseTest(BitcoinTestFramework):
         assert("used" not in self.nodes[0].getbalances()["mine"])
 
         self.nodes[1].sendtoaddress(retaddr, 5)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         # listunspent should show 1 single, unused 5 btc output
@@ -194,7 +194,7 @@ class AvoidReuseTest(BitcoinTestFramework):
         assert_balances(self.nodes[1], mine={"used": 0, "trusted": 5})
 
         self.nodes[0].sendtoaddress(fundaddr, 10)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         # listunspent should show 2 total outputs (5, 10 btc), one unused (5), one reused (10)
@@ -228,7 +228,7 @@ class AvoidReuseTest(BitcoinTestFramework):
         retaddr = self.nodes[0].getnewaddress()
 
         self.nodes[0].sendtoaddress(fundaddr, 10)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         # listunspent should show 1 single, unused 10 btc output
@@ -237,7 +237,7 @@ class AvoidReuseTest(BitcoinTestFramework):
         assert_balances(self.nodes[1], mine={"used": 0, "trusted": 10})
 
         self.nodes[1].sendtoaddress(retaddr, 5)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         # listunspent should show 1 single, unused 5 btc output
@@ -259,7 +259,7 @@ class AvoidReuseTest(BitcoinTestFramework):
                 assert_equal(second_addr_type, "legacy")
 
             self.nodes[0].sendtoaddress(new_fundaddr, 10)
-            self.nodes[0].generate(1)
+            self.generate(self.nodes[0], 1)
             self.sync_all()
 
             # listunspent should show 2 total outputs (5, 10 btc), one unused (5), one reused (10)
@@ -302,7 +302,7 @@ class AvoidReuseTest(BitcoinTestFramework):
         for _ in range(101):
             self.nodes[0].sendtoaddress(new_addr, 1)
 
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         # send transaction that should not use all the available outputs
@@ -334,7 +334,7 @@ class AvoidReuseTest(BitcoinTestFramework):
         for _ in range(101):
             self.nodes[0].sendtoaddress(new_addr, 1)
 
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         # Sending a transaction that is smaller than each one of the
@@ -363,7 +363,7 @@ class AvoidReuseTest(BitcoinTestFramework):
         for _ in range(202):
             self.nodes[0].sendtoaddress(new_addr, 1)
 
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         # Sending a transaction that needs to use the full groups

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -88,7 +88,7 @@ class WalletBackupTest(BitcoinTestFramework):
         # Have the miner (node3) mine a block.
         # Must sync mempools before mining.
         self.sync_mempools()
-        self.nodes[3].generate(1)
+        self.generate(self.nodes[3], 1)
         self.sync_blocks()
 
     # As above, this mirrors the original bash test.
@@ -130,13 +130,13 @@ class WalletBackupTest(BitcoinTestFramework):
 
     def run_test(self):
         self.log.info("Generating initial blockchain")
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_blocks()
-        self.nodes[1].generate(1)
+        self.generate(self.nodes[1], 1)
         self.sync_blocks()
-        self.nodes[2].generate(1)
+        self.generate(self.nodes[2], 1)
         self.sync_blocks()
-        self.nodes[3].generate(COINBASE_MATURITY)
+        self.generate(self.nodes[3], COINBASE_MATURITY)
         self.sync_blocks()
 
         assert_equal(self.nodes[0].getbalance(), 50)
@@ -165,7 +165,7 @@ class WalletBackupTest(BitcoinTestFramework):
             self.do_one_round()
 
         # Generate 101 more blocks, so any fees paid mature
-        self.nodes[3].generate(COINBASE_MATURITY + 1)
+        self.generate(self.nodes[3], COINBASE_MATURITY + 1)
         self.sync_all()
 
         balance0 = self.nodes[0].getbalance()

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -70,10 +70,10 @@ class WalletTest(BitcoinTestFramework):
             assert 'watchonly' not in self.nodes[1].getbalances()
 
         self.log.info("Mining blocks ...")
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
-        self.nodes[1].generate(1)
-        self.nodes[1].generatetoaddress(COINBASE_MATURITY + 1, ADDRESS_WATCHONLY)
+        self.generate(self.nodes[1], 1)
+        self.generatetoaddress(self.nodes[1], COINBASE_MATURITY + 1, ADDRESS_WATCHONLY)
         self.sync_all()
 
         if not self.options.descriptors:
@@ -196,7 +196,7 @@ class WalletTest(BitcoinTestFramework):
         self.log.info("Test getbalance and getbalances.mine.untrusted_pending with conflicted unconfirmed inputs")
         test_balances(fee_node_1=Decimal('0.02'))
 
-        self.nodes[1].generatetoaddress(1, ADDRESS_WATCHONLY)
+        self.generatetoaddress(self.nodes[1], 1, ADDRESS_WATCHONLY)
         self.sync_all()
 
         # balances are correct after the transactions are confirmed
@@ -210,7 +210,7 @@ class WalletTest(BitcoinTestFramework):
         # Send total balance away from node 1
         txs = create_transactions(self.nodes[1], self.nodes[0].getnewaddress(), Decimal('29.97'), [Decimal('0.01')])
         self.nodes[1].sendrawtransaction(txs[0]['hex'])
-        self.nodes[1].generatetoaddress(2, ADDRESS_WATCHONLY)
+        self.generatetoaddress(self.nodes[1], 2, ADDRESS_WATCHONLY)
         self.sync_all()
 
         # getbalance with a minconf incorrectly excludes coins that have been spent more recently than the minconf blocks ago
@@ -257,7 +257,7 @@ class WalletTest(BitcoinTestFramework):
         self.nodes[1].sendrawtransaction(hexstring=tx_replace, maxfeerate=0)
 
         # Now confirm tx_replace
-        block_reorg = self.nodes[1].generatetoaddress(1, ADDRESS_WATCHONLY)[0]
+        block_reorg = self.generatetoaddress(self.nodes[1], 1, ADDRESS_WATCHONLY)[0]
         self.sync_all()
         assert_equal(self.nodes[0].getbalance(minconf=0), total_amount)
 
@@ -265,7 +265,7 @@ class WalletTest(BitcoinTestFramework):
         self.nodes[0].invalidateblock(block_reorg)
         self.nodes[1].invalidateblock(block_reorg)
         assert_equal(self.nodes[0].getbalance(minconf=0), 0)  # wallet txs not in the mempool are untrusted
-        self.nodes[0].generatetoaddress(1, ADDRESS_WATCHONLY)
+        self.generatetoaddress(self.nodes[0], 1, ADDRESS_WATCHONLY)
         assert_equal(self.nodes[0].getbalance(minconf=0), 0)  # wallet txs not in the mempool are untrusted
 
         # Now confirm tx_orig
@@ -273,7 +273,7 @@ class WalletTest(BitcoinTestFramework):
         self.connect_nodes(0, 1)
         self.sync_blocks()
         self.nodes[1].sendrawtransaction(tx_orig)
-        self.nodes[1].generatetoaddress(1, ADDRESS_WATCHONLY)
+        self.generatetoaddress(self.nodes[1], 1, ADDRESS_WATCHONLY)
         self.sync_all()
         assert_equal(self.nodes[0].getbalance(minconf=0), total_amount + 1)  # The reorg recovered our fee of 1 coin
 

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -59,14 +59,14 @@ class WalletTest(BitcoinTestFramework):
 
         self.log.info("Mining blocks...")
 
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
 
         walletinfo = self.nodes[0].getwalletinfo()
         assert_equal(walletinfo['immature_balance'], 50)
         assert_equal(walletinfo['balance'], 0)
 
         self.sync_all(self.nodes[0:3])
-        self.nodes[1].generate(COINBASE_MATURITY + 1)
+        self.generate(self.nodes[1], COINBASE_MATURITY + 1)
         self.sync_all(self.nodes[0:3])
 
         assert_equal(self.nodes[0].getbalance(), 50)
@@ -115,7 +115,7 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(walletinfo['immature_balance'], 0)
 
         # Have node0 mine a block, thus it will collect its own fee.
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all(self.nodes[0:3])
 
         # Exercise locking of unspent outputs
@@ -159,7 +159,7 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(len(self.nodes[1].listlockunspent()), 0)
 
         # Have node1 generate 100 blocks (so node0 can recover the fee)
-        self.nodes[1].generate(COINBASE_MATURITY)
+        self.generate(self.nodes[1], COINBASE_MATURITY)
         self.sync_all(self.nodes[0:3])
 
         # node0 should end up with 100 btc in block rewards plus fees, but
@@ -188,7 +188,7 @@ class WalletTest(BitcoinTestFramework):
         self.nodes[1].sendrawtransaction(hexstring=txns_to_send[1]["hex"], maxfeerate=0)
 
         # Have node1 mine a block to confirm transactions:
-        self.nodes[1].generate(1)
+        self.generate(self.nodes[1], 1)
         self.sync_all(self.nodes[0:3])
 
         assert_equal(self.nodes[0].getbalance(), 0)
@@ -203,14 +203,14 @@ class WalletTest(BitcoinTestFramework):
         fee_per_byte = Decimal('0.001') / 1000
         self.nodes[2].settxfee(fee_per_byte * 1000)
         txid = self.nodes[2].sendtoaddress(address, 10, "", "", False)
-        self.nodes[2].generate(1)
+        self.generate(self.nodes[2], 1)
         self.sync_all(self.nodes[0:3])
         node_2_bal = self.check_fee_amount(self.nodes[2].getbalance(), Decimal('84'), fee_per_byte, self.get_vsize(self.nodes[2].gettransaction(txid)['hex']))
         assert_equal(self.nodes[0].getbalance(), Decimal('10'))
 
         # Send 10 BTC with subtract fee from amount
         txid = self.nodes[2].sendtoaddress(address, 10, "", "", True)
-        self.nodes[2].generate(1)
+        self.generate(self.nodes[2], 1)
         self.sync_all(self.nodes[0:3])
         node_2_bal -= Decimal('10')
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
@@ -220,7 +220,7 @@ class WalletTest(BitcoinTestFramework):
 
         # Sendmany 10 BTC
         txid = self.nodes[2].sendmany('', {address: 10}, 0, "", [])
-        self.nodes[2].generate(1)
+        self.generate(self.nodes[2], 1)
         self.sync_all(self.nodes[0:3])
         node_0_bal += Decimal('10')
         node_2_bal = self.check_fee_amount(self.nodes[2].getbalance(), node_2_bal - Decimal('10'), fee_per_byte, self.get_vsize(self.nodes[2].gettransaction(txid)['hex']))
@@ -228,7 +228,7 @@ class WalletTest(BitcoinTestFramework):
 
         # Sendmany 10 BTC with subtract fee from amount
         txid = self.nodes[2].sendmany('', {address: 10}, 0, "", [address])
-        self.nodes[2].generate(1)
+        self.generate(self.nodes[2], 1)
         self.sync_all(self.nodes[0:3])
         node_2_bal -= Decimal('10')
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
@@ -241,7 +241,7 @@ class WalletTest(BitcoinTestFramework):
 
         # Test passing fee_rate as a string
         txid = self.nodes[2].sendmany(amounts={address: 10}, fee_rate=str(fee_rate_sat_vb))
-        self.nodes[2].generate(1)
+        self.generate(self.nodes[2], 1)
         self.sync_all(self.nodes[0:3])
         balance = self.nodes[2].getbalance()
         node_2_bal = self.check_fee_amount(balance, node_2_bal - Decimal('10'), explicit_fee_rate_btc_kvb, self.get_vsize(self.nodes[2].gettransaction(txid)['hex']))
@@ -252,7 +252,7 @@ class WalletTest(BitcoinTestFramework):
         # Test passing fee_rate as an integer
         amount = Decimal("0.0001")
         txid = self.nodes[2].sendmany(amounts={address: amount}, fee_rate=fee_rate_sat_vb)
-        self.nodes[2].generate(1)
+        self.generate(self.nodes[2], 1)
         self.sync_all(self.nodes[0:3])
         balance = self.nodes[2].getbalance()
         node_2_bal = self.check_fee_amount(balance, node_2_bal - amount, explicit_fee_rate_btc_kvb, self.get_vsize(self.nodes[2].gettransaction(txid)['hex']))
@@ -314,7 +314,7 @@ class WalletTest(BitcoinTestFramework):
         self.nodes[1].sendrawtransaction(signed_raw_tx['hex'])
 
         self.sync_all()
-        self.nodes[1].generate(1)  # mine a block
+        self.generate(self.nodes[1], 1)  # mine a block
         self.sync_all()
 
         unspent_txs = self.nodes[0].listunspent()  # zero value tx must be in listunspents output
@@ -337,13 +337,13 @@ class WalletTest(BitcoinTestFramework):
 
         txid_not_broadcast = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 2)
         tx_obj_not_broadcast = self.nodes[0].gettransaction(txid_not_broadcast)
-        self.nodes[1].generate(1)  # mine a block, tx should not be in there
+        self.generate(self.nodes[1], 1)  # mine a block, tx should not be in there
         self.sync_all(self.nodes[0:3])
         assert_equal(self.nodes[2].getbalance(), node_2_bal)  # should not be changed because tx was not broadcasted
 
         # now broadcast from another node, mine a block, sync, and check the balance
         self.nodes[1].sendrawtransaction(tx_obj_not_broadcast['hex'])
-        self.nodes[1].generate(1)
+        self.generate(self.nodes[1], 1)
         self.sync_all(self.nodes[0:3])
         node_2_bal += 2
         tx_obj_not_broadcast = self.nodes[0].gettransaction(txid_not_broadcast)
@@ -362,7 +362,7 @@ class WalletTest(BitcoinTestFramework):
         self.connect_nodes(0, 2)
         self.sync_blocks(self.nodes[0:3])
 
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_blocks(self.nodes[0:3])
         node_2_bal += 2
 
@@ -391,7 +391,7 @@ class WalletTest(BitcoinTestFramework):
         assert_raises_rpc_error(-3, "Invalid amount", self.nodes[0].sendtoaddress, self.nodes[2].getnewaddress(), "1f-4")
 
         # This will raise an exception since generate does not accept a string
-        assert_raises_rpc_error(-1, "not an integer", self.nodes[0].generate, "2")
+        assert_raises_rpc_error(-1, "not an integer", self.generate, self.nodes[0], "2")
 
         if not self.options.descriptors:
 
@@ -427,7 +427,7 @@ class WalletTest(BitcoinTestFramework):
             # 1. Send some coins to generate new UTXO
             address_to_import = self.nodes[2].getnewaddress()
             txid = self.nodes[0].sendtoaddress(address_to_import, 1)
-            self.nodes[0].generate(1)
+            self.generate(self.nodes[0], 1)
             self.sync_all(self.nodes[0:3])
 
             self.log.info("Test sendtoaddress with fee_rate param (explicit fee rate in sat/vB)")
@@ -440,7 +440,7 @@ class WalletTest(BitcoinTestFramework):
             # Test passing fee_rate as an integer
             txid = self.nodes[2].sendtoaddress(address=address, amount=amount, fee_rate=fee_rate_sat_vb)
             tx_size = self.get_vsize(self.nodes[2].gettransaction(txid)['hex'])
-            self.nodes[0].generate(1)
+            self.generate(self.nodes[0], 1)
             self.sync_all(self.nodes[0:3])
             postbalance = self.nodes[2].getbalance()
             fee = prebalance - postbalance - Decimal(amount)
@@ -453,7 +453,7 @@ class WalletTest(BitcoinTestFramework):
             # Test passing fee_rate as a string
             txid = self.nodes[2].sendtoaddress(address=address, amount=amount, fee_rate=str(fee_rate_sat_vb))
             tx_size = self.get_vsize(self.nodes[2].gettransaction(txid)['hex'])
-            self.nodes[0].generate(1)
+            self.generate(self.nodes[0], 1)
             self.sync_all(self.nodes[0:3])
             postbalance = self.nodes[2].getbalance()
             fee = prebalance - postbalance - amount
@@ -515,7 +515,7 @@ class WalletTest(BitcoinTestFramework):
 
         # Mine a block from node0 to an address from node1
         coinbase_addr = self.nodes[1].getnewaddress()
-        block_hash = self.nodes[0].generatetoaddress(1, coinbase_addr)[0]
+        block_hash = self.generatetoaddress(self.nodes[0], 1, coinbase_addr)[0]
         coinbase_txid = self.nodes[0].getblock(block_hash)['tx'][0]
         self.sync_all(self.nodes[0:3])
 
@@ -524,7 +524,7 @@ class WalletTest(BitcoinTestFramework):
 
         # check if wallet or blockchain maintenance changes the balance
         self.sync_all(self.nodes[0:3])
-        blocks = self.nodes[0].generate(2)
+        blocks = self.generate(self.nodes[0], 2)
         self.sync_all(self.nodes[0:3])
         balance_nodes = [self.nodes[i].getbalance() for i in range(3)]
         block_count = self.nodes[0].getblockcount()
@@ -572,13 +572,13 @@ class WalletTest(BitcoinTestFramework):
         # Get all non-zero utxos together
         chain_addrs = [self.nodes[0].getnewaddress(), self.nodes[0].getnewaddress()]
         singletxid = self.nodes[0].sendtoaddress(chain_addrs[0], self.nodes[0].getbalance(), "", "", True)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         node0_balance = self.nodes[0].getbalance()
         # Split into two chains
         rawtx = self.nodes[0].createrawtransaction([{"txid": singletxid, "vout": 0}], {chain_addrs[0]: node0_balance / 2 - Decimal('0.01'), chain_addrs[1]: node0_balance / 2 - Decimal('0.01')})
         signedtx = self.nodes[0].signrawtransactionwithwallet(rawtx)
         singletxid = self.nodes[0].sendrawtransaction(hexstring=signedtx["hex"], maxfeerate=0)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
 
         # Make a long chain of unconfirmed payments without hitting mempool limit
         # Each tx we make leaves only one output of change on a chain 1 longer
@@ -629,7 +629,7 @@ class WalletTest(BitcoinTestFramework):
         assert not address_info["ischange"]
 
         # Test getaddressinfo 'ischange' field on change address.
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         destination = self.nodes[1].getnewaddress()
         txid = self.nodes[0].sendtoaddress(destination, 0.123)
         tx = self.nodes[0].decoderawtransaction(self.nodes[0].gettransaction(txid)['hex'])

--- a/test/functional/wallet_coinbase_category.py
+++ b/test/functional/wallet_coinbase_category.py
@@ -33,7 +33,7 @@ class CoinbaseCategoryTest(BitcoinTestFramework):
     def run_test(self):
         # Generate one block to an address
         address = self.nodes[0].getnewaddress()
-        self.nodes[0].generatetoaddress(1, address)
+        self.generatetoaddress(self.nodes[0], 1, address)
         hash = self.nodes[0].getbestblockhash()
         txid = self.nodes[0].getblock(hash)["tx"][0]
 
@@ -41,12 +41,12 @@ class CoinbaseCategoryTest(BitcoinTestFramework):
         self.assert_category("immature", address, txid, 0)
 
         # Mine another 99 blocks on top
-        self.nodes[0].generate(99)
+        self.generate(self.nodes[0], 99)
         # Coinbase transaction is still immature after 100 confirmations
         self.assert_category("immature", address, txid, 99)
 
         # Mine one more block
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         # Coinbase transaction is now matured, so category is "generate"
         self.assert_category("generate", address, txid, 100)
 

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -24,7 +24,7 @@ class CreateTxWalletTest(BitcoinTestFramework):
     def run_test(self):
         self.log.info('Create some old blocks')
         self.nodes[0].setmocktime(TIME_GENESIS_BLOCK)
-        self.nodes[0].generate(200)
+        self.generate(self.nodes[0], 200)
         self.nodes[0].setmocktime(0)
 
         self.test_anti_fee_sniping()
@@ -38,7 +38,7 @@ class CreateTxWalletTest(BitcoinTestFramework):
         assert_equal(tx['locktime'], 0)
 
         self.log.info('Check that anti-fee-sniping is enabled when we mine a recent block')
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
         tx = self.nodes[0].decoderawtransaction(self.nodes[0].gettransaction(txid)['hex'])
         assert 0 < tx['locktime'] <= 201

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -24,7 +24,7 @@ class CreateWalletTest(BitcoinTestFramework):
 
     def run_test(self):
         node = self.nodes[0]
-        node.generate(1) # Leave IBD for sethdseed
+        self.generate(node, 1) # Leave IBD for sethdseed
 
         self.nodes[0].createwallet(wallet_name='w0')
         w0 = node.get_wallet_rpc('w0')

--- a/test/functional/wallet_disable.py
+++ b/test/functional/wallet_disable.py
@@ -28,8 +28,8 @@ class DisableWalletTest (BitcoinTestFramework):
 
         # Checking mining to an address without a wallet. Generating to a valid address should succeed
         # but generating to an invalid address will fail.
-        self.nodes[0].generatetoaddress(1, 'mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ')
-        assert_raises_rpc_error(-5, "Invalid address", self.nodes[0].generatetoaddress, 1, '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')
+        self.generatetoaddress(self.nodes[0], 1, 'mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ')
+        assert_raises_rpc_error(-5, "Invalid address", self.generatetoaddress, self.nodes[0], 1, '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')
 
 if __name__ == '__main__':
     DisableWalletTest ().main ()

--- a/test/functional/wallet_dump.py
+++ b/test/functional/wallet_dump.py
@@ -134,7 +134,7 @@ class WalletDumpTest(BitcoinTestFramework):
         self.log.info('Mine a block one second before the wallet is dumped')
         dump_time = int(time.time())
         self.nodes[0].setmocktime(dump_time - 1)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.nodes[0].setmocktime(dump_time)
         dump_time_str = '# * Created on {}Z'.format(
             datetime.datetime.fromtimestamp(

--- a/test/functional/wallet_fallbackfee.py
+++ b/test/functional/wallet_fallbackfee.py
@@ -17,7 +17,7 @@ class WalletRBFTest(BitcoinTestFramework):
         self.skip_if_no_wallet()
 
     def run_test(self):
-        self.nodes[0].generate(COINBASE_MATURITY + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
 
         # sending a transaction without fee estimations must be possible by default on regtest
         self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -34,7 +34,7 @@ class WalletGroupTest(BitcoinTestFramework):
     def run_test(self):
         self.log.info("Setting up")
         # Mine some coins
-        self.nodes[0].generate(COINBASE_MATURITY + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
 
         # Get some addresses from the two nodes
         addr1 = [self.nodes[1].getnewaddress() for _ in range(3)]
@@ -45,7 +45,7 @@ class WalletGroupTest(BitcoinTestFramework):
         [self.nodes[0].sendtoaddress(addr, 1.0) for addr in addrs]
         [self.nodes[0].sendtoaddress(addr, 0.5) for addr in addrs]
 
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         # For each node, send 0.2 coins back to 0;
@@ -77,7 +77,7 @@ class WalletGroupTest(BitcoinTestFramework):
 
         self.log.info("Test avoiding partial spends if warranted, even if avoidpartialspends is disabled")
         self.sync_all()
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         # Nodes 1-2 now have confirmed UTXOs (letters denote destinations):
         # Node #1:      Node #2:
         # - A  1.0      - D0 1.0
@@ -113,7 +113,7 @@ class WalletGroupTest(BitcoinTestFramework):
         addr_aps = self.nodes[3].getnewaddress()
         self.nodes[0].sendtoaddress(addr_aps, 1.0)
         self.nodes[0].sendtoaddress(addr_aps, 1.0)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
         with self.nodes[3].assert_debug_log(['Fee non-grouped = 2820, grouped = 4160, using grouped']):
             txid4 = self.nodes[3].sendtoaddress(self.nodes[0].getnewaddress(), 0.1)
@@ -125,7 +125,7 @@ class WalletGroupTest(BitcoinTestFramework):
 
         addr_aps2 = self.nodes[3].getnewaddress()
         [self.nodes[0].sendtoaddress(addr_aps2, 1.0) for _ in range(5)]
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
         with self.nodes[3].assert_debug_log(['Fee non-grouped = 5520, grouped = 8240, using non-grouped']):
             txid5 = self.nodes[3].sendtoaddress(self.nodes[0].getnewaddress(), 2.95)
@@ -139,7 +139,7 @@ class WalletGroupTest(BitcoinTestFramework):
         self.log.info("Test wallet option maxapsfee threshold from non-grouped to grouped")
         addr_aps3 = self.nodes[4].getnewaddress()
         [self.nodes[0].sendtoaddress(addr_aps3, 1.0) for _ in range(5)]
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
         with self.nodes[4].assert_debug_log(['Fee non-grouped = 5520, grouped = 8240, using grouped']):
             txid6 = self.nodes[4].sendtoaddress(self.nodes[0].getnewaddress(), 2.95)
@@ -151,7 +151,7 @@ class WalletGroupTest(BitcoinTestFramework):
         # Empty out node2's wallet
         self.nodes[2].sendtoaddress(address=self.nodes[0].getnewaddress(), amount=self.nodes[2].getbalance(), subtractfeefromamount=True)
         self.sync_all()
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
 
         self.log.info("Fill a wallet with 10,000 outputs corresponding to the same scriptPubKey")
         for _ in range(5):
@@ -162,7 +162,7 @@ class WalletGroupTest(BitcoinTestFramework):
             funded_tx = self.nodes[0].fundrawtransaction(tx.serialize().hex())
             signed_tx = self.nodes[0].signrawtransactionwithwallet(funded_tx['hex'])
             self.nodes[0].sendrawtransaction(signed_tx['hex'])
-            self.nodes[0].generate(1)
+            self.generate(self.nodes[0], 1)
             self.sync_all()
 
         # Check that we can create a transaction that only requires ~100 of our

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -49,7 +49,7 @@ class WalletHDTest(BitcoinTestFramework):
 
         # Derive some HD addresses and remember the last
         # Also send funds to each add
-        self.nodes[0].generate(COINBASE_MATURITY + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
         hd_add = None
         NUM_HD_ADDS = 10
         for i in range(1, NUM_HD_ADDS + 1):
@@ -61,9 +61,9 @@ class WalletHDTest(BitcoinTestFramework):
                 assert_equal(hd_info["hdkeypath"], "m/0'/0'/" + str(i) + "'")
             assert_equal(hd_info["hdmasterfingerprint"], hd_fingerprint)
             self.nodes[0].sendtoaddress(hd_add, 1)
-            self.nodes[0].generate(1)
+            self.generate(self.nodes[0], 1)
         self.nodes[0].sendtoaddress(non_hd_add, 1)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
 
         # create an internal key (again)
         change_addr = self.nodes[1].getrawchangeaddress()
@@ -179,7 +179,7 @@ class WalletHDTest(BitcoinTestFramework):
             assert_raises_rpc_error(-5, "Already have this key", self.nodes[1].sethdseed, False, self.nodes[1].dumpprivkey(self.nodes[1].getnewaddress()))
 
             self.log.info('Test sethdseed restoring with keys outside of the initial keypool')
-            self.nodes[0].generate(10)
+            self.generate(self.nodes[0], 10)
             # Restart node 1 with keypool of 3 and a different wallet
             self.nodes[1].createwallet(wallet_name='origin', blank=True)
             self.restart_node(1, extra_args=['-keypool=3', '-wallet=origin'])
@@ -228,7 +228,7 @@ class WalletHDTest(BitcoinTestFramework):
             # The wallet that has set a new seed (restore_rpc) should not detect this transaction.
             txid = self.nodes[0].sendtoaddress(addr, 1)
             origin_rpc.sendrawtransaction(self.nodes[0].gettransaction(txid)['hex'])
-            self.nodes[0].generate(1)
+            self.generate(self.nodes[0], 1)
             self.sync_blocks()
             origin_rpc.gettransaction(txid)
             assert_raises_rpc_error(-5, 'Invalid or non-wallet transaction id', restore_rpc.gettransaction, txid)
@@ -239,7 +239,7 @@ class WalletHDTest(BitcoinTestFramework):
             # The previous transaction (out_of_kp_txid) should still not be detected as a rescan is required.
             txid = self.nodes[0].sendtoaddress(last_addr, 1)
             origin_rpc.sendrawtransaction(self.nodes[0].gettransaction(txid)['hex'])
-            self.nodes[0].generate(1)
+            self.generate(self.nodes[0], 1)
             self.sync_blocks()
             origin_rpc.gettransaction(txid)
             restore_rpc.gettransaction(txid)

--- a/test/functional/wallet_import_rescan.py
+++ b/test/functional/wallet_import_rescan.py
@@ -178,7 +178,7 @@ class ImportRescanTest(BitcoinTestFramework):
             variant.key = self.nodes[1].dumpprivkey(variant.address["address"])
             variant.initial_amount = get_rand_amount()
             variant.initial_txid = self.nodes[0].sendtoaddress(variant.address["address"], variant.initial_amount)
-            self.nodes[0].generate(1)  # Generate one block for each send
+            self.generate(self.nodes[0], 1)  # Generate one block for each send
             variant.confirmation_height = self.nodes[0].getblockcount()
             variant.timestamp = self.nodes[0].getblockheader(self.nodes[0].getbestblockhash())["time"]
         self.sync_all() # Conclude sync before calling setmocktime to avoid timeouts
@@ -189,7 +189,7 @@ class ImportRescanTest(BitcoinTestFramework):
             self.nodes,
             self.nodes[0].getblockheader(self.nodes[0].getbestblockhash())["time"] + TIMESTAMP_WINDOW + 1,
         )
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         # For each variation of wallet key import, invoke the import RPC and
@@ -212,7 +212,7 @@ class ImportRescanTest(BitcoinTestFramework):
         for i, variant in enumerate(IMPORT_VARIANTS):
             variant.sent_amount = get_rand_amount()
             variant.sent_txid = self.nodes[0].sendtoaddress(variant.address["address"], variant.sent_amount)
-            self.nodes[0].generate(1)  # Generate one block for each send
+            self.generate(self.nodes[0], 1)  # Generate one block for each send
             variant.confirmation_height = self.nodes[0].getblockcount()
 
         assert_equal(self.nodes[0].getrawmempool(), [])

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -451,12 +451,12 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         assert_equal(change_addr, 'bcrt1qt9uhe3a9hnq7vajl7a094z4s3crm9ttf8zw3f5v9gr2nyd7e3lnsy44n8e')
         assert_equal(wmulti_priv.getwalletinfo()['keypoolsize'], 1000)
         txid = w0.sendtoaddress(addr, 10)
-        self.nodes[0].generate(6)
+        self.generate(self.nodes[0], 6)
         self.sync_all()
         send_txid = wmulti_priv.sendtoaddress(w0.getnewaddress(), 8)
         decoded = wmulti_priv.decoderawtransaction(wmulti_priv.gettransaction(send_txid)['hex'])
         assert_equal(len(decoded['vin'][0]['txinwitness']), 4)
-        self.nodes[0].generate(6)
+        self.generate(self.nodes[0], 6)
         self.sync_all()
 
         self.nodes[1].createwallet(wallet_name="wmulti_pub", disable_private_keys=True, blank=True, descriptors=True)
@@ -494,7 +494,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         txid2 = w0.sendtoaddress(addr2, 10)
         vout2 = find_vout_for_address(self.nodes[0], txid2, addr2)
 
-        self.nodes[0].generate(6)
+        self.generate(self.nodes[0], 6)
         self.sync_all()
         assert_equal(wmulti_pub.getbalance(), wmulti_priv.getbalance())
 
@@ -582,7 +582,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
 
         addr = wmulti_priv_big.getnewaddress()
         w0.sendtoaddress(addr, 10)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
         # It is standard and would relay.
         txid = wmulti_priv_big.sendtoaddress(w0.getnewaddress(), 9.999)
@@ -617,7 +617,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
 
         addr = multi_priv_big.getnewaddress("", "legacy")
         w0.sendtoaddress(addr, 10)
-        self.nodes[0].generate(6)
+        self.generate(self.nodes[0], 6)
         self.sync_all()
         # It is standard and would relay.
         txid = multi_priv_big.sendtoaddress(w0.getnewaddress(), 10, "", "",

--- a/test/functional/wallet_importmulti.py
+++ b/test/functional/wallet_importmulti.py
@@ -62,8 +62,8 @@ class ImportMultiTest(BitcoinTestFramework):
 
     def run_test(self):
         self.log.info("Mining blocks...")
-        self.nodes[0].generate(1)
-        self.nodes[1].generate(1)
+        self.generate(self.nodes[0], 1)
+        self.generate(self.nodes[1], 1)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
         self.nodes[1].syncwithvalidationinterfacequeue()  # Sync the timestamp to the wallet, so that importmulti works
 
@@ -256,9 +256,9 @@ class ImportMultiTest(BitcoinTestFramework):
 
         # P2SH address
         multisig = get_multisig(self.nodes[0])
-        self.nodes[1].generate(COINBASE_MATURITY)
+        self.generate(self.nodes[1], COINBASE_MATURITY)
         self.nodes[1].sendtoaddress(multisig.p2sh_addr, 10.00)
-        self.nodes[1].generate(1)
+        self.generate(self.nodes[1], 1)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
         self.nodes[1].syncwithvalidationinterfacequeue()
 
@@ -277,9 +277,9 @@ class ImportMultiTest(BitcoinTestFramework):
 
         # P2SH + Redeem script
         multisig = get_multisig(self.nodes[0])
-        self.nodes[1].generate(COINBASE_MATURITY)
+        self.generate(self.nodes[1], COINBASE_MATURITY)
         self.nodes[1].sendtoaddress(multisig.p2sh_addr, 10.00)
-        self.nodes[1].generate(1)
+        self.generate(self.nodes[1], 1)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
         self.nodes[1].syncwithvalidationinterfacequeue()
 
@@ -298,9 +298,9 @@ class ImportMultiTest(BitcoinTestFramework):
 
         # P2SH + Redeem script + Private Keys + !Watchonly
         multisig = get_multisig(self.nodes[0])
-        self.nodes[1].generate(COINBASE_MATURITY)
+        self.generate(self.nodes[1], COINBASE_MATURITY)
         self.nodes[1].sendtoaddress(multisig.p2sh_addr, 10.00)
-        self.nodes[1].generate(1)
+        self.generate(self.nodes[1], 1)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
         self.nodes[1].syncwithvalidationinterfacequeue()
 
@@ -324,9 +324,9 @@ class ImportMultiTest(BitcoinTestFramework):
 
         # P2SH + Redeem script + Private Keys + Watchonly
         multisig = get_multisig(self.nodes[0])
-        self.nodes[1].generate(COINBASE_MATURITY)
+        self.generate(self.nodes[1], COINBASE_MATURITY)
         self.nodes[1].sendtoaddress(multisig.p2sh_addr, 10.00)
-        self.nodes[1].generate(1)
+        self.generate(self.nodes[1], 1)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
         self.nodes[1].syncwithvalidationinterfacequeue()
 

--- a/test/functional/wallet_importprunedfunds.py
+++ b/test/functional/wallet_importprunedfunds.py
@@ -25,7 +25,7 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
 
     def run_test(self):
         self.log.info("Mining blocks...")
-        self.nodes[0].generate(COINBASE_MATURITY + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
 
         self.sync_all()
 
@@ -64,17 +64,17 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
 
         # Send funds to self
         txnid1 = self.nodes[0].sendtoaddress(address1, 0.1)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         rawtxn1 = self.nodes[0].gettransaction(txnid1)['hex']
         proof1 = self.nodes[0].gettxoutproof([txnid1])
 
         txnid2 = self.nodes[0].sendtoaddress(address2, 0.05)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         rawtxn2 = self.nodes[0].gettransaction(txnid2)['hex']
         proof2 = self.nodes[0].gettxoutproof([txnid2])
 
         txnid3 = self.nodes[0].sendtoaddress(address3, 0.025)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         rawtxn3 = self.nodes[0].gettransaction(txnid3)['hex']
         proof3 = self.nodes[0].gettxoutproof([txnid3])
 

--- a/test/functional/wallet_keypool.py
+++ b/test/functional/wallet_keypool.py
@@ -156,7 +156,7 @@ class KeyPoolTest(BitcoinTestFramework):
         w1.walletpassphrase('test', 100)
 
         res = w1.sendtoaddress(address=address, amount=0.00010000)
-        nodes[0].generate(1)
+        self.generate(nodes[0], 1)
         destination = addr.pop()
 
         # Using a fee rate (10 sat / byte) well above the minimum relay rate

--- a/test/functional/wallet_keypool_topup.py
+++ b/test/functional/wallet_keypool_topup.py
@@ -32,7 +32,7 @@ class KeypoolRestoreTest(BitcoinTestFramework):
     def run_test(self):
         wallet_path = os.path.join(self.nodes[1].datadir, self.chain, "wallets", self.default_wallet_name, self.wallet_data_filename)
         wallet_backup_path = os.path.join(self.nodes[1].datadir, "wallet.bak")
-        self.nodes[0].generate(COINBASE_MATURITY + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
 
         self.log.info("Make backup of wallet")
         self.stop_node(1)
@@ -63,9 +63,9 @@ class KeypoolRestoreTest(BitcoinTestFramework):
 
             self.log.info("Send funds to wallet")
             self.nodes[0].sendtoaddress(addr_oldpool, 10)
-            self.nodes[0].generate(1)
+            self.generate(self.nodes[0], 1)
             self.nodes[0].sendtoaddress(addr_extpool, 5)
-            self.nodes[0].generate(1)
+            self.generate(self.nodes[0], 1)
             self.sync_blocks()
 
             self.log.info("Restart node with wallet backup")

--- a/test/functional/wallet_labels.py
+++ b/test/functional/wallet_labels.py
@@ -32,8 +32,8 @@ class WalletLabelsTest(BitcoinTestFramework):
 
         # Note each time we call generate, all generated coins go into
         # the same address, so we call twice to get two addresses w/50 each
-        node.generatetoaddress(nblocks=1, address=node.getnewaddress(label='coinbase'))
-        node.generatetoaddress(nblocks=COINBASE_MATURITY + 1, address=node.getnewaddress(label='coinbase'))
+        self.generatetoaddress(node, nblocks=1, address=node.getnewaddress(label='coinbase'))
+        self.generatetoaddress(node, nblocks=COINBASE_MATURITY + 1, address=node.getnewaddress(label='coinbase'))
         assert_equal(node.getbalance(), 100)
 
         # there should be 2 address groups
@@ -65,7 +65,7 @@ class WalletLabelsTest(BitcoinTestFramework):
         assert_equal(set([a[0] for a in address_groups[0]]), linked_addresses)
         assert_equal([a[1] for a in address_groups[0]], [0, 0])
 
-        node.generate(1)
+        self.generate(node, 1)
 
         # we want to reset so that the "" label has what's expected.
         # otherwise we're off by exactly the fee amount as that's mined
@@ -89,7 +89,7 @@ class WalletLabelsTest(BitcoinTestFramework):
             label.verify(node)
 
         # Check the amounts received.
-        node.generate(1)
+        self.generate(node, 1)
         for label in labels:
             assert_equal(
                 node.getreceivedbyaddress(label.addresses[0]), amount_to_send)
@@ -98,14 +98,14 @@ class WalletLabelsTest(BitcoinTestFramework):
         for i, label in enumerate(labels):
             to_label = labels[(i + 1) % len(labels)]
             node.sendtoaddress(to_label.addresses[0], amount_to_send)
-        node.generate(1)
+        self.generate(node, 1)
         for label in labels:
             address = node.getnewaddress(label.name)
             label.add_receive_address(address)
             label.verify(node)
             assert_equal(node.getreceivedbylabel(label.name), 2)
             label.verify(node)
-        node.generate(COINBASE_MATURITY + 1)
+        self.generate(node, COINBASE_MATURITY + 1)
 
         # Check that setlabel can assign a label to a new unused address.
         for label in labels:
@@ -125,7 +125,7 @@ class WalletLabelsTest(BitcoinTestFramework):
                 label.add_address(multisig_address)
                 label.purpose[multisig_address] = "send"
                 label.verify(node)
-            node.generate(COINBASE_MATURITY + 1)
+            self.generate(node, COINBASE_MATURITY + 1)
 
         # Check that setlabel can change the label of an address from a
         # different label.
@@ -152,7 +152,7 @@ class WalletLabelsTest(BitcoinTestFramework):
             for l in BECH32_VALID:
                 ad = BECH32_VALID[l]
                 wallet_watch_only.importaddress(label=l, rescan=False, address=ad)
-                node.generatetoaddress(1, ad)
+                self.generatetoaddress(node, 1, ad)
                 assert_equal(wallet_watch_only.getaddressesbylabel(label=l), {ad: {'purpose': 'receive'}})
                 assert_equal(wallet_watch_only.getreceivedbylabel(label=l), 0)
             for l in BECH32_INVALID:

--- a/test/functional/wallet_listreceivedby.py
+++ b/test/functional/wallet_listreceivedby.py
@@ -24,7 +24,7 @@ class ReceivedByTest(BitcoinTestFramework):
 
     def run_test(self):
         # Generate block to get out of IBD
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_blocks()
 
         # save the number of coinbase reward addresses so far
@@ -43,7 +43,7 @@ class ReceivedByTest(BitcoinTestFramework):
                             {},
                             True)
         # Bury Tx under 10 block so it will be returned by listreceivedbyaddress
-        self.nodes[1].generate(10)
+        self.generate(self.nodes[1], 10)
         self.sync_all()
         assert_array_result(self.nodes[1].listreceivedbyaddress(),
                             {"address": addr},
@@ -78,7 +78,7 @@ class ReceivedByTest(BitcoinTestFramework):
         assert_equal(len(res), 2 + num_cb_reward_addresses)  # Right now 2 entries
         other_addr = self.nodes[1].getnewaddress()
         txid2 = self.nodes[0].sendtoaddress(other_addr, 0.1)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
         # Same test as above should still pass
         expected = {"address": addr, "label": "", "amount": Decimal("0.1"), "confirmations": 11, "txids": [txid, ]}
@@ -115,7 +115,7 @@ class ReceivedByTest(BitcoinTestFramework):
         assert_equal(balance, Decimal("0.1"))
 
         # Bury Tx under 10 block so it will be returned by the default getreceivedbyaddress
-        self.nodes[1].generate(10)
+        self.generate(self.nodes[1], 10)
         self.sync_all()
         balance = self.nodes[1].getreceivedbyaddress(addr)
         assert_equal(balance, Decimal("0.1"))
@@ -144,7 +144,7 @@ class ReceivedByTest(BitcoinTestFramework):
         balance = self.nodes[1].getreceivedbylabel(label)
         assert_equal(balance, balance_by_label)
 
-        self.nodes[1].generate(10)
+        self.generate(self.nodes[1], 10)
         self.sync_all()
         # listreceivedbylabel should return updated received list
         assert_array_result(self.nodes[1].listreceivedbylabel(),

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -30,7 +30,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
         # All nodes are in IBD from genesis, so they'll need the miner (node2) to be an outbound connection, or have
         # only one connection. (See fPreferredDownload in net_processing)
         self.connect_nodes(1, 2)
-        self.nodes[2].generate(COINBASE_MATURITY + 1)
+        self.generate(self.nodes[2], COINBASE_MATURITY + 1)
         self.sync_all()
 
         self.test_no_blockhash()
@@ -44,7 +44,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
     def test_no_blockhash(self):
         self.log.info("Test no blockhash")
         txid = self.nodes[2].sendtoaddress(self.nodes[0].getnewaddress(), 1)
-        blockhash, = self.nodes[2].generate(1)
+        blockhash, = self.generate(self.nodes[2], 1)
         blockheight = self.nodes[2].getblockheader(blockhash)['height']
         self.sync_all()
 
@@ -86,7 +86,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
         a -8 invalid parameter error is thrown.
         '''
         self.log.info("Test target_confirmations")
-        blockhash, = self.nodes[2].generate(1)
+        blockhash, = self.generate(self.nodes[2], 1)
         blockheight = self.nodes[2].getblockheader(blockhash)['height']
         self.sync_all()
 
@@ -136,8 +136,8 @@ class ListSinceBlockTest(BitcoinTestFramework):
         senttx = self.nodes[2].sendtoaddress(self.nodes[0].getnewaddress(), 1)
 
         # generate on both sides
-        nodes1_last_blockhash = self.nodes[1].generate(6)[-1]
-        nodes2_first_blockhash = self.nodes[2].generate(7)[0]
+        nodes1_last_blockhash = self.generate(self.nodes[1], 6)[-1]
+        nodes2_first_blockhash = self.generate(self.nodes[2], 7)[0]
         self.log.debug("nodes[1] last blockhash = {}".format(nodes1_last_blockhash))
         self.log.debug("nodes[2] first blockhash = {}".format(nodes2_first_blockhash))
 
@@ -191,7 +191,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
         privkey = bytes_to_wif(eckey.get_bytes())
         address = key_to_p2wpkh(eckey.get_pubkey().get_bytes())
         self.nodes[2].sendtoaddress(address, 10)
-        self.nodes[2].generate(6)
+        self.generate(self.nodes[2], 6)
         self.sync_all()
         self.nodes[2].importprivkey(privkey)
         utxos = self.nodes[2].listunspent()
@@ -225,8 +225,8 @@ class ListSinceBlockTest(BitcoinTestFramework):
                 self.nodes[2].createrawtransaction(utxo_dicts, recipient_dict2))['hex'])
 
         # generate on both sides
-        lastblockhash = self.nodes[1].generate(3)[2]
-        self.nodes[2].generate(4)
+        lastblockhash = self.generate(self.nodes[1], 3)[2]
+        self.generate(self.nodes[2], 4)
 
         self.join_network()
 
@@ -297,7 +297,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
         txid1 = self.nodes[1].sendrawtransaction(signedtx)
 
         # generate bb1-bb2 on right side
-        self.nodes[2].generate(2)
+        self.generate(self.nodes[2], 2)
 
         # send from nodes[2]; this will end up in bb3
         txid2 = self.nodes[2].sendrawtransaction(signedtx)
@@ -305,8 +305,8 @@ class ListSinceBlockTest(BitcoinTestFramework):
         assert_equal(txid1, txid2)
 
         # generate on both sides
-        lastblockhash = self.nodes[1].generate(3)[2]
-        self.nodes[2].generate(2)
+        lastblockhash = self.generate(self.nodes[1], 3)[2]
+        self.generate(self.nodes[2], 2)
 
         self.join_network()
 
@@ -365,7 +365,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
         assert_equal(original_found, True)
         assert_equal(double_found, True)
 
-        lastblockhash = spending_node.generate(1)[0]
+        lastblockhash = self.generate(spending_node, 1)[0]
 
         # check that neither transaction exists
         block_hash = spending_node.listsinceblock(lastblockhash)

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -36,7 +36,7 @@ class ListTransactionsTest(BitcoinTestFramework):
                             {"txid": txid},
                             {"category": "receive", "amount": Decimal("0.1"), "confirmations": 0})
         self.log.info("Test confirmations change after mining a block")
-        blockhash = self.nodes[0].generate(1)[0]
+        blockhash = self.generate(self.nodes[0], 1)[0]
         blockheight = self.nodes[0].getblockheader(blockhash)['height']
         self.sync_all()
         assert_array_result(self.nodes[0].listtransactions(),
@@ -94,7 +94,7 @@ class ListTransactionsTest(BitcoinTestFramework):
             multisig = self.nodes[1].createmultisig(1, [pubkey])
             self.nodes[0].importaddress(multisig["redeemScript"], "watchonly", False, True)
             txid = self.nodes[1].sendtoaddress(multisig["address"], 0.1)
-            self.nodes[1].generate(1)
+            self.generate(self.nodes[1], 1)
             self.sync_all()
             assert_equal(len(self.nodes[0].listtransactions(label="watchonly", include_watchonly=True)), 1)
             assert_equal(len(self.nodes[0].listtransactions(dummy="watchonly", include_watchonly=True)), 1)
@@ -205,7 +205,7 @@ class ListTransactionsTest(BitcoinTestFramework):
             assert_equal(n.gettransaction(txid_4)["bip125-replaceable"], "unknown")
 
         self.log.info("Test mined transactions are no longer bip125-replaceable")
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         assert txid_3b not in self.nodes[0].getrawmempool()
         assert_equal(self.nodes[0].gettransaction(txid_3b)["bip125-replaceable"], "no")
         assert_equal(self.nodes[0].gettransaction(txid_4)["bip125-replaceable"], "unknown")

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -185,7 +185,7 @@ class MultiWalletTest(BitcoinTestFramework):
         self.nodes[0].createwallet("w5")
         assert_equal(set(node.listwallets()), {"w4", "w5"})
         w5 = wallet("w5")
-        node.generatetoaddress(nblocks=1, address=w5.getnewaddress())
+        self.generatetoaddress(node, nblocks=1, address=w5.getnewaddress())
 
         # now if wallets/ exists again, but the rootdir is specified as the walletdir, w4 and w5 should still be loaded
         os.rename(wallet_dir2, wallet_dir())
@@ -217,7 +217,7 @@ class MultiWalletTest(BitcoinTestFramework):
         wallet_bad = wallet("bad")
 
         # check wallet names and balances
-        node.generatetoaddress(nblocks=1, address=wallets[0].getnewaddress())
+        self.generatetoaddress(node, nblocks=1, address=wallets[0].getnewaddress())
         for wallet_name, wallet in zip(wallet_names, wallets):
             info = wallet.getwalletinfo()
             assert_equal(info['immature_balance'], 50 if wallet is wallets[0] else 0)
@@ -230,7 +230,7 @@ class MultiWalletTest(BitcoinTestFramework):
         assert_raises_rpc_error(-19, "Wallet file not specified", node.getwalletinfo)
 
         w1, w2, w3, w4, *_ = wallets
-        node.generatetoaddress(nblocks=COINBASE_MATURITY + 1, address=w1.getnewaddress())
+        self.generatetoaddress(node, nblocks=COINBASE_MATURITY + 1, address=w1.getnewaddress())
         assert_equal(w1.getbalance(), 100)
         assert_equal(w2.getbalance(), 0)
         assert_equal(w3.getbalance(), 0)
@@ -239,7 +239,7 @@ class MultiWalletTest(BitcoinTestFramework):
         w1.sendtoaddress(w2.getnewaddress(), 1)
         w1.sendtoaddress(w3.getnewaddress(), 2)
         w1.sendtoaddress(w4.getnewaddress(), 3)
-        node.generatetoaddress(nblocks=1, address=w1.getnewaddress())
+        self.generatetoaddress(node, nblocks=1, address=w1.getnewaddress())
         assert_equal(w2.getbalance(), 1)
         assert_equal(w3.getbalance(), 2)
         assert_equal(w4.getbalance(), 3)

--- a/test/functional/wallet_orphanedreward.py
+++ b/test/functional/wallet_orphanedreward.py
@@ -18,19 +18,19 @@ class OrphanedBlockRewardTest(BitcoinTestFramework):
     def run_test(self):
         # Generate some blocks and obtain some coins on node 0.  We send
         # some balance to node 1, which will hold it as a single coin.
-        self.nodes[0].generate(150)
+        self.generate(self.nodes[0], 150)
         self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 10)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
 
         # Get a block reward with node 1 and remember the block so we can orphan
         # it later.
         self.sync_blocks()
-        blk = self.nodes[1].generate(1)[0]
+        blk = self.generate(self.nodes[1], 1)[0]
         self.sync_blocks()
 
         # Let the block reward mature and send coins including both
         # the existing balance and the block reward.
-        self.nodes[0].generate(150)
+        self.generate(self.nodes[0], 150)
         self.sync_blocks()
         assert_equal(self.nodes[1].getbalance(), 10 + 25)
         txid = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 30)
@@ -38,7 +38,7 @@ class OrphanedBlockRewardTest(BitcoinTestFramework):
         # Orphan the block reward and make sure that the original coins
         # from the wallet can still be spent.
         self.nodes[0].invalidateblock(blk)
-        self.nodes[0].generate(152)
+        self.generate(self.nodes[0], 152)
         self.sync_blocks()
         # Without the following abandontransaction call, the coins are
         # not considered available yet.

--- a/test/functional/wallet_reorgsrestore.py
+++ b/test/functional/wallet_reorgsrestore.py
@@ -32,7 +32,7 @@ class ReorgsRestoreTest(BitcoinTestFramework):
     def run_test(self):
         # Send a tx from which to conflict outputs later
         txid_conflict_from = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_blocks()
 
         # Disconnect node1 from others to reorg its chain later
@@ -43,7 +43,7 @@ class ReorgsRestoreTest(BitcoinTestFramework):
         # Send a tx to be unconfirmed later
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
         tx = self.nodes[0].gettransaction(txid)
-        self.nodes[0].generate(4)
+        self.generate(self.nodes[0], 4)
         tx_before_reorg = self.nodes[0].gettransaction(txid)
         assert_equal(tx_before_reorg["confirmations"], 4)
 
@@ -62,9 +62,9 @@ class ReorgsRestoreTest(BitcoinTestFramework):
         conflicting = self.nodes[0].signrawtransactionwithwallet(self.nodes[0].createrawtransaction(inputs, outputs_2))
 
         conflicted_txid = self.nodes[0].sendrawtransaction(conflicted["hex"])
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         conflicting_txid = self.nodes[2].sendrawtransaction(conflicting["hex"])
-        self.nodes[2].generate(9)
+        self.generate(self.nodes[2], 9)
 
         # Reconnect node0 and node2 and check that conflicted_txid is effectively conflicted
         self.connect_nodes(0, 2)
@@ -78,11 +78,11 @@ class ReorgsRestoreTest(BitcoinTestFramework):
         self.restart_node(0)
 
         # The block chain re-orgs and the tx is included in a different block
-        self.nodes[1].generate(9)
+        self.generate(self.nodes[1], 9)
         self.nodes[1].sendrawtransaction(tx["hex"])
-        self.nodes[1].generate(1)
+        self.generate(self.nodes[1], 1)
         self.nodes[1].sendrawtransaction(conflicted["hex"])
-        self.nodes[1].generate(1)
+        self.generate(self.nodes[1], 1)
 
         # Node0 wallet file is loaded on longest sync'ed node1
         self.stop_node(1)

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -241,7 +241,7 @@ class WalletSendTest(BitcoinTestFramework):
                 assert_equal(res, [{"success": True}, {"success": True}])
 
         w0.sendtoaddress(a2_receive, 10) # fund w3
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_blocks()
 
         if not self.options.descriptors:
@@ -260,7 +260,7 @@ class WalletSendTest(BitcoinTestFramework):
                 assert_equal(res, [{"success": True}])
 
             w0.sendtoaddress(a2_receive, 10) # fund w4
-            self.nodes[0].generate(1)
+            self.generate(self.nodes[0], 1)
             self.sync_blocks()
 
         self.log.info("Send to address...")
@@ -435,14 +435,14 @@ class WalletSendTest(BitcoinTestFramework):
         assert not res[0]["allowed"]
         assert_equal(res[0]["reject-reason"], "non-final")
         # It shouldn't be confirmed in the next block
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         assert_equal(self.nodes[0].gettransaction(txid)["confirmations"], 0)
         # The mempool should allow it now:
         res = self.nodes[0].testmempoolaccept([hex])
         assert res[0]["allowed"]
         # Don't wait for wallet to add it to the mempool:
         res = self.nodes[0].sendrawtransaction(hex)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         assert_equal(self.nodes[0].gettransaction(txid)["confirmations"], 1)
         self.sync_all()
 

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -108,7 +108,7 @@ class WalletSignerTest(BitcoinTestFramework):
 
         self.log.info('Prepare mock PSBT')
         self.nodes[0].sendtoaddress(address1, 1)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
         self.sync_all()
 
         # Load private key into wallet to generate a signed PSBT for the mock

--- a/test/functional/wallet_taproot.py
+++ b/test/functional/wallet_taproot.py
@@ -272,11 +272,11 @@ class WalletTaprootTest(BitcoinTestFramework):
             boring_balance = int(self.boring.getbalance() * 100000000)
             to_amnt = random.randrange(1000000, boring_balance)
             self.boring.sendtoaddress(address=addr_g, amount=Decimal(to_amnt) / 100000000, subtractfeefromamount=True)
-            self.nodes[0].generatetoaddress(1, self.boring.getnewaddress())
+            self.generatetoaddress(self.nodes[0], 1, self.boring.getnewaddress())
             test_balance = int(self.rpc_online.getbalance() * 100000000)
             ret_amnt = random.randrange(100000, test_balance)
             res = self.rpc_online.sendtoaddress(address=self.boring.getnewaddress(), amount=Decimal(ret_amnt) / 100000000, subtractfeefromamount=True)
-            self.nodes[0].generatetoaddress(1, self.boring.getnewaddress())
+            self.generatetoaddress(self.nodes[0], 1, self.boring.getnewaddress())
             assert(self.rpc_online.gettransaction(res)["confirmations"] > 0)
 
     def do_test_psbt(self, comment, pattern, privmap, treefn, keys_pay, keys_change):
@@ -303,7 +303,7 @@ class WalletTaprootTest(BitcoinTestFramework):
             boring_balance = int(self.boring.getbalance() * 100000000)
             to_amnt = random.randrange(1000000, boring_balance)
             self.boring.sendtoaddress(address=addr_g, amount=Decimal(to_amnt) / 100000000, subtractfeefromamount=True)
-            self.nodes[0].generatetoaddress(1, self.boring.getnewaddress())
+            self.generatetoaddress(self.nodes[0], 1, self.boring.getnewaddress())
             test_balance = int(self.psbt_online.getbalance() * 100000000)
             ret_amnt = random.randrange(100000, test_balance)
             psbt = self.psbt_online.walletcreatefundedpsbt([], [{self.boring.getnewaddress(): Decimal(ret_amnt) / 100000000}], None, {"subtractFeeFromOutputs":[0]})['psbt']
@@ -311,7 +311,7 @@ class WalletTaprootTest(BitcoinTestFramework):
             assert(res['complete'])
             rawtx = self.nodes[0].finalizepsbt(res['psbt'])['hex']
             txid = self.nodes[0].sendrawtransaction(rawtx)
-            self.nodes[0].generatetoaddress(1, self.boring.getnewaddress())
+            self.generatetoaddress(self.nodes[0], 1, self.boring.getnewaddress())
             assert(self.psbt_online.gettransaction(txid)['confirmations'] > 0)
 
     def do_test(self, comment, pattern, privmap, treefn, nkeys):
@@ -343,7 +343,7 @@ class WalletTaprootTest(BitcoinTestFramework):
 
         self.log.info("Mining blocks...")
         gen_addr = self.boring.getnewaddress()
-        self.nodes[0].generatetoaddress(101, gen_addr)
+        self.generatetoaddress(self.nodes[0], 101, gen_addr)
 
         self.do_test(
             "tr(XPRV)",
@@ -412,7 +412,7 @@ class WalletTaprootTest(BitcoinTestFramework):
         self.log.info("Sending everything back...")
 
         txid = self.rpc_online.sendtoaddress(address=self.boring.getnewaddress(), amount=self.rpc_online.getbalance(), subtractfeefromamount=True)
-        self.nodes[0].generatetoaddress(1, self.boring.getnewaddress())
+        self.generatetoaddress(self.nodes[0], 1, self.boring.getnewaddress())
         assert(self.rpc_online.gettransaction(txid)["confirmations"] > 0)
 
         psbt = self.psbt_online.walletcreatefundedpsbt([], [{self.boring.getnewaddress(): self.psbt_online.getbalance()}], None, {"subtractFeeFromOutputs": [0]})['psbt']
@@ -420,7 +420,7 @@ class WalletTaprootTest(BitcoinTestFramework):
         assert(res['complete'])
         rawtx = self.nodes[0].finalizepsbt(res['psbt'])['hex']
         txid = self.nodes[0].sendrawtransaction(rawtx)
-        self.nodes[0].generatetoaddress(1, self.boring.getnewaddress())
+        self.generatetoaddress(self.nodes[0], 1, self.boring.getnewaddress())
         assert(self.psbt_online.gettransaction(txid)['confirmations'] > 0)
 
 if __name__ == '__main__':

--- a/test/functional/wallet_txn_clone.py
+++ b/test/functional/wallet_txn_clone.py
@@ -84,7 +84,7 @@ class TxnMallTest(BitcoinTestFramework):
 
         # Have node0 mine a block, if requested:
         if (self.options.mine_block):
-            self.nodes[0].generate(1)
+            self.generate(self.nodes[0], 1)
             self.sync_blocks(self.nodes[0:2])
 
         tx1 = self.nodes[0].gettransaction(txid1)
@@ -114,13 +114,13 @@ class TxnMallTest(BitcoinTestFramework):
             return
 
         # ... mine a block...
-        self.nodes[2].generate(1)
+        self.generate(self.nodes[2], 1)
 
         # Reconnect the split network, and sync chain:
         self.connect_nodes(1, 2)
         self.nodes[2].sendrawtransaction(node0_tx2["hex"])
         self.nodes[2].sendrawtransaction(tx2["hex"])
-        self.nodes[2].generate(1)  # Mine another block to make sure we sync
+        self.generate(self.nodes[2], 1)  # Mine another block to make sure we sync
         self.sync_blocks()
 
         # Re-fetch transaction info:

--- a/test/functional/wallet_txn_doublespend.py
+++ b/test/functional/wallet_txn_doublespend.py
@@ -82,7 +82,7 @@ class TxnMallTest(BitcoinTestFramework):
 
         # Have node0 mine a block:
         if (self.options.mine_block):
-            self.nodes[0].generate(1)
+            self.generate(self.nodes[0], 1)
             self.sync_blocks(self.nodes[0:2])
 
         tx1 = self.nodes[0].gettransaction(txid1)
@@ -111,11 +111,11 @@ class TxnMallTest(BitcoinTestFramework):
         self.nodes[2].sendrawtransaction(fund_bar_tx["hex"])
         doublespend_txid = self.nodes[2].sendrawtransaction(doublespend["hex"])
         # ... mine a block...
-        self.nodes[2].generate(1)
+        self.generate(self.nodes[2], 1)
 
         # Reconnect the split network, and sync chain:
         self.connect_nodes(1, 2)
-        self.nodes[2].generate(1)  # Mine another block to make sure we sync
+        self.generate(self.nodes[2], 1)  # Mine another block to make sure we sync
         self.sync_blocks()
         assert_equal(self.nodes[0].gettransaction(doublespend_txid)["confirmations"], 2)
 

--- a/test/functional/wallet_upgradewallet.py
+++ b/test/functional/wallet_upgradewallet.py
@@ -119,7 +119,7 @@ class UpgradeWalletTest(BitcoinTestFramework):
         assert_equal(wallet.getwalletinfo()["walletversion"], previous_version)
 
     def run_test(self):
-        self.nodes[0].generatetoaddress(COINBASE_MATURITY + 1, self.nodes[0].getnewaddress())
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 1, self.nodes[0].getnewaddress())
         self.dumb_sync_blocks()
         # # Sanity check the test framework:
         res = self.nodes[0].getblockchaininfo()
@@ -131,7 +131,7 @@ class UpgradeWalletTest(BitcoinTestFramework):
         # Send coins to old wallets for later conversion checks.
         v16_3_wallet  = v16_3_node.get_wallet_rpc('wallet.dat')
         v16_3_address = v16_3_wallet.getnewaddress()
-        node_master.generatetoaddress(COINBASE_MATURITY + 1, v16_3_address)
+        self.generatetoaddress(node_master, COINBASE_MATURITY + 1, v16_3_address)
         self.dumb_sync_blocks()
         v16_3_balance = v16_3_wallet.getbalance()
 

--- a/test/functional/wallet_watchonly.py
+++ b/test/functional/wallet_watchonly.py
@@ -37,11 +37,11 @@ class CreateWalletWatchonlyTest(BitcoinTestFramework):
         wo_wallet.importpubkey(pubkey=def_wallet.getaddressinfo(wo_change)['pubkey'])
 
         # generate some btc for testing
-        node.generatetoaddress(COINBASE_MATURITY + 1, a1)
+        self.generatetoaddress(node, COINBASE_MATURITY + 1, a1)
 
         # send 1 btc to our watch-only address
         txid = def_wallet.sendtoaddress(wo_addr, 1)
-        self.nodes[0].generate(1)
+        self.generate(self.nodes[0], 1)
 
         # getbalance
         self.log.info('include_watchonly should default to true for watch-only wallets')


### PR DESCRIPTION
This is needed for #22567.

By using the newly added `generate*` member functions of the test framework, it paves the way to make it easier to implicitly call `sync_all` after block generation to avoid intermittent issues.