### PR TITLE
test: add aarch64-apple-darwin platform entry to get_previous_releases

### DIFF
--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -190,6 +190,7 @@ def check_host(args) -> int:
             'aarch64-*-linux*': 'aarch64-linux-gnu',
             'x86_64-*-linux*': 'x86_64-linux-gnu',
             'x86_64-apple-darwin*': 'osx64',
+            'aarch64-apple-darwin*': 'osx64',
         }
         args.platform = ''
         for pattern, target in platforms.items():


### PR DESCRIPTION
Over the course of reviewing a PR, I had to edit `test/get_previous_releases.py` (after I ran `git clean -xdff`) to run the backwards compatibility tests (e.g. `wallet_upgradewallet`, `feature_backwards_compatibility`, etc.), as currently on master, running the script as indicated in [`test/README.md`](https://github.com/bitcoin/bitcoin/blob/master/test/README.md), for example, on an M1 machine results in the following error, as the `aarch64-apple-darwin*` platform entry is presently not recognised:

> Output from an M1 machine running macOS v11.5.2

```sh
$ test/get_previous_releases.py -b v0.20.1 v0.19.1 v0.18.1 v0.17.2 v0.16.3 v0.15.2
Releases directory: releases
Not sure which binary to download for aarch64-apple-darwin20.6.0
```

As a quick fix, this PR adds the missing `aarch64-apple-darwin*` platform entry. Running the script now results in fetching the old binaries, as expected:

```sh
$ test/get_previous_releases.py -b v0.20.1 v0.19.1 v0.18.1 v0.17.2 v0.16.3 v0.15.2

Releases directory: releases
Fetching: https://bitcoincore.org/bin/bitcoin-core-0.20.1/bitcoin-0.20.1-osx64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0 20.9M    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 20.9M  100 20.9M    0     0   136k      0  0:02:37  0:02:37 --:--:-- 95607
Checksum matched

…

Checksum matched
```

After this patch, the backwards compatibility tests also run successfully, as expected.

**Note**: I am open to other possible solutions.

---

Steps to reproduce:

> Ensure you take out the binaries in `releases` if they already exist.

Try running `test/get_previous_releases.py -b v0.15.2` or similar to fetch the old release binaries.