### PR TITLE
test: Verify if wallet is compiled in rpc_invalid_address_message.py test

### DIFF
--- a/test/functional/rpc_invalid_address_message.py
+++ b/test/functional/rpc_invalid_address_message.py
@@ -29,9 +29,6 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
 
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
-
     def test_validateaddress(self):
         node = self.nodes[0]
 
@@ -87,7 +84,10 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
 
     def run_test(self):
         self.test_validateaddress()
-        self.test_getaddressinfo()
+
+        if self.is_wallet_compiled():
+            self.init_wallet(0)
+            self.test_getaddressinfo()
 
 
 if __name__ == '__main__':

--- a/test/functional/rpc_invalid_address_message.py
+++ b/test/functional/rpc_invalid_address_message.py
@@ -57,6 +57,10 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
         assert info['isvalid']
         assert 'error' not in info
 
+        info = node.validateaddress(BECH32_INVALID_VERSION)
+        assert not info['isvalid']
+        assert_equal(info['error'], 'Invalid Bech32 address witness version')
+
         # Base58
         info = node.validateaddress(BASE58_INVALID_PREFIX)
         assert not info['isvalid']


### PR DESCRIPTION
Most of  `test/functional/rpc_invalid_address_message.py` does not requires wallet.
But if the project is compiled in disable-wallet mode, the entire test will be skipped.


This PR changes the test to run the RPC tests first and then checks if the wallet is compiled.