### PR TITLE
validation: fix verification progress during IBD.

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4634,7 +4634,7 @@ bool DumpMempool(const CTxMemPool& pool, FopenFn mockable_fopen_function, bool s
 //! Guess how far we are in the verification process at the given block index
 //! require cs_main if pindex has not been validated yet (because nChainTx might be unset)
 double GuessVerificationProgress(const ChainTxData& data, const CBlockIndex *pindex) {
-    if (pindex == nullptr)
+    if (pindex == nullptr || pindex->nHeight == 0)
         return 0.0;
 
     int64_t nNow = time(nullptr);


### PR DESCRIPTION
## Description 

**Motivation**: 
Currently `verificationprogress` attribute of `getblockchaininfo` returns incorrect value(`1.92338932716318e-06`) during the headers synchronization phase of IBD. This PR fixes this by returning `0` instead of `...e-0x`.

<details>
<summary>getblockchaininfo on master</summary>

```shell
$ ./src/bitcoin-cli -signet getblockchaininfo                                                                                                                                                               
{
  "chain": "signet",
  "blocks": 0,
  "headers": 32410,
  "bestblockhash": "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
  "difficulty": 0.001126515290698186,
  "time": 1598918400,
  "mediantime": 1598918400,
  "verificationprogress": 1.921578597095376e-06,
  "initialblockdownload": true,
  "chainwork": "000000000000000000000000000000000000000000000000000000000049d414",
  "size_on_disk": 17095548,
  "pruned": false,
  "softforks": {
    "bip34": {
      "type": "buried",
      "active": true,
      "height": 1
    },
    "bip66": {
      "type": "buried",
      "active": true,
      "height": 1
    },
    "bip65": {
      "type": "buried",
      "active": true,
      "height": 1
    },
    "csv": {
      "type": "buried",
      "active": true,
      "height": 1
    },
    "segwit": {
      "type": "buried",
      "active": true,
      "height": 1
    },
    "taproot": {
      "type": "bip9",
      "bip9": {
        "status": "active",
        "start_time": -1,
        "timeout": 9223372036854775807,
        "since": 0,
        "min_activation_height": 0
      },
      "height": 0,
      "active": true
    }
  },
  "warnings": "This is a pre-release test build - use at your own risk - do not use for mining or merchant applications"
}
```
</details>

<details>
<summary>getblockchaininfo in this PR</summary>

```shell
$ ./src/bitcoin-cli -signet getblockchaininfo                                                                                                                                                               
{
  "chain": "signet",
  "blocks": 0,
  "headers": 21940,
  "bestblockhash": "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
  "difficulty": 0.001126515290698186,
  "time": 1598918400,
  "mediantime": 1598918400,
  "verificationprogress": 0,
  "initialblockdownload": true,
  "chainwork": "000000000000000000000000000000000000000000000000000000000049d414",
  "size_on_disk": 8546460,
  "pruned": false,
  "softforks": {
    "bip34": {
      "type": "buried",
      "active": true,
      "height": 1
    },
    "bip66": {
      "type": "buried",
      "active": true,
      "height": 1
    },
    "bip65": {
      "type": "buried",
      "active": true,
      "height": 1
    },
    "csv": {
      "type": "buried",
      "active": true,
      "height": 1
    },
    "segwit": {
      "type": "buried",
      "active": true,
      "height": 1
    },
    "taproot": {
      "type": "bip9",
      "bip9": {
        "status": "active",
        "start_time": -1,
        "timeout": 9223372036854775807,
        "since": 0,
        "min_activation_height": 0
      },
      "height": 0,
      "active": true
    }
  },
  "warnings": "This is a pre-release test build - use at your own risk - do not use for mining or merchant applications"
}
```

</details>

**Conext**: 
* During IBD all block headers are downloaded before the transactions of each block.
* `verificationprogress`  is calculated using the `GuessVerificationProgress` method in `src/validation.cpp`
    https://github.com/bitcoin/bitcoin/blob/0492b56e38c24e599a221b5bb276957c674cfafe/src/validation.cpp#L4650
* Currently `nChainTx` is artificially set to `1` when the are no predecessor blocks.
     https://github.com/bitcoin/bitcoin/blob/0492b56e38c24e599a221b5bb276957c674cfafe/src/validation.cpp#L4960
* This results in the value of `verificationprogress` to be `1/fTxTotal`(`...e-0x`) during block headers download in IBD.
   
**Changes**:
* This PR fixes the issue by returning `0.0` in `GuessVerificationProgress` option when `nHeight == 0`

## Reviewing 

**Testing**: 

You can test this by running `bitconid` with `-reindex` option and immediately running `getblockchainfo` afterward.

```shell
$ ./src/bitcoind --daemon -signet -reindex
$ ./src/bitcoin-cli -signet getblockchaininfo
```