### PR TITLE
RPC: Add universal options argument to listtransactions

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -72,6 +72,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "waitfornewblock", 0, "timeout" },
     { "listtransactions", 1, "count" },
     { "listtransactions", 2, "skip" },
+    { "listtransactions", 2, "options" },
     { "listtransactions", 3, "include_watchonly" },
     { "walletpassphrase", 1, "timeout" },
     { "getblocktemplate", 0, "template_request" },


### PR DESCRIPTION
Taken from #19443. There two additional arguments `paginatebypointer` and `nextpagepointer` were added and @luke-jr proposed that they could be united with existing `skip` argument into single `options` JSON argument. This is better approach than continue adding more and more different arguments for different output options. #22775 proposes to add sorting order as additional argument, I think it's better to use the same approach there too. Having this as a separate PR will make reviews and testing simpler.

Tests for old and new way of providing `skip` argument should be added, but didn't do it here as functional tests currently don't have tests for `skip` at all. I plan to add them later in a separate PR.