### PR TITLE
build: Fix depends build system when working with subtargets

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -76,7 +76,7 @@ $(1)_extracted=$$($(1)_extract_dir)/.stamp_extracted
 $(1)_preprocessed=$$($(1)_extract_dir)/.stamp_preprocessed
 $(1)_cleaned=$$($(1)_extract_dir)/.stamp_cleaned
 $(1)_built=$$($(1)_build_dir)/.stamp_built
-$(1)_configured=$$($(1)_build_dir)/.stamp_configured
+$(1)_configured=$(host_prefix)/.$(1)_stamp_configured
 $(1)_staged=$$($(1)_staging_dir)/.stamp_staged
 $(1)_postprocessed=$$($(1)_staging_prefix_dir)/.stamp_postprocessed
 $(1)_download_path_fixed=$(subst :,\:,$$($(1)_download_path))
@@ -214,8 +214,8 @@ $($(1)_preprocessed): | $($(1)_extracted)
 $($(1)_configured): | $($(1)_dependencies) $($(1)_preprocessed)
 	echo Configuring $(1)...
 	rm -rf $(host_prefix); mkdir -p $(host_prefix)/lib; cd $(host_prefix); $(foreach package,$($(1)_all_dependencies), $(build_TAR) --no-same-owner -xf $($(package)_cached); )
-	mkdir -p $$(@D)
-	+{ cd $$(@D); export $($(1)_config_env); $($(1)_config_cmds); } $$($(1)_logging)
+	mkdir -p $$($(1)_build_dir)
+	+{ cd $$($(1)_build_dir); export $($(1)_config_env); $($(1)_config_cmds); } $$($(1)_logging)
 	touch $$@
 $($(1)_built): | $($(1)_configured)
 	echo Building $(1)...


### PR DESCRIPTION
On master (f3e0ace8ecd84009a23da6b0de47f01d79c45772), the depends build system does _not_ guarantee that dependencies packages are available for `$(package)_built` target because these dependencies being prepared in `$(host_prefix)` at `$(package)_configured` target can be wiped out during building other package.

Please consider:
```
$ cd depends
$ make clean
$ make fontconfig_configured
$ make
...
  CC       fcdir.lo
In file included from fcftint.h:26,
                 from fcdir.c:26:
../fontconfig/fcfreetype.h:27:10: fatal error: ft2build.h: No such file or directory
   27 | #include <ft2build.h>
      |          ^~~~~~~~~~~~
compilation terminated.
make[4]: *** [Makefile:642: fcdir.lo] Error 1
make[4]: *** Waiting for unfinished jobs....
make[4]: Leaving directory '/home/hebasto/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/fontconfig/2.12.6-7daa5620c94/src'
make[3]: *** [Makefile:503: all] Error 2
make[3]: Leaving directory '/home/hebasto/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/fontconfig/2.12.6-7daa5620c94/src'
make[2]: *** [Makefile:581: all-recursive] Error 1
make[2]: Leaving directory '/home/hebasto/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/fontconfig/2.12.6-7daa5620c94'
make[1]: *** [Makefile:465: all] Error 2
make[1]: Leaving directory '/home/hebasto/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/fontconfig/2.12.6-7daa5620c94'
make: *** [funcs.mk:288: /home/hebasto/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/fontconfig/2.12.6-7daa5620c94/./.stamp_built] Error 2
```

The following commands:
```
$ cd depends
$ make clean
$ make qt_configured
$ make
```
also fail.

The similar issue was reported earlier: #21381.

This PR guarantees that dependencies packages are available for `$(package)_built` target.

Guix builds:
```
accef9ffccfe280fec1114c0440092ed5d792e9c53d95abc7fe65435aa136656  guix-build-978852aad8e2/output/aarch64-linux-gnu/SHA256SUMS.part
a75f1250975525a21d2e213e23f1f0dab516d2b28d0c7d747de292fe5c906013  guix-build-978852aad8e2/output/aarch64-linux-gnu/bitcoin-978852aad8e2-aarch64-linux-gnu-debug.tar.gz
d20787af2e7a14a3b7b1d21e0d8784aa6ebad1e916f02aebfa25afe9229ba43c  guix-build-978852aad8e2/output/aarch64-linux-gnu/bitcoin-978852aad8e2-aarch64-linux-gnu.tar.gz
11c94a39c084763858c6de31b221868e52554f5500c0dc5589def429bb6b54c8  guix-build-978852aad8e2/output/arm-linux-gnueabihf/SHA256SUMS.part
3935b0e14d78800977dc813a3824215797096b6fb29c84b5996f48338908a65f  guix-build-978852aad8e2/output/arm-linux-gnueabihf/bitcoin-978852aad8e2-arm-linux-gnueabihf-debug.tar.gz
c828c3f87a453db443a385a266331661f623f8f4684d88eb006290c83bfa8150  guix-build-978852aad8e2/output/arm-linux-gnueabihf/bitcoin-978852aad8e2-arm-linux-gnueabihf.tar.gz
b6ff14e1cc36e568fc726b50300f77498560322b3582738eb70e7144784f7e63  guix-build-978852aad8e2/output/arm64-apple-darwin/SHA256SUMS.part
2a3e6ba5843eaf9562e9dcfdb4595024a71738079cea00e391558feca4d5bde1  guix-build-978852aad8e2/output/arm64-apple-darwin/bitcoin-978852aad8e2-arm64-apple-darwin-unsigned.dmg
ffd2ad39e8b9f95dd714513ba1e1c77666b0f3cc4b67be4ab763ebd431fe9276  guix-build-978852aad8e2/output/arm64-apple-darwin/bitcoin-978852aad8e2-arm64-apple-darwin-unsigned.tar.gz
5c9f8acd1777effc1e860b64143ba9d06ba5e3d0330e7341529eeae5cc6b3c5e  guix-build-978852aad8e2/output/arm64-apple-darwin/bitcoin-978852aad8e2-arm64-apple-darwin.tar.gz
e34c693ecef6159c57fdedabff9dc3d69ec20387966083b828532c58e1e6e30b  guix-build-978852aad8e2/output/dist-archive/bitcoin-978852aad8e2.tar.gz
8de4681114d96425bf9b0ccc47d49f696293ead514faa3fa83ddcccfdca2eeb2  guix-build-978852aad8e2/output/powerpc64-linux-gnu/SHA256SUMS.part
d780330a105931eb4c66a536c332eb09e4b6d8c288832bb5a74b931c4600c0b3  guix-build-978852aad8e2/output/powerpc64-linux-gnu/bitcoin-978852aad8e2-powerpc64-linux-gnu-debug.tar.gz
af036a6d714ef362a2facfe4e5c63deaa9dfa391d20542ead9ffb4a43b2b7ca2  guix-build-978852aad8e2/output/powerpc64-linux-gnu/bitcoin-978852aad8e2-powerpc64-linux-gnu.tar.gz
dc6b4365632e7de386ead512b1cdcdd3c985623f63cff8b62974bd9ed8c05d5d  guix-build-978852aad8e2/output/powerpc64le-linux-gnu/SHA256SUMS.part
5543a6dec58515186b71139a4a5c603d85638672f205e7c9fabb281c98018461  guix-build-978852aad8e2/output/powerpc64le-linux-gnu/bitcoin-978852aad8e2-powerpc64le-linux-gnu-debug.tar.gz
dd791be2e61ce6cbd3e14c165ce2f8c2d22881992e0df72bd338423d092cc467  guix-build-978852aad8e2/output/powerpc64le-linux-gnu/bitcoin-978852aad8e2-powerpc64le-linux-gnu.tar.gz
2b740db8e5b9c435be3e7b186c3b4a40885302243326ec990e24fe4ba4f777da  guix-build-978852aad8e2/output/riscv64-linux-gnu/SHA256SUMS.part
de899c89874d4f34afeca179a6c7c8f49b0a975983ab2b31afd9f2d365674578  guix-build-978852aad8e2/output/riscv64-linux-gnu/bitcoin-978852aad8e2-riscv64-linux-gnu-debug.tar.gz
9052b1db22c56692d99a61c3783b36c6f76537d9aec14f17d87a155beac82532  guix-build-978852aad8e2/output/riscv64-linux-gnu/bitcoin-978852aad8e2-riscv64-linux-gnu.tar.gz
5e79ddf57a94c5978ad819896786107f735d5742bbd042c2c64ae2d0681ce53a  guix-build-978852aad8e2/output/x86_64-apple-darwin/SHA256SUMS.part
96443ad839f87c723db1c0a96d8ead0afc69e9d96ad45b5814344866da2dae73  guix-build-978852aad8e2/output/x86_64-apple-darwin/bitcoin-978852aad8e2-x86_64-apple-darwin-unsigned.dmg
14b0a3081772e81a463398a2702aca039d2f276e301dee9f5a0ccffbb09e2749  guix-build-978852aad8e2/output/x86_64-apple-darwin/bitcoin-978852aad8e2-x86_64-apple-darwin-unsigned.tar.gz
6bfb8252524202028308267f5e96bc30f284052f5feaa58ed3697dde27a3130f  guix-build-978852aad8e2/output/x86_64-apple-darwin/bitcoin-978852aad8e2-x86_64-apple-darwin.tar.gz
5f8ea6297e246b08ffd806913897cc863feeec6522fcfb4456a59c5f154e0c2d  guix-build-978852aad8e2/output/x86_64-linux-gnu/SHA256SUMS.part
40d1bcf491660d54fe20b2db24828ebf61be848eefdc38fba09ed43f6bdba4b1  guix-build-978852aad8e2/output/x86_64-linux-gnu/bitcoin-978852aad8e2-x86_64-linux-gnu-debug.tar.gz
3200e67a4dea115e8e341b4d71d84dc5e8bd2ae35e550cde6aef88d120c65eae  guix-build-978852aad8e2/output/x86_64-linux-gnu/bitcoin-978852aad8e2-x86_64-linux-gnu.tar.gz
0b0bf7effc493ecc68398f23fc81647f64fdee115e8ccd7ae91e7881804ec328  guix-build-978852aad8e2/output/x86_64-w64-mingw32/SHA256SUMS.part
e2064c9ddeb4af18468f37ba8cf70004062c31e1387b4cc0fe4b445fae518e8d  guix-build-978852aad8e2/output/x86_64-w64-mingw32/bitcoin-978852aad8e2-win64-debug.zip
be347a901b896e0a1dc2f0f5a7f84614075805cccf1f2af8ec8df678d086fdbc  guix-build-978852aad8e2/output/x86_64-w64-mingw32/bitcoin-978852aad8e2-win64-setup-unsigned.exe
bab8700e9e266970e8c7cad494902058ad12d1f2a6462e0039daa637b1a0ce0d  guix-build-978852aad8e2/output/x86_64-w64-mingw32/bitcoin-978852aad8e2-win64-unsigned.tar.gz
c8e55e64b248fd7c9056fe811a1eba992bbb92e44857204e3024416d9ba6307d  guix-build-978852aad8e2/output/x86_64-w64-mingw32/bitcoin-978852aad8e2-win64.zip
```