### PR TITLE
refactor: various RecursiveMutex replacements in CConnman

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2879,7 +2879,6 @@ bool CConnman::DisconnectNode(NodeId id)
 
 void CConnman::RecordBytesRecv(uint64_t bytes)
 {
-    LOCK(cs_totalBytesRecv);
     nTotalBytesRecv += bytes;
 }
 
@@ -2956,7 +2955,6 @@ uint64_t CConnman::GetOutboundTargetBytesLeft() const
 
 uint64_t CConnman::GetTotalBytesRecv() const
 {
-    LOCK(cs_totalBytesRecv);
     return nTotalBytesRecv;
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -1098,7 +1098,7 @@ private:
     bool fAddressesInitialized{false};
     AddrMan& addrman;
     std::deque<std::string> m_addr_fetches GUARDED_BY(m_addr_fetches_mutex);
-    RecursiveMutex m_addr_fetches_mutex;
+    Mutex m_addr_fetches_mutex;
     std::vector<std::string> m_added_nodes GUARDED_BY(m_added_nodes_mutex);
     mutable RecursiveMutex m_added_nodes_mutex;
     std::vector<CNode*> m_nodes GUARDED_BY(m_nodes_mutex);

--- a/src/net.h
+++ b/src/net.h
@@ -1100,7 +1100,7 @@ private:
     std::deque<std::string> m_addr_fetches GUARDED_BY(m_addr_fetches_mutex);
     Mutex m_addr_fetches_mutex;
     std::vector<std::string> m_added_nodes GUARDED_BY(m_added_nodes_mutex);
-    mutable RecursiveMutex m_added_nodes_mutex;
+    mutable Mutex m_added_nodes_mutex;
     std::vector<CNode*> m_nodes GUARDED_BY(m_nodes_mutex);
     std::list<CNode*> m_nodes_disconnected;
     mutable RecursiveMutex m_nodes_mutex;

--- a/src/net.h
+++ b/src/net.h
@@ -1074,9 +1074,8 @@ private:
     static bool NodeFullyConnected(const CNode* pnode);
 
     // Network usage totals
-    mutable RecursiveMutex cs_totalBytesRecv;
     mutable RecursiveMutex cs_totalBytesSent;
-    uint64_t nTotalBytesRecv GUARDED_BY(cs_totalBytesRecv) {0};
+    std::atomic<uint64_t> nTotalBytesRecv{0};
     uint64_t nTotalBytesSent GUARDED_BY(cs_totalBytesSent) {0};
 
     // outbound limit & stats

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -25,16 +25,16 @@ struct ConnmanTestMsg : public CConnman {
 
     void AddTestNode(CNode& node)
     {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&node);
+        LOCK(m_nodes_mutex);
+        m_nodes.push_back(&node);
     }
     void ClearTestNodes()
     {
-        LOCK(cs_vNodes);
-        for (CNode* node : vNodes) {
+        LOCK(m_nodes_mutex);
+        for (CNode* node : m_nodes) {
             delete node;
         }
-        vNodes.clear();
+        m_nodes.clear();
     }
 
     void ProcessMessagesOnce(CNode& node) { m_msgproc->ProcessMessages(&node, flagInterruptMsgProc); }


### PR DESCRIPTION
This PR is related to #19303 and gets rid of the following RecursiveMutex members in class `CConnman`:
* for `cs_totalBytesRecv`, protecting `nTotalBytesRecv`, `std::atomic` is used instead (the member is only increment at one and read at another place, so this is sufficient)
* for `m_addr_fetches_mutex`, protecting `m_addr_fetches`, a regular `Mutex` is used instead (there is no chance that within one critical section, another one is called)
* for `cs_vAddedNodes`, protecting `vAddedNodes`, a regular `Mutex` is used instead (there is no chance that within one critical section, another one is called)

Additionally, the PR takes the chance to rename all node vector members (vNodes, vAddedNodes) and its corresponding mutexes (cs_vNodes, cs_vAddedNodes) to match the coding guidelines via a scripted-diff.
