### PR TITLE
net: remove reinit of the onion proxy

### DIFF
--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -373,15 +373,6 @@ void TorController::auth_cb(TorControlConnection& _conn, const TorControlReply& 
     if (reply.code == 250) {
         LogPrint(BCLog::TOR, "tor: Authentication successful\n");
 
-        // Now that we know Tor is running setup the proxy for onion addresses
-        // if -onion isn't set to something else.
-        if (gArgs.GetArg("-onion", "") == "") {
-            CService resolved(LookupNumeric("127.0.0.1", 9050));
-            proxyType addrOnion = proxyType(resolved, true);
-            SetProxy(NET_ONION, addrOnion);
-            SetReachable(NET_ONION, true);
-        }
-
         // Finally - now create the service
         if (private_key.empty()) { // No private key, generate one
             private_key = "NEW:ED25519-V3"; // Explicitly request key type - see issue #9214


### PR DESCRIPTION
onion proxy is already initialized by AppInitMain() function in init.cpp

The removed code contains the assumption that the proxy is local.

If it has been initialized to be remote and configured by using the
-proxy option, the removed code was breaking the config.

Signed-off-by: Olivier Langlois <olivier@trillion01.com>
