### PR TITLE
build: fix unoptimized libraries in depends

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -12,7 +12,7 @@ $(package)_config_opts_mingw32=--enable-mingw
 $(package)_config_opts_linux=--with-pic
 $(package)_config_opts_android=--with-pic
 $(package)_cflags+=-Wno-error=implicit-function-declaration
-$(package)_cxxflags=-std=c++17
+$(package)_cxxflags+=-std=c++17
 $(package)_cppflags_mingw32=-DUNICODE -D_UNICODE
 endef
 

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -23,7 +23,7 @@ else
 $(package)_toolset_$(host_os)=gcc
 endif
 $(package)_config_libraries=filesystem,system,test
-$(package)_cxxflags=-std=c++17 -fvisibility=hidden
+$(package)_cxxflags+=-std=c++17 -fvisibility=hidden
 $(package)_cxxflags_linux=-fPIC
 $(package)_cxxflags_android=-fPIC
 $(package)_cxxflags_x86_64_darwin=-fcf-protection=full

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -12,7 +12,7 @@ define $(package)_set_vars
   $(package)_config_opts += --disable-Werror --disable-drafts --enable-option-checking
   $(package)_config_opts_linux=--with-pic
   $(package)_config_opts_android=--with-pic
-  $(package)_cxxflags=-std=c++17
+  $(package)_cxxflags+=-std=c++17
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
We need to append-to rather than set CXXFLAGS, otherwise we loose `-O2` & `-pipe` from our defaults. Currently this results in zeromq being built without optimizations at all (or whatever the compiler would default too, essentially  always `-O0`).

Bdb is the same, for the CXX portion of its code. C code has been built with `-O2`. Boost has actually been unaffected because it receives `-O3` from it's own build flags.

Noticed while reworking #22380. For bdb & zeromq, I assume (haven't checked) this has been the case since #7165.

You can inspect the effcts in bitcoind comparing a function from a unoptimised library, i.e libzmq.

Build bitcoind with zeromq from depends (7be143a960e2bb9ac81144f55c45731c1bb209c5):
```
gmake -C depends NO_QT=1 NO_UPNP=1 NO_NATPMP=1 NO_WALLET=1 -j9

./autogen.sh
CONFIG_SITE=/path/to/share/config.site ./configure
gmake -C src bitcoind -j9
```

Find a zeromq function:
```bash
nm -C src/bitcoind | rg zmq
...
000000010053a7e0 T _zmq_ctx_new
```

Disassemble it:
```bash
lldb src/bitcoind
disassemble -a 000000010053a7e0
...
bitcoind`zmq_ctx_new:
bitcoind[0x10053a7e0] <+0>:   pushq  %rbp
bitcoind[0x10053a7e1] <+1>:   movq   %rsp, %rbp
bitcoind[0x10053a7e4] <+4>:   subq   $0x50, %rsp
bitcoind[0x10053a7e8] <+8>:   callq  0x1004b2ee0               ; zmq::initialize_network()
bitcoind[0x10053a7ed] <+13>:  testb  $0x1, %al
bitcoind[0x10053a7ef] <+15>:  jne    0x10053a802               ; <+34>
bitcoind[0x10053a7f5] <+21>:  movq   $0x0, -0x8(%rbp)
bitcoind[0x10053a7fd] <+29>:  jmp    0x10053a8e8               ; <+264>
bitcoind[0x10053a802] <+34>:  movq   0xadab7(%rip), %rsi       ; (void *)0x0000000000000000
bitcoind[0x10053a809] <+41>:  movl   $0x2b8, %edi              ; imm = 0x2B8 
bitcoind[0x10053a80e] <+46>:  callq  0x100556c58               ; symbol stub for: operator new(unsigned long, std::nothrow_t const&)
bitcoind[0x10053a813] <+51>:  xorl   %ecx, %ecx
bitcoind[0x10053a815] <+53>:  movl   %ecx, %edx
bitcoind[0x10053a817] <+55>:  movb   $0x0, -0x19(%rbp)
bitcoind[0x10053a81b] <+59>:  cmpq   $0x0, %rax
bitcoind[0x10053a81f] <+63>:  movq   %rax, -0x38(%rbp)
bitcoind[0x10053a823] <+67>:  movq   %rdx, -0x40(%rbp)
bitcoind[0x10053a827] <+71>:  je     0x10053a858               ; <+120>
bitcoind[0x10053a82d] <+77>:  movq   -0x38(%rbp), %rax
bitcoind[0x10053a831] <+81>:  movq   %rax, -0x18(%rbp)
bitcoind[0x10053a835] <+85>:  movb   $0x1, -0x19(%rbp)
bitcoind[0x10053a839] <+89>:  movq   -0x38(%rbp), %rdi
bitcoind[0x10053a83d] <+93>:  movq   %rax, -0x48(%rbp)
bitcoind[0x10053a841] <+97>:  callq  0x100497aa0               ; zmq::ctx_t::ctx_t()
bitcoind[0x10053a846] <+102>: jmp    0x10053a84b               ; <+107>
bitcoind[0x10053a84b] <+107>: movq   -0x48(%rbp), %rax
bitcoind[0x10053a84f] <+111>: movq   %rax, -0x40(%rbp)
bitcoind[0x10053a853] <+115>: jmp    0x10053a858               ; <+120>
bitcoind[0x10053a858] <+120>: movq   -0x40(%rbp), %rax
bitcoind[0x10053a85c] <+124>: movq   %rax, -0x10(%rbp)
bitcoind[0x10053a860] <+128>: cmpq   $0x0, -0x10(%rbp)
bitcoind[0x10053a865] <+133>: je     0x10053a8e0               ; <+256>
bitcoind[0x10053a86b] <+139>: movq   -0x10(%rbp), %rdi
bitcoind[0x10053a86f] <+143>: callq  0x100497ee0               ; zmq::ctx_t::valid() const
bitcoind[0x10053a874] <+148>: testb  $0x1, %al
bitcoind[0x10053a876] <+150>: jne    0x10053a8db               ; <+251>
bitcoind[0x10053a87c] <+156>: movq   -0x10(%rbp), %rax
bitcoind[0x10053a880] <+160>: cmpq   $0x0, %rax
bitcoind[0x10053a884] <+164>: movq   %rax, -0x50(%rbp)
bitcoind[0x10053a888] <+168>: je     0x10053a8a3               ; <+195>
bitcoind[0x10053a88e] <+174>: movq   -0x50(%rbp), %rdi
bitcoind[0x10053a892] <+178>: callq  0x100497ec0               ; zmq::ctx_t::~ctx_t()
bitcoind[0x10053a897] <+183>: movq   -0x50(%rbp), %rax
bitcoind[0x10053a89b] <+187>: movq   %rax, %rdi
bitcoind[0x10053a89e] <+190>: callq  0x100556c3a               ; symbol stub for: operator delete(void*)
bitcoind[0x10053a8a3] <+195>: movq   $0x0, -0x8(%rbp)
bitcoind[0x10053a8ab] <+203>: jmp    0x10053a8e8               ; <+264>
bitcoind[0x10053a8b0] <+208>: movq   %rax, -0x28(%rbp)
bitcoind[0x10053a8b4] <+212>: movl   %edx, -0x2c(%rbp)
bitcoind[0x10053a8b7] <+215>: testb  $0x1, -0x19(%rbp)
bitcoind[0x10053a8bb] <+219>: jne    0x10053a8c6               ; <+230>
bitcoind[0x10053a8c1] <+225>: jmp    0x10053a8d6               ; <+246>
bitcoind[0x10053a8c6] <+230>: movq   0xad9f3(%rip), %rsi       ; (void *)0x0000000000000000
bitcoind[0x10053a8cd] <+237>: movq   -0x18(%rbp), %rdi
bitcoind[0x10053a8d1] <+241>: callq  0x100556c40               ; symbol stub for: operator delete(void*, std::nothrow_t const&)
bitcoind[0x10053a8d6] <+246>: jmp    0x10053a8f2               ; <+274>
bitcoind[0x10053a8db] <+251>: jmp    0x10053a8e0               ; <+256>
bitcoind[0x10053a8e0] <+256>: movq   -0x10(%rbp), %rax
bitcoind[0x10053a8e4] <+260>: movq   %rax, -0x8(%rbp)
bitcoind[0x10053a8e8] <+264>: movq   -0x8(%rbp), %rax
bitcoind[0x10053a8ec] <+268>: addq   $0x50, %rsp
bitcoind[0x10053a8f0] <+272>: popq   %rbp
bitcoind[0x10053a8f1] <+273>: retq   
bitcoind[0x10053a8f2] <+274>: movq   -0x28(%rbp), %rdi
bitcoind[0x10053a8f6] <+278>: callq  0x100556856               ; symbol stub for: _Unwind_Resume
bitcoind[0x10053a8fb] <+283>: ud2    
bitcoind[0x10053a8fd] <+285>: nopl   (%rax)
```

Cleanup and repeat after changing the zeromq cxxflags to be `$(package)_cxxflags+=-std=c++17`:
```bash
gmake clean
gmake -C depends NO_QT=1 NO_UPNP=1 NO_NATPMP=1 NO_WALLET=1 -j9
gmake -C src bitcoind -j9

nm -C src/bitcoind | rg zmq
...
00000001004d5170 T _zmq_ctx_new
```

Disassemble the same function which has now been built with `-O2`:
```bash
lldb src/bitcoind
disassemble -a 00000001004d5170
...
bitcoind`zmq_ctx_new:
bitcoind[0x1004d5170] <+0>:   pushq  %rbp
bitcoind[0x1004d5171] <+1>:   movq   %rsp, %rbp
bitcoind[0x1004d5174] <+4>:   pushq  %r14
bitcoind[0x1004d5176] <+6>:   pushq  %rbx
bitcoind[0x1004d5177] <+7>:   callq  0x10049cbc0               ; zmq::initialize_network()
bitcoind[0x1004d517c] <+12>:  testb  %al, %al
bitcoind[0x1004d517e] <+14>:  je     0x1004d51bd               ; <+77>
bitcoind[0x1004d5180] <+16>:  movq   0xab139(%rip), %rsi       ; (void *)0x0000000000000000
bitcoind[0x1004d5187] <+23>:  movl   $0x2b8, %edi              ; imm = 0x2B8 
bitcoind[0x1004d518c] <+28>:  callq  0x1004f0e5a               ; symbol stub for: operator new(unsigned long, std::nothrow_t const&)
bitcoind[0x1004d5191] <+33>:  testq  %rax, %rax
bitcoind[0x1004d5194] <+36>:  je     0x1004d51bd               ; <+77>
bitcoind[0x1004d5196] <+38>:  movq   %rax, %rbx
bitcoind[0x1004d5199] <+41>:  movq   %rax, %rdi
bitcoind[0x1004d519c] <+44>:  callq  0x100493400               ; zmq::ctx_t::ctx_t()
bitcoind[0x1004d51a1] <+49>:  movq   %rbx, %rdi
bitcoind[0x1004d51a4] <+52>:  callq  0x1004936e0               ; zmq::ctx_t::valid() const
bitcoind[0x1004d51a9] <+57>:  testb  %al, %al
bitcoind[0x1004d51ab] <+59>:  jne    0x1004d51bf               ; <+79>
bitcoind[0x1004d51ad] <+61>:  movq   %rbx, %rdi
bitcoind[0x1004d51b0] <+64>:  callq  0x1004936d0               ; zmq::ctx_t::~ctx_t()
bitcoind[0x1004d51b5] <+69>:  movq   %rbx, %rdi
bitcoind[0x1004d51b8] <+72>:  callq  0x1004f0e42               ; symbol stub for: operator delete(void*)
bitcoind[0x1004d51bd] <+77>:  xorl   %ebx, %ebx
bitcoind[0x1004d51bf] <+79>:  movq   %rbx, %rax
bitcoind[0x1004d51c2] <+82>:  popq   %rbx
bitcoind[0x1004d51c3] <+83>:  popq   %r14
bitcoind[0x1004d51c5] <+85>:  popq   %rbp
bitcoind[0x1004d51c6] <+86>:  retq   
bitcoind[0x1004d51c7] <+87>:  movq   %rax, %r14
bitcoind[0x1004d51ca] <+90>:  movq   0xab0ef(%rip), %rsi       ; (void *)0x0000000000000000
bitcoind[0x1004d51d1] <+97>:  movq   %rbx, %rdi
bitcoind[0x1004d51d4] <+100>: callq  0x1004f0e48               ; symbol stub for: operator delete(void*, std::nothrow_t const&)
bitcoind[0x1004d51d9] <+105>: movq   %r14, %rdi
bitcoind[0x1004d51dc] <+108>: callq  0x1004f0a6a               ; symbol stub for: _Unwind_Resume
bitcoind[0x1004d51e1] <+113>: ud2    
bitcoind[0x1004d51e3] <+115>: nopw   %cs:(%rax,%rax)
bitcoind[0x1004d51ed] <+125>: nopl   (%rax)
```