### PR TITLE
msvc: update bitcoin_config.h defines

### DIFF
--- a/build_msvc/bitcoin_config.h
+++ b/build_msvc/bitcoin_config.h
@@ -5,9 +5,6 @@
 #ifndef BITCOIN_BITCOIN_CONFIG_H
 #define BITCOIN_BITCOIN_CONFIG_H
 
-/* Define if building universal (internal helper macro) */
-/* #undef AC_APPLE_UNIVERSAL_BUILD */
-
 /* Version Build */
 #define CLIENT_VERSION_BUILD 0
 
@@ -59,14 +56,11 @@
 /* define if the Boost::Unit_Test_Framework library is available */
 #define HAVE_BOOST_UNIT_TEST_FRAMEWORK /**/
 
-/* Define to 1 if you have the <byteswap.h> header file. */
-/* #undef HAVE_BYTESWAP_H */
-
 /* Define this symbol if the consensus lib has been built */
 #define HAVE_CONSENSUS_LIB 1
 
-/* define if the compiler supports basic C++11 syntax */
-#define HAVE_CXX11 1
+/* define if the compiler supports basic C++17 syntax */
+#define HAVE_CXX17 1
 
 /* Define to 1 if you have the declaration of `be16toh', and to 0 if you
    don't. */
@@ -144,36 +138,11 @@
    don't. */
 #define HAVE_DECL_STRNLEN 1
 
-/* Define to 1 if you have the <dlfcn.h> header file. */
-/* #undef HAVE_DLFCN_H */
-
-/* Define to 1 if you have the <endian.h> header file. */
-/* #undef HAVE_ENDIAN_H */
-
-/* Define to 1 if the system has the `dllexport' function attribute */
-#define HAVE_FUNC_ATTRIBUTE_DLLEXPORT 1
-
-/* Define to 1 if the system has the `dllimport' function attribute */
-#define HAVE_FUNC_ATTRIBUTE_DLLIMPORT 1
-
-/* Define to 1 if the system has the `visibility' function attribute */
-#define HAVE_FUNC_ATTRIBUTE_VISIBILITY 1
-
-/* Define this symbol if the BSD getentropy system call is available */
-/* #undef HAVE_GETENTROPY */
-
-/* Define this symbol if the BSD getentropy system call is available with
-   sys/random.h */
-/* #undef HAVE_GETENTROPY_RAND */
+/* Define if the dllexport attribute is supported. */
+#define HAVE_DLLEXPORT_ATTRIBUTE 1
 
 /* Define to 1 if you have the <inttypes.h> header file. */
 #define HAVE_INTTYPES_H 1
-
-/* Define this symbol if you have malloc_info */
-/* #undef HAVE_MALLOC_INFO */
-
-/* Define this symbol if you have mallopt with M_ARENA_MAX */
-/* #undef HAVE_MALLOPT_ARENA_MAX */
 
 /* Define to 1 if you have the <memory.h> header file. */
 #define HAVE_MEMORY_H 1
@@ -187,18 +156,6 @@
 /* Define to 1 if you have the <miniupnpc/upnperrors.h> header file. */
 #define HAVE_MINIUPNPC_UPNPERRORS_H 1
 
-/* Define this symbol if you have MSG_DONTWAIT */
-/* #undef HAVE_MSG_DONTWAIT */
-
-/* Define this symbol if you have MSG_NOSIGNAL */
-/* #undef HAVE_MSG_NOSIGNAL */
-
-/* Define if you have POSIX threads libraries and header files. */
-//#define HAVE_PTHREAD 1
-
-/* Have PTHREAD_PRIO_INHERIT. */
-//#define HAVE_PTHREAD_PRIO_INHERIT 1
-
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1
 
@@ -208,44 +165,17 @@
 /* Define to 1 if you have the <stdlib.h> header file. */
 #define HAVE_STDLIB_H 1
 
-/* Define to 1 if you have the `strerror_r' function. */
-/* #undef HAVE_STRERROR_R */
-
 /* Define to 1 if you have the <strings.h> header file. */
 #define HAVE_STRINGS_H 1
 
 /* Define to 1 if you have the <string.h> header file. */
 #define HAVE_STRING_H 1
 
-/* Define this symbol if the BSD sysctl(KERN_ARND) is available */
-/* #undef HAVE_SYSCTL_ARND */
-
-/* Define to 1 if you have the <sys/endian.h> header file. */
-/* #undef HAVE_SYS_ENDIAN_H */
-
-/* Define this symbol if the Linux getrandom system call is available */
-/* #undef HAVE_SYS_GETRANDOM */
-
-/* Define to 1 if you have the <sys/prctl.h> header file. */
-/* #undef HAVE_SYS_PRCTL_H */
-
-/* Define to 1 if you have the <sys/select.h> header file. */
-/* #undef HAVE_SYS_SELECT_H */
-
 /* Define to 1 if you have the <sys/stat.h> header file. */
 #define HAVE_SYS_STAT_H 1
 
 /* Define to 1 if you have the <sys/types.h> header file. */
 #define HAVE_SYS_TYPES_H 1
-
-/* Define to 1 if you have the <unistd.h> header file. */
-//#define HAVE_UNISTD_H 1
-
-/* Define if the visibility attribute is supported. */
-#define HAVE_VISIBILITY_ATTRIBUTE 1
-
-/* Define to the sub-directory where libtool stores uninstalled libraries. */
-#define LT_OBJDIR ".libs/"
 
 /* Define to the address where bug reports for this package should be sent. */
 #define PACKAGE_BUGREPORT "https://github.com/bitcoin/bitcoin/issues"
@@ -256,21 +186,11 @@
 /* Define to the full name and version of this package. */
 #define PACKAGE_STRING "Bitcoin Core 22.99.0"
 
-/* Define to the one symbol short name of this package. */
-#define PACKAGE_TARNAME "bitcoin"
-
 /* Define to the home page for this package. */
 #define PACKAGE_URL "https://bitcoincore.org/"
 
 /* Define to the version of this package. */
 #define PACKAGE_VERSION "22.99.0"
-
-/* Define to necessary symbol if this constant uses a non-standard name on
-   your system. */
-/* #undef PTHREAD_CREATE_JOINABLE */
-
-/* Define this symbol if the qt platform is cocoa */
-/* #undef QT_QPA_PLATFORM_COCOA */
 
 /* Define this symbol if the minimal qt platform exists */
 #define QT_QPA_PLATFORM_MINIMAL 1
@@ -278,53 +198,8 @@
 /* Define this symbol if the qt platform is windows */
 #define QT_QPA_PLATFORM_WINDOWS 1
 
-/* Define this symbol if the qt platform is xcb */
-/* #undef QT_QPA_PLATFORM_XCB */
-
 /* Define this symbol if qt plugins are static */
 #define QT_STATICPLUGIN 1
-
-/* Define to 1 if you have the ANSI C header files. */
-#define STDC_HEADERS 1
-
-/* Define to 1 if strerror_r returns char *. */
-/* #undef STRERROR_R_CHAR_P */
-
-/* Define this symbol to build in assembly routines */
-//#define USE_ASM 1
-
-/* Define if dbus support should be compiled in */
-/* #undef USE_DBUS */
-
-/* Define if QR support should be compiled in */
-//#define USE_QRCODE 1
-
-/* UPnP support not compiled if undefined, otherwise value (0 or 1) determines
-   default state */
-//#define USE_UPNP 0
-
-/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
-   significant byte first (like Motorola and SPARC, unlike Intel). */
-#if defined AC_APPLE_UNIVERSAL_BUILD
-# if defined __BIG_ENDIAN__
-#  define WORDS_BIGENDIAN 1
-# endif
-#else
-# ifndef WORDS_BIGENDIAN
-/* #  undef WORDS_BIGENDIAN */
-# endif
-#endif
-
-/* Enable large inode numbers on Mac OS X 10.5.  */
-#ifndef _DARWIN_USE_64_BIT_INODE
-# define _DARWIN_USE_64_BIT_INODE 1
-#endif
-
-/* Number of bits in a file offset, on hosts where this is settable. */
-#define _FILE_OFFSET_BITS 64
-
-/* Define for large files, on AIX-style hosts. */
-/* #undef _LARGE_FILES */
 
 /* Windows Universal Platform constraints */
 #if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)


### PR DESCRIPTION
While not many of these are used, some, like `HAVE_DLLEXPORT_ATTRIBUTE`, are used when creating libbitcoinconsensus.

Given this file is static, also just remove everything that is commented out.