### PR TITLE
feature: enable mypy to run without --ignore-imports

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -16,6 +16,7 @@ ${CI_RETRY_EXE} pip3 install flake8==3.8.3
 ${CI_RETRY_EXE} pip3 install yq
 ${CI_RETRY_EXE} pip3 install mypy==0.781
 ${CI_RETRY_EXE} pip3 install vulture==2.3
+${CI_RETRY_EXE} pip3 install pyzmq==22.2.1
 
 SHELLCHECK_VERSION=v0.7.2
 curl -sL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar --xz -xf - --directory /tmp/

--- a/contrib/devtools/security-check.py
+++ b/contrib/devtools/security-check.py
@@ -10,7 +10,7 @@ Otherwise the exit status will be 1 and it will log which executables failed whi
 import sys
 from typing import List, Optional
 
-import lief
+import lief #type:ignore
 import pixie
 
 def check_ELF_PIE(executable) -> bool:

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 from typing import List, Optional
 
-import lief
+import lief #type:ignore
 import pixie
 
 from utils import determine_wellknown_cmd

--- a/test/lint/lint-python.sh
+++ b/test/lint/lint-python.sh
@@ -102,7 +102,7 @@ if ! PYTHONWARNINGS="ignore" flake8 --ignore=B,C,E,F,I,N,W --select=$(IFS=","; e
     EXIT_CODE=1
 fi
 
-if ! mypy --ignore-missing-imports --show-error-codes $(git ls-files "test/functional/*.py" "contrib/devtools/*.py"); then
+if ! mypy --show-error-codes $(git ls-files "test/functional/*.py" "contrib/devtools/*.py"); then
     EXIT_CODE=1
 fi
 


### PR DESCRIPTION
This relates to #19389 by enabling mypy to run without `--ignore-imports`. This is the minimum amount of work needed to get mypy running in the linter, after which annotations can be added to scripts in `contrib/` and `test_framework/` to get the full benefit of running mypy in the linter.

## special notes

This also involved updating PyZMQ per https://github.com/bitcoin/bitcoin/issues/19389#issuecomment-850092152 .

## how to test

after making these changes, I ran `./test/lint/lint-python.sh` and verified no errors. 

To be sure mypy would actually catch type errors when they existed, I added the following lines to `contrib/devtools/symbol-checker.py`:

```
def check_imported_symbols(filename: str) -> bool:
    test = filename + 1
    ...
```

First, `filename` needed to be annotated as str, or else mypy treats it as `Any` and `Any +1` is allowed. After annotating `filename: str` and adding an illegal operation, running ./test/lint/lint-python.sh` returned the following error:

```bash
contrib/devtools/symbol-check.py:170:5: F841 local variable 'test' is assigned to but never used
contrib/devtools/symbol-check.py:170: error: Unsupported operand types for + ("str" and "int")  [operator]
```

## next steps

Where we do have mypy annotations, they are often incomplete. This causes mypy to evaluate arguments as `Any` (see example above with `symbol-checker.py`). I propose a follow-up PR adding annotations. At a minimum, annotations should be added for everything in `test_framework/`, which can be done fairly easily with `monkeytype`. The benefit of this is, now that we are running without `--ignore-imports`, mypy can detect errors in the functional tests even if they don't have annotations, so long as all of the files in `test_framework/` are fully annotated.