### PR TITLE
policy: unit test Segwit dust thresholds

### DIFF
--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -955,6 +955,33 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
     BOOST_CHECK_EQUAL(reason, "bare-multisig");
     fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
+
+    // Check P2WPKH outputs dust threshold
+    t.vout[0].scriptPubKey = CScript() << OP_0 << ParseHex("ffffffffffffffffffffffffffffffffffffffff");
+    t.vout[0].nValue = 294;
+    BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
+    t.vout[0].nValue = 293;
+    BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
+    BOOST_CHECK_EQUAL(reason, "dust");
+
+    // Check P2WSH outputs dust threshold
+    t.vout[0].scriptPubKey = CScript() << OP_0 << ParseHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    t.vout[0].nValue = 330;
+    BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
+    t.vout[0].nValue = 329;
+    BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
+    BOOST_CHECK_EQUAL(reason, "dust");
+
+    // Check future Witness Program versions dust threshold
+    for (int op = OP_2; op <= OP_16; op += 1) {
+        t.vout[0].scriptPubKey = CScript() << (opcodetype)op << ParseHex("ffff");
+        t.vout[0].nValue = 240;
+        BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
+
+        t.vout[0].nValue = 239;
+        BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
+        BOOST_CHECK_EQUAL(reason, "dust");
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is the unit testing part of #22779, hence without the threshold modification.