### PR TITLE
guix/prelude: Override `VERSION` with `FORCE_VERSION`

### DIFF
--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -49,7 +49,7 @@ fi
 # Set common variables
 ################
 
-VERSION="${VERSION:-$(git_head_version)}"
+VERSION="${FORCE_VERSION:-$(git_head_version)}"
 DISTNAME="${DISTNAME:-bitcoin-${VERSION}}"
 
 version_base_prefix="${PWD}/guix-build-"


### PR DESCRIPTION
```
Previously, if the builder exported $VERSION in their environment (as
past Gitian-building docs told them to), but their HEAD does not
actually point to v$VERSION, their build outputs will differ from those
of other builders.

This is because the contrib/guix/guix-* scripts only ever act on the
current git worktree, and does not try to check out $VERSION if $VERSION
is set in the environment.

Setting $VERSION only makes the scripts pretend like the current
worktree is $VERSION.

This problem was seen in jonatack's attestation for all.SHA256SUMS,
where only his bitcoin-22.0rc3-osx-signed.dmg differed from everyone
else's.

Here is my deduced sequence of events:

1. Aug 27th: He guix-builds 22.0rc3 and uploads his attestations up to
   guix.sigs

2. Aug 30th, sometime after POSIX time 1630310848: he pulls the latest
   changes from master in the same worktree where he guix-built 22.0rc3
   and ends up at 7be143a960e2

3. Aug 30th, sometime before POSIX time 1630315907: With his worktree
   still on 7be143a960e2, he guix-codesigns. Normally, this would result
   in outputs going in guix-build-7be143a960e2, but he had
   VERSION=22.0rc3 in his environment, so the guix-* scripts pretended
   like he was building 22.0rc3, and used 22.0rc3's guix-build directory
   to locate un-codesigned outputs and dump codesigned ones.

   However, our SOURCE_DATE_EPOCH defaults to the POSIX time of HEAD
   (7be143a960e2), which made all timestamps in the resulting codesigned
   DMG 1630310848, 7be143a960e2's POSIX timestamp. This differs from the
   POSIX timestamp of 22.0rc3, which is 1630348517. Note that the
   windows codesigning procedure does not consider SOURCE_DATE_EPOCH.

We resolve this by only allowing VERSION overrides via the FORCE_VERSION
environment variable.
```

Please ignore the branch name, it's not relevant to the change.