### PR TITLE
MOVEONLY: Expose BanMapToJson / BanMapFromJson

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -548,6 +548,7 @@ libbitcoin_common_a_SOURCES = \
   key.cpp \
   key_io.cpp \
   merkleblock.cpp \
+  net_types.cpp \
   netaddress.cpp \
   netbase.cpp \
   net_permissions.cpp \

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -19,64 +19,7 @@
 #include <util/settings.h>
 #include <util/system.h>
 
-CBanEntry::CBanEntry(const UniValue& json)
-    : nVersion(json["version"].get_int()), nCreateTime(json["ban_created"].get_int64()),
-      nBanUntil(json["banned_until"].get_int64())
-{
-}
-
-UniValue CBanEntry::ToJson() const
-{
-    UniValue json(UniValue::VOBJ);
-    json.pushKV("version", nVersion);
-    json.pushKV("ban_created", nCreateTime);
-    json.pushKV("banned_until", nBanUntil);
-    return json;
-}
-
 namespace {
-
-static const char* BANMAN_JSON_ADDR_KEY = "address";
-
-/**
- * Convert a `banmap_t` object to a JSON array.
- * @param[in] bans Bans list to convert.
- * @return a JSON array, similar to the one returned by the `listbanned` RPC. Suitable for
- * passing to `BanMapFromJson()`.
- */
-UniValue BanMapToJson(const banmap_t& bans)
-{
-    UniValue bans_json(UniValue::VARR);
-    for (const auto& it : bans) {
-        const auto& address = it.first;
-        const auto& ban_entry = it.second;
-        UniValue j = ban_entry.ToJson();
-        j.pushKV(BANMAN_JSON_ADDR_KEY, address.ToString());
-        bans_json.push_back(j);
-    }
-    return bans_json;
-}
-
-/**
- * Convert a JSON array to a `banmap_t` object.
- * @param[in] bans_json JSON to convert, must be as returned by `BanMapToJson()`.
- * @param[out] bans Bans list to create from the JSON.
- * @throws std::runtime_error if the JSON does not have the expected fields or they contain
- * unparsable values.
- */
-void BanMapFromJson(const UniValue& bans_json, banmap_t& bans)
-{
-    for (const auto& ban_entry_json : bans_json.getValues()) {
-        CSubNet subnet;
-        const auto& subnet_str = ban_entry_json[BANMAN_JSON_ADDR_KEY].get_str();
-        if (!LookupSubNet(subnet_str, subnet)) {
-            throw std::runtime_error(
-                strprintf("Cannot parse banned address or subnet: %s", subnet_str));
-        }
-        bans.insert_or_assign(subnet, CBanEntry{ban_entry_json});
-    }
-}
-
 template <typename Stream, typename Data>
 bool SerializeDB(Stream& stream, const Data& data)
 {

--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -16,33 +16,6 @@ class CAddress;
 class CAddrMan;
 class CDataStream;
 
-class CBanEntry
-{
-public:
-    static constexpr int CURRENT_VERSION{1};
-    int nVersion{CBanEntry::CURRENT_VERSION};
-    int64_t nCreateTime{0};
-    int64_t nBanUntil{0};
-
-    CBanEntry() {}
-
-    explicit CBanEntry(int64_t nCreateTimeIn)
-        : nCreateTime{nCreateTimeIn} {}
-
-    /**
-     * Create a ban entry from JSON.
-     * @param[in] json A JSON representation of a ban entry, as created by `ToJson()`.
-     * @throw std::runtime_error if the JSON does not have the expected fields.
-     */
-    explicit CBanEntry(const UniValue& json);
-
-    /**
-     * Generate a JSON representation of this ban entry.
-     * @return JSON suitable for passing to the `CBanEntry(const UniValue&)` constructor.
-     */
-    UniValue ToJson() const;
-};
-
 /** Access to the (IP) address database (peers.dat) */
 class CAddrDB
 {

--- a/src/net_types.cpp
+++ b/src/net_types.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <net_types.h>
+
+#include <netaddress.h>
+#include <netbase.h>
+#include <univalue.h>
+
+CBanEntry::CBanEntry(const UniValue& json)
+    : nVersion(json["version"].get_int()), nCreateTime(json["ban_created"].get_int64()),
+      nBanUntil(json["banned_until"].get_int64())
+{
+}
+
+UniValue CBanEntry::ToJson() const
+{
+    UniValue json(UniValue::VOBJ);
+    json.pushKV("version", nVersion);
+    json.pushKV("ban_created", nCreateTime);
+    json.pushKV("banned_until", nBanUntil);
+    return json;
+}
+
+static const char* BANMAN_JSON_ADDR_KEY = "address";
+
+/**
+ * Convert a `banmap_t` object to a JSON array.
+ * @param[in] bans Bans list to convert.
+ * @return a JSON array, similar to the one returned by the `listbanned` RPC. Suitable for
+ * passing to `BanMapFromJson()`.
+ */
+UniValue BanMapToJson(const banmap_t& bans)
+{
+    UniValue bans_json(UniValue::VARR);
+    for (const auto& it : bans) {
+        const auto& address = it.first;
+        const auto& ban_entry = it.second;
+        UniValue j = ban_entry.ToJson();
+        j.pushKV(BANMAN_JSON_ADDR_KEY, address.ToString());
+        bans_json.push_back(j);
+    }
+    return bans_json;
+}
+
+/**
+ * Convert a JSON array to a `banmap_t` object.
+ * @param[in] bans_json JSON to convert, must be as returned by `BanMapToJson()`.
+ * @param[out] bans Bans list to create from the JSON.
+ * @throws std::runtime_error if the JSON does not have the expected fields or they contain
+ * unparsable values.
+ */
+void BanMapFromJson(const UniValue& bans_json, banmap_t& bans)
+{
+    for (const auto& ban_entry_json : bans_json.getValues()) {
+        CSubNet subnet;
+        const auto& subnet_str = ban_entry_json[BANMAN_JSON_ADDR_KEY].get_str();
+        if (!LookupSubNet(subnet_str, subnet)) {
+            throw std::runtime_error(
+                strprintf("Cannot parse banned address or subnet: %s", subnet_str));
+        }
+        bans.insert_or_assign(subnet, CBanEntry{ban_entry_json});
+    }
+}

--- a/src/net_types.h
+++ b/src/net_types.h
@@ -5,11 +5,56 @@
 #ifndef BITCOIN_NET_TYPES_H
 #define BITCOIN_NET_TYPES_H
 
+#include <cstdint>
 #include <map>
 
-class CBanEntry;
 class CSubNet;
+class UniValue;
+
+class CBanEntry
+{
+public:
+    static constexpr int CURRENT_VERSION{1};
+    int nVersion{CBanEntry::CURRENT_VERSION};
+    int64_t nCreateTime{0};
+    int64_t nBanUntil{0};
+
+    CBanEntry() {}
+
+    explicit CBanEntry(int64_t nCreateTimeIn)
+        : nCreateTime{nCreateTimeIn} {}
+
+    /**
+     * Create a ban entry from JSON.
+     * @param[in] json A JSON representation of a ban entry, as created by `ToJson()`.
+     * @throw std::runtime_error if the JSON does not have the expected fields.
+     */
+    explicit CBanEntry(const UniValue& json);
+
+    /**
+     * Generate a JSON representation of this ban entry.
+     * @return JSON suitable for passing to the `CBanEntry(const UniValue&)` constructor.
+     */
+    UniValue ToJson() const;
+};
 
 using banmap_t = std::map<CSubNet, CBanEntry>;
+
+/**
+ * Convert a `banmap_t` object to a JSON array.
+ * @param[in] bans Bans list to convert.
+ * @return a JSON array, similar to the one returned by the `listbanned` RPC. Suitable for
+ * passing to `BanMapFromJson()`.
+ */
+UniValue BanMapToJson(const banmap_t& bans);
+
+/**
+ * Convert a JSON array to a `banmap_t` object.
+ * @param[in] bans_json JSON to convert, must be as returned by `BanMapToJson()`.
+ * @param[out] bans Bans list to create from the JSON.
+ * @throws std::runtime_error if the JSON does not have the expected fields or they contain
+ * unparsable values.
+ */
+void BanMapFromJson(const UniValue& bans_json, banmap_t& bans);
 
 #endif // BITCOIN_NET_TYPES_H


### PR DESCRIPTION
This PR is part of the [process separation project](https://github.com/bitcoin/bitcoin/projects/10).

---

CSubNet serialization code that was removed in #22570 fa4e6afdae7b82df638b60edf37ac36d57a8cb4f was needed by multiprocess code to share ban map between gui and node processes.

Rather than adding it back, use suggestion from MarcoFalke https://github.com/bitcoin/bitcoin/pull/10102#discussion_r690922929 to use JSON serialization. This requires making BanMapToJson / BanMapFromJson functions public.