### PR TITLE
Remove unused SERIALIZE_METHODS for CBanEntry

### DIFF
--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -8,10 +8,8 @@
 
 #include <fs.h>
 #include <net_types.h> // For banmap_t
-#include <serialize.h>
 #include <univalue.h>
 
-#include <string>
 #include <vector>
 
 class CAddress;
@@ -43,12 +41,6 @@ public:
      * @throw std::runtime_error if the JSON does not have the expected fields.
      */
     explicit CBanEntry(const UniValue& json);
-
-    SERIALIZE_METHODS(CBanEntry, obj)
-    {
-        uint8_t ban_reason = 2; //! For backward compatibility
-        READWRITE(obj.nVersion, obj.nCreateTime, obj.nBanUntil, ban_reason);
-    }
 
     void SetNull()
     {

--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -19,21 +19,15 @@ class CDataStream;
 class CBanEntry
 {
 public:
-    static const int CURRENT_VERSION=1;
-    int nVersion;
-    int64_t nCreateTime;
-    int64_t nBanUntil;
+    static constexpr int CURRENT_VERSION{1};
+    int nVersion{CBanEntry::CURRENT_VERSION};
+    int64_t nCreateTime{0};
+    int64_t nBanUntil{0};
 
-    CBanEntry()
-    {
-        SetNull();
-    }
+    CBanEntry() {}
 
     explicit CBanEntry(int64_t nCreateTimeIn)
-    {
-        SetNull();
-        nCreateTime = nCreateTimeIn;
-    }
+        : nCreateTime{nCreateTimeIn} {}
 
     /**
      * Create a ban entry from JSON.
@@ -41,13 +35,6 @@ public:
      * @throw std::runtime_error if the JSON does not have the expected fields.
      */
     explicit CBanEntry(const UniValue& json);
-
-    void SetNull()
-    {
-        nVersion = CBanEntry::CURRENT_VERSION;
-        nCreateTime = 0;
-        nBanUntil = 0;
-    }
 
     /**
      * Generate a JSON representation of this ban entry.

--- a/src/test/fuzz/addrdb.cpp
+++ b/src/test/fuzz/addrdb.cpp
@@ -18,20 +18,6 @@ FUZZ_TARGET(addrdb)
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
 
     // The point of this code is to exercise all CBanEntry constructors.
-    const CBanEntry ban_entry = [&] {
-        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 2)) {
-        case 0:
-            return CBanEntry{fuzzed_data_provider.ConsumeIntegral<int64_t>()};
-            break;
-        case 1: {
-            const std::optional<CBanEntry> ban_entry = ConsumeDeserializable<CBanEntry>(fuzzed_data_provider);
-            if (ban_entry) {
-                return *ban_entry;
-            }
-            break;
-        }
-        }
-        return CBanEntry{};
-    }();
+    const CBanEntry ban_entry{fuzzed_data_provider.ConsumeIntegral<int64_t>()};
     (void)ban_entry; // currently unused
 }

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -195,10 +195,6 @@ FUZZ_TARGET_DESERIALIZE(blockheader_deserialize, {
     CBlockHeader bh;
     DeserializeFromFuzzingInput(buffer, bh);
 })
-FUZZ_TARGET_DESERIALIZE(banentry_deserialize, {
-    CBanEntry be;
-    DeserializeFromFuzzingInput(buffer, be);
-})
 FUZZ_TARGET_DESERIALIZE(txundo_deserialize, {
     CTxUndo tu;
     DeserializeFromFuzzingInput(buffer, tu);


### PR DESCRIPTION
It would be confusing to keep unused and dead code.