### PR TITLE
[22.x] Backports 

### DIFF
--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -49,7 +49,7 @@ fi
 # Set common variables
 ################
 
-VERSION="${VERSION:-$(git_head_version)}"
+VERSION="${FORCE_VERSION:-$(git_head_version)}"
 DISTNAME="${DISTNAME:-bitcoin-${VERSION}}"
 
 version_base_prefix="${PWD}/guix-build-"

--- a/doc/descriptors.md
+++ b/doc/descriptors.md
@@ -99,7 +99,7 @@ Descriptors consist of several types of expressions. The top level expression is
 `ADDR` expressions are any type of supported address:
 - P2PKH addresses (base58, of the form `1...` for mainnet or `[nm]...` for testnet). Note that P2PKH addresses in descriptors cannot be used for P2PK outputs (use the `pk` function instead).
 - P2SH addresses (base58, of the form `3...` for mainnet or `2...` for testnet, defined in [BIP 13](https://github.com/bitcoin/bips/blob/master/bip-0013.mediawiki)).
-- Segwit addresses (bech32, of the form `bc1...` for mainnet or `tb1...` for testnet, defined in [BIP 173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)).
+- Segwit addresses (bech32 and bech32m, of the form `bc1...` for mainnet or `tb1...` for testnet, defined in [BIP 173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki) and [BIP 350](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki)).
 
 ## Explanation
 


### PR DESCRIPTION
Backports:
* #22847 - guix/prelude: Override VERSION with FORCE_VERSION
* #22837 - doc: mention bech32m/BIP350 in doc/descriptors.md

Theses are both minor enough that they would not require and rc4.