### PR TITLE
util: Fix Racy ParseOpCode function initialization

### DIFF
--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -21,13 +21,15 @@
 #include <string>
 
 namespace {
-
-opcodetype ParseOpCode(const std::string& s)
+class OpCodeParser
 {
-    static std::map<std::string, opcodetype> mapOpNames;
+private:
+    std::map<std::string, opcodetype> mapOpNames;
 
-    if (mapOpNames.empty()) {
-        for (unsigned int op = 0; op <= MAX_OPCODE; op++) {
+public:
+    OpCodeParser()
+    {
+        for (unsigned int op = 0; op <= MAX_OPCODE; ++op) {
             // Allow OP_RESERVED to get into mapOpNames
             if (op < OP_NOP && op != OP_RESERVED) {
                 continue;
@@ -44,10 +46,18 @@ opcodetype ParseOpCode(const std::string& s)
             }
         }
     }
+    opcodetype Parse(const std::string& s) const
+    {
+        auto it = mapOpNames.find(s);
+        if (it == mapOpNames.end()) throw std::runtime_error("script parse error: unknown opcode");
+        return it->second;
+    }
+};
 
-    auto it = mapOpNames.find(s);
-    if (it == mapOpNames.end()) throw std::runtime_error("script parse error: unknown opcode");
-    return it->second;
+opcodetype ParseOpCode(const std::string& s)
+{
+    static const OpCodeParser ocp;
+    return ocp.Parse(s);
 }
 
 } // namespace


### PR DESCRIPTION
If multiple callers call ParseOpCode concurrently it will cause a race condition. We can either move the static to it's own area and require init be called explicitly, or just allow concurrent first callers to race to fill in an atomic variable that never changes thereafter. The second approach is taken here.

Static initialization *is* threadsafe, but only insofar as definining the variable being guaranteed to be called once. This is used incorrectly here.

practicalswift --> are there tools we can deploy to catch usage like this?