### PR TITLE
[TESTS] Update Transaction Tests to permit setting a flag as always on and disabling the exhaustive failure test

### DIFF
--- a/src/test/data/tx_valid.json
+++ b/src/test/data/tx_valid.json
@@ -2,7 +2,7 @@
 ["The following are deserialized transactions which are valid."],
 ["They are in the form"],
 ["[[[prevout hash, prevout index, prevout scriptPubKey, amount?], [input 2], ...],"],
-["serializedTransaction, excluded verifyFlags]"],
+["serializedTransaction, excluded verifyFlags, always included verifyFlags?, skip excluded one by one?]"],
 ["Objects that are only a single string (like this one) are ignored"],
 
 ["The following is 23b397edccd3740a74adb603c9756370fafcde9bcc4483eb271ecad09a94dd63"],

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -198,11 +198,19 @@ BOOST_AUTO_TEST_CASE(tx_valid)
         std::string strTest = test.write();
         if (test[0].isArray())
         {
-            if (test.size() != 3 || !test[1].isStr() || !test[2].isStr())
+            const size_t size = test.size();
+            const bool default_args = size == 3;
+            const bool has_skip_exclude_one = size == 5;
+            const bool has_extra_flags = size == 4;
+            const bool size_correct = default_args || has_extra_flags || has_skip_exclude_one;
+            const bool extra_flags_correct = !has_extra_flags || test[3].isStr();
+            const bool skip_exclude_one_correct = !has_skip_exclude_one  || test[4].isBool();
+            if (!size_correct || !test[1].isStr() || !test[2].isStr() || !extra_flags_correct || !skip_exclude_one_correct)
             {
                 BOOST_ERROR("Bad test: " << strTest);
                 continue;
             }
+            const bool skip_exclude_one = has_skip_exclude_one? test[4].get_bool() : false;
 
             std::map<COutPoint, CScript> mapprevOutScriptPubKeys;
             std::map<COutPoint, int64_t> mapprevOutValues;
@@ -243,33 +251,36 @@ BOOST_AUTO_TEST_CASE(tx_valid)
 
             PrecomputedTransactionData txdata(tx);
             unsigned int verify_flags = ParseScriptFlags(test[2].get_str());
+            unsigned int extra_verify_flags = has_extra_flags? ParseScriptFlags(test[3].get_str()) : 0;
 
             // Check that the test gives a valid combination of flags (otherwise VerifyScript will throw). Don't edit the flags.
             if (~verify_flags != FillFlags(~verify_flags)) {
                 BOOST_ERROR("Bad test flags: " << strTest);
             }
 
-            BOOST_CHECK_MESSAGE(CheckTxScripts(tx, mapprevOutScriptPubKeys, mapprevOutValues, ~verify_flags, txdata, strTest, /*expect_valid=*/true),
+            BOOST_CHECK_MESSAGE(CheckTxScripts(tx, mapprevOutScriptPubKeys, mapprevOutValues, extra_verify_flags|~verify_flags, txdata, strTest, /* expect_valid=*/ true),
                                 "Tx unexpectedly failed: " << strTest);
 
             // Backwards compatibility of script verification flags: Removing any flag(s) should not invalidate a valid transaction
             for (const auto& [name, flag] : mapFlagNames) {
                 // Removing individual flags
-                unsigned int flags = TrimFlags(~(verify_flags | flag));
-                if (!CheckTxScripts(tx, mapprevOutScriptPubKeys, mapprevOutValues, flags, txdata, strTest, /*expect_valid=*/true)) {
+                unsigned int flags = TrimFlags(extra_verify_flags | ~(verify_flags | flag));
+                if (!CheckTxScripts(tx, mapprevOutScriptPubKeys, mapprevOutValues, flags, txdata, strTest, /* expect_valid=*/ true)) {
                     BOOST_ERROR("Tx unexpectedly failed with flag " << name << " unset: " << strTest);
                 }
                 // Removing random combinations of flags
-                flags = TrimFlags(~(verify_flags | (unsigned int)InsecureRandBits(mapFlagNames.size())));
-                if (!CheckTxScripts(tx, mapprevOutScriptPubKeys, mapprevOutValues, flags, txdata, strTest, /*expect_valid=*/true)) {
+                flags = TrimFlags(extra_verify_flags | ~(verify_flags | (unsigned int)InsecureRandBits(mapFlagNames.size())));
+                if (!CheckTxScripts(tx, mapprevOutScriptPubKeys, mapprevOutValues, flags, txdata, strTest, /* expect_valid=*/ true)) {
                     BOOST_ERROR("Tx unexpectedly failed with random flags " << ToString(flags) << ": " << strTest);
                 }
             }
 
             // Check that flags are maximal: transaction should fail if any unset flags are set.
-            for (auto flags_excluding_one : ExcludeIndividualFlags(verify_flags)) {
-                if (!CheckTxScripts(tx, mapprevOutScriptPubKeys, mapprevOutValues, ~flags_excluding_one, txdata, strTest, /*expect_valid=*/false)) {
-                    BOOST_ERROR("Too many flags unset: " << strTest);
+            if (!skip_exclude_one) {
+                for (auto flags_excluding_one : ExcludeIndividualFlags(verify_flags)) {
+                    if (!CheckTxScripts(tx, mapprevOutScriptPubKeys, mapprevOutValues, ~flags_excluding_one, txdata, strTest, /* expect_valid=*/ false)) {
+                        BOOST_ERROR("Too many flags unset: " << strTest);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/22865. Required for https://github.com/bitcoin/bitcoin/pull/21702 tests.

The basic issue is that that the current exclude flag doesn't play nicely with flags like DISCOURAGE_UPGRADABLE_NOPS + SOME_OPCODE_VERIFY.

When you have a valid TX under SOME_OPCODE_VERIFY, then the tests will try disabling that flag and it will trip over DISCOURAGE_UPGRADABLE_NOPS.

When you exclude DISCOURAGE_UPGRADABLE_NOPS, then it gets re-included when the test checks all cominations of the excluded flags being re-enabled to show failure, but then it doesn't fail when SOME_OPCODE_VERIFY is set.

To address this, we add two optional fields: 1, a list of flags to *always enable*; 2, a bool of if to disable the one-by-one checker.

By then testing the same vector with:
```
...'DISCOURAGE_UPGRADABLE_NOPS', 'NONE', true]
...'NONE', 'SOME_OPCODE_VERIFY']
```

we get around the one flag at a time checker.


An alternative approach, that would provide better testing coverage, would allow a more abritrary relationship checker that can be specificed by the test writer (e.g., a map of flag to implied flag) to be used during the one-by-one checker.

We cannot simply apply these rules in FillFlags/TrimFlags because if we have a transaction that *should* fail normally with VERIFY_SOME_OPCODE and DISCOURAGE_UPGRADABLE_OPCODES we can't support both cases.

This gap arose when implementing test vectors for BIP-119. Along the way I also discovered that, e.g., CHECKSEQUENCEVERIFY's Upgradable NOP treatment is improperly asserted as per:

```
                   // To provide for future soft-fork extensibility, if the
                    // operand has the disabled lock-time flag set,
                    // CHECKSEQUENCEVERIFY behaves as a NOP.
                    if ((nSequence & CTxIn::SEQUENCE_LOCKTIME_DISABLE_FLAG) != 0)
                        break
```

which does not assert the proper DISCOURAGE_UPGRADABLE_NOP behavior. I beleive that lack of discouragement to be mildly worrying but not a major security concern. Fixing the testing harnesses would allow us to properly implement DISCOURAGE_UPGRADABLE_NOPS for CSV and add the corresponding test cases.