### PR TITLE
doc: Added hyperlink for doc/build

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,1 @@
-Building Bitcoin
-================
-
-See doc/build-*.md for instructions on building the various
-elements of the Bitcoin Core reference implementation of Bitcoin.
+See [doc/build-\*.md](/doc)


### PR DESCRIPTION
Added hyperlink for the doc/build directory (https://github.com/bitcoin/bitcoin/tree/master/doc). This will be convenient for visitors to redirect.
![Screenshot (84)](https://user-images.githubusercontent.com/51878265/132031506-9f5f3935-b1ef-4b70-a097-cd453540108d.png)

