### PR TITLE
doc: provide context for CNetAddr::UnserializeV1Array() and span.h with lifetimebound

### DIFF
--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -386,6 +386,12 @@ private:
 
     /**
      * Unserialize from a pre-ADDRv2/BIP155 format from an array.
+     *
+     * This function is only called from UnserializeV1Stream() and is a wrapper
+     * for SetLegacyIPv6(); however, we keep it for symmetry with
+     * SerializeV1Array() to have pairs of ser/unser functions and to make clear
+     * that if one is altered, a corresponding reverse modification should be
+     * applied to the other.
      */
     void UnserializeV1Array(uint8_t (&arr)[V1_SERIALIZATION_SIZE])
     {

--- a/src/span.h
+++ b/src/span.h
@@ -30,7 +30,11 @@
 
 /** A Span is an object that can refer to a contiguous sequence of objects.
  *
- * It implements a subset of C++20's std::span.
+ * This file implements a subset of C++20's std::span.  It can be considered
+ * temporary compatibility code until C++20 and is designed to be a
+ * self-contained abstraction without depending on other project files. For this
+ * reason, Clang lifetimebound is defined here instead of including
+ * <attributes.h>, which also defines it.
  *
  * Things to be aware of when writing code that deals with Spans:
  *
@@ -60,7 +64,7 @@
  *   types that expose a data() and size() member function), functions that
  *   accept a Span as input parameter can be called with any compatible
  *   range-like object. For example, this works:
-*
+ *
  *       void Foo(Span<const int> arg);
  *
  *       Foo(std::vector<int>{1, 2, 3}); // Works


### PR DESCRIPTION
Add contextual documentation for developers and future readers of the code regarding
- CNetAddr::UnserializeV1Array (see #22140)
- Span and why it defines Clang lifetimebound locally rather than using the one in attributes.h