### PR TITLE
build: Update default platform toolset in msvc-autogen.py

### DIFF
--- a/build_msvc/msvc-autogen.py
+++ b/build_msvc/msvc-autogen.py
@@ -9,7 +9,7 @@ import argparse
 from shutil import copyfile
 
 SOURCE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
-DEFAULT_PLATFORM_TOOLSET = R'v141'
+DEFAULT_PLATFORM_TOOLSET = R'v142'
 
 libs = [
     'libbitcoin_cli',


### PR DESCRIPTION
The platform toolset was updated from v141 to v142 in #17364.