### PR TITLE
netinfo: clarify client and server versions in header

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -514,7 +514,7 @@ public:
         }
 
         // Generate report header.
-        std::string result{strprintf("%s %s%s - %i%s\n\n", PACKAGE_NAME, FormatFullVersion(), ChainToString(), networkinfo["protocolversion"].get_int(), networkinfo["subversion"].get_str())};
+        std::string result{strprintf("%s client %s%s - server %i%s\n\n", PACKAGE_NAME, FormatFullVersion(), ChainToString(), networkinfo["protocolversion"].get_int(), networkinfo["subversion"].get_str())};
 
         // Report detailed peer connections list sorted by direction and minimum ping time.
         if (DetailsRequested() && !m_peers.empty()) {


### PR DESCRIPTION
Clarify in -netinfo output that both the client and the server versions are provided.

before 
```
Bitcoin Core v22.0.0rc3 - 70016/Satoshi:22.99.0/
```

after
```
Bitcoin Core client v22.0.0rc3 - server 70016/Satoshi:22.99.0/
```

Closes #22873.