### PR TITLE
ci: Build and cache static Qt instead of downloading a pre-built one

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -85,65 +85,68 @@ task:
     image: cirrusci/windowsservercore:visualstudio2019
   timeout_in: 120m
   env:
-    CIRRUS_SHELL: powershell
-    PATH: 'C:\Python39;C:\Python39\Scripts;C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin;%PATH%'
+    PATH: 'C:\jom;C:\Python39;C:\Python39\Scripts;C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin;%PATH%'
     PYTHONUTF8: 1
     VCPKG_TAG: '75522bb1f2e7d863078bcd06322348f053a9e33f'
     VCPKG_FEATURE_FLAGS: 'manifests'
-    QT_DOWNLOAD_URL: 'https://github.com/sipsorcery/qt_win_binary/releases/download/qt51211x64_static_vs2019_160900/Qt5.12.11_x64_static_vs2019_160900.zip'
-    QT_DOWNLOAD_HASH: 'b24436bbc49ac69d992efc148e640f02e8dec426bed5f8497abf735e7d7d59d0'
-    QT_LOCAL_PATH: 'C:\Qt5.12.11_x64_static_vs2019_160900'
+    QT_DOWNLOAD_URL: 'https://download.qt.io/official_releases/qt/5.12/5.12.11/single/qt-everywhere-src-5.12.11.zip'
+    QT_LOCAL_PATH: 'C:\qt-everywhere-src-5.12.11.zip'
+    QT_SOURCE_DIR: 'C:\qt-everywhere-src-5.12.11'
+    QTBASEDIR: 'C:\Qt5.12.11_x64_static_vs2019_160900'
+    x64_NATIVE_TOOLS: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"'
     IgnoreWarnIntDirInTempDetected: 'true'
   merge_script:
-    - git config --global user.email "ci@ci.ci"
-    - git config --global user.name "ci"
+    - ps: git config --global user.email "ci@ci.ci"
+    - ps: git config --global user.name "ci"
     # Windows filesystem loses the executable bit, and all of the executable
     # files are considered "modified" now. It will break the following `git merge`
     # command. The next two commands make git ignore this issue.
-    - git config core.filemode false
-    - git reset --hard
-    - if ($env:CIRRUS_PR -eq $null) { exit 0; }
-    - git fetch $env:CIRRUS_REPO_CLONE_URL $env:CIRRUS_BASE_BRANCH
+    - ps: git config core.filemode false
+    - ps: git reset --hard
+    - ps: if ($env:CIRRUS_PR -eq $null) { exit 0; }
+    - ps: git fetch $env:CIRRUS_REPO_CLONE_URL $env:CIRRUS_BASE_BRANCH
     # Merge base to detect silent merge conflicts.
-    - git merge FETCH_HEAD
+    - ps: git merge FETCH_HEAD
+  msvc_qt_built_cache:
+    folder: "%QTBASEDIR%"
+    reupload_on_changes: false
+    fingerprint_script:
+      - echo %QT_DOWNLOAD_URL%
+      - msbuild -version
+    populate_script:
+      - curl -L -o C:\jom.zip http://download.qt.io/official_releases/jom/jom.zip
+      - mkdir C:\jom
+      - tar -xf C:\jom.zip -C C:\jom
+      - curl -L -o %QT_LOCAL_PATH% %QT_DOWNLOAD_URL%
+      - tar -xf %QT_LOCAL_PATH% -C C:\
+      - '%x64_NATIVE_TOOLS%'
+      - cd %QT_SOURCE_DIR%
+      - mkdir build
+      - cd build
+      - ..\configure -release -silent -opensource -confirm-license -opengl desktop -no-shared -static -static-runtime -mp -qt-zlib -qt-pcre -qt-libpng -no-libjpeg -nomake examples -nomake tests -nomake tools -no-dbus -no-libudev -no-icu -no-gtk -no-opengles3 -no-angle -no-sql-sqlite -no-sql-odbc -no-sqlite -no-libudev -no-vulkan -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcanvas3d -skip qtcharts -skip qtconnectivity -skip qtdatavis3d -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtmacextras -skip qtmultimedia -skip qtnetworkauth -skip qtpurchasing -skip qtquickcontrols -skip qtquickcontrols2 -skip qtscript -skip qtscxml -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtvirtualkeyboard -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebsockets -skip qtwebview -skip qtx11extras -skip qtxmlpatterns -no-openssl -no-feature-sql -no-feature-sqlmodel -prefix %QTBASEDIR%
+      - jom
+      - jom install
   vcpkg_cache:
     folder: 'C:\Users\ContainerAdministrator\AppData\Local\vcpkg\archives'
   install_python_script:
     - choco install --yes --no-progress python3 --version=3.9.6
-    - Write-Host ""
     - python -VV
   install_vcpkg_script:
     - cd ..
     - git clone --quiet https://github.com/microsoft/vcpkg.git
     - cd vcpkg
-    - git -c advice.detachedHead=false checkout $env:VCPKG_TAG
+    - git -c advice.detachedHead=false checkout %VCPKG_TAG%
     - .\bootstrap-vcpkg -disableMetrics
-    - Add-Content "triplets\x64-windows-static.cmake" "set(VCPKG_BUILD_TYPE release)"
+    - echo set(VCPKG_BUILD_TYPE release) >> triplets\x64-windows-static.cmake
     - .\vcpkg integrate install
-    - Write-Host ""
     - .\vcpkg version
-  download_qt_binaries_script: |
-      Invoke-WebRequest -Uri $env:QT_DOWNLOAD_URL -Out qtdownload.zip;
-      Write-Host "Qt binaries successfully downloaded, checking hash against $env:QT_DOWNLOAD_HASH...";
-      if ((Get-FileHash qtdownload.zip).Hash -eq $env:QT_DOWNLOAD_HASH) {
-        Write-Host "Downloaded Qt binaries archive matched the expected hash.";
-        Expand-Archive qtdownload.zip -DestinationPath $env:QT_LOCAL_PATH;
-      }
-      else {
-        Write-Host "ERROR: Downloaded Qt binaries archive did not match the expected hash.";
-        exit 1;
-      }
-  build_environment_script:
-    - choco list --localonly
-    - Write-Host ""
-    - msbuild -version
   build_script:
-    - cd $env:CIRRUS_WORKING_DIR
+    - cd %CIRRUS_WORKING_DIR%
     - python build_msvc\msvc-autogen.py
     - msbuild build_msvc\bitcoin.sln -property:Configuration=Release -maxCpuCount -verbosity:minimal -noLogo
   unit_tests_script:
     - src\test_bitcoin.exe -l test_suite
-    - src\bench_bitcoin.exe > $null
+    - src\bench_bitcoin.exe > NUL
     - python test\util\test_runner.py
     - python test\util\rpcauth-test.py
 


### PR DESCRIPTION
This PR makes the MSVC build CI task free of [pre-built static Qt binaries](https://github.com/sipsorcery/qt_win_binary/releases). It uses the approach which is documented in #22890.

It takes about 13 minutes to build a static Qt dependency (for 8 CPUs):

![Screenshot from 2021-09-06 08-59-08](https://user-images.githubusercontent.com/32963518/132167857-bce49c74-f258-4468-b45b-75d0cf3c670c.png)

with the maximum total time:

![Screenshot from 2021-09-06 08-59-26](https://user-images.githubusercontent.com/32963518/132167881-b84bd4de-38cc-4cb1-b9f7-35642cbea8cc.png)

There is an additional benefit of this PR. It is no longer required to build a new static Qt package when a CI Windows image upgrades its building tools, and breaks the compatibility with the recent Qt package.