### PR TITLE
sync, log: inline lock contention logging macro to fix duration, improve BCLog::LogMsg()

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -268,6 +268,7 @@ BITCOIN_CORE_H = \
   util/tokenpipe.h \
   util/trace.h \
   util/translation.h \
+  util/types.h \
   util/ui_change_type.h \
   util/url.h \
   util/vector.h \

--- a/src/logging/timer.h
+++ b/src/logging/timer.h
@@ -60,21 +60,13 @@ public:
 
         if (std::is_same<TimeType, std::chrono::microseconds>::value) {
             return strprintf("%s: %s (%iμs)", m_prefix, msg, end_time.count());
-        }
-
-        std::string units;
-        float divisor = 1;
-
-        if (std::is_same<TimeType, std::chrono::milliseconds>::value) {
-            units = "ms";
-            divisor = 1000.;
+        } else if (std::is_same<TimeType, std::chrono::milliseconds>::value) {
+            return strprintf("%s: %s (%.2fms)", m_prefix, msg, end_time.count() * 0.001);
         } else if (std::is_same<TimeType, std::chrono::seconds>::value) {
-            units = "s";
-            divisor = 1000. * 1000.;
+            return strprintf("%s: %s (%.2fs)", m_prefix, msg, end_time.count() * 0.000001);
+        } else {
+            return "Error: unexpected time type";
         }
-
-        const float time_ms = end_time.count() / divisor;
-        return strprintf("%s: %s (%.2f%s)", m_prefix, msg, time_ms, units);
     }
 
 private:

--- a/src/logging/timer.h
+++ b/src/logging/timer.h
@@ -9,6 +9,7 @@
 #include <logging.h>
 #include <util/macros.h>
 #include <util/time.h>
+#include <util/types.h>
 
 #include <chrono>
 #include <string>
@@ -58,14 +59,14 @@ public:
             return strprintf("%s: %s", m_prefix, msg);
         }
 
-        if (std::is_same<TimeType, std::chrono::microseconds>::value) {
+        if constexpr (std::is_same<TimeType, std::chrono::microseconds>::value) {
             return strprintf("%s: %s (%iμs)", m_prefix, msg, end_time.count());
-        } else if (std::is_same<TimeType, std::chrono::milliseconds>::value) {
+        } else if constexpr (std::is_same<TimeType, std::chrono::milliseconds>::value) {
             return strprintf("%s: %s (%.2fms)", m_prefix, msg, end_time.count() * 0.001);
-        } else if (std::is_same<TimeType, std::chrono::seconds>::value) {
+        } else if constexpr (std::is_same<TimeType, std::chrono::seconds>::value) {
             return strprintf("%s: %s (%.2fs)", m_prefix, msg, end_time.count() * 0.000001);
         } else {
-            return "Error: unexpected time type";
+            static_assert(ALWAYS_FALSE<TimeType>, "Error: unexpected time type");
         }
     }
 
@@ -81,7 +82,6 @@ private:
     //! Forwarded on to LogPrint if specified - has the effect of only
     //! outputting the timing log when a particular debug= category is specified.
     const BCLog::LogFlags m_log_category{};
-
 };
 
 } // namespace BCLog

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -9,7 +9,6 @@
 #include <sync.h>
 
 #include <logging.h>
-#include <logging/timer.h>
 #include <tinyformat.h>
 #include <util/strencodings.h>
 #include <util/threadnames.h>
@@ -23,11 +22,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-void LockContention(const char* pszName, const char* pszFile, int nLine)
-{
-    LOG_TIME_MICROS_WITH_CATEGORY(strprintf("%s, %s:%d", pszName, pszFile, nLine), BCLog::LOCK);
-}
 
 #ifdef DEBUG_LOCKORDER
 //

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -15,9 +15,9 @@ BOOST_FIXTURE_TEST_SUITE(logging_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(logging_timer)
 {
     SetMockTime(1);
-    auto sec_timer = BCLog::Timer<std::chrono::seconds>("tests", "end_msg");
+    auto micro_timer = BCLog::Timer<std::chrono::microseconds>("tests", "end_msg");
     SetMockTime(2);
-    BOOST_CHECK_EQUAL(sec_timer.LogMsg("test secs"), "tests: test secs (1.00s)");
+    BOOST_CHECK_EQUAL(micro_timer.LogMsg("test micros"), "tests: test micros (1000000μs)");
 
     SetMockTime(1);
     auto ms_timer = BCLog::Timer<std::chrono::milliseconds>("tests", "end_msg");
@@ -25,9 +25,14 @@ BOOST_AUTO_TEST_CASE(logging_timer)
     BOOST_CHECK_EQUAL(ms_timer.LogMsg("test ms"), "tests: test ms (1000.00ms)");
 
     SetMockTime(1);
-    auto micro_timer = BCLog::Timer<std::chrono::microseconds>("tests", "end_msg");
+    auto sec_timer = BCLog::Timer<std::chrono::seconds>("tests", "end_msg");
     SetMockTime(2);
-    BOOST_CHECK_EQUAL(micro_timer.LogMsg("test micros"), "tests: test micros (1000000μs)");
+    BOOST_CHECK_EQUAL(sec_timer.LogMsg("test secs"), "tests: test secs (1.00s)");
+
+    SetMockTime(1);
+    auto minute_timer = BCLog::Timer<std::chrono::minutes>("tests", "end_msg");
+    SetMockTime(2);
+    BOOST_CHECK_EQUAL(minute_timer.LogMsg("test minutes"), "Error: unexpected time type");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -28,11 +28,6 @@ BOOST_AUTO_TEST_CASE(logging_timer)
     auto sec_timer = BCLog::Timer<std::chrono::seconds>("tests", "end_msg");
     SetMockTime(2);
     BOOST_CHECK_EQUAL(sec_timer.LogMsg("test secs"), "tests: test secs (1.00s)");
-
-    SetMockTime(1);
-    auto minute_timer = BCLog::Timer<std::chrono::minutes>("tests", "end_msg");
-    SetMockTime(2);
-    BOOST_CHECK_EQUAL(minute_timer.LogMsg("test minutes"), "Error: unexpected time type");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -1,0 +1,11 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_TYPES_H
+#define BITCOIN_UTIL_TYPES_H
+
+template <class>
+inline constexpr bool ALWAYS_FALSE{false};
+
+#endif // BITCOIN_UTIL_TYPES_H


### PR DESCRIPTION
Follow-up to #22736.

The first commit addresses the issue identified and reported by Martin Ankerl in https://github.com/bitcoin/bitcoin/pull/22736#discussion_r703019629 to fix the lock contention duration reporting.

The next three commits make improvements to the timer code in `BCLog::LogMsg()` and add `util/types.h` with an `ALWAYS_FALSE` template, that springboard from https://github.com/bitcoin/bitcoin/pull/22736#discussion_r702747920 by Marco Falke.
