### PR TITLE
ci: Add missed comments and test_bitcoin.exe command line option

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -97,10 +97,14 @@ task:
   merge_script:
     - git config --global user.email "ci@ci.ci"
     - git config --global user.name "ci"
+    # Windows filesystem loses the executable bit, and all of the executable
+    # files are considered "modified" now. It will break the following `git merge`
+    # command. The next two commands make git ignore this issue.
     - git config core.filemode false
     - git reset --hard
     - if ($env:CIRRUS_PR -eq $null) { exit 0; }
     - git fetch $env:CIRRUS_REPO_CLONE_URL $env:CIRRUS_BASE_BRANCH
+    # Merge base to detect silent merge conflicts.
     - git merge FETCH_HEAD
   vcpkg_cache:
     folder: 'C:\Users\ContainerAdministrator\AppData\Local\vcpkg\archives'
@@ -138,7 +142,7 @@ task:
     - python build_msvc\msvc-autogen.py
     - msbuild build_msvc\bitcoin.sln -property:Configuration=Release -maxCpuCount -verbosity:minimal -noLogo
   unit_tests_script:
-    - src\test_bitcoin.exe
+    - src\test_bitcoin.exe -l test_suite
     - src\bench_bitcoin.exe > $null
     - python test\util\test_runner.py
     - python test\util\rpcauth-test.py


### PR DESCRIPTION
This PR is a #21551 follow up, and it:
- adds missed comments, see https://github.com/bitcoin/bitcoin/pull/21551#discussion_r703342550
- restores missed `-l test_suite` command line option for `test_bitcoin.exe`, see https://github.com/bitcoin/bitcoin/pull/21551#discussion_r703348955