### PR TITLE
ci: Fix merge_script in MSVC task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -96,17 +96,14 @@ task:
     x64_NATIVE_TOOLS: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"'
     IgnoreWarnIntDirInTempDetected: 'true'
   merge_script:
-    - ps: git config --global user.email "ci@ci.ci"
-    - ps: git config --global user.name "ci"
+    - git config --global user.email "ci@ci.ci"
+    - git config --global user.name "ci"
     # Windows filesystem loses the executable bit, and all of the executable
     # files are considered "modified" now. It will break the following `git merge`
     # command. The next two commands make git ignore this issue.
-    - ps: git config core.filemode false
-    - ps: git reset --hard
-    - ps: if ($env:CIRRUS_PR -eq $null) { exit 0; }
-    - ps: git fetch $env:CIRRUS_REPO_CLONE_URL $env:CIRRUS_BASE_BRANCH
-    # Merge base to detect silent merge conflicts.
-    - ps: git merge FETCH_HEAD
+    - git config core.filemode false
+    - git reset --hard
+    - PowerShell -NoLogo -Command if ($env:CIRRUS_PR -ne $null) { git fetch $env:CIRRUS_REPO_CLONE_URL $env:CIRRUS_BASE_BRANCH; git merge FETCH_HEAD; }
   msvc_qt_built_cache:
     folder: "%QTBASEDIR%"
     reupload_on_changes: false


### PR DESCRIPTION
The new `merge_script` in the MSVC build task does not really exit early when the task is triggered by a non-pr.

In the current code https://github.com/bitcoin/bitcoin/blob/e4aa9b15b9f80a08076ad329b473fe9107d9e65e/.cirrus.yml#L104

the `exit 0` command exits from the PowerShell call, not the recent `merge_script`. This cause the next lines https://github.com/bitcoin/bitcoin/blob/e4aa9b15b9f80a08076ad329b473fe9107d9e65e/.cirrus.yml#L105-L107 are executed unconditionally.

Here is an excerpt from [CI task log](https://api.cirrus-ci.com/v1/task/4578647416766464/logs/merge.log) for the ["Merge #22915: Remove confusing CAddrDB " commit](https://github.com/bitcoin/bitcoin/commit/896649996bdaa80300fa20027a9789558233268d):
```
...
C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>call powershell.exe -NoLogo -EncodedCommand ZwBpAHQAIAByAGUAcwBlAHQAIAAtAC0AaABhAHIAZAA= 
HEAD is now at 896649996 Merge bitcoin/bitcoin#22915: Remove confusing CAddrDB

C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>if 0 NEQ 0 exit /b 0 

C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>call powershell.exe -NoLogo -EncodedCommand aQBmACAAKAAkAGUAbgB2ADoAQwBJAFIAUgBVAFMAXwBQAFIAIAAtAGUAcQAgACQAbgB1AGwAbAApACAAewAgAGUAeABpAHQAIAAwADsAIAB9AA== 

C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>if 0 NEQ 0 exit /b 0 

C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>call powershell.exe -NoLogo -EncodedCommand ZwBpAHQAIABmAGUAdABjAGgAIAAkAGUAbgB2ADoAQwBJAFIAUgBVAFMAXwBSAEUAUABPAF8AQwBMAE8ATgBFAF8AVQBSAEwAIAAkAGUAbgB2ADoAQwBJAFIAUgBVAFMAXwBCAEEAUwBFAF8AQgBSAEEATgBDAEgA 
From https://github.com/bitcoin/bitcoin
 * branch                HEAD       -> FETCH_HEAD

C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>if 0 NEQ 0 exit /b 0 

C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>call powershell.exe -NoLogo -EncodedCommand ZwBpAHQAIABtAGUAcgBnAGUAIABGAEUAVABDAEgAXwBIAEUAQQBEAA== 
Already up to date.

C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>if 0 NEQ 0 exit /b 0 
```

This PR fixes this issue, and makes `merge_script` log more readable.