### PR TITLE
Fix the case where the peer status is not updated

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4578,6 +4578,8 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                 // Try to find first header that our peer doesn't have, and
                 // then send all headers past that one.  If we come across any
                 // headers that aren't on m_chainman.ActiveChain(), give up.
+                bool fForceSendHeaders = false;
+
                 for (const uint256& hash : peer->m_blocks_for_headers_relay) {
                     const CBlockIndex* pindex = m_chainman.m_blockman.LookupBlockIndex(hash);
                     assert(pindex);
@@ -4601,8 +4603,10 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                         fRevertToInv = true;
                         break;
                     }
+                    if (state.pindexBestHeaderSent == pindex->pprev)
+                        fForceSendHeaders = true;
                     pBestIndex = pindex;
-                    if (fFoundStartingHeader) {
+                    if (fForceSendHeaders) {
                         // add this to the headers message
                         vHeaders.push_back(pindex->GetBlockHeader());
                     } else if (PeerHasHeader(&state, pindex)) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4607,6 +4607,8 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                         fForceSendHeaders = true;
                     pBestIndex = pindex;
                     if (fForceSendHeaders) {
+                        vHeaders.push_back(pindex->GetBlockHeader());
+                    } else if (fFoundStartingHeader) {
                         // add this to the headers message
                         vHeaders.push_back(pindex->GetBlockHeader());
                     } else if (PeerHasHeader(&state, pindex)) {


### PR DESCRIPTION
This PR is an improvement proposal to solve the problem of issue  #22898 "There are cases where the peer status is not updated forever".

I used this line:
https://github.com/bitcoin/bitcoin/blob/ecf580e40f607091a5e5d5fff9865237e037ea7f/src/net_processing.cpp#L4605
because it is meaningless (always false).