### PR TITLE
doc: add missing copyright header to getuniquepath.cpp

### DIFF
--- a/src/util/getuniquepath.cpp
+++ b/src/util/getuniquepath.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include <random.h>
 #include <fs.h>
 #include <util/strencodings.h>


### PR DESCRIPTION
This was missed in #21052.