### PR TITLE
build: Copy appropriate MSVC build output to src/qt automatically

### DIFF
--- a/build_msvc/bitcoin-qt/bitcoin-qt.vcxproj
+++ b/build_msvc/bitcoin-qt/bitcoin-qt.vcxproj
@@ -81,4 +81,5 @@
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="..\common.qt.vcxproj" />
 </Project>

--- a/build_msvc/common.qt.vcxproj
+++ b/build_msvc/common.qt.vcxproj
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<PropertyGroup><BuildDependsOn>$(BuildDependsOn);CopyBuildArtifacts</BuildDependsOn></PropertyGroup>
+  <Target Name="CopyBuildArtifacts" Condition="'$(ConfigurationType)' != 'StaticLibrary'">
+    <ItemGroup>
+      <BuildArtifacts Include="$(OutDir)$(TargetName)$(TargetExt)"></BuildArtifacts>
+      <BuildArtifacts Include="$(OutDir)$(TargetName).pdb" Condition="Exists('$(OutDir)$(TargetName).pdb')"></BuildArtifacts>
+    </ItemGroup>
+    <Copy SourceFiles="@(BuildArtifacts)" SkipUnchangedFiles="true" DestinationFolder="..\..\src\qt\" Condition="'$(OutDir)' != ''"></Copy>
+  </Target>
+  <Import Project="common.qt.vcxproj.user" Condition="Exists('common.qt.vcxproj.user')" />
+</Project>

--- a/build_msvc/test_bitcoin-qt/test_bitcoin-qt.vcxproj
+++ b/build_msvc/test_bitcoin-qt/test_bitcoin-qt.vcxproj
@@ -116,4 +116,5 @@
         $(CleanDependsOn);
     </CleanDependsOn>
   </PropertyGroup>
+  <Import Project="..\common.qt.vcxproj" />
 </Project>


### PR DESCRIPTION
This functionality is already present for non-qt output since #16308, and it was skipped to add in #15529.

Not finding `bitcoin-qt.exe` and `test_bitcoin-qt.exe` in the `src\qt\` folder could confuse users.

This PR fixes that issue in the same way like #16308 did.