### PR TITLE
test: Switch multiprocess to clang i686 build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -235,7 +235,7 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_native_fuzz.sh"
 
 task:
-  name: '[multiprocess, DEBUG] [focal]'
+  name: '[multiprocess, i686, DEBUG] [focal]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
     image: ubuntu:focal
@@ -244,7 +244,7 @@ task:
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
     MAKEJOBS: "-j8"
-    FILE_ENV: "./ci/test/00_setup_env_native_multiprocess.sh"
+    FILE_ENV: "./ci/test/00_setup_env_i686_multiprocess.sh"
 
 task:
   name: '[no wallet] [bionic]'

--- a/ci/test/00_setup_env_i686_multiprocess.sh
+++ b/ci/test/00_setup_env_i686_multiprocess.sh
@@ -6,11 +6,12 @@
 
 export LC_ALL=C.UTF-8
 
-export CONTAINER_NAME=ci_native_multiprocess
+export HOST=i686-pc-linux-gnu
+export CONTAINER_NAME=ci_i686_multiprocess
 export DOCKER_NAME_TAG=ubuntu:20.04
-export PACKAGES="cmake python3 python3-pip llvm clang"
+export PACKAGES="cmake python3 python3-pip llvm clang g++-multilib"
 export DEP_OPTS="DEBUG=1 MULTIPROCESS=1"
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-debug CC=clang CXX=clang++"  # Use clang to avoid OOM
+export BITCOIN_CONFIG="--enable-debug CC='clang -m32' CXX='clang++ -m32' LDFLAGS='--rtlib=compiler-rt -lgcc_s'"
 export TEST_RUNNER_ENV="BITCOIND=bitcoin-node"
 export PIP_PACKAGES="lief"

--- a/src/bench/addrman.cpp
+++ b/src/bench/addrman.cpp
@@ -5,6 +5,7 @@
 #include <addrman.h>
 #include <bench/bench.h>
 #include <random.h>
+#include <util/check.h>
 #include <util/time.h>
 
 #include <optional>
@@ -110,7 +111,8 @@ static void AddrManGood(benchmark::Bench& bench)
      * we want to do the same amount of work in every loop iteration. */
 
     bench.epochs(5).epochIterations(1);
-    const size_t addrman_count{bench.epochs() * bench.epochIterations()};
+    const uint64_t addrman_count{bench.epochs() * bench.epochIterations()};
+    Assert(addrman_count == 5U);
 
     std::vector<std::unique_ptr<CAddrMan>> addrmans(addrman_count);
     for (size_t i{0}; i < addrman_count; ++i) {


### PR DESCRIPTION
Building for i686 with clang helps to catch bugs early for:
* The OSS-Fuzz i686 clang libFuzzer build
* The arm 32-bit native clang build

Fixes  #22889