### PR TITLE
test: Add missing suppression signed-integer-overflow:addrman.cpp

### DIFF
--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -5,6 +5,8 @@
 # names can be used.
 # See https://github.com/google/sanitizers/issues/1364
 signed-integer-overflow:txmempool.cpp
+# nLastSuccess read from peers.dat might cause an overflow in IsTerrible
+signed-integer-overflow:addrman.cpp
 # https://github.com/bitcoin/bitcoin/pull/21798#issuecomment-829180719
 signed-integer-overflow:policy/feerate.cpp
 


### PR DESCRIPTION
Steps to reproduce:

[crash-d5f88bd8d0d460ffbab217b856b8582600c00503.log](https://github.com/bitcoin/bitcoin/files/7130854/crash-d5f88bd8d0d460ffbab217b856b8582600c00503.log)


```
$ FUZZ=addrman ./src/test/fuzz/fuzz ./crash-d5f88bd8d0d460ffbab217b856b8582600c00503.log 
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 1257085025
INFO: Loaded 1 modules   (379531 inline 8-bit counters): 379531 [0x562577b768a8, 0x562577bd3333), 
INFO: Loaded 1 PC tables (379531 PCs): 379531 [0x562577bd3338,0x56257819dbe8), 
./src/test/fuzz/fuzz: Running 1 inputs 1 time(s) each.
Running: ./crash-d5f88bd8d0d460ffbab217b856b8582600c00503.log
addrman.cpp:80:14: runtime error: signed integer overflow: 2105390 - -9223372036854775808 cannot be represented in type 'long'
    #0 0x5625752f0179 in CAddrInfo::IsTerrible(long) const addrman.cpp:80:14
    #1 0x56257531917d in CAddrMan::GetAddr_(std::vector<CAddress, std::allocator<CAddress> >&, unsigned long, unsigned long, std::optional<Network>) const addrman.cpp:874:16
    #2 0x562574f0251b in CAddrMan::GetAddr(unsigned long, unsigned long, std::optional<Network>) const ./addrman.h:259:9
    #3 0x562574eff7ad in addrman_fuzz_target(Span<unsigned char const>) test/fuzz/addrman.cpp:295:26



SUMMARY: UndefinedBehaviorSanitizer: signed-integer-overflow addrman.cpp:80:14 in 
