### PR TITLE
doc: Set PYTHONUTF8=1 for functional tests on Windows

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -26,12 +26,19 @@ See [/doc/fuzzing.md](/doc/fuzzing.md)
 
 ### Functional tests
 
-#### Dependencies
+#### Dependencies and prerequisites
 
 The ZMQ functional test requires a python ZMQ library. To install it:
 
 - on Unix, run `sudo apt-get install python3-zmq`
 - on mac OS, run `pip3 install pyzmq`
+
+
+On Windows the `PYTHONUTF8` environment variable must be set to 1:
+
+```cmd
+set PYTHONUTF8=1
+```
 
 #### Running the tests
 


### PR DESCRIPTION
The `PYTHONUTF8` environment variable is defined in [PEP 540](https://www.python.org/dev/peps/pep-0540/), and it is actually used in our CI: https://github.com/bitcoin/bitcoin/blob/5e3380b9f59481fc18e05b9d651c3c733abe4053/.cirrus.yml#L89

This PR documents such usage to avoid users' [errors](https://github.com/bitcoin/bitcoin/pull/22922#issuecomment-915511037).