### PR TITLE
test: don't try and use os.killpg() on Windows

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -17,6 +17,7 @@ from collections import deque
 import configparser
 import datetime
 import os
+import platform
 import time
 import shutil
 import signal
@@ -564,7 +565,8 @@ def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=
     # Killing the process group will also terminate the current process but that is
     # not an issue
     if len(job_queue.jobs):
-        os.killpg(os.getpgid(0), signal.SIGKILL)
+        if platform.system() != "Windows":
+            os.killpg(os.getpgid(0), signal.SIGKILL)
 
     sys.exit(not all_passed)
 


### PR DESCRIPTION
os.killpg and os.getpgid are [Unix only](https://docs.python.org/3.6/library/os.html#os.killpg). Seen in at least [#20744](https://github.com/bitcoin/bitcoin/pull/20744/checks?check_run_id=3563419559):

```bash
Runtime: 1 s

Traceback (most recent call last):
  File "C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build\test\functional\test_runner.py", line 797, in <module>
    main()
  File "C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build\test\functional\test_runner.py", line 446, in main
    run_tests(
  File "C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build\test\functional\test_runner.py", line 567, in run_tests
    os.killpg(os.getpgid(0), signal.SIGKILL)
AttributeError: module 'os' has no attribute 'killpg'

C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>if 1 NEQ 0 exit /b 1 
```