### PR TITLE
fuzz: Reset addrman when consistency check fails

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -755,20 +755,20 @@ void CAddrMan::Check() const
 {
     AssertLockHeld(cs);
 
-    const int err = Check_();
+    // Run consistency checks 1 in m_consistency_check_ratio times if enabled
+    if (m_consistency_check_ratio == 0) return;
+    if (insecure_rand.randrange(m_consistency_check_ratio) >= 1) return;
+
+    const int err{ForceCheckAddrman()};
     if (err) {
         LogPrintf("ADDRMAN CONSISTENCY CHECK FAILED!!! err=%i\n", err);
         assert(false);
     }
 }
 
-int CAddrMan::Check_() const
+int CAddrMan::ForceCheckAddrman() const
 {
     AssertLockHeld(cs);
-
-    // Run consistency checks 1 in m_consistency_check_ratio times if enabled
-    if (m_consistency_check_ratio == 0) return 0;
-    if (insecure_rand.randrange(m_consistency_check_ratio) >= 1) return 0;
 
     LogPrint(BCLog::ADDRMAN, "Addrman checks started: new %i, tried %i, total %u\n", nNew, nTried, vRandom.size());
 

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -751,6 +751,17 @@ CAddrInfo CAddrMan::Select_(bool newOnly) const
     }
 }
 
+void CAddrMan::Check() const
+{
+    AssertLockHeld(cs);
+
+    const int err = Check_();
+    if (err) {
+        LogPrintf("ADDRMAN CONSISTENCY CHECK FAILED!!! err=%i\n", err);
+        assert(false);
+    }
+}
+
 int CAddrMan::Check_() const
 {
     AssertLockHeld(cs);

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -392,16 +392,7 @@ private:
     CAddrInfo SelectTriedCollision_() EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     //! Consistency check
-    void Check() const EXCLUSIVE_LOCKS_REQUIRED(cs)
-    {
-        AssertLockHeld(cs);
-
-        const int err = Check_();
-        if (err) {
-            LogPrintf("ADDRMAN CONSISTENCY CHECK FAILED!!! err=%i\n", err);
-            assert(false);
-        }
-    }
+    void Check() const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     //! Perform consistency check. Returns an error code or zero.
     int Check_() const EXCLUSIVE_LOCKS_REQUIRED(cs);

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -391,11 +391,11 @@ private:
     //! Return a random to-be-evicted tried table address.
     CAddrInfo SelectTriedCollision_() EXCLUSIVE_LOCKS_REQUIRED(cs);
 
-    //! Consistency check
+    //! Consistency check, taking into account m_consistency_check_ratio.
     void Check() const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
-    //! Perform consistency check. Returns an error code or zero.
-    int Check_() const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    //! Perform consistency check, regardless of m_consistency_check_ratio. Returns an error code or zero.
+    int ForceCheckAddrman() const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /**
      * Return all or many randomly selected addresses, optionally by network.

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -306,6 +306,7 @@ FUZZ_TARGET_INIT(addrman, initialize_addrman)
     (void)const_addr_man.size();
     CDataStream data_stream(SER_NETWORK, PROTOCOL_VERSION);
     data_stream << const_addr_man;
+    assert(0 == WITH_LOCK(addr_man_ptr->cs, return addr_man_ptr->ForceCheckAddrman()));
 }
 
 // Check that serialize followed by unserialize produces the same addrman.

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -5,8 +5,6 @@
 # names can be used.
 # See https://github.com/google/sanitizers/issues/1364
 signed-integer-overflow:txmempool.cpp
-# nLastSuccess read from peers.dat might cause an overflow in IsTerrible
-signed-integer-overflow:addrman.cpp
 # https://github.com/bitcoin/bitcoin/pull/21798#issuecomment-829180719
 signed-integer-overflow:policy/feerate.cpp
 


### PR DESCRIPTION
It doesn't really make sense to continue when the deserialized addrman isn't consistent in the `addrman` test.

For example, if `nLastSuccess` is negative, it would  later result in integer overflows. Thus, this patch fixes #22931.

Also,
Fixes #22503
Fixes #22504
Fixes #22519