### PR TITLE
wallet: refactor: inline functions `{Read,Write}OrderPos`

### DIFF
--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -20,17 +20,6 @@
 typedef std::map<std::string, std::string> mapValue_t;
 
 
-static inline void ReadOrderPos(int64_t& nOrderPos, mapValue_t& mapValue)
-{
-    if (!mapValue.count("n"))
-    {
-        nOrderPos = -1; // TODO: calculate elsewhere
-        return;
-    }
-    nOrderPos = atoi64(mapValue["n"]);
-}
-
-
 static inline void WriteOrderPos(const int64_t& nOrderPos, mapValue_t& mapValue)
 {
     if (nOrderPos == -1)
@@ -232,7 +221,8 @@ public:
             setConfirmed();
         }
 
-        ReadOrderPos(nOrderPos, mapValue);
+        const auto it_op = mapValue.find("n");
+        nOrderPos = (it_op != mapValue.end()) ? atoi64(it_op->second) : -1;
         nTimeSmart = mapValue.count("timesmart") ? (unsigned int)atoi64(mapValue["timesmart"]) : 0;
 
         mapValue.erase("fromaccount");

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -217,7 +217,8 @@ public:
 
         const auto it_op = mapValue.find("n");
         nOrderPos = (it_op != mapValue.end()) ? atoi64(it_op->second) : -1;
-        nTimeSmart = mapValue.count("timesmart") ? (unsigned int)atoi64(mapValue["timesmart"]) : 0;
+        const auto it_ts = mapValue.find("timesmart");
+        nTimeSmart = (it_ts != mapValue.end()) ? static_cast<unsigned int>(atoi64(it_ts->second)) : 0;
 
         mapValue.erase("fromaccount");
         mapValue.erase("spent");

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -19,14 +19,6 @@
 
 typedef std::map<std::string, std::string> mapValue_t;
 
-
-static inline void WriteOrderPos(const int64_t& nOrderPos, mapValue_t& mapValue)
-{
-    if (nOrderPos == -1)
-        return;
-    mapValue["n"] = ToString(nOrderPos);
-}
-
 /** Legacy class used for deserializing vtxPrev for backwards compatibility.
  * vtxPrev was removed in commit 93a18a3650292afbb441a47d1fa1b94aeb0164e3,
  * but old wallet.dat files may still contain vtxPrev vectors of CMerkleTxs.
@@ -181,7 +173,9 @@ public:
         mapValue_t mapValueCopy = mapValue;
 
         mapValueCopy["fromaccount"] = "";
-        WriteOrderPos(nOrderPos, mapValueCopy);
+        if (nOrderPos != -1) {
+            mapValueCopy["n"] = ToString(nOrderPos);
+        }
         if (nTimeSmart) {
             mapValueCopy["timesmart"] = strprintf("%u", nTimeSmart);
         }


### PR DESCRIPTION
The functions `ReadOrderPos` and `WriteOrderPos` have been introduced in commit 9c7722b7c5ce49130bd978b932f73b629ce5cebe in 2012. Since accounts have been removed in #13825 (commit c9c32e6b844fc79467b7e24c6c916142a0d08484), they are only called at one place in `CWalletTx::{Serialize,Unserialize}` and thus can be directly inlined instead. Additionally, this PR aims to avoids duplicate lookups on the map `mapValue` (affects keys "n" and "timesmart").