### PR TITLE
[Tests] Compute the Power Set of all flags instead of one by one exclusion

### DIFF
--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -173,31 +173,19 @@ unsigned int FillFlags(unsigned int flags)
 // Assumes that mapFlagNames contains all script verify flags.
 std::set<unsigned int> GenerateAllSubMasks(unsigned int flags)
 {
-    std::vector<unsigned int> set_flags;
-    const size_t n_flags = sizeof(unsigned int)*8;
-    set_flags.reserve(n_flags);
-    for (size_t i = 0; i < n_flags; ++i) {
-        const unsigned int flag = flags & (1 << i);
-        if (flag) {
-            set_flags.push_back(flag);
-        }
-    }
-    const size_t combos = 1 << set_flags.size();
-    // skip last all set flags
-    std::vector<unsigned int> all_flag_combos(combos-1);
-    for (size_t i = 0; i < combos-1; ++i){
-        for(size_t j = 0; j < set_flags.size(); ++j) {
-            if (i & (1<<j)) {
-                all_flag_combos[i] |= set_flags[j];
-            }
-        }
-    }
+    // Submask Algorithm adapted from
+    // https://cp-algorithms.com/algebra/all-submasks.html
 
-    std::set<unsigned int> flags_combos;
-    for (const unsigned int submask : all_flag_combos) {
-        flags_combos.insert(TrimFlags(submask));
+    // The algorithm does not process 0, manually include it
+    std::set<unsigned int> flags_combos{0};
+    for (unsigned int s{flags}; s; s = (s - 1) & flags) {
+        // TrimFlags before inserting into set so that we only have valid flag
+        // combinations
+        flags_combos.insert(TrimFlags(s));
     }
-    flags_combos.erase(flags);
+    // remove flags from set (even if we skipped the first loop iteration above,
+    // because of TrimFlags we must always erase here)
+    flags_combos.erase(TrimFlags(flags));
     return flags_combos;
 }
 


### PR DESCRIPTION
Currently, at the end of a test vector (valid or invalid) we iterate the flags one by one and unset them and check that it makes the transaction succeed or fail. 

This is called 'minimality' in that we want to check that each flag is sufficient on it's own. However, I think we should be instead doing the 2**(specified) combinations of flag, to ensure that for all combinations of flags only the one we have specified is either valid or invalid.

Otherwise, we might have e.g. subsets of flags that have interactions we're not detecting here.

Interestingly, the asymptotic runtime here should be better on average (since we don't usually set that many flags, v.s. 32 iterations on the one by one checker), but the worst case is 2**32 flag combos. It's up to the test writers to not abuse this check.

Contrived example demonstrating the problem:

```c++
const auto sum = flag_a_set + flag_b_set +flag_c_set ;
// check parity is even
if (sum & 1) throw "Oops";
```

having set "a,b,c", the one-by-one checker for "a,b,c," expects failure would check ["a,b", "a,c", "b,c"] and see no failures since the parity of each is 2. However, ["a", "b", "c"] would fail since the parity is 1. 

I'm not aware of any code that is written in this specific manner, but similar circumstance might arise naturally in the code.