### PR TITLE
validation: log CChainState::CheckBlockIndex() consistency checks

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -161,6 +161,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::IPC, "ipc"},
     {BCLog::LOCK, "lock"},
     {BCLog::UTIL, "util"},
+    {BCLog::BLOCK, "block"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -61,6 +61,7 @@ namespace BCLog {
         IPC         = (1 << 23),
         LOCK        = (1 << 24),
         UTIL        = (1 << 25),
+        BLOCK       = (1 << 26),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4199,6 +4199,8 @@ void CChainState::CheckBlockIndex()
         return;
     }
 
+    LOG_TIME_MILLIS_WITH_CATEGORY("consistency checks", BCLog::BLOCK);
+
     LOCK(cs_main);
 
     // During a reindex, we read the genesis block and call CheckBlockIndex before ActivateBestChain,

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -57,7 +57,7 @@ class RpcMiscTest(BitcoinTestFramework):
         self.log.info("test logging rpc and help")
 
         # Test logging RPC returns the expected number of logging categories.
-        assert_equal(len(node.logging()), 26)
+        assert_equal(len(node.logging()), 27)
 
         # Test toggling a logging category on/off/on with the logging RPC.
         assert_equal(node.logging()['qt'], True)


### PR DESCRIPTION
The `-checkblockindex` configuration option performs occasional consistency checks of the block tree, chainstate, and other validation data structures.

There is currently no logging of the checks to see when they happen and their duration.

This patch:
- adds a `BLOCK` logging category, as the validation category is high-frequency
- logs the `CChainState::CheckBlockIndex()` consistency checks and duration

Example (on signet, while catching up to chain tip):

```
$ ./src/bitcoind -signet -checkaddrman=10 -debug=lock -debug=block
...
2021-09-12T13:03:18Z [msghand] CheckBlockIndex: consistency checks started
2021-09-12T13:03:18Z [opencon] Enter: lock contention cs_main, net_processing.cpp:1152 started
2021-09-12T13:03:18Z [msghand] CheckBlockIndex: consistency checks completed (433.58ms)
2021-09-12T13:03:18Z [msghand] CheckBlockIndex: consistency checks started
2021-09-12T13:03:19Z [msghand] CheckBlockIndex: consistency checks completed (411.67ms)
2021-09-12T13:03:19Z [opencon] Enter: lock contention cs_main, net_processing.cpp:1152 completed (811929μs)
```

To test:

`$ ./src/bitcoind -debug=block`