### PR TITLE
test: Set peertimeout in write_config

### DIFF
--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -41,10 +41,7 @@ class BIP68Test(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.extra_args = [
-            [
-                "-acceptnonstdtxn=1",
-                "-peertimeout=9999",  # bump because mocktime might cause a disconnect otherwise
-            ],
+            ["-acceptnonstdtxn=1"],
             ["-acceptnonstdtxn=0"],
         ]
 

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -94,7 +94,6 @@ class BIP68_112_113Test(BitcoinTestFramework):
         self.num_nodes = 1
         self.setup_clean_chain = True
         self.extra_args = [[
-            '-peertimeout=999999',  # bump because mocktime might cause a disconnect otherwise
             '-whitelist=noban@127.0.0.1',
             '-par=1',  # Use only one script thread to get the exact reject reason for testing
         ]]

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -38,7 +38,6 @@ class MaxUploadTest(BitcoinTestFramework):
         self.extra_args = [[
             "-maxuploadtarget=800",
             "-acceptnonstdtxn=1",
-            "-peertimeout=9999",  # bump because mocktime might cause a disconnect otherwise
         ]]
         self.supports_cli = False
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -364,6 +364,11 @@ def write_config(config_path, *, n, chain, extra_config="", disable_autoconnect=
         f.write("dnsseed=0\n")
         f.write("fixedseeds=0\n")
         f.write("listenonion=0\n")
+        # Increase peertimeout to avoid disconnects while using mocktime.
+        # peertimeout is measured in wall clock time, so setting it to the
+        # duration of the longest test is sufficient. It can be overriden in
+        # tests.
+        f.write("peertimeout=999999\n")
         f.write("printtoconsole=0\n")
         f.write("upnp=0\n")
         f.write("natpmp=0\n")


### PR DESCRIPTION
This avoids having to remember to set it whenever mocktime is used with
peer connections. Also, it might help avoiding disconnects when
attaching a debugger to a running test.