### PR TITLE
Update zmq to 4.3.4

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -1,8 +1,8 @@
 package=zeromq
-$(package)_version=4.3.1
+$(package)_version=4.3.4
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d835cd21eb
+$(package)_sha256_hash=c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5
 $(package)_patches=remove_libstd_link.patch
 
 define $(package)_set_vars

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -26,7 +26,7 @@ These are the dependencies currently used by Bitcoin Core. You can find instruct
 | XCB |  |  |  |  | [Yes](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/qt.mk) (Linux only) |
 | systemtap ([tracing](tracing.md))|  |  |  |  | |
 | xkbcommon |  |  |  |  | [Yes](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/qt.mk) (Linux only) |
-| ZeroMQ | [4.3.1](https://github.com/zeromq/libzmq/releases) | 4.0.0 | No |  |  |
+| ZeroMQ | [4.3.4](https://github.com/zeromq/libzmq/releases) | 4.0.0 | No |  |  |
 | zlib |  |  |  |  | [Yes](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/qt.mk) |
 
 <a name="note1">Note \*</a> : When compiling with `-stdlib=libc++`, the minimum supported libc++ version is 7.0.


### PR DESCRIPTION
Addresses https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-13132 and https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15166