### PR TITLE
Remove unused SERIALIZE_METHODS on CFeeRate

### DIFF
--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -7,7 +7,6 @@
 #define BITCOIN_POLICY_FEERATE_H
 
 #include <amount.h>
-#include <serialize.h>
 
 #include <string>
 
@@ -62,8 +61,6 @@ public:
     friend bool operator!=(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK != b.nSatoshisPerK; }
     CFeeRate& operator+=(const CFeeRate& a) { nSatoshisPerK += a.nSatoshisPerK; return *this; }
     std::string ToString(const FeeEstimateMode& fee_estimate_mode = FeeEstimateMode::BTC_KVB) const;
-
-    SERIALIZE_METHODS(CFeeRate, obj) { READWRITE(obj.nSatoshisPerK); }
 };
 
 #endif //  BITCOIN_POLICY_FEERATE_H

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -6,14 +6,14 @@
 #define BITCOIN_POLICY_FEES_H
 
 #include <amount.h>
-#include <policy/feerate.h>
-#include <uint256.h>
 #include <random.h>
 #include <sync.h>
+#include <uint256.h>
 
 #include <array>
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -115,11 +115,6 @@ FUZZ_TARGET_DESERIALIZE(block_header_and_short_txids_deserialize, {
     CBlockHeaderAndShortTxIDs block_header_and_short_txids;
     DeserializeFromFuzzingInput(buffer, block_header_and_short_txids);
 })
-FUZZ_TARGET_DESERIALIZE(fee_rate_deserialize, {
-    CFeeRate fee_rate;
-    DeserializeFromFuzzingInput(buffer, fee_rate);
-    AssertEqualAfterSerializeDeserialize(fee_rate);
-})
 FUZZ_TARGET_DESERIALIZE(merkle_block_deserialize, {
     CMerkleBlock merkle_block;
     DeserializeFromFuzzingInput(buffer, merkle_block);

--- a/src/test/policy_fee_tests.cpp
+++ b/src/test/policy_fee_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <amount.h>
+#include <policy/feerate.h>
 #include <policy/fees.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/util/fees.cpp
+++ b/src/util/fees.cpp
@@ -5,6 +5,7 @@
 
 #include <util/fees.h>
 
+#include <policy/feerate.h>
 #include <policy/fees.h>
 #include <util/strencodings.h>
 #include <util/string.h>


### PR DESCRIPTION
CFeeRate serialization has several issues:

* It is confusing, because feerates can be in BTC/kvB, sat/vB, ... making any serialization ambigious. If there was future code using the serialize method, it would be better off using a serialization method that mentions the unit.
* It is unused, only used in fuzzing. The useless fuzz test will consume CPU time of the other fuzz targets and make fuzzing less effective overall.

Fix both by removing the methods.