### PR TITLE
doc: Improve documentation around the ACK statement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -341,8 +341,8 @@ A review can be a conceptual review, where the reviewer leaves a comment
 
 After conceptual agreement on the change, code review can be provided. A review
 begins with `ACK BRANCH_COMMIT`, where `BRANCH_COMMIT` is the top of the PR
-branch, followed by a description of how the reviewer did the review. The
-following language is used within pull request comments:
+branch. The ACK statement is followed by a description of how the reviewer did
+the review. The following language is used within pull request comments:
 
   - "I have tested the code", involving change-specific manual testing in
     addition to running the unit, functional, or fuzz tests, and in case it is
@@ -350,6 +350,11 @@ following language is used within pull request comments:
   - "I have not tested the code, but I have reviewed it and it looks
     OK, I agree it can be merged";
   - A "nit" refers to a trivial, often non-blocking issue.
+
+The following are variations to the ACK statement that convey meaning as shorthand:
+  - `tACK BRANCH_COMMIT`: Short for 'Tested ACK', meaning "I have tested the code and approve the changes".
+  - `utACK BRANCH_COMMIT`: Short for 'Untested ACK', meaning "I have not tested the code, but I approve the changes".
+  - `crACK BRANCH_COMMIT`: Short for 'Code Review ACK', meaning "I have only reviewed the code and approve the changes".
 
 Project maintainers reserve the right to weigh the opinions of peer reviewers
 using common sense judgement and may also weigh based on merit. Reviewers that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -322,6 +322,13 @@ maintainers take into account the peer review when determining if there is
 consensus to merge a pull request (remember that discussions may have been
 spread out over GitHub, mailing list and IRC discussions).
 
+#### ACK Statement
+
+The `ACK` statement is the foundation of a peer review; It represents approval,
+or refusal (`NACK`), of the concept or code. A `NACK` needs to include a
+rationale for why the change is not worthwhile. NACKs without accompanying reasoning
+may be disregarded.
+
 #### Conceptual Review
 
 A review can be a conceptual review, where the reviewer leaves a comment
@@ -329,9 +336,6 @@ A review can be a conceptual review, where the reviewer leaves a comment
    request",
  * `Approach (N)ACK`, meaning `Concept ACK`, but "I do (not) agree with the
    approach of this change".
-
-A `NACK` needs to include a rationale why the change is not worthwhile.
-NACKs without accompanying reasoning may be disregarded.
 
 #### Code Review
 


### PR DESCRIPTION
We currently use several undocumented ACK statement's in every day review, namely: `tACK`, `utACK`, and `crACK`. Because of their ubiquitous usage, it's time to properly document them. 📝

In this PR, we document these ACK statement variations. Additionally, this performs some slight improvements to the general documentation around the ACK statement. Also, adds a dedicated section, 'ACK Statement' which explains what an 'ACK' is. Currently, one has to decipher the meaning by looking at the "Conceptual Review" and "Code Review" sections.

Master: [render](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md)

PR: [render](https://github.com/jarolrod/bitcoin/blob/8b34635dc224921aaf8b3ead0b5dd162e0d58f72/CONTRIBUTING.md)