### PR TITLE
test: fix misleading fee unit in mempool_limit.py

### DIFF
--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -7,8 +7,14 @@
 from decimal import Decimal
 
 from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.messages import COIN
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_greater_than, assert_raises_rpc_error, gen_return_txouts
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_raises_rpc_error,
+    gen_return_txouts,
+)
 from test_framework.wallet import MiniWallet
 
 
@@ -23,16 +29,19 @@ class MempoolLimitTest(BitcoinTestFramework):
         ]]
         self.supports_cli = False
 
-    def send_large_txs(self, node, miniwallet, txouts, fee_rate, tx_batch_size):
+    def send_large_txs(self, node, miniwallet, txouts, fee, tx_batch_size):
         for _ in range(tx_batch_size):
-            tx = miniwallet.create_self_transfer(from_node=node, fee_rate=fee_rate)['tx']
+            tx = miniwallet.create_self_transfer(from_node=node, fee_rate=0, mempool_valid=False)['tx']
             for txout in txouts:
                 tx.vout.append(txout)
+            tx.vout[0].nValue -= int(fee * COIN)
+            res = node.testmempoolaccept([tx.serialize().hex()])[0]
+            assert_equal(res['fees']['base'], fee)
             miniwallet.sendrawtransaction(from_node=node, tx_hex=tx.serialize().hex())
 
     def run_test(self):
         txouts = gen_return_txouts()
-        node=self.nodes[0]
+        node = self.nodes[0]
         miniwallet = MiniWallet(node)
         relayfee = node.getnetworkinfo()['relayfee']
 
@@ -54,13 +63,15 @@ class MempoolLimitTest(BitcoinTestFramework):
         self.log.info('Create a mempool tx that will be evicted')
         tx_to_be_evicted_id = miniwallet.send_self_transfer(from_node=node, fee_rate=relayfee)["txid"]
 
-        # Increase the tx fee rate massively to give the subsequent transactions a higher priority in the mempool
-        base_fee = relayfee * 1000
+        # Increase the tx fee rate to give the subsequent transactions a higher priority in the mempool
+        # The tx has an approx. vsize of 65k, i.e. multiplying the previous fee rate (in sats/kvB)
+        # by 130 should result in a fee that corresponds to 2x of that fee rate
+        base_fee = relayfee * 130
 
         self.log.info("Fill up the mempool with txs with higher fee rate")
         for batch_of_txid in range(num_of_batches):
-            fee_rate=(batch_of_txid + 1) * base_fee
-            self.send_large_txs(node, miniwallet, txouts, fee_rate, tx_batch_size)
+            fee = (batch_of_txid + 1) * base_fee
+            self.send_large_txs(node, miniwallet, txouts, fee, tx_batch_size)
 
         self.log.info('The tx should be evicted by now')
         # The number of transactions created should be greater than the ones present in the mempool


### PR DESCRIPTION
The PR is a follow-up to #22543. The helper `send_large_txs` in its current interface has a fee_rate parameter, implying that it would create a transaction with exactly that rate. Unfortunately, this fee rate is only passed to MiniWallet's `create_self_transfer` method, which can't know that we append several tx outputs after, increasing the tx's vsize and decreasing it's fee rate accordingly.

In our case, the fee rate is off by several orders of magnitude, as the tx's vsize changes changes from 96 to 67552 vbytes (>700x), i.e. the value passed to this function is neither really a fee rate nor an absolute fee, but something in-between, which is very confusing. It was suggested to simply in-line this helper as it's currently only used in this single test (https://github.com/bitcoin/bitcoin/pull/22543#discussion_r701685136, https://github.com/bitcoin/bitcoin/pull/22543#issuecomment-918986896), but I could imagine that this helper may also become useful for other tests and may be moved to a library (e.g. wallet.py) in the future.

Clarify the interface by passing an absolute fee that is deducted in the end (and also verified, via testmempoolaccept) and also describe how we come up with the value passed. On master, the comment says that the fee rate needs to increased "massively"; this word is also removed because the fee rate only needs to be higher for the test to succeed.