### PR TITLE
qa: Ignore `--failfast` option of `test_runner.py` on Windows

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -146,7 +146,7 @@ task:
     - python test\util\test_runner.py
     - python test\util\rpcauth-test.py
   functional_tests_script:
-    - python test\functional\test_runner.py --ci --quiet --combinedlogslen=4000 --jobs=4 --timeout-factor=8 rpc_help feature_config_args rpc_signer feature_presegwit_node_upgrade "tool_wallet.py --descriptors" --failfast  # TODO enable '--extended' and remove cherry-picked test list
+    - python test\functional\test_runner.py --ci --quiet --combinedlogslen=4000 --jobs=4 --timeout-factor=8 rpc_help feature_config_args rpc_signer feature_presegwit_node_upgrade "tool_wallet.py --descriptors"  # TODO enable '--extended' and remove cherry-picked test list
 
 task:
   name: 'ARM [unit tests, no functional tests] [buster]'

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -17,6 +17,7 @@ from collections import deque
 import configparser
 import datetime
 import os
+import platform
 import time
 import shutil
 import signal
@@ -343,7 +344,7 @@ def main():
     parser.add_argument('--keepcache', '-k', action='store_true', help='the default behavior is to flush the cache directory on startup. --keepcache retains the cache from the previous testrun.')
     parser.add_argument('--quiet', '-q', action='store_true', help='only print dots, results summary and failure logs')
     parser.add_argument('--tmpdirprefix', '-t', default=tempfile.gettempdir(), help="Root directory for datadirs")
-    parser.add_argument('--failfast', action='store_true', help='stop execution after the first test failure')
+    parser.add_argument('--failfast', action='store_true', help='stop execution after the first test failure (ignored on Windows)')
     parser.add_argument('--filter', help='filter scripts to run by regular expression')
 
     args, unknown_args = parser.parse_known_args()
@@ -452,7 +453,7 @@ def main():
         enable_coverage=args.coverage,
         args=passon_args,
         combined_logs_len=args.combinedlogslen,
-        failfast=args.failfast,
+        failfast=args.failfast if platform.system() != "Windows" else False,
         use_term_control=args.ansi,
     )
 


### PR DESCRIPTION
The current `--failfast` [implementation](https://github.com/bitcoin/bitcoin/pull/22249) does [not work](https://github.com/bitcoin/bitcoin/pull/22249#pullrequestreview-683640698) on Windows.

This PR is an alternative to #22936, and it is based on the https://github.com/bitcoin/bitcoin/pull/22936#pullrequestreview-751153668:
> An alternative would be to just not fix it. I mean who uses Windows anyway (to run the functional tests with --failfast).
>
> At least with the error message, it well be clear that something went wrong. With this patch it will leave them dangling.

