### PR TITLE
ci: use Debian Bullseye in ARM CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -149,10 +149,10 @@ task:
     - python test\functional\test_runner.py --ci --quiet --combinedlogslen=4000 --jobs=4 --timeout-factor=8 rpc_help feature_config_args rpc_signer feature_presegwit_node_upgrade "tool_wallet.py --descriptors" --failfast  # TODO enable '--extended' and remove cherry-picked test list
 
 task:
-  name: 'ARM [unit tests, no functional tests] [buster]'
+  name: 'ARM [unit tests, no functional tests] [bullseye]'
   << : *GLOBAL_TASK_TEMPLATE
   arm_container:
-    image: debian:buster
+    image: debian:bullseye
     cpu: 2
     memory: 8G
   env:

--- a/ci/test/00_setup_env_arm.sh
+++ b/ci/test/00_setup_env_arm.sh
@@ -18,7 +18,7 @@ if [ -n "$QEMU_USER_CMD" ]; then
 fi
 export CONTAINER_NAME=ci_arm_linux
 # Use debian to avoid 404 apt errors when cross compiling
-export DOCKER_NAME_TAG="debian:buster"
+export DOCKER_NAME_TAG="debian:bullseye"
 export USE_BUSY_BOX=true
 export RUN_UNIT_TESTS=true
 export RUN_FUNCTIONAL_TESTS=false


### PR DESCRIPTION
This works around an issue when trying to use `std::filesystem::remove_all` with the ARM GCC on Buster.  Has been split out of #20744.

See commentary starting here: https://github.com/bitcoin/bitcoin/pull/20744#issuecomment-810279549.
Also: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93201.