### PR TITLE
 doc: Remove stale comment for CPrivKey

### DIFF
--- a/src/key.h
+++ b/src/key.h
@@ -17,7 +17,6 @@
 
 
 /**
- * secure_allocator is defined in allocators.h
  * CPrivKey is a serialized private key, with all parameters included
  * (SIZE bytes)
  */


### PR DESCRIPTION
Removes stale doc about `secure_allocator` being defined in `allocators.h`.