### PR TITLE
bench: add `-quiet` and `-iters=<n>` benchmark config args

### DIFF
--- a/src/bench/bech32.cpp
+++ b/src/bench/bech32.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-#include <bench/nanobench.h>
 
 #include <bech32.h>
 #include <util/strencodings.h>

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -61,6 +61,8 @@ void benchmark::BenchRunner::RunAll(const Args& args)
 
         Bench bench;
         bench.name(p.first);
+        bench.m_quiet = args.quiet;
+
         if (args.asymptote.empty()) {
             p.second(bench);
         } else {

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -4,9 +4,7 @@
 
 #include <bench/bench.h>
 
-#include <chainparams.h>
 #include <test/util/setup_common.h>
-#include <validation.h>
 
 #include <regex>
 

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -57,22 +57,27 @@ void benchmark::BenchRunner::RunAll(const Args& args)
             continue;
         }
 
-        Bench bench;
-        bench.name(p.first);
-        bench.m_quiet = args.quiet;
-
-        if (args.asymptote.empty()) {
-            p.second(bench);
-        } else {
-            for (auto n : args.asymptote) {
-                bench.complexityN(n);
-                p.second(bench);
+        for (int i = 0; i < args.iters; ++i) {
+            if (i == 0 && args.iters > 1) {
+                std::cout << std::endl;
             }
-            std::cout << bench.complexityBigO() << std::endl;
-        }
+            Bench bench;
+            bench.name(p.first);
+            bench.m_quiet = args.quiet;
 
-        if (!bench.results().empty()) {
-            benchmarkResults.push_back(bench.results().back());
+            if (args.asymptote.empty()) {
+                p.second(bench);
+            } else {
+                for (auto n : args.asymptote) {
+                    bench.complexityN(n);
+                    p.second(bench);
+                }
+                std::cout << bench.complexityBigO() << std::endl;
+            }
+
+            if (!bench.results().empty()) {
+                benchmarkResults.push_back(bench.results().back());
+            }
         }
     }
 

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -41,12 +41,12 @@ using ankerl::nanobench::Bench;
 typedef std::function<void(Bench&)> BenchFunction;
 
 struct Args {
-    std::string regex_filter;
     bool is_list_only;
     bool quiet;
     std::vector<double> asymptote;
     std::string output_csv;
     std::string output_json;
+    std::string regex_filter;
 };
 
 class BenchRunner

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -43,6 +43,7 @@ typedef std::function<void(Bench&)> BenchFunction;
 struct Args {
     std::string regex_filter;
     bool is_list_only;
+    bool quiet;
     std::vector<double> asymptote;
     std::string output_csv;
     std::string output_json;

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -43,6 +43,7 @@ typedef std::function<void(Bench&)> BenchFunction;
 struct Args {
     bool is_list_only;
     bool quiet;
+    int iters;
     std::vector<double> asymptote;
     std::string output_csv;
     std::string output_json;

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -11,6 +11,7 @@
 #include <memory>
 
 static const char* DEFAULT_BENCH_FILTER = ".*";
+static const int DEFAULT_BENCH_ITERS{1};
 
 static void SetupBenchArgs(ArgsManager& argsman)
 {
@@ -18,6 +19,7 @@ static void SetupBenchArgs(ArgsManager& argsman)
 
     argsman.AddArg("-asymptote=<n1,n2,n3,...>", "Test asymptotic growth of the runtime of an algorithm, if supported by the benchmark", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-filter=<regex>", strprintf("Regular expression filter to select benchmark by name (default: %s)", DEFAULT_BENCH_FILTER), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-iters=<n>", strprintf("Iterations of each benchmark to run (default: %i)", DEFAULT_BENCH_ITERS), ArgsManager::ALLOW_INT, OptionsCategory::OPTIONS);
     argsman.AddArg("-list", "List benchmarks without executing them", ArgsManager::ALLOW_BOOL, OptionsCategory::OPTIONS);
     argsman.AddArg("-output_csv=<output.csv>", "Generate CSV file with the most important benchmark results", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-output_json=<output.json>", "Generate JSON file with all benchmark results", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -57,6 +59,7 @@ int main(int argc, char** argv)
     benchmark::Args args;
     args.asymptote = parseAsymptote(argsman.GetArg("-asymptote", ""));
     args.is_list_only = argsman.GetBoolArg("-list", false);
+    args.iters = argsman.GetArg("-iters", DEFAULT_BENCH_ITERS);
     args.output_csv = argsman.GetArg("-output_csv", "");
     args.output_json = argsman.GetArg("-output_json", "");
     args.regex_filter = argsman.GetArg("-filter", DEFAULT_BENCH_FILTER);

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -16,9 +16,9 @@ static void SetupBenchArgs(ArgsManager& argsman)
 {
     SetupHelpOptions(argsman);
 
-    argsman.AddArg("-asymptote=n1,n2,n3,...", "Test asymptotic growth of the runtime of an algorithm, if supported by the benchmark", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-asymptote=<n1,n2,n3,...>", "Test asymptotic growth of the runtime of an algorithm, if supported by the benchmark", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-filter=<regex>", strprintf("Regular expression filter to select benchmark by name (default: %s)", DEFAULT_BENCH_FILTER), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-list", "List benchmarks without executing them", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-list", "List benchmarks without executing them", ArgsManager::ALLOW_BOOL, OptionsCategory::OPTIONS);
     argsman.AddArg("-output_csv=<output.csv>", "Generate CSV file with the most important benchmark results", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-output_json=<output.json>", "Generate JSON file with all benchmark results", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-quiet", "Silence warnings and recommendations in benchmark results", ArgsManager::ALLOW_BOOL, OptionsCategory::OPTIONS);
@@ -55,11 +55,11 @@ int main(int argc, char** argv)
     }
 
     benchmark::Args args;
-    args.regex_filter = argsman.GetArg("-filter", DEFAULT_BENCH_FILTER);
-    args.is_list_only = argsman.GetBoolArg("-list", false);
     args.asymptote = parseAsymptote(argsman.GetArg("-asymptote", ""));
+    args.is_list_only = argsman.GetBoolArg("-list", false);
     args.output_csv = argsman.GetArg("-output_csv", "");
     args.output_json = argsman.GetArg("-output_json", "");
+    args.regex_filter = argsman.GetArg("-filter", DEFAULT_BENCH_FILTER);
     args.quiet = argsman.GetBoolArg("-quiet", false);
 
     benchmark::BenchRunner::RunAll(args);

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -21,6 +21,7 @@ static void SetupBenchArgs(ArgsManager& argsman)
     argsman.AddArg("-list", "List benchmarks without executing them", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-output_csv=<output.csv>", "Generate CSV file with the most important benchmark results", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-output_json=<output.json>", "Generate JSON file with all benchmark results", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-quiet", "Silence warnings and recommendations in benchmark results", ArgsManager::ALLOW_BOOL, OptionsCategory::OPTIONS);
 }
 
 // parses a comma separated list like "10,20,30,50"
@@ -59,6 +60,7 @@ int main(int argc, char** argv)
     args.asymptote = parseAsymptote(argsman.GetArg("-asymptote", ""));
     args.output_csv = argsman.GetArg("-output_csv", "");
     args.output_json = argsman.GetArg("-output_json", "");
+    args.quiet = argsman.GetBoolArg("-quiet", false);
 
     benchmark::BenchRunner::RunAll(args);
 

--- a/src/bench/nanobench.h
+++ b/src/bench/nanobench.h
@@ -624,6 +624,9 @@ public:
     Bench& operator=(Bench const& other);
     ~Bench() noexcept;
 
+    //! Whether to suppress warnings and recommendations. Equivalent to NANOBENCH_SUPPRESS_WARNINGS.
+    bool m_quiet{false};
+
     /*!
       @brief Repeatedly calls `op()` based on the configuration, and performs measurements.
 


### PR DESCRIPTION
Running a benchmark 10 times, twice (before and after), for #22974 and then editing the output by hand to remove the warnings and recommendations, brought home the point that it would be nice to be able to do that *automatisch*.  This PR adds a `-quiet` arg to silence warnings and recommendations and an `iters=<n>` arg to run each benchmark for the number of iterations passed.

```
$ src/bench/bench_bitcoin -?
Options:

  -?
       Print this help message and exit

  -asymptote=<n1,n2,n3,...>
       Test asymptotic growth of the runtime of an algorithm, if supported by
       the benchmark

  -filter=<regex>
       Regular expression filter to select benchmark by name (default: .*)

  -iters=<n>
       Iterations of each benchmark to run (default: 1)

  -list
       List benchmarks without executing them

  -output_csv=<output.csv>
       Generate CSV file with the most important benchmark results

  -output_json=<output.json>
       Generate JSON file with all benchmark results

  -quiet
       Silence warnings and recommendations in benchmark results

```
examples
```
$ ./src/bench/bench_bitcoin -filter=AddrManGood -iters=5 -quiet

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|    2,538,968,665.00 |                0.39 |   15.9% |     12.12 | `AddrManGood`
|    2,536,901,200.00 |                0.39 |   13.0% |     13.73 | `AddrManGood`
|    2,337,840,590.00 |                0.43 |    3.9% |     12.07 | `AddrManGood`
|    1,997,515,936.00 |                0.50 |    2.6% |     10.09 | `AddrManGood`
|    2,217,950,210.00 |                0.45 |    1.3% |     11.30 | `AddrManGood`
```
```
$ ./src/bench/bench_bitcoin -filter=PrevectorDes*.* -iters=2 -quiet=1

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|            8,062.56 |          124,030.15 |    5.7% |      0.09 | `PrevectorDeserializeNontrivial`
|            7,784.81 |          128,455.29 |    1.5% |      0.09 | `PrevectorDeserializeNontrivial`

|              356.44 |        2,805,497.65 |    1.5% |      0.00 | `PrevectorDeserializeTrivial`
|              354.52 |        2,820,715.33 |    0.9% |      0.00 | `PrevectorDeserializeTrivial`

|              241.27 |        4,144,791.38 |    0.9% |      0.00 | `PrevectorDestructorNontrivial`
|              241.45 |        4,141,658.77 |    0.9% |      0.00 | `PrevectorDestructorNontrivial`

|              146.64 |        6,819,400.81 |    0.9% |      0.00 | `PrevectorDestructorTrivial`
|              147.98 |        6,757,806.43 |    0.6% |      0.00 | `PrevectorDestructorTrivial`
```
```
$ ./src/bench/bench_bitcoin -filter=PrevectorDes*.* -iters=-1 -quiet=0
$ ./src/bench/bench_bitcoin -filter=PrevectorDes*.* -iters=0 -quiet=0
$ ./src/bench/bench_bitcoin -filter=PrevectorDes*.* -iters=1 -quiet=0
Warning, results might be unstable:
* DEBUG defined
* CPU frequency scaling enabled: CPU 0 between 400.0 and 3,100.0 MHz
* Turbo is enabled, CPU frequency will fluctuate

Recommendations
* Make sure you compile for Release
* Use 'pyperf system tune' before benchmarking. See https://github.com/psf/pyperf

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|            6,204.87 |          161,163.71 |   15.2% |      0.07 | :wavy_dash: `PrevectorDeserializeNontrivial` (Unstable with ~1.0 iters. Increase `minEpochIterations` to e.g. 10)
|              214.33 |        4,665,680.65 |    0.1% |      0.00 | `PrevectorDeserializeTrivial`
|              257.23 |        3,887,584.03 |    8.6% |      0.00 | :wavy_dash: `PrevectorDestructorNontrivial` (Unstable with ~43.5 iters. Increase `minEpochIterations` to e.g. 435)
|              151.34 |        6,607,846.82 |    1.9% |      0.00 | `PrevectorDestructorTrivial`
```
