### PR TITLE
net: update signet seeds

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -281,7 +281,8 @@ public:
         if (!args.IsArgSet("-signetchallenge")) {
             bin = ParseHex("512103ad5e0edad18cb1f0fc0d28a3d4f1f3e445640337489abb10404f2d1e086be430210359ef5021964fe22d6f8e05b2463c9540ce96883fe3b278760f048f5189f2e6c452ae");
             vSeeds.emplace_back("178.128.221.177");
-            vSeeds.emplace_back("2a01:7c8:d005:390::5");
+            vSeeds.emplace_back("136.144.237.250");
+            vSeeds.emplace_back("2a01:7c8:d008:e9::3");
             vSeeds.emplace_back("v7ajjeirttkbnt32wpy3c6w3emwnfr3fkla7hpxcfokr3ysd3kqtzmqd.onion:38333");
 
             consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000000000008546553c03");


### PR DESCRIPTION
I had to reinstall the server that hosts my DNS seed (see #11962) and Signet seed node. This replaces the IPv6 address and also adds an IPv4 address (identical to `seed1.testnet.bitcoin.sprovoost.nl`).

Alternatively and/or additionally I could spin up a DNS seed for Signet, which only requires a hostname, to avoid future IP address change pull requests.