### PR TITLE
doc: Enable TLS in links in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,8 @@ Most communication about Bitcoin Core development happens on IRC, in the
 `#bitcoin-core-dev` channel on Libera Chat. The easiest way to participate on IRC is
 with the web client, [web.libera.chat](https://web.libera.chat/#bitcoin-core-dev). Chat
 history logs can be found
-on [http://www.erisian.com.au/bitcoin-core-dev/](http://www.erisian.com.au/bitcoin-core-dev/)
-and [http://gnusha.org/bitcoin-core-dev/](http://gnusha.org/bitcoin-core-dev/).
+on [https://www.erisian.com.au/bitcoin-core-dev/](https://www.erisian.com.au/bitcoin-core-dev/)
+and [https://gnusha.org/bitcoin-core-dev/](https://gnusha.org/bitcoin-core-dev/).
 
 Discussion about codebase improvements happens in GitHub issues and pull
 requests.

--- a/contrib/guix/INSTALL.md
+++ b/contrib/guix/INSTALL.md
@@ -358,7 +358,7 @@ This is especially notable because Ubuntu Focal packages `libgit2 v0.28.4`, and
 Should you be in this situation, you need to build both `libgit2 v1.1.x` and
 `guile-git` from source.
 
-Source: http://logs.guix.gnu.org/guix/2020-11-12.log#232527
+Source: https://logs.guix.gnu.org/guix/2020-11-12.log#232527
 
 ##### `{scheme,guile}-bytestructures` v1.0.8 and v1.0.9 are broken for Guile v2.2
 

--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -467,7 +467,7 @@ start over.
     - `/root/.cache/guix/`
     - `/root/.guix-profile/`
 
-[b17e]: http://bootstrappable.org/
+[b17e]: https://bootstrappable.org/
 [r12e/source-date-epoch]: https://reproducible-builds.org/docs/source-date-epoch/
 
 [guix/install.sh]: https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -349,7 +349,7 @@ make cov
 
 Profiling is a good way to get a precise idea of where time is being spent in
 code. One tool for doing profiling on Linux platforms is called
-[`perf`](http://www.brendangregg.com/perf.html), and has been integrated into
+[`perf`](https://www.brendangregg.com/perf.html), and has been integrated into
 the functional test framework. Perf can observe a running process and sample
 (at some frequency) where its execution is.
 

--- a/src/test/data/README.md
+++ b/src/test/data/README.md
@@ -8,5 +8,5 @@ License
 
 The data files in this directory are distributed under the MIT software
 license, see the accompanying file COPYING or
-http://www.opensource.org/licenses/mit-license.php.
+https://www.opensource.org/licenses/mit-license.php.
 

--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -188,5 +188,5 @@ perf report -i /path/to/datadir/send-big-msgs.perf.data.xxxx --stdio | c++filt |
 #### See also:
 
 - [Installing perf](https://askubuntu.com/q/50145)
-- [Perf examples](http://www.brendangregg.com/perf.html)
+- [Perf examples](https://www.brendangregg.com/perf.html)
 - [Hotspot](https://github.com/KDAB/hotspot): a GUI for perf output analysis


### PR DESCRIPTION
This PR enables TLS in several documentation links, which improves security.