### PR TITLE
multiprocess: Make interfaces::Chain::isTaprootActive non-const

### DIFF
--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -289,7 +289,7 @@ public:
     virtual void requestMempoolTransactions(Notifications& notifications) = 0;
 
     //! Check if Taproot has activated
-    virtual bool isTaprootActive() const = 0;
+    virtual bool isTaprootActive() = 0;
 };
 
 //! Interface to let node manage chain clients (wallets, or maybe tools for

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -698,7 +698,7 @@ public:
             notifications.transactionAddedToMempool(entry.GetSharedTx(), 0 /* mempool_sequence */);
         }
     }
-    bool isTaprootActive() const override
+    bool isTaprootActive() override
     {
         LOCK(::cs_main);
         const CBlockIndex* tip = Assert(m_node.chainman)->ActiveChain().Tip();


### PR DESCRIPTION
`interfaces::Chain` is an abstract class, so declaring the method const would be exposing internal implementation details of subclasses to interface callers. And specifically this doesn't work because the multiprocess implementation of the `interfaces::Chain::isTaprootActive` method can't be const because IPC connection state and request state is not constant during the call.

---

This PR is part of the [process separation project](https://github.com/bitcoin/bitcoin/projects/10).
