### PR TITLE
multiprocess: add interfaces::ExternalSigner class

### DIFF
--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -6,7 +6,6 @@
 #define BITCOIN_INTERFACES_NODE_H
 
 #include <consensus/amount.h>
-#include <external_signer.h>
 #include <net.h>        // For NodeId
 #include <net_types.h>  // For banmap_t
 #include <netaddress.h> // For Network
@@ -48,6 +47,16 @@ struct BlockAndHeaderTipInfo
     int header_height;
     int64_t header_time;
     double verification_progress;
+};
+
+//! External signer interface used by the GUI.
+class ExternalSigner
+{
+public:
+    virtual ~ExternalSigner() {};
+
+    //! Get signer display name
+    virtual std::string getName() = 0;
 };
 
 //! Top-level interface for a bitcoin node (bitcoind process).
@@ -111,8 +120,8 @@ public:
     //! Disconnect node by id.
     virtual bool disconnectById(NodeId id) = 0;
 
-    //! List external signers
-    virtual std::vector<ExternalSigner> externalSigners() = 0;
+    //! Return list of external signers (attached devices which can sign transactions).
+    virtual std::vector<std::unique_ptr<ExternalSigner>> listExternalSigners() = 0;
 
     //! Get total bytes recv.
     virtual int64_t getTotalBytesRecv() = 0;

--- a/src/qt/createwalletdialog.cpp
+++ b/src/qt/createwalletdialog.cpp
@@ -6,7 +6,7 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <external_signer.h>
+#include <interfaces/node.h>
 #include <qt/createwalletdialog.h>
 #include <qt/forms/ui_createwalletdialog.h>
 
@@ -113,7 +113,7 @@ CreateWalletDialog::~CreateWalletDialog()
     delete ui;
 }
 
-void CreateWalletDialog::setSigners(const std::vector<ExternalSigner>& signers)
+void CreateWalletDialog::setSigners(const std::vector<std::unique_ptr<interfaces::ExternalSigner>>& signers)
 {
     m_has_signers = !signers.empty();
     if (m_has_signers) {
@@ -126,7 +126,7 @@ void CreateWalletDialog::setSigners(const std::vector<ExternalSigner>& signers)
         ui->blank_wallet_checkbox->setChecked(false);
         ui->disable_privkeys_checkbox->setEnabled(false);
         ui->disable_privkeys_checkbox->setChecked(true);
-        const std::string label = signers[0].m_name;
+        const std::string label = signers[0]->getName();
         ui->wallet_name_line_edit->setText(QString::fromStdString(label));
         ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
     } else {

--- a/src/qt/createwalletdialog.h
+++ b/src/qt/createwalletdialog.h
@@ -7,7 +7,12 @@
 
 #include <QDialog>
 
+#include <memory>
+
+namespace interfaces {
 class ExternalSigner;
+} // namespace interfaces
+
 class WalletModel;
 
 namespace Ui {
@@ -24,7 +29,7 @@ public:
     explicit CreateWalletDialog(QWidget* parent);
     virtual ~CreateWalletDialog();
 
-    void setSigners(const std::vector<ExternalSigner>& signers);
+    void setSigners(const std::vector<std::unique_ptr<interfaces::ExternalSigner>>& signers);
 
     QString walletName() const;
     bool isEncryptWalletChecked() const;

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -274,9 +274,9 @@ void CreateWalletActivity::create()
 {
     m_create_wallet_dialog = new CreateWalletDialog(m_parent_widget);
 
-    std::vector<ExternalSigner> signers;
+    std::vector<std::unique_ptr<interfaces::ExternalSigner>> signers;
     try {
-        signers = node().externalSigners();
+        signers = node().listExternalSigners();
     } catch (const std::runtime_error& e) {
         QMessageBox::critical(nullptr, tr("Can't list signers"), e.what());
     }


### PR DESCRIPTION
Add `interfaces::ExternalSigner` class to let signer objects be passed between processes and let signer code run in the original process where the object was created.

---

This PR is part of the [process separation project](https://github.com/bitcoin/bitcoin/projects/10).