### PR TITLE
rpc, wallet: Add listaddresses RPC

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -236,6 +236,151 @@ static void SetFeeEstimateMode(const CWallet& wallet, CCoinControl& cc, const Un
     }
 }
 
+UniValue AddDestinationInfo(const CTxDestination& dest, const CWallet& pwallet, bool detailed)
+{
+    UniValue ret(UniValue::VOBJ);
+
+    std::string currentAddress = EncodeDestination(dest);
+    ret.pushKV("address", currentAddress);
+
+    CScript scriptPubKey = GetScriptForDestination(dest);
+    if (detailed) ret.pushKV("scriptPubKey", HexStr(scriptPubKey));
+
+    std::unique_ptr<SigningProvider> provider = pwallet.GetSolvingProvider(scriptPubKey);
+
+    if (provider) {
+        auto inferred = InferDescriptor(scriptPubKey, *provider);
+        bool solvable = inferred->IsSolvable() || IsSolvable(*provider, scriptPubKey);
+        ret.pushKV("solvable", solvable);
+        if (solvable) {
+            ret.pushKV("desc", inferred->ToString());
+        }
+    } else {
+        ret.pushKV("solvable", false);
+    }
+
+    ScriptPubKeyMan* spk_man = pwallet.GetScriptPubKeyMan(scriptPubKey);
+    if (spk_man) {
+        if (const std::unique_ptr<CKeyMetadata> meta = spk_man->GetMetadata(dest)) {
+            if (detailed) ret.pushKV("timestamp", meta->nCreateTime);
+            if (meta->has_key_origin) {
+                ret.pushKV("hdkeypath", WriteHDKeypath(meta->key_origin.path));
+                if (detailed) ret.pushKV("hdseedid", meta->hd_seed_id.GetHex());
+                if (detailed) ret.pushKV("hdmasterfingerprint", HexStr(meta->key_origin.fingerprint));
+            }
+        }
+    }
+
+    return ret;
+}
+
+static RPCHelpMan listaddresses()
+{
+    return RPCHelpMan{"listaddresses",
+                "\nLists wallet addresses\n"
+                "In legacy wallets, addresses may be displayed in any order \n"
+                "In descriptor wallets, addresses are displayed in the BIP32 derivation order.  \n",
+                {
+                    {"address_type", RPCArg::Type::STR, RPCArg::DefaultHint{"set by -addresstype"}, "The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\"."},
+                },
+                RPCResult{
+                    RPCResult::Type::OBJ, "", "",{
+                    {
+                        RPCResult::Type::ARR, "", "",
+                        {
+                            {RPCResult::Type::OBJ, "", "", {
+                                {RPCResult::Type::STR, "address", "The bitcoin address"},
+                                {RPCResult::Type::STR, "hdkeypath", "The BIP 32 HD path of the address"},
+                                {RPCResult::Type::STR, "descriptor", "The address descriptor"},
+                                {RPCResult::Type::BOOL, "internal", "The address is internal (change) or external (receive)"},
+                                {RPCResult::Type::STR, "address_type", "The address type (legacy, p2sh-segwit, and bech32)"},
+                                {RPCResult::Type::NUM, "amount", "Available amount at address"},
+                                {RPCResult::Type::BOOL, "address_used", "This address has already received funds or not"}
+                            }},
+                        },
+                    }},
+                },
+                RPCExamples{
+                    HelpExampleCli("listaddresses", "")
+                    + HelpExampleCli("listaddresses", "\"legacy\"")
+            + HelpExampleRpc("listaddresses", "")
+                },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!pwallet) return NullUniValue;
+
+    pwallet->BlockUntilSyncedToCurrentChain();
+
+    LOCK(pwallet->cs_wallet);
+
+    if (!pwallet->CanGetAddresses()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Error: This wallet has no available keys");
+    }
+
+    OutputType output_type = pwallet->m_default_address_type;
+    if (!request.params[0].isNull()) {
+        std::optional<OutputType> parsed = ParseOutputType(request.params[0].get_str());
+        if (!parsed) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Unknown address type '%s'", request.params[1].get_str()));
+        } else if (parsed.value() == OutputType::BECH32M && pwallet->GetLegacyScriptPubKeyMan()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Legacy wallets cannot provide bech32m addresses");
+        }
+        output_type = parsed.value();
+    }
+
+    auto addressbalances = GetAddressBalances(*pwallet);
+
+    UniValue result(UniValue::VOBJ);
+
+    std::map<std::string, bool> used_addresses;
+
+    for (const std::pair<const uint256, CWalletTx>& wtx_pair : pwallet->mapWallet) {
+        const CWalletTx& wtx = wtx_pair.second;
+
+        for (const CTxOut& txout : wtx.tx->vout) {
+            CTxDestination address;
+            if (ExtractDestination(txout.scriptPubKey, address) && pwallet->IsMine(address)) {
+                used_addresses[EncodeDestination(address)] = true;
+                break;
+            }
+        }
+    }
+
+    bilingual_str error;
+    std::map<bool, std::vector<CTxDestination>> map_internal_destinations;
+    if (!pwallet->ListAddresses(output_type, map_internal_destinations, error)) {
+        throw JSONRPCError(RPC_WALLET_ERROR, error.original);
+    }
+
+    for (auto const& [internal, destinations] : map_internal_destinations)
+    {
+        UniValue list_address(UniValue::VARR);
+
+        for(auto destination : destinations) {
+            auto it = addressbalances.find(destination);
+            auto amount = (it != addressbalances.end()) ? it->second : 0;
+
+            UniValue item = AddDestinationInfo(destination, *pwallet, false);
+            item.pushKV("address_type", FormatOutputType(output_type));
+            item.pushKV("internal", internal);
+            item.pushKV("amount", ValueFromAmount(amount));
+            item.pushKV("address_used", used_addresses[item["address"].get_str()]);
+
+            list_address.push_back(item);
+        }
+
+        result.pushKV(
+            internal ? "change_addresses" : "receive_addresses",
+            list_address
+        );
+    }
+
+    return result;
+},
+    };
+}
+
 static RPCHelpMan getnewaddress()
 {
     return RPCHelpMan{"getnewaddress",
@@ -4778,6 +4923,7 @@ static const CRPCCommand commands[] =
     { "wallet",             &importwallet,                   },
     { "wallet",             &keypoolrefill,                  },
     { "wallet",             &listaddressgroupings,           },
+    { "wallet",             &listaddresses,                  },
     { "wallet",             &listdescriptors,                },
     { "wallet",             &listlabels,                     },
     { "wallet",             &listlockunspent,                },

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -163,6 +163,8 @@ protected:
 public:
     explicit ScriptPubKeyMan(WalletStorage& storage) : m_storage(storage) {}
     virtual ~ScriptPubKeyMan() {};
+
+    virtual void ListAddresses(const OutputType type, std::vector<CTxDestination>& addresses, bool internal) {}
     virtual bool GetNewDestination(const OutputType type, CTxDestination& dest, bilingual_str& error) { return false; }
     virtual isminetype IsMine(const CScript& script) const { return ISMINE_NO; }
 
@@ -344,6 +346,7 @@ private:
 public:
     using ScriptPubKeyMan::ScriptPubKeyMan;
 
+    void ListAddresses(const OutputType type, std::vector<CTxDestination>& addresses, bool internal) override;
     bool GetNewDestination(const OutputType type, CTxDestination& dest, bilingual_str& error) override;
     isminetype IsMine(const CScript& script) const override;
 
@@ -548,6 +551,7 @@ public:
 
     mutable RecursiveMutex cs_desc_man;
 
+    void ListAddresses(const OutputType type, std::vector<CTxDestination>& addresses, bool internal) override;
     bool GetNewDestination(const OutputType type, CTxDestination& dest, bilingual_str& error) override;
     isminetype IsMine(const CScript& script) const override;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -221,6 +221,21 @@ struct CRecipient
     bool fSubtractFeeFromAmount;
 };
 
+struct AddressInfo
+{
+    CTxDestination destination;
+    std::string address;
+    std::string hdkeypath;
+    std::string descriptor;
+    bool internal;
+    std::string output_type;
+    bool address_used;
+
+    AddressInfo(
+        CTxDestination destination, std::string address, std::string hdkeypath, std::string descriptor, bool internal, std::string output_type, bool address_used)
+        : destination{destination}, address{address}, hdkeypath{hdkeypath}, descriptor{descriptor}, internal{internal}, output_type{output_type}, address_used{address_used} {}
+};
+
 class WalletRescanReserver; //forward declarations for ScanForWalletTransactions/RescanFromTime
 /**
  * A CWallet maintains a set of transactions and balances, and provides the ability to create new transactions.
@@ -338,6 +353,8 @@ private:
      * notifications about new blocks and transactions.
      */
     static bool AttachChain(const std::shared_ptr<CWallet>& wallet, interfaces::Chain& chain, bilingual_str& error, std::vector<bilingual_str>& warnings);
+
+    void GetDestinationsFromAddressBook(std::vector<CTxDestination>& destinations, bool internal);
 
 public:
     /**
@@ -641,6 +658,8 @@ public:
      */
     void MarkDestinationsDirty(const std::set<CTxDestination>& destinations) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
+    void GetAddressInfoFromDestinations(const OutputType output_type, ScriptPubKeyMan* spk_man, std::vector<CTxDestination>& destinations, std::vector<AddressInfo>& address_info_list, bool internal);
+    bool ListAddresses(const OutputType output_type, std::map<bool, std::vector<CTxDestination>>& map_internal_destinations, bilingual_str& error);
     bool GetNewDestination(const OutputType type, const std::string label, CTxDestination& dest, bilingual_str& error);
     bool GetNewChangeDestination(const OutputType type, CTxDestination& dest, bilingual_str& error);
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -158,6 +158,8 @@ BASE_SCRIPTS = [
     'wallet_createwallet.py --legacy-wallet',
     'wallet_createwallet.py --usecli',
     'wallet_createwallet.py --descriptors',
+    'wallet_listaddresses.py --legacy-wallet',
+    'wallet_listaddresses.py --descriptors',
     'wallet_listtransactions.py --legacy-wallet',
     'wallet_listtransactions.py --descriptors',
     'wallet_watchonly.py --legacy-wallet',

--- a/test/functional/wallet_listaddresses.py
+++ b/test/functional/wallet_listaddresses.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the listaddresses RPC."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal
+)
+from random import randrange
+
+class ListAddressesTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def test_addresses(self, wallet, address_type = None):
+
+        new_address_list = []
+        count_addr = 0
+
+        for i in range (10, randrange(15,20)):
+            new_address_list.append(wallet.getnewaddress('', address_type))
+
+        list_addresses = wallet.listaddresses(address_type)
+
+        for i in range(0, len(list_addresses["receive_addresses"])):
+            rec_addr_item = list_addresses['receive_addresses'][i]
+            rec_addr = rec_addr_item['address']
+            if rec_addr in new_address_list:
+                count_addr = count_addr + 1
+
+                rec_addr_info = wallet.getaddressinfo(rec_addr)
+
+                assert_equal(rec_addr_item['hdkeypath'], rec_addr_info['hdkeypath'])
+                assert_equal(rec_addr_item['desc'], rec_addr_info['desc'])
+                assert_equal(rec_addr_item['internal'], rec_addr_info['ischange'])
+
+        assert_equal(count_addr, len(new_address_list))
+
+        for i in range(0, len(list_addresses["change_addresses"])):
+            chg_addr_item = list_addresses['change_addresses'][i]
+            chg_addr = chg_addr_item['address']
+
+            chg_addr_info = wallet.getaddressinfo(chg_addr)
+
+            assert_equal(chg_addr_item['hdkeypath'], chg_addr_info['hdkeypath'])
+            assert_equal(chg_addr_item['desc'], chg_addr_info['desc'])
+            assert_equal(chg_addr_item['internal'], chg_addr_info['ischange'])
+
+    def run_test(self):
+
+        wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+
+        self.test_addresses(wallet)
+        self.test_addresses(wallet, "legacy")
+        self.test_addresses(wallet, "p2sh-segwit")
+        self.test_addresses(wallet, "bech32")
+
+if __name__ == '__main__':
+    ListAddressesTest().main()


### PR DESCRIPTION
This PR adds an address explorer RPC to Bitcoin Core, similar to "Address" tab of Electrum or Specter Desktop.

This allows the user to know any arbitrary range of external and internal addresses and can be used with legacy or descriptor wallet.

This same functionality can be used to build an "Address" tab in the GUI later.

For better visualization in manual tests, the reviewer can start the node with the keypool reduced to 2. (default is 1000) and create a new wallet.
```
./src/bitcoind -keypool=2
./src/bitcoin-cli -rpcwallet=<wallet_name> listaddresses
./src/bitcoin-cli -rpcwallet=<wallet_name> listaddresses "p2sh-segwit"
./test/functional/wallet_listaddresses.py --descriptors
./test/functional/wallet_listaddresses.py --legacy-wallet
```
<img width="1175" alt="image-2" src="https://user-images.githubusercontent.com/84432093/133831379-65c07e7d-d9f5-48dd-93ef-22838b91e9f2.png">
