### PR TITLE
net: switch to signet DNS seed

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -280,8 +280,10 @@ public:
 
         if (!args.IsArgSet("-signetchallenge")) {
             bin = ParseHex("512103ad5e0edad18cb1f0fc0d28a3d4f1f3e445640337489abb10404f2d1e086be430210359ef5021964fe22d6f8e05b2463c9540ce96883fe3b278760f048f5189f2e6c452ae");
+            vSeeds.emplace_back("seed.signet.bitcoin.sprovoost.nl");
+
+            // TODO: remove hardcoded nodes once there are more DNS seeds
             vSeeds.emplace_back("178.128.221.177");
-            vSeeds.emplace_back("2a01:7c8:d005:390::5");
             vSeeds.emplace_back("v7ajjeirttkbnt32wpy3c6w3emwnfr3fkla7hpxcfokr3ysd3kqtzmqd.onion:38333");
 
             consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000000000008546553c03");


### PR DESCRIPTION
I spun up a DNS seed for Signet, source: https://github.com/sipa/bitcoin-seeder/pull/94

If anyone else spins up a DNS seed, let me know in the comment and I'll add it.

Because one DNS seed is not very diverse, this PR leaves two hardcoded nodes just in case (). The one dropped node no longer exists.

Replaces #23000.