### PR TITLE
src/randomenv.cpp: fix uclibc build

### DIFF
--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -53,7 +53,7 @@
 #include <sys/vmmeter.h>
 #endif
 #endif
-#if defined(HAVE_STRONG_GETAUXVAL) || defined(HAVE_WEAK_GETAUXVAL)
+#if defined(HAVE_STRONG_GETAUXVAL)
 #include <sys/auxv.h>
 #endif
 


### PR DESCRIPTION
Don't include `sys/auxv.h` if `HAVE_STRONG_GETAUXVAL` is not defined to avoid a build failure on uclibc

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>