### PR TITLE
p2p, rpc, test: expose tried and refcount in getnodeaddresses, update/improve tests

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -851,7 +851,7 @@ int CAddrMan::ForceCheckAddrman() const
     return 0;
 }
 
-void CAddrMan::GetAddr_(std::vector<CAddress>& vAddr, size_t max_addresses, size_t max_pct, std::optional<Network> network) const
+void CAddrMan::GetAddr_(AddrMan::Addresses& vAddr, size_t max_addresses, size_t max_pct, std::optional<Network> network) const
 {
     AssertLockHeld(cs);
 
@@ -882,7 +882,7 @@ void CAddrMan::GetAddr_(std::vector<CAddress>& vAddr, size_t max_addresses, size
         // Filter for quality
         if (ai.IsTerrible(now)) continue;
 
-        vAddr.push_back(ai);
+        vAddr.push_back({ai, ai.nRefCount, ai.fInTried});
     }
 }
 

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -250,12 +250,12 @@ public:
      * @param[in] max_pct        Maximum percentage of addresses to return (0 = all).
      * @param[in] network        Select only addresses of this network (nullopt = all).
      */
-    std::vector<CAddress> GetAddr(size_t max_addresses, size_t max_pct, std::optional<Network> network) const
+    AddrMan::Addresses GetAddr(size_t max_addresses, size_t max_pct, std::optional<Network> network) const
         EXCLUSIVE_LOCKS_REQUIRED(!cs)
     {
         LOCK(cs);
         Check();
-        std::vector<CAddress> vAddr;
+        AddrMan::Addresses vAddr;
         GetAddr_(vAddr, max_addresses, max_pct, network);
         Check();
         return vAddr;
@@ -416,7 +416,7 @@ private:
      * @param[in] max_pct        Maximum percentage of addresses to return (0 = all).
      * @param[in] network        Select only addresses of this network (nullopt = all).
      */
-    void GetAddr_(std::vector<CAddress>& vAddr, size_t max_addresses, size_t max_pct, std::optional<Network> network) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void GetAddr_(AddrMan::Addresses& vAddr, size_t max_addresses, size_t max_pct, std::optional<Network> network) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** We have successfully connected to this peer. Calling this function
      *  updates the CAddress's nTime, which is used in our IsTerrible()

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -22,6 +22,16 @@
 /** Default for -checkaddrman */
 static constexpr int32_t DEFAULT_ADDRMAN_CONSISTENCY_CHECKS{0};
 
+namespace AddrMan {
+/** Statistics about a CAddress for RPC getnodeaddresses. */
+struct Address : CAddress {
+    int nRefCount{0};     //! reference count in new sets (memory only)
+    bool fInTried{false}; //! in tried set? (memory only)
+    Address(const CAddress& addr, int count, bool tried) : CAddress(addr), nRefCount(count), fInTried(tried){};
+};
+using Addresses = std::vector<Address>;
+} // namespace AddrMan
+
 /**
  * Extended statistics about a CAddress
  */

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2704,18 +2704,18 @@ CConnman::~CConnman()
     Stop();
 }
 
-std::vector<CAddress> CConnman::GetAddresses(size_t max_addresses, size_t max_pct, std::optional<Network> network) const
+AddrMan::Addresses CConnman::GetAddresses(size_t max_addresses, size_t max_pct, std::optional<Network> network) const
 {
-    std::vector<CAddress> addresses = addrman.GetAddr(max_addresses, max_pct, network);
+    AddrMan::Addresses addresses = addrman.GetAddr(max_addresses, max_pct, network);
     if (m_banman) {
         addresses.erase(std::remove_if(addresses.begin(), addresses.end(),
-                        [this](const CAddress& addr){return m_banman->IsDiscouraged(addr) || m_banman->IsBanned(addr);}),
+                        [this](const auto& addr) { return m_banman->IsDiscouraged(addr) || m_banman->IsBanned(addr); }),
                         addresses.end());
     }
     return addresses;
 }
 
-std::vector<CAddress> CConnman::GetAddresses(CNode& requestor, size_t max_addresses, size_t max_pct)
+AddrMan::Addresses CConnman::GetAddresses(CNode& requestor, size_t max_addresses, size_t max_pct)
 {
     auto local_socket_bytes = requestor.addrBind.GetAddrBytes();
     uint64_t cache_id = GetDeterministicRandomizer(RANDOMIZER_ID_ADDRCACHE)

--- a/src/net.h
+++ b/src/net.h
@@ -847,14 +847,14 @@ public:
      * @param[in] max_pct        Maximum percentage of addresses to return (0 = all).
      * @param[in] network        Select only addresses of this network (nullopt = all).
      */
-    std::vector<CAddress> GetAddresses(size_t max_addresses, size_t max_pct, std::optional<Network> network) const;
+    AddrMan::Addresses GetAddresses(size_t max_addresses, size_t max_pct, std::optional<Network> network) const;
     /**
      * Cache is used to minimize topology leaks, so it should
      * be used for all non-trusted calls, for example, p2p.
      * A non-malicious call (from RPC or a peer with addr permission) should
      * call the function without a parameter to avoid using the cache.
      */
-    std::vector<CAddress> GetAddresses(CNode& requestor, size_t max_addresses, size_t max_pct);
+    AddrMan::Addresses GetAddresses(CNode& requestor, size_t max_addresses, size_t max_pct);
 
     // This allows temporarily exceeding m_max_outbound_full_relay, with the goal of finding
     // a peer that is better than all our current peers.
@@ -1067,7 +1067,7 @@ private:
      * with fresh timestamps (per self-announcement).
      */
     struct CachedAddrResponse {
-        std::vector<CAddress> m_addrs_response_cache;
+        AddrMan::Addresses m_addrs_response_cache;
         std::chrono::microseconds m_cache_entry_expiration{0};
     };
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3764,14 +3764,14 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         peer->m_getaddr_recvd = true;
 
         peer->m_addrs_to_send.clear();
-        std::vector<CAddress> vAddr;
+        AddrMan::Addresses vAddr;
         if (pfrom.HasPermission(NetPermissionFlags::Addr)) {
             vAddr = m_connman.GetAddresses(MAX_ADDR_TO_SEND, MAX_PCT_ADDR_TO_SEND, /* network */ std::nullopt);
         } else {
             vAddr = m_connman.GetAddresses(pfrom, MAX_ADDR_TO_SEND, MAX_PCT_ADDR_TO_SEND);
         }
         FastRandomContext insecure_rand;
-        for (const CAddress &addr : vAddr) {
+        for (const auto& addr : vAddr) {
             PushAddress(*peer, addr, insecure_rand);
         }
         return;

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -873,6 +873,8 @@ static RPCHelpMan getnodeaddresses()
                             {RPCResult::Type::STR, "address", "The address of the node"},
                             {RPCResult::Type::NUM, "port", "The port number of the node"},
                             {RPCResult::Type::STR, "network", "The network (" + Join(GetNetworkNames(), ", ") + ") the node connected through"},
+                            {RPCResult::Type::BOOL, "tried", "Whether a connection to this node was successfully made and its address is in our addrman tried table"},
+                            {RPCResult::Type::NUM, "reference_count", /* optional */ true, "The addrman new table reference count for the node address. Only returned if it is in our new table, i.e. \"tried\" is false"},
                         }},
                     }
                 },
@@ -907,6 +909,10 @@ static RPCHelpMan getnodeaddresses()
         obj.pushKV("address", addr.ToStringIP());
         obj.pushKV("port", addr.GetPort());
         obj.pushKV("network", GetNetworkName(addr.GetNetClass()));
+        obj.pushKV("tried", addr.fInTried);
+        if (!addr.fInTried) {
+            obj.pushKV("reference_count", addr.nRefCount);
+        }
         ret.push_back(obj);
     }
     return ret;

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -897,10 +897,10 @@ static RPCHelpMan getnodeaddresses()
     }
 
     // returns a shuffled list of CAddress
-    const std::vector<CAddress> vAddr{connman.GetAddresses(count, /* max_pct */ 0, network)};
+    const AddrMan::Addresses addrs{connman.GetAddresses(count, /* max_pct */ 0, network)};
     UniValue ret(UniValue::VARR);
 
-    for (const CAddress& addr : vAddr) {
+    for (const auto& addr : addrs) {
         UniValue obj(UniValue::VOBJ);
         obj.pushKV("time", (int)addr.nTime);
         obj.pushKV("services", (uint64_t)addr.nServices);

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -434,7 +434,7 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
     // Test: Sanity check, GetAddr should never return anything if addrman
     //  is empty.
     BOOST_CHECK_EQUAL(addrman.size(), 0U);
-    std::vector<CAddress> vAddr1 = addrman.GetAddr(/* max_addresses */ 0, /* max_pct */ 0, /* network */ std::nullopt);
+    const AddrMan::Addresses vAddr1 = addrman.GetAddr(/* max_addresses */ 0, /* max_pct */ 0, /* network */ std::nullopt);
     BOOST_CHECK_EQUAL(vAddr1.size(), 0U);
 
     CAddress addr1 = CAddress(ResolveService("250.250.2.1", 8333), NODE_NONE);
@@ -477,7 +477,7 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
         if (i % 8 == 0)
             addrman.Good(addr);
     }
-    std::vector<CAddress> vAddr = addrman.GetAddr(/* max_addresses */ 2500, /* max_pct */ 23, /* network */ std::nullopt);
+    const AddrMan::Addresses vAddr = addrman.GetAddr(/* max_addresses */ 2500, /* max_pct */ 23, /* network */ std::nullopt);
 
     size_t percent23 = (addrman.size() * 23) / 100;
     BOOST_CHECK_EQUAL(vAddr.size(), percent23);


### PR DESCRIPTION
Based on #22831, this pull implements the suggestion in https://github.com/bitcoin/bitcoin/pull/22831#issuecomment-920199755 to extend RPC getnodeaddresses to return whether the address is in the tried or new table, and if it's in the new table, its refcount. Doing so allows us to better test the contents of the addrman using a public interface instead of relying on assert_debug_log in the functional tests. The pull then updates the getnodeaddresses and addpeeraddress test coverage, followed by improving the relevant asmap test coverage.

Credit to John Newbery for the idea.