### PR TITLE
refactor: Remove unused validation includes

### DIFF
--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -4,6 +4,7 @@
 
 #include <chainparams.h>
 #include <consensus/validation.h>
+#include <node/utxo_snapshot.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -24,6 +24,7 @@
 #include <node/blockstorage.h>
 #include <node/coinstats.h>
 #include <node/ui_interface.h>
+#include <node/utxo_snapshot.h>
 #include <policy/policy.h>
 #include <policy/rbf.h>
 #include <policy/settings.h>

--- a/src/validation.h
+++ b/src/validation.h
@@ -14,16 +14,10 @@
 #include <arith_uint256.h>
 #include <attributes.h>
 #include <chain.h>
-#include <coins.h>
-#include <consensus/validation.h>
-#include <crypto/common.h> // for ReadLE64
 #include <fs.h>
-#include <node/utxo_snapshot.h>
 #include <policy/feerate.h>
 #include <policy/packages.h>
-#include <protocol.h> // For CMessageHeader::MessageStartChars
 #include <script/script_error.h>
-#include <serialize.h>
 #include <sync.h>
 #include <txdb.h>
 #include <txmempool.h> // For CTxMemPool::cs
@@ -44,18 +38,13 @@
 #include <vector>
 
 class CChainState;
-class BlockValidationState;
 class CBlockTreeDB;
-class CBlockUndo;
 class CChainParams;
 struct CCheckpointData;
-class CInv;
-class CConnman;
-class CScriptCheck;
 class CTxMemPool;
 class ChainstateManager;
+class SnapshotMetadata;
 struct ChainTxData;
-
 struct DisconnectedBlockTransactions;
 struct PrecomputedTransactionData;
 struct LockPoints;


### PR DESCRIPTION
Unused includes will cause needless recompilation when headers are changed. Also, they pretend there are dependencies that don't exist.

Fix both by removing them.