### PR TITLE
log: change an incorrect fee to fee rate, and vice-versa

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -237,7 +237,7 @@ void BlockAssembler::AddToBlock(CTxMemPool::txiter iter)
 
     bool fPrintPriority = gArgs.GetBoolArg("-printpriority", DEFAULT_PRINTPRIORITY);
     if (fPrintPriority) {
-        LogPrintf("fee %s txid %s\n",
+        LogPrintf("fee rate %s txid %s\n",
                   CFeeRate(iter->GetModifiedFee(), iter->GetTxSize()).ToString(),
                   iter->GetTx().GetHash().ToString());
     }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -924,7 +924,7 @@ void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeD
             ++nTransactionsUpdated;
         }
     }
-    LogPrintf("PrioritiseTransaction: %s feerate += %s\n", hash.ToString(), FormatMoney(nFeeDelta));
+    LogPrintf("PrioritiseTransaction: %s fee += %s\n", hash.ToString(), FormatMoney(nFeeDelta));
 }
 
 void CTxMemPool::ApplyDelta(const uint256& hash, CAmount &nFeeDelta) const


### PR DESCRIPTION
This is a tale of two fees, er, fee rates... indeed, one is misdescribed as a fee, and the other is incorrectly called a fee rate.

From this review discussion: https://github.com/bitcoin/bitcoin/pull/22689#discussion_r695866211 (thanks to John Newbery).
