### PR TITLE
[fuzz] Use public methods in addrman fuzz tests

### DIFF
--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -77,8 +77,7 @@ CNetAddr RandAddr(FuzzedDataProvider& fuzzed_data_provider, FastRandomContext& f
 /** Fill addrman with lots of addresses from lots of sources.  */
 void FillAddrman(AddrMan& addrman, FuzzedDataProvider& fuzzed_data_provider)
 {
-    // Add some of the addresses directly to the "tried" table.
-
+    // Add a fraction of the addresses to the "tried" table.
     // 0, 1, 2, 3 corresponding to 0%, 100%, 50%, 33%
     const size_t n = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 3);
 


### PR DESCRIPTION
#22974 improved the performance of `CAddrMan::Good()` significantly so that it could be used directly in the fuzz tests, instead of those tests reaching directly into addrman's internal data structures.

This PR continues the work of making the fuzz tests only use `CAddrMan`'s public methods and pulls the `Fill()` and `RandAddr()` methods from `CAddrManDeterministic` into free functions, since they no longer need access to `CAddrMan` internals.