### PR TITLE
log: Consolidate timedata logging

### DIFF
--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -11,6 +11,7 @@
 #include <netaddress.h>
 #include <node/ui_interface.h>
 #include <sync.h>
+#include <tinyformat.h>
 #include <util/system.h>
 #include <util/translation.h>
 #include <warnings.h>
@@ -98,11 +99,12 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
         }
 
         if (LogAcceptCategory(BCLog::NET)) {
+            std::string log_message{"time data samples: "};
             for (const int64_t n : vSorted) {
-                LogPrint(BCLog::NET, "%+d  ", n); /* Continued */
+                log_message += strprintf("%+d  ", n);
             }
-            LogPrint(BCLog::NET, "|  "); /* Continued */
-            LogPrint(BCLog::NET, "nTimeOffset = %+d  (%+d minutes)\n", nTimeOffset, nTimeOffset / 60);
+            log_message += strprintf("|  median offset = %+d  (%+d minutes)", nTimeOffset, nTimeOffset / 60);
+            LogPrint(BCLog::NET, "%s\n", log_message);
         }
     }
 }


### PR DESCRIPTION
When timedata samples are logged, `LogPrint()` is currently invoked multiple times on the same log entry.
This can lead to chaos in the log when other threads log concurrently, as in this example which motivated this PR:
```
2021-09-20T00:28:57Z -48  -26  -11  -8  -6  Addrman checks started: new 37053, tried 83, total 37136
2021-09-20T00:28:57Z -3  -1  -1  -1  -1  +0  |  nTimeOffset = -3  (+0 minutes)
```
Fix this by building the log message in a string and logging it one `LogPrint()` call. I also changed the wording slightly so that it becomes understandable what is being logged, example:

```
2021-09-21T21:03:24Z time data samples: -43  -18  -12  -4  -1  -1  +0  +0  +268  |  median offset = -1  (+0 minutes)
```