### PR TITLE
fuzz: Fix memory leak in system fuzz target

### DIFF
--- a/src/test/fuzz/system.cpp
+++ b/src/test/fuzz/system.cpp
@@ -5,6 +5,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <test/util/setup_common.h>
 #include <util/system.h>
 
 #include <cstdint>
@@ -12,6 +13,11 @@
 #include <vector>
 
 namespace {
+void initialize_system()
+{
+    static const auto testing_setup = MakeNoLogFileContext<>();
+}
+
 std::string GetArgumentName(const std::string& name)
 {
     size_t idx = name.find('=');
@@ -20,9 +26,8 @@ std::string GetArgumentName(const std::string& name)
     }
     return name.substr(0, idx);
 }
-} // namespace
 
-FUZZ_TARGET(system)
+FUZZ_TARGET_INIT(system, initialize_system)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     ArgsManager args_manager{};
@@ -114,3 +119,4 @@ FUZZ_TARGET(system)
 
     (void)HelpRequested(args_manager);
 }
+} // namespace


### PR DESCRIPTION
Might fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=36906

To test:

```
$ FUZZ=system valgrind --tool=massif ./src/test/fuzz/fuzz ../btc_qa_assets/fuzz_seed_corpus/system/
^C
$ massif-visualizer ./massif.out.952024
```
