### PR TITLE
Add aliases to the `-chain` param

### DIFF
--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -15,6 +15,10 @@ const std::string CBaseChainParams::TESTNET = "test";
 const std::string CBaseChainParams::SIGNET = "signet";
 const std::string CBaseChainParams::REGTEST = "regtest";
 
+const std::string CBaseChainParams::MAINNET_ALIAS = "mainnet";
+const std::string CBaseChainParams::TESTNET_ALIAS = "testnet";
+const std::string CBaseChainParams::TESTNET3_ALIAS = "testnet3";
+
 void SetupChainParamsBaseOptions(ArgsManager& argsman)
 {
     argsman.AddArg("-chain=<chain>", "Use the chain <chain> (default: main). Allowed values: main, test, signet, regtest", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -25,6 +25,13 @@ public:
     static const std::string REGTEST;
     ///@}
 
+    ///@{
+    /** Chain name string aliases */
+    static const std::string MAINNET_ALIAS;
+    static const std::string TESTNET_ALIAS;
+    static const std::string TESTNET3_ALIAS;
+    ///@}
+
     const std::string& DataDir() const { return strDataDir; }
     uint16_t RPCPort() const { return m_rpc_port; }
     uint16_t OnionServiceTargetPort() const { return m_onion_service_target_port; }

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1011,7 +1011,18 @@ std::string ArgsManager::GetChainName() const
     if (fTestNet)
         return CBaseChainParams::TESTNET;
 
-    return GetArg("-chain", CBaseChainParams::MAIN);
+    auto chain_name = GetArg("-chain", CBaseChainParams::MAIN);
+    std::string chain_name_post_alias;
+    if (chain_name == CBaseChainParams::MAINNET_ALIAS) {
+        chain_name_post_alias = CBaseChainParams::MAIN;
+    } else if (chain_name == CBaseChainParams::TESTNET_ALIAS) {
+        chain_name_post_alias = CBaseChainParams::TESTNET;
+    } else if (chain_name == CBaseChainParams::TESTNET3_ALIAS) {
+        chain_name_post_alias = CBaseChainParams::TESTNET;
+    } else {
+        chain_name_post_alias = chain_name;
+    }
+    return chain_name_post_alias;
 }
 
 bool ArgsManager::UseDefaultSection(const std::string& arg) const


### PR DESCRIPTION
This change adds some aliases to the `-chain` param. `-chain=signet`
is accepted, and this changes it into accepting `-chain=testnet` too.

Stay a private API, no documentation is changed. Some tests could be
added, or not, depending on the software's code coverage policy.
