### PR TITLE
test: use MiniWallet for p2p_filter.py

### DIFF
--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -8,6 +8,7 @@ Test BIP 37
 
 from test_framework.messages import (
     CInv,
+    COIN,
     MAX_BLOOM_FILTER_SIZE,
     MAX_BLOOM_HASH_FUNCS,
     MSG_BLOCK,
@@ -28,11 +29,15 @@ from test_framework.p2p import (
 )
 from test_framework.script import MAX_SCRIPT_ELEMENT_SIZE
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.wallet import (
+    MiniWallet,
+    random_p2wpkh,
+)
 
 
 class P2PBloomFilter(P2PInterface):
     # This is a P2SH watch-only wallet
-    watch_script_pubkey = 'a914ffffffffffffffffffffffffffffffffffffffff87'
+    watch_script_pubkey = bytes.fromhex('a914ffffffffffffffffffffffffffffffffffffffff87')
     # The initial filter (n=10, fp=0.000001) with just the above scriptPubKey added
     watch_filter_init = msg_filterload(
         data=
@@ -93,8 +98,9 @@ class FilterTest(BitcoinTestFramework):
             '-whitelist=noban@127.0.0.1',  # immediate tx relay
         ]]
 
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
+    def generatetoscriptpubkey(self, scriptpubkey):
+        """Helper to generate a single block to the given scriptPubKey."""
+        return self.generatetodescriptor(self.nodes[0], 1, f'raw({scriptpubkey.hex()})')[0]
 
     def test_size_limits(self, filter_peer):
         self.log.info('Check that too large filter is rejected')
@@ -130,8 +136,7 @@ class FilterTest(BitcoinTestFramework):
         filter_peer = P2PBloomFilter()
 
         self.log.debug("Create a tx relevant to the peer before connecting")
-        filter_address = self.nodes[0].decodescript(filter_peer.watch_script_pubkey)['address']
-        txid = self.nodes[0].sendtoaddress(filter_address, 90)
+        txid, _ = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=filter_peer.watch_script_pubkey, amount=9 * COIN)
 
         self.log.debug("Send a mempool msg after connecting and check that the tx is received")
         self.nodes[0].add_p2p_connection(filter_peer)
@@ -142,8 +147,7 @@ class FilterTest(BitcoinTestFramework):
     def test_frelay_false(self, filter_peer):
         self.log.info("Check that a node with fRelay set to false does not receive invs until the filter is set")
         filter_peer.tx_received = False
-        filter_address = self.nodes[0].decodescript(filter_peer.watch_script_pubkey)['address']
-        self.nodes[0].sendtoaddress(filter_address, 90)
+        self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=filter_peer.watch_script_pubkey, amount=9 * COIN)
         # Sync to make sure the reason filter_peer doesn't receive the tx is not p2p delays
         filter_peer.sync_with_ping()
         assert not filter_peer.tx_received
@@ -156,45 +160,44 @@ class FilterTest(BitcoinTestFramework):
         filter_peer.send_and_ping(filter_peer.watch_filter_init)
         # If fRelay is not already True, sending filterload sets it to True
         assert self.nodes[0].getpeerinfo()[0]['relaytxes']
-        filter_address = self.nodes[0].decodescript(filter_peer.watch_script_pubkey)['address']
 
         self.log.info('Check that we receive merkleblock and tx if the filter matches a tx in a block')
-        block_hash = self.generatetoaddress(self.nodes[0], 1, filter_address)[0]
+        block_hash = self.generatetoscriptpubkey(filter_peer.watch_script_pubkey)
         txid = self.nodes[0].getblock(block_hash)['tx'][0]
         filter_peer.wait_for_merkleblock(block_hash)
         filter_peer.wait_for_tx(txid)
 
         self.log.info('Check that we only receive a merkleblock if the filter does not match a tx in a block')
         filter_peer.tx_received = False
-        block_hash = self.generatetoaddress(self.nodes[0], 1, self.nodes[0].getnewaddress())[0]
+        block_hash = self.generatetoscriptpubkey(random_p2wpkh())
         filter_peer.wait_for_merkleblock(block_hash)
         assert not filter_peer.tx_received
 
         self.log.info('Check that we not receive a tx if the filter does not match a mempool tx')
         filter_peer.merkleblock_received = False
         filter_peer.tx_received = False
-        self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 90)
+        self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=random_p2wpkh(), amount=7 * COIN)
         filter_peer.sync_send_with_ping()
         assert not filter_peer.merkleblock_received
         assert not filter_peer.tx_received
 
         self.log.info('Check that we receive a tx if the filter matches a mempool tx')
         filter_peer.merkleblock_received = False
-        txid = self.nodes[0].sendtoaddress(filter_address, 90)
+        txid, _ = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=filter_peer.watch_script_pubkey, amount=9 * COIN)
         filter_peer.wait_for_tx(txid)
         assert not filter_peer.merkleblock_received
 
         self.log.info('Check that after deleting filter all txs get relayed again')
         filter_peer.send_and_ping(msg_filterclear())
         for _ in range(5):
-            txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 7)
+            txid, _ = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=random_p2wpkh(), amount=7 * COIN)
             filter_peer.wait_for_tx(txid)
 
         self.log.info('Check that request for filtered blocks is ignored if no filter is set')
         filter_peer.merkleblock_received = False
         filter_peer.tx_received = False
         with self.nodes[0].assert_debug_log(expected_msgs=['received getdata']):
-            block_hash = self.generatetoaddress(self.nodes[0], 1, self.nodes[0].getnewaddress())[0]
+            block_hash = self.generatetoscriptpubkey(random_p2wpkh())
             filter_peer.wait_for_inv([CInv(MSG_BLOCK, int(block_hash, 16))])
             filter_peer.sync_with_ping()
             assert not filter_peer.merkleblock_received
@@ -210,6 +213,9 @@ class FilterTest(BitcoinTestFramework):
         self.nodes[0].disconnect_p2ps()
 
     def run_test(self):
+        self.wallet = MiniWallet(self.nodes[0])
+        self.wallet.rescan_utxos()
+
         filter_peer = self.nodes[0].add_p2p_connection(P2PBloomFilter())
         self.log.info('Test filter size limits')
         self.test_size_limits(filter_peer)

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -28,6 +28,7 @@ from test_framework.script import (
     OP_NOP,
     SIGHASH_ALL,
 )
+from test_framework.script_util import key_to_p2wpkh_script
 from test_framework.util import (
     assert_equal,
     assert_greater_than_or_equal,
@@ -205,6 +206,14 @@ class MiniWallet:
         txid = from_node.sendrawtransaction(tx_hex)
         self.scan_tx(from_node.decoderawtransaction(tx_hex))
         return txid
+
+
+def random_p2wpkh():
+    """Generate a random P2WPKH scriptPubKey. Can be used when a random destination is needed,
+    but no compiled wallet is available (e.g. as replacement to the getnewaddress RPC)."""
+    key = ECKey()
+    key.generate()
+    return key_to_p2wpkh_script(key.get_pubkey().get_bytes())
 
 
 def make_chain(node, address, privkeys, parent_txid, parent_value, n=0, parent_locking_script=None, fee=DEFAULT_FEE):


### PR DESCRIPTION
This PR enables one more of the non-wallet functional tests (p2p_filter.py) to be run even with the Bitcoin Core wallet disabled by using the MiniWallet instead, as proposed in #20078.
For this purpose, a MiniWallet method `send_to` is introduced first, which allows to create arbitrary outputs (scriptPubKey/amount). Note that the implementation for this is already present in feature_rbf.py (recently added in PR #22998), i.e. it is simply moved to the MiniWallet interface.