### PR TITLE
test: avoid non-determinism in asmap-addrman test

### DIFF
--- a/test/functional/feature_asmap.py
+++ b/test/functional/feature_asmap.py
@@ -42,8 +42,8 @@ class AsmapTest(BitcoinTestFramework):
         self.extra_args = [["-checkaddrman=1"]]  # Do addrman checks on all operations.
 
     def fill_addrman(self, node_id):
-        """Add 2 tried addresses to the addrman, followed by 2 new addresses."""
-        for addr, tried in [[0, True], [1, True], [2, False], [3, False]]:
+        """Add 1 tried address to the addrman, followed by 1 new address."""
+        for addr, tried in [[0, True], [1, False]]:
             self.nodes[node_id].addpeeraddress(address=f"101.{addr}.0.0", tried=tried, port=8333)
 
     def test_without_asmap_arg(self):
@@ -89,7 +89,7 @@ class AsmapTest(BitcoinTestFramework):
         self.restart_node(0, ["-asmap", "-checkaddrman=1"])
         with self.node.assert_debug_log(
             expected_msgs=[
-                "Addrman checks started: new 2, tried 2, total 4",
+                "Addrman checks started: new 1, tried 1, total 2",
                 "Addrman checks completed successfully",
             ]
         ):


### PR DESCRIPTION
This is the same approach as for the addpeeraddress test in `test/functional/rpc_net.py` in commit 869f1368.

The probability of collision when adding an addrman entry is expected to be 1/2^16 = 1/65536 for an address from a different /16.  This change hopes to avoid these collisions by adding 1 tried entry before adding 1 new table one, instead of 2 tried entries followed by 2 new entries, which appears to have caused a collision in the CI.
    
To verify the regression test still fails when expected:
    
- `git checkout 181a120 && git cherry-pick ef242f5`
- recompile bitcoind
- git checkout this branch and run `test/functional/feature_asmap.py`. Expected output:

```
AssertionError: Unexpected stderr bitcoind: ./addrman.h:739: void CAddrMan::Check() const: Assertion `false' failed. !=
```

Closes #23078.

Co-authored-by: Martin Zumsande <mzumsande@gmail.com>