### PR TITLE
Deprecate `main` and `test` `-chain` params

### DIFF
--- a/doc/bitcoin-conf.md
+++ b/doc/bitcoin-conf.md
@@ -29,7 +29,7 @@ Comments may appear in two ways:
 ### Network specific options
 
 Network specific options can be:
-- placed into sections with headers `[main]` (not `[mainnet]`), `[test]` (not `[testnet]`), `[signet]` or `[regtest]`;
+- placed into sections with headers `[mainnet]`, `[testnet]`, `[signet]` or `[regtest]`;
 - prefixed with a chain name; e.g., `regtest.maxmempool=100`.
 
 Network specific options take precedence over non-network specific options.

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -35,7 +35,7 @@ static void DeserializeAndCheckBlockTest(benchmark::Bench& bench)
     stream.write(&a, 1); // Prevent compaction
 
     ArgsManager bench_args;
-    const auto chainParams = CreateChainParams(bench_args, CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(bench_args, CBaseChainParams::MAINNET);
 
     bench.unit("block").run([&] {
         CBlock block; // Note that CBlock caches its checked state, so we need to recreate it here

--- a/src/bench/mempool_stress.cpp
+++ b/src/bench/mempool_stress.cpp
@@ -79,7 +79,7 @@ static void ComplexMemPool(benchmark::Bench& bench)
         ordered_coins.emplace_back(MakeTransactionRef(tx));
         available_coins.emplace_back(ordered_coins.back(), tx_counter++);
     }
-    const auto testing_setup = MakeNoLogFileContext<const TestingSetup>(CBaseChainParams::MAIN);
+    const auto testing_setup = MakeNoLogFileContext<const TestingSetup>(CBaseChainParams::MAINNET);
     CTxMemPool pool;
     LOCK2(cs_main, pool.cs);
     bench.run([&]() NO_THREAD_SAFETY_ANALYSIS {

--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -15,7 +15,7 @@
 namespace {
 
 struct TestBlockAndIndex {
-    const std::unique_ptr<const TestingSetup> testing_setup{MakeNoLogFileContext<const TestingSetup>(CBaseChainParams::MAIN)};
+    const std::unique_ptr<const TestingSetup> testing_setup{MakeNoLogFileContext<const TestingSetup>(CBaseChainParams::MAINNET)};
     CBlock block{};
     uint256 blockHash{};
     CBlockIndex blockindex{};

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -60,7 +60,7 @@ static void SetupCliArgs(ArgsManager& argsman)
 {
     SetupHelpOptions(argsman);
 
-    const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::MAIN);
+    const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::MAINNET);
     const auto testnetBaseParams = CreateBaseChainParams(CBaseChainParams::TESTNET);
     const auto signetBaseParams = CreateBaseChainParams(CBaseChainParams::SIGNET);
     const auto regtestBaseParams = CreateBaseChainParams(CBaseChainParams::REGTEST);

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -61,7 +61,7 @@ static CBlock CreateGenesisBlock(uint32_t nTime, uint32_t nNonce, uint32_t nBits
 class CMainParams : public CChainParams {
 public:
     CMainParams() {
-        strNetworkID = CBaseChainParams::MAIN;
+        strNetworkID = CBaseChainParams::MAINNET;
         consensus.signet_blocks = false;
         consensus.signet_challenge.clear();
         consensus.nSubsidyHalvingInterval = 210000;
@@ -565,7 +565,7 @@ const CChainParams &Params() {
 
 std::unique_ptr<const CChainParams> CreateChainParams(const ArgsManager& args, const std::string& chain)
 {
-    if (chain == CBaseChainParams::MAIN) {
+    if (chain == CBaseChainParams::MAINNET) {
         return std::unique_ptr<CChainParams>(new CMainParams());
     } else if (chain == CBaseChainParams::TESTNET) {
         return std::unique_ptr<CChainParams>(new CTestNetParams());

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -10,10 +10,10 @@
 
 #include <assert.h>
 
-/* [[deprecated]] */ const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::MAINNET = "mainnet";
-/* [[deprecated]] */ const std::string CBaseChainParams::TEST = "test";
+const std::string CBaseChainParams::MAINNET_OLD = "main";
 const std::string CBaseChainParams::TESTNET = "testnet";
+const std::string CBaseChainParams::TESTNET_OLD = "test";
 const std::string CBaseChainParams::SIGNET = "signet";
 const std::string CBaseChainParams::REGTEST = "regtest";
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -10,8 +10,10 @@
 
 #include <assert.h>
 
-const std::string CBaseChainParams::MAIN = "main";
-const std::string CBaseChainParams::TESTNET = "test";
+/* [[deprecated]] */ const std::string CBaseChainParams::MAIN = "main";
+const std::string CBaseChainParams::MAINNET = "mainnet";
+/* [[deprecated]] */ const std::string CBaseChainParams::TEST = "test";
+const std::string CBaseChainParams::TESTNET = "testnet";
 const std::string CBaseChainParams::SIGNET = "signet";
 const std::string CBaseChainParams::REGTEST = "regtest";
 
@@ -42,7 +44,7 @@ const CBaseChainParams& BaseParams()
  */
 std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain)
 {
-    if (chain == CBaseChainParams::MAIN) {
+    if (chain == CBaseChainParams::MAINNET) {
         return std::make_unique<CBaseChainParams>("", 8332, 8334);
     } else if (chain == CBaseChainParams::TESTNET) {
         return std::make_unique<CBaseChainParams>("testnet3", 18332, 18334);

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -19,10 +19,10 @@ class CBaseChainParams
 public:
     ///@{
     /** Chain name strings */
-    /* [[deprecated]] */ static const std::string MAIN;
     static const std::string MAINNET;
-    /* [[deprecated]] */ static const std::string TEST;
+    static const std::string MAINNET_OLD;
     static const std::string TESTNET;
+    static const std::string TESTNET_OLD;
     static const std::string SIGNET;
     static const std::string REGTEST;
     ///@}

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -19,7 +19,9 @@ class CBaseChainParams
 public:
     ///@{
     /** Chain name strings */
-    static const std::string MAIN;
+    /* [[deprecated]] */ static const std::string MAIN;
+    static const std::string MAINNET;
+    /* [[deprecated]] */ static const std::string TEST;
     static const std::string TESTNET;
     static const std::string SIGNET;
     static const std::string REGTEST;

--- a/src/external_signer.h
+++ b/src/external_signer.h
@@ -29,7 +29,7 @@ private:
 public:
     //! @param[in] command      the command which handles interaction with the external signer
     //! @param[in] fingerprint  master key fingerprint of the signer
-    //! @param[in] chain        "main", "test", "regtest" or "signet"
+    //! @param[in] chain        "mainnet", "testnet", "regtest" or "signet"
     //! @param[in] name         device name
     ExternalSigner(const std::string& command, const std::string chain, const std::string& fingerprint, const std::string name);
 
@@ -42,7 +42,7 @@ public:
     //! Obtain a list of signers. Calls `<command> enumerate`.
     //! @param[in]              command the command which handles interaction with the external signer
     //! @param[in,out] signers  vector to which new signers (with a unique master key fingerprint) are added
-    //! @param chain            "main", "test", "regtest" or "signet"
+    //! @param chain            "mainnet", "testnet", "regtest" or "signet"
     //! @returns success
     static bool Enumerate(const std::string& command, std::vector<ExternalSigner>& signers, const std::string chain);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -355,11 +355,11 @@ void SetupServerArgs(ArgsManager& argsman)
 
     init::AddLoggingArgs(argsman);
 
-    const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::MAIN);
+    const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::MAINNET);
     const auto testnetBaseParams = CreateBaseChainParams(CBaseChainParams::TESTNET);
     const auto signetBaseParams = CreateBaseChainParams(CBaseChainParams::SIGNET);
     const auto regtestBaseParams = CreateBaseChainParams(CBaseChainParams::REGTEST);
-    const auto defaultChainParams = CreateChainParams(argsman, CBaseChainParams::MAIN);
+    const auto defaultChainParams = CreateChainParams(argsman, CBaseChainParams::MAINNET);
     const auto testnetChainParams = CreateChainParams(argsman, CBaseChainParams::TESTNET);
     const auto signetChainParams = CreateChainParams(argsman, CBaseChainParams::SIGNET);
     const auto regtestChainParams = CreateChainParams(argsman, CBaseChainParams::REGTEST);

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -489,8 +489,9 @@ bool LabelOutOfFocusEventFilter::eventFilter(QObject* watched, QEvent* event)
 fs::path static StartupShortcutPath()
 {
     std::string chain = gArgs.GetChainName();
-    if (chain == CBaseChainParams::MAIN)
+    if (chain == CBaseChainParams::MAINNET) {
         return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin.lnk";
+    }
     if (chain == CBaseChainParams::TESTNET) // Remove this special case when CBaseChainParams::TESTNET = "testnet4"
         return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin (testnet).lnk";
     return GetSpecialFolderPath(CSIDL_STARTUP) / strprintf("Bitcoin (%s).lnk", chain);
@@ -572,8 +573,9 @@ fs::path static GetAutostartDir()
 fs::path static GetAutostartFilePath()
 {
     std::string chain = gArgs.GetChainName();
-    if (chain == CBaseChainParams::MAIN)
+    if (chain == CBaseChainParams::MAINNET) {
         return GetAutostartDir() / "bitcoin.desktop";
+    }
     return GetAutostartDir() / strprintf("bitcoin-%s.desktop", chain);
 }
 
@@ -617,8 +619,9 @@ bool SetStartOnSystemStartup(bool fAutoStart)
         // Write a bitcoin.desktop file to the autostart directory:
         optionFile << "[Desktop Entry]\n";
         optionFile << "Type=Application\n";
-        if (chain == CBaseChainParams::MAIN)
+        if (chain == CBaseChainParams::MAINNET) {
             optionFile << "Name=Bitcoin\n";
+        }
         else
             optionFile << strprintf("Name=Bitcoin (%s)\n", chain);
         optionFile << "Exec=" << pszExePath << strprintf(" -min -chain=%s\n", chain);

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -17,8 +17,8 @@ static const struct {
     const int iconColorHueShift;
     const int iconColorSaturationReduction;
 } network_styles[] = {
-    {"main", QAPP_APP_NAME_DEFAULT, 0, 0},
-    {"test", QAPP_APP_NAME_TESTNET, 70, 30},
+    {"mainnet", QAPP_APP_NAME_DEFAULT, 0, 0},
+    {"testnet", QAPP_APP_NAME_TESTNET, 70, 30},
     {"signet", QAPP_APP_NAME_SIGNET, 35, 15},
     {"regtest", QAPP_APP_NAME_REGTEST, 160, 30},
 };
@@ -79,7 +79,7 @@ NetworkStyle::NetworkStyle(const QString &_appName, const int iconColorHueShift,
 
 const NetworkStyle* NetworkStyle::instantiate(const std::string& networkId)
 {
-    std::string titleAddText = networkId == CBaseChainParams::MAIN ? "" : strprintf("[%s]", networkId);
+    std::string titleAddText = networkId == CBaseChainParams::MAINNET ? "" : strprintf("[%s]", networkId);
     for (const auto& network_style : network_styles) {
         if (networkId == network_style.networkId) {
             return new NetworkStyle(

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -93,10 +93,10 @@ void PaymentServer::ipcParseCommandLine(int argc, char* argv[])
             SendCoinsRecipient r;
             if (GUIUtil::parseBitcoinURI(arg, &r) && !r.address.isEmpty())
             {
-                auto tempChainParams = CreateChainParams(gArgs, CBaseChainParams::MAIN);
+                auto tempChainParams = CreateChainParams(gArgs, CBaseChainParams::MAINNET);
 
                 if (IsValidDestinationString(r.address.toStdString(), *tempChainParams)) {
-                    SelectParams(CBaseChainParams::MAIN);
+                    SelectParams(CBaseChainParams::MAINNET);
                 } else {
                     tempChainParams = CreateChainParams(gArgs, CBaseChainParams::TESTNET);
                     if (IsValidDestinationString(r.address.toStdString(), *tempChainParams)) {

--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -55,7 +55,7 @@ void RPCNestedTests::rpcNestedTests()
     std::string result2;
     std::string filtered;
     RPCConsole::RPCExecuteCommandLine(m_node, result, "getblockchaininfo()[chain]", &filtered); //simple result filtering with path
-    QVERIFY(result=="mainnet");
+    QVERIFY(result == "mainnet");
     QVERIFY(filtered == "getblockchaininfo()[chain]");
 
     RPCConsole::RPCExecuteCommandLine(m_node, result, "getblock(getbestblockhash())"); //simple 2 level nesting

--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -55,7 +55,7 @@ void RPCNestedTests::rpcNestedTests()
     std::string result2;
     std::string filtered;
     RPCConsole::RPCExecuteCommandLine(m_node, result, "getblockchaininfo()[chain]", &filtered); //simple result filtering with path
-    QVERIFY(result=="main");
+    QVERIFY(result=="mainnet");
     QVERIFY(filtered == "getblockchaininfo()[chain]");
 
     RPCConsole::RPCExecuteCommandLine(m_node, result, "getblock(getbestblockhash())"); //simple 2 level nesting

--- a/src/test/data/key_io_valid.json
+++ b/src/test/data/key_io_valid.json
@@ -3,7 +3,7 @@
         "1BShJZ8A5q53oJJfMJoEF1gfZCWdZqZwwD",
         "76a914728d4cc27d19707b0197cfcd7c412d43287864b588ac",
         {
-            "chain": "main",
+            "chain": "mainnet",
             "isPrivkey": false
         }
     ],
@@ -11,7 +11,7 @@
         "3L1YkZjdeNSqaZcNKZFXQfyokx3zVYm7r6",
         "a914c8f37c3cc21561296ad81f4bec6b5de10ebc185187",
         {
-            "chain": "main",
+            "chain": "mainnet",
             "isPrivkey": false
         }
     ],
@@ -19,7 +19,7 @@
         "mhJuoGLgnJC8gdBgBzEigsoyG4omQXejPT",
         "76a91413a92d1998e081354d36c13ce0c9dc04b865d40a88ac",
         {
-            "chain": "test",
+            "chain": "testnet",
             "isPrivkey": false
         }
     ],
@@ -27,7 +27,7 @@
         "2N5VpzKEuYvZJbmg6eUNGnfrrD1ir92FWGu",
         "a91486648cc2faaf05660e72c04c7a837bcc3e986f1787",
         {
-            "chain": "test",
+            "chain": "testnet",
             "isPrivkey": false
         }
     ],
@@ -67,7 +67,7 @@
         "5KcrFZvJ2p4dM6QVUPu53cKXcCfozA1PJLHm1mNAxkDYhgThLu4",
         "ed6c796e2f62377410766214f55aa81ac9a6590ad7ed57c509c983bf648409ac",
         {
-            "chain": "main",
+            "chain": "mainnet",
             "isCompressed": false,
             "isPrivkey": true
         }
@@ -76,7 +76,7 @@
         "L195WBrf2G3nCnun4CLxrb8XKk9LbCqH43THh4n4QrL5SzRzpq9j",
         "74f76c106e38d20514a99a86e4fe3bb28319e7dd2ad21dbc170cbb516a5358fa",
         {
-            "chain": "main",
+            "chain": "mainnet",
             "isCompressed": true,
             "isPrivkey": true
         }
@@ -85,7 +85,7 @@
         "92z6HnMQR4tWqjfVA3UaUN5EuUMgoVMdCa5rZFYZfmgyD7wxYCw",
         "b8511e1d74549e305517d48a1d394d1be2cfa5d0f3c0d83f9f450316ffa01276",
         {
-            "chain": "test",
+            "chain": "testnet",
             "isCompressed": false,
             "isPrivkey": true
         }
@@ -94,7 +94,7 @@
         "cTPnaF52x4w4Tq6afPxRHux3wbYb86thS7S45A7r3oZc1AHTQ6Qm",
         "ad68c48d337181da125de9061933ececcdf7d917631af7d34f7e38082bff9a11",
         {
-            "chain": "test",
+            "chain": "testnet",
             "isCompressed": true,
             "isPrivkey": true
         }
@@ -139,7 +139,7 @@
         "bc1q5cuatynjmk4szh40mmunszfzh7zrc5xm9w8ccy",
         "0014a639d59272ddab015eafdef9380922bf843c50db",
         {
-            "chain": "main",
+            "chain": "mainnet",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -148,7 +148,7 @@
         "bc1qkw7lz3ahms6e0ajv27mzh7g62tchjpmve4afc29u7w49tddydy2syv0087",
         "0020b3bdf147b7dc3597f64c57b62bf91a52f179076ccd7a9c28bcf3aa55b5a46915",
         {
-            "chain": "main",
+            "chain": "mainnet",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -157,7 +157,7 @@
         "bc1p5rgvqejqh9dh37t9g94dd9cm8vtqns7dndgj423egwggsggcdzmsspvr7j",
         "5120a0d0c06640b95b78f965416ad6971b3b1609c3cd9b512aaa39439088211868b7",
         {
-            "chain": "main",
+            "chain": "mainnet",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -166,7 +166,7 @@
         "bc1zr4pq63udck",
         "52021d42",
         {
-            "chain": "main",
+            "chain": "mainnet",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -175,7 +175,7 @@
         "tb1q74fxwnvhsue0l8wremgq66xzvn48jlc5zthsvz",
         "0014f552674d978732ff9dc3ced00d68c264ea797f14",
         {
-            "chain": "test",
+            "chain": "testnet",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -184,7 +184,7 @@
         "tb1qpt7cqgq8ukv92dcraun9c3n0s3aswrt62vtv8nqmkfpa2tjfghesv9ln74",
         "00200afd802007e598553703ef265c466f847b070d7a5316c3cc1bb243d52e4945f3",
         {
-            "chain": "test",
+            "chain": "testnet",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -193,7 +193,7 @@
         "tb1ph9v3e8nxct57hknlkhkz75p5pnxnkn05cw8ewpxu6tek56g29xgqydzfu7",
         "5120b9591c9e66c2e9ebda7fb5ec2f50340ccd3b4df4c38f9704dcd2f36a690a2990",
         {
-            "chain": "test",
+            "chain": "testnet",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -202,7 +202,7 @@
         "tb1ray6e8gxfx49ers6c4c70l3c8lsxtcmlx",
         "5310e93593a0c9354b91c358ae3cffc707fc",
         {
-            "chain": "test",
+            "chain": "testnet",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -283,7 +283,7 @@
         "16y3Q1XVRZqMR9T1XL1FkvNtD2E1bXBuYa",
         "76a9144171ec673aeb9fcf42af6094a3c82207e3b9a78188ac",
         {
-            "chain": "main",
+            "chain": "mainnet",
             "isPrivkey": false
         }
     ],
@@ -291,7 +291,7 @@
         "3CmZZnAiHVQgiAKSakf864oJMxN2BP1eLC",
         "a914798575fc1041b9440c4e63c28e57e597d00b7e4387",
         {
-            "chain": "main",
+            "chain": "mainnet",
             "isPrivkey": false
         }
     ],
@@ -299,7 +299,7 @@
         "mtCB3SoBo7EYUv8j54kUubGY4x3aJPY8nk",
         "76a9148b0c5f9ee714e0d1d24642ad63d9d5f398d9b56588ac",
         {
-            "chain": "test",
+            "chain": "testnet",
             "isPrivkey": false
         }
     ],
@@ -307,7 +307,7 @@
         "2N5ymzzKpx6EdUR4UdMZ7t9hcuwqtpHwgw5",
         "a9148badb3c3b5c0d39f906f7618e0018b7eae4baf7387",
         {
-            "chain": "test",
+            "chain": "testnet",
             "isPrivkey": false
         }
     ],
@@ -347,7 +347,7 @@
         "5JUHCgyxNSHg64wwju72eNsG6ajqo4Z2fHHw9iLDLfh69rSiL7w",
         "5644d06d88855dacf3192a31df8f4acd8e4c155c52a86d2c1fa48303f5cff053",
         {
-            "chain": "main",
+            "chain": "mainnet",
             "isCompressed": false,
             "isPrivkey": true
         }
@@ -356,7 +356,7 @@
         "L2kZaexG69VSriMe9T2m1jkS86iPe3xNbjcdfakRC1PHe7ay78Ji",
         "a50ee94aefcabf5a5d7c85be5b3844dee03c5604861dbfc77fe388c91e5a30f8",
         {
-            "chain": "main",
+            "chain": "mainnet",
             "isCompressed": true,
             "isPrivkey": true
         }
@@ -365,7 +365,7 @@
         "927JwT1ViCr5TD2ZX8CsMNhg17dXmou5xu4y2KiH54zD7i34UJq",
         "4502a54c0026b0150281d41f40860d1e23870c63cdc32645bbed688f2ee41f64",
         {
-            "chain": "test",
+            "chain": "testnet",
             "isCompressed": false,
             "isPrivkey": true
         }
@@ -374,7 +374,7 @@
         "cTpGGNPVy2Eagawohbr4aGtRJzpLnjxGsGYh9DUcBM45f3KdKGF6",
         "ba005a0cb39587aab00bd54c848b59e8adaed47403228567ddc739c2a344ff59",
         {
-            "chain": "test",
+            "chain": "testnet",
             "isCompressed": true,
             "isPrivkey": true
         }
@@ -419,7 +419,7 @@
         "bc1qz377zwe5awr68dnggengqx9vrjt05k98q3sw2n",
         "0014147de13b34eb87a3b66846668018ac1c96fa58a7",
         {
-            "chain": "main",
+            "chain": "mainnet",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -428,7 +428,7 @@
         "bc1qkmhskpdzg8kdkfywhu09kswwn9qan9vnkrf6mk40jvnr06s6sz5ssf82ya",
         "0020b6ef0b05a241ecdb248ebf1e5b41ce9941d99593b0d3addaaf932637ea1a80a9",
         {
-            "chain": "main",
+            "chain": "mainnet",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -437,7 +437,7 @@
         "bc1ps8cndas60cntk8x79sg9f5e5jz7x050z8agyugln2ukkks23rryqpejzkc",
         "512081f136f61a7e26bb1cde2c1054d33490bc67d1e23f504e23f3572d6b415118c8",
         {
-            "chain": "main",
+            "chain": "mainnet",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -446,7 +446,7 @@
         "bc1zn4tsczge9l",
         "52029d57",
         {
-            "chain": "main",
+            "chain": "mainnet",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -455,7 +455,7 @@
         "tb1q6xw0wwd9n9d7ge87dryz4vm5vtahzhvz6yett3",
         "0014d19cf739a5995be464fe68c82ab37462fb715d82",
         {
-            "chain": "test",
+            "chain": "testnet",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -464,7 +464,7 @@
         "tb1qwn9zq9fu5uk35ykpgsc7rz4uawy4yh0r5m5er26768h5ur50su3qj6evun",
         "002074ca20153ca72d1a12c14431e18abceb89525de3a6e991ab5ed1ef4e0e8f8722",
         {
-            "chain": "test",
+            "chain": "testnet",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -473,7 +473,7 @@
         "tb1pmcdc5d8gr92rtemfsnhpeqanvs0nr82upn5dktxluz9n0qcv34lqxke0wq",
         "5120de1b8a34e8195435e76984ee1c83b3641f319d5c0ce8db2cdfe08b37830c8d7e",
         {
-            "chain": "test",
+            "chain": "testnet",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -482,7 +482,7 @@
         "tb1rgxjvtfzp0xczz6dlzqv8d5cmuykk4qkk",
         "531041a4c5a44179b02169bf101876d31be1",
         {
-            "chain": "test",
+            "chain": "testnet",
             "isPrivkey": false,
             "tryCaseFlip": true
         }
@@ -563,7 +563,7 @@
         "12agZTajtRE3STSchwWNWnrm467zzTQ916",
         "76a9141156e00f70061e5faba8b71593a8c7554b47090c88ac",
         {
-            "chain": "main",
+            "chain": "mainnet",
             "isPrivkey": false
         }
     ],
@@ -571,7 +571,7 @@
         "3NXqB6iZiPYbKruNT3d9xNBTmtb73xMvvf",
         "a914e49decc9e5d97e0547d3642f3a4795b13ae62bca87",
         {
-            "chain": "main",
+            "chain": "mainnet",
             "isPrivkey": false
         }
     ],
@@ -579,7 +579,7 @@
         "mjgt4BoCYxjzWvJFoh68x7cj5GeaKDYhyx",
         "76a9142dc11fc7b8072f733f690ffb0591c00f4062295c88ac",
         {
-            "chain": "test",
+            "chain": "testnet",
             "isPrivkey": false
         }
     ],
@@ -587,7 +587,7 @@
         "2NCT6FdQ5MxorHgnFxLeHyGwTGRdkHcrJDH",
         "a914d2a8ec992b0894a0d9391ca5d9c45c388c41be7e87",
         {
-            "chain": "test",
+            "chain": "testnet",
             "isPrivkey": false
         }
     ],

--- a/src/test/fuzz/descriptor_parse.cpp
+++ b/src/test/fuzz/descriptor_parse.cpp
@@ -11,7 +11,7 @@ void initialize_descriptor_parse()
 {
     static const ECCVerifyHandle verify_handle;
     ECC_Start();
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::MAINNET);
 }
 
 FUZZ_TARGET_INIT(descriptor_parse, initialize_descriptor_parse)

--- a/src/test/fuzz/key_io.cpp
+++ b/src/test/fuzz/key_io.cpp
@@ -15,7 +15,7 @@ void initialize_key_io()
 {
     static const ECCVerifyHandle verify_handle;
     ECC_Start();
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::MAINNET);
 }
 
 FUZZ_TARGET_INIT(key_io, initialize_key_io)

--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -23,7 +23,7 @@
 
 void initialize_net()
 {
-    static const auto testing_setup = MakeNoLogFileContext<>(CBaseChainParams::MAIN);
+    static const auto testing_setup = MakeNoLogFileContext<>(CBaseChainParams::MAINNET);
 }
 
 FUZZ_TARGET_INIT(net, initialize_net)

--- a/src/test/fuzz/pow.cpp
+++ b/src/test/fuzz/pow.cpp
@@ -17,7 +17,7 @@
 
 void initialize_pow()
 {
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::MAINNET);
 }
 
 FUZZ_TARGET_INIT(pow, initialize_pow)

--- a/src/test/fuzz/versionbits.cpp
+++ b/src/test/fuzz/versionbits.cpp
@@ -104,7 +104,7 @@ std::unique_ptr<const CChainParams> g_params;
 void initialize()
 {
     // this is actually comparatively slow, so only do it once
-    g_params = CreateChainParams(ArgsManager{}, CBaseChainParams::MAIN);
+    g_params = CreateChainParams(ArgsManager{}, CBaseChainParams::MAINNET);
     assert(g_params != nullptr);
 }
 

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE(key_io_valid_parse)
     UniValue tests = read_json(std::string(json_tests::key_io_valid, json_tests::key_io_valid + sizeof(json_tests::key_io_valid)));
     CKey privkey;
     CTxDestination destination;
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::MAINNET);
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(key_io_valid_gen)
         }
     }
 
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::MAINNET);
 }
 
 
@@ -136,7 +136,8 @@ BOOST_AUTO_TEST_CASE(key_io_invalid)
         std::string exp_base58string = test[0].get_str();
 
         // must be invalid as public and as private key
-        for (const auto& chain : { CBaseChainParams::MAIN, CBaseChainParams::TESTNET, CBaseChainParams::SIGNET, CBaseChainParams::REGTEST }) {
+        for (const auto & chain : { CBaseChainParams::MAINNET, CBaseChainParams::TESTNET,
+                                    CBaseChainParams::SIGNET, CBaseChainParams::REGTEST }) {
             SelectParams(chain);
             destination = DecodeDestination(exp_base58string);
             BOOST_CHECK_MESSAGE(!IsValidDestination(destination), "IsValid pubkey in mainnet:" + strTest);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -192,7 +192,7 @@ void MinerTestingSetup::TestPackageSelection(const CChainParams& chainparams, co
 BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 {
     // Note that by default, these tests run with size accounting enabled.
-    const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(* m_node.args, CBaseChainParams::MAINNET);
     const CChainParams& chainparams = *chainParams;
     CScript scriptPubKey = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
     std::unique_ptr<CBlockTemplate> pblocktemplate;

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -169,17 +169,17 @@ BOOST_AUTO_TEST_CASE(ChainParams_MAIN_sanity)
 
 BOOST_AUTO_TEST_CASE(ChainParams_REGTEST_sanity)
 {
-    sanity_check_chainparams(* m_node.args, CBaseChainParams::REGTEST);
+    sanity_check_chainparams(*m_node.args, CBaseChainParams::REGTEST);
 }
 
 BOOST_AUTO_TEST_CASE(ChainParams_TESTNET_sanity)
 {
-    sanity_check_chainparams(* m_node.args, CBaseChainParams::TESTNET);
+    sanity_check_chainparams(*m_node.args, CBaseChainParams::TESTNET);
 }
 
 BOOST_AUTO_TEST_CASE(ChainParams_SIGNET_sanity)
 {
-    sanity_check_chainparams(* m_node.args, CBaseChainParams::SIGNET);
+    sanity_check_chainparams(*m_node.args, CBaseChainParams::SIGNET);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -14,7 +14,7 @@ BOOST_FIXTURE_TEST_SUITE(pow_tests, BasicTestingSetup)
 /* Test calculation of next difficulty target with no constraints applying */
 BOOST_AUTO_TEST_CASE(get_next_work)
 {
-    const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(* m_node.args, CBaseChainParams::MAINNET);
     int64_t nLastRetargetTime = 1261130161; // Block #30240
     CBlockIndex pindexLast;
     pindexLast.nHeight = 32255;
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(get_next_work)
 /* Test the constraint on the upper bound for next work */
 BOOST_AUTO_TEST_CASE(get_next_work_pow_limit)
 {
-    const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(* m_node.args, CBaseChainParams::MAINNET);
     int64_t nLastRetargetTime = 1231006505; // Block #0
     CBlockIndex pindexLast;
     pindexLast.nHeight = 2015;
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_pow_limit)
 /* Test the constraint on the lower bound for actual time taken */
 BOOST_AUTO_TEST_CASE(get_next_work_lower_limit_actual)
 {
-    const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(* m_node.args, CBaseChainParams::MAINNET);
     int64_t nLastRetargetTime = 1279008237; // Block #66528
     CBlockIndex pindexLast;
     pindexLast.nHeight = 68543;
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_lower_limit_actual)
 /* Test the constraint on the upper bound for actual time taken */
 BOOST_AUTO_TEST_CASE(get_next_work_upper_limit_actual)
 {
-    const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(* m_node.args, CBaseChainParams::MAINNET);
     int64_t nLastRetargetTime = 1263163443; // NOTE: Not an actual block time
     CBlockIndex pindexLast;
     pindexLast.nHeight = 46367;
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_upper_limit_actual)
 
 BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_negative_target)
 {
-    const auto consensus = CreateChainParams(*m_node.args, CBaseChainParams::MAIN)->GetConsensus();
+    const auto consensus = CreateChainParams(* m_node.args, CBaseChainParams::MAINNET)->GetConsensus();
     uint256 hash;
     unsigned int nBits;
     nBits = UintToArith256(consensus.powLimit).GetCompact(true);
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_negative_target)
 
 BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_overflow_target)
 {
-    const auto consensus = CreateChainParams(*m_node.args, CBaseChainParams::MAIN)->GetConsensus();
+    const auto consensus = CreateChainParams(* m_node.args, CBaseChainParams::MAINNET)->GetConsensus();
     uint256 hash;
     unsigned int nBits = ~0x00800000;
     hash.SetHex("0x1");
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_overflow_target)
 
 BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_too_easy_target)
 {
-    const auto consensus = CreateChainParams(*m_node.args, CBaseChainParams::MAIN)->GetConsensus();
+    const auto consensus = CreateChainParams(* m_node.args, CBaseChainParams::MAINNET)->GetConsensus();
     uint256 hash;
     unsigned int nBits;
     arith_uint256 nBits_arith = UintToArith256(consensus.powLimit);
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_too_easy_target)
 
 BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_biger_hash_than_target)
 {
-    const auto consensus = CreateChainParams(*m_node.args, CBaseChainParams::MAIN)->GetConsensus();
+    const auto consensus = CreateChainParams(* m_node.args, CBaseChainParams::MAINNET)->GetConsensus();
     uint256 hash;
     unsigned int nBits;
     arith_uint256 hash_arith = UintToArith256(consensus.powLimit);
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_biger_hash_than_target)
 
 BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_zero_target)
 {
-    const auto consensus = CreateChainParams(*m_node.args, CBaseChainParams::MAIN)->GetConsensus();
+    const auto consensus = CreateChainParams(* m_node.args, CBaseChainParams::MAINNET)->GetConsensus();
     uint256 hash;
     unsigned int nBits;
     arith_uint256 hash_arith{0};
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_zero_target)
 
 BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
 {
-    const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(* m_node.args, CBaseChainParams::MAINNET);
     std::vector<CBlockIndex> blocks(10000);
     for (int i = 0; i < 10000; i++) {
         blocks[i].pprev = i ? &blocks[i - 1] : nullptr;
@@ -164,22 +164,22 @@ void sanity_check_chainparams(const ArgsManager& args, std::string chainName)
 
 BOOST_AUTO_TEST_CASE(ChainParams_MAIN_sanity)
 {
-    sanity_check_chainparams(*m_node.args, CBaseChainParams::MAIN);
+    sanity_check_chainparams(* m_node.args, CBaseChainParams::MAINNET);
 }
 
 BOOST_AUTO_TEST_CASE(ChainParams_REGTEST_sanity)
 {
-    sanity_check_chainparams(*m_node.args, CBaseChainParams::REGTEST);
+    sanity_check_chainparams(* m_node.args, CBaseChainParams::REGTEST);
 }
 
 BOOST_AUTO_TEST_CASE(ChainParams_TESTNET_sanity)
 {
-    sanity_check_chainparams(*m_node.args, CBaseChainParams::TESTNET);
+    sanity_check_chainparams(* m_node.args, CBaseChainParams::TESTNET);
 }
 
 BOOST_AUTO_TEST_CASE(ChainParams_SIGNET_sanity)
 {
-    sanity_check_chainparams(*m_node.args, CBaseChainParams::SIGNET);
+    sanity_check_chainparams(* m_node.args, CBaseChainParams::SIGNET);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/settings_tests.cpp
+++ b/src/test/settings_tests.cpp
@@ -183,7 +183,7 @@ BOOST_FIXTURE_TEST_CASE(Merge, MergeTestingSetup)
         if (!out_file) throw std::system_error(errno, std::generic_category(), "fopen failed");
     }
 
-    const std::string& network = CBaseChainParams::MAIN;
+    const std::string & network = CBaseChainParams::MAINNET;
     ForEachMergeSetup([&](const ActionList& arg_actions, const ActionList& conf_actions, bool force_set,
                           bool ignore_default_section_config) {
         std::string desc;
@@ -252,7 +252,7 @@ BOOST_FIXTURE_TEST_CASE(Merge, MergeTestingSetup)
     // Results file is formatted like:
     //
     //   <input> || GetSetting() | GetSettingsList() | OnlyHasDefaultSectionSetting()
-    BOOST_CHECK_EQUAL(out_sha_hex, "79db02d74e3e193196541b67c068b40ebd0c124a24b3ecbe9cbf7e85b1c4ba7a");
+    BOOST_CHECK_EQUAL(out_sha_hex, "1c148e00e7a4b6291162dd70687e82abc606e94d295acac5b6ff577195fb42a4");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -77,7 +77,8 @@ struct BasicTestingSetup {
     ECCVerifyHandle globalVerifyHandle;
     NodeContext m_node;
 
-    explicit BasicTestingSetup(const std::string& chainName = CBaseChainParams::MAIN, const std::vector<const char*>& extra_args = {});
+    explicit BasicTestingSetup(const std::string & chainName = CBaseChainParams::MAINNET,
+                               const std::vector<const char *> & extra_args = {});
     ~BasicTestingSetup();
 
     const fs::path m_path_root;
@@ -90,14 +91,16 @@ struct BasicTestingSetup {
  */
 struct ChainTestingSetup : public BasicTestingSetup {
 
-    explicit ChainTestingSetup(const std::string& chainName = CBaseChainParams::MAIN, const std::vector<const char*>& extra_args = {});
+    explicit ChainTestingSetup(const std::string & chainName = CBaseChainParams::MAINNET,
+                               const std::vector<const char *> & extra_args = {});
     ~ChainTestingSetup();
 };
 
 /** Testing setup that configures a complete environment.
  */
 struct TestingSetup : public ChainTestingSetup {
-    explicit TestingSetup(const std::string& chainName = CBaseChainParams::MAIN, const std::vector<const char*>& extra_args = {});
+    explicit TestingSetup(const std::string & chainName = CBaseChainParams::MAINNET,
+                          const std::vector<const char *> & extra_args = {});
 };
 
 /** Identical to TestingSetup, but chain set to regtest */

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -741,7 +741,7 @@ BOOST_AUTO_TEST_CASE(util_ReadConfigStream)
     test_args.SetNetworkOnlyArg("-ccc");
     test_args.SetNetworkOnlyArg("-h");
 
-    test_args.SelectConfigNetwork(CBaseChainParams::MAIN);
+    test_args.SelectConfigNetwork(CBaseChainParams::MAINNET);
     BOOST_CHECK(test_args.GetArg("-d", "xxx") == "e");
     BOOST_CHECK(test_args.GetArgs("-ccc").size() == 2);
     BOOST_CHECK(test_args.GetArg("-h", "xxx") == "0");
@@ -816,27 +816,27 @@ BOOST_AUTO_TEST_CASE(util_GetChainName)
     std::string error;
 
     BOOST_CHECK(test_args.ParseParameters(0, (char**)argv_testnet, error));
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "main");
+    BOOST_CHECK_EQUAL(test_args.GetChainName(), "mainnet");
 
     BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_testnet, error));
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
+    BOOST_CHECK_EQUAL(test_args.GetChainName(), "testnet");
 
     BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_regtest, error));
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "regtest");
 
     BOOST_CHECK(test_args.ParseParameters(3, (char**)argv_test_no_reg, error));
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
+    BOOST_CHECK_EQUAL(test_args.GetChainName(), "testnet");
 
     BOOST_CHECK(test_args.ParseParameters(3, (char**)argv_both, error));
     BOOST_CHECK_THROW(test_args.GetChainName(), std::runtime_error);
 
     BOOST_CHECK(test_args.ParseParameters(0, (char**)argv_testnet, error));
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
+    BOOST_CHECK_EQUAL(test_args.GetChainName(), "testnet");
 
     BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_testnet, error));
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
+    BOOST_CHECK_EQUAL(test_args.GetChainName(), "testnet");
 
     BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_regtest, error));
     test_args.ReadConfigString(testnetconf);
@@ -844,7 +844,7 @@ BOOST_AUTO_TEST_CASE(util_GetChainName)
 
     BOOST_CHECK(test_args.ParseParameters(3, (char**)argv_test_no_reg, error));
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
+    BOOST_CHECK_EQUAL(test_args.GetChainName(), "testnet");
 
     BOOST_CHECK(test_args.ParseParameters(3, (char**)argv_both, error));
     test_args.ReadConfigString(testnetconf);
@@ -852,15 +852,15 @@ BOOST_AUTO_TEST_CASE(util_GetChainName)
 
     // check setting the network to test (and thus making
     // [test] regtest=1 potentially relevant) doesn't break things
-    test_args.SelectConfigNetwork("test");
+    test_args.SelectConfigNetwork("testnet");
 
     BOOST_CHECK(test_args.ParseParameters(0, (char**)argv_testnet, error));
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
+    BOOST_CHECK_EQUAL(test_args.GetChainName(), "testnet");
 
     BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_testnet, error));
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
+    BOOST_CHECK_EQUAL(test_args.GetChainName(), "testnet");
 
     BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_regtest, error));
     test_args.ReadConfigString(testnetconf);
@@ -868,7 +868,7 @@ BOOST_AUTO_TEST_CASE(util_GetChainName)
 
     BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_test_no_reg, error));
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
+    BOOST_CHECK_EQUAL(test_args.GetChainName(), "testnet");
 
     BOOST_CHECK(test_args.ParseParameters(3, (char**)argv_both, error));
     test_args.ReadConfigString(testnetconf);
@@ -889,7 +889,7 @@ BOOST_AUTO_TEST_CASE(util_GetChainName)
 //
 // - Combining SoftSet and ForceSet calls.
 //
-// - Testing "main" and "test" network values to make sure settings from network
+// - Testing "mainnet" and "testnet" network values to make sure settings from network
 //   sections are applied and to check for mainnet-specific behaviors like
 //   inheriting settings from the default section.
 //
@@ -916,8 +916,10 @@ struct ArgsMergeTestingSetup : public BasicTestingSetup {
             ForEachNoDup(conf_actions, SET, SECTION_NEGATE, [&] {
                 for (bool soft_set : {false, true}) {
                     for (bool force_set : {false, true}) {
-                        for (const std::string& section : {CBaseChainParams::MAIN, CBaseChainParams::TESTNET, CBaseChainParams::SIGNET}) {
-                            for (const std::string& network : {CBaseChainParams::MAIN, CBaseChainParams::TESTNET, CBaseChainParams::SIGNET}) {
+                        for (const std::string & section : { CBaseChainParams::MAINNET, CBaseChainParams::TESTNET,
+                                                             CBaseChainParams::SIGNET}) {
+                            for (const std::string & network : { CBaseChainParams::MAINNET, CBaseChainParams::TESTNET,
+                                                                 CBaseChainParams::SIGNET}) {
                                 for (bool net_specific : {false, true}) {
                                     fn(arg_actions, conf_actions, soft_set, force_set, section, network, net_specific);
                                 }
@@ -1071,7 +1073,7 @@ BOOST_FIXTURE_TEST_CASE(util_ArgsMerge, ArgsMergeTestingSetup)
     // Results file is formatted like:
     //
     //   <input> || <IsArgSet/IsArgNegated/GetArg output> | <GetArgs output> | <GetUnsuitable output>
-    BOOST_CHECK_EQUAL(out_sha_hex, "d1e436c1cd510d0ec44d5205d4b4e3bee6387d316e0075c58206cb16603f3d82");
+    BOOST_CHECK_EQUAL(out_sha_hex, "99ddcb43f22fd6ee9e4d954a97cc6bd2552ecd74819cceb0e0b7a577621e254d");
 }
 
 // Similar test as above, but for ArgsManager::GetChainName function.
@@ -1174,7 +1176,7 @@ BOOST_FIXTURE_TEST_CASE(util_ChainMerge, ChainMergeTestingSetup)
     // Results file is formatted like:
     //
     //   <input> || <output>
-    BOOST_CHECK_EQUAL(out_sha_hex, "f263493e300023b6509963887444c41386f44b63bc30047eb8402e8c1144854c");
+    BOOST_CHECK_EQUAL(out_sha_hex, "3de27eac4523a2a5e9966caecc37937908b997ddc20ec55dfb6a091322ef5568");
 }
 
 BOOST_AUTO_TEST_CASE(util_ReadWriteSettings)

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -40,7 +40,7 @@ static void TestBlockSubsidyHalvings(int nSubsidyHalvingInterval)
 
 BOOST_AUTO_TEST_CASE(block_subsidy_test)
 {
-    const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(* m_node.args, CBaseChainParams::MAINNET);
     TestBlockSubsidyHalvings(chainParams->GetConsensus()); // As in main
     TestBlockSubsidyHalvings(150); // As in regtest
     TestBlockSubsidyHalvings(1000); // Just another interval
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(block_subsidy_test)
 
 BOOST_AUTO_TEST_CASE(subsidy_limit_test)
 {
-    const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(* m_node.args, CBaseChainParams::MAINNET);
     CAmount nSum = 0;
     for (int nHeight = 0; nHeight < 14000000; nHeight += 1000) {
         CAmount nSubsidy = GetBlockSubsidy(nHeight, chainParams->GetConsensus());

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -416,7 +416,8 @@ BOOST_AUTO_TEST_CASE(versionbits_computeblockversion)
 {
     // check that any deployment on any chain can conceivably reach both
     // ACTIVE and FAILED states in roughly the way we expect
-    for (const auto& chain_name : {CBaseChainParams::MAIN, CBaseChainParams::TESTNET, CBaseChainParams::SIGNET, CBaseChainParams::REGTEST}) {
+    for (const auto & chain_name : { CBaseChainParams::MAINNET, CBaseChainParams::TESTNET,
+                                     CBaseChainParams::SIGNET, CBaseChainParams::REGTEST}) {
         const auto chainParams = CreateChainParams(*m_node.args, chain_name);
         uint32_t chain_all_vbits{0};
         for (int i = 0; i < (int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++i) {

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1014,11 +1014,11 @@ std::string ArgsManager::GetChainName() const
         return CBaseChainParams::TESTNET;
 
     auto chain_name = GetArg("-chain", CBaseChainParams::MAINNET);
-    if (chain_name == CBaseChainParams::MAIN) {
+    if (chain_name == CBaseChainParams::MAINNET_OLD) {
         std::cout << "WARNING -chain=main is deprecated. Please switch to -chain=mainnet" << std::endl;  // XXX bitcoin logging
         std::cerr << "WARNING -chain=main is deprecated. Please switch to -chain=mainnet" << std::endl;  // XXX bitcoin logging
         return CBaseChainParams::MAINNET;
-    } else if (chain_name == CBaseChainParams::TEST) {
+    } else if (chain_name == CBaseChainParams::TESTNET_OLD) {
         std::cout << "WARNING -chain=test is deprecated. Please switch to -testnet or to -chain=testnet" << std::endl;  // XXX bitcoin logging
         std::cerr << "WARNING -chain=test is deprecated. Please switch to -testnet or to -chain=testnet" << std::endl;  // XXX bitcoin logging
         return CBaseChainParams::TESTNET;

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -362,7 +362,7 @@ protected:
 
     /**
      * Returns the appropriate chain name from the program arguments.
-     * @return CBaseChainParams::MAIN by default; raises runtime error if an invalid combination is given.
+     * @return CBaseChainParams::MAINNET by default; raises runtime error if an invalid combination is given.
      */
     std::string GetChainName() const;
 

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -344,7 +344,7 @@ void BerkeleyDatabase::Open()
 
             ret = pdb_temp->open(nullptr,                             // Txn pointer
                             fMockDb ? nullptr : strFile.c_str(),      // Filename
-                            fMockDb ? strFile.c_str() : "main",       // Logical db name
+                            fMockDb ? strFile.c_str() : "mainnet",    // Logical db name
                             DB_BTREE,                                 // Database type
                             nFlags,                                   // Flags
                             0);
@@ -464,9 +464,9 @@ bool BerkeleyDatabase::Rewrite(const char* pszSkip)
                     BerkeleyBatch db(*this, true);
                     std::unique_ptr<Db> pdbCopy = std::make_unique<Db>(env->dbenv.get(), 0);
 
-                    int ret = pdbCopy->open(nullptr,               // Txn pointer
+                    int ret = pdbCopy->open(nullptr,            // Txn pointer
                                             strFileRes.c_str(), // Filename
-                                            "main",             // Logical db name
+                                            "mainnet",          // Logical db name
                                             DB_BTREE,           // Database type
                                             DB_CREATE,          // Flags
                                             0);

--- a/src/wallet/salvage.cpp
+++ b/src/wallet/salvage.cpp
@@ -120,9 +120,9 @@ bool RecoverDatabaseFile(const fs::path& file_path, bilingual_str& error, std::v
     }
 
     std::unique_ptr<Db> pdbCopy = std::make_unique<Db>(env->dbenv.get(), 0);
-    int ret = pdbCopy->open(nullptr,               // Txn pointer
+    int ret = pdbCopy->open(nullptr,            // Txn pointer
                             filename.c_str(),   // Filename
-                            "main",             // Logical db name
+                            "mainnet",          // Logical db name
                             DB_BTREE,           // Database type
                             DB_CREATE,          // Flags
                             0);

--- a/src/wallet/test/init_test_fixture.h
+++ b/src/wallet/test/init_test_fixture.h
@@ -12,7 +12,7 @@
 
 
 struct InitWalletDirTestingSetup: public BasicTestingSetup {
-    explicit InitWalletDirTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
+    explicit InitWalletDirTestingSetup(const std::string & chainName = CBaseChainParams::MAINNET);
     ~InitWalletDirTestingSetup();
     void SetWalletDir(const fs::path& walletdir_path);
 

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -18,7 +18,7 @@
 /** Testing setup and teardown for wallet.
  */
 struct WalletTestingSetup : public TestingSetup {
-    explicit WalletTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
+    explicit WalletTestingSetup(const std::string & chainName = CBaseChainParams::MAINNET);
 
     std::unique_ptr<interfaces::WalletClient> m_wallet_client = interfaces::MakeWalletClient(*m_node.chain, *Assert(m_node.args));
     CWallet m_wallet;

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -49,7 +49,7 @@ class ConfArgsTest(BitcoinTestFramework):
         util.write_config(main_conf_file_path, n=0, chain='', extra_config=f'includeconf={inc_conf_file_path}\n')
         with open(inc_conf_file_path, 'w', encoding='utf-8') as conf:
             conf.write('acceptnonstdtxn=1\n')
-        self.nodes[0].assert_start_raises_init_error(extra_args=[f"-conf={main_conf_file_path}"], expected_msg='Error: acceptnonstdtxn is not currently supported for main chain')
+        self.nodes[0].assert_start_raises_init_error(extra_args=[f"-conf={main_conf_file_path}"], expected_msg='Error: acceptnonstdtxn is not currently supported for mainnet chain')
 
         with open(inc_conf_file_path, 'w', encoding='utf-8') as conf:
             conf.write('nono\n')
@@ -74,9 +74,9 @@ class ConfArgsTest(BitcoinTestFramework):
         with open(inc_conf_file_path, 'w', encoding='utf-8') as conf:
             conf.write('testnot.datadir=1\n')
         with open(inc_conf_file2_path, 'w', encoding='utf-8') as conf:
-            conf.write('[testnet]\n')
+            conf.write('[testnut]\n')
         self.restart_node(0)
-        self.nodes[0].stop_node(expected_stderr=f'Warning: {inc_conf_file_path}:1 Section [testnot] is not recognized.{os.linesep}{inc_conf_file2_path}:1 Section [testnet] is not recognized.')
+        self.nodes[0].stop_node(expected_stderr=f'Warning: {inc_conf_file_path}:1 Section [testnot] is not recognized.{os.linesep}{inc_conf_file2_path}:1 Section [testnut] is not recognized.')
 
         with open(inc_conf_file_path, 'w', encoding='utf-8') as conf:
             conf.write('')  # clear

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -76,7 +76,8 @@ class ConfArgsTest(BitcoinTestFramework):
         with open(inc_conf_file2_path, 'w', encoding='utf-8') as conf:
             conf.write('[testnut]\n')
         self.restart_node(0)
-        self.nodes[0].stop_node(expected_stderr=f'Warning: {inc_conf_file_path}:1 Section [testnot] is not recognized.{os.linesep}{inc_conf_file2_path}:1 Section [testnut] is not recognized.')
+        self.nodes[0].stop_node(expected_stderr=f'Warning: {inc_conf_file_path}:1 Section [testnot] is not recognized.{os.linesep}\
+            {inc_conf_file2_path}:1 Section [testnut] is not recognized.')
 
         with open(inc_conf_file_path, 'w', encoding='utf-8') as conf:
             conf.write('')  # clear

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -346,7 +346,7 @@ def write_config(config_path, *, n, chain, extra_config="", disable_autoconnect=
     # Translate chain subdirectory name to config name
     if chain == 'testnet3':
         chain_name_conf_arg = 'testnet'
-        chain_name_conf_section = 'test'
+        chain_name_conf_section = 'testnet'
     else:
         chain_name_conf_arg = chain
         chain_name_conf_section = chain


### PR DESCRIPTION
'Main' and 'test' is old terminology,
with which it seems 'signet' as a name has broken with.

Deprecate `main` and `test` `-chain` params in favor of
`mainnet` and `testnet`, in line with `signet`.

`main` and `test` shouldn't be removed from the source code
_until most users are unaffected by the removal_.

This supersedes #23068.

