### PR TITLE
fuzz: fix checks on number of required sigs and keys in multisig scripts

### DIFF
--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -72,8 +72,8 @@ FUZZ_TARGET_INIT(script, initialize_script)
                    type_ret == TxoutType::NULL_DATA);
         }
     } else {
-        assert(required_ret >= 1 && required_ret <= 16);
-        assert((unsigned long)required_ret == addresses.size());
+        assert(required_ret >= 1 && required_ret <= 20);
+        assert((unsigned long)required_ret <= addresses.size());
         assert(type_ret == TxoutType::MULTISIG || required_ret == 1);
     }
     if (type_ret == TxoutType::NONSTANDARD || type_ret == TxoutType::NULL_DATA) {


### PR DESCRIPTION
Fuzz test coverage was added around the ExtractDestination(s) functions in
a29f522ba4aa71582b54025c5682b4c1687ae9f3. This commit contained an incorrect
assertion that the number of required signatures in a multisig script was equal
to the number of addresses. This is incorrect, as for an m-of-n multisig, m <= n.

a29f522ba4aa71582b54025c5682b4c1687ae9f3 also had an incorrect assertion on
the maximum number of public keys per multisig. It checked that the number of
keys was less than or equal to 16. This is incorrect, as it should be <= 20
(see MAX_PUBKEYS_PER_MULTISIG).

Both of these incorrect assertions are fixed in this commit accordingly.

Note: this is sort of moot because this behavior is deprecated and these
fuzz tests are slated for removal in v23 when the deprecation period for
-deprecatedrpc=addresses ends. However, for correctness and just in case,
it's fixed here.

Noticed here: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=39152
Moot because this PR #22650 gets rid of all this code anyways

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
