### PR TITLE
doc: Remove outdated comments

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -871,8 +871,6 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     nUserMaxConnections = args.GetArg("-maxconnections", DEFAULT_MAX_PEER_CONNECTIONS);
     nMaxConnections = std::max(nUserMaxConnections, 0);
 
-    // Trim requested connection counts, to fit into system limitations
-    // <int> in std::min<int>(...) to work around FreeBSD compilation issue described in #2695
     nFD = RaiseFileDescriptorLimit(nMaxConnections + MIN_CORE_FILEDESCRIPTORS + MAX_ADDNODE_CONNECTIONS + nBind + NUM_FDS_MESSAGE_CAPTURE);
 
 #ifdef USE_POLL


### PR DESCRIPTION
The first removed comment was introduced in #5288, the second one in #13503.

Both are outdated since #14336.