### PR TITLE
util: Treat empty settings.json file as valid

### DIFF
--- a/src/util/settings.cpp
+++ b/src/util/settings.cpp
@@ -61,7 +61,8 @@ bool ReadSettings(const fs::path& path, std::map<std::string, SettingsValue>& va
     errors.clear();
 
     // Ok for file to not exist
-    if (!fs::exists(path)) return true;
+    // Also treat empty file as equivalent to not existing
+    if (!fs::exists(path) || fs::is_empty(path)) return true;
 
     fsbridge::ifstream file;
     file.open(path);

--- a/src/util/settings.cpp
+++ b/src/util/settings.cpp
@@ -61,14 +61,20 @@ bool ReadSettings(const fs::path& path, std::map<std::string, SettingsValue>& va
     errors.clear();
 
     // Ok for file to not exist
-    // Also treat empty file as equivalent to not existing
-    if (!fs::exists(path) || fs::is_empty(path)) return true;
+    if (!fs::exists(path)) return true;
 
     fsbridge::ifstream file;
     file.open(path);
     if (!file.is_open()) {
       errors.emplace_back(strprintf("%s. Please check permissions.", path.string()));
       return false;
+    }
+
+    // If the file is empty, still return true,
+    // which is the same behaviour as for an empty valid JSON file "{}"
+    if (file.peek() == std::ifstream::traits_type::eof()) {
+        file.close();
+        return true;
     }
 
     SettingsValue in;


### PR DESCRIPTION
Previously, if the settings.json file was empty, it failed to parse.
Now, it is handled like non-existent, which should help avoid issues if

- The user decides to empty it
- The file gets saved improperly
- The user touches it before starting Bitcoin Core