### PR TITLE
Run specified functional tests with all matching flags

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -401,8 +401,9 @@ def main():
         for test in tests:
             script = test.split("/")[-1]
             script = script + ".py" if ".py" not in script else script
-            if script in ALL_SCRIPTS:
-                test_list.append(script)
+            matching_scripts = [s for s in ALL_SCRIPTS if s.startswith(script)]
+            if matching_scripts:
+                test_list.extend(matching_scripts)
             else:
                 print("{}WARNING!{} Test '{}' not found in full test list.".format(BOLD[1], BOLD[0], test))
     elif args.extended:


### PR DESCRIPTION
Functional tests which use flags like `--descriptors` or `--legacy-wallet` won't run if only the base script is given to `test_runner.py` because it doesn't match any script in the list exactly. It would be easier if it would just run both options.

For example, instead of:
```
test_runner.py 'wallet_basic.py --legacy-wallet' 'wallet_basic.py --descriptors' 
```

We can now just run:
```
test_runner.py wallet_basic 
```

Also useful for `--usecli`, the IPv4/IPv6/nonloopback `rpc_bind.py` variations, etc.