### PR TITLE
net: Bypass increasing nMaxOutbound for peers with download permission

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -1015,7 +1015,7 @@ private:
 
     // Network stats
     void RecordBytesRecv(uint64_t bytes);
-    void RecordBytesSent(uint64_t bytes);
+    void RecordBytesSent(uint64_t bytes, bool increase_max_outbound);
 
     /**
      * Return vector of current BLOCK_RELAY peers.


### PR DESCRIPTION
I came across a [TODO](https://github.com/bitcoin/bitcoin/blob/master/src/net.cpp#L2872) in CConnman::RecordBytesSent that wanted to exclude increasing `nMaxOutboundTotalBytesSentInCycle`  for peers with download permission

This PR will exclude increasing `nMaxOutboundTotalBytesSentInCycle` by adding a bool `increaseMaxOutbound` to method 
`CConnman::RecordBytesSent`

Methods `CConnman::PushMessage` and `CConnman::SocketHandler`  uses `pnode->HasPermission` to check if peer has download permission. 

Should we make the new arg (increaseMaxOutbound) default to true? 
