### PR TITLE
test: refactor: introduce `script_util` helper for creating P2PK scripts

### DIFF
--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -31,11 +31,11 @@ from test_framework.script import (
     OP_1,
     OP_2,
     OP_CHECKMULTISIG,
-    OP_CHECKSIG,
     OP_DROP,
     OP_TRUE,
 )
 from test_framework.script_util import (
+    key_to_p2pk_script,
     key_to_p2pkh_script,
     key_to_p2wpkh_script,
     script_to_p2sh_script,
@@ -459,7 +459,7 @@ class SegWitTest(BitcoinTestFramework):
                 importlist.append(script_to_p2wsh_script(bare).hex())
             else:
                 pubkey = bytes.fromhex(v['pubkey'])
-                p2pk = CScript([pubkey, OP_CHECKSIG])
+                p2pk = key_to_p2pk_script(pubkey)
                 p2pkh = key_to_p2pkh_script(pubkey)
                 importlist.append(p2pk.hex())
                 importlist.append(p2pkh.hex())
@@ -628,7 +628,7 @@ class SegWitTest(BitcoinTestFramework):
         pubkey = bytes.fromhex(v['pubkey'])
         p2wpkh = key_to_p2wpkh_script(pubkey)
         p2sh_p2wpkh = script_to_p2sh_script(p2wpkh)
-        p2pk = CScript([pubkey, OP_CHECKSIG])
+        p2pk = key_to_p2pk_script(pubkey)
         p2pkh = CScript(bytes.fromhex(v['scriptPubKey']))
         p2sh_p2pk = script_to_p2sh_script(p2pk)
         p2sh_p2pkh = script_to_p2sh_script(p2pkh)

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -76,6 +76,7 @@ from test_framework.script import (
     taproot_construct,
 )
 from test_framework.script_util import (
+    key_to_p2pk_script,
     key_to_p2wpkh_script,
     keyhash_to_p2pkh_script,
     script_to_p2sh_script,
@@ -1109,7 +1110,7 @@ def spenders_taproot_active():
             for witv0 in [False, True]:
                 for hashtype in VALID_SIGHASHES_ECDSA + [random.randrange(0x04, 0x80), random.randrange(0x84, 0x100)]:
                     standard = (hashtype in VALID_SIGHASHES_ECDSA) and (compressed or not witv0)
-                    add_spender(spenders, "legacy/pk-wrongkey", hashtype=hashtype, p2sh=p2sh, witv0=witv0, standard=standard, script=CScript([pubkey1, OP_CHECKSIG]), **SINGLE_SIG, key=eckey1, failure={"key": eckey2}, sigops_weight=4-3*witv0, **ERR_NO_SUCCESS)
+                    add_spender(spenders, "legacy/pk-wrongkey", hashtype=hashtype, p2sh=p2sh, witv0=witv0, standard=standard, script=key_to_p2pk_script(pubkey1), **SINGLE_SIG, key=eckey1, failure={"key": eckey2}, sigops_weight=4-3*witv0, **ERR_NO_SUCCESS)
                     add_spender(spenders, "legacy/pkh-sighashflip", hashtype=hashtype, p2sh=p2sh, witv0=witv0, standard=standard, pkh=pubkey1, key=eckey1, **SIGHASH_BITFLIP, sigops_weight=4-3*witv0, **ERR_NO_SUCCESS)
 
     # Verify that OP_CHECKSIGADD wasn't accidentally added to pre-taproot validation logic.

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -72,6 +72,7 @@ from test_framework.script import (
     hash160,
 )
 from test_framework.script_util import (
+    key_to_p2pk_script,
     key_to_p2wpkh_script,
     keyhash_to_p2pkh_script,
     script_to_p2sh_script,
@@ -1455,7 +1456,7 @@ class SegWitTest(BitcoinTestFramework):
 
         # Now try to spend it. Send it to a P2WSH output, which we'll
         # use in the next test.
-        witness_script = CScript([pubkey, CScriptOp(OP_CHECKSIG)])
+        witness_script = key_to_p2pk_script(pubkey)
         script_wsh = script_to_p2wsh_script(witness_script)
 
         tx2 = CTransaction()
@@ -1533,7 +1534,7 @@ class SegWitTest(BitcoinTestFramework):
         key.generate()
         pubkey = key.get_pubkey().get_bytes()
 
-        witness_script = CScript([pubkey, CScriptOp(OP_CHECKSIG)])
+        witness_script = key_to_p2pk_script(pubkey)
         script_pubkey = script_to_p2wsh_script(witness_script)
 
         # First create a witness output for use in the tests.

--- a/test/functional/rpc_signrawtransaction.py
+++ b/test/functional/rpc_signrawtransaction.py
@@ -25,12 +25,12 @@ from test_framework.messages import (
 from test_framework.script import (
     CScript,
     OP_CHECKLOCKTIMEVERIFY,
-    OP_CHECKSIG,
     OP_CHECKSEQUENCEVERIFY,
     OP_DROP,
     OP_TRUE,
 )
 from test_framework.script_util import (
+    key_to_p2pk_script,
     key_to_p2pkh_script,
     script_to_p2sh_p2wsh_script,
     script_to_p2wsh_script,
@@ -229,7 +229,7 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         embedded_pubkey = eckey.get_pubkey().get_bytes().hex()
         witness_script = {
             'P2PKH': key_to_p2pkh_script(embedded_pubkey).hex(),
-            'P2PK': CScript([bytes.fromhex(embedded_pubkey), OP_CHECKSIG]).hex()
+            'P2PK': key_to_p2pk_script(embedded_pubkey).hex()
         }.get(tx_type, "Invalid tx_type")
         redeem_script = script_to_p2wsh_script(witness_script).hex()
         addr = script_to_p2sh(redeem_script)

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -33,11 +33,11 @@ from .script import (
     CScriptOp,
     OP_1,
     OP_CHECKMULTISIG,
-    OP_CHECKSIG,
     OP_RETURN,
     OP_TRUE,
 )
 from .script_util import (
+    key_to_p2pk_script,
     key_to_p2wpkh_script,
     script_to_p2wsh_script,
 )
@@ -134,7 +134,7 @@ def create_coinbase(height, pubkey=None, extra_output_script=None, fees=0, nValu
         coinbaseoutput.nValue >>= halvings
         coinbaseoutput.nValue += fees
     if pubkey is not None:
-        coinbaseoutput.scriptPubKey = CScript([pubkey, OP_CHECKSIG])
+        coinbaseoutput.scriptPubKey = key_to_p2pk_script(pubkey)
     else:
         coinbaseoutput.scriptPubKey = CScript([OP_TRUE])
     coinbase.vout = [coinbaseoutput]

--- a/test/functional/test_framework/script_util.py
+++ b/test/functional/test_framework/script_util.py
@@ -5,14 +5,14 @@
 """Useful Script constants and utils."""
 from test_framework.script import (
     CScript,
-    hash160,
-    sha256,
     OP_0,
-    OP_DUP,
-    OP_HASH160,
     OP_CHECKSIG,
+    OP_DUP,
     OP_EQUAL,
     OP_EQUALVERIFY,
+    OP_HASH160,
+    hash160,
+    sha256,
 )
 
 # To prevent a "tx-size-small" policy rule error, a transaction has to have a
@@ -34,6 +34,11 @@ from test_framework.script import (
 # met.
 DUMMY_P2WPKH_SCRIPT = CScript([b'a' * 21])
 DUMMY_2_P2WPKH_SCRIPT = CScript([b'b' * 21])
+
+
+def key_to_p2pk_script(key):
+    key = check_key(key)
+    return CScript([key, OP_CHECKSIG])
 
 
 def keyhash_to_p2pkh_script(hash):

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -23,12 +23,14 @@ from test_framework.messages import (
 from test_framework.script import (
     CScript,
     LegacySignatureHash,
-    OP_CHECKSIG,
     OP_TRUE,
     OP_NOP,
     SIGHASH_ALL,
 )
-from test_framework.script_util import key_to_p2wpkh_script
+from test_framework.script_util import (
+    key_to_p2pk_script,
+    key_to_p2wpkh_script,
+)
 from test_framework.util import (
     assert_equal,
     assert_greater_than_or_equal,
@@ -75,7 +77,7 @@ class MiniWallet:
             self._priv_key = ECKey()
             self._priv_key.set((1).to_bytes(32, 'big'), True)
             pub_key = self._priv_key.get_pubkey()
-            self._scriptPubKey = bytes(CScript([pub_key.get_bytes(), OP_CHECKSIG]))
+            self._scriptPubKey = key_to_p2pk_script(pub_key.get_bytes())
         elif mode == MiniWalletMode.ADDRESS_OP_TRUE:
             self._address = ADDRESS_BCRT1_P2WSH_OP_TRUE
             self._scriptPubKey = bytes.fromhex(self._test_node.validateaddress(self._address)['scriptPubKey'])


### PR DESCRIPTION
This PR is a follow-up to #22363, which took use of already existing `script_util` helpers to get rid of manual CScript for the P2{PKH,SH,WPKH,WSH} output types, in order to increase readability and maintainability of the test code. Here the same is done for P2PK scripts by introducing a helper `key_to_p2pk_script` and using it. Note that the helper only accepts ECDSA pubkeys (i.e. ones with a size of 33 or 65 bytes), hence it can't be used for scripts in the form of [x-only-pubkey, OP_CHECKSIG].