### PR TITLE
tests: Use test framework utils where possible

### DIFF
--- a/test/functional/feature_backwards_compatibility.py
+++ b/test/functional/feature_backwards_compatibility.py
@@ -27,6 +27,7 @@ from test_framework.descriptors import descsum_create
 
 from test_framework.util import (
     assert_equal,
+    assert_greater_than,
     assert_raises_rpc_error,
 )
 
@@ -101,7 +102,7 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
         wallet = node_master.get_wallet_rpc("w1")
         info = wallet.getwalletinfo()
         assert info['private_keys_enabled']
-        assert info['keypoolsize'] > 0
+        assert_greater_than(info['keypoolsize'], 0)
         # Create a confirmed transaction, receiving coins
         address = wallet.getnewaddress()
         node_miner.sendtoaddress(address, 10)
@@ -125,7 +126,7 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
         wallet = node_v19.get_wallet_rpc("w1_v19")
         info = wallet.getwalletinfo()
         assert info['private_keys_enabled']
-        assert info['keypoolsize'] > 0
+        assert_greater_than(info['keypoolsize'], 0)
         # Use addmultisigaddress (see #18075)
         address_18075 = wallet.rpc.addmultisigaddress(1, ["0296b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52", "037211a824f55b505228e4c3d5194c1fcfaa15a456abdf37f9b9d97a4040afc073"], "", "legacy")["address"]
         assert wallet.getaddressinfo(address_18075)["solvable"]
@@ -136,7 +137,7 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
         wallet = node_v18.get_wallet_rpc("w1_v18")
         info = wallet.getwalletinfo()
         assert info['private_keys_enabled']
-        assert info['keypoolsize'] > 0
+        assert_greater_than(info['keypoolsize'], 0)
 
         # w2: wallet with private keys disabled, created on master: update this
         #     test when default wallets private keys disabled can no longer be
@@ -144,8 +145,8 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
         node_master.createwallet(wallet_name="w2", disable_private_keys=True)
         wallet = node_master.get_wallet_rpc("w2")
         info = wallet.getwalletinfo()
-        assert info['private_keys_enabled'] == False
-        assert info['keypoolsize'] == 0
+        assert_equal(info['private_keys_enabled'], False)
+        assert_equal(info['keypoolsize'], 0)
 
         # w3: blank wallet, created on master: update this
         #     test when default blank wallets can no longer be opened by older versions.
@@ -153,7 +154,7 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
         wallet = node_master.get_wallet_rpc("w3")
         info = wallet.getwalletinfo()
         assert info['private_keys_enabled']
-        assert info['keypoolsize'] == 0
+        assert_equal(info['keypoolsize'], 0)
 
         # Unload wallets and copy to older nodes:
         node_master_wallets_dir = os.path.join(node_master.datadir, "regtest/wallets")
@@ -236,7 +237,7 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
             self.restart_node(node_v16.index, extra_args=["-wallet=w2"])
             wallet = node_v16.get_wallet_rpc("w2")
             info = wallet.getwalletinfo()
-            assert info['keypoolsize'] == 1
+            assert_equal(info['keypoolsize'], 1)
 
         # Create upgrade wallet in v0.16
         self.restart_node(node_v16.index, extra_args=["-wallet=u1_v16"])

--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -88,7 +88,7 @@ class BIP68Test(BitcoinTestFramework):
         self.nodes[0].sendtoaddress(new_addr, 2) # send 2 BTC
 
         utxos = self.nodes[0].listunspent(0, 0)
-        assert len(utxos) > 0
+        assert_greater_than(len(utxos), 0)
 
         utxo = utxos[0]
 

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -201,7 +201,7 @@ class PruneTest(BitcoinTestFramework):
             self.nodes[1].invalidateblock(curhash)
             curhash = self.nodes[1].getblockhash(self.forkheight - 1)
 
-        assert self.nodes[1].getblockcount() == self.forkheight - 1
+        assert_equal(self.nodes[1].getblockcount(), self.forkheight - 1)
         self.log.info(f"New best height: {self.nodes[1].getblockcount()}")
 
         # Disconnect node1 and generate the new chain

--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -44,9 +44,9 @@ from test_framework.script_util import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_not_equal,
     assert_greater_than_or_equal,
     assert_is_hex_string,
+    assert_not_equal,
     assert_raises_rpc_error,
     try_rpc,
 )

--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -44,6 +44,7 @@ from test_framework.script_util import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_not_equal,
     assert_greater_than_or_equal,
     assert_is_hex_string,
     assert_raises_rpc_error,
@@ -221,16 +222,16 @@ class SegWitTest(BitcoinTestFramework):
         self.fail_accept(self.nodes[0], "non-mandatory-script-verify-flag (Witness program was passed an empty witness)", p2sh_ids[NODE_0][P2WSH][0], sign=False, redeem_script=witness_script(True, self.pubkey[0]))
 
         self.log.info("Verify block and transaction serialization rpcs return differing serializations depending on rpc serialization flag")
-        assert self.nodes[2].getblock(blockhash, False) != self.nodes[0].getblock(blockhash, False)
-        assert self.nodes[1].getblock(blockhash, False) == self.nodes[2].getblock(blockhash, False)
+        assert_not_equal(self.nodes[2].getblock(blockhash, False), self.nodes[0].getblock(blockhash, False))
+        assert_equal(self.nodes[1].getblock(blockhash, False), self.nodes[2].getblock(blockhash, False))
 
         for tx_id in segwit_tx_list:
             tx = tx_from_hex(self.nodes[2].gettransaction(tx_id)["hex"])
-            assert self.nodes[2].getrawtransaction(tx_id, False, blockhash) != self.nodes[0].getrawtransaction(tx_id, False, blockhash)
-            assert self.nodes[1].getrawtransaction(tx_id, False, blockhash) == self.nodes[2].getrawtransaction(tx_id, False, blockhash)
-            assert self.nodes[0].getrawtransaction(tx_id, False, blockhash) != self.nodes[2].gettransaction(tx_id)["hex"]
-            assert self.nodes[1].getrawtransaction(tx_id, False, blockhash) == self.nodes[2].gettransaction(tx_id)["hex"]
-            assert self.nodes[0].getrawtransaction(tx_id, False, blockhash) == tx.serialize_without_witness().hex()
+            assert_not_equal(self.nodes[2].getrawtransaction(tx_id, False, blockhash), self.nodes[0].getrawtransaction(tx_id, False, blockhash))
+            assert_equal(self.nodes[1].getrawtransaction(tx_id, False, blockhash), self.nodes[2].getrawtransaction(tx_id, False, blockhash))
+            assert_not_equal(self.nodes[0].getrawtransaction(tx_id, False, blockhash), self.nodes[2].gettransaction(tx_id)["hex"])
+            assert_equal(self.nodes[1].getrawtransaction(tx_id, False, blockhash), self.nodes[2].gettransaction(tx_id)["hex"])
+            assert_equal(self.nodes[0].getrawtransaction(tx_id, False, blockhash), tx.serialize_without_witness().hex())
 
         # Coinbase contains the witness commitment nonce, check that RPC shows us
         coinbase_txid = self.nodes[2].getblock(blockhash)['tx'][0]

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -94,6 +94,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_raises_rpc_error,
     assert_equal,
+    assert_greater_than,
+    assert_greater_than_or_equal,
     random_bytes,
 )
 from test_framework.key import generate_privkey, compute_xonly_pubkey, sign_schnorr, tweak_add_privkey, ECKey
@@ -769,7 +771,7 @@ def spenders_taproot_active():
             for witlen in [20, 31, 32, 33]:
                 def mutate(spk):
                     prog = spk[2:]
-                    assert len(prog) == 32
+                    assert_equal(len(prog), 32)
                     if witlen < 32:
                         prog = prog[0:witlen]
                     elif witlen > 32:
@@ -1248,8 +1250,10 @@ class TaprootTest(BitcoinTestFramework):
         block.solve()
         block_response = node.submitblock(block.serialize().hex())
         if err_msg is not None:
+            # Use assert instead of assert_equal, because it contains a custom message
             assert block_response is not None and err_msg in block_response, "Missing error message '%s' from block response '%s': %s" % (err_msg, "(None)" if block_response is None else block_response, msg)
         if accept:
+            # Use assert instead of assert_equal, because it contains a custom message
             assert node.getbestblockhash() == block.hash, "Failed to accept: %s (response: %s)" % (msg, block_response)
             self.tip = block.sha256
             self.lastblockhash = block.hash
@@ -1352,7 +1356,7 @@ class TaprootTest(BitcoinTestFramework):
         self.log.info("- Running %i spending tests" % done)
         random.shuffle(normal_utxos)
         random.shuffle(mismatching_utxos)
-        assert done == len(normal_utxos) + len(mismatching_utxos)
+        assert_equal(done, len(normal_utxos) + len(mismatching_utxos))
 
         left = done
         while left:
@@ -1391,7 +1395,9 @@ class TaprootTest(BitcoinTestFramework):
             for i in range(len(input_utxos)):
                 if input_utxos[i].spender.need_vin_vout_mismatch:
                     first_mismatch_input = i
-            assert first_mismatch_input is None or first_mismatch_input > 0
+
+            if first_mismatch_input is not None:
+                assert_greater_than(first_mismatch_input, 0)
 
             # Decide fee, and add CTxIns to tx.
             amount = sum(utxo.output.nValue for utxo in input_utxos)
@@ -1404,7 +1410,8 @@ class TaprootTest(BitcoinTestFramework):
 
             # Add 1 to 4 random outputs (but constrained by inputs that require mismatching outputs)
             num_outputs = random.choice(range(1, 1 + min(4, 4 if first_mismatch_input is None else first_mismatch_input)))
-            assert in_value >= 0 and fee - num_outputs * DUST_LIMIT >= MIN_FEE
+            assert_greater_than_or_equal(in_value, 0)
+            assert_greater_than_or_equal(fee - num_outputs * DUST_LIMIT, MIN_FEE)
             for i in range(num_outputs):
                 tx.vout.append(CTxOut())
                 if in_value <= DUST_LIMIT:
@@ -1417,7 +1424,7 @@ class TaprootTest(BitcoinTestFramework):
                 tx.vout[-1].scriptPubKey = random.choice(host_spks)
                 sigops_weight += CScript(tx.vout[-1].scriptPubKey).GetSigOpCount(False) * WITNESS_SCALE_FACTOR
             fee += in_value
-            assert fee >= 0
+            assert_greater_than_or_equal(fee, 0)
 
             # Select coinbase pubkey
             cb_pubkey = random.choice(host_pubkeys)
@@ -1465,9 +1472,9 @@ class TaprootTest(BitcoinTestFramework):
             if (len(spenders) - left) // 200 > (len(spenders) - left - len(input_utxos)) // 200:
                 self.log.info("  - %i tests done" % (len(spenders) - left))
 
-        assert left == 0
-        assert len(normal_utxos) == 0
-        assert len(mismatching_utxos) == 0
+        assert_equal(left, 0)
+        assert_equal(len(normal_utxos), 0)
+        assert_equal(len(mismatching_utxos), 0)
         self.log.info("  - Done")
 
     def gen_test_vectors(self):

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -578,7 +578,7 @@ def bitflipper(expr):
     """Return a callable that evaluates expr and returns it with a random bitflip."""
     def fn(ctx):
         sub = deep_eval(ctx, expr)
-        assert_true(isinstance(sub, bytes), message="It is not a bytes instance")
+        assert_true(isinstance(sub, bytes), err_msg="It is not a bytes instance")
         return (int.from_bytes(sub, 'little') ^ (1 << random.randrange(len(sub) * 8))).to_bytes(len(sub), 'little')
     return fn
 

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -92,12 +92,12 @@ from test_framework.script_util import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
-    assert_raises_rpc_error,
     assert_equal,
-    assert_not_equal,
-    assert_true,
     assert_greater_than,
     assert_greater_than_or_equal,
+    assert_not_equal,
+    assert_raises_rpc_error,
+    assert_true,
     random_bytes,
 )
 from test_framework.key import generate_privkey, compute_xonly_pubkey, sign_schnorr, tweak_add_privkey, ECKey
@@ -1253,7 +1253,7 @@ class TaprootTest(BitcoinTestFramework):
         block_response = node.submitblock(block.serialize().hex())
         if err_msg is not None:
             assert_true(block_response is not None and err_msg in block_response,
-                        err_msg= "Missing error message '%s' from block response '%s': %s" % (err_msg, "(None)" if block_response is None else block_response, msg))
+                        err_msg="Missing error message '%s' from block response '%s': %s" % (err_msg, "(None)" if block_response is None else block_response, msg))
         if accept:
             assert_equal(node.getbestblockhash(), block.hash, err_msg="Failed to accept: %s (response: %s)" % (msg, block_response))
             self.tip = block.sha256

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -94,6 +94,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_raises_rpc_error,
     assert_equal,
+    assert_true,
     assert_greater_than,
     assert_greater_than_or_equal,
     random_bytes,
@@ -497,11 +498,11 @@ def make_spender(comment, *, tap=None, witv0=False, script=None, pkh=None, p2sh=
 
     # Compute scriptPubKey and set useful defaults based on the inputs.
     if witv0:
-        assert tap is None
+        assert_equal(tap, None)
         conf["mode"] = "witv0"
         if pkh is not None:
             # P2WPKH
-            assert script is None
+            assert_equal(script, None)
             pubkeyhash = hash160(pkh)
             spk = key_to_p2wpkh_script(pkh)
             conf["scriptcode"] = keyhash_to_p2pkh_script(pubkeyhash)
@@ -518,7 +519,7 @@ def make_spender(comment, *, tap=None, witv0=False, script=None, pkh=None, p2sh=
         conf["mode"] = "legacy"
         if pkh is not None:
             # P2PKH
-            assert script is None
+            assert_equal(script, None)
             pubkeyhash = hash160(pkh)
             spk = keyhash_to_p2pkh_script(pubkeyhash)
             conf["scriptcode"] = spk
@@ -530,7 +531,7 @@ def make_spender(comment, *, tap=None, witv0=False, script=None, pkh=None, p2sh=
         else:
             assert False
     else:
-        assert script is None
+        assert_equal(script, None)
         conf["mode"] = "taproot"
         conf["tap"] = tap
         spk = tap.scriptPubKey
@@ -549,7 +550,7 @@ def make_spender(comment, *, tap=None, witv0=False, script=None, pkh=None, p2sh=
         if valid:
             return spend(tx, idx, utxos, **conf)
         else:
-            assert failure is not None
+            assert_not_equal(failure, None)
             return spend(tx, idx, utxos, **{**conf, **failure})
 
     return Spender(script=spk, comment=comment, is_standard=standard, sat_function=sat_fn, err_msg=err_msg, sigops_weight=sigops_weight, no_fail=failure is None, need_vin_vout_mismatch=need_vin_vout_mismatch)
@@ -576,7 +577,7 @@ def bitflipper(expr):
     """Return a callable that evaluates expr and returns it with a random bitflip."""
     def fn(ctx):
         sub = deep_eval(ctx, expr)
-        assert isinstance(sub, bytes)
+        assert_true(isinstance(sub, bytes), message="It is not a bytes instance")
         return (int.from_bytes(sub, 'little') ^ (1 << random.randrange(len(sub) * 8))).to_bytes(len(sub), 'little')
     return fn
 

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1252,17 +1252,16 @@ class TaprootTest(BitcoinTestFramework):
         block.solve()
         block_response = node.submitblock(block.serialize().hex())
         if err_msg is not None:
-e
             assert_true(block_response is not None and err_msg in block_response,
                         err_msg= "Missing error message '%s' from block response '%s': %s" % (err_msg, "(None)" if block_response is None else block_response, msg))
         if accept:
-            assert_equal(node.getbestblockhash() == block.hash, err_msg="Failed to accept: %s (response: %s)" % (msg, block_response))
+            assert_equal(node.getbestblockhash(), block.hash, err_msg="Failed to accept: %s (response: %s)" % (msg, block_response))
             self.tip = block.sha256
             self.lastblockhash = block.hash
             self.lastblocktime += 1
             self.lastblockheight += 1
         else:
-            assert_equal(node.getbestblockhash() == self.lastblockhash, err_msg="Failed to reject: " + msg)
+            assert_equal(node.getbestblockhash(), self.lastblockhash, err_msg="Failed to reject: " + msg)
 
     def init_blockinfo(self, node):
         # Initialize variables used by block_submit().

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -160,7 +160,7 @@ Final = namedtuple("Final", "value")
 
 def get(ctx, name):
     """Evaluate name in context ctx."""
-    assert name in ctx, "Missing '%s' in context" % name
+    assert_true(name in ctx, err_msg="Missing '%s' in context" % name)
     expr = ctx[name]
     if not isinstance(expr, Final):
         # Evaluate and cache the result.
@@ -1252,17 +1252,17 @@ class TaprootTest(BitcoinTestFramework):
         block.solve()
         block_response = node.submitblock(block.serialize().hex())
         if err_msg is not None:
-            # Use assert instead of assert_equal, because it contains a custom message
-            assert block_response is not None and err_msg in block_response, "Missing error message '%s' from block response '%s': %s" % (err_msg, "(None)" if block_response is None else block_response, msg)
+e
+            assert_true(block_response is not None and err_msg in block_response,
+                        err_msg= "Missing error message '%s' from block response '%s': %s" % (err_msg, "(None)" if block_response is None else block_response, msg))
         if accept:
-            # Use assert instead of assert_equal, because it contains a custom message
-            assert node.getbestblockhash() == block.hash, "Failed to accept: %s (response: %s)" % (msg, block_response)
+            assert_equal(node.getbestblockhash() == block.hash, err_msg="Failed to accept: %s (response: %s)" % (msg, block_response))
             self.tip = block.sha256
             self.lastblockhash = block.hash
             self.lastblocktime += 1
             self.lastblockheight += 1
         else:
-            assert node.getbestblockhash() == self.lastblockhash, "Failed to reject: " + msg
+            assert_equal(node.getbestblockhash() == self.lastblockhash, err_msg="Failed to reject: " + msg)
 
     def init_blockinfo(self, node):
         # Initialize variables used by block_submit().

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -94,6 +94,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_raises_rpc_error,
     assert_equal,
+    assert_not_equal,
     assert_true,
     assert_greater_than,
     assert_greater_than_or_equal,

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -22,6 +22,7 @@ from test_framework.messages import (
 from test_framework.util import (
     assert_equal,
     assert_true,
+    assert_greater_than,
     assert_raises_rpc_error,
 )
 from test_framework.wallet import (
@@ -73,7 +74,7 @@ class ZMQSubscriber:
         if mempool_sequence is not None:
             assert_true(label == "A" or label == "R", message="{} different from A or C".format(label))
         else:
-            assert_true(label == "D" or label == "C", message="{} different from D or C".format(label)
+            assert_true(label == "D" or label == "C", message="{} different from D or C".format(label))
         return (hash, label, mempool_sequence)
 
 
@@ -379,7 +380,7 @@ class ZMQTest (BitcoinTestFramework):
 
             # Make sure getrawmempool mempool_sequence results aren't "queued" but immediately reflective
             # of the time they were gathered.
-            assert_assert_greater_than(self.nodes[0].getrawmempool(mempool_sequence=True)["mempool_sequence"], seq_num)
+            assert_greater_than(self.nodes[0].getrawmempool(mempool_sequence=True)["mempool_sequence"], seq_num)
 
         assert_equal((best_hash, "D", None), seq.receive_sequence())
         assert_equal((rbf_txid, "A", seq_num), seq.receive_sequence())

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -21,6 +21,7 @@ from test_framework.messages import (
 )
 from test_framework.util import (
     assert_equal,
+    assert_true,
     assert_raises_rpc_error,
 )
 from test_framework.wallet import (
@@ -70,9 +71,9 @@ class ZMQSubscriber:
         label = chr(body[32])
         mempool_sequence = None if len(body) != 32+1+8 else struct.unpack("<Q", body[32+1:])[0]
         if mempool_sequence is not None:
-            assert label == "A" or label == "R"
+            assert_true(label == "A" or label == "R", message="{} different from A or C".format(label))
         else:
-            assert label == "D" or label == "C"
+            assert_true(label == "D" or label == "C", message="{} different from D or C".format(label)
         return (hash, label, mempool_sequence)
 
 
@@ -359,12 +360,11 @@ class ZMQTest (BitcoinTestFramework):
         assert_equal((payment_txid_2, "A", seq_num), seq.receive_sequence())
         seq_num += 1
 
-        # Spot check getrawmempool results that they only show up when asked for
         assert type(self.nodes[0].getrawmempool()) is list
         assert type(self.nodes[0].getrawmempool(mempool_sequence=False)) is list
         assert "mempool_sequence" not in self.nodes[0].getrawmempool(verbose=True)
-        assert_raises_rpc_error(-8, "Verbose results cannot contain mempool sequence values.", self.nodes[0].getrawmempool, True, True)
-        assert_equal(self.nodes[0].getrawmempool(mempool_sequence=True)["mempool_sequence"], seq_num)
+            assert_raises_rpc_error(-8, "Verbose results cannot contain mempool sequence values.", self.nodes[0].getrawmempool, True, True)
+            assert_equal(self.nodes[0].getrawmempool(mempool_sequence=True)["mempool_sequence"], seq_num)
 
         self.log.info("Testing reorg notifications")
         # Manually invalidate the last block to test mempool re-entry
@@ -377,9 +377,9 @@ class ZMQTest (BitcoinTestFramework):
         self.nodes[0].invalidateblock(best_hash)
         sleep(2)  # Bit of room to make sure transaction things happened
 
-        # Make sure getrawmempool mempool_sequence results aren't "queued" but immediately reflective
-        # of the time they were gathered.
-        assert self.nodes[0].getrawmempool(mempool_sequence=True)["mempool_sequence"] > seq_num
+            # Make sure getrawmempool mempool_sequence results aren't "queued" but immediately reflective
+            # of the time they were gathered.
+            assert_assert_greater_than(self.nodes[0].getrawmempool(mempool_sequence=True)["mempool_sequence"], seq_num)
 
         assert_equal((best_hash, "D", None), seq.receive_sequence())
         assert_equal((rbf_txid, "A", seq_num), seq.receive_sequence())
@@ -463,8 +463,8 @@ class ZMQTest (BitcoinTestFramework):
         while zmq_mem_seq is None:
             (hash_str, label, zmq_mem_seq) = seq.receive_sequence()
 
-        assert label == "A" or label == "R"
-        assert hash_str is not None
+        assert_true(label == "A" or label == "R", message="{} is different from A or R")
+        assert_true(hash_str is not None)
 
         # 2) We need to "seed" our view of the mempool
         mempool_snapshot = self.nodes[0].getrawmempool(mempool_sequence=True)
@@ -509,16 +509,16 @@ class ZMQTest (BitcoinTestFramework):
                     # Detected "R" gap, means this a conflict eviction, and mempool tx are being evicted before its
                     # position in the incoming block message "C"
                     if label == "R":
-                        assert mempool_sequence > expected_sequence
+                        assert_greater_than(mempool_sequence, expected_sequence)
                         r_gap += mempool_sequence - expected_sequence
                     else:
                         raise Exception(f"WARNING: txhash has unexpected mempool sequence value: {mempool_sequence} vs expected {expected_sequence}")
             if label == "A":
-                assert hash_str not in mempool_view
+                assert_true(hash_str not in mempool_view)
                 mempool_view.add(hash_str)
                 expected_sequence = mempool_sequence + 1
             elif label == "R":
-                assert hash_str in mempool_view
+                assert_true(hash_str in mempool_view)
                 mempool_view.remove(hash_str)
                 expected_sequence = mempool_sequence + 1
             elif label == "C":

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -364,8 +364,8 @@ class ZMQTest (BitcoinTestFramework):
         assert type(self.nodes[0].getrawmempool()) is list
         assert type(self.nodes[0].getrawmempool(mempool_sequence=False)) is list
         assert "mempool_sequence" not in self.nodes[0].getrawmempool(verbose=True)
-            assert_raises_rpc_error(-8, "Verbose results cannot contain mempool sequence values.", self.nodes[0].getrawmempool, True, True)
-            assert_equal(self.nodes[0].getrawmempool(mempool_sequence=True)["mempool_sequence"], seq_num)
+        assert_raises_rpc_error(-8, "Verbose results cannot contain mempool sequence values.", self.nodes[0].getrawmempool, True, True)
+        assert_equal(self.nodes[0].getrawmempool(mempool_sequence=True)["mempool_sequence"], seq_num)
 
         self.log.info("Testing reorg notifications")
         # Manually invalidate the last block to test mempool re-entry
@@ -378,9 +378,9 @@ class ZMQTest (BitcoinTestFramework):
         self.nodes[0].invalidateblock(best_hash)
         sleep(2)  # Bit of room to make sure transaction things happened
 
-            # Make sure getrawmempool mempool_sequence results aren't "queued" but immediately reflective
-            # of the time they were gathered.
-            assert_greater_than(self.nodes[0].getrawmempool(mempool_sequence=True)["mempool_sequence"], seq_num)
+        # Make sure getrawmempool mempool_sequence results aren't "queued" but immediately reflective
+        # of the time they were gathered.
+        assert_greater_than(self.nodes[0].getrawmempool(mempool_sequence=True)["mempool_sequence"], seq_num)
 
         assert_equal((best_hash, "D", None), seq.receive_sequence())
         assert_equal((rbf_txid, "A", seq_num), seq.receive_sequence())

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -72,9 +72,9 @@ class ZMQSubscriber:
         label = chr(body[32])
         mempool_sequence = None if len(body) != 32+1+8 else struct.unpack("<Q", body[32+1:])[0]
         if mempool_sequence is not None:
-            assert_true(label == "A" or label == "R", message="{} different from A or C".format(label))
+            assert_true(label == "A" or label == "R", err_msg="{} different from A or C".format(label))
         else:
-            assert_true(label == "D" or label == "C", message="{} different from D or C".format(label))
+            assert_true(label == "D" or label == "C", err_msg="{} different from D or C".format(label))
         return (hash, label, mempool_sequence)
 
 
@@ -464,7 +464,7 @@ class ZMQTest (BitcoinTestFramework):
         while zmq_mem_seq is None:
             (hash_str, label, zmq_mem_seq) = seq.receive_sequence()
 
-        assert_true(label == "A" or label == "R", message="{} is different from A or R")
+        assert_true(label == "A" or label == "R", err_msg="{} is different from A or R")
         assert_true(hash_str is not None)
 
         # 2) We need to "seed" our view of the mempool

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -21,9 +21,9 @@ from test_framework.messages import (
 )
 from test_framework.util import (
     assert_equal,
-    assert_true,
     assert_greater_than,
     assert_raises_rpc_error,
+    assert_true,
 )
 from test_framework.wallet import (
     MiniWallet,
@@ -72,7 +72,7 @@ class ZMQSubscriber:
         label = chr(body[32])
         mempool_sequence = None if len(body) != 32+1+8 else struct.unpack("<Q", body[32+1:])[0]
         if mempool_sequence is not None:
-            assert_true(label == "A" or label == "R", err_msg="{} different from A or C".format(label))
+            assert_true(label == "A" or label == "R", err_msg="{} different from A or R".format(label))
         else:
             assert_true(label == "D" or label == "C", err_msg="{} different from D or C".format(label))
         return (hash, label, mempool_sequence)
@@ -519,7 +519,7 @@ class ZMQTest (BitcoinTestFramework):
                 mempool_view.add(hash_str)
                 expected_sequence = mempool_sequence + 1
             elif label == "R":
-                assert_true(hash_str in mempool_view)
+                assert hash_str in mempool_view
                 mempool_view.remove(hash_str)
                 expected_sequence = mempool_sequence + 1
             elif label == "C":

--- a/test/functional/mining_getblocktemplate_longpoll.py
+++ b/test/functional/mining_getblocktemplate_longpoll.py
@@ -10,7 +10,7 @@ import threading
 
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import get_rpc_proxy
+from test_framework.util import get_rpc_proxy, assert_true
 from test_framework.wallet import MiniWallet
 
 
@@ -39,7 +39,7 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
         template = self.nodes[0].getblocktemplate({'rules': ['segwit']})
         longpollid = template['longpollid']
         template2 = self.nodes[0].getblocktemplate({'rules': ['segwit']})
-        assert template2['longpollid'] == longpollid
+        assert_equal(template2['longpollid'], longpollid)
 
         self.log.info("Test that longpoll waits if we do nothing")
         thr = LongpollThread(self.nodes[0])

--- a/test/functional/mining_getblocktemplate_longpoll.py
+++ b/test/functional/mining_getblocktemplate_longpoll.py
@@ -10,7 +10,7 @@ import threading
 
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import get_rpc_proxy, assert_true
+from test_framework.util import get_rpc_proxy, assert_equal
 from test_framework.wallet import MiniWallet
 
 

--- a/test/functional/mining_getblocktemplate_longpoll.py
+++ b/test/functional/mining_getblocktemplate_longpoll.py
@@ -10,7 +10,7 @@ import threading
 
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import get_rpc_proxy, assert_equal
+from test_framework.util import assert_equal, get_rpc_proxy
 from test_framework.wallet import MiniWallet
 
 

--- a/test/functional/p2p_addrfetch.py
+++ b/test/functional/p2p_addrfetch.py
@@ -50,8 +50,8 @@ class P2PAddrFetch(BitcoinTestFramework):
         self.log.info("Check that we send getaddr but don't try to sync headers with the addr-fetch peer")
         peer.sync_send_with_ping()
         with p2p_lock:
-            assert peer.message_count['getaddr'] == 1
-            assert peer.message_count['getheaders'] == 0
+            assert_equal(peer.message_count['getaddr'], 1)
+            assert_equal(peer.message_count['getheaders'], 0)
 
         self.log.info("Check that answering the getaddr with a single address does not lead to disconnect")
         # This prevents disconnecting on self-announcements

--- a/test/functional/p2p_blockfilters.py
+++ b/test/functional/p2p_blockfilters.py
@@ -22,6 +22,7 @@ from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_not_equal,
 )
 
 class FiltersClient(P2PInterface):
@@ -69,12 +70,12 @@ class CompactFiltersTest(BitcoinTestFramework):
         assert_equal(self.nodes[1].getblockcount(), 2000)
 
         # Check that nodes have signalled NODE_COMPACT_FILTERS correctly.
-        assert peer_0.nServices & NODE_COMPACT_FILTERS != 0
-        assert peer_1.nServices & NODE_COMPACT_FILTERS == 0
+        assert_not_equal(peer_0.nServices & NODE_COMPACT_FILTERS, 0)
+        assert_equal(peer_1.nServices & NODE_COMPACT_FILTERS, 0)
 
         # Check that the localservices is as expected.
-        assert int(self.nodes[0].getnetworkinfo()['localservices'], 16) & NODE_COMPACT_FILTERS != 0
-        assert int(self.nodes[1].getnetworkinfo()['localservices'], 16) & NODE_COMPACT_FILTERS == 0
+        assert_not_equal(int(self.nodes[0].getnetworkinfo()['localservices'], 16) & NODE_COMPACT_FILTERS, 0)
+        assert_equal(int(self.nodes[1].getnetworkinfo()['localservices'], 16) & NODE_COMPACT_FILTERS, 0)
 
         self.log.info("get cfcheckpt on chain to be re-orged out.")
         request = msg_getcfcheckpt(

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -291,8 +291,7 @@ class CompactBlocksTest(BitcoinTestFramework):
             if not tx.wit.is_null():
                 segwit_tx_generated = True
 
-        if use_witness_address:
-            assert segwit_tx_generated  # check that our test is not broken
+        assert segwit_tx_generated  # check that our test is not broken
 
         # Wait until we've seen the block announcement for the resulting tip
         tip = int(node.getbestblockhash(), 16)

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -58,8 +58,8 @@ from test_framework.script import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_true,
     assert_greater_than_or_equal,
+    assert_true,
     softfork_active,
 )
 from test_framework.wallet import MiniWallet

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -292,7 +292,7 @@ class CompactBlocksTest(BitcoinTestFramework):
                 segwit_tx_generated = True
 
         if use_witness_address:
-        assert segwit_tx_generated  # check that our test is not broken
+            assert segwit_tx_generated  # check that our test is not broken
 
         # Wait until we've seen the block announcement for the resulting tip
         tip = int(node.getbestblockhash(), 16)

--- a/test/functional/p2p_disconnect_ban.py
+++ b/test/functional/p2p_disconnect_ban.py
@@ -8,6 +8,7 @@ import time
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_true,
     assert_raises_rpc_error,
 )
 
@@ -106,7 +107,7 @@ class DisconnectBanTest(BitcoinTestFramework):
         address1 = self.nodes[0].getpeerinfo()[0]['addr']
         self.nodes[0].disconnectnode(address=address1)
         self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 1, timeout=10)
-        assert not [node for node in self.nodes[0].getpeerinfo() if node['addr'] == address1]
+        assert_true(not [node for node in self.nodes[0].getpeerinfo() if node['addr'] == address1])
 
         self.log.info("disconnectnode: successfully reconnect node")
         self.connect_nodes(0, 1)  # reconnect the node
@@ -117,7 +118,7 @@ class DisconnectBanTest(BitcoinTestFramework):
         id1 = self.nodes[0].getpeerinfo()[0]['id']
         self.nodes[0].disconnectnode(nodeid=id1)
         self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 1, timeout=10)
-        assert not [node for node in self.nodes[0].getpeerinfo() if node['id'] == id1]
+        assert_true(not [node for node in self.nodes[0].getpeerinfo() if node['id'] == id1])
 
 if __name__ == '__main__':
     DisconnectBanTest().main()

--- a/test/functional/p2p_getaddr_caching.py
+++ b/test/functional/p2p_getaddr_caching.py
@@ -14,8 +14,6 @@ from test_framework.p2p import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    PORT_MIN,
-    PORT_RANGE,
     p2p_port,
     assert_greater_than,
 )

--- a/test/functional/p2p_getaddr_caching.py
+++ b/test/functional/p2p_getaddr_caching.py
@@ -14,7 +14,10 @@ from test_framework.p2p import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    PORT_MIN,
+    PORT_RANGE,
     p2p_port,
+    assert_greater_than,
 )
 
 # As defined in net_processing.
@@ -60,7 +63,7 @@ class AddrTest(BitcoinTestFramework):
 
         # Need to make sure we hit MAX_ADDR_TO_SEND records in the addr response later because
         # only a fraction of all known addresses can be cached and returned.
-        assert(len(self.nodes[0].getnodeaddresses(0)) > int(MAX_ADDR_TO_SEND / (MAX_PCT_ADDR_TO_SEND / 100)))
+        assert_greater_than(len(self.nodes[0].getnodeaddresses(0)), int(MAX_ADDR_TO_SEND / (MAX_PCT_ADDR_TO_SEND / 100)))
 
         last_response_on_local_bind = None
         last_response_on_onion_bind1 = None

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -253,7 +253,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
         conn = self.nodes[0].add_p2p_connection(P2PDataStore())
         conn2 = self.nodes[0].add_p2p_connection(P2PDataStore())
         msg_at_size = msg_unrecognized(str_data="b" * VALID_DATA_LIMIT)
-        assert len(msg_at_size.serialize()) == MAX_PROTOCOL_MESSAGE_LENGTH
+        assert_equal(len(msg_at_size.serialize()), MAX_PROTOCOL_MESSAGE_LENGTH)
 
         self.log.info("(a) Send 80 messages, each of maximum valid data size (4MB)")
         for _ in range(80):

--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -119,7 +119,7 @@ class TxDownloadTest(BitcoinTestFramework):
         #   peer, plus
         # * the first time it is re-requested from the outbound peer, plus
         # * 2 seconds to avoid races
-        assert self.nodes[1].getpeerinfo()[0]['inbound'] == False
+        assert_equal(self.nodes[1].getpeerinfo()[0]['inbound'], False)
         timeout = 2 + INBOUND_PEER_TX_DELAY + GETDATA_TX_INTERVAL
         self.log.info("Tx should be received at node 1 after {} seconds".format(timeout))
         self.sync_mempools(timeout=timeout)

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -14,8 +14,8 @@ from test_framework.descriptors import descsum_create, drop_origins
 from test_framework.key import ECPubKey, ECKey
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
-    assert_raises_rpc_error,
     assert_equal,
+    assert_raises_rpc_error,
     assert_true,
 )
 from test_framework.wallet_util import bytes_to_wif

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -16,6 +16,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_raises_rpc_error,
     assert_equal,
+    assert_true,
 )
 from test_framework.wallet_util import bytes_to_wif
 from test_framework.wallet import (
@@ -141,10 +142,10 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
         balw = self.wallet.get_balance()
 
         height = node0.getblockchaininfo()["blocks"]
-        assert 150 < height < 350
+        assert_true(150 < height < 350)
         total = 149 * 50 + (height - 149 - 100) * 25
-        assert bal1 == 0
-        assert bal2 == self.moved
+        assert_equal(bal1, 0)
+        assert_equal(bal2, self.moved)
         assert_equal(bal0 + bal1 + bal2 + balw, total)
 
     def do_multisig(self):
@@ -178,7 +179,7 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
         mredeem = msig["redeemScript"]
         assert_equal(desc, msig['descriptor'])
         if self.output_type == 'bech32':
-            assert madd[0:4] == "bcrt"  # actually a bech32 address
+            assert_equal(madd[0:4], "bcrt")  # actually a bech32 address
 
         if self.is_bdb_compiled():
             # compare against addmultisigaddress
@@ -187,15 +188,15 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
             mredeemw = msigw["redeemScript"]
             assert_equal(desc, drop_origins(msigw['descriptor']))
             # addmultisigiaddress and createmultisig work the same
-            assert maddw == madd
-            assert mredeemw == mredeem
+            assert_equal(maddw, madd)
+            assert_equal(mredeemw, mredeem)
             wmulti.unloadwallet()
 
         spk = bytes.fromhex(node0.validateaddress(madd)["scriptPubKey"])
         txid, _ = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=spk, amount=1300)
         tx = node0.getrawtransaction(txid, True)
         vout = [v["n"] for v in tx["vout"] if madd == v["scriptPubKey"]["address"]]
-        assert len(vout) == 1
+        assert_equal(len(vout), 1)
         vout = vout[0]
         scriptPubKey = tx["vout"][vout]["scriptPubKey"]["hex"]
         value = tx["vout"][vout]["value"]

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -23,8 +23,8 @@ from test_framework.util import (
     assert_greater_than_or_equal,
     assert_raises_rpc_error,
     assert_true,
-    fail,
     count_bytes,
+    fail,
     find_vout_for_address,
 )
 from test_framework.wallet_util import bytes_to_wif

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -22,6 +22,8 @@ from test_framework.util import (
     assert_greater_than,
     assert_greater_than_or_equal,
     assert_raises_rpc_error,
+    assert_true,
+    fail,
     count_bytes,
     find_vout_for_address,
 )
@@ -65,7 +67,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         elif outputtype in ["bech32", "wpkh"]:
             prefixes = ["wpkh(", "wsh("]
         else:
-            assert False, f"Unknown output type {outputtype}"
+            fail(f"Unknown output type {outputtype}")
 
         to_lock = []
         for utxo in wallet.listunspent():
@@ -179,7 +181,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
-        assert len(dec_tx['vin']) > 0  #test that we have enough inputs
+        assert_greater_than(len(dec_tx['vin']), 0)  #test that we have enough inputs
 
     def test_simple_two_coins(self):
         self.log.info("Test fundrawtxn with 2 coins")
@@ -190,7 +192,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
-        assert len(dec_tx['vin']) > 0  #test if we have enough inputs
+        assert_greater_than(len(dec_tx['vin']), 0)  #test if we have enough inputs
         assert_equal(dec_tx['vin'][0]['scriptSig']['hex'], '')
 
     def test_simple_two_outputs(self):
@@ -207,7 +209,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         for out in dec_tx['vout']:
             totalOut += out['value']
 
-        assert len(dec_tx['vin']) > 0
+        assert_greater_than(len(dec_tx['vin']), 0)
         assert_equal(dec_tx['vin'][0]['scriptSig']['hex'], '')
 
     def test_change(self):
@@ -425,7 +427,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # Compare fee.
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
-        assert feeDelta >= 0 and feeDelta <= self.fee_tolerance
+        assert_true(feeDelta >= 0 and feeDelta <= self.fee_tolerance)
 
         self.unlock_utxos(self.nodes[0])
 
@@ -451,7 +453,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # Compare fee.
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
-        assert feeDelta >= 0 and feeDelta <= self.fee_tolerance
+        assert_true(feeDelta >= 0 and feeDelta <= self.fee_tolerance)
 
         self.unlock_utxos(self.nodes[0])
 
@@ -478,7 +480,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # Compare fee.
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
-        assert feeDelta >= 0 and feeDelta <= self.fee_tolerance
+        assert_true(feeDelta >= 0 and feeDelta <= self.fee_tolerance)
 
         self.unlock_utxos(self.nodes[0])
 
@@ -522,7 +524,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # Compare fee.
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
-        assert feeDelta >= 0 and feeDelta <= self.fee_tolerance
+        assert_true(feeDelta >= 0 and feeDelta <= self.fee_tolerance)
 
         self.unlock_utxos(self.nodes[0])
 
@@ -654,7 +656,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # Compare fee.
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
-        assert feeDelta >= 0 and feeDelta <= self.fee_tolerance * 19  #~19 inputs
+        assert_true(feeDelta >= 0 and feeDelta <= self.fee_tolerance * 19)  #~19 inputs
 
     def test_many_inputs_send(self):
         """Multiple (~19) inputs tx test | sign/send."""
@@ -743,7 +745,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         result = wwatch.fundrawtransaction(rawtx, {'includeWatching': True, 'changeAddress': w3.getrawchangeaddress(), 'subtractFeeFromOutputs': [0]})
         res_dec = self.nodes[0].decoderawtransaction(result["hex"])
         assert_equal(len(res_dec["vin"]), 1)
-        assert res_dec["vin"][0]["txid"] == self.watchonly_txid
+        assert_equal(res_dec["vin"][0]["txid"], self.watchonly_txid)
 
         assert_greater_than(result["fee"], 0)
         assert_equal(result["changepos"], -1)

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -13,8 +13,8 @@ import re
 
 
 def parse_string(s):
-    assert s[0] == '"'
-    assert s[-1] == '"'
+    assert_equal(s[0], '"')
+    assert_equal(s[-1], '"')
     return s[1:-1]
 
 
@@ -83,7 +83,7 @@ class HelpRpcTest(BitcoinTestFramework):
         for argname, convert in converts_by_argname.items():
             if all(convert) != any(convert):
                 # Only allow dummy to fail consistency check
-                assert argname == 'dummy', ('WARNING: conversion mismatch for argument named %s (%s)' % (argname, list(zip(all_methods_by_argname[argname], converts_by_argname[argname]))))
+                assert_equal(argname, 'dummy', err_msg=('WARNING: conversion mismatch for argument named %s (%s)' % (argname, list(zip(all_methods_by_argname[argname], converts_by_argname[argname])))))
 
     def test_categories(self):
         node = self.nodes[0]

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -38,7 +38,7 @@ def assert_net_servicesnames(servicesflag, servicenames):
     servicesflag_generated = 0
     for servicename in servicenames:
         servicesflag_generated |= getattr(test_framework.messages, 'NODE_' + servicename)
-    assert servicesflag_generated == servicesflag
+    assert_equal(servicesflag_generated, servicesflag)
 
 
 class NetTest(BitcoinTestFramework):

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -94,6 +94,7 @@ def assert_true(thing, err_msg=None):
             msg = err_msg
         raise AssertionError(msg)
 
+
 def assert_raises(exc, fun, *args, **kwds):
     assert_raises_message(exc, None, fun, *args, **kwds)
 
@@ -224,6 +225,10 @@ def assert_array_result(object_array, to_match, expected, should_not_find=False)
         raise AssertionError("No objects matched %s" % (str(to_match)))
     if num_matched > 0 and should_not_find:
         raise AssertionError("Objects were found %s" % (str(to_match)))
+
+
+def fail(message):
+    raise AssertionError(message)
 
 
 # Utility functions

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -71,6 +71,14 @@ def assert_greater_than(thing1, thing2, err_msg=None):
         raise AssertionError(msg)
 
 
+def assert_less_than(thing1, thing2, err_msg=None):
+    if thing1 <= thing2:
+        msg = "%s >= %s" % (str(thing1), str(thing2))
+        if err_msg is not None:
+            msg = err_msg
+        raise AssertionError(msg)
+
+
 def assert_greater_than_or_equal(thing1, thing2, err_msg=None):
     if thing1 < thing2:
         msg = "%s < %s" % (str(thing1), str(thing2))

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -47,24 +47,36 @@ def assert_fee_amount(fee, tx_size, feerate_BTC_kvB):
         raise AssertionError("Fee of %s BTC too high! (Should be %s BTC)" % (str(fee), str(target_fee)))
 
 
-def assert_equal(thing1, thing2, *args):
+def assert_equal(thing1, thing2, *args, err_msg=None):
     if thing1 != thing2 or any(thing1 != arg for arg in args):
-        raise AssertionError("not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args))
+        msg = "not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args)
+        if err_msg is not None:
+            msg = err_msg
+        raise AssertionError(msg)
 
 
-def assert_not_equal(thing1, thing2, *args):
+def assert_not_equal(thing1, thing2, *args, err_msg=None):
     if thing1 == thing2 or any(thing1 == arg for arg in args):
-        raise AssertionError("%s" % " == ".join(str(arg) for arg in (thing1, thing2) + args))
+        msg = "%s" % " == ".join(str(arg) for arg in (thing1, thing2) + args)
+        if err_msg is not None:
+            msg = err_msg
+        raise AssertionError(msg)
 
 
-def assert_greater_than(thing1, thing2):
+def assert_greater_than(thing1, thing2, err_msg=None):
     if thing1 <= thing2:
-        raise AssertionError("%s <= %s" % (str(thing1), str(thing2)))
+        msg = "%s <= %s" % (str(thing1), str(thing2))
+        if err_msg is not None:
+            msg = err_msg
+        raise AssertionError(msg)
 
 
-def assert_greater_than_or_equal(thing1, thing2):
+def assert_greater_than_or_equal(thing1, thing2, err_msg=None):
     if thing1 < thing2:
-        raise AssertionError("%s < %s" % (str(thing1), str(thing2)))
+        msg = "%s < %s" % (str(thing1), str(thing2))
+        if err_msg is not None:
+            msg = err_msg
+        raise AssertionError(msg)
 
 
 def assert_true(thing, message = None):

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -52,6 +52,11 @@ def assert_equal(thing1, thing2, *args):
         raise AssertionError("not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args))
 
 
+def assert_not_equal(thing1, thing2, *args):
+    if thing1 == thing2 or any(thing1 == arg for arg in args):
+        raise AssertionError("%s" % " == ".join(str(arg) for arg in (thing1, thing2) + args))
+
+
 def assert_greater_than(thing1, thing2):
     if thing1 <= thing2:
         raise AssertionError("%s <= %s" % (str(thing1), str(thing2)))

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -81,7 +81,9 @@ def assert_greater_than_or_equal(thing1, thing2, err_msg=None):
 
 def assert_true(thing, err_msg=None):
     if thing is not True:
-        msg = "%s it is not True" if err_msg is None else err_msg
+        msg = "%s it is not True" % str(thing)
+        if err_msg is not None:
+            msg = err_msg
         raise AssertionError(msg)
 
 def assert_raises(exc, fun, *args, **kwds):

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -67,6 +67,11 @@ def assert_greater_than_or_equal(thing1, thing2):
         raise AssertionError("%s < %s" % (str(thing1), str(thing2)))
 
 
+def assert_true(thing, message = None):
+    if thing is not True:
+        msg = "%s it is not True" if message is None else message
+        raise AssertionError(msg)
+
 def assert_raises(exc, fun, *args, **kwds):
     assert_raises_message(exc, None, fun, *args, **kwds)
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -79,7 +79,7 @@ def assert_greater_than_or_equal(thing1, thing2, err_msg=None):
 
 def assert_true(thing, err_msg=None):
     if thing is not True:
-        msg = err_msg or "%s it is not True" % str(thing)
+        msg = err_msg or "%s is not True" % str(thing)
         raise AssertionError(msg)
 
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -79,9 +79,9 @@ def assert_greater_than_or_equal(thing1, thing2, err_msg=None):
         raise AssertionError(msg)
 
 
-def assert_true(thing, message = None):
+def assert_true(thing, err_msg=None):
     if thing is not True:
-        msg = "%s it is not True" if message is None else message
+        msg = "%s it is not True" if err_msg is None else err_msg
         raise AssertionError(msg)
 
 def assert_raises(exc, fun, *args, **kwds):

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -72,7 +72,7 @@ def assert_greater_than(thing1, thing2, err_msg=None):
 
 
 def assert_less_than(thing1, thing2, err_msg=None):
-    if thing1 <= thing2:
+    if thing1 >= thing2:
         msg = "%s >= %s" % (str(thing1), str(thing2))
         if err_msg is not None:
             msg = err_msg

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -49,49 +49,37 @@ def assert_fee_amount(fee, tx_size, feerate_BTC_kvB):
 
 def assert_equal(thing1, thing2, *args, err_msg=None):
     if thing1 != thing2 or any(thing1 != arg for arg in args):
-        msg = "not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args)
-        if err_msg is not None:
-            msg = err_msg
+        msg = err_msg or "not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args)
         raise AssertionError(msg)
 
 
 def assert_not_equal(thing1, thing2, *args, err_msg=None):
     if thing1 == thing2 or any(thing1 == arg for arg in args):
-        msg = "%s" % " == ".join(str(arg) for arg in (thing1, thing2) + args)
-        if err_msg is not None:
-            msg = err_msg
+        msg = err_msg or "%s" % " == ".join(str(arg) for arg in (thing1, thing2) + args)
         raise AssertionError(msg)
 
 
 def assert_greater_than(thing1, thing2, err_msg=None):
     if thing1 <= thing2:
-        msg = "%s <= %s" % (str(thing1), str(thing2))
-        if err_msg is not None:
-            msg = err_msg
+        msg = err_msg or "%s <= %s" % (str(thing1), str(thing2))
         raise AssertionError(msg)
 
 
 def assert_less_than(thing1, thing2, err_msg=None):
     if thing1 >= thing2:
-        msg = "%s >= %s" % (str(thing1), str(thing2))
-        if err_msg is not None:
-            msg = err_msg
+        msg = err_msg or "%s >= %s" % (str(thing1), str(thing2))
         raise AssertionError(msg)
 
 
 def assert_greater_than_or_equal(thing1, thing2, err_msg=None):
     if thing1 < thing2:
-        msg = "%s < %s" % (str(thing1), str(thing2))
-        if err_msg is not None:
-            msg = err_msg
+        msg = err_msg or "%s < %s" % (str(thing1), str(thing2))
         raise AssertionError(msg)
 
 
 def assert_true(thing, err_msg=None):
     if thing is not True:
-        msg = "%s it is not True" % str(thing)
-        if err_msg is not None:
-            msg = err_msg
+        msg = err_msg or "%s it is not True" % str(thing)
         raise AssertionError(msg)
 
 

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -111,7 +111,7 @@ class ToolWalletTest(BitcoinTestFramework):
     def assert_is_sqlite(self, filename):
         with open(filename, 'rb') as f:
             file_magic = f.read(16)
-            assert file_magic == b'SQLite format 3\x00'
+            assert_equal(file_magic, b'SQLite format 3\x00')
 
     def assert_is_bdb(self, filename):
         with open(filename, 'rb') as f:

--- a/test/functional/wallet_address_types.py
+++ b/test/functional/wallet_address_types.py
@@ -63,6 +63,7 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than,
     assert_raises_rpc_error,
+    fail,
 )
 
 class AddressTypeTest(BitcoinTestFramework):
@@ -178,12 +179,12 @@ class AddressTypeTest(BitcoinTestFramework):
         # Verify the descriptor checksum against the Python implementation
         assert descsum_check(info['desc'])
         # Verify that stripping the checksum and recreating it using Python roundtrips
-        assert info['desc'] == descsum_create(info['desc'][:-9])
+        assert_equal(info['desc'], descsum_create(info['desc'][:-9]))
         # Verify that stripping the checksum and feeding it to getdescriptorinfo roundtrips
-        assert info['desc'] == self.nodes[0].getdescriptorinfo(info['desc'][:-9])['descriptor']
+        assert_equal(info['desc'], self.nodes[0].getdescriptorinfo(info['desc'][:-9])['descriptor'])
         assert_equal(info['desc'][-8:], self.nodes[0].getdescriptorinfo(info['desc'][:-9])['checksum'])
         # Verify that keeping the checksum and feeding it to getdescriptorinfo roundtrips
-        assert info['desc'] == self.nodes[0].getdescriptorinfo(info['desc'])['descriptor']
+        assert_equal(info['desc'], self.nodes[0].getdescriptorinfo(info['desc'])['descriptor'])
         assert_equal(info['desc'][-8:], self.nodes[0].getdescriptorinfo(info['desc'])['checksum'])
 
         if not multisig and typ == 'legacy':
@@ -206,7 +207,7 @@ class AddressTypeTest(BitcoinTestFramework):
             assert_equal(info['desc'], descsum_create("wsh(multi(2,%s,%s))" % (key_descs[info['pubkeys'][0]], key_descs[info['pubkeys'][1]])))
         else:
             # Unknown type
-            assert False
+            fail("Unknown type")
 
     def test_change_output_type(self, node_sender, destinations, expected_type):
         txid = self.nodes[node_sender].sendmany(dummy="", amounts=dict.fromkeys(destinations, 0.001))

--- a/test/functional/wallet_address_types.py
+++ b/test/functional/wallet_address_types.py
@@ -206,7 +206,6 @@ class AddressTypeTest(BitcoinTestFramework):
             # P2WSH-multisig
             assert_equal(info['desc'], descsum_create("wsh(multi(2,%s,%s))" % (key_descs[info['pubkeys'][0]], key_descs[info['pubkeys'][1]])))
         else:
-            # Unknown type
             fail("Unknown type")
 
     def test_change_output_type(self, node_sender, destinations, expected_type):

--- a/test/functional/wallet_disable.py
+++ b/test/functional/wallet_disable.py
@@ -10,8 +10,8 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
-    assert_raises_rpc_error,
     assert_equal,
+    assert_raises_rpc_error,
 )
 
 class DisableWalletTest (BitcoinTestFramework):

--- a/test/functional/wallet_disable.py
+++ b/test/functional/wallet_disable.py
@@ -9,7 +9,10 @@
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_raises_rpc_error
+from test_framework.util import (
+    assert_raises_rpc_error,
+    assert_equal,
+)
 
 class DisableWalletTest (BitcoinTestFramework):
     def set_test_params(self):
@@ -22,9 +25,9 @@ class DisableWalletTest (BitcoinTestFramework):
         # Make sure wallet is really disabled
         assert_raises_rpc_error(-32601, 'Method not found', self.nodes[0].getwalletinfo)
         x = self.nodes[0].validateaddress('3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')
-        assert x['isvalid'] == False
+        assert_equal(x['isvalid'], False)
         x = self.nodes[0].validateaddress('mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ')
-        assert x['isvalid'] == True
+        assert_equal(x['isvalid'], True)
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_dump.py
+++ b/test/functional/wallet_dump.py
@@ -53,7 +53,7 @@ def read_dump(file_name, addrs, script_addrs, hd_master_addr_old):
                 keypath = None
                 if keytype == "inactivehdseed=1":
                     # ensure the old master is still available
-                    assert hd_master_addr_old == addr
+                    assert_equal(hd_master_addr_old, addr)
                 elif keytype == "hdseed=1":
                     # ensure we have generated a new hd master key
                     assert hd_master_addr_old != addr

--- a/test/functional/wallet_keypool.py
+++ b/test/functional/wallet_keypool.py
@@ -23,7 +23,7 @@ class KeyPoolTest(BitcoinTestFramework):
         addr_before_encrypting_data = nodes[0].getaddressinfo(addr_before_encrypting)
         wallet_info_old = nodes[0].getwalletinfo()
         if not self.options.descriptors:
-            assert addr_before_encrypting_data['hdseedid'] == wallet_info_old['hdseedid']
+            assert_equal(addr_before_encrypting_data['hdseedid'], wallet_info_old['hdseedid'])
 
         # Encrypt wallet and wait to terminate
         nodes[0].encryptwallet('test')
@@ -78,7 +78,7 @@ class KeyPoolTest(BitcoinTestFramework):
         wallet_info = nodes[0].getwalletinfo()
         assert addr_before_encrypting_data['hdmasterfingerprint'] != addr_data['hdmasterfingerprint']
         if not self.options.descriptors:
-            assert addr_data['hdseedid'] == wallet_info['hdseedid']
+            assert_equal(addr_data['hdseedid'], wallet_info['hdseedid'])
         assert_raises_rpc_error(-12, "Error: Keypool ran out, please call keypoolrefill first", nodes[0].getnewaddress)
 
         # put six (plus 2) new keys in the keypool (100% external-, +100% internal-keys, 1 in min)
@@ -111,7 +111,7 @@ class KeyPoolTest(BitcoinTestFramework):
         addr.add(nodes[0].getnewaddress(address_type="bech32"))
         addr.add(nodes[0].getnewaddress(address_type="bech32"))
         addr.add(nodes[0].getnewaddress(address_type="bech32"))
-        assert len(addr) == 6
+        assert_equal(len(addr), 6)
         # the next one should fail
         assert_raises_rpc_error(-12, "Error: Keypool ran out, please call keypoolrefill first", nodes[0].getnewaddress)
 

--- a/test/functional/wallet_listdescriptors.py
+++ b/test/functional/wallet_listdescriptors.py
@@ -48,8 +48,8 @@ class ListDescriptorsTest(BitcoinTestFramework):
         assert_equal(4, len([d for d in result['descriptors'] if d['internal']]))
         for item in result['descriptors']:
             assert item['desc'] != ''
-            assert item['next'] == 0
-            assert item['range'] == [0, 0]
+            assert_equal(item['next'], 0)
+            assert_equal(item['range'], [0, 0])
             assert item['timestamp'] is not None
 
         self.log.info('Test descriptors with hardened derivations are listed in importable form.')

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -237,7 +237,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
         self.sync_all()
 
         # gettransaction should work for txid1
-        assert self.nodes[0].gettransaction(txid1)['txid'] == txid1, "gettransaction failed to find txid1"
+        assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1, err_msg="gettransaction failed to find txid1")
 
         # listsinceblock(lastblockhash) should now include txid1, as seen from nodes[0]
         lsbres = self.nodes[0].listsinceblock(lastblockhash)

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -101,7 +101,7 @@ class ListTransactionsTest(BitcoinTestFramework):
             self.generate(self.nodes[1], 1)
             assert_equal(len(self.nodes[0].listtransactions(label="watchonly", include_watchonly=True)), 1)
             assert_equal(len(self.nodes[0].listtransactions(dummy="watchonly", include_watchonly=True)), 1)
-            assert len(self.nodes[0].listtransactions(label="watchonly", count=100, include_watchonly=False)) == 0
+            assert_equal(len(self.nodes[0].listtransactions(label="watchonly", count=100, include_watchonly=False)), 0)
             assert_array_result(self.nodes[0].listtransactions(label="watchonly", count=100, include_watchonly=True),
                                 {"category": "receive", "amount": Decimal("0.1")},
                                 {"txid": txid, "label": "watchonly"})

--- a/test/functional/wallet_txn_doublespend.py
+++ b/test/functional/wallet_txn_doublespend.py
@@ -46,7 +46,7 @@ class TxnMallTest(BitcoinTestFramework):
         # blockchain sync later in the test when nodes are connected, due to
         # timing issues.
         for n in self.nodes:
-            assert n.getblockchaininfo()["initialblockdownload"] == False
+            assert_equal(n.getblockchaininfo()["initialblockdownload"], False)
 
         for i in range(3):
             assert_equal(self.nodes[i].getbalance(), starting_balance)


### PR DESCRIPTION
This PR removes when it is possible the native python assert, and use the test utils function, like `assert_equal`, `assert_greater_than`, `assert_greater_than_or_equal`.

### Update

In addition, this PR includes a new operator `assert_not_equal`, which IMO it is useful to test other conditions and add the error message as a parameter of the function to give more flexibility.

Fixes https://github.com/bitcoin/bitcoin/issues/23119

Edit laanwj: removed HTML comment from post