### PR TITLE
doc: Remove TODO 'exclude peers with download permission'

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2899,7 +2899,6 @@ void CConnman::RecordBytesSent(uint64_t bytes)
         nMaxOutboundTotalBytesSentInCycle = 0;
     }
 
-    // TODO, exclude peers with download permission
     nMaxOutboundTotalBytesSentInCycle += bytes;
 }
 


### PR DESCRIPTION
Following from PR https://github.com/bitcoin/bitcoin/pull/23109
The [TODO](https://github.com/bitcoin/bitcoin/blob/master/src/net.cpp#L2872)  is no longer necessary.
Removing it to  prevent future confusion. 
