### PR TITLE
doc: Revert "Remove outdated comments" and place comment correctly

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -878,6 +878,8 @@ bool AppInitParameterInteraction(const ArgsManager& args)
 #else
     int fd_max = FD_SETSIZE;
 #endif
+    // Trim requested connection counts, to fit into system limitations
+    // <int> in std::min<int>(...) to work around FreeBSD compilation issue described in #2695
     nMaxConnections = std::max(std::min<int>(nMaxConnections, fd_max - nBind - MIN_CORE_FILEDESCRIPTORS - MAX_ADDNODE_CONNECTIONS - NUM_FDS_MESSAGE_CAPTURE), 0);
     if (nFD < MIN_CORE_FILEDESCRIPTORS)
         return InitError(_("Not enough file descriptors available."));


### PR DESCRIPTION
Unfortunately, in #23094 the assumption that #14336 makes comments outdated is wrong. As pointed in  https://github.com/bitcoin/bitcoin/pull/23094#discussion_r717226839, the #14336 just moved the relevant code a few lines down.

This PR reverts commit ee7891a0c412728cf8bec667f25263682a9baaaf, and moves the comments into the right place.

I apologize about that.