### PR TITLE
 Update crc32c subtree 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 
 language: cpp
 dist: bionic
-osx_image: xcode10.3
+osx_image: xcode12.5
 
 compiler:
 - gcc
@@ -24,20 +24,20 @@ env:
 addons:
   apt:
     sources:
-    - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
+    - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-12 main'
       key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
     - sourceline: 'ppa:ubuntu-toolchain-r/test'
     packages:
-    - clang-9
+    - clang-12
     - cmake
-    - gcc-9
-    - g++-9
+    - gcc-11
+    - g++-11
     - ninja-build
   homebrew:
     packages:
     - cmake
-    - gcc@9
-    - llvm@9
+    - gcc@11
+    - llvm@12
     - ninja
     update: true
 
@@ -48,14 +48,14 @@ install:
     export PATH="$(brew --prefix llvm)/bin:$PATH";
   fi
 # /usr/bin/gcc points to an older compiler on both Linux and macOS.
-- if [ "$CXX" = "g++" ]; then export CXX="g++-9" CC="gcc-9"; fi
+- if [ "$CXX" = "g++" ]; then export CXX="g++-11" CC="gcc-11"; fi
 # /usr/bin/clang points to an older compiler on both Linux and macOS.
 #
 # Homebrew's llvm package doesn't ship a versioned clang++ binary, so the values
 # below don't work on macOS. Fortunately, the path change above makes the
 # default values (clang and clang++) resolve to the correct compiler on macOS.
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-    if [ "$CXX" = "clang++" ]; then export CXX="clang++-9" CC="clang-9"; fi;
+    if [ "$CXX" = "clang++" ]; then export CXX="clang++-12" CC="clang-12"; fi;
   fi
 - echo ${CC}
 - echo ${CXX}

--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -4,10 +4,10 @@
 """YouCompleteMe configuration that interprets a .clang_complete file.
 
 This module implementes the YouCompleteMe configuration API documented at:
-https://github.com/Valloric/ycmd#ycm_extra_confpy-specification
+https://github.com/ycm-core/ycmd#ycm_extra_confpy-specification
 
 The implementation loads and processes a .clang_complete file, documented at:
-https://github.com/Rip-Rip/clang_complete/blob/master/README.md
+https://github.com/xavierd/clang_complete/blob/master/README.md
 """
 
 import os

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ apm install autocomplete-clang build build-cmake clang-format language-cmake \
 
 If you don't mind more setup in return for more speed, replace
 `autocomplete-clang` and `linter-clang` with `you-complete-me`. This requires
-[setting up ycmd](https://github.com/Valloric/ycmd#building).
+[setting up ycmd](https://github.com/ycm-core/ycmd#building).
 
 ```bash
 apm install autocomplete-plus build build-cmake clang-format language-cmake \

--- a/src/crc32c_arm64_check.h
+++ b/src/crc32c_arm64_check.h
@@ -40,7 +40,15 @@ inline bool CanUseArm64Crc32() {
   // From 'arch/arm64/include/uapi/asm/hwcap.h' in Linux kernel source code.
   constexpr unsigned long kHWCAP_PMULL = 1 << 4;
   constexpr unsigned long kHWCAP_CRC32 = 1 << 7;
-  unsigned long hwcap = (&getauxval != nullptr) ? getauxval(AT_HWCAP) : 0;
+  unsigned long hwcap =
+#if HAVE_STRONG_GETAUXVAL
+      // Some compilers warn on (&getauxval != nullptr) in the block below.
+      getauxval(AT_HWCAP);
+#elif HAVE_WEAK_GETAUXVAL
+      (&getauxval != nullptr) ? getauxval(AT_HWCAP) : 0;
+#else
+#error This is supposed to be nested inside a check for HAVE_*_GETAUXVAL.
+#endif  // HAVE_STRONG_GETAUXVAL
   return (hwcap & (kHWCAP_PMULL | kHWCAP_CRC32)) ==
          (kHWCAP_PMULL | kHWCAP_CRC32);
 #elif defined(__APPLE__)


### PR DESCRIPTION
Only change is a warning fix for arm.

```
  CXX      crc32c/src/crc32c_libcrc32c_a-crc32c.o
In file included from crc32c/src/crc32c.cc:11:0:
crc32c/src/./crc32c_arm64_check.h: In function ‘bool crc32c::CanUseArm64Crc32()’:
crc32c/src/./crc32c_arm64_check.h:43:37: warning: the address of ‘long unsigned int getauxval(long unsigned int)’ will never be NULL [-Waddress]
   unsigned long hwcap = (&getauxval != nullptr) ? getauxval(AT_HWCAP) : 0;
                          ~~~~~~~~~~~^~~~~~~~~~