### PR TITLE
Move-only: bloom to src/common

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -123,7 +123,6 @@ BITCOIN_CORE_H = \
   bech32.h \
   blockencodings.h \
   blockfilter.h \
-  common/bloom.h \
   chain.h \
   chainparams.h \
   chainparamsbase.h \
@@ -131,6 +130,7 @@ BITCOIN_CORE_H = \
   checkqueue.h \
   clientversion.h \
   coins.h \
+  common/bloom.h \
   compat.h \
   compat/assumptions.h \
   compat/byteswap.h \
@@ -538,9 +538,9 @@ libbitcoin_common_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_common_a_SOURCES = \
   base58.cpp \
   bech32.cpp \
-  common/bloom.cpp \
   chainparams.cpp \
   coins.cpp \
+  common/bloom.cpp \
   compressor.cpp \
   core_read.cpp \
   core_write.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -123,7 +123,7 @@ BITCOIN_CORE_H = \
   bech32.h \
   blockencodings.h \
   blockfilter.h \
-  bloom.h \
+  common/bloom.h \
   chain.h \
   chainparams.h \
   chainparamsbase.h \
@@ -538,7 +538,7 @@ libbitcoin_common_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_common_a_SOURCES = \
   base58.cpp \
   bech32.cpp \
-  bloom.cpp \
+  common/bloom.cpp \
   chainparams.cpp \
   coins.cpp \
   compressor.cpp \

--- a/src/banman.h
+++ b/src/banman.h
@@ -6,7 +6,7 @@
 #define BITCOIN_BANMAN_H
 
 #include <addrdb.h>
-#include <bloom.h>
+#include <common/bloom.h>
 #include <fs.h>
 #include <net_types.h> // For banmap_t
 #include <sync.h>

--- a/src/bench/rollingbloom.cpp
+++ b/src/bench/rollingbloom.cpp
@@ -4,7 +4,7 @@
 
 
 #include <bench/bench.h>
-#include <bloom.h>
+#include <common/bloom.h>
 
 static void RollingBloom(benchmark::Bench& bench)
 {

--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -82,7 +82,7 @@ bool CBloomFilter::contains(const COutPoint& outpoint) const
 {
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << outpoint;
-    return contains(MakeUCharSpan(stream));
+    return contains(stream);
 }
 
 bool CBloomFilter::IsWithinSizeConstraints() const

--- a/src/common/bloom.cpp
+++ b/src/common/bloom.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <bloom.h>
+#include <common/bloom.h>
 
 #include <hash.h>
 #include <primitives/transaction.h>

--- a/src/common/bloom.h
+++ b/src/common/bloom.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_BLOOM_H
-#define BITCOIN_BLOOM_H
+#ifndef BITCOIN_COMMON_BLOOM_H
+#define BITCOIN_COMMON_BLOOM_H
 
 #include <serialize.h>
 #include <span.h>
@@ -124,4 +124,4 @@ private:
     int nHashFuncs;
 };
 
-#endif // BITCOIN_BLOOM_H
+#endif // BITCOIN_COMMON_BLOOM_H

--- a/src/merkleblock.h
+++ b/src/merkleblock.h
@@ -6,10 +6,10 @@
 #ifndef BITCOIN_MERKLEBLOCK_H
 #define BITCOIN_MERKLEBLOCK_H
 
+#include <common/bloom.h>
+#include <primitives/block.h>
 #include <serialize.h>
 #include <uint256.h>
-#include <primitives/block.h>
-#include <common/bloom.h>
 
 #include <vector>
 

--- a/src/merkleblock.h
+++ b/src/merkleblock.h
@@ -9,7 +9,7 @@
 #include <serialize.h>
 #include <uint256.h>
 #include <primitives/block.h>
-#include <bloom.h>
+#include <common/bloom.h>
 
 #include <vector>
 

--- a/src/net.h
+++ b/src/net.h
@@ -7,8 +7,8 @@
 #define BITCOIN_NET_H
 
 #include <addrman.h>
-#include <common/bloom.h>
 #include <chainparams.h>
+#include <common/bloom.h>
 #include <compat.h>
 #include <consensus/amount.h>
 #include <crypto/siphash.h>

--- a/src/net.h
+++ b/src/net.h
@@ -7,7 +7,7 @@
 #define BITCOIN_NET_H
 
 #include <addrman.h>
-#include <bloom.h>
+#include <common/bloom.h>
 #include <chainparams.h>
 #include <compat.h>
 #include <consensus/amount.h>

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <bloom.h>
+#include <common/bloom.h>
 
 #include <clientversion.h>
 #include <key.h>

--- a/src/test/fuzz/bloom_filter.cpp
+++ b/src/test/fuzz/bloom_filter.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <bloom.h>
+#include <common/bloom.h>
 #include <primitives/transaction.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>

--- a/src/test/fuzz/rolling_bloom_filter.cpp
+++ b/src/test/fuzz/rolling_bloom_filter.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <bloom.h>
+#include <common/bloom.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -22,7 +22,7 @@ unsigned-integer-overflow:arith_uint256.h
 unsigned-integer-overflow:basic_string.h
 unsigned-integer-overflow:bench/bench.h
 unsigned-integer-overflow:bitcoin-tx.cpp
-unsigned-integer-overflow:bloom.cpp
+unsigned-integer-overflow:common/bloom.cpp
 unsigned-integer-overflow:chain.cpp
 unsigned-integer-overflow:chain.h
 unsigned-integer-overflow:coded_stream.h
@@ -48,7 +48,7 @@ implicit-integer-sign-change:*/new_allocator.h
 implicit-integer-sign-change:addrman.h
 implicit-integer-sign-change:arith_uint256.cpp
 implicit-integer-sign-change:bech32.cpp
-implicit-integer-sign-change:bloom.cpp
+implicit-integer-sign-change:common/bloom.cpp
 implicit-integer-sign-change:chain.cpp
 implicit-integer-sign-change:chain.h
 implicit-integer-sign-change:coins.h


### PR DESCRIPTION
To avoid having all files at the top level `./src` directory, start moving them to their respective sub directory according to https://github.com/bitcoin/bitcoin/issues/15732.

`bloom` currently depends on libconsensus (`CTransaction`, `CScript`, ...) and it is currently located in the libcommon. Thus, move it to `src/common/`. (libutil in `src/util/` is for stuff that doesn't depend on libconsensus).