### PR TITLE
test: Fix intermitent failure in wallet_basic.py

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -36,7 +36,7 @@ def assert_approx(v, vexp, vspan=0.00001):
 
 def assert_fee_amount(fee, tx_size, fee_per_kB):
     """Assert the fee was in range"""
-    target_fee = round(tx_size * fee_per_kB / 1000, 8)
+    target_fee = satoshi_round(tx_size * fee_per_kB / 1000)
     if fee < target_fee:
         raise AssertionError("Fee of %s BTC too low! (Should be %s BTC)" % (str(fee), str(target_fee)))
     # allow the wallet's estimation to be at most 2 bytes off


### PR DESCRIPTION
`assert_fee_amount` currently uses `round()` when calculating the fee rate, which causes intermittent failure in `wallet_basic.py`:
https://cirrus-ci.com/task/5721255786577920?logs=ci#L145

```
2021-09-29T23:28:41.198000Z TestFramework (INFO): Test sendtoaddress with fee_rate param (explicit fee rate in sat/vB)
2021-09-29T23:28:49.992000Z TestFramework (ERROR): Assertion failed
Traceback (most recent call last):
  File "/tmp/cirrus-ci-build/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/test/functional/test_framework/test_framework.py", line 131, in main
    self.run_test()
  File "/tmp/cirrus-ci-build/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/test/functional/wallet_basic.py", line 500, in run_test
    assert_fee_amount(fee, tx_size, Decimal(fee_rate_btc_kvb))
  File "/tmp/cirrus-ci-build/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/test/functional/test_framework/util.py", line 41, in assert_fee_amount
    raise AssertionError("Fee of %s BTC too low! (Should be %s BTC)" % (str(fee), str(target_fee)))
AssertionError: Fee of 0.00000255 BTC too low! (Should be 0.00000256 BTC)
```

We should truncate rather than rounding.

This would also be fixed by #22949 but it makes more sense to make the test consistent with the current code.