### PR TITLE
refactor: rename DBErrors::RESCAN_REQUIRED to NEED_RESCAN

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2560,7 +2560,7 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
         {
             error = strprintf(_("Wallet needed to be rewritten: restart %s to complete"), PACKAGE_NAME);
             return nullptr;
-        } else if (nLoadWalletRet == DBErrors::RESCAN_REQUIRED) {
+        } else if (nLoadWalletRet == DBErrors::NEED_RESCAN) {
             warnings.push_back(strprintf(_("Error reading %s! Transaction data may be missing or incorrect."
                                            " Rescanning wallet."), walletFile));
             rescan_required = true;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -861,7 +861,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     }
 
     if (rescan_required && result == DBErrors::LOAD_OK) {
-        result = DBErrors::RESCAN_REQUIRED;
+        result = DBErrors::NEED_RESCAN;
     } else if (fNoncriticalErrors && result == DBErrors::LOAD_OK) {
         result = DBErrors::NONCRITICAL_ERROR;
     }

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -49,7 +49,7 @@ enum class DBErrors
     TOO_NEW,
     LOAD_FAIL,
     NEED_REWRITE,
-    RESCAN_REQUIRED
+    NEED_RESCAN
 };
 
 namespace DBKeys {

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -76,7 +76,7 @@ static std::shared_ptr<CWallet> MakeWallet(const std::string& name, const fs::pa
         } else if (load_wallet_ret == DBErrors::NEED_REWRITE) {
             tfm::format(std::cerr, "Wallet needed to be rewritten: restart %s to complete", PACKAGE_NAME);
             return nullptr;
-        } else if (load_wallet_ret == DBErrors::RESCAN_REQUIRED) {
+        } else if (load_wallet_ret == DBErrors::NEED_RESCAN) {
             tfm::format(std::cerr, "Error reading %s! Some transaction data might be missing or"
                            " incorrect. Wallet requires a rescan.",
                 name);


### PR DESCRIPTION
Suggested here as a trivial follow-up: https://github.com/bitcoin/bitcoin/pull/23123#discussion_r719709924

Makes RESCAN_REQUIRED consistent with NEED_REWRITE