### PR TITLE
build: no-longer fail default configure if BDB isn't available

### DIFF
--- a/build-aux/m4/bitcoin_find_bdb48.m4
+++ b/build-aux/m4/bitcoin_find_bdb48.m4
@@ -48,15 +48,22 @@ AC_DEFUN([BITCOIN_FIND_BDB48],[
     if test "x$bdbpath" = "xX"; then
       use_bdb=no
       AC_MSG_RESULT([no])
-      AC_MSG_ERROR([libdb_cxx headers missing, ]AC_PACKAGE_NAME[ requires this library for BDB wallet support (--without-bdb to disable BDB wallet support)])
+      AC_MSG_WARN([libdb_cxx headers missing])
+      AC_MSG_WARN(AC_PACKAGE_NAME[ requires this library for BDB (legacy) wallet support])
+      AC_MSG_WARN([Passing --without-bdb will suppress this warning])
     elif test "x$bdb48path" = "xX"; then
       BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdbpath}],db_cxx)
       AC_ARG_WITH([incompatible-bdb],[AS_HELP_STRING([--with-incompatible-bdb], [allow using a bdb version other than 4.8])],[
-        AC_MSG_WARN([Found Berkeley DB other than 4.8; BDB wallets opened by this build will not be portable!])
+        AC_MSG_WARN([Found Berkeley DB other than 4.8])
+        AC_MSG_WARN([BDB (legacy) wallets opened by this build will not be portable!])
+        use_bdb=yes
       ],[
-        AC_MSG_ERROR([Found Berkeley DB other than 4.8, required for portable BDB wallets (--with-incompatible-bdb to ignore or --without-bdb to disable BDB wallet support)])
+        AC_MSG_WARN([Found Berkeley DB other than 4.8])
+        AC_MSG_WARN([BDB (legacy) wallets opened by this build would not be portable!])
+        AC_MSG_WARN([If this is intended, pass --with-incompatible-bdb])
+        AC_MSG_WARN([Passing --without-bdb will suppress this warning])
+        use_bdb=no
       ])
-      use_bdb=yes
     else
       BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdb48path}],db_cxx)
       bdbpath="${bdb48path}"
@@ -78,7 +85,9 @@ AC_DEFUN([BITCOIN_FIND_BDB48],[
       ])
     done
     if test "x$BDB_LIBS" = "x"; then
-        AC_MSG_ERROR([libdb_cxx missing, ]AC_PACKAGE_NAME[ requires this library for BDB wallet support (--without-bdb to disable BDB wallet support)])
+        AC_MSG_WARN([libdb_cxx headers missing])
+        AC_MSG_WARN(AC_PACKAGE_NAME[ requires this library for BDB (legacy) wallet support])
+        AC_MSG_WARN([Passing --without-bdb will suppress this warning])
     fi
   fi
   if test "x$use_bdb" != "xno"; then


### PR DESCRIPTION
Inline with moving to descriptor (sqlite) wallets by default for 0.23,
this adapts the build system so that a default `./configure` invocation
no-longer fails if BDB isn't present. Currently, if configure is run
with no options, and no BDB is present, we'll fail with:
```bash
checking for Berkeley DB C++ headers... no
configure: error: libdb_cxx headers missing, Bitcoin Core requires this library for BDB wallet support (--without-bdb to disable BDB wallet support)
```

If descriptor wallets are to be the default, this behaviour no longer
makes sense, as a builder should be able to configure and build, to use
a wallet, without BDB installed, and without passing additional
arguments, i.e `--without-bdb` or `--with-incompatible-bdb`, to
configure.

With this change, running configure will no-longer fail, but will
instead print:
```bash
checking for Berkeley DB C++ headers... no
configure: WARNING: libdb_cxx headers missing
configure: WARNING: Bitcoin Core requires this library for BDB (legacy) wallet support
configure: WARNING: Passing --without-bdb will suppress this warning
checking for sqlite3 >= 3.7.17... yes
checking whether to build wallet with support for sqlite... yes
```