### PR TITLE
fix initialization in FastRandomContext: removes undefined behavior & uninitialized read

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -633,7 +633,7 @@ std::vector<unsigned char> FastRandomContext::randbytes(size_t len)
     return ret;
 }
 
-FastRandomContext::FastRandomContext(const uint256& seed) noexcept : requires_seed(false), bytebuf_size(0), bitbuf_size(0)
+FastRandomContext::FastRandomContext(const uint256& seed) noexcept : requires_seed(false)
 {
     rng.SetKey(seed.begin(), 32);
 }
@@ -684,7 +684,7 @@ bool Random_SanityCheck()
     return true;
 }
 
-FastRandomContext::FastRandomContext(bool fDeterministic) noexcept : requires_seed(!fDeterministic), bytebuf_size(0), bitbuf_size(0)
+FastRandomContext::FastRandomContext(bool fDeterministic) noexcept : requires_seed(!fDeterministic)
 {
     if (!fDeterministic) {
         return;
@@ -697,9 +697,13 @@ FastRandomContext& FastRandomContext::operator=(FastRandomContext&& from) noexce
 {
     requires_seed = from.requires_seed;
     rng = from.rng;
-    std::copy(std::begin(from.bytebuf), std::end(from.bytebuf), std::begin(bytebuf));
+    if (from.bytebuf_size != 0) {
+        std::copy(std::begin(from.bytebuf), std::end(from.bytebuf), std::begin(bytebuf));
+    }
     bytebuf_size = from.bytebuf_size;
-    bitbuf = from.bitbuf;
+    if (from.bitbuf_size != 0) {
+        bitbuf = from.bitbuf;
+    }
     bitbuf_size = from.bitbuf_size;
     from.requires_seed = true;
     from.bytebuf_size = 0;

--- a/src/random.h
+++ b/src/random.h
@@ -119,14 +119,14 @@ void RandAddEvent(const uint32_t event_info) noexcept;
 class FastRandomContext
 {
 private:
-    bool requires_seed;
-    ChaCha20 rng;
+    bool requires_seed{true};
+    ChaCha20 rng{};
 
     unsigned char bytebuf[64];
-    int bytebuf_size;
+    int bytebuf_size{0};
 
     uint64_t bitbuf;
-    int bitbuf_size;
+    int bitbuf_size{0};
 
     void RandomSeed();
 


### PR DESCRIPTION
When building #23152 with g++ 11.1 a few `-Wmaybe-uninitialized` warnings are shown. The warning in `FastRandomContext` seems legit, and this PR fixes that.

Note that there are more warnings in leveldb code which I did not investigate. There are warnings in fuzz/float.cpp and fuzz/string.cpp which are also left untouched (see https://github.com/bitcoin/bitcoin/pull/23169#discussion_r721084621)