### PR TITLE
validation: have LoadBlockIndex account for snapshot use

### DIFF
--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -232,6 +232,9 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_activate_snapshot, TestChain100Setup)
         *chainman.ActiveChainstate().m_from_snapshot_blockhash,
         *chainman.SnapshotBlockhash());
 
+    // Ensure that the genesis block was not marked assumed-valid.
+    BOOST_CHECK(!chainman.ActiveChain().Genesis()->IsAssumedValid());
+
     const AssumeutxoData& au_data = *ExpectedAssumeutxo(snapshot_height, ::Params());
     const CBlockIndex* tip = chainman.ActiveTip();
 

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -312,4 +312,81 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_activate_snapshot, TestChain100Setup)
         loaded_snapshot_blockhash);
 }
 
+//! Test LoadBlockIndex behavior when multiple chainstates are in use.
+//!
+//! - First, verfiy that setBlockIndexCandidates is as expected when using a single,
+//!   fully-validating chainstate.
+//!
+//! - Then mark a region of the chain BLOCK_ASSUMED_VALID and introduce a second chainstate
+//!   that will tolerate assumed-valid blocks. Run LoadBlockIndex() and ensure that the first
+//!   chainstate only contains fully validated blocks and the other chainstate contains all blocks,
+//!   even those assumed-valid.
+//!
+BOOST_FIXTURE_TEST_CASE(chainstatemanager_loadblockindex, TestChain100Setup)
+{
+    ChainstateManager& chainman = *Assert(m_node.chainman);
+    CTxMemPool& mempool = *m_node.mempool;
+    CChainState& cs1 = chainman.ActiveChainstate();
+
+    int num_indexes{0};
+    int num_assumed_valid{0};
+    const int expected_assumed_valid{20};
+    const int last_assumed_valid_idx{40};
+    const int assumed_valid_start_idx = last_assumed_valid_idx - expected_assumed_valid;
+
+    CBlockIndex* validated_tip{nullptr};
+    CBlockIndex* assumed_tip{chainman.ActiveChain().Tip()};
+
+    auto reload_all_block_indexes = [&]() {
+        for (CChainState* cs : chainman.GetAll()) {
+            LOCK(::cs_main);
+            cs->UnloadBlockIndex();
+            BOOST_CHECK(cs->setBlockIndexCandidates.empty());
+        }
+
+        WITH_LOCK(::cs_main, chainman.LoadBlockIndex());
+    };
+
+    // Ensure that without any assumed-valid BlockIndex entries, all entries are considered
+    // tip candidates.
+    reload_all_block_indexes();
+    BOOST_CHECK_EQUAL(cs1.setBlockIndexCandidates.size(), cs1.m_chain.Height() + 1);
+
+    // Mark some region of the chain assumed-valid.
+    for (int i = 0; i <= cs1.m_chain.Height(); ++i) {
+        auto index = cs1.m_chain[i];
+
+        if (i < last_assumed_valid_idx && i >= assumed_valid_start_idx) {
+            index->nStatus = BlockStatus::BLOCK_VALID_TREE | BlockStatus::BLOCK_ASSUMED_VALID;
+        }
+
+        ++num_indexes;
+        if (index->IsAssumedValid()) ++num_assumed_valid;
+
+        // Note the last fully-validated block as the expected validated tip.
+        if (i == (assumed_valid_start_idx - 1)) {
+            validated_tip = index;
+            BOOST_CHECK(!index->IsAssumedValid());
+        }
+    }
+
+    BOOST_CHECK_EQUAL(expected_assumed_valid, num_assumed_valid);
+
+    CChainState& cs2 = WITH_LOCK(::cs_main,
+        return chainman.InitializeChainstate(&mempool, GetRandHash()));
+
+    reload_all_block_indexes();
+
+    // The fully validated chain only has candidates up to the start of the assumed-valid
+    // blocks.
+    BOOST_CHECK_EQUAL(cs1.setBlockIndexCandidates.count(validated_tip), 1);
+    BOOST_CHECK_EQUAL(cs1.setBlockIndexCandidates.count(assumed_tip), 0);
+    BOOST_CHECK_EQUAL(cs1.setBlockIndexCandidates.size(), assumed_valid_start_idx);
+
+    // The assumed-valid tolerant chain has all blocks as candidates.
+    BOOST_CHECK_EQUAL(cs2.setBlockIndexCandidates.count(validated_tip), 1);
+    BOOST_CHECK_EQUAL(cs2.setBlockIndexCandidates.count(assumed_tip), 1);
+    BOOST_CHECK_EQUAL(cs2.setBlockIndexCandidates.size(), num_indexes);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.h
+++ b/src/validation.h
@@ -427,20 +427,16 @@ public:
 
     std::unique_ptr<CBlockTreeDB> m_block_tree_db GUARDED_BY(::cs_main);
 
-    bool LoadBlockIndexDB(std::set<CBlockIndex*, CBlockIndexWorkComparator>& setBlockIndexCandidates) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    bool LoadBlockIndexDB(ChainstateManager& chainman) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**
      * Load the blocktree off disk and into memory. Populate certain metadata
      * per index entry (nStatus, nChainWork, nTimeMax, etc.) as well as peripheral
      * collections like setDirtyBlockIndex.
-     *
-     * @param[out] block_index_candidates  Fill this set with any valid blocks for
-     *                                     which we've downloaded all transactions.
      */
     bool LoadBlockIndex(
         const Consensus::Params& consensus_params,
-        std::set<CBlockIndex*, CBlockIndexWorkComparator>& block_index_candidates)
-        EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+        ChainstateManager& chainman) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /** Clear all data members. */
     void Unload() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
@@ -625,6 +621,10 @@ public:
      * std::nullopt if this chainstate was not created from a snapshot.
      */
     const std::optional<uint256> m_from_snapshot_blockhash;
+
+    //! Return true if this chainstate relies on blocks that are assumed-valid. In
+    //! practice this means it was created based on a UTXO snapshot.
+    bool reliesOnAssumedValid() { return m_from_snapshot_blockhash.has_value(); }
 
     /**
      * The set of all CBlockIndex entries with either BLOCK_VALID_TRANSACTIONS (for


### PR DESCRIPTION
This is part of the [assumeutxo project](https://github.com/bitcoin/bitcoin/projects/11) (parent PR: #15606) 

---

Currently, `BlockManager::LoadBlockIndex` adds all blocks that have downloaded transactions to the active chain state's `setBlockIndexCandidates` set, ignoring the background chain state.

This PR changes ChainstateManager::LoadBlockIndex to update `setBlockIndexCandidates` in the background chain, not just the active chain. In the active chain, the same blocks are added as before. In the background chain, only blocks that have actually been validated, not blocks marked assumed-valid are added so the background chain will continue to download and validate assumed-valid blocks.