### PR TITLE
Use stricter ToIntegral over LocaleIndependentAtoi where possible

### DIFF
--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -11,6 +11,7 @@
 #include <serialize.h>
 #include <streams.h>
 #include <univalue.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 #include <version.h>
 
@@ -69,7 +70,9 @@ CScript ParseScript(const std::string& s)
             (w->front() == '-' && w->size() > 1 && std::all_of(w->begin()+1, w->end(), ::IsDigit)))
         {
             // Number
-            int64_t n = LocaleIndependentAtoi<int64_t>(*w);
+            const auto parsed{ToIntegral<int64_t>(*w)};
+            CHECK_NONFATAL(parsed.has_value());
+            const int64_t n{*parsed};
 
             //limit the range of numbers ParseScript accepts in decimal
             //since numbers outside -0xFFFFFFFF...0xFFFFFFFF are illegal in scripts

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -247,10 +247,11 @@ bool RPCConsole::RPCParseCommandLine(interfaces::Node* node, std::string &strRes
                                 UniValue subelement;
                                 if (lastResult.isArray())
                                 {
-                                    for(char argch: curarg)
-                                        if (!IsDigit(argch))
-                                            throw std::runtime_error("Invalid result query");
-                                    subelement = lastResult[LocaleIndependentAtoi<int>(curarg)];
+                                    const auto parsed{ToIntegral<size_t>(curarg)};
+                                    if (!parsed) {
+                                        throw std::runtime_error("Invalid result query");
+                                    }
+                                    subelement = lastResult[parsed.value()];
                                 }
                                 else if (lastResult.isObject())
                                     subelement = find_value(lastResult, curarg);

--- a/src/test/fuzz/parse_script.cpp
+++ b/src/test/fuzz/parse_script.cpp
@@ -5,12 +5,15 @@
 #include <core_io.h>
 #include <script/script.h>
 #include <test/fuzz/fuzz.h>
+#include <util/check.h>
 
 FUZZ_TARGET(parse_script)
 {
     const std::string script_string(buffer.begin(), buffer.end());
     try {
         (void)ParseScript(script_string);
+    } catch (const NonFatalCheckError&) {
+        assert(false); // fail on internal logic error
     } catch (const std::runtime_error&) {
     }
 }

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1281,6 +1281,11 @@ BOOST_AUTO_TEST_CASE(util_ParseMoney)
     BOOST_CHECK(!ParseMoney(" 1.2 3 "));
     BOOST_CHECK(!ParseMoney(" 1 2.3 "));
 
+    // Embedded whitespace should fail
+    BOOST_CHECK(!ParseMoney(" -1 .2  "));
+    BOOST_CHECK(!ParseMoney("  1 .2  "));
+    BOOST_CHECK(!ParseMoney(" +1 .2  "));
+
     // Attempted 63 bit overflow should fail
     BOOST_CHECK(!ParseMoney("92233720368.54775808"));
 

--- a/src/util/moneystr.cpp
+++ b/src/util/moneystr.cpp
@@ -7,6 +7,7 @@
 
 #include <consensus/amount.h>
 #include <tinyformat.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 
@@ -77,7 +78,7 @@ std::optional<CAmount> ParseMoney(const std::string& money_string)
         return std::nullopt;
     if (nUnits < 0 || nUnits > COIN)
         return std::nullopt;
-    int64_t nWhole = LocaleIndependentAtoi<int64_t>(strWhole);
+    const int64_t nWhole{*Assert(ToIntegral<int64_t>(strWhole))};
     CAmount value = nWhole * COIN + nUnits;
 
     if (!MoneyRange(value)) {

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -72,7 +72,7 @@ void SplitHostPort(std::string in, uint16_t& portOut, std::string& hostOut);
 
 // LocaleIndependentAtoi is provided for backwards compatibility reasons.
 //
-// New code should use the ParseInt64/ParseUInt64/ParseInt32/ParseUInt32 functions
+// New code should use ToIntegral or the ParseInt* functions
 // which provide parse error feedback.
 //
 // The goal of LocaleIndependentAtoi is to replicate the exact defined behaviour
@@ -125,7 +125,7 @@ constexpr inline bool IsSpace(char c) noexcept {
 /**
  * Convert string to integral type T. Leading whitespace, a leading +, or any
  * trailing character fail the parsing. The required format expressed as regex
- * is `-?[0-9]+`.
+ * is `-?[0-9]+`. The minus sign is only permitted for signed integer types.
  *
  * @returns std::nullopt if the entire string could not be parsed, or if the
  *   parsed value is not in the range representable by the type T.

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -38,7 +38,7 @@ export LC_ALL=C
 # https://stackoverflow.com/a/34878283 for more details.
 
 # TODO: Reduce KNOWN_VIOLATIONS by replacing uses of locale dependent stoul/strtol with locale
-#       independent ToIntegral<T>(...).
+#       independent ToIntegral<T>(...) or the ParseInt*() functions.
 # TODO: Reduce KNOWN_VIOLATIONS by replacing uses of locale dependent snprintf with strprintf.
 KNOWN_VIOLATIONS=(
     "src/bitcoin-tx.cpp.*stoul"


### PR DESCRIPTION
No need to use `LocaleIndependentAtoi` when a string is entirely composed of `IsDigit`s and `ToIntegral` is sufficient.