### PR TITLE
build: Disable -Wbraced-scalar-init, which is incompatible with -Wc++11-narrowing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -475,6 +475,8 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wunused-parameter],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-unused-parameter"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wself-assign],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-self-assign"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wunused-local-typedef],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-unused-local-typedef"],,[[$CXXFLAG_WERROR]])
+  dnl -Wbraced-scalar-init is incompatible with -Wc++11-narrowing
+  AX_CHECK_COMPILE_FLAG([-Wbraced-scalar-init],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-braced-scalar-init"],,[[$CXXFLAG_WERROR]])
   if test x$suppress_external_warnings != xyes ; then
     AX_CHECK_COMPILE_FLAG([-Wdeprecated-copy],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-deprecated-copy"],,[[$CXXFLAG_WERROR]])
   fi


### PR DESCRIPTION
To test:

```cpp
void Fun(int) {}
int main() {
    unsigned a(-1);
    Fun({a});
}
```

Before:
```
$ clang++ -Wbraced-scalar-init -Wc++11-narrowing -std=c++17 /tmp/1.cpp -o /tmp/exe 
/tmp/1.cpp:4:10: error: non-constant-expression cannot be narrowed from type 'unsigned int' to 'int' in initializer list [-Wc++11-narrowing]
    Fun({a});
         ^
/tmp/1.cpp:4:10: note: insert an explicit cast to silence this issue
    Fun({a});
         ^
         static_cast<int>( )
/tmp/1.cpp:4:9: warning: braces around scalar initializer [-Wbraced-scalar-init]
    Fun({a});
        ^~~
1 warning and 1 error generated.
```

After:
```
$ clang++ -Wno-braced-scalar-init -Wc++11-narrowing -std=c++17 /tmp/1.cpp -o /tmp/exe 
/tmp/1.cpp:4:10: error: non-constant-expression cannot be narrowed from type 'unsigned int' to 'int' in initializer list [-Wc++11-narrowing]
    Fun({a});
         ^
/tmp/1.cpp:4:10: note: insert an explicit cast to silence this issue
    Fun({a});
         ^
         static_cast<int>( )
1 error generated.
