### PR TITLE
p2p: fix CSubNet::ToString() UBSan and banman fuzz crash

### DIFF
--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -1187,7 +1187,12 @@ std::string CSubNet::ToString() const
             if (netmask[i] == 0x00) {
                 break;
             }
-            cidr += NetmaskBits(netmask[i]);
+            const int bits{NetmaskBits(netmask[i])};
+            if (bits == -1) {
+                // Invalid subnet mask.
+                break;
+            }
+            cidr += bits;
         }
 
         suffix = strprintf("/%u", cidr);

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -89,7 +89,6 @@ implicit-signed-integer-truncation:leveldb/
 implicit-signed-integer-truncation:miner.cpp
 implicit-signed-integer-truncation:net.cpp
 implicit-signed-integer-truncation:net_processing.cpp
-implicit-signed-integer-truncation:netaddress.cpp
 implicit-signed-integer-truncation:streams.h
 implicit-signed-integer-truncation:test/arith_uint256_tests.cpp
 implicit-signed-integer-truncation:test/skiplist_tests.cpp


### PR DESCRIPTION
If an invalid subnet netmask is encountered and `NetmaskBits()` returns -1, it could be written to `uint8_t cidr` in `CSubNet::ToString()` with an implicit conversion to 255 instead of exiting.

Solution: in the case of an invalid subnet netmask, break to exit the loop like when the netmask bit is 0 in the preceding conditional.

Fixes this banman fuzzer crash and allows dropping the suppression:

https://cirrus-ci.com/task/4787303177519104?logs=ci#L3020
```
SUMMARY: UndefinedBehaviorSanitizer: implicit-signed-integer-truncation netaddress.cpp:1190:18 in
MS: 0 ; base unit: 0000000000000000000000000000000000000000
artifact_prefix='./'; Test unit written to ./crash-0671aac15e619e99522e2119487eaa9cc97e5a34

netaddress.cpp:1190:18: runtime error: implicit conversion
  from type 'int' of value -1 (32-bit, signed) to type 'uint8_t' (aka 'unsigned char') changed the value to 255 (8-bit, unsigned)
```