### PR TITLE
build: Parse version information in msvc-autogen.py

### DIFF
--- a/build_msvc/bitcoin_config.h.in
+++ b/build_msvc/bitcoin_config.h.in
@@ -6,16 +6,16 @@
 #define BITCOIN_BITCOIN_CONFIG_H
 
 /* Version Build */
-#define CLIENT_VERSION_BUILD 0
+#define CLIENT_VERSION_BUILD $
 
 /* Version is release */
-#define CLIENT_VERSION_IS_RELEASE false
+#define CLIENT_VERSION_IS_RELEASE $
 
 /* Major version */
-#define CLIENT_VERSION_MAJOR 22
+#define CLIENT_VERSION_MAJOR $
 
 /* Minor version */
-#define CLIENT_VERSION_MINOR 99
+#define CLIENT_VERSION_MINOR $
 
 /* Copyright holder(s) before %s replacement */
 #define COPYRIGHT_HOLDERS "The %s developers"
@@ -27,7 +27,7 @@
 #define COPYRIGHT_HOLDERS_SUBSTITUTION "Bitcoin Core"
 
 /* Copyright year */
-#define COPYRIGHT_YEAR 2021
+#define COPYRIGHT_YEAR $
 
 /* Define to 1 to enable wallet functions */
 #define ENABLE_WALLET 1
@@ -184,13 +184,13 @@
 #define PACKAGE_NAME "Bitcoin Core"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "Bitcoin Core 22.99.0"
+#define PACKAGE_STRING $
 
 /* Define to the home page for this package. */
 #define PACKAGE_URL "https://bitcoincore.org/"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "22.99.0"
+#define PACKAGE_VERSION $
 
 /* Define this symbol if the minimal qt platform exists */
 #define QT_QPA_PLATFORM_MINIMAL 1

--- a/build_msvc/msvc-autogen.py
+++ b/build_msvc/msvc-autogen.py
@@ -57,6 +57,41 @@ def set_common_properties(toolset):
     with open(os.path.join(SOURCE_DIR, '../build_msvc/common.init.vcxproj'), 'w', encoding='utf-8',newline='\n') as wfile:
         wfile.write(s)
 
+def parse_config_into_btc_config():
+    def find_between( s, first, last ):
+        try:
+            start = s.index( first ) + len( first )
+            end = s.index( last, start )
+            return s[start:end]
+        except ValueError:
+            return ""
+
+    config_info = []
+    with open(os.path.join(SOURCE_DIR,'../configure.ac'), encoding="utf8") as f:
+        for line in f:
+            if line.startswith("define"):
+                config_info.append(find_between(line, "(_", ")"))
+
+    config_info = [c for c in config_info if not c.startswith("COPYRIGHT_HOLDERS")]
+
+    config_dict = dict(item.split(", ") for item in config_info)
+    config_dict["PACKAGE_VERSION"] = f"\"{config_dict['CLIENT_VERSION_MAJOR']}.{config_dict['CLIENT_VERSION_MINOR']}.{config_dict['CLIENT_VERSION_BUILD']}\""
+    version = config_dict["PACKAGE_VERSION"].strip('"')
+    config_dict["PACKAGE_STRING"] = f"\"Bitcoin Core {version}\""
+
+    with open(os.path.join(SOURCE_DIR,'../build_msvc/bitcoin_config.h.in'), "r", encoding="utf8") as template_file:
+        template = template_file.readlines()
+
+    for index, line in enumerate(template):
+        header = ""
+        if line.startswith("#define"):
+            header = line.split(" ")[1]
+        if header in config_dict:
+            template[index] = line.replace("$", f"{config_dict[header]}")
+
+    with open(os.path.join(SOURCE_DIR,'../build_msvc/bitcoin_config.h'), "w", encoding="utf8") as btc_config:
+        btc_config.writelines(template)
+
 def main():
     parser = argparse.ArgumentParser(description='Bitcoin-core msbuild configuration initialiser.')
     parser.add_argument('-toolset', nargs='?',help='Optionally sets the msbuild platform toolset, e.g. v142 for Visual Studio 2019.'
@@ -79,6 +114,7 @@ def main():
             with open(vcxproj_filename, 'w', encoding='utf-8') as vcxproj_file:
                 vcxproj_file.write(vcxproj_in_file.read().replace(
                     '@SOURCE_FILES@\n', content))
+    parse_config_into_btc_config()
     copyfile(os.path.join(SOURCE_DIR,'../build_msvc/bitcoin_config.h'), os.path.join(SOURCE_DIR, 'config/bitcoin-config.h'))
     copyfile(os.path.join(SOURCE_DIR,'../build_msvc/libsecp256k1_config.h'), os.path.join(SOURCE_DIR, 'secp256k1/src/libsecp256k1-config.h'))
 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -19,8 +19,7 @@ Release Process
 
 * On both the master branch and the new release branch:
   - update `CLIENT_VERSION_MAJOR` in [`configure.ac`](../configure.ac)
-  - update `CLIENT_VERSION_MAJOR`, `PACKAGE_VERSION`, and `PACKAGE_STRING` in [`build_msvc/bitcoin_config.h`](/build_msvc/bitcoin_config.h)
-* On the new release branch in [`configure.ac`](../configure.ac) and [`build_msvc/bitcoin_config.h`](/build_msvc/bitcoin_config.h) (see [this commit](https://github.com/bitcoin/bitcoin/commit/742f7dd)):
+* On the new release branch in [`configure.ac`](../configure.ac)(see [this commit](https://github.com/bitcoin/bitcoin/commit/742f7dd)):
   - set `CLIENT_VERSION_MINOR` to `0`
   - set `CLIENT_VERSION_BUILD` to `0`
   - set `CLIENT_VERSION_IS_RELEASE` to `true`


### PR DESCRIPTION
Added a function that parses version information from `configure.ac` into `build_msvc/bitcoin_config.h`. This is done by default in `msvc-autogen.py`, so manual changing of `build_msvc/bitcoin_config.h` is no longer required. 
In addition to that I updated the Release Process doc.

Following values are updated:

   -**CLIENT_VERSION_BUILD**
   -**CLIENT_VERSION_IS_RELEASE**
   -**CLIENT_VERSION_MAJOR**
   -**CLIENT_VERSION_MINOR**
   -**COPYRIGHT_YEAR**
   -**PACKAGE_STRING**
   -**PACKAGE_VERSION**

fixes #23073