### PR TITLE
Fix intermittent failure in wallet_send.py and rpc_fundrawtransaction.py

### DIFF
--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -583,7 +583,7 @@ class ZMQTest (BitcoinTestFramework):
         ], ipv6=True)
 
         # Generate 1 block in nodes[0]
-        self.nodes[0].generatetoaddress(1, ADDRESS_BCRT1_UNSPENDABLE)
+        self.generatetoaddress(self.nodes[0], 1, ADDRESS_BCRT1_UNSPENDABLE)
 
         # Should receive the same block hash
         assert_equal(self.nodes[0].getbestblockhash(), subscribers[0].receive().hex())

--- a/test/functional/p2p_compactblocks_blocksonly.py
+++ b/test/functional/p2p_compactblocks_blocksonly.py
@@ -33,7 +33,7 @@ class P2PCompactBlocksBlocksOnly(BitcoinTestFramework):
         self.sync_all()
 
     def build_block_on_tip(self):
-        blockhash = self.nodes[2].generate(1)[0]
+        blockhash = self.generate(self.nodes[2], 1)[0]
         block_hex = self.nodes[2].getblock(blockhash=blockhash, verbosity=0)
         block = from_hex(CBlock(), block_hex)
         block.rehash()

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -1011,6 +1011,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[0].sendtoaddress(addr, 10)
         self.nodes[0].sendtoaddress(wallet.getnewaddress(), 10)
         self.generate(self.nodes[0], 6)
+        self.sync_all()
         ext_utxo = self.nodes[0].listunspent(addresses=[addr])[0]
 
         # An external input without solving data should result in an error

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -1010,7 +1010,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         self.nodes[0].sendtoaddress(addr, 10)
         self.nodes[0].sendtoaddress(wallet.getnewaddress(), 10)
-        self.nodes[0].generate(6)
+        self.generate(self.nodes[0], 6)
         ext_utxo = self.nodes[0].listunspent(addresses=[addr])[0]
 
         # An external input without solving data should result in an error

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -628,6 +628,7 @@ class PSBTTest(BitcoinTestFramework):
 
         self.nodes[0].sendtoaddress(addr, 10)
         self.generate(self.nodes[0], 6)
+        self.sync_all()
         ext_utxo = self.nodes[0].listunspent(addresses=[addr])[0]
 
         # An external input without solving data should result in an error

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -627,7 +627,7 @@ class PSBTTest(BitcoinTestFramework):
         addr_info = self.nodes[0].getaddressinfo(addr)
 
         self.nodes[0].sendtoaddress(addr, 10)
-        self.nodes[0].generate(6)
+        self.generate(self.nodes[0], 6)
         ext_utxo = self.nodes[0].listunspent(addresses=[addr])[0]
 
         # An external input without solving data should result in an error

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -502,7 +502,7 @@ class WalletSendTest(BitcoinTestFramework):
 
         self.nodes[0].sendtoaddress(addr, 10)
         self.nodes[0].sendtoaddress(ext_wallet.getnewaddress(), 10)
-        self.nodes[0].generate(6)
+        self.generate(self.nodes[0], 6)
         ext_utxo = ext_fund.listunspent(addresses=[addr])[0]
 
         # An external input without solving data should result in an error

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -503,6 +503,7 @@ class WalletSendTest(BitcoinTestFramework):
         self.nodes[0].sendtoaddress(addr, 10)
         self.nodes[0].sendtoaddress(ext_wallet.getnewaddress(), 10)
         self.generate(self.nodes[0], 6)
+        self.sync_all()
         ext_utxo = ext_fund.listunspent(addresses=[addr])[0]
 
         # An external input without solving data should result in an error


### PR DESCRIPTION
After #17211 was merged, there have been a few intermittent test failures in `wallet_send.py`, `rpc_fundrawtransaction.py`, and `rpc_psbt.py`

I believe all these failures are due to these missing `sync_all()`s