### PR TITLE
[POC] build: static musl libc based bitcoind

### DIFF
--- a/depends/hosts/default.mk
+++ b/depends/hosts/default.mk
@@ -2,6 +2,11 @@ ifneq ($(host),$(build))
 host_toolchain:=$(host)-
 endif
 
+ifneq ($(USE_MUSL_LIBC),)
+default_host_binutils = native_musl_cross_make
+default_host_toolchain = native_musl_cross_make
+endif
+
 default_host_CC = $(host_toolchain)gcc
 default_host_CXX = $(host_toolchain)g++
 default_host_AR = $(host_toolchain)ar

--- a/depends/hosts/linux.mk
+++ b/depends/hosts/linux.mk
@@ -11,6 +11,11 @@ linux_NM = $(host_toolchain)gcc-nm
 linux_RANLIB = $(host_toolchain)gcc-ranlib
 endif
 
+ifneq ($(USE_MUSL_LIBC),)
+linux_CFLAGS += -static
+linux_CXXFLAGS += -static
+endif
+
 linux_release_CFLAGS=-O2
 linux_release_CXXFLAGS=$(linux_release_CFLAGS)
 
@@ -27,6 +32,7 @@ i686_linux_RANLIB=ranlib
 i686_linux_NM=nm
 i686_linux_STRIP=strip
 
+# HAVE TO CHANGE HERE TO OVERRIDE?
 x86_64_linux_CC=gcc -m64
 x86_64_linux_CXX=g++ -m64
 x86_64_linux_AR=ar
@@ -39,4 +45,5 @@ i686_linux_CXX=$(default_host_CXX) -m32
 x86_64_linux_CC=$(default_host_CC) -m64
 x86_64_linux_CXX=$(default_host_CXX) -m64
 endif
+
 linux_cmake_system=Linux

--- a/depends/packages/native_musl_cross_make.mk
+++ b/depends/packages/native_musl_cross_make.mk
@@ -1,0 +1,24 @@
+package=native_musl_cross_make
+$(package)_version=fe915821b652a7fa37b34a596f47d8e20bc72338
+$(package)_download_path=https://github.com/richfelker/musl-cross-make/archive
+$(package)_download_file=$($(package)_version).tar.gz
+$(package)_file_name=musl-cross-make-$($(package)_version).tar.gz
+$(package)_sha256_hash=c5df9afd5efd41c97fc7f3866664ef0c91af0ff65116e27cd9cba078c7ab33ae
+$(package)_patches=binutils_2_37.patch config.mak
+
+define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/binutils_2_37.patch && \
+  cp -f $($(package)_patch_dir)/config.mak config.mak && \
+  sed -i.old "s/TARGET =/TARGET = $(host)/g" config.mak
+endef
+
+define $(package)_build_cmds
+  $(MAKE)
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) install && \
+  mkdir -p "$($(package)_staging_prefix_dir)"/ && \
+  rm -rf output/share && \
+  cp -rf output/* "$($(package)_staging_prefix_dir)"/
+endef

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -25,6 +25,10 @@ usdt_linux_packages=systemtap
 
 darwin_native_packages = native_ds_store native_mac_alias
 
+ifneq ($(USE_MUSL_LIBC),)
+linux_native_packages = native_musl_cross_make
+endif
+
 ifneq ($(build_os),darwin)
 darwin_native_packages += native_cctools native_libtapi
 

--- a/depends/patches/native_musl_cross_make/binutils_2_37.patch
+++ b/depends/patches/native_musl_cross_make/binutils_2_37.patch
@@ -1,0 +1,15 @@
+commit 18c6929bda38ae1ee32d1b957720153e20055f9c
+Author: fanquake <fanquake@gmail.com>
+Date:   Thu Oct 14 13:59:56 2021 +0800
+
+    binutils 2.37
+
+    No patches. Looks like 0004 from binutils 2.33.1 is already in the tree.
+
+diff --git a/hashes/binutils-2.37.tar.xz.sha1 b/hashes/binutils-2.37.tar.xz.sha1
+new file mode 100644
+index 0000000..ed5fabc
+--- /dev/null
++++ b/hashes/binutils-2.37.tar.xz.sha1
+@@ -0,0 +1 @@
++e9cf391b000010d6c752771974b394c9c743c928  binutils-2.37.tar.xz

--- a/depends/patches/native_musl_cross_make/config.mak
+++ b/depends/patches/native_musl_cross_make/config.mak
@@ -1,0 +1,23 @@
+TARGET =
+
+BINUTILS_VER = 2.37
+GCC_VER = 10.3.0
+MUSL_VER = 1.2.3
+LINUX_VER = headers-4.19.88-1
+
+COMMON_CONFIG += --with-debug-prefix-map=$(CURDIR)=
+
+COMMON_CONFIG += CFLAGS="-fPIC -g0 -O2"
+COMMON_CONFIG += CXXFLAGS="-fPIC -g0 -O2"
+COMMON_CONFIG += LDFLAGS="-s"
+
+COMMON_CONFIG += --disable-shared
+COMMON_CONFIG += --enable-static
+
+DL_CMD = curl -C - -L -o
+
+GCC_CONFIG += --disable-libquadmath
+GCC_CONFIG += --disable-multilib
+GCC_CONFIG += --disable-nls
+GCC_CONFIG += --enable-default-pie
+GCC_CONFIG += --enable-default-ssp


### PR DESCRIPTION
This proof of concept is one approach to static [musl libc](https://musl.libc.org/) based builds. It leverages [musl-cross-make](https://github.com/richfelker/musl-cross-make) to compile a musl libc targeting toolchain, made up of GCC 10.3.0 + binutils 2.37 + musl libc 1.2.3, and then uses that toolchain to build our depends libraries, and ultimately `bitcoind`.

More than likely we'd take a different approach in Guix for (potentially) release builds, however, something like this could exist in depends, and provide an alternative to building against glibc outside Guix. Or, this may well end up being something we just throw away in favour of a better approach; still lots to be thought about here.

Only tested compiling on, for `x86_64-pc-linux-gnu` so far.

You can use it as follows:
```bash
make -C depends/ -j9 NO_QT=1 NO_WALLET=1 NO_UPNP=1 NO_ZMQ=1 NO_NATPMP=1 USE_MUSL_LIBC=1 HOST=x86_64-linux-musl
./autogen.sh
CONFIG_SITE=/path/to/your/bitcoin/depends/x86_64-pc-linux-musl/share/config.site ./configure --enable-reduce-exports --enable-lto LDFLAGS="-Wl,-O2" LIBTOOL_APP_LDFLAGS="-all-static"
make src/bitcoind
```

The end result (once stripped) is a ~10mb static `bitcoind`:
```bash
ldd src/bitcoind
	statically linked
```

If you see:
```bash
terminate called after throwing an instance of 'std::runtime_error'
  what():  locale::facet::_S_create_c_locale name not valid
Aborted (core dumped)
```
when running, pass `LC_ALL=C`. i.e `LC_ALL=C src/bitcoind`. 

I've taken the binary onto a few different system / inside VMs, and am running a full sync.

Note that all dependencies do compile, except for Qt (build issue with FreeType I have not investigated), I've just excluded all optional dependencies from the depends build above.

When building, you may see warnings about libraries, such as `libstdc++`, as having been moved, during linking, and/or other warnings, from dependencies, such as sqlite, due to `-flto` usage.

Related to #18110.