### PR TITLE
test: Replace satoshi_round with int() or Decimal()

### DIFF
--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -24,7 +24,6 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than,
     assert_raises_rpc_error,
-    satoshi_round,
     softfork_active,
 )
 from test_framework.script_util import DUMMY_P2WPKH_SCRIPT
@@ -94,7 +93,7 @@ class BIP68Test(BitcoinTestFramework):
         utxo = utxos[0]
 
         tx1 = CTransaction()
-        value = int(satoshi_round(utxo["amount"] - self.relayfee)*COIN)
+        value = int((utxo["amount"] - self.relayfee) * COIN)
 
         # Check that the disable flag disables relative locktime.
         # If sequence locks were used, this would require 1 block for the

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -14,7 +14,6 @@ from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
     chain_transaction,
-    satoshi_round,
 )
 
 # default limits
@@ -209,10 +208,10 @@ class MempoolPackagesTest(BitcoinTestFramework):
             entry = self.nodes[0].getmempoolentry(x)
             descendant_fees += entry['fee']
             if (x == chain[-1]):
-                assert_equal(entry['modifiedfee'], entry['fee']+satoshi_round(0.00002))
-                assert_equal(entry['fees']['modified'], entry['fee']+satoshi_round(0.00002))
+                assert_equal(entry['modifiedfee'], entry['fee'] + Decimal("0.00002"))
+                assert_equal(entry['fees']['modified'], entry['fee'] + Decimal("0.00002"))
             assert_equal(entry['descendantfees'], descendant_fees * COIN + 2000)
-            assert_equal(entry['fees']['descendant'], descendant_fees+satoshi_round(0.00002))
+            assert_equal(entry['fees']['descendant'], descendant_fees + Decimal("0.00002"))
 
         # Check that node1's mempool is as expected (-> custom ancestor limit)
         mempool0 = self.nodes[0].getrawmempool(False)
@@ -308,7 +307,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         value = utxo[0]['amount']
         vout = utxo[0]['vout']
 
-        send_value = satoshi_round((value - fee)/2)
+        send_value = (value - fee) / 2
         inputs = [ {'txid' : txid, 'vout' : vout} ]
         outputs = {}
         for _ in range(2):


### PR DESCRIPTION
satoshi_round will round down. To make the code easier to parse use
Decimal() where possible, which does not round. Or use int(), which
explicitly rounds down.