### PR TITLE
rest: Return error when header count is not integral

### DIFF
--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -279,6 +279,13 @@ class RESTTest (BitcoinTestFramework):
         json_obj = self.test_rest_request(f"/headers/5/{bb_hash}")
         assert_equal(len(json_obj), 5)  # now we should have 5 header objects
 
+        # Test number parsing
+        for num in ['5a', '-5', '0', '2001', '99999999999999999999999999999999999']:
+            assert_equal(
+                bytes(f'Header count out of range: {num}\r\n', 'ascii'),
+                self.test_rest_request(f"/headers/{num}/{bb_hash}", ret_type=RetType.BYTES, status=400),
+            )
+
         self.log.info("Test tx inclusion in the /mempool and /block URIs")
 
         # Make 3 tx and mine them on node 1

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -43,7 +43,6 @@ export LC_ALL=C
 KNOWN_VIOLATIONS=(
     "src/bitcoin-tx.cpp.*stoul"
     "src/dbwrapper.cpp:.*vsnprintf"
-    "src/rest.cpp:.*strtol"
     "src/test/dbwrapper_tests.cpp:.*snprintf"
     "src/test/fuzz/locale.cpp"
     "src/test/fuzz/string.cpp"


### PR DESCRIPTION
Seems odd to interpret a hash (or any other string) as integer when it contains more than the digits 0 to 9.