### PR TITLE
Replace stoul with ToIntegral in dbwrapper

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -197,13 +197,15 @@ bool CDBWrapper::WriteBatch(CDBBatch& batch, bool fSync)
     return true;
 }
 
-size_t CDBWrapper::DynamicMemoryUsage() const {
+size_t CDBWrapper::DynamicMemoryUsage() const
+{
     std::string memory;
-    if (!pdb->GetProperty("leveldb.approximate-memory-usage", &memory)) {
+    std::optional<size_t> parsed;
+    if (!pdb->GetProperty("leveldb.approximate-memory-usage", &memory) || !(parsed = ToIntegral<size_t>(memory))) {
         LogPrint(BCLog::LEVELDB, "Failed to get approximate-memory-usage property\n");
         return 0;
     }
-    return stoul(memory);
+    return parsed.value();
 }
 
 // Prefixed with null character to avoid collisions with other keys

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -42,7 +42,6 @@ export LC_ALL=C
 # TODO: Reduce KNOWN_VIOLATIONS by replacing uses of locale dependent snprintf with strprintf.
 KNOWN_VIOLATIONS=(
     "src/bitcoin-tx.cpp.*stoul"
-    "src/dbwrapper.cpp.*stoul"
     "src/dbwrapper.cpp:.*vsnprintf"
     "src/rest.cpp:.*strtol"
     "src/test/dbwrapper_tests.cpp:.*snprintf"


### PR DESCRIPTION
The string is created with `%llu`. See: https://github.com/bitcoin/bitcoin/blob/7fcf53f7b4524572d1d0c9a5fdc388e87eb02416/src/leveldb/db/db_impl.cc#L1436-L1437

So it seems odd to silently accept when parsing: whitespace, a sign character, trailing chars, overflow, ....

Fix that by using the stricter ToIntegral.