### PR TITLE
ci: Add vcpkg tools cache

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -86,6 +86,7 @@ task:
     PATH: 'C:\jom;C:\Python39;C:\Python39\Scripts;C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin;%PATH%'
     PYTHONUTF8: 1
     CI_VCPKG_TAG: '2021.05.12'
+    VCPKG_DOWNLOADS: 'C:\Users\ContainerAdministrator\AppData\Local\vcpkg\downloads'
     VCPKG_DEFAULT_BINARY_CACHE: 'C:\Users\ContainerAdministrator\AppData\Local\vcpkg\archives'
     QT_DOWNLOAD_URL: 'https://download.qt.io/official_releases/qt/5.12/5.12.11/single/qt-everywhere-src-5.12.11.zip'
     QT_LOCAL_PATH: 'C:\qt-everywhere-src-5.12.11.zip'
@@ -121,6 +122,12 @@ task:
       - ..\configure -release -silent -opensource -confirm-license -opengl desktop -no-shared -static -static-runtime -mp -qt-zlib -qt-pcre -qt-libpng -no-libjpeg -nomake examples -nomake tests -nomake tools -no-dbus -no-libudev -no-icu -no-gtk -no-opengles3 -no-angle -no-sql-sqlite -no-sql-odbc -no-sqlite -no-libudev -no-vulkan -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcanvas3d -skip qtcharts -skip qtconnectivity -skip qtdatavis3d -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtmacextras -skip qtmultimedia -skip qtnetworkauth -skip qtpurchasing -skip qtquickcontrols -skip qtquickcontrols2 -skip qtscript -skip qtscxml -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtvirtualkeyboard -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebsockets -skip qtwebview -skip qtx11extras -skip qtxmlpatterns -no-openssl -no-feature-sql -no-feature-sqlmodel -prefix %QTBASEDIR%
       - jom
       - jom install
+  vcpkg_tools_cache:
+    folder: '%VCPKG_DOWNLOADS%\tools'
+    reupload_on_changes: false
+    fingerprint_script:
+      - echo %CI_VCPKG_TAG%
+      - msbuild -version
   vcpkg_binary_cache:
     folder: '%VCPKG_DEFAULT_BINARY_CACHE%'
     reupload_on_changes: true


### PR DESCRIPTION
On master (02feae54a53ff654f7cecf17ed467edcd612cd0c) vcpkg downloads some tools that are used internally:
```
...
  A suitable version of cmake was not found (required v3.20.0). Downloading portable cmake v3.20.0...
  Downloading cmake...
    https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2-windows-i386.zip -> C:\Users\ContainerAdministrator\AppData\Local\Temp\vcpkg\downloads\cmake-3.20.2-windows-i386.zip
  Extracting cmake...
  A suitable version of 7zip was not found (required v18.1.0). Downloading portable 7zip v18.1.0...
  Downloading 7zip...
    https://www.nuget.org/api/v2/package/7-Zip.CommandLine/18.1.0 -> C:\Users\ContainerAdministrator\AppData\Local\Temp\vcpkg\downloads\7-zip.commandline.18.1.0.nupkg
  Extracting 7zip...
  A suitable version of nuget was not found (required v5.5.0). Downloading portable nuget v5.5.0...
  Downloading nuget...
    https://dist.nuget.org/win-x86-commandline/v5.5.1/nuget.exe -> C:\Users\ContainerAdministrator\AppData\Local\Temp\vcpkg\downloads\22ea847d-nuget.exe
  Detecting compiler hash for triplet x64-windows-static...
  A suitable version of powershell-core was not found (required v7.1.0). Downloading portable powershell-core v7.1.0...
  Downloading powershell-core...
    https://github.com/PowerShell/PowerShell/releases/download/v7.1.3/PowerShell-7.1.3-win-x86.zip -> C:\Users\ContainerAdministrator\AppData\Local\Temp\vcpkg\downloads\PowerShell-7.1.3-win-x86.zip
  Extracting powershell-core...
...
```

If any of downloads above fails the whole CI task fails (see #23107). The most recent failure examples in the master branch:
- https://github.com/bitcoin/bitcoin/commit/c001da306b29c46ef1e7421002c3aba3ff5ed514, [log](https://api.cirrus-ci.com/v1/task/5182966176415744/logs/build.log)
- https://github.com/bitcoin/bitcoin/commit/12ff8993bcc7315f4a9b69bf16def980bb0e5197, [log](https://api.cirrus-ci.com/v1/task/5367684129882112/logs/build.log)

This PR adds vcpkg tools cache.

Closes #23107.

---

Note for reviewers. Some patches from the initial PR were split into separated PRs: #23310 and #23329. Therefore, a discussion here could be outdated or irrelevant until the recent [push](https://github.com/bitcoin/bitcoin/pull/23215#issuecomment-949556531).