### PR TITLE
clang-format: Set BraceWrapping:AfterControlStatement:MultiLine

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -17,6 +17,7 @@ BreakBeforeBinaryOperators: false
 BreakBeforeBraces: Custom
 BraceWrapping:
   AfterClass: true
+  AfterControlStatement: MultiLine
   AfterFunction: true
 BreakBeforeTernaryOperators: false
 BreakConstructorInitializersBeforeComma: false


### PR DESCRIPTION
Currently there is no visual break between the condition of a control statement and the body. For example:

```cpp
if (IsThisTrue() ||
    IsThatTrue()) {
    DoThis;
    DoThat;
}
```

Fix this by allowing the brace to be on a new line.

Currently clang-format won't re-format existing code, presumably due to the line-limit setting. However, the new line can be manually inserted and clang-format will no longer remove it with this new setting. So this can be tested by "injecting" a newline after a multi line control statement and calling clang-format-diff, as explained in the dev notes.

Example location to test:
```diff
diff --git a/src/net_processing.cpp b/src/net_processing.cpp
index 66b99aa2bb..f7dee82335 100644
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4313,7 +4313,8 @@ void PeerManagerImpl::CheckForStaleTipAndEvictPeers()
 void PeerManagerImpl::MaybeSendPing(CNode& node_to, Peer& peer, std::chrono::microseconds now)
 {
     if (m_connman.ShouldRunInactivityChecks(node_to) && peer.m_ping_nonce_sent &&
-        now > peer.m_ping_start.load() + std::chrono::seconds{TIMEOUT_INTERVAL}) {
+        now > peer.m_ping_start.load() + std::chrono::seconds{TIMEOUT_INTERVAL} )
+{
         LogPrint(BCLog::NET, "ping timeout: %fs peer=%d\n", 0.000001 * count_microseconds(now - peer.m_ping_start.load()), peer.m_id);
         node_to.fDisconnect = true;
         return;
```

See also: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
Fixes #21735