### PR TITLE
ci: Reduce Windows memory for faster scheduling

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -79,7 +79,7 @@ task:
   << : *FILTER_TEMPLATE
   windows_container:
     cpu: 4
-    memory: 16G
+    memory: 8G
     image: cirrusci/windowsservercore:visualstudio2019
   timeout_in: 120m
   env:


### PR DESCRIPTION
A rebased https://github.com/bitcoin/bitcoin/commit/fac3ae2333229109c4c65289fcdd6905d8f94467 from #23043.

The worst scenario (all caches are invalidated) tested in #23217.