### PR TITLE
test: reject float at satoshi_round

### DIFF
--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -57,7 +57,7 @@ def small_txpuzzle_randfee(from_node, conflist, unconflist, amount, min_fee, fee
     # It's best to exponentially distribute our random fees
     # because the buckets are exponentially spaced.
     # Exponentially distributed from 1-128 * fee_increment
-    rand_fee = float(fee_increment) * (1.1892 ** random.randint(0, 28))
+    rand_fee = fee_increment * Decimal(1.1892 ** random.randint(0, 28))
     # Total fee ranges from min_fee to min_fee + 127*fee_increment
     fee = min_fee - fee_increment + satoshi_round(rand_fee)
     tx = CTransaction()

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -209,10 +209,10 @@ class MempoolPackagesTest(BitcoinTestFramework):
             entry = self.nodes[0].getmempoolentry(x)
             descendant_fees += entry['fee']
             if (x == chain[-1]):
-                assert_equal(entry['modifiedfee'], entry['fee']+satoshi_round(0.00002))
-                assert_equal(entry['fees']['modified'], entry['fee']+satoshi_round(0.00002))
+                assert_equal(entry['modifiedfee'], entry['fee']+satoshi_round('0.00002'))
+                assert_equal(entry['fees']['modified'], entry['fee']+satoshi_round('0.00002'))
             assert_equal(entry['descendantfees'], descendant_fees * COIN + 2000)
-            assert_equal(entry['fees']['descendant'], descendant_fees+satoshi_round(0.00002))
+            assert_equal(entry['fees']['descendant'], descendant_fees+satoshi_round('0.00002'))
 
         # Check that node1's mempool is as expected (-> custom ancestor limit)
         mempool0 = self.nodes[0].getrawmempool(False)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -220,7 +220,7 @@ def str_to_b64str(string):
 
 def satoshi_round(amount):
     """ Doesn't accept floating point rational numbers. """
-    if type(amount) == type(0.1):
+    if isinstance(amount, float):
         # For best predictabilty do not convert floating point rational
         # numbers into fixed point rational numbers.
         raise TypeError(

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -219,6 +219,14 @@ def str_to_b64str(string):
 
 
 def satoshi_round(amount):
+    """ Doesn't accept floating point rational numbers. """
+    if type(amount) == type(0.1):
+        # For best predictabilty do not convert floating point rational
+        # numbers into fixed point rational numbers.
+        raise TypeError(
+            'contract transgression receiving {} of type {}'
+            ', try passing an integer or a string'.format(
+                amount, type(amount)))
     return Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
 
 


### PR DESCRIPTION
Using strings and integers will be more predictable than using float,
which is less repeatable.

satoshi_round was used with almost no floats already, I suppose
that because it rounds in a single direction and when floating
point rounding occurs it can go either up or downwards so it
is a risky thing to do. Forbid it explicitly.
