### PR TITLE
wallet: Add size check on meta.key_origin.path

### DIFF
--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -376,7 +376,10 @@ void LegacyScriptPubKeyMan::MarkUnusedAddresses(const CScript& script)
             CKeyMetadata meta = it->second;
             if (!meta.hd_seed_id.IsNull() && meta.hd_seed_id != m_hd_chain.seed_id) {
                 if (meta.key_origin.path.size() < 3) {
-                    WalletLogPrintf("%s: Adding inactive seed keys failed, insufficient path size: %d\n", __func__, meta.key_origin.path.size());
+                    WalletLogPrintf("%s: Adding inactive seed keys failed, insufficient path size: %d, has_key_origin: %s\n",
+                                    __func__,
+                                    meta.key_origin.path.size(),
+                                    meta.has_key_origin);
                 } else {
                     bool internal = (meta.key_origin.path[1] & ~BIP32_HARDENED_KEY_LIMIT) != 0;
                     int64_t index = meta.key_origin.path[2] & ~BIP32_HARDENED_KEY_LIMIT;

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -375,11 +375,15 @@ void LegacyScriptPubKeyMan::MarkUnusedAddresses(const CScript& script)
         if (it != mapKeyMetadata.end()){
             CKeyMetadata meta = it->second;
             if (!meta.hd_seed_id.IsNull() && meta.hd_seed_id != m_hd_chain.seed_id) {
-                bool internal = (meta.key_origin.path[1] & ~BIP32_HARDENED_KEY_LIMIT) != 0;
-                int64_t index = meta.key_origin.path[2] & ~BIP32_HARDENED_KEY_LIMIT;
+                if (meta.key_origin.path.size() < 3) {
+                    WalletLogPrintf("%s: Adding inactive seed keys failed, insufficient path size: %d\n", __func__, meta.key_origin.path.size());
+                } else {
+                    bool internal = (meta.key_origin.path[1] & ~BIP32_HARDENED_KEY_LIMIT) != 0;
+                    int64_t index = meta.key_origin.path[2] & ~BIP32_HARDENED_KEY_LIMIT;
 
-                if (!TopUpInactiveHDChain(meta.hd_seed_id, index, internal)) {
-                    WalletLogPrintf("%s: Adding inactive seed keys failed\n", __func__);
+                    if (!TopUpInactiveHDChain(meta.hd_seed_id, index, internal)) {
+                        WalletLogPrintf("%s: Adding inactive seed keys failed\n", __func__);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Resolves https://github.com/bitcoin/bitcoin/issues/21605 segfault on legacy wallet

I also encountered same [*] when resyncing a 2017 era blockchain.
* https://gist.github.com/rooprob/91d78358b920b8f8b7df78af8b2ce99c