### PR TITLE
init: Coalesce Chainstate loading sequence between {,non-}unittest codepaths

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -174,6 +174,7 @@ BITCOIN_CORE_H = \
   netbase.h \
   netmessagemaker.h \
   node/blockstorage.h \
+  node/chainstate.h \
   node/coin.h \
   node/coinstats.h \
   node/context.h \
@@ -339,6 +340,7 @@ libbitcoin_server_a_SOURCES = \
   net.cpp \
   net_processing.cpp \
   node/blockstorage.cpp \
+  node/chainstate.cpp \
   node/coin.cpp \
   node/coinstats.cpp \
   node/context.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -174,6 +174,7 @@ BITCOIN_CORE_H = \
   netbase.h \
   netmessagemaker.h \
   node/blockstorage.h \
+  node/caches.h \
   node/chainstate.h \
   node/coin.h \
   node/coinstats.h \
@@ -340,6 +341,7 @@ libbitcoin_server_a_SOURCES = \
   net.cpp \
   net_processing.cpp \
   node/blockstorage.cpp \
+  node/caches.cpp \
   node/chainstate.cpp \
   node/coin.cpp \
   node/coinstats.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1427,9 +1427,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                                  fReindexChainState,
                                  nBlockTreeDBCache,
                                  nCoinDBCache,
-                                 nCoinCacheUsage,
-                                 args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS),
-                                 args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL));
+                                 nCoinCacheUsage);
         if (rv.has_value()) {
             switch (rv.value()) {
             case ChainstateLoadingError::ERROR_LOADING_BLOCK_DB:
@@ -1461,20 +1459,34 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                 strLoadError = strprintf(_("Witness data for blocks after height %d requires validation. Please restart with -reindex."),
                                          chainparams.GetConsensus().SegwitHeight);
                 break;
-            case ChainstateLoadingError::ERROR_BLOCK_FROM_FUTURE:
-                strLoadError = _("The block database contains a block which appears to be from the future. "
-                                 "This may be due to your computer's date and time being set incorrectly. "
-                                 "Only rebuild the block database if you are sure that your computer's date and time are correct");
-                break;
-            case ChainstateLoadingError::ERROR_CORRUPTED_BLOCK_DB:
-                strLoadError = _("Corrupted block database detected");
-                break;
             case ChainstateLoadingError::SHUTDOWN_PROBED:
                 break;
             }
         } else {
-            fLoaded = true;
-            LogPrintf(" block index %15dms\n", GetTimeMillis() - load_block_index_start_time);
+            auto rv2 = VerifyLoadedChainstate(chainman,
+                                              fReset,
+                                              fReindexChainState,
+                                              chainparams,
+                                              args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS),
+                                              args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL));
+            if (rv2.has_value()) {
+                switch (rv2.value()) {
+                case ChainstateLoadVerifyError::ERROR_BLOCK_FROM_FUTURE:
+                    strLoadError = _("The block database contains a block which appears to be from the future. "
+                                     "This may be due to your computer's date and time being set incorrectly. "
+                                     "Only rebuild the block database if you are sure that your computer's date and time are correct");
+                    break;
+                case ChainstateLoadVerifyError::ERROR_CORRUPTED_BLOCK_DB:
+                    strLoadError = _("Corrupted block database detected");
+                    break;
+                case ChainstateLoadVerifyError::ERROR_GENERIC_FAILURE:
+                    strLoadError = _("Error opening block database");
+                    break;
+                }
+            } else {
+                fLoaded = true;
+                LogPrintf(" block index %15dms\n", GetTimeMillis() - load_block_index_start_time);
+            }
         }
 
         if (!fLoaded && !ShutdownRequested()) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1487,7 +1487,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                                              fReindexChainState,
                                              chainparams,
                                              check_blocks,
-                                             args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL));
+                                             args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL),
+                                             static_cast<int64_t(*)()>(GetTime));
             } catch (const std::exception& e) {
                 LogPrintf("%s\n", e.what());
                 rv2 = ChainstateLoadVerifyError::ERROR_GENERIC_FAILURE;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1777,7 +1777,17 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // ********************************************************* Step 13: finished
 
+    // At this point, the RPC is "started", but still in warmup, which means it
+    // cannot yet be called. Before we make it callable, we need to make sure
+    // that the RPC's view of the best block is valid and consistent with
+    // ChainstateManager's ActiveTip.
+    //
+    // If we do not do this, RPC's view of the best block will be height=0 and
+    // hash=0x0. This will lead to erroroneous responses for things like
+    // waitforblockheight.
+    RPCNotifyBlockChange(chainman.ActiveTip());
     SetRPCWarmupFinished();
+
     uiInterface.InitMessage(_("Done loading").translated);
 
     for (const auto& client : node.chain_clients) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1436,6 +1436,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                 strLoadError = _("Error loading block database");
                 break;
             case ChainstateLoadingError::ERROR_BAD_GENESIS_BLOCK:
+                // If the loaded chain has a wrong genesis, bail out immediately
+                // (we're likely using a testnet datadir, or the other way around).
                 return InitError(_("Incorrect or no genesis block found. Wrong datadir for network?"));
             case ChainstateLoadingError::ERROR_PRUNED_NEEDS_REINDEX:
                 strLoadError = _("You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1415,6 +1415,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                                 cache_sizes.block_tree_db,
                                 cache_sizes.coins_db,
                                 cache_sizes.coins,
+                                false,
+                                false,
                                 ShutdownRequested,
                                 []() {
                                     uiInterface.ThreadSafeMessageBox(

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1477,11 +1477,16 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             std::optional<ChainstateLoadVerifyError> rv2;
             try {
                 uiInterface.InitMessage(_("Verifying blocks…").translated);
+                auto check_blocks = args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS);
+                if (fHavePruned && check_blocks > MIN_BLOCKS_TO_KEEP) {
+                    LogPrintf("Prune: pruned datadir may not have more than %d blocks; only checking available blocks\n",
+                              MIN_BLOCKS_TO_KEEP);
+                }
                 rv2 = VerifyLoadedChainstate(chainman,
                                              fReset,
                                              fReindexChainState,
                                              chainparams,
-                                             args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS),
+                                             check_blocks,
                                              args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL));
             } catch (const std::exception& e) {
                 LogPrintf("%s\n", e.what());

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -34,8 +34,8 @@
 #include <net_processing.h>
 #include <netbase.h>
 #include <node/blockstorage.h>
-#include <node/caches.h> // for CalculateCacheSizes
-#include <node/chainstate.h> // for LoadChainstate
+#include <node/caches.h>
+#include <node/chainstate.h>
 #include <node/context.h>
 #include <node/miner.h>
 #include <node/ui_interface.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1421,7 +1421,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         const int64_t load_block_index_start_time = GetTimeMillis();
         auto rv = LoadChainstate(fReset,
                                  chainman,
-                                 node.mempool.get(),
+                                 Assert(node.mempool.get()),
                                  fPruneMode,
                                  chainparams,
                                  fReindexChainState,

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1427,7 +1427,12 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                                  fReindexChainState,
                                  nBlockTreeDBCache,
                                  nCoinDBCache,
-                                 nCoinCacheUsage);
+                                 nCoinCacheUsage,
+                                 []() {
+                                     uiInterface.ThreadSafeMessageBox(
+                                         _("Error reading from database, shutting down."),
+                                         "", CClientUIInterface::MSG_ERROR);
+                                 });
         if (rv.has_value()) {
             switch (rv.value()) {
             case ChainstateLoadingError::ERROR_LOADING_BLOCK_DB:
@@ -1463,6 +1468,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                 break;
             }
         } else {
+            uiInterface.InitMessage(_("Verifying blocks…").translated);
             auto rv2 = VerifyLoadedChainstate(chainman,
                                               fReset,
                                               fReindexChainState,

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1424,11 +1424,12 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                                  node,
                                  fPruneMode,
                                  chainparams,
-                                 args,
                                  fReindexChainState,
                                  nBlockTreeDBCache,
                                  nCoinDBCache,
-                                 nCoinCacheUsage);
+                                 nCoinCacheUsage,
+                                 args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS),
+                                 args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL));
         if (rv.has_value()) {
             switch (rv.value()) {
             case ChainstateLoadingError::ERROR_LOADING_BLOCK_DB:

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1430,6 +1430,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                                 nBlockTreeDBCache,
                                 nCoinDBCache,
                                 nCoinCacheUsage,
+                                ShutdownRequested,
                                 []() {
                                     uiInterface.ThreadSafeMessageBox(
                                                                      _("Error reading from database, shutting down."),

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1421,7 +1421,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         const int64_t load_block_index_start_time = GetTimeMillis();
         auto rv = LoadChainstate(fReset,
                                  chainman,
-                                 node,
+                                 node.mempool.get(),
                                  fPruneMode,
                                  chainparams,
                                  fReindexChainState,

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1419,6 +1419,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
         uiInterface.InitMessage(_("Loading block index…").translated);
 
+        const int64_t load_block_index_start_time = GetTimeMillis();
         bool rv = LoadChainstate(fLoaded,
                                  strLoadError,
                                  fReset,
@@ -1432,6 +1433,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                                  nCoinDBCache,
                                  nCoinCacheUsage);
         if (!rv) return false;
+        if (fLoaded) {
+            LogPrintf(" block index %15dms\n", GetTimeMillis() - load_block_index_start_time);
+        }
 
         if (!fLoaded && !ShutdownRequested()) {
             // first suggest a reindex

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -34,6 +34,7 @@
 #include <net_processing.h>
 #include <netbase.h>
 #include <node/blockstorage.h>
+#include <node/caches.h> // for CalculateCacheSizes
 #include <node/chainstate.h> // for LoadChainstate
 #include <node/context.h>
 #include <node/miner.h>
@@ -1381,36 +1382,20 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     bool fReindexChainState = args.GetBoolArg("-reindex-chainstate", false);
 
     // cache size calculations
-    int64_t nTotalCache = (args.GetIntArg("-dbcache", nDefaultDbCache) << 20);
-    nTotalCache = std::max(nTotalCache, nMinDbCache << 20); // total cache cannot be less than nMinDbCache
-    nTotalCache = std::min(nTotalCache, nMaxDbCache << 20); // total cache cannot be greater than nMaxDbcache
-    int64_t nBlockTreeDBCache = std::min(nTotalCache / 8, nMaxBlockDBCache << 20);
-    nTotalCache -= nBlockTreeDBCache;
-    int64_t nTxIndexCache = std::min(nTotalCache / 8, args.GetBoolArg("-txindex", DEFAULT_TXINDEX) ? nMaxTxIndexCache << 20 : 0);
-    nTotalCache -= nTxIndexCache;
-    int64_t filter_index_cache = 0;
-    if (!g_enabled_filter_types.empty()) {
-        size_t n_indexes = g_enabled_filter_types.size();
-        int64_t max_cache = std::min(nTotalCache / 8, max_filter_index_cache << 20);
-        filter_index_cache = max_cache / n_indexes;
-        nTotalCache -= filter_index_cache * n_indexes;
-    }
-    int64_t nCoinDBCache = std::min(nTotalCache / 2, (nTotalCache / 4) + (1 << 23)); // use 25%-50% of the remainder for disk cache
-    nCoinDBCache = std::min(nCoinDBCache, nMaxCoinsDBCache << 20); // cap total coins db cache
-    nTotalCache -= nCoinDBCache;
-    int64_t nCoinCacheUsage = nTotalCache; // the rest goes to in-memory cache
+    CacheSizes cache_sizes = CalculateCacheSizes(args, g_enabled_filter_types.size());
+
     int64_t nMempoolSizeMax = args.GetIntArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
     LogPrintf("Cache configuration:\n");
-    LogPrintf("* Using %.1f MiB for block index database\n", nBlockTreeDBCache * (1.0 / 1024 / 1024));
+    LogPrintf("* Using %.1f MiB for block index database\n", cache_sizes.block_tree_db * (1.0 / 1024 / 1024));
     if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
-        LogPrintf("* Using %.1f MiB for transaction index database\n", nTxIndexCache * (1.0 / 1024 / 1024));
+        LogPrintf("* Using %.1f MiB for transaction index database\n", cache_sizes.tx_index * (1.0 / 1024 / 1024));
     }
     for (BlockFilterType filter_type : g_enabled_filter_types) {
         LogPrintf("* Using %.1f MiB for %s block filter index database\n",
-                  filter_index_cache * (1.0 / 1024 / 1024), BlockFilterTypeName(filter_type));
+                  cache_sizes.filter_index * (1.0 / 1024 / 1024), BlockFilterTypeName(filter_type));
     }
-    LogPrintf("* Using %.1f MiB for chain state database\n", nCoinDBCache * (1.0 / 1024 / 1024));
-    LogPrintf("* Using %.1f MiB for in-memory UTXO set (plus up to %.1f MiB of unused mempool space)\n", nCoinCacheUsage * (1.0 / 1024 / 1024), nMempoolSizeMax * (1.0 / 1024 / 1024));
+    LogPrintf("* Using %.1f MiB for chain state database\n", cache_sizes.coins_db * (1.0 / 1024 / 1024));
+    LogPrintf("* Using %.1f MiB for in-memory UTXO set (plus up to %.1f MiB of unused mempool space)\n", cache_sizes.coins * (1.0 / 1024 / 1024), nMempoolSizeMax * (1.0 / 1024 / 1024));
 
     bool fLoaded = false;
     while (!fLoaded && !ShutdownRequested()) {
@@ -1427,9 +1412,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                                 fPruneMode,
                                 chainparams.GetConsensus(),
                                 fReindexChainState,
-                                nBlockTreeDBCache,
-                                nCoinDBCache,
-                                nCoinCacheUsage,
+                                cache_sizes.block_tree_db,
+                                cache_sizes.coins_db,
+                                cache_sizes.coins,
                                 ShutdownRequested,
                                 []() {
                                     uiInterface.ThreadSafeMessageBox(
@@ -1548,14 +1533,14 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             return InitError(*error);
         }
 
-        g_txindex = std::make_unique<TxIndex>(nTxIndexCache, false, fReindex);
+        g_txindex = std::make_unique<TxIndex>(cache_sizes.tx_index, false, fReindex);
         if (!g_txindex->Start(chainman.ActiveChainstate())) {
             return false;
         }
     }
 
     for (const auto& filter_type : g_enabled_filter_types) {
-        InitBlockFilterIndex(filter_type, filter_index_cache, false, fReindex);
+        InitBlockFilterIndex(filter_type, cache_sizes.filter_index, false, fReindex);
         if (!GetBlockFilterIndex(filter_type)->Start(chainman.ActiveChainstate())) {
             return false;
         }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1425,7 +1425,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                                 chainman,
                                 Assert(node.mempool.get()),
                                 fPruneMode,
-                                chainparams,
+                                chainparams.GetConsensus(),
                                 fReindexChainState,
                                 nBlockTreeDBCache,
                                 nCoinDBCache,
@@ -1486,7 +1486,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                 rv2 = VerifyLoadedChainstate(chainman,
                                              fReset,
                                              fReindexChainState,
-                                             chainparams,
+                                             chainparams.GetConsensus(),
                                              check_blocks,
                                              args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL),
                                              static_cast<int64_t(*)()>(GetTime));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -34,6 +34,7 @@
 #include <net_processing.h>
 #include <netbase.h>
 #include <node/blockstorage.h>
+#include <node/chainstate.h> // for LoadChainstate
 #include <node/context.h>
 #include <node/miner.h>
 #include <node/ui_interface.h>
@@ -1414,183 +1415,23 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     bool fLoaded = false;
     while (!fLoaded && !ShutdownRequested()) {
         const bool fReset = fReindex;
-        auto is_coinsview_empty = [&](CChainState* chainstate) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
-            return fReset || fReindexChainState || chainstate->CoinsTip().GetBestBlock().IsNull();
-        };
         bilingual_str strLoadError;
 
         uiInterface.InitMessage(_("Loading block index…").translated);
 
-        do {
-            const int64_t load_block_index_start_time = GetTimeMillis();
-            try {
-                LOCK(cs_main);
-                chainman.InitializeChainstate(Assert(node.mempool.get()));
-                chainman.m_total_coinstip_cache = nCoinCacheUsage;
-                chainman.m_total_coinsdb_cache = nCoinDBCache;
-
-                UnloadBlockIndex(node.mempool.get(), chainman);
-
-                auto& pblocktree{chainman.m_blockman.m_block_tree_db};
-                // new CBlockTreeDB tries to delete the existing file, which
-                // fails if it's still open from the previous loop. Close it first:
-                pblocktree.reset();
-                pblocktree.reset(new CBlockTreeDB(nBlockTreeDBCache, false, fReset));
-
-                if (fReset) {
-                    pblocktree->WriteReindexing(true);
-                    //If we're reindexing in prune mode, wipe away unusable block files and all undo data files
-                    if (fPruneMode)
-                        CleanupBlockRevFiles();
-                }
-
-                if (ShutdownRequested()) break;
-
-                // LoadBlockIndex will load fHavePruned if we've ever removed a
-                // block file from disk.
-                // Note that it also sets fReindex based on the disk flag!
-                // From here on out fReindex and fReset mean something different!
-                if (!chainman.LoadBlockIndex()) {
-                    if (ShutdownRequested()) break;
-                    strLoadError = _("Error loading block database");
-                    break;
-                }
-
-                // If the loaded chain has a wrong genesis, bail out immediately
-                // (we're likely using a testnet datadir, or the other way around).
-                if (!chainman.BlockIndex().empty() &&
-                        !chainman.m_blockman.LookupBlockIndex(chainparams.GetConsensus().hashGenesisBlock)) {
-                    return InitError(_("Incorrect or no genesis block found. Wrong datadir for network?"));
-                }
-
-                // Check for changed -prune state.  What we are concerned about is a user who has pruned blocks
-                // in the past, but is now trying to run unpruned.
-                if (fHavePruned && !fPruneMode) {
-                    strLoadError = _("You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain");
-                    break;
-                }
-
-                // At this point blocktree args are consistent with what's on disk.
-                // If we're not mid-reindex (based on disk + args), add a genesis block on disk
-                // (otherwise we use the one already on disk).
-                // This is called again in ThreadImport after the reindex completes.
-                if (!fReindex && !chainman.ActiveChainstate().LoadGenesisBlock()) {
-                    strLoadError = _("Error initializing block database");
-                    break;
-                }
-
-                // At this point we're either in reindex or we've loaded a useful
-                // block tree into BlockIndex()!
-
-                bool failed_chainstate_init = false;
-
-                for (CChainState* chainstate : chainman.GetAll()) {
-                    chainstate->InitCoinsDB(
-                        /* cache_size_bytes */ nCoinDBCache,
-                        /* in_memory */ false,
-                        /* should_wipe */ fReset || fReindexChainState);
-
-                    chainstate->CoinsErrorCatcher().AddReadErrCallback([]() {
-                        uiInterface.ThreadSafeMessageBox(
-                            _("Error reading from database, shutting down."),
-                            "", CClientUIInterface::MSG_ERROR);
-                    });
-
-                    // If necessary, upgrade from older database format.
-                    // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
-                    if (!chainstate->CoinsDB().Upgrade()) {
-                        strLoadError = _("Error upgrading chainstate database");
-                        failed_chainstate_init = true;
-                        break;
-                    }
-
-                    // ReplayBlocks is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
-                    if (!chainstate->ReplayBlocks()) {
-                        strLoadError = _("Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.");
-                        failed_chainstate_init = true;
-                        break;
-                    }
-
-                    // The on-disk coinsdb is now in a good state, create the cache
-                    chainstate->InitCoinsCache(nCoinCacheUsage);
-                    assert(chainstate->CanFlushToDisk());
-
-                    if (!is_coinsview_empty(chainstate)) {
-                        // LoadChainTip initializes the chain based on CoinsTip()'s best block
-                        if (!chainstate->LoadChainTip()) {
-                            strLoadError = _("Error initializing block database");
-                            failed_chainstate_init = true;
-                            break; // out of the per-chainstate loop
-                        }
-                        assert(chainstate->m_chain.Tip() != nullptr);
-                    }
-                }
-
-                if (failed_chainstate_init) {
-                    break; // out of the chainstate activation do-while
-                }
-            } catch (const std::exception& e) {
-                LogPrintf("%s\n", e.what());
-                strLoadError = _("Error opening block database");
-                break;
-            }
-
-            if (!fReset) {
-                LOCK(cs_main);
-                auto chainstates{chainman.GetAll()};
-                if (std::any_of(chainstates.begin(), chainstates.end(),
-                                [](const CChainState* cs) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return cs->NeedsRedownload(); })) {
-                    strLoadError = strprintf(_("Witness data for blocks after height %d requires validation. Please restart with -reindex."),
-                                             chainparams.GetConsensus().SegwitHeight);
-                    break;
-                }
-            }
-
-            bool failed_verification = false;
-
-            try {
-                LOCK(cs_main);
-
-                for (CChainState* chainstate : chainman.GetAll()) {
-                    if (!is_coinsview_empty(chainstate)) {
-                        uiInterface.InitMessage(_("Verifying blocks…").translated);
-                        if (fHavePruned && args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS) > MIN_BLOCKS_TO_KEEP) {
-                            LogPrintf("Prune: pruned datadir may not have more than %d blocks; only checking available blocks\n",
-                                MIN_BLOCKS_TO_KEEP);
-                        }
-
-                        const CBlockIndex* tip = chainstate->m_chain.Tip();
-                        RPCNotifyBlockChange(tip);
-                        if (tip && tip->nTime > GetTime() + MAX_FUTURE_BLOCK_TIME) {
-                            strLoadError = _("The block database contains a block which appears to be from the future. "
-                                    "This may be due to your computer's date and time being set incorrectly. "
-                                    "Only rebuild the block database if you are sure that your computer's date and time are correct");
-                            failed_verification = true;
-                            break;
-                        }
-
-                        if (!CVerifyDB().VerifyDB(
-                                *chainstate, chainparams, chainstate->CoinsDB(),
-                                args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL),
-                                args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS))) {
-                            strLoadError = _("Corrupted block database detected");
-                            failed_verification = true;
-                            break;
-                        }
-                    }
-                }
-            } catch (const std::exception& e) {
-                LogPrintf("%s\n", e.what());
-                strLoadError = _("Error opening block database");
-                failed_verification = true;
-                break;
-            }
-
-            if (!failed_verification) {
-                fLoaded = true;
-                LogPrintf(" block index %15dms\n", GetTimeMillis() - load_block_index_start_time);
-            }
-        } while(false);
+        bool rv = LoadChainstate(fLoaded,
+                                 strLoadError,
+                                 fReset,
+                                 chainman,
+                                 node,
+                                 fPruneMode,
+                                 chainparams,
+                                 args,
+                                 fReindexChainState,
+                                 nBlockTreeDBCache,
+                                 nCoinDBCache,
+                                 nCoinCacheUsage);
+        if (!rv) return false;
 
         if (!fLoaded && !ShutdownRequested()) {
             // first suggest a reindex

--- a/src/node/caches.cpp
+++ b/src/node/caches.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/caches.h>
+
+#include <txdb.h>
+#include <util/system.h>
+#include <validation.h>
+
+CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes)
+{
+    int64_t nTotalCache = (args.GetIntArg("-dbcache", nDefaultDbCache) << 20);
+    nTotalCache = std::max(nTotalCache, nMinDbCache << 20); // total cache cannot be less than nMinDbCache
+    nTotalCache = std::min(nTotalCache, nMaxDbCache << 20); // total cache cannot be greater than nMaxDbcache
+    int64_t nBlockTreeDBCache = std::min(nTotalCache / 8, nMaxBlockDBCache << 20);
+    nTotalCache -= nBlockTreeDBCache;
+    int64_t nTxIndexCache = std::min(nTotalCache / 8, args.GetBoolArg("-txindex", DEFAULT_TXINDEX) ? nMaxTxIndexCache << 20 : 0);
+    nTotalCache -= nTxIndexCache;
+    int64_t filter_index_cache = 0;
+    if (n_indexes > 0) {
+        int64_t max_cache = std::min(nTotalCache / 8, max_filter_index_cache << 20);
+        filter_index_cache = max_cache / n_indexes;
+        nTotalCache -= filter_index_cache * n_indexes;
+    }
+    int64_t nCoinDBCache = std::min(nTotalCache / 2, (nTotalCache / 4) + (1 << 23)); // use 25%-50% of the remainder for disk cache
+    nCoinDBCache = std::min(nCoinDBCache, nMaxCoinsDBCache << 20); // cap total coins db cache
+    nTotalCache -= nCoinDBCache;
+    int64_t nCoinCacheUsage = nTotalCache; // the rest goes to in-memory cache
+
+    return {
+        nBlockTreeDBCache,
+        nCoinDBCache,
+        nCoinCacheUsage,
+        nTxIndexCache,
+        filter_index_cache,
+    };
+}

--- a/src/node/caches.cpp
+++ b/src/node/caches.cpp
@@ -13,26 +13,20 @@ CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes)
     int64_t nTotalCache = (args.GetIntArg("-dbcache", nDefaultDbCache) << 20);
     nTotalCache = std::max(nTotalCache, nMinDbCache << 20); // total cache cannot be less than nMinDbCache
     nTotalCache = std::min(nTotalCache, nMaxDbCache << 20); // total cache cannot be greater than nMaxDbcache
-    int64_t nBlockTreeDBCache = std::min(nTotalCache / 8, nMaxBlockDBCache << 20);
-    nTotalCache -= nBlockTreeDBCache;
-    int64_t nTxIndexCache = std::min(nTotalCache / 8, args.GetBoolArg("-txindex", DEFAULT_TXINDEX) ? nMaxTxIndexCache << 20 : 0);
-    nTotalCache -= nTxIndexCache;
-    int64_t filter_index_cache = 0;
+    CacheSizes sizes;
+    sizes.block_tree_db = std::min(nTotalCache / 8, nMaxBlockDBCache << 20);
+    nTotalCache -= sizes.block_tree_db;
+    sizes.tx_index = std::min(nTotalCache / 8, args.GetBoolArg("-txindex", DEFAULT_TXINDEX) ? nMaxTxIndexCache << 20 : 0);
+    nTotalCache -= sizes.tx_index;
+    sizes.filter_index = 0;
     if (n_indexes > 0) {
         int64_t max_cache = std::min(nTotalCache / 8, max_filter_index_cache << 20);
-        filter_index_cache = max_cache / n_indexes;
-        nTotalCache -= filter_index_cache * n_indexes;
+        sizes.filter_index = max_cache / n_indexes;
+        nTotalCache -= sizes.filter_index * n_indexes;
     }
-    int64_t nCoinDBCache = std::min(nTotalCache / 2, (nTotalCache / 4) + (1 << 23)); // use 25%-50% of the remainder for disk cache
-    nCoinDBCache = std::min(nCoinDBCache, nMaxCoinsDBCache << 20); // cap total coins db cache
-    nTotalCache -= nCoinDBCache;
-    int64_t nCoinCacheUsage = nTotalCache; // the rest goes to in-memory cache
-
-    return {
-        nBlockTreeDBCache,
-        nCoinDBCache,
-        nCoinCacheUsage,
-        nTxIndexCache,
-        filter_index_cache,
-    };
+    sizes.coins_db = std::min(nTotalCache / 2, (nTotalCache / 4) + (1 << 23)); // use 25%-50% of the remainder for disk cache
+    sizes.coins_db = std::min(sizes.coins_db, nMaxCoinsDBCache << 20); // cap total coins db cache
+    nTotalCache -= sizes.coins_db;
+    sizes.coins = nTotalCache; // the rest goes to in-memory cache
+    return sizes;
 }

--- a/src/node/caches.h
+++ b/src/node/caches.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_CACHES_H
+#define BITCOIN_NODE_CACHES_H
+
+#include <cstddef> // for size_t
+#include <cstdint> // for int64_t
+
+class ArgsManager;
+
+struct CacheSizes {
+    int64_t block_tree_db;
+    int64_t coins_db;
+    int64_t coins;
+    int64_t tx_index;
+    int64_t filter_index;
+};
+CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes = 0);
+
+#endif // BITCOIN_NODE_CACHES_H

--- a/src/node/caches.h
+++ b/src/node/caches.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_NODE_CACHES_H
 #define BITCOIN_NODE_CACHES_H
 
-#include <cstddef> // for size_t
-#include <cstdint> // for int64_t
+#include <cstddef>
+#include <cstdint>
 
 class ArgsManager;
 

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -17,6 +17,8 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
                                                      int64_t nBlockTreeDBCache,
                                                      int64_t nCoinDBCache,
                                                      int64_t nCoinCacheUsage,
+                                                     bool block_tree_db_in_memory,
+                                                     bool coins_db_in_memory,
                                                      std::function<bool()> shutdown_requested,
                                                      std::function<void()> coins_error_cb)
 {
@@ -36,7 +38,7 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
         // new CBlockTreeDB tries to delete the existing file, which
         // fails if it's still open from the previous loop. Close it first:
         pblocktree.reset();
-        pblocktree.reset(new CBlockTreeDB(nBlockTreeDBCache, false, fReset));
+        pblocktree.reset(new CBlockTreeDB(nBlockTreeDBCache, block_tree_db_in_memory, fReset));
 
         if (fReset) {
             pblocktree->WriteReindexing(true);
@@ -81,7 +83,7 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
         for (CChainState* chainstate : chainman.GetAll()) {
             chainstate->InitCoinsDB(
                 /* cache_size_bytes */ nCoinDBCache,
-                /* in_memory */ false,
+                /* in_memory */ coins_db_in_memory,
                 /* should_wipe */ fReset || fReindexChainState);
 
             if (coins_error_cb) {

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -7,25 +7,23 @@
 #include <chainparams.h> // for CChainParams
 #include <rpc/blockchain.h> // for RPCNotifyBlockChange
 #include <util/time.h> // for GetTime
-#include <util/translation.h> // for bilingual_str
 #include <node/blockstorage.h> // for CleanupBlockRevFiles, fHavePruned, fReindex
 #include <node/context.h> // for NodeContext
 #include <node/ui_interface.h> // for InitError, uiInterface, and CClientUIInterface member access
 #include <shutdown.h> // for ShutdownRequested
 #include <validation.h> // for a lot of things
 
-bool LoadChainstate(bool& fLoaded,
-                    bilingual_str& strLoadError,
-                    bool fReset,
-                    ChainstateManager& chainman,
-                    NodeContext& node,
-                    bool fPruneMode,
-                    const CChainParams& chainparams,
-                    const ArgsManager& args,
-                    bool fReindexChainState,
-                    int64_t nBlockTreeDBCache,
-                    int64_t nCoinDBCache,
-                    int64_t nCoinCacheUsage) {
+std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
+                                                     ChainstateManager& chainman,
+                                                     NodeContext& node,
+                                                     bool fPruneMode,
+                                                     const CChainParams& chainparams,
+                                                     const ArgsManager& args,
+                                                     bool fReindexChainState,
+                                                     int64_t nBlockTreeDBCache,
+                                                     int64_t nCoinDBCache,
+                                                     int64_t nCoinCacheUsage)
+{
     auto is_coinsview_empty = [&](CChainState* chainstate) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
         return fReset || fReindexChainState || chainstate->CoinsTip().GetBestBlock().IsNull();
     };
@@ -52,30 +50,28 @@ bool LoadChainstate(bool& fLoaded,
                     CleanupBlockRevFiles();
             }
 
-            if (ShutdownRequested()) break;
+            if (ShutdownRequested()) return ChainstateLoadingError::SHUTDOWN_PROBED;
 
             // LoadBlockIndex will load fHavePruned if we've ever removed a
             // block file from disk.
             // Note that it also sets fReindex based on the disk flag!
             // From here on out fReindex and fReset mean something different!
             if (!chainman.LoadBlockIndex()) {
-                if (ShutdownRequested()) break;
-                strLoadError = _("Error loading block database");
-                break;
+                if (ShutdownRequested()) return ChainstateLoadingError::SHUTDOWN_PROBED;
+                return ChainstateLoadingError::ERROR_LOADING_BLOCK_DB;
             }
 
             // If the loaded chain has a wrong genesis, bail out immediately
             // (we're likely using a testnet datadir, or the other way around).
             if (!chainman.BlockIndex().empty() &&
                     !chainman.m_blockman.LookupBlockIndex(chainparams.GetConsensus().hashGenesisBlock)) {
-                return InitError(_("Incorrect or no genesis block found. Wrong datadir for network?"));
+                return ChainstateLoadingError::ERROR_BAD_GENESIS_BLOCK;
             }
 
             // Check for changed -prune state.  What we are concerned about is a user who has pruned blocks
             // in the past, but is now trying to run unpruned.
             if (fHavePruned && !fPruneMode) {
-                strLoadError = _("You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain");
-                break;
+                return ChainstateLoadingError::ERROR_PRUNED_NEEDS_REINDEX;
             }
 
             // At this point blocktree args are consistent with what's on disk.
@@ -83,14 +79,11 @@ bool LoadChainstate(bool& fLoaded,
             // (otherwise we use the one already on disk).
             // This is called again in ThreadImport after the reindex completes.
             if (!fReindex && !chainman.ActiveChainstate().LoadGenesisBlock()) {
-                strLoadError = _("Error initializing block database");
-                break;
+                return ChainstateLoadingError::ERROR_LOAD_GENESIS_BLOCK_FAILED;
             }
 
             // At this point we're either in reindex or we've loaded a useful
             // block tree into BlockIndex()!
-
-            bool failed_chainstate_init = false;
 
             for (CChainState* chainstate : chainman.GetAll()) {
                 chainstate->InitCoinsDB(
@@ -107,16 +100,12 @@ bool LoadChainstate(bool& fLoaded,
                 // If necessary, upgrade from older database format.
                 // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
                 if (!chainstate->CoinsDB().Upgrade()) {
-                    strLoadError = _("Error upgrading chainstate database");
-                    failed_chainstate_init = true;
-                    break;
+                    return ChainstateLoadingError::ERROR_CHAINSTATE_UPGRADE_FAILED;
                 }
 
                 // ReplayBlocks is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
                 if (!chainstate->ReplayBlocks()) {
-                    strLoadError = _("Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.");
-                    failed_chainstate_init = true;
-                    break;
+                    return ChainstateLoadingError::ERROR_REPLAYBLOCKS_FAILED;
                 }
 
                 // The on-disk coinsdb is now in a good state, create the cache
@@ -126,21 +115,14 @@ bool LoadChainstate(bool& fLoaded,
                 if (!is_coinsview_empty(chainstate)) {
                     // LoadChainTip initializes the chain based on CoinsTip()'s best block
                     if (!chainstate->LoadChainTip()) {
-                        strLoadError = _("Error initializing block database");
-                        failed_chainstate_init = true;
-                        break; // out of the per-chainstate loop
+                        return ChainstateLoadingError::ERROR_LOADCHAINTIP_FAILED;
                     }
                     assert(chainstate->m_chain.Tip() != nullptr);
                 }
             }
-
-            if (failed_chainstate_init) {
-                break; // out of the chainstate activation do-while
-            }
         } catch (const std::exception& e) {
             LogPrintf("%s\n", e.what());
-            strLoadError = _("Error opening block database");
-            break;
+            return ChainstateLoadingError::ERROR_GENERIC_BLOCKDB_OPEN_FAILED;
         }
 
         if (!fReset) {
@@ -148,13 +130,9 @@ bool LoadChainstate(bool& fLoaded,
             auto chainstates{chainman.GetAll()};
             if (std::any_of(chainstates.begin(), chainstates.end(),
                             [](const CChainState* cs) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return cs->NeedsRedownload(); })) {
-                strLoadError = strprintf(_("Witness data for blocks after height %d requires validation. Please restart with -reindex."),
-                                         chainparams.GetConsensus().SegwitHeight);
-                break;
+                return ChainstateLoadingError::ERROR_BLOCKS_WITNESS_INSUFFICIENTLY_VALIDATED;
             }
         }
-
-        bool failed_verification = false;
 
         try {
             LOCK(cs_main);
@@ -170,33 +148,21 @@ bool LoadChainstate(bool& fLoaded,
                     const CBlockIndex* tip = chainstate->m_chain.Tip();
                     RPCNotifyBlockChange(tip);
                     if (tip && tip->nTime > GetTime() + MAX_FUTURE_BLOCK_TIME) {
-                        strLoadError = _("The block database contains a block which appears to be from the future. "
-                                "This may be due to your computer's date and time being set incorrectly. "
-                                "Only rebuild the block database if you are sure that your computer's date and time are correct");
-                        failed_verification = true;
-                        break;
+                        return ChainstateLoadingError::ERROR_BLOCK_FROM_FUTURE;
                     }
 
                     if (!CVerifyDB().VerifyDB(
                             *chainstate, chainparams, chainstate->CoinsDB(),
                             args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL),
                             args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS))) {
-                        strLoadError = _("Corrupted block database detected");
-                        failed_verification = true;
-                        break;
+                        return ChainstateLoadingError::ERROR_CORRUPTED_BLOCK_DB;
                     }
                 }
             }
         } catch (const std::exception& e) {
             LogPrintf("%s\n", e.what());
-            strLoadError = _("Error opening block database");
-            failed_verification = true;
-            break;
-        }
-
-        if (!failed_verification) {
-            fLoaded = true;
+            return ChainstateLoadingError::ERROR_GENERIC_BLOCKDB_OPEN_FAILED;
         }
     } while(false);
-    return true;
+    return std::nullopt;
 }

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -4,9 +4,9 @@
 
 #include <node/chainstate.h>
 
-#include <consensus/params.h> // for Consensus::Params
-#include <node/blockstorage.h> // for CleanupBlockRevFiles, fHavePruned, fReindex
-#include <validation.h> // for a lot of things
+#include <consensus/params.h>
+#include <node/blockstorage.h>
+#include <validation.h>
 
 std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
                                                      ChainstateManager& chainman,

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -6,7 +6,7 @@
 
 #include <chainparams.h> // for CChainParams
 #include <rpc/blockchain.h> // for RPCNotifyBlockChange
-#include <util/time.h> // for GetTime, GetTimeMillis
+#include <util/time.h> // for GetTime
 #include <util/translation.h> // for bilingual_str
 #include <node/blockstorage.h> // for CleanupBlockRevFiles, fHavePruned, fReindex
 #include <node/context.h> // for NodeContext
@@ -31,7 +31,6 @@ bool LoadChainstate(bool& fLoaded,
     };
 
     do {
-        const int64_t load_block_index_start_time = GetTimeMillis();
         try {
             LOCK(cs_main);
             chainman.InitializeChainstate(Assert(node.mempool.get()));
@@ -197,7 +196,6 @@ bool LoadChainstate(bool& fLoaded,
 
         if (!failed_verification) {
             fLoaded = true;
-            LogPrintf(" block index %15dms\n", GetTimeMillis() - load_block_index_start_time);
         }
     } while(false);
     return true;

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -1,0 +1,204 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/chainstate.h>
+
+#include <chainparams.h> // for CChainParams
+#include <rpc/blockchain.h> // for RPCNotifyBlockChange
+#include <util/time.h> // for GetTime, GetTimeMillis
+#include <util/translation.h> // for bilingual_str
+#include <node/blockstorage.h> // for CleanupBlockRevFiles, fHavePruned, fReindex
+#include <node/context.h> // for NodeContext
+#include <node/ui_interface.h> // for InitError, uiInterface, and CClientUIInterface member access
+#include <shutdown.h> // for ShutdownRequested
+#include <validation.h> // for a lot of things
+
+bool LoadChainstate(bool& fLoaded,
+                    bilingual_str& strLoadError,
+                    bool fReset,
+                    ChainstateManager& chainman,
+                    NodeContext& node,
+                    bool fPruneMode,
+                    const CChainParams& chainparams,
+                    const ArgsManager& args,
+                    bool fReindexChainState,
+                    int64_t nBlockTreeDBCache,
+                    int64_t nCoinDBCache,
+                    int64_t nCoinCacheUsage) {
+    auto is_coinsview_empty = [&](CChainState* chainstate) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
+        return fReset || fReindexChainState || chainstate->CoinsTip().GetBestBlock().IsNull();
+    };
+
+    do {
+        const int64_t load_block_index_start_time = GetTimeMillis();
+        try {
+            LOCK(cs_main);
+            chainman.InitializeChainstate(Assert(node.mempool.get()));
+            chainman.m_total_coinstip_cache = nCoinCacheUsage;
+            chainman.m_total_coinsdb_cache = nCoinDBCache;
+
+            UnloadBlockIndex(node.mempool.get(), chainman);
+
+            auto& pblocktree{chainman.m_blockman.m_block_tree_db};
+            // new CBlockTreeDB tries to delete the existing file, which
+            // fails if it's still open from the previous loop. Close it first:
+            pblocktree.reset();
+            pblocktree.reset(new CBlockTreeDB(nBlockTreeDBCache, false, fReset));
+
+            if (fReset) {
+                pblocktree->WriteReindexing(true);
+                //If we're reindexing in prune mode, wipe away unusable block files and all undo data files
+                if (fPruneMode)
+                    CleanupBlockRevFiles();
+            }
+
+            if (ShutdownRequested()) break;
+
+            // LoadBlockIndex will load fHavePruned if we've ever removed a
+            // block file from disk.
+            // Note that it also sets fReindex based on the disk flag!
+            // From here on out fReindex and fReset mean something different!
+            if (!chainman.LoadBlockIndex()) {
+                if (ShutdownRequested()) break;
+                strLoadError = _("Error loading block database");
+                break;
+            }
+
+            // If the loaded chain has a wrong genesis, bail out immediately
+            // (we're likely using a testnet datadir, or the other way around).
+            if (!chainman.BlockIndex().empty() &&
+                    !chainman.m_blockman.LookupBlockIndex(chainparams.GetConsensus().hashGenesisBlock)) {
+                return InitError(_("Incorrect or no genesis block found. Wrong datadir for network?"));
+            }
+
+            // Check for changed -prune state.  What we are concerned about is a user who has pruned blocks
+            // in the past, but is now trying to run unpruned.
+            if (fHavePruned && !fPruneMode) {
+                strLoadError = _("You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain");
+                break;
+            }
+
+            // At this point blocktree args are consistent with what's on disk.
+            // If we're not mid-reindex (based on disk + args), add a genesis block on disk
+            // (otherwise we use the one already on disk).
+            // This is called again in ThreadImport after the reindex completes.
+            if (!fReindex && !chainman.ActiveChainstate().LoadGenesisBlock()) {
+                strLoadError = _("Error initializing block database");
+                break;
+            }
+
+            // At this point we're either in reindex or we've loaded a useful
+            // block tree into BlockIndex()!
+
+            bool failed_chainstate_init = false;
+
+            for (CChainState* chainstate : chainman.GetAll()) {
+                chainstate->InitCoinsDB(
+                    /* cache_size_bytes */ nCoinDBCache,
+                    /* in_memory */ false,
+                    /* should_wipe */ fReset || fReindexChainState);
+
+                chainstate->CoinsErrorCatcher().AddReadErrCallback([]() {
+                    uiInterface.ThreadSafeMessageBox(
+                        _("Error reading from database, shutting down."),
+                        "", CClientUIInterface::MSG_ERROR);
+                });
+
+                // If necessary, upgrade from older database format.
+                // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
+                if (!chainstate->CoinsDB().Upgrade()) {
+                    strLoadError = _("Error upgrading chainstate database");
+                    failed_chainstate_init = true;
+                    break;
+                }
+
+                // ReplayBlocks is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
+                if (!chainstate->ReplayBlocks()) {
+                    strLoadError = _("Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.");
+                    failed_chainstate_init = true;
+                    break;
+                }
+
+                // The on-disk coinsdb is now in a good state, create the cache
+                chainstate->InitCoinsCache(nCoinCacheUsage);
+                assert(chainstate->CanFlushToDisk());
+
+                if (!is_coinsview_empty(chainstate)) {
+                    // LoadChainTip initializes the chain based on CoinsTip()'s best block
+                    if (!chainstate->LoadChainTip()) {
+                        strLoadError = _("Error initializing block database");
+                        failed_chainstate_init = true;
+                        break; // out of the per-chainstate loop
+                    }
+                    assert(chainstate->m_chain.Tip() != nullptr);
+                }
+            }
+
+            if (failed_chainstate_init) {
+                break; // out of the chainstate activation do-while
+            }
+        } catch (const std::exception& e) {
+            LogPrintf("%s\n", e.what());
+            strLoadError = _("Error opening block database");
+            break;
+        }
+
+        if (!fReset) {
+            LOCK(cs_main);
+            auto chainstates{chainman.GetAll()};
+            if (std::any_of(chainstates.begin(), chainstates.end(),
+                            [](const CChainState* cs) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return cs->NeedsRedownload(); })) {
+                strLoadError = strprintf(_("Witness data for blocks after height %d requires validation. Please restart with -reindex."),
+                                         chainparams.GetConsensus().SegwitHeight);
+                break;
+            }
+        }
+
+        bool failed_verification = false;
+
+        try {
+            LOCK(cs_main);
+
+            for (CChainState* chainstate : chainman.GetAll()) {
+                if (!is_coinsview_empty(chainstate)) {
+                    uiInterface.InitMessage(_("Verifying blocks…").translated);
+                    if (fHavePruned && args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS) > MIN_BLOCKS_TO_KEEP) {
+                        LogPrintf("Prune: pruned datadir may not have more than %d blocks; only checking available blocks\n",
+                            MIN_BLOCKS_TO_KEEP);
+                    }
+
+                    const CBlockIndex* tip = chainstate->m_chain.Tip();
+                    RPCNotifyBlockChange(tip);
+                    if (tip && tip->nTime > GetTime() + MAX_FUTURE_BLOCK_TIME) {
+                        strLoadError = _("The block database contains a block which appears to be from the future. "
+                                "This may be due to your computer's date and time being set incorrectly. "
+                                "Only rebuild the block database if you are sure that your computer's date and time are correct");
+                        failed_verification = true;
+                        break;
+                    }
+
+                    if (!CVerifyDB().VerifyDB(
+                            *chainstate, chainparams, chainstate->CoinsDB(),
+                            args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL),
+                            args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS))) {
+                        strLoadError = _("Corrupted block database detected");
+                        failed_verification = true;
+                        break;
+                    }
+                }
+            }
+        } catch (const std::exception& e) {
+            LogPrintf("%s\n", e.what());
+            strLoadError = _("Error opening block database");
+            failed_verification = true;
+            break;
+        }
+
+        if (!failed_verification) {
+            fLoaded = true;
+            LogPrintf(" block index %15dms\n", GetTimeMillis() - load_block_index_start_time);
+        }
+    } while(false);
+    return true;
+}

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -5,7 +5,6 @@
 #include <node/chainstate.h>
 
 #include <chainparams.h> // for CChainParams
-#include <util/time.h> // for GetTime
 #include <node/blockstorage.h> // for CleanupBlockRevFiles, fHavePruned, fReindex
 #include <shutdown.h> // for ShutdownRequested
 #include <validation.h> // for a lot of things
@@ -131,7 +130,8 @@ std::optional<ChainstateLoadVerifyError> VerifyLoadedChainstate(ChainstateManage
                                                                 bool fReindexChainState,
                                                                 const CChainParams& chainparams,
                                                                 unsigned int check_blocks,
-                                                                unsigned int check_level)
+                                                                unsigned int check_level,
+                                                                std::function<int64_t()> get_unix_time_seconds)
 {
     auto is_coinsview_empty = [&](CChainState* chainstate) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
         return fReset || fReindexChainState || chainstate->CoinsTip().GetBestBlock().IsNull();
@@ -143,7 +143,7 @@ std::optional<ChainstateLoadVerifyError> VerifyLoadedChainstate(ChainstateManage
         for (CChainState* chainstate : chainman.GetAll()) {
             if (!is_coinsview_empty(chainstate)) {
                 const CBlockIndex* tip = chainstate->m_chain.Tip();
-                if (tip && tip->nTime > GetTime() + MAX_FUTURE_BLOCK_TIME) {
+                if (tip && tip->nTime > get_unix_time_seconds() + 2 * 60 * 60) {
                     return ChainstateLoadVerifyError::ERROR_BLOCK_FROM_FUTURE;
                 }
 

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -143,11 +143,6 @@ std::optional<ChainstateLoadVerifyError> VerifyLoadedChainstate(ChainstateManage
 
         for (CChainState* chainstate : chainman.GetAll()) {
             if (!is_coinsview_empty(chainstate)) {
-                if (fHavePruned && check_blocks > MIN_BLOCKS_TO_KEEP) {
-                    LogPrintf("Prune: pruned datadir may not have more than %d blocks; only checking available blocks\n",
-                        MIN_BLOCKS_TO_KEEP);
-                }
-
                 const CBlockIndex* tip = chainstate->m_chain.Tip();
                 RPCNotifyBlockChange(tip);
                 if (tip && tip->nTime > GetTime() + MAX_FUTURE_BLOCK_TIME) {

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -61,8 +61,6 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
                 return ChainstateLoadingError::ERROR_LOADING_BLOCK_DB;
             }
 
-            // If the loaded chain has a wrong genesis, bail out immediately
-            // (we're likely using a testnet datadir, or the other way around).
             if (!chainman.BlockIndex().empty() &&
                     !chainman.m_blockman.LookupBlockIndex(chainparams.GetConsensus().hashGenesisBlock)) {
                 return ChainstateLoadingError::ERROR_BAD_GENESIS_BLOCK;

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -5,7 +5,6 @@
 #include <node/chainstate.h>
 
 #include <chainparams.h> // for CChainParams
-#include <rpc/blockchain.h> // for RPCNotifyBlockChange
 #include <util/time.h> // for GetTime
 #include <node/blockstorage.h> // for CleanupBlockRevFiles, fHavePruned, fReindex
 #include <shutdown.h> // for ShutdownRequested
@@ -144,7 +143,6 @@ std::optional<ChainstateLoadVerifyError> VerifyLoadedChainstate(ChainstateManage
         for (CChainState* chainstate : chainman.GetAll()) {
             if (!is_coinsview_empty(chainstate)) {
                 const CBlockIndex* tip = chainstate->m_chain.Tip();
-                RPCNotifyBlockChange(tip);
                 if (tip && tip->nTime > GetTime() + MAX_FUTURE_BLOCK_TIME) {
                     return ChainstateLoadVerifyError::ERROR_BLOCK_FROM_FUTURE;
                 }

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -4,7 +4,7 @@
 
 #include <node/chainstate.h>
 
-#include <chainparams.h> // for CChainParams
+#include <consensus/params.h> // for Consensus::Params
 #include <node/blockstorage.h> // for CleanupBlockRevFiles, fHavePruned, fReindex
 #include <validation.h> // for a lot of things
 
@@ -12,7 +12,7 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
                                                      ChainstateManager& chainman,
                                                      CTxMemPool* mempool,
                                                      bool fPruneMode,
-                                                     const CChainParams& chainparams,
+                                                     const Consensus::Params& consensus_params,
                                                      bool fReindexChainState,
                                                      int64_t nBlockTreeDBCache,
                                                      int64_t nCoinDBCache,
@@ -57,7 +57,7 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
         }
 
         if (!chainman.BlockIndex().empty() &&
-                !chainman.m_blockman.LookupBlockIndex(chainparams.GetConsensus().hashGenesisBlock)) {
+                !chainman.m_blockman.LookupBlockIndex(consensus_params.hashGenesisBlock)) {
             return ChainstateLoadingError::ERROR_BAD_GENESIS_BLOCK;
         }
 
@@ -128,7 +128,7 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
 std::optional<ChainstateLoadVerifyError> VerifyLoadedChainstate(ChainstateManager& chainman,
                                                                 bool fReset,
                                                                 bool fReindexChainState,
-                                                                const CChainParams& chainparams,
+                                                                const Consensus::Params& consensus_params,
                                                                 unsigned int check_blocks,
                                                                 unsigned int check_level,
                                                                 std::function<int64_t()> get_unix_time_seconds)
@@ -148,7 +148,7 @@ std::optional<ChainstateLoadVerifyError> VerifyLoadedChainstate(ChainstateManage
                 }
 
                 if (!CVerifyDB().VerifyDB(
-                        *chainstate, chainparams, chainstate->CoinsDB(),
+                        *chainstate, consensus_params, chainstate->CoinsDB(),
                         check_level,
                         check_blocks)) {
                     return ChainstateLoadVerifyError::ERROR_CORRUPTED_BLOCK_DB;

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -26,100 +26,98 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
         return fReset || fReindexChainState || chainstate->CoinsTip().GetBestBlock().IsNull();
     };
 
-    {
-        LOCK(cs_main);
-        chainman.InitializeChainstate(mempool);
-        chainman.m_total_coinstip_cache = nCoinCacheUsage;
-        chainman.m_total_coinsdb_cache = nCoinDBCache;
+    LOCK(cs_main);
+    chainman.InitializeChainstate(mempool);
+    chainman.m_total_coinstip_cache = nCoinCacheUsage;
+    chainman.m_total_coinsdb_cache = nCoinDBCache;
 
-        UnloadBlockIndex(mempool, chainman);
+    UnloadBlockIndex(mempool, chainman);
 
-        auto& pblocktree{chainman.m_blockman.m_block_tree_db};
-        // new CBlockTreeDB tries to delete the existing file, which
-        // fails if it's still open from the previous loop. Close it first:
-        pblocktree.reset();
-        pblocktree.reset(new CBlockTreeDB(nBlockTreeDBCache, block_tree_db_in_memory, fReset));
+    auto& pblocktree{chainman.m_blockman.m_block_tree_db};
+    // new CBlockTreeDB tries to delete the existing file, which
+    // fails if it's still open from the previous loop. Close it first:
+    pblocktree.reset();
+    pblocktree.reset(new CBlockTreeDB(nBlockTreeDBCache, block_tree_db_in_memory, fReset));
 
-        if (fReset) {
-            pblocktree->WriteReindexing(true);
-            //If we're reindexing in prune mode, wipe away unusable block files and all undo data files
-            if (fPruneMode)
-                CleanupBlockRevFiles();
-        }
+    if (fReset) {
+        pblocktree->WriteReindexing(true);
+        //If we're reindexing in prune mode, wipe away unusable block files and all undo data files
+        if (fPruneMode)
+            CleanupBlockRevFiles();
+    }
 
+    if (shutdown_requested && shutdown_requested()) return ChainstateLoadingError::SHUTDOWN_PROBED;
+
+    // LoadBlockIndex will load fHavePruned if we've ever removed a
+    // block file from disk.
+    // Note that it also sets fReindex based on the disk flag!
+    // From here on out fReindex and fReset mean something different!
+    if (!chainman.LoadBlockIndex()) {
         if (shutdown_requested && shutdown_requested()) return ChainstateLoadingError::SHUTDOWN_PROBED;
+        return ChainstateLoadingError::ERROR_LOADING_BLOCK_DB;
+    }
 
-        // LoadBlockIndex will load fHavePruned if we've ever removed a
-        // block file from disk.
-        // Note that it also sets fReindex based on the disk flag!
-        // From here on out fReindex and fReset mean something different!
-        if (!chainman.LoadBlockIndex()) {
-            if (shutdown_requested && shutdown_requested()) return ChainstateLoadingError::SHUTDOWN_PROBED;
-            return ChainstateLoadingError::ERROR_LOADING_BLOCK_DB;
+    if (!chainman.BlockIndex().empty() &&
+            !chainman.m_blockman.LookupBlockIndex(consensus_params.hashGenesisBlock)) {
+        return ChainstateLoadingError::ERROR_BAD_GENESIS_BLOCK;
+    }
+
+    // Check for changed -prune state.  What we are concerned about is a user who has pruned blocks
+    // in the past, but is now trying to run unpruned.
+    if (fHavePruned && !fPruneMode) {
+        return ChainstateLoadingError::ERROR_PRUNED_NEEDS_REINDEX;
+    }
+
+    // At this point blocktree args are consistent with what's on disk.
+    // If we're not mid-reindex (based on disk + args), add a genesis block on disk
+    // (otherwise we use the one already on disk).
+    // This is called again in ThreadImport after the reindex completes.
+    if (!fReindex && !chainman.ActiveChainstate().LoadGenesisBlock()) {
+        return ChainstateLoadingError::ERROR_LOAD_GENESIS_BLOCK_FAILED;
+    }
+
+    // At this point we're either in reindex or we've loaded a useful
+    // block tree into BlockIndex()!
+
+    for (CChainState* chainstate : chainman.GetAll()) {
+        chainstate->InitCoinsDB(
+            /* cache_size_bytes */ nCoinDBCache,
+            /* in_memory */ coins_db_in_memory,
+            /* should_wipe */ fReset || fReindexChainState);
+
+        if (coins_error_cb) {
+            chainstate->CoinsErrorCatcher().AddReadErrCallback(coins_error_cb);
         }
 
-        if (!chainman.BlockIndex().empty() &&
-                !chainman.m_blockman.LookupBlockIndex(consensus_params.hashGenesisBlock)) {
-            return ChainstateLoadingError::ERROR_BAD_GENESIS_BLOCK;
+        // If necessary, upgrade from older database format.
+        // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
+        if (!chainstate->CoinsDB().Upgrade()) {
+            return ChainstateLoadingError::ERROR_CHAINSTATE_UPGRADE_FAILED;
         }
 
-        // Check for changed -prune state.  What we are concerned about is a user who has pruned blocks
-        // in the past, but is now trying to run unpruned.
-        if (fHavePruned && !fPruneMode) {
-            return ChainstateLoadingError::ERROR_PRUNED_NEEDS_REINDEX;
+        // ReplayBlocks is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
+        if (!chainstate->ReplayBlocks()) {
+            return ChainstateLoadingError::ERROR_REPLAYBLOCKS_FAILED;
         }
 
-        // At this point blocktree args are consistent with what's on disk.
-        // If we're not mid-reindex (based on disk + args), add a genesis block on disk
-        // (otherwise we use the one already on disk).
-        // This is called again in ThreadImport after the reindex completes.
-        if (!fReindex && !chainman.ActiveChainstate().LoadGenesisBlock()) {
-            return ChainstateLoadingError::ERROR_LOAD_GENESIS_BLOCK_FAILED;
+        // The on-disk coinsdb is now in a good state, create the cache
+        chainstate->InitCoinsCache(nCoinCacheUsage);
+        assert(chainstate->CanFlushToDisk());
+
+        if (!is_coinsview_empty(chainstate)) {
+            // LoadChainTip initializes the chain based on CoinsTip()'s best block
+            if (!chainstate->LoadChainTip()) {
+                return ChainstateLoadingError::ERROR_LOADCHAINTIP_FAILED;
+            }
+            assert(chainstate->m_chain.Tip() != nullptr);
         }
+    }
 
-        // At this point we're either in reindex or we've loaded a useful
-        // block tree into BlockIndex()!
-
-        for (CChainState* chainstate : chainman.GetAll()) {
-            chainstate->InitCoinsDB(
-                /* cache_size_bytes */ nCoinDBCache,
-                /* in_memory */ coins_db_in_memory,
-                /* should_wipe */ fReset || fReindexChainState);
-
-            if (coins_error_cb) {
-                chainstate->CoinsErrorCatcher().AddReadErrCallback(coins_error_cb);
-            }
-
-            // If necessary, upgrade from older database format.
-            // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
-            if (!chainstate->CoinsDB().Upgrade()) {
-                return ChainstateLoadingError::ERROR_CHAINSTATE_UPGRADE_FAILED;
-            }
-
-            // ReplayBlocks is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
-            if (!chainstate->ReplayBlocks()) {
-                return ChainstateLoadingError::ERROR_REPLAYBLOCKS_FAILED;
-            }
-
-            // The on-disk coinsdb is now in a good state, create the cache
-            chainstate->InitCoinsCache(nCoinCacheUsage);
-            assert(chainstate->CanFlushToDisk());
-
-            if (!is_coinsview_empty(chainstate)) {
-                // LoadChainTip initializes the chain based on CoinsTip()'s best block
-                if (!chainstate->LoadChainTip()) {
-                    return ChainstateLoadingError::ERROR_LOADCHAINTIP_FAILED;
-                }
-                assert(chainstate->m_chain.Tip() != nullptr);
-            }
-        }
-
-        if (!fReset) {
-            auto chainstates{chainman.GetAll()};
-            if (std::any_of(chainstates.begin(), chainstates.end(),
-                            [](const CChainState* cs) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return cs->NeedsRedownload(); })) {
-                return ChainstateLoadingError::ERROR_BLOCKS_WITNESS_INSUFFICIENTLY_VALIDATED;
-            }
+    if (!fReset) {
+        auto chainstates{chainman.GetAll()};
+        if (std::any_of(chainstates.begin(), chainstates.end(),
+                        [](const CChainState* cs) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return cs->NeedsRedownload(); })) {
+            return ChainstateLoadingError::ERROR_BLOCKS_WITNESS_INSUFFICIENTLY_VALIDATED;
         }
     }
 
@@ -138,22 +136,20 @@ std::optional<ChainstateLoadVerifyError> VerifyLoadedChainstate(ChainstateManage
         return fReset || fReindexChainState || chainstate->CoinsTip().GetBestBlock().IsNull();
     };
 
-    {
-        LOCK(cs_main);
+    LOCK(cs_main);
 
-        for (CChainState* chainstate : chainman.GetAll()) {
-            if (!is_coinsview_empty(chainstate)) {
-                const CBlockIndex* tip = chainstate->m_chain.Tip();
-                if (tip && tip->nTime > get_unix_time_seconds() + 2 * 60 * 60) {
-                    return ChainstateLoadVerifyError::ERROR_BLOCK_FROM_FUTURE;
-                }
+    for (CChainState* chainstate : chainman.GetAll()) {
+        if (!is_coinsview_empty(chainstate)) {
+            const CBlockIndex* tip = chainstate->m_chain.Tip();
+            if (tip && tip->nTime > get_unix_time_seconds() + 2 * 60 * 60) {
+                return ChainstateLoadVerifyError::ERROR_BLOCK_FROM_FUTURE;
+            }
 
-                if (!CVerifyDB().VerifyDB(
-                        *chainstate, consensus_params, chainstate->CoinsDB(),
-                        check_level,
-                        check_blocks)) {
-                    return ChainstateLoadVerifyError::ERROR_CORRUPTED_BLOCK_DB;
-                }
+            if (!CVerifyDB().VerifyDB(
+                    *chainstate, consensus_params, chainstate->CoinsDB(),
+                    check_level,
+                    check_blocks)) {
+                return ChainstateLoadVerifyError::ERROR_CORRUPTED_BLOCK_DB;
             }
         }
     }

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -113,14 +113,13 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
                 assert(chainstate->m_chain.Tip() != nullptr);
             }
         }
-    }
 
-    if (!fReset) {
-        LOCK(cs_main);
-        auto chainstates{chainman.GetAll()};
-        if (std::any_of(chainstates.begin(), chainstates.end(),
-                        [](const CChainState* cs) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return cs->NeedsRedownload(); })) {
-            return ChainstateLoadingError::ERROR_BLOCKS_WITNESS_INSUFFICIENTLY_VALIDATED;
+        if (!fReset) {
+            auto chainstates{chainman.GetAll()};
+            if (std::any_of(chainstates.begin(), chainstates.end(),
+                            [](const CChainState* cs) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return cs->NeedsRedownload(); })) {
+                return ChainstateLoadingError::ERROR_BLOCKS_WITNESS_INSUFFICIENTLY_VALIDATED;
+            }
         }
     }
 

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -8,14 +8,13 @@
 #include <rpc/blockchain.h> // for RPCNotifyBlockChange
 #include <util/time.h> // for GetTime
 #include <node/blockstorage.h> // for CleanupBlockRevFiles, fHavePruned, fReindex
-#include <node/context.h> // for NodeContext
 #include <node/ui_interface.h> // for InitError, uiInterface, and CClientUIInterface member access
 #include <shutdown.h> // for ShutdownRequested
 #include <validation.h> // for a lot of things
 
 std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
                                                      ChainstateManager& chainman,
-                                                     NodeContext& node,
+                                                     CTxMemPool* mempool,
                                                      bool fPruneMode,
                                                      const CChainParams& chainparams,
                                                      bool fReindexChainState,
@@ -32,11 +31,11 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
     do {
         try {
             LOCK(cs_main);
-            chainman.InitializeChainstate(Assert(node.mempool.get()));
+            chainman.InitializeChainstate(Assert(mempool));
             chainman.m_total_coinstip_cache = nCoinCacheUsage;
             chainman.m_total_coinsdb_cache = nCoinDBCache;
 
-            UnloadBlockIndex(node.mempool.get(), chainman);
+            UnloadBlockIndex(mempool, chainman);
 
             auto& pblocktree{chainman.m_blockman.m_block_tree_db};
             // new CBlockTreeDB tries to delete the existing file, which

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -31,7 +31,7 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
     do {
         try {
             LOCK(cs_main);
-            chainman.InitializeChainstate(Assert(mempool));
+            chainman.InitializeChainstate(mempool);
             chainman.m_total_coinstip_cache = nCoinCacheUsage;
             chainman.m_total_coinsdb_cache = nCoinDBCache;
 

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -28,139 +28,138 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
         return fReset || fReindexChainState || chainstate->CoinsTip().GetBestBlock().IsNull();
     };
 
-    do {
-        try {
-            LOCK(cs_main);
-            chainman.InitializeChainstate(mempool);
-            chainman.m_total_coinstip_cache = nCoinCacheUsage;
-            chainman.m_total_coinsdb_cache = nCoinDBCache;
+    try {
+        LOCK(cs_main);
+        chainman.InitializeChainstate(mempool);
+        chainman.m_total_coinstip_cache = nCoinCacheUsage;
+        chainman.m_total_coinsdb_cache = nCoinDBCache;
 
-            UnloadBlockIndex(mempool, chainman);
+        UnloadBlockIndex(mempool, chainman);
 
-            auto& pblocktree{chainman.m_blockman.m_block_tree_db};
-            // new CBlockTreeDB tries to delete the existing file, which
-            // fails if it's still open from the previous loop. Close it first:
-            pblocktree.reset();
-            pblocktree.reset(new CBlockTreeDB(nBlockTreeDBCache, false, fReset));
+        auto& pblocktree{chainman.m_blockman.m_block_tree_db};
+        // new CBlockTreeDB tries to delete the existing file, which
+        // fails if it's still open from the previous loop. Close it first:
+        pblocktree.reset();
+        pblocktree.reset(new CBlockTreeDB(nBlockTreeDBCache, false, fReset));
 
-            if (fReset) {
-                pblocktree->WriteReindexing(true);
-                //If we're reindexing in prune mode, wipe away unusable block files and all undo data files
-                if (fPruneMode)
-                    CleanupBlockRevFiles();
-            }
+        if (fReset) {
+            pblocktree->WriteReindexing(true);
+            //If we're reindexing in prune mode, wipe away unusable block files and all undo data files
+            if (fPruneMode)
+                CleanupBlockRevFiles();
+        }
 
+        if (ShutdownRequested()) return ChainstateLoadingError::SHUTDOWN_PROBED;
+
+        // LoadBlockIndex will load fHavePruned if we've ever removed a
+        // block file from disk.
+        // Note that it also sets fReindex based on the disk flag!
+        // From here on out fReindex and fReset mean something different!
+        if (!chainman.LoadBlockIndex()) {
             if (ShutdownRequested()) return ChainstateLoadingError::SHUTDOWN_PROBED;
-
-            // LoadBlockIndex will load fHavePruned if we've ever removed a
-            // block file from disk.
-            // Note that it also sets fReindex based on the disk flag!
-            // From here on out fReindex and fReset mean something different!
-            if (!chainman.LoadBlockIndex()) {
-                if (ShutdownRequested()) return ChainstateLoadingError::SHUTDOWN_PROBED;
-                return ChainstateLoadingError::ERROR_LOADING_BLOCK_DB;
-            }
-
-            if (!chainman.BlockIndex().empty() &&
-                    !chainman.m_blockman.LookupBlockIndex(chainparams.GetConsensus().hashGenesisBlock)) {
-                return ChainstateLoadingError::ERROR_BAD_GENESIS_BLOCK;
-            }
-
-            // Check for changed -prune state.  What we are concerned about is a user who has pruned blocks
-            // in the past, but is now trying to run unpruned.
-            if (fHavePruned && !fPruneMode) {
-                return ChainstateLoadingError::ERROR_PRUNED_NEEDS_REINDEX;
-            }
-
-            // At this point blocktree args are consistent with what's on disk.
-            // If we're not mid-reindex (based on disk + args), add a genesis block on disk
-            // (otherwise we use the one already on disk).
-            // This is called again in ThreadImport after the reindex completes.
-            if (!fReindex && !chainman.ActiveChainstate().LoadGenesisBlock()) {
-                return ChainstateLoadingError::ERROR_LOAD_GENESIS_BLOCK_FAILED;
-            }
-
-            // At this point we're either in reindex or we've loaded a useful
-            // block tree into BlockIndex()!
-
-            for (CChainState* chainstate : chainman.GetAll()) {
-                chainstate->InitCoinsDB(
-                    /* cache_size_bytes */ nCoinDBCache,
-                    /* in_memory */ false,
-                    /* should_wipe */ fReset || fReindexChainState);
-
-                chainstate->CoinsErrorCatcher().AddReadErrCallback([]() {
-                    uiInterface.ThreadSafeMessageBox(
-                        _("Error reading from database, shutting down."),
-                        "", CClientUIInterface::MSG_ERROR);
-                });
-
-                // If necessary, upgrade from older database format.
-                // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
-                if (!chainstate->CoinsDB().Upgrade()) {
-                    return ChainstateLoadingError::ERROR_CHAINSTATE_UPGRADE_FAILED;
-                }
-
-                // ReplayBlocks is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
-                if (!chainstate->ReplayBlocks()) {
-                    return ChainstateLoadingError::ERROR_REPLAYBLOCKS_FAILED;
-                }
-
-                // The on-disk coinsdb is now in a good state, create the cache
-                chainstate->InitCoinsCache(nCoinCacheUsage);
-                assert(chainstate->CanFlushToDisk());
-
-                if (!is_coinsview_empty(chainstate)) {
-                    // LoadChainTip initializes the chain based on CoinsTip()'s best block
-                    if (!chainstate->LoadChainTip()) {
-                        return ChainstateLoadingError::ERROR_LOADCHAINTIP_FAILED;
-                    }
-                    assert(chainstate->m_chain.Tip() != nullptr);
-                }
-            }
-        } catch (const std::exception& e) {
-            LogPrintf("%s\n", e.what());
-            return ChainstateLoadingError::ERROR_GENERIC_BLOCKDB_OPEN_FAILED;
+            return ChainstateLoadingError::ERROR_LOADING_BLOCK_DB;
         }
 
-        if (!fReset) {
-            LOCK(cs_main);
-            auto chainstates{chainman.GetAll()};
-            if (std::any_of(chainstates.begin(), chainstates.end(),
-                            [](const CChainState* cs) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return cs->NeedsRedownload(); })) {
-                return ChainstateLoadingError::ERROR_BLOCKS_WITNESS_INSUFFICIENTLY_VALIDATED;
-            }
+        if (!chainman.BlockIndex().empty() &&
+                !chainman.m_blockman.LookupBlockIndex(chainparams.GetConsensus().hashGenesisBlock)) {
+            return ChainstateLoadingError::ERROR_BAD_GENESIS_BLOCK;
         }
 
-        try {
-            LOCK(cs_main);
+        // Check for changed -prune state.  What we are concerned about is a user who has pruned blocks
+        // in the past, but is now trying to run unpruned.
+        if (fHavePruned && !fPruneMode) {
+            return ChainstateLoadingError::ERROR_PRUNED_NEEDS_REINDEX;
+        }
 
-            for (CChainState* chainstate : chainman.GetAll()) {
-                if (!is_coinsview_empty(chainstate)) {
-                    uiInterface.InitMessage(_("Verifying blocks…").translated);
-                    if (fHavePruned && check_blocks > MIN_BLOCKS_TO_KEEP) {
-                        LogPrintf("Prune: pruned datadir may not have more than %d blocks; only checking available blocks\n",
-                            MIN_BLOCKS_TO_KEEP);
-                    }
+        // At this point blocktree args are consistent with what's on disk.
+        // If we're not mid-reindex (based on disk + args), add a genesis block on disk
+        // (otherwise we use the one already on disk).
+        // This is called again in ThreadImport after the reindex completes.
+        if (!fReindex && !chainman.ActiveChainstate().LoadGenesisBlock()) {
+            return ChainstateLoadingError::ERROR_LOAD_GENESIS_BLOCK_FAILED;
+        }
 
-                    const CBlockIndex* tip = chainstate->m_chain.Tip();
-                    RPCNotifyBlockChange(tip);
-                    if (tip && tip->nTime > GetTime() + MAX_FUTURE_BLOCK_TIME) {
-                        return ChainstateLoadingError::ERROR_BLOCK_FROM_FUTURE;
-                    }
+        // At this point we're either in reindex or we've loaded a useful
+        // block tree into BlockIndex()!
 
-                    if (!CVerifyDB().VerifyDB(
-                            *chainstate, chainparams, chainstate->CoinsDB(),
-                            check_level,
-                            check_blocks)) {
-                        return ChainstateLoadingError::ERROR_CORRUPTED_BLOCK_DB;
-                    }
+        for (CChainState* chainstate : chainman.GetAll()) {
+            chainstate->InitCoinsDB(
+                /* cache_size_bytes */ nCoinDBCache,
+                /* in_memory */ false,
+                /* should_wipe */ fReset || fReindexChainState);
+
+            chainstate->CoinsErrorCatcher().AddReadErrCallback([]() {
+                uiInterface.ThreadSafeMessageBox(
+                    _("Error reading from database, shutting down."),
+                    "", CClientUIInterface::MSG_ERROR);
+            });
+
+            // If necessary, upgrade from older database format.
+            // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
+            if (!chainstate->CoinsDB().Upgrade()) {
+                return ChainstateLoadingError::ERROR_CHAINSTATE_UPGRADE_FAILED;
+            }
+
+            // ReplayBlocks is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
+            if (!chainstate->ReplayBlocks()) {
+                return ChainstateLoadingError::ERROR_REPLAYBLOCKS_FAILED;
+            }
+
+            // The on-disk coinsdb is now in a good state, create the cache
+            chainstate->InitCoinsCache(nCoinCacheUsage);
+            assert(chainstate->CanFlushToDisk());
+
+            if (!is_coinsview_empty(chainstate)) {
+                // LoadChainTip initializes the chain based on CoinsTip()'s best block
+                if (!chainstate->LoadChainTip()) {
+                    return ChainstateLoadingError::ERROR_LOADCHAINTIP_FAILED;
+                }
+                assert(chainstate->m_chain.Tip() != nullptr);
+            }
+        }
+    } catch (const std::exception& e) {
+        LogPrintf("%s\n", e.what());
+        return ChainstateLoadingError::ERROR_GENERIC_BLOCKDB_OPEN_FAILED;
+    }
+
+    if (!fReset) {
+        LOCK(cs_main);
+        auto chainstates{chainman.GetAll()};
+        if (std::any_of(chainstates.begin(), chainstates.end(),
+                        [](const CChainState* cs) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return cs->NeedsRedownload(); })) {
+            return ChainstateLoadingError::ERROR_BLOCKS_WITNESS_INSUFFICIENTLY_VALIDATED;
+        }
+    }
+
+    try {
+        LOCK(cs_main);
+
+        for (CChainState* chainstate : chainman.GetAll()) {
+            if (!is_coinsview_empty(chainstate)) {
+                uiInterface.InitMessage(_("Verifying blocks…").translated);
+                if (fHavePruned && check_blocks > MIN_BLOCKS_TO_KEEP) {
+                    LogPrintf("Prune: pruned datadir may not have more than %d blocks; only checking available blocks\n",
+                        MIN_BLOCKS_TO_KEEP);
+                }
+
+                const CBlockIndex* tip = chainstate->m_chain.Tip();
+                RPCNotifyBlockChange(tip);
+                if (tip && tip->nTime > GetTime() + MAX_FUTURE_BLOCK_TIME) {
+                    return ChainstateLoadingError::ERROR_BLOCK_FROM_FUTURE;
+                }
+
+                if (!CVerifyDB().VerifyDB(
+                        *chainstate, chainparams, chainstate->CoinsDB(),
+                        check_level,
+                        check_blocks)) {
+                    return ChainstateLoadingError::ERROR_CORRUPTED_BLOCK_DB;
                 }
             }
-        } catch (const std::exception& e) {
-            LogPrintf("%s\n", e.what());
-            return ChainstateLoadingError::ERROR_GENERIC_BLOCKDB_OPEN_FAILED;
         }
-    } while(false);
+    } catch (const std::exception& e) {
+        LogPrintf("%s\n", e.what());
+        return ChainstateLoadingError::ERROR_GENERIC_BLOCKDB_OPEN_FAILED;
+    }
+
     return std::nullopt;
 }

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -26,7 +26,7 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
         return fReset || fReindexChainState || chainstate->CoinsTip().GetBestBlock().IsNull();
     };
 
-    try {
+    {
         LOCK(cs_main);
         chainman.InitializeChainstate(mempool);
         chainman.m_total_coinstip_cache = nCoinCacheUsage;
@@ -113,9 +113,6 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
                 assert(chainstate->m_chain.Tip() != nullptr);
             }
         }
-    } catch (const std::exception& e) {
-        LogPrintf("%s\n", e.what());
-        return ChainstateLoadingError::ERROR_GENERIC_BLOCKDB_OPEN_FAILED;
     }
 
     if (!fReset) {
@@ -141,7 +138,7 @@ std::optional<ChainstateLoadVerifyError> VerifyLoadedChainstate(ChainstateManage
         return fReset || fReindexChainState || chainstate->CoinsTip().GetBestBlock().IsNull();
     };
 
-    try {
+    {
         LOCK(cs_main);
 
         for (CChainState* chainstate : chainman.GetAll()) {
@@ -165,9 +162,6 @@ std::optional<ChainstateLoadVerifyError> VerifyLoadedChainstate(ChainstateManage
                 }
             }
         }
-    } catch (const std::exception& e) {
-        LogPrintf("%s\n", e.what());
-        return ChainstateLoadVerifyError::ERROR_GENERIC_FAILURE;
     }
 
     return std::nullopt;

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -6,12 +6,27 @@
 #define BITCOIN_NODE_CHAINSTATE_H
 
 #include <cstdint> // for int64_t
+#include <optional> // for std::optional
 
 class ArgsManager;
-struct bilingual_str;
 class CChainParams;
 class ChainstateManager;
 struct NodeContext;
+
+enum class ChainstateLoadingError {
+    ERROR_LOADING_BLOCK_DB,
+    ERROR_BAD_GENESIS_BLOCK,
+    ERROR_PRUNED_NEEDS_REINDEX,
+    ERROR_LOAD_GENESIS_BLOCK_FAILED,
+    ERROR_CHAINSTATE_UPGRADE_FAILED,
+    ERROR_REPLAYBLOCKS_FAILED,
+    ERROR_LOADCHAINTIP_FAILED,
+    ERROR_GENERIC_BLOCKDB_OPEN_FAILED,
+    ERROR_BLOCKS_WITNESS_INSUFFICIENTLY_VALIDATED,
+    ERROR_BLOCK_FROM_FUTURE,
+    ERROR_CORRUPTED_BLOCK_DB,
+    SHUTDOWN_PROBED,
+};
 
 /** This sequence can have 4 types of outcomes:
  *
@@ -24,25 +39,30 @@ struct NodeContext;
  *  4. Hard failure
  *    - a failure that definitively cannot be recovered from with a reindex
  *
- *  Currently, LoadChainstate returns a bool which:
- *      - if false
- *          - Definitely a "Hard failure"
- *      - if true
- *          - if fLoaded -> "Success"
- *          - if ShutdownRequested() -> "Shutdown requested"
- *          - else -> "Soft failure"
+ *  Currently, LoadChainstate returns a std::optional<ChainstateLoadingError>
+ *  which:
+ *
+ *  - if has_value()
+ *      - Either "Soft failure", "Hard failure", or "Shutdown requested",
+ *        differentiable by the specific enumerator.
+ *
+ *        Note that a return value of SHUTDOWN_PROBED means ONLY that "during
+ *        this sequence, when we explicitly checked ShutdownRequested() at
+ *        arbitrary points, one of those calls returned true". Therefore, a
+ *        return value other than SHUTDOWN_PROBED does not guarantee that
+ *        ShutdownRequested() hasn't been called indirectly.
+ *  - else
+ *      - Success!
  */
-bool LoadChainstate(bool& fLoaded,
-                    bilingual_str& strLoadError,
-                    bool fReset,
-                    ChainstateManager& chainman,
-                    NodeContext& node,
-                    bool fPruneMode,
-                    const CChainParams& chainparams,
-                    const ArgsManager& args,
-                    bool fReindexChainState,
-                    int64_t nBlockTreeDBCache,
-                    int64_t nCoinDBCache,
-                    int64_t nCoinCacheUsage);
+std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
+                                                     ChainstateManager& chainman,
+                                                     NodeContext& node,
+                                                     bool fPruneMode,
+                                                     const CChainParams& chainparams,
+                                                     const ArgsManager& args,
+                                                     bool fReindexChainState,
+                                                     int64_t nBlockTreeDBCache,
+                                                     int64_t nCoinDBCache,
+                                                     int64_t nCoinCacheUsage);
 
 #endif // BITCOIN_NODE_CHAINSTATE_H

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_CHAINSTATE_H
+#define BITCOIN_NODE_CHAINSTATE_H
+
+#include <cstdint> // for int64_t
+
+class ArgsManager;
+struct bilingual_str;
+class CChainParams;
+class ChainstateManager;
+struct NodeContext;
+
+/** This sequence can have 4 types of outcomes:
+ *
+ *  1. Success
+ *  2. Shutdown requested
+ *    - nothing failed but a shutdown was triggered in the middle of the
+ *      sequence
+ *  3. Soft failure
+ *    - a failure that might be recovered from with a reindex
+ *  4. Hard failure
+ *    - a failure that definitively cannot be recovered from with a reindex
+ *
+ *  Currently, LoadChainstate returns a bool which:
+ *      - if false
+ *          - Definitely a "Hard failure"
+ *      - if true
+ *          - if fLoaded -> "Success"
+ *          - if ShutdownRequested() -> "Shutdown requested"
+ *          - else -> "Soft failure"
+ */
+bool LoadChainstate(bool& fLoaded,
+                    bilingual_str& strLoadError,
+                    bool fReset,
+                    ChainstateManager& chainman,
+                    NodeContext& node,
+                    bool fPruneMode,
+                    const CChainParams& chainparams,
+                    const ArgsManager& args,
+                    bool fReindexChainState,
+                    int64_t nBlockTreeDBCache,
+                    int64_t nCoinDBCache,
+                    int64_t nCoinCacheUsage);
+
+#endif // BITCOIN_NODE_CHAINSTATE_H

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -10,7 +10,7 @@
 
 class CChainParams;
 class ChainstateManager;
-struct NodeContext;
+class CTxMemPool;
 
 enum class ChainstateLoadingError {
     ERROR_LOADING_BLOCK_DB,
@@ -55,7 +55,7 @@ enum class ChainstateLoadingError {
  */
 std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
                                                      ChainstateManager& chainman,
-                                                     NodeContext& node,
+                                                     CTxMemPool* mempool,
                                                      bool fPruneMode,
                                                      const CChainParams& chainparams,
                                                      bool fReindexChainState,

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -63,6 +63,8 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
                                                      int64_t nBlockTreeDBCache,
                                                      int64_t nCoinDBCache,
                                                      int64_t nCoinCacheUsage,
+                                                     bool block_tree_db_in_memory,
+                                                     bool coins_db_in_memory,
                                                      std::function<bool()> shutdown_requested = nullptr,
                                                      std::function<void()> coins_error_cb = nullptr);
 

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -5,9 +5,9 @@
 #ifndef BITCOIN_NODE_CHAINSTATE_H
 #define BITCOIN_NODE_CHAINSTATE_H
 
-#include <cstdint> // for int64_t
-#include <functional> // for std::function
-#include <optional> // for std::optional
+#include <cstdint>
+#include <functional>
+#include <optional>
 
 class ChainstateManager;
 namespace Consensus {

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -45,10 +45,10 @@ enum class ChainstateLoadingError {
  *        differentiable by the specific enumerator.
  *
  *        Note that a return value of SHUTDOWN_PROBED means ONLY that "during
- *        this sequence, when we explicitly checked ShutdownRequested() at
+ *        this sequence, when we explicitly checked shutdown_requested() at
  *        arbitrary points, one of those calls returned true". Therefore, a
  *        return value other than SHUTDOWN_PROBED does not guarantee that
- *        ShutdownRequested() hasn't been called indirectly.
+ *        shutdown_requested() hasn't been called indirectly.
  *  - else
  *      - Success!
  */
@@ -61,6 +61,7 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
                                                      int64_t nBlockTreeDBCache,
                                                      int64_t nCoinDBCache,
                                                      int64_t nCoinCacheUsage,
+                                                     std::function<bool()> shutdown_requested = nullptr,
                                                      std::function<void()> coins_error_cb = nullptr);
 
 enum class ChainstateLoadVerifyError {

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -6,6 +6,7 @@
 #define BITCOIN_NODE_CHAINSTATE_H
 
 #include <cstdint> // for int64_t
+#include <functional> // for std::function
 #include <optional> // for std::optional
 
 class CChainParams;
@@ -59,7 +60,8 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
                                                      bool fReindexChainState,
                                                      int64_t nBlockTreeDBCache,
                                                      int64_t nCoinDBCache,
-                                                     int64_t nCoinCacheUsage);
+                                                     int64_t nCoinCacheUsage,
+                                                     std::function<void()> coins_error_cb = nullptr);
 
 enum class ChainstateLoadVerifyError {
     ERROR_BLOCK_FROM_FUTURE,

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -74,6 +74,7 @@ std::optional<ChainstateLoadVerifyError> VerifyLoadedChainstate(ChainstateManage
                                                                 bool fReindexChainState,
                                                                 const CChainParams& chainparams,
                                                                 unsigned int check_blocks,
-                                                                unsigned int check_level);
+                                                                unsigned int check_level,
+                                                                std::function<int64_t()> get_unix_time_seconds);
 
 #endif // BITCOIN_NODE_CHAINSTATE_H

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -8,7 +8,6 @@
 #include <cstdint> // for int64_t
 #include <optional> // for std::optional
 
-class ArgsManager;
 class CChainParams;
 class ChainstateManager;
 struct NodeContext;
@@ -59,10 +58,11 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
                                                      NodeContext& node,
                                                      bool fPruneMode,
                                                      const CChainParams& chainparams,
-                                                     const ArgsManager& args,
                                                      bool fReindexChainState,
                                                      int64_t nBlockTreeDBCache,
                                                      int64_t nCoinDBCache,
-                                                     int64_t nCoinCacheUsage);
+                                                     int64_t nCoinCacheUsage,
+                                                     unsigned int check_blocks,
+                                                     unsigned int check_level);
 
 #endif // BITCOIN_NODE_CHAINSTATE_H

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -9,8 +9,10 @@
 #include <functional> // for std::function
 #include <optional> // for std::optional
 
-class CChainParams;
 class ChainstateManager;
+namespace Consensus {
+    struct Params;
+}
 class CTxMemPool;
 
 enum class ChainstateLoadingError {
@@ -56,7 +58,7 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
                                                      ChainstateManager& chainman,
                                                      CTxMemPool* mempool,
                                                      bool fPruneMode,
-                                                     const CChainParams& chainparams,
+                                                     const Consensus::Params& consensus_params,
                                                      bool fReindexChainState,
                                                      int64_t nBlockTreeDBCache,
                                                      int64_t nCoinDBCache,
@@ -73,7 +75,7 @@ enum class ChainstateLoadVerifyError {
 std::optional<ChainstateLoadVerifyError> VerifyLoadedChainstate(ChainstateManager& chainman,
                                                                 bool fReset,
                                                                 bool fReindexChainState,
-                                                                const CChainParams& chainparams,
+                                                                const Consensus::Params& consensus_params,
                                                                 unsigned int check_blocks,
                                                                 unsigned int check_level,
                                                                 std::function<int64_t()> get_unix_time_seconds);

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -22,8 +22,6 @@ enum class ChainstateLoadingError {
     ERROR_LOADCHAINTIP_FAILED,
     ERROR_GENERIC_BLOCKDB_OPEN_FAILED,
     ERROR_BLOCKS_WITNESS_INSUFFICIENTLY_VALIDATED,
-    ERROR_BLOCK_FROM_FUTURE,
-    ERROR_CORRUPTED_BLOCK_DB,
     SHUTDOWN_PROBED,
 };
 
@@ -61,8 +59,19 @@ std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
                                                      bool fReindexChainState,
                                                      int64_t nBlockTreeDBCache,
                                                      int64_t nCoinDBCache,
-                                                     int64_t nCoinCacheUsage,
-                                                     unsigned int check_blocks,
-                                                     unsigned int check_level);
+                                                     int64_t nCoinCacheUsage);
+
+enum class ChainstateLoadVerifyError {
+    ERROR_BLOCK_FROM_FUTURE,
+    ERROR_CORRUPTED_BLOCK_DB,
+    ERROR_GENERIC_FAILURE,
+};
+
+std::optional<ChainstateLoadVerifyError> VerifyLoadedChainstate(ChainstateManager& chainman,
+                                                                bool fReset,
+                                                                bool fReindexChainState,
+                                                                const CChainParams& chainparams,
+                                                                unsigned int check_blocks,
+                                                                unsigned int check_level);
 
 #endif // BITCOIN_NODE_CHAINSTATE_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1364,7 +1364,7 @@ static RPCHelpMan verifychain()
 
     CChainState& active_chainstate = chainman.ActiveChainstate();
     return CVerifyDB().VerifyDB(
-        active_chainstate, Params(), active_chainstate.CoinsTip(), check_level, check_depth);
+        active_chainstate, Params().GetConsensus(), active_chainstate.CoinsTip(), check_level, check_depth);
 },
     };
 }

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -17,8 +17,8 @@
 #include <net_processing.h>
 #include <node/miner.h>
 #include <noui.h>
-#include <node/blockstorage.h> // for fReindex, fPruneMode
-#include <node/chainstate.h> // for LoadChainstate
+#include <node/blockstorage.h>
+#include <node/chainstate.h>
 #include <policy/fees.h>
 #include <pow.h>
 #include <rpc/blockchain.h>
@@ -26,7 +26,7 @@
 #include <rpc/server.h>
 #include <scheduler.h>
 #include <script/sigcache.h>
-#include <shutdown.h> // for ShutdownRequested
+#include <shutdown.h>
 #include <streams.h>
 #include <txdb.h>
 #include <util/strencodings.h>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -17,6 +17,8 @@
 #include <net_processing.h>
 #include <node/miner.h>
 #include <noui.h>
+#include <node/blockstorage.h> // for fReindex, fPruneMode
+#include <node/chainstate.h> // for LoadChainstate
 #include <policy/fees.h>
 #include <pow.h>
 #include <rpc/blockchain.h>
@@ -24,6 +26,7 @@
 #include <rpc/server.h>
 #include <scheduler.h>
 #include <script/sigcache.h>
+#include <shutdown.h> // for ShutdownRequested
 #include <streams.h>
 #include <txdb.h>
 #include <util/strencodings.h>
@@ -143,8 +146,10 @@ ChainTestingSetup::ChainTestingSetup(const std::string& chainName, const std::ve
     m_node.fee_estimator = std::make_unique<CBlockPolicyEstimator>();
     m_node.mempool = std::make_unique<CTxMemPool>(m_node.fee_estimator.get(), 1);
 
+    m_cache_sizes = CalculateCacheSizes(m_args);
+
     m_node.chainman = std::make_unique<ChainstateManager>();
-    m_node.chainman->m_blockman.m_block_tree_db = std::make_unique<CBlockTreeDB>(1 << 20, true);
+    m_node.chainman->m_blockman.m_block_tree_db = std::make_unique<CBlockTreeDB>(m_cache_sizes.block_tree_db, true);
 
     // Start script-checking threads. Set g_parallel_script_checks to true so they are used.
     constexpr int script_check_threads = 2;
@@ -177,15 +182,18 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
     // instead of unit tests, but for now we need these here.
     RegisterAllCoreRPCCommands(tableRPC);
 
-    m_node.chainman->InitializeChainstate(m_node.mempool.get());
-    m_node.chainman->ActiveChainstate().InitCoinsDB(
-        /*cache_size_bytes=*/1 << 23, /*in_memory=*/true, /*should_wipe=*/false);
-    assert(!m_node.chainman->ActiveChainstate().CanFlushToDisk());
-    m_node.chainman->ActiveChainstate().InitCoinsCache(1 << 23);
-    assert(m_node.chainman->ActiveChainstate().CanFlushToDisk());
-    if (!m_node.chainman->ActiveChainstate().LoadGenesisBlock()) {
-        throw std::runtime_error("LoadGenesisBlock failed.");
-    }
+    auto rv = LoadChainstate(fReindex.load(),
+                             *Assert(m_node.chainman.get()),
+                             Assert(m_node.mempool.get()),
+                             fPruneMode,
+                             chainparams.GetConsensus(),
+                             m_args.GetBoolArg("-reindex-chainstate", false),
+                             m_cache_sizes.block_tree_db,
+                             m_cache_sizes.coins_db,
+                             m_cache_sizes.coins,
+                             true,
+                             true);
+    assert(!rv.has_value());
 
     BlockValidationState state;
     if (!m_node.chainman->ActiveChainstate().ActivateBestChain(state)) {

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -9,6 +9,7 @@
 #include <fs.h>
 #include <key.h>
 #include <util/system.h>
+#include <node/caches.h>
 #include <node/context.h>
 #include <pubkey.h>
 #include <random.h>
@@ -89,6 +90,7 @@ struct BasicTestingSetup {
  * initialization behaviour.
  */
 struct ChainTestingSetup : public BasicTestingSetup {
+    CacheSizes m_cache_sizes{};
 
     explicit ChainTestingSetup(const std::string& chainName = CBaseChainParams::MAIN, const std::vector<const char*>& extra_args = {});
     ~ChainTestingSetup();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3860,7 +3860,7 @@ CVerifyDB::~CVerifyDB()
 
 bool CVerifyDB::VerifyDB(
     CChainState& chainstate,
-    const CChainParams& chainparams,
+    const Consensus::Params& consensus_params,
     CCoinsView& coinsview,
     int nCheckLevel, int nCheckDepth)
 {
@@ -3902,10 +3902,10 @@ bool CVerifyDB::VerifyDB(
         }
         CBlock block;
         // check level 0: read from disk
-        if (!ReadBlockFromDisk(block, pindex, chainparams.GetConsensus()))
+        if (!ReadBlockFromDisk(block, pindex, consensus_params))
             return error("VerifyDB(): *** ReadBlockFromDisk failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
         // check level 1: verify block validity
-        if (nCheckLevel >= 1 && !CheckBlock(block, state, chainparams.GetConsensus()))
+        if (nCheckLevel >= 1 && !CheckBlock(block, state, consensus_params))
             return error("%s: *** found bad block at %d, hash=%s (%s)\n", __func__,
                          pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());
         // check level 2: verify undo validity
@@ -3953,7 +3953,7 @@ bool CVerifyDB::VerifyDB(
             uiInterface.ShowProgress(_("Verifying blocks…").translated, percentageDone, false);
             pindex = chainstate.m_chain.Next(pindex);
             CBlock block;
-            if (!ReadBlockFromDisk(block, pindex, chainparams.GetConsensus()))
+            if (!ReadBlockFromDisk(block, pindex, consensus_params))
                 return error("VerifyDB(): *** ReadBlockFromDisk failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
             if (!chainstate.ConnectBlock(block, state, pindex, coins)) {
                 return error("VerifyDB(): *** found unconnectable block at %d, hash=%s (%s)", pindex->nHeight, pindex->GetBlockHash().ToString(), state.ToString());

--- a/src/validation.h
+++ b/src/validation.h
@@ -344,7 +344,7 @@ public:
     ~CVerifyDB();
     bool VerifyDB(
         CChainState& chainstate,
-        const CChainParams& chainparams,
+        const Consensus::Params& consensus_params,
         CCoinsView& coinsview,
         int nCheckLevel,
         int nCheckDepth) EXCLUSIVE_LOCKS_REQUIRED(cs_main);


### PR DESCRIPTION
This PR:
1. Coalesce the Chainstate loading sequence between `AppInitMain` and `*TestingSetup` (which makes it more tested)
2. Makes the Chainstate loading sequence reusable in preparation for future work extracting out our consensus engine.

Code-wise, this PR:
1. Extracts `AppInitMain`'s Chainstate loading sequence into a `::LoadChainstateSequence` function
2. Makes this `::LoadChainstateSequence` function reusable by
    1. Decoupling it from various concepts (`ArgsManager`, `uiInterface`, etc)
    2. Making it report errors using an `enum` rather than by setting a `bilingual_str`
3. Makes `*TestingSetup` use this new `::LoadChainstateSequence`

Reviewers: Aside from commentary, I've also included `git diff` flags of interest in the commit messages which I hope will aid review!
