### PR TITLE
test: get and decode tx with a single `gettransaction` RPC call

### DIFF
--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -65,8 +65,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
             value = sent_value
             chain.append(txid)
             # We need the wtxids to check P2P announcements
-            fulltx = self.nodes[0].getrawtransaction(txid)
-            witnesstx = self.nodes[0].decoderawtransaction(fulltx, True)
+            witnesstx = self.nodes[0].gettransaction(txid=txid, verbose=True)['decoded']
             witness_chain.append(witnesstx['hash'])
 
             # Check that listunspent ancestor{count, size, fees} yield the correct results

--- a/test/functional/wallet_address_types.py
+++ b/test/functional/wallet_address_types.py
@@ -204,8 +204,7 @@ class AddressTypeTest(BitcoinTestFramework):
 
     def test_change_output_type(self, node_sender, destinations, expected_type):
         txid = self.nodes[node_sender].sendmany(dummy="", amounts=dict.fromkeys(destinations, 0.001))
-        raw_tx = self.nodes[node_sender].getrawtransaction(txid)
-        tx = self.nodes[node_sender].decoderawtransaction(raw_tx)
+        tx = self.nodes[node_sender].gettransaction(txid=txid, verbose=True)['decoded']
 
         # Make sure the transaction has change:
         assert_equal(len(tx["vout"]), len(destinations) + 1)

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -666,7 +666,7 @@ class WalletTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 1)
         destination = self.nodes[1].getnewaddress()
         txid = self.nodes[0].sendtoaddress(destination, 0.123)
-        tx = self.nodes[0].decoderawtransaction(self.nodes[0].gettransaction(txid)['hex'])
+        tx = self.nodes[0].gettransaction(txid=txid, verbose=True)['decoded']
         output_addresses = [vout['scriptPubKey']['address'] for vout in tx["vout"]]
         assert len(output_addresses) > 1
         for address in output_addresses:

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -34,13 +34,13 @@ class CreateTxWalletTest(BitcoinTestFramework):
         self.log.info('Check that we have some (old) blocks and that anti-fee-sniping is disabled')
         assert_equal(self.nodes[0].getblockchaininfo()['blocks'], 200)
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
-        tx = self.nodes[0].decoderawtransaction(self.nodes[0].gettransaction(txid)['hex'])
+        tx = self.nodes[0].gettransaction(txid=txid, verbose=True)['decoded']
         assert_equal(tx['locktime'], 0)
 
         self.log.info('Check that anti-fee-sniping is enabled when we mine a recent block')
         self.generate(self.nodes[0], 1)
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
-        tx = self.nodes[0].decoderawtransaction(self.nodes[0].gettransaction(txid)['hex'])
+        tx = self.nodes[0].gettransaction(txid=txid, verbose=True)['decoded']
         assert 0 < tx['locktime'] <= 201
 
     def test_tx_size_too_large(self):

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -129,7 +129,7 @@ class WalletHDTest(BitcoinTestFramework):
 
         # send a tx and make sure its using the internal chain for the changeoutput
         txid = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1)
-        outs = self.nodes[1].decoderawtransaction(self.nodes[1].gettransaction(txid)['hex'])['vout']
+        outs = self.nodes[1].gettransaction(txid=txid, verbose=True)['decoded']['vout']
         keypath = ""
         for out in outs:
             if out['value'] != 1:

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -454,7 +454,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 6)
         self.sync_all()
         send_txid = wmulti_priv.sendtoaddress(w0.getnewaddress(), 8)
-        decoded = wmulti_priv.decoderawtransaction(wmulti_priv.gettransaction(send_txid)['hex'])
+        decoded = wmulti_priv.gettransaction(txid=send_txid, verbose=True)['decoded']
         assert_equal(len(decoded['vin'][0]['txinwitness']), 4)
         self.generate(self.nodes[0], 6)
         self.sync_all()
@@ -586,7 +586,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         self.sync_all()
         # It is standard and would relay.
         txid = wmulti_priv_big.sendtoaddress(w0.getnewaddress(), 9.999)
-        decoded = wmulti_priv_big.decoderawtransaction(wmulti_priv_big.gettransaction(txid)['hex'])
+        decoded = wmulti_priv_big.gettransaction(txid=txid, verbose=True)['decoded']
         # 20 sigs + dummy + witness script
         assert_equal(len(decoded['vin'][0]['txinwitness']), 22)
 
@@ -620,12 +620,8 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 6)
         self.sync_all()
         # It is standard and would relay.
-        txid = multi_priv_big.sendtoaddress(w0.getnewaddress(), 10, "", "",
-                                            True)
-        decoded = multi_priv_big.decoderawtransaction(
-            multi_priv_big.gettransaction(txid)['hex']
-        )
-
+        txid = multi_priv_big.sendtoaddress(w0.getnewaddress(), 10, "", "", True)
+        decoded = multi_priv_big.gettransaction(txid=txid, verbose=True)['decoded']
 
         self.log.info("Amending multisig with new private keys")
         self.nodes[1].createwallet(wallet_name="wmulti_priv3", descriptors=True)


### PR DESCRIPTION
Rather than subsequently calling `gettransaction` and `decoderawtransaction` to get the decoded information  for a specific tx-id, we can simply use the verbose version of `gettransaction`, which returns this in a 'decoded' key. I.e.

```
node.decoderawtransaction(node.gettransaction(txid)['hex'])
```

can simply be replaced by:

```
node.gettransaction(txid=txid, verbose=True)['decoded']
```

Rationale: shorter code, shorter test logs, less RPC calls.