### PR TITLE
doc: Add comment to COIN constant

### DIFF
--- a/src/consensus/amount.h
+++ b/src/consensus/amount.h
@@ -11,6 +11,7 @@
 /** Amount in satoshis (Can be negative) */
 typedef int64_t CAmount;
 
+/** The amount of satoshis in one BTC. */
 static constexpr CAmount COIN = 100000000;
 
 /** No amount larger than this (in satoshi) is valid.


### PR DESCRIPTION
The COIN constant is critical in understanding Bitcoin's supply, but what it represents isn't clear from the name of the constant. Adding a comment clarifies the meaning of the constant for future readers.