### PR TITLE
refactor: remove redundant inclusion of header files in the fuzz tests

### DIFF
--- a/src/test/fuzz/addition_overflow.cpp
+++ b/src/test/fuzz/addition_overflow.cpp
@@ -2,13 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <string>
-#include <vector>
 
 #if defined(__has_builtin)
 #if __has_builtin(__builtin_add_overflow)

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -6,19 +6,12 @@
 #include <addrman.h>
 #include <addrman_impl.h>
 #include <chainparams.h>
-#include <merkleblock.h>
 #include <random.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <time.h>
 #include <util/asmap.h>
 
 #include <cassert>
-#include <cstdint>
-#include <optional>
-#include <string>
-#include <vector>
 
 void initialize_addrman()
 {

--- a/src/test/fuzz/asmap.cpp
+++ b/src/test/fuzz/asmap.cpp
@@ -6,7 +6,6 @@
 #include <test/fuzz/fuzz.h>
 #include <util/asmap.h>
 
-#include <cstdint>
 #include <vector>
 
 //! asmap code that consumes nothing

--- a/src/test/fuzz/asmap_direct.cpp
+++ b/src/test/fuzz/asmap_direct.cpp
@@ -6,7 +6,6 @@
 #include <util/asmap.h>
 #include <test/fuzz/fuzz.h>
 
-#include <cstdint>
 #include <optional>
 #include <vector>
 

--- a/src/test/fuzz/autofile.cpp
+++ b/src/test/fuzz/autofile.cpp
@@ -2,17 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <streams.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
-#include <array>
-#include <cstdint>
 #include <iostream>
-#include <optional>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(autofile)
 {

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -4,19 +4,12 @@
 
 #include <banman.h>
 #include <fs.h>
-#include <netaddress.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
 #include <util/readwritefile.h>
 #include <util/system.h>
 
 #include <cassert>
-#include <cstdint>
-#include <limits>
-#include <string>
-#include <vector>
 
 namespace {
 int64_t ConsumeBanTimeOffset(FuzzedDataProvider& fuzzed_data_provider) noexcept

--- a/src/test/fuzz/base_encode_decode.cpp
+++ b/src/test/fuzz/base_encode_decode.cpp
@@ -10,7 +10,6 @@
 #include <util/string.h>
 
 #include <cassert>
-#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/test/fuzz/bech32.cpp
+++ b/src/test/fuzz/bech32.cpp
@@ -8,7 +8,6 @@
 #include <util/strencodings.h>
 
 #include <cassert>
-#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/test/fuzz/block_header.cpp
+++ b/src/test/fuzz/block_header.cpp
@@ -3,16 +3,9 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <primitives/block.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-#include <uint256.h>
 
 #include <cassert>
-#include <cstdint>
-#include <optional>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(block_header)
 {

--- a/src/test/fuzz/blockfilter.cpp
+++ b/src/test/fuzz/blockfilter.cpp
@@ -3,14 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <blockfilter.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <optional>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(blockfilter)
 {

--- a/src/test/fuzz/bloom_filter.cpp
+++ b/src/test/fuzz/bloom_filter.cpp
@@ -3,17 +3,9 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bloom.h>
-#include <primitives/transaction.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-#include <uint256.h>
 
 #include <cassert>
-#include <cstdint>
-#include <optional>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(bloom_filter)
 {

--- a/src/test/fuzz/buffered_file.cpp
+++ b/src/test/fuzz/buffered_file.cpp
@@ -2,17 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <streams.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
-#include <array>
-#include <cstdint>
 #include <iostream>
-#include <optional>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(buffered_file)
 {

--- a/src/test/fuzz/chain.cpp
+++ b/src/test/fuzz/chain.cpp
@@ -3,13 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chain.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <optional>
-#include <vector>
 
 FUZZ_TARGET(chain)
 {

--- a/src/test/fuzz/checkqueue.cpp
+++ b/src/test/fuzz/checkqueue.cpp
@@ -3,13 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <checkqueue.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <string>
-#include <vector>
 
 namespace {
 struct DumbCheck {

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -3,28 +3,16 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
-#include <chainparamsbase.h>
-#include <coins.h>
-#include <consensus/amount.h>
 #include <consensus/tx_check.h>
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <key.h>
 #include <node/coinstats.h>
 #include <policy/policy.h>
-#include <primitives/transaction.h>
 #include <pubkey.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
 #include <validation.h>
-
-#include <cstdint>
-#include <limits>
-#include <optional>
-#include <string>
-#include <vector>
 
 namespace {
 const TestingSetup* g_setup;

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -3,18 +3,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
-#include <chainparamsbase.h>
-#include <net.h>
-#include <netaddress.h>
 #include <protocol.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
 #include <util/translation.h>
-
-#include <cstdint>
-#include <vector>
 
 void initialize_connman()
 {

--- a/src/test/fuzz/crypto.cpp
+++ b/src/test/fuzz/crypto.cpp
@@ -10,12 +10,7 @@
 #include <crypto/sha3.h>
 #include <crypto/sha512.h>
 #include <hash.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <vector>
 
 FUZZ_TARGET(crypto)
 {

--- a/src/test/fuzz/crypto_aes256.cpp
+++ b/src/test/fuzz/crypto_aes256.cpp
@@ -3,13 +3,9 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <crypto/aes.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
 #include <cassert>
-#include <cstdint>
-#include <vector>
 
 FUZZ_TARGET(crypto_aes256)
 {

--- a/src/test/fuzz/crypto_aes256cbc.cpp
+++ b/src/test/fuzz/crypto_aes256cbc.cpp
@@ -3,13 +3,9 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <crypto/aes.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
 #include <cassert>
-#include <cstdint>
-#include <vector>
 
 FUZZ_TARGET(crypto_aes256cbc)
 {

--- a/src/test/fuzz/crypto_chacha20.cpp
+++ b/src/test/fuzz/crypto_chacha20.cpp
@@ -3,12 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <crypto/chacha20.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <vector>
 
 FUZZ_TARGET(crypto_chacha20)
 {

--- a/src/test/fuzz/crypto_chacha20_poly1305_aead.cpp
+++ b/src/test/fuzz/crypto_chacha20_poly1305_aead.cpp
@@ -4,14 +4,9 @@
 
 #include <crypto/chacha_poly_aead.h>
 #include <crypto/poly1305.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
 #include <cassert>
-#include <cstdint>
-#include <limits>
-#include <vector>
 
 FUZZ_TARGET(crypto_chacha20_poly1305_aead)
 {

--- a/src/test/fuzz/crypto_common.cpp
+++ b/src/test/fuzz/crypto_common.cpp
@@ -3,15 +3,9 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <crypto/common.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
-#include <array>
 #include <cassert>
-#include <cstdint>
-#include <cstring>
-#include <vector>
 
 FUZZ_TARGET(crypto_common)
 {

--- a/src/test/fuzz/crypto_hkdf_hmac_sha256_l32.cpp
+++ b/src/test/fuzz/crypto_hkdf_hmac_sha256_l32.cpp
@@ -3,13 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <crypto/hkdf_sha256_32.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(crypto_hkdf_hmac_sha256_l32)
 {

--- a/src/test/fuzz/crypto_poly1305.cpp
+++ b/src/test/fuzz/crypto_poly1305.cpp
@@ -3,12 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <crypto/poly1305.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <vector>
 
 FUZZ_TARGET(crypto_poly1305)
 {

--- a/src/test/fuzz/cuckoocache.cpp
+++ b/src/test/fuzz/cuckoocache.cpp
@@ -4,14 +4,8 @@
 
 #include <cuckoocache.h>
 #include <script/sigcache.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
-
-#include <cstdint>
-#include <string>
-#include <vector>
 
 namespace {
 FuzzedDataProvider* fuzzed_data_provider_ptr = nullptr;

--- a/src/test/fuzz/decode_tx.cpp
+++ b/src/test/fuzz/decode_tx.cpp
@@ -8,7 +8,6 @@
 #include <util/strencodings.h>
 
 #include <cassert>
-#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/test/fuzz/eval_script.cpp
+++ b/src/test/fuzz/eval_script.cpp
@@ -7,8 +7,6 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 
-#include <limits>
-
 void initialize_eval_script()
 {
     static const ECCVerifyHandle verify_handle;

--- a/src/test/fuzz/fee_rate.cpp
+++ b/src/test/fuzz/fee_rate.cpp
@@ -2,16 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <consensus/amount.h>
 #include <policy/feerate.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <limits>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(fee_rate)
 {

--- a/src/test/fuzz/fees.cpp
+++ b/src/test/fuzz/fees.cpp
@@ -2,16 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <consensus/amount.h>
 #include <policy/fees.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <util/fees.h>
-
-#include <cstdint>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(fees)
 {

--- a/src/test/fuzz/flatfile.cpp
+++ b/src/test/fuzz/flatfile.cpp
@@ -3,15 +3,9 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <flatfile.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
 #include <cassert>
-#include <cstdint>
-#include <optional>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(flatfile)
 {

--- a/src/test/fuzz/float.cpp
+++ b/src/test/fuzz/float.cpp
@@ -3,15 +3,11 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <memusage.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <util/serfloat.h>
-#include <version.h>
 
 #include <cassert>
 #include <cmath>
-#include <limits>
 
 FUZZ_TARGET(float)
 {

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -10,7 +10,6 @@
 #include <util/check.h>
 #include <util/sock.h>
 
-#include <cstdint>
 #include <exception>
 #include <memory>
 #include <string>

--- a/src/test/fuzz/golomb_rice.cpp
+++ b/src/test/fuzz/golomb_rice.cpp
@@ -3,20 +3,13 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <blockfilter.h>
-#include <serialize.h>
-#include <streams.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <util/bytevectorhash.h>
 #include <util/golombrice.h>
 
-#include <algorithm>
 #include <cassert>
-#include <cstdint>
 #include <iosfwd>
 #include <unordered_set>
-#include <vector>
 
 namespace {
 uint64_t MapIntoRange(const uint64_t x, const uint64_t n)

--- a/src/test/fuzz/hex.cpp
+++ b/src/test/fuzz/hex.cpp
@@ -12,7 +12,6 @@
 #include <util/strencodings.h>
 
 #include <cassert>
-#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/test/fuzz/http_request.cpp
+++ b/src/test/fuzz/http_request.cpp
@@ -3,9 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <httpserver.h>
-#include <netaddress.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <util/strencodings.h>
 
@@ -15,9 +12,6 @@
 #include <event2/http_struct.h>
 
 #include <cassert>
-#include <cstdint>
-#include <string>
-#include <vector>
 
 // workaround for libevent versions before 2.1.1,
 // when internal functions didn't have underscores at the end

--- a/src/test/fuzz/i2p.cpp
+++ b/src/test/fuzz/i2p.cpp
@@ -3,10 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <i2p.h>
-#include <netaddress.h>
-#include <netbase.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
 #include <threadinterrupt.h>

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -2,27 +2,18 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <arith_uint256.h>
 #include <compressor.h>
-#include <consensus/amount.h>
 #include <consensus/merkle.h>
 #include <core_io.h>
 #include <crypto/common.h>
 #include <crypto/siphash.h>
 #include <key_io.h>
 #include <memusage.h>
-#include <netbase.h>
 #include <policy/settings.h>
 #include <pow.h>
 #include <protocol.h>
 #include <pubkey.h>
-#include <script/standard.h>
-#include <serialize.h>
-#include <streams.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-#include <uint256.h>
 #include <univalue.h>
 #include <util/check.h>
 #include <util/moneystr.h>
@@ -30,14 +21,11 @@
 #include <util/string.h>
 #include <util/system.h>
 #include <util/time.h>
-#include <version.h>
 
 #include <cassert>
 #include <chrono>
 #include <ctime>
-#include <limits>
 #include <set>
-#include <vector>
 
 void initialize_integer()
 {

--- a/src/test/fuzz/key.cpp
+++ b/src/test/fuzz/key.cpp
@@ -20,7 +20,6 @@
 #include <util/strencodings.h>
 
 #include <cassert>
-#include <cstdint>
 #include <numeric>
 #include <string>
 #include <vector>

--- a/src/test/fuzz/key_io.cpp
+++ b/src/test/fuzz/key_io.cpp
@@ -7,7 +7,6 @@
 #include <test/fuzz/fuzz.h>
 
 #include <cassert>
-#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/test/fuzz/kitchen_sink.cpp
+++ b/src/test/fuzz/kitchen_sink.cpp
@@ -2,19 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <merkleblock.h>
 #include <policy/fees.h>
 #include <rpc/util.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <util/error.h>
 #include <util/translation.h>
-
-#include <array>
-#include <cstdint>
-#include <optional>
-#include <vector>
 
 namespace {
 constexpr TransactionError ALL_TRANSACTION_ERROR[] = {

--- a/src/test/fuzz/load_external_block_file.cpp
+++ b/src/test/fuzz/load_external_block_file.cpp
@@ -4,14 +4,9 @@
 
 #include <chainparams.h>
 #include <flatfile.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
 #include <validation.h>
-
-#include <cstdint>
-#include <vector>
 
 namespace {
 const TestingSetup* g_setup;

--- a/src/test/fuzz/locale.cpp
+++ b/src/test/fuzz/locale.cpp
@@ -10,10 +10,7 @@
 
 #include <cassert>
 #include <clocale>
-#include <cstdint>
 #include <locale>
-#include <string>
-#include <vector>
 
 namespace {
 const std::string locale_identifiers[] = {

--- a/src/test/fuzz/merkleblock.cpp
+++ b/src/test/fuzz/merkleblock.cpp
@@ -2,16 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <merkleblock.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-#include <uint256.h>
-
-#include <cstdint>
-#include <optional>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(merkleblock)
 {

--- a/src/test/fuzz/message.cpp
+++ b/src/test/fuzz/message.cpp
@@ -4,17 +4,12 @@
 
 #include <chainparams.h>
 #include <key_io.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <util/message.h>
 #include <util/strencodings.h>
 
 #include <cassert>
-#include <cstdint>
 #include <iostream>
-#include <string>
-#include <vector>
 
 void initialize_message()
 {

--- a/src/test/fuzz/muhash.cpp
+++ b/src/test/fuzz/muhash.cpp
@@ -3,11 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <crypto/muhash.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <vector>
 
 FUZZ_TARGET(muhash)
 {

--- a/src/test/fuzz/multiplication_overflow.cpp
+++ b/src/test/fuzz/multiplication_overflow.cpp
@@ -6,13 +6,7 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <string>
-#include <vector>
 
 namespace {
 template <typename T>

--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -3,23 +3,12 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
-#include <chainparamsbase.h>
-#include <net.h>
 #include <net_permissions.h>
-#include <netaddress.h>
 #include <protocol.h>
 #include <random.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-#include <test/util/net.h>
 #include <test/util/setup_common.h>
 #include <util/asmap.h>
-
-#include <cstdint>
-#include <optional>
-#include <string>
-#include <vector>
 
 void initialize_net()
 {

--- a/src/test/fuzz/net_permissions.cpp
+++ b/src/test/fuzz/net_permissions.cpp
@@ -3,15 +3,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <net_permissions.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <util/translation.h>
 
 #include <cassert>
-#include <cstdint>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(net_permissions)
 {

--- a/src/test/fuzz/netaddress.cpp
+++ b/src/test/fuzz/netaddress.cpp
@@ -2,14 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <netaddress.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
 #include <cassert>
-#include <cstdint>
-#include <vector>
 
 FUZZ_TARGET(netaddress)
 {

--- a/src/test/fuzz/netbase_dns_lookup.cpp
+++ b/src/test/fuzz/netbase_dns_lookup.cpp
@@ -2,15 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <netaddress.h>
-#include <netbase.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(netbase_dns_lookup)
 {

--- a/src/test/fuzz/node_eviction.cpp
+++ b/src/test/fuzz/node_eviction.cpp
@@ -2,17 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <net.h>
 #include <protocol.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
-#include <algorithm>
 #include <cassert>
-#include <cstdint>
-#include <optional>
-#include <vector>
 
 FUZZ_TARGET(node_eviction)
 {

--- a/src/test/fuzz/p2p_transport_serialization.cpp
+++ b/src/test/fuzz/p2p_transport_serialization.cpp
@@ -11,10 +11,7 @@
 #include <test/fuzz/fuzz.h>
 
 #include <cassert>
-#include <cstdint>
-#include <limits>
 #include <optional>
-#include <vector>
 
 void initialize_p2p_transport_serialization()
 {

--- a/src/test/fuzz/parse_hd_keypath.cpp
+++ b/src/test/fuzz/parse_hd_keypath.cpp
@@ -2,13 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <util/bip32.h>
-
-#include <cstdint>
-#include <vector>
 
 FUZZ_TARGET(parse_hd_keypath)
 {

--- a/src/test/fuzz/parse_iso8601.cpp
+++ b/src/test/fuzz/parse_iso8601.cpp
@@ -7,9 +7,6 @@
 #include <util/time.h>
 
 #include <cassert>
-#include <cstdint>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(parse_iso8601)
 {

--- a/src/test/fuzz/policy_estimator.cpp
+++ b/src/test/fuzz/policy_estimator.cpp
@@ -3,17 +3,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <policy/fees.h>
-#include <primitives/transaction.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
-#include <txmempool.h>
-
-#include <cstdint>
-#include <optional>
-#include <string>
-#include <vector>
 
 void initialize_policy_estimator()
 {

--- a/src/test/fuzz/policy_estimator_io.cpp
+++ b/src/test/fuzz/policy_estimator_io.cpp
@@ -3,13 +3,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <policy/fees.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
-
-#include <cstdint>
-#include <vector>
 
 void initialize_policy_estimator_io()
 {

--- a/src/test/fuzz/pow.cpp
+++ b/src/test/fuzz/pow.cpp
@@ -6,14 +6,7 @@
 #include <chainparams.h>
 #include <pow.h>
 #include <primitives/block.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <optional>
-#include <string>
-#include <vector>
 
 void initialize_pow()
 {

--- a/src/test/fuzz/prevector.cpp
+++ b/src/test/fuzz/prevector.cpp
@@ -6,7 +6,6 @@
 #include <test/fuzz/fuzz.h>
 
 #include <prevector.h>
-#include <vector>
 
 #include <reverse_iterator.h>
 #include <serialize.h>

--- a/src/test/fuzz/primitives_transaction.cpp
+++ b/src/test/fuzz/primitives_transaction.cpp
@@ -2,15 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <primitives/transaction.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <optional>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(primitives_transaction)
 {

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -4,32 +4,22 @@
 
 #include <banman.h>
 #include <chainparams.h>
-#include <consensus/consensus.h>
-#include <net.h>
 #include <net_processing.h>
 #include <protocol.h>
 #include <scheduler.h>
-#include <script/script.h>
-#include <streams.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/mining.h>
-#include <test/util/net.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
 #include <txorphanage.h>
 #include <validationinterface.h>
-#include <version.h>
 
 #include <atomic>
 #include <cassert>
 #include <chrono>
-#include <cstdint>
 #include <iosfwd>
 #include <iostream>
 #include <memory>
-#include <string>
 
 namespace {
 const TestingSetup* g_setup;

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -2,15 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <consensus/consensus.h>
-#include <net.h>
 #include <net_processing.h>
 #include <protocol.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/mining.h>
-#include <test/util/net.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
 #include <txorphanage.h>

--- a/src/test/fuzz/protocol.cpp
+++ b/src/test/fuzz/protocol.cpp
@@ -3,14 +3,9 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <protocol.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
-#include <cstdint>
-#include <optional>
 #include <stdexcept>
-#include <vector>
 
 FUZZ_TARGET(protocol)
 {

--- a/src/test/fuzz/psbt.cpp
+++ b/src/test/fuzz/psbt.cpp
@@ -13,10 +13,7 @@
 #include <util/check.h>
 #include <version.h>
 
-#include <cstdint>
 #include <optional>
-#include <string>
-#include <vector>
 
 void initialize_psbt()
 {

--- a/src/test/fuzz/random.cpp
+++ b/src/test/fuzz/random.cpp
@@ -3,14 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <random.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <algorithm>
-#include <cstdint>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(random)
 {

--- a/src/test/fuzz/rbf.cpp
+++ b/src/test/fuzz/rbf.cpp
@@ -3,17 +3,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <policy/rbf.h>
-#include <primitives/transaction.h>
 #include <sync.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-#include <txmempool.h>
-
-#include <cstdint>
-#include <optional>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(rbf)
 {

--- a/src/test/fuzz/rolling_bloom_filter.cpp
+++ b/src/test/fuzz/rolling_bloom_filter.cpp
@@ -3,16 +3,9 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bloom.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-#include <uint256.h>
 
 #include <cassert>
-#include <cstdint>
-#include <optional>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(rolling_bloom_filter)
 {

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -8,17 +8,12 @@
 #include <key_io.h>
 #include <node/context.h>
 #include <primitives/block.h>
-#include <primitives/transaction.h>
 #include <psbt.h>
 #include <rpc/blockchain.h>
 #include <rpc/client.h>
 #include <rpc/request.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
-#include <span.h>
-#include <streams.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
 #include <tinyformat.h>
@@ -27,13 +22,9 @@
 #include <util/string.h>
 #include <util/time.h>
 
-#include <cstdint>
 #include <iostream>
 #include <memory>
-#include <optional>
 #include <stdexcept>
-#include <string>
-#include <vector>
 
 namespace {
 struct RPCFuzzTestingSetup : public TestingSetup {

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -12,23 +12,13 @@
 #include <rpc/util.h>
 #include <script/descriptor.h>
 #include <script/interpreter.h>
-#include <script/script.h>
 #include <script/script_error.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
-#include <script/standard.h>
-#include <streams.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <univalue.h>
 
-#include <algorithm>
 #include <cassert>
-#include <cstdint>
-#include <optional>
-#include <string>
-#include <vector>
 
 void initialize_script()
 {

--- a/src/test/fuzz/script_assets_test_minimizer.cpp
+++ b/src/test/fuzz/script_assets_test_minimizer.cpp
@@ -13,7 +13,6 @@
 #include <util/strencodings.h>
 
 #include <boost/algorithm/string.hpp>
-#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/test/fuzz/script_bitcoin_consensus.cpp
+++ b/src/test/fuzz/script_bitcoin_consensus.cpp
@@ -4,13 +4,7 @@
 
 #include <script/bitcoinconsensus.h>
 #include <script/interpreter.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(script_bitcoin_consensus)
 {

--- a/src/test/fuzz/script_descriptor_cache.cpp
+++ b/src/test/fuzz/script_descriptor_cache.cpp
@@ -4,14 +4,7 @@
 
 #include <pubkey.h>
 #include <script/descriptor.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <optional>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(script_descriptor_cache)
 {

--- a/src/test/fuzz/script_interpreter.cpp
+++ b/src/test/fuzz/script_interpreter.cpp
@@ -2,16 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <primitives/transaction.h>
 #include <script/interpreter.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <optional>
-#include <string>
-#include <vector>
 
 bool CastToBool(const std::vector<unsigned char>& vch);
 

--- a/src/test/fuzz/script_ops.cpp
+++ b/src/test/fuzz/script_ops.cpp
@@ -2,14 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <script/script.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(script_ops)
 {

--- a/src/test/fuzz/script_sigcache.cpp
+++ b/src/test/fuzz/script_sigcache.cpp
@@ -3,18 +3,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
-#include <chainparamsbase.h>
 #include <key.h>
 #include <pubkey.h>
 #include <script/sigcache.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <optional>
-#include <string>
-#include <vector>
 
 void initialize_script_sigcache()
 {

--- a/src/test/fuzz/script_sign.cpp
+++ b/src/test/fuzz/script_sign.cpp
@@ -3,25 +3,17 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
-#include <chainparamsbase.h>
 #include <key.h>
 #include <pubkey.h>
 #include <script/keyorigin.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
-#include <streams.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <util/translation.h>
 
 #include <cassert>
-#include <cstdint>
 #include <iostream>
 #include <map>
-#include <optional>
-#include <string>
-#include <vector>
 
 void initialize_script_sign()
 {

--- a/src/test/fuzz/scriptnum_ops.cpp
+++ b/src/test/fuzz/scriptnum_ops.cpp
@@ -2,15 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <script/script.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
 #include <cassert>
-#include <cstdint>
-#include <limits>
-#include <vector>
 
 namespace {
 bool IsValidAddition(const CScriptNum& lhs, const CScriptNum& rhs)

--- a/src/test/fuzz/secp256k1_ec_seckey_import_export_der.cpp
+++ b/src/test/fuzz/secp256k1_ec_seckey_import_export_der.cpp
@@ -4,12 +4,7 @@
 
 #include <key.h>
 #include <secp256k1.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <vector>
 
 int ec_seckey_import_der(const secp256k1_context* ctx, unsigned char* out32, const unsigned char* seckey, size_t seckeylen);
 int ec_seckey_export_der(const secp256k1_context* ctx, unsigned char* seckey, size_t* seckeylen, const unsigned char* key32, bool compressed);

--- a/src/test/fuzz/secp256k1_ecdsa_signature_parse_der_lax.cpp
+++ b/src/test/fuzz/secp256k1_ecdsa_signature_parse_der_lax.cpp
@@ -4,12 +4,7 @@
 
 #include <key.h>
 #include <secp256k1.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-
-#include <cstdint>
-#include <vector>
 
 bool SigHasLowR(const secp256k1_ecdsa_signature* sig);
 int ecdsa_signature_parse_der_lax(const secp256k1_context* ctx, secp256k1_ecdsa_signature* sig, const unsigned char* input, size_t inputlen);

--- a/src/test/fuzz/signature_checker.cpp
+++ b/src/test/fuzz/signature_checker.cpp
@@ -4,15 +4,8 @@
 
 #include <pubkey.h>
 #include <script/interpreter.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/script.h>
-
-#include <cstdint>
-#include <limits>
-#include <string>
-#include <vector>
 
 void initialize_signature_checker()
 {

--- a/src/test/fuzz/signet.cpp
+++ b/src/test/fuzz/signet.cpp
@@ -6,15 +6,8 @@
 #include <consensus/validation.h>
 #include <primitives/block.h>
 #include <signet.h>
-#include <streams.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
-
-#include <cstdint>
-#include <optional>
-#include <vector>
 
 void initialize_signet()
 {

--- a/src/test/fuzz/socks5.cpp
+++ b/src/test/fuzz/socks5.cpp
@@ -2,16 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <netaddress.h>
-#include <netbase.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
-
-#include <cstdint>
-#include <string>
-#include <vector>
 
 namespace {
 int default_socks5_recv_timeout;

--- a/src/test/fuzz/span.cpp
+++ b/src/test/fuzz/span.cpp
@@ -2,16 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <span.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
 #include <cassert>
-#include <cstddef>
-#include <cstdint>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(span)
 {

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -5,19 +5,12 @@
 #include <blockfilter.h>
 #include <clientversion.h>
 #include <logging.h>
-#include <netaddress.h>
-#include <netbase.h>
 #include <outputtype.h>
 #include <rpc/client.h>
 #include <rpc/request.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
 #include <script/descriptor.h>
-#include <script/script.h>
-#include <serialize.h>
-#include <streams.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <util/error.h>
 #include <util/fees.h>
@@ -28,12 +21,8 @@
 #include <util/system.h>
 #include <util/translation.h>
 #include <util/url.h>
-#include <version.h>
 
-#include <cstdint>
 #include <cstdlib>
-#include <string>
-#include <vector>
 
 namespace {
 bool LegacyParsePrechecks(const std::string& str)

--- a/src/test/fuzz/strprintf.cpp
+++ b/src/test/fuzz/strprintf.cpp
@@ -2,17 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <tinyformat.h>
 #include <util/strencodings.h>
 #include <util/translation.h>
-
-#include <algorithm>
-#include <cstdint>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(str_printf)
 {

--- a/src/test/fuzz/system.cpp
+++ b/src/test/fuzz/system.cpp
@@ -2,15 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
 #include <util/system.h>
-
-#include <cstdint>
-#include <string>
-#include <vector>
 
 namespace {
 void initialize_system()

--- a/src/test/fuzz/timedata.cpp
+++ b/src/test/fuzz/timedata.cpp
@@ -2,14 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <timedata.h>
-
-#include <cstdint>
-#include <string>
-#include <vector>
 
 FUZZ_TARGET(timedata)
 {

--- a/src/test/fuzz/torcontrol.cpp
+++ b/src/test/fuzz/torcontrol.cpp
@@ -2,15 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
 #include <torcontrol.h>
-
-#include <cstdint>
-#include <string>
-#include <vector>
 
 class DummyTorControlConnection : public TorControlConnection
 {

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -4,8 +4,6 @@
 
 #include <consensus/validation.h>
 #include <miner.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/mining.h>
 #include <test/util/script.h>

--- a/src/test/fuzz/txrequest.cpp
+++ b/src/test/fuzz/txrequest.cpp
@@ -10,7 +10,6 @@
 #include <txrequest.h>
 
 #include <bitset>
-#include <cstdint>
 #include <queue>
 #include <vector>
 

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -2,13 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <consensus/amount.h>
 #include <pubkey.h>
 #include <test/fuzz/util.h>
 #include <test/util/script.h>
 #include <util/rbf.h>
 #include <util/time.h>
-#include <version.h>
 
 FuzzedSock::FuzzedSock(FuzzedDataProvider& fuzzed_data_provider)
     : m_fuzzed_data_provider{fuzzed_data_provider}

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -5,8 +5,6 @@
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <node/utxo_snapshot.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/mining.h>
 #include <test/util/setup_common.h>

--- a/src/test/fuzz/validation_load_mempool.cpp
+++ b/src/test/fuzz/validation_load_mempool.cpp
@@ -2,17 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <chainparamsbase.h>
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
-#include <txmempool.h>
 #include <util/time.h>
 #include <validation.h>
-
-#include <cstdint>
-#include <vector>
 
 namespace {
 const TestingSetup* g_setup;

--- a/src/test/fuzz/versionbits.cpp
+++ b/src/test/fuzz/versionbits.cpp
@@ -9,14 +9,9 @@
 #include <util/system.h>
 #include <versionbits.h>
 
-#include <test/fuzz/FuzzedDataProvider.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
-#include <cstdint>
-#include <limits>
 #include <memory>
-#include <vector>
 
 namespace {
 class TestConditionChecker : public AbstractThresholdConditionChecker


### PR DESCRIPTION
This PR removes redundant inclusion of header files in the fuzz test files. Most of the header files like `#include<string>`, `#include<vector>` etc.. are redundant because it’s imports are already included in one of these header files - `src/test/fuzz/fuzz.h`, `src/test/fuzz/util.h` and `src/test/fuzz/FuzzedDataProvider.h`. So they can be removed.

This bash script was used to delete redundant import occurrences. The text files `headers-fuzz.txt`, `headers-util.txt` and `headers-FuzzedDataProvider.txt` were provided with the header file information which are present in `src/test/fuzz/fuzz.h`, `src/test/fuzz/util.h` and `src/test/fuzz/FuzzedDataProvider.h` respectively.
```
#!/bin/bash
remove-lines() (
  remove_lines="$1"
  all_lines="$2"
  tmp_file="$(mktemp)"
  grep -Fvxf "$remove_lines" "$all_lines" > "$tmp_file"
  mv "$tmp_file" "$all_lines"
)

for filename in bitcoin/src/test/fuzz/*.cpp; do
    # if FuzzedDataProvider.h is imported
    if grep -q "#include <test/fuzz/FuzzedDataProvider.h>" "$filename"
    then
        remove-lines "headers-FuzzedDataProvider.txt" "$filename"
    fi
    # if fuzz.h is imported
    if grep -q "#include <test/fuzz/fuzz.h>" "$filename"
    then
        remove-lines "headers-fuzz.txt" "$filename"
    fi
    # if util.h is imported
    if grep -q "#include <test/fuzz/util.h>" "$filename"
    then
        remove-lines "headers-util.txt" "$filename"
    fi
    # don't let 2 empty lines occur after deletion
    tempfile=$(cat -s "$filename")
    echo "$tempfile" > "$filename";
done
```