### PR TITLE
test: Remove unused node from mining_prioritisetransaction

### DIFF
--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -13,7 +13,7 @@ from test_framework.util import assert_equal, assert_raises_rpc_error, create_co
 class PrioritiseTransactionTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
-        self.num_nodes = 2
+        self.num_nodes = 1
         self.extra_args = [[
             "-printpriority=1",
             "-acceptnonstdtxn=1",


### PR DESCRIPTION
No need to make the test slower with an unused node