### PR TITLE
Update basic multisig test/docs to use multipath descriptor

### DIFF
--- a/doc/descriptors.md
+++ b/doc/descriptors.md
@@ -158,9 +158,9 @@ The basic steps are:
      the participant's signer wallet. Avoid reusing this wallet for any purpose other than signing transactions from the
      corresponding multisig we are about to create. Hint: extract the wallet's xpubs using `listdescriptors` and pick the one from the
      `pkh` descriptor since it's least likely to be accidentally reused (legacy addresses)
-  2. Create a watch-only descriptor wallet (blank, private keys disabled). Now the multisig is created by importing the two descriptors:
-     `wsh(sortedmulti(<M>,XPUB1/0/*,XPUB2/0/*,…,XPUBN/0/*))` and `wsh(sortedmulti(<M>,XPUB1/1/*,XPUB2/1/*,…,XPUBN/1/*))`
-     (one descriptor w/ `0` for receiving addresses and another w/ `1` for change). Every participant does this
+  2. Create a watch-only descriptor wallet (blank, private keys disabled). Now the multisig is created by importing the descriptor:
+     `wsh(sortedmulti(<M>,XPUB1/<0;1>/*,XPUB2/<0;1>/*,…,XPUBN/<0;1>/*))` (this multipath descriptor specifies both receiving and change
+     addresses in a single string). Every participant does this
   3. A receiving address is generated for the multisig. As a check to ensure step 2 was done correctly, every participant
      should verify they get the same addresses
   4. Funds are sent to the resulting address

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -151,7 +151,7 @@ void TestGUI(interfaces::Node& node)
         // Add the coinbase key
         FlatSigningProvider provider;
         std::string error;
-        std::unique_ptr<Descriptor> desc = Parse("combo(" + EncodeSecret(test.coinbaseKey) + ")", provider, error, /* require_checksum=*/ false);
+        std::unique_ptr<Descriptor> desc = Parse("combo(" + EncodeSecret(test.coinbaseKey) + ")", provider, error, /* require_checksum=*/ false).first;
         assert(desc);
         WalletDescriptor w_desc(std::move(desc), 0, 0, 1, 1);
         if (!wallet->AddWalletDescriptor(w_desc, provider, "", false)) assert(false);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -175,7 +175,11 @@ static UniValue generateBlocks(ChainstateManager& chainman, const CTxMemPool& me
 static bool getScriptFromDescriptor(const std::string& descriptor, CScript& script, std::string& error)
 {
     FlatSigningProvider key_provider;
-    const auto desc = Parse(descriptor, key_provider, error, /* require_checksum = */ false);
+    const auto descs = Parse(descriptor, key_provider, error, /* require_checksum = */ false);
+    if (descs.second) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Multipath descriptor not accepted");
+    }
+    const auto& desc = descs.first;
     if (desc) {
         if (desc->IsRange()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Ranged descriptor not accepted. Maybe pass through deriveaddresses first?");

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -1089,7 +1089,7 @@ std::unique_ptr<PubkeyProvider> ParsePubkey(uint32_t key_exp_index, const Span<c
 }
 
 /** Parse a script in a particular context. */
-std::unique_ptr<DescriptorImpl> ParseScript(uint32_t& key_exp_index, Span<const char>& sp, ParseScriptContext ctx, FlatSigningProvider& out, std::string& error)
+std::pair<std::unique_ptr<DescriptorImpl>, std::unique_ptr<DescriptorImpl>> ParseScript(uint32_t& key_exp_index, Span<const char>& sp, ParseScriptContext ctx, FlatSigningProvider& out, std::string& error)
 {
     using namespace spanparsing;
 
@@ -1097,27 +1097,36 @@ std::unique_ptr<DescriptorImpl> ParseScript(uint32_t& key_exp_index, Span<const 
     bool sorted_multi = false;
     if (Func("pk", expr)) {
         auto pubkey = ParsePubkey(key_exp_index, expr, ctx, out, error);
-        if (!pubkey) return nullptr;
+        if (!pubkey) return {nullptr, nullptr};
         ++key_exp_index;
-        return std::make_unique<PKDescriptor>(std::move(pubkey), ctx == ParseScriptContext::P2TR);
+        return {
+            std::make_unique<PKDescriptor>(std::move(pubkey), ctx == ParseScriptContext::P2TR),
+            nullptr
+        };
     }
     if ((ctx == ParseScriptContext::TOP || ctx == ParseScriptContext::P2SH || ctx == ParseScriptContext::P2WSH) && Func("pkh", expr)) {
         auto pubkey = ParsePubkey(key_exp_index, expr, ctx, out, error);
-        if (!pubkey) return nullptr;
+        if (!pubkey) return {nullptr, nullptr};
         ++key_exp_index;
-        return std::make_unique<PKHDescriptor>(std::move(pubkey));
+        return {
+            std::make_unique<PKHDescriptor>(std::move(pubkey)),
+            nullptr
+        };
     } else if (Func("pkh", expr)) {
         error = "Can only have pkh at top level, in sh(), or in wsh()";
-        return nullptr;
+        return {nullptr, nullptr};
     }
     if (ctx == ParseScriptContext::TOP && Func("combo", expr)) {
         auto pubkey = ParsePubkey(key_exp_index, expr, ctx, out, error);
-        if (!pubkey) return nullptr;
+        if (!pubkey) return {nullptr, nullptr};
         ++key_exp_index;
-        return std::make_unique<ComboDescriptor>(std::move(pubkey));
+        return {
+            std::make_unique<ComboDescriptor>(std::move(pubkey)),
+            nullptr
+        };
     } else if (Func("combo", expr)) {
         error = "Can only have combo() at top level";
-        return nullptr;
+        return {nullptr, nullptr};
     }
     if ((ctx == ParseScriptContext::TOP || ctx == ParseScriptContext::P2SH || ctx == ParseScriptContext::P2WSH) && ((sorted_multi = Func("sortedmulti", expr)) || Func("multi", expr))) {
         auto threshold = Expr(expr);
@@ -1125,96 +1134,111 @@ std::unique_ptr<DescriptorImpl> ParseScript(uint32_t& key_exp_index, Span<const 
         std::vector<std::unique_ptr<PubkeyProvider>> providers;
         if (!ParseUInt32(std::string(threshold.begin(), threshold.end()), &thres)) {
             error = strprintf("Multi threshold '%s' is not valid", std::string(threshold.begin(), threshold.end()));
-            return nullptr;
+            return {nullptr, nullptr};
         }
         size_t script_size = 0;
         while (expr.size()) {
             if (!Const(",", expr)) {
                 error = strprintf("Multi: expected ',', got '%c'", expr[0]);
-                return nullptr;
+                return {nullptr, nullptr};
             }
             auto arg = Expr(expr);
             auto pk = ParsePubkey(key_exp_index, arg, ctx, out, error);
-            if (!pk) return nullptr;
+            if (!pk) return {nullptr, nullptr};
             script_size += pk->GetSize() + 1;
             providers.emplace_back(std::move(pk));
             key_exp_index++;
         }
         if (providers.empty() || providers.size() > MAX_PUBKEYS_PER_MULTISIG) {
             error = strprintf("Cannot have %u keys in multisig; must have between 1 and %d keys, inclusive", providers.size(), MAX_PUBKEYS_PER_MULTISIG);
-            return nullptr;
+            return {nullptr, nullptr};
         } else if (thres < 1) {
             error = strprintf("Multisig threshold cannot be %d, must be at least 1", thres);
-            return nullptr;
+            return {nullptr, nullptr};
         } else if (thres > providers.size()) {
             error = strprintf("Multisig threshold cannot be larger than the number of keys; threshold is %d but only %u keys specified", thres, providers.size());
-            return nullptr;
+            return {nullptr, nullptr};
         }
         if (ctx == ParseScriptContext::TOP) {
             if (providers.size() > 3) {
                 error = strprintf("Cannot have %u pubkeys in bare multisig; only at most 3 pubkeys", providers.size());
-                return nullptr;
+                return {nullptr, nullptr};
             }
         }
         if (ctx == ParseScriptContext::P2SH) {
             // This limits the maximum number of compressed pubkeys to 15.
             if (script_size + 3 > MAX_SCRIPT_ELEMENT_SIZE) {
                 error = strprintf("P2SH script is too large, %d bytes is larger than %d bytes", script_size + 3, MAX_SCRIPT_ELEMENT_SIZE);
-                return nullptr;
+                return {nullptr, nullptr};
             }
         }
-        return std::make_unique<MultisigDescriptor>(thres, std::move(providers), sorted_multi);
+        return {
+            std::make_unique<MultisigDescriptor>(thres, std::move(providers), sorted_multi),
+            nullptr
+        };
     } else if (Func("sortedmulti", expr) || Func("multi", expr)) {
         error = "Can only have multi/sortedmulti at top level, in sh(), or in wsh()";
-        return nullptr;
+        return {nullptr, nullptr};
     }
     if ((ctx == ParseScriptContext::TOP || ctx == ParseScriptContext::P2SH) && Func("wpkh", expr)) {
         auto pubkey = ParsePubkey(key_exp_index, expr, ParseScriptContext::P2WPKH, out, error);
-        if (!pubkey) return nullptr;
+        if (!pubkey) return {nullptr, nullptr};
         key_exp_index++;
-        return std::make_unique<WPKHDescriptor>(std::move(pubkey));
+        return {
+            std::make_unique<WPKHDescriptor>(std::move(pubkey)),
+            nullptr
+        };
     } else if (Func("wpkh", expr)) {
         error = "Can only have wpkh() at top level or inside sh()";
-        return nullptr;
+        return {nullptr, nullptr};
     }
     if (ctx == ParseScriptContext::TOP && Func("sh", expr)) {
         auto desc = ParseScript(key_exp_index, expr, ParseScriptContext::P2SH, out, error);
-        if (!desc || expr.size()) return nullptr;
-        return std::make_unique<SHDescriptor>(std::move(desc));
+        if (!desc.first || expr.size()) return {nullptr, nullptr};
+        return {
+            std::make_unique<SHDescriptor>(std::move(desc.first)),
+            nullptr
+        };
     } else if (Func("sh", expr)) {
         error = "Can only have sh() at top level";
-        return nullptr;
+        return {nullptr, nullptr};
     }
     if ((ctx == ParseScriptContext::TOP || ctx == ParseScriptContext::P2SH) && Func("wsh", expr)) {
         auto desc = ParseScript(key_exp_index, expr, ParseScriptContext::P2WSH, out, error);
-        if (!desc || expr.size()) return nullptr;
-        return std::make_unique<WSHDescriptor>(std::move(desc));
+        if (!desc.first || expr.size()) return {nullptr, nullptr};
+        return {
+            std::make_unique<WSHDescriptor>(std::move(desc.first)),
+            nullptr
+        };
     } else if (Func("wsh", expr)) {
         error = "Can only have wsh() at top level or inside sh()";
-        return nullptr;
+        return {nullptr, nullptr};
     }
     if (ctx == ParseScriptContext::TOP && Func("addr", expr)) {
         CTxDestination dest = DecodeDestination(std::string(expr.begin(), expr.end()));
         if (!IsValidDestination(dest)) {
             error = "Address is not valid";
-            return nullptr;
+            return {nullptr, nullptr};
         }
-        return std::make_unique<AddressDescriptor>(std::move(dest));
+        return {
+            std::make_unique<AddressDescriptor>(std::move(dest)),
+            nullptr
+        };
     } else if (Func("addr", expr)) {
         error = "Can only have addr() at top level";
-        return nullptr;
+        return {nullptr, nullptr};
     }
     if (ctx == ParseScriptContext::TOP && Func("tr", expr)) {
         auto arg = Expr(expr);
         auto internal_key = ParsePubkey(key_exp_index, arg, ParseScriptContext::P2TR, out, error);
-        if (!internal_key) return nullptr;
+        if (!internal_key) return {nullptr, nullptr};
         ++key_exp_index;
-        std::vector<std::unique_ptr<DescriptorImpl>> subscripts; //!< list of script subexpressions
+        std::pair<std::vector<std::unique_ptr<DescriptorImpl>>, std::vector<std::unique_ptr<DescriptorImpl>>> subscripts; //!< list of script subexpressions
         std::vector<int> depths; //!< depth in the tree of each subexpression (same length subscripts)
         if (expr.size()) {
             if (!Const(",", expr)) {
                 error = strprintf("tr: expected ',', got '%c'", expr[0]);
-                return nullptr;
+                return {nullptr, nullptr};
             }
             /** The path from the top of the tree to what we're currently processing.
              * branches[i] == false: left branch in the i'th step from the top; true: right branch.
@@ -1228,19 +1252,21 @@ std::unique_ptr<DescriptorImpl> ParseScript(uint32_t& key_exp_index, Span<const 
                     branches.push_back(false); // new left branch
                     if (branches.size() > TAPROOT_CONTROL_MAX_NODE_COUNT) {
                         error = strprintf("tr() supports at most %i nesting levels", TAPROOT_CONTROL_MAX_NODE_COUNT);
-                        return nullptr;
+                        return {nullptr, nullptr};
                     }
                 }
                 // Process the actual script expression.
                 auto sarg = Expr(expr);
-                subscripts.emplace_back(ParseScript(key_exp_index, sarg, ParseScriptContext::P2TR, out, error));
-                if (!subscripts.back()) return nullptr;
+                auto parsed_scripts = ParseScript(key_exp_index, sarg, ParseScriptContext::P2TR, out, error);
+                if (!parsed_scripts.first) return {nullptr, nullptr};
+                subscripts.second.emplace_back(parsed_scripts.second ? std::move(parsed_scripts.second) : std::move(parsed_scripts.first->Clone()));
+                subscripts.first.emplace_back(std::move(parsed_scripts.first));
                 depths.push_back(branches.size());
                 // Process closing braces; one is expected for every right branch we were in.
                 while (branches.size() && branches.back()) {
                     if (!Const("}", expr)) {
                         error = strprintf("tr(): expected '}' after script expression");
-                        return nullptr;
+                        return {nullptr, nullptr};
                     }
                     branches.pop_back(); // move up one level after encountering '}'
                 }
@@ -1248,7 +1274,7 @@ std::unique_ptr<DescriptorImpl> ParseScript(uint32_t& key_exp_index, Span<const 
                 if (branches.size() && !branches.back()) {
                     if (!Const(",", expr)) {
                         error = strprintf("tr(): expected ',' after script expression");
-                        return nullptr;
+                        return {nullptr, nullptr};
                     }
                     branches.back() = true; // And now we're in a right branch.
                 }
@@ -1256,36 +1282,42 @@ std::unique_ptr<DescriptorImpl> ParseScript(uint32_t& key_exp_index, Span<const 
             // After we've explored a whole tree, we must be at the end of the expression.
             if (expr.size()) {
                 error = strprintf("tr(): expected ')' after script expression");
-                return nullptr;
+                return {nullptr, nullptr};
             }
         }
         assert(TaprootBuilder::ValidDepths(depths));
-        return std::make_unique<TRDescriptor>(std::move(internal_key), std::move(subscripts), std::move(depths));
+        return {
+            std::make_unique<TRDescriptor>(std::move(internal_key), std::move(subscripts.first), std::move(depths)),
+            nullptr
+        };
     } else if (Func("tr", expr)) {
         error = "Can only have tr at top level";
-        return nullptr;
+        return {nullptr, nullptr};
     }
     if (ctx == ParseScriptContext::TOP && Func("raw", expr)) {
         std::string str(expr.begin(), expr.end());
         if (!IsHex(str)) {
             error = "Raw script is not hex";
-            return nullptr;
+            return {nullptr, nullptr};
         }
         auto bytes = ParseHex(str);
-        return std::make_unique<RawDescriptor>(CScript(bytes.begin(), bytes.end()));
+        return {
+            std::make_unique<RawDescriptor>(CScript(bytes.begin(), bytes.end())),
+            nullptr
+        };
     } else if (Func("raw", expr)) {
         error = "Can only have raw() at top level";
-        return nullptr;
+        return {nullptr, nullptr};
     }
     if (ctx == ParseScriptContext::P2SH) {
         error = "A function is needed within P2SH";
-        return nullptr;
+        return {nullptr, nullptr};
     } else if (ctx == ParseScriptContext::P2WSH) {
         error = "A function is needed within P2WSH";
-        return nullptr;
+        return {nullptr, nullptr};
     }
     error = strprintf("%s is not a valid descriptor function", std::string(expr.begin(), expr.end()));
-    return nullptr;
+    return {nullptr, nullptr};
 }
 
 std::unique_ptr<PubkeyProvider> InferPubkey(const CPubKey& pubkey, ParseScriptContext, const SigningProvider& provider)
@@ -1459,7 +1491,7 @@ std::unique_ptr<Descriptor> Parse(const std::string& descriptor, FlatSigningProv
     if (!CheckChecksum(sp, require_checksum, error)) return nullptr;
     uint32_t key_exp_index = 0;
     auto ret = ParseScript(key_exp_index, sp, ParseScriptContext::TOP, out, error);
-    if (sp.size() == 0 && ret) return std::unique_ptr<Descriptor>(std::move(ret));
+    if (sp.size() == 0 && ret.first) return std::unique_ptr<Descriptor>(std::move(ret.first));
     return nullptr;
 }
 

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -185,6 +185,9 @@ public:
 
     /** Derive a private key, if private data is available in arg. */
     virtual bool GetPrivKey(int pos, const SigningProvider& arg, CKey& key) const = 0;
+
+    /** Make a deep copy of this PubkeyProvider */
+    virtual std::unique_ptr<PubkeyProvider> Clone() const = 0;
 };
 
 class OriginPubkeyProvider final : public PubkeyProvider
@@ -235,6 +238,10 @@ public:
     {
         return m_provider->GetPrivKey(pos, arg, key);
     }
+    std::unique_ptr<PubkeyProvider> Clone() const override
+    {
+        return std::make_unique<OriginPubkeyProvider>(m_expr_index, m_origin, m_provider->Clone());
+    }
 };
 
 /** An object representing a parsed constant public key in a descriptor. */
@@ -271,6 +278,10 @@ public:
     bool GetPrivKey(int pos, const SigningProvider& arg, CKey& key) const override
     {
         return arg.GetKey(m_pubkey.GetID(), key);
+    }
+    std::unique_ptr<PubkeyProvider> Clone() const override
+    {
+        return std::make_unique<ConstPubkeyProvider>(m_expr_index, m_pubkey, m_xonly);
     }
 };
 
@@ -479,6 +490,10 @@ public:
         if (m_derive == DeriveType::HARDENED) extkey.Derive(extkey, pos | 0x80000000UL);
         key = extkey.key;
         return true;
+    }
+    std::unique_ptr<PubkeyProvider> Clone() const override
+    {
+        return std::make_unique<BIP32PubkeyProvider>(m_expr_index, m_root_extkey, m_path, m_derive);
     }
 };
 

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -983,7 +983,7 @@ enum class ParseScriptContext {
 }
 
 /** Parse a public key that excludes origin information. */
-std::unique_ptr<PubkeyProvider> ParsePubkeyInner(uint32_t key_exp_index, const Span<const char>& sp, ParseScriptContext ctx, FlatSigningProvider& out, std::string& error)
+std::pair<std::unique_ptr<PubkeyProvider>, std::unique_ptr<PubkeyProvider>> ParsePubkeyInner(uint32_t key_exp_index, const Span<const char>& sp, ParseScriptContext ctx, FlatSigningProvider& out, std::string& error)
 {
     using namespace spanparsing;
 
@@ -992,7 +992,7 @@ std::unique_ptr<PubkeyProvider> ParsePubkeyInner(uint32_t key_exp_index, const S
     std::string str(split[0].begin(), split[0].end());
     if (str.size() == 0) {
         error = "No key provided";
-        return nullptr;
+        return {nullptr, nullptr};
     }
     if (split.size() == 1) {
         if (IsHex(str)) {
@@ -1000,31 +1000,31 @@ std::unique_ptr<PubkeyProvider> ParsePubkeyInner(uint32_t key_exp_index, const S
             CPubKey pubkey(data);
             if (pubkey.IsFullyValid()) {
                 if (permit_uncompressed || pubkey.IsCompressed()) {
-                    return std::make_unique<ConstPubkeyProvider>(key_exp_index, pubkey, false);
+                    return {std::make_unique<ConstPubkeyProvider>(key_exp_index, pubkey, false), nullptr};
                 } else {
                     error = "Uncompressed keys are not allowed";
-                    return nullptr;
+                    return {nullptr, nullptr};
                 }
             } else if (data.size() == 32 && ctx == ParseScriptContext::P2TR) {
                 unsigned char fullkey[33] = {0x02};
                 std::copy(data.begin(), data.end(), fullkey + 1);
                 pubkey.Set(std::begin(fullkey), std::end(fullkey));
                 if (pubkey.IsFullyValid()) {
-                    return std::make_unique<ConstPubkeyProvider>(key_exp_index, pubkey, true);
+                    return {std::make_unique<ConstPubkeyProvider>(key_exp_index, pubkey, true), nullptr};
                 }
             }
             error = strprintf("Pubkey '%s' is invalid", str);
-            return nullptr;
+            return {nullptr, nullptr};
         }
         CKey key = DecodeSecret(str);
         if (key.IsValid()) {
             if (permit_uncompressed || key.IsCompressed()) {
                 CPubKey pubkey = key.GetPubKey();
                 out.keys.emplace(pubkey.GetID(), key);
-                return std::make_unique<ConstPubkeyProvider>(key_exp_index, pubkey, ctx == ParseScriptContext::P2TR);
+                return {std::make_unique<ConstPubkeyProvider>(key_exp_index, pubkey, ctx == ParseScriptContext::P2TR), nullptr};
             } else {
                 error = "Uncompressed keys are not allowed";
-                return nullptr;
+                return {nullptr, nullptr};
             }
         }
     }
@@ -1032,7 +1032,7 @@ std::unique_ptr<PubkeyProvider> ParsePubkeyInner(uint32_t key_exp_index, const S
     CExtPubKey extpubkey = DecodeExtPubKey(str);
     if (!extkey.key.IsValid() && !extpubkey.pubkey.IsValid()) {
         error = strprintf("key '%s' is not valid", str);
-        return nullptr;
+        return {nullptr, nullptr};
     }
     KeyPath path;
     DeriveType type = DeriveType::NO;
@@ -1043,49 +1043,55 @@ std::unique_ptr<PubkeyProvider> ParsePubkeyInner(uint32_t key_exp_index, const S
         split.pop_back();
         type = DeriveType::HARDENED;
     }
-    if (!ParseKeyPath(split, path, error)) return nullptr;
+    if (!ParseKeyPath(split, path, error)) return {nullptr, nullptr};
     if (extkey.key.IsValid()) {
         extpubkey = extkey.Neuter();
         out.keys.emplace(extpubkey.pubkey.GetID(), extkey.key);
     }
-    return std::make_unique<BIP32PubkeyProvider>(key_exp_index, extpubkey, std::move(path), type);
+    return {
+        std::make_unique<BIP32PubkeyProvider>(key_exp_index, extpubkey, std::move(path), type),
+        nullptr
+    };
 }
 
 /** Parse a public key including origin information (if enabled). */
-std::unique_ptr<PubkeyProvider> ParsePubkey(uint32_t key_exp_index, const Span<const char>& sp, ParseScriptContext ctx, FlatSigningProvider& out, std::string& error)
+std::pair<std::unique_ptr<PubkeyProvider>, std::unique_ptr<PubkeyProvider>> ParsePubkey(uint32_t key_exp_index, const Span<const char>& sp, ParseScriptContext ctx, FlatSigningProvider& out, std::string& error)
 {
     using namespace spanparsing;
 
     auto origin_split = Split(sp, ']');
     if (origin_split.size() > 2) {
         error = "Multiple ']' characters found for a single pubkey";
-        return nullptr;
+        return {nullptr, nullptr};
     }
     if (origin_split.size() == 1) return ParsePubkeyInner(key_exp_index, origin_split[0], ctx, out, error);
     if (origin_split[0].empty() || origin_split[0][0] != '[') {
         error = strprintf("Key origin start '[ character expected but not found, got '%c' instead",
                           origin_split[0].empty() ? /** empty, implies split char */ ']' : origin_split[0][0]);
-        return nullptr;
+        return {nullptr, nullptr};
     }
     auto slash_split = Split(origin_split[0].subspan(1), '/');
     if (slash_split[0].size() != 8) {
         error = strprintf("Fingerprint is not 4 bytes (%u characters instead of 8 characters)", slash_split[0].size());
-        return nullptr;
+        return {nullptr, nullptr};
     }
     std::string fpr_hex = std::string(slash_split[0].begin(), slash_split[0].end());
     if (!IsHex(fpr_hex)) {
         error = strprintf("Fingerprint '%s' is not hex", fpr_hex);
-        return nullptr;
+        return {nullptr, nullptr};
     }
     auto fpr_bytes = ParseHex(fpr_hex);
     KeyOriginInfo info;
     static_assert(sizeof(info.fingerprint) == 4, "Fingerprint must be 4 bytes");
     assert(fpr_bytes.size() == 4);
     std::copy(fpr_bytes.begin(), fpr_bytes.end(), info.fingerprint);
-    if (!ParseKeyPath(slash_split, info.path, error)) return nullptr;
-    auto provider = ParsePubkeyInner(key_exp_index, origin_split[1], ctx, out, error);
-    if (!provider) return nullptr;
-    return std::make_unique<OriginPubkeyProvider>(key_exp_index, std::move(info), std::move(provider));
+    if (!ParseKeyPath(slash_split, info.path, error)) return {nullptr, nullptr};
+    auto providers = ParsePubkeyInner(key_exp_index, origin_split[1], ctx, out, error);
+    if (!providers.first) return {nullptr, nullptr};
+    return {
+        std::make_unique<OriginPubkeyProvider>(key_exp_index, info, std::move(providers.first)),
+        providers.second ? std::make_unique<OriginPubkeyProvider>(key_exp_index, info, std::move(providers.second)) : nullptr
+    };
 }
 
 /** Parse a script in a particular context. */
@@ -1096,33 +1102,33 @@ std::pair<std::unique_ptr<DescriptorImpl>, std::unique_ptr<DescriptorImpl>> Pars
     auto expr = Expr(sp);
     bool sorted_multi = false;
     if (Func("pk", expr)) {
-        auto pubkey = ParsePubkey(key_exp_index, expr, ctx, out, error);
-        if (!pubkey) return {nullptr, nullptr};
+        auto pubkeys = ParsePubkey(key_exp_index, expr, ctx, out, error);
+        if (!pubkeys.first) return {nullptr, nullptr};
         ++key_exp_index;
         return {
-            std::make_unique<PKDescriptor>(std::move(pubkey), ctx == ParseScriptContext::P2TR),
-            nullptr
+            std::make_unique<PKDescriptor>(std::move(pubkeys.first), ctx == ParseScriptContext::P2TR),
+            pubkeys.second ? std::make_unique<PKDescriptor>(std::move(pubkeys.second), ctx == ParseScriptContext::P2TR) : nullptr
         };
     }
     if ((ctx == ParseScriptContext::TOP || ctx == ParseScriptContext::P2SH || ctx == ParseScriptContext::P2WSH) && Func("pkh", expr)) {
-        auto pubkey = ParsePubkey(key_exp_index, expr, ctx, out, error);
-        if (!pubkey) return {nullptr, nullptr};
+        auto pubkeys = ParsePubkey(key_exp_index, expr, ctx, out, error);
+        if (!pubkeys.first) return {nullptr, nullptr};
         ++key_exp_index;
         return {
-            std::make_unique<PKHDescriptor>(std::move(pubkey)),
-            nullptr
+            std::make_unique<PKHDescriptor>(std::move(pubkeys.first)),
+            pubkeys.second ? std::make_unique<PKHDescriptor>(std::move(pubkeys.second)) : nullptr
         };
     } else if (Func("pkh", expr)) {
         error = "Can only have pkh at top level, in sh(), or in wsh()";
         return {nullptr, nullptr};
     }
     if (ctx == ParseScriptContext::TOP && Func("combo", expr)) {
-        auto pubkey = ParsePubkey(key_exp_index, expr, ctx, out, error);
-        if (!pubkey) return {nullptr, nullptr};
+        auto pubkeys = ParsePubkey(key_exp_index, expr, ctx, out, error);
+        if (!pubkeys.first) return {nullptr, nullptr};
         ++key_exp_index;
         return {
-            std::make_unique<ComboDescriptor>(std::move(pubkey)),
-            nullptr
+            std::make_unique<ComboDescriptor>(std::move(pubkeys.first)),
+            pubkeys.second ? std::make_unique<ComboDescriptor>(std::move(pubkeys.second)) : nullptr
         };
     } else if (Func("combo", expr)) {
         error = "Can only have combo() at top level";
@@ -1131,37 +1137,43 @@ std::pair<std::unique_ptr<DescriptorImpl>, std::unique_ptr<DescriptorImpl>> Pars
     if ((ctx == ParseScriptContext::TOP || ctx == ParseScriptContext::P2SH || ctx == ParseScriptContext::P2WSH) && ((sorted_multi = Func("sortedmulti", expr)) || Func("multi", expr))) {
         auto threshold = Expr(expr);
         uint32_t thres;
-        std::vector<std::unique_ptr<PubkeyProvider>> providers;
+        std::pair<std::vector<std::unique_ptr<PubkeyProvider>>, std::vector<std::unique_ptr<PubkeyProvider>>> providers;
         if (!ParseUInt32(std::string(threshold.begin(), threshold.end()), &thres)) {
             error = strprintf("Multi threshold '%s' is not valid", std::string(threshold.begin(), threshold.end()));
             return {nullptr, nullptr};
         }
         size_t script_size = 0;
+        bool has_multipath = false;
         while (expr.size()) {
             if (!Const(",", expr)) {
                 error = strprintf("Multi: expected ',', got '%c'", expr[0]);
                 return {nullptr, nullptr};
             }
             auto arg = Expr(expr);
-            auto pk = ParsePubkey(key_exp_index, arg, ctx, out, error);
-            if (!pk) return {nullptr, nullptr};
-            script_size += pk->GetSize() + 1;
-            providers.emplace_back(std::move(pk));
+            auto pks = ParsePubkey(key_exp_index, arg, ctx, out, error);
+            if (!pks.first) return {nullptr, nullptr};
+            if (pks.second) {
+                has_multipath = true;
+            }
+            script_size += pks.first->GetSize() + 1;
+            providers.first.emplace_back(std::move(pks.first));
+            providers.second.emplace_back(pks.second ? std::move(pks.second) : std::move(pks.first->Clone()));
             key_exp_index++;
         }
-        if (providers.empty() || providers.size() > MAX_PUBKEYS_PER_MULTISIG) {
-            error = strprintf("Cannot have %u keys in multisig; must have between 1 and %d keys, inclusive", providers.size(), MAX_PUBKEYS_PER_MULTISIG);
+        assert(providers.first.size() == providers.second.size());
+        if (providers.first.empty() || providers.first.size() > MAX_PUBKEYS_PER_MULTISIG) {
+            error = strprintf("Cannot have %u keys in multisig; must have between 1 and %d keys, inclusive", providers.first.size(), MAX_PUBKEYS_PER_MULTISIG);
             return {nullptr, nullptr};
         } else if (thres < 1) {
             error = strprintf("Multisig threshold cannot be %d, must be at least 1", thres);
             return {nullptr, nullptr};
-        } else if (thres > providers.size()) {
-            error = strprintf("Multisig threshold cannot be larger than the number of keys; threshold is %d but only %u keys specified", thres, providers.size());
+        } else if (thres > providers.first.size()) {
+            error = strprintf("Multisig threshold cannot be larger than the number of keys; threshold is %d but only %u keys specified", thres, providers.first.size());
             return {nullptr, nullptr};
         }
         if (ctx == ParseScriptContext::TOP) {
-            if (providers.size() > 3) {
-                error = strprintf("Cannot have %u pubkeys in bare multisig; only at most 3 pubkeys", providers.size());
+            if (providers.first.size() > 3) {
+                error = strprintf("Cannot have %u pubkeys in bare multisig; only at most 3 pubkeys", providers.first.size());
                 return {nullptr, nullptr};
             }
         }
@@ -1173,20 +1185,20 @@ std::pair<std::unique_ptr<DescriptorImpl>, std::unique_ptr<DescriptorImpl>> Pars
             }
         }
         return {
-            std::make_unique<MultisigDescriptor>(thres, std::move(providers), sorted_multi),
-            nullptr
+            std::make_unique<MultisigDescriptor>(thres, std::move(providers.first), sorted_multi),
+            has_multipath ? std::make_unique<MultisigDescriptor>(thres, std::move(providers.second), sorted_multi) : nullptr
         };
     } else if (Func("sortedmulti", expr) || Func("multi", expr)) {
         error = "Can only have multi/sortedmulti at top level, in sh(), or in wsh()";
         return {nullptr, nullptr};
     }
     if ((ctx == ParseScriptContext::TOP || ctx == ParseScriptContext::P2SH) && Func("wpkh", expr)) {
-        auto pubkey = ParsePubkey(key_exp_index, expr, ParseScriptContext::P2WPKH, out, error);
-        if (!pubkey) return {nullptr, nullptr};
+        auto pubkeys = ParsePubkey(key_exp_index, expr, ParseScriptContext::P2WPKH, out, error);
+        if (!pubkeys.first) return {nullptr, nullptr};
         key_exp_index++;
         return {
-            std::make_unique<WPKHDescriptor>(std::move(pubkey)),
-            nullptr
+            std::make_unique<WPKHDescriptor>(std::move(pubkeys.first)),
+            pubkeys.second ? std::make_unique<WPKHDescriptor>(std::move(pubkeys.second)) : nullptr
         };
     } else if (Func("wpkh", expr)) {
         error = "Can only have wpkh() at top level or inside sh()";
@@ -1197,7 +1209,7 @@ std::pair<std::unique_ptr<DescriptorImpl>, std::unique_ptr<DescriptorImpl>> Pars
         if (!desc.first || expr.size()) return {nullptr, nullptr};
         return {
             std::make_unique<SHDescriptor>(std::move(desc.first)),
-            nullptr
+            desc.second ? std::make_unique<SHDescriptor>(std::move(desc.second)) : nullptr
         };
     } else if (Func("sh", expr)) {
         error = "Can only have sh() at top level";
@@ -1208,7 +1220,7 @@ std::pair<std::unique_ptr<DescriptorImpl>, std::unique_ptr<DescriptorImpl>> Pars
         if (!desc.first || expr.size()) return {nullptr, nullptr};
         return {
             std::make_unique<WSHDescriptor>(std::move(desc.first)),
-            nullptr
+            desc.second ? std::make_unique<WSHDescriptor>(std::move(desc.second)) : nullptr
         };
     } else if (Func("wsh", expr)) {
         error = "Can only have wsh() at top level or inside sh()";
@@ -1230,8 +1242,12 @@ std::pair<std::unique_ptr<DescriptorImpl>, std::unique_ptr<DescriptorImpl>> Pars
     }
     if (ctx == ParseScriptContext::TOP && Func("tr", expr)) {
         auto arg = Expr(expr);
-        auto internal_key = ParsePubkey(key_exp_index, arg, ParseScriptContext::P2TR, out, error);
-        if (!internal_key) return {nullptr, nullptr};
+        auto internal_keys = ParsePubkey(key_exp_index, arg, ParseScriptContext::P2TR, out, error);
+        if (!internal_keys.first) return {nullptr, nullptr};
+        bool has_multipath = (bool)internal_keys.second;
+        if (!has_multipath) {
+            internal_keys.second = internal_keys.first->Clone();
+        }
         ++key_exp_index;
         std::pair<std::vector<std::unique_ptr<DescriptorImpl>>, std::vector<std::unique_ptr<DescriptorImpl>>> subscripts; //!< list of script subexpressions
         std::vector<int> depths; //!< depth in the tree of each subexpression (same length subscripts)
@@ -1257,10 +1273,13 @@ std::pair<std::unique_ptr<DescriptorImpl>, std::unique_ptr<DescriptorImpl>> Pars
                 }
                 // Process the actual script expression.
                 auto sarg = Expr(expr);
+
                 auto parsed_scripts = ParseScript(key_exp_index, sarg, ParseScriptContext::P2TR, out, error);
                 if (!parsed_scripts.first) return {nullptr, nullptr};
                 subscripts.second.emplace_back(parsed_scripts.second ? std::move(parsed_scripts.second) : std::move(parsed_scripts.first->Clone()));
                 subscripts.first.emplace_back(std::move(parsed_scripts.first));
+                has_multipath |= (bool)parsed_scripts.second;
+
                 depths.push_back(branches.size());
                 // Process closing braces; one is expected for every right branch we were in.
                 while (branches.size() && branches.back()) {
@@ -1287,8 +1306,8 @@ std::pair<std::unique_ptr<DescriptorImpl>, std::unique_ptr<DescriptorImpl>> Pars
         }
         assert(TaprootBuilder::ValidDepths(depths));
         return {
-            std::make_unique<TRDescriptor>(std::move(internal_key), std::move(subscripts.first), std::move(depths)),
-            nullptr
+            std::make_unique<TRDescriptor>(std::move(internal_keys.first), std::move(subscripts.first), std::move(depths)),
+            has_multipath ? std::make_unique<TRDescriptor>(std::move(internal_keys.second), std::move(subscripts.second), std::move(depths)) : nullptr
         };
     } else if (Func("tr", expr)) {
         error = "Can only have tr at top level";

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -1553,14 +1553,14 @@ bool CheckChecksum(Span<const char>& sp, bool require_checksum, std::string& err
     return true;
 }
 
-std::unique_ptr<Descriptor> Parse(const std::string& descriptor, FlatSigningProvider& out, std::string& error, bool require_checksum)
+std::pair<std::unique_ptr<Descriptor>, std::unique_ptr<Descriptor>> Parse(const std::string& descriptor, FlatSigningProvider& out, std::string& error, bool require_checksum)
 {
     Span<const char> sp{descriptor};
-    if (!CheckChecksum(sp, require_checksum, error)) return nullptr;
+    if (!CheckChecksum(sp, require_checksum, error)) return {nullptr, nullptr};
     uint32_t key_exp_index = 0;
     auto ret = ParseScript(key_exp_index, sp, ParseScriptContext::TOP, out, error);
-    if (sp.size() == 0 && ret.first) return std::unique_ptr<Descriptor>(std::move(ret.first));
-    return nullptr;
+    if (sp.size() == 0 && ret.first) return {std::unique_ptr<Descriptor>(std::move(ret.first)), ret.second ? std::unique_ptr<Descriptor>(std::move(ret.second)) : nullptr};
+    return {nullptr, nullptr};
 }
 
 std::string GetDescriptorChecksum(const std::string& descriptor)

--- a/src/script/descriptor.h
+++ b/src/script/descriptor.h
@@ -156,7 +156,7 @@ struct Descriptor {
  * If a parse error occurs, or the checksum is missing/invalid, or anything
  * else is wrong, `nullptr` is returned.
  */
-std::unique_ptr<Descriptor> Parse(const std::string& descriptor, FlatSigningProvider& out, std::string& error, bool require_checksum = false);
+std::pair<std::unique_ptr<Descriptor>, std::unique_ptr<Descriptor>> Parse(const std::string& descriptor, FlatSigningProvider& out, std::string& error, bool require_checksum = false);
 
 /** Get the checksum for a `descriptor`.
  *

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -21,8 +21,8 @@ void CheckUnparsable(const std::string& prv, const std::string& pub, const std::
 {
     FlatSigningProvider keys_priv, keys_pub;
     std::string error;
-    auto parse_priv = Parse(prv, keys_priv, error);
-    auto parse_pub = Parse(pub, keys_pub, error);
+    auto parse_priv = Parse(prv, keys_priv, error).first;
+    auto parse_pub = Parse(pub, keys_pub, error).first;
     BOOST_CHECK_MESSAGE(!parse_priv, prv);
     BOOST_CHECK_MESSAGE(!parse_pub, pub);
     BOOST_CHECK_EQUAL(error, expected_error);
@@ -86,14 +86,14 @@ void DoCheck(const std::string& prv, const std::string& pub, const std::string& 
     std::unique_ptr<Descriptor> parse_pub;
     // Check that parsing succeeds.
     if (replace_apostrophe_with_h_in_prv) {
-        parse_priv = Parse(UseHInsteadOfApostrophe(prv), keys_priv, error);
+        parse_priv = Parse(UseHInsteadOfApostrophe(prv), keys_priv, error).first;
     } else {
-        parse_priv = Parse(prv, keys_priv, error);
+        parse_priv = Parse(prv, keys_priv, error).first;
     }
     if (replace_apostrophe_with_h_in_pub) {
-        parse_pub = Parse(UseHInsteadOfApostrophe(pub), keys_pub, error);
+        parse_pub = Parse(UseHInsteadOfApostrophe(pub), keys_pub, error).first;
     } else {
-        parse_pub = Parse(pub, keys_pub, error);
+        parse_pub = Parse(pub, keys_pub, error).first;
     }
 
     BOOST_CHECK(parse_priv);

--- a/src/test/fuzz/descriptor_parse.cpp
+++ b/src/test/fuzz/descriptor_parse.cpp
@@ -21,10 +21,16 @@ FUZZ_TARGET_INIT(descriptor_parse, initialize_descriptor_parse)
     std::string error;
     for (const bool require_checksum : {true, false}) {
         const auto desc = Parse(descriptor, signing_provider, error, require_checksum);
-        if (desc) {
-            (void)desc->ToString();
-            (void)desc->IsRange();
-            (void)desc->IsSolvable();
+        if (desc.first) {
+            (void)desc.first->ToString();
+            (void)desc.first->IsRange();
+            (void)desc.first->IsSolvable();
+        }
+        if (desc.second) {
+            assert(desc.first);
+            (void)desc.second->ToString();
+            assert(desc.first->IsRange() == desc.second->IsRange());
+            assert(desc.first->IsSolvable() == desc.second->IsSolvable());
         }
     }
 }

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -489,7 +489,7 @@ RPCHelpMan importpubkey()
 
         pwallet->ImportScriptPubKeys(strLabel, script_pub_keys, true /* have_solving_data */, true /* apply_label */, 1 /* timestamp */);
 
-        pwallet->ImportPubKeys({pubKey.GetID()}, {{pubKey.GetID(), pubKey}} , {} /* key_origins */, false /* add_keypool */, false /* internal */, 1 /* timestamp */);
+        pwallet->ImportPubKeys({{pubKey.GetID(), false}}, {{pubKey.GetID(), pubKey}} , {} /* key_origins */, false /* add_keypool */, 1 /* timestamp */);
     }
     if (fRescan)
     {
@@ -940,7 +940,7 @@ static std::string RecurseImportData(const CScript& script, ImportData& import_d
     CHECK_NONFATAL(false);
 }
 
-static UniValue ProcessImportLegacy(ImportData& import_data, std::map<CKeyID, CPubKey>& pubkey_map, std::map<CKeyID, CKey>& privkey_map, std::set<CScript>& script_pub_keys, bool& have_solving_data, const UniValue& data, std::vector<CKeyID>& ordered_pubkeys)
+static UniValue ProcessImportLegacy(ImportData& import_data, std::map<CKeyID, CPubKey>& pubkey_map, std::map<CKeyID, CKey>& privkey_map, std::set<CScript>& script_pub_keys, bool& have_solving_data, const UniValue& data, std::vector<std::pair<CKeyID, bool>>& ordered_pubkeys)
 {
     UniValue warnings(UniValue::VARR);
 
@@ -1014,7 +1014,7 @@ static UniValue ProcessImportLegacy(ImportData& import_data, std::map<CKeyID, CP
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Pubkey \"" + str + "\" is not a valid public key");
         }
         pubkey_map.emplace(pubkey.GetID(), pubkey);
-        ordered_pubkeys.push_back(pubkey.GetID());
+        ordered_pubkeys.push_back({pubkey.GetID(), internal});
     }
     for (size_t i = 0; i < keys.size(); ++i) {
         const auto& str = keys[i].get_str();
@@ -1087,8 +1087,10 @@ static UniValue ProcessImportLegacy(ImportData& import_data, std::map<CKeyID, CP
     return warnings;
 }
 
-static UniValue ProcessImportDescriptor(ImportData& import_data, std::map<CKeyID, CPubKey>& pubkey_map, std::map<CKeyID, CKey>& privkey_map, std::set<CScript>& script_pub_keys, bool& have_solving_data, const UniValue& data, std::vector<CKeyID>& ordered_pubkeys)
+static UniValue ProcessImportDescriptor(ImportData& import_data, std::map<CKeyID, CPubKey>& pubkey_map, std::map<CKeyID, CKey>& privkey_map, std::set<CScript>& script_pub_keys, bool& have_solving_data, const UniValue& data, std::vector<std::pair<CKeyID, bool>>& ordered_pubkeys)
 {
+    const bool internal = data.exists("internal") ? data["internal"].get_bool() : false;
+
     UniValue warnings(UniValue::VARR);
 
     const std::string& descriptor = data["desc"].get_str();
@@ -1124,7 +1126,7 @@ static UniValue ProcessImportDescriptor(ImportData& import_data, std::map<CKeyID
         parsed_desc->Expand(i, keys, scripts_temp, out_keys);
         std::copy(scripts_temp.begin(), scripts_temp.end(), std::inserter(script_pub_keys, script_pub_keys.end()));
         for (const auto& key_pair : out_keys.pubkeys) {
-            ordered_pubkeys.push_back(key_pair.first);
+            ordered_pubkeys.push_back({key_pair.first, internal});
         }
 
         for (const auto& x : out_keys.scripts) {
@@ -1199,7 +1201,7 @@ static UniValue ProcessImport(CWallet& wallet, const UniValue& data, const int64
         std::map<CKeyID, CPubKey> pubkey_map;
         std::map<CKeyID, CKey> privkey_map;
         std::set<CScript> script_pub_keys;
-        std::vector<CKeyID> ordered_pubkeys;
+        std::vector<std::pair<CKeyID, bool>> ordered_pubkeys;
         bool have_solving_data;
 
         if (data.exists("scriptPubKey") && data.exists("desc")) {
@@ -1232,7 +1234,7 @@ static UniValue ProcessImport(CWallet& wallet, const UniValue& data, const int64
         if (!wallet.ImportPrivKeys(privkey_map, timestamp)) {
             throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");
         }
-        if (!wallet.ImportPubKeys(ordered_pubkeys, pubkey_map, import_data.key_origins, add_keypool, internal, timestamp)) {
+        if (!wallet.ImportPubKeys(ordered_pubkeys, pubkey_map, import_data.key_origins, add_keypool, timestamp)) {
             throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
         }
         if (!wallet.ImportScriptPubKeys(label, script_pub_keys, have_solving_data, !internal, timestamp)) {

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -1094,7 +1094,7 @@ static UniValue ProcessImportDescriptor(ImportData& import_data, std::map<CKeyID
     const std::string& descriptor = data["desc"].get_str();
     FlatSigningProvider keys;
     std::string error;
-    auto parsed_desc = Parse(descriptor, keys, error, /* require_checksum = */ true);
+    auto parsed_desc = Parse(descriptor, keys, error, /* require_checksum = */ true).first;
     if (!parsed_desc) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, error);
     }
@@ -1471,7 +1471,7 @@ static UniValue ProcessDescriptorImport(CWallet& wallet, const UniValue& data, c
         // Parse descriptor string
         FlatSigningProvider keys;
         std::string error;
-        auto parsed_desc = Parse(descriptor, keys, error, /* require_checksum = */ true);
+        auto parsed_desc = Parse(descriptor, keys, error, /* require_checksum = */ true).first;
         if (!parsed_desc) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, error);
         }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3384,12 +3384,16 @@ void FundTransaction(CWallet& wallet, CMutableTransaction& tx, CAmount& fee_out,
                 FlatSigningProvider desc_out;
                 std::string error;
                 std::vector<CScript> scripts_temp;
-                std::unique_ptr<Descriptor> desc = Parse(desc_str, desc_out, error, true);
-                if (!desc) {
+                std::pair<std::unique_ptr<Descriptor>, std::unique_ptr<Descriptor>> descs = Parse(desc_str, desc_out, error, true);
+                if (!descs.first) {
                     throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Unable to parse descriptor '%s': %s", desc_str, error));
                 }
-                desc->Expand(0, desc_out, scripts_temp, desc_out);
+                descs.first->Expand(0, desc_out, scripts_temp, desc_out);
                 coinControl.m_external_provider = Merge(coinControl.m_external_provider, desc_out);
+                if (descs.second) {
+                    descs.second->Expand(0, desc_out, scripts_temp, desc_out);
+                    coinControl.m_external_provider = Merge(coinControl.m_external_provider, desc_out);
+                }
             }
         }
     }

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1555,13 +1555,13 @@ bool LegacyScriptPubKeyMan::ImportPrivKeys(const std::map<CKeyID, CKey>& privkey
     return true;
 }
 
-bool LegacyScriptPubKeyMan::ImportPubKeys(const std::vector<CKeyID>& ordered_pubkeys, const std::map<CKeyID, CPubKey>& pubkey_map, const std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>>& key_origins, const bool add_keypool, const bool internal, const int64_t timestamp)
+bool LegacyScriptPubKeyMan::ImportPubKeys(const std::vector<std::pair<CKeyID, bool>>& ordered_pubkeys, const std::map<CKeyID, CPubKey>& pubkey_map, const std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>>& key_origins, const bool add_keypool, const int64_t timestamp)
 {
     WalletBatch batch(m_storage.GetDatabase());
     for (const auto& entry : key_origins) {
         AddKeyOriginWithDB(batch, entry.second.first, entry.second.second);
     }
-    for (const CKeyID& id : ordered_pubkeys) {
+    for (const auto& [id, internal] : ordered_pubkeys) {
         auto entry = pubkey_map.find(id);
         if (entry == pubkey_map.end()) {
             continue;

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1928,7 +1928,7 @@ bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(const CExtKey& master_
     // Make the descriptor
     FlatSigningProvider keys;
     std::string error;
-    std::unique_ptr<Descriptor> desc = Parse(desc_str, keys, error, false);
+    std::unique_ptr<Descriptor> desc = Parse(desc_str, keys, error, false).first;
     WalletDescriptor w_desc(std::move(desc), creation_time, 0, 0, 0);
     m_wallet_descriptor = w_desc;
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -448,7 +448,7 @@ public:
 
     bool ImportScripts(const std::set<CScript> scripts, int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
     bool ImportPrivKeys(const std::map<CKeyID, CKey>& privkey_map, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
-    bool ImportPubKeys(const std::vector<CKeyID>& ordered_pubkeys, const std::map<CKeyID, CPubKey>& pubkey_map, const std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>>& key_origins, const bool add_keypool, const bool internal, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
+    bool ImportPubKeys(const std::vector<std::pair<CKeyID, bool>>& ordered_pubkeys, const std::map<CKeyID, CPubKey>& pubkey_map, const std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>>& key_origins, const bool add_keypool, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
     bool ImportScriptPubKeys(const std::set<CScript>& script_pub_keys, const bool have_solving_data, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
 
     /* Returns true if the wallet can generate new keys */

--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -18,7 +18,7 @@ static void import_descriptor(CWallet& wallet, const std::string& descriptor)
     LOCK(wallet.cs_wallet);
     FlatSigningProvider provider;
     std::string error;
-    std::unique_ptr<Descriptor> desc = Parse(descriptor, provider, error, /* require_checksum=*/ false);
+    std::unique_ptr<Descriptor> desc = Parse(descriptor, provider, error, /* require_checksum=*/ false).first;
     assert(desc);
     WalletDescriptor w_desc(std::move(desc), 0, 0, 10, 0);
     wallet.AddWalletDescriptor(w_desc, provider, "", false);

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -30,7 +30,7 @@ std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, CChain& cc
 
         FlatSigningProvider provider;
         std::string error;
-        std::unique_ptr<Descriptor> desc = Parse("combo(" + EncodeSecret(key) + ")", provider, error, /* require_checksum=*/ false);
+        std::unique_ptr<Descriptor> desc = Parse("combo(" + EncodeSecret(key) + ")", provider, error, /* require_checksum=*/ false).first;
         assert(desc);
         WalletDescriptor w_desc(std::move(desc), 0, 0, 1, 1);
         if (!wallet->AddWalletDescriptor(w_desc, provider, "", false)) assert(false);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -82,7 +82,7 @@ static void AddKey(CWallet& wallet, const CKey& key)
     LOCK(wallet.cs_wallet);
     FlatSigningProvider provider;
     std::string error;
-    std::unique_ptr<Descriptor> desc = Parse("combo(" + EncodeSecret(key) + ")", provider, error, /* require_checksum=*/ false);
+    std::unique_ptr<Descriptor> desc = Parse("combo(" + EncodeSecret(key) + ")", provider, error, /* require_checksum=*/ false).first;
     assert(desc);
     WalletDescriptor w_desc(std::move(desc), 0, 0, 1, 1);
     if (!wallet.AddWalletDescriptor(w_desc, provider, "", false)) assert(false);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3199,7 +3199,7 @@ void CWallet::SetupDescriptorScriptPubKeyMans()
                 std::string desc_str = desc_val.getValStr();
                 FlatSigningProvider keys;
                 std::string dummy_error;
-                std::unique_ptr<Descriptor> desc = Parse(desc_str, keys, dummy_error, false);
+                std::unique_ptr<Descriptor> desc = Parse(desc_str, keys, dummy_error, false).first;
                 if (!desc->GetOutputType()) {
                     continue;
                 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1505,14 +1505,14 @@ bool CWallet::ImportPrivKeys(const std::map<CKeyID, CKey>& privkey_map, const in
     return spk_man->ImportPrivKeys(privkey_map, timestamp);
 }
 
-bool CWallet::ImportPubKeys(const std::vector<CKeyID>& ordered_pubkeys, const std::map<CKeyID, CPubKey>& pubkey_map, const std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>>& key_origins, const bool add_keypool, const bool internal, const int64_t timestamp)
+bool CWallet::ImportPubKeys(const std::vector<std::pair<CKeyID, bool>>& ordered_pubkeys, const std::map<CKeyID, CPubKey>& pubkey_map, const std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>>& key_origins, const bool add_keypool, const int64_t timestamp)
 {
     auto spk_man = GetLegacyScriptPubKeyMan();
     if (!spk_man) {
         return false;
     }
     LOCK(spk_man->cs_KeyStore);
-    return spk_man->ImportPubKeys(ordered_pubkeys, pubkey_map, key_origins, add_keypool, internal, timestamp);
+    return spk_man->ImportPubKeys(ordered_pubkeys, pubkey_map, key_origins, add_keypool, timestamp);
 }
 
 bool CWallet::ImportScriptPubKeys(const std::string& label, const std::set<CScript>& script_pub_keys, const bool have_solving_data, const bool apply_label, const int64_t timestamp)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -586,7 +586,7 @@ public:
 
     bool ImportScripts(const std::set<CScript> scripts, int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool ImportPrivKeys(const std::map<CKeyID, CKey>& privkey_map, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    bool ImportPubKeys(const std::vector<CKeyID>& ordered_pubkeys, const std::map<CKeyID, CPubKey>& pubkey_map, const std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>>& key_origins, const bool add_keypool, const bool internal, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool ImportPubKeys(const std::vector<std::pair<CKeyID, bool>>& ordered_pubkeys, const std::map<CKeyID, CPubKey>& pubkey_map, const std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>>& key_origins, const bool add_keypool, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool ImportScriptPubKeys(const std::string& label, const std::set<CScript>& script_pub_keys, const bool have_solving_data, const bool apply_label, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     CFeeRate m_pay_tx_fee{DEFAULT_PAY_TX_FEE};

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -86,7 +86,7 @@ public:
     {
         std::string error;
         FlatSigningProvider keys;
-        descriptor = Parse(str, keys, error, true);
+        descriptor = Parse(str, keys, error, true).first;
         if (!descriptor) {
             throw std::ios_base::failure("Invalid descriptor: " + error);
         }

--- a/test/functional/rpc_deriveaddresses.py
+++ b/test/functional/rpc_deriveaddresses.py
@@ -29,6 +29,9 @@ class DeriveaddressesTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].deriveaddresses(ranged_descriptor, [1, 2]), ["bcrt1qhku5rq7jz8ulufe2y6fkcpnlvpsta7rq4442dy", "bcrt1qpgptk2gvshyl0s9lqshsmx932l9ccsv265tvaq"])
         assert_equal(self.nodes[0].deriveaddresses(ranged_descriptor, 2), [address, "bcrt1qhku5rq7jz8ulufe2y6fkcpnlvpsta7rq4442dy", "bcrt1qpgptk2gvshyl0s9lqshsmx932l9ccsv265tvaq"])
 
+        ranged_descriptor = descsum_create("wpkh(tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK/1/<0;1>/*)")
+        assert_equal(self.nodes[0].deriveaddresses(ranged_descriptor, [1, 2]), {"receive": ["bcrt1q7c8mdmdktrzs8xgpjmqw90tjn65j5a3yj04m3n", "bcrt1qs6n37uzu0v0qfzf0r0csm0dwa7prc0v5uavgy0"], "change":["bcrt1qhku5rq7jz8ulufe2y6fkcpnlvpsta7rq4442dy", "bcrt1qpgptk2gvshyl0s9lqshsmx932l9ccsv265tvaq"]})
+
         assert_raises_rpc_error(-8, "Range should not be specified for an un-ranged descriptor", self.nodes[0].deriveaddresses, descsum_create("wpkh(tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK/1/1/0)"), [0, 2])
 
         assert_raises_rpc_error(-8, "Range must be specified for a ranged descriptor", self.nodes[0].deriveaddresses, descsum_create("wpkh(tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK/1/1/*)"))

--- a/test/functional/rpc_getdescriptorinfo.py
+++ b/test/functional/rpc_getdescriptorinfo.py
@@ -19,10 +19,17 @@ class DescriptorTest(BitcoinTestFramework):
         self.extra_args = [["-disablewallet"]]
         self.wallet_names = []
 
-    def test_desc(self, desc, isrange, issolvable, hasprivatekeys):
+    def test_desc(self, desc, isrange, issolvable, hasprivatekeys, receive_desc=None, change_desc=None):
         info = self.nodes[0].getdescriptorinfo(desc)
         assert_equal(info, self.nodes[0].getdescriptorinfo(descsum_create(desc)))
-        assert_equal(info['descriptor'], descsum_create(desc))
+        if receive_desc is not None:
+            assert_equal(info["descriptor"], descsum_create(receive_desc))
+        else:
+            assert_equal(info['descriptor'], descsum_create(desc))
+        if change_desc is not None:
+            assert_equal(info["descriptor_change"], descsum_create(change_desc))
+        else:
+            assert "descriptor_change" not in info
         assert_equal(info['isrange'], isrange)
         assert_equal(info['issolvable'], issolvable)
         assert_equal(info['hasprivatekeys'], hasprivatekeys)
@@ -60,6 +67,13 @@ class DescriptorTest(BitcoinTestFramework):
         self.test_desc("pkh([d34db33f/44'/0'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/*)", isrange=True, issolvable=True, hasprivatekeys=False)
         # A set of *1-of-2* P2WSH multisig outputs where the first multisig key is the *1/0/`i`* child of the first specified xpub and the second multisig key is the *0/0/`i`* child of the second specified xpub, and `i` is any number in a configurable range (`0-1000` by default).
         self.test_desc("wsh(multi(1,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/0/*,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/0/*))", isrange=True, issolvable=True, hasprivatekeys=False)
+        # A multipath descriptor
+        self.test_desc("wpkh(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/<0;1>/*)", isrange=True, issolvable=True, hasprivatekeys=False,
+            receive_desc="wpkh(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/*)",
+            change_desc="wpkh(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/*)")
+        self.test_desc("wsh(multi(1,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/<1;2>/0/*,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/<2;3>/0/*))", isrange=True, issolvable=True, hasprivatekeys=False,
+            receive_desc="wsh(multi(1,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/0/*,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/2/0/*))",
+            change_desc="wsh(multi(1,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/2/0/*,tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/3/0/*))")
 
 
 if __name__ == '__main__':

--- a/test/functional/rpc_scantxoutset.py
+++ b/test/functional/rpc_scantxoutset.py
@@ -111,6 +111,7 @@ class ScantxoutsetTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].scantxoutset("start", [ {"desc": "combo(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/1/*)", "range": 1499}])['total_amount'], Decimal("12.288"))
         assert_equal(self.nodes[0].scantxoutset("start", [ {"desc": "combo(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/1/*)", "range": 1500}])['total_amount'], Decimal("28.672"))
         assert_equal(self.nodes[0].scantxoutset("start", [ {"desc": "combo(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/1/*)", "range": [1500,1500]}])['total_amount'], Decimal("16.384"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ {"desc": "pkh(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/1/<0;1>)"}])["total_amount"], Decimal("12.288"))
 
         # Test the reported descriptors for a few matches
         assert_equal(descriptors(self.nodes[0].scantxoutset("start", [ {"desc": "combo(tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK/0h/0'/*)", "range": 1499}])), ["pkh([0c5f9a1e/0'/0'/0]026dbd8b2315f296d36e6b6920b1579ca75569464875c7ebe869b536a7d9503c8c)#dzxw429x", "pkh([0c5f9a1e/0'/0'/1]033e6f25d76c00bedb3a8993c7d5739ee806397f0529b1b31dda31ef890f19a60c)#43rvceed"])

--- a/test/functional/wallet_importmulti.py
+++ b/test/functional/wallet_importmulti.py
@@ -879,6 +879,43 @@ class ImportMultiTest(BitcoinTestFramework):
             addr = wrpc.getnewaddress('', 'bech32')
             assert_equal(addr, addresses[i])
 
+        self.log.info("Multipath descriptors")
+        self.nodes[1].createwallet(wallet_name="multipath", blank=True, disable_private_keys=True)
+        w_multipath = self.nodes[1].get_wallet_rpc("multipath")
+        self.nodes[1].createwallet(wallet_name="multipath_split", blank=True, disable_private_keys=True)
+        w_multisplit = self.nodes[1].get_wallet_rpc("multipath_split")
+
+        res = w_multipath.importmulti([{"desc": descsum_create(f"wpkh({xpub}/<10;20>/0/*)"),
+                              "keypool": True,
+                              "range": 10,
+                              "timestamp": "now",
+                              "internal": True}])
+        assert_equal(res[0]["success"], False)
+        assert_equal(res[0]["error"]["code"], -5)
+        assert_equal(res[0]["error"]["message"], "Cannot have multipath descriptor while also specifying 'internal'")
+
+        res = w_multipath.importmulti([{"desc": descsum_create(f"wpkh({xpub}/<10;20>/0/*)"),
+                              "keypool": True,
+                              "range": 10,
+                              "timestamp": "now"}])
+        assert_equal(res[0]["success"], True)
+
+        res = w_multisplit.importmulti([{"desc": descsum_create(f"wpkh({xpub}/10/0/*)"),
+                              "keypool": True,
+                              "range": 10,
+                              "timestamp": "now"}])
+        assert_equal(res[0]["success"], True)
+        res = w_multisplit.importmulti([{"desc": descsum_create(f"wpkh({xpub}/20/0/*)"),
+                              "keypool": True,
+                              "range": 10,
+                              "internal": True,
+                              "timestamp": timestamp}])
+        assert_equal(res[0]["success"], True)
+
+        for _ in range(0, 9):
+            assert_equal(w_multipath.getnewaddress(address_type="bech32"), w_multisplit.getnewaddress(address_type="bech32"))
+            assert_equal(w_multipath.getrawchangeaddress(address_type="bech32"), w_multisplit.getrawchangeaddress(address_type="bech32"))
+
 
 if __name__ == '__main__':
     ImportMultiTest().main()

--- a/test/functional/wallet_multisig_descriptor_psbt.py
+++ b/test/functional/wallet_multisig_descriptor_psbt.py
@@ -55,19 +55,12 @@ class WalletMultisigDescriptorPSBTTest(BitcoinTestFramework):
         for i, node in enumerate(self.nodes):
             node.createwallet(wallet_name=f"{self.name}_{i}", blank=True, descriptors=True, disable_private_keys=True)
             multisig = node.get_wallet_rpc(f"{self.name}_{i}")
-            external = multisig.getdescriptorinfo(f"wsh(sortedmulti({self.M},{f'/0/*,'.join(xpubs)}/0/*))")
-            internal = multisig.getdescriptorinfo(f"wsh(sortedmulti({self.M},{f'/1/*,'.join(xpubs)}/1/*))")
+            descriptor = f"wsh(sortedmulti({self.M},{f'/<0;1>/*,'.join(xpubs)}/<0;1>/*))"
+            checksum = multisig.getdescriptorinfo(descriptor)["checksum"]
             result = multisig.importdescriptors([
-                {  # receiving addresses (internal: False)
-                    "desc": external["descriptor"],
+                {
+                    "desc": f"{descriptor}#{checksum}",
                     "active": True,
-                    "internal": False,
-                    "timestamp": "now",
-                },
-                {  # change addresses (internal: True)
-                    "desc": internal["descriptor"],
-                    "active": True,
-                    "internal": True,
                     "timestamp": "now",
                 },
             ])


### PR DESCRIPTION
This is on top of #22838, only my last commit should be considered here. This highlights how a basic multisig like our example can be cleaned up a bit with multipath descriptors. Also serves as some light additional testing for #22838