### PR TITLE
[22.x] build: explicitly disable libsecp256k1 openssl based tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1894,7 +1894,7 @@ if test x$need_bundled_univalue = xyes; then
   AC_CONFIG_SUBDIRS([src/univalue])
 fi
 
-ac_configure_args="${ac_configure_args} --disable-shared --with-pic --enable-benchmark=no --enable-module-recovery --enable-module-schnorrsig --enable-experimental"
+ac_configure_args="${ac_configure_args} --disable-shared --with-pic --enable-benchmark=no --enable-module-recovery --enable-module-schnorrsig --enable-experimental --disable-openssl-tests"
 AC_CONFIG_SUBDIRS([src/secp256k1])
 
 AC_OUTPUT


### PR DESCRIPTION
Backport of #23314

These tests are failing when run against OpenSSL 3, and have been
removed upstream, bitcoin-core/secp256k1#983, so
disabled them for now to avoid `make check` failures.

Note that this will also remove warning output from our build, due to
the use of deprecated OpenSSL API functions. See #23048.