### PR TITLE
test: make the node param explicit in init_wallet()

### DIFF
--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -539,7 +539,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         assert_equal(json1["vin"][0]["sequence"], 4294967295)
 
         if self.is_wallet_compiled():
-            self.init_wallet(0)
+            self.init_wallet(node=0)
             rawtx2 = self.nodes[0].createrawtransaction([], outs)
             frawtx2a = self.nodes[0].fundrawtransaction(rawtx2, {"replaceable": True})
             frawtx2b = self.nodes[0].fundrawtransaction(rawtx2, {"replaceable": False})

--- a/test/functional/rpc_invalid_address_message.py
+++ b/test/functional/rpc_invalid_address_message.py
@@ -90,7 +90,7 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
         self.test_validateaddress()
 
         if self.is_wallet_compiled():
-            self.init_wallet(0)
+            self.init_wallet(node=0)
             self.test_getaddressinfo()
 
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -423,12 +423,12 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
 
     def import_deterministic_coinbase_privkeys(self):
         for i in range(self.num_nodes):
-            self.init_wallet(i)
+            self.init_wallet(node=i)
 
-    def init_wallet(self, i):
-        wallet_name = self.default_wallet_name if self.wallet_names is None else self.wallet_names[i] if i < len(self.wallet_names) else False
+    def init_wallet(self, *, node):
+        wallet_name = self.default_wallet_name if self.wallet_names is None else self.wallet_names[node] if node < len(self.wallet_names) else False
         if wallet_name is not False:
-            n = self.nodes[i]
+            n = self.nodes[node]
             if wallet_name is not None:
                 n.createwallet(wallet_name=wallet_name, descriptors=self.options.descriptors, load_on_startup=True)
             n.importprivkey(privkey=n.get_deterministic_priv_key().key, label='coinbase')

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -124,9 +124,9 @@ class WalletBackupTest(BitcoinTestFramework):
         assert_raises_rpc_error(-8, "Wallet name already exists.", node.restorewallet, wallet_name, wallet_file)
 
     def init_three(self):
-        self.init_wallet(0)
-        self.init_wallet(1)
-        self.init_wallet(2)
+        self.init_wallet(node=0)
+        self.init_wallet(node=1)
+        self.init_wallet(node=2)
 
     def run_test(self):
         self.log.info("Generating initial blockchain")

--- a/test/functional/wallet_listdescriptors.py
+++ b/test/functional/wallet_listdescriptors.py
@@ -23,7 +23,7 @@ class ListDescriptorsTest(BitcoinTestFramework):
         self.skip_if_no_sqlite()
 
     # do not create any wallet by default
-    def init_wallet(self, i):
+    def init_wallet(self, *, node):
         return
 
     def run_test(self):

--- a/test/functional/wallet_taproot.py
+++ b/test/functional/wallet_taproot.py
@@ -185,7 +185,7 @@ class WalletTaprootTest(BitcoinTestFramework):
     def setup_network(self):
         self.setup_nodes()
 
-    def init_wallet(self, i):
+    def init_wallet(self, *, node):
         pass
 
     @staticmethod


### PR DESCRIPTION
This PR changes the definition of `def init_wallet(self, i)` to `def init_wallet(self, *, node)` to make the node parameter explicit, as suggested in https://github.com/bitcoin/bitcoin/pull/22794#discussion_r713287448 .
