### PR TITLE
doc: Add note on deleting past-EOL release branches

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -60,7 +60,7 @@ Release Process
 
 To tag the version (or release candidate) in git, use the `make-tag.py` script from [bitcoin-maintainer-tools](https://github.com/bitcoin-core/bitcoin-maintainer-tools). From the root of the repository run:
 
-    ../bitcoin-maintainer-tools/make-tag.py v(new version, e.g. 0.20.0)
+    ../bitcoin-maintainer-tools/make-tag.py v(new version, e.g. 23.0)
 
 This will perform a few last-minute consistency checks in the build system files, and if they pass, create a signed tag.
 
@@ -252,6 +252,10 @@ cat "$VERSION"/*/all.SHA256SUMS.asc > SHA256SUMS.asc
 
   - bitcoincore.org maintained versions update:
     [table](https://github.com/bitcoin-core/bitcoincore.org/commits/master/_includes/posts/maintenance-table.md)
+
+  - Delete post-EOL [release branches](https://github.com/bitcoin/bitcoin/branches/all) and create a tag `v${branch_name}-final`.
+
+  - Delete ["Needs backport" labels](https://github.com/bitcoin/bitcoin/labels?q=backport) for non-existing branches.
 
   - bitcoincore.org RPC documentation update
 


### PR DESCRIPTION
This is being done for years now, but wasn't documented.

Some reasons to do it:
* Backports to those branches are unlikely to be tested both on CI (since it is often fragile and broken for stale branches) and by users (since those users likely don't exist). If a user exists, they are better off backporting any fixes they need from the last still-supported branch and test them on their own infrastructure.
* Community support of those branches is still possible, though this will need to be done in another project to relieve the burden on this project.
* All release tags will remain, so no historic code is lost.