### PR TITLE
refactor: include a missing <limits> header in fs.cpp

### DIFF
--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -16,6 +16,7 @@
 #define NOMINMAX
 #endif
 #include <codecvt>
+#include <limits>
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
I get this compilation error on versions `0.21.1` and `22.0`:

```
fs.cpp: In member function 'bool fsbridge::FileLock::TryLock()':
fs.cpp:123:89: error: 'numeric_limits' is not a member of 'std'
  123 |     if (!LockFileEx(hFile, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0, std::numeric_limits<DWORD>::max(), std::numeric_limits<DWORD>::max(), &overlapped)) {
      |                                                                                         ^~~~~~~~~~~~~~
fs.cpp:123:109: error: expected primary-expression before '>' token
  123 |     if (!LockFileEx(hFile, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0, std::numeric_limits<DWORD>::max(), std::numeric_limits<DWORD>::max(), &overlapped)) {
      |                                                                                                             ^
fs.cpp:123:112: error: '::max' has not been declared; did you mean 'std::max'?
  123 |     if (!LockFileEx(hFile, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0, std::numeric_limits<DWORD>::max(), std::numeric_limits<DWORD>::max(), &overlapped)) {
      |                                                                                                                ^~~
      |                                                                                                                std::max
In file included from C:/dev/msys64/mingw64/include/c++/11.2.0/bits/char_traits.h:39,
                 from C:/dev/msys64/mingw64/include/c++/11.2.0/string:40,
                 from ./fs.h:9,
                 from fs.cpp:5:
C:/dev/msys64/mingw64/include/c++/11.2.0/bits/stl_algobase.h:300:5: note: 'std::max' declared here
  300 |     max(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |     ^~~
fs.cpp:123:124: error: 'numeric_limits' is not a member of 'std'
  123 |     if (!LockFileEx(hFile, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0, std::numeric_limits<DWORD>::max(), std::numeric_limits<DWORD>::max(), &overlapped)) {
      |                                                                                                                            ^~~~~~~~~~~~~~
fs.cpp:123:144: error: expected primary-expression before '>' token
  123 |     if (!LockFileEx(hFile, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0, std::numeric_limits<DWORD>::max(), std::numeric_limits<DWORD>::max(), &overlapped)) {
      |                                                                                                                                                ^
fs.cpp:123:147: error: '::max' has not been declared; did you mean 'std::max'?
  123 |     if (!LockFileEx(hFile, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0, std::numeric_limits<DWORD>::max(), std::numeric_limits<DWORD>::max(), &overlapped)) {
      |                                                                                                                                                   ^~~
      |                                                                                                                                                   std::max
In file included from C:/dev/msys64/mingw64/include/c++/11.2.0/bits/char_traits.h:39,
                 from C:/dev/msys64/mingw64/include/c++/11.2.0/string:40,
                 from ./fs.h:9,
                 from fs.cpp:5:
C:/dev/msys64/mingw64/include/c++/11.2.0/bits/stl_algobase.h:300:5: note: 'std::max' declared here
  300 |     max(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |     ^~~
```

It appears that `std::numeric_limits<T>::max` is used without the `limits` header being included. Probably on other STL implementations it's included transitively, but not in the one in MinGW. Including it fixes the compilation problem.

Environment:
OS: Windows 10
Compiler: gcc 11.2.0
Qt: 5.15.2 (included in msys2)
Using the latest mingw w64 shipped with msys2.
