### PR TITLE
RPC: Better safety with newkeypool command and wallet backups

### DIFF
--- a/src/wallet/rpc/addresses.cpp
+++ b/src/wallet/rpc/addresses.cpp
@@ -347,7 +347,12 @@ RPCHelpMan keypoolrefill()
 RPCHelpMan newkeypool()
 {
     return RPCHelpMan{"newkeypool",
-                "\nEntirely clears and refills the keypool."+
+                "\nEntirely clears and refills the keypool.\n"
+                "WARNING: On non-HD wallets, this will require a new backup immediately, to include the new keys.\n"
+                "When restoring a backup of an HD wallet created before the newkeypool command is run, funds received to\n"
+                "new addresses may not appear automatically. They have not been lost, but the wallet may not find them.\n"
+                "This can be fixed by running the newkeypool command on the backup and then rescanning, so the wallet\n"
+                "re-generates the required keys." +
             HELP_REQUIRING_PASSPHRASE,
                 {},
                 RPCResult{RPCResult::Type::NONE, "", ""},


### PR DESCRIPTION
This PR prevents `newkeypool` from being run on non-HD wallets, because this would require a new backup every time, so it isn't very safe.

David Harding also suggested [here](https://github.com/bitcoin/bitcoin/pull/23093#issuecomment-945350003) that the RPC help text should include a warning to the users about the interaction between newkeypool.