### PR TITLE
util, refactor: Improve headers for bitcoin-wallet tool

### DIFF
--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -8,14 +8,21 @@
 
 #include <chainparams.h>
 #include <chainparamsbase.h>
+#include <clientversion.h>
 #include <interfaces/init.h>
+#include <key.h>
 #include <logging.h>
+#include <pubkey.h>
+#include <tinyformat.h>
 #include <util/system.h>
 #include <util/translation.h>
 #include <util/url.h>
 #include <wallet/wallettool.h>
 
+#include <exception>
 #include <functional>
+#include <string>
+#include <tuple>
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 UrlDecodeFn* const URL_DECODE = nullptr;

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -2,6 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <wallet/wallettool.h>
+
 #include <fs.h>
 #include <util/system.h>
 #include <util/translation.h>

--- a/src/wallet/wallettool.h
+++ b/src/wallet/wallettool.h
@@ -5,11 +5,12 @@
 #ifndef BITCOIN_WALLET_WALLETTOOL_H
 #define BITCOIN_WALLET_WALLETTOOL_H
 
-#include <wallet/wallet.h>
+#include <string>
+
+class ArgsManager;
 
 namespace WalletTool {
 
-void WalletShowInfo(CWallet* wallet_instance);
 bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command);
 
 } // namespace WalletTool


### PR DESCRIPTION
This PR:
- removes unneeded `#include <wallet/wallet.h>` from `<wallet/wallettool.h>`
- introduces class forward declaration in `<wallet/wallettool.h>`
- added `#include <config/bitcoin-config.h>` to `wallet/wallettool.cpp` where the `USE_BDB` macro is used