### PR TITLE
util: Use FEATURE_LATEST for wallets created with bitcoin-wallet

### DIFF
--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -26,7 +26,7 @@ static void WalletCreate(CWallet* wallet_instance, uint64_t wallet_creation_flag
 {
     LOCK(wallet_instance->cs_wallet);
 
-    wallet_instance->SetMinVersion(FEATURE_HD_SPLIT);
+    wallet_instance->SetMinVersion(FEATURE_LATEST);
     wallet_instance->AddWalletFlags(wallet_creation_flags);
 
     if (!wallet_instance->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {


### PR DESCRIPTION
Since the 49d2374acf5845c5f760b5fd241482f292164147 commit was athored by **jonasschnelli** in 2016, the wallet version was bumped twice: in 2017 (bitcoin/bitcoin#11250) and in 2018 (bitcoin/bitcoin#12560).

This PR bumps the version of wallets created with `bitcoin-wallet` offline tool.

On master (04437ee721e66a7b76bef5ec2f88dd1efcd03b84) -- `"walletversion": 139900`:
```
$ src/bitcoin-wallet -signet -wallet=211025-test-master create
Topping up keypool...
Wallet info
===========
Name: 211025-test-master
Format: sqlite
Descriptors: yes
Encrypted: no
HD (hd seed available): yes
Keypool Size: 6000
Transactions: 0
Address Book: 0
$ src/bitcoin-cli -signet -rpcwallet=211025-test-master getwalletinfo
{
  "walletname": "211025-test-master",
  "walletversion": 139900,
  "format": "sqlite",
  "balance": 0.00000000,
  "unconfirmed_balance": 0.00000000,
  "immature_balance": 0.00000000,
  "txcount": 0,
  "keypoolsize": 3000,
  "keypoolsize_hd_internal": 3000,
  "paytxfee": 0.00000000,
  "private_keys_enabled": true,
  "avoid_reuse": false,
  "scanning": false,
  "descriptors": true
}
```

With this PR -- `"walletversion": 169900`:
```
$ src/bitcoin-wallet -signet -wallet=211025-test-pr create
Topping up keypool...
Wallet info
===========
Name: 211025-test-pr
Format: sqlite
Descriptors: yes
Encrypted: no
HD (hd seed available): yes
Keypool Size: 6000
Transactions: 0
Address Book: 0
$ src/bitcoin-cli -signet -rpcwallet=211025-test-pr getwalletinfo
{
  "walletname": "211025-test-pr",
  "walletversion": 169900,
  "format": "sqlite",
  "balance": 0.00000000,
  "unconfirmed_balance": 0.00000000,
  "immature_balance": 0.00000000,
  "txcount": 0,
  "keypoolsize": 3000,
  "keypoolsize_hd_internal": 3000,
  "paytxfee": 0.00000000,
  "private_keys_enabled": true,
  "avoid_reuse": false,
  "scanning": false,
  "descriptors": true
}
```