### PR TITLE
test: Extend stale_tip_peer_management test

### DIFF
--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -60,6 +60,14 @@ std::vector<std::shared_ptr<CBlock>> CreateBlockChain(size_t total_height, const
     return ret;
 }
 
+void SolvePow(CBlock& block)
+{
+    while (!CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus())) {
+        ++block.nNonce;
+        assert(block.nNonce);
+    }
+}
+
 COutPoint MineBlock(const NodeContext& node, const CScript& coinbase_scriptPubKey)
 {
     auto block = PrepareBlock(node, coinbase_scriptPubKey);
@@ -86,10 +94,7 @@ protected:
 
 COutPoint MineBlock(const NodeContext& node, std::shared_ptr<CBlock>& block)
 {
-    while (!CheckProofOfWork(block->GetHash(), block->nBits, Params().GetConsensus())) {
-        ++block->nNonce;
-        assert(block->nNonce);
-    }
+    SolvePow(*block);
 
     auto& chainman{*Assert(node.chainman)};
     const auto old_height = WITH_LOCK(chainman.GetMutex(), return chainman.ActiveHeight());

--- a/src/test/util/mining.h
+++ b/src/test/util/mining.h
@@ -22,6 +22,9 @@ struct NodeContext;
 /** Create a blockchain, starting from genesis */
 std::vector<std::shared_ptr<CBlock>> CreateBlockChain(size_t total_height, const CChainParams& params);
 
+/** Work on the proof-of-work puzzle */
+void SolvePow(CBlock& block);
+
 /** Returns the generated coin */
 COutPoint MineBlock(const node::NodeContext&, const CScript& coinbase_scriptPubKey);
 

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -10,6 +10,7 @@
 #include <net_permissions.h>
 #include <net_processing.h>
 #include <netaddress.h>
+#include <netmessagemaker.h>
 #include <node/connection_types.h>
 #include <node/eviction.h>
 #include <sync.h>
@@ -78,6 +79,12 @@ struct ConnmanTestMsg : public CConnman {
     void NodeReceiveMsgBytes(CNode& node, Span<const uint8_t> msg_bytes, bool& complete) const;
 
     bool ReceiveMsgFrom(CNode& node, CSerializedNetMsg&& ser_msg) const;
+
+    template <typename... Args>
+    void ReceiveMsgFrom(CNode& node, std::string type, Args&&... payload)
+    {
+        assert(ReceiveMsgFrom(node, NetMsg::Make(std::move(type), std::forward<Args>(payload)...)));
+    }
     void FlushSendBuffer(CNode& node) const;
 
     bool AlreadyConnectedPublic(const CAddress& addr) { return AlreadyConnectedToAddress(addr); };


### PR DESCRIPTION
Add coverage for the case where a peer is protected when it pretends to have a block.

Also, add some `ASSERT_DEBUG_LOG` to document the tests for the reader.