### PR TITLE
Introduce new V4 format addrman

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -171,7 +171,7 @@ void AddrManImpl::Serialize(Stream& s_) const
 
     // Increment `lowest_compatible` iff a newly introduced format is incompatible with
     // the previous one.
-    static constexpr uint8_t lowest_compatible = Format::V3_BIP155;
+    static constexpr uint8_t lowest_compatible = Format::V4_MULTIPORT;
     s << static_cast<uint8_t>(INCOMPATIBILITY_BASE + lowest_compatible);
 
     s << nKey;

--- a/src/addrman_impl.h
+++ b/src/addrman_impl.h
@@ -157,6 +157,7 @@ private:
         V1_DETERMINISTIC = 1, //!< for pre-asmap files
         V2_ASMAP = 2,         //!< for files including asmap version
         V3_BIP155 = 3,        //!< same as V2_ASMAP plus addresses are in BIP155 format
+        V4_MULTIPORT = 4,     //!< adds support for multiple ports per IP
     };
 
     //! The maximum format this software knows it can unserialize. Also, we always serialize
@@ -164,7 +165,7 @@ private:
     //! The format (first byte in the serialized stream) can be higher than this and
     //! still this software may be able to unserialize the file - if the second byte
     //! (see `lowest_compatible` in `Unserialize()`) is less or equal to this.
-    static constexpr Format FILE_FORMAT = Format::V3_BIP155;
+    static constexpr Format FILE_FORMAT = Format::V4_MULTIPORT;
 
     //! The initial value of a field that is incremented every time an incompatible format
     //! change is made (such that old software versions would not be able to parse and

--- a/test/functional/feature_addrman.py
+++ b/test/functional/feature_addrman.py
@@ -18,7 +18,7 @@ from test_framework.util import assert_equal
 def serialize_addrman(
     *,
     format=1,
-    lowest_compatible=3,
+    lowest_compatible=4,
     net_magic="regtest",
     bucket_key=1,
     len_new=None,
@@ -75,7 +75,7 @@ class AddrmanTest(BitcoinTestFramework):
             expected_msg=init_error(
                 "Unsupported format of addrman database: 1. It is compatible with "
                 "formats >=111, but the maximum supported by this version of "
-                f"{self.config['environment']['PACKAGE_NAME']} is 3.: (.+)"
+                f"{self.config['environment']['PACKAGE_NAME']} is 4.: (.+)"
             ),
             match=ErrorMatch.FULL_REGEX,
         )


### PR DESCRIPTION
#23306 effectively changed the on-disk format in an incompatible way: old deserializers cannot deal with multiple entries for the same IP.

Introduce a `V4_MULTIPORT` format, and increment the compatibility base, so that old versions correctly recognize it as an incompatible future version, rather than corruption.
