### PR TITLE
Revert "build: fix ASLR for bitcoin-cli on Windows"

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -1202,19 +1202,11 @@ static int CommandLineRPC(int argc, char *argv[])
     return nRet;
 }
 
-#ifdef WIN32
-// Export main() and ensure working ASLR on Windows.
-// Exporting a symbol will prevent the linker from stripping
-// the .reloc section from the binary, which is a requirement
-// for ASLR. This is a temporary workaround until a fixed
-// version of binutils is used for releases.
-__declspec(dllexport) int main(int argc, char* argv[])
-{
-    util::WinCmdLineArgs winArgs;
-    std::tie(argc, argv) = winArgs.get();
-#else
 int main(int argc, char* argv[])
 {
+#ifdef WIN32
+    util::WinCmdLineArgs winArgs;
+    std::tie(argc, argv) = winArgs.get();
 #endif
     SetupEnvironment();
     if (!SetupNetworking()) {


### PR DESCRIPTION
I found it possible to revert #18702 for the following reasons:

- guix `bitcoin-cli.exe` binary passes `security-check.py`
- VMMap tool shows that ASLR is indeed working for `bitcoin-cli.exe` (rebooted between screenshots):

![Screenshot from 2021-10-26 13-34-20](https://user-images.githubusercontent.com/32963518/138861970-d307dce8-dbb5-4731-94e5-bd1ad379656e.png)
 
![Screenshot from 2021-10-26 13-34-46](https://user-images.githubusercontent.com/32963518/138861990-b7fc8207-28b7-48dc-918a-b176fb338388.png)

![Screenshot from 2021-10-26 13-35-14](https://user-images.githubusercontent.com/32963518/138862031-4844cf47-5a50-4303-821e-518c47f5bde8.png)
