### PR TITLE
util: Add "importfromcoldcard" command to bitcoin-wallet tool

### DIFF
--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -39,6 +39,7 @@ static void SetupWalletToolArgs(ArgsManager& argsman)
     argsman.AddCommand("salvage", "Attempt to recover private keys from a corrupt wallet. Warning: 'salvage' is experimental.");
     argsman.AddCommand("dump", "Print out all of the wallet key-value records");
     argsman.AddCommand("createfromdump", "Create new wallet file from dumped records");
+    argsman.AddCommand("importfromcoldcard", "Create new wallet file and import descriptors from Coldcard wallet");
 }
 
 static bool WalletAppInit(ArgsManager& args, int argc, char* argv[])

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -1453,7 +1453,7 @@ RPCHelpMan importmulti()
     };
 }
 
-static UniValue ProcessDescriptorImport(CWallet& wallet, const UniValue& data, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+UniValue ProcessDescriptorImport(CWallet& wallet, const UniValue& data, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
     UniValue warnings(UniValue::VARR);
     UniValue result(UniValue::VOBJ);

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -26,7 +26,7 @@ static void WalletCreate(CWallet* wallet_instance, uint64_t wallet_creation_flag
 {
     LOCK(wallet_instance->cs_wallet);
 
-    wallet_instance->SetMinVersion(FEATURE_HD_SPLIT);
+    wallet_instance->SetMinVersion(FEATURE_LATEST);
     wallet_instance->AddWalletFlags(wallet_creation_flags);
 
     if (!wallet_instance->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -3,12 +3,20 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <fs.h>
+#include <tinyformat.h>
+#include <univalue.h>
 #include <util/system.h>
 #include <util/translation.h>
 #include <wallet/dump.h>
 #include <wallet/salvage.h>
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
+
+#include <cassert>
+#include <string>
+
+UniValue ProcessDescriptorImport(CWallet& wallet, const UniValue& data, const int64_t timestamp)
+    EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 
 namespace WalletTool {
 
@@ -28,6 +36,10 @@ static void WalletCreate(CWallet* wallet_instance, uint64_t wallet_creation_flag
 
     wallet_instance->SetMinVersion(FEATURE_LATEST);
     wallet_instance->AddWalletFlags(wallet_creation_flags);
+
+    if (wallet_instance->IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET)) {
+        return;
+    }
 
     if (!wallet_instance->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
         auto spk_man = wallet_instance->GetOrCreateLegacyScriptPubKeyMan();
@@ -106,14 +118,40 @@ static void WalletShowInfo(CWallet* wallet_instance)
     tfm::format(std::cout, "Address Book: %zu\n", wallet_instance->m_address_book.size());
 }
 
+static bool ReadAndParseColdcardFile(const fs::path& path, UniValue& decriptors)
+{
+    fsbridge::ifstream file;
+    file.open(path);
+    if (!file.is_open()) {
+        tfm::format(std::cerr, "%s. Please check permissions.\n", fs::PathToString(path));
+        return false;
+    }
+
+    std::string line;
+    while (std::getline(file, line)) {
+        if (line.substr(0, 22) == "importdescriptors \'[{\"") break;
+    }
+
+    file.close();
+
+    decriptors.clear();
+    if (!decriptors.read(line.substr(19, line.size() - 20))) {
+        tfm::format(std::cerr, "Unable to parse %s\n", fs::PathToString(path));
+        return false;
+    }
+
+    assert(decriptors.isArray());
+    return true;
+}
+
 bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
 {
     if (args.IsArgSet("-format") && command != "createfromdump") {
         tfm::format(std::cerr, "The -format option can only be used with the \"createfromdump\" command.\n");
         return false;
     }
-    if (args.IsArgSet("-dumpfile") && command != "dump" && command != "createfromdump") {
-        tfm::format(std::cerr, "The -dumpfile option can only be used with the \"dump\" and \"createfromdump\" commands.\n");
+    if (args.IsArgSet("-dumpfile") && command != "dump" && command != "createfromdump" && command != "importfromcoldcard") {
+        tfm::format(std::cerr, "The -dumpfile option can only be used with the \"dump\", \"createfromdump\" and \"importfromcoldcard\" commands.\n");
         return false;
     }
     if (args.IsArgSet("-descriptors") && command != "create") {
@@ -205,6 +243,43 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
             tfm::format(std::cerr, "%s\n", error.original);
         }
         return ret;
+    } else if (command == "importfromcoldcard") {
+        std::string filename = gArgs.GetArg("-dumpfile", "");
+        if (filename.empty()) {
+            tfm::format(std::cerr, "To use importfromcoldcard, -dumpfile=<filename> must be provided.\n");
+            return false;
+        }
+
+        const fs::path import_file_path{fs::absolute(fs::PathFromString(filename))};
+        if (!fs::exists(import_file_path)) {
+            tfm::format(std::cerr, "File %s does not exist.\n", fs::PathToString(import_file_path));
+            return false;
+        }
+
+        UniValue descriptors;
+        if (!ReadAndParseColdcardFile(import_file_path, descriptors)) {
+            return false;
+        }
+
+        DatabaseOptions options;
+        options.require_create = true;
+        options.create_flags |= WALLET_FLAG_DESCRIPTORS;
+        options.create_flags |= WALLET_FLAG_DISABLE_PRIVATE_KEYS;
+        options.create_flags |= WALLET_FLAG_BLANK_WALLET;
+        options.require_format = DatabaseFormat::SQLITE;
+        std::shared_ptr<CWallet> wallet_instance = MakeWallet(name, path, options);
+        if (!wallet_instance) {
+            return false;
+        }
+
+        LOCK(wallet_instance->cs_wallet);
+        for (const UniValue& descriptor : descriptors.getValues()) {
+            const UniValue result = ::ProcessDescriptorImport(*wallet_instance, descriptor, 0);
+            tfm::format(std::cerr, "%s\n", result.write(2));
+        }
+
+        WalletShowInfo(wallet_instance.get());
+        wallet_instance->Close();
     } else {
         tfm::format(std::cerr, "Invalid command: %s\n", command);
         return false;


### PR DESCRIPTION
Coldcard firmware v4.1.3+ supports wallet export via descriptors:
- https://github.com/Coldcard/firmware/commit/3151369e67951f68e86ba993ef1e7dfaaa39c13f
- [Using Coldcard with Bitcoin Core](https://github.com/Coldcard/firmware/blob/3151369e67951f68e86ba993ef1e7dfaaa39c13f/docs/bitcoin-core-usage.md#bitcoin-core-v0210)

This PR adds a new command `importfromcoldcard` for the `bitcoin-wallet` tool which creates a new wallet and fills it with the provided descriptors.

Usage example:
```
$ src/bitcoin-wallet -wallet=MyNewShinyCC -dumpfile=/home/hebasto/Coldcard/bitcoin-core.txt importfromcoldcard
```

To point to the "bitcoin-core.txt" file, the `-dumpfile` option is re-used.

Also the created wallet is forced for rescanning, to guarantee the access to all transactions even for wallets that were previously used some time before being imported into Bitcoin Core.

TODO (not here):
- [ ] add tests for the `importfromcoldcard` command to the `tool_wallet.py` functional test
- [ ] add the same functionality to the GUI

Based on bitcoin/bitcoin#23349.
