### PR TITLE
Optimize coin selection by dropping BnB upper limit

### DIFF
--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -93,7 +93,6 @@ std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_poo
         // Conditions for starting a backtrack
         bool backtrack = false;
         if (curr_value + curr_available_value < selection_target ||                // Cannot possibly reach target with the amount remaining in the curr_available_value.
-            curr_value > selection_target + cost_of_change ||    // Selected value is out of range, go back and try other branch
             (curr_waste > best_waste && (utxo_pool.at(0).fee - utxo_pool.at(0).long_term_fee) > 0)) { // Don't select things which we know will be more wasteful if the waste is increasing
             backtrack = true;
         } else if (curr_value >= selection_target) {       // Selected value is within range

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -63,7 +63,7 @@ static const size_t TOTAL_TRIES = 100000;
 
 std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_pool, const CAmount& selection_target, const CAmount& cost_of_change)
 {
-    SelectionResult result(selection_target);
+    SelectionResult result(selection_target, /* force_no_change=*/ true);
     CAmount curr_value = 0;
 
     std::vector<bool> curr_selection; // select the utxo at this index

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -170,6 +170,9 @@ std::optional<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& ut
 {
     SelectionResult result(target_value);
 
+    // Increase target to avoid making really small change.
+    target_value += MIN_FINAL_CHANGE;
+
     std::vector<size_t> indexes;
     indexes.resize(utxo_pool.size());
     std::iota(indexes.begin(), indexes.end(), 0);

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -32,10 +32,11 @@ public:
         effective_value = txout.nValue;
     }
 
-    CInputCoin(const CTransactionRef& tx, unsigned int i, int input_bytes, int input_weight) : CInputCoin(tx, i)
+    CInputCoin(const CTransactionRef& tx, unsigned int i, int input_bytes, int input_weight, bool isSegwit) : CInputCoin(tx, i)
     {
         m_input_bytes = input_bytes;
         m_input_weight = input_weight;
+        m_isSegwit = isSegwit;
     }
 
     CInputCoin(const COutPoint& outpoint_in, const CTxOut& txout_in)
@@ -45,10 +46,11 @@ public:
         effective_value = txout.nValue;
     }
 
-    CInputCoin(const COutPoint& outpoint_in, const CTxOut& txout_in, int input_bytes, int input_weight) : CInputCoin(outpoint_in, txout_in)
+    CInputCoin(const COutPoint& outpoint_in, const CTxOut& txout_in, int input_bytes, int input_weight, bool isSegwit) : CInputCoin(outpoint_in, txout_in)
     {
         m_input_bytes = input_bytes;
         m_input_weight = input_weight;
+        m_isSegwit = isSegwit;
     }
 
     COutPoint outpoint;
@@ -60,6 +62,8 @@ public:
     /** Pre-computed estimated size of this output as a fully-signed input in a transaction. Can be -1 if it could not be calculated */
     int m_input_bytes{-1};
     int m_input_weight{-1};
+
+    bool m_isSegwit;
 
     bool operator<(const CInputCoin& rhs) const {
         return outpoint < rhs.outpoint;

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -217,10 +217,12 @@ private:
     bool m_use_effective{false};
     /** The computed waste */
     std::optional<CAmount> m_waste;
+    /** Force no change even if more than enough inputs are selected */
+    bool m_force_no_change{false};
 
 public:
-    explicit SelectionResult(const CAmount target)
-        : m_target(target) {}
+    explicit SelectionResult(const CAmount target, const bool force_no_change = false)
+        : m_target(target), m_force_no_change(force_no_change) {}
 
     SelectionResult() = delete;
 

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -212,7 +212,7 @@ private:
     /** Set of inputs selected by the algorithm to use in the transaction */
     std::set<CInputCoin> m_selected_inputs;
     /** The target the algorithm selected for. Note that this may not be equal to the recipient amount as it can include non-input fees */
-    const CAmount m_target;
+    CAmount m_target;
     /** Whether the input values for calculations should be the effective value (true) or normal value (false) */
     bool m_use_effective{false};
     /** The computed waste */
@@ -234,15 +234,22 @@ public:
     void AddInput(const OutputGroup& group);
 
     /** Calculates and stores the waste for this selection via GetSelectionWaste */
-    void ComputeAndSetWaste(CAmount change_cost);
+    void ComputeAndSetWaste(const CoinSelectionParams& coin_selection_params);
     [[nodiscard]] CAmount GetWaste() const;
+
+    void Merge(const SelectionResult& other);
 
     /** Get m_selected_inputs */
     const std::set<CInputCoin>& GetInputSet() const;
     /** Get the vector of CInputCoins that will be used to fill in a CTransaction's vin */
+
     std::vector<CInputCoin> GetShuffledInputVector() const;
 
     bool operator<(SelectionResult other) const;
+
+    CAmount GetInputsWeight() const;
+
+    CAmount GetChange(const CoinSelectionParams& coin_selection_params) const;
 };
 
 std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_pool, const CAmount& selection_target, const CAmount& cost_of_change);

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -32,9 +32,10 @@ public:
         effective_value = txout.nValue;
     }
 
-    CInputCoin(const CTransactionRef& tx, unsigned int i, int input_bytes) : CInputCoin(tx, i)
+    CInputCoin(const CTransactionRef& tx, unsigned int i, int input_bytes, int input_weight) : CInputCoin(tx, i)
     {
         m_input_bytes = input_bytes;
+        m_input_weight = input_weight;
     }
 
     CInputCoin(const COutPoint& outpoint_in, const CTxOut& txout_in)
@@ -44,9 +45,10 @@ public:
         effective_value = txout.nValue;
     }
 
-    CInputCoin(const COutPoint& outpoint_in, const CTxOut& txout_in, int input_bytes) : CInputCoin(outpoint_in, txout_in)
+    CInputCoin(const COutPoint& outpoint_in, const CTxOut& txout_in, int input_bytes, int input_weight) : CInputCoin(outpoint_in, txout_in)
     {
         m_input_bytes = input_bytes;
+        m_input_weight = input_weight;
     }
 
     COutPoint outpoint;
@@ -57,6 +59,7 @@ public:
 
     /** Pre-computed estimated size of this output as a fully-signed input in a transaction. Can be -1 if it could not be calculated */
     int m_input_bytes{-1};
+    int m_input_weight{-1};
 
     bool operator<(const CInputCoin& rhs) const {
         return outpoint < rhs.outpoint;

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -564,19 +564,6 @@ void FundTransaction(CWallet& wallet, CMutableTransaction& tx, CAmount& fee_out,
         setSubtractFeeFromOutputs.insert(pos);
     }
 
-    // Fetch specified UTXOs from the UTXO set to get the scriptPubKeys and values of the outputs being selected
-    // and to match with the given solving_data. Only used for non-wallet outputs.
-    std::map<COutPoint, Coin> coins;
-    for (const CTxIn& txin : tx.vin) {
-        coins[txin.prevout]; // Create empty map entry keyed by prevout.
-    }
-    wallet.chain().findCoins(coins);
-    for (const auto& coin : coins) {
-        if (!coin.second.out.IsNull()) {
-            coinControl.SelectExternal(coin.first, coin.second.out);
-        }
-    }
-
     bilingual_str error;
 
     if (!FundTransaction(wallet, tx, fee_out, change_position, error, lockUnspents, setSubtractFeeFromOutputs, coinControl)) {

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -992,13 +992,27 @@ bool FundTransaction(CWallet& wallet, CMutableTransaction& tx, CAmount& nFeeRet,
 
     coinControl.fAllowOtherInputs = true;
 
-    for (const CTxIn& txin : tx.vin) {
-        coinControl.Select(txin.prevout);
-    }
-
     // Acquire the locks to prevent races to the new locked unspents between the
     // CreateTransaction call and LockCoin calls (when lockUnspents is true).
     LOCK(wallet.cs_wallet);
+
+    // Fetch specified UTXOs from the UTXO set to get the scriptPubKeys and values of the outputs being selected
+    // and to match with the given solving_data. Only used for non-wallet outputs.
+    std::map<COutPoint, Coin> coins;
+    for (const CTxIn& txin : tx.vin) {
+        coins[txin.prevout]; // Create empty map entry keyed by prevout.
+    }
+    wallet.chain().findCoins(coins);
+
+    for (const CTxIn& txin : tx.vin) {
+        // if it's not in the wallet and corresponding UTXO is found than select as external output
+        const auto& outPoint = txin.prevout;
+        if (wallet.mapWallet.find(outPoint.hash) == wallet.mapWallet.end() && !coins[outPoint].out.IsNull()) {
+            coinControl.SelectExternal(outPoint, coins[outPoint].out);
+        } else {
+            coinControl.Select(outPoint);
+        }
+    }
 
     CTransactionRef tx_new;
     FeeCalculation fee_calc_out;

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -399,9 +399,8 @@ std::optional<SelectionResult> AttemptSelection(const CWallet& wallet, const CAm
         results.push_back(*knapsack_result);
     }
 
-    // We include the minimum final change for SRD as we do want to avoid making really small change.
-    // KnapsackSolver does not need this because it includes MIN_CHANGE internally.
-    const CAmount srd_target = nTargetValue + coin_selection_params.m_change_fee + MIN_FINAL_CHANGE;
+    // SRD always produced at least MIN_FINAL_CHANGE change
+    const CAmount srd_target = nTargetValue + coin_selection_params.m_change_fee;
     if (auto srd_result{SelectCoinsSRD(positive_groups, srd_target)}) {
         srd_result->ComputeAndSetWaste(coin_selection_params.m_cost_of_change);
         results.push_back(*srd_result);

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -384,7 +384,7 @@ std::optional<SelectionResult> AttemptSelection(const CWallet& wallet, const CAm
     // Note that unlike KnapsackSolver, we do not include the fee for creating a change output as BnB will not create a change output.
     std::vector<OutputGroup> positive_groups = GroupOutputs(wallet, coins, coin_selection_params, eligibility_filter, true /* positive_only */);
     if (auto bnb_result{SelectCoinsBnB(positive_groups, nTargetValue, coin_selection_params.m_cost_of_change)}) {
-        bnb_result->ComputeAndSetWaste(CAmount(0));
+        bnb_result->ComputeAndSetWaste(coin_selection_params);
         results.push_back(*bnb_result);
     }
 
@@ -397,14 +397,14 @@ std::optional<SelectionResult> AttemptSelection(const CWallet& wallet, const CAm
         knapsack_target += coin_selection_params.m_change_fee;
     }
     if (auto knapsack_result{KnapsackSolver(all_groups, knapsack_target)}) {
-        knapsack_result->ComputeAndSetWaste(coin_selection_params.m_cost_of_change);
+        knapsack_result->ComputeAndSetWaste(coin_selection_params);
         results.push_back(*knapsack_result);
     }
 
     // SRD always produced at least MIN_FINAL_CHANGE change
     const CAmount srd_target = nTargetValue + coin_selection_params.m_change_fee;
     if (auto srd_result{SelectCoinsSRD(positive_groups, srd_target)}) {
-        srd_result->ComputeAndSetWaste(coin_selection_params.m_cost_of_change);
+        srd_result->ComputeAndSetWaste(coin_selection_params);
         results.push_back(*srd_result);
     }
 
@@ -436,9 +436,16 @@ std::optional<SelectionResult> SelectCoins(const CWallet& wallet, const std::vec
              */
             preset_inputs.Insert(out.GetInputCoin(), 0, false, 0, 0, false);
         }
+        if (preset_inputs.GetSelectionAmount() < nTargetValue) return std::nullopt;
+
+        if (preset_inputs.GetSelectionAmount() > nTargetValue + coin_selection_params.m_cost_of_change) {
+            SelectionResult result(nTargetValue + coin_selection_params.m_change_fee);
+            result.AddInput(preset_inputs);
+            return result;
+        }
+
         SelectionResult result(nTargetValue);
         result.AddInput(preset_inputs);
-        if (result.GetSelectedValue() < nTargetValue) return std::nullopt;
         return result;
     }
 
@@ -492,6 +499,7 @@ std::optional<SelectionResult> SelectCoins(const CWallet& wallet, const std::vec
          */
         preset_inputs.Insert(coin, 0, false, 0, 0, false);
     }
+    // TODO: value_to_select -= preset_inputs.GetSelectionAmount();
 
     // remove preset inputs from vCoins so that Coin Selection doesn't pick them.
     for (std::vector<COutput>::iterator it = vCoins.begin(); it != vCoins.end() && coin_control.HasSelected();)
@@ -518,12 +526,16 @@ std::optional<SelectionResult> SelectCoins(const CWallet& wallet, const std::vec
         Shuffle(vCoins.begin(), vCoins.end(), FastRandomContext());
     }
 
+    SelectionResult preselected(preset_inputs.GetSelectionAmount());
+    preselected.AddInput(preset_inputs);
+
     // Coin Selection attempts to select inputs from a pool of eligible UTXOs to fund the
     // transaction at a target feerate. If an attempt fails, more attempts may be made using a more
     // permissive CoinEligibilityFilter.
     std::optional<SelectionResult> res = [&] {
         // Pre-selected inputs already cover the target amount.
-        if (value_to_select <= 0) return std::make_optional(SelectionResult(nTargetValue));
+        if (value_to_select < -coin_selection_params.m_cost_of_change) return std::make_optional(SelectionResult(value_to_select + coin_selection_params.m_change_fee));
+        if (value_to_select <= 0) return std::make_optional(SelectionResult(value_to_select));
 
         // If possible, fund the transaction with confirmed UTXOs only. Prefer at least six
         // confirmations on outputs received from other wallets and only spend confirmed change.
@@ -576,7 +588,7 @@ std::optional<SelectionResult> SelectCoins(const CWallet& wallet, const std::vec
     if (!res) return std::nullopt;
 
     // Add preset inputs to result
-    res->AddInput(preset_inputs);
+    res->Merge(preselected);
 
     return res;
 }
@@ -744,9 +756,17 @@ static bool CreateTransactionInternal(
     coin_selection_params.m_change_fee = coin_selection_params.m_effective_feerate.GetFee(coin_selection_params.change_output_size);
     coin_selection_params.m_cost_of_change = coin_selection_params.m_discard_feerate.GetFee(coin_selection_params.change_spend_size) + coin_selection_params.m_change_fee;
 
+    // We want to drop the change to fees if:
+    // 1. The change output would be dust
+    // 2. The change is within the (almost) exact match window, i.e. it is less than or equal to the cost of the change output (cost_of_change)
+    const auto dust = GetDustThreshold(change_prototype_txout, coin_selection_params.m_discard_feerate);
+    // TODO: disambiguate between min_change and m_cost_of_change
+    if (dust > coin_selection_params.m_cost_of_change) coin_selection_params.m_cost_of_change = dust;
+
     // vouts to the payees
     if (!coin_selection_params.m_subtract_fee_outputs) {
-        coin_selection_params.tx_noinputs_size = 11; // Static vsize overhead + outputs vsize. 4 nVersion, 4 nLocktime, 1 input count, 1 output count, 1 witness overhead (dummy, flag, stack size)
+        coin_selection_params.tx_noinputs_size = 10; // Static vsize overhead + outputs vsize. 4 nVersion, 4 nLocktime, 1 input count, 1 witness overhead (dummy, flag, stack size)
+        coin_selection_params.tx_noinputs_size += GetSizeOfCompactSize(vecSend.size()); // bytes for output count
     }
     for (const auto& recipient : vecSend)
     {
@@ -780,25 +800,25 @@ static bool CreateTransactionInternal(
         return false;
     }
 
-    // Always make a change output
-    // We will reduce the fee from this change output later, and remove the output if it is too small.
-    const CAmount change_and_fee = result->GetSelectedValue() - recipients_sum;
-    assert(change_and_fee >= 0);
-    CTxOut newTxOut(change_and_fee, scriptChange);
+    const CAmount change_amount = result->GetChange(coin_selection_params);
+    if (change_amount > 0) {
+        CTxOut newTxOut(change_amount, scriptChange);
 
-    if (nChangePosInOut == -1)
-    {
-        // Insert change txn at random position:
-        nChangePosInOut = GetRandInt(txNew.vout.size()+1);
-    }
-    else if ((unsigned int)nChangePosInOut > txNew.vout.size())
-    {
-        error = _("Change index out of range");
-        return false;
-    }
+        if (nChangePosInOut == -1)
+        {
+            // Insert change txn at random position:
+            nChangePosInOut = GetRandInt(txNew.vout.size()+1);
+        }
+        else if ((unsigned int)nChangePosInOut > txNew.vout.size())
+        {
+            error = _("Change index out of range");
+            return false;
+        }
 
-    assert(nChangePosInOut != -1);
-    auto change_position = txNew.vout.insert(txNew.vout.begin() + nChangePosInOut, newTxOut);
+        txNew.vout.insert(txNew.vout.begin() + nChangePosInOut, newTxOut);
+    } else {
+        nChangePosInOut = -1;
+    }
 
     // Shuffle selected coins and fill in final vin
     std::vector<CInputCoin> selected_coins = result->GetShuffledInputVector();
@@ -823,42 +843,16 @@ static bool CreateTransactionInternal(
         error = _("Missing solving data for estimating transaction size");
         return false;
     }
-    nFeeRet = coin_selection_params.m_effective_feerate.GetFee(nBytes);
-
-    // Subtract fee from the change output if not subtracting it from recipient outputs
-    CAmount fee_needed = nFeeRet;
-    if (!coin_selection_params.m_subtract_fee_outputs) {
-        change_position->nValue -= fee_needed;
-    }
-
-    // We want to drop the change to fees if:
-    // 1. The change output would be dust
-    // 2. The change is within the (almost) exact match window, i.e. it is less than or equal to the cost of the change output (cost_of_change)
-    CAmount change_amount = change_position->nValue;
-    if (IsDust(*change_position, coin_selection_params.m_discard_feerate) || change_amount <= coin_selection_params.m_cost_of_change)
-    {
-        nChangePosInOut = -1;
-        change_amount = 0;
-        txNew.vout.erase(change_position);
-
-        // Because we have dropped this change, the tx size and required fee will be different, so let's recalculate those
-        tx_sizes = CalculateMaximumSignedTxSize(CTransaction(txNew), &wallet, &coin_control);
-        nBytes = tx_sizes.vsize;
-        fee_needed = coin_selection_params.m_effective_feerate.GetFee(nBytes);
-    }
+    CAmount fee_needed = coin_selection_params.m_effective_feerate.GetFee(nBytes);
+    nFeeRet = result->GetSelectedValue() - recipients_sum - change_amount;
 
     // The only time that fee_needed should be less than the amount available for fees (in change_and_fee - change_amount) is when
     // we are subtracting the fee from the outputs. If this occurs at any other time, it is a bug.
-    assert(coin_selection_params.m_subtract_fee_outputs || fee_needed <= change_and_fee - change_amount);
-
-    // Update nFeeRet in case fee_needed changed due to dropping the change output
-    if (fee_needed <= change_and_fee - change_amount) {
-        nFeeRet = change_and_fee - change_amount;
-    }
+    assert(coin_selection_params.m_subtract_fee_outputs || fee_needed <= nFeeRet);
 
     // Reduce output values for subtractFeeFromAmount
     if (coin_selection_params.m_subtract_fee_outputs) {
-        CAmount to_reduce = fee_needed + change_amount - change_and_fee;
+        CAmount to_reduce = fee_needed - nFeeRet;
         int i = 0;
         bool fFirst = true;
         for (const auto& recipient : vecSend)

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -469,7 +469,14 @@ std::optional<SelectionResult> SelectCoins(const CWallet& wallet, const std::vec
             input_size = CalculateMaximumSignedInputSize(txout, outpoint, &coin_control.m_external_provider, &coin_control);
         }
 
-        CInputCoin coin(outpoint, txout, input_size.vsize, input_size.weight);
+        const auto& provider = wallet.GetSolvingProvider(txout.scriptPubKey);
+        bool isSegwit = false;
+        if (provider) {
+            isSegwit = IsSegWitOutput(*provider, txout.scriptPubKey);
+        } else {
+            isSegwit = IsSegWitOutput(coin_control.m_external_provider, txout.scriptPubKey);
+        }
+        CInputCoin coin(outpoint, txout, input_size.vsize, input_size.weight, isSegwit);
         if (coin.m_input_bytes == -1) {
             return std::nullopt; // Not solvable, can't estimate size for fee
         }

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -49,13 +49,18 @@ public:
      */
     bool fSafe;
 
+    bool isSegwit;
+
     COutput(const CWallet& wallet, const CWalletTx& wtx, int iIn, int nDepthIn, bool fSpendableIn, bool fSolvableIn, bool fSafeIn, const CCoinControl* coin_control = nullptr)
     {
         tx = &wtx; i = iIn; nDepth = nDepthIn; fSpendable = fSpendableIn; fSolvable = fSolvableIn; fSafe = fSafeIn; nInputSize = {-1, -1};
+        const CTxOut &txout = wtx.tx->vout[i];
+        const auto provider = wallet.GetSolvingProvider(txout.scriptPubKey);
         // If known and signable by the given wallet, compute nInputSize
         // Failure will keep this value -1
-        if (fSpendable) {
+        if (fSpendable && provider) {
             nInputSize = GetTxSpendSize(wallet, wtx, i, coin_control);
+            isSegwit = IsSegWitOutput(*provider, txout.scriptPubKey);
         }
     }
 
@@ -63,7 +68,7 @@ public:
 
     inline CInputCoin GetInputCoin() const
     {
-        return CInputCoin(tx->tx, i, nInputSize.vsize, nInputSize.weight);
+        return CInputCoin(tx->tx, i, nInputSize.vsize, nInputSize.weight, isSegwit);
     }
 };
 

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -343,8 +343,10 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
         coin_control.fAllowOtherInputs = true;
         coin_control.Select(COutPoint(coins.at(0).tx->GetHash(), coins.at(0).i));
         coin_selection_params_bnb.m_effective_feerate = CFeeRate(0);
-        const auto result10 = SelectCoins(*wallet, coins, 10 * CENT, coin_control, coin_selection_params_bnb);
+        auto result10 = SelectCoins(*wallet, coins, 10 * CENT, coin_control, coin_selection_params_bnb);
         BOOST_CHECK(result10);
+        result10->ComputeAndSetWaste(coin_selection_params_bnb);
+        BOOST_CHECK(result10->GetWaste() == -68 * 3); // - (long_term_fee * input) * 3coins
     }
 }
 

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -314,13 +314,13 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
         std::vector<COutput> coins;
 
         add_coin(coins, *wallet, 1);
-        coins.at(0).nInputBytes = 40; // Make sure that it has a negative effective value. The next check should assert if this somehow got through. Otherwise it will fail
+        coins.at(0).nInputSize.vsize = 40; // Make sure that it has a negative effective value. The next check should assert if this somehow got through. Otherwise it will fail
         BOOST_CHECK(!SelectCoinsBnB(GroupCoins(coins), 1 * CENT, coin_selection_params_bnb.m_cost_of_change));
 
         // Test fees subtracted from output:
         coins.clear();
         add_coin(coins, *wallet, 1 * CENT);
-        coins.at(0).nInputBytes = 40;
+        coins.at(0).nInputSize.vsize = 40;
         coin_selection_params_bnb.m_subtract_fee_outputs = true;
         const auto result9 = SelectCoinsBnB(GroupCoins(coins), 1 * CENT, coin_selection_params_bnb.m_cost_of_change);
         BOOST_CHECK(result9);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1461,12 +1461,15 @@ bool CWallet::AddWalletFlags(uint64_t flags)
 
 // Helper for producing a max-sized low-S low-R signature (eg 71 bytes)
 // or a max-sized low-S signature (e.g. 72 bytes) if use_max_sig is true
-bool DummySignInput(const SigningProvider& provider, CTxIn &tx_in, const CTxOut &txout, bool use_max_sig)
+bool DummySignInput(const SigningProvider& provider, CTxIn &tx_in, const CTxOut &txout, const CCoinControl* coin_control)
 {
     // Fill in dummy signatures for fee calculation.
     const CScript& scriptPubKey = txout.scriptPubKey;
     SignatureData sigdata;
 
+    // Use max sig if watch only inputs were used or if this particular input is an external input
+    // to ensure a sufficient fee is attained for the requested feerate.
+    const bool use_max_sig = coin_control && (coin_control->fAllowWatchOnly || coin_control->IsExternalSelected(tx_in.prevout));
     if (!ProduceSignature(provider, use_max_sig ? DUMMY_MAXIMUM_SIGNATURE_CREATOR : DUMMY_SIGNATURE_CREATOR, scriptPubKey, sigdata)) {
         return false;
     }
@@ -1482,12 +1485,9 @@ bool CWallet::DummySignTx(CMutableTransaction &txNew, const std::vector<CTxOut> 
     for (const auto& txout : txouts)
     {
         CTxIn& txin = txNew.vin[nIn];
-        // Use max sig if watch only inputs were used or if this particular input is an external input
-        // to ensure a sufficient fee is attained for the requested feerate.
-        const bool use_max_sig = coin_control && (coin_control->fAllowWatchOnly || coin_control->IsExternalSelected(txin.prevout));
         const std::unique_ptr<SigningProvider> provider = GetSolvingProvider(txout.scriptPubKey);
-        if (!provider || !DummySignInput(*provider, txin, txout, use_max_sig)) {
-            if (!coin_control || !DummySignInput(coin_control->m_external_provider, txin, txout, use_max_sig)) {
+        if (!provider || !DummySignInput(*provider, txin, txout, coin_control)) {
+            if (!coin_control || !DummySignInput(coin_control->m_external_provider, txin, txout, coin_control)) {
                 return false;
             }
         }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -934,6 +934,6 @@ bool AddWalletSetting(interfaces::Chain& chain, const std::string& wallet_name);
 //! Remove wallet name from persistent configuration so it will not be loaded on startup.
 bool RemoveWalletSetting(interfaces::Chain& chain, const std::string& wallet_name);
 
-bool DummySignInput(const SigningProvider& provider, CTxIn &tx_in, const CTxOut &txout, bool use_max_sig);
+bool DummySignInput(const SigningProvider& provider, CTxIn &tx_in, const CTxOut &txout, const CCoinControl* coin_control = nullptr);
 
 #endif // BITCOIN_WALLET_WALLET_H


### PR DESCRIPTION
Requires #22019 and #22949

Removing upper bound allows to find more changeless solutions. Most of them would be terrible due to huge excess and hence waste, so another solution would be chosen. But in some cases excess higher than upper bound would be
economically optimal based on waste metric.

This change also makes transaction building and waste calculation consistent. Specifically it eliminates two sources of discrepancy: 

1. for knapsack we used to always calculate waste as if they produce change (that's not always true)
2. change could be dropped to fees during tx building after waste is calculated 

As a result we should see more changeless solutions which is good for: privacy, utxo set, total fees paid. 