### PR TITLE
test: Add ios_base::width tsan suppression

### DIFF
--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -41,3 +41,6 @@ race:CZMQAbstractPublishNotifier::SendZmqMessage
 
 # https://github.com/bitcoin/bitcoin/pull/20218, https://github.com/bitcoin/bitcoin/pull/20745
 race:epoll_ctl
+
+# https://github.com/bitcoin/bitcoin/issues/23366
+race:std::__1::ios_base::width


### PR DESCRIPTION
This PR:
- adds tsan suppression for intermittent failures in CI
```
SUMMARY: ThreadSanitizer: data race /usr/lib/llvm-12/bin/../include/c++/v1/ios:523:12 in std::__1::ios_base::width() const
```

- fixes #23366