### PR TITLE
addrman: bump peers.dat format version number

### DIFF
--- a/src/addrman_impl.h
+++ b/src/addrman_impl.h
@@ -157,6 +157,7 @@ private:
         V1_DETERMINISTIC = 1, //!< for pre-asmap files
         V2_ASMAP = 2,         //!< for files including asmap version
         V3_BIP155 = 3,        //!< same as V2_ASMAP plus addresses are in BIP155 format
+        V4_DUPADDR = 4,       //!< V3_BIP155 + entries with the same address but different port
     };
 
     //! The maximum format this software knows it can unserialize. Also, we always serialize
@@ -164,7 +165,7 @@ private:
     //! The format (first byte in the serialized stream) can be higher than this and
     //! still this software may be able to unserialize the file - if the second byte
     //! (see `lowest_compatible` in `Unserialize()`) is less or equal to this.
-    static constexpr Format FILE_FORMAT = Format::V3_BIP155;
+    static constexpr Format FILE_FORMAT = Format::V4_DUPADDR;
 
     //! The initial value of a field that is incremented every time an incompatible format
     //! change is made (such that old software versions would not be able to parse and


### PR DESCRIPTION
After 92617b7a758c0425330fba4b886296730567927c (https://github.com/bitcoin/bitcoin/pull/23306) we allow multiple entries in addrman with the same address that only differ by port.

Such `peers.dat` trips versions before the above commit and they fail to read it with an obscure "corruption" error:

```
Corrupt data. Consistency check failed with code -5
```

So, if we detect that there are such "duplicate" entries, write the file with a newver format version, so that old software emits:

```
Unsupported format of addrman database: 4. It is compatible with formats >=4, but the maximum supported by this version of Bitcoin Core is 3.
```