### PR TITLE
refactor: get wallet path relative to wallet_dir

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -12,7 +12,6 @@
 
 std::vector<fs::path> ListDatabases(const fs::path& wallet_dir)
 {
-    const size_t offset = wallet_dir.native().size() + (wallet_dir == wallet_dir.root_name() ? 0 : 1);
     std::vector<fs::path> paths;
     boost::system::error_code ec;
 
@@ -28,10 +27,7 @@ std::vector<fs::path> ListDatabases(const fs::path& wallet_dir)
         }
 
         try {
-            // Get wallet path relative to walletdir by removing walletdir from the wallet path.
-            // This can be replaced by boost::filesystem::lexically_relative once boost is bumped to 1.60.
-            const auto path_str = it->path().native().substr(offset);
-            const fs::path path{path_str.begin(), path_str.end()};
+            const fs::path path{it->path().lexically_relative(wallet_dir)};
 
             if (it->status().type() == fs::directory_file &&
                 (IsBDBFile(BDBDataFile(it->path())) || IsSQLiteFile(SQLiteDataFile(it->path())))) {


### PR DESCRIPTION
Now that boost has been updated > 1.60 (see #22320), we can simplify how we get
wallet path relative to wallet_dir by using:
`boost::filesystem::lexically_relative`, removing a TODO.

Test coverage comes from `test/functional/wallet_multiwallet.py`

I first tried this in #20265 which was my first attempted PR, and funny enough exactly 1 year later I'm opening this one to hopefully finally close this.