### PR TITLE
WIP: add support to save fee estimates without having to shut down the node

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -883,12 +883,7 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation 
 
 void CBlockPolicyEstimator::Flush() {
     FlushUnconfirmed();
-
-    fs::path est_filepath = gArgs.GetDataDirNet() / FEE_ESTIMATES_FILENAME;
-    CAutoFile est_file(fsbridge::fopen(est_filepath, "wb"), SER_DISK, CLIENT_VERSION);
-    if (est_file.IsNull() || !Write(est_file)) {
-        LogPrintf("Failed to write fee estimates to %s. Continue anyway.\n", fs::PathToString(est_filepath));
-    }
+    Write();
 }
 
 bool CBlockPolicyEstimator::Write(CAutoFile& fileout) const
@@ -911,6 +906,17 @@ bool CBlockPolicyEstimator::Write(CAutoFile& fileout) const
     }
     catch (const std::exception&) {
         LogPrintf("CBlockPolicyEstimator::Write(): unable to write policy estimator data (non-fatal)\n");
+        return false;
+    }
+    return true;
+}
+
+bool CBlockPolicyEstimator::Write() const
+{
+    fs::path est_filepath = gArgs.GetDataDirNet() / FEE_ESTIMATES_FILENAME;
+    CAutoFile est_file(fsbridge::fopen(est_filepath, "wb"), SER_DISK, CLIENT_VERSION);
+    if (est_file.IsNull() || !Write(est_file)) {
+        LogPrintf("Failed to write fee estimates to %s. Continue anyway.\n", fs::PathToString(est_filepath));
         return false;
     }
     return true;

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -213,6 +213,9 @@ public:
     /** Write estimation data to a file */
     bool Write(CAutoFile& fileout) const;
 
+    /** Write estimation data to the default file */
+    bool Write() const;
+
     /** Read estimation data from a file */
     bool Read(CAutoFile& filein);
 

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -76,6 +76,7 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
     "importwallet", // avoid reading from disk
     "loadwallet",   // avoid reading from disk
     "prioritisetransaction", // avoid signed integer overflow in CTxMemPool::PrioritiseTransaction(uint256 const&, long const&) (https://github.com/bitcoin/bitcoin/issues/20626)
+    "savefeeestimates",      // disabled as a precautionary measure: may take a file path argument in the future
     "savemempool",           // disabled as a precautionary measure: may take a file path argument in the future
     "setban",                // avoid DNS lookups
     "stop",                  // avoid shutdown state

--- a/test/functional/feature_fee_estimates_persist.py
+++ b/test/functional/feature_fee_estimates_persist.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test fee estimates persistence.
+
+By default, bitcoind will dump fee estimates on shutdown and
+then reload it on startup.
+
+Test is as follows:
+
+  - start node0
+  - call the savefeeestimates RPC and verify the RPC succeeds and
+    that the file exists
+  - make the file read only and attempt to call the savefeeestimates RPC
+    with the expecation that it will fail
+  - move the read only file and shut down the node, verify the node writes
+    on shutdown a file that is identical to the one we saved via the RPC
+
+"""
+
+import filecmp
+import os
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_raises_rpc_error
+
+
+class FeeEstimatesPersistTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def run_test(self):
+        fee_estimatesdat = os.path.join(self.nodes[0].datadir, self.chain, 'fee_estimates.dat')
+        self.log.debug('Verify the fee_estimates.dat file does not exists on start up')
+        assert not os.path.isfile(fee_estimatesdat)
+        self.nodes[0].savefeeestimates()
+        self.log.debug('Verify the fee_estimates.dat file exists after calling savefeeestimates RPC')
+        assert os.path.isfile(fee_estimatesdat)
+        self.log.debug("Prevent bitcoind from writing fee_estimates.dat to disk. Verify that `savefeeestimates` fails")
+        fee_estimatesdatold = fee_estimatesdat + '.old'
+        os.rename(fee_estimatesdat, fee_estimatesdatold)
+        os.mkdir(fee_estimatesdat)
+        assert_raises_rpc_error(-1, "Unable to dump fee estimates to disk", self.nodes[0].savefeeestimates)
+        os.rmdir(fee_estimatesdat)
+        self.stop_nodes()
+        self.log.debug("Verify that fee_estimates are written on shutdown")
+        assert os.path.isfile(fee_estimatesdat)
+        self.log.debug("Verify that the fee estimates from a shutdown are identical from the ones from savefeeestimates")
+        assert filecmp.cmp(fee_estimatesdat, fee_estimatesdatold)
+
+
+if __name__ == "__main__":
+    FeeEstimatesPersistTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -135,6 +135,7 @@ BASE_SCRIPTS = [
     # vv Tests less than 30s vv
     'wallet_keypool_topup.py --legacy-wallet',
     'wallet_keypool_topup.py --descriptors',
+    'feature_fee_estimates_persist.py',
     'feature_fee_estimation.py',
     'interface_zmq.py',
     'rpc_invalid_address_message.py',


### PR DESCRIPTION
This PR adds a new RPC method called savefeeestimates in a similar fashion to savemempool RPC.

The rational behind this is that currently there is no way to save the fee estimates without shutting down the node and this makes it harder/slower to bring up new instances of bitcoin core.

For example in https://github.com/Blockstream/esplora/ when we do new deployments or when we have higher traffic we need to bring up new instances, currently the procedure uses a snapshot of the blockchain (say a few weeks old) brings it up to the tip, then stops it, calls savemempool on a long running instance, copies that file over and restarts the new node so that the new instance has all the transactions in mempool even though it wasn't live to receive them when they occurred.

However the fee estimation of that new node are not up to date and as such the new node will report bad fee estimates.

This PR will make it possible to start a new node with reasonable fee estimates from an old running node without having to shut down said old running node.

Any feedback welcome and thanks for reviewing/reading.