### PR TITLE
test: move check_node_connections to util

### DIFF
--- a/test/functional/feature_anchors.py
+++ b/test/functional/feature_anchors.py
@@ -8,16 +8,10 @@ import os
 
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import check_node_connections
 
 INBOUND_CONNECTIONS = 5
 BLOCK_RELAY_CONNECTIONS = 2
-
-
-def check_node_connections(*, node, num_in, num_out):
-    info = node.getnetworkinfo()
-    assert_equal(info["connections_in"], num_in)
-    assert_equal(info["connections_out"], num_out)
 
 
 class AnchorsTest(BitcoinTestFramework):

--- a/test/functional/p2p_add_connections.py
+++ b/test/functional/p2p_add_connections.py
@@ -6,13 +6,7 @@
 
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
-
-
-def check_node_connections(*, node, num_in, num_out):
-    info = node.getnetworkinfo()
-    assert_equal(info["connections_in"], num_in)
-    assert_equal(info["connections_out"], num_out)
+from test_framework.util import check_node_connections
 
 
 class P2PAddConnections(BitcoinTestFramework):

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -269,6 +269,7 @@ def wait_until_helper(predicate, *, attempts=float('inf'), timeout=float('inf'),
         raise AssertionError("Predicate {} not true after {} seconds".format(predicate_source, timeout))
     raise RuntimeError('Unreachable')
 
+
 def sha256sum_file(filename):
     h = hashlib.sha256()
     with open(filename, 'rb') as f:
@@ -443,6 +444,12 @@ def softfork_active(node, key):
 def set_node_times(nodes, t):
     for node in nodes:
         node.setmocktime(t)
+
+
+def check_node_connections(*, node, num_in, num_out):
+    info = node.getnetworkinfo()
+    assert_equal(info["connections_in"], num_in)
+    assert_equal(info["connections_out"], num_out)
 
 
 # Transaction/Block functions


### PR DESCRIPTION
This function (`check_node_connections`) exists in `feature_anchors.py` and `p2p_add_connections.py` and does the same thing in both, this PR moves this function to util to avoid repetition and facilitate maintenance.