### PR TITLE
Avoid excessive lock contention in CCheckQueue::Add

### DIFF
--- a/src/checkqueue.h
+++ b/src/checkqueue.h
@@ -167,6 +167,10 @@ public:
     //! Add a batch of checks to the queue
     void Add(std::vector<T>& vChecks)
     {
+        if (vChecks.empty()) {
+            return;
+        }
+
         {
             LOCK(m_mutex);
             for (T& check : vChecks) {
@@ -176,10 +180,11 @@ public:
             nTodo += vChecks.size();
         }
 
-        if (vChecks.size() == 1)
+        if (vChecks.size() == 1) {
             m_worker_cv.notify_one();
-        else if (vChecks.size() > 1)
+        } else {
             m_worker_cv.notify_all();
+        }
     }
 
     //! Stop all of the worker threads.

--- a/src/checkqueue.h
+++ b/src/checkqueue.h
@@ -167,12 +167,15 @@ public:
     //! Add a batch of checks to the queue
     void Add(std::vector<T>& vChecks)
     {
-        LOCK(m_mutex);
-        for (T& check : vChecks) {
-            queue.push_back(T());
-            check.swap(queue.back());
+        {
+            LOCK(m_mutex);
+            for (T& check : vChecks) {
+                queue.emplace_back();
+                check.swap(queue.back());
+            }
+            nTodo += vChecks.size();
         }
-        nTodo += vChecks.size();
+
         if (vChecks.size() == 1)
             m_worker_cv.notify_one();
         else if (vChecks.size() > 1)


### PR DESCRIPTION
This PR significantly reduces lock contention in the `CCheckQueue` class by releasing a mutex before calling `std::condition_variable::notify_one` and `std::condition_variable::notify_all`.

From C++ [docs](https://en.cppreference.com/w/cpp/thread/condition_variable/notify_one):
> The notifying thread does not need to hold the lock on the same mutex as the one held by the waiting thread(s); in fact doing so is a pessimization, since the notified thread would immediately block again, waiting for the notifying thread to release the lock.

Related to:
- #23167
- #23223