### PR TITLE
rpc: add return message to savemempool RPC

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2202,7 +2202,11 @@ static RPCHelpMan savemempool()
     return RPCHelpMan{"savemempool",
                 "\nDumps the mempool to disk. It will fail until the previous dump is fully loaded.\n",
                 {},
-                RPCResult{RPCResult::Type::NONE, "", ""},
+                RPCResult{
+                    RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR, "filename", "the directory and file where the mempool was saved"},
+                    }},
                 RPCExamples{
                     HelpExampleCli("savemempool", "")
             + HelpExampleRpc("savemempool", "")
@@ -2210,6 +2214,8 @@ static RPCHelpMan savemempool()
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
     const CTxMemPool& mempool = EnsureAnyMemPool(request.context);
+
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
 
     if (!mempool.IsLoaded()) {
         throw JSONRPCError(RPC_MISC_ERROR, "The mempool was not loaded yet");
@@ -2219,7 +2225,10 @@ static RPCHelpMan savemempool()
         throw JSONRPCError(RPC_MISC_ERROR, "Unable to dump mempool to disk");
     }
 
-    return NullUniValue;
+    UniValue ret(UniValue::VOBJ);
+    ret.pushKV("filename", fs::path((node.args->GetDataDirNet() / "mempool.dat")).u8string());
+
+    return ret;
 },
     };
 }

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -149,8 +149,9 @@ class MempoolPersistTest(BitcoinTestFramework):
         mempooldat1 = os.path.join(self.nodes[1].datadir, self.chain, 'mempool.dat')
         self.log.debug("Remove the mempool.dat file. Verify that savemempool to disk via RPC re-creates it")
         os.remove(mempooldat0)
-        self.nodes[0].savemempool()
+        result0 = self.nodes[0].savemempool()
         assert os.path.isfile(mempooldat0)
+        assert_equal(result0['filename'], mempooldat0)
 
         self.log.debug("Stop nodes, make node1 use mempool.dat from node0. Verify it has 6 transactions")
         os.rename(mempooldat0, mempooldat1)


### PR DESCRIPTION
Currently, if the user calls the `savemempool` RPC method, there is no way to know 
where the file was created (unless the user knows internal implementation details).

This PR adds a return message stating the file name and path where the mempool was saved and changes `mempool_persist.py` to validate this new return message.