### PR TITLE
test: Fix segfault in the psbt_wallet_tests/psbt_updater_test

### DIFF
--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -14,8 +14,9 @@
 BOOST_FIXTURE_TEST_SUITE(psbt_wallet_tests, WalletTestingSetup)
 
 static void import_descriptor(CWallet& wallet, const std::string& descriptor)
+    EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
-    LOCK(wallet.cs_wallet);
+    AssertLockHeld(wallet.cs_wallet);
     FlatSigningProvider provider;
     std::string error;
     std::unique_ptr<Descriptor> desc = Parse(descriptor, provider, error, /* require_checksum=*/ false);

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -4,6 +4,8 @@
 
 #include <wallet/test/wallet_test_fixture.h>
 
+#include <scheduler.h>
+
 WalletTestingSetup::WalletTestingSetup(const std::string& chainName)
     : TestingSetup(chainName),
       m_wallet(m_node.chain.get(), "", CreateMockWalletDatabase())
@@ -11,4 +13,9 @@ WalletTestingSetup::WalletTestingSetup(const std::string& chainName)
     m_wallet.LoadWallet();
     m_chain_notifications_handler = m_node.chain->handleNotifications({ &m_wallet, [](CWallet*) {} });
     m_wallet_client->registerRpcs();
+}
+
+WalletTestingSetup::~WalletTestingSetup()
+{
+    if (m_node.scheduler) m_node.scheduler->stop();
 }

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -19,6 +19,7 @@
  */
 struct WalletTestingSetup : public TestingSetup {
     explicit WalletTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
+    ~WalletTestingSetup();
 
     std::unique_ptr<interfaces::WalletClient> m_wallet_client = interfaces::MakeWalletClient(*m_node.chain, *Assert(m_node.args));
     CWallet m_wallet;


### PR DESCRIPTION
The dcd6eeb64adb2b532f5003cbb86ba65b3c08a87b commit (bitcoin/bitcoin#23288) introduced an intermittent failure in the `psbt_wallet_tests/psbt_updater_test` unit test. See bitcoin/bitcoin#23368.

The test failure can be easily made reproducible with the following patch:
```diff
--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -57,6 +57,8 @@ void CScheduler::serviceQueue()
             Function f = taskQueue.begin()->second;
             taskQueue.erase(taskQueue.begin());
 
+            UninterruptibleSleep(100ms);
+
             {
                 // Unlock before calling f, so it can reschedule itself or another task
                 // without deadlocking:
```

This PR implements an idea which was mentioned in the [comment](https://github.com/bitcoin/bitcoin/issues/23368#issuecomment-953796339):
> Yes, as I said before this looks like a race where the wallet is deleted before stopping the scheduler: [#23368 (comment)](https://github.com/bitcoin/bitcoin/issues/23368#issuecomment-952808824)
> 
> IIRC, the order should be:
> 
>    * stop scheduler
> 
>    * delete wallet
> 
>    * delete scheduler

The second commit introduces a refactoring with no behavior change.

Fixes bitcoin/bitcoin#23368.