### PR TITLE
wallet: Fix comment grammar in bdb.h

### DIFF
--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -113,7 +113,7 @@ public:
      */
     bool Rewrite(const char* pszSkip=nullptr) override;
 
-    /** Indicate the a new database user has began using the database. */
+    /** Indicate that a new database user has begun using the database. */
     void AddRef() override;
     /** Indicate that database user has stopped using the database and that it could be flushed or closed. */
     void RemoveRef() override;


### PR DESCRIPTION
A comment in bdb.h file in the wallet directory contains a grammatical error that makes the underlying code harder to reason about . 
The comment which says `/** Indicate the a new database user has began using the database. */` should actually be 
`/** indicate that a new database user has began using the database. */`. The former is quite confusing , and leaves you wondering what "the a new database user " is refering to . This pull request thus provides value to the bitcoin codebase by improving readability .