### PR TITLE
doc: Remove fee delta TODO from txmempool.cpp

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -422,8 +422,6 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, setEntries &setAnces
     indexed_transaction_set::iterator newit = mapTx.insert(entry).first;
 
     // Update transaction for any feeDelta created by PrioritiseTransaction
-    // TODO: refactor so that the fee delta is calculated before inserting
-    // into mapTx.
     CAmount delta{0};
     ApplyDelta(entry.GetTx().GetHash(), delta);
     if (delta) {


### PR DESCRIPTION
This refactor request was added in commit eb306664e786ae43d539fde66f0fbe2a3e89d910, though it didn't explain why the refactor is needed and what the goal is. Given that this wasn't touched for more than 5 years, it doesn't seem critical. Generally, non-trivial `TODO`s make more sense as GitHub issues, so that they can be discussed and triaged more easily.