### PR TITLE
wallet, spkm: Move key management from DescriptorScriptPubKeyMan to wallet level KeyManager

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -324,6 +324,7 @@ BITCOIN_CORE_H = \
   wallet/salvage.h \
   wallet/scriptpubkeyman.h \
   wallet/spend.h \
+  wallet/storage.h \
   wallet/sqlite.h \
   wallet/transaction.h \
   wallet/wallet.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -317,6 +317,7 @@ BITCOIN_CORE_H = \
   wallet/feebumper.h \
   wallet/fees.h \
   wallet/ismine.h \
+  wallet/keyman.h \
   wallet/load.h \
   wallet/receive.h \
   wallet/rpc/util.h \
@@ -467,6 +468,7 @@ libbitcoin_wallet_a_SOURCES = \
   wallet/feebumper.cpp \
   wallet/fees.cpp \
   wallet/interfaces.cpp \
+  wallet/keyman.cpp \
   wallet/load.cpp \
   wallet/receive.cpp \
   wallet/rpc/addresses.cpp \

--- a/src/script/descriptor.h
+++ b/src/script/descriptor.h
@@ -146,6 +146,13 @@ struct Descriptor {
 
     /** @return The OutputType of the scriptPubKey(s) produced by this descriptor. Or nullopt if indeterminate (multiple or none) */
     virtual std::optional<OutputType> GetOutputType() const = 0;
+
+    /** Return all (extended) public keys for this descriptor, including any from subdescriptors.
+     *
+     * @param[out] pubkeys Any public keys
+     * @param[out] ext_pubs Any extended public keys
+     */
+    virtual void GetPubkeys(std::set<CPubKey>& pubkeys, std::set<CExtPubKey>& ext_pubs) const = 0;
 };
 
 /** Parse a `descriptor` string. Included private keys are put in `out`.

--- a/src/wallet/external_signer_scriptpubkeyman.h
+++ b/src/wallet/external_signer_scriptpubkeyman.h
@@ -13,11 +13,11 @@ namespace wallet {
 class ExternalSignerScriptPubKeyMan : public DescriptorScriptPubKeyMan
 {
   public:
-  ExternalSignerScriptPubKeyMan(WalletStorage& storage, WalletDescriptor& descriptor)
-      :   DescriptorScriptPubKeyMan(storage, descriptor)
+  ExternalSignerScriptPubKeyMan(WalletStorage& storage, WalletDescriptor& descriptor, KeyManager& keyman)
+      :   DescriptorScriptPubKeyMan(storage, descriptor, keyman)
       {}
-  ExternalSignerScriptPubKeyMan(WalletStorage& storage)
-      :   DescriptorScriptPubKeyMan(storage)
+  ExternalSignerScriptPubKeyMan(WalletStorage& storage, KeyManager& keyman)
+      :   DescriptorScriptPubKeyMan(storage, keyman)
       {}
 
   /** Provide a descriptor at setup time

--- a/src/wallet/keyman.cpp
+++ b/src/wallet/keyman.cpp
@@ -76,6 +76,14 @@ std::optional<CExtKey> KeyManager::GetActiveHDKey() const
     return master_key;
 }
 
+std::optional<CExtPubKey> KeyManager::GetActiveHDPubKey() const
+{
+    if (!m_active_xpub.pubkey.IsValid()) {
+        return std::nullopt;
+    }
+    return m_active_xpub;
+}
+
 bool KeyManager::AddKeyInner(WalletBatch& batch, const CKey& key, const CPubKey& pubkey)
 {
     AssertLockHeld(cs_keyman);

--- a/src/wallet/keyman.cpp
+++ b/src/wallet/keyman.cpp
@@ -243,11 +243,13 @@ std::map<CKeyID, CKey> KeyManager::GetKeys() const
         for (const auto& [id, key_pair] : m_map_crypted_keys) {
             const auto& [pubkey, crypted_secret] = key_pair;
             CKey key;
-            DecryptKey(m_storage.GetEncryptionKey(), crypted_secret, pubkey, key);
+            bool ok = DecryptKey(m_storage.GetEncryptionKey(), crypted_secret, pubkey, key);
+            assert(ok);
             keys[id] = key;
         }
         return keys;
     }
+    // If the wallet is encrypted and locked, then this will just be an empty map
     return m_map_keys;
 }
 

--- a/src/wallet/keyman.cpp
+++ b/src/wallet/keyman.cpp
@@ -1,0 +1,246 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <key.h>
+#include <logging.h>
+#include <pubkey.h>
+#include <random.h>
+#include <wallet/crypter.h>
+#include <wallet/keyman.h>
+#include <wallet/walletdb.h>
+
+namespace wallet {
+void KeyManager::GenerateAndSetHDKey()
+{
+    LOCK(cs_keyman);
+    CKey key;
+    key.MakeNewKey(true);
+    CPubKey seed_pub = key.GetPubKey();
+    assert(key.VerifyPubKey(seed_pub));
+
+    CExtKey master_key;
+    master_key.SetSeed(key);
+    CExtPubKey master_xpub = master_key.Neuter();
+
+    WalletBatch batch(m_storage.GetDatabase());
+    AddHDKey(batch, master_key, master_xpub);
+    SetActiveHDKey(master_xpub);
+}
+
+void KeyManager::LoadActiveHDKey(const CExtPubKey& extpub)
+{
+    LOCK(cs_keyman);
+    m_active_xpub = extpub;
+}
+
+void KeyManager::SetActiveHDKey(const CExtPubKey& extpub)
+{
+    LOCK(cs_keyman);
+    LoadActiveHDKey(extpub);
+    WalletBatch batch(m_storage.GetDatabase());
+    batch.WriteActiveHDKey(extpub);
+}
+
+std::optional<CExtKey> KeyManager::GetActiveHDKey() const
+{
+    if (!m_active_xpub.pubkey.IsValid()) {
+        return std::nullopt;
+    }
+
+    CKey key;
+    if (m_storage.HasEncryptionKeys()) {
+        if (m_storage.IsLocked()) {
+            return std::nullopt;
+        }
+        const auto& it = m_map_crypted_keys.find(m_active_xpub.pubkey.GetID());
+        assert(it != m_map_crypted_keys.end());
+        const auto& [pubkey, ckey] = it->second;
+
+        if (!DecryptKey(m_storage.GetEncryptionKey(), ckey, pubkey, key)) {
+            return std::nullopt;
+        }
+    } else {
+        const auto& it = m_map_keys.find(m_active_xpub.pubkey.GetID());
+        assert(it != m_map_keys.end());
+        key = it->second;
+    }
+    assert(key.IsValid());
+
+    CExtKey master_key;
+    master_key.nDepth = m_active_xpub.nDepth;
+    std::copy(m_active_xpub.vchFingerprint, m_active_xpub.vchFingerprint + sizeof(master_key.vchFingerprint), master_key.vchFingerprint);
+    master_key.nChild = m_active_xpub.nChild;
+    master_key.chaincode = m_active_xpub.chaincode;
+    master_key.key = key;
+    return master_key;
+}
+
+bool KeyManager::AddKeyInner(WalletBatch& batch, const CKey& key, const CPubKey& pubkey)
+{
+    AssertLockHeld(cs_keyman);
+    assert(!m_storage.HasEncryptionKeys());
+
+    const CKeyID& id = pubkey.GetID();
+    if (m_map_keys.find(id) != m_map_keys.end()) {
+        return true;
+    }
+
+    m_map_keys[id] = key;
+    return batch.WriteKeyManKey(pubkey, key.GetPrivKey());
+}
+
+std::vector<unsigned char> KeyManager::AddCryptedKeyInner(WalletBatch& batch, const CKey& key, const CPubKey& pubkey)
+{
+    AssertLockHeld(cs_keyman);
+
+    assert(m_storage.HasEncryptionKeys());
+    if (m_storage.IsLocked()) {
+        return {};
+    }
+
+    const CKeyID& id = pubkey.GetID();
+    const auto& it = m_map_crypted_keys.find(id);
+    if (it != m_map_crypted_keys.end()) {
+        return it->second.second;
+    }
+
+    std::vector<unsigned char> crypted_secret;
+    CKeyingMaterial secret(key.begin(), key.end());
+    if (!EncryptSecret(m_storage.GetEncryptionKey(), secret, pubkey.GetHash(), crypted_secret)) {
+        return {};
+    }
+
+    m_map_crypted_keys[id] = make_pair(pubkey, crypted_secret);
+
+    if (!batch.WriteCryptedKeyManKey(pubkey, crypted_secret)) {
+        return {};
+    }
+
+    return crypted_secret;
+}
+
+bool KeyManager::AddDescriptorKey(WalletBatch& batch, const uint256& desc_id, const CKey& key, const CPubKey& pubkey)
+{
+    LOCK(cs_keyman);
+    assert(!m_storage.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS));
+
+    if (m_storage.HasEncryptionKeys()) {
+        std::vector<unsigned char> ckey = AddCryptedKeyInner(batch, key, pubkey);
+        if (ckey.empty()) {
+            return false;
+        }
+        return batch.WriteCryptedDescriptorKey(desc_id, pubkey, ckey);
+    } else {
+        return AddKeyInner(batch, key, pubkey) && batch.WriteDescriptorKey(desc_id, pubkey, key.GetPrivKey());
+    }
+}
+
+bool KeyManager::AddHDKey(WalletBatch& batch, const CExtKey& extkey, const CExtPubKey& extpub)
+{
+    LOCK(cs_keyman);
+    const CKeyID& id = extpub.pubkey.GetID();
+    m_map_xpubs[id] = extpub;
+    batch.WriteHDPubKey(extpub);
+
+    if (m_storage.HasEncryptionKeys()) {
+        std::vector<unsigned char> ckey = AddCryptedKeyInner(batch, extkey.key, extpub.pubkey);
+        return !ckey.empty();
+    } else {
+        return AddKeyInner(batch, extkey.key, extpub.pubkey);
+    }
+}
+
+void KeyManager::LoadKey(const CKeyID& key_id, const CKey& key)
+{
+    LOCK(cs_keyman);
+    m_map_keys[key_id] = key;
+}
+
+bool KeyManager::LoadCryptedKey(const CKeyID& key_id, const CPubKey& pubkey, const std::vector<unsigned char>& ckey)
+{
+    LOCK(cs_keyman);
+    if (!m_map_keys.empty()) {
+        return false;
+    }
+
+    m_map_crypted_keys[key_id] = make_pair(pubkey, ckey);
+    return true;
+}
+
+void KeyManager::LoadHDKey(const CKeyID& key_id, const CExtPubKey& xpub)
+{
+    LOCK(cs_keyman);
+    m_map_xpubs[key_id] = xpub;
+}
+
+bool KeyManager::CheckDecryptionKey(const CKeyingMaterial& master_key, bool accept_no_keys)
+{
+    LOCK(cs_keyman);
+    if (!m_map_keys.empty()) {
+        return false;
+    }
+
+    bool keyPass = m_map_crypted_keys.empty(); // Always pass when there are no encrypted keys
+    bool keyFail = false;
+    for (const auto& mi : m_map_crypted_keys) {
+        const CPubKey& pubkey = mi.second.first;
+        const std::vector<unsigned char>& crypted_secret = mi.second.second;
+        CKey key;
+        if (!DecryptKey(master_key, crypted_secret, pubkey, key)) {
+            keyFail = true;
+            break;
+        }
+        keyPass = true;
+        if (m_decryption_thoroughly_checked) {
+            break;
+        }
+    }
+    if (keyPass && keyFail) {
+        LogPrintf("The wallet is probably corrupted: Some keys decrypt but not all.\n");
+        throw std::runtime_error("Error unlocking wallet: some keys decrypt but not all. Your wallet file may be corrupt.");
+    }
+    if (keyFail || (!keyPass && !accept_no_keys)) {
+        return false;
+    }
+    m_decryption_thoroughly_checked = true;
+    return true;
+}
+
+bool KeyManager::Encrypt(const CKeyingMaterial& master_key, WalletBatch* batch)
+{
+    LOCK(cs_keyman);
+
+    // Nothing to encrypt
+    if (m_map_keys.empty()) {
+        return true;
+    }
+
+    if (!m_map_crypted_keys.empty()) {
+        return false;
+    }
+
+    for (const auto& [id, key] : m_map_keys)
+    {
+        CPubKey pubkey = key.GetPubKey();
+        CKeyingMaterial secret(key.begin(), key.end());
+        std::vector<unsigned char> crypted_secret;
+        if (!EncryptSecret(master_key, secret, pubkey.GetHash(), crypted_secret)) {
+            return false;
+        }
+        m_map_crypted_keys[id] = make_pair(pubkey, crypted_secret);
+        batch->WriteCryptedKeyManKey(pubkey, crypted_secret);
+    }
+    m_map_keys.clear();
+    return true;
+}
+
+std::optional<std::pair<CPubKey, std::vector<unsigned char>>> KeyManager::GetCryptedKey(const CKeyID& id) const
+{
+    AssertLockHeld(cs_keyman);
+    if (m_map_crypted_keys.count(id) == 0) {
+        return std::nullopt;
+    }
+    return m_map_crypted_keys.at(id);
+}
+} // namespace wallet

--- a/src/wallet/keyman.h
+++ b/src/wallet/keyman.h
@@ -23,9 +23,7 @@ class WalletBatch;
 
 class KeyManager
 {
-//private:
-public:
-    // TODO: Everything up to cs_keyman need to be private, but we make them public so DescriptorScriptPubKeyMan can access these during the transition
+private:
     WalletStorage& m_storage;
 
     std::map<CKeyID, CKey> m_map_keys GUARDED_BY(cs_keyman);
@@ -39,7 +37,7 @@ public:
     bool AddKeyInner(WalletBatch& batch, const CKey& key, const CPubKey& pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_keyman);
     std::vector<unsigned char> AddCryptedKeyInner(WalletBatch& batch, const CKey& key, const CPubKey& pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_keyman);
 
-//public:
+public:
     mutable RecursiveMutex cs_keyman;
 
     KeyManager(WalletStorage& storage) : m_storage(storage) {}

--- a/src/wallet/keyman.h
+++ b/src/wallet/keyman.h
@@ -52,6 +52,7 @@ public:
     bool AddHDKey(WalletBatch& batch, const CExtKey& extkey, const CExtPubKey& extpub);
 
     std::optional<CExtKey> GetActiveHDKey() const EXCLUSIVE_LOCKS_REQUIRED(cs_keyman);
+    std::map<CKeyID, CKey> GetKeys() const EXCLUSIVE_LOCKS_REQUIRED(cs_keyman);
     std::optional<std::pair<CPubKey, std::vector<unsigned char>>> GetCryptedKey(const CKeyID& id) const EXCLUSIVE_LOCKS_REQUIRED(cs_keyman);
 
     void LoadKey(const CKeyID&, const CKey& key);
@@ -61,6 +62,7 @@ public:
 
     bool CheckDecryptionKey(const CKeyingMaterial& master_key, bool accept_no_keys);
     bool Encrypt(const CKeyingMaterial& master_key, WalletBatch* batch);
+    bool HavePrivateKeys() const;
 };
 } // namespace wallet
 

--- a/src/wallet/keyman.h
+++ b/src/wallet/keyman.h
@@ -50,6 +50,7 @@ public:
     bool AddHDKey(WalletBatch& batch, const CExtKey& extkey, const CExtPubKey& extpub);
 
     std::optional<CExtKey> GetActiveHDKey() const EXCLUSIVE_LOCKS_REQUIRED(cs_keyman);
+    std::optional<CExtPubKey> GetActiveHDPubKey() const EXCLUSIVE_LOCKS_REQUIRED(cs_keyman);
     std::map<CKeyID, CKey> GetKeys() const EXCLUSIVE_LOCKS_REQUIRED(cs_keyman);
     std::optional<std::pair<CPubKey, std::vector<unsigned char>>> GetCryptedKey(const CKeyID& id) const EXCLUSIVE_LOCKS_REQUIRED(cs_keyman);
 

--- a/src/wallet/keyman.h
+++ b/src/wallet/keyman.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_WALLET_KEYMAN_H
+#define BITCOIN_WALLET_KEYMAN_H
+
+#include <sync.h>
+#include <wallet/db.h>
+#include <wallet/storage.h>
+
+#include <map>
+#include <optional>
+#include <set>
+#include <vector>
+
+class CKey;
+class CKeyID;
+class CPubKey;
+
+namespace wallet {
+class WalletBatch;
+
+class KeyManager
+{
+//private:
+public:
+    // TODO: Everything up to cs_keyman need to be private, but we make them public so DescriptorScriptPubKeyMan can access these during the transition
+    WalletStorage& m_storage;
+
+    std::map<CKeyID, CKey> m_map_keys GUARDED_BY(cs_keyman);
+    std::map<CKeyID, CExtPubKey> m_map_xpubs GUARDED_BY(cs_keyman);
+    std::map<CKeyID, std::pair<CPubKey, std::vector<unsigned char>>> m_map_crypted_keys GUARDED_BY(cs_keyman);
+
+    bool m_decryption_thoroughly_checked = false;
+
+    CExtPubKey m_active_xpub GUARDED_BY(cs_keyman);
+
+    bool AddKeyInner(WalletBatch& batch, const CKey& key, const CPubKey& pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_keyman);
+    std::vector<unsigned char> AddCryptedKeyInner(WalletBatch& batch, const CKey& key, const CPubKey& pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_keyman);
+
+//public:
+    mutable RecursiveMutex cs_keyman;
+
+    KeyManager(WalletStorage& storage) : m_storage(storage) {}
+    KeyManager() = delete;
+
+    void GenerateAndSetHDKey();
+    void SetActiveHDKey(const CExtPubKey& extpub);
+
+    bool AddDescriptorKey(WalletBatch& batch, const uint256& desc_id, const CKey& key, const CPubKey& pubkey);
+    bool AddHDKey(WalletBatch& batch, const CExtKey& extkey, const CExtPubKey& extpub);
+
+    std::optional<CExtKey> GetActiveHDKey() const EXCLUSIVE_LOCKS_REQUIRED(cs_keyman);
+    std::optional<std::pair<CPubKey, std::vector<unsigned char>>> GetCryptedKey(const CKeyID& id) const EXCLUSIVE_LOCKS_REQUIRED(cs_keyman);
+
+    void LoadKey(const CKeyID&, const CKey& key);
+    bool LoadCryptedKey(const CKeyID&, const CPubKey& pubkey, const std::vector<unsigned char>& ckey);
+    void LoadHDKey(const CKeyID& key_id, const CExtPubKey& xpub);
+    void LoadActiveHDKey(const CExtPubKey& extpub);
+
+    bool CheckDecryptionKey(const CKeyingMaterial& master_key, bool accept_no_keys);
+    bool Encrypt(const CKeyingMaterial& master_key, WalletBatch* batch);
+};
+} // namespace wallet
+
+#endif // BITCOIN_WALLET_KEYMAN_H

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -768,6 +768,7 @@ RPCHelpMan listlabels();
 #ifdef ENABLE_EXTERNAL_SIGNER
 RPCHelpMan walletdisplayaddress();
 #endif // ENABLE_EXTERNAL_SIGNER
+RPCHelpMan getxpub();
 
 // backup
 RPCHelpMan dumpprivkey();
@@ -852,6 +853,7 @@ Span<const CRPCCommand> GetWalletRPCCommands()
         {"wallet", &getunconfirmedbalance},
         {"wallet", &getbalances},
         {"wallet", &getwalletinfo},
+        {"wallet", &getxpub},
         {"wallet", &importaddress},
         {"wallet", &importdescriptors},
         {"wallet", &importmulti},

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2609,6 +2609,7 @@ bool DescriptorScriptPubKeyMan::AddKey(const CKeyID& key_id, const CKey& key)
 {
     LOCK(cs_desc_man);
     m_map_keys[key_id] = key;
+    m_set_stored_keys.insert(key_id);
     return true;
 }
 
@@ -2620,6 +2621,7 @@ bool DescriptorScriptPubKeyMan::AddCryptedKey(const CKeyID& key_id, const CPubKe
     }
 
     m_map_crypted_keys[key_id] = make_pair(pubkey, crypted_key);
+    m_set_stored_keys.insert(key_id);
     return true;
 }
 

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2170,9 +2170,9 @@ void DescriptorScriptPubKeyMan::AddDescriptorKey(const CKey& key, const CPubKey 
     m_set_stored_keys.insert(pubkey.GetID());
 }
 
-bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(const CExtKey& master_key, OutputType addr_type, bool internal)
+bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(OutputType addr_type, bool internal)
 {
-    LOCK(cs_desc_man);
+    LOCK2(cs_desc_man, m_keyman.cs_keyman);
     assert(m_storage.IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
 
     // Ignore when there is already a descriptor
@@ -2181,6 +2181,10 @@ bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(const CExtKey& master_
     }
 
     int64_t creation_time = GetTime();
+
+    std::optional<CExtKey> extkey = m_keyman.GetActiveHDKey();
+    assert(extkey != std::nullopt);
+    CExtKey& master_key = extkey.value();
 
     std::string xpub = EncodeExtPubKey(master_key.Neuter());
 

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2534,22 +2534,6 @@ void DescriptorScriptPubKeyMan::SetCache(const DescriptorCache& cache)
     }
 }
 
-bool DescriptorScriptPubKeyMan::AddKey(const CKeyID& key_id, const CKey& key)
-{
-    m_keyman.LoadKey(key_id, key);
-    m_set_stored_keys.insert(key_id);
-    return true;
-}
-
-bool DescriptorScriptPubKeyMan::AddCryptedKey(const CKeyID& key_id, const CPubKey& pubkey, const std::vector<unsigned char>& crypted_key)
-{
-    if (!m_keyman.LoadCryptedKey(key_id, pubkey, crypted_key)) {
-        return false;
-    }
-    m_set_stored_keys.insert(key_id);
-    return true;
-}
-
 bool DescriptorScriptPubKeyMan::HasWalletDescriptor(const WalletDescriptor& desc) const
 {
     LOCK(cs_desc_man);

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2265,8 +2265,7 @@ bool DescriptorScriptPubKeyMan::CanGetAddresses(bool internal) const
 
 bool DescriptorScriptPubKeyMan::HavePrivateKeys() const
 {
-    LOCK(cs_desc_man);
-    return m_keyman.m_map_keys.size() > 0 || m_keyman.m_map_crypted_keys.size() > 0;
+    return m_keyman.HavePrivateKeys();
 }
 
 std::optional<int64_t> DescriptorScriptPubKeyMan::GetOldestKeyPoolTime() const

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1718,7 +1718,7 @@ const std::unordered_set<CScript, SaltedSipHasher> LegacyScriptPubKeyMan::GetScr
     return spks;
 }
 
-std::optional<MigrationData> LegacyScriptPubKeyMan::MigrateToDescriptor()
+std::optional<MigrationData> LegacyScriptPubKeyMan::MigrateToDescriptor(KeyManager& keyman)
 {
     LOCK(cs_KeyStore);
     if (m_storage.IsLocked()) {
@@ -1785,7 +1785,7 @@ std::optional<MigrationData> LegacyScriptPubKeyMan::MigrateToDescriptor()
         WalletDescriptor w_desc(std::move(desc), creation_time, 0, 0, 0);
 
         // Make the DescriptorScriptPubKeyMan and get the scriptPubKeys
-        auto desc_spk_man = std::unique_ptr<DescriptorScriptPubKeyMan>(new DescriptorScriptPubKeyMan(m_storage, w_desc));
+        auto desc_spk_man = std::unique_ptr<DescriptorScriptPubKeyMan>(new DescriptorScriptPubKeyMan(m_storage, w_desc, keyman));
         desc_spk_man->AddDescriptorKey(key, key.GetPubKey());
         desc_spk_man->TopUp();
         auto desc_spks = desc_spk_man->GetScriptPubKeys();
@@ -1830,7 +1830,7 @@ std::optional<MigrationData> LegacyScriptPubKeyMan::MigrateToDescriptor()
             WalletDescriptor w_desc(std::move(desc), 0, 0, chain_counter, 0);
 
             // Make the DescriptorScriptPubKeyMan and get the scriptPubKeys
-            auto desc_spk_man = std::unique_ptr<DescriptorScriptPubKeyMan>(new DescriptorScriptPubKeyMan(m_storage, w_desc));
+            auto desc_spk_man = std::unique_ptr<DescriptorScriptPubKeyMan>(new DescriptorScriptPubKeyMan(m_storage, w_desc, keyman));
             desc_spk_man->AddDescriptorKey(master_key.key, master_key.key.GetPubKey());
             desc_spk_man->TopUp();
             auto desc_spks = desc_spk_man->GetScriptPubKeys();
@@ -1892,7 +1892,7 @@ std::optional<MigrationData> LegacyScriptPubKeyMan::MigrateToDescriptor()
         } else {
             // Make the DescriptorScriptPubKeyMan and get the scriptPubKeys
             WalletDescriptor w_desc(std::move(desc), creation_time, 0, 0, 0);
-            auto desc_spk_man = std::unique_ptr<DescriptorScriptPubKeyMan>(new DescriptorScriptPubKeyMan(m_storage, w_desc));
+            auto desc_spk_man = std::unique_ptr<DescriptorScriptPubKeyMan>(new DescriptorScriptPubKeyMan(m_storage, w_desc, keyman));
             for (const auto& keyid : privkeyids) {
                 CKey key;
                 if (!GetKey(keyid, key)) {

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2547,20 +2547,16 @@ void DescriptorScriptPubKeyMan::SetCache(const DescriptorCache& cache)
 
 bool DescriptorScriptPubKeyMan::AddKey(const CKeyID& key_id, const CKey& key)
 {
-    LOCK(cs_desc_man);
-    m_keyman.m_map_keys[key_id] = key;
+    m_keyman.LoadKey(key_id, key);
     m_set_stored_keys.insert(key_id);
     return true;
 }
 
 bool DescriptorScriptPubKeyMan::AddCryptedKey(const CKeyID& key_id, const CPubKey& pubkey, const std::vector<unsigned char>& crypted_key)
 {
-    LOCK(cs_desc_man);
-    if (!m_keyman.m_map_keys.empty()) {
+    if (!m_keyman.LoadCryptedKey(key_id, pubkey, crypted_key)) {
         return false;
     }
-
-    m_keyman.m_map_crypted_keys[key_id] = make_pair(pubkey, crypted_key);
     m_set_stored_keys.insert(key_id);
     return true;
 }

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -583,7 +583,7 @@ public:
     bool IsHDEnabled() const override;
 
     //! Setup descriptors based on the given CExtkey
-    bool SetupDescriptorGeneration(const CExtKey& master_key, OutputType addr_type, bool internal);
+    bool SetupDescriptorGeneration(OutputType addr_type, bool internal);
 
     /** Provide a descriptor at setup time
     * Returns false if already setup or setup fails, true if setup is successful

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -15,6 +15,7 @@
 #include <util/time.h>
 #include <wallet/crypter.h>
 #include <wallet/ismine.h>
+#include <wallet/keyman.h>
 #include <wallet/storage.h>
 #include <wallet/walletdb.h>
 #include <wallet/walletutil.h>
@@ -531,13 +532,8 @@ private:
     PubKeyMap m_map_pubkeys GUARDED_BY(cs_desc_man);
     int32_t m_max_cached_index = -1;
 
-    KeyMap m_map_keys GUARDED_BY(cs_desc_man);
-    CryptedKeyMap m_map_crypted_keys GUARDED_BY(cs_desc_man);
-
     //! keeps track of whether Unlock has run a thorough check before
     bool m_decryption_thoroughly_checked = false;
-
-    bool AddDescriptorKeyWithDB(WalletBatch& batch, const CKey& key, const CPubKey &pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
     KeyMap GetKeys() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
@@ -550,16 +546,20 @@ private:
     // Fetch the SigningProvider for a given index and optionally include private keys. Called by the above functions.
     std::unique_ptr<FlatSigningProvider> GetSigningProvider(int32_t index, bool include_private = false) const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
+    KeyManager m_keyman;
+
 protected:
   WalletDescriptor m_wallet_descriptor GUARDED_BY(cs_desc_man);
 
 public:
     DescriptorScriptPubKeyMan(WalletStorage& storage, WalletDescriptor& descriptor)
         :   ScriptPubKeyMan(storage),
+            m_keyman(storage),
             m_wallet_descriptor(descriptor)
         {}
     DescriptorScriptPubKeyMan(WalletStorage& storage)
-        :   ScriptPubKeyMan(storage)
+        :   ScriptPubKeyMan(storage),
+            m_keyman(storage)
         {}
 
     mutable RecursiveMutex cs_desc_man;

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -613,9 +613,6 @@ public:
 
     void SetCache(const DescriptorCache& cache);
 
-    bool AddKey(const CKeyID& key_id, const CKey& key);
-    bool AddCryptedKey(const CKeyID& key_id, const CPubKey& pubkey, const std::vector<unsigned char>& crypted_key);
-
     bool HasWalletDescriptor(const WalletDescriptor& desc) const;
     void UpdateWalletDescriptor(WalletDescriptor& descriptor);
     bool CanUpdateToWalletDescriptor(const WalletDescriptor& descriptor, std::string& error);

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -526,6 +526,7 @@ private:
     using CryptedKeyMap = std::map<CKeyID, std::pair<CPubKey, std::vector<unsigned char>>>;
     using KeyMap = std::map<CKeyID, CKey>;
 
+    std::set<CKeyID> m_set_stored_keys GUARDED_BY(cs_desc_man); // Set of keys this DescriptorSPKM needs
     ScriptPubKeyMap m_map_script_pub_keys GUARDED_BY(cs_desc_man);
     PubKeyMap m_map_pubkeys GUARDED_BY(cs_desc_man);
     int32_t m_max_cached_index = -1;

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -498,7 +498,7 @@ public:
 
     /** Get the DescriptorScriptPubKeyMans (with private keys) that have the same scriptPubKeys as this LegacyScriptPubKeyMan.
      * Does not modify this ScriptPubKeyMan. */
-    std::optional<MigrationData> MigrateToDescriptor();
+    std::optional<MigrationData> MigrateToDescriptor(KeyManager& keyman);
     /** Delete all the records ofthis LegacyScriptPubKeyMan from disk*/
     bool DeleteRecords();
 };
@@ -545,20 +545,20 @@ private:
     // Fetch the SigningProvider for a given index and optionally include private keys. Called by the above functions.
     std::unique_ptr<FlatSigningProvider> GetSigningProvider(int32_t index, bool include_private = false) const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
-    KeyManager m_keyman;
+    KeyManager& m_keyman;
 
 protected:
   WalletDescriptor m_wallet_descriptor GUARDED_BY(cs_desc_man);
 
 public:
-    DescriptorScriptPubKeyMan(WalletStorage& storage, WalletDescriptor& descriptor)
+    DescriptorScriptPubKeyMan(WalletStorage& storage, WalletDescriptor& descriptor, KeyManager& keyman)
         :   ScriptPubKeyMan(storage),
-            m_keyman(storage),
+            m_keyman(keyman),
             m_wallet_descriptor(descriptor)
         {}
-    DescriptorScriptPubKeyMan(WalletStorage& storage)
+    DescriptorScriptPubKeyMan(WalletStorage& storage, KeyManager& keyman)
         :   ScriptPubKeyMan(storage),
-            m_keyman(storage)
+            m_keyman(keyman)
         {}
 
     mutable RecursiveMutex cs_desc_man;

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -15,6 +15,7 @@
 #include <util/time.h>
 #include <wallet/crypter.h>
 #include <wallet/ismine.h>
+#include <wallet/storage.h>
 #include <wallet/walletdb.h>
 #include <wallet/walletutil.h>
 
@@ -27,26 +28,6 @@ enum class OutputType;
 struct bilingual_str;
 
 namespace wallet {
-// Wallet storage things that ScriptPubKeyMans need in order to be able to store things to the wallet database.
-// It provides access to things that are part of the entire wallet and not specific to a ScriptPubKeyMan such as
-// wallet flags, wallet version, encryption keys, encryption status, and the database itself. This allows a
-// ScriptPubKeyMan to have callbacks into CWallet without causing a circular dependency.
-// WalletStorage should be the same for all ScriptPubKeyMans of a wallet.
-class WalletStorage
-{
-public:
-    virtual ~WalletStorage() = default;
-    virtual const std::string GetDisplayName() const = 0;
-    virtual WalletDatabase& GetDatabase() const = 0;
-    virtual bool IsWalletFlagSet(uint64_t) const = 0;
-    virtual void UnsetBlankWalletFlag(WalletBatch&) = 0;
-    virtual bool CanSupportFeature(enum WalletFeature) const = 0;
-    virtual void SetMinVersion(enum WalletFeature, WalletBatch* = nullptr) = 0;
-    virtual const CKeyingMaterial& GetEncryptionKey() const = 0;
-    virtual bool HasEncryptionKeys() const = 0;
-    virtual bool IsLocked() const = 0;
-};
-
 //! Default for -keypool
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -535,10 +535,9 @@ private:
     //! keeps track of whether Unlock has run a thorough check before
     bool m_decryption_thoroughly_checked = false;
 
-    KeyMap GetKeys() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
-
     // Cached FlatSigningProviders to avoid regenerating them each time they are needed.
     mutable std::map<int32_t, FlatSigningProvider> m_map_signing_providers;
+
     // Fetch the SigningProvider for the given script and optionally include private keys
     std::unique_ptr<FlatSigningProvider> GetSigningProvider(const CScript& script, bool include_private = false) const;
     // Fetch the SigningProvider for the given pubkey and always include private keys. This should only be called by signing code.

--- a/src/wallet/storage.h
+++ b/src/wallet/storage.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2019-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_WALLET_STORAGE_H
+#define BITCOIN_WALLET_STORAGE_H
+
+#include <wallet/crypter.h>
+#include <wallet/db.h>
+#include <wallet/walletdb.h>
+#include <wallet/walletutil.h>
+
+#include <string>
+
+namespace wallet {
+// Wallet storage things that ScriptPubKeyMans need in order to be able to store things to the wallet database.
+// It provides access to things that are part of the entire wallet and not specific to a ScriptPubKeyMan such as
+// wallet flags, wallet version, encryption keys, encryption status, and the database itself. This allows a
+// ScriptPubKeyMan to have callbacks into CWallet without causing a circular dependency.
+// WalletStorage should be the same for all ScriptPubKeyMans of a wallet.
+class WalletStorage
+{
+public:
+    virtual ~WalletStorage() = default;
+    virtual const std::string GetDisplayName() const = 0;
+    virtual WalletDatabase& GetDatabase() const = 0;
+    virtual bool IsWalletFlagSet(uint64_t) const = 0;
+    virtual void UnsetBlankWalletFlag(WalletBatch&) = 0;
+    virtual bool CanSupportFeature(enum WalletFeature) const = 0;
+    virtual void SetMinVersion(enum WalletFeature, WalletBatch* = nullptr) = 0;
+    virtual const CKeyingMaterial& GetEncryptionKey() const = 0;
+    virtual bool HasEncryptionKeys() const = 0;
+    virtual bool IsLocked() const = 0;
+};
+} // namespace wallet
+
+#endif // BITCOIN_WALLET_STORAGE_H

--- a/src/wallet/test/walletload_tests.cpp
+++ b/src/wallet/test/walletload_tests.cpp
@@ -29,6 +29,7 @@ public:
     bool Expand(int pos, const SigningProvider& provider, std::vector<CScript>& output_scripts, FlatSigningProvider& out, DescriptorCache* write_cache = nullptr) const override { return false; };
     bool ExpandFromCache(int pos, const DescriptorCache& read_cache, std::vector<CScript>& output_scripts, FlatSigningProvider& out) const override { return false; }
     void ExpandPrivate(int pos, const SigningProvider& provider, FlatSigningProvider& out) const override {}
+    void GetPubkeys(std::set<CPubKey>& pubkeys, std::set<CExtPubKey>& ext_pubs) const override {}
 };
 
 BOOST_FIXTURE_TEST_CASE(wallet_load_unknown_descriptor, TestingSetup)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -915,7 +915,6 @@ public:
     void DeactivateScriptPubKeyMan(uint256 id, OutputType type, bool internal);
 
     //! Create new DescriptorScriptPubKeyMans and add them to the wallet
-    void SetupDescriptorScriptPubKeyMans(const CExtKey& master_key) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void SetupDescriptorScriptPubKeyMans() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Return the DescriptorScriptPubKeyMan for a WalletDescriptor if it is already in the wallet

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -942,6 +942,8 @@ public:
     //! Adds the ScriptPubKeyMans given in MigrationData to this wallet, removes LegacyScriptPubKeyMan,
     //! and where needed, moves tx and address book entries to watchonly_wallet or solvable_wallet
     bool ApplyMigrationData(MigrationData& data, bilingual_str& error) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
+    KeyManager& GetKeyManager() { return m_keyman; }
 };
 
 /**

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -24,6 +24,7 @@
 #include <validationinterface.h>
 #include <wallet/crypter.h>
 #include <wallet/scriptpubkeyman.h>
+#include <wallet/storage.h>
 #include <wallet/transaction.h>
 #include <wallet/walletdb.h>
 #include <wallet/walletutil.h>

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -351,6 +351,8 @@ private:
 
     static int64_t GetDefaultNextResend();
 
+    KeyManager m_keyman;
+
 public:
     /**
      * Main wallet lock.
@@ -377,7 +379,8 @@ public:
         : m_args(args),
           m_chain(chain),
           m_name(name),
-          m_database(std::move(database))
+          m_database(std::move(database)),
+          m_keyman(*this)
     {
     }
 
@@ -934,7 +937,7 @@ public:
     bool MigrateToSQLite(bilingual_str& error) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Get all of the descriptors from a legacy wallet
-    std::optional<MigrationData> GetDescriptorsForLegacy(bilingual_str& error) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    std::optional<MigrationData> GetDescriptorsForLegacy(bilingual_str& error) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Adds the ScriptPubKeyMans given in MigrationData to this wallet, removes LegacyScriptPubKeyMan,
     //! and where needed, moves tx and address book entries to watchonly_wallet or solvable_wallet

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -799,7 +799,9 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 strErr = ErrorString(res).original;
                 return false;
             }
-            wss.m_descriptor_keys.insert(std::make_pair(std::make_pair(desc_id, res->GetPubKey().GetID()), res.value()));
+            if (!pwallet->IsWalletFlagSet(WALLET_FLAG_USES_KEYMAN)) {
+                wss.m_descriptor_keys.insert(std::make_pair(std::make_pair(desc_id, res->GetPubKey().GetID()), res.value()));
+            }
         } else if (strType == DBKeys::WALLETDESCRIPTORCKEY) {
             uint256 desc_id;
             CPubKey pubkey;
@@ -814,7 +816,9 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             ssValue >> privkey;
             wss.nCKeys++;
 
-            wss.m_descriptor_crypt_keys.insert(std::make_pair(std::make_pair(desc_id, pubkey.GetID()), std::make_pair(pubkey, privkey)));
+            if (!pwallet->IsWalletFlagSet(WALLET_FLAG_USES_KEYMAN)) {
+                wss.m_descriptor_crypt_keys.insert(std::make_pair(std::make_pair(desc_id, pubkey.GetID()), std::make_pair(pubkey, privkey)));
+            }
             wss.fIsEncrypted = true;
         } else if (strType == DBKeys::LOCKED_UTXO) {
             uint256 hash;
@@ -1080,6 +1084,8 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
             }
         }
     }
+
+    // TODO: Upgrade to using KeyMan
 
     return result;
 }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -31,6 +31,7 @@ namespace DBKeys {
 const std::string ACENTRY{"acentry"};
 const std::string ACTIVEEXTERNALSPK{"activeexternalspk"};
 const std::string ACTIVEINTERNALSPK{"activeinternalspk"};
+const std::string ACTIVEHDKEY{"activehdkey"};
 const std::string BESTBLOCK_NOMERKLE{"bestblock_nomerkle"};
 const std::string BESTBLOCK{"bestblock"};
 const std::string CRYPTED_KEY{"ckey"};
@@ -39,6 +40,7 @@ const std::string DEFAULTKEY{"defaultkey"};
 const std::string DESTDATA{"destdata"};
 const std::string FLAGS{"flags"};
 const std::string HDCHAIN{"hdchain"};
+const std::string HDPUBKEY{"hdxpubkey"};
 const std::string KEYMETA{"keymeta"};
 const std::string KEY{"key"};
 const std::string LOCKED_UTXO{"lockedutxo"};
@@ -295,6 +297,29 @@ bool WalletBatch::WriteLockedUTXO(const COutPoint& output)
 bool WalletBatch::EraseLockedUTXO(const COutPoint& output)
 {
     return EraseIC(std::make_pair(DBKeys::LOCKED_UTXO, std::make_pair(output.hash, output.n)));
+}
+
+bool WalletBatch::WriteHDPubKey(const CExtPubKey& extpub)
+{
+    std::vector<unsigned char> xpub(BIP32_EXTKEY_SIZE);
+    extpub.Encode(xpub.data());
+
+    return WriteIC(std::make_pair(DBKeys::HDPUBKEY, xpub), uint8_t(1), false);
+}
+
+bool WalletBatch::WriteActiveHDKey(const CExtPubKey& extpub)
+{
+    std::vector<unsigned char> xpub(BIP32_EXTKEY_SIZE);
+    extpub.Encode(xpub.data());
+
+    if (!WriteIC(DBKeys::ACTIVEHDKEY, xpub, false)) {
+        std::vector<unsigned char> read_xpub(BIP32_EXTKEY_SIZE);
+        if (!m_batch->Read(DBKeys::ACTIVEHDKEY, read_xpub)) {
+            return false;
+        }
+        return xpub == read_xpub;
+    }
+    return true;
 }
 
 class CWalletScanState {

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1009,16 +1009,6 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
         ((DescriptorScriptPubKeyMan*)spk_man)->SetCache(desc_cache_pair.second);
     }
 
-    // Set the descriptor keys
-    for (const auto& desc_key_pair : wss.m_descriptor_keys) {
-        auto spk_man = pwallet->GetScriptPubKeyMan(desc_key_pair.first.first);
-        ((DescriptorScriptPubKeyMan*)spk_man)->AddKey(desc_key_pair.first.second, desc_key_pair.second);
-    }
-    for (const auto& desc_key_pair : wss.m_descriptor_crypt_keys) {
-        auto spk_man = pwallet->GetScriptPubKeyMan(desc_key_pair.first.first);
-        ((DescriptorScriptPubKeyMan*)spk_man)->AddCryptedKey(desc_key_pair.first.second, desc_key_pair.second.first, desc_key_pair.second.second);
-    }
-
     if (rescan_required && result == DBErrors::LOAD_OK) {
         result = DBErrors::NEED_RESCAN;
     } else if (fNoncriticalErrors && result == DBErrors::LOAD_OK) {

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -71,6 +71,8 @@ extern const std::string HDCHAIN;
 extern const std::string HDPUBKEY; // A HD key, identified by extended pubkey
 extern const std::string KEY;
 extern const std::string KEYMETA;
+extern const std::string KEYMAN_KEY;
+extern const std::string KEYMAN_CKEY;
 extern const std::string LOCKED_UTXO;
 extern const std::string MASTER_KEY;
 extern const std::string MINVERSION;
@@ -275,6 +277,9 @@ public:
 
     bool WriteHDPubKey(const CExtPubKey& extpub);
     bool WriteActiveHDKey(const CExtPubKey& extpub);
+
+    bool WriteKeyManKey(const CPubKey& pubkey, const CPrivKey& privkey);
+    bool WriteCryptedKeyManKey(const CPubKey& pubkey, const std::vector<unsigned char>& ckey);
 
     DBErrors LoadWallet(CWallet* pwallet);
     DBErrors FindWalletTx(std::vector<uint256>& vTxHash, std::list<CWalletTx>& vWtx);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -59,6 +59,7 @@ namespace DBKeys {
 extern const std::string ACENTRY;
 extern const std::string ACTIVEEXTERNALSPK;
 extern const std::string ACTIVEINTERNALSPK;
+extern const std::string ACTIVEHDKEY; // Active HD Master key, identified by extended pubkey
 extern const std::string BESTBLOCK;
 extern const std::string BESTBLOCK_NOMERKLE;
 extern const std::string CRYPTED_KEY;
@@ -67,6 +68,7 @@ extern const std::string DEFAULTKEY;
 extern const std::string DESTDATA;
 extern const std::string FLAGS;
 extern const std::string HDCHAIN;
+extern const std::string HDPUBKEY; // A HD key, identified by extended pubkey
 extern const std::string KEY;
 extern const std::string KEYMETA;
 extern const std::string LOCKED_UTXO;
@@ -270,6 +272,9 @@ public:
 
     bool WriteActiveScriptPubKeyMan(uint8_t type, const uint256& id, bool internal);
     bool EraseActiveScriptPubKeyMan(uint8_t type, bool internal);
+
+    bool WriteHDPubKey(const CExtPubKey& extpub);
+    bool WriteActiveHDKey(const CExtPubKey& extpub);
 
     DBErrors LoadWallet(CWallet* pwallet);
     DBErrors FindWalletTx(std::vector<uint256>& vTxHash, std::list<CWalletTx>& vWtx);

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -47,6 +47,9 @@ enum WalletFlags : uint64_t {
     // Indicates that the descriptor cache has been upgraded to cache last hardened xpubs
     WALLET_FLAG_LAST_HARDENED_XPUB_CACHED = (1ULL << 2),
 
+    // Indicate that the KeyManager should be used instead of DescSPKM keys
+    WALLET_FLAG_USES_KEYMAN = (1ULL << 3),
+
     // will enforce the rule that the wallet can't contain any private keys (only watch-only/pubkeys)
     WALLET_FLAG_DISABLE_PRIVATE_KEYS = (1ULL << 32),
 


### PR DESCRIPTION
This PR changes DescriptorScriptPubKeyMan to no longer handle relevant keys directly. Instead all keys for all DescriptorSPKMs will be handled by a new `KeyManager` class which exists within `CWallet` (a reference to it is passed to each DescriptorSPKM). This allows us to have a concept of a wallet HD key for descriptor wallets. This makes it easier to add new single key descriptors that use the same HD master key as the rest of the autogenerated descriptors (e.g. for taproot). Multisigs will also be easier as an xpub belonging to the wallet can be exported without needing to do weird things like descriptor introspection and guessing about which descriptor's key to use.

`KeyManager` is a class which handles all of the keys for DescriptorSPKMs. It contains the maps that hold the keys, deals with writing those keys to disk, and handles their encryption. Encryption keys are still managed by `CWallet` but provided to `KeyManager` through the `WalletStorage` interface. Signing is still done through `DescriptorScriptPubKeyMan::SignTransaction` however this will fetch the keys from `KeyManager` rather than storing keys in the DescriptorSPKM to be used.

This change is backwards compatible. Although `KeyManager` writes and uses keys in new `keyman_key` and `keyman_ckey` records, it will still write keys for each descriptor in `walletdescriptorkey` and `walletdescriptorckey` records. This allows a descriptor wallet created using this change to be opened by 22.0 and 0.21. Additionally, wallets created with older software will automatically be upgraded to using the `KeyManager` at first loading. This is done in the background and does not require any user interaction (i.e. no passphrase required).