### PR TITLE
p2p: fix regression in AddrManImpl::AddSingle()

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -544,6 +544,7 @@ bool AddrManImpl::AddSingle(const CAddress& addr, const CNetAddr& source, int64_
     if (!addr.IsRoutable())
         return false;
 
+    bool fNew{false};
     int nId;
     AddrInfo* pinfo = Find(addr, &nId);
 
@@ -584,6 +585,7 @@ bool AddrManImpl::AddSingle(const CAddress& addr, const CNetAddr& source, int64_
         pinfo = Create(addr, source, &nId);
         pinfo->nTime = std::max((int64_t)0, (int64_t)pinfo->nTime - nTimePenalty);
         nNew++;
+        fNew = true;
     }
 
     int nUBucket = pinfo->GetNewBucket(nKey, source, m_asmap);
@@ -609,7 +611,7 @@ bool AddrManImpl::AddSingle(const CAddress& addr, const CNetAddr& source, int64_
             }
         }
     }
-    return fInsert;
+    return fNew && fInsert;
 }
 
 void AddrManImpl::Good_(const CService& addr, bool test_before_evict, int64_t nTime)


### PR DESCRIPTION
Hopefully fixes the addrman unit test failures that appear to have been introduced in commit 2095df7b "Add Add_() inner function, fix Add() return semantics" of PR #23380, which was merged in 994aaaa8.

That commit removed the bool fNew logic from AddSingle() and replaced it with returning fInsert. This patch brings back
the fNew logic and combines it with fInsert, so AddSingle() returns whether or not fNew and fInsert are both true.

Labelling this as a draft while I catch up on review of the recent changes.

Tentatively closes #23433.