### PR TITLE
test: Open streams_test_tmp file in temporary folder

### DIFF
--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -215,7 +215,9 @@ BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
 
 BOOST_AUTO_TEST_CASE(streams_buffered_file)
 {
-    FILE* file = fsbridge::fopen("streams_test_tmp", "w+b");
+    fs::path streams_test_filename = m_args.GetDataDirBase() / "streams_test_tmp";
+    FILE* file = fsbridge::fopen(streams_test_filename, "w+b");
+
     // The value at each offset is the offset.
     for (uint8_t j = 0; j < 40; ++j) {
         fwrite(&j, 1, 1, file);
@@ -343,7 +345,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file)
     // We can explicitly close the file, or the destructor will do it.
     bf.fclose();
 
-    fs::remove("streams_test_tmp");
+    fs::remove(streams_test_filename);
 }
 
 BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
@@ -351,8 +353,9 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
     // Make this test deterministic.
     SeedInsecureRand(SeedRand::ZEROS);
 
+    fs::path streams_test_filename = m_args.GetDataDirBase() / "streams_test_tmp";
     for (int rep = 0; rep < 50; ++rep) {
-        FILE* file = fsbridge::fopen("streams_test_tmp", "w+b");
+        FILE* file = fsbridge::fopen(streams_test_filename, "w+b");
         size_t fileSize = InsecureRandRange(256);
         for (uint8_t i = 0; i < fileSize; ++i) {
             fwrite(&i, 1, 1, file);
@@ -453,7 +456,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
                 maxPos = currentPos;
         }
     }
-    fs::remove("streams_test_tmp");
+    fs::remove(streams_test_filename);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The tests `streams_tests/streams_buffered_file` and `streams_tests/streams_buffered_file_rand`
did not use a the temporary directory provided by  `BasicTestingSetup`, so it was not possible
to execute multiple of them in parallel. This fixes that.

To reproduce, run

```sh
parallel --halt now,fail=1 './src/test/test_bitcoin --run_test=streams_tests/streams_buffered_file_rand' -- ::: {1..1000}
```

This executes the test 1000 times, one job per CPU. It works on that commit but mergebase fails quickly.
