### PR TITLE
refactor, consensus: remove calls to global `Params()` in validation layer

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -435,7 +435,7 @@ public:
 
     std::unique_ptr<CBlockTreeDB> m_block_tree_db GUARDED_BY(::cs_main);
 
-    bool LoadBlockIndexDB(std::set<CBlockIndex*, CBlockIndexWorkComparator>& setBlockIndexCandidates) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    bool LoadBlockIndexDB(const Consensus::Params& consensus, std::set<CBlockIndex*, CBlockIndexWorkComparator>& setBlockIndexCandidates) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**
      * Load the blocktree off disk and into memory. Populate certain metadata


### PR DESCRIPTION
This PR removes calls to global `Params()` in validation layer (except in the `CChainState` constructor).

Motivation: Reducing the use of global variables makes code more predictable. 

Requires #23437 as it changes the visibility of `CChainState::m_params` to public.