### PR TITLE
ci: Do not print `git log` for empty COMMIT_RANGE

### DIFF
--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -8,8 +8,8 @@ export LC_ALL=C
 
 GIT_HEAD=$(git rev-parse HEAD)
 if [ -n "$CIRRUS_PR" ]; then
-  COMMIT_RANGE="$CIRRUS_BASE_SHA..$GIT_HEAD"
-  test/lint/commit-script-check.sh $COMMIT_RANGE
+  COMMIT_RANGE="${CIRRUS_BASE_SHA}..$GIT_HEAD"
+  test/lint/commit-script-check.sh "$COMMIT_RANGE"
 fi
 export COMMIT_RANGE
 
@@ -34,5 +34,7 @@ if [ "$CIRRUS_REPO_FULL_NAME" = "bitcoin/bitcoin" ] && [ "$CIRRUS_PR" = "" ] ; t
     ./contrib/verify-commits/verify-commits.py;
 fi
 
-echo
-git log --no-merges --oneline $COMMIT_RANGE
+if [ -n "$COMMIT_RANGE" ]; then
+  echo
+  git log --no-merges --oneline "$COMMIT_RANGE"
+fi


### PR DESCRIPTION
On master (77a2f5d30c5ecb764b8a7c098492e1f5cdec90f0) a CI lint task [log](https://api.cirrus-ci.com/v1/task/4817858858319872/logs/lint.log) exceeds 20K lines.

This PR fixes this issue.