### PR TITLE
test: Enable SC2046 and SC2086 shellcheck rules

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -8,8 +8,8 @@ export LC_ALL=C
 
 ${CI_RETRY_EXE} apt-get update
 ${CI_RETRY_EXE} apt-get install -y clang-format-9 python3-pip curl git gawk jq
-update-alternatives --install /usr/bin/clang-format      clang-format      $(which clang-format-9     ) 100
-update-alternatives --install /usr/bin/clang-format-diff clang-format-diff $(which clang-format-diff-9) 100
+update-alternatives --install /usr/bin/clang-format      clang-format      "$(which clang-format-9     )" 100
+update-alternatives --install /usr/bin/clang-format-diff clang-format-diff "$(which clang-format-diff-9)" 100
 
 ${CI_RETRY_EXE} pip3 install codespell==2.0.0
 ${CI_RETRY_EXE} pip3 install flake8==3.8.3

--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -31,7 +31,8 @@ if [ "$CIRRUS_REPO_FULL_NAME" = "bitcoin/bitcoin" ] && [ "$CIRRUS_PR" = "" ] ; t
     # sanity checking only a few (10) commits seems sufficient and cheap.
     git log HEAD~10 -1 --format='%H' > ./contrib/verify-commits/trusted-sha512-root-commit
     git log HEAD~10 -1 --format='%H' > ./contrib/verify-commits/trusted-git-root
-    ${CI_RETRY_EXE}  gpg --keyserver hkps://keys.openpgp.org --recv-keys $(<contrib/verify-commits/trusted-keys) &&
+    mapfile -t KEYS < contrib/verify-commits/trusted-keys
+    ${CI_RETRY_EXE} gpg --keyserver hkps://keys.openpgp.org --recv-keys "${KEYS[@]}" &&
     ./contrib/verify-commits/verify-commits.py;
 fi
 

--- a/ci/test/00_setup_env_native_qt5.sh
+++ b/ci/test/00_setup_env_native_qt5.sh
@@ -15,5 +15,5 @@ export RUN_UNIT_TESTS_SEQUENTIAL="true"
 export RUN_UNIT_TESTS="false"
 export GOAL="install"
 export PREVIOUS_RELEASES_TO_DOWNLOAD="v0.15.2 v0.16.3 v0.17.2 v0.18.1 v0.19.1 v0.20.1"
-export BITCOIN_CONFIG="--enable-zmq --with-libs=no --with-gui=qt5 --enable-reduce-exports
+export BITCOIN_CONFIG="--enable-zmq --with-libs=no --with-gui=qt5 --enable-reduce-exports \
 --enable-debug --disable-fuzz-binary  CFLAGS=\"-g0 -O2 -funsigned-char\" CXXFLAGS=\"-g0 -O2 -funsigned-char\" CC=gcc-8 CXX=g++-8"

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -82,7 +82,7 @@ if [ "$CI_OS_NAME" == "macos" ]; then
 else
   DOCKER_EXEC free -m -h
   DOCKER_EXEC echo "Number of CPUs \(nproc\):" \$\(nproc\)
-  DOCKER_EXEC echo $(lscpu | grep Endian)
+  DOCKER_EXEC echo "$(lscpu | grep Endian)"
 fi
 DOCKER_EXEC echo "Free disk space:"
 DOCKER_EXEC df -h

--- a/ci/test/05_before_script.sh
+++ b/ci/test/05_before_script.sh
@@ -8,12 +8,12 @@ export LC_ALL=C.UTF-8
 
 # Make sure default datadir does not exist and is never read by creating a dummy file
 if [ "$CI_OS_NAME" == "macos" ]; then
-  echo > $HOME/Library/Application\ Support/Bitcoin
+  echo > "${HOME}/Library/Application Support/Bitcoin"
 else
   DOCKER_EXEC echo \> \$HOME/.bitcoin
 fi
 
-DOCKER_EXEC mkdir -p ${DEPENDS_DIR}/SDKs ${DEPENDS_DIR}/sdk-sources
+DOCKER_EXEC mkdir -p "${DEPENDS_DIR}/SDKs" "${DEPENDS_DIR}/sdk-sources"
 
 OSX_SDK_BASENAME="Xcode-${XCODE_VERSION}-${XCODE_BUILD_ID}-extracted-SDK-with-libcxx-headers.tar.gz"
 OSX_SDK_PATH="${DEPENDS_DIR}/sdk-sources/${OSX_SDK_BASENAME}"
@@ -42,7 +42,7 @@ if [ -n "$XCODE_VERSION" ] && [ -f "$OSX_SDK_PATH" ]; then
   DOCKER_EXEC tar -C "${DEPENDS_DIR}/SDKs" -xf "$OSX_SDK_PATH"
 fi
 if [[ $HOST = *-mingw32 ]]; then
-  DOCKER_EXEC update-alternatives --set $HOST-g++ \$\(which $HOST-g++-posix\)
+  DOCKER_EXEC update-alternatives --set "${HOST}-g++" \$\(which "${HOST}-g++-posix"\)
 fi
 if [ -z "$NO_DEPENDS" ]; then
   if [[ $DOCKER_NAME_TAG == centos* ]]; then
@@ -53,7 +53,7 @@ if [ -z "$NO_DEPENDS" ]; then
   else
     SHELL_OPTS="CONFIG_SHELL="
   fi
-  DOCKER_EXEC $SHELL_OPTS make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS
+  DOCKER_EXEC "$SHELL_OPTS" make "$MAKEJOBS" -C depends HOST="$HOST" "$DEP_OPTS"
 fi
 if [ -n "$PREVIOUS_RELEASES_TO_DOWNLOAD" ]; then
   DOCKER_EXEC test/get_previous_releases.py -b -t "$PREVIOUS_RELEASES_DIR" "${PREVIOUS_RELEASES_TO_DOWNLOAD}"

--- a/ci/test/06_script_a.sh
+++ b/ci/test/06_script_a.sh
@@ -9,7 +9,7 @@ export LC_ALL=C.UTF-8
 if [ -n "$ANDROID_TOOLS_URL" ]; then
   DOCKER_EXEC make distclean || true
   DOCKER_EXEC ./autogen.sh
-  DOCKER_EXEC ./configure $BITCOIN_CONFIG --prefix=$DEPENDS_DIR/aarch64-linux-android || ( (DOCKER_EXEC cat config.log) && false)
+  DOCKER_EXEC ./configure "$BITCOIN_CONFIG" --prefix="${DEPENDS_DIR}/aarch64-linux-android" || ( (DOCKER_EXEC cat config.log) && false)
   DOCKER_EXEC "make $MAKEJOBS && cd src/qt && ANDROID_HOME=${ANDROID_HOME} ANDROID_NDK_HOME=${ANDROID_NDK_HOME} make apk"
   exit 0
 fi
@@ -29,13 +29,13 @@ fi
 DOCKER_EXEC mkdir -p "${BASE_BUILD_DIR}"
 export P_CI_DIR="${BASE_BUILD_DIR}"
 
-DOCKER_EXEC "${BASE_ROOT_DIR}/configure" --cache-file=config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( (DOCKER_EXEC cat config.log) && false)
+DOCKER_EXEC "${BASE_ROOT_DIR}/configure" --cache-file=config.cache "$BITCOIN_CONFIG_ALL" "$BITCOIN_CONFIG" || ( (DOCKER_EXEC cat config.log) && false)
 
-DOCKER_EXEC make distdir VERSION=$HOST
+DOCKER_EXEC make distdir VERSION="$HOST"
 
 export P_CI_DIR="${BASE_BUILD_DIR}/bitcoin-$HOST"
 
-DOCKER_EXEC ./configure --cache-file=../config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( (DOCKER_EXEC cat config.log) && false)
+DOCKER_EXEC ./configure --cache-file=../config.cache "$BITCOIN_CONFIG_ALL" "$BITCOIN_CONFIG" || ( (DOCKER_EXEC cat config.log) && false)
 
 set -o errtrace
 trap 'DOCKER_EXEC "cat ${BASE_SCRATCH_DIR}/sanitizer-output/* 2> /dev/null"' ERR
@@ -48,7 +48,7 @@ if [[ ${USE_MEMORY_SANITIZER} == "true" ]]; then
   DOCKER_EXEC 'grep -v HAVE_SYS_GETRANDOM src/config/bitcoin-config.h > src/config/bitcoin-config.h.tmp && mv src/config/bitcoin-config.h.tmp src/config/bitcoin-config.h'
 fi
 
-DOCKER_EXEC make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && DOCKER_EXEC make $GOAL V=1 ; false )
+DOCKER_EXEC make "$MAKEJOBS" "$GOAL" || ( echo "Build failure. Verbose build follows." && DOCKER_EXEC make "$GOAL" V=1 ; false )
 
 DOCKER_EXEC "ccache --version | head -n 1 && ccache --show-stats"
 DOCKER_EXEC du -sh "${DEPENDS_DIR}"/*/

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -8,13 +8,13 @@ export LC_ALL=C.UTF-8
 
 if [[ $HOST = *-mingw32 ]]; then
   # Generate all binaries, so that they can be wrapped
-  DOCKER_EXEC make $MAKEJOBS -C src/secp256k1 VERBOSE=1
+  DOCKER_EXEC make "$MAKEJOBS" -C src/secp256k1 VERBOSE=1
   DOCKER_EXEC "${BASE_ROOT_DIR}/ci/test/wrap-wine.sh"
 fi
 
 if [ -n "$QEMU_USER_CMD" ]; then
   # Generate all binaries, so that they can be wrapped
-  DOCKER_EXEC make $MAKEJOBS -C src/secp256k1 VERBOSE=1
+  DOCKER_EXEC make "$MAKEJOBS" -C src/secp256k1 VERBOSE=1
   DOCKER_EXEC "${BASE_ROOT_DIR}/ci/test/wrap-qemu.sh"
 fi
 
@@ -23,15 +23,15 @@ if [ -n "$USE_VALGRIND" ]; then
 fi
 
 if [ "$RUN_UNIT_TESTS" = "true" ]; then
-  DOCKER_EXEC ${TEST_RUNNER_ENV} DIR_UNIT_TEST_DATA=${DIR_UNIT_TEST_DATA} LD_LIBRARY_PATH=$DEPENDS_DIR/$HOST/lib make $MAKEJOBS check VERBOSE=1
+  DOCKER_EXEC "${TEST_RUNNER_ENV}" DIR_UNIT_TEST_DATA="${DIR_UNIT_TEST_DATA}" LD_LIBRARY_PATH="${DEPENDS_DIR}/${HOST}/lib" make "$MAKEJOBS" check VERBOSE=1
 fi
 
 if [ "$RUN_UNIT_TESTS_SEQUENTIAL" = "true" ]; then
-  DOCKER_EXEC ${TEST_RUNNER_ENV} DIR_UNIT_TEST_DATA=${DIR_UNIT_TEST_DATA} LD_LIBRARY_PATH=$DEPENDS_DIR/$HOST/lib "${BASE_BUILD_DIR}/bitcoin-*/src/test/test_bitcoin*" --catch_system_errors=no -l test_suite
+  DOCKER_EXEC "${TEST_RUNNER_ENV}" DIR_UNIT_TEST_DATA="${DIR_UNIT_TEST_DATA}" LD_LIBRARY_PATH="${DEPENDS_DIR}/${HOST}/lib" "${BASE_BUILD_DIR}/bitcoin-*/src/test/test_bitcoin*" --catch_system_errors=no -l test_suite
 fi
 
 if [ "$RUN_FUNCTIONAL_TESTS" = "true" ]; then
-  DOCKER_EXEC LD_LIBRARY_PATH=$DEPENDS_DIR/$HOST/lib ${TEST_RUNNER_ENV} test/functional/test_runner.py --ci $MAKEJOBS --tmpdirprefix "${BASE_SCRATCH_DIR}/test_runner/" --ansi --combinedlogslen=4000 --timeout-factor=${TEST_RUNNER_TIMEOUT_FACTOR} ${TEST_RUNNER_EXTRA} --quiet --failfast
+  DOCKER_EXEC LD_LIBRARY_PATH="${DEPENDS_DIR}/${HOST}/lib" "${TEST_RUNNER_ENV}" test/functional/test_runner.py --ci "$MAKEJOBS" --tmpdirprefix "${BASE_SCRATCH_DIR}/test_runner/" --ansi --combinedlogslen=4000 --timeout-factor="${TEST_RUNNER_TIMEOUT_FACTOR}" "${TEST_RUNNER_EXTRA}" --quiet --failfast
 fi
 
 if [ "$RUN_SECURITY_TESTS" = "true" ]; then
@@ -39,5 +39,5 @@ if [ "$RUN_SECURITY_TESTS" = "true" ]; then
 fi
 
 if [ "$RUN_FUZZ_TESTS" = "true" ]; then
-  DOCKER_EXEC LD_LIBRARY_PATH=$DEPENDS_DIR/$HOST/lib test/fuzz/test_runner.py ${FUZZ_TESTS_CONFIG} $MAKEJOBS -l DEBUG ${DIR_FUZZ_IN}
+  DOCKER_EXEC LD_LIBRARY_PATH="${DEPENDS_DIR}/${HOST}/lib" test/fuzz/test_runner.py "${FUZZ_TESTS_CONFIG}" "$MAKEJOBS" -l DEBUG "${DIR_FUZZ_IN}"
 fi

--- a/ci/test/wrap-qemu.sh
+++ b/ci/test/wrap-qemu.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 for b_name in {"${BASE_OUTDIR}/bin"/*,src/secp256k1/*tests,src/minisketch/test{,-verify},src/univalue/{no_nul,test_json,unitester,object}}; do
     # shellcheck disable=SC2044
-    for b in $(find "${BASE_ROOT_DIR}" -executable -type f -name $(basename $b_name)); do
+    for b in $(find "${BASE_ROOT_DIR}" -executable -type f -name $(basename "$b_name")); do
       echo "Wrap $b ..."
       mv "$b" "${b}_orig"
       echo '#!/usr/bin/env bash' > "$b"

--- a/ci/test/wrap-qemu.sh
+++ b/ci/test/wrap-qemu.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 for b_name in {"${BASE_OUTDIR}/bin"/*,src/secp256k1/*tests,src/minisketch/test{,-verify},src/univalue/{no_nul,test_json,unitester,object}}; do
     # shellcheck disable=SC2044
-    for b in $(find "${BASE_ROOT_DIR}" -executable -type f -name $(basename "$b_name")); do
+    for b in $(find "${BASE_ROOT_DIR}" -executable -type f -name "$(basename "$b_name")"); do
       echo "Wrap $b ..."
       mv "$b" "${b}_orig"
       echo '#!/usr/bin/env bash' > "$b"

--- a/ci/test/wrap-valgrind.sh
+++ b/ci/test/wrap-valgrind.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 for b_name in "${BASE_OUTDIR}/bin"/*; do
     # shellcheck disable=SC2044
-    for b in $(find "${BASE_ROOT_DIR}" -executable -type f -name $(basename "$b_name")); do
+    for b in $(find "${BASE_ROOT_DIR}" -executable -type f -name "$(basename "$b_name")"); do
       echo "Wrap $b ..."
       mv "$b" "${b}_orig"
       echo '#!/usr/bin/env bash' > "$b"

--- a/ci/test/wrap-valgrind.sh
+++ b/ci/test/wrap-valgrind.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 for b_name in "${BASE_OUTDIR}/bin"/*; do
     # shellcheck disable=SC2044
-    for b in $(find "${BASE_ROOT_DIR}" -executable -type f -name $(basename $b_name)); do
+    for b in $(find "${BASE_ROOT_DIR}" -executable -type f -name $(basename "$b_name")); do
       echo "Wrap $b ..."
       mv "$b" "${b}_orig"
       echo '#!/usr/bin/env bash' > "$b"

--- a/ci/test/wrap-wine.sh
+++ b/ci/test/wrap-wine.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 for b_name in {"${BASE_OUTDIR}/bin"/*,src/secp256k1/*tests,src/minisketch/test{,-verify},src/univalue/{no_nul,test_json,unitester,object}}.exe; do
     # shellcheck disable=SC2044
-    for b in $(find "${BASE_ROOT_DIR}" -executable -type f -name "$(basename $b_name)"); do
+    for b in $(find "${BASE_ROOT_DIR}" -executable -type f -name "$(basename "$b_name")"); do
       if (file "$b" | grep "Windows"); then
         echo "Wrap $b ..."
         mv "$b" "${b}_orig"

--- a/contrib/devtools/gen-manpages.sh
+++ b/contrib/devtools/gen-manpages.sh
@@ -17,7 +17,7 @@ WALLET_TOOL=${WALLET_TOOL:-$BINDIR/bitcoin-wallet}
 BITCOINUTIL=${BITCOINQT:-$BINDIR/bitcoin-util}
 BITCOINQT=${BITCOINQT:-$BINDIR/qt/bitcoin-qt}
 
-[ ! -x $BITCOIND ] && echo "$BITCOIND not found or not executable." && exit 1
+[ ! -x "$BITCOIND" ] && echo "$BITCOIND not found or not executable." && exit 1
 
 # Don't allow man pages to be generated for binaries built from a dirty tree
 DIRTY=""
@@ -30,7 +30,7 @@ done
 if [ -n "$DIRTY" ]
 then
   echo -e "WARNING: the following binaries were built from a dirty tree:\n"
-  echo -e $DIRTY
+  echo -e "$DIRTY"
   echo "man pages generated from dirty binaries should NOT be committed."
   echo "To properly generate man pages, please commit your changes to the above binaries, rebuild them, then run this script again."
 fi
@@ -46,8 +46,8 @@ $BITCOIND --version | sed -n '1!p' >> footer.h2m
 
 for cmd in $BITCOIND $BITCOINCLI $BITCOINTX $WALLET_TOOL $BITCOINUTIL $BITCOINQT; do
   cmdname="${cmd##*/}"
-  help2man -N --version-string=${BTCVER[0]} --include=footer.h2m -o ${MANDIR}/${cmdname}.1 ${cmd}
-  sed -i "s/\\\-${BTCVER[1]}//g" ${MANDIR}/${cmdname}.1
+  help2man -N --version-string="${BTCVER[0]}" --include=footer.h2m -o "${MANDIR}/${cmdname}.1" "${cmd}"
+  sed -i "s/\\\-${BTCVER[1]}//g" "${MANDIR}/${cmdname}.1"
 done
 
 rm -f footer.h2m

--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -20,7 +20,7 @@ expand_path() {
   cd "${1}" && pwd -P
 }
 
-BDB_PREFIX="$(expand_path ${1})/db4"; shift;
+BDB_PREFIX="$(expand_path "${1}")/db4"; shift;
 BDB_VERSION='db-4.8.30.NC'
 BDB_HASH='12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef'
 BDB_URL="https://download.oracle.com/berkeley-db/${BDB_VERSION}.tar.gz"

--- a/contrib/macdeploy/detached-sig-apply.sh
+++ b/contrib/macdeploy/detached-sig-apply.sh
@@ -22,6 +22,6 @@ if [ -z "$SIGNATURE" ]; then
   exit 1
 fi
 
-${SIGNAPPLE} apply ${UNSIGNED} ${SIGNATURE}
+${SIGNAPPLE} apply "${UNSIGNED}" "${SIGNATURE}"
 mv ${ROOTDIR} ${OUTDIR}
 echo "Signed: ${OUTDIR}"

--- a/contrib/verify-commits/pre-push-hook.sh
+++ b/contrib/verify-commits/pre-push-hook.sh
@@ -9,11 +9,11 @@ if ! [[ "$2" =~ ^(git@)?(www.)?github.com(:|/)bitcoin/bitcoin(.git)?$ ]]; then
 fi
 
 while read LINE; do
-    set -- A $LINE
+    set -- A "$LINE"
     if [ "$4" != "refs/heads/master" ]; then
         continue
     fi
-    if ! ./contrib/verify-commits/verify-commits.py $3 > /dev/null 2>&1; then
+    if ! ./contrib/verify-commits/verify-commits.py "$3" > /dev/null 2>&1; then
         echo "ERROR: A commit is not signed, can't push"
         ./contrib/verify-commits/verify-commits.py
         exit 1

--- a/contrib/windeploy/detached-sig-create.sh
+++ b/contrib/windeploy/detached-sig-create.sh
@@ -23,6 +23,7 @@ TIMESERVER=http://timestamp.comodoca.com
 CERTFILE="win-codesign.cert"
 
 mkdir -p "${OUTSUBDIR}"
+# shellcheck disable=SC2046
 basename -a $(ls -1 "${SRCDIR}"/*-unsigned.exe) | while read UNSIGNED; do
   echo Signing "${UNSIGNED}"
   "${OSSLSIGNCODE}" sign -certs "${CERTFILE}" -t "${TIMESERVER}" -h sha256 -in "${SRCDIR}/${UNSIGNED}" -out "${WORKDIR}/${UNSIGNED}" "$@"

--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -26,7 +26,7 @@ if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$(command -v git)" ] && [ "$
 
     # if latest commit is tagged and not dirty, then override using the tag name
     RAWDESC=$(git describe --abbrev=0 2>/dev/null)
-    if [ "$(git rev-parse HEAD)" = "$(git rev-list -1 $RAWDESC 2>/dev/null)" ]; then
+    if [ "$(git rev-parse HEAD)" = "$(git rev-list -1 "$RAWDESC" 2>/dev/null)" ]; then
         git diff-index --quiet HEAD -- && GIT_TAG=$RAWDESC
     fi
 

--- a/src/qt/res/animation/makespinner.sh
+++ b/src/qt/res/animation/makespinner.sh
@@ -5,10 +5,10 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 export LC_ALL=C
-FRAMEDIR=$(dirname $0)
+FRAMEDIR=$(dirname "$0")
 for i in {0..35}
 do
-    frame=$(printf "%03d" $i)
+    frame=$(printf "%03d" "$i")
     angle=$((i * 10))
-    convert $FRAMEDIR/../src/spinner.png -background "rgba(0,0,0,0.0)" -distort SRT $angle $FRAMEDIR/spinner-$frame.png
+    convert "${FRAMEDIR}/../src/spinner.png" -background "rgba(0,0,0,0.0)" -distort SRT $angle "${FRAMEDIR}/spinner-${frame}.png"
 done

--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -12,7 +12,7 @@
 # one. Any remaining diff signals an error.
 
 export LC_ALL=C
-if test -z $1; then
+if test -z "$1"; then
     echo "Usage: $0 <commit>..."
     exit 1
 fi
@@ -20,10 +20,10 @@ fi
 RET=0
 PREV_BRANCH=$(git name-rev --name-only HEAD)
 PREV_HEAD=$(git rev-parse HEAD)
-for commit in $(git rev-list --reverse $1); do
-    if git rev-list -n 1 --pretty="%s" $commit | grep -q "^scripted-diff:"; then
-        git checkout --quiet $commit^ || exit
-        SCRIPT="$(git rev-list --format=%b -n1 $commit | sed '/^-BEGIN VERIFY SCRIPT-$/,/^-END VERIFY SCRIPT-$/{//!b};d')"
+for commit in $(git rev-list --reverse "$1"); do
+    if git rev-list -n 1 --pretty="%s" "$commit" | grep -q "^scripted-diff:"; then
+        git checkout --quiet "$commit"^ || exit
+        SCRIPT="$(git rev-list --format=%b -n1 "$commit" | sed '/^-BEGIN VERIFY SCRIPT-$/,/^-END VERIFY SCRIPT-$/{//!b};d')"
         if test -z "$SCRIPT"; then
             echo "Error: missing script for: $commit"
             echo "Failed"
@@ -32,16 +32,16 @@ for commit in $(git rev-list --reverse $1); do
             echo "Running script for: $commit"
             echo "$SCRIPT"
             (eval "$SCRIPT")
-            git --no-pager diff --exit-code $commit && echo "OK" || (echo "Failed"; false) || RET=1
+            git --no-pager diff --exit-code "$commit" && echo "OK" || (echo "Failed"; false) || RET=1
         fi
         git reset --quiet --hard HEAD
      else
-        if git rev-list "--format=%b" -n1 $commit | grep -q '^-\(BEGIN\|END\)[ a-zA-Z]*-$'; then
+        if git rev-list "--format=%b" -n1 "$commit" | grep -q '^-\(BEGIN\|END\)[ a-zA-Z]*-$'; then
             echo "Error: script block marker but no scripted-diff in title of commit $commit"
             echo "Failed"
             RET=1
         fi
     fi
 done
-git checkout --quiet $PREV_BRANCH 2>/dev/null || git checkout --quiet $PREV_HEAD
+git checkout --quiet "$PREV_BRANCH" 2>/dev/null || git checkout --quiet "$PREV_HEAD"
 exit $RET

--- a/test/lint/git-subtree-check.sh
+++ b/test/lint/git-subtree-check.sh
@@ -82,6 +82,7 @@ if [ -z "$latest_squash" ]; then
     echo "ERROR: $DIR is not a subtree" >&2
     exit 2
 fi
+# shellcheck disable=SC2086
 set $latest_squash
 old=$1
 rev=$2
@@ -92,6 +93,7 @@ if [ -z "$tree_actual" ]; then
     echo "FAIL: subtree directory $DIR not found in $COMMIT" >&2
     exit 1
 fi
+# shellcheck disable=SC2086
 set $tree_actual
 tree_actual_type=$2
 tree_actual_tree=$3
@@ -102,23 +104,23 @@ if [ "d$tree_actual_type" != "dtree" ]; then
 fi
 
 # get the tree at the time of the last subtree update
-tree_commit=$(git show -s --format="%T" $old)
+tree_commit=$(git show -s --format="%T" "$old")
 echo "$DIR in $COMMIT was last updated in commit $old (tree $tree_commit)"
 
 # ... and compare the actual tree with it
 if [ "$tree_actual_tree" != "$tree_commit" ]; then
-    git diff $tree_commit $tree_actual_tree >&2
+    git diff "$tree_commit" "$tree_actual_tree" >&2
     echo "FAIL: subtree directory was touched without subtree merge" >&2
     exit 1
 fi
 
 if [ "$check_remote" != "0" ]; then
     # get the tree in the subtree commit referred to
-    if [ "d$(git cat-file -t $rev 2>/dev/null)" != dcommit ]; then
+    if [ "d$(git cat-file -t "$rev" 2>/dev/null)" != dcommit ]; then
         echo "subtree commit $rev unavailable: cannot compare. Did you add and fetch the remote?" >&2
         exit 1
     fi
-    tree_subtree=$(git show -s --format="%T" $rev)
+    tree_subtree=$(git show -s --format="%T" "$rev")
     echo "$DIR in $COMMIT was last updated to upstream commit $rev (tree $tree_subtree)"
 
     # ... and compare the actual tree with it

--- a/test/lint/lint-files.sh
+++ b/test/lint/lint-files.sh
@@ -3,5 +3,5 @@
 export LC_ALL=C
 
 set -e
-cd "$(dirname $0)/../.."
+cd "$(dirname "$0")/../.."
 test/lint/lint-files.py

--- a/test/lint/lint-git-commit-check.sh
+++ b/test/lint/lint-git-commit-check.sh
@@ -38,7 +38,7 @@ while IFS= read -r commit_hash  || [[ -n "$commit_hash" ]]; do
     while IFS= read -r line || [[ -n "$line" ]]; do
         n_line=$((n_line+1))
         length=${#line}
-        if [ $n_line -eq 2 ] && [ $length -ne 0 ]; then
+        if [ $n_line -eq 2 ] && [ "$length" -ne 0 ]; then
             echo "The subject line of commit hash ${commit_hash} is followed by a non-empty line. Subject lines should always be followed by a blank line."
             EXIT_CODE=1
         fi

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -12,7 +12,7 @@ export LC_ALL=C
 IGNORE_REGEXP="/(leveldb|secp256k1|minisketch|univalue|crc32c)/"
 
 # cd to root folder of git repo for git ls-files to work properly
-cd "$(dirname $0)/../.." || exit 1
+cd "$(dirname "$0")/../.." || exit 1
 
 filter_suffix() {
     git ls-files | grep -E "^src/.*\.${1}"'$' | grep -Ev "${IGNORE_REGEXP}"

--- a/test/lint/lint-python-dead-code.sh
+++ b/test/lint/lint-python-dead-code.sh
@@ -15,9 +15,8 @@ fi
 
 # --min-confidence 100 will only report code that is guaranteed to be unused within the analyzed files.
 # Any value below 100 introduces the risk of false positives, which would create an unacceptable maintenance burden.
-if ! vulture \
-    --min-confidence 100 \
-    $(git ls-files -- "*.py"); then
+mapfile -t FILES < <(git ls-files -- "*.py")
+if ! vulture --min-confidence 100 "${FILES[@]}"; then
     echo "Python dead code detection found some issues"
     exit 1
 fi

--- a/test/lint/lint-python.sh
+++ b/test/lint/lint-python.sh
@@ -92,6 +92,7 @@ fi
 
 EXIT_CODE=0
 
+# shellcheck disable=SC2046
 if ! PYTHONWARNINGS="ignore" flake8 --ignore=B,C,E,F,I,N,W --select=$(IFS=","; echo "${enabled[*]}") $(
     if [[ $# == 0 ]]; then
         git ls-files "*.py"
@@ -102,7 +103,8 @@ if ! PYTHONWARNINGS="ignore" flake8 --ignore=B,C,E,F,I,N,W --select=$(IFS=","; e
     EXIT_CODE=1
 fi
 
-if ! mypy --show-error-codes $(git ls-files "test/functional/*.py" "contrib/devtools/*.py"); then
+mapfile -t FILES < <(git ls-files "test/functional/*.py" "contrib/devtools/*.py")
+if ! mypy --show-error-codes "${FILES[@]}"; then
     EXIT_CODE=1
 fi
 

--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -11,7 +11,6 @@ export LC_ALL=C
 # Disabled warnings:
 disabled=(
     SC2046 # Quote this to prevent word splitting.
-    SC2086 # Double quote to prevent globbing and word splitting.
     SC2162 # read without -r will mangle backslashes.
 )
 
@@ -24,8 +23,9 @@ fi
 
 SHELLCHECK_CMD=(shellcheck --external-sources --check-sourced)
 EXCLUDE="--exclude=$(IFS=','; echo "${disabled[*]}")"
-SOURCED_FILES=$(git ls-files | xargs gawk '/^# shellcheck shell=/ {print FILENAME} {nextfile}')  # Check shellcheck directive used for sourced files
-if ! "${SHELLCHECK_CMD[@]}" "$EXCLUDE" $SOURCED_FILES $(git ls-files -- '*.sh' | grep -vE 'src/(leveldb|secp256k1|minisketch|univalue)/'); then
+# Check shellcheck directive used for sourced files
+mapfile -t SOURCED_FILES < <(git ls-files | xargs gawk '/^# shellcheck shell=/ {print FILENAME} {nextfile}')
+if ! "${SHELLCHECK_CMD[@]}" "$EXCLUDE" "${SOURCED_FILES[@]}" $(git ls-files -- '*.sh' | grep -vE 'src/(leveldb|secp256k1|minisketch|univalue)/'); then
     EXIT_CODE=1
 fi
 

--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -10,7 +10,6 @@ export LC_ALL=C
 
 # Disabled warnings:
 disabled=(
-    SC2046 # Quote this to prevent word splitting.
     SC2162 # read without -r will mangle backslashes.
 )
 
@@ -25,7 +24,8 @@ SHELLCHECK_CMD=(shellcheck --external-sources --check-sourced)
 EXCLUDE="--exclude=$(IFS=','; echo "${disabled[*]}")"
 # Check shellcheck directive used for sourced files
 mapfile -t SOURCED_FILES < <(git ls-files | xargs gawk '/^# shellcheck shell=/ {print FILENAME} {nextfile}')
-if ! "${SHELLCHECK_CMD[@]}" "$EXCLUDE" "${SOURCED_FILES[@]}" $(git ls-files -- '*.sh' | grep -vE 'src/(leveldb|secp256k1|minisketch|univalue)/'); then
+mapfile -t FILES < <(git ls-files -- '*.sh' | grep -vE 'src/(leveldb|secp256k1|minisketch|univalue)/')
+if ! "${SHELLCHECK_CMD[@]}" "$EXCLUDE" "${SOURCED_FILES[@]}" "${FILES[@]}"; then
     EXIT_CODE=1
 fi
 

--- a/test/lint/lint-spelling.sh
+++ b/test/lint/lint-spelling.sh
@@ -15,6 +15,7 @@ if ! command -v codespell > /dev/null; then
 fi
 
 IGNORE_WORDS_FILE=test/lint/lint-spelling.ignore-words.txt
-if ! codespell --check-filenames --disable-colors --quiet-level=7 --ignore-words=${IGNORE_WORDS_FILE} $(git ls-files -- ":(exclude)build-aux/m4/" ":(exclude)contrib/seeds/*.txt" ":(exclude)depends/" ":(exclude)doc/release-notes/" ":(exclude)src/leveldb/" ":(exclude)src/crc32c/" ":(exclude)src/qt/locale/" ":(exclude)src/qt/*.qrc" ":(exclude)src/secp256k1/" ":(exclude)src/minisketch/" ":(exclude)src/univalue/" ":(exclude)contrib/builder-keys/keys.txt" ":(exclude)contrib/guix/patches"); then
+mapfile -t FILES < <(git ls-files -- ":(exclude)build-aux/m4/" ":(exclude)contrib/seeds/*.txt" ":(exclude)depends/" ":(exclude)doc/release-notes/" ":(exclude)src/leveldb/" ":(exclude)src/crc32c/" ":(exclude)src/qt/locale/" ":(exclude)src/qt/*.qrc" ":(exclude)src/secp256k1/" ":(exclude)src/minisketch/" ":(exclude)src/univalue/" ":(exclude)contrib/builder-keys/keys.txt" ":(exclude)contrib/guix/patches")
+if ! codespell --check-filenames --disable-colors --quiet-level=7 --ignore-words=${IGNORE_WORDS_FILE} "${FILES[@]}"; then
     echo "^ Warning: codespell identified likely spelling errors. Any false positives? Add them to the list of ignored words in ${IGNORE_WORDS_FILE}"
 fi


### PR DESCRIPTION
Closes #20879.
Replaces #22695.

**Note for reviewers**. Some touched shell scripts are not being run in CI, therefore they require more thorough reviewing:
- `contrib/devtools/gen-manpages.sh`
- `contrib/macdeploy/detached-sig-apply.sh`
- `contrib/windeploy/detached-sig-create.sh`
- `src/qt/res/animation/makespinner.sh`