### PR TITLE
ci: Increase --timeout-factor in the native Windows CI task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -164,7 +164,7 @@ task:
     - netsh int ipv4 set dynamicport tcp start=1025 num=64511
     - netsh int ipv6 set dynamicport tcp start=1025 num=64511
     # Exclude feature_dbcrash for now due to timeout
-    - python test\functional\test_runner.py --nocleanup --ci --quiet --combinedlogslen=4000 --jobs=4 --timeout-factor=8 --failfast --extended --exclude feature_dbcrash
+    - python test\functional\test_runner.py --nocleanup --ci --quiet --combinedlogslen=4000 --jobs=4 --timeout-factor=12 --failfast --extended --exclude feature_dbcrash
 
 task:
   name: 'ARM [unit tests, no functional tests] [bullseye]'


### PR DESCRIPTION
This PR should mitigate timeouts for `wait_until()` in the `p2p_feefilter.py` functional test.

Such failures are only observable recently, since the native Windows task was improved:
- https://cirrus-ci.com/task/6483187195969536
- https://cirrus-ci.com/task/4572770743877632

The value `12` is just my guess.