### PR TITLE
doc: remove mention of system univalue from build-unix.md

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -45,7 +45,6 @@ Optional dependencies:
  libdb4.8    | Berkeley DB      | Optional, wallet storage (only needed when wallet enabled)
  qt          | GUI              | GUI toolkit (only needed when GUI enabled)
  libqrencode | QR codes in GUI  | Optional for generating QR codes (only needed when GUI enabled)
- univalue    | Utility          | JSON parsing and encoding (bundled version will be used unless --with-system-univalue passed to configure)
  libzmq3     | ZMQ notification | Optional, allows generating ZMQ notifications (requires ZMQ version >= 4.0.0)
  sqlite3     | SQLite DB        | Optional, wallet storage (only needed when wallet enabled)
  systemtap   | Tracing (USDT)   | Optional, statically defined tracepoints


### PR DESCRIPTION
Should have been part of #22646.
