### PR TITLE
doc: Remove Boost build note from build-unix.md

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -234,15 +234,6 @@ Otherwise, you can build Bitcoin Core from self-compiled [depends](/depends/READ
 
 **Note**: You only need Berkeley DB if the wallet is enabled (see [*Disable-wallet mode*](#disable-wallet-mode)).
 
-Boost
------
-If you need to build Boost yourself:
-
-    sudo su
-    ./bootstrap.sh
-    ./bjam install
-
-
 Security
 --------
 To help make your Bitcoin Core installation more secure by making certain attacks impossible to

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -42,12 +42,12 @@ Optional dependencies:
  ------------|------------------|----------------------
  miniupnpc   | UPnP Support     | Firewall-jumping support
  libnatpmp   | NAT-PMP Support  | Firewall-jumping support
- libdb4.8    | Berkeley DB      | Optional, wallet storage (only needed when legacy wallet enabled)
+ libdb4.8    | Berkeley DB      | Wallet storage (only needed when legacy wallet enabled)
  qt          | GUI              | GUI toolkit (only needed when GUI enabled)
- libqrencode | QR codes in GUI  | Optional for generating QR codes (only needed when GUI enabled)
- libzmq3     | ZMQ notification | Optional, allows generating ZMQ notifications (requires ZMQ version >= 4.0.0)
- sqlite3     | SQLite DB        | Optional, wallet storage (only needed when descriptor wallet enabled)
- systemtap   | Tracing (USDT)   | Optional, statically defined tracepoints
+ libqrencode | QR codes in GUI  | QR code generation (only needed when GUI enabled)
+ libzmq3     | ZMQ notification | ZMQ notifications (requires ZMQ version >= 4.0.0)
+ sqlite3     | SQLite DB        | Wallet storage (only needed when descriptor wallet enabled)
+ systemtap   | Tracing (USDT)   | Statically defined tracepoints
 
 For the versions used, see [dependencies.md](dependencies.md)
 


### PR DESCRIPTION
We don't have build instructions for any other dependency, and in any case, this isn't something we should maintain in our docs. If someone wants to know how to build Boost, or any other dependency, they can look at the relevant website / external build documentation.