### PR TITLE
doc: consolidate legacy wallet documentation

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -52,20 +52,19 @@ git clone https://github.com/bitcoin/bitcoin.git
 ### 3. Install Optional Dependencies
 
 #### Wallet Dependencies
-It is not necessary to build wallet functionality to run bitcoind or the GUI. To enable legacy wallets, you must install `db5`. To enable [descriptor wallets](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md), `sqlite3` is required. Skip `db5` if you intend to *exclusively* use descriptor wallets
 
-###### Legacy Wallet Support
-`db5` is required to enable support for legacy wallets. Skip if you don't intend to use legacy wallets
+###### Wallet
+
+`sqlite3` is used for ([descriptor based](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md)) wallets.
+``` bash
+pkg install sqlite3
+```
+
+###### Legacy Wallet
+`db5` is required to enable support for legacy wallets.
 
 ```bash
 pkg install db5
-```
-
-###### Descriptor Wallet Support
-
-`sqlite3` is required to enable support for descriptor wallets. Skip if you don't intend to use descriptor wallets.
-``` bash
-pkg install sqlite3
 ```
 ---
 
@@ -98,8 +97,8 @@ pkg install python3
 ### 1. Configuration
 
 There are many ways to configure Bitcoin Core, here are a few common examples:
-##### Wallet (BDB + SQlite) Support, No GUI:
-This explicitly enables legacy wallet support and disables the GUI. If `sqlite3` is installed, then descriptor wallet support will be built.
+##### Wallet & Legacy Wallet Support, No GUI:
+This explicitly enables legacy wallet support and disables the GUI. If `sqlite3` is installed, then wallet support will also be built.
 ```bash
 ./autogen.sh
 ./configure --with-gui=no --with-incompatible-bdb \
@@ -108,8 +107,8 @@ This explicitly enables legacy wallet support and disables the GUI. If `sqlite3`
     MAKE=gmake
 ```
 
-##### Wallet (only SQlite) and GUI Support:
-This explicitly enables the GUI and disables legacy wallet support. If `qt5` is not installed, this will throw an error. If `sqlite3` is installed then descriptor wallet functionality will be built. If `sqlite3` is not installed, then wallet functionality will be disabled.
+##### Wallet and GUI Support:
+This explicitly enables the GUI and disables legacy wallet support. If `qt5` is not installed, this will throw an error. If `sqlite3` is installed then wallet functionality will be built. If `sqlite3` is not installed, then wallet functionality will be disabled.
 ```bash
 ./autogen.sh
 ./configure --without-bdb --with-gui=yes MAKE=gmake

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -21,16 +21,16 @@ libevent
 libtool
 pkg-config
 python37
+sqlite3
 
 git clone https://github.com/bitcoin/bitcoin.git
 ```
 
 See [dependencies.md](dependencies.md) for a complete overview.
 
-### Building BerkeleyDB
+### Building Berkeley DB
 
-BerkeleyDB is only necessary for the wallet functionality. To skip this, pass
-`--disable-wallet` to `./configure` and skip to the next section.
+Berkeley DB is only necessary for legacy wallet functionality.
 
 It is recommended to use Berkeley DB 4.8. You cannot use the BerkeleyDB library
 from ports, for the same reason as boost above (g++/libstd++ incompatibility).
@@ -54,16 +54,15 @@ export BDB_PREFIX="$PWD/db4"
 With wallet:
 ```bash
 ./autogen.sh
-./configure --with-gui=no CPPFLAGS="-I/usr/pkg/include" \
+./configure --with-gui=no \
+    CPPFLAGS="-I/usr/pkg/include" \
     LDFLAGS="-L/usr/pkg/lib" \
     BOOST_CPPFLAGS="-I/usr/pkg/include" \
     BOOST_LDFLAGS="-L/usr/pkg/lib" \
-    BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
-    BDB_CFLAGS="-I${BDB_PREFIX}/include" \
     MAKE=gmake
 ```
 
-Without wallet:
+With legacy wallet:
 ```bash
 ./autogen.sh
 ./configure --with-gui=no --disable-wallet \
@@ -71,6 +70,8 @@ Without wallet:
     LDFLAGS="-L/usr/pkg/lib" \
     BOOST_CPPFLAGS="-I/usr/pkg/include" \
     BOOST_LDFLAGS="-L/usr/pkg/lib" \
+    BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
+    BDB_CFLAGS="-I${BDB_PREFIX}/include" \
     MAKE=gmake
 ```
 

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -30,8 +30,7 @@ compilers within the same executable will result in errors.
 
 ### Building BerkeleyDB
 
-BerkeleyDB is only necessary for the wallet functionality. To skip this, pass
-`--disable-wallet` to `./configure` and skip to the next section.
+BerkeleyDB is only necessary for legacy wallet functionality.
 
 It is recommended to use Berkeley DB 4.8. You cannot use the BerkeleyDB library
 from ports, for the same reason as boost above (g++/libstd++ incompatibility).
@@ -77,22 +76,21 @@ and preprocessor defines like `waitid()` and `WEXITED` that are not available.)
 To configure with wallet:
 ```bash
 ./configure --with-gui=no --disable-external-signer CC=cc CXX=c++ \
+    MAKE=gmake
+```
+
+To configure with legacy wallet:
+```bash
+./configure --with-gui=no --disable-external-signer CC=cc CXX=c++ \
     BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
     BDB_CFLAGS="-I${BDB_PREFIX}/include" \
     MAKE=gmake
 ```
 
-To configure without wallet:
+To configure without wallet or gui:
 ```bash
-./configure --disable-wallet --with-gui=no --disable-external-signer CC=cc CC_FOR_BUILD=cc CXX=c++ MAKE=gmake
-```
-
-To configure with GUI:
-```bash
-./configure --with-gui=yes --disable-external-signer CC=cc CXX=c++ \
-    BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
-    BDB_CFLAGS="-I${BDB_PREFIX}/include" \
-    MAKE=gmake
+./configure --disable-wallet --with-gui=no --disable-external-signer \
+    CC=cc CC_FOR_BUILD=cc CXX=c++ MAKE=gmake
 ```
 
 Build and run the tests:

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -99,30 +99,22 @@ git clone https://github.com/bitcoin/bitcoin.git
 
 #### Wallet Dependencies
 
-It is not necessary to build wallet functionality to run `bitcoind` or  `bitcoin-qt`.
-To enable legacy wallets, you must install `berkeley-db@4`.
-To enable [descriptor wallets](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md), `sqlite` is required.
-Skip `berkeley-db@4` if you intend to *exclusively* use descriptor wallets.
+###### Wallet
 
-###### Legacy Wallet Support
-
-`berkeley-db@4` is required to enable support for legacy wallets.
-Skip if you don't intend to use legacy wallets.
-
-``` bash
-brew install berkeley-db@4
-```
-
-###### Descriptor Wallet Support
-
-Note: Apple has included a useable `sqlite` package since macOS 10.14.
-You may not need to install this package.
-
-`sqlite` is required to enable support for descriptor wallets.
-Skip if you don't intend to use descriptor wallets.
+`sqlite` is required for the wallet ([descriptor based](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md)).
 
 ``` bash
 brew install sqlite
+```
+
+Note: macOS ships with a version of `sqlite`. You may not need to install it.
+
+###### Legacy Wallet
+
+`berkeley-db@4` is only required to enable support for legacy wallets.
+
+``` bash
+brew install berkeley-db@4
 ```
 ---
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -84,7 +84,7 @@ Now, you can either build from self-compiled [depends](/depends/README.md) or in
 
     sudo apt-get install libevent-dev libboost-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev
 
-SQLite is required for the descriptor wallet:
+SQLite is required for the wallet:
 
     sudo apt install libsqlite3-dev
 
@@ -141,7 +141,7 @@ Now, you can either build from self-compiled [depends](/depends/README.md) or in
 
     sudo dnf install libevent-devel boost-devel
 
-SQLite is required for the descriptor wallet:
+SQLite is required for the wallet:
 
     sudo dnf install sqlite-devel
 
@@ -232,7 +232,7 @@ from the root of the repository.
 
 Otherwise, you can build Bitcoin Core from self-compiled [depends](/depends/README.md).
 
-**Note**: You only need Berkeley DB if the wallet is enabled (see [*Disable-wallet mode*](#disable-wallet-mode)).
+**Note**: You only need Berkeley DB if you want to use the legacy wallet.
 
 Security
 --------
@@ -287,7 +287,7 @@ disable-wallet mode with:
 
     ./configure --disable-wallet
 
-In this case there is no dependency on Berkeley DB 4.8 and SQLite.
+In this case there is no dependency on SQLite or Berkeley DB 4.8.
 
 Mining is also possible in disable-wallet mode using the `getblocktemplate` RPC call.
 


### PR DESCRIPTION
Tries to cleanup the wallet build / install documentation. Similar to #23446. 
Always mention how to build for the wallet (sqlite) first, then legacy wallets (bdb).

Where possible, just use "wallet", rather than "descriptor wallet". Non-technical
or causal users don't care about whether the wallet is a descriptor wallet or not,
or what it's backed by they just want to build (and or download) and use Bitcoin Core, 
create a wallet, and accept a payment. Using "descriptor wallet" could also imply 
that there is some other not legacy but also not a descriptor wallet alternative,
which there is not.

Using 2 terms (wallet and legacy wallet), rather than 5 terms (wallet, 
legacy wallet, bdb wallet, sqlite wallet, descriptor wallet) for the same two things
is also much less confusing.

Note that most builders now likely have to do nothing to get "wallet support" as
there's a decent probability they will already have sqlite installed on their system,
and configure no-longer fails if BDB isn't present and `--disable-wallet` hasn't been passed.