### PR TITLE
ci, qa: Adjust timeouts per test instead of global `--timeout-factor`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -164,7 +164,7 @@ task:
     - netsh int ipv4 set dynamicport tcp start=1025 num=64511
     - netsh int ipv6 set dynamicport tcp start=1025 num=64511
     # Exclude feature_dbcrash for now due to timeout
-    - python test\functional\test_runner.py --nocleanup --ci --quiet --combinedlogslen=4000 --jobs=4 --timeout-factor=8 --failfast --extended --exclude feature_dbcrash
+    - python test\functional\test_runner.py --nocleanup --ci --quiet --combinedlogslen=4000 --jobs=4 --failfast --extended --exclude feature_dbcrash
 
 task:
   name: 'ARM [unit tests, no functional tests] [bullseye]'

--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -41,7 +41,7 @@ export RUN_SECURITY_TESTS=${RUN_SECURITY_TESTS:-false}
 # By how much to scale the test_runner timeouts (option --timeout-factor).
 # This is needed because some ci machines have slow CPU or disk, so sanitizers
 # might be slow or a reindex might be waiting on disk IO.
-export TEST_RUNNER_TIMEOUT_FACTOR=${TEST_RUNNER_TIMEOUT_FACTOR:-40}
+export TEST_RUNNER_TIMEOUT_FACTOR=${TEST_RUNNER_TIMEOUT_FACTOR:-1}
 export TEST_RUNNER_ENV=${TEST_RUNNER_ENV:-}
 export RUN_FUZZ_TESTS=${RUN_FUZZ_TESTS:-false}
 export EXPECTED_TESTS_DURATION_IN_SECONDS=${EXPECTED_TESTS_DURATION_IN_SECONDS:-1000}

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -94,7 +94,7 @@ class PruneTest(BitcoinTestFramework):
             ["-maxreceivebuffer=20000"],
             ["-prune=550"],
         ]
-        self.rpc_timeout = 120
+        self.rpc_timeout = 480
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -722,7 +722,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         node.submitblock(block.serialize().hex())
 
         for l in listeners:
-            l.wait_until(lambda: "cmpctblock" in l.last_message, timeout=30)
+            l.wait_until(lambda: "cmpctblock" in l.last_message)
         with p2p_lock:
             for l in listeners:
                 l.last_message["cmpctblock"].header_and_shortids.header.calc_sha256()

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -84,7 +84,7 @@ class RpcMiscTest(BitcoinTestFramework):
 
         # Restart the node with indices and wait for them to sync
         self.restart_node(0, ["-txindex", "-blockfilterindex", "-coinstatsindex"])
-        self.wait_until(lambda: all(i["synced"] for i in node.getindexinfo().values()))
+        self.wait_until(lambda: all(i["synced"] for i in node.getindexinfo().values()), timeout=120)
 
         # Returns a list of all running indices by default
         values = {"synced": True, "best_block_height": 200}


### PR DESCRIPTION
A timeout failure in a functional test could point at a flaw in the test itself, e.g., https://github.com/bitcoin/bitcoin/pull/23463#issuecomment-963046108).

Therefore, setting `--timeout-factor` globally can just hide such flaws.

This PR drops non-default `--timeout-factor` in CI, and adjusts timeouts in three tests only.