### PR TITLE
build: Add support for Android NDK r23 LTS

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -41,7 +41,7 @@ Common `host-platform-triplet`s for cross compilation are:
 - `i686-linux-android` for Android x86 32 bit
 - `x86_64-linux-android` for Android x86 64 bit
 
-The paths are automatically configured and no other options are needed unless targeting [Android](#Android).
+The paths are automatically configured and no other options are needed unless targeting [Android](../doc/build-android.md).
 
 ### Install the required dependencies: Ubuntu & Debian
 
@@ -132,18 +132,6 @@ options will be passed to bitcoin's configure. In this case, `--disable-wallet`.
     download-win: run 'make download-win' to fetch all sources needed for win builds
     download-linux: run 'make download-linux' to fetch all sources needed for linux builds
 
-
-### Android
-
-Before proceeding with an Android build one needs to get the [Android SDK](https://developer.android.com/studio) and use the "SDK Manager" tool to download the NDK and one or more "Platform packages" (these are Android versions and have a corresponding API level).
-In order to build `ANDROID_API_LEVEL` (API level corresponding to the Android version targeted, e.g. Android 9.0 Pie is 28 and its "Platform package" needs to be available) and `ANDROID_TOOLCHAIN_BIN` (path to toolchain binaries depending on the platform the build is being performed on) need to be set.
-
-API levels from 24 to 29 have been tested to work.
-
-If the build includes Qt, environment variables `ANDROID_SDK` and `ANDROID_NDK` need to be set as well but can otherwise be omitted.
-This is an example command for a default build with no disabled dependencies:
-
-    ANDROID_SDK=/home/user/Android/Sdk ANDROID_NDK=/home/user/Android/Sdk/ndk-bundle make HOST=aarch64-linux-android ANDROID_API_LEVEL=28 ANDROID_TOOLCHAIN_BIN=/home/user/Android/Sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin
 
 ### Other documentation
 

--- a/depends/hosts/android.mk
+++ b/depends/hosts/android.mk
@@ -1,12 +1,11 @@
 ifeq ($(HOST),armv7a-linux-android)
-android_AR=$(ANDROID_TOOLCHAIN_BIN)/arm-linux-androideabi-ar
 android_CXX=$(ANDROID_TOOLCHAIN_BIN)/$(HOST)eabi$(ANDROID_API_LEVEL)-clang++
 android_CC=$(ANDROID_TOOLCHAIN_BIN)/$(HOST)eabi$(ANDROID_API_LEVEL)-clang
-android_RANLIB=$(ANDROID_TOOLCHAIN_BIN)/arm-linux-androideabi-ranlib
 else
-android_AR=$(ANDROID_TOOLCHAIN_BIN)/$(HOST)-ar
 android_CXX=$(ANDROID_TOOLCHAIN_BIN)/$(HOST)$(ANDROID_API_LEVEL)-clang++
 android_CC=$(ANDROID_TOOLCHAIN_BIN)/$(HOST)$(ANDROID_API_LEVEL)-clang
-android_RANLIB=$(ANDROID_TOOLCHAIN_BIN)/$(HOST)-ranlib
 endif
+android_AR=$(ANDROID_TOOLCHAIN_BIN)/llvm-ar
+android_RANLIB=$(ANDROID_TOOLCHAIN_BIN)/llvm-ranlib
+
 android_cmake_system=Android

--- a/doc/build-android.md
+++ b/doc/build-android.md
@@ -3,9 +3,19 @@ ANDROID BUILD NOTES
 
 This guide describes how to build and package the `bitcoin-qt` GUI for Android on Linux and macOS.
 
-## Preparation
 
-You will need to get the Android NDK and build dependencies for Android as described in [depends/README.md](../depends/README.md).
+## Dependencies
+
+Before proceeding with an Android build one needs to get the [Android SDK](https://developer.android.com/studio) and use the "SDK Manager" tool to download the NDK and one or more "Platform packages" (these are Android versions and have a corresponding API level).
+In order to build `ANDROID_API_LEVEL` (API level corresponding to the Android version targeted, e.g. Android 9.0 Pie is 28 and its "Platform package" needs to be available) and `ANDROID_TOOLCHAIN_BIN` (path to toolchain binaries depending on the platform the build is being performed on) need to be set.
+
+API levels from 24 to 29 have been tested to work.
+
+If the build includes Qt, environment variables `ANDROID_SDK` and `ANDROID_NDK` need to be set as well but can otherwise be omitted.
+This is an example command for a default build with no disabled dependencies:
+
+    ANDROID_SDK=/home/user/Android/Sdk ANDROID_NDK=/home/user/Android/Sdk/ndk-bundle make HOST=aarch64-linux-android ANDROID_API_LEVEL=28 ANDROID_TOOLCHAIN_BIN=/home/user/Android/Sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin
+
 
 ## Building and packaging
 

--- a/doc/build-android.md
+++ b/doc/build-android.md
@@ -7,6 +7,9 @@ This guide describes how to build and package the `bitcoin-qt` GUI for Android o
 ## Dependencies
 
 Before proceeding with an Android build one needs to get the [Android SDK](https://developer.android.com/studio) and use the "SDK Manager" tool to download the NDK and one or more "Platform packages" (these are Android versions and have a corresponding API level).
+
+The minimum supported Android NDK version is [r21](https://github.com/android/ndk/wiki/Changelog-r21).
+
 In order to build `ANDROID_API_LEVEL` (API level corresponding to the Android version targeted, e.g. Android 9.0 Pie is 28 and its "Platform package" needs to be available) and `ANDROID_TOOLCHAIN_BIN` (path to toolchain binaries depending on the platform the build is being performed on) need to be set.
 
 API levels from 24 to 29 have been tested to work.


### PR DESCRIPTION
The new Long Term Support release of the Android NDK is [available](https://groups.google.com/g/android-ndk-announce/c/MS6Qoub0DKE/m/Zfp5Ys8eAAAJ) since 2021-08-11:

> As r23 is the new LTS, the support windows for r21 and r22 have now ended.

On master (8ae4ba481ce8f7da173bef24432729c87a36cb70), dependency build fails because it expects GNU Binutils are present in the Android NDK. In [fact](https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#binutils):
> GNU Binutils remains available up to and including r22. All binutils tools with the exception of the assembler (GAS) were removed in r23. GAS was removed in r24.

This PR switches our depends build system to llvm binutils. The usage of `llvm-ar` and `llvm-ranlib` tools effectively makes r21 the minimum supported version of NDK.

With this PR:
- building depends against NDK r23 LTS now is possible with `NO_QT=1`
- building the `qt` package in depends against NDK r23 LTS still fails:
```
Creating qmake...
...

ERROR: Cannot detect Android NDK toolchain.
Please use -android-toolchain-version to specify it.
```

The issue with the `qt` package is going to be addressed in another PR.