### PR TITLE
scripted-diff: Move minisketchwrapper to src/node

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -167,7 +167,7 @@ BITCOIN_CORE_H = \
   memusage.h \
   merkleblock.h \
   miner.h \
-  minisketchwrapper.h \
+  node/minisketchwrapper.h \
   net.h \
   net_permissions.h \
   net_processing.h \
@@ -335,7 +335,7 @@ libbitcoin_server_a_SOURCES = \
   init.cpp \
   mapport.cpp \
   miner.cpp \
-  minisketchwrapper.cpp \
+  node/minisketchwrapper.cpp \
   net.cpp \
   net_processing.cpp \
   node/blockstorage.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -167,7 +167,6 @@ BITCOIN_CORE_H = \
   memusage.h \
   merkleblock.h \
   miner.h \
-  node/minisketchwrapper.h \
   net.h \
   net_permissions.h \
   net_processing.h \
@@ -179,6 +178,7 @@ BITCOIN_CORE_H = \
   node/coin.h \
   node/coinstats.h \
   node/context.h \
+  node/minisketchwrapper.h \
   node/psbt.h \
   node/transaction.h \
   node/ui_interface.h \
@@ -335,7 +335,6 @@ libbitcoin_server_a_SOURCES = \
   init.cpp \
   mapport.cpp \
   miner.cpp \
-  node/minisketchwrapper.cpp \
   net.cpp \
   net_processing.cpp \
   node/blockstorage.cpp \
@@ -343,6 +342,7 @@ libbitcoin_server_a_SOURCES = \
   node/coinstats.cpp \
   node/context.cpp \
   node/interfaces.cpp \
+  node/minisketchwrapper.cpp \
   node/psbt.cpp \
   node/transaction.cpp \
   node/ui_interface.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -63,11 +63,10 @@ endif
 
 # test_bitcoin binary #
 BITCOIN_TESTS =\
-  test/arith_uint256_tests.cpp \
-  test/scriptnum10.h \
   test/addrman_tests.cpp \
-  test/amount_tests.cpp \
   test/allocator_tests.cpp \
+  test/amount_tests.cpp \
+  test/arith_uint256_tests.cpp \
   test/base32_tests.cpp \
   test/base58_tests.cpp \
   test/base64_tests.cpp \
@@ -75,8 +74,8 @@ BITCOIN_TESTS =\
   test/bip32_tests.cpp \
   test/blockchain_tests.cpp \
   test/blockencodings_tests.cpp \
-  test/blockfilter_tests.cpp \
   test/blockfilter_index_tests.cpp \
+  test/blockfilter_tests.cpp \
   test/bloom_tests.cpp \
   test/bswap_tests.cpp \
   test/checkqueue_tests.cpp \
@@ -86,6 +85,7 @@ BITCOIN_TESTS =\
   test/compress_tests.cpp \
   test/crypto_tests.cpp \
   test/cuckoocache_tests.cpp \
+  test/dbwrapper_tests.cpp \
   test/denialofservice_tests.cpp \
   test/descriptor_tests.cpp \
   test/flatfile_tests.cpp \
@@ -97,13 +97,11 @@ BITCOIN_TESTS =\
   test/key_io_tests.cpp \
   test/key_tests.cpp \
   test/logging_tests.cpp \
-  test/dbwrapper_tests.cpp \
-  test/validation_tests.cpp \
   test/mempool_tests.cpp \
   test/merkle_tests.cpp \
   test/merkleblock_tests.cpp \
-  test/minisketch_tests.cpp \
   test/miner_tests.cpp \
+  test/minisketch_tests.cpp \
   test/multisig_tests.cpp \
   test/net_peer_eviction_tests.cpp \
   test/net_tests.cpp \
@@ -123,6 +121,7 @@ BITCOIN_TESTS =\
   test/script_parse_tests.cpp \
   test/script_standard_tests.cpp \
   test/script_tests.cpp \
+  test/scriptnum10.h \
   test/scriptnum_tests.cpp \
   test/serfloat_tests.cpp \
   test/serialize_tests.cpp \
@@ -134,21 +133,22 @@ BITCOIN_TESTS =\
   test/streams_tests.cpp \
   test/sync_tests.cpp \
   test/system_tests.cpp \
-  test/util_threadnames_tests.cpp \
   test/timedata_tests.cpp \
   test/torcontrol_tests.cpp \
   test/transaction_tests.cpp \
   test/txindex_tests.cpp \
-  test/txrequest_tests.cpp \
   test/txpackage_tests.cpp \
+  test/txrequest_tests.cpp \
   test/txvalidation_tests.cpp \
   test/txvalidationcache_tests.cpp \
   test/uint256_tests.cpp \
   test/util_tests.cpp \
+  test/util_threadnames_tests.cpp \
   test/validation_block_tests.cpp \
   test/validation_chainstate_tests.cpp \
   test/validation_chainstatemanager_tests.cpp \
   test/validation_flush_tests.cpp \
+  test/validation_tests.cpp \
   test/validationinterface_tests.cpp \
   test/versionbits_tests.cpp
 

--- a/src/node/minisketchwrapper.cpp
+++ b/src/node/minisketchwrapper.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <minisketchwrapper.h>
+#include <node/minisketchwrapper.h>
 
 #include <logging.h>
 #include <util/time.h>

--- a/src/node/minisketchwrapper.h
+++ b/src/node/minisketchwrapper.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_MINISKETCHWRAPPER_H
-#define BITCOIN_MINISKETCHWRAPPER_H
+#ifndef BITCOIN_NODE_MINISKETCHWRAPPER_H
+#define BITCOIN_NODE_MINISKETCHWRAPPER_H
 
 #include <minisketch.h>
 #include <cstddef>
@@ -14,4 +14,4 @@ Minisketch MakeMinisketch32(size_t capacity);
 /** Wrapper around Minisketch::CreateFP. */
 Minisketch MakeMinisketch32FP(size_t max_elements, uint32_t fpbits);
 
-#endif // BITCOIN_DBWRAPPER_H
+#endif // BITCOIN_NODE_MINISKETCHWRAPPER_H

--- a/src/node/minisketchwrapper.h
+++ b/src/node/minisketchwrapper.h
@@ -6,6 +6,7 @@
 #define BITCOIN_NODE_MINISKETCHWRAPPER_H
 
 #include <minisketch.h>
+
 #include <cstddef>
 #include <cstdint>
 

--- a/src/test/minisketch_tests.cpp
+++ b/src/test/minisketch_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <minisketch.h>
-#include <minisketchwrapper.h>
+#include <node/minisketchwrapper.h>
 #include <random.h>
 #include <test/util/setup_common.h>
 


### PR DESCRIPTION
The newly added wrapper is currently in the node library, but not placed in the node directory. While it is possible to use the wrapper outside of a node context (for example in a utility), it seems unlikely. Either way, I think the wrapper should either be moved to the util lib+dir or the node lib+dir, not something in-between.

Also, fix incorrect comment `BITCOIN_DBWRAPPER_H`.