### PR TITLE
Use c++17 in clang-format

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -34,14 +34,6 @@ IndentWidth:     4
 KeepEmptyLinesAtTheStartOfBlocks: false
 MaxEmptyLinesToKeep: 2
 NamespaceIndentation: None
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: false
-PenaltyBreakBeforeFirstCallParameter: 1
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 1000
-PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
@@ -51,6 +43,5 @@ SpacesInAngles:  false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
-Standard:        Cpp11
-TabWidth:        8
+Standard:        c++17
 UseTab:          Never


### PR DESCRIPTION
We currently use `Cpp11`, which "is a deprecated alias for `Latest`" according to https://clang.llvm.org/docs/ClangFormatStyleOptions.html . I doubt this has any effect, but I think for clarity setting to `c++17` make sense.

Also, remove unneeded settings:

* `ObjC*`, as we don't write objc code
* `Penalty`, as there is currently no line limit, so this has no effect
* `TabWidth`, as we don't use tabs