### PR TITLE
Add `src/node/` and `src/wallet/` code to `node::` and `wallet::` namespaces

### DIFF
--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -11,6 +11,8 @@
 
 #include <set>
 
+using node::NodeContext;
+
 static void addCoin(const CAmount& nValue, const CWallet& wallet, std::vector<std::unique_ptr<CWalletTx>>& wtxs)
 {
     static int nextLockTime = 0;

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -12,6 +12,17 @@
 #include <set>
 
 using node::NodeContext;
+using wallet::AttemptSelection;
+using wallet::CInputCoin;
+using wallet::COutput;
+using wallet::CWallet;
+using wallet::CWalletTx;
+using wallet::CoinEligibilityFilter;
+using wallet::CoinSelectionParams;
+using wallet::CreateDummyWalletDatabase;
+using wallet::OutputGroup;
+using wallet::SelectCoinsBnB;
+using wallet::TxStateInactive;
 
 static void addCoin(const CAmount& nValue, const CWallet& wallet, std::vector<std::unique_ptr<CWalletTx>>& wtxs)
 {

--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -14,6 +14,12 @@
 
 #include <optional>
 
+using wallet::CWallet;
+using wallet::CreateMockWalletDatabase;
+using wallet::DBErrors;
+using wallet::GetBalance;
+using wallet::WALLET_FLAG_DESCRIPTORS;
+
 static void WalletBalance(benchmark::Bench& bench, const bool set_dirty, const bool add_mine)
 {
     const auto test_setup = MakeNoLogFileContext<const TestingSetup>();

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -123,7 +123,7 @@ int main(int argc, char* argv[])
 
     ECCVerifyHandle globalVerifyHandle;
     ECC_Start();
-    if (!WalletTool::ExecuteWalletToolFunc(args, command->command)) {
+    if (!wallet::WalletTool::ExecuteWalletToolFunc(args, command->command)) {
         return EXIT_FAILURE;
     }
     ECC_Stop();

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -30,6 +30,8 @@
 #include <functional>
 #include <optional>
 
+using node::NodeContext;
+
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 UrlDecodeFn* const URL_DECODE = urlDecode;
 

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -4,6 +4,12 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chain.h>
+#include <util/time.h>
+
+std::string CBlockFileInfo::ToString() const
+{
+    return strprintf("CBlockFileInfo(blocks=%u, size=%u, heights=%u...%u, time=%s...%s)", nBlocks, nSize, nHeightFirst, nHeightLast, FormatISO8601Date(nTimeFirst), FormatISO8601Date(nTimeLast));
+}
 
 void CChain::SetTip(CBlockIndex *pindex) {
     if (pindex == nullptr) {

--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -21,7 +21,7 @@ public:
     bool HasWalletSupport() const override {return false;}
     void AddWalletOptions(ArgsManager& argsman) const override;
     bool ParameterInteraction() const override {return true;}
-    void Construct(NodeContext& node) const override {LogPrintf("No wallet support compiled in!\n");}
+    void Construct(node::NodeContext& node) const override {LogPrintf("No wallet support compiled in!\n");}
 };
 
 void DummyWalletInit::AddWalletOptions(ArgsManager& argsman) const

--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -6,7 +6,6 @@
 #include <walletinitinterface.h>
 
 class ArgsManager;
-class CWallet;
 
 namespace interfaces {
 class Chain;
@@ -58,11 +57,6 @@ void DummyWalletInit::AddWalletOptions(ArgsManager& argsman) const
 const WalletInitInterface& g_wallet_init_interface = DummyWalletInit();
 
 namespace interfaces {
-
-std::unique_ptr<Wallet> MakeWallet(const std::shared_ptr<CWallet>& wallet)
-{
-    throw std::logic_error("Wallet function called in non-wallet build.");
-}
 
 std::unique_ptr<WalletLoader> MakeWalletLoader(Chain& chain, ArgsManager& args)
 {

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -14,6 +14,8 @@
 #include <validation.h> // For g_chainman
 #include <warnings.h>
 
+using node::ReadBlockFromDisk;
+
 constexpr uint8_t DB_BEST_BLOCK{'B'};
 
 constexpr int64_t SYNC_LOG_INTERVAL = 30; // seconds

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -9,6 +9,8 @@
 #include <node/blockstorage.h>
 #include <util/system.h>
 
+using node::UndoReadFromDisk;
+
 /* The index database stores three items for each block: the disk location of the encoded filter,
  * its dSHA256 hash, and the header. Those belonging to blocks on the active chain are indexed by
  * height, and those belonging to blocks that have been reorganized out of the active chain are

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -12,6 +12,12 @@
 #include <undo.h>
 #include <validation.h>
 
+using node::CCoinsStats;
+using node::GetBogoSize;
+using node::ReadBlockFromDisk;
+using node::TxOutSer;
+using node::UndoReadFromDisk;
+
 static constexpr uint8_t DB_BLOCK_HASH{'s'};
 static constexpr uint8_t DB_BLOCK_HEIGHT{'t'};
 static constexpr uint8_t DB_MUHASH{'M'};

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -52,7 +52,7 @@ public:
     explicit CoinStatsIndex(size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
     // Look up stats for a specific block using CBlockIndex
-    bool LookUpStats(const CBlockIndex* block_index, CCoinsStats& coins_stats) const;
+    bool LookUpStats(const CBlockIndex* block_index, node::CCoinsStats& coins_stats) const;
 };
 
 /// The global UTXO set hash object.

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -9,6 +9,8 @@
 #include <util/system.h>
 #include <validation.h>
 
+using node::OpenBlockFile;
+
 constexpr uint8_t DB_TXINDEX{'t'};
 
 std::unique_ptr<TxIndex> g_txindex;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -95,6 +95,22 @@
 #include <zmq/zmqrpc.h>
 #endif
 
+using node::CacheSizes;
+using node::CalculateCacheSizes;
+using node::ChainstateLoadVerifyError;
+using node::ChainstateLoadingError;
+using node::CleanupBlockRevFiles;
+using node::DEFAULT_PRINTPRIORITY;
+using node::DEFAULT_STOPAFTERBLOCKIMPORT;
+using node::LoadChainstate;
+using node::NodeContext;
+using node::ThreadImport;
+using node::VerifyLoadedChainstate;
+using node::fHavePruned;
+using node::fPruneMode;
+using node::fReindex;
+using node::nPruneTarget;
+
 static const bool DEFAULT_PROXYRANDOMIZE = true;
 static const bool DEFAULT_REST_ENABLE = false;
 

--- a/src/init.h
+++ b/src/init.h
@@ -16,14 +16,16 @@ static constexpr bool DEFAULT_DAEMON = false;
 static constexpr bool DEFAULT_DAEMONWAIT = false;
 
 class ArgsManager;
-struct NodeContext;
 namespace interfaces {
 struct BlockAndHeaderTipInfo;
 }
+namespace node {
+struct NodeContext;
+} // namespace node
 
 /** Interrupt threads */
-void Interrupt(NodeContext& node);
-void Shutdown(NodeContext& node);
+void Interrupt(node::NodeContext& node);
+void Shutdown(node::NodeContext& node);
 //!Initialize the logging infrastructure
 void InitLogging(const ArgsManager& args);
 //!Parameter interaction: change current parameters depending on various rules
@@ -55,13 +57,13 @@ bool AppInitLockDataDirectory();
 /**
  * Initialize node and wallet interface pointers. Has no prerequisites or side effects besides allocating memory.
  */
-bool AppInitInterfaces(NodeContext& node);
+bool AppInitInterfaces(node::NodeContext& node);
 /**
  * Bitcoin core main initialization.
  * @note This should only be done after daemonization. Call Shutdown() if this function fails.
  * @pre Parameters should be parsed and config file should be read, AppInitLockDataDirectory should have been called.
  */
-bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info = nullptr);
+bool AppInitMain(node::NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info = nullptr);
 
 /**
  * Register all arguments with the ArgsManager

--- a/src/init/bitcoin-gui.cpp
+++ b/src/init/bitcoin-gui.cpp
@@ -33,7 +33,7 @@ public:
     }
     std::unique_ptr<interfaces::Echo> makeEcho() override { return interfaces::MakeEcho(); }
     interfaces::Ipc* ipc() override { return m_ipc.get(); }
-    NodeContext m_node;
+    node::NodeContext m_node;
     std::unique_ptr<interfaces::Ipc> m_ipc;
 };
 } // namespace

--- a/src/init/bitcoin-node.cpp
+++ b/src/init/bitcoin-node.cpp
@@ -20,7 +20,7 @@ const char* EXE_NAME = "bitcoin-node";
 class BitcoinNodeInit : public interfaces::Init
 {
 public:
-    BitcoinNodeInit(NodeContext& node, const char* arg0)
+    BitcoinNodeInit(node::NodeContext& node, const char* arg0)
         : m_node(node),
           m_ipc(interfaces::MakeIpc(EXE_NAME, arg0, *this))
     {
@@ -35,14 +35,14 @@ public:
     }
     std::unique_ptr<interfaces::Echo> makeEcho() override { return interfaces::MakeEcho(); }
     interfaces::Ipc* ipc() override { return m_ipc.get(); }
-    NodeContext& m_node;
+    node::NodeContext& m_node;
     std::unique_ptr<interfaces::Ipc> m_ipc;
 };
 } // namespace
 } // namespace init
 
 namespace interfaces {
-std::unique_ptr<Init> MakeNodeInit(NodeContext& node, int argc, char* argv[], int& exit_status)
+std::unique_ptr<Init> MakeNodeInit(node::NodeContext& node, int argc, char* argv[], int& exit_status)
 {
     auto init = std::make_unique<init::BitcoinNodeInit>(node, argc > 0 ? argv[0] : "");
     // Check if bitcoin-node is being invoked as an IPC server. If so, then

--- a/src/init/bitcoin-qt.cpp
+++ b/src/init/bitcoin-qt.cpp
@@ -29,7 +29,7 @@ public:
         return MakeWalletLoader(chain, *Assert(m_node.args));
     }
     std::unique_ptr<interfaces::Echo> makeEcho() override { return interfaces::MakeEcho(); }
-    NodeContext m_node;
+    node::NodeContext m_node;
 };
 } // namespace
 } // namespace init

--- a/src/init/bitcoind.cpp
+++ b/src/init/bitcoind.cpp
@@ -12,6 +12,8 @@
 
 #include <memory>
 
+using node::NodeContext;
+
 namespace init {
 namespace {
 class BitcoindInit : public interfaces::Init

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -28,7 +28,9 @@ enum class RBFTransactionState;
 struct bilingual_str;
 struct CBlockLocator;
 struct FeeCalculation;
+namespace node {
 struct NodeContext;
+} // namespace node
 
 namespace interfaces {
 
@@ -316,7 +318,7 @@ public:
 };
 
 //! Return implementation of Chain interface.
-std::unique_ptr<Chain> MakeChain(NodeContext& node);
+std::unique_ptr<Chain> MakeChain(node::NodeContext& node);
 
 } // namespace interfaces
 

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -7,7 +7,9 @@
 
 #include <memory>
 
+namespace node {
 struct NodeContext;
+} // namespace node
 
 namespace interfaces {
 class Chain;
@@ -40,7 +42,7 @@ public:
 //! status code to exit with. If this returns non-null, the caller can start up
 //! normally and use the Init object to spawn and connect to other processes
 //! while it is running.
-std::unique_ptr<Init> MakeNodeInit(NodeContext& node, int argc, char* argv[], int& exit_status);
+std::unique_ptr<Init> MakeNodeInit(node::NodeContext& node, int argc, char* argv[], int& exit_status);
 
 //! Return implementation of Init interface for the wallet process.
 std::unique_ptr<Init> MakeWalletInit(int argc, char* argv[], int& exit_status);

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -22,7 +22,6 @@
 #include <vector>
 
 class BanMan;
-class CCoinControl;
 class CFeeRate;
 class CNodeStats;
 class Coin;
@@ -36,6 +35,9 @@ struct bilingual_str;
 namespace node {
 struct NodeContext;
 } // namespace node
+namespace wallet {
+class CCoinControl;
+} // namespace wallet
 
 namespace interfaces {
 class Handler;

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -32,8 +32,10 @@ class proxyType;
 enum class SynchronizationState;
 enum class TransactionError;
 struct CNodeStateStats;
-struct NodeContext;
 struct bilingual_str;
+namespace node {
+struct NodeContext;
+} // namespace node
 
 namespace interfaces {
 class Handler;
@@ -242,12 +244,12 @@ public:
 
     //! Get and set internal node context. Useful for testing, but not
     //! accessible across processes.
-    virtual NodeContext* context() { return nullptr; }
-    virtual void setContext(NodeContext* context) { }
+    virtual node::NodeContext* context() { return nullptr; }
+    virtual void setContext(node::NodeContext* context) { }
 };
 
 //! Return implementation of Node interface.
-std::unique_ptr<Node> MakeNode(NodeContext& context);
+std::unique_ptr<Node> MakeNode(node::NodeContext& context);
 
 //! Block tip (could be a header or not, depends on the subscribed signal).
 struct BlockTip {

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -23,19 +23,21 @@
 #include <utility>
 #include <vector>
 
-class CCoinControl;
 class CFeeRate;
 class CKey;
-class CWallet;
 enum class FeeReason;
 enum class OutputType;
 enum class TransactionError;
+struct PartiallySignedTransaction;
+struct bilingual_str;
+namespace wallet {
+class CCoinControl;
+class CWallet;
 enum isminetype : unsigned int;
 struct CRecipient;
-struct PartiallySignedTransaction;
 struct WalletContext;
-struct bilingual_str;
 using isminefilter = std::underlying_type<isminetype>::type;
+} // namespace wallet
 
 namespace interfaces {
 
@@ -107,7 +109,7 @@ public:
     //! Look up address in wallet, return whether exists.
     virtual bool getAddress(const CTxDestination& dest,
         std::string* name,
-        isminetype* is_mine,
+        wallet::isminetype* is_mine,
         std::string* purpose) = 0;
 
     //! Get wallet address list.
@@ -135,8 +137,8 @@ public:
     virtual void listLockedCoins(std::vector<COutPoint>& outputs) = 0;
 
     //! Create transaction.
-    virtual CTransactionRef createTransaction(const std::vector<CRecipient>& recipients,
-        const CCoinControl& coin_control,
+    virtual CTransactionRef createTransaction(const std::vector<wallet::CRecipient>& recipients,
+        const wallet::CCoinControl& coin_control,
         bool sign,
         int& change_pos,
         CAmount& fee,
@@ -158,7 +160,7 @@ public:
 
     //! Create bump transaction.
     virtual bool createBumpTransaction(const uint256& txid,
-        const CCoinControl& coin_control,
+        const wallet::CCoinControl& coin_control,
         std::vector<bilingual_str>& errors,
         CAmount& old_fee,
         CAmount& new_fee,
@@ -213,19 +215,19 @@ public:
     virtual CAmount getBalance() = 0;
 
     //! Get available balance.
-    virtual CAmount getAvailableBalance(const CCoinControl& coin_control) = 0;
+    virtual CAmount getAvailableBalance(const wallet::CCoinControl& coin_control) = 0;
 
     //! Return whether transaction input belongs to wallet.
-    virtual isminetype txinIsMine(const CTxIn& txin) = 0;
+    virtual wallet::isminetype txinIsMine(const CTxIn& txin) = 0;
 
     //! Return whether transaction output belongs to wallet.
-    virtual isminetype txoutIsMine(const CTxOut& txout) = 0;
+    virtual wallet::isminetype txoutIsMine(const CTxOut& txout) = 0;
 
     //! Return debit amount if transaction input belongs to wallet.
-    virtual CAmount getDebit(const CTxIn& txin, isminefilter filter) = 0;
+    virtual CAmount getDebit(const CTxIn& txin, wallet::isminefilter filter) = 0;
 
     //! Return credit amount if transaction input belongs to wallet.
-    virtual CAmount getCredit(const CTxOut& txout, isminefilter filter) = 0;
+    virtual CAmount getCredit(const CTxOut& txout, wallet::isminefilter filter) = 0;
 
     //! Return AvailableCoins + LockedCoins grouped by wallet address.
     //! (put change in one group with wallet address)
@@ -240,7 +242,7 @@ public:
 
     //! Get minimum fee.
     virtual CAmount getMinimumFee(unsigned int tx_bytes,
-        const CCoinControl& coin_control,
+        const wallet::CCoinControl& coin_control,
         int* returned_target,
         FeeReason* reason) = 0;
 
@@ -307,7 +309,7 @@ public:
     virtual std::unique_ptr<Handler> handleCanGetAddressesChanged(CanGetAddressesChangedFn fn) = 0;
 
     //! Return pointer to internal wallet class, useful for testing.
-    virtual CWallet* wallet() { return nullptr; }
+    virtual wallet::CWallet* wallet() { return nullptr; }
 };
 
 //! Wallet chain client that in addition to having chain client methods for
@@ -341,18 +343,18 @@ public:
    virtual std::unique_ptr<Handler> handleLoadWallet(LoadWalletFn fn) = 0;
 
    //! Return pointer to internal context, useful for testing.
-   virtual WalletContext* context() { return nullptr; }
+   virtual wallet::WalletContext* context() { return nullptr; }
 };
 
 //! Information about one wallet address.
 struct WalletAddress
 {
     CTxDestination dest;
-    isminetype is_mine;
+    wallet::isminetype is_mine;
     std::string name;
     std::string purpose;
 
-    WalletAddress(CTxDestination dest, isminetype is_mine, std::string name, std::string purpose)
+    WalletAddress(CTxDestination dest, wallet::isminetype is_mine, std::string name, std::string purpose)
         : dest(std::move(dest)), is_mine(is_mine), name(std::move(name)), purpose(std::move(purpose))
     {
     }
@@ -382,10 +384,10 @@ struct WalletBalances
 struct WalletTx
 {
     CTransactionRef tx;
-    std::vector<isminetype> txin_is_mine;
-    std::vector<isminetype> txout_is_mine;
+    std::vector<wallet::isminetype> txin_is_mine;
+    std::vector<wallet::isminetype> txout_is_mine;
     std::vector<CTxDestination> txout_address;
-    std::vector<isminetype> txout_address_is_mine;
+    std::vector<wallet::isminetype> txout_address_is_mine;
     CAmount credit;
     CAmount debit;
     CAmount change;
@@ -420,7 +422,7 @@ struct WalletTxOut
 
 //! Return implementation of Wallet interface. This function is defined in
 //! dummywallet.cpp and throws if the wallet component is not compiled.
-std::unique_ptr<Wallet> MakeWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet);
+std::unique_ptr<Wallet> MakeWallet(wallet::WalletContext& context, const std::shared_ptr<wallet::CWallet>& wallet);
 
 //! Return implementation of ChainClient interface for a wallet loader. This
 //! function will be undefined in builds where ENABLE_WALLET is false.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -45,6 +45,12 @@
 #include <optional>
 #include <typeinfo>
 
+using node::ReadBlockFromDisk;
+using node::ReadRawBlockFromDisk;
+using node::fImporting;
+using node::fPruneMode;
+using node::fReindex;
+
 /** How long to cache transactions in mapRelay for normal relay */
 static constexpr auto RELAY_TX_CACHE_TIME = 15min;
 /** How long a transaction has to be in the mempool before it can unconditionally be relayed (even when not in mapRelay). */

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -473,14 +473,7 @@ void CleanupBlockRevFiles()
         remove(item.second);
     }
 }
-} // namespace node
 
-std::string CBlockFileInfo::ToString() const
-{
-    return strprintf("CBlockFileInfo(blocks=%u, size=%u, heights=%u...%u, time=%s...%s)", nBlocks, nSize, nHeightFirst, nHeightLast, FormatISO8601Date(nTimeFirst), FormatISO8601Date(nTimeLast));
-}
-
-namespace node {
 CBlockFileInfo* BlockManager::GetBlockFileInfo(size_t n)
 {
     LOCK(cs_LastBlockFile);

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -21,6 +21,7 @@
 #include <util/system.h>
 #include <validation.h>
 
+namespace node {
 std::atomic_bool fImporting(false);
 std::atomic_bool fReindex(false);
 bool fHavePruned = false;
@@ -472,12 +473,14 @@ void CleanupBlockRevFiles()
         remove(item.second);
     }
 }
+} // namespace node
 
 std::string CBlockFileInfo::ToString() const
 {
     return strprintf("CBlockFileInfo(blocks=%u, size=%u, heights=%u...%u, time=%s...%s)", nBlocks, nSize, nHeightFirst, nHeightLast, FormatISO8601Date(nTimeFirst), FormatISO8601Date(nTimeLast));
 }
 
+namespace node {
 CBlockFileInfo* BlockManager::GetBlockFileInfo(size_t n)
 {
     LOCK(cs_LastBlockFile);
@@ -939,3 +942,4 @@ void ThreadImport(ChainstateManager& chainman, std::vector<fs::path> vImportFile
     } // End scope of CImportingNow
     chainman.ActiveChainstate().LoadMempool(args);
 }
+} // namespace node

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -29,6 +29,7 @@ namespace Consensus {
 struct Params;
 }
 
+namespace node {
 static constexpr bool DEFAULT_STOPAFTERBLOCKIMPORT{false};
 
 /** The pre-allocation chunk size for blk?????.dat files (since 0.8) */
@@ -185,5 +186,6 @@ bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CBlockIndex* pindex
 bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex);
 
 void ThreadImport(ChainstateManager& chainman, std::vector<fs::path> vImportFiles, const ArgsManager& args);
+} // namespace node
 
 #endif // BITCOIN_NODE_BLOCKSTORAGE_H

--- a/src/node/caches.cpp
+++ b/src/node/caches.cpp
@@ -8,6 +8,7 @@
 #include <util/system.h>
 #include <validation.h>
 
+namespace node {
 CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes)
 {
     int64_t nTotalCache = (args.GetIntArg("-dbcache", nDefaultDbCache) << 20);
@@ -30,3 +31,4 @@ CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes)
     sizes.coins = nTotalCache; // the rest goes to in-memory cache
     return sizes;
 }
+} // namespace node

--- a/src/node/caches.h
+++ b/src/node/caches.h
@@ -10,6 +10,7 @@
 
 class ArgsManager;
 
+namespace node {
 struct CacheSizes {
     int64_t block_tree_db;
     int64_t coins_db;
@@ -18,5 +19,6 @@ struct CacheSizes {
     int64_t filter_index;
 };
 CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes = 0);
+} // namespace node
 
 #endif // BITCOIN_NODE_CACHES_H

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -8,6 +8,7 @@
 #include <node/blockstorage.h>
 #include <validation.h>
 
+namespace node {
 std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,
                                                      ChainstateManager& chainman,
                                                      CTxMemPool* mempool,
@@ -156,3 +157,4 @@ std::optional<ChainstateLoadVerifyError> VerifyLoadedChainstate(ChainstateManage
 
     return std::nullopt;
 }
+} // namespace node

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -10,11 +10,12 @@
 #include <optional>
 
 class ChainstateManager;
-namespace Consensus {
-    struct Params;
-}
 class CTxMemPool;
+namespace Consensus {
+struct Params;
+} // namespace Consensus
 
+namespace node {
 enum class ChainstateLoadingError {
     ERROR_LOADING_BLOCK_DB,
     ERROR_BAD_GENESIS_BLOCK,
@@ -81,5 +82,6 @@ std::optional<ChainstateLoadVerifyError> VerifyLoadedChainstate(ChainstateManage
                                                                 unsigned int check_blocks,
                                                                 unsigned int check_level,
                                                                 std::function<int64_t()> get_unix_time_seconds);
+} // namespace node
 
 #endif // BITCOIN_NODE_CHAINSTATE_H

--- a/src/node/coin.cpp
+++ b/src/node/coin.cpp
@@ -8,6 +8,7 @@
 #include <txmempool.h>
 #include <validation.h>
 
+namespace node {
 void FindCoins(const NodeContext& node, std::map<COutPoint, Coin>& coins)
 {
     assert(node.mempool);
@@ -22,3 +23,4 @@ void FindCoins(const NodeContext& node, std::map<COutPoint, Coin>& coins)
         }
     }
 }
+} // namespace node

--- a/src/node/coin.h
+++ b/src/node/coin.h
@@ -9,6 +9,8 @@
 
 class COutPoint;
 class Coin;
+
+namespace node {
 struct NodeContext;
 
 /**
@@ -19,6 +21,7 @@ struct NodeContext;
  * @param[in] node The node context to use for lookup
  * @param[in,out] coins map to fill
  */
-void FindCoins(const NodeContext& node, std::map<COutPoint, Coin>& coins);
+void FindCoins(const node::NodeContext& node, std::map<COutPoint, Coin>& coins);
+} // namespace node
 
 #endif // BITCOIN_NODE_COIN_H

--- a/src/node/coinstats.cpp
+++ b/src/node/coinstats.cpp
@@ -17,6 +17,7 @@
 
 #include <map>
 
+namespace node {
 // Database-independent metric indicating the UTXO set size
 uint64_t GetBogoSize(const CScript& script_pub_key)
 {
@@ -181,3 +182,4 @@ static void FinalizeHash(MuHash3072& muhash, CCoinsStats& stats)
     stats.hashSerialized = out;
 }
 static void FinalizeHash(std::nullptr_t, CCoinsStats& stats) {}
+} // namespace node

--- a/src/node/coinstats.h
+++ b/src/node/coinstats.h
@@ -15,9 +15,12 @@
 #include <cstdint>
 #include <functional>
 
-class BlockManager;
 class CCoinsView;
+namespace node {
+class BlockManager;
+} // namespace node
 
+namespace node {
 enum class CoinStatsHashType {
     HASH_SERIALIZED,
     MUHASH,
@@ -71,10 +74,11 @@ struct CCoinsStats {
 };
 
 //! Calculate statistics about the unspent transaction output set
-bool GetUTXOStats(CCoinsView* view, BlockManager& blockman, CCoinsStats& stats, const std::function<void()>& interruption_point = {}, const CBlockIndex* pindex = nullptr);
+bool GetUTXOStats(CCoinsView* view, node::BlockManager& blockman, CCoinsStats& stats, const std::function<void()>& interruption_point = {}, const CBlockIndex* pindex = nullptr);
 
 uint64_t GetBogoSize(const CScript& script_pub_key);
 
 CDataStream TxOutSer(const COutPoint& outpoint, const Coin& coin);
+} // namespace node
 
 #endif // BITCOIN_NODE_COINSTATS_H

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -14,5 +14,7 @@
 #include <txmempool.h>
 #include <validation.h>
 
+namespace node {
 NodeContext::NodeContext() {}
 NodeContext::~NodeContext() {}
+} // namespace node

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -26,6 +26,7 @@ class Init;
 class WalletLoader;
 } // namespace interfaces
 
+namespace node {
 //! NodeContext struct containing references to chain state and connection
 //! state.
 //!
@@ -62,5 +63,6 @@ struct NodeContext {
     NodeContext();
     ~NodeContext();
 };
+} // namespace node
 
 #endif // BITCOIN_NODE_CONTEXT_H

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -249,8 +249,8 @@ public:
     bool isInitialBlockDownload() override {
         return chainman().ActiveChainstate().IsInitialBlockDownload();
     }
-    bool getReindex() override { return ::fReindex; }
-    bool getImporting() override { return ::fImporting; }
+    bool getReindex() override { return node::fReindex; }
+    bool getImporting() override { return node::fImporting; }
     void setNetworkActive(bool active) override
     {
         if (m_context->connman) {
@@ -649,9 +649,9 @@ public:
     bool havePruned() override
     {
         LOCK(cs_main);
-        return ::fHavePruned;
+        return node::fHavePruned;
     }
-    bool isReadyToBroadcast() override { return !::fImporting && !::fReindex && !isInitialBlockDownload(); }
+    bool isReadyToBroadcast() override { return !node::fImporting && !node::fReindex && !isInitialBlockDownload(); }
     bool isInitialBlockDownload() override {
         return chainman().ActiveChainstate().IsInitialBlockDownload();
     }
@@ -729,6 +729,6 @@ public:
 } // namespace node
 
 namespace interfaces {
-std::unique_ptr<Node> MakeNode(NodeContext& context) { return std::make_unique<node::NodeImpl>(context); }
-std::unique_ptr<Chain> MakeChain(NodeContext& context) { return std::make_unique<node::ChainImpl>(context); }
+std::unique_ptr<Node> MakeNode(node::NodeContext& context) { return std::make_unique<node::NodeImpl>(context); }
+std::unique_ptr<Chain> MakeChain(node::NodeContext& context) { return std::make_unique<node::ChainImpl>(context); }
 } // namespace interfaces

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <utility>
 
+namespace node {
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
 {
     int64_t nOldTime = pblock->nTime;
@@ -464,3 +465,4 @@ void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned
     pblock->vtx[0] = MakeTransactionRef(std::move(txCoinbase));
     pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
 }
+} // namespace node

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -23,6 +23,7 @@ class CScript;
 
 namespace Consensus { struct Params; };
 
+namespace node {
 static const bool DEFAULT_PRINTPRIORITY = false;
 
 struct CBlockTemplate
@@ -206,5 +207,6 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 
 /** Update an old GenerateCoinbaseCommitment from CreateNewBlock after the block txs have changed */
 void RegenerateCommitments(CBlock& block, ChainstateManager& chainman);
+} // namespace node
 
 #endif // BITCOIN_NODE_MINER_H

--- a/src/node/minisketchwrapper.cpp
+++ b/src/node/minisketchwrapper.cpp
@@ -16,6 +16,7 @@
 #include <utility>
 #include <vector>
 
+namespace node {
 namespace {
 
 static constexpr uint32_t BITS = 32;
@@ -75,3 +76,4 @@ Minisketch MakeMinisketch32FP(size_t max_elements, uint32_t fpbits)
 {
     return Minisketch::CreateFP(BITS, Minisketch32Implementation(), max_elements, fpbits);
 }
+} // namespace node

--- a/src/node/minisketchwrapper.h
+++ b/src/node/minisketchwrapper.h
@@ -10,9 +10,11 @@
 #include <cstddef>
 #include <cstdint>
 
+namespace node {
 /** Wrapper around Minisketch::Minisketch(32, implementation, capacity). */
 Minisketch MakeMinisketch32(size_t capacity);
 /** Wrapper around Minisketch::CreateFP. */
 Minisketch MakeMinisketch32FP(size_t max_elements, uint32_t fpbits);
+} // namespace node
 
 #endif // BITCOIN_NODE_MINISKETCHWRAPPER_H

--- a/src/node/psbt.cpp
+++ b/src/node/psbt.cpp
@@ -12,6 +12,7 @@
 
 #include <numeric>
 
+namespace node {
 PSBTAnalysis AnalyzePSBT(PartiallySignedTransaction psbtx)
 {
     // Go through each input and build status
@@ -147,3 +148,4 @@ PSBTAnalysis AnalyzePSBT(PartiallySignedTransaction psbtx)
 
     return result;
 }
+} // namespace node

--- a/src/node/psbt.h
+++ b/src/node/psbt.h
@@ -9,6 +9,7 @@
 
 #include <optional>
 
+namespace node {
 /**
  * Holds an analysis of one input from a PSBT
  */
@@ -52,5 +53,6 @@ struct PSBTAnalysis {
  * @return A PSBTAnalysis with information about the provided PSBT.
  */
 PSBTAnalysis AnalyzePSBT(PartiallySignedTransaction psbtx);
+} // namespace node
 
 #endif // BITCOIN_NODE_PSBT_H

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -16,6 +16,7 @@
 
 #include <future>
 
+namespace node {
 static TransactionError HandleATMPError(const TxValidationState& state, std::string& err_string_out)
 {
     err_string_out = state.ToString();
@@ -153,3 +154,4 @@ CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMe
     }
     return nullptr;
 }
+} // namespace node

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -12,10 +12,12 @@
 
 class CBlockIndex;
 class CTxMemPool;
-struct NodeContext;
 namespace Consensus {
 struct Params;
 }
+
+namespace node {
+struct NodeContext;
 
 /** Maximum fee rate for sendrawtransaction and testmempoolaccept RPC calls.
  * Also used by the GUI when broadcasting a completed PSBT.
@@ -57,5 +59,6 @@ static const CFeeRate DEFAULT_MAX_RAW_TX_FEE_RATE{COIN / 10};
  * @returns                    The tx if found, otherwise nullptr
  */
 CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool, const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock);
+} // namespace node
 
 #endif // BITCOIN_NODE_TRANSACTION_H

--- a/src/node/utxo_snapshot.h
+++ b/src/node/utxo_snapshot.h
@@ -9,6 +9,7 @@
 #include <uint256.h>
 #include <serialize.h>
 
+namespace node {
 //! Metadata describing a serialized version of a UTXO set from which an
 //! assumeutxo CChainState can be constructed.
 class SnapshotMetadata
@@ -32,5 +33,6 @@ public:
 
     SERIALIZE_METHODS(SnapshotMetadata, obj) { READWRITE(obj.m_base_blockhash, obj.m_coins_count); }
 };
+} // namespace node
 
 #endif // BITCOIN_NODE_UTXO_SNAPSHOT_H

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -76,6 +76,8 @@ Q_DECLARE_METATYPE(CAmount)
 Q_DECLARE_METATYPE(SynchronizationState)
 Q_DECLARE_METATYPE(uint256)
 
+using node::NodeContext;
+
 static void RegisterMetaTypes()
 {
     // Register meta types used for QMetaObject::invokeMethod and Qt::QueuedConnection

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -31,6 +31,9 @@
 #include <QSettings>
 #include <QTreeWidget>
 
+using wallet::CCoinControl;
+using wallet::MIN_CHANGE;
+
 QList<CAmount> CoinControlDialog::payAmounts;
 bool CoinControlDialog::fSubtractFeeFromAmount = false;
 

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -19,7 +19,9 @@
 class PlatformStyle;
 class WalletModel;
 
+namespace wallet {
 class CCoinControl;
+} // namespace wallet
 
 namespace Ui {
     class CoinControlDialog;
@@ -42,11 +44,11 @@ class CoinControlDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit CoinControlDialog(CCoinControl& coin_control, WalletModel* model, const PlatformStyle *platformStyle, QWidget *parent = nullptr);
+    explicit CoinControlDialog(wallet::CCoinControl& coin_control, WalletModel* model, const PlatformStyle *platformStyle, QWidget *parent = nullptr);
     ~CoinControlDialog();
 
     // static because also called from sendcoinsdialog
-    static void updateLabels(CCoinControl& m_coin_control, WalletModel*, QDialog*);
+    static void updateLabels(wallet::CCoinControl& m_coin_control, WalletModel*, QDialog*);
 
     static QList<CAmount> payAmounts;
     static bool fSubtractFeeFromAmount;
@@ -56,7 +58,7 @@ protected:
 
 private:
     Ui::CoinControlDialog *ui;
-    CCoinControl& m_coin_control;
+    wallet::CCoinControl& m_coin_control;
     WalletModel *model;
     int sortColumn;
     Qt::SortOrder sortOrder;

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -17,6 +17,9 @@
 
 #include <iostream>
 
+using node::AnalyzePSBT;
+using node::DEFAULT_MAX_RAW_TX_FEE_RATE;
+using node::PSBTAnalysis;
 
 PSBTOperationsDialog::PSBTOperationsDialog(
     QWidget* parent, WalletModel* wallet_model, ClientModel* client_model) : QDialog(parent, GUIUtil::dialog_flags),

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -35,6 +35,9 @@
 #include <QSettings>
 #include <QTextDocument>
 
+using wallet::CCoinControl;
+using wallet::DEFAULT_PAY_TX_FEE;
+
 static constexpr std::array confTargets{2, 4, 6, 12, 24, 48, 144, 504, 1008};
 int getConfTargetForIndex(int index) {
     if (index+1 > static_cast<int>(confTargets.size())) {

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -12,12 +12,14 @@
 #include <QString>
 #include <QTimer>
 
-class CCoinControl;
 class ClientModel;
 class PlatformStyle;
 class SendCoinsEntry;
 class SendCoinsRecipient;
 enum class SynchronizationState;
+namespace wallet {
+class CCoinControl;
+} // namespace wallet
 
 namespace Ui {
     class SendCoinsDialog;
@@ -62,7 +64,7 @@ private:
     Ui::SendCoinsDialog *ui;
     ClientModel *clientModel;
     WalletModel *model;
-    std::unique_ptr<CCoinControl> m_coin_control;
+    std::unique_ptr<wallet::CCoinControl> m_coin_control;
     std::unique_ptr<WalletModelTransaction> m_current_transaction;
     bool fNewRecipientAllowed;
     bool fFeeMinimized;

--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -24,6 +24,13 @@
 #include <QTimer>
 #include <QMessageBox>
 
+using wallet::AddWallet;
+using wallet::CWallet;
+using wallet::CreateMockWalletDatabase;
+using wallet::RemoveWallet;
+using wallet::WALLET_FLAG_DESCRIPTORS;
+using wallet::WalletContext;
+
 namespace
 {
 

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -39,6 +39,8 @@ Q_IMPORT_PLUGIN(QAndroidPlatformIntegrationPlugin)
 #endif
 #endif
 
+using node::NodeContext;
+
 const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
 
 // This is all you need to run all the tests

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -39,6 +39,15 @@
 #include <QListView>
 #include <QDialogButtonBox>
 
+using wallet::AddWallet;
+using wallet::CWallet;
+using wallet::CreateMockWalletDatabase;
+using wallet::RemoveWallet;
+using wallet::WALLET_FLAG_DESCRIPTORS;
+using wallet::WalletContext;
+using wallet::WalletDescriptor;
+using wallet::WalletRescanReserver;
+
 namespace
 {
 //! Press "Yes" or "Cancel" buttons in modal send confirmation dialog.

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -28,6 +28,11 @@
 
 #include <QLatin1String>
 
+using wallet::ISMINE_ALL;
+using wallet::ISMINE_SPENDABLE;
+using wallet::ISMINE_WATCH_ONLY;
+using wallet::isminetype;
+
 QString TransactionDesc::FormatTxStatus(const interfaces::WalletTx& wtx, const interfaces::WalletTxStatus& status, bool inMempool, int numBlocks)
 {
     if (!status.is_final)

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -13,6 +13,10 @@
 
 #include <QDateTime>
 
+using wallet::ISMINE_SPENDABLE;
+using wallet::ISMINE_WATCH_ONLY;
+using wallet::isminetype;
+
 /* Return positive answer if transaction should be shown in list.
  */
 bool TransactionRecord::showTransaction()

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -28,6 +28,11 @@
 #include <QTimer>
 #include <QWindow>
 
+using wallet::WALLET_FLAG_BLANK_WALLET;
+using wallet::WALLET_FLAG_DESCRIPTORS;
+using wallet::WALLET_FLAG_DISABLE_PRIVATE_KEYS;
+using wallet::WALLET_FLAG_EXTERNAL_SIGNER;
+
 WalletController::WalletController(ClientModel& client_model, const PlatformStyle* platform_style, QObject* parent)
     : QObject(parent)
     , m_activity_thread(new QThread(this))

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -36,6 +36,9 @@
 #include <QSet>
 #include <QTimer>
 
+using wallet::CCoinControl;
+using wallet::CRecipient;
+using wallet::DEFAULT_DISABLE_WALLET;
 
 WalletModel::WalletModel(std::unique_ptr<interfaces::Wallet> wallet, ClientModel& client_model, const PlatformStyle *platformStyle, QObject *parent) :
     QObject(parent),

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -32,16 +32,17 @@ class SendCoinsRecipient;
 class TransactionTableModel;
 class WalletModelTransaction;
 
-class CCoinControl;
 class CKeyID;
 class COutPoint;
-class COutput;
 class CPubKey;
 class uint256;
 
 namespace interfaces {
 class Node;
 } // namespace interfaces
+namespace wallet {
+class CCoinControl;
+} // namespace wallet
 
 QT_BEGIN_NAMESPACE
 class QTimer;
@@ -99,7 +100,7 @@ public:
     };
 
     // prepare transaction for getting txfee before sending coins
-    SendCoinsReturn prepareTransaction(WalletModelTransaction &transaction, const CCoinControl& coinControl);
+    SendCoinsReturn prepareTransaction(WalletModelTransaction &transaction, const wallet::CCoinControl& coinControl);
 
     // Send coins to a list of recipients
     SendCoinsReturn sendCoins(WalletModelTransaction &transaction);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -32,6 +32,11 @@
 
 #include <univalue.h>
 
+using node::GetTransaction;
+using node::IsBlockPruned;
+using node::NodeContext;
+using node::ReadBlockFromDisk;
+
 static const size_t MAX_GETUTXOS_OUTPOINTS = 15; //allow a max of 15 outpoints to be queried at once
 static constexpr unsigned int MAX_REST_HEADERS_RESULTS = 2000;
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -56,6 +56,16 @@
 #include <memory>
 #include <mutex>
 
+using node::BlockManager;
+using node::CCoinsStats;
+using node::CoinStatsHashType;
+using node::GetUTXOStats;
+using node::IsBlockPruned;
+using node::NodeContext;
+using node::ReadBlockFromDisk;
+using node::SnapshotMetadata;
+using node::UndoReadFromDisk;
+
 struct CUpdatedBlock
 {
     uint256 hash;
@@ -1112,7 +1122,7 @@ static RPCHelpMan pruneblockchain()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    if (!fPruneMode)
+    if (!node::fPruneMode)
         throw JSONRPCError(RPC_MISC_ERROR, "Cannot prune blocks because node is not in prune mode.");
 
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
@@ -1565,8 +1575,8 @@ RPCHelpMan getblockchaininfo()
     obj.pushKV("initialblockdownload",  active_chainstate.IsInitialBlockDownload());
     obj.pushKV("chainwork",             tip->nChainWork.GetHex());
     obj.pushKV("size_on_disk", chainman.m_blockman.CalculateCurrentUsage());
-    obj.pushKV("pruned",                fPruneMode);
-    if (fPruneMode) {
+    obj.pushKV("pruned",                node::fPruneMode);
+    if (node::fPruneMode) {
         const CBlockIndex* block = tip;
         CHECK_NONFATAL(block);
         while (block->pprev && (block->pprev->nStatus & BLOCK_HAVE_DATA)) {
@@ -1579,7 +1589,7 @@ RPCHelpMan getblockchaininfo()
         bool automatic_pruning{args.GetIntArg("-prune", 0) != 1};
         obj.pushKV("automatic_pruning",  automatic_pruning);
         if (automatic_pruning) {
-            obj.pushKV("prune_target_size",  nPruneTarget);
+            obj.pushKV("prune_target_size",  node::nPruneTarget);
         }
     }
 

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -22,7 +22,9 @@ class CBlockIndex;
 class CChainState;
 class CTxMemPool;
 class UniValue;
+namespace node {
 struct NodeContext;
+} // namespace node
 
 static constexpr int NUM_GETBLOCKSTATS_PERCENTILES = 5;
 
@@ -57,7 +59,7 @@ void CalculatePercentilesByWeight(CAmount result[NUM_GETBLOCKSTATS_PERCENTILES],
  * @return a UniValue map containing metadata about the snapshot.
  */
 UniValue CreateUTXOSnapshot(
-    NodeContext& node,
+    node::NodeContext& node,
     CChainState& chainstate,
     CAutoFile& afile,
     const fs::path& path,

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -41,6 +41,13 @@
 #include <memory>
 #include <stdint.h>
 
+using node::BlockAssembler;
+using node::CBlockTemplate;
+using node::IncrementExtraNonce;
+using node::NodeContext;
+using node::RegenerateCommitments;
+using node::UpdateTime;
+
 /**
  * Return average network hashes per second based on the last 'lookup' blocks,
  * or from the last difficulty change if 'lookup' is nonpositive.

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -35,6 +35,8 @@
 
 #include <univalue.h>
 
+using node::NodeContext;
+
 static RPCHelpMan validateaddress()
 {
     return RPCHelpMan{

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -32,6 +32,8 @@
 
 #include <univalue.h>
 
+using node::NodeContext;
+
 const std::vector<std::string> CONNECTION_TYPE_DOC{
         "outbound-full-relay (default automatic connections)",
         "block-relay-only (does not relay transactions or addresses)",

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -45,6 +45,15 @@
 
 #include <univalue.h>
 
+using node::AnalyzePSBT;
+using node::BroadcastTransaction;
+using node::DEFAULT_MAX_RAW_TX_FEE_RATE;
+using node::FindCoins;
+using node::GetTransaction;
+using node::NodeContext;
+using node::PSBTAnalysis;
+using node::ReadBlockFromDisk;
+
 static void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry, CChainState& active_chainstate)
 {
     // Call into TxToUniv() in bitcoin-common to decode the transaction hex.

--- a/src/rpc/server_util.cpp
+++ b/src/rpc/server_util.cpp
@@ -15,6 +15,8 @@
 
 #include <any>
 
+using node::NodeContext;
+
 NodeContext& EnsureAnyNodeContext(const std::any& context)
 {
     auto node_context = util::AnyPtr<NodeContext>(context);

--- a/src/rpc/server_util.h
+++ b/src/rpc/server_util.h
@@ -13,18 +13,20 @@ class CConnman;
 class CTxMemPool;
 class ChainstateManager;
 class PeerManager;
+namespace node {
 struct NodeContext;
+} // namespace node
 
-NodeContext& EnsureAnyNodeContext(const std::any& context);
-CTxMemPool& EnsureMemPool(const NodeContext& node);
+node::NodeContext& EnsureAnyNodeContext(const std::any& context);
+CTxMemPool& EnsureMemPool(const node::NodeContext& node);
 CTxMemPool& EnsureAnyMemPool(const std::any& context);
-ArgsManager& EnsureArgsman(const NodeContext& node);
+ArgsManager& EnsureArgsman(const node::NodeContext& node);
 ArgsManager& EnsureAnyArgsman(const std::any& context);
-ChainstateManager& EnsureChainman(const NodeContext& node);
+ChainstateManager& EnsureChainman(const node::NodeContext& node);
 ChainstateManager& EnsureAnyChainman(const std::any& context);
-CBlockPolicyEstimator& EnsureFeeEstimator(const NodeContext& node);
+CBlockPolicyEstimator& EnsureFeeEstimator(const node::NodeContext& node);
 CBlockPolicyEstimator& EnsureAnyFeeEstimator(const std::any& context);
-CConnman& EnsureConnman(const NodeContext& node);
-PeerManager& EnsurePeerman(const NodeContext& node);
+CConnman& EnsureConnman(const node::NodeContext& node);
+PeerManager& EnsurePeerman(const node::NodeContext& node);
 
 #endif // BITCOIN_RPC_SERVER_UTIL_H

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -16,6 +16,10 @@
 
 #include <boost/test/unit_test.hpp>
 
+using node::BlockAssembler;
+using node::CBlockTemplate;
+using node::IncrementExtraNonce;
+
 BOOST_AUTO_TEST_SUITE(blockfilter_index_tests)
 
 struct BuildChainTestingSetup : public TestChain100Setup {

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -11,6 +11,8 @@
 
 #include <chrono>
 
+using node::CCoinsStats;
+using node::CoinStatsHashType;
 
 BOOST_AUTO_TEST_SUITE(coinstatsindex_tests)
 

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -26,6 +26,10 @@
 #include <string>
 #include <vector>
 
+using node::CCoinsStats;
+using node::CoinStatsHashType;
+using node::GetUTXOStats;
+
 namespace {
 const TestingSetup* g_setup;
 const Coin EMPTY_COIN{};

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -33,6 +33,8 @@
 
 #include <test/fuzz/fuzz.h>
 
+using node::SnapshotMetadata;
+
 void initialize_deserialize()
 {
     // Fuzzers using pubkey must hold an ECCVerifyHandle.

--- a/src/test/fuzz/minisketch.cpp
+++ b/src/test/fuzz/minisketch.cpp
@@ -12,6 +12,8 @@
 #include <map>
 #include <numeric>
 
+using node::MakeMinisketch32;
+
 FUZZ_TARGET(minisketch)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};

--- a/src/test/fuzz/psbt.cpp
+++ b/src/test/fuzz/psbt.cpp
@@ -18,6 +18,10 @@
 #include <string>
 #include <vector>
 
+using node::AnalyzePSBT;
+using node::PSBTAnalysis;
+using node::PSBTInputAnalysis;
+
 void initialize_psbt()
 {
     static const ECCVerifyHandle verify_handle;

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -14,6 +14,8 @@
 #include <validation.h>
 #include <validationinterface.h>
 
+using node::BlockAssembler;
+
 namespace {
 
 const TestingSetup* g_setup;

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -13,6 +13,8 @@
 #include <validation.h>
 #include <validationinterface.h>
 
+using node::SnapshotMetadata;
+
 namespace {
 
 const std::vector<std::shared_ptr<CBlock>>* g_chain;

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -24,6 +24,9 @@
 
 #include <boost/test/unit_test.hpp>
 
+using node::BlockAssembler;
+using node::CBlockTemplate;
+
 namespace miner_tests {
 struct MinerTestingSetup : public TestingSetup {
     void TestPackageSelection(const CChainParams& chainparams, const CScript& scriptPubKey, const std::vector<CTransactionRef>& txFirst) EXCLUSIVE_LOCKS_REQUIRED(::cs_main, m_node.mempool->cs);

--- a/src/test/minisketch_tests.cpp
+++ b/src/test/minisketch_tests.cpp
@@ -11,6 +11,8 @@
 
 #include <utility>
 
+using node::MakeMinisketch32;
+
 BOOST_AUTO_TEST_SUITE(minisketch_tests)
 
 BOOST_AUTO_TEST_CASE(minisketch_test)

--- a/src/test/util/blockfilter.cpp
+++ b/src/test/util/blockfilter.cpp
@@ -8,6 +8,8 @@
 #include <node/blockstorage.h>
 #include <validation.h>
 
+using node::ReadBlockFromDisk;
+using node::UndoReadFromDisk;
 
 bool ComputeFilter(BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter)
 {

--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -16,7 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-const auto NoMalleation = [](CAutoFile& file, SnapshotMetadata& meta){};
+const auto NoMalleation = [](CAutoFile& file, node::SnapshotMetadata& meta){};
 
 /**
  * Create and activate a UTXO snapshot, optionally providing a function to
@@ -24,7 +24,7 @@ const auto NoMalleation = [](CAutoFile& file, SnapshotMetadata& meta){};
  */
 template<typename F = decltype(NoMalleation)>
 static bool
-CreateAndActivateUTXOSnapshot(NodeContext& node, const fs::path root, F malleation = NoMalleation)
+CreateAndActivateUTXOSnapshot(node::NodeContext& node, const fs::path root, F malleation = NoMalleation)
 {
     // Write out a snapshot to the test's tempdir.
     //
@@ -43,7 +43,7 @@ CreateAndActivateUTXOSnapshot(NodeContext& node, const fs::path root, F malleati
     //
     FILE* infile{fsbridge::fopen(snapshot_path, "rb")};
     CAutoFile auto_infile{infile, SER_DISK, CLIENT_VERSION};
-    SnapshotMetadata metadata;
+    node::SnapshotMetadata metadata;
     auto_infile >> metadata;
 
     malleation(auto_infile, metadata);

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -16,6 +16,9 @@
 #include <validation.h>
 #include <versionbits.h>
 
+using node::BlockAssembler;
+using node::NodeContext;
+
 CTxIn generatetoaddress(const NodeContext& node, const std::string& address)
 {
     const auto dest = DecodeDestination(address);

--- a/src/test/util/mining.h
+++ b/src/test/util/mining.h
@@ -13,18 +13,20 @@ class CBlock;
 class CChainParams;
 class CScript;
 class CTxIn;
+namespace node {
 struct NodeContext;
+} // namespace node
 
 /** Create a blockchain, starting from genesis */
 std::vector<std::shared_ptr<CBlock>> CreateBlockChain(size_t total_height, const CChainParams& params);
 
 /** Returns the generated coin */
-CTxIn MineBlock(const NodeContext&, const CScript& coinbase_scriptPubKey);
+CTxIn MineBlock(const node::NodeContext&, const CScript& coinbase_scriptPubKey);
 
 /** Prepare a block to be mined */
-std::shared_ptr<CBlock> PrepareBlock(const NodeContext&, const CScript& coinbase_scriptPubKey);
+std::shared_ptr<CBlock> PrepareBlock(const node::NodeContext&, const CScript& coinbase_scriptPubKey);
 
 /** RPC-like helper function, returns the generated coin */
-CTxIn generatetoaddress(const NodeContext&, const std::string& address);
+CTxIn generatetoaddress(const node::NodeContext&, const std::string& address);
 
 #endif // BITCOIN_TEST_UTIL_MINING_H

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -43,6 +43,14 @@
 
 #include <functional>
 
+using node::BlockAssembler;
+using node::CalculateCacheSizes;
+using node::LoadChainstate;
+using node::RegenerateCommitments;
+using node::VerifyLoadedChainstate;
+using node::fPruneMode;
+using node::fReindex;
+
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 UrlDecodeFn* const URL_DECODE = nullptr;
 

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -26,11 +26,13 @@
 extern const std::function<void(const std::string&)> G_TEST_LOG_FUN;
 
 // Enable BOOST_CHECK_EQUAL for enum class types
+namespace std {
 template <typename T>
 std::ostream& operator<<(typename std::enable_if<std::is_enum<T>::value, std::ostream>::type& stream, const T& e)
 {
     return stream << static_cast<typename std::underlying_type<T>::type>(e);
 }
+} // namespace std
 
 /**
  * This global and the helpers that use it are not thread-safe.

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -76,7 +76,7 @@ static constexpr CAmount CENT{1000000};
  */
 struct BasicTestingSetup {
     ECCVerifyHandle globalVerifyHandle;
-    NodeContext m_node;
+    node::NodeContext m_node;
 
     explicit BasicTestingSetup(const std::string& chainName = CBaseChainParams::MAIN, const std::vector<const char*>& extra_args = {});
     ~BasicTestingSetup();
@@ -90,7 +90,7 @@ struct BasicTestingSetup {
  * initialization behaviour.
  */
 struct ChainTestingSetup : public BasicTestingSetup {
-    CacheSizes m_cache_sizes{};
+    node::CacheSizes m_cache_sizes{};
 
     explicit ChainTestingSetup(const std::string& chainName = CBaseChainParams::MAIN, const std::vector<const char*>& extra_args = {});
     ~ChainTestingSetup();

--- a/src/test/util/wallet.cpp
+++ b/src/test/util/wallet.cpp
@@ -12,6 +12,8 @@
 #include <wallet/wallet.h>
 #endif
 
+using wallet::CWallet;
+
 const std::string ADDRESS_BCRT1_UNSPENDABLE = "bcrt1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3xueyj";
 
 #ifdef ENABLE_WALLET

--- a/src/test/util/wallet.h
+++ b/src/test/util/wallet.h
@@ -7,7 +7,9 @@
 
 #include <string>
 
+namespace wallet {
 class CWallet;
+} // namespace wallet
 
 // Constants //
 
@@ -16,9 +18,9 @@ extern const std::string ADDRESS_BCRT1_UNSPENDABLE;
 // RPC-like //
 
 /** Import the address to the wallet */
-void importaddress(CWallet& wallet, const std::string& address);
+void importaddress(wallet::CWallet& wallet, const std::string& address);
 /** Returns a new address from the wallet */
-std::string getnewaddress(CWallet& w);
+std::string getnewaddress(wallet::CWallet& w);
 
 
 #endif // BITCOIN_TEST_UTIL_WALLET_H

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -19,6 +19,8 @@
 
 #include <thread>
 
+using node::BlockAssembler;
+
 namespace validation_block_tests {
 struct MinerTestingSetup : public RegTestingSetup {
     std::shared_ptr<CBlock> Block(const uint256& prev_hash);

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -20,6 +20,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+using node::SnapshotMetadata;
+
 BOOST_FIXTURE_TEST_SUITE(validation_chainstatemanager_tests, ChainTestingSetup)
 
 //! Basic tests for ChainstateManager.

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -9,6 +9,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+using node::BlockManager;
+
 BOOST_FIXTURE_TEST_SUITE(validation_flush_tests, ChainTestingSetup)
 
 //! Test utilities for detecting when we need to flush the coins cache based

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -62,6 +62,25 @@
 
 #include <boost/algorithm/string/replace.hpp>
 
+using node::BLOCKFILE_CHUNK_SIZE;
+using node::BlockManager;
+using node::BlockMap;
+using node::CBlockIndexWorkComparator;
+using node::CCoinsStats;
+using node::CoinStatsHashType;
+using node::GetUTXOStats;
+using node::OpenBlockFile;
+using node::ReadBlockFromDisk;
+using node::SnapshotMetadata;
+using node::UNDOFILE_CHUNK_SIZE;
+using node::UndoReadFromDisk;
+using node::UnlinkPrunedFiles;
+using node::fHavePruned;
+using node::fImporting;
+using node::fPruneMode;
+using node::fReindex;
+using node::nPruneTarget;
+
 #define MICRO 0.000001
 #define MILLI 0.001
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -43,12 +43,14 @@ class CBlockTreeDB;
 class CChainParams;
 class CTxMemPool;
 class ChainstateManager;
-class SnapshotMetadata;
 struct ChainTxData;
 struct DisconnectedBlockTransactions;
 struct PrecomputedTransactionData;
 struct LockPoints;
 struct AssumeutxoData;
+namespace node {
+class SnapshotMetadata;
+} // namespace node
 
 /** Default for -minrelaytxfee, minimum relay fee for transactions */
 static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 1000;
@@ -476,7 +478,7 @@ protected:
 public:
     //! Reference to a BlockManager instance which itself is shared across all
     //! CChainState instances.
-    BlockManager& m_blockman;
+    node::BlockManager& m_blockman;
 
     /** Chain parameters for this chainstate */
     const CChainParams& m_params;
@@ -488,7 +490,7 @@ public:
 
     explicit CChainState(
         CTxMemPool* mempool,
-        BlockManager& blockman,
+        node::BlockManager& blockman,
         ChainstateManager& chainman,
         std::optional<uint256> from_snapshot_blockhash = std::nullopt);
 
@@ -535,7 +537,7 @@ public:
      * chainstates) and as good as our current tip or better. Entries may be failed,
      * though, and pruning nodes may be missing the data for the block.
      */
-    std::set<CBlockIndex*, CBlockIndexWorkComparator> setBlockIndexCandidates;
+    std::set<CBlockIndex*, node::CBlockIndexWorkComparator> setBlockIndexCandidates;
 
     //! @returns A reference to the in-memory cache of the UTXO set.
     CCoinsViewCache& CoinsTip() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
@@ -803,13 +805,13 @@ private:
     bool m_snapshot_validated{false};
 
     CBlockIndex* m_best_invalid;
-    friend bool BlockManager::LoadBlockIndex(const Consensus::Params&, ChainstateManager&);
+    friend bool node::BlockManager::LoadBlockIndex(const Consensus::Params&, ChainstateManager&);
 
     //! Internal helper for ActivateSnapshot().
     [[nodiscard]] bool PopulateAndValidateSnapshot(
         CChainState& snapshot_chainstate,
         CAutoFile& coins_file,
-        const SnapshotMetadata& metadata);
+        const node::SnapshotMetadata& metadata);
 
     /**
      * If a block header hasn't already been seen, call CheckBlockHeader on it, ensure
@@ -826,7 +828,7 @@ public:
     std::thread m_load_block;
     //! A single BlockManager instance is shared across each constructed
     //! chainstate to avoid duplicating block metadata.
-    BlockManager m_blockman GUARDED_BY(::cs_main);
+    node::BlockManager m_blockman GUARDED_BY(::cs_main);
 
     /**
      * In order to efficiently track invalidity of headers, we keep the set of
@@ -886,7 +888,7 @@ public:
     //! - Move the new chainstate to `m_snapshot_chainstate` and make it our
     //!   ChainstateActive().
     [[nodiscard]] bool ActivateSnapshot(
-        CAutoFile& coins_file, const SnapshotMetadata& metadata, bool in_memory);
+        CAutoFile& coins_file, const node::SnapshotMetadata& metadata, bool in_memory);
 
     //! The most-work chain.
     CChainState& ActiveChainstate() const;
@@ -894,7 +896,7 @@ public:
     int ActiveHeight() const { return ActiveChain().Height(); }
     CBlockIndex* ActiveTip() const { return ActiveChain().Tip(); }
 
-    BlockMap& BlockIndex() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+    node::BlockMap& BlockIndex() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
     {
         return m_blockman.m_block_index;
     }

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -15,6 +15,7 @@
 #include <sys/stat.h>
 #endif
 
+namespace wallet {
 namespace {
 
 //! Make sure database has a unique fileid within the environment. If it
@@ -846,3 +847,4 @@ std::unique_ptr<BerkeleyDatabase> MakeBerkeleyDatabase(const fs::path& path, con
     status = DatabaseStatus::SUCCESS;
     return db;
 }
+} // namespace wallet

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -31,6 +31,7 @@
 
 struct bilingual_str;
 
+namespace wallet {
 static const unsigned int DEFAULT_WALLET_DBLOGSIZE = 100;
 static const bool DEFAULT_WALLET_PRIVDB = true;
 
@@ -229,5 +230,6 @@ bool BerkeleyDatabaseSanityCheck();
 
 //! Return object giving access to Berkeley database at specified path.
 std::unique_ptr<BerkeleyDatabase> MakeBerkeleyDatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_BDB_H

--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -6,7 +6,9 @@
 
 #include <util/system.h>
 
+namespace wallet {
 CCoinControl::CCoinControl()
 {
     m_avoid_partial_spends = gArgs.GetBoolArg("-avoidpartialspends", DEFAULT_AVOIDPARTIALSPENDS);
 }
+} // namespace wallet

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -18,6 +18,7 @@
 #include <map>
 #include <set>
 
+namespace wallet {
 const int DEFAULT_MIN_DEPTH = 0;
 const int DEFAULT_MAX_DEPTH = 9999999;
 
@@ -118,5 +119,6 @@ private:
     std::set<COutPoint> setSelected;
     std::map<COutPoint, CTxOut> m_external_txouts;
 };
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_COINCONTROL_H

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -13,6 +13,7 @@
 #include <numeric>
 #include <optional>
 
+namespace wallet {
 // Descending order comparator
 struct {
     bool operator()(const OutputGroup& a, const OutputGroup& b) const
@@ -429,3 +430,4 @@ bool SelectionResult::operator<(SelectionResult other) const
     // As this operator is only used in std::min_element, we want the result that has more inputs when waste are equal.
     return *m_waste < *other.m_waste || (*m_waste == *other.m_waste && m_selected_inputs.size() > other.m_selected_inputs.size());
 }
+} // namespace wallet

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -12,6 +12,7 @@
 
 #include <optional>
 
+namespace wallet {
 //! target minimum change amount
 static constexpr CAmount MIN_CHANGE{COIN / 100};
 //! final minimum change amount after paying for fees
@@ -249,5 +250,6 @@ std::optional<SelectionResult> SelectCoinsSRD(const std::vector<OutputGroup>& ut
 
 // Original coin selection algorithm as a fallback
 std::optional<SelectionResult> KnapsackSolver(std::vector<OutputGroup>& groups, const CAmount& nTargetValue);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_COINSELECTION_H

--- a/src/wallet/context.cpp
+++ b/src/wallet/context.cpp
@@ -4,5 +4,7 @@
 
 #include <wallet/context.h>
 
+namespace wallet {
 WalletContext::WalletContext() {}
 WalletContext::~WalletContext() {}
+} // namespace wallet

--- a/src/wallet/context.h
+++ b/src/wallet/context.h
@@ -13,12 +13,13 @@
 #include <vector>
 
 class ArgsManager;
-class CWallet;
 namespace interfaces {
 class Chain;
 class Wallet;
 } // namespace interfaces
 
+namespace wallet {
+class CWallet;
 using LoadWalletFn = std::function<void(std::unique_ptr<interfaces::Wallet> wallet)>;
 
 //! WalletContext struct containing references to state shared between CWallet
@@ -46,5 +47,6 @@ struct WalletContext {
     WalletContext();
     ~WalletContext();
 };
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_CONTEXT_H

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -10,6 +10,7 @@
 
 #include <vector>
 
+namespace wallet {
 int CCrypter::BytesToKeySHA512AES(const std::vector<unsigned char>& chSalt, const SecureString& strKeyData, int count, unsigned char *key,unsigned char *iv) const
 {
     // This mimics the behavior of openssl's EVP_BytesToKey with an aes256cbc
@@ -136,3 +137,4 @@ bool DecryptKey(const CKeyingMaterial& vMasterKey, const std::vector<unsigned ch
     key.Set(vchSecret.begin(), vchSecret.end(), vchPubKey.IsCompressed());
     return key.VerifyPubKey(vchPubKey);
 }
+} // namespace wallet

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -10,6 +10,7 @@
 #include <script/signingprovider.h>
 
 
+namespace wallet {
 const unsigned int WALLET_CRYPTO_KEY_SIZE = 32;
 const unsigned int WALLET_CRYPTO_SALT_SIZE = 8;
 const unsigned int WALLET_CRYPTO_IV_SIZE = 16;
@@ -105,5 +106,6 @@ public:
 bool EncryptSecret(const CKeyingMaterial& vMasterKey, const CKeyingMaterial &vchPlaintext, const uint256& nIV, std::vector<unsigned char> &vchCiphertext);
 bool DecryptSecret(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char>& vchCiphertext, const uint256& nIV, CKeyingMaterial& vchPlaintext);
 bool DecryptKey(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char>& vchCryptedSecret, const CPubKey& vchPubKey, CKey& key);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_CRYPTER_H

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -10,6 +10,7 @@
 
 #include <string>
 
+namespace wallet {
 std::vector<fs::path> ListDatabases(const fs::path& wallet_dir)
 {
     std::vector<fs::path> paths;
@@ -132,3 +133,4 @@ bool IsSQLiteFile(const fs::path& path)
     // Check the application id matches our network magic
     return memcmp(Params().MessageStart(), app_id, 4) == 0;
 }
+} // namespace wallet

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -18,6 +18,7 @@
 
 struct bilingual_str;
 
+namespace wallet {
 void SplitWalletPath(const fs::path& wallet_path, fs::path& env_directory, std::string& database_filename);
 
 /** RAII class that provides access to a WalletDatabase */
@@ -232,5 +233,6 @@ fs::path BDBDataFile(const fs::path& path);
 fs::path SQLiteDataFile(const fs::path& path);
 bool IsBDBFile(const fs::path& path);
 bool IsSQLiteFile(const fs::path& path);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_DB_H

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -7,6 +7,7 @@
 #include <util/translation.h>
 #include <wallet/wallet.h>
 
+namespace wallet {
 static const std::string DUMP_MAGIC = "BITCOIN_CORE_WALLET_DUMP";
 uint32_t DUMP_VERSION = 1;
 
@@ -284,3 +285,4 @@ bool CreateFromDump(const std::string& name, const fs::path& wallet_path, biling
 
     return ret;
 }
+} // namespace wallet

--- a/src/wallet/dump.h
+++ b/src/wallet/dump.h
@@ -7,11 +7,12 @@
 
 #include <fs.h>
 
-class CWallet;
-
 struct bilingual_str;
 
+namespace wallet {
+class CWallet;
 bool DumpWallet(CWallet& wallet, bilingual_str& error);
 bool CreateFromDump(const std::string& name, const fs::path& wallet_path, bilingual_str& error, std::vector<bilingual_str>& warnings);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_DUMP_H

--- a/src/wallet/external_signer_scriptpubkeyman.cpp
+++ b/src/wallet/external_signer_scriptpubkeyman.cpp
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 
+namespace wallet {
 bool ExternalSignerScriptPubKeyMan::SetupDescriptor(std::unique_ptr<Descriptor> desc)
 {
     LOCK(cs_desc_man);
@@ -82,3 +83,4 @@ TransactionError ExternalSignerScriptPubKeyMan::FillPSBT(PartiallySignedTransact
     if (finalize) FinalizePSBT(psbt); // This won't work in a multisig setup
     return TransactionError::OK;
 }
+} // namespace wallet

--- a/src/wallet/external_signer_scriptpubkeyman.h
+++ b/src/wallet/external_signer_scriptpubkeyman.h
@@ -9,6 +9,7 @@
 
 #include <memory>
 
+namespace wallet {
 class ExternalSignerScriptPubKeyMan : public DescriptorScriptPubKeyMan
 {
   public:
@@ -30,4 +31,5 @@ class ExternalSignerScriptPubKeyMan : public DescriptorScriptPubKeyMan
 
   TransactionError FillPSBT(PartiallySignedTransaction& psbt, const PrecomputedTransactionData& txdata, int sighash_type = 1 /* SIGHASH_ALL */, bool sign = true, bool bip32derivs = false, int* n_signed = nullptr, bool finalize = true) const override;
 };
+} // namespace wallet
 #endif // BITCOIN_WALLET_EXTERNAL_SIGNER_SCRIPTPUBKEYMAN_H

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -16,6 +16,7 @@
 #include <wallet/spend.h>
 #include <wallet/wallet.h>
 
+namespace wallet {
 //! Check whether transaction has descendant in wallet or mempool, or has been
 //! mined, or conflicts with a mined transaction. Return a feebumper::Result.
 static feebumper::Result PreconditionChecks(const CWallet& wallet, const CWalletTx& wtx, std::vector<bilingual_str>& errors) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
@@ -282,3 +283,4 @@ Result CommitTransaction(CWallet& wallet, const uint256& txid, CMutableTransacti
 }
 
 } // namespace feebumper
+} // namespace wallet

--- a/src/wallet/feebumper.h
+++ b/src/wallet/feebumper.h
@@ -7,12 +7,14 @@
 
 #include <primitives/transaction.h>
 
-class CWallet;
-class CWalletTx;
 class uint256;
-class CCoinControl;
 enum class FeeEstimateMode;
 struct bilingual_str;
+
+namespace wallet {
+class CCoinControl;
+class CWallet;
+class CWalletTx;
 
 namespace feebumper {
 
@@ -54,5 +56,6 @@ Result CommitTransaction(CWallet& wallet,
     uint256& bumped_txid);
 
 } // namespace feebumper
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_FEEBUMPER_H

--- a/src/wallet/fees.cpp
+++ b/src/wallet/fees.cpp
@@ -9,6 +9,7 @@
 #include <wallet/wallet.h>
 
 
+namespace wallet {
 CAmount GetRequiredFee(const CWallet& wallet, unsigned int nTxBytes)
 {
     return GetRequiredFeeRate(wallet).GetFee(nTxBytes);
@@ -90,3 +91,4 @@ CFeeRate GetDiscardRate(const CWallet& wallet)
     discard_rate = std::max(discard_rate, wallet.chain().relayDustFee());
     return discard_rate;
 }
+} // namespace wallet

--- a/src/wallet/fees.h
+++ b/src/wallet/fees.h
@@ -8,10 +8,12 @@
 
 #include <consensus/amount.h>
 
-class CCoinControl;
 class CFeeRate;
-class CWallet;
 struct FeeCalculation;
+
+namespace wallet {
+class CCoinControl;
+class CWallet;
 
 /**
  * Return the minimum required absolute fee for this size
@@ -41,5 +43,6 @@ CFeeRate GetMinimumFeeRate(const CWallet& wallet, const CCoinControl& coin_contr
  * Return the maximum feerate for discarding change.
  */
 CFeeRate GetDiscardRate(const CWallet& wallet);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_FEES_H

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -25,6 +25,7 @@
 
 using node::NodeContext;
 
+namespace wallet {
 class WalletInit : public WalletInitInterface
 {
 public:
@@ -40,8 +41,6 @@ public:
     //! Add wallets that should be opened to list of chain clients.
     void Construct(NodeContext& node) const override;
 };
-
-const WalletInitInterface& g_wallet_init_interface = WalletInit();
 
 void WalletInit::AddWalletOptions(ArgsManager& argsman) const
 {
@@ -139,3 +138,6 @@ void WalletInit::Construct(NodeContext& node) const
     node.wallet_loader = wallet_loader.get();
     node.chain_clients.emplace_back(std::move(wallet_loader));
 }
+} // namespace wallet
+
+const WalletInitInterface& g_wallet_init_interface = wallet::WalletInit();

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -23,6 +23,8 @@
 #include <wallet/wallet.h>
 #include <walletinitinterface.h>
 
+using node::NodeContext;
+
 class WalletInit : public WalletInitInterface
 {
 public:

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -598,7 +598,7 @@ public:
 } // namespace wallet
 
 namespace interfaces {
-std::unique_ptr<Wallet> MakeWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet) { return wallet ? std::make_unique<wallet::WalletImpl>(context, wallet) : nullptr; }
+std::unique_ptr<Wallet> MakeWallet(wallet::WalletContext& context, const std::shared_ptr<wallet::CWallet>& wallet) { return wallet ? std::make_unique<wallet::WalletImpl>(context, wallet) : nullptr; }
 
 std::unique_ptr<WalletLoader> MakeWalletLoader(Chain& chain, ArgsManager& args)
 {

--- a/src/wallet/ismine.h
+++ b/src/wallet/ismine.h
@@ -12,8 +12,10 @@
 #include <cstdint>
 #include <type_traits>
 
-class CWallet;
 class CScript;
+
+namespace wallet {
+class CWallet;
 
 /**
  * IsMine() return codes, which depend on ScriptPubKeyMan implementation.
@@ -66,5 +68,6 @@ struct CachableAmount
         m_value[filter] = value;
     }
 };
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_ISMINE_H

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -19,6 +19,7 @@
 
 #include <univalue.h>
 
+namespace wallet {
 bool VerifyWallets(WalletContext& context)
 {
     interfaces::Chain& chain = *context.chain;
@@ -169,3 +170,4 @@ void UnloadWallets(WalletContext& context)
         UnloadWallet(std::move(wallet));
     }
 }
+} // namespace wallet

--- a/src/wallet/load.h
+++ b/src/wallet/load.h
@@ -11,11 +11,13 @@
 
 class ArgsManager;
 class CScheduler;
-struct WalletContext;
 
 namespace interfaces {
 class Chain;
 } // namespace interfaces
+
+namespace wallet {
+struct WalletContext;
 
 //! Responsible for reading and validating the -wallet arguments and verifying the wallet database.
 bool VerifyWallets(WalletContext& context);
@@ -34,5 +36,6 @@ void StopWallets(WalletContext& context);
 
 //! Close all wallets.
 void UnloadWallets(WalletContext& context);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_LOAD_H

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -8,6 +8,7 @@
 #include <wallet/transaction.h>
 #include <wallet/wallet.h>
 
+namespace wallet {
 isminetype InputIsMine(const CWallet& wallet, const CTxIn &txin)
 {
     AssertLockHeld(wallet.cs_wallet);
@@ -473,3 +474,4 @@ std::set< std::set<CTxDestination> > GetAddressGroupings(const CWallet& wallet)
 
     return ret;
 }
+} // namespace wallet

--- a/src/wallet/receive.h
+++ b/src/wallet/receive.h
@@ -10,6 +10,7 @@
 #include <wallet/transaction.h>
 #include <wallet/wallet.h>
 
+namespace wallet {
 isminetype InputIsMine(const CWallet& wallet, const CTxIn& txin) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 
 /** Returns whether all of the inputs match the filter */
@@ -60,5 +61,6 @@ Balance GetBalance(const CWallet& wallet, int min_depth = 0, bool avoid_reuse = 
 
 std::map<CTxDestination, CAmount> GetAddressBalances(const CWallet& wallet);
 std::set<std::set<CTxDestination>> GetAddressGroupings(const CWallet& wallet) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_RECEIVE_H

--- a/src/wallet/rpc/addresses.cpp
+++ b/src/wallet/rpc/addresses.cpp
@@ -13,6 +13,7 @@
 
 #include <univalue.h>
 
+namespace wallet {
 RPCHelpMan getnewaddress()
 {
     return RPCHelpMan{"getnewaddress",
@@ -802,3 +803,4 @@ RPCHelpMan walletdisplayaddress()
     };
 }
 #endif // ENABLE_EXTERNAL_SIGNER
+} // namespace wallet

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -31,6 +31,7 @@
 
 using interfaces::FoundBlock;
 
+namespace wallet {
 std::string static EncodeDumpString(const std::string &str) {
     std::stringstream ret;
     for (const unsigned char c : str) {
@@ -1900,3 +1901,4 @@ RPCHelpMan restorewallet()
 },
     };
 }
+} // namespace wallet

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -15,6 +15,7 @@
 #include <univalue.h>
 
 
+namespace wallet {
 static CAmount GetReceived(const CWallet& wallet, const UniValue& params, bool by_label) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
     std::set<CTxDestination> address_set;
@@ -731,3 +732,4 @@ RPCHelpMan listunspent()
 },
     };
 }
+} // namespace wallet

--- a/src/wallet/rpc/encrypt.cpp
+++ b/src/wallet/rpc/encrypt.cpp
@@ -7,6 +7,7 @@
 #include <wallet/wallet.h>
 
 
+namespace wallet {
 RPCHelpMan walletpassphrase()
 {
     return RPCHelpMan{"walletpassphrase",
@@ -246,3 +247,4 @@ RPCHelpMan encryptwallet()
 },
     };
 }
+} // namespace wallet

--- a/src/wallet/rpc/signmessage.cpp
+++ b/src/wallet/rpc/signmessage.cpp
@@ -10,6 +10,7 @@
 
 #include <univalue.h>
 
+namespace wallet {
 RPCHelpMan signmessage()
 {
     return RPCHelpMan{"signmessage",
@@ -66,3 +67,4 @@ RPCHelpMan signmessage()
         },
     };
 }
+} // namespace wallet

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -19,6 +19,7 @@
 #include <univalue.h>
 
 
+namespace wallet {
 static void ParseRecipients(const UniValue& address_amounts, const UniValue& subtract_fee_outputs, std::vector<CRecipient> &recipients) {
     std::set<CTxDestination> destinations;
     int i = 0;
@@ -1367,3 +1368,4 @@ RPCHelpMan walletcreatefundedpsbt()
 },
     };
 }
+} // namespace wallet

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -13,6 +13,7 @@
 
 using interfaces::FoundBlock;
 
+namespace wallet {
 static void WalletTxToJSON(const CWallet& wallet, const CWalletTx& wtx, UniValue& entry)
 {
     interfaces::Chain& chain = wallet.chain();
@@ -958,3 +959,4 @@ RPCHelpMan abortrescan()
 },
     };
 }
+} // namespace wallet

--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -12,6 +12,7 @@
 
 #include <univalue.h>
 
+namespace wallet {
 static const std::string WALLET_ENDPOINT_BASE = "/wallet/";
 const std::string HELP_REQUIRING_PASSPHRASE{"\nRequires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.\n"};
 
@@ -148,3 +149,4 @@ void HandleWalletError(const std::shared_ptr<CWallet> wallet, DatabaseStatus& st
         throw JSONRPCError(code, error.original);
     }
 }
+} // namespace wallet

--- a/src/wallet/rpc/util.h
+++ b/src/wallet/rpc/util.h
@@ -10,12 +10,14 @@
 #include <string>
 #include <vector>
 
-struct bilingual_str;
-class CWallet;
-enum class DatabaseStatus;
 class JSONRPCRequest;
-class LegacyScriptPubKeyMan;
 class UniValue;
+struct bilingual_str;
+
+namespace wallet {
+class CWallet;
+class LegacyScriptPubKeyMan;
+enum class DatabaseStatus;
 struct WalletContext;
 
 extern const std::string HELP_REQUIRING_PASSPHRASE;
@@ -39,5 +41,6 @@ bool ParseIncludeWatchonly(const UniValue& include_watchonly, const CWallet& wal
 std::string LabelFromValue(const UniValue& value);
 
 void HandleWalletError(const std::shared_ptr<CWallet> wallet, DatabaseStatus& status, bilingual_str& error);
+} //  namespace wallet
 
 #endif // BITCOIN_WALLET_RPC_UTIL_H

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -18,6 +18,7 @@
 #include <univalue.h>
 
 
+namespace wallet {
 /** Checks if a CKey is in the given CWallet compressed or otherwise*/
 bool HaveKey(const SigningProvider& wallet, const CKey& key)
 {
@@ -729,3 +730,4 @@ static const CRPCCommand commands[] =
 // clang-format on
     return commands;
 }
+} // namespace wallet

--- a/src/wallet/rpc/wallet.h
+++ b/src/wallet/rpc/wallet.h
@@ -9,6 +9,8 @@
 
 class CRPCCommand;
 
+namespace wallet {
 Span<const CRPCCommand> GetWalletRPCCommands();
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_RPC_WALLET_H

--- a/src/wallet/salvage.cpp
+++ b/src/wallet/salvage.cpp
@@ -11,6 +11,7 @@
 #include <wallet/wallet.h>
 #include <wallet/walletdb.h>
 
+namespace wallet {
 /* End of headers, beginning of key/value data */
 static const char *HEADER_END = "HEADER=END";
 /* End of key/value data */
@@ -165,3 +166,4 @@ bool RecoverDatabaseFile(const fs::path& file_path, bilingual_str& error, std::v
 
     return fSuccess;
 }
+} // namespace wallet

--- a/src/wallet/salvage.h
+++ b/src/wallet/salvage.h
@@ -11,6 +11,8 @@
 
 struct bilingual_str;
 
+namespace wallet {
 bool RecoverDatabaseFile(const fs::path& file_path, bilingual_str& error, std::vector<bilingual_str>& warnings);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_SALVAGE_H

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -17,6 +17,7 @@
 
 #include <optional>
 
+namespace wallet {
 //! Value for the first BIP 32 hardened derivation. Can be used as a bit mask and as a value. See BIP 32 for more details.
 const uint32_t BIP32_HARDENED_KEY_LIMIT = 0x80000000;
 
@@ -2359,3 +2360,4 @@ bool DescriptorScriptPubKeyMan::CanUpdateToWalletDescriptor(const WalletDescript
 
     return true;
 }
+} // namespace wallet

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -25,6 +25,7 @@
 enum class OutputType;
 struct bilingual_str;
 
+namespace wallet {
 // Wallet storage things that ScriptPubKeyMans need in order to be able to store things to the wallet database.
 // It provides access to things that are part of the entire wallet and not specific to a ScriptPubKeyMan such as
 // wallet flags, wallet version, encryption keys, encryption status, and the database itself. This allows a
@@ -631,5 +632,6 @@ public:
 
     void UpgradeDescriptorCache();
 };
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_SCRIPTPUBKEYMAN_H

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -21,6 +21,7 @@
 
 using interfaces::FoundBlock;
 
+namespace wallet {
 static constexpr size_t OUTPUT_GROUP_MAX_ENTRIES{100};
 
 int GetTxSpendSize(const CWallet& wallet, const CWalletTx& wtx, unsigned int out, bool use_max_sig)
@@ -1030,3 +1031,4 @@ bool FundTransaction(CWallet& wallet, CMutableTransaction& tx, CAmount& nFeeRet,
 
     return true;
 }
+} // namespace wallet

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -10,6 +10,7 @@
 #include <wallet/transaction.h>
 #include <wallet/wallet.h>
 
+namespace wallet {
 /** Get the marginal bytes if spending the specified output from this transaction */
 int GetTxSpendSize(const CWallet& wallet, const CWalletTx& wtx, unsigned int out, bool use_max_sig = false);
 
@@ -142,5 +143,6 @@ bool CreateTransaction(CWallet& wallet, const std::vector<CRecipient>& vecSend, 
  * calling CreateTransaction();
  */
 bool FundTransaction(CWallet& wallet, CMutableTransaction& tx, CAmount& nFeeRet, int& nChangePosInOut, bilingual_str& error, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, CCoinControl);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_SPEND_H

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 #include <vector>
 
+namespace wallet {
 static constexpr int32_t WALLET_SCHEMA_VERSION = 0;
 
 static Mutex g_sqlite_mutex;
@@ -578,3 +579,4 @@ std::string SQLiteDatabaseVersion()
 {
     return std::string(sqlite3_libversion());
 }
+} // namespace wallet

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -10,6 +10,8 @@
 #include <sqlite3.h>
 
 struct bilingual_str;
+
+namespace wallet {
 class SQLiteDatabase;
 
 /** RAII class that provides access to a WalletDatabase */
@@ -116,5 +118,6 @@ public:
 std::unique_ptr<SQLiteDatabase> MakeSQLiteDatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error);
 
 std::string SQLiteDatabaseVersion();
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_SQLITE_H

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -18,6 +18,7 @@
 #include <boost/test/unit_test.hpp>
 #include <random>
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(coinselector_tests, WalletTestingSetup)
 
 // how many times to run all the tests to have a chance to catch errors that only show up with particular random shuffles
@@ -807,3 +808,4 @@ BOOST_AUTO_TEST_CASE(waste_test)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -11,6 +11,7 @@
 #include <wallet/bdb.h>
 
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(db_tests, BasicTestingSetup)
 
 static std::shared_ptr<BerkeleyEnvironment> GetWalletEnv(const fs::path& path, std::string& database_filename)
@@ -77,3 +78,4 @@ BOOST_AUTO_TEST_CASE(getwalletenv_g_dbenvs_free_instance)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/fuzz/notifications.cpp
+++ b/src/wallet/test/fuzz/notifications.cpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 
+namespace wallet {
 namespace {
 const TestingSetup* g_setup;
 
@@ -168,3 +169,4 @@ FUZZ_TARGET_INIT(wallet_notifications, initialize_setup)
     }
 }
 } // namespace
+} // namespace wallet

--- a/src/wallet/test/init_test_fixture.cpp
+++ b/src/wallet/test/init_test_fixture.cpp
@@ -9,6 +9,7 @@
 
 #include <wallet/test/init_test_fixture.h>
 
+namespace wallet {
 InitWalletDirTestingSetup::InitWalletDirTestingSetup(const std::string& chainName) : BasicTestingSetup(chainName)
 {
     m_wallet_loader = MakeWalletLoader(*m_node.chain, *Assert(m_node.args));
@@ -48,3 +49,4 @@ void InitWalletDirTestingSetup::SetWalletDir(const fs::path& walletdir_path)
 {
     gArgs.ForceSetArg("-walletdir", fs::PathToString(walletdir_path));
 }
+} // namespace wallet

--- a/src/wallet/test/init_test_fixture.h
+++ b/src/wallet/test/init_test_fixture.h
@@ -11,6 +11,7 @@
 #include <test/util/setup_common.h>
 
 
+namespace wallet {
 struct InitWalletDirTestingSetup: public BasicTestingSetup {
     explicit InitWalletDirTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
     ~InitWalletDirTestingSetup();
@@ -23,3 +24,4 @@ struct InitWalletDirTestingSetup: public BasicTestingSetup {
 };
 
 #endif // BITCOIN_WALLET_TEST_INIT_TEST_FIXTURE_H
+} // namespace wallet

--- a/src/wallet/test/init_tests.cpp
+++ b/src/wallet/test/init_tests.cpp
@@ -10,6 +10,7 @@
 #include <util/system.h>
 #include <wallet/test/init_test_fixture.h>
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(init_tests, InitWalletDirTestingSetup)
 
 BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_default)
@@ -83,3 +84,4 @@ BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_no_trailing2)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/ismine_tests.cpp
+++ b/src/wallet/test/ismine_tests.cpp
@@ -13,6 +13,7 @@
 #include <boost/test/unit_test.hpp>
 
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(ismine_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(ismine_standard)
@@ -417,3 +418,4 @@ BOOST_AUTO_TEST_CASE(ismine_standard)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -11,6 +11,7 @@
 #include <test/util/setup_common.h>
 #include <wallet/test/wallet_test_fixture.h>
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(psbt_wallet_tests, WalletTestingSetup)
 
 static void import_descriptor(CWallet& wallet, const std::string& descriptor)
@@ -145,3 +146,4 @@ BOOST_AUTO_TEST_CASE(parse_hd_keypath)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/scriptpubkeyman_tests.cpp
+++ b/src/wallet/test/scriptpubkeyman_tests.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(scriptpubkeyman_tests, BasicTestingSetup)
 
 // Test LegacyScriptPubKeyMan::CanProvide behavior, making sure it returns true
@@ -39,3 +40,4 @@ BOOST_AUTO_TEST_CASE(CanProvide)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/spend_tests.cpp
+++ b/src/wallet/test/spend_tests.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(spend_tests, WalletTestingSetup)
 
 BOOST_FIXTURE_TEST_CASE(SubtractFee, TestChain100Setup)
@@ -63,3 +64,4 @@ BOOST_FIXTURE_TEST_CASE(SubtractFee, TestChain100Setup)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -15,6 +15,7 @@
 
 #include <memory>
 
+namespace wallet {
 std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, CChain& cchain, ArgsManager& args, const CKey& key)
 {
     auto wallet = std::make_unique<CWallet>(&chain, "", args, CreateMockWalletDatabase());
@@ -44,3 +45,4 @@ std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, CChain& cc
     BOOST_CHECK(result.last_failed_block.IsNull());
     return wallet;
 }
+} // namespace wallet

--- a/src/wallet/test/util.h
+++ b/src/wallet/test/util.h
@@ -10,11 +10,14 @@
 class ArgsManager;
 class CChain;
 class CKey;
-class CWallet;
 namespace interfaces {
 class Chain;
 } // namespace interfaces
 
+namespace wallet {
+class CWallet;
+
 std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, CChain& cchain, ArgsManager& args, const CKey& key);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_TEST_UTIL_H

--- a/src/wallet/test/wallet_crypto_tests.cpp
+++ b/src/wallet/test/wallet_crypto_tests.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(wallet_crypto_tests, BasicTestingSetup)
 
 class TestCrypter
@@ -124,3 +125,4 @@ BOOST_AUTO_TEST_CASE(decrypt) {
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -6,6 +6,7 @@
 
 #include <scheduler.h>
 
+namespace wallet {
 WalletTestingSetup::WalletTestingSetup(const std::string& chainName)
     : TestingSetup(chainName),
       m_wallet(m_node.chain.get(), "", m_args, CreateMockWalletDatabase())
@@ -19,3 +20,4 @@ WalletTestingSetup::~WalletTestingSetup()
 {
     if (m_node.scheduler) m_node.scheduler->stop();
 }
+} // namespace wallet

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -15,6 +15,7 @@
 
 #include <memory>
 
+namespace wallet {
 /** Testing setup and teardown for wallet.
  */
 struct WalletTestingSetup : public TestingSetup {
@@ -25,5 +26,6 @@ struct WalletTestingSetup : public TestingSetup {
     CWallet m_wallet;
     std::unique_ptr<interfaces::Handler> m_chain_notifications_handler;
 };
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_TEST_WALLET_TEST_FIXTURE_H

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -30,6 +30,9 @@
 #include <boost/test/unit_test.hpp>
 #include <univalue.h>
 
+using node::MAX_BLOCKFILE_SIZE;
+using node::UnlinkPrunedFiles;
+
 RPCHelpMan importmulti();
 RPCHelpMan dumpwallet();
 RPCHelpMan importwallet();

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -33,6 +33,7 @@
 using node::MAX_BLOCKFILE_SIZE;
 using node::UnlinkPrunedFiles;
 
+namespace wallet {
 RPCHelpMan importmulti();
 RPCHelpMan dumpwallet();
 RPCHelpMan importwallet();
@@ -292,7 +293,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         request.params.setArray();
         request.params.push_back(backup_file);
 
-        ::dumpwallet().HandleRequest(request);
+        wallet::dumpwallet().HandleRequest(request);
         RemoveWallet(context, wallet, /* load_on_start= */ std::nullopt);
     }
 
@@ -311,7 +312,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         request.params.push_back(backup_file);
         AddWallet(context, wallet);
         wallet->SetLastBlockProcessed(m_node.chainman->ActiveChain().Height(), m_node.chainman->ActiveChain().Tip()->GetBlockHash());
-        ::importwallet().HandleRequest(request);
+        wallet::importwallet().HandleRequest(request);
         RemoveWallet(context, wallet, /* load_on_start= */ std::nullopt);
 
         BOOST_CHECK_EQUAL(wallet->mapWallet.size(), 3U);
@@ -854,3 +855,4 @@ BOOST_FIXTURE_TEST_CASE(ZapSelectTx, TestChain100Setup)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/wallet_transaction_tests.cpp
+++ b/src/wallet/test/wallet_transaction_tests.cpp
@@ -8,6 +8,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(wallet_transaction_tests, WalletTestingSetup)
 
 BOOST_AUTO_TEST_CASE(roundtrip)
@@ -22,3 +23,4 @@ BOOST_AUTO_TEST_CASE(roundtrip)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/walletdb_tests.cpp
+++ b/src/wallet/test/walletdb_tests.cpp
@@ -9,6 +9,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(walletdb_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(walletdb_readkeyvalue)
@@ -27,3 +28,4 @@ BOOST_AUTO_TEST_CASE(walletdb_readkeyvalue)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/transaction.cpp
+++ b/src/wallet/transaction.cpp
@@ -4,6 +4,7 @@
 
 #include <wallet/transaction.h>
 
+namespace wallet {
 bool CWalletTx::IsEquivalentTo(const CWalletTx& _tx) const
 {
         CMutableTransaction tx1 {*this->tx};
@@ -23,3 +24,4 @@ int64_t CWalletTx::GetTxTime() const
     int64_t n = nTimeSmart;
     return n ? n : nTimeReceived;
 }
+} // namespace wallet

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -19,6 +19,7 @@
 #include <variant>
 #include <vector>
 
+namespace wallet {
 //! State of transaction confirmed in a block.
 struct TxStateConfirmed {
     uint256 confirmed_block_hash;
@@ -303,5 +304,6 @@ public:
     CWalletTx(CWalletTx const &) = delete;
     void operator=(CWalletTx const &x) = delete;
 };
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_TRANSACTION_H

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -48,6 +48,7 @@
 
 using interfaces::FoundBlock;
 
+namespace wallet {
 const std::map<uint64_t,std::string> WALLET_FLAG_CAVEATS{
     {WALLET_FLAG_AVOID_REUSE,
         "You need to rescan the blockchain in order to correctly mark used "
@@ -3433,3 +3434,4 @@ ScriptPubKeyMan* CWallet::AddWalletDescriptor(WalletDescriptor& desc, const Flat
 
     return spk_man;
 }
+} // namespace wallet

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -40,11 +40,16 @@
 
 #include <boost/signals2/signal.hpp>
 
-struct WalletContext;
 
 using LoadWalletFn = std::function<void(std::unique_ptr<interfaces::Wallet> wallet)>;
 
+class CScript;
+enum class FeeEstimateMode;
+struct FeeCalculation;
 struct bilingual_str;
+
+namespace wallet {
+struct WalletContext;
 
 //! Explicitly unload and delete the wallet.
 //! Blocks the current thread after signaling the unload intent so that all
@@ -107,10 +112,7 @@ static constexpr size_t DUMMY_NESTED_P2WPKH_INPUT_SIZE = 91;
 
 class CCoinControl;
 class COutput;
-class CScript;
 class CWalletTx;
-struct FeeCalculation;
-enum class FeeEstimateMode;
 class ReserveDestination;
 
 //! Default for -addresstype
@@ -936,5 +938,6 @@ bool AddWalletSetting(interfaces::Chain& chain, const std::string& wallet_name);
 bool RemoveWalletSetting(interfaces::Chain& chain, const std::string& wallet_name);
 
 bool DummySignInput(const SigningProvider& provider, CTxIn &tx_in, const CTxOut &txout, bool use_max_sig);
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_WALLET_H

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -26,6 +26,7 @@
 #include <optional>
 #include <string>
 
+namespace wallet {
 namespace DBKeys {
 const std::string ACENTRY{"acentry"};
 const std::string ACTIVEEXTERNALSPK{"activeexternalspk"};
@@ -1194,3 +1195,4 @@ std::unique_ptr<WalletDatabase> CreateMockWalletDatabase()
     return std::make_unique<BerkeleyDatabase>(std::make_shared<BerkeleyEnvironment>(), "");
 #endif
 }
+} // namespace wallet

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -15,6 +15,18 @@
 #include <string>
 #include <vector>
 
+class CScript;
+class uint160;
+class uint256;
+struct CBlockLocator;
+
+namespace wallet {
+class CKeyPool;
+class CMasterKey;
+class CWallet;
+class CWalletTx;
+struct WalletContext;
+
 /**
  * Overview of wallet database classes:
  *
@@ -28,16 +40,6 @@
  */
 
 static const bool DEFAULT_FLUSHWALLET = true;
-
-struct CBlockLocator;
-struct WalletContext;
-class CKeyPool;
-class CMasterKey;
-class CScript;
-class CWallet;
-class CWalletTx;
-class uint160;
-class uint256;
 
 /** Error statuses for the wallet database */
 enum class DBErrors
@@ -297,5 +299,6 @@ std::unique_ptr<WalletDatabase> CreateDummyWalletDatabase();
 
 /** Return object for accessing temporary in-memory database. */
 std::unique_ptr<WalletDatabase> CreateMockWalletDatabase();
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_WALLETDB_H

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -16,6 +16,7 @@
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
 
+namespace wallet {
 namespace WalletTool {
 
 // The standard wallet deleter function blocks on the validation interface
@@ -219,3 +220,4 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
     return true;
 }
 } // namespace WalletTool
+} // namespace wallet

--- a/src/wallet/wallettool.h
+++ b/src/wallet/wallettool.h
@@ -9,10 +9,12 @@
 
 class ArgsManager;
 
+namespace wallet {
 namespace WalletTool {
 
 bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command);
 
 } // namespace WalletTool
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_WALLETTOOL_H

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -7,6 +7,7 @@
 #include <logging.h>
 #include <util/system.h>
 
+namespace wallet {
 fs::path GetWalletDir()
 {
     fs::path path;
@@ -42,3 +43,4 @@ WalletFeature GetClosestWalletFeature(int version)
     }
     return static_cast<WalletFeature>(0);
 }
+} // namespace wallet

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -10,6 +10,7 @@
 
 #include <vector>
 
+namespace wallet {
 /** (client) version numbers for particular wallet features */
 enum WalletFeature
 {
@@ -103,5 +104,6 @@ public:
     WalletDescriptor() {}
     WalletDescriptor(std::shared_ptr<Descriptor> descriptor, uint64_t creation_time, int32_t range_start, int32_t range_end, int32_t next_index) : descriptor(descriptor), creation_time(creation_time), range_start(range_start), range_end(range_end), next_index(next_index) {}
 };
+} // namespace wallet
 
 #endif // BITCOIN_WALLET_WALLETUTIL_H

--- a/src/walletinitinterface.h
+++ b/src/walletinitinterface.h
@@ -7,7 +7,9 @@
 
 class ArgsManager;
 
+namespace node {
 struct NodeContext;
+} // namespace node
 
 class WalletInitInterface {
 public:
@@ -18,7 +20,7 @@ public:
     /** Check wallet parameter interaction */
     virtual bool ParameterInteraction() const = 0;
     /** Add wallets that should be opened to list of chain clients. */
-    virtual void Construct(NodeContext& node) const = 0;
+    virtual void Construct(node::NodeContext& node) const = 0;
 
     virtual ~WalletInitInterface() {}
 };

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -23,6 +23,8 @@
 #include <string>
 #include <utility>
 
+using node::ReadBlockFromDisk;
+
 static std::multimap<std::string, CZMQAbstractPublishNotifier*> mapPublishNotifiers;
 
 static const char *MSG_HASHBLOCK = "hashblock";


### PR DESCRIPTION
There are no code changes, this is just adding `namespace` and `using` declarations and `node::` or `wallet::` qualifiers in some places.

Motivations for this change are:

- To make it easier to see when node and wallet code is being accessed places where it shouldn't be. For example if GUI code is accessing node and wallet internals or if wallet and node code are referencing each other.
- To make source code organization clearer ([#15732](https://github.com/bitcoin/bitcoin/issues/15732)), being able to know that `wallet::` code is in `src/wallet/`, `node::` code is in `src/node/`, `init::` code is in `src/init/`, `util::` code is in `src/util/`, etc.

Reviewing with `git log -p -n1 -U0 --word-diff-regex=.` can be helpful to verify this is only updating declarations, not changing code.