### PR TITLE
test: remove unnecessary block rehashing prior to solving

### DIFF
--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -126,7 +126,6 @@ class AssumeValidTest(BitcoinTestFramework):
         self.block_time += 1
         block102.vtx.extend([tx])
         block102.hashMerkleRoot = block102.calc_merkle_root()
-        block102.rehash()
         block102.solve()
         self.blocks.append(block102)
         self.tip = block102.sha256

--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -335,7 +335,6 @@ class BIP68Test(BitcoinTestFramework):
         # tx3 to be removed.
         for i in range(2):
             block = create_block(tmpl=tmpl, ntime=cur_time)
-            block.rehash()
             block.solve()
             tip = block.sha256
             assert_equal(None if i == 1 else 'inconclusive', self.nodes[0].submitblock(block.serialize().hex()))
@@ -392,7 +391,6 @@ class BIP68Test(BitcoinTestFramework):
         block = create_block(tmpl=self.nodes[0].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS))
         block.vtx.extend([tx1, tx2, tx3])
         block.hashMerkleRoot = block.calc_merkle_root()
-        block.rehash()
         add_witness_commitment(block)
         block.solve()
 

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -612,7 +612,6 @@ class FullBlockTest(BitcoinTestFramework):
         b45.nBits = 0x207fffff
         b45.vtx.append(non_coinbase)
         b45.hashMerkleRoot = b45.calc_merkle_root()
-        b45.calc_sha256()
         b45.solve()
         self.block_heights[b45.sha256] = self.block_heights[self.tip.sha256] + 1
         self.tip = b45

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -177,7 +177,6 @@ class BIP68_112_113Test(BitcoinTestFramework):
         block.nVersion = 4
         block.vtx.extend(txs)
         block.hashMerkleRoot = block.calc_merkle_root()
-        block.rehash()
         block.solve()
         return block
 

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -88,7 +88,6 @@ class BIP66Test(BitcoinTestFramework):
         block = create_block(int(tip, 16), create_coinbase(DERSIG_HEIGHT - 1), block_time)
         block.vtx.append(spendtx)
         block.hashMerkleRoot = block.calc_merkle_root()
-        block.rehash()
         block.solve()
 
         assert_equal(self.nodes[0].getblockcount(), DERSIG_HEIGHT - 2)
@@ -103,7 +102,6 @@ class BIP66Test(BitcoinTestFramework):
         block_time += 1
         block = create_block(tip, create_coinbase(DERSIG_HEIGHT), block_time)
         block.nVersion = 2
-        block.rehash()
         block.solve()
 
         with self.nodes[0].assert_debug_log(expected_msgs=[f'{block.hash}, bad-version(0x00000002)']):
@@ -133,7 +131,6 @@ class BIP66Test(BitcoinTestFramework):
         # Now we verify that a block with this transaction is also invalid.
         block.vtx.append(spendtx)
         block.hashMerkleRoot = block.calc_merkle_root()
-        block.rehash()
         block.solve()
 
         with self.nodes[0].assert_debug_log(expected_msgs=[f'CheckInputScripts on {block.vtx[-1].hash} failed with non-mandatory-script-verify-flag (Non-canonical DER signature)']):
@@ -144,7 +141,6 @@ class BIP66Test(BitcoinTestFramework):
         self.log.info("Test that a block with a DERSIG-compliant transaction is accepted")
         block.vtx[1] = self.create_tx(self.coinbase_txids[1])
         block.hashMerkleRoot = block.calc_merkle_root()
-        block.rehash()
         block.solve()
 
         self.test_dersig_info(is_active=True)  # Not active as of current tip, but next block must obey rules

--- a/test/functional/feature_nulldummy.py
+++ b/test/functional/feature_nulldummy.py
@@ -130,7 +130,6 @@ class NULLDUMMYTest(BitcoinTestFramework):
         block.hashMerkleRoot = block.calc_merkle_root()
         if with_witness:
             add_witness_commitment(block)
-        block.rehash()
         block.solve()
         assert_equal(None if accept else NULLDUMMY_ERROR, node.submitblock(block.serialize().hex()))
         if accept:

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1240,7 +1240,6 @@ class TaprootTest(BitcoinTestFramework):
             block.vtx.append(tx)
         block.hashMerkleRoot = block.calc_merkle_root()
         witness and add_witness_commitment(block)
-        block.rehash()
         block.solve()
         block_response = node.submitblock(block.serialize().hex())
         if err_msg is not None:
@@ -1488,7 +1487,6 @@ class TaprootTest(BitcoinTestFramework):
         # Mine a block with the transaction
         block = create_block(tmpl=self.nodes[1].getblocktemplate(NORMAL_GBT_REQUEST_PARAMS), txlist=[rawtx])
         add_witness_commitment(block)
-        block.rehash()
         block.solve()
         assert_equal(None, self.nodes[1].submitblock(block.serialize().hex()))
         self.sync_blocks()

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -75,7 +75,6 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
 
         block2.vtx.extend([tx1, tx2])
         block2.hashMerkleRoot = block2.calc_merkle_root()
-        block2.rehash()
         block2.solve()
         orig_hash = block2.sha256
         block2_orig = copy.deepcopy(block2)
@@ -95,7 +94,6 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
         block2_dup.vtx[2].vin.append(block2_dup.vtx[2].vin[0])
         block2_dup.vtx[2].rehash()
         block2_dup.hashMerkleRoot = block2_dup.calc_merkle_root()
-        block2_dup.rehash()
         block2_dup.solve()
         peer.send_blocks_and_test([block2_dup], node, success=False, reject_reason='bad-txns-inputs-duplicate')
 
@@ -107,7 +105,6 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
         block3.vtx[0].sha256 = None
         block3.vtx[0].calc_sha256()
         block3.hashMerkleRoot = block3.calc_merkle_root()
-        block3.rehash()
         block3.solve()
 
         peer.send_blocks_and_test([block3], node, success=False, reject_reason='bad-cb-amount')
@@ -134,7 +131,6 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
         tx3.rehash()
         block4.vtx.append(tx3)
         block4.hashMerkleRoot = block4.calc_merkle_root()
-        block4.rehash()
         block4.solve()
         self.log.info("Test inflation by duplicating input")
         peer.send_blocks_and_test([block4], node, success=False,  reject_reason='bad-txns-inputs-duplicate')

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -790,7 +790,6 @@ class SegWitTest(BitcoinTestFramework):
         block_3.vtx[0].vout.append(CTxOut(0, CScript([OP_RETURN, WITNESS_COMMITMENT_HEADER + ser_uint256(2), 10])))
         block_3.vtx[0].rehash()
         block_3.hashMerkleRoot = block_3.calc_merkle_root()
-        block_3.rehash()
         block_3.solve()
 
         test_witness_block(self.nodes[0], self.test_node, block_3, accepted=False, reason='bad-witness-merkle-match')
@@ -804,7 +803,6 @@ class SegWitTest(BitcoinTestFramework):
         block_3.vtx[0].vout[-1].nValue += 1
         block_3.vtx[0].rehash()
         block_3.hashMerkleRoot = block_3.calc_merkle_root()
-        block_3.rehash()
         assert len(block_3.vtx[0].vout) == 4  # 3 OP_returns
         block_3.solve()
         test_witness_block(self.nodes[0], self.test_node, block_3, accepted=True)

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -598,7 +598,6 @@ def submit_block_with_tx(node, tx):
     block_time = node.getblockheader(tip)["mediantime"] + 1
     block = create_block(int(tip, 16), create_coinbase(height), block_time)
     block.vtx.append(ctx)
-    block.rehash()
     block.hashMerkleRoot = block.calc_merkle_root()
     add_witness_commitment(block)
     block.solve()

--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -48,7 +48,6 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         block_time = int(time.time()) + 6 * 60
         node.setmocktime(block_time)
         block = create_block(int(node.getbestblockhash(), 16), create_coinbase(node.getblockcount() + 1), block_time)
-        block.rehash()
         block.solve()
         node.submitblock(block.serialize().hex())
 


### PR DESCRIPTION
Solving a block involves continously rehashing it,

https://github.com/bitcoin/bitcoin/blob/c9dd5c8d6e59e27af98e99d2844d6ead8eec3162/test/functional/test_framework/messages.py#L759-L764

i.e. any extra `rehash` calls before are not necessary and can be dropped.

The instances were identified by searching for all block solving calls via `git grep "solve("` in `./test/functional/`. From 95 instances of `CBlock.solve()` calls, 20 contained an unnecessary rehashing instruction before that are removed in this PR.