### PR TITLE
ci, refactor: Use Ubuntu release date tags instead of release names

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -179,7 +179,7 @@ task:
     QEMU_USER_CMD: ""  # Disable qemu and run the test natively
 
 task:
-  name: 'Win64 [unit tests, no gui tests, no boost::process, no functional tests] [focal]'
+  name: 'Win64 [unit tests, no gui tests, no boost::process, no functional tests] [focal 20.04]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
     image: ubuntu:focal
@@ -208,7 +208,7 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_native_qt5.sh"
 
 task:
-  name: '[depends, sanitizers: thread (TSan), no gui] [hirsute]'
+  name: '[depends, sanitizers: thread (TSan), no gui] [hirsute 21:04]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
     image: ubuntu:hirsute
@@ -220,7 +220,7 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_native_tsan.sh"
 
 task:
-  name: '[depends, sanitizers: memory (MSan)] [focal]'
+  name: '[depends, sanitizers: memory (MSan)] [focal 20.04]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
     image: ubuntu:focal
@@ -229,7 +229,7 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_native_msan.sh"
 
 task:
-  name: '[no depends, sanitizers: address/leak (ASan + LSan) + undefined (UBSan) + integer] [hirsute]'
+  name: '[no depends, sanitizers: address/leak (ASan + LSan) + undefined (UBSan) + integer] [hirsute 21:04]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
     image: ubuntu:hirsute
@@ -238,7 +238,7 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_native_asan.sh"
 
 task:
-  name: '[no depends, sanitizers: fuzzer,address,undefined,integer] [focal]'
+  name: '[no depends, sanitizers: fuzzer,address,undefined,integer] [focal 20.04]'
   only_if: $CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH || $CIRRUS_BASE_BRANCH == $CIRRUS_DEFAULT_BRANCH
   << : *GLOBAL_TASK_TEMPLATE
   container:
@@ -251,7 +251,7 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_native_fuzz.sh"
 
 task:
-  name: '[multiprocess, i686, DEBUG] [focal]'
+  name: '[multiprocess, i686, DEBUG] [focal 20.04]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
     image: ubuntu:focal
@@ -272,7 +272,7 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_native_nowallet.sh"
 
 task:
-  name: 'macOS 10.15 [gui, no tests] [focal]'
+  name: 'macOS 10.15 [gui, no tests] [focal 20.04]'
   << : *DEPENDS_SDK_CACHE_TEMPLATE
   << : *GLOBAL_TASK_TEMPLATE
   container:
@@ -296,7 +296,7 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_mac_host.sh"
 
 task:
-  name: 'ARM64 Android APK [focal]'
+  name: 'ARM64 Android APK [focal 20.04]'
   << : *DEPENDS_SDK_CACHE_TEMPLATE
   << : *BASE_TEMPLATE
   depends_sources_cache:

--- a/ci/test/00_setup_env_android.sh
+++ b/ci/test/00_setup_env_android.sh
@@ -9,7 +9,7 @@ export LC_ALL=C.UTF-8
 export HOST=aarch64-linux-android
 export PACKAGES="clang llvm unzip openjdk-8-jdk gradle"
 export CONTAINER_NAME=ci_android
-export DOCKER_NAME_TAG="ubuntu:focal"
+export DOCKER_NAME_TAG="ubuntu:20.04"
 
 export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false

--- a/ci/test/00_setup_env_native_asan.sh
+++ b/ci/test/00_setup_env_native_asan.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_asan
 export PACKAGES="clang llvm python3-zmq qtbase5-dev qttools5-dev-tools libevent-dev bsdmainutils libboost-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libsqlite3-dev"
-export DOCKER_NAME_TAG=ubuntu:hirsute
+export DOCKER_NAME_TAG=ubuntu:21.04
 export NO_DEPENDS=1
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=qt5 CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER' --with-sanitizers=address,integer,undefined CC=clang CXX=clang++"

--- a/ci/test/00_setup_env_native_tsan.sh
+++ b/ci/test/00_setup_env_native_tsan.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_tsan
-export DOCKER_NAME_TAG=ubuntu:hirsute
+export DOCKER_NAME_TAG=ubuntu:21.04
 export PACKAGES="clang llvm libc++abi-dev libc++-dev python3-zmq"
 export DEP_OPTS="CC=clang CXX='clang++ -stdlib=libc++'"
 export GOAL="install"


### PR DESCRIPTION
A few ci jobs use release names (`hiruste`) while others use date tag.
This pull request aligns Ubuntu image date release tags in ci/test/*.sh