### PR TITLE
Bury taproot deployment

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -72,6 +72,7 @@ public:
         consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
         consensus.CSVHeight = 419328; // 000000000000000004a1b34462cb8aeebd5799177f7a29cf28f2d1961716b5b5
         consensus.SegwitHeight = 481824; // 0000000000000000001c8018d9cb3b742ef25114f27563e3fc4a1902167f9893
+        consensus.TaprootHeight = 709632; // 0000000000000000000687bca986194dc2c1f949318629b44bb54ec0a94d8244
         consensus.MinBIP9WarningHeight = 483840; // segwit activation height + miner confirmation window
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -84,12 +85,6 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].min_activation_height = 0; // No activation delay
-
-        // Deployment of Taproot (BIPs 340-342)
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].bit = 2;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = 1619222400; // April 24th, 2021
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1628640000; // August 11th, 2021
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 709632; // Approximately November 12th, 2021
 
         consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000001fa4663bbbe19f82de910280");
         consensus.defaultAssumeValid = uint256S("0x00000000000000000008a89e854d57e5667df88f1cdef6fde2fbca1de5b639ad"); // 691719
@@ -191,6 +186,7 @@ public:
         consensus.BIP66Height = 330776; // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
         consensus.CSVHeight = 770112; // 00000000025e930139bac5c6c31a403776da130831ab85be56578f3fa75369bb
         consensus.SegwitHeight = 834624; // 00000000002b980fcd729daaa248fd9316a5200e9b367f4ff2c42453e84201ca
+        consensus.TaprootHeight = 2011968; // 000000000000eb906ab072652b86b05a1afeb95df53ed5c5a63aa3574e1f1b33
         consensus.MinBIP9WarningHeight = 836640; // segwit activation height + miner confirmation window
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -203,12 +199,6 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].min_activation_height = 0; // No activation delay
-
-        // Deployment of Taproot (BIPs 340-342)
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].bit = 2;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = 1619222400; // April 24th, 2021
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1628640000; // August 11th, 2021
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000005180c3bd8290da33a1a");
         consensus.defaultAssumeValid = uint256S("0x0000000000004ae2f3896ca8ecd41c460a35bf6184e145d91558cece1c688a76"); // 2010000
@@ -330,6 +320,7 @@ public:
         consensus.BIP66Height = 1;
         consensus.CSVHeight = 1;
         consensus.SegwitHeight = 1;
+        consensus.TaprootHeight = 1;
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = false;
@@ -342,12 +333,6 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].min_activation_height = 0; // No activation delay
-
-        // Activation of Taproot (BIPs 340-342)
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].bit = 2;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
         // message start is defined as the first 4 bytes of the sha256d of the block script
         CHashWriter h(SER_DISK, 0);
@@ -398,6 +383,7 @@ public:
         consensus.BIP66Height = 1;  // Always active unless overridden
         consensus.CSVHeight = 1;    // Always active unless overridden
         consensus.SegwitHeight = 1; // Always active unless overridden
+        consensus.TaprootHeight = 1; // Always active unless overridden
         consensus.MinBIP9WarningHeight = 0;
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -411,11 +397,6 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].min_activation_height = 0; // No activation delay
-
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].bit = 2;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
         consensus.nMinimumChainWork = uint256{};
         consensus.defaultAssumeValid = uint256{};
@@ -512,6 +493,8 @@ static void MaybeUpdateHeights(const ArgsManager& args, Consensus::Params& conse
             consensus.BIP65Height = int{height};
         } else if (name == "csv") {
             consensus.CSVHeight = int{height};
+        } else if (name == "taproot") {
+            consensus.TaprootHeight = int{height};
         } else {
             throw std::runtime_error(strprintf("Invalid name (%s) for -testactivationheight=name@height.", arg));
         }

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -24,12 +24,12 @@ enum BuriedDeployment : int16_t {
     DEPLOYMENT_DERSIG,
     DEPLOYMENT_CSV,
     DEPLOYMENT_SEGWIT,
+    DEPLOYMENT_TAPROOT,
 };
-constexpr bool ValidDeployment(BuriedDeployment dep) { return dep <= DEPLOYMENT_SEGWIT; }
+constexpr bool ValidDeployment(BuriedDeployment dep) { return dep <= DEPLOYMENT_TAPROOT; }
 
 enum DeploymentPos : uint16_t {
     DEPLOYMENT_TESTDUMMY,
-    DEPLOYMENT_TAPROOT, // Deployment of Schnorr/Taproot (BIPs 340-342)
     // NOTE: Also add new deployments to VersionBitsDeploymentInfo in deploymentinfo.cpp
     MAX_VERSION_BITS_DEPLOYMENTS
 };
@@ -87,6 +87,8 @@ struct Params {
      * Note that segwit v0 script rules are enforced on all blocks except the
      * BIP 16 exception blocks. */
     int SegwitHeight;
+    /** Block height at which Schnorr/Taproot (BIPs 340-342) becomes active. */
+    int TaprootHeight;
     /** Don't warn about unknown BIP 9 activations below this height.
      * This prevents us from warning about the CSV and segwit activations. */
     int MinBIP9WarningHeight;
@@ -125,6 +127,7 @@ struct Params {
         case DEPLOYMENT_DERSIG: return BIP66Height;
         case DEPLOYMENT_CSV: return CSVHeight;
         case DEPLOYMENT_SEGWIT: return SegwitHeight;
+        case DEPLOYMENT_TAPROOT: return TaprootHeight;
         } // no default case, so the compiler can warn about missing cases
         assert(false);
     }

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -7,6 +7,8 @@
 #define BITCOIN_CONSENSUS_PARAMS_H
 
 #include <uint256.h>
+
+#include <cassert>
 #include <limits>
 
 namespace Consensus {
@@ -118,18 +120,13 @@ struct Params {
     int DeploymentHeight(BuriedDeployment dep) const
     {
         switch (dep) {
-        case DEPLOYMENT_HEIGHTINCB:
-            return BIP34Height;
-        case DEPLOYMENT_CLTV:
-            return BIP65Height;
-        case DEPLOYMENT_DERSIG:
-            return BIP66Height;
-        case DEPLOYMENT_CSV:
-            return CSVHeight;
-        case DEPLOYMENT_SEGWIT:
-            return SegwitHeight;
+        case DEPLOYMENT_HEIGHTINCB: return BIP34Height;
+        case DEPLOYMENT_CLTV: return BIP65Height;
+        case DEPLOYMENT_DERSIG: return BIP66Height;
+        case DEPLOYMENT_CSV: return CSVHeight;
+        case DEPLOYMENT_SEGWIT: return SegwitHeight;
         } // no default case, so the compiler can warn about missing cases
-        return std::numeric_limits<int>::max();
+        assert(false);
     }
 };
 

--- a/src/deploymentinfo.cpp
+++ b/src/deploymentinfo.cpp
@@ -11,10 +11,6 @@ const struct VBDeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_B
         /*.name =*/ "testdummy",
         /*.gbt_force =*/ true,
     },
-    {
-        /*.name =*/ "taproot",
-        /*.gbt_force =*/ true,
-    },
 };
 
 std::string DeploymentName(Consensus::BuriedDeployment dep)
@@ -26,6 +22,7 @@ std::string DeploymentName(Consensus::BuriedDeployment dep)
     case Consensus::DEPLOYMENT_DERSIG: return "bip66";
     case Consensus::DEPLOYMENT_CSV: return "csv";
     case Consensus::DEPLOYMENT_SEGWIT: return "segwit";
+    case Consensus::DEPLOYMENT_TAPROOT: return "taproot";
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }

--- a/src/deploymentinfo.cpp
+++ b/src/deploymentinfo.cpp
@@ -21,16 +21,11 @@ std::string DeploymentName(Consensus::BuriedDeployment dep)
 {
     assert(ValidDeployment(dep));
     switch (dep) {
-    case Consensus::DEPLOYMENT_HEIGHTINCB:
-        return "bip34";
-    case Consensus::DEPLOYMENT_CLTV:
-        return "bip65";
-    case Consensus::DEPLOYMENT_DERSIG:
-        return "bip66";
-    case Consensus::DEPLOYMENT_CSV:
-        return "csv";
-    case Consensus::DEPLOYMENT_SEGWIT:
-        return "segwit";
+    case Consensus::DEPLOYMENT_HEIGHTINCB: return "bip34";
+    case Consensus::DEPLOYMENT_CLTV: return "bip65";
+    case Consensus::DEPLOYMENT_DERSIG: return "bip66";
+    case Consensus::DEPLOYMENT_CSV: return "csv";
+    case Consensus::DEPLOYMENT_SEGWIT: return "segwit";
     } // no default case, so the compiler can warn about missing cases
-    return "";
+    assert(false);
 }

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1260,7 +1260,7 @@ class TaprootTest(BitcoinTestFramework):
         if self.options.previous_release:
             self.wallet_names = [None, self.default_wallet_name]
         else:
-            self.extra_args[0].append("-vbparams=taproot:1:1")
+            self.extra_args[0].append("-testactivationheight=taproot@999999")
 
     def setup_nodes(self):
         self.add_nodes(self.num_nodes, self.extra_args, versions=[

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -148,6 +148,7 @@ class BlockchainTest(BitcoinTestFramework):
             '-testactivationheight=cltv@4',
             '-testactivationheight=csv@5',
             '-testactivationheight=segwit@6',
+            '-testactivationheight=taproot@7',
         ])
 
         res = self.nodes[0].getblockchaininfo()
@@ -167,6 +168,7 @@ class BlockchainTest(BitcoinTestFramework):
             'bip65': {'type': 'buried', 'active': True, 'height': 4},
             'csv': {'type': 'buried', 'active': True, 'height': 5},
             'segwit': {'type': 'buried', 'active': True, 'height': 6},
+            'taproot': {'type': 'buried', 'active': True, 'height': 7},
             'testdummy': {
                 'type': 'bip9',
                 'bip9': {
@@ -186,18 +188,6 @@ class BlockchainTest(BitcoinTestFramework):
                 },
                 'active': False
             },
-            'taproot': {
-                'type': 'bip9',
-                'bip9': {
-                    'status': 'active',
-                    'start_time': -1,
-                    'timeout': 9223372036854775807,
-                    'since': 0,
-                    'min_activation_height': 0,
-                },
-                'height': 0,
-                'active': True
-            }
         })
 
     def _test_getchaintxstats(self):

--- a/test/functional/wallet_taproot.py
+++ b/test/functional/wallet_taproot.py
@@ -180,7 +180,11 @@ class WalletTaprootTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 3
         self.setup_clean_chain = True
-        self.extra_args = [['-keypool=100'], ['-keypool=100'], ["-vbparams=taproot:1:1"]]
+        self.extra_args = [
+            ['-keypool=100'],
+            ['-keypool=100'],
+            ["-testactivationheight=taproot@999999"],
+        ]
         self.supports_cli = False
 
     def skip_test_if_missing_module(self):


### PR DESCRIPTION
Now that the decision to activate taproot at block height 709632 has been buried under more than 5 months of POW, the deployment should be buried in a future release (see benefits below). If this patch is first included in version 23.0, the decision will be buried by ~10 months of POW at release time.

Benefits:
* All deployments will use the same code paths. Thus, in the extremely unlikely case of bugs being introduced in the future in the versionbits activation code, it won't have any effect on previous deployments.
* Less code and complexity of the activation, because the versionbits params can be removed.
* Features can be developed assuming that taproot absolutely does activate at a specific block height. Thus, code to handle non-activation of taproot does not need to be maintained.
* Easier testing, because on regtest the newly introduced `-testactivationheight=name@height` (introduced in https://github.com/bitcoin/bitcoin/pull/22818) can be used.

For reference, previous buried versionbits deployments were:
* https://github.com/bitcoin/bitcoin/pull/11398 (abandoned)
* https://github.com/bitcoin/bitcoin/pull/12360 (abandoned 2)
* https://github.com/bitcoin/bitcoin/pull/16060 (merged)

Unlike previous buried deployments, this one is *not* a non-backwards compatible change, as explained in BIP90 (section considerations): https://github.com/bitcoin/bips/blob/master/bip-0090.mediawiki#considerations . Due to the use of a minimum activation height, there can not exist an alternative chain where the activation occurred at a lower block height than that.
Obviously this patch can still result in a *theoretical* consensus split (though a "backwards compatible" one) if there were a massive reorg that activated taproot at a *higher* (or no) block height. In this case the BIP90 considerations on large reorgs apply.

This changes the output of the `getblockchaininfo` RPC. I will add release notes when and if this patch is merged.