### PR TITLE
test: Make more shell scripts verifiable by the `shellcheck` tool

### DIFF
--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -2,10 +2,10 @@
 export LC_ALL=C
 set -e -o pipefail
 
-# shellcheck source=../../shell/realpath.bash
+# shellcheck source=contrib/shell/realpath.bash
 source contrib/shell/realpath.bash
 
-# shellcheck source=../../shell/git-utils.bash
+# shellcheck source=contrib/shell/git-utils.bash
 source contrib/shell/git-utils.bash
 
 ################

--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -20,12 +20,13 @@ if ! command -v shellcheck > /dev/null; then
     exit $EXIT_CODE
 fi
 
-SHELLCHECK_CMD=(shellcheck --external-sources --check-sourced)
+SHELLCHECK_CMD=(shellcheck --external-sources --check-sourced --source-path=SCRIPTDIR)
 EXCLUDE="--exclude=$(IFS=','; echo "${disabled[*]}")"
 # Check shellcheck directive used for sourced files
 mapfile -t SOURCED_FILES < <(git ls-files | xargs gawk '/^# shellcheck shell=/ {print FILENAME} {nextfile}')
+mapfile -t GUIX_FILES < <(git ls-files contrib/guix contrib/shell | xargs gawk '/^#!\/usr\/bin\/env bash/ {print FILENAME} {nextfile}')
 mapfile -t FILES < <(git ls-files -- '*.sh' | grep -vE 'src/(leveldb|secp256k1|minisketch|univalue)/')
-if ! "${SHELLCHECK_CMD[@]}" "$EXCLUDE" "${SOURCED_FILES[@]}" "${FILES[@]}"; then
+if ! "${SHELLCHECK_CMD[@]}" "$EXCLUDE" "${SOURCED_FILES[@]}" "${GUIX_FILES[@]}" "${FILES[@]}"; then
     EXIT_CODE=1
 fi
 


### PR DESCRIPTION
Some shell scripts from `contrib/guix` and `contrib/shell` are not verifiable by the `shellcheck` tool for the following reasons:
- they have no extension (see https://github.com/bitcoin/bitcoin/pull/21375/commits/4eccf063b252bfe256cf72d363a24cf0183e926e from bitcoin/bitcoin#21375)
- they have the `.bash` extension while `.sh` is expected

This PR adds these scripts to the input for the `shellcheck` tool, and it fixes discovered `shellcheck` warnings.