### PR TITLE
Refactor: Improve API design of `ScriptToUniv`, `TxToUniv` etc to return the `UniValue` instead of mutating a parameter/reference

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -943,13 +943,13 @@ static void GetProgressBar(double progress, std::string& progress_bar)
 
 /**
  * ParseGetInfoResult takes in -getinfo result in UniValue object and parses it
- * into a user friendly UniValue string to be printed on the console.
- * @param[out] result  Reference to UniValue result containing the -getinfo output.
+ * into a string.
+ * @param[in] result  Reference to UniValue result containing the -getinfo output.
+ *
+ * @return A user friendly string to be printed on the console.
  */
-static void ParseGetInfoResult(UniValue& result)
+static std::string ParseGetInfoResult(const UniValue& result)
 {
-    if (!find_value(result, "error").isNull()) return;
-
     std::string RESET, GREEN, BLUE, YELLOW, MAGENTA, CYAN;
     bool should_colorize = false;
 
@@ -1062,7 +1062,7 @@ static void ParseGetInfoResult(UniValue& result)
     const std::string warnings{result["warnings"].getValStr()};
     result_string += strprintf("%sWarnings:%s %s", YELLOW, RESET, warnings.empty() ? "(none)" : warnings);
 
-    result.setStr(result_string);
+    return result_string;
 }
 
 /**
@@ -1192,7 +1192,9 @@ static int CommandLineRPC(int argc, char *argv[])
                             result.pushKV("balances", balances.value());
                         }
                     }
-                    ParseGetInfoResult(result);
+                    if (find_value(result, "error").isNull()) {
+                        result.setStr(ParseGetInfoResult(result));
+                    }
                 }
 
                 ParseResult(result, strPrint);

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -742,8 +742,7 @@ static void MutateTx(CMutableTransaction& tx, const std::string& command,
 
 static void OutputTxJSON(const CTransaction& tx)
 {
-    UniValue entry(UniValue::VOBJ);
-    TxToUniv(tx, /*block_hash=*/uint256(), entry);
+    UniValue entry{TxToUniv(tx, /*block_hash=*/uint256())};
 
     std::string jsonOutput = entry.write(4);
     tfm::format(std::cout, "%s\n", jsonOutput);

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -53,6 +53,6 @@ std::string FormatScript(const CScript& script);
 std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags = 0);
 std::string SighashToStr(unsigned char sighash_type);
 UniValue ScriptToUniv(const CScript& script, bool include_hex = true, bool include_address = false);
-void TxToUniv(const CTransaction& tx, const uint256& block_hash, UniValue& entry, bool include_hex = true, int serialize_flags = 0, const CTxUndo* txundo = nullptr, TxVerbosity verbosity = TxVerbosity::SHOW_DETAILS);
+UniValue TxToUniv(const CTransaction& tx, const uint256& block_hash, bool include_hex = true, int serialize_flags = 0, const CTxUndo* txundo = nullptr, TxVerbosity verbosity = TxVerbosity::SHOW_DETAILS);
 
 #endif // BITCOIN_CORE_IO_H

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -52,7 +52,7 @@ UniValue ValueFromAmount(const CAmount amount);
 std::string FormatScript(const CScript& script);
 std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags = 0);
 std::string SighashToStr(unsigned char sighash_type);
-void ScriptToUniv(const CScript& script, UniValue& out, bool include_hex = true, bool include_address = false);
+UniValue ScriptToUniv(const CScript& script, bool include_hex = true, bool include_address = false);
 void TxToUniv(const CTransaction& tx, const uint256& block_hash, UniValue& entry, bool include_hex = true, int serialize_flags = 0, const CTxUndo* txundo = nullptr, TxVerbosity verbosity = TxVerbosity::SHOW_DETAILS);
 
 #endif // BITCOIN_CORE_IO_H

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -170,8 +170,9 @@ UniValue ScriptToUniv(const CScript& script, bool include_hex, bool include_addr
     return out;
 }
 
-void TxToUniv(const CTransaction& tx, const uint256& block_hash, UniValue& entry, bool include_hex, int serialize_flags, const CTxUndo* txundo, TxVerbosity verbosity)
+UniValue TxToUniv(const CTransaction& tx, const uint256& block_hash, bool include_hex, int serialize_flags, const CTxUndo* txundo, TxVerbosity verbosity)
 {
+    UniValue entry(UniValue::VOBJ);
     entry.pushKV("txid", tx.GetHash().GetHex());
     entry.pushKV("hash", tx.GetWitnessHash().GetHex());
     // Transaction version is actually unsigned in consensus checks, just signed in memory,
@@ -260,4 +261,5 @@ void TxToUniv(const CTransaction& tx, const uint256& block_hash, UniValue& entry
     if (include_hex) {
         entry.pushKV("hex", EncodeHexTx(tx, serialize_flags)); // The hex-encoded transaction. Used the name "hex" to be consistent with the verbose output of "getrawtransaction".
     }
+    return entry;
 }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -445,7 +445,7 @@ void RPCExecutor::request(const QString &command, const WalletModel* wallet_mode
 
         Q_EMIT reply(RPCConsole::CMD_REPLY, QString::fromStdString(result));
     }
-    catch (UniValue& objError)
+    catch (const UniValue& objError)
     {
         try // Nice formatting for standard-format error
         {

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -855,11 +855,7 @@ static bool rest_getutxos(const std::any& context, HTTPRequest* req, const std::
             UniValue utxo(UniValue::VOBJ);
             utxo.pushKV("height", (int32_t)coin.nHeight);
             utxo.pushKV("value", ValueFromAmount(coin.out.nValue));
-
-            // include the script in a json output
-            UniValue o(UniValue::VOBJ);
-            ScriptToUniv(coin.out.scriptPubKey, /*out=*/o, /*include_hex=*/true, /*include_address=*/true);
-            utxo.pushKV("scriptPubKey", o);
+            utxo.pushKV("scriptPubKey", ScriptToUniv(coin.out.scriptPubKey, /*include_hex=*/true, /*include_address=*/true));
             utxos.push_back(utxo);
         }
         objGetUTXOResponse.pushKV("utxos", utxos);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -668,8 +668,7 @@ static bool rest_tx(const std::any& context, HTTPRequest* req, const std::string
     }
 
     case RESTResponseFormat::JSON: {
-        UniValue objTx(UniValue::VOBJ);
-        TxToUniv(*tx, /*block_hash=*/hashBlock, /*entry=*/ objTx);
+        UniValue objTx{TxToUniv(*tx, /*block_hash=*/hashBlock)};
         std::string strJSON = objTx.write() + "\n";
         req->WriteHeader("Content-Type", "application/json");
         req->WriteReply(HTTP_OK, strJSON);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1072,9 +1072,7 @@ static RPCHelpMan gettxout()
         ret.pushKV("confirmations", (int64_t)(pindex->nHeight - coin.nHeight + 1));
     }
     ret.pushKV("value", ValueFromAmount(coin.out.nValue));
-    UniValue o(UniValue::VOBJ);
-    ScriptToUniv(coin.out.scriptPubKey, /*out=*/o, /*include_hex=*/true, /*include_address=*/true);
-    ret.pushKV("scriptPubKey", o);
+    ret.pushKV("scriptPubKey", ScriptToUniv(coin.out.scriptPubKey, /*include_hex=*/true, /*include_address=*/true));
     ret.pushKV("coinbase", (bool)coin.fCoinBase);
 
     return ret;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -187,9 +187,7 @@ UniValue blockToJSON(BlockManager& blockman, const CBlock& block, const CBlockIn
                 const CTransactionRef& tx = block.vtx.at(i);
                 // coinbase transaction (i.e. i == 0) doesn't have undo data
                 const CTxUndo* txundo = (have_undo && i > 0) ? &blockUndo.vtxundo.at(i - 1) : nullptr;
-                UniValue objTx(UniValue::VOBJ);
-                TxToUniv(*tx, /*block_hash=*/uint256(), /*entry=*/objTx, /*include_hex=*/true, RPCSerializationFlags(), txundo, verbosity);
-                txs.push_back(objTx);
+                txs.push_back(TxToUniv(*tx, /*block_hash=*/uint256(), /*include_hex=*/true, RPCSerializationFlags(), txundo, verbosity));
             }
             break;
     }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -58,12 +58,11 @@ static UniValue TxToJSON(const CTransaction& tx, const uint256 block_hash, Chain
     // Blockchain contextual information (confirmations and blocktime) is not
     // available to code in bitcoin-common, so we query them here and push the
     // data into the returned UniValue.
-    UniValue entry{TxToUniv(tx, /*block_hash=*/uint256(), /*include_hex=*/true, RPCSerializationFlags())};
+    UniValue entry{TxToUniv(tx, block_hash, /*include_hex=*/true, RPCSerializationFlags())};
 
     if (!block_hash.IsNull()) {
         LOCK(cs_main);
 
-        entry.pushKV("blockhash", block_hash.GetHex());
         const CBlockIndex* pindex = active_chainstate.m_blockman.LookupBlockIndex(block_hash);
         if (pindex) {
             if (active_chainstate.m_chain.Contains(pindex)) {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -51,7 +51,7 @@ using node::GetTransaction;
 using node::NodeContext;
 using node::PSBTAnalysis;
 
-static UniValue TxToJSON(const CTransaction& tx, const uint256 hashBlock, Chainstate& active_chainstate)
+static UniValue TxToJSON(const CTransaction& tx, const uint256 block_hash, Chainstate& active_chainstate)
 {
     // Call into TxToUniv() in bitcoin-common to decode the transaction hex.
     //
@@ -60,11 +60,11 @@ static UniValue TxToJSON(const CTransaction& tx, const uint256 hashBlock, Chains
     // data into the returned UniValue.
     UniValue entry{TxToUniv(tx, /*block_hash=*/uint256(), /*include_hex=*/true, RPCSerializationFlags())};
 
-    if (!hashBlock.IsNull()) {
+    if (!block_hash.IsNull()) {
         LOCK(cs_main);
 
-        entry.pushKV("blockhash", hashBlock.GetHex());
-        const CBlockIndex* pindex = active_chainstate.m_blockman.LookupBlockIndex(hashBlock);
+        entry.pushKV("blockhash", block_hash.GetHex());
+        const CBlockIndex* pindex = active_chainstate.m_blockman.LookupBlockIndex(block_hash);
         if (pindex) {
             if (active_chainstate.m_chain.Contains(pindex)) {
                 entry.pushKV("confirmations", 1 + active_chainstate.m_chain.Height() - pindex->nHeight);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -58,8 +58,7 @@ static UniValue TxToJSON(const CTransaction& tx, const uint256 hashBlock, Chains
     // Blockchain contextual information (confirmations and blocktime) is not
     // available to code in bitcoin-common, so we query them here and push the
     // data into the returned UniValue.
-    UniValue entry(UniValue::VOBJ);
-    TxToUniv(tx, /*block_hash=*/uint256(), entry, /*include_hex=*/true, RPCSerializationFlags());
+    UniValue entry{TxToUniv(tx, /*block_hash=*/uint256(), /*include_hex=*/true, RPCSerializationFlags())};
 
     if (!hashBlock.IsNull()) {
         LOCK(cs_main);
@@ -349,10 +348,7 @@ static RPCHelpMan decoderawtransaction()
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
     }
 
-    UniValue result(UniValue::VOBJ);
-    TxToUniv(CTransaction(std::move(mtx)), /*block_hash=*/uint256(), /*entry=*/result, /*include_hex=*/false);
-
-    return result;
+    return TxToUniv(CTransaction(std::move(mtx)), /*block_hash=*/uint256(), /*include_hex=*/false);
 },
     };
 }
@@ -932,9 +928,7 @@ static RPCHelpMan decodepsbt()
     UniValue result(UniValue::VOBJ);
 
     // Add the decoded tx
-    UniValue tx_univ(UniValue::VOBJ);
-    TxToUniv(CTransaction(*psbtx.tx), /*block_hash=*/uint256(), /*entry=*/tx_univ, /*include_hex=*/false);
-    result.pushKV("tx", tx_univ);
+    result.pushKV("tx", TxToUniv(CTransaction(*psbtx.tx), /*block_hash=*/uint256(), /*include_hex=*/false));
 
     // Add the global xpubs
     UniValue global_xpubs(UniValue::VARR);
@@ -998,9 +992,7 @@ static RPCHelpMan decodepsbt()
         if (input.non_witness_utxo) {
             txout = input.non_witness_utxo->vout[psbtx.tx->vin[i].prevout.n];
 
-            UniValue non_wit(UniValue::VOBJ);
-            TxToUniv(*input.non_witness_utxo, /*block_hash=*/uint256(), /*entry=*/non_wit, /*include_hex=*/false);
-            in.pushKV("non_witness_utxo", non_wit);
+            in.pushKV("non_witness_utxo", TxToUniv(*input.non_witness_utxo, /*block_hash=*/uint256(), /*include_hex=*/false));
 
             have_a_utxo = true;
         }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -393,7 +393,6 @@ static RPCHelpMan decodescript()
 {
     RPCTypeCheck(request.params, {UniValue::VSTR});
 
-    UniValue r(UniValue::VOBJ);
     CScript script;
     if (request.params[0].get_str().size() > 0){
         std::vector<unsigned char> scriptData(ParseHexV(request.params[0], "argument"));
@@ -401,7 +400,7 @@ static RPCHelpMan decodescript()
     } else {
         // Empty scripts are valid
     }
-    ScriptToUniv(script, /*out=*/r, /*include_hex=*/false, /*include_address=*/true);
+    UniValue r{ScriptToUniv(script, /*include_hex=*/false, /*include_address=*/true)};
 
     std::vector<std::vector<unsigned char>> solutions_data;
     const TxoutType which_type{Solver(script, solutions_data)};
@@ -468,7 +467,6 @@ static RPCHelpMan decodescript()
             NONFATAL_UNREACHABLE();
         }()};
         if (can_wrap_P2WSH) {
-            UniValue sr(UniValue::VOBJ);
             CScript segwitScr;
             if (which_type == TxoutType::PUBKEY) {
                 segwitScr = GetScriptForDestination(WitnessV0KeyHash(Hash160(solutions_data[0])));
@@ -478,7 +476,7 @@ static RPCHelpMan decodescript()
                 // Scripts that are not fit for P2WPKH are encoded as P2WSH.
                 segwitScr = GetScriptForDestination(WitnessV0ScriptHash(script));
             }
-            ScriptToUniv(segwitScr, /*out=*/sr, /*include_hex=*/true, /*include_address=*/true);
+            UniValue sr{ScriptToUniv(segwitScr, /*include_hex=*/true, /*include_address=*/true)};
             sr.pushKV("p2sh-segwit", EncodeDestination(ScriptHash(segwitScr)));
             r.pushKV("segwit", sr);
         }
@@ -989,13 +987,9 @@ static RPCHelpMan decodepsbt()
         if (!input.witness_utxo.IsNull()) {
             txout = input.witness_utxo;
 
-            UniValue o(UniValue::VOBJ);
-            ScriptToUniv(txout.scriptPubKey, /*out=*/o, /*include_hex=*/true, /*include_address=*/true);
-
             UniValue out(UniValue::VOBJ);
             out.pushKV("amount", ValueFromAmount(txout.nValue));
-            out.pushKV("scriptPubKey", o);
-
+            out.pushKV("scriptPubKey", ScriptToUniv(txout.scriptPubKey, /*include_hex=*/true, /*include_address=*/true));
             in.pushKV("witness_utxo", out);
 
             have_a_utxo = true;
@@ -1036,14 +1030,10 @@ static RPCHelpMan decodepsbt()
 
         // Redeem script and witness script
         if (!input.redeem_script.empty()) {
-            UniValue r(UniValue::VOBJ);
-            ScriptToUniv(input.redeem_script, /*out=*/r);
-            in.pushKV("redeem_script", r);
+            in.pushKV("redeem_script", ScriptToUniv(input.redeem_script));
         }
         if (!input.witness_script.empty()) {
-            UniValue r(UniValue::VOBJ);
-            ScriptToUniv(input.witness_script, /*out=*/r);
-            in.pushKV("witness_script", r);
+            in.pushKV("witness_script", ScriptToUniv(input.witness_script));
         }
 
         // keypaths
@@ -1212,14 +1202,10 @@ static RPCHelpMan decodepsbt()
         UniValue out(UniValue::VOBJ);
         // Redeem script and witness script
         if (!output.redeem_script.empty()) {
-            UniValue r(UniValue::VOBJ);
-            ScriptToUniv(output.redeem_script, /*out=*/r);
-            out.pushKV("redeem_script", r);
+            out.pushKV("redeem_script", ScriptToUniv(output.redeem_script));
         }
         if (!output.witness_script.empty()) {
-            UniValue r(UniValue::VOBJ);
-            ScriptToUniv(output.witness_script, /*out=*/r);
-            out.pushKV("witness_script", r);
+            out.pushKV("witness_script", ScriptToUniv(output.witness_script));
         }
 
         // keypaths

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -664,10 +664,7 @@ static RPCHelpMan signrawtransactionwithkey()
 
     // Parse the prevtxs array
     ParsePrevouts(request.params[2], &keystore, coins);
-
-    UniValue result(UniValue::VOBJ);
-    SignTransaction(mtx, &keystore, coins, request.params[3], result);
-    return result;
+    return SignTransaction(mtx, &keystore, coins, request.params[3]);
 },
     };
 }

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -280,20 +280,18 @@ void ParsePrevouts(const UniValue& prevTxsUnival, FillableSigningProvider* keyst
 
 UniValue SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, const std::map<COutPoint, Coin>& coins, const UniValue& hashType)
 {
-    UniValue result(UniValue::VOBJ);
     int nHashType = ParseSighashString(hashType);
 
     // Script verification errors
     std::map<int, bilingual_str> input_errors;
 
     bool complete = SignTransaction(mtx, keystore, coins, nHashType, input_errors);
-    SignTransactionResultToJSON(mtx, complete, coins, input_errors, result);
-    return result;
+    return SignTransactionResultToJSON(mtx, complete, coins, input_errors);
 }
 
-void SignTransactionResultToJSON(CMutableTransaction& mtx, bool complete, const std::map<COutPoint, Coin>& coins, const std::map<int, bilingual_str>& input_errors, UniValue& result)
+UniValue SignTransactionResultToJSON(CMutableTransaction& mtx, bool complete, const std::map<COutPoint, Coin>& coins, const std::map<int, bilingual_str>& input_errors)
 {
-    // Make errors UniValue
+    UniValue result(UniValue::VOBJ);
     UniValue vErrors(UniValue::VARR);
     for (const auto& err_pair : input_errors) {
         if (err_pair.second.original == "Missing amount") {
@@ -311,4 +309,5 @@ void SignTransactionResultToJSON(CMutableTransaction& mtx, bool complete, const 
         }
         result.pushKV("errors", vErrors);
     }
+    return result;
 }

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -278,8 +278,9 @@ void ParsePrevouts(const UniValue& prevTxsUnival, FillableSigningProvider* keyst
     }
 }
 
-void SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, const std::map<COutPoint, Coin>& coins, const UniValue& hashType, UniValue& result)
+UniValue SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, const std::map<COutPoint, Coin>& coins, const UniValue& hashType)
 {
+    UniValue result(UniValue::VOBJ);
     int nHashType = ParseSighashString(hashType);
 
     // Script verification errors
@@ -287,6 +288,7 @@ void SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, 
 
     bool complete = SignTransaction(mtx, keystore, coins, nHashType, input_errors);
     SignTransactionResultToJSON(mtx, complete, coins, input_errors, result);
+    return result;
 }
 
 void SignTransactionResultToJSON(CMutableTransaction& mtx, bool complete, const std::map<COutPoint, Coin>& coins, const std::map<int, bilingual_str>& input_errors, UniValue& result)

--- a/src/rpc/rawtransaction_util.h
+++ b/src/rpc/rawtransaction_util.h
@@ -27,7 +27,7 @@ class SigningProvider;
  * @return               UniValue object containing JSON where signed transaction results accumulate
  */
 UniValue SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, const std::map<COutPoint, Coin>& coins, const UniValue& hashType);
-void SignTransactionResultToJSON(CMutableTransaction& mtx, bool complete, const std::map<COutPoint, Coin>& coins, const std::map<int, bilingual_str>& input_errors, UniValue& result);
+UniValue SignTransactionResultToJSON(CMutableTransaction& mtx, bool complete, const std::map<COutPoint, Coin>& coins, const std::map<int, bilingual_str>& input_errors);
 
 /**
   * Parse a prevtxs UniValue array and get the map of coins from it

--- a/src/rpc/rawtransaction_util.h
+++ b/src/rpc/rawtransaction_util.h
@@ -24,9 +24,9 @@ class SigningProvider;
  * @param  keystore      Temporary keystore containing signing keys
  * @param  coins         Map of unspent outputs
  * @param  hashType      The signature hash type
- * @param result         JSON object where signed transaction results accumulate
+ * @return               UniValue object containing JSON where signed transaction results accumulate
  */
-void SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, const std::map<COutPoint, Coin>& coins, const UniValue& hashType, UniValue& result);
+UniValue SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, const std::map<COutPoint, Coin>& coins, const UniValue& hashType);
 void SignTransactionResultToJSON(CMutableTransaction& mtx, bool complete, const std::map<COutPoint, Coin>& coins, const std::map<int, bilingual_str>& input_errors, UniValue& result);
 
 /**

--- a/src/rpc/txoutproof.cpp
+++ b/src/rpc/txoutproof.cpp
@@ -55,12 +55,12 @@ static RPCHelpMan gettxoutproof()
             }
 
             const CBlockIndex* pblockindex = nullptr;
-            uint256 hashBlock;
+            uint256 block_hash;
             ChainstateManager& chainman = EnsureAnyChainman(request.context);
             if (!request.params[1].isNull()) {
                 LOCK(cs_main);
-                hashBlock = ParseHashV(request.params[1], "blockhash");
-                pblockindex = chainman.m_blockman.LookupBlockIndex(hashBlock);
+                block_hash = ParseHashV(request.params[1], "blockhash");
+                pblockindex = chainman.m_blockman.LookupBlockIndex(block_hash);
                 if (!pblockindex) {
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
                 }
@@ -87,11 +87,11 @@ static RPCHelpMan gettxoutproof()
             LOCK(cs_main);
 
             if (pblockindex == nullptr) {
-                const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, /*mempool=*/nullptr, *setTxids.begin(), chainman.GetConsensus(), hashBlock);
-                if (!tx || hashBlock.IsNull()) {
+                const CTransactionRef tx = GetTransaction(/*block_index=*/nullptr, /*mempool=*/nullptr, *setTxids.begin(), chainman.GetConsensus(), block_hash);
+                if (!tx || block_hash.IsNull()) {
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not yet in block");
                 }
-                pblockindex = chainman.m_blockman.LookupBlockIndex(hashBlock);
+                pblockindex = chainman.m_blockman.LookupBlockIndex(block_hash);
                 if (!pblockindex) {
                     throw JSONRPCError(RPC_INTERNAL_ERROR, "Transaction index corrupt");
                 }

--- a/src/test/fuzz/script_format.cpp
+++ b/src/test/fuzz/script_format.cpp
@@ -27,7 +27,5 @@ FUZZ_TARGET_INIT(script_format, initialize_script_format)
 
     (void)FormatScript(script);
     (void)ScriptToAsmStr(script, /*fAttemptSighashDecode=*/fuzzed_data_provider.ConsumeBool());
-
-    UniValue o1(UniValue::VOBJ);
-    ScriptToUniv(script, /*out=*/o1, /*include_hex=*/fuzzed_data_provider.ConsumeBool(), /*include_address=*/fuzzed_data_provider.ConsumeBool());
+    (void)ScriptToUniv(script, /*include_hex=*/fuzzed_data_provider.ConsumeBool(), /*include_address=*/fuzzed_data_provider.ConsumeBool());
 }

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -100,7 +100,6 @@ FUZZ_TARGET_INIT(transaction, initialize_transaction)
     (void)AreInputsStandard(tx, coins_view_cache);
     (void)IsWitnessStandard(tx, coins_view_cache);
 
-    UniValue u(UniValue::VOBJ);
-    TxToUniv(tx, /*block_hash=*/uint256::ZERO, /*entry=*/u);
-    TxToUniv(tx, /*block_hash=*/uint256::ONE, /*entry=*/u);
+    (void)TxToUniv(tx, /*block_hash=*/uint256::ZERO);
+    (void)TxToUniv(tx, /*block_hash=*/uint256::ONE);
 }

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -923,9 +923,7 @@ RPCHelpMan signrawtransactionwithwallet()
     std::map<int, bilingual_str> input_errors;
 
     bool complete = pwallet->SignTransaction(mtx, coins, nHashType, input_errors);
-    UniValue result(UniValue::VOBJ);
-    SignTransactionResultToJSON(mtx, complete, coins, input_errors, result);
-    return result;
+    return SignTransactionResultToJSON(mtx, complete, coins, input_errors);
 },
     };
 }

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -784,9 +784,7 @@ RPCHelpMan gettransaction()
     entry.pushKV("hex", strHex);
 
     if (verbose) {
-        UniValue decoded(UniValue::VOBJ);
-        TxToUniv(*wtx.tx, /*block_hash=*/uint256(), /*entry=*/decoded, /*include_hex=*/false);
-        entry.pushKV("decoded", decoded);
+        entry.pushKV("decoded", TxToUniv(*wtx.tx, /*block_hash=*/uint256(), /*include_hex=*/false));
     }
 
     return entry;


### PR DESCRIPTION
Now functions return a `UniValue` instead of mutating a parameter that's passed by reference.

After this PR, any time a `UniValue` is passed by reference, it should be `const`. This is the case everywhere in the codebase now (please double check me on this) except for `SoftForkDescPushBack` (which I didn't want to touch), and the RPC request handling logic.

Motivation for this PR was based on a suggestion in #22924 review:
> I wonder why we don't return the UniValue (or optional<UniValue> in case it can fail) instead of having it as second parameter. It would seem better API design to me.

I figured it's simple enough, why not do this across the entire codebase. Hopefully I didn't get carried away