### PR TITLE
ci: Drop --failfast in functional tests on native Windows CI task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -164,7 +164,7 @@ task:
     - netsh int ipv4 set dynamicport tcp start=1025 num=64511
     - netsh int ipv6 set dynamicport tcp start=1025 num=64511
     # Exclude feature_dbcrash for now due to timeout
-    - python test\functional\test_runner.py --nocleanup --ci --quiet --combinedlogslen=4000 --jobs=4 --timeout-factor=8 --failfast --extended --exclude feature_dbcrash
+    - python test\functional\test_runner.py --nocleanup --ci --quiet --combinedlogslen=4000 --jobs=4 --timeout-factor=8 --extended --exclude feature_dbcrash
 
 task:
   name: 'ARM [unit tests, no functional tests] [bullseye]'


### PR DESCRIPTION
As it was [discussed](https://github.com/bitcoin/bitcoin/pull/22980#issuecomment-964073830) in bitcoin/bitcoin#22980:
> seeing _all_ of the failed tests can give us a useful hint for debugging (was thinking about that while reviewing and testing bitcoin/bitcoin#23300).

There is a [concern](https://github.com/bitcoin/bitcoin/pull/22980#issuecomment-964085922) about such approach:
> If there is a CI failure, it will be good to know the result as early as possible after opening the pull request.

But, [OTOH](https://github.com/bitcoin/bitcoin/pull/22980#issuecomment-964095026):
> the average amount of saved time for such an approach [using `--failfast`] is less significant than it could appear.