### PR TITLE
scripted-diff: Move miner to src/node

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -166,7 +166,7 @@ BITCOIN_CORE_H = \
   mapport.h \
   memusage.h \
   merkleblock.h \
-  miner.h \
+  node/miner.h \
   net.h \
   net_permissions.h \
   net_processing.h \
@@ -334,7 +334,7 @@ libbitcoin_server_a_SOURCES = \
   index/txindex.cpp \
   init.cpp \
   mapport.cpp \
-  miner.cpp \
+  node/miner.cpp \
   net.cpp \
   net_processing.cpp \
   node/blockstorage.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -166,7 +166,6 @@ BITCOIN_CORE_H = \
   mapport.h \
   memusage.h \
   merkleblock.h \
-  node/miner.h \
   net.h \
   net_permissions.h \
   net_processing.h \
@@ -178,6 +177,7 @@ BITCOIN_CORE_H = \
   node/coin.h \
   node/coinstats.h \
   node/context.h \
+  node/miner.h \
   node/minisketchwrapper.h \
   node/psbt.h \
   node/transaction.h \
@@ -334,7 +334,6 @@ libbitcoin_server_a_SOURCES = \
   index/txindex.cpp \
   init.cpp \
   mapport.cpp \
-  node/miner.cpp \
   net.cpp \
   net_processing.cpp \
   node/blockstorage.cpp \
@@ -342,6 +341,7 @@ libbitcoin_server_a_SOURCES = \
   node/coinstats.cpp \
   node/context.cpp \
   node/interfaces.cpp \
+  node/miner.cpp \
   node/minisketchwrapper.cpp \
   node/psbt.cpp \
   node/transaction.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -29,7 +29,7 @@
 #include <interfaces/init.h>
 #include <interfaces/node.h>
 #include <mapport.h>
-#include <miner.h>
+#include <node/miner.h>
 #include <net.h>
 #include <net_permissions.h>
 #include <net_processing.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -29,13 +29,13 @@
 #include <interfaces/init.h>
 #include <interfaces/node.h>
 #include <mapport.h>
-#include <node/miner.h>
 #include <net.h>
 #include <net_permissions.h>
 #include <net_processing.h>
 #include <netbase.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
+#include <node/miner.h>
 #include <node/ui_interface.h>
 #include <policy/feerate.h>
 #include <policy/fees.h>

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -21,6 +21,7 @@
 #include <timedata.h>
 #include <util/moneystr.h>
 #include <util/system.h>
+#include <validation.h>
 
 #include <algorithm>
 #include <utility>

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -3,7 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <miner.h>
+#include <node/miner.h>
 
 #include <chain.h>
 #include <chainparams.h>

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_MINER_H
-#define BITCOIN_MINER_H
+#ifndef BITCOIN_NODE_MINER_H
+#define BITCOIN_NODE_MINER_H
 
 #include <primitives/block.h>
 #include <txmempool.h>
@@ -205,4 +205,4 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 /** Update an old GenerateCoinbaseCommitment from CreateNewBlock after the block txs have changed */
 void RegenerateCommitments(CBlock& block, ChainstateManager& chainman);
 
-#endif // BITCOIN_MINER_H
+#endif // BITCOIN_NODE_MINER_H

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -8,15 +8,15 @@
 
 #include <primitives/block.h>
 #include <txmempool.h>
-#include <validation.h>
 
 #include <memory>
 #include <optional>
 #include <stdint.h>
 
-#include <boost/multi_index_container.hpp>
 #include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index_container.hpp>
 
+class ChainstateManager;
 class CBlockIndex;
 class CChainParams;
 class CScript;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -13,7 +13,7 @@
 #include <deploymentinfo.h>
 #include <deploymentstatus.h>
 #include <key_io.h>
-#include <miner.h>
+#include <node/miner.h>
 #include <net.h>
 #include <node/context.h>
 #include <policy/fees.h>

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -13,9 +13,9 @@
 #include <deploymentinfo.h>
 #include <deploymentstatus.h>
 #include <key_io.h>
-#include <node/miner.h>
 #include <net.h>
 #include <node/context.h>
+#include <node/miner.h>
 #include <policy/fees.h>
 #include <pow.h>
 #include <rpc/blockchain.h>

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -6,7 +6,7 @@
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <index/blockfilterindex.h>
-#include <miner.h>
+#include <node/miner.h>
 #include <pow.h>
 #include <script/standard.h>
 #include <test/util/blockfilter.h>

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/validation.h>
-#include <miner.h>
+#include <node/miner.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -7,7 +7,7 @@
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
 #include <consensus/tx_verify.h>
-#include <miner.h>
+#include <node/miner.h>
 #include <policy/policy.h>
 #include <script/standard.h>
 #include <txmempool.h>

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -7,8 +7,8 @@
 #include <chainparams.h>
 #include <consensus/merkle.h>
 #include <key_io.h>
-#include <node/miner.h>
 #include <node/context.h>
+#include <node/miner.h>
 #include <pow.h>
 #include <script/standard.h>
 #include <test/util/script.h>

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -7,7 +7,7 @@
 #include <chainparams.h>
 #include <consensus/merkle.h>
 #include <key_io.h>
-#include <miner.h>
+#include <node/miner.h>
 #include <node/context.h>
 #include <pow.h>
 #include <script/standard.h>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -13,7 +13,7 @@
 #include <crypto/sha256.h>
 #include <init.h>
 #include <interfaces/chain.h>
-#include <miner.h>
+#include <node/miner.h>
 #include <net.h>
 #include <net_processing.h>
 #include <noui.h>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -13,9 +13,9 @@
 #include <crypto/sha256.h>
 #include <init.h>
 #include <interfaces/chain.h>
-#include <node/miner.h>
 #include <net.h>
 #include <net_processing.h>
+#include <node/miner.h>
 #include <noui.h>
 #include <policy/fees.h>
 #include <pow.h>

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -7,7 +7,7 @@
 #include <chainparams.h>
 #include <consensus/merkle.h>
 #include <consensus/validation.h>
-#include <miner.h>
+#include <node/miner.h>
 #include <pow.h>
 #include <random.h>
 #include <script/standard.h>

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -88,7 +88,7 @@ implicit-signed-integer-truncation:chain.h
 implicit-signed-integer-truncation:crypto/
 implicit-signed-integer-truncation:cuckoocache.h
 implicit-signed-integer-truncation:leveldb/
-implicit-signed-integer-truncation:miner.cpp
+implicit-signed-integer-truncation:node/miner.cpp
 implicit-signed-integer-truncation:net.cpp
 implicit-signed-integer-truncation:net_processing.cpp
 implicit-signed-integer-truncation:netaddress.cpp


### PR DESCRIPTION
It is impossible to run the miner without a node (validation, chainstate, mempool, rpc, ...). Also, the module is in the node library. Thus, it should be moved to `src/node`.


Also, replace the `validation.h` include in the header with a forward-declaration.