### PR TITLE
test: add functional test for -startupnotify

### DIFF
--- a/test/functional/feature_startupnotify.py
+++ b/test/functional/feature_startupnotify.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test -startupnotify."""
+
+import os
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+
+NODE_DIR = "node0"
+FILE_NAME = "test.txt"
+
+
+class StartupNotifyTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.disable_syscall_sandbox = True
+
+    def run_test(self):
+        tmpdir_file = os.path.join(self.options.tmpdir, NODE_DIR, FILE_NAME)
+        assert not os.path.exists(tmpdir_file)
+
+        self.log.info("Test -startupnotify command is run when node starts")
+        self.restart_node(0, extra_args=[f"-startupnotify=echo '{FILE_NAME}' >> {NODE_DIR}/{FILE_NAME}"])
+        assert os.path.exists(tmpdir_file)
+
+        self.log.info("Test -startupnotify is executed once")
+        with open(tmpdir_file, "r", encoding="utf8") as f:
+            file_content = f.read()
+            assert_equal(file_content.count(FILE_NAME), 1)
+
+        self.log.info("Test node is fully started")
+        assert_equal(self.nodes[0].getblockcount(), 200)
+
+
+if __name__ == '__main__':
+    StartupNotifyTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -253,6 +253,7 @@ BASE_SCRIPTS = [
     'wallet_bumpfee.py --descriptors',
     'wallet_implicitsegwit.py --legacy-wallet',
     'rpc_named_arguments.py',
+    'feature_startupnotify.py',
     'wallet_listsinceblock.py --legacy-wallet',
     'wallet_listsinceblock.py --descriptors',
     'wallet_listdescriptors.py --descriptors',


### PR DESCRIPTION
This PR adds a functional test for -startupnotify. It basically starts the node passing a command on -startupnotify to create a file on tmp and then, we check if the file has been successfully created.
