### PR TITLE
PE: check for control flow instrumentation

### DIFF
--- a/contrib/devtools/test-security-check.py
+++ b/contrib/devtools/test-security-check.py
@@ -70,16 +70,18 @@ class TestSecurityChecks(unittest.TestCase):
         write_testcode(source)
 
         self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--no-nxcompat','-Wl,--disable-reloc-section','-Wl,--no-dynamicbase','-Wl,--no-high-entropy-va','-no-pie','-fno-PIE']),
-            (1, executable+': failed PIE DYNAMIC_BASE HIGH_ENTROPY_VA NX RELOC_SECTION'))
+            (1, executable+': failed PIE DYNAMIC_BASE HIGH_ENTROPY_VA NX RELOC_SECTION CONTROL_FLOW'))
         self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--disable-reloc-section','-Wl,--no-dynamicbase','-Wl,--no-high-entropy-va','-no-pie','-fno-PIE']),
-            (1, executable+': failed PIE DYNAMIC_BASE HIGH_ENTROPY_VA RELOC_SECTION'))
+            (1, executable+': failed PIE DYNAMIC_BASE HIGH_ENTROPY_VA RELOC_SECTION CONTROL_FLOW'))
         self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--enable-reloc-section','-Wl,--no-dynamicbase','-Wl,--no-high-entropy-va','-no-pie','-fno-PIE']),
-            (1, executable+': failed PIE DYNAMIC_BASE HIGH_ENTROPY_VA'))
+            (1, executable+': failed PIE DYNAMIC_BASE HIGH_ENTROPY_VA CONTROL_FLOW'))
         self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--enable-reloc-section','-Wl,--no-dynamicbase','-Wl,--no-high-entropy-va','-pie','-fPIE']),
-            (1, executable+': failed PIE DYNAMIC_BASE HIGH_ENTROPY_VA'))  # -pie -fPIE does nothing unless --dynamicbase is also supplied
+            (1, executable+': failed PIE DYNAMIC_BASE HIGH_ENTROPY_VA CONTROL_FLOW'))  # -pie -fPIE does nothing unless --dynamicbase is also supplied
         self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--enable-reloc-section','-Wl,--dynamicbase','-Wl,--no-high-entropy-va','-pie','-fPIE']),
-            (1, executable+': failed HIGH_ENTROPY_VA'))
+            (1, executable+': failed HIGH_ENTROPY_VA CONTROL_FLOW'))
         self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--enable-reloc-section','-Wl,--dynamicbase','-Wl,--high-entropy-va','-pie','-fPIE']),
+            (1, executable+': failed CONTROL_FLOW'))
+        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--enable-reloc-section','-Wl,--dynamicbase','-Wl,--high-entropy-va','-pie','-fPIE', '-fcf-protection=full']),
             (0, ''))
 
         clean_files(source, executable)

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -27,6 +27,7 @@ $(package)_cxxflags+=-std=c++17
 $(package)_cxxflags_linux=-fPIC
 $(package)_cxxflags_android=-fPIC
 $(package)_cxxflags_x86_64_darwin=-fcf-protection=full
+$(package)_cxxflags_mingw32=-fcf-protection=full
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
Addresses the Windows portion of #21888.

Now that we require GCC 8+ we can unconditionally use `-fcf-protection=full` when building Boost in depends. Building Boost with this option is required so that the `main` provided to `test_bitcoin.exe` has instrumentation.

Note that the presence of instrumentation does not mean it will be used, as that is determined at runtime by the CPU.
From the Intel control flow enforcement documentation:

> The ENDBR32 and ENDBR64 instructions will have the same effect as the NOP instruction on Intel 64 processors that do not support CET. On processors supporting CET, these instructions do not change register or flag state. This allows CET instrumented programs to execute on processors that do not support CET. Even when CET is supported and enabled, these NOP–like instructions do not affect the execution state of the program, do not cause any additional register pressure, and are minimally intrusive from power and performance perspectives.

Guix Build:
```bash
bash-5.1# find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
5d41d43c44945810f92193504e8b4c1ac8eb9dfc3b19d0ab8d53bff0c8443a2a  guix-build-f31d4bd21401/output/aarch64-linux-gnu/SHA256SUMS.part
8edb0e01b7bc2d646b62e4e35b1867ee940acca18a02ee609c52c4f7680de5ae  guix-build-f31d4bd21401/output/aarch64-linux-gnu/bitcoin-f31d4bd21401-aarch64-linux-gnu-debug.tar.gz
1a06306f365e8329cea0eba7436085d30fe59c244a888ecb6407faf5110c57ab  guix-build-f31d4bd21401/output/aarch64-linux-gnu/bitcoin-f31d4bd21401-aarch64-linux-gnu.tar.gz
b5b74926ff9ff597d66b92d33926df34c3e1c6f92b863850a6fb1beea019fd6e  guix-build-f31d4bd21401/output/arm-linux-gnueabihf/SHA256SUMS.part
743b5c5cec7881b032520a309ae2399ec8dadb82eb9da424aefd646f9252ff1d  guix-build-f31d4bd21401/output/arm-linux-gnueabihf/bitcoin-f31d4bd21401-arm-linux-gnueabihf-debug.tar.gz
1f218a954b65b352c80922ea6b61276e8e7050ad8bdd9d7610049b87c66069e5  guix-build-f31d4bd21401/output/arm-linux-gnueabihf/bitcoin-f31d4bd21401-arm-linux-gnueabihf.tar.gz
c164de32c6cc24ec247b5a8de7f1a5442369d5804a4b2a3e0d9dc4ab4e5ec401  guix-build-f31d4bd21401/output/dist-archive/bitcoin-f31d4bd21401.tar.gz
feb0a055eabd6ddd2ce0dac954f5f5886044800a7535b8f78c7dfbd9c243512c  guix-build-f31d4bd21401/output/powerpc64-linux-gnu/SHA256SUMS.part
0b6e877b5de7b69a5d474469d666a536cd8f6f6e865230a7763f62426357ae91  guix-build-f31d4bd21401/output/powerpc64-linux-gnu/bitcoin-f31d4bd21401-powerpc64-linux-gnu-debug.tar.gz
fb38bcfd319af1e8bace03f240b32592940ac3efe15d23fd39353f36f9ae3838  guix-build-f31d4bd21401/output/powerpc64-linux-gnu/bitcoin-f31d4bd21401-powerpc64-linux-gnu.tar.gz
15fffe69f33297ef30a8b2eb8bdef8564f030920bed6d5ff56d6e7b8bef9c199  guix-build-f31d4bd21401/output/powerpc64le-linux-gnu/SHA256SUMS.part
f847b92c7c098bf8a4f6c84714270c173d4323e2d3025dd8f4444ee921a0bdd0  guix-build-f31d4bd21401/output/powerpc64le-linux-gnu/bitcoin-f31d4bd21401-powerpc64le-linux-gnu-debug.tar.gz
9b8b6e12dd8a1a3ba0f5522c2a22f2bd60d5473880fa22d42e91364a08e48396  guix-build-f31d4bd21401/output/powerpc64le-linux-gnu/bitcoin-f31d4bd21401-powerpc64le-linux-gnu.tar.gz
6f0f3b603b35c751a364b77ca94477085cf54a1c5d811dd3407dd1b86b2e3c64  guix-build-f31d4bd21401/output/riscv64-linux-gnu/SHA256SUMS.part
69f1a93a8d698e68d8baf81a6c871f9eab0446ec352f7709971293b0b898f128  guix-build-f31d4bd21401/output/riscv64-linux-gnu/bitcoin-f31d4bd21401-riscv64-linux-gnu-debug.tar.gz
b71d415f30a893fada9d6609fab309a3c099716462c795e444bf49bd8631ea53  guix-build-f31d4bd21401/output/riscv64-linux-gnu/bitcoin-f31d4bd21401-riscv64-linux-gnu.tar.gz
6f842bc5483e867b8d1c769d1faa19b9f08bc0fa28d027fe0fac108858a4926e  guix-build-f31d4bd21401/output/x86_64-apple-darwin19/SHA256SUMS.part
a9a43aa4aade18bf606493009229ad3239af7365594ef60a0c39789d870f159d  guix-build-f31d4bd21401/output/x86_64-apple-darwin19/bitcoin-f31d4bd21401-osx-unsigned.dmg
26891e7d258ec8a85344a0a888fd4159378d747a2a77fb8d9e5655f1a3ad4aee  guix-build-f31d4bd21401/output/x86_64-apple-darwin19/bitcoin-f31d4bd21401-osx-unsigned.tar.gz
a2578799da61a3f1b6cd047aa5641e050de2e810162ec8596931cec12d1cbb56  guix-build-f31d4bd21401/output/x86_64-apple-darwin19/bitcoin-f31d4bd21401-osx64.tar.gz
571803809f358ed5ef1f1ed6b6266b54bd33b0e6308c53ddae967e53af930a46  guix-build-f31d4bd21401/output/x86_64-linux-gnu/SHA256SUMS.part
ea45499e8d2a2f0791f29732a5f169fb97525d6d8adcdfa1c160e950944ce8fe  guix-build-f31d4bd21401/output/x86_64-linux-gnu/bitcoin-f31d4bd21401-x86_64-linux-gnu-debug.tar.gz
ba5b63e64267d7685de77e3063e24659f223d4b4c42d43f42fb15e716afcfe78  guix-build-f31d4bd21401/output/x86_64-linux-gnu/bitcoin-f31d4bd21401-x86_64-linux-gnu.tar.gz
b4ba9d8cfd6999c0039890330afab5d5b1faf5ded33dcbebc5e73d8dae308246  guix-build-f31d4bd21401/output/x86_64-w64-mingw32/SHA256SUMS.part
3aa5cf722341b79aca78ea11fe4e65e0c642997b0214d3893a86a2e808afbe87  guix-build-f31d4bd21401/output/x86_64-w64-mingw32/bitcoin-f31d4bd21401-win-unsigned.tar.gz
b48402235751f15f09fad64b7bd42f851a64a9744e47ed6888b4e9754fb0d3d9  guix-build-f31d4bd21401/output/x86_64-w64-mingw32/bitcoin-f31d4bd21401-win64-debug.zip
e33183aa7316f399621fd7b1c258d850294cdaaebb505364410a399467c0943b  guix-build-f31d4bd21401/output/x86_64-w64-mingw32/bitcoin-f31d4bd21401-win64-setup-unsigned.exe
4baba568a8a93d04086055df512d680c8365d42779123c56bccee41e4de33e5e  guix-build-f31d4bd21401/output/x86_64-w64-mingw32/bitcoin-f31d4bd21401-win64.zip
```