### PR TITLE
test: Prevent non-compatible sed binary for scripted-diffs

### DIFF
--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -17,6 +17,11 @@ if test -z "$1"; then
     exit 1
 fi
 
+if ! sed --help | grep -q 'GNU'; then
+    echo "Error: the installed sed package is not compatible. Please make sure you have GNU sed installed in your system.";
+    exit 1;
+fi
+
 RET=0
 PREV_BRANCH=$(git name-rev --name-only HEAD)
 PREV_HEAD=$(git rev-parse HEAD)

--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -17,7 +17,7 @@ if test -z "$1"; then
     exit 1
 fi
 
-if ! sed --help | grep -q 'GNU'; then
+if ! sed --help 2>&1 | grep -q 'GNU'; then
     echo "Error: the installed sed package is not compatible. Please make sure you have GNU sed installed in your system.";
     exit 1;
 fi


### PR DESCRIPTION
This Pull request improve scripted diff by checking for non-compatible sed binary. Fixes #19815
