### PR TITLE
build: actually set CXX and CXXFLAGS for native_b2 build

### DIFF
--- a/depends/packages/native_b2.mk
+++ b/depends/packages/native_b2.mk
@@ -11,7 +11,7 @@ $(package)_toolset_$(host_os)=gcc
 endif
 
 define $(package)_build_cmds
-  CXX="$($(package)_cxx)" CXXFLAGS="$($(package)_cxxflags)" ./build.sh "$($(package)_toolset_$(host_os))"
+  ./build.sh "$($(package)_toolset_$(host_os))"
 endef
 
 define $(package)_stage_cmds


### PR DESCRIPTION
Currently, ./build.sh doesn't seem to respect `CXX` and `CXXFLAGS`. This
becomes more obvious when you build depends with `CC` and `CXX` set,
without another compiler installed. i.e when using `g++-8` on Ubuntu
Bionic, but not having `g++` (GGC-7) installed. The native_b2 build will
fail with:
```bash
make -C depends/ -j9 CC=gcc-8 CXX=g++-8
...
/bitcoin/depends/sources/boost_1_71_0.tar.bz2: OK
Preprocessing native_b2...
Configuring native_b2...
Building native_b2...
B2_TOOLSET is gcc, but the 'gcc' command cannot be executed.
Make sure 'gcc' is in PATH, or use a different toolset.
```

Instead, don't set CXX or CXXFLAGS before calling `build.sh`. 
In this case, we either get the default CXX (`g++`), or, we'll get the CXX set by the user. i.e:

```bash
make -C depends/ -j9 CC=gcc-8 CXX=g++-8
...
/bitcoin/depends/sources/boost_1_71_0.tar.bz2: OK
Preprocessing native_b2...
Configuring native_b2...
Building native_b2...
g++-8 --version
g++-8 (Ubuntu 8.4.0-1ubuntu1~18.04) 8.4.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

g++-8 -x c++ -std=c++11 -O2 -s .... <snip>
```
