### PR TITLE
test: Remove sanitizer suppression implicit-signed-integer-truncation:netaddress.cpp

### DIFF
--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -91,7 +91,6 @@ implicit-signed-integer-truncation:leveldb/
 implicit-signed-integer-truncation:miner.cpp
 implicit-signed-integer-truncation:net.cpp
 implicit-signed-integer-truncation:net_processing.cpp
-implicit-signed-integer-truncation:netaddress.cpp
 implicit-signed-integer-truncation:streams.h
 implicit-signed-integer-truncation:test/arith_uint256_tests.cpp
 implicit-signed-integer-truncation:test/skiplist_tests.cpp


### PR DESCRIPTION
This reverts commit fa865287e5f35e0a376785834e966dd202d2959e.

This was fixed in commit efd6f904c78769ad2e93c1f1de43014d284e7561.