### PR TITLE
configure.ac: remove Bashism

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1923,7 +1923,7 @@ if test x$bitcoin_enable_qt != xno; then
     echo "    with qr       = $use_qr"
 fi
 echo "  with zmq        = $use_zmq"
-if test x$enable_fuzz == xno; then
+if test x$enable_fuzz = xno; then
     echo "  with test       = $use_tests"
 else
     echo "  with test       = not building test_bitcoin because fuzzing is enabled"


### PR DESCRIPTION
Configure scripts are supposed to adhere to the POSIX shell language. The POSIX `test` builtin does not implement an `==` operator. Bash does, but not all systems have Bash installed as `/bin/sh`. In particular, many systems use the lighter-weight Dash as the default POSIX shell. Dash emits the following error when running `configure`:

```
./configure: 39065: test: xno: unexpected operator
```

This PR removes the Bashism and restores correct operation with POSIX-compliant shells like Dash.