### PR TITLE
build: Propagate user-defined tools to native packages

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -226,6 +226,14 @@ $(host_prefix)/.stamp_$(final_build_id): $(native_packages) $(packages)
 $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_build_id)
 	@mkdir -p $(@D)
 	sed -e 's|@HOST@|$(host)|' \
+            -e 's|@CC_FOR_BUILD@|$(build_CC)|' \
+            -e 's|@CXX_FOR_BUILD@|$(build_CXX)|' \
+            -e 's|@AR_FOR_BUILD@|$(build_AR)|' \
+            -e 's|@TAR_FOR_BUILD@|$(build_TAR)|' \
+            -e 's|@RANLIB_FOR_BUILD@|$(build_RANLIB)|' \
+            -e 's|@NM_FOR_BUILD@|$(build_NM)|' \
+            -e 's|@STRIP_FOR_BUILD@|$(build_STRIP)|' \
+            -e 's|@build_os@|$(build_os)|' \
             -e 's|@CC@|$(host_CC)|' \
             -e 's|@CXX@|$(host_CXX)|' \
             -e 's|@AR@|$(host_AR)|' \
@@ -235,7 +243,6 @@ $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_
             -e 's|@OTOOL@|$(host_OTOOL)|' \
             -e 's|@INSTALL_NAME_TOOL@|$(host_INSTALL_NAME_TOOL)|' \
             -e 's|@DSYMUTIL@|$(host_DSYMUTIL)|' \
-            -e 's|@build_os@|$(build_os)|' \
             -e 's|@host_os@|$(host_os)|' \
             -e 's|@CFLAGS@|$(strip $(host_CFLAGS) $(host_$(release_type)_CFLAGS))|' \
             -e 's|@CXXFLAGS@|$(strip $(host_CXXFLAGS) $(host_$(release_type)_CXXFLAGS))|' \

--- a/depends/README.md
+++ b/depends/README.md
@@ -122,6 +122,8 @@ The following can be set when running make: `make FOO=bar`
   resides in the `depends` directory, and the log file is printed out automatically in case
   of build error. After successful build log files are moved along with package archives
 - `LTO`: Use LTO when building packages.
+- `{CC,CXX,...}_FOR_BUILD`: Build native packages with specified tools when
+  a package build script allows it
 
 If some packages are not built, for example `make NO_WALLET=1`, the appropriate
 options will be passed to bitcoin's configure. In this case, `--disable-wallet`.

--- a/depends/builders/default.mk
+++ b/depends/builders/default.mk
@@ -7,12 +7,12 @@ default_build_STRIP = strip
 default_build_NM = nm
 
 define add_build_tool_func
-ifneq ($(filter $(origin $1),undefined default),)
+ifeq ($(origin $(1)_FOR_BUILD),undefined)
 build_$(build_os)_$1 ?= $$(default_build_$1)
 build_$(build_arch)_$(build_os)_$1 ?= $$(build_$(build_os)_$1)
 else
-build_$(build_os)_$1 = $(or $($1),$(build_$(build_os)_$1),$(default_build_$1))
-build_$(build_arch)_$(build_os)_$1 = $(or $($1),$(build_$(build_arch)_$(build_os)_$1),$$(build_$(build_os)_$1))
+build_$(build_os)_$1 = $(or $($(1)_FOR_BUILD),$(build_$(build_os)_$1),$(default_build_$1))
+build_$(build_arch)_$(build_os)_$1 = $(or $($(1)_FOR_BUILD),$(build_$(build_arch)_$(build_os)_$1),$$(build_$(build_os)_$1))
 endif
 build_$1 = $$(build_$(build_arch)_$(build_os)_$1)
 endef

--- a/depends/builders/default.mk
+++ b/depends/builders/default.mk
@@ -7,11 +7,17 @@ default_build_STRIP = strip
 default_build_NM = nm
 
 define add_build_tool_func
+ifneq ($(filter $(origin $1),undefined default),)
 build_$(build_os)_$1 ?= $$(default_build_$1)
 build_$(build_arch)_$(build_os)_$1 ?= $$(build_$(build_os)_$1)
-build_$1=$$(build_$(build_arch)_$(build_os)_$1)
+else
+build_$(build_os)_$1 = $(or $($1),$(build_$(build_os)_$1),$(default_build_$1))
+build_$(build_arch)_$(build_os)_$1 = $(or $($1),$(build_$(build_arch)_$(build_os)_$1),$$(build_$(build_os)_$1))
+endif
+build_$1 = $$(build_$(build_arch)_$(build_os)_$1)
 endef
 $(foreach var,CC CXX AR TAR RANLIB NM STRIP SHA256SUM DOWNLOAD OTOOL INSTALL_NAME_TOOL DSYMUTIL,$(eval $(call add_build_tool_func,$(var))))
+
 define add_build_flags_func
 build_$(build_arch)_$(build_os)_$1 += $(build_$(build_os)_$1)
 build_$1=$$(build_$(build_arch)_$(build_os)_$1)

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -92,6 +92,28 @@ fi
 CPPFLAGS="-I${depends_prefix}/include/ ${CPPFLAGS}"
 LDFLAGS="-L${depends_prefix}/lib ${LDFLAGS}"
 
+if test -n "@CC_FOR_BUILD@" -a -z "${CC_FOR_BUILD}"; then
+  CC_FOR_BUILD="@CC_FOR_BUILD@"
+fi
+if test -n "@CXX_FOR_BUILD@" -a -z "${CXX_FOR_BUILD}"; then
+  CXX_FOR_BUILD="@CXX_FOR_BUILD@"
+fi
+if test -n "@AR_FOR_BUILD@"; then
+  AR_FOR_BUILD="@AR_FOR_BUILD@"
+fi
+if test -n "@TAR_FOR_BUILD@"; then
+  TAR_FOR_BUILD="@TAR_FOR_BUILD@"
+fi
+if test -n "@RANLIB_FOR_BUILD@"; then
+  RANLIB_FOR_BUILD="@RANLIB_FOR_BUILD@"
+fi
+if test -n "@NM_FOR_BUILD@"; then
+  NM_FOR_BUILD="@NM_FOR_BUILD@"
+fi
+if test -n "@STRIP_FOR_BUILD@"; then
+  STRIP_FOR_BUILD="@STRIP_FOR_BUILD@"
+fi
+
 if test -n "@CC@" -a -z "${CC}"; then
   CC="@CC@"
 fi


### PR DESCRIPTION
On master (66636ca438cb65fb18bcaa4540856cef0cee2029) build tools for native packages are set to [defaults](https://github.com/bitcoin/bitcoin/blob/66636ca438cb65fb18bcaa4540856cef0cee2029/depends/builders/default.mk#L1-L9), even when such a tool is not available in the system by its default name:
```
$ cd depends
$ make print-native_capnp_cxx MULTIPROCESS=1 CC=clang CXX=clang++
native_capnp_cxx=g++
```

On system without GCC installed, this causes an error:
```
$ make native_capnp_configured MULTIPROCESS=1 CC=clang CXX=clang++
Configuring native_capnp...
...
configure: error: *** A compiler with support for C++14 language features is required.
make: *** [funcs.mk:283: /home/hebasto/GitHub/bitcoin/depends/work/build/x86_64-pc-linux-gnu/native_capnp/0.7.0-4f60a88ce07/./.stamp_configured] Error 1
```

This PR fixes this issue with introducing support of `{CC,CXX}_FOR_BUILD` variables.

With this PR:
```
$ make print-native_capnp_cxx MULTIPROCESS=1 CC_FOR_BUILD=clang CXX_FOR_BUILD=clang++
native_capnp_cxx=clang++
$ make native_capnp_configured MULTIPROCESS=1 CC_FOR_BUILD=clang CXX_FOR_BUILD=clang++
# no errors
```