### PR TITLE
refactor: cast bool operands to int to silence compiler warning

### DIFF
--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -540,8 +540,11 @@ public:
         const CBlockIndex* block2 = m_node.chainman->m_blockman.LookupBlockIndex(block_hash2);
         const CBlockIndex* ancestor = block1 && block2 ? LastCommonAncestor(block1, block2) : nullptr;
         // Using & instead of && below to avoid short circuiting and leaving
-        // output uninitialized.
-        return FillBlock(ancestor, ancestor_out, lock, active) & FillBlock(block1, block1_out, lock, active) & FillBlock(block2, block2_out, lock, active);
+        // output uninitialized. Cast bool to int to avoid -Wbitwise-instead-of-logical
+        // compiler warnings.
+        return int{FillBlock(ancestor, ancestor_out, lock, active)} &
+               int{FillBlock(block1, block1_out, lock, active)} &
+               int{FillBlock(block2, block2_out, lock, active)};
     }
     void findCoins(std::map<COutPoint, Coin>& coins) override { return FindCoins(m_node, coins); }
     double guessVerificationProgress(const uint256& block_hash) override


### PR DESCRIPTION
This fixes a compiler warning:
```
node/interfaces.cpp:544:16: warning: use of bitwise '&' with boolean operands [-Wbitwise-instead-of-logical]
        return FillBlock(ancestor, ancestor_out, lock, active) & FillBlock(block1, block1_out, lock, active) & FillBlock(block2, block2_out, lock, active);
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                                             &&
node/interfaces.cpp:544:16: note: cast one or both operands to int to silence this warning
node/interfaces.cpp:544:16: warning: use of bitwise '&' with boolean operands [-Wbitwise-instead-of-logical]
        return FillBlock(ancestor, ancestor_out, lock, active) & FillBlock(block1, block1_out, lock, active) & FillBlock(block2, block2_out, lock, active);
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                               &&
node/interfaces.cpp:544:16: note: cast one or both operands to int to silence this warning
2 warnings generated.
```
