### PR TITLE
script install_db4.sh check for `patch` command before continuing to install db4

### DIFF
--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (c) 2017-2019 The Bitcoin Core developers
+# Copyright (c) 2017-2021 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -61,6 +61,12 @@ http_get() {
 
   sha256_check "${3}" "${2}"
 }
+
+# Ensure the commands we use exist on the system
+if ! check_exists patch; then
+    echo "Command-line tool 'patch' not found.  Install patch and try again."
+    exit 1
+fi
 
 mkdir -p "${BDB_PREFIX}"
 http_get "${BDB_URL}" "${BDB_VERSION}.tar.gz" "${BDB_HASH}"


### PR DESCRIPTION
First contribution.  I've read the CONTRIBUTING guide and hope I'm doing this correctly, but please kindly point out anything I should do differently.

I found while running the contrib/install_db4.sh patch that it would fail suddenly with "patch: command not found".  I'd rather see it fail early before doing any work, allow me to install the `patch` command, and then run again.  (CentOS Linux) Here's a PR proposed to fix it.

error message:
```
...
db-4.8.30.NC/txn/txn_rec.c
db-4.8.30.NC/txn/txn_region.c
db-4.8.30.NC/txn/txn_stat.c
db-4.8.30.NC/txn/txn_util.c
./contrib/install_db4.sh: line 71: patch: command not found
```
