### PR TITLE
build, qt, macOS: Don't hard-code x86_64 as the arch when using qmake

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -87,14 +87,6 @@ For linux S390X cross compilation:
 
     sudo apt-get install g++-s390x-linux-gnu binutils-s390x-linux-gnu
 
-### Install the required dependencies: M1-based macOS
-
-To be able to build the `qt` package, ensure that Rosetta 2 is installed:
-
-```
-softwareupdate --install-rosetta
-```
-
 ### Dependency Options
 
 The following can be set when running make: `make FOO=bar`

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -10,7 +10,7 @@ $(package)_linguist_tools = lrelease lupdate lconvert
 $(package)_patches = qt.pro qttools_src.pro
 $(package)_patches += fix_qt_pkgconfig.patch mac-qmake.conf fix_no_printer.patch no-xlib.patch
 $(package)_patches += support_new_android_ndks.patch fix_android_jni_static.patch dont_hardcode_pwd.patch
-$(package)_patches+= no_sdk_version_check.patch
+$(package)_patches += dont_hardcode_x86_64.patch no_sdk_version_check.patch
 $(package)_patches+= fix_lib_paths.patch fix_android_pch.patch
 $(package)_patches+= qtbase-moc-ignore-gcc-macro.patch fix_limits_header.patch
 $(package)_patches+= fix_montery_include.patch
@@ -229,6 +229,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/fix_android_jni_static.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_android_pch.patch && \
   patch -p1 -i $($(package)_patch_dir)/no-xlib.patch && \
+  patch -p1 -i $($(package)_patch_dir)/dont_hardcode_x86_64.patch && \
   patch -p1 -i $($(package)_patch_dir)/no_sdk_version_check.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_lib_paths.patch && \
   patch -p1 -i $($(package)_patch_dir)/qtbase-moc-ignore-gcc-macro.patch && \

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -128,8 +128,10 @@ $(package)_config_opts_darwin += -device-option MAC_TARGET=$(host)
 $(package)_config_opts_darwin += -device-option XCODE_VERSION=$(XCODE_VERSION)
 endif
 
-# for macOS on Apple Silicon (ARM) see https://bugreports.qt.io/browse/QTBUG-85279
+ifneq ($(build_arch),$(host_arch))
 $(package)_config_opts_aarch64_darwin += -device-option QMAKE_APPLE_DEVICE_ARCHS=arm64
+$(package)_config_opts_x86_64_darwin += -device-option QMAKE_APPLE_DEVICE_ARCHS=x86_64
+endif
 
 $(package)_config_opts_linux = -qt-xcb
 $(package)_config_opts_linux += -no-xcb-xlib

--- a/depends/patches/qt/dont_hardcode_x86_64.patch
+++ b/depends/patches/qt/dont_hardcode_x86_64.patch
@@ -1,0 +1,123 @@
+macOS: Don't hard-code x86_64 as the architecture when using qmake
+
+Upstream commit:
+ - Qt 6.1: 9082cc8e8d5a6441dabe5e7a95bc0cd9085b95fe
+
+For other Qt branches see
+https://codereview.qt-project.org/q/I70db7e4c27f0d3da5d0af33cb491d72c312d3fa8
+
+
+--- old/qtbase/configure.json
++++ new/qtbase/configure.json
+@@ -208,11 +208,18 @@
+ 
+     "testTypeDependencies": {
+         "linkerSupportsFlag": [ "use_gold_linker" ],
+-        "verifySpec": [ "shared", "use_gold_linker", "compiler-flags", "qmakeargs", "commit" ],
++        "verifySpec": [
++            "shared",
++            "use_gold_linker",
++            "compiler-flags", "qmakeargs",
++            "simulator_and_device",
++            "thread",
++            "commit" ],
+         "compile": [ "verifyspec" ],
+         "detectPkgConfig": [ "cross_compile", "machineTuple" ],
+         "library": [ "pkg-config", "compiler-flags" ],
+-        "getPkgConfigVariable": [ "pkg-config" ]
++        "getPkgConfigVariable": [ "pkg-config" ],
++        "architecture" : [ "verifyspec" ]
+     },
+ 
+     "testTypeAliases": {
+@@ -653,7 +660,7 @@
+         },
+         "architecture": {
+             "label": "Architecture",
+-            "output": [ "architecture" ]
++            "output": [ "architecture", "commitConfig" ]
+         },
+         "pkg-config": {
+             "label": "Using pkg-config",
+diff --git a/configure.pri b/configure.pri
+index 33c90a8c2f..71767e29d6 100644
+
+--- old/qtbase/configure.pri
++++ new/qtbase/configure.pri
+@@ -642,6 +642,13 @@ defineTest(qtConfOutput_commitOptions) {
+     write_file($$QT_BUILD_TREE/mkspecs/qdevice.pri, $${currentConfig}.output.devicePro)|error()
+ }
+ 
++# Output is written after configuring each Qt module,
++# but some tests within a module might depend on the
++# configuration output of previous tests.
++defineTest(qtConfOutput_commitConfig) {
++    qtConfProcessOutput()
++}
++
+ # type (empty or 'host'), option name, default value
+ defineTest(processQtPath) {
+     out_var = config.rel_input.$${2}
+diff --git a/mkspecs/common/macx.conf b/mkspecs/common/macx.conf
+index 7d4a406134..de96c12fc9 100644
+
+--- old/qtbase/mkspecs/common/macx.conf
++++ new/qtbase/mkspecs/common/macx.conf
+@@ -6,7 +6,6 @@ QMAKE_PLATFORM         += macos osx macx
+ QMAKE_MAC_SDK           = macosx
+ 
+ QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.12
+-QMAKE_APPLE_DEVICE_ARCHS = x86_64
+ 
+ QT_MAC_SDK_VERSION_MIN = 10.13
+ QT_MAC_SDK_VERSION_MAX = 11.0
+diff --git a/mkspecs/features/mac/default_post.prf b/mkspecs/features/mac/default_post.prf
+index d052808c14..0a89effe87 100644
+
+--- old/qtbase/mkspecs/features/mac/default_post.prf
++++ new/qtbase/mkspecs/features/mac/default_post.prf
+@@ -89,6 +89,11 @@ app_extension_api_only {
+     QMAKE_LFLAGS              += $$QMAKE_CFLAGS_APPLICATION_EXTENSION
+ }
+ 
++# Non-universal builds do not set QMAKE_APPLE_DEVICE_ARCHS,
++# so we pick it up from what the arch test resolved instead.
++isEmpty(QMAKE_APPLE_DEVICE_ARCHS): \
++    QMAKE_APPLE_DEVICE_ARCHS = $$QT_ARCH
++
+ macx-xcode {
+     qmake_pkginfo_typeinfo.name = QMAKE_PKGINFO_TYPEINFO
+     !isEmpty(QMAKE_PKGINFO_TYPEINFO): \
+@@ -144,9 +149,6 @@ macx-xcode {
+     simulator: VALID_SIMULATOR_ARCHS = $$QMAKE_APPLE_SIMULATOR_ARCHS
+     VALID_ARCHS = $$VALID_DEVICE_ARCHS $$VALID_SIMULATOR_ARCHS
+ 
+-    isEmpty(VALID_ARCHS): \
+-        error("QMAKE_APPLE_DEVICE_ARCHS or QMAKE_APPLE_SIMULATOR_ARCHS must contain at least one architecture")
+-
+     single_arch: VALID_ARCHS = $$first(VALID_ARCHS)
+ 
+     ACTIVE_ARCHS = $(filter $(EXPORT_VALID_ARCHS), $(ARCHS))
+diff --git a/mkspecs/features/toolchain.prf b/mkspecs/features/toolchain.prf
+index 5003679bd0..c7c080cb07 100644
+
+--- old/qtbase/mkspecs/features/toolchain.prf
++++ new/qtbase/mkspecs/features/toolchain.prf
+@@ -182,9 +182,14 @@ isEmpty($${target_prefix}.INCDIRS) {
+         # UIKit simulator platforms will see the device SDK's sysroot in
+         # QMAKE_DEFAULT_*DIRS, because they're handled in a single build pass.
+         darwin {
+-            # Clang doesn't pick up the architecture from the sysroot, and will
+-            # default to the host architecture, so we need to manually set it.
+-            cxx_flags += -arch $$QMAKE_APPLE_DEVICE_ARCHS
++            uikit {
++                # Clang doesn't automatically pick up the architecture, just because
++                # we're passing the iOS sysroot below, and we will end up building the
++                # test for the host architecture, resulting in linker errors when
++                # linking against the iOS libraries. We work around this by passing
++                # the architecture explicitly.
++                cxx_flags += -arch $$first(QMAKE_APPLE_DEVICE_ARCHS)
++            }
+ 
+             uikit:macx-xcode: \
+                 cxx_flags += -isysroot $$sdk_path_device.value

--- a/depends/patches/qt/mac-qmake.conf
+++ b/depends/patches/qt/mac-qmake.conf
@@ -13,7 +13,6 @@ QMAKE_MAC_SDK.macosx.Path = $${MAC_SDK_PATH}
 QMAKE_MAC_SDK.macosx.platform_name = macosx
 QMAKE_MAC_SDK.macosx.SDKVersion = $${MAC_SDK_VERSION}
 QMAKE_MAC_SDK.macosx.PlatformPath = /phony
-QMAKE_APPLE_DEVICE_ARCHS=x86_64
 !host_build: QMAKE_CFLAGS += -target $${MAC_TARGET}
 !host_build: QMAKE_OBJECTIVE_CFLAGS += $$QMAKE_CFLAGS
 !host_build: QMAKE_CXXFLAGS += $$QMAKE_CFLAGS


### PR DESCRIPTION
On master (4018e23aa7e7bb57d721c7c41c55dfbb659b8c34) the Qt build system hard-coded the x86_64 as the architecture when using qmake.

This means that compiling the `qt` package on M1 Apple Silicon for the same system, i.e., without providing the `HOST` variable,—that is supposed to be compiled natively—is a cross-compiling actually:
```
% make -C depends qt_configured
...
Configure summary:

Building on: macx-clang (x86_64, CPU features: cx16 mmx sse sse2 sse3 ssse3 sse4.1)
Building for: macx-clang (arm64, CPU features: neon crc32)
Target compiler: clang (Apple) 13.0.0
Configuration: cross_compile largefile neon precompile_header silent release c++11 c++14 c++1z reduce_exports static stl
...
```

Also this bug caused another [issue](https://github.com/bitcoin/bitcoin/pull/22402) which currently is worked around by installing Rosetta.

With this PR it is no longer needed to have Rosetta installed on M1-based macOS, and:
```
% make -C depends qt_configured
...
Configure summary:

Build type: macx-clang (arm64, CPU features: neon crc32)
Compiler: clang (Apple) 13.0.0
Configuration: largefile neon precompile_header silent release c++11 c++14 c++1z reduce_exports static stl
...
```