### PR TITLE
refactor: Use underlying type of isminetype for isminefilter

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -13,12 +13,13 @@
 #include <util/message.h>
 #include <util/ui_change_type.h>
 
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
-#include <stdint.h>
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -34,7 +35,7 @@ struct CRecipient;
 struct PartiallySignedTransaction;
 struct WalletContext;
 struct bilingual_str;
-typedef uint8_t isminefilter;
+using isminefilter = std::underlying_type<isminetype>::type;
 
 namespace interfaces {
 

--- a/src/wallet/ismine.h
+++ b/src/wallet/ismine.h
@@ -8,8 +8,9 @@
 
 #include <script/standard.h>
 
-#include <stdint.h>
 #include <bitset>
+#include <cstdint>
+#include <type_traits>
 
 class CWallet;
 class CScript;
@@ -35,8 +36,7 @@ class CScript;
  * ISMINE_USED: the scriptPubKey corresponds to a used address owned by the wallet user.
  *
  */
-enum isminetype : unsigned int
-{
+enum isminetype : unsigned int {
     ISMINE_NO         = 0,
     ISMINE_WATCH_ONLY = 1 << 0,
     ISMINE_SPENDABLE  = 1 << 1,
@@ -46,7 +46,7 @@ enum isminetype : unsigned int
     ISMINE_ENUM_ELEMENTS,
 };
 /** used for bitflags of isminetype */
-typedef uint8_t isminefilter;
+using isminefilter = std::underlying_type<isminetype>::type;
 
 /**
  * Cachable amount subdivided into watchonly and spendable parts.


### PR DESCRIPTION
This does not change behavior, but it would be good for code clarity and to avoid `-Wimplicit-int-conversion` compiler warnings to use the an int of the same width for both `isminetype` and `isminefilter`.