### PR TITLE
build: don't set PORT=no in config.site

### DIFF
--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -72,7 +72,6 @@ fi
 
 if test "@host_os@" = darwin; then
   BREW=no
-  PORT=no
 fi
 
 PATH="${depends_prefix}/native/bin:${PATH}"


### PR DESCRIPTION
This should have been a part of dropping macports support in #15175.