### PR TITLE
contrib: Specify wb mode when creating mac sdk

### DIFF
--- a/contrib/macdeploy/gen-sdk
+++ b/contrib/macdeploy/gen-sdk
@@ -81,7 +81,7 @@ def run():
 
     print("Creating output .tar.gz file...")
     with out_sdktgz_path.open("wb") as fp:
-        with gzip.GzipFile(fileobj=fp, compresslevel=9, mtime=0) as gzf:
+        with gzip.GzipFile(fileobj=fp, mode='wb', compresslevel=9, mtime=0) as gzf:
             with tarfile.open(mode="w", fileobj=gzf) as tarfp:
                 print("Adding MacOSX SDK {} files...".format(sdk_version))
                 tarfp_add_with_base_change(tarfp, sdk_dir, out_name)


### PR DESCRIPTION
Fix the warning:
```
./contrib/macdeploy/gen-sdk:84: FutureWarning: GzipFile was opened for writing, but this will change in future Python releases.  Specify the mode argument for opening it for writing.
```
