### PR TITLE
[WIP] DRAFT NOMERGE Tidy up RPCTxSerializationFlags

### DIFF
--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -40,7 +40,7 @@ static void BlockToJsonVerbose(benchmark::Bench& bench)
 {
     TestBlockAndIndex data;
     bench.run([&] {
-        auto univalue = blockToJSON(data.testing_setup->m_node.chainman->m_blockman, data.block, &data.blockindex, &data.blockindex, TxVerbosity::SHOW_DETAILS_AND_PREVOUT);
+        auto univalue = blockToJSON(data.testing_setup->m_node.chainman->m_blockman, /*tx_ser_flags=*/0, data.block, &data.blockindex, &data.blockindex, TxVerbosity::SHOW_DETAILS_AND_PREVOUT);
         ankerl::nanobench::doNotOptimizeAway(univalue);
     });
 }
@@ -50,7 +50,7 @@ BENCHMARK(BlockToJsonVerbose);
 static void BlockToJsonVerboseWrite(benchmark::Bench& bench)
 {
     TestBlockAndIndex data;
-    auto univalue = blockToJSON(data.testing_setup->m_node.chainman->m_blockman, data.block, &data.blockindex, &data.blockindex, TxVerbosity::SHOW_DETAILS_AND_PREVOUT);
+    auto univalue = blockToJSON(data.testing_setup->m_node.chainman->m_blockman, /*tx_ser_flags=*/0, data.block, &data.blockindex, &data.blockindex, TxVerbosity::SHOW_DETAILS_AND_PREVOUT);
     bench.run([&] {
         auto str = univalue.write();
         ankerl::nanobench::doNotOptimizeAway(str);

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -285,8 +285,8 @@ public:
     //! Run function after given number of seconds. Cancel any previous calls with same name.
     virtual void rpcRunLater(const std::string& name, std::function<void()> fn, int64_t seconds) = 0;
 
-    //! Current RPC serialization flags.
-    virtual int rpcSerializationFlags() = 0;
+    //! Current RPC tx serialization flags.
+    virtual int rpcTxSerializationFlags() = 0;
 
     //! Get settings value.
     virtual util::SettingsValue getSetting(const std::string& arg) = 0;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -728,7 +728,10 @@ public:
     {
         RPCRunLater(name, std::move(fn), seconds);
     }
-    int rpcSerializationFlags() override { return RPCSerializationFlags(); }
+    int rpcTxSerializationFlags() override
+    {
+        return RPCTxSerializationFlags(::gArgs);
+    }
     util::SettingsValue getSetting(const std::string& name) override
     {
         return gArgs.GetSetting(name);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -284,7 +284,7 @@ static bool rest_block(const std::any& context,
     std::string hashStr;
     const RESTResponseFormat rf = ParseDataFormat(hashStr, strURIPart);
 
-    const int tx_ser_flags{RPCSerializationFlags()};
+    const int tx_ser_flags{RPCTxSerializationFlags(::gArgs)};
 
     uint256 hash;
     if (!ParseHashStr(hashStr, hash))
@@ -632,7 +632,7 @@ static bool rest_tx(const std::any& context, HTTPRequest* req, const std::string
     std::string hashStr;
     const RESTResponseFormat rf = ParseDataFormat(hashStr, strURIPart);
 
-    const int tx_ser_flags{RPCSerializationFlags()};
+    const int tx_ser_flags{RPCTxSerializationFlags(::gArgs)};
 
     uint256 hash;
     if (!ParseHashStr(hashStr, hash))

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -284,6 +284,8 @@ static bool rest_block(const std::any& context,
     std::string hashStr;
     const RESTResponseFormat rf = ParseDataFormat(hashStr, strURIPart);
 
+    const int tx_ser_flags{RPCSerializationFlags()};
+
     uint256 hash;
     if (!ParseHashStr(hashStr, hash))
         return RESTERR(req, HTTP_BAD_REQUEST, "Invalid hash: " + hashStr);
@@ -311,7 +313,7 @@ static bool rest_block(const std::any& context,
 
     switch (rf) {
     case RESTResponseFormat::BINARY: {
-        CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
+        CDataStream ssBlock{SER_NETWORK, PROTOCOL_VERSION | tx_ser_flags};
         ssBlock << block;
         std::string binaryBlock = ssBlock.str();
         req->WriteHeader("Content-Type", "application/octet-stream");
@@ -320,7 +322,7 @@ static bool rest_block(const std::any& context,
     }
 
     case RESTResponseFormat::HEX: {
-        CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
+        CDataStream ssBlock{SER_NETWORK, PROTOCOL_VERSION | tx_ser_flags};
         ssBlock << block;
         std::string strHex = HexStr(ssBlock) + "\n";
         req->WriteHeader("Content-Type", "text/plain");
@@ -329,7 +331,7 @@ static bool rest_block(const std::any& context,
     }
 
     case RESTResponseFormat::JSON: {
-        UniValue objBlock = blockToJSON(chainman.m_blockman, block, tip, pblockindex, tx_verbosity);
+        UniValue objBlock = blockToJSON(chainman.m_blockman, tx_ser_flags, block, tip, pblockindex, tx_verbosity);
         std::string strJSON = objBlock.write() + "\n";
         req->WriteHeader("Content-Type", "application/json");
         req->WriteReply(HTTP_OK, strJSON);
@@ -630,6 +632,8 @@ static bool rest_tx(const std::any& context, HTTPRequest* req, const std::string
     std::string hashStr;
     const RESTResponseFormat rf = ParseDataFormat(hashStr, strURIPart);
 
+    const int tx_ser_flags{RPCSerializationFlags()};
+
     uint256 hash;
     if (!ParseHashStr(hashStr, hash))
         return RESTERR(req, HTTP_BAD_REQUEST, "Invalid hash: " + hashStr);
@@ -648,7 +652,7 @@ static bool rest_tx(const std::any& context, HTTPRequest* req, const std::string
 
     switch (rf) {
     case RESTResponseFormat::BINARY: {
-        CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
+        CDataStream ssTx{SER_NETWORK, PROTOCOL_VERSION | tx_ser_flags};
         ssTx << tx;
 
         std::string binaryTx = ssTx.str();
@@ -658,7 +662,7 @@ static bool rest_tx(const std::any& context, HTTPRequest* req, const std::string
     }
 
     case RESTResponseFormat::HEX: {
-        CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
+        CDataStream ssTx{SER_NETWORK, PROTOCOL_VERSION | tx_ser_flags};
         ssTx << tx;
 
         std::string strHex = HexStr(ssTx) + "\n";

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -700,7 +700,8 @@ static RPCHelpMan getblock()
 {
     uint256 hash(ParseHashV(request.params[0], "blockhash"));
 
-    const int tx_ser_flags{RPCSerializationFlags()};
+    const ArgsManager& args{EnsureAnyArgsman(request.context)};
+    const int tx_ser_flags{RPCTxSerializationFlags(args)};
 
     int verbosity = 1;
     if (!request.params[1].isNull()) {

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -40,7 +40,8 @@ double GetDifficulty(const CBlockIndex* blockindex);
 void RPCNotifyBlockChange(const CBlockIndex*);
 
 /** Block description to JSON */
-UniValue blockToJSON(node::BlockManager& blockman, const CBlock& block, const CBlockIndex* tip, const CBlockIndex* blockindex, TxVerbosity verbosity) LOCKS_EXCLUDED(cs_main);
+UniValue blockToJSON(node::BlockManager& blockman, int tx_ser_flags, const CBlock& block, const CBlockIndex* tip, const CBlockIndex* blockindex, TxVerbosity verbosity)
+    LOCKS_EXCLUDED(::cs_main);
 
 /** Block header to JSON */
 UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex) LOCKS_EXCLUDED(cs_main);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -210,7 +210,8 @@ static RPCHelpMan getrawtransaction()
 {
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     ChainstateManager& chainman = EnsureChainman(node);
-    const int tx_ser_flags{RPCSerializationFlags()};
+    ArgsManager& args{EnsureArgsman(node)};
+    const int tx_ser_flags{RPCTxSerializationFlags(args)};
 
     bool in_active_chain = true;
     uint256 hash = ParseHashV(request.params[0], "parameter 1");

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -535,11 +535,12 @@ void RPCRunLater(const std::string& name, std::function<void()> func, int64_t nS
     deadlineTimers.emplace(name, std::unique_ptr<RPCTimerBase>(timerInterface->NewTimer(func, nSeconds*1000)));
 }
 
-int RPCSerializationFlags()
+int RPCTxSerializationFlags(const ArgsManager& args)
 {
     int flag = 0;
-    if (gArgs.GetIntArg("-rpcserialversion", DEFAULT_RPC_SERIALIZE_VERSION) == 0)
+    if (args.GetIntArg("-rpcserialversion", DEFAULT_RPC_SERIALIZE_VERSION) == 0) {
         flag |= SERIALIZE_TRANSACTION_NO_WITNESS;
+    }
     return flag;
 }
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -18,6 +18,7 @@
 
 static const unsigned int DEFAULT_RPC_SERIALIZE_VERSION = 1;
 
+class ArgsManager;
 class CRPCCommand;
 
 namespace RPCServer
@@ -174,7 +175,7 @@ void InterruptRPC();
 void StopRPC();
 std::string JSONRPCExecBatch(const JSONRPCRequest& jreq, const UniValue& vReq);
 
-// Retrieves any serialization flags requested in command line argument
-int RPCSerializationFlags();
+/** Retrieves any tx serialization flags requested in command line argument */
+int RPCTxSerializationFlags(const ArgsManager& args);
 
 #endif // BITCOIN_RPC_SERVER_H

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -780,7 +780,7 @@ RPCHelpMan gettransaction()
     ListTransactions(*pwallet, wtx, 0, false, details, filter, nullptr /* filter_label */);
     entry.pushKV("details", details);
 
-    std::string strHex = EncodeHexTx(*wtx.tx, pwallet->chain().rpcSerializationFlags());
+    std::string strHex = EncodeHexTx(*wtx.tx, pwallet->chain().rpcTxSerializationFlags());
     entry.pushKV("hex", strHex);
 
     if (verbose) {

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -232,7 +232,7 @@ bool CZMQPublishRawBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
     LogPrint(BCLog::ZMQ, "Publish rawblock %s to %s\n", pindex->GetBlockHash().GetHex(), this->address);
 
     const Consensus::Params& consensusParams = Params().GetConsensus();
-    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
+    CDataStream ss{SER_NETWORK, PROTOCOL_VERSION | RPCTxSerializationFlags(::gArgs)};
     {
         LOCK(cs_main);
         CBlock block;
@@ -252,7 +252,7 @@ bool CZMQPublishRawTransactionNotifier::NotifyTransaction(const CTransaction &tr
 {
     uint256 hash = transaction.GetHash();
     LogPrint(BCLog::ZMQ, "Publish rawtx %s to %s\n", hash.GetHex(), this->address);
-    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
+    CDataStream ss{SER_NETWORK, PROTOCOL_VERSION | RPCTxSerializationFlags(::gArgs)};
     ss << transaction;
     return SendZmqMessage(MSG_RAWTX, &(*ss.begin()), ss.size());
 }


### PR DESCRIPTION
`RPCSerializationFlags` has several issues:

* It is only used in places where transactions (and blocks) are serialized to raw hex, however the name implies this should be used for any every place that serializes data. See the confusion it caused here: https://github.com/bitcoin/bitcoin/pull/17631#discussion_r727703209
* It depends on the `gArgs` global, blocking progress on https://github.com/bitcoin/bitcoin/issues/21005

Fix all issues in this pull.