### PR TITLE
Don't check if the listening socket is valid

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1640,7 +1640,7 @@ void CConnman::SocketHandlerListening(const std::set<SOCKET>& recv_set)
         if (interruptNet) {
             return;
         }
-        if (listen_socket.socket != INVALID_SOCKET && recv_set.count(listen_socket.socket) > 0) {
+        if (recv_set.count(listen_socket.socket) > 0) {
             AcceptConnection(listen_socket);
         }
     }


### PR DESCRIPTION
_This is a piece of #21878, chopped off to ease review._

Listening sockets in `CConnman::vhListenSocket` are always valid
(underlying file descriptor is not `INVALID_SOCKET`).
