### PR TITLE
Use Sock in CNode

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -517,7 +517,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
 void CNode::CloseSocketDisconnect()
 {
     fDisconnect = true;
-    LOCK(cs_hSocket);
+    LOCK(m_sock_mutex);
     if (m_sock) {
         LogPrint(BCLog::NET, "disconnecting peer=%d\n", id);
         m_sock.reset();
@@ -798,7 +798,7 @@ size_t CConnman::SocketSendData(CNode& node) const
         assert(data.size() > node.nSendOffset);
         int nBytes = 0;
         {
-            LOCK(node.cs_hSocket);
+            LOCK(node.m_sock_mutex);
             if (!node.m_sock) {
                 break;
             }
@@ -1381,7 +1381,7 @@ bool CConnman::GenerateSelectSet(const std::vector<CNode*>& nodes,
             select_send = !pnode->vSendMsg.empty();
         }
 
-        LOCK(pnode->cs_hSocket);
+        LOCK(pnode->m_sock_mutex);
         if (!pnode->m_sock) {
             continue;
         }
@@ -1562,7 +1562,7 @@ void CConnman::SocketHandlerConnected(const std::vector<CNode*>& nodes,
         bool sendSet = false;
         bool errorSet = false;
         {
-            LOCK(pnode->cs_hSocket);
+            LOCK(pnode->m_sock_mutex);
             if (!pnode->m_sock) {
                 continue;
             }
@@ -1576,7 +1576,7 @@ void CConnman::SocketHandlerConnected(const std::vector<CNode*>& nodes,
             uint8_t pchBuf[0x10000];
             int nBytes = 0;
             {
-                LOCK(pnode->cs_hSocket);
+                LOCK(pnode->m_sock_mutex);
                 if (!pnode->m_sock) {
                     continue;
                 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -505,7 +505,16 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
     if (!addr_bind.IsValid()) {
         addr_bind = GetBindAddress(sock->Get());
     }
-    CNode* pnode = new CNode(id, nLocalServices, std::move(sock), addrConnect, CalculateKeyedNetGroup(addrConnect), nonce, addr_bind, pszDest ? pszDest : "", conn_type, /* inbound_onion */ false);
+    CNode* pnode = new CNode(id,
+                             nLocalServices,
+                             std::move(sock),
+                             addrConnect,
+                             CalculateKeyedNetGroup(addrConnect),
+                             nonce,
+                             addr_bind,
+                             pszDest ? pszDest : "",
+                             conn_type,
+                             /*inbound_onion=*/false);
     pnode->AddRef();
 
     // We're making a new connection, harvest entropy from the time (and our peer count)
@@ -1197,7 +1206,16 @@ void CConnman::CreateNodeFromAcceptedSocket(std::unique_ptr<Sock>&& sock,
     }
 
     const bool inbound_onion = std::find(m_onion_binds.begin(), m_onion_binds.end(), addr_bind) != m_onion_binds.end();
-    CNode* pnode = new CNode(id, nodeServices, std::move(sock), addr, CalculateKeyedNetGroup(addr), nonce, addr_bind, "", ConnectionType::INBOUND, inbound_onion);
+    CNode* pnode = new CNode(id,
+                             nodeServices,
+                             std::move(sock),
+                             addr,
+                             CalculateKeyedNetGroup(addr),
+                             nonce,
+                             addr_bind,
+                             /*addrNameIn=*/"",
+                             ConnectionType::INBOUND,
+                             inbound_onion);
     pnode->AddRef();
     pnode->m_permissionFlags = permissionFlags;
     pnode->m_prefer_evict = discouraged;

--- a/src/net.h
+++ b/src/net.h
@@ -402,7 +402,17 @@ public:
 
     NetPermissionFlags m_permissionFlags{NetPermissionFlags::None};
     std::atomic<ServiceFlags> nServices{NODE_NONE};
-    SOCKET hSocket GUARDED_BY(cs_hSocket);
+
+    /**
+     * Socket used for communication with the node.
+     * May not own a Sock object (after `CloseSocketDisconnect()` or during tests).
+     * `shared_ptr` (instead of `unique_ptr`) is used to avoid premature close of
+     * the underlying file descriptor by one thread while another thread is
+     * poll(2)-ing it for activity.
+     * @see https://github.com/bitcoin/bitcoin/issues/21744 for details.
+     */
+    std::shared_ptr<Sock> m_sock GUARDED_BY(cs_hSocket);
+
     /** Total size of all vSendMsg entries */
     size_t nSendSize GUARDED_BY(cs_vSend){0};
     /** Offset inside the first vSendMsg already sent */
@@ -578,8 +588,7 @@ public:
      * criterium in CConnman::AttemptToEvictConnection. */
     std::atomic<std::chrono::microseconds> m_min_ping_time{std::chrono::microseconds::max()};
 
-    CNode(NodeId id, ServiceFlags nLocalServicesIn, SOCKET hSocketIn, const CAddress& addrIn, uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn, const CAddress& addrBindIn, const std::string& addrNameIn, ConnectionType conn_type_in, bool inbound_onion);
-    ~CNode();
+    CNode(NodeId id, ServiceFlags nLocalServicesIn, std::shared_ptr<Sock> sock, const CAddress& addrIn, uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn, const CAddress& addrBindIn, const std::string& addrNameIn, ConnectionType conn_type_in, bool inbound_onion);
     CNode(const CNode&) = delete;
     CNode& operator=(const CNode&) = delete;
 

--- a/src/net.h
+++ b/src/net.h
@@ -411,7 +411,7 @@ public:
      * poll(2)-ing it for activity.
      * @see https://github.com/bitcoin/bitcoin/issues/21744 for details.
      */
-    std::shared_ptr<Sock> m_sock GUARDED_BY(cs_hSocket);
+    std::shared_ptr<Sock> m_sock GUARDED_BY(m_sock_mutex);
 
     /** Total size of all vSendMsg entries */
     size_t nSendSize GUARDED_BY(cs_vSend){0};
@@ -420,7 +420,7 @@ public:
     uint64_t nSendBytes GUARDED_BY(cs_vSend){0};
     std::deque<std::vector<unsigned char>> vSendMsg GUARDED_BY(cs_vSend);
     Mutex cs_vSend;
-    Mutex cs_hSocket;
+    Mutex m_sock_mutex;
     Mutex cs_vRecv;
 
     RecursiveMutex cs_vProcessMsg;

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -59,7 +59,16 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
 
     // Mock an outbound peer
     CAddress addr1(ip(0xa0b0c001), NODE_NONE);
-    CNode dummyNode1(id++, ServiceFlags(NODE_NETWORK | NODE_WITNESS), INVALID_SOCKET, addr1, /*nKeyedNetGroupIn=*/0, /*nLocalHostNonceIn=*/0, CAddress(), /*addrNameIn=*/"", ConnectionType::OUTBOUND_FULL_RELAY, /*inbound_onion=*/false);
+    CNode dummyNode1{id++,
+                     ServiceFlags(NODE_NETWORK | NODE_WITNESS),
+                     /*sock=*/nullptr,
+                     addr1,
+                     /*nKeyedNetGroupIn=*/0,
+                     /*nLocalHostNonceIn=*/0,
+                     CAddress(),
+                     /*addrNameIn=*/"",
+                     ConnectionType::OUTBOUND_FULL_RELAY,
+                     /*inbound_onion=*/false};
     dummyNode1.SetCommonVersion(PROTOCOL_VERSION);
 
     peerLogic->InitializeNode(&dummyNode1);
@@ -108,7 +117,16 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
 static void AddRandomOutboundPeer(std::vector<CNode*>& vNodes, PeerManager& peerLogic, ConnmanTestMsg& connman, ConnectionType connType)
 {
     CAddress addr(ip(g_insecure_rand_ctx.randbits(32)), NODE_NONE);
-    vNodes.emplace_back(new CNode(id++, ServiceFlags(NODE_NETWORK | NODE_WITNESS), INVALID_SOCKET, addr, /*nKeyedNetGroupIn=*/0, /*nLocalHostNonceIn=*/0, CAddress(), /*addrNameIn=*/"", connType, /*inbound_onion=*/false));
+    vNodes.emplace_back(new CNode{id++,
+                                  ServiceFlags(NODE_NETWORK | NODE_WITNESS),
+                                  /*sock=*/nullptr,
+                                  addr,
+                                  /*nKeyedNetGroupIn=*/0,
+                                  /*nLocalHostNonceIn=*/0,
+                                  CAddress(),
+                                  /*addrNameIn=*/"",
+                                  connType,
+                                  /*inbound_onion=*/false});
     CNode &node = *vNodes.back();
     node.SetCommonVersion(PROTOCOL_VERSION);
 
@@ -279,9 +297,16 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     std::array<CNode*, 3> nodes;
 
     banman->ClearBanned();
-    nodes[0] = new CNode{id++, NODE_NETWORK, INVALID_SOCKET, addr[0], /*nKeyedNetGroupIn=*/0,
-                         /*nLocalHostNonceIn=*/0, CAddress(), /*addrNameIn=*/"",
-                         ConnectionType::INBOUND, /*inbound_onion=*/false};
+    nodes[0] = new CNode{id++,
+                         NODE_NETWORK,
+                         /*sock=*/nullptr,
+                         addr[0],
+                         /*nKeyedNetGroupIn=*/0,
+                         /*nLocalHostNonceIn=*/0,
+                         CAddress(),
+                         /*addrNameIn=*/"",
+                         ConnectionType::INBOUND,
+                         /*inbound_onion=*/false};
     nodes[0]->SetCommonVersion(PROTOCOL_VERSION);
     peerLogic->InitializeNode(nodes[0]);
     nodes[0]->fSuccessfullyConnected = true;
@@ -295,9 +320,16 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     BOOST_CHECK(nodes[0]->fDisconnect);
     BOOST_CHECK(!banman->IsDiscouraged(other_addr)); // Different address, not discouraged
 
-    nodes[1] = new CNode{id++, NODE_NETWORK, INVALID_SOCKET, addr[1], /*nKeyedNetGroupIn=*/1,
-                         /*nLocalHostNonceIn=*/1, CAddress(), /*addrNameIn=*/"",
-                         ConnectionType::INBOUND, /*inbound_onion=*/false};
+    nodes[1] = new CNode{id++,
+                         NODE_NETWORK,
+                         /*sock=*/nullptr,
+                         addr[1],
+                         /*nKeyedNetGroupIn=*/1,
+                         /*nLocalHostNonceIn=*/1,
+                         CAddress(),
+                         /*addrNameIn=*/"",
+                         ConnectionType::INBOUND,
+                         /*inbound_onion=*/false};
     nodes[1]->SetCommonVersion(PROTOCOL_VERSION);
     peerLogic->InitializeNode(nodes[1]);
     nodes[1]->fSuccessfullyConnected = true;
@@ -326,9 +358,16 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
 
     // Make sure non-IP peers are discouraged and disconnected properly.
 
-    nodes[2] = new CNode{id++, NODE_NETWORK, INVALID_SOCKET, addr[2], /*nKeyedNetGroupIn=*/1,
-                         /*nLocalHostNonceIn=*/1, CAddress(), /*addrNameIn=*/"",
-                         ConnectionType::OUTBOUND_FULL_RELAY, /*inbound_onion=*/false};
+    nodes[2] = new CNode{id++,
+                         NODE_NETWORK,
+                         /*sock=*/nullptr,
+                         addr[2],
+                         /*nKeyedNetGroupIn=*/1,
+                         /*nLocalHostNonceIn=*/1,
+                         CAddress(),
+                         /*addrNameIn=*/"",
+                         ConnectionType::OUTBOUND_FULL_RELAY,
+                         /*inbound_onion=*/false};
     nodes[2]->SetCommonVersion(PROTOCOL_VERSION);
     peerLogic->InitializeNode(nodes[2]);
     nodes[2]->fSuccessfullyConnected = true;
@@ -364,7 +403,16 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     SetMockTime(nStartTime); // Overrides future calls to GetTime()
 
     CAddress addr(ip(0xa0b0c001), NODE_NONE);
-    CNode dummyNode(id++, NODE_NETWORK, INVALID_SOCKET, addr, /*nKeyedNetGroupIn=*/4, /*nLocalHostNonceIn=*/4, CAddress(), /*addrNameIn=*/"", ConnectionType::INBOUND, /*inbound_onion=*/false);
+    CNode dummyNode{id++,
+                    NODE_NETWORK,
+                    /*sock=*/nullptr,
+                    addr,
+                    /*nKeyedNetGroupIn=*/4,
+                    /*nLocalHostNonceIn=*/4,
+                    CAddress(),
+                    /*addrNameIn=*/"",
+                    ConnectionType::INBOUND,
+                    /*inbound_onion=*/false};
     dummyNode.SetCommonVersion(PROTOCOL_VERSION);
     peerLogic->InitializeNode(&dummyNode);
     dummyNode.fSuccessfullyConnected = true;

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -290,7 +290,7 @@ auto ConsumeNode(FuzzedDataProvider& fuzzed_data_provider, const std::optional<N
 {
     const NodeId node_id = node_id_in.value_or(fuzzed_data_provider.ConsumeIntegralInRange<NodeId>(0, std::numeric_limits<NodeId>::max()));
     const ServiceFlags local_services = ConsumeWeakEnum(fuzzed_data_provider, ALL_SERVICE_FLAGS);
-    const SOCKET socket = INVALID_SOCKET;
+    const auto sock = std::make_shared<FuzzedSock>(fuzzed_data_provider);
     const CAddress address = ConsumeAddress(fuzzed_data_provider);
     const uint64_t keyed_net_group = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
     const uint64_t local_host_nonce = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
@@ -299,9 +299,27 @@ auto ConsumeNode(FuzzedDataProvider& fuzzed_data_provider, const std::optional<N
     const ConnectionType conn_type = fuzzed_data_provider.PickValueInArray(ALL_CONNECTION_TYPES);
     const bool inbound_onion{conn_type == ConnectionType::INBOUND ? fuzzed_data_provider.ConsumeBool() : false};
     if constexpr (ReturnUniquePtr) {
-        return std::make_unique<CNode>(node_id, local_services, socket, address, keyed_net_group, local_host_nonce, addr_bind, addr_name, conn_type, inbound_onion);
+        return std::make_unique<CNode>(node_id,
+                                       local_services,
+                                       sock,
+                                       address,
+                                       keyed_net_group,
+                                       local_host_nonce,
+                                       addr_bind,
+                                       addr_name,
+                                       conn_type,
+                                       inbound_onion);
     } else {
-        return CNode{node_id, local_services, socket, address, keyed_net_group, local_host_nonce, addr_bind, addr_name, conn_type, inbound_onion};
+        return CNode{node_id,
+                     local_services,
+                     sock,
+                     address,
+                     keyed_net_group,
+                     local_host_nonce,
+                     addr_bind,
+                     addr_name,
+                     conn_type,
+                     inbound_onion};
     }
 }
 inline std::unique_ptr<CNode> ConsumeNodeAsUniquePtr(FuzzedDataProvider& fdp, const std::optional<NodeId>& node_id_in = std::nullopt) { return ConsumeNode<true>(fdp, node_id_in); }

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -43,7 +43,6 @@ BOOST_AUTO_TEST_CASE(cnode_listen_port)
 
 BOOST_AUTO_TEST_CASE(cnode_simple_test)
 {
-    SOCKET hSocket = INVALID_SOCKET;
     NodeId id = 0;
 
     in_addr ipv4Addr;
@@ -52,12 +51,16 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
     CAddress addr = CAddress(CService(ipv4Addr, 7777), NODE_NETWORK);
     std::string pszDest;
 
-    std::unique_ptr<CNode> pnode1 = std::make_unique<CNode>(
-        id++, NODE_NETWORK, hSocket, addr,
-        /* nKeyedNetGroupIn = */ 0,
-        /* nLocalHostNonceIn = */ 0,
-        CAddress(), pszDest, ConnectionType::OUTBOUND_FULL_RELAY,
-        /* inbound_onion = */ false);
+    std::unique_ptr<CNode> pnode1 = std::make_unique<CNode>(id++,
+                                                            NODE_NETWORK,
+                                                            /*sock=*/nullptr,
+                                                            addr,
+                                                            /*nKeyedNetGroupIn=*/0,
+                                                            /*nLocalHostNonceIn=*/0,
+                                                            CAddress(),
+                                                            pszDest,
+                                                            ConnectionType::OUTBOUND_FULL_RELAY,
+                                                            /*inbound_onion=*/false);
     BOOST_CHECK(pnode1->IsFullOutboundConn() == true);
     BOOST_CHECK(pnode1->IsManualConn() == false);
     BOOST_CHECK(pnode1->IsBlockOnlyConn() == false);
@@ -67,12 +70,16 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
     BOOST_CHECK(pnode1->m_inbound_onion == false);
     BOOST_CHECK_EQUAL(pnode1->ConnectedThroughNetwork(), Network::NET_IPV4);
 
-    std::unique_ptr<CNode> pnode2 = std::make_unique<CNode>(
-        id++, NODE_NETWORK, hSocket, addr,
-        /* nKeyedNetGroupIn = */ 1,
-        /* nLocalHostNonceIn = */ 1,
-        CAddress(), pszDest, ConnectionType::INBOUND,
-        /* inbound_onion = */ false);
+    std::unique_ptr<CNode> pnode2 = std::make_unique<CNode>(id++,
+                                                            NODE_NETWORK,
+                                                            /*sock=*/nullptr,
+                                                            addr,
+                                                            /*nKeyedNetGroupIn=*/1,
+                                                            /*nLocalHostNonceIn=*/1,
+                                                            CAddress(),
+                                                            pszDest,
+                                                            ConnectionType::INBOUND,
+                                                            /*inbound_onion=*/false);
     BOOST_CHECK(pnode2->IsFullOutboundConn() == false);
     BOOST_CHECK(pnode2->IsManualConn() == false);
     BOOST_CHECK(pnode2->IsBlockOnlyConn() == false);
@@ -82,12 +89,16 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
     BOOST_CHECK(pnode2->m_inbound_onion == false);
     BOOST_CHECK_EQUAL(pnode2->ConnectedThroughNetwork(), Network::NET_IPV4);
 
-    std::unique_ptr<CNode> pnode3 = std::make_unique<CNode>(
-        id++, NODE_NETWORK, hSocket, addr,
-        /* nKeyedNetGroupIn = */ 0,
-        /* nLocalHostNonceIn = */ 0,
-        CAddress(), pszDest, ConnectionType::OUTBOUND_FULL_RELAY,
-        /* inbound_onion = */ false);
+    std::unique_ptr<CNode> pnode3 = std::make_unique<CNode>(id++,
+                                                            NODE_NETWORK,
+                                                            /*sock=*/nullptr,
+                                                            addr,
+                                                            /*nKeyedNetGroupIn=*/0,
+                                                            /*nLocalHostNonceIn=*/0,
+                                                            CAddress(),
+                                                            pszDest,
+                                                            ConnectionType::OUTBOUND_FULL_RELAY,
+                                                            /*inbound_onion=*/false);
     BOOST_CHECK(pnode3->IsFullOutboundConn() == true);
     BOOST_CHECK(pnode3->IsManualConn() == false);
     BOOST_CHECK(pnode3->IsBlockOnlyConn() == false);
@@ -97,12 +108,16 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
     BOOST_CHECK(pnode3->m_inbound_onion == false);
     BOOST_CHECK_EQUAL(pnode3->ConnectedThroughNetwork(), Network::NET_IPV4);
 
-    std::unique_ptr<CNode> pnode4 = std::make_unique<CNode>(
-        id++, NODE_NETWORK, hSocket, addr,
-        /* nKeyedNetGroupIn = */ 1,
-        /* nLocalHostNonceIn = */ 1,
-        CAddress(), pszDest, ConnectionType::INBOUND,
-        /* inbound_onion = */ true);
+    std::unique_ptr<CNode> pnode4 = std::make_unique<CNode>(id++,
+                                                            NODE_NETWORK,
+                                                            /*sock=*/nullptr,
+                                                            addr,
+                                                            /*nKeyedNetGroupIn=*/1,
+                                                            /*nLocalHostNonceIn=*/1,
+                                                            CAddress(),
+                                                            pszDest,
+                                                            ConnectionType::INBOUND,
+                                                            /*inbound_onion=*/true);
     BOOST_CHECK(pnode4->IsFullOutboundConn() == false);
     BOOST_CHECK(pnode4->IsManualConn() == false);
     BOOST_CHECK(pnode4->IsBlockOnlyConn() == false);
@@ -607,7 +622,16 @@ BOOST_AUTO_TEST_CASE(ipv4_peer_with_ipv6_addrMe_test)
     in_addr ipv4AddrPeer;
     ipv4AddrPeer.s_addr = 0xa0b0c001;
     CAddress addr = CAddress(CService(ipv4AddrPeer, 7777), NODE_NETWORK);
-    std::unique_ptr<CNode> pnode = std::make_unique<CNode>(0, NODE_NETWORK, INVALID_SOCKET, addr, /*nKeyedNetGroupIn=*/0, /*nLocalHostNonceIn=*/0, CAddress{}, /*pszDest=*/std::string{}, ConnectionType::OUTBOUND_FULL_RELAY, /*inbound_onion=*/false);
+    std::unique_ptr<CNode> pnode = std::make_unique<CNode>(/*id=*/0,
+                                                           NODE_NETWORK,
+                                                           /*sock=*/nullptr,
+                                                           addr,
+                                                           /*nKeyedNetGroupIn=*/0,
+                                                           /*nLocalHostNonceIn=*/0,
+                                                           CAddress{},
+                                                           /*pszDest=*/std::string{},
+                                                           ConnectionType::OUTBOUND_FULL_RELAY,
+                                                           /*inbound_onion=*/false);
     pnode->fSuccessfullyConnected.store(true);
 
     // the peer claims to be reaching us via IPv6


### PR DESCRIPTION
_This is a piece of #21878, chopped off to ease review._

Change `CNode` to use a pointer to `Sock` instead of a bare `SOCKET`.
This will help mocking / testing / fuzzing more code.
