### PR TITLE
util: Add TorControlArgumentCheck function

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -873,6 +873,11 @@ bool AppInitParameterInteraction(const ArgsManager& args)
         return InitError(Untranslated("Cannot set -listen=0 together with -listenonion=1"));
     }
 
+    // if torcontrol given, it needs to be in form of <host>:<port>
+    if (!TorControlArgumentCheck(args.GetArg("-torcontrol", DEFAULT_TOR_CONTROL))) {
+        return InitError(Untranslated("-torcontrol has to be in the form <host>:<port>"));
+    }
+
     // Make sure enough file descriptors are available
     int nBind = std::max(nUserBind, size_t(1));
     nUserMaxConnections = args.GetIntArg("-maxconnections", DEFAULT_MAX_PEER_CONNECTIONS);

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -204,6 +204,10 @@ bool Lookup(const std::string& name, std::vector<CService>& vAddr, uint16_t port
     std::string hostname;
     SplitHostPort(name, port, hostname);
 
+    if (port == 0) {
+      return false;
+    }
+
     std::vector<CNetAddr> vIP;
     bool fRet = LookupIntern(hostname, vIP, nMaxSolutions, fAllowLookup, dns_lookup_function);
     if (!fRet)

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -136,7 +136,7 @@ bool TorControlConnection::Connect(const std::string& tor_control_center, const 
     }
 
     CService control_service;
-    if (!Lookup(tor_control_center, control_service, 9051, fNameLookup)) {
+    if (!Lookup(tor_control_center, control_service, 0, fNameLookup)) {
         LogPrintf("tor: Failed to look up control center %s\n", tor_control_center);
         return false;
     }
@@ -587,6 +587,17 @@ void TorController::reconnect_cb(evutil_socket_t fd, short what, void *arg)
 /****** Thread ********/
 static struct event_base *gBase;
 static std::thread torControlThread;
+
+bool TorControlArgumentCheck(const std::string& arguments)
+{
+    CService control_service;
+
+    if (!Lookup(arguments, control_service, 0, fNameLookup)) {
+        LogPrintf("tor: Failed to look up control center %s\n", arguments);
+        return false;
+    }
+    return true;
+}
 
 static void TorControlThread(CService onion_service_target)
 {

--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -27,6 +27,7 @@ class CService;
 extern const std::string DEFAULT_TOR_CONTROL;
 static const bool DEFAULT_LISTEN_ONION = true;
 
+bool TorControlArgumentCheck(const std::string& arguments);
 void StartTorControl(CService onion_service_target);
 void InterruptTorControl();
 void StopTorControl();


### PR DESCRIPTION
This PR fixes #23589

This PR adds a new utility function, `TorControlArgumentCheck`, which can be used to check if a given string is a valid `<host>:<port>` pair or not.
This PR also uses this new function to check the validity of the `-torcontrol` argument and raises an `InitError` in case the value of this argument is invalid.

|Master|PR|
|---------|----|
|![Screenshot from 2021-11-26 18-27-19](https://user-images.githubusercontent.com/85434418/143585182-f0958a62-b5b2-45d3-b190-9c04541a90be.png)|![Screenshot from 2021-11-26 18-25-15](https://user-images.githubusercontent.com/85434418/143585203-f94843ce-e7b7-4220-ae2d-13a0098dca2f.png)| 
