### PR TITLE
rpc: Pass const char* to evhttp_connection_get_peer for new libevent

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1510,15 +1510,25 @@ if test x$build_bitcoin_cli$build_bitcoind$bitcoin_enable_qt$use_tests$use_bench
   fi
 fi
 
-AC_MSG_CHECKING([if evhttp_connection_get_peer expects const char**])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-    #include <cstdint>
-    #include <event2/http.h>
-  ]],
-  [[ evhttp_connection_get_peer((evhttp_connection*) nullptr,(const char**) nullptr,(uint16_t*) nullptr); ]])],
-  [ AC_MSG_RESULT([yes]); AC_DEFINE([HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR], [1], [Define this symbol if evhttp_connection_get_peer expects const char**]) ],
-  [ AC_MSG_RESULT([no]); AC_DEFINE([HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR], [0], [Define this symbol if evhttp_connection_get_peer expects const char**]) ]
-)
+if test x$use_libevent = xyes; then
+  TEMP_CXXFLAGS="$CXXFLAGS"
+  CXXFLAGS="$CXXFLAGS $EVENT_CFLAGS"
+  AC_MSG_CHECKING([if evhttp_connection_get_peer expects const char**])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+      #include <cstdint>
+      #include <event2/http.h>
+    ]], [[
+      evhttp_connection *conn = (evhttp_connection *)1;
+      const char *host;
+      uint16_t port;
+
+      evhttp_connection_get_peer(conn, &host, &port);
+    ]])],
+    [ AC_MSG_RESULT([yes]); AC_DEFINE([HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR], [1], [Define this symbol if evhttp_connection_get_peer expects const char**]) ],
+    [ AC_MSG_RESULT([no]) ]
+  )
+  CXXFLAGS="$TEMP_CXXFLAGS"
+fi
 
 dnl QR Code encoding library check
 

--- a/configure.ac
+++ b/configure.ac
@@ -1510,6 +1510,16 @@ if test x$build_bitcoin_cli$build_bitcoind$bitcoin_enable_qt$use_tests$use_bench
   fi
 fi
 
+AC_MSG_CHECKING([if evhttp_connection_get_peer expects const char**])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    #include <cstdint>
+    #include <event2/http.h>
+  ]],
+  [[ evhttp_connection_get_peer((evhttp_connection*) nullptr,(const char**) nullptr,(uint16_t*) nullptr); ]])],
+  [ AC_MSG_RESULT([yes]); AC_DEFINE([HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR], [1], [Define this symbol if evhttp_connection_get_peer expects const char**]) ],
+  [ AC_MSG_RESULT([no]); AC_DEFINE([HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR], [0], [Define this symbol if evhttp_connection_get_peer expects const char**]) ]
+)
+
 dnl QR Code encoding library check
 
 if test "x$use_qr" != xno; then
@@ -1870,6 +1880,7 @@ AC_SUBST(HAVE_BUILTIN_PREFETCH)
 AC_SUBST(HAVE_MM_PREFETCH)
 AC_SUBST(HAVE_STRONG_GETAUXVAL)
 AC_SUBST(ANDROID_ARCH)
+AC_SUBST(HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR)
 AC_CONFIG_FILES([Makefile src/Makefile doc/man/Makefile share/setup.nsi share/qt/Info.plist test/config.ini])
 AC_CONFIG_FILES([contrib/devtools/split-debug.sh],[chmod +x contrib/devtools/split-debug.sh])
 AM_COND_IF([HAVE_DOXYGEN], [AC_CONFIG_FILES([doc/Doxyfile])])

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -602,7 +602,7 @@ CService HTTPRequest::GetPeer() const
         const char* address = "";
         uint16_t port = 0;
 
-#if HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR
+#ifdef HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR
         evhttp_connection_get_peer(con, &address, &port);
 #else
         evhttp_connection_get_peer(con, (char**)&address, &port);

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -2,6 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
 #include <httpserver.h>
 
 #include <chainparamsbase.h>
@@ -597,7 +601,13 @@ CService HTTPRequest::GetPeer() const
         // evhttp retains ownership over returned address string
         const char* address = "";
         uint16_t port = 0;
+
+#if HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR
+        evhttp_connection_get_peer(con, &address, &port);
+#else
         evhttp_connection_get_peer(con, (char**)&address, &port);
+#endif // HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR
+
         peer = LookupNumeric(address, port);
     }
     return peer;


### PR DESCRIPTION
The second parameter of evhttp_connection_get_peer in libevent already has type as `const char **`
The compilation of bitcoind with the fresh libevent occurs errors

Details: https://github.com/bitcoin/bitcoin/issues/23606