### PR TITLE
build: Add -fvisibility=hidden flag for macOS host

### DIFF
--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -109,8 +109,8 @@ darwin_CXX=env -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH \
                -Xclang -internal-externc-isystem$(clang_resource_dir)/include \
                -Xclang -internal-externc-isystem$(OSX_SDK)/usr/include
 
-darwin_CFLAGS=-pipe -std=$(C_STANDARD)
-darwin_CXXFLAGS=-pipe -std=$(CXX_STANDARD)
+darwin_CFLAGS=-pipe -std=$(C_STANDARD) -fvisibility=hidden
+darwin_CXXFLAGS=-pipe -std=$(CXX_STANDARD) -fvisibility=hidden
 
 ifneq ($(LTO),)
 darwin_CFLAGS += -flto


### PR DESCRIPTION
On master (a213bd63ca0c96e8c98e84ec916f83c4ba28d486) when building `bitcoin-qt` with depends for macOS, clang spams with a load of warnings like this one:
```
ld: warning: direct access in function 'QMetaTypeIdQObject<QWindow*, 8>::qt_metatype_id()' from file '/Users/hebasto/bitcoin/depends/aarch64-apple-darwin21.1.0/plugins/platforms/libqcocoa.a(qcocoaintegration.o)' to global weak symbol 'QtMetaTypePrivate::QMetaTypeFunctionHelper<QWindow*, true>::Construct(void*, void const*)' from file 'qt/libbitcoinqt.a(libbitcoinqt_a-walletcontroller.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
```

The cause of such warnings is the fact that `-fvisibility=hidden` is used during building of the `qt` package by default, but not for all of other building stages. That is fixed in this PR.