### PR TITLE
build: Fix cross compiling with DEBUG=1 for Windows

### DIFF
--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -115,6 +115,10 @@ if test -n "@debug@"; then
   enable_reduce_exports=no
 fi
 
+if test -n "@debug@" && test "@host_os@" = "mingw32"; then
+  enable_shared=no
+fi
+
 if test -n "@CFLAGS@"; then
   CFLAGS="@CFLAGS@ ${CFLAGS}"
 fi


### PR DESCRIPTION
On master (200d97faf2ed0bd0cbef93dd4bbbe77cf8fe5d13) cross compiling for Windows with depends being built with `DEBUG=1` is broken in two places:
- `libbitcoinconsensus`, see bitcoin/bitcoin#19772
- `libunivalue`, see https://github.com/bitcoin/bitcoin/pull/22646#issuecomment-974780821

This PR workarounds both cases.

Closes bitcoin/bitcoin#19772.

The previous attempt was #21344.