### PR TITLE
refactor: Fix implicit-signed-integer-truncation in cuckoocache.h

### DIFF
--- a/src/cuckoocache.h
+++ b/src/cuckoocache.h
@@ -89,7 +89,7 @@ public:
      */
     inline void bit_set(uint32_t s)
     {
-        mem[s >> 3].fetch_or(1 << (s & 7), std::memory_order_relaxed);
+        mem[s >> 3].fetch_or(uint8_t(1 << (s & 7)), std::memory_order_relaxed);
     }
 
     /** bit_unset marks an entry as something that should not be overwritten.
@@ -100,7 +100,7 @@ public:
      */
     inline void bit_unset(uint32_t s)
     {
-        mem[s >> 3].fetch_and(~(1 << (s & 7)), std::memory_order_relaxed);
+        mem[s >> 3].fetch_and(uint8_t(~(1 << (s & 7))), std::memory_order_relaxed);
     }
 
     /** bit_is_set queries the table for discardability at `s`.

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -86,7 +86,6 @@ implicit-signed-integer-truncation:addrman.cpp
 implicit-signed-integer-truncation:addrman.h
 implicit-signed-integer-truncation:chain.h
 implicit-signed-integer-truncation:crypto/
-implicit-signed-integer-truncation:cuckoocache.h
 implicit-signed-integer-truncation:leveldb/
 implicit-signed-integer-truncation:node/miner.cpp
 implicit-signed-integer-truncation:net.cpp


### PR DESCRIPTION
Using a file-wide suppression for this implicit truncation has several issues:

* It is file-wide, thus suppressing any other (newly introduced) issues
* The file doesn't compile with `-Wimplicit-int-conversion`

Fix both issues by making the truncation explicit.