### PR TITLE
refactor tests to fix ubsan suppressions

### DIFF
--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -129,11 +129,11 @@ static void shiftArrayRight(unsigned char* to, const unsigned char* from, unsign
     {
         unsigned int F = (T+bitsToShift/8);
         if (F < arrayLength)
-            to[T]  = from[F] >> (bitsToShift%8);
+            to[T] = uint8_t(from[F] >> (bitsToShift % 8));
         else
             to[T] = 0;
         if (F + 1 < arrayLength)
-            to[T] |= from[(F+1)] << (8-bitsToShift%8);
+            to[T] |= uint8_t(from[(F + 1)] << (8 - bitsToShift % 8));
     }
 }
 
@@ -144,9 +144,9 @@ static void shiftArrayLeft(unsigned char* to, const unsigned char* from, unsigne
         if (T >= bitsToShift/8)
         {
             unsigned int F = T-bitsToShift/8;
-            to[T]  = from[F] << (bitsToShift%8);
+            to[T] = uint8_t(from[F] << (bitsToShift % 8));
             if (T >= bitsToShift/8+1)
-                to[T] |= from[F-1] >> (8-bitsToShift%8);
+                to[T] |= uint8_t(from[F - 1] >> (8 - bitsToShift % 8));
         }
         else {
             to[T] = 0;
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE( unaryOperators ) // !    ~    -
     BOOST_CHECK(~ZeroL == MaxL);
 
     unsigned char TmpArray[32];
-    for (unsigned int i = 0; i < 32; ++i) { TmpArray[i] = ~R1Array[i]; }
+    for (unsigned int i = 0; i < 32; ++i) { TmpArray[i] = uint8_t(~R1Array[i]); }
     BOOST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (~R1L));
 
     BOOST_CHECK(-ZeroL == ZeroL);
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE( unaryOperators ) // !    ~    -
 // Check if doing _A_ _OP_ _B_ results in the same as applying _OP_ onto each
 // element of Aarray and Barray, and then converting the result into an arith_uint256.
 #define CHECKBITWISEOPERATOR(_A_,_B_,_OP_)                              \
-    for (unsigned int i = 0; i < 32; ++i) { TmpArray[i] = _A_##Array[i] _OP_ _B_##Array[i]; } \
+    for (unsigned int i = 0; i < 32; ++i) { TmpArray[i] = uint8_t(_A_##Array[i] _OP_ _B_##Array[i]); } \
     BOOST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (_A_##L _OP_ _B_##L));
 
 #define CHECKASSIGNMENTOPERATOR(_A_,_B_,_OP_)                           \

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -393,11 +393,11 @@ BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
             // Update the expected result to know about the new output coins
             assert(tx.vout.size() == 1);
             const COutPoint outpoint(tx.GetHash(), 0);
-            result[outpoint] = Coin(tx.vout[0], height, CTransaction(tx).IsCoinBase());
+            result[outpoint] = Coin{tx.vout[0], int(height), CTransaction(tx).IsCoinBase()};
 
             // Call UpdateCoins on the top cache
             CTxUndo undo;
-            UpdateCoins(CTransaction(tx), *(stack.back()), undo, height);
+            UpdateCoins(CTransaction(tx), *(stack.back()), undo, int(height));
 
             // Update the utxo set for future spends
             utxoset.insert(outpoint);

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_overflow_target)
 {
     const auto consensus = CreateChainParams(*m_node.args, CBaseChainParams::MAIN)->GetConsensus();
     uint256 hash;
-    unsigned int nBits = ~0x00800000;
+    unsigned int nBits{~0x00800000U};
     hash.SetHex("0x1");
     BOOST_CHECK(!CheckProofOfWork(hash, nBits, consensus));
 }

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(PrevectorTestInt)
         prevector_tester<8, int> test;
         for (int i = 0; i < 2048; i++) {
             if (InsecureRandBits(2) == 0) {
-                test.insert(InsecureRandRange(test.size() + 1), InsecureRand32());
+                test.insert(InsecureRandRange(test.size() + 1), int(InsecureRand32()));
             }
             if (test.size() > 0 && InsecureRandBits(2) == 1) {
                 test.erase(InsecureRandRange(test.size()));
@@ -230,7 +230,7 @@ BOOST_AUTO_TEST_CASE(PrevectorTestInt)
                 test.resize(new_size);
             }
             if (InsecureRandBits(3) == 3) {
-                test.insert(InsecureRandRange(test.size() + 1), 1 + InsecureRandBool(), InsecureRand32());
+                test.insert(InsecureRandRange(test.size() + 1), 1 + InsecureRandBool(), int(InsecureRand32()));
             }
             if (InsecureRandBits(3) == 4) {
                 int del = std::min<int>(test.size(), 1 + (InsecureRandBool()));
@@ -238,7 +238,7 @@ BOOST_AUTO_TEST_CASE(PrevectorTestInt)
                 test.erase(beg, beg + del);
             }
             if (InsecureRandBits(4) == 5) {
-                test.push_back(InsecureRand32());
+                test.push_back(int(InsecureRand32()));
             }
             if (test.size() > 0 && InsecureRandBits(4) == 6) {
                 test.pop_back();
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE(PrevectorTestInt)
                 int values[4];
                 int num = 1 + (InsecureRandBits(2));
                 for (int k = 0; k < num; k++) {
-                    values[k] = InsecureRand32();
+                    values[k] = int(InsecureRand32());
                 }
                 test.insert_range(InsecureRandRange(test.size() + 1), values, values + num);
             }
@@ -263,13 +263,13 @@ BOOST_AUTO_TEST_CASE(PrevectorTestInt)
                 test.shrink_to_fit();
             }
             if (test.size() > 0) {
-                test.update(InsecureRandRange(test.size()), InsecureRand32());
+                test.update(InsecureRandRange(test.size()), int(InsecureRand32()));
             }
             if (InsecureRandBits(10) == 11) {
                 test.clear();
             }
             if (InsecureRandBits(9) == 12) {
-                test.assign(InsecureRandBits(5), InsecureRand32());
+                test.assign(InsecureRandBits(5), int(InsecureRand32()));
             }
             if (InsecureRandBits(3) == 3) {
                 test.swap();
@@ -283,8 +283,8 @@ BOOST_AUTO_TEST_CASE(PrevectorTestInt)
             if (InsecureRandBits(5) == 19) {
                 unsigned int num = 1 + (InsecureRandBits(4));
                 std::vector<int> values(num);
-                for (auto &v : values) {
-                    v = InsecureRand32();
+                for (int& v : values) {
+                    v = int(InsecureRand32());
                 }
                 test.resize_uninitialized(values);
             }

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -91,8 +91,9 @@ void static RandomScript(CScript &script) {
         script << oplist[InsecureRandRange(std::size(oplist))];
 }
 
-void static RandomTransaction(CMutableTransaction &tx, bool fSingle) {
-    tx.nVersion = InsecureRand32();
+void static RandomTransaction(CMutableTransaction& tx, bool fSingle)
+{
+    tx.nVersion = int(InsecureRand32());
     tx.vin.clear();
     tx.vout.clear();
     tx.nLockTime = (InsecureRandBool()) ? InsecureRand32() : 0;
@@ -126,7 +127,7 @@ BOOST_AUTO_TEST_CASE(sighash_test)
     int nRandomTests = 50000;
     #endif
     for (int i=0; i<nRandomTests; i++) {
-        int nHashType = InsecureRand32();
+        int nHashType{int(InsecureRand32())};
         CMutableTransaction txTo;
         RandomTransaction(txTo, (nHashType & 0x1f) == SIGHASH_SINGLE);
         CScript scriptCode;

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -114,8 +114,8 @@ BOOST_AUTO_TEST_CASE(findearliestatleast_test)
         } else {
             // randomly choose something in the range [MTP, MTP*2]
             int64_t medianTimePast = vBlocksMain[i].GetMedianTimePast();
-            int r = InsecureRandRange(medianTimePast);
-            vBlocksMain[i].nTime = r + medianTimePast;
+            int r{int(InsecureRandRange(medianTimePast))};
+            vBlocksMain[i].nTime = uint32_t(r + medianTimePast);
             vBlocksMain[i].nTimeMax = std::max(vBlocksMain[i].nTime, vBlocksMain[i-1].nTimeMax);
         }
     }

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(tx_valid)
                     fValid = false;
                     break;
                 }
-                COutPoint outpoint(uint256S(vinput[0].get_str()), vinput[1].get_int());
+                COutPoint outpoint{uint256S(vinput[0].get_str()), uint32_t(vinput[1].get_int())};
                 mapprevOutScriptPubKeys[outpoint] = ParseScript(vinput[2].get_str());
                 if (vinput.size() >= 4)
                 {
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE(tx_invalid)
                     fValid = false;
                     break;
                 }
-                COutPoint outpoint(uint256S(vinput[0].get_str()), vinput[1].get_int());
+                COutPoint outpoint{uint256S(vinput[0].get_str()), uint32_t(vinput[1].get_int())};
                 mapprevOutScriptPubKeys[outpoint] = ParseScript(vinput[2].get_str());
                 if (vinput.size() >= 4)
                 {

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -77,18 +77,10 @@ implicit-integer-sign-change:prevector.h
 implicit-integer-sign-change:script/bitcoinconsensus.cpp
 implicit-integer-sign-change:script/interpreter.cpp
 implicit-integer-sign-change:serialize.h
-implicit-integer-sign-change:test/arith_uint256_tests.cpp
-implicit-integer-sign-change:test/coins_tests.cpp
-implicit-integer-sign-change:test/pow_tests.cpp
-implicit-integer-sign-change:test/prevector_tests.cpp
-implicit-integer-sign-change:test/sighash_tests.cpp
-implicit-integer-sign-change:test/skiplist_tests.cpp
 implicit-integer-sign-change:test/streams_tests.cpp
-implicit-integer-sign-change:test/transaction_tests.cpp
 implicit-integer-sign-change:txmempool.cpp
 implicit-integer-sign-change:zmq/zmqpublishnotifier.cpp
 implicit-signed-integer-truncation,implicit-integer-sign-change:chain.h
-implicit-signed-integer-truncation,implicit-integer-sign-change:test/skiplist_tests.cpp
 implicit-signed-integer-truncation:addrman.cpp
 implicit-signed-integer-truncation:addrman.h
 implicit-signed-integer-truncation:chain.h
@@ -96,8 +88,6 @@ implicit-signed-integer-truncation:crypto/
 implicit-signed-integer-truncation:node/miner.cpp
 implicit-signed-integer-truncation:net.cpp
 implicit-signed-integer-truncation:streams.h
-implicit-signed-integer-truncation:test/arith_uint256_tests.cpp
-implicit-signed-integer-truncation:test/skiplist_tests.cpp
 implicit-signed-integer-truncation:torcontrol.cpp
 implicit-unsigned-integer-truncation:crypto/
 shift-base:arith_uint256.cpp


### PR DESCRIPTION
The ubsan suppressions for test files have several issues:

* They bloat the suppressions file, distracting from real bugs
* They are file-wide, thus suppressing any other (newly introduced) issues in the same file
* Some of them are causing compile issues with -Wimplicit-int-conversion

Fix all issues by making the integer truncations or sign changes explicit.

This is a refactor that shouldn't change the test binary unless compiled with sanitizers.