### PR TITLE
Remove GetSpendHeight

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -478,13 +478,6 @@ public:
     //! Returns last CBlockIndex* that is a checkpoint
     CBlockIndex* GetLastCheckpoint(const CCheckpointData& data) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-    /**
-     * Return the spend height, which is one more than the inputs.GetBestBlock().
-     * While checking, GetBestBlock() refers to the parent block. (protected by cs_main)
-     * This is also true for mempool checks.
-     */
-    int GetSpendHeight(const CCoinsViewCache& inputs) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-
     ~BlockManager() {
         Unload();
     }


### PR DESCRIPTION
It is unclear what the goal of the helper is, as the caller already
knows the spend height before calling the helper.

Also, in case the coins view is corrupted, LookupBlockIndex will return
nullptr. Dereferencing a nullptr is UB.

Fix both issues by removing it. Also, add a sanity check, which aborts
if the coins view is corrupted.
