### PR TITLE
Make `CFeeRate` work with `uint64_t` sizes

### DIFF
--- a/src/policy/feerate.cpp
+++ b/src/policy/feerate.cpp
@@ -9,7 +9,7 @@
 
 #include <cmath>
 
-CFeeRate::CFeeRate(const CAmount& nFeePaid, uint32_t num_bytes)
+CFeeRate::CFeeRate(const CAmount& nFeePaid, uint64_t num_bytes)
 {
     const int64_t nSize{num_bytes};
 
@@ -20,7 +20,7 @@ CFeeRate::CFeeRate(const CAmount& nFeePaid, uint32_t num_bytes)
     }
 }
 
-CAmount CFeeRate::GetFee(uint32_t num_bytes) const
+CAmount CFeeRate::GetFee(uint64_t num_bytes) const
 {
     const int64_t nSize{num_bytes};
 

--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -45,12 +45,12 @@ public:
      *  e.g. (nFeePaid * 1e8 / 1e3) == (nFeePaid / 1e5),
      *  where 1e5 is the ratio to convert from BTC/kvB to sat/vB.
      */
-    CFeeRate(const CAmount& nFeePaid, uint32_t num_bytes);
+    CFeeRate(const CAmount& nFeePaid, uint64_t num_bytes);
     /**
      * Return the fee in satoshis for the given size in bytes.
      * If the calculated fee would have fractional satoshis, then the returned fee will always be rounded up to the nearest satoshi.
      */
-    CAmount GetFee(uint32_t num_bytes) const;
+    CAmount GetFee(uint64_t num_bytes) const;
     /**
      * Return the fee in satoshis for a size of 1000 bytes
      */


### PR DESCRIPTION
`txmempool.h` contains functions:

* `uint64_t GetSizeWithDescendants() const`
* `uint64_t GetSizeWithAncestors() const`

A return value (i.e. `uint64_t`) of these functions can be used to instantiate `CFeeRate`. In the current master branch, this would require a cast to `uint32_t` because `CFeeRate` has the following constructor:

https://github.com/bitcoin/bitcoin/blob/29074ba8364d4c0bf70121210222aff3fbf1e4df/src/policy/feerate.cpp#L12

This PR attempts to remove the need for the casting. 

The PR's commit is cherry-picked from sipa's https://github.com/sipa/bitcoin/commits/202111_mempoolfr branch (see https://github.com/bitcoin/bitcoin/pull/21422#issuecomment-978235017) which improves #21422.

The PR is currently a draft as I get:

```
policy/feerate.cpp: In constructor ‘CFeeRate::CFeeRate(const CAmount&, uint64_t)’:
policy/feerate.cpp:14:25: warning: narrowing conversion of ‘num_bytes’ from ‘uint64_t’ {aka ‘long unsigned int’} to ‘int64_t’ {aka ‘long int’} [-Wnarrowing]
   14 |     const int64_t nSize{num_bytes};
      |                         ^~~~~~~~~
policy/feerate.cpp: In member function ‘CAmount CFeeRate::GetFee(uint64_t) const’:
policy/feerate.cpp:25:25: warning: narrowing conversion of ‘num_bytes’ from ‘uint64_t’ {aka ‘long unsigned int’} to ‘int64_t’ {aka ‘long int’} [-Wnarrowing]
   25 |     const int64_t nSize{num_bytes};
```

during compilation. 

Anyway, I would like to get some early feedback if the PR makes sense to you or not.