### PR TITLE
test: Bump shellcheck version to 0.8.0

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -17,6 +17,6 @@ ${CI_RETRY_EXE} pip3 install mypy==0.910
 ${CI_RETRY_EXE} pip3 install pyzmq==22.3.0
 ${CI_RETRY_EXE} pip3 install vulture==2.3
 
-SHELLCHECK_VERSION=v0.7.2
+SHELLCHECK_VERSION=v0.8.0
 curl -sL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar --xz -xf - --directory /tmp/
 export PATH="/tmp/shellcheck-${SHELLCHECK_VERSION}:${PATH}"

--- a/contrib/guix/guix-clean
+++ b/contrib/guix/guix-clean
@@ -34,7 +34,7 @@ check_tools cat mkdir make git guix
 #
 under_dir() {
     local path_residue
-    path_residue="${2##${1}}"
+    path_residue="${2##"${1}"}"
     if [ -z "$path_residue" ] || [ "$path_residue" = "$2" ]; then
         return 1
     else


### PR DESCRIPTION
Among [added](https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#v080---2021-11-06) rules, SC2295 could be [useful](https://github.com/bitcoin/bitcoin/pull/23506#issuecomment-982201468) for us.