### PR TITLE
rpc: remove info about mallocinfo needing glibc 2.10+

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -558,7 +558,7 @@ static RPCHelpMan getmemoryinfo()
 #ifdef HAVE_MALLOC_INFO
         return RPCMallocInfo();
 #else
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "mallocinfo is only available when compiled with glibc 2.10+");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "mallocinfo mode not available");
 #endif
     } else {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "unknown mode " + mode);

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -50,7 +50,7 @@ class RpcMiscTest(BitcoinTestFramework):
             assert_equal(tree.tag, 'malloc')
         except JSONRPCException:
             self.log.info('getmemoryinfo(mode="mallocinfo") not available')
-            assert_raises_rpc_error(-8, 'mallocinfo is only available when compiled with glibc 2.10+', node.getmemoryinfo, mode="mallocinfo")
+            assert_raises_rpc_error(-8, 'mallocinfo mode not available', node.getmemoryinfo, mode="mallocinfo")
 
         assert_raises_rpc_error(-8, "unknown mode foobar", node.getmemoryinfo, mode="foobar")
 


### PR DESCRIPTION
We require glibc 2.18+.