### PR TITLE
fuzz: Rework rpc fuzz target

### DIFF
--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -41,13 +41,17 @@ struct RPCFuzzTestingSetup : public TestingSetup {
     {
     }
 
-    UniValue CallRPC(const std::string& rpc_method, const std::vector<std::string>& arguments)
+    void CallRPC(const std::string& rpc_method, const std::vector<std::string>& arguments)
     {
         JSONRPCRequest request;
         request.context = &m_node;
         request.strMethod = rpc_method;
-        request.params = RPCConvertValues(rpc_method, arguments);
-        return tableRPC.execute(request);
+        try {
+            request.params = RPCConvertValues(rpc_method, arguments);
+        } catch (const std::runtime_error&) {
+            return;
+        }
+        tableRPC.execute(request);
     }
 
     std::vector<std::string> GetRPCCommands() const
@@ -353,7 +357,11 @@ FUZZ_TARGET_INIT(rpc, initialize_rpc)
     }
     try {
         rpc_testing_setup->CallRPC(rpc_command, arguments);
-    } catch (const UniValue&) {
-    } catch (const std::runtime_error&) {
+    } catch (const UniValue& json_rpc_error) {
+        const std::string error_msg{find_value(json_rpc_error, "message").get_str()};
+        if (error_msg.find("Internal bug detected") != std::string::npos) {
+            // Only allow the intentional internal bug
+            assert(error_msg.find("trigger_internal_bug") != std::string::npos);
+        }
     }
 }


### PR DESCRIPTION
Changes (reason):

* Return `void` in `CallRPC` (the result is unused anyway)
* Reduce the `catch`-scope of `std::runtime_error` to `RPCConvertValues` (Code clarity and easier bug-finding)
* Crash when an internal bug is detected (bugs are bad)