### PR TITLE
build: Include native_X.mk before X.mk

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -264,7 +264,8 @@ $(foreach package,$(packages),$(eval $(package)_type=$(host_arch)_$(host_os)))
 $(foreach package,$(all_packages),$(eval $(call int_vars,$(package))))
 
 #include package files
-$(foreach package,$(all_packages),$(eval include packages/$(package).mk))
+$(foreach native_package,$(native_packages),$(eval include packages/$(native_package).mk))
+$(foreach package,$(packages),$(eval include packages/$(package).mk))
 
 #compute a hash of all files that comprise this package's build recipe
 $(foreach package,$(all_packages),$(eval $(call int_get_build_recipe_hash,$(package))))


### PR DESCRIPTION
Unfortunately, our depends build system still lacks 100% reliability.

On master (57982f419e36d0023c83af2dd0d683ca3160dc2a):
```
$ make --no-print-directory -C depends print-capnp_version MULTIPROCESS=1
capnp_version=
```

This PR fixes this issue:
```
$ make --no-print-directory -C depends print-capnp_version MULTIPROCESS=1
capnp_version=0.7.0
```

This PR split off from bitcoin/bitcoin#22552, bitcoin/bitcoin#22555 and bitcoin/bitcoin#22708.