### PR TITLE
build, qt: Use Android NDK r23 LTS

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -300,7 +300,7 @@ task:
   << : *BASE_TEMPLATE
   android_sdk_cache:
     folder: "depends/SDKs/android"
-    fingerprint_key: "ANDROID_API_LEVEL=28 ANDROID_BUILD_TOOLS_VERSION=28.0.3 ANDROID_NDK_VERSION=22.1.7171670"
+    fingerprint_key: "ANDROID_API_LEVEL=28 ANDROID_BUILD_TOOLS_VERSION=28.0.3 ANDROID_NDK_VERSION=23.1.7779620"
   depends_sources_cache:
     folder: "depends/sources"
     fingerprint_script: git rev-list -1 HEAD ./depends

--- a/ci/test/00_setup_env_android.sh
+++ b/ci/test/00_setup_env_android.sh
@@ -16,7 +16,7 @@ export RUN_FUNCTIONAL_TESTS=false
 
 export ANDROID_API_LEVEL=28
 export ANDROID_BUILD_TOOLS_VERSION=28.0.3
-export ANDROID_NDK_VERSION=22.1.7171670
+export ANDROID_NDK_VERSION=23.1.7779620
 export ANDROID_TOOLS_URL=https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip
 export ANDROID_HOME="${DEPENDS_DIR}/SDKs/android"
 export ANDROID_NDK_HOME="${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}"

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -12,7 +12,7 @@ $(package)_patches += fix_qt_pkgconfig.patch mac-qmake.conf fix_no_printer.patch
 $(package)_patches += dont_hardcode_x86_64.patch fix_montery_include.patch
 $(package)_patches += fix_android_jni_static.patch dont_hardcode_pwd.patch
 $(package)_patches += qtbase-moc-ignore-gcc-macro.patch fix_limits_header.patch
-$(package)_patches += fix_bigsur_style.patch
+$(package)_patches += fix_bigsur_style.patch use_android_ndk23.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=d5788e86257b21d5323f1efd94376a213e091d1e5e03b45a95dd052b5f570db8
@@ -237,6 +237,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/fix_limits_header.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_montery_include.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_bigsur_style.patch && \
+  patch -p1 -i $($(package)_patch_dir)/use_android_ndk23.patch && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f $($(package)_patch_dir)/mac-qmake.conf qtbase/mkspecs/macx-clang-linux/qmake.conf && \

--- a/depends/patches/qt/use_android_ndk23.patch
+++ b/depends/patches/qt/use_android_ndk23.patch
@@ -1,0 +1,13 @@
+Use Android NDK r23 LTS
+
+--- old/qtbase/mkspecs/features/android/default_pre.prf
++++ new/qtbase/mkspecs/features/android/default_pre.prf
+@@ -73,7 +73,7 @@ else: equals(QT_ARCH, x86_64): CROSS_COMPILE = $$NDK_LLVM_PATH/bin/x86_64-linux-
+ else: equals(QT_ARCH, arm64-v8a): CROSS_COMPILE = $$NDK_LLVM_PATH/bin/aarch64-linux-android-
+ else: CROSS_COMPILE = $$NDK_LLVM_PATH/bin/arm-linux-androideabi-
+ 
+-QMAKE_RANLIB            = $${CROSS_COMPILE}ranlib
++QMAKE_RANLIB            = $$NDK_LLVM_PATH/bin/llvm-ranlib
+ QMAKE_LINK_SHLIB        = $$QMAKE_LINK
+ QMAKE_LFLAGS            =
+ 

--- a/doc/build-android.md
+++ b/doc/build-android.md
@@ -8,7 +8,7 @@ This guide describes how to build and package the `bitcoin-qt` GUI for Android o
 
 Before proceeding with an Android build one needs to get the [Android SDK](https://developer.android.com/studio) and use the "SDK Manager" tool to download the NDK and one or more "Platform packages" (these are Android versions and have a corresponding API level).
 
-The minimum supported Android NDK version is [r21](https://github.com/android/ndk/wiki/Changelog-r21).
+The minimum supported Android NDK version is [r23](https://github.com/android/ndk/wiki/Changelog-r23).
 
 In order to build `ANDROID_API_LEVEL` (API level corresponding to the Android version targeted, e.g. Android 9.0 Pie is 28 and its "Platform package" needs to be available) and `ANDROID_TOOLCHAIN_BIN` (path to toolchain binaries depending on the platform the build is being performed on) need to be set.
 


### PR DESCRIPTION
This is a continuation of bitcoin/bitcoin#23478, and, thanks to bitcoin/bitcoin#23489, a oneline patch is only required to be able build the `qt` package in depends with Android NDK r23 LTS.