### PR TITLE
build: Fix build for Android x86_64

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -9,7 +9,7 @@ $(package)_qt_libs=corelib network widgets gui plugins testlib
 $(package)_linguist_tools = lrelease lupdate lconvert
 $(package)_patches = qt.pro qttools_src.pro
 $(package)_patches += fix_qt_pkgconfig.patch mac-qmake.conf fix_no_printer.patch no-xlib.patch
-$(package)_patches += dont_hardcode_x86_64.patch fix_montery_include.patch
+$(package)_patches += dont_use_avx_android_x86_64.patch dont_hardcode_x86_64.patch fix_montery_include.patch
 $(package)_patches += fix_android_jni_static.patch dont_hardcode_pwd.patch
 $(package)_patches += qtbase-moc-ignore-gcc-macro.patch fix_limits_header.patch
 $(package)_patches += fix_bigsur_style.patch
@@ -232,6 +232,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/fix_no_printer.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_android_jni_static.patch && \
   patch -p1 -i $($(package)_patch_dir)/no-xlib.patch && \
+  patch -p1 -i $($(package)_patch_dir)/dont_use_avx_android_x86_64.patch && \
   patch -p1 -i $($(package)_patch_dir)/dont_hardcode_x86_64.patch && \
   patch -p1 -i $($(package)_patch_dir)/qtbase-moc-ignore-gcc-macro.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_limits_header.patch && \

--- a/depends/patches/qt/dont_use_avx_android_x86_64.patch
+++ b/depends/patches/qt/dont_use_avx_android_x86_64.patch
@@ -1,0 +1,32 @@
+Android: don't use avx and avx2 when building for Android x86_64
+
+AVX and AVX2 are not supported on x86_64 ABI.
+See:
+ - https://developer.android.com/ndk/guides/abis#86-64
+ - https://bugreports.qt.io/browse/QTBUG-86785
+
+Upstream commits:
+ - Qt 6.0: ff1a44be33f4bc05d502a2ca49171e0408992f61
+ - Qt 5.15: 8b2cc0f6deb038a4c9d4f0d9b690c7726bd809a9
+
+
+--- old/qtbase/configure.json
++++ new/qtbase/configure.json
+@@ -1098,7 +1098,7 @@
+         },
+         "avx": {
+             "label": "AVX",
+-            "condition": "features.sse4_2 && tests.avx",
++            "condition": "features.sse4_2 && tests.avx && (!config.android || !arch.x86_64)",
+             "output": [
+                 "privateConfig",
+                 { "type": "define", "name": "QT_COMPILER_SUPPORTS_AVX", "value": 1 }
+@@ -1114,7 +1114,7 @@
+         },
+         "avx2": {
+             "label": "AVX2",
+-            "condition": "features.avx && tests.avx2",
++            "condition": "features.avx && tests.avx2 && (!config.android || !arch.x86_64)",
+             "output": [
+                 "privateConfig",
+                 "privateFeature",


### PR DESCRIPTION
bitcoin/bitcoin#23489 [introduced](https://github.com/bitcoin/bitcoin/pull/23489#issuecomment-985457915) a regression making build for `HOST=x86_64-linux-android` broken due to the [QTBUG-86785](https://bugreports.qt.io/browse/QTBUG-86785).

This PR fixes this regression.