### PR TITLE
ci: Make macOS native task sqlite only

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -282,9 +282,9 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_mac.sh"
 
 task:
-  name: 'macOS 11 native [gui] [no depends]'
+  name: 'macOS 11 native [gui, sqlite only] [no depends]'
   brew_install_script:
-    - brew install boost libevent berkeley-db@4 qt@5 miniupnpc libnatpmp ccache zeromq qrencode sqlite libtool automake pkg-config gnu-getopt
+    - brew install boost libevent qt@5 miniupnpc libnatpmp ccache zeromq qrencode sqlite libtool automake pkg-config gnu-getopt
   << : *GLOBAL_TASK_TEMPLATE
   osx_instance:
     # Use latest image, but hardcode version to avoid silent upgrades (and breaks)


### PR DESCRIPTION
There are many sqlite-only test failures (#23563, #23562), so make one CI task sqlite-only.

Obviously this removes bdb coverage from macOS, but I don't expect this to break very often.