### PR TITLE
validation, refactor: remove CChainState::GetMempool()

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1099,8 +1099,7 @@ MempoolAcceptResult AcceptToMemoryPool(CChainState& active_chainstate, const CTr
     EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const CChainParams& chainparams{active_chainstate.m_params};
-    assert(active_chainstate.GetMempool() != nullptr);
-    CTxMemPool& pool{*active_chainstate.GetMempool()};
+    CTxMemPool& pool{*Assert(active_chainstate.m_mempool)};
 
     std::vector<COutPoint> coins_to_uncache;
     auto args = MemPoolAccept::ATMPArgs::SingleAccept(chainparams, accept_time, bypass_limits, coins_to_uncache, test_accept);
@@ -3500,13 +3499,13 @@ bool ChainstateManager::ProcessNewBlock(const CChainParams& chainparams, const s
 MempoolAcceptResult ChainstateManager::ProcessTransaction(const CTransactionRef& tx, bool test_accept)
 {
     CChainState& active_chainstate = ActiveChainstate();
-    if (!active_chainstate.GetMempool()) {
+    if (!active_chainstate.m_mempool) {
         TxValidationState state;
         state.Invalid(TxValidationResult::TX_NO_MEMPOOL, "no-mempool");
         return MempoolAcceptResult::Failure(state);
     }
     auto result = AcceptToMemoryPool(active_chainstate, tx, GetTime(), /*bypass_limits=*/ false, test_accept);
-    active_chainstate.GetMempool()->check(active_chainstate.CoinsTip(), active_chainstate.m_chain.Height() + 1);
+    active_chainstate.m_mempool->check(active_chainstate.CoinsTip(), active_chainstate.m_chain.Height() + 1);
     return result;
 }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -567,14 +567,14 @@ protected:
      */
     mutable std::atomic<bool> m_cached_finished_ibd{false};
 
-    //! Optional mempool that is kept in sync with the chain.
-    //! Only the active chainstate has a mempool.
-    CTxMemPool* m_mempool;
-
     //! Manages the UTXO set, which is a reflection of the contents of `m_chain`.
     std::unique_ptr<CoinsViews> m_coins_views;
 
 public:
+    //! Optional mempool that is kept in sync with the chain.
+    //! Only the active chainstate has a mempool.
+    CTxMemPool* m_mempool;
+
     //! Reference to a BlockManager instance which itself is shared across all
     //! CChainState instances.
     BlockManager& m_blockman;
@@ -645,12 +645,6 @@ public:
     CCoinsViewDB& CoinsDB() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         return m_coins_views->m_dbview;
-    }
-
-    //! @returns A pointer to the mempool.
-    CTxMemPool* GetMempool()
-    {
-        return m_mempool;
     }
 
     //! @returns A reference to a wrapped view of the in-memory UTXO set that


### PR DESCRIPTION
Simplify CChainState validation code by removing an unnecessary GetMempool() getter.

Reason: A trivial getter or setter adds no semantic value; unless I am missing something, the data item (CChainState::m_mempool) could just as well be public.

Relevant C++ Core Guidelines (among others)
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c131-avoid-trivial-getters-and-setters
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-public
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-protected

This change allows simplifying the tx_pool fuzzer chainstate code in the second commit.