### PR TITLE
fuzz: Fix RPC internal bug detection

### DIFF
--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -360,7 +360,9 @@ FUZZ_TARGET_INIT(rpc, initialize_rpc)
         rpc_testing_setup->CallRPC(rpc_command, arguments);
     } catch (const UniValue& json_rpc_error) {
         const std::string error_msg{find_value(json_rpc_error, "message").get_str()};
-        if (error_msg.find("Internal bug detected") != std::string::npos) {
+        // Once c++20 is allowed, starts_with can be used.
+        // if (error_msg.starts_with("Internal bug detected")) {
+        if (0 == error_msg.rfind("Internal bug detected", 0)) {
             // Only allow the intentional internal bug
             assert(error_msg.find("trigger_internal_bug") != std::string::npos);
         }

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -33,11 +33,11 @@ class NonFatalCheckError : public std::runtime_error
     do {                                                          \
         if (!(condition)) {                                       \
             throw NonFatalCheckError(                             \
-                strprintf("%s:%d (%s)\n"                          \
-                          "Internal bug detected: '%s'\n"         \
+                strprintf("Internal bug detected: '%s'\n"         \
+                          "%s:%d (%s)\n"                          \
                           "You may report this issue here: %s\n", \
-                    __FILE__, __LINE__, __func__,                 \
                     (#condition),                                 \
+                    __FILE__, __LINE__, __func__,                 \
                     PACKAGE_BUGREPORT));                          \
         }                                                         \
     } while (false)


### PR DESCRIPTION
Previously the fuzz test considered any exception which contains the string `Internal bug detected` (magic string) as a bug. This is not true when the user (fuzzer) passes in the magic string from outside.

Fix that by:

1. Changing the format the string in `NonFatalCheckError` to start with the magic string.
2. Only treat exceptions that start with the magic string as internal bugs.

This should fix the bug because any other exception shouldn't start with the magic string.

To test:

```
echo 'bG9nZ2luZ1y+bUludGVybmFsIGJ1ZyBkZXRlY3RlZAAXCqNcjqNcjuYjeg==' | base64 --decode > /tmp/a
FUZZ=rpc ./src/test/fuzz/fuzz /tmp/a
```

Before:
```
fuzz: test/fuzz/rpc.cpp:365: void rpc_fuzz_target(FuzzBufferType): Assertion `error_msg.find("trigger_internal_bug") != std::string::npos' failed.
```

After:
```
Executed /tmp/a in 0 ms
