### PR TITLE
test: interface_bitcoin_cli.py: check specified wallet type availability

### DIFF
--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -66,10 +66,16 @@ def cli_get_info_string_to_dict(cli_get_info_string):
 
 
 class TestBitcoinCli(BitcoinTestFramework):
+    def is_specified_wallet_compiled(self):
+        if self.options.descriptors:
+            return self.is_sqlite_compiled()
+        else:
+            return self.is_bdb_compiled()
+
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
-        if self.is_wallet_compiled():
+        if self.is_specified_wallet_compiled():
             self.requires_wallet = True
 
     def skip_test_if_missing_module(self):
@@ -113,7 +119,7 @@ class TestBitcoinCli(BitcoinTestFramework):
         assert_raises_process_error(1, "Invalid value for -color option. Valid values: always, auto, never.", self.nodes[0].cli('-getinfo', '-color=foo').send_cli)
 
         self.log.info("Test -getinfo returns expected network and blockchain info")
-        if self.is_wallet_compiled():
+        if self.is_specified_wallet_compiled():
             self.nodes[0].encryptwallet(password)
         cli_get_info_string = self.nodes[0].cli('-getinfo').send_cli()
         cli_get_info = cli_get_info_string_to_dict(cli_get_info_string)
@@ -138,7 +144,7 @@ class TestBitcoinCli(BitcoinTestFramework):
         cli_get_info = cli_get_info_string_to_dict(cli_get_info_string)
         assert_equal(cli_get_info["Proxies"], "127.0.0.1:9050 (ipv4, ipv6, onion, cjdns), 127.0.0.1:7656 (i2p)")
 
-        if self.is_wallet_compiled():
+        if self.is_specified_wallet_compiled():
             self.log.info("Test -getinfo and bitcoin-cli getwalletinfo return expected wallet info")
             # Explicitely set the output type in order to have constintent tx vsize / fees
             # for both legacy and descriptor wallets (disables the change address type detection algorithm)


### PR DESCRIPTION
Currently the test `interface_bitcoin_cli.py` performs the wallet-relevant parts if _any_ wallet type support is compiled in, independently of
whether the test is run with legacy or descriptor wallet specified. This leads to a failure if the test is started with the `--legacy-wallet` parameter, but bitcoind is compiled without BDB support, see e.g
 https://github.com/bitcoin/bitcoin/pull/23686#issuecomment-987705540

Fix this by checking if the specified wallet type (BDB for legacy wallet, SQLite for descriptor wallet) is available.

Should further pave the way for #23682.