### PR TITLE
doc: Normalize RPC description whitespace

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -301,7 +301,7 @@ static RPCHelpMan deriveaddresses()
 static RPCHelpMan verifymessage()
 {
     return RPCHelpMan{"verifymessage",
-                "\nVerify a signed message\n",
+                "Verify a signed message.",
                 {
                     {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The bitcoin address to use for the signature."},
                     {"signature", RPCArg::Type::STR, RPCArg::Optional::NO, "The signature provided by the signer in base 64 encoding (see signmessage)."},

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -620,10 +620,9 @@ std::string RPCHelpMan::ToString() const
         ret += arg.ToString(/* oneline */ true);
     }
     if (was_optional) ret += " )";
-    ret += "\n";
 
     // Description
-    ret += m_description;
+    ret += "\n\n" + TrimString(m_description) + "\n";
 
     // Arguments
     Sections sections;

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -17,9 +17,9 @@ class RPCGenerateTest(BitcoinTestFramework):
 
     def run_test(self):
         message = (
-            "generate\n"
+            "generate\n\n"
             "has been replaced by the -generate "
-            "cli option. Refer to -help for more information."
+            "cli option. Refer to -help for more information.\n"
         )
 
         self.log.info("Test rpc generate raises with message to use cli option")


### PR DESCRIPTION
It is tedious to manually add trailing newlines after the description so that there is an empty new line before the `Arguments` section.

Fix that by adding it with C++ code.