### PR TITLE
build: Always assume cross compiling for mingw32 hosts

### DIFF
--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -10,7 +10,12 @@ true  # Dummy command because shellcheck treats all directives before first
 # shellcheck disable=SC2154
 depends_prefix="$(cd "$(dirname "$ac_site_file")/.." && pwd)"
 
-cross_compiling=maybe
+if test "@host_os@" = "mingw32"; then
+  cross_compiling=yes
+else
+  cross_compiling=maybe
+fi
+
 host_alias="@HOST@"
 ac_tool_prefix="${host_alias}-"
 


### PR DESCRIPTION
This PR fixes cross compiling on systems with both enabled `binfmt_misc` kernel feature and installed `wine-binfmt` package:

```
$ cat /proc/sys/fs/binfmt_misc/status
enabled
$ dpkg -l wine-binfmt
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version      Architecture Description
+++-==============-============-============-========================================================
ii  wine-binfmt    5.0-3ubuntu1 all          Register Wine as the interpreter for Windows executables
```

On master (f727d814bd8df5a5346c128dd4573e457c1970e1):
```
$ CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure 2>&1 | grep -e 'checking whether we are cross compiling'
checking whether we are cross compiling... no
checking whether we are cross compiling... no
```

With this PR:
```
$ CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure 2>&1 | grep -e 'checking whether we are cross compiling'
checking whether we are cross compiling... yes
checking whether we are cross compiling... yes
```

Guix build:
```
$ find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
6b91e005fb0243f5b40470f6bee515b96ee7a05cf8a639a5caa8b967e80b0d25  guix-build-06c8fb66fbc2/output/dist-archive/bitcoin-06c8fb66fbc2.tar.gz
43759a18e2272ae77cbe268a938746070fa2870ab303ecf727a730f6cc01b580  guix-build-06c8fb66fbc2/output/x86_64-w64-mingw32/SHA256SUMS.part
7888ccdfc3753949d9a4c018b329dd9a48b62ece3188f428dde666e44319a381  guix-build-06c8fb66fbc2/output/x86_64-w64-mingw32/bitcoin-06c8fb66fbc2-win-unsigned.tar.gz
921dae20148bce7ea3973cc034da8186e7a92c7ba6e42a233e62d986ecaac3fd  guix-build-06c8fb66fbc2/output/x86_64-w64-mingw32/bitcoin-06c8fb66fbc2-win64-debug.zip
501581fbd32d4fa8371aefa3a8d6610d2e1ac52f261b03e763f14af1d10410d0  guix-build-06c8fb66fbc2/output/x86_64-w64-mingw32/bitcoin-06c8fb66fbc2-win64-setup-unsigned.exe
5c2c8b53780689253f9de20d30b60dacc82c12ed8a81660ae112e53f675d749a  guix-build-06c8fb66fbc2/output/x86_64-w64-mingw32/bitcoin-06c8fb66fbc2-win64.zip
```

Fixes bitcoin/bitcoin#22854.