### PR TITLE
Use the imperative mood in example subject line

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ own without warnings, errors, regressions, or test failures.
 
 Commit messages should be verbose by default consisting of a short subject line
 (50 chars max), a blank line and detailed explanatory text as separate
-paragraph(s), unless the title alone is self-explanatory (like "Corrected typo
+paragraph(s), unless the title alone is self-explanatory (like "Correct typo
 in init.cpp") in which case a single title line is sufficient. Commit messages should be
 helpful to people reading your code in the future, so explain the reasoning for
 your decisions. Further explanation [here](https://chris.beams.io/posts/git-commit/).


### PR DESCRIPTION
The section `Committing Patches` within `CONTIBUTING.md` contains an example commit subject line that violates rule seven of the linked guide to writing commit logs (Chris Beams famous blog post).

We should practice what we preach, especially in examples :)

Use the imperative mood in example commit message subject line.
