### PR TITLE
[RFC] wallet: Always prefer bech32(m) change by default

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1935,27 +1935,15 @@ OutputType CWallet::TransactionChangeType(const std::optional<OutputType>& chang
         return *change_type;
     }
 
-    // if m_default_address_type is legacy, use legacy address as change (even
-    // if some of the outputs are P2WPKH or P2WSH).
+    // if m_default_address_type is legacy, use legacy address as change.
     if (m_default_address_type == OutputType::LEGACY) {
         return OutputType::LEGACY;
     }
 
-    // if any destination is P2WPKH or P2WSH, use P2WPKH for the change
-    // output.
-    for (const auto& recipient : vecSend) {
-        // Check if any destination contains a witness program:
-        int witnessversion = 0;
-        std::vector<unsigned char> witnessprogram;
-        if (recipient.scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram)) {
-            if (GetScriptPubKeyMan(OutputType::BECH32M, true)) {
-                return OutputType::BECH32M;
-            } else if (GetScriptPubKeyMan(OutputType::BECH32, true)) {
-                return OutputType::BECH32;
-            } else {
-                return m_default_address_type;
-            }
-        }
+    if (GetScriptPubKeyMan(OutputType::BECH32M, true)) {
+        return OutputType::BECH32M;
+    } else if (GetScriptPubKeyMan(OutputType::BECH32, true)) {
+        return OutputType::BECH32;
     }
 
     // else use m_default_address_type for change


### PR DESCRIPTION
This function was added in commit 95941396fff81f60d75fc8cca70716b26efe820e.

However, now that taproot was added, I think it might be worth unconditionally trying bech32(m).

Reminder:

* If the user picked the change type, this patch won't change anything.
* If the user left all settings unchanged or explicitly set address type to bech32(m), the change will already be bech32(m) for all code paths.
* If there is any bech32(m) output, the change will already be bech32(m)

This patch will only change behaviour if the user picked `p2sh-witness` as address type and there are no bech32(m) outputs. However, it seems inconsistent to special-case this one for a questionable privacy benefit, given that there are already potential privacy leaks with the other settings. Moreover, any potential privacy leak seems questionable, since `p2sh-witness` will later be revealed to be a wrapped witness spend on-chain. So I think we might as well use native witness to at least save the user some fees.