### PR TITLE
fuzz: Move ISO8601 to one place

### DIFF
--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -29,12 +29,10 @@
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/system.h>
-#include <util/time.h>
 #include <version.h>
 
 #include <cassert>
 #include <chrono>
-#include <ctime>
 #include <limits>
 #include <set>
 #include <vector>
@@ -81,8 +79,6 @@ FUZZ_TARGET_INIT(integer, initialize_integer)
     (void)ComputeMerkleRoot(v256);
     (void)CountBits(u64);
     (void)DecompressAmount(u64);
-    (void)FormatISO8601Date(i64);
-    (void)FormatISO8601DateTime(i64);
     {
         if (std::optional<CAmount> parsed = ParseMoney(FormatMoney(i64))) {
             assert(parsed.value() == i64);

--- a/src/test/fuzz/parse_iso8601.cpp
+++ b/src/test/fuzz/parse_iso8601.cpp
@@ -19,6 +19,7 @@ FUZZ_TARGET(parse_iso8601)
     const std::string random_string = fuzzed_data_provider.ConsumeRemainingBytesAsString();
 
     const std::string iso8601_datetime = FormatISO8601DateTime(random_time);
+    (void)FormatISO8601Date(random_time);
     const int64_t parsed_time_1 = ParseISO8601DateTime(iso8601_datetime);
     if (random_time >= 0) {
         assert(parsed_time_1 >= 0);


### PR DESCRIPTION
Seems confusing to split this to two places.

Also fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=42178