### PR TITLE
test: call VerifyLoadedChainstate during ChainTestingSetup

### DIFF
--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -195,6 +195,16 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
                              true);
     assert(!rv.has_value());
 
+    auto maybe_verify_failure = VerifyLoadedChainstate(
+        *Assert(m_node.chainman),
+        fReindex.load(),
+        m_args.GetBoolArg("-reindex-chainstate", false),
+        chainparams.GetConsensus(),
+        m_args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS),
+        m_args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL),
+        static_cast<int64_t(*)()>(GetTime));
+    assert(!maybe_verify_failure.has_value());
+
     BlockValidationState state;
     if (!m_node.chainman->ActiveChainstate().ActivateBestChain(state)) {
         throw std::runtime_error(strprintf("ActivateBestChain failed. (%s)", state.ToString()));


### PR DESCRIPTION
for additional coverage and similarity to actual init process.

Followup to #23280.