### PR TITLE
validation, log: improve logging of ChainstateManager snapshot persistance

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4848,7 +4848,6 @@ static void FlushSnapshotToDisk(CCoinsViewCache& coins_cache, bool snapshot_load
                   coins_cache.DynamicMemoryUsage() / (1000 * 1000)),
         BCLog::LogFlags::ALL);
 
-    // TODO: if #17487 is merged, add erase=false here if snapshot is loaded, for better performance.
     coins_cache.Flush();
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4842,16 +4842,14 @@ bool ChainstateManager::ActivateSnapshot(
 
 static void FlushSnapshotToDisk(CCoinsViewCache& coins_cache, bool snapshot_loaded)
 {
-    LogPrintf("[snapshot] flushing %s (%.2f MB)... ", /* Continued */
-              snapshot_loaded ? "snapshot chainstate to disk" : "coins cache",
-              coins_cache.DynamicMemoryUsage() / (1000 * 1000));
-
-    const int64_t flush_now{GetTimeMillis()};
+    LOG_TIME_MILLIS_WITH_CATEGORY_MSG_ONCE(
+        strprintf("%s (%.2f MB)",
+                  snapshot_loaded ? "saving snapshot chainstate" : "flushing coins cache",
+                  coins_cache.DynamicMemoryUsage() / (1000 * 1000)),
+        BCLog::LogFlags::ALL);
 
     // TODO: if #17487 is merged, add erase=false here if snapshot is loaded, for better performance.
     coins_cache.Flush();
-
-    LogPrintf("done (%.2fms)\n", GetTimeMillis() - flush_now);
 }
 
 bool ChainstateManager::PopulateAndValidateSnapshot(


### PR DESCRIPTION
Use the `LOG_TIME_MILLIS_WITH_CATEGORY_MSG_ONCE` macro to improve the logging of ChainstateManager snapshot persistance, log task start and completion separately and no longer manually track the duration, as suggested by Marco Falke in https://github.com/bitcoin/bitcoin/pull/22872#discussion_r715571280.

Extract the flushing into one function, which clarifies the logic, extends the improved logging to both flushing call sites, and allows logging the prefix `FlushSnapshotToDisk`, which is similar to `FlushStateToDisk`.

before
```
[snapshot] flushing coins cache (0 MB)... done (0.00ms)

[snapshot] flushing snapshot chainstate to disk
```
after
```
FlushSnapshotToDisk: flushing coins cache (0 MB) started
...
FlushSnapshotToDisk: completed (0.00ms)

FlushSnapshotToDisk: saving snapshot chainstate (0 MB) started
...
FlushSnapshotToDisk: completed (0.00ms)
```
The logging can be observed in the output of
```
./src/test/test_bitcoin -t validation_chainstate_tests -- DEBUG_LOG_OUT
```
