### PR TITLE
build, qt: Drop support for i686-linux-android host

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -776,10 +776,7 @@ case $host in
         *armv7a*)
           ANDROID_ARCH=armeabi-v7a
           ;;
-        *i686*)
-          ANDROID_ARCH=i686
-          ;;
-        *) AC_MSG_ERROR([Could not determine Android arch]) ;;
+        *) AC_MSG_ERROR([Could not determine Android arch, or it is unsupported]) ;;
       esac
      ;;
    *linux*)

--- a/depends/README.md
+++ b/depends/README.md
@@ -38,7 +38,6 @@ Common `host-platform-triplet`s for cross compilation are:
 - `s390x-linux-gnu` for Linux S390X
 - `armv7a-linux-android` for Android ARM 32 bit
 - `aarch64-linux-android` for Android ARM 64 bit
-- `i686-linux-android` for Android x86 32 bit
 - `x86_64-linux-android` for Android x86 64 bit
 
 The paths are automatically configured and no other options are needed unless targeting [Android](../doc/build-android.md).

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -182,7 +182,6 @@ $(package)_config_opts_android += -no-feature-vulkan
 $(package)_config_opts_aarch64_android += -android-arch arm64-v8a
 $(package)_config_opts_armv7a_android += -android-arch armeabi-v7a
 $(package)_config_opts_x86_64_android += -android-arch x86_64
-$(package)_config_opts_i686_android += -android-arch i686
 endef
 
 define $(package)_fetch_cmds


### PR DESCRIPTION
There are no reasons to keep support for `i686-linux-android` host, which is actually broken in master (50c502f54abd9eb15c8ddca013f0fdfae3d132a9), and this fact has been unnoticed for months :)

https://github.com/bitcoin/bitcoin/pull/23675#issuecomment-986206434:
> I'm surprised `i686-linux-android` ABI is still supported. I would love to drop it...

https://github.com/bitcoin/bitcoin/pull/23675#issuecomment-991340132
> What is `i686-linux-android`? 32-bit x86 android? is that really a thing?