### PR TITLE
rpcwallet: mention labels are disabled for ranged descriptors

### DIFF
--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -1595,7 +1595,7 @@ RPCHelpMan importdescriptors()
                                         /* oneline_description */ "", {"timestamp | \"now\"", "integer / string"}
                                     },
                                     {"internal", RPCArg::Type::BOOL, RPCArg::Default{false}, "Whether matching outputs should be treated as not incoming payments (e.g. change)"},
-                                    {"label", RPCArg::Type::STR, RPCArg::Default{""}, "Label to assign to the address, only allowed with internal=false"},
+                                    {"label", RPCArg::Type::STR, RPCArg::Default{""}, "Label to assign to the address, only allowed with internal=false. Disabled for ranged descriptors"},
                                 },
                             },
                         },


### PR DESCRIPTION
It was confusing when trying to use it as a blackbox. So mention it so next ones don't have to open the said box :)

See #23749 for context