### PR TITLE
build, qt: No need to set inapplicable QPA backend for Android

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -173,7 +173,6 @@ $(package)_config_opts_android += -android-sdk $(ANDROID_SDK)
 $(package)_config_opts_android += -android-ndk $(ANDROID_NDK)
 $(package)_config_opts_android += -android-ndk-platform android-$(ANDROID_API_LEVEL)
 $(package)_config_opts_android += -egl
-$(package)_config_opts_android += -qpa xcb
 $(package)_config_opts_android += -no-dbus
 $(package)_config_opts_android += -opengl es2
 $(package)_config_opts_android += -qt-freetype

--- a/src/qt/android/src/org/bitcoincore/qt/BitcoinQtActivity.java
+++ b/src/qt/android/src/org/bitcoincore/qt/BitcoinQtActivity.java
@@ -18,12 +18,6 @@ public class BitcoinQtActivity extends QtActivity
             bitcoinDir.mkdir();
         }
 
-        try {
-            Os.setenv("QT_QPA_PLATFORM", "android", true);
-        } catch (ErrnoException e) {
-            e.printStackTrace();
-        }
-
         super.onCreate(savedInstanceState);
     }
 }


### PR DESCRIPTION
The current workflow looks weird. At first, the inapplicable `xcb` QPA backend is set in Qt `configure` options. Then the correct `android` QPA backend is forced via the `QT_QPA_PLATFORM` environment variable.

Using the default QPA backend, which is `android` for Android devices, is just fine.