### PR TITLE
net: Use type-safe mockable time for peer connection time

### DIFF
--- a/src/bench/peer_eviction.cpp
+++ b/src/bench/peer_eviction.cpp
@@ -42,7 +42,7 @@ static void EvictionProtection0Networks250Candidates(benchmark::Bench& bench)
         bench,
         250 /* num_candidates */,
         [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_network = NET_IPV4;
         });
 }
@@ -53,7 +53,7 @@ static void EvictionProtection1Networks250Candidates(benchmark::Bench& bench)
         bench,
         250 /* num_candidates */,
         [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = false;
             if (c.id >= 130 && c.id < 240) { // 110 Tor
                 c.m_network = NET_ONION;
@@ -69,7 +69,7 @@ static void EvictionProtection2Networks250Candidates(benchmark::Bench& bench)
         bench,
         250 /* num_candidates */,
         [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = false;
             if (c.id >= 90 && c.id < 160) { // 70 Tor
                 c.m_network = NET_ONION;
@@ -87,7 +87,7 @@ static void EvictionProtection3Networks050Candidates(benchmark::Bench& bench)
         bench,
         50 /* num_candidates */,
         [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 28 || c.id == 47); //  2 localhost
             if (c.id >= 30 && c.id < 47) {             // 17 I2P
                 c.m_network = NET_I2P;
@@ -105,7 +105,7 @@ static void EvictionProtection3Networks100Candidates(benchmark::Bench& bench)
         bench,
         100 /* num_candidates */,
         [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id >= 55 && c.id < 60); //  5 localhost
             if (c.id >= 70 && c.id < 80) {            // 10 I2P
                 c.m_network = NET_I2P;
@@ -123,7 +123,7 @@ static void EvictionProtection3Networks250Candidates(benchmark::Bench& bench)
         bench,
         250 /* num_candidates */,
         [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id >= 140 && c.id < 160); // 20 localhost
             if (c.id >= 170 && c.id < 180) {            // 10 I2P
                 c.m_network = NET_I2P;

--- a/src/bench/peer_eviction.cpp
+++ b/src/bench/peer_eviction.cpp
@@ -42,7 +42,7 @@ static void EvictionProtection0Networks250Candidates(benchmark::Bench& bench)
         bench,
         250 /* num_candidates */,
         [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_network = NET_IPV4;
         });
 }
@@ -53,7 +53,7 @@ static void EvictionProtection1Networks250Candidates(benchmark::Bench& bench)
         bench,
         250 /* num_candidates */,
         [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = false;
             if (c.id >= 130 && c.id < 240) { // 110 Tor
                 c.m_network = NET_ONION;
@@ -69,7 +69,7 @@ static void EvictionProtection2Networks250Candidates(benchmark::Bench& bench)
         bench,
         250 /* num_candidates */,
         [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = false;
             if (c.id >= 90 && c.id < 160) { // 70 Tor
                 c.m_network = NET_ONION;
@@ -87,7 +87,7 @@ static void EvictionProtection3Networks050Candidates(benchmark::Bench& bench)
         bench,
         50 /* num_candidates */,
         [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 28 || c.id == 47); //  2 localhost
             if (c.id >= 30 && c.id < 47) {             // 17 I2P
                 c.m_network = NET_I2P;
@@ -105,7 +105,7 @@ static void EvictionProtection3Networks100Candidates(benchmark::Bench& bench)
         bench,
         100 /* num_candidates */,
         [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id >= 55 && c.id < 60); //  5 localhost
             if (c.id >= 70 && c.id < 80) {            // 10 I2P
                 c.m_network = NET_I2P;
@@ -123,7 +123,7 @@ static void EvictionProtection3Networks250Candidates(benchmark::Bench& bench)
         bench,
         250 /* num_candidates */,
         [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id >= 140 && c.id < 160); // 20 localhost
             if (c.id >= 170 && c.id < 180) {            // 10 I2P
                 c.m_network = NET_I2P;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2975,7 +2975,7 @@ ServiceFlags CConnman::GetLocalServices() const
 unsigned int CConnman::GetReceiveFloodSize() const { return nReceiveFloodSize; }
 
 CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, SOCKET hSocketIn, const CAddress& addrIn, uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn, const CAddress& addrBindIn, const std::string& addrNameIn, ConnectionType conn_type_in, bool inbound_onion)
-    : nTimeConnected(GetTimeSeconds()),
+    : nTimeConnected{GetTime<std::chrono::seconds>()},
       addr(addrIn),
       addrBind(addrBindIn),
       m_addr_name{addrNameIn.empty() ? addr.ToStringIPPort() : addrNameIn},

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -588,9 +588,9 @@ void CNode::CopyStats(CNodeStats& stats)
     }
     X(m_last_send);
     X(m_last_recv);
-    X(nLastTXTime);
-    X(nLastBlockTime);
-    X(nTimeConnected);
+    X(m_last_tx_time);
+    X(m_last_block_time);
+    X(m_connected);
     X(nTimeOffset);
     X(m_addr_name);
     X(nVersion);
@@ -847,7 +847,7 @@ static bool ReverseCompareNodeMinPingTime(const NodeEvictionCandidate &a, const 
 
 static bool ReverseCompareNodeTimeConnected(const NodeEvictionCandidate &a, const NodeEvictionCandidate &b)
 {
-    return a.nTimeConnected > b.nTimeConnected;
+    return a.m_connected > b.m_connected;
 }
 
 static bool CompareNetGroupKeyed(const NodeEvictionCandidate &a, const NodeEvictionCandidate &b) {
@@ -857,27 +857,27 @@ static bool CompareNetGroupKeyed(const NodeEvictionCandidate &a, const NodeEvict
 static bool CompareNodeBlockTime(const NodeEvictionCandidate &a, const NodeEvictionCandidate &b)
 {
     // There is a fall-through here because it is common for a node to have many peers which have not yet relayed a block.
-    if (a.nLastBlockTime != b.nLastBlockTime) return a.nLastBlockTime < b.nLastBlockTime;
+    if (a.m_last_block_time != b.m_last_block_time) return a.m_last_block_time < b.m_last_block_time;
     if (a.fRelevantServices != b.fRelevantServices) return b.fRelevantServices;
-    return a.nTimeConnected > b.nTimeConnected;
+    return a.m_connected > b.m_connected;
 }
 
 static bool CompareNodeTXTime(const NodeEvictionCandidate &a, const NodeEvictionCandidate &b)
 {
     // There is a fall-through here because it is common for a node to have more than a few peers that have not yet relayed txn.
-    if (a.nLastTXTime != b.nLastTXTime) return a.nLastTXTime < b.nLastTXTime;
+    if (a.m_last_tx_time != b.m_last_tx_time) return a.m_last_tx_time < b.m_last_tx_time;
     if (a.fRelayTxes != b.fRelayTxes) return b.fRelayTxes;
     if (a.fBloomFilter != b.fBloomFilter) return a.fBloomFilter;
-    return a.nTimeConnected > b.nTimeConnected;
+    return a.m_connected > b.m_connected;
 }
 
 // Pick out the potential block-relay only peers, and sort them by last block time.
 static bool CompareNodeBlockRelayOnlyTime(const NodeEvictionCandidate &a, const NodeEvictionCandidate &b)
 {
     if (a.fRelayTxes != b.fRelayTxes) return a.fRelayTxes;
-    if (a.nLastBlockTime != b.nLastBlockTime) return a.nLastBlockTime < b.nLastBlockTime;
+    if (a.m_last_block_time != b.m_last_block_time) return a.m_last_block_time < b.m_last_block_time;
     if (a.fRelevantServices != b.fRelevantServices) return b.fRelevantServices;
-    return a.nTimeConnected > b.nTimeConnected;
+    return a.m_connected > b.m_connected;
 }
 
 /**
@@ -896,7 +896,7 @@ struct CompareNodeNetworkTime {
     {
         if (m_is_local && a.m_is_local != b.m_is_local) return b.m_is_local;
         if ((a.m_network == m_network) != (b.m_network == m_network)) return b.m_network == m_network;
-        return a.nTimeConnected > b.nTimeConnected;
+        return a.m_connected > b.m_connected;
     };
 };
 
@@ -1028,7 +1028,7 @@ void ProtectEvictionCandidatesByRatio(std::vector<NodeEvictionCandidate>& evicti
     for (const NodeEvictionCandidate &node : vEvictionCandidates) {
         std::vector<NodeEvictionCandidate> &group = mapNetGroupNodes[node.nKeyedNetGroup];
         group.push_back(node);
-        const auto grouptime{group[0].nTimeConnected};
+        const auto grouptime{group[0].m_connected};
 
         if (group.size() > nMostConnections || (group.size() == nMostConnections && grouptime > nMostConnectionsTime)) {
             nMostConnections = group.size();
@@ -1072,8 +1072,8 @@ bool CConnman::AttemptToEvictConnection()
                 peer_relay_txes = node->m_tx_relay->fRelayTxes;
                 peer_filter_not_null = node->m_tx_relay->pfilter != nullptr;
             }
-            NodeEvictionCandidate candidate = {node->GetId(), node->nTimeConnected, node->m_min_ping_time,
-                                               node->nLastBlockTime, node->nLastTXTime,
+            NodeEvictionCandidate candidate = {node->GetId(), node->m_connected, node->m_min_ping_time,
+                                               node->m_last_block_time, node->m_last_tx_time,
                                                HasAllDesirableServiceFlags(node->nServices),
                                                peer_relay_txes, peer_filter_not_null, node->nKeyedNetGroup,
                                                node->m_prefer_evict, node->addr.IsLocal(),
@@ -1320,7 +1320,7 @@ void CConnman::NotifyNumConnectionsChanged()
 
 bool CConnman::ShouldRunInactivityChecks(const CNode& node, std::chrono::seconds now) const
 {
-    return node.nTimeConnected + m_peer_connect_timeout < now;
+    return node.m_connected + m_peer_connect_timeout < now;
 }
 
 bool CConnman::InactivityCheck(const CNode& node) const
@@ -2975,7 +2975,7 @@ ServiceFlags CConnman::GetLocalServices() const
 unsigned int CConnman::GetReceiveFloodSize() const { return nReceiveFloodSize; }
 
 CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, SOCKET hSocketIn, const CAddress& addrIn, uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn, const CAddress& addrBindIn, const std::string& addrNameIn, ConnectionType conn_type_in, bool inbound_onion)
-    : nTimeConnected{GetTime<std::chrono::seconds>()},
+    : m_connected{GetTime<std::chrono::seconds>()},
       addr(addrIn),
       addrBind(addrBindIn),
       m_addr_name{addrNameIn.empty() ? addr.ToStringIPPort() : addrNameIn},

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1023,12 +1023,12 @@ void ProtectEvictionCandidatesByRatio(std::vector<NodeEvictionCandidate>& evicti
     // (vEvictionCandidates is already sorted by reverse connect time)
     uint64_t naMostConnections;
     unsigned int nMostConnections = 0;
-    int64_t nMostConnectionsTime = 0;
+    std::chrono::seconds nMostConnectionsTime{0};
     std::map<uint64_t, std::vector<NodeEvictionCandidate> > mapNetGroupNodes;
     for (const NodeEvictionCandidate &node : vEvictionCandidates) {
         std::vector<NodeEvictionCandidate> &group = mapNetGroupNodes[node.nKeyedNetGroup];
         group.push_back(node);
-        const int64_t grouptime = group[0].nTimeConnected;
+        const auto grouptime{group[0].nTimeConnected};
 
         if (group.size() > nMostConnections || (group.size() == nMostConnections && grouptime > nMostConnectionsTime)) {
             nMostConnections = group.size();
@@ -1320,7 +1320,7 @@ void CConnman::NotifyNumConnectionsChanged()
 
 bool CConnman::ShouldRunInactivityChecks(const CNode& node, std::chrono::seconds now) const
 {
-    return std::chrono::seconds{node.nTimeConnected} + m_peer_connect_timeout < now;
+    return node.nTimeConnected + m_peer_connect_timeout < now;
 }
 
 bool CConnman::InactivityCheck(const CNode& node) const

--- a/src/net.h
+++ b/src/net.h
@@ -243,9 +243,9 @@ public:
     bool fRelayTxes;
     std::chrono::seconds m_last_send;
     std::chrono::seconds m_last_recv;
-    std::chrono::seconds nLastTXTime;
-    std::chrono::seconds nLastBlockTime;
-    std::chrono::seconds nTimeConnected;
+    std::chrono::seconds m_last_tx_time;
+    std::chrono::seconds m_last_block_time;
+    std::chrono::seconds m_connected;
     int64_t nTimeOffset;
     std::string m_addr_name;
     int nVersion;
@@ -423,7 +423,7 @@ public:
     std::atomic<std::chrono::seconds> m_last_send{0s};
     std::atomic<std::chrono::seconds> m_last_recv{0s};
     //! Unix epoch time at peer connection
-    const std::chrono::seconds nTimeConnected;
+    const std::chrono::seconds m_connected;
     std::atomic<int64_t> nTimeOffset{0};
     // Address of this peer
     const CAddress addr;
@@ -562,13 +562,13 @@ public:
      * preliminary validity checks and was saved to disk, even if we don't
      * connect the block or it eventually fails connection. Used as an inbound
      * peer eviction criterium in CConnman::AttemptToEvictConnection. */
-    std::atomic<std::chrono::seconds> nLastBlockTime{0s};
+    std::atomic<std::chrono::seconds> m_last_block_time{0s};
 
     /** UNIX epoch time of the last transaction received from this peer that we
      * had not yet seen (e.g. not already received from another peer) and that
      * was accepted into our mempool. Used as an inbound peer eviction criterium
      * in CConnman::AttemptToEvictConnection. */
-    std::atomic<std::chrono::seconds> nLastTXTime{0s};
+    std::atomic<std::chrono::seconds> m_last_tx_time{0s};
 
     /** Last measured round-trip time. Used only for RPC/GUI stats/debugging.*/
     std::atomic<std::chrono::microseconds> m_last_ping_time{0us};
@@ -1274,10 +1274,10 @@ void CaptureMessage(const CAddress& addr, const std::string& msg_type, const Spa
 struct NodeEvictionCandidate
 {
     NodeId id;
-    std::chrono::seconds nTimeConnected;
+    std::chrono::seconds m_connected;
     std::chrono::microseconds m_min_ping_time;
-    std::chrono::seconds nLastBlockTime;
-    std::chrono::seconds nLastTXTime;
+    std::chrono::seconds m_last_block_time;
+    std::chrono::seconds m_last_tx_time;
     bool fRelevantServices;
     bool fRelayTxes;
     bool fBloomFilter;

--- a/src/net.h
+++ b/src/net.h
@@ -243,9 +243,9 @@ public:
     bool fRelayTxes;
     std::chrono::seconds m_last_send;
     std::chrono::seconds m_last_recv;
-    int64_t nLastTXTime;
-    int64_t nLastBlockTime;
-    int64_t nTimeConnected;
+    std::chrono::seconds nLastTXTime;
+    std::chrono::seconds nLastBlockTime;
+    std::chrono::seconds nTimeConnected;
     int64_t nTimeOffset;
     std::string m_addr_name;
     int nVersion;
@@ -422,8 +422,8 @@ public:
 
     std::atomic<std::chrono::seconds> m_last_send{0s};
     std::atomic<std::chrono::seconds> m_last_recv{0s};
-    //! Unix epoch time at peer connection, in seconds.
-    const int64_t nTimeConnected;
+    //! Unix epoch time at peer connection
+    const std::chrono::seconds nTimeConnected;
     std::atomic<int64_t> nTimeOffset{0};
     // Address of this peer
     const CAddress addr;
@@ -562,13 +562,13 @@ public:
      * preliminary validity checks and was saved to disk, even if we don't
      * connect the block or it eventually fails connection. Used as an inbound
      * peer eviction criterium in CConnman::AttemptToEvictConnection. */
-    std::atomic<int64_t> nLastBlockTime{0};
+    std::atomic<std::chrono::seconds> nLastBlockTime{0s};
 
     /** UNIX epoch time of the last transaction received from this peer that we
      * had not yet seen (e.g. not already received from another peer) and that
      * was accepted into our mempool. Used as an inbound peer eviction criterium
      * in CConnman::AttemptToEvictConnection. */
-    std::atomic<int64_t> nLastTXTime{0};
+    std::atomic<std::chrono::seconds> nLastTXTime{0s};
 
     /** Last measured round-trip time. Used only for RPC/GUI stats/debugging.*/
     std::atomic<std::chrono::microseconds> m_last_ping_time{0us};
@@ -1274,10 +1274,10 @@ void CaptureMessage(const CAddress& addr, const std::string& msg_type, const Spa
 struct NodeEvictionCandidate
 {
     NodeId id;
-    int64_t nTimeConnected;
+    std::chrono::seconds nTimeConnected;
     std::chrono::microseconds m_min_ping_time;
-    int64_t nLastBlockTime;
-    int64_t nLastTXTime;
+    std::chrono::seconds nLastBlockTime;
+    std::chrono::seconds nLastTXTime;
     bool fRelevantServices;
     bool fRelayTxes;
     bool fBloomFilter;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2511,7 +2511,7 @@ void PeerManagerImpl::ProcessBlock(CNode& node, const std::shared_ptr<const CBlo
     bool new_block{false};
     m_chainman.ProcessNewBlock(m_chainparams, block, force_processing, &new_block);
     if (new_block) {
-        node.nLastBlockTime = GetTime<std::chrono::seconds>();
+        node.m_last_block_time = GetTime<std::chrono::seconds>();
     } else {
         LOCK(cs_main);
         mapBlockSource.erase(block->GetHash());
@@ -3314,7 +3314,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             _RelayTransaction(tx.GetHash(), tx.GetWitnessHash());
             m_orphanage.AddChildrenToWorkSet(tx, peer->m_orphan_work_set);
 
-            pfrom.nLastTXTime = GetTime<std::chrono::seconds>();
+            pfrom.m_last_tx_time = GetTime<std::chrono::seconds>();
 
             LogPrint(BCLog::MEMPOOL, "AcceptToMemoryPool: peer=%d: accepted %s (poolsz %u txn, %u kB)\n",
                 pfrom.GetId(),
@@ -4244,7 +4244,7 @@ void PeerManagerImpl::EvictExtraOutboundPeers(std::chrono::seconds now)
             if (pnode->GetId() > youngest_peer.first) {
                 next_youngest_peer = youngest_peer;
                 youngest_peer.first = pnode->GetId();
-                youngest_peer.second = pnode->nLastBlockTime;
+                youngest_peer.second = pnode->m_last_block_time;
             }
         });
         NodeId to_disconnect = youngest_peer.first;
@@ -4262,14 +4262,14 @@ void PeerManagerImpl::EvictExtraOutboundPeers(std::chrono::seconds now)
             // valid headers chain with at least as much work as our tip.
             CNodeState *node_state = State(pnode->GetId());
             if (node_state == nullptr ||
-                (now - pnode->nTimeConnected >= MINIMUM_CONNECT_TIME && node_state->nBlocksInFlight == 0)) {
+                (now - pnode->m_connected >= MINIMUM_CONNECT_TIME && node_state->nBlocksInFlight == 0)) {
                 pnode->fDisconnect = true;
                 LogPrint(BCLog::NET, "disconnecting extra block-relay-only peer=%d (last block received at time %d)\n",
-                         pnode->GetId(), count_seconds(pnode->nLastBlockTime));
+                         pnode->GetId(), count_seconds(pnode->m_last_block_time));
                 return true;
             } else {
                 LogPrint(BCLog::NET, "keeping block-relay-only peer=%d chosen for eviction (connect time: %d, blocks_in_flight: %d)\n",
-                         pnode->GetId(), count_seconds(pnode->nTimeConnected), node_state->nBlocksInFlight);
+                         pnode->GetId(), count_seconds(pnode->m_connected), node_state->nBlocksInFlight);
             }
             return false;
         });
@@ -4309,13 +4309,13 @@ void PeerManagerImpl::EvictExtraOutboundPeers(std::chrono::seconds now)
                 // Also don't disconnect any peer we're trying to download a
                 // block from.
                 CNodeState &state = *State(pnode->GetId());
-                if (now - pnode->nTimeConnected > MINIMUM_CONNECT_TIME && state.nBlocksInFlight == 0) {
+                if (now - pnode->m_connected > MINIMUM_CONNECT_TIME && state.nBlocksInFlight == 0) {
                     LogPrint(BCLog::NET, "disconnecting extra outbound peer=%d (last block announcement received at time %d)\n", pnode->GetId(), oldest_block_announcement);
                     pnode->fDisconnect = true;
                     return true;
                 } else {
                     LogPrint(BCLog::NET, "keeping outbound peer=%d chosen for eviction (connect time: %d, blocks_in_flight: %d)\n",
-                             pnode->GetId(), count_seconds(pnode->nTimeConnected), state.nBlocksInFlight);
+                             pnode->GetId(), count_seconds(pnode->m_connected), state.nBlocksInFlight);
                     return false;
                 }
             });
@@ -4567,7 +4567,7 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
 
     const auto current_time = GetTime<std::chrono::microseconds>();
 
-    if (pto->IsAddrFetchConn() && current_time - pto->nTimeConnected > 10 * AVG_ADDRESS_BROADCAST_INTERVAL) {
+    if (pto->IsAddrFetchConn() && current_time - pto->m_connected > 10 * AVG_ADDRESS_BROADCAST_INTERVAL) {
         LogPrint(BCLog::NET, "addrfetch connection timeout; disconnecting peer=%d\n", pto->GetId());
         pto->fDisconnect = true;
         return true;

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1173,9 +1173,9 @@ void RPCConsole::updateDetailWidget()
     if (bip152_hb_settings.isEmpty()) bip152_hb_settings = ts.no;
     ui->peerHighBandwidth->setText(bip152_hb_settings);
     const auto time_now{GetTime<std::chrono::seconds>()};
-    ui->peerConnTime->setText(GUIUtil::formatDurationStr(time_now - std::chrono::seconds{stats->nodeStats.nTimeConnected}));
-    ui->peerLastBlock->setText(TimeDurationField(time_now, std::chrono::seconds{stats->nodeStats.nLastBlockTime}));
-    ui->peerLastTx->setText(TimeDurationField(time_now, std::chrono::seconds{stats->nodeStats.nLastTXTime}));
+    ui->peerConnTime->setText(GUIUtil::formatDurationStr(time_now - stats->nodeStats.nTimeConnected));
+    ui->peerLastBlock->setText(TimeDurationField(time_now, stats->nodeStats.nLastBlockTime));
+    ui->peerLastTx->setText(TimeDurationField(time_now, stats->nodeStats.nLastTXTime));
     ui->peerLastSend->setText(TimeDurationField(time_now, stats->nodeStats.m_last_send));
     ui->peerLastRecv->setText(TimeDurationField(time_now, stats->nodeStats.m_last_recv));
     ui->peerBytesSent->setText(GUIUtil::formatBytes(stats->nodeStats.nSendBytes));

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1173,9 +1173,9 @@ void RPCConsole::updateDetailWidget()
     if (bip152_hb_settings.isEmpty()) bip152_hb_settings = ts.no;
     ui->peerHighBandwidth->setText(bip152_hb_settings);
     const auto time_now{GetTime<std::chrono::seconds>()};
-    ui->peerConnTime->setText(GUIUtil::formatDurationStr(time_now - stats->nodeStats.nTimeConnected));
-    ui->peerLastBlock->setText(TimeDurationField(time_now, stats->nodeStats.nLastBlockTime));
-    ui->peerLastTx->setText(TimeDurationField(time_now, stats->nodeStats.nLastTXTime));
+    ui->peerConnTime->setText(GUIUtil::formatDurationStr(time_now - stats->nodeStats.m_connected));
+    ui->peerLastBlock->setText(TimeDurationField(time_now, stats->nodeStats.m_last_block_time));
+    ui->peerLastTx->setText(TimeDurationField(time_now, stats->nodeStats.m_last_tx_time));
     ui->peerLastSend->setText(TimeDurationField(time_now, stats->nodeStats.m_last_send));
     ui->peerLastRecv->setText(TimeDurationField(time_now, stats->nodeStats.m_last_recv));
     ui->peerBytesSent->setText(GUIUtil::formatBytes(stats->nodeStats.nSendBytes));

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -198,11 +198,11 @@ static RPCHelpMan getpeerinfo()
         obj.pushKV("relaytxes", stats.fRelayTxes);
         obj.pushKV("lastsend", count_seconds(stats.m_last_send));
         obj.pushKV("lastrecv", count_seconds(stats.m_last_recv));
-        obj.pushKV("last_transaction", count_seconds(stats.nLastTXTime));
-        obj.pushKV("last_block", count_seconds(stats.nLastBlockTime));
+        obj.pushKV("last_transaction", count_seconds(stats.m_last_tx_time));
+        obj.pushKV("last_block", count_seconds(stats.m_last_block_time));
         obj.pushKV("bytessent", stats.nSendBytes);
         obj.pushKV("bytesrecv", stats.nRecvBytes);
-        obj.pushKV("conntime", count_seconds(stats.nTimeConnected));
+        obj.pushKV("conntime", count_seconds(stats.m_connected));
         obj.pushKV("timeoffset", stats.nTimeOffset);
         if (stats.m_last_ping_time > 0us) {
             obj.pushKV("pingtime", CountSecondsDouble(stats.m_last_ping_time));

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -198,11 +198,11 @@ static RPCHelpMan getpeerinfo()
         obj.pushKV("relaytxes", stats.fRelayTxes);
         obj.pushKV("lastsend", count_seconds(stats.m_last_send));
         obj.pushKV("lastrecv", count_seconds(stats.m_last_recv));
-        obj.pushKV("last_transaction", stats.nLastTXTime);
-        obj.pushKV("last_block", stats.nLastBlockTime);
+        obj.pushKV("last_transaction", count_seconds(stats.nLastTXTime));
+        obj.pushKV("last_block", count_seconds(stats.nLastBlockTime));
         obj.pushKV("bytessent", stats.nSendBytes);
         obj.pushKV("bytesrecv", stats.nRecvBytes);
-        obj.pushKV("conntime", stats.nTimeConnected);
+        obj.pushKV("conntime", count_seconds(stats.nTimeConnected));
         obj.pushKV("timeoffset", stats.nTimeOffset);
         if (stats.m_last_ping_time > 0us) {
             obj.pushKV("pingtime", CountSecondsDouble(stats.m_last_ping_time));

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -237,7 +237,7 @@ BOOST_AUTO_TEST_CASE(block_relay_only_eviction)
     // Update the last block time for the extra peer,
     // and check that the next youngest peer gets evicted.
     vNodes.back()->fDisconnect = false;
-    vNodes.back()->nLastBlockTime = GetTime();
+    vNodes.back()->nLastBlockTime = GetTime<std::chrono::seconds>();
 
     peerLogic->CheckForStaleTipAndEvictPeers();
     for (int i = 0; i < max_outbound_block_relay - 1; ++i) {

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -242,7 +242,7 @@ BOOST_AUTO_TEST_CASE(block_relay_only_eviction)
     // Update the last block time for the extra peer,
     // and check that the next youngest peer gets evicted.
     vNodes.back()->fDisconnect = false;
-    vNodes.back()->nLastBlockTime = GetTime<std::chrono::seconds>();
+    vNodes.back()->m_last_block_time = GetTime<std::chrono::seconds>();
 
     peerLogic->CheckForStaleTipAndEvictPeers();
     for (int i = 0; i < max_outbound_block_relay - 1; ++i) {

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -131,6 +131,9 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
     options.m_max_outbound_full_relay = max_outbound_full_relay;
     options.nMaxFeeler = MAX_FEELER_CONNECTIONS;
 
+    const auto time_init{GetTime<std::chrono::seconds>()};
+    SetMockTime(time_init);
+    const auto time_later{time_init + 3 * std::chrono::seconds{chainparams.GetConsensus().nPowTargetSpacing} + 1s};
     connman->Init(options);
     std::vector<CNode *> vNodes;
 
@@ -146,7 +149,7 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
         BOOST_CHECK(node->fDisconnect == false);
     }
 
-    SetMockTime(GetTime() + 3 * chainparams.GetConsensus().nPowTargetSpacing + 1);
+    SetMockTime(time_later);
 
     // Now tip should definitely be stale, and we should look for an extra
     // outbound peer
@@ -161,7 +164,9 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
     // If we add one more peer, something should get marked for eviction
     // on the next check (since we're mocking the time to be in the future, the
     // required time connected check should be satisfied).
+    SetMockTime(time_init);
     AddRandomOutboundPeer(vNodes, *peerLogic, *connman, ConnectionType::OUTBOUND_FULL_RELAY);
+    SetMockTime(time_later);
 
     peerLogic->CheckForStaleTipAndEvictPeers();
     for (int i = 0; i < max_outbound_full_relay; ++i) {

--- a/src/test/fuzz/node_eviction.cpp
+++ b/src/test/fuzz/node_eviction.cpp
@@ -21,10 +21,10 @@ FUZZ_TARGET(node_eviction)
     LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000) {
         eviction_candidates.push_back({
             /*id=*/fuzzed_data_provider.ConsumeIntegral<NodeId>(),
-            /*nTimeConnected=*/fuzzed_data_provider.ConsumeIntegral<int64_t>(),
+            /*nTimeConnected=*/std::chrono::seconds{fuzzed_data_provider.ConsumeIntegral<int64_t>()},
             /*m_min_ping_time=*/std::chrono::microseconds{fuzzed_data_provider.ConsumeIntegral<int64_t>()},
-            /*nLastBlockTime=*/fuzzed_data_provider.ConsumeIntegral<int64_t>(),
-            /*nLastTXTime=*/fuzzed_data_provider.ConsumeIntegral<int64_t>(),
+            /*nLastBlockTime=*/std::chrono::seconds{fuzzed_data_provider.ConsumeIntegral<int64_t>()},
+            /*nLastTXTime=*/std::chrono::seconds{fuzzed_data_provider.ConsumeIntegral<int64_t>()},
             /*fRelevantServices=*/fuzzed_data_provider.ConsumeBool(),
             /*fRelayTxes=*/fuzzed_data_provider.ConsumeBool(),
             /*fBloomFilter=*/fuzzed_data_provider.ConsumeBool(),

--- a/src/test/fuzz/node_eviction.cpp
+++ b/src/test/fuzz/node_eviction.cpp
@@ -21,10 +21,10 @@ FUZZ_TARGET(node_eviction)
     LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000) {
         eviction_candidates.push_back({
             /*id=*/fuzzed_data_provider.ConsumeIntegral<NodeId>(),
-            /*nTimeConnected=*/std::chrono::seconds{fuzzed_data_provider.ConsumeIntegral<int64_t>()},
+            /*m_connected=*/std::chrono::seconds{fuzzed_data_provider.ConsumeIntegral<int64_t>()},
             /*m_min_ping_time=*/std::chrono::microseconds{fuzzed_data_provider.ConsumeIntegral<int64_t>()},
-            /*nLastBlockTime=*/std::chrono::seconds{fuzzed_data_provider.ConsumeIntegral<int64_t>()},
-            /*nLastTXTime=*/std::chrono::seconds{fuzzed_data_provider.ConsumeIntegral<int64_t>()},
+            /*m_last_block_time=*/std::chrono::seconds{fuzzed_data_provider.ConsumeIntegral<int64_t>()},
+            /*m_last_tx_time=*/std::chrono::seconds{fuzzed_data_provider.ConsumeIntegral<int64_t>()},
             /*fRelevantServices=*/fuzzed_data_provider.ConsumeBool(),
             /*fRelayTxes=*/fuzzed_data_provider.ConsumeBool(),
             /*fBloomFilter=*/fuzzed_data_provider.ConsumeBool(),

--- a/src/test/net_peer_eviction_tests.cpp
+++ b/src/test/net_peer_eviction_tests.cpp
@@ -64,11 +64,11 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     FastRandomContext random_context{true};
     int num_peers{12};
 
-    // Expect half of the peers with greatest uptime (the lowest nTimeConnected)
+    // Expect half of the peers with greatest uptime (the lowest m_connected)
     // to be protected from eviction.
     BOOST_CHECK(IsProtected(
         num_peers, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = false;
             c.m_network = NET_IPV4;
         },
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // Verify in the opposite direction.
     BOOST_CHECK(IsProtected(
         num_peers, [num_peers](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{num_peers - c.id};
+            c.m_connected = std::chrono::seconds{num_peers - c.id};
             c.m_is_local = false;
             c.m_network = NET_IPV6;
         },
@@ -101,10 +101,10 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
         random_context));
 
     // Expect 1/4 onion peers and 1/4 of the other peers to be protected,
-    // sorted by longest uptime (lowest nTimeConnected), if no localhost or I2P peers.
+    // sorted by longest uptime (lowest m_connected), if no localhost or I2P peers.
     BOOST_CHECK(IsProtected(
         num_peers, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = false;
             c.m_network = (c.id == 3 || c.id > 7) ? NET_ONION : NET_IPV6;
         },
@@ -124,10 +124,10 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
         random_context));
 
     // Expect 1/4 localhost peers and 1/4 of the other peers to be protected,
-    // sorted by longest uptime (lowest nTimeConnected), if no onion or I2P peers.
+    // sorted by longest uptime (lowest m_connected), if no onion or I2P peers.
     BOOST_CHECK(IsProtected(
         num_peers, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id > 6);
             c.m_network = NET_IPV6;
         },
@@ -147,10 +147,10 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
         random_context));
 
     // Expect 1/4 I2P peers and 1/4 of the other peers to be protected,
-    // sorted by longest uptime (lowest nTimeConnected), if no onion or localhost peers.
+    // sorted by longest uptime (lowest m_connected), if no onion or localhost peers.
     BOOST_CHECK(IsProtected(
         num_peers, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = false;
             c.m_network = (c.id == 4 || c.id > 8) ? NET_I2P : NET_IPV6;
         },
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // stable sort breaks tie with array order of localhost first.
     BOOST_CHECK(IsProtected(
         4, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 4);
             c.m_network = (c.id == 3) ? NET_ONION : NET_IPV4;
         },
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // uptime; stable sort breaks tie with array order of localhost first.
     BOOST_CHECK(IsProtected(
         7, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 6);
             c.m_network = (c.id == 5) ? NET_ONION : NET_IPV4;
         },
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // by uptime; stable sort breaks tie with array order of localhost first.
     BOOST_CHECK(IsProtected(
         8, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 6);
             c.m_network = (c.id == 5) ? NET_ONION : NET_IPV4;
         },
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // uptime; stable sort breaks ties with the array order of localhost first.
     BOOST_CHECK(IsProtected(
         num_peers, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 6 || c.id == 9 || c.id == 11);
             c.m_network = (c.id == 7 || c.id == 8 || c.id == 10) ? NET_ONION : NET_IPV6;
         },
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // protect 2 localhost and 1 onion, plus 3 other peers, sorted by longest uptime.
     BOOST_CHECK(IsProtected(
         num_peers, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id > 4 && c.id < 9);
             c.m_network = (c.id == 10) ? NET_ONION : NET_IPV4;
         },
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // protect 2 localhost and 2 onions, plus 4 other peers, sorted by longest uptime.
     BOOST_CHECK(IsProtected(
         16, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 6 || c.id == 9 || c.id == 11 || c.id == 12);
             c.m_network = (c.id == 8 || c.id == 10) ? NET_ONION : NET_IPV6;
         },
@@ -241,7 +241,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // others, sorted by longest uptime.
     BOOST_CHECK(IsProtected(
         16, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id > 10);
             c.m_network = (c.id == 10) ? NET_ONION : NET_IPV4;
         },
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // plus 4 others, sorted by longest uptime.
     BOOST_CHECK(IsProtected(
         16, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 15);
             c.m_network = (c.id > 6 && c.id < 11) ? NET_ONION : NET_IPV6;
         },
@@ -267,7 +267,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // others, sorted by longest uptime.
     BOOST_CHECK(IsProtected(
         num_peers, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = false;
             if (c.id == 8 || c.id == 10) {
                 c.m_network = NET_ONION;
@@ -288,7 +288,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // by longest uptime; stable sort breaks tie with array order of I2P first.
     BOOST_CHECK(IsProtected(
         4, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 3);
             if (c.id == 4) {
                 c.m_network = NET_I2P;
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // by longest uptime; stable sort breaks tie with array order of I2P first.
     BOOST_CHECK(IsProtected(
         7, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 4);
             if (c.id == 6) {
                 c.m_network = NET_I2P;
@@ -326,7 +326,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // by uptime; stable sort breaks tie with array order of I2P then localhost.
     BOOST_CHECK(IsProtected(
         8, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 6);
             if (c.id == 5) {
                 c.m_network = NET_I2P;
@@ -345,7 +345,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // for 8 total, sorted by longest uptime.
     BOOST_CHECK(IsProtected(
         16, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 6 || c.id > 11);
             if (c.id == 7 || c.id == 11) {
                 c.m_network = NET_I2P;
@@ -364,7 +364,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // sorted by longest uptime.
     BOOST_CHECK(IsProtected(
         24, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 12);
             if (c.id > 14 && c.id < 23) { // 4 protected instead of usual 2
                 c.m_network = NET_I2P;
@@ -383,7 +383,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // unused localhost slot), plus 6 others for 12/24 total, sorted by longest uptime.
     BOOST_CHECK(IsProtected(
         24, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 15);
             if (c.id == 12 || c.id == 14 || c.id == 17) {
                 c.m_network = NET_I2P;
@@ -402,7 +402,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // for 12/24 total, sorted by longest uptime.
     BOOST_CHECK(IsProtected(
         24, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 13);
             if (c.id > 16) {
                 c.m_network = NET_I2P;
@@ -421,7 +421,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // by longest uptime.
     BOOST_CHECK(IsProtected(
         24, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = std::chrono::seconds{c.id};
+            c.m_connected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id > 15);
             if (c.id > 10 && c.id < 15) {
                 c.m_network = NET_I2P;
@@ -484,7 +484,7 @@ BOOST_AUTO_TEST_CASE(peer_eviction_test)
         // into our mempool should be protected from eviction.
         BOOST_CHECK(!IsEvicted(
                         number_of_nodes, [number_of_nodes](NodeEvictionCandidate& candidate) {
-                            candidate.nLastTXTime = std::chrono::seconds{number_of_nodes - candidate.id};
+                            candidate.m_last_tx_time = std::chrono::seconds{number_of_nodes - candidate.id};
                         },
                         {0, 1, 2, 3}, random_context));
 
@@ -492,7 +492,7 @@ BOOST_AUTO_TEST_CASE(peer_eviction_test)
         // blocks should be protected from eviction.
         BOOST_CHECK(!IsEvicted(
                         number_of_nodes, [number_of_nodes](NodeEvictionCandidate& candidate) {
-                            candidate.nLastBlockTime = std::chrono::seconds{number_of_nodes - candidate.id};
+                            candidate.m_last_block_time = std::chrono::seconds{number_of_nodes - candidate.id};
                             if (candidate.id <= 7) {
                                 candidate.fRelayTxes = false;
                                 candidate.fRelevantServices = true;
@@ -504,14 +504,14 @@ BOOST_AUTO_TEST_CASE(peer_eviction_test)
         // protected from eviction.
         BOOST_CHECK(!IsEvicted(
                         number_of_nodes, [number_of_nodes](NodeEvictionCandidate& candidate) {
-                            candidate.nLastBlockTime = std::chrono::seconds{number_of_nodes - candidate.id};
+                            candidate.m_last_block_time = std::chrono::seconds{number_of_nodes - candidate.id};
                         },
                         {0, 1, 2, 3}, random_context));
 
         // Combination of the previous two tests.
         BOOST_CHECK(!IsEvicted(
                         number_of_nodes, [number_of_nodes](NodeEvictionCandidate& candidate) {
-                            candidate.nLastBlockTime = std::chrono::seconds{number_of_nodes - candidate.id};
+                            candidate.m_last_block_time = std::chrono::seconds{number_of_nodes - candidate.id};
                             if (candidate.id <= 7) {
                                 candidate.fRelayTxes = false;
                                 candidate.fRelevantServices = true;
@@ -524,8 +524,8 @@ BOOST_AUTO_TEST_CASE(peer_eviction_test)
                         number_of_nodes, [number_of_nodes](NodeEvictionCandidate& candidate) {
                             candidate.nKeyedNetGroup = number_of_nodes - candidate.id;           // 4 protected
                             candidate.m_min_ping_time = std::chrono::microseconds{candidate.id}; // 8 protected
-                            candidate.nLastTXTime = std::chrono::seconds{number_of_nodes - candidate.id};    // 4 protected
-                            candidate.nLastBlockTime = std::chrono::seconds{number_of_nodes - candidate.id}; // 4 protected
+                            candidate.m_last_tx_time = std::chrono::seconds{number_of_nodes - candidate.id};    // 4 protected
+                            candidate.m_last_block_time = std::chrono::seconds{number_of_nodes - candidate.id}; // 4 protected
                         },
                         {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19}, random_context));
 

--- a/src/test/net_peer_eviction_tests.cpp
+++ b/src/test/net_peer_eviction_tests.cpp
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // to be protected from eviction.
     BOOST_CHECK(IsProtected(
         num_peers, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = false;
             c.m_network = NET_IPV4;
         },
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // Verify in the opposite direction.
     BOOST_CHECK(IsProtected(
         num_peers, [num_peers](NodeEvictionCandidate& c) {
-            c.nTimeConnected = num_peers - c.id;
+            c.nTimeConnected = std::chrono::seconds{num_peers - c.id};
             c.m_is_local = false;
             c.m_network = NET_IPV6;
         },
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // sorted by longest uptime (lowest nTimeConnected), if no localhost or I2P peers.
     BOOST_CHECK(IsProtected(
         num_peers, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = false;
             c.m_network = (c.id == 3 || c.id > 7) ? NET_ONION : NET_IPV6;
         },
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // sorted by longest uptime (lowest nTimeConnected), if no onion or I2P peers.
     BOOST_CHECK(IsProtected(
         num_peers, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id > 6);
             c.m_network = NET_IPV6;
         },
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // sorted by longest uptime (lowest nTimeConnected), if no onion or localhost peers.
     BOOST_CHECK(IsProtected(
         num_peers, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = false;
             c.m_network = (c.id == 4 || c.id > 8) ? NET_I2P : NET_IPV6;
         },
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // stable sort breaks tie with array order of localhost first.
     BOOST_CHECK(IsProtected(
         4, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 4);
             c.m_network = (c.id == 3) ? NET_ONION : NET_IPV4;
         },
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // uptime; stable sort breaks tie with array order of localhost first.
     BOOST_CHECK(IsProtected(
         7, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 6);
             c.m_network = (c.id == 5) ? NET_ONION : NET_IPV4;
         },
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // by uptime; stable sort breaks tie with array order of localhost first.
     BOOST_CHECK(IsProtected(
         8, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 6);
             c.m_network = (c.id == 5) ? NET_ONION : NET_IPV4;
         },
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // uptime; stable sort breaks ties with the array order of localhost first.
     BOOST_CHECK(IsProtected(
         num_peers, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 6 || c.id == 9 || c.id == 11);
             c.m_network = (c.id == 7 || c.id == 8 || c.id == 10) ? NET_ONION : NET_IPV6;
         },
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // protect 2 localhost and 1 onion, plus 3 other peers, sorted by longest uptime.
     BOOST_CHECK(IsProtected(
         num_peers, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id > 4 && c.id < 9);
             c.m_network = (c.id == 10) ? NET_ONION : NET_IPV4;
         },
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // protect 2 localhost and 2 onions, plus 4 other peers, sorted by longest uptime.
     BOOST_CHECK(IsProtected(
         16, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 6 || c.id == 9 || c.id == 11 || c.id == 12);
             c.m_network = (c.id == 8 || c.id == 10) ? NET_ONION : NET_IPV6;
         },
@@ -241,7 +241,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // others, sorted by longest uptime.
     BOOST_CHECK(IsProtected(
         16, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id > 10);
             c.m_network = (c.id == 10) ? NET_ONION : NET_IPV4;
         },
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // plus 4 others, sorted by longest uptime.
     BOOST_CHECK(IsProtected(
         16, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 15);
             c.m_network = (c.id > 6 && c.id < 11) ? NET_ONION : NET_IPV6;
         },
@@ -267,7 +267,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // others, sorted by longest uptime.
     BOOST_CHECK(IsProtected(
         num_peers, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = false;
             if (c.id == 8 || c.id == 10) {
                 c.m_network = NET_ONION;
@@ -288,7 +288,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // by longest uptime; stable sort breaks tie with array order of I2P first.
     BOOST_CHECK(IsProtected(
         4, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 3);
             if (c.id == 4) {
                 c.m_network = NET_I2P;
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // by longest uptime; stable sort breaks tie with array order of I2P first.
     BOOST_CHECK(IsProtected(
         7, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 4);
             if (c.id == 6) {
                 c.m_network = NET_I2P;
@@ -326,7 +326,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // by uptime; stable sort breaks tie with array order of I2P then localhost.
     BOOST_CHECK(IsProtected(
         8, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 6);
             if (c.id == 5) {
                 c.m_network = NET_I2P;
@@ -345,7 +345,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // for 8 total, sorted by longest uptime.
     BOOST_CHECK(IsProtected(
         16, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 6 || c.id > 11);
             if (c.id == 7 || c.id == 11) {
                 c.m_network = NET_I2P;
@@ -364,7 +364,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // sorted by longest uptime.
     BOOST_CHECK(IsProtected(
         24, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 12);
             if (c.id > 14 && c.id < 23) { // 4 protected instead of usual 2
                 c.m_network = NET_I2P;
@@ -383,7 +383,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // unused localhost slot), plus 6 others for 12/24 total, sorted by longest uptime.
     BOOST_CHECK(IsProtected(
         24, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 15);
             if (c.id == 12 || c.id == 14 || c.id == 17) {
                 c.m_network = NET_I2P;
@@ -402,7 +402,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // for 12/24 total, sorted by longest uptime.
     BOOST_CHECK(IsProtected(
         24, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id == 13);
             if (c.id > 16) {
                 c.m_network = NET_I2P;
@@ -421,7 +421,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
     // by longest uptime.
     BOOST_CHECK(IsProtected(
         24, [](NodeEvictionCandidate& c) {
-            c.nTimeConnected = c.id;
+            c.nTimeConnected = std::chrono::seconds{c.id};
             c.m_is_local = (c.id > 15);
             if (c.id > 10 && c.id < 15) {
                 c.m_network = NET_I2P;
@@ -484,7 +484,7 @@ BOOST_AUTO_TEST_CASE(peer_eviction_test)
         // into our mempool should be protected from eviction.
         BOOST_CHECK(!IsEvicted(
                         number_of_nodes, [number_of_nodes](NodeEvictionCandidate& candidate) {
-                            candidate.nLastTXTime = number_of_nodes - candidate.id;
+                            candidate.nLastTXTime = std::chrono::seconds{number_of_nodes - candidate.id};
                         },
                         {0, 1, 2, 3}, random_context));
 
@@ -492,7 +492,7 @@ BOOST_AUTO_TEST_CASE(peer_eviction_test)
         // blocks should be protected from eviction.
         BOOST_CHECK(!IsEvicted(
                         number_of_nodes, [number_of_nodes](NodeEvictionCandidate& candidate) {
-                            candidate.nLastBlockTime = number_of_nodes - candidate.id;
+                            candidate.nLastBlockTime = std::chrono::seconds{number_of_nodes - candidate.id};
                             if (candidate.id <= 7) {
                                 candidate.fRelayTxes = false;
                                 candidate.fRelevantServices = true;
@@ -504,14 +504,14 @@ BOOST_AUTO_TEST_CASE(peer_eviction_test)
         // protected from eviction.
         BOOST_CHECK(!IsEvicted(
                         number_of_nodes, [number_of_nodes](NodeEvictionCandidate& candidate) {
-                            candidate.nLastBlockTime = number_of_nodes - candidate.id;
+                            candidate.nLastBlockTime = std::chrono::seconds{number_of_nodes - candidate.id};
                         },
                         {0, 1, 2, 3}, random_context));
 
         // Combination of the previous two tests.
         BOOST_CHECK(!IsEvicted(
                         number_of_nodes, [number_of_nodes](NodeEvictionCandidate& candidate) {
-                            candidate.nLastBlockTime = number_of_nodes - candidate.id;
+                            candidate.nLastBlockTime = std::chrono::seconds{number_of_nodes - candidate.id};
                             if (candidate.id <= 7) {
                                 candidate.fRelayTxes = false;
                                 candidate.fRelevantServices = true;
@@ -524,8 +524,8 @@ BOOST_AUTO_TEST_CASE(peer_eviction_test)
                         number_of_nodes, [number_of_nodes](NodeEvictionCandidate& candidate) {
                             candidate.nKeyedNetGroup = number_of_nodes - candidate.id;           // 4 protected
                             candidate.m_min_ping_time = std::chrono::microseconds{candidate.id}; // 8 protected
-                            candidate.nLastTXTime = number_of_nodes - candidate.id;              // 4 protected
-                            candidate.nLastBlockTime = number_of_nodes - candidate.id;           // 4 protected
+                            candidate.nLastTXTime = std::chrono::seconds{number_of_nodes - candidate.id};    // 4 protected
+                            candidate.nLastBlockTime = std::chrono::seconds{number_of_nodes - candidate.id}; // 4 protected
                         },
                         {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19}, random_context));
 

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -47,10 +47,10 @@ std::vector<NodeEvictionCandidate> GetRandomNodeEvictionCandidates(int n_candida
     for (int id = 0; id < n_candidates; ++id) {
         candidates.push_back({
             /*id=*/id,
-            /*nTimeConnected=*/std::chrono::seconds{random_context.randrange(100)},
+            /*m_connected=*/std::chrono::seconds{random_context.randrange(100)},
             /*m_min_ping_time=*/std::chrono::microseconds{random_context.randrange(100)},
-            /*nLastBlockTime=*/std::chrono::seconds{random_context.randrange(100)},
-            /*nLastTXTime=*/std::chrono::seconds{random_context.randrange(100)},
+            /*m_last_block_time=*/std::chrono::seconds{random_context.randrange(100)},
+            /*m_last_tx_time=*/std::chrono::seconds{random_context.randrange(100)},
             /*fRelevantServices=*/random_context.randbool(),
             /*fRelayTxes=*/random_context.randbool(),
             /*fBloomFilter=*/random_context.randbool(),

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -47,10 +47,10 @@ std::vector<NodeEvictionCandidate> GetRandomNodeEvictionCandidates(int n_candida
     for (int id = 0; id < n_candidates; ++id) {
         candidates.push_back({
             /*id=*/id,
-            /*nTimeConnected=*/static_cast<int64_t>(random_context.randrange(100)),
+            /*nTimeConnected=*/std::chrono::seconds{random_context.randrange(100)},
             /*m_min_ping_time=*/std::chrono::microseconds{random_context.randrange(100)},
-            /*nLastBlockTime=*/static_cast<int64_t>(random_context.randrange(100)),
-            /*nLastTXTime=*/static_cast<int64_t>(random_context.randrange(100)),
+            /*nLastBlockTime=*/std::chrono::seconds{random_context.randrange(100)},
+            /*nLastTXTime=*/std::chrono::seconds{random_context.randrange(100)},
             /*fRelevantServices=*/random_context.randbool(),
             /*fRelayTxes=*/random_context.randbool(),
             /*fBloomFilter=*/random_context.randbool(),

--- a/test/functional/p2p_timeouts.py
+++ b/test/functional/p2p_timeouts.py
@@ -86,7 +86,7 @@ class TimeoutsTest(BitcoinTestFramework):
         ]
 
         with self.nodes[0].assert_debug_log(expected_msgs=expected_timeout_logs):
-            self.mock_forward(5)
+            self.mock_forward(2)
             no_verack_node.wait_for_disconnect(timeout=1)
             no_version_node.wait_for_disconnect(timeout=1)
             no_send_node.wait_for_disconnect(timeout=1)


### PR DESCRIPTION
Benefits:
* Type-safe
* Mockable
* Allows to revert a temporary test workaround