### PR TITLE
build: use __SIZEOF_INT128__ for checking __int128 availability

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -837,9 +837,6 @@ if test "$use_lcov_branch" != "no"; then
   AC_SUBST(LCOV_OPTS, "$LCOV_OPTS --rc lcov_branch_coverage=1")
 fi
 
-dnl Check for __int128
-AC_CHECK_TYPES([__int128])
-
 dnl Check for endianness
 AC_C_BIGENDIAN
 

--- a/src/crypto/muhash.h
+++ b/src/crypto/muhash.h
@@ -24,7 +24,7 @@ private:
 public:
     static constexpr size_t BYTE_SIZE = 384;
 
-#ifdef HAVE___INT128
+#ifdef __SIZEOF_INT128__
     typedef unsigned __int128 double_limb_t;
     typedef uint64_t limb_t;
     static constexpr int LIMBS = 48;


### PR DESCRIPTION
We already use this in the blockfilter code, 

https://github.com/bitcoin/bitcoin/blob/bf66e258a84e18935fde3ebb9a4b0392bf883222/src/blockfilter.cpp#L34-L36

so not sure we need to maintain two different ways of testing
for the same functionality. Consolidate on testing for `__SIZEOF_INT128__`,
which we already use, is supported by the compilers we care about, and is
also used by libsecp256k1.
