### PR TITLE
refactor, test: update `addrman_tests.cpp` to use output from `AddrMan::Good()`

### DIFF
--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(addrman_select)
     BOOST_CHECK_EQUAL(addr_ret1.ToString(), "250.1.1.1:8333");
 
     // Test: move addr to tried, select from new expected nothing returned.
-    addrman.Good(CAddress(addr1, NODE_NONE));
+    BOOST_CHECK(addrman.Good(CAddress(addr1, NODE_NONE)));
     BOOST_CHECK_EQUAL(addrman.size(), 1U);
     auto addr_ret2 = addrman.Select(newOnly).first;
     BOOST_CHECK_EQUAL(addr_ret2.ToString(), "[::]:0");
@@ -220,11 +220,11 @@ BOOST_AUTO_TEST_CASE(addrman_select)
     CService addr7 = ResolveService("250.4.6.6", 8333);
 
     BOOST_CHECK(addrman.Add({CAddress(addr5, NODE_NONE)}, ResolveService("250.3.1.1", 8333)));
-    addrman.Good(CAddress(addr5, NODE_NONE));
+    BOOST_CHECK(addrman.Good(CAddress(addr5, NODE_NONE)));
     BOOST_CHECK(addrman.Add({CAddress(addr6, NODE_NONE)}, ResolveService("250.3.1.1", 8333)));
-    addrman.Good(CAddress(addr6, NODE_NONE));
+    BOOST_CHECK(addrman.Good(CAddress(addr6, NODE_NONE)));
     BOOST_CHECK(addrman.Add({CAddress(addr7, NODE_NONE)}, ResolveService("250.1.1.3", 8333)));
-    addrman.Good(CAddress(addr7, NODE_NONE));
+    BOOST_CHECK(addrman.Good(CAddress(addr7, NODE_NONE)));
 
     // Test: 6 addrs + 1 addr from last test = 7.
     BOOST_CHECK_EQUAL(addrman.size(), 7U);

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -816,19 +816,21 @@ BOOST_AUTO_TEST_CASE(addrman_selecttriedcollision)
     for (unsigned int i = 1; i < 23; i++) {
         CService addr = ResolveService("250.1.1." + ToString(i));
         BOOST_CHECK(addrman.Add({CAddress(addr, NODE_NONE)}, source));
-        addrman.Good(addr);
 
-        // No collisions yet.
-        BOOST_CHECK(addrman.size() == i);
+        // No collisions in tried.
+        BOOST_CHECK(addrman.Good(addr));
         BOOST_CHECK(addrman.SelectTriedCollision().first.ToString() == "[::]:0");
     }
 
     // Ensure Good handles duplicates well.
+    // If an address is a duplicate, Good will return false but will not count it as a collision.
     for (unsigned int i = 1; i < 23; i++) {
         CService addr = ResolveService("250.1.1." + ToString(i));
-        addrman.Good(addr);
 
-        BOOST_CHECK(addrman.size() == 22);
+        // Unable to add duplicate address to tried table.
+        BOOST_CHECK(!addrman.Good(addr));
+
+        // Verify duplicate address not marked as a collision.
         BOOST_CHECK(addrman.SelectTriedCollision().first.ToString() == "[::]:0");
     }
 }


### PR DESCRIPTION
As a follow-up to #23713 , this PR refactors the remaining tests in `src/tests/addrman_tests.cpp` to use the output from `AddrMan::Good()` where appropriate.