### PR TITLE
test: Fix `system_tests/run_command` on Windows

### DIFF
--- a/src/test/system_tests.cpp
+++ b/src/test/system_tests.cpp
@@ -58,10 +58,8 @@ BOOST_AUTO_TEST_CASE(run_command)
     }
     {
 #ifdef WIN32
-        // Windows requires single quotes to prevent escaping double quotes from the JSON...
-        const UniValue result = RunCommandParseJSON("echo '{\"success\": true}'");
+        const UniValue result = RunCommandParseJSON("cmd.exe /c echo {\"success\": true}");
 #else
-        // ... but Linux and macOS echo a single quote if it's used
         const UniValue result = RunCommandParseJSON("echo \"{\"success\": true}\"");
 #endif
         BOOST_CHECK(result.isObject());


### PR DESCRIPTION
An attempt to fix bitcoin/bitcoin#23775.

With this PR on Windows 10 Pro 21H1 (build 19043.1348):
```
C:\Users\hebasto\bitcoin>src\test_bitcoin.exe --run_test=system_tests/run_command
Running 1 test case...

*** No errors detected

C:\Users\hebasto\bitcoin>src\test_bitcoin.exe
Running 482 test cases...

*** No errors detected

```