### PR TITLE
test: include two more interruptions points

### DIFF
--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -57,21 +57,23 @@ class InitStressTest(BitcoinTestFramework):
             assert_equal(200, node.getblockcount())
 
         lines_to_terminate_after = [
+            'Validating signatures for all blocks',
             'scheduler thread start',
+            'Starting HTTP server',
             'Loading P2P addresses',
             'Loading banlist',
             'Loading block index',
             'Switching active chainstate',
+            'Checking all blk files are present',
             'Loaded best chain:',
             'init message: Verifying blocks',
+            'init message: Starting network threads',
+            'net thread start',
+            'addcon thread start',
             'loadblk thread start',
             # TODO: reenable - see above TODO
             # 'txindex thread start',
-            'net thread start',
-            'addcon thread start',
-            'msghand thread start',
-            'Checking all blk files are present',
-            'init message: Starting network threads'
+            'msghand thread start'
         ]
         if self.is_wallet_compiled():
             lines_to_terminate_after.append('Verifying wallet')

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -70,6 +70,8 @@ class InitStressTest(BitcoinTestFramework):
             'net thread start',
             'addcon thread start',
             'msghand thread start',
+            'Checking all blk files are present',
+            'init message: Starting network threads'
         ]
         if self.is_wallet_compiled():
             lines_to_terminate_after.append('Verifying wallet')


### PR DESCRIPTION
This PR aims to introduce 2 more interruption points in the process of initialization, in order to make the` feature_init `testcase more complete. These are the following:

-` Checking all blk files are present`
-` init message: Starting network threads`

It is a small improvement for increasing the coverage of potential interruptions, and making sure that the node can restart successfully after these interruptions.