### PR TITLE
validation: followups for de-duplication of packages

### DIFF
--- a/src/policy/packages.h
+++ b/src/policy/packages.h
@@ -25,6 +25,7 @@ enum class PackageValidationResult {
     PCKG_RESULT_UNSET = 0,        //!< Initial value. The package has not yet been rejected.
     PCKG_POLICY,                  //!< The package itself is invalid (e.g. too many transactions).
     PCKG_TX,                      //!< At least one tx is invalid.
+    PCKG_MEMPOOL_ERROR,           //!< Mempool logic error.
 };
 
 /** A package is an ordered list of transactions. The transactions cannot conflict with (spend the

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -332,6 +332,8 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
 // the mempool.
 BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
 {
+    // Mine blocks to mature coinbases.
+    mineBlocks(5);
     LOCK(cs_main);
 
     // Transactions with a same-txid-different-witness transaction in the mempool should be ignored,
@@ -445,6 +447,116 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
         BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(ptx_child2->GetHash())));
         BOOST_CHECK(!m_node.mempool->exists(GenTxid::Wtxid(ptx_child2->GetWitnessHash())));
         BOOST_CHECK(m_node.mempool->exists(GenTxid::Wtxid(ptx_grandchild->GetWitnessHash())));
+    }
+
+    // A package Package{parent1, parent2, parent3, child} where the parents are a mixture of
+    // identical-tx-in-mempool, same-txid-different-witness-in-mempool, and new transactions.
+    Package package_mixed;
+
+    // Give all the parents anyone-can-spend scripts so we don't have to deal with signing the child.
+    CScript acs_script = CScript() << OP_TRUE;
+    CScript acs_spk = GetScriptForDestination(WitnessV0ScriptHash(acs_script));
+    CScriptWitness acs_witness;
+    acs_witness.stack.push_back(std::vector<unsigned char>(acs_script.begin(), acs_script.end()));
+
+    // parent1 will already be in the mempool
+    auto mtx_parent1 = CreateValidMempoolTransaction(/*input_transaction=*/ m_coinbase_txns[1], /*vout=*/ 0,
+                                                     /*input_height=*/ 0, /*input_signing_key=*/ coinbaseKey,
+                                                     /*output_destination=*/ acs_spk,
+                                                     /*output_amount=*/ CAmount(49 * COIN), /*submit=*/ true);
+    CTransactionRef ptx_parent1 = MakeTransactionRef(mtx_parent1);
+    package_mixed.push_back(ptx_parent1);
+
+    // parent2 will have a same-txid-different-witness tx already in the mempool
+    CScript grandparent2_script = CScript() << OP_DROP << OP_TRUE;
+    CScript grandparent2_spk = GetScriptForDestination(WitnessV0ScriptHash(grandparent2_script));
+    CScriptWitness parent2_witness1;
+    parent2_witness1.stack.push_back(std::vector<unsigned char>(1));
+    parent2_witness1.stack.push_back(std::vector<unsigned char>(grandparent2_script.begin(), grandparent2_script.end()));
+    CScriptWitness parent2_witness2;
+    parent2_witness2.stack.push_back(std::vector<unsigned char>(2));
+    parent2_witness2.stack.push_back(std::vector<unsigned char>(grandparent2_script.begin(), grandparent2_script.end()));
+
+    // Create grandparent2 creating an output with multiple spending paths. Submit to mempool.
+    auto mtx_grandparent2 = CreateValidMempoolTransaction(/*input_transaction=*/ m_coinbase_txns[2], /* vout=*/ 0,
+                                                          /*input_height=*/ 0, /*input_signing_key=*/ coinbaseKey,
+                                                          /*output_destination=*/ grandparent2_spk,
+                                                          /*output_amount=*/ CAmount(49 * COIN), /*submit=*/ true);
+    CTransactionRef ptx_grandparent2 = MakeTransactionRef(mtx_grandparent2);
+
+    CMutableTransaction mtx_parent2_v1;
+    mtx_parent2_v1.nVersion = 1;
+    mtx_parent2_v1.vin.resize(1);
+    mtx_parent2_v1.vin[0].prevout.hash = ptx_grandparent2->GetHash();
+    mtx_parent2_v1.vin[0].prevout.n = 0;
+    mtx_parent2_v1.vin[0].scriptSig = CScript();
+    mtx_parent2_v1.vin[0].scriptWitness = parent2_witness1;
+    mtx_parent2_v1.vout.resize(1);
+    mtx_parent2_v1.vout[0].nValue = CAmount(48 * COIN);
+    mtx_parent2_v1.vout[0].scriptPubKey = acs_spk;
+
+    CMutableTransaction mtx_parent2_v2{mtx_parent2_v1};
+    mtx_parent2_v2.vin[0].scriptWitness = parent2_witness2;
+
+    CTransactionRef ptx_parent2_v1 = MakeTransactionRef(mtx_parent2_v1);
+    CTransactionRef ptx_parent2_v2 = MakeTransactionRef(mtx_parent2_v2);
+    // Put parent2_v1 in the package, submit parent2_v2 to the mempool.
+    const MempoolAcceptResult parent2_v2_result = m_node.chainman->ProcessTransaction(ptx_parent2_v2);
+    BOOST_CHECK(parent2_v2_result.m_result_type == MempoolAcceptResult::ResultType::VALID);
+    package_mixed.push_back(ptx_parent2_v1);
+
+    // parent3 will be a new transaction
+    auto mtx_parent3 = CreateValidMempoolTransaction(/*input_transaction=*/ m_coinbase_txns[3], /*vout=*/ 0,
+                                                     /*input_height=*/ 0, /*input_signing_key=*/ coinbaseKey,
+                                                     /*output_destination=*/ acs_spk,
+                                                     /*output_amount=*/ CAmount(49 * COIN), /*submit=*/ false);
+    CTransactionRef ptx_parent3 = MakeTransactionRef(mtx_parent3);
+    package_mixed.push_back(ptx_parent3);
+
+    // child spends parent1, parent2, and parent3
+    CKey mixed_grandchild_key;
+    mixed_grandchild_key.MakeNewKey(true);
+    CScript mixed_child_spk = GetScriptForDestination(WitnessV0KeyHash(mixed_grandchild_key.GetPubKey()));
+
+    CMutableTransaction mtx_mixed_child;
+    mtx_mixed_child.vin.push_back(CTxIn(COutPoint(ptx_parent1->GetHash(), 0)));
+    mtx_mixed_child.vin.push_back(CTxIn(COutPoint(ptx_parent2_v1->GetHash(), 0)));
+    mtx_mixed_child.vin.push_back(CTxIn(COutPoint(ptx_parent3->GetHash(), 0)));
+    mtx_mixed_child.vin[0].scriptWitness = acs_witness;
+    mtx_mixed_child.vin[1].scriptWitness = acs_witness;
+    mtx_mixed_child.vin[2].scriptWitness = acs_witness;
+    mtx_mixed_child.vout.push_back(CTxOut(145 * COIN, mixed_child_spk));
+    CTransactionRef ptx_mixed_child = MakeTransactionRef(mtx_mixed_child);
+    package_mixed.push_back(ptx_mixed_child);
+
+    // Submit package:
+    // parent1 should be ignored
+    // parent2_v1 should be ignored (and v2 wtxid returned)
+    // parent3 should be accepted
+    // child should be accepted
+    {
+        const auto mixed_result = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_mixed, false);
+        BOOST_CHECK_MESSAGE(mixed_result.m_state.IsValid(), mixed_result.m_state.GetRejectReason());
+        auto it_parent1 = mixed_result.m_tx_results.find(ptx_parent1->GetWitnessHash());
+        auto it_parent2 = mixed_result.m_tx_results.find(ptx_parent2_v1->GetWitnessHash());
+        auto it_parent3 = mixed_result.m_tx_results.find(ptx_parent3->GetWitnessHash());
+        auto it_child = mixed_result.m_tx_results.find(ptx_mixed_child->GetWitnessHash());
+        BOOST_CHECK(it_parent1 != mixed_result.m_tx_results.end());
+        BOOST_CHECK(it_parent2 != mixed_result.m_tx_results.end());
+        BOOST_CHECK(it_parent3 != mixed_result.m_tx_results.end());
+        BOOST_CHECK(it_child != mixed_result.m_tx_results.end());
+
+        BOOST_CHECK(it_parent1->second.m_result_type == MempoolAcceptResult::ResultType::MEMPOOL_ENTRY);
+        BOOST_CHECK(it_parent2->second.m_result_type == MempoolAcceptResult::ResultType::DIFFERENT_WITNESS);
+        BOOST_CHECK(it_parent3->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
+        BOOST_CHECK(it_child->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
+        BOOST_CHECK_EQUAL(ptx_parent2_v2->GetWitnessHash(), it_parent2->second.m_other_wtxid.value());
+
+        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(ptx_parent1->GetHash())));
+        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(ptx_parent2_v1->GetHash())));
+        BOOST_CHECK(!m_node.mempool->exists(GenTxid::Wtxid(ptx_parent2_v1->GetWitnessHash())));
+        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(ptx_parent3->GetHash())));
+        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(ptx_mixed_child->GetHash())));
     }
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1274,9 +1274,10 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
             // transaction for the mempool one. Note that we are ignoring the validity of the
             // package transaction passed in.
             // TODO: allow witness replacement in packages.
-            auto iter = m_pool.GetIter(wtxid);
+            auto iter = m_pool.GetIter(txid);
             assert(iter != std::nullopt);
-            results.emplace(txid, MempoolAcceptResult::MempoolTx(iter.value()->GetTxSize(), iter.value()->GetFee()));
+            // Provide the wtxid of the mempool tx so that the caller can look it up in the mempool.
+            results.emplace(wtxid, MempoolAcceptResult::MempoolTxDifferentWitness(iter.value()->GetTx().GetWitnessHash()));
         } else {
             // Transaction does not already exist in the mempool.
             txns_new.push_back(tx);

--- a/src/validation.h
+++ b/src/validation.h
@@ -161,8 +161,12 @@ struct MempoolAcceptResult {
         VALID, //!> Fully validated, valid.
         INVALID, //!> Invalid.
         MEMPOOL_ENTRY, //!> Valid, transaction was already in the mempool.
+        DIFFERENT_WITNESS, //!> Not validated. A same-txid-different-witness tx (see m_other_wtxid) already exists in the mempool and was not replaced.
     };
+    /** Result type. Present in all MempoolAcceptResults. */
     const ResultType m_result_type;
+
+    /** Contains information about why the transaction failed. */
     const TxValidationState m_state;
 
     // The following fields are only present when m_result_type = ResultType::VALID or MEMPOOL_ENTRY
@@ -172,6 +176,10 @@ struct MempoolAcceptResult {
     const std::optional<int64_t> m_vsize;
     /** Raw base fees in satoshis. */
     const std::optional<CAmount> m_base_fees;
+
+    // The following field is only present when m_result_type = ResultType::DIFFERENT_WITNESS
+    /** The wtxid of the transaction in the mempool which has the same txid but different witness. */
+    const std::optional<uint256> m_other_wtxid;
 
     static MempoolAcceptResult Failure(TxValidationState state) {
         return MempoolAcceptResult(state);
@@ -183,6 +191,10 @@ struct MempoolAcceptResult {
 
     static MempoolAcceptResult MempoolTx(int64_t vsize, CAmount fees) {
         return MempoolAcceptResult(vsize, fees);
+    }
+
+    static MempoolAcceptResult MempoolTxDifferentWitness(const uint256& other_wtxid) {
+        return MempoolAcceptResult(other_wtxid);
     }
 
 // Private constructors. Use static methods MempoolAcceptResult::Success, etc. to construct.
@@ -201,6 +213,10 @@ private:
     /** Constructor for already-in-mempool case. It wouldn't replace any transactions. */
     explicit MempoolAcceptResult(int64_t vsize, CAmount fees)
         : m_result_type(ResultType::MEMPOOL_ENTRY), m_vsize{vsize}, m_base_fees(fees) {}
+
+    /** Constructor for witness-swapped case. */
+    explicit MempoolAcceptResult(const uint256& other_wtxid)
+        : m_result_type(ResultType::DIFFERENT_WITNESS), m_other_wtxid(other_wtxid) {}
 };
 
 /**
@@ -210,7 +226,7 @@ struct PackageMempoolAcceptResult
 {
     const PackageValidationState m_state;
     /**
-    * Map from (w)txid to finished MempoolAcceptResults. The client is responsible
+    * Map from wtxid to finished MempoolAcceptResults. The client is responsible
     * for keeping track of the transaction objects themselves. If a result is not
     * present, it means validation was unfinished for that transaction. If there
     * was a package-wide error (see result in m_state), m_tx_results will be empty.


### PR DESCRIPTION
This addresses some comments from review on e12fafda2dfbbdf63f125e5af797ecfaa6488f66 from #22674.

- Improve documentation about de-duplication: [comment](https://github.com/bitcoin/bitcoin/pull/22674/files#r770156708)
- Fix code looking up same-txid-different-witness transaction in mempool: [comment](https://github.com/bitcoin/bitcoin/pull/22674/files#r770804029)
- Improve the interface for when a same-txid-different-witness transaction is swapped: [comment](https://github.com/bitcoin/bitcoin/pull/22674/files#r770782822)
- Add a test for witness swapping: [comment](https://github.com/bitcoin/bitcoin/pull/22674/files#r770804029)
- Add a test for packages with a mix of duplicate/different witness/new parents: [comment](https://github.com/bitcoin/bitcoin/pull/22674#discussion_r773037608)
- Fix issue with not notifying `CValidationInterface` when there's a partial submission due to fail-fast: [comment](https://github.com/bitcoin/bitcoin/pull/22674#discussion_r773013162)