### PR TITLE
tracing: reduce instructions generated by net:message tracepoints

### DIFF
--- a/contrib/tracing/log_p2p_traffic.bt
+++ b/contrib/tracing/log_p2p_traffic.bt
@@ -2,14 +2,15 @@
 
 BEGIN
 {
-  printf("Logging P2P traffic\n")
+  printf("Logging P2P traffic\n");
 }
 
 usdt:./src/bitcoind:net:inbound_message
 {
   $peer_id = (int64) arg0;
   $peer_addr = str(arg1);
-  $peer_type = str(arg2);
+  $ct = (uint32)arg2;
+  $peer_type = ($ct == 0 ? "inbound":($ct == 1 ? "outbound-full-relay":($ct == 2 ? "manual":($ct == 3 ? "feeler":($ct == 4 ? "block-relay":($ct == 5 ? "addr-fetch":"unknown"))))));
   $msg_type = str(arg3);
   $msg_len = arg4;
   printf("inbound '%s' msg from peer %d (%s, %s) with %d bytes\n", $msg_type, $peer_id, $peer_type, $peer_addr, $msg_len);
@@ -19,7 +20,8 @@ usdt:./src/bitcoind:net:outbound_message
 {
   $peer_id = (int64) arg0;
   $peer_addr = str(arg1);
-  $peer_type = str(arg2);
+  $ct = (uint32)arg2;
+  $peer_type = ($ct == 0 ? "inbound":($ct == 1 ? "outbound-full-relay":($ct == 2 ? "manual":($ct == 3 ? "feeler":($ct == 4 ? "block-relay":($ct == 5 ? "addr-fetch":"unknown"))))));
   $msg_type = str(arg3);
   $msg_len = arg4;
 

--- a/contrib/tracing/net_common.py
+++ b/contrib/tracing/net_common.py
@@ -1,0 +1,15 @@
+
+# see ConnectionType enum in net.h
+CONN_TYPES = [
+    'inbound',
+    'outbound-full-relay',
+    'manual',
+    'feeler',
+    'block-relay',
+    'addr-fetch'
+]
+
+def describe_conn_type(conn_type):
+    if conn_type < len(CONN_TYPES):
+        return CONN_TYPES[conn_type]
+    return 'unknown'

--- a/contrib/tracing/p2p_monitor.py
+++ b/contrib/tracing/p2p_monitor.py
@@ -16,6 +16,8 @@ import curses
 from curses import wrapper, panel
 from bcc import BPF, USDT
 
+from net_common import describe_conn_type
+
 # BCC: The C program to be compiled to an eBPF program (by BCC) and loaded into
 # a sandboxed Linux kernel VM.
 program = """
@@ -24,14 +26,13 @@ program = """
 // Tor v3 addresses are 62 chars + 6 chars for the port (':12345').
 // I2P addresses are 60 chars + 6 chars for the port (':12345').
 #define MAX_PEER_ADDR_LENGTH 62 + 6
-#define MAX_PEER_CONN_TYPE_LENGTH 20
 #define MAX_MSG_TYPE_LENGTH 20
 
 struct p2p_message
 {
     u64     peer_id;
     char    peer_addr[MAX_PEER_ADDR_LENGTH];
-    char    peer_conn_type[MAX_PEER_CONN_TYPE_LENGTH];
+    u32     peer_conn_type;
     char    msg_type[MAX_MSG_TYPE_LENGTH];
     u64     msg_size;
 };
@@ -46,7 +47,7 @@ int trace_inbound_message(struct pt_regs *ctx) {
 
     bpf_usdt_readarg(1, ctx, &msg.peer_id);
     bpf_usdt_readarg_p(2, ctx, &msg.peer_addr, MAX_PEER_ADDR_LENGTH);
-    bpf_usdt_readarg_p(3, ctx, &msg.peer_conn_type, MAX_PEER_CONN_TYPE_LENGTH);
+    bpf_usdt_readarg(3, ctx, &msg.peer_conn_type);
     bpf_usdt_readarg_p(4, ctx, &msg.msg_type, MAX_MSG_TYPE_LENGTH);
     bpf_usdt_readarg(5, ctx, &msg.msg_size);
 
@@ -59,7 +60,7 @@ int trace_outbound_message(struct pt_regs *ctx) {
 
     bpf_usdt_readarg(1, ctx, &msg.peer_id);
     bpf_usdt_readarg_p(2, ctx, &msg.peer_addr, MAX_PEER_ADDR_LENGTH);
-    bpf_usdt_readarg_p(3, ctx, &msg.peer_conn_type, MAX_PEER_CONN_TYPE_LENGTH);
+    bpf_usdt_readarg(3, ctx, &msg.peer_conn_type);
     bpf_usdt_readarg_p(4, ctx, &msg.msg_type, MAX_MSG_TYPE_LENGTH);
     bpf_usdt_readarg(5, ctx, &msg.msg_size);
 
@@ -67,7 +68,6 @@ int trace_outbound_message(struct pt_regs *ctx) {
     return 0;
 };
 """
-
 
 class Message:
     """ A P2P network message. """
@@ -132,7 +132,7 @@ def main(bitcoind_path):
         event = bpf["inbound_messages"].event(data)
         if event.peer_id not in peers:
             peer = Peer(event.peer_id, event.peer_addr.decode(
-                "utf-8"), event.peer_conn_type.decode("utf-8"))
+                "utf-8"), describe_conn_type(event.peer_conn_type))
             peers[peer.id] = peer
         peers[event.peer_id].add_message(
             Message(event.msg_type.decode("utf-8"), event.msg_size, True))
@@ -145,7 +145,7 @@ def main(bitcoind_path):
         event = bpf["outbound_messages"].event(data)
         if event.peer_id not in peers:
             peer = Peer(event.peer_id, event.peer_addr.decode(
-                "utf-8"), event.peer_conn_type.decode("utf-8"))
+                "utf-8"), describe_conn_type(event.peer_conn_type))
             peers[peer.id] = peer
         peers[event.peer_id].add_message(
             Message(event.msg_type.decode("utf-8"), event.msg_size, False))

--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -63,7 +63,7 @@ information about our peer, the connection and the message as arguments.
 Arguments passed:
 1. Peer ID as `int64`
 2. Peer Address and Port (IPv4, IPv6, Tor v3, I2P, ...) as `pointer to C-style String` (max. length 68 characters)
-3. Connection Type (inbound, feeler, outbound-full-relay, ...) as `pointer to C-style String` (max. length 20 characters)
+3. Connection Type (`0` inbound, `1` outbound-full-relay, `2` manual, `3` feeler, `4` block-relay, `5` addr-fetch) as `uint32`
 4. Message Type (inv, ping, getdata, addrv2, ...) as `pointer to C-style String` (max. length 20 characters)
 5. Message Size in bytes as `uint64`
 6. Message Bytes as `pointer to unsigned chars` (i.e. bytes)
@@ -82,7 +82,7 @@ information about our peer, the connection and the message as arguments.
 Arguments passed:
 1. Peer ID as `int64`
 2. Peer Address and Port (IPv4, IPv6, Tor v3, I2P, ...) as `pointer to C-style String` (max. length 68 characters)
-3. Connection Type (inbound, feeler, outbound-full-relay, ...) as `pointer to C-style String` (max. length 20 characters)
+3. Connection Type (`0` inbound, `1` outbound-full-relay, `2` manual, `3` feeler, `4` block-relay, `5` addr-fetch) as `uint32`
 4. Message Type (inv, ping, getdata, addrv2, ...) as `pointer to C-style String` (max. length 20 characters)
 5. Message Size in bytes as `uint64`
 6. Message Bytes as `pointer to unsigned chars` (i.e. bytes)
@@ -190,7 +190,7 @@ For example:
 TRACE6(net, inbound_message,
     pnode->GetId(),
     pnode->m_addr_name.c_str(),
-    pnode->ConnectionTypeAsString().c_str(),
+    pnode->GetConnectionType(),
     sanitizedType.c_str(),
     msg.data.size(),
     msg.data.data()

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3029,7 +3029,7 @@ void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
     TRACE6(net, outbound_message,
         pnode->GetId(),
         pnode->m_addr_name.c_str(),
-        pnode->ConnectionTypeAsString().c_str(),
+        (uint32_t)pnode->GetConnectionType(),
         msg.m_type.c_str(),
         msg.data.size(),
         msg.data.data()

--- a/src/net.h
+++ b/src/net.h
@@ -660,6 +660,8 @@ public:
 
     std::string ConnectionTypeAsString() const { return ::ConnectionTypeAsString(m_conn_type); }
 
+    ConnectionType GetConnectionType() const { return m_conn_type; }
+
     /** A ping-pong round trip has completed successfully. Update latest and minimum ping times. */
     void PongReceived(std::chrono::microseconds ping_time) {
         m_last_ping_time = ping_time;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4146,7 +4146,7 @@ bool PeerManagerImpl::ProcessMessages(CNode* pfrom, std::atomic<bool>& interrupt
     TRACE6(net, inbound_message,
         pfrom->GetId(),
         pfrom->m_addr_name.c_str(),
-        pfrom->ConnectionTypeAsString().c_str(),
+        (uint32_t)pfrom->GetConnectionType(),
         msg.m_command.c_str(),
         msg.m_recv.size(),
         msg.m_recv.data()


### PR DESCRIPTION
In the net:{inbound,outbound}_message tracepoint, we are calling the
ConnectionTypeAsString helper function that converts the enum to a
string. This has been shown to generate quite a few instructions, even
when there is no code hooked into the tracepoint.

Here's the output from gdb when tracing the number of instructions
between two breakpoints around this tracepoint (see [1] for how to do
this):

	Recorded 293 instructions in 27 functions

Tracepoints should be almost zero cost, 293 instructions is a bit much
for effectively doing nothing most of the time.

Instead of calling the ConnectionTypeAsString function, simply add a
ConnectionType getter that returns the connection type enum directly.
This way the tracepoint simplifies to nine instructions that load values
into registers in preparation for a tracepoint call, which may or may
not be there depending on if there are any attached ebpf programs.

With this patch applied:

	Recorded 9 instructions in 1 functions

This tightens up these tracepoints in preparation for enabling tracing
in release builds[2].

Signed-off-by: William Casarin <jb55@jb55.com>

[1] https://github.com/bitcoin/bitcoin/pull/23724#issuecomment-996919963
[2] https://github.com/bitcoin/bitcoin/pull/23724

