### PR TITLE
docs: avoid C-style casts; use modern C++ casts

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -104,6 +104,10 @@ code.
   - `++i` is preferred over `i++`.
   - `nullptr` is preferred over `NULL` or `(void*)0`.
   - `static_assert` is preferred over `assert` where possible. Generally; compile-time checking is preferred over run-time checking.
+  - Use a named cast or functional cast, not a C-Style cast. When casting
+    between integer types, use functional casts such as `int(x)` or `int{x}`
+    instead of `(int) x`. When casting between more complex types, use static_cast.
+    Use reinterpret_cast and const_cast as appropriate.
 
 Block style example:
 ```c++


### PR DESCRIPTION
In the words of practicalswift:
```
A C-style cast is equivalent to try casting in the following order:

    const_cast(...)
    static_cast(...)
    const_cast(static_cast(...))
    reinterpret_cast(...)
    const_cast(reinterpret_cast(...))

By using static_cast<T>(...) explicitly we avoid the possibility of an unintentional and 
dangerous reinterpret_cast. Furthermore static_cast<T>(...) allows for easier grepping of casts.

For a more thorough discussion, see "ES.49: If you must use a cast, use a named cast"
in the C++ Core Guidelines (Stroustrup & Sutter).
```

Modern tooling, specifically `-Wold-style-cast` can enable us to enforce never using C-style casts. I believe this is especially important due to the number of C-style casts the codebase is currently being used as a reinterpret_cast. reinterpret_casts are especially dangerous, and should never be done via C-style casts.

Update the docs to suggest the use of named cast or functional casts.