### PR TITLE
scripts: match on `EXE_FORMATS` rather than name string

### DIFF
--- a/contrib/devtools/security-check.py
+++ b/contrib/devtools/security-check.py
@@ -180,14 +180,14 @@ def check_control_flow(binary) -> bool:
 
 
 CHECKS = {
-'ELF': [
+lief.EXE_FORMATS.ELF: [
     ('PIE', check_PIE),
     ('NX', check_NX),
     ('RELRO', check_ELF_RELRO),
     ('Canary', check_ELF_Canary),
     ('separate_code', check_ELF_separate_code),
 ],
-'PE': [
+lief.EXE_FORMATS.PE: [
     ('PIE', check_PIE),
     ('DYNAMIC_BASE', check_PE_DYNAMIC_BASE),
     ('HIGH_ENTROPY_VA', check_PE_HIGH_ENTROPY_VA),
@@ -195,7 +195,7 @@ CHECKS = {
     ('RELOC_SECTION', check_PE_RELOC_SECTION),
     ('CONTROL_FLOW', check_PE_control_flow),
 ],
-'MACHO': [
+lief.EXE_FORMATS.MACHO: [
     ('PIE', check_PIE),
     ('NOUNDEFS', check_MACHO_NOUNDEFS),
     ('NX', check_NX),
@@ -210,7 +210,7 @@ if __name__ == '__main__':
     for filename in sys.argv[1:]:
         try:
             binary = lief.parse(filename)
-            etype = binary.format.name
+            etype = binary.format
             if etype == lief.EXE_FORMATS.UNKNOWN:
                 print(f'{filename}: unknown executable format')
                 retval = 1

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -254,18 +254,18 @@ def check_ELF_interpreter(binary) -> bool:
     return binary.concrete.interpreter == expected_interpreter
 
 CHECKS = {
-'ELF': [
+lief.EXE_FORMATS.ELF: [
     ('IMPORTED_SYMBOLS', check_imported_symbols),
     ('EXPORTED_SYMBOLS', check_exported_symbols),
     ('LIBRARY_DEPENDENCIES', check_ELF_libraries),
     ('INTERPRETER_NAME', check_ELF_interpreter),
 ],
-'MACHO': [
+lief.EXE_FORMATS.MACHO: [
     ('DYNAMIC_LIBRARIES', check_MACHO_libraries),
     ('MIN_OS', check_MACHO_min_os),
     ('SDK', check_MACHO_sdk),
 ],
-'PE' : [
+lief.EXE_FORMATS.PE: [
     ('DYNAMIC_LIBRARIES', check_PE_libraries),
     ('SUBSYSTEM_VERSION', check_PE_subsystem_version),
 ]
@@ -276,7 +276,7 @@ if __name__ == '__main__':
     for filename in sys.argv[1:]:
         try:
             binary = lief.parse(filename)
-            etype = binary.format.name
+            etype = binary.format
             if etype == lief.EXE_FORMATS.UNKNOWN:
                 print(f'{filename}: unknown executable format')
                 retval = 1


### PR DESCRIPTION
This is a minor change, but matching on the `EXE_FORMAT` is slightly simpler and more robust, and this reduces the diff for a future change I plan on making.

Guix build:
```bash
ba2e4f2ff66206cc793483977386016ffd8c018c553f76e3a432ffdf7d33cc00  guix-build-d1711a40b30a/output/aarch64-linux-gnu/SHA256SUMS.part
296feb453c6b3f6a24ef45ccabe6e35b4b6728f8dab34493d76debd0cf38cb70  guix-build-d1711a40b30a/output/aarch64-linux-gnu/bitcoin-d1711a40b30a-aarch64-linux-gnu-debug.tar.gz
319ce7e2178c479e0e065593e903c1696d38504b69bc0a7cca45a0aeccbb83dc  guix-build-d1711a40b30a/output/aarch64-linux-gnu/bitcoin-d1711a40b30a-aarch64-linux-gnu.tar.gz
7e961a14ace0523303e6a381f2d59aac1072cb68517a205cce704c5f324c97fa  guix-build-d1711a40b30a/output/arm-linux-gnueabihf/SHA256SUMS.part
7cb96340ccd7911114e84aba731b7924500aa18731e6a10e4750898c523052a5  guix-build-d1711a40b30a/output/arm-linux-gnueabihf/bitcoin-d1711a40b30a-arm-linux-gnueabihf-debug.tar.gz
8c5858498054753363a14a57447b77c9c3ad4b8a5584fa3ff9e96b58c358008f  guix-build-d1711a40b30a/output/arm-linux-gnueabihf/bitcoin-d1711a40b30a-arm-linux-gnueabihf.tar.gz
10299105a0011df9d5ec5ff0af500b902d1d16617c1f620f7836a255e6ecf155  guix-build-d1711a40b30a/output/dist-archive/bitcoin-d1711a40b30a.tar.gz
3115d3e51c50e1c41374544be76386684f6bc3a3ad3bce8fa47ad953950d1f6f  guix-build-d1711a40b30a/output/powerpc64-linux-gnu/SHA256SUMS.part
e1ac147d026323f486a702872cd05e96c1dfa6dc052512e80e01a9a6b9957aac  guix-build-d1711a40b30a/output/powerpc64-linux-gnu/bitcoin-d1711a40b30a-powerpc64-linux-gnu-debug.tar.gz
6f793fe6218754d78f3353644cc34d8caa1aff5d3ffd4b2fd3f3c2d5547c50b1  guix-build-d1711a40b30a/output/powerpc64-linux-gnu/bitcoin-d1711a40b30a-powerpc64-linux-gnu.tar.gz
44b5e75dc090ba409fb426d41aa546e14c280a0f89038cbef483ffa26644703c  guix-build-d1711a40b30a/output/powerpc64le-linux-gnu/SHA256SUMS.part
cdebf42e32efab57ce82bb431db0666e5df539d65bf2936cb9e766d4b903126a  guix-build-d1711a40b30a/output/powerpc64le-linux-gnu/bitcoin-d1711a40b30a-powerpc64le-linux-gnu-debug.tar.gz
2646ec19f145ef302f75f5d5aa0b565573077e474dfa9e0650fb3da61b97d102  guix-build-d1711a40b30a/output/powerpc64le-linux-gnu/bitcoin-d1711a40b30a-powerpc64le-linux-gnu.tar.gz
2b45352095a32f058fe55358a875a8b43bc76daeb834f42346a01e0e5aec4e95  guix-build-d1711a40b30a/output/riscv64-linux-gnu/SHA256SUMS.part
11119508a14f75af5d3eb47e7be059dc171691a5d6e6aefd2ab89cc57bdebce9  guix-build-d1711a40b30a/output/riscv64-linux-gnu/bitcoin-d1711a40b30a-riscv64-linux-gnu-debug.tar.gz
7f834a91e2cb2c114101f1dd030dde56591bad42ca94cb25e33251a24aa05976  guix-build-d1711a40b30a/output/riscv64-linux-gnu/bitcoin-d1711a40b30a-riscv64-linux-gnu.tar.gz
26c36170daaa91187367a1137ed5cce6707a20dbea7d4a18fcf6c69e3201a50a  guix-build-d1711a40b30a/output/x86_64-apple-darwin/SHA256SUMS.part
9cbe875de7fa98684682786da66a10ee9bdf111f51cd01174355b2de0cff69e6  guix-build-d1711a40b30a/output/x86_64-apple-darwin/bitcoin-d1711a40b30a-osx-unsigned.dmg
83fe4ebe0d9a23b55c990f9587af78cf54a9323e4f809f354945cff234889164  guix-build-d1711a40b30a/output/x86_64-apple-darwin/bitcoin-d1711a40b30a-osx-unsigned.tar.gz
68b03467521d678cf7c6b4ae95eb13685b5684492106c5fa98a6243e21b51433  guix-build-d1711a40b30a/output/x86_64-apple-darwin/bitcoin-d1711a40b30a-osx64.tar.gz
52b85be0df8c041ea280833ba1f6ead15bff57f8f7d96e0660756c5d22676893  guix-build-d1711a40b30a/output/x86_64-linux-gnu/SHA256SUMS.part
df43b04f4cb720996dc3d6006d8d7cf19123806b5168429e2c63012763122a4a  guix-build-d1711a40b30a/output/x86_64-linux-gnu/bitcoin-d1711a40b30a-x86_64-linux-gnu-debug.tar.gz
ccdecd3b22c70fd1f7efef9a42ba22e1fa7d28d5adc4235587b77a7d98373a73  guix-build-d1711a40b30a/output/x86_64-linux-gnu/bitcoin-d1711a40b30a-x86_64-linux-gnu.tar.gz
b1a80c07945cbfc768981ecbb35646d84fde8fa9ea7d68b1024fe0602224c007  guix-build-d1711a40b30a/output/x86_64-w64-mingw32/SHA256SUMS.part
c7888791485e5ee37e987aa516b7c1d5cb3d39d77eed5a75110be164e2da81bc  guix-build-d1711a40b30a/output/x86_64-w64-mingw32/bitcoin-d1711a40b30a-win-unsigned.tar.gz
650d3544cfea1a76967a8ddcc77340245280d0a07045bfaef01e65f579a33d68  guix-build-d1711a40b30a/output/x86_64-w64-mingw32/bitcoin-d1711a40b30a-win64-debug.zip
2f068168a9261517f8be577fc78f13bc11bb6bb018b9bb949707043016cdf526  guix-build-d1711a40b30a/output/x86_64-w64-mingw32/bitcoin-d1711a40b30a-win64-setup-unsigned.exe
f8776caf9c363a680589b50397f5aa2d57378cbf8dd49d4574e1ea636fe5ebbe  guix-build-d1711a40b30a/output/x86_64-w64-mingw32/bitcoin-d1711a40b30a-win64.zip
```