### PR TITLE
test: fix intermittent failures in p2p_timeouts.py

### DIFF
--- a/test/functional/p2p_timeouts.py
+++ b/test/functional/p2p_timeouts.py
@@ -48,10 +48,13 @@ class TimeoutsTest(BitcoinTestFramework):
         self.mock_time = int(time.time())
         self.mock_forward(0)
 
-        # Setup the p2p connections
-        no_verack_node = self.nodes[0].add_p2p_connection(TestP2PConn(), wait_for_verack=False)
-        no_version_node = self.nodes[0].add_p2p_connection(TestP2PConn(), send_version=False, wait_for_verack=False)
-        no_send_node = self.nodes[0].add_p2p_connection(TestP2PConn(), send_version=False, wait_for_verack=False)
+        # Setup the p2p connections, making sure the connections are established before the mocktime is bumped
+        with self.nodes[0].assert_debug_log(['Added connection peer=0']):
+            no_verack_node = self.nodes[0].add_p2p_connection(TestP2PConn(), wait_for_verack=False)
+        with self.nodes[0].assert_debug_log(['Added connection peer=1']):
+            no_version_node = self.nodes[0].add_p2p_connection(TestP2PConn(), send_version=False, wait_for_verack=False)
+        with self.nodes[0].assert_debug_log(['Added connection peer=2']):
+            no_send_node = self.nodes[0].add_p2p_connection(TestP2PConn(), send_version=False, wait_for_verack=False)
 
         # Wait until we got the verack in response to the version. Though, don't wait for the other node to receive the
         # verack, since we never sent one


### PR DESCRIPTION
Fixes  #23800 by making sure that all peers are connected (i.e. `m_connected` is set) before the mocktime is bumped.
We can't wait for verack here, but we can wait for a debug log entry ("Added connection peer=2") instead. 

In the failed CI runs (e.g. https://cirrus-ci.com/task/5600553806856192?logs=ci#L7469)  different peers were added at different mocktimes.
