### PR TITLE
build: Fix regression introduced in PR23603

### DIFF
--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -22,7 +22,7 @@ darwin_INSTALL_NAME_TOOL:=$(shell xcrun -f install_name_tool)
 darwin_native_binutils=
 darwin_native_toolchain=
 
-x86_64_darwin_CFLAGS = -arch x86_64
-x86_64_darwin_CXXFLAGS = $(x86_64_darwin_CFLAGS)
-aarch64_darwin_CFLAGS = -arch arm64
-aarch64_darwin_CXXFLAGS = $(aarch64_darwin_CFLAGS)
+x86_64_darwin_CFLAGS += -arch x86_64
+x86_64_darwin_CXXFLAGS += -arch x86_64
+aarch64_darwin_CFLAGS += -arch arm64
+aarch64_darwin_CXXFLAGS += -arch arm64


### PR DESCRIPTION
It appears 7629efcc2c3a8a8a7c17b1300cd466ec6c8c1f3f from bitcoin/bitcoin#23603 introduced a regression in build tool flag evaluation.

On macOS system:
- pre-PR23603 master (ae017b81604761b57e22c28913c4ce81bf2e31ce):
```
% make -C depends print-darwin_CXXFLAGS 
darwin_CXXFLAGS=-pipe
% make -C depends print-host_CXXFLAGS
host_CXXFLAGS=-pipe
```
- the current master (369978686e156ad34df703f1e60bd90aeaa8f2d6):
```
% make -C depends print-darwin_CXXFLAGS
darwin_CXXFLAGS=-pipe
% make -C depends print-host_CXXFLAGS  
host_CXXFLAGS=-arch x86_64
```

It's obvious a flag being set in `depends/hosts/darwin.mk`, i.e., `-pipe`, is lost.

With this PR:
```
% make -C depends print-darwin_CXXFLAGS        
darwin_CXXFLAGS=-pipe
% make -C depends print-host_CXXFLAGS          
host_CXXFLAGS=-pipe -arch x86_64
```