### PR TITLE
wallettool: Check that the dumpfile checksum is the correct size

### DIFF
--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -214,6 +214,11 @@ bool CreateFromDump(const std::string& name, const fs::path& wallet_path, biling
 
             if (key == "checksum") {
                 std::vector<unsigned char> parsed_checksum = ParseHex(value);
+                if (parsed_checksum.size() != checksum.size()) {
+                    error = Untranslated("Error: Checksum is not the correct size");
+                    ret = false;
+                    break;
+                }
                 std::copy(parsed_checksum.begin(), parsed_checksum.end(), checksum.begin());
                 break;
             }

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -390,7 +390,11 @@ class ToolWalletTest(BitcoinTestFramework):
         bad_sum_wallet_dump = os.path.join(self.nodes[0].datadir, "wallet-bad_sum3.dump")
         dump_data["checksum"] = "2" * 10
         self.write_dump(dump_data, bad_sum_wallet_dump)
-        self.assert_raises_tool_error('Error: Dumpfile checksum does not match. Computed {}, expected {}{}'.format(checksum, "2" * 10, "0" * 54), '-wallet=badload', '-dumpfile={}'.format(bad_sum_wallet_dump), 'createfromdump')
+        self.assert_raises_tool_error('Error: Checksum is not the correct size', '-wallet=badload', '-dumpfile={}'.format(bad_sum_wallet_dump), 'createfromdump')
+        assert not os.path.isdir(os.path.join(self.nodes[0].datadir, "regtest/wallets", "badload"))
+        dump_data["checksum"] = "3" * 66
+        self.write_dump(dump_data, bad_sum_wallet_dump)
+        self.assert_raises_tool_error('Error: Checksum is not the correct size', '-wallet=badload', '-dumpfile={}'.format(bad_sum_wallet_dump), 'createfromdump')
         assert not os.path.isdir(os.path.join(self.nodes[0].datadir, "regtest/wallets", "badload"))
 
 


### PR DESCRIPTION
After parsing the checksum, make sure that it is the size that we expect it to be.

This issue was reported by Pedro Baptista.