### PR TITLE
test: check for invalid listtransactions RPC parameters

### DIFF
--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -16,6 +16,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_array_result,
     assert_equal,
+    assert_raises_rpc_error,
 )
 
 
@@ -107,6 +108,7 @@ class ListTransactionsTest(BitcoinTestFramework):
 
         self.run_rbf_opt_in_test()
         self.run_externally_generated_address_test()
+        self.run_invalid_parameters_test()
 
     def run_rbf_opt_in_test(self):
         """Test the opt-in-rbf flag for sent and received transactions."""
@@ -274,6 +276,13 @@ class ListTransactionsTest(BitcoinTestFramework):
         assert_equal(['pizza1'], self.nodes[0].getaddressinfo(addr1)['labels'])
         assert_equal(['pizza2'], self.nodes[0].getaddressinfo(addr2)['labels'])
         assert_equal(['pizza3'], self.nodes[0].getaddressinfo(addr3)['labels'])
+
+    def run_invalid_parameters_test(self):
+        self.log.info("Test listtransactions RPC parameter validity")
+        assert_raises_rpc_error(-8, 'Label argument must be a valid label name or "*".', self.nodes[0].listtransactions, label="")
+        self.nodes[0].listtransactions(label="*")
+        assert_raises_rpc_error(-8, "Negative count", self.nodes[0].listtransactions, count=-1)
+        assert_raises_rpc_error(-8, "Negative from", self.nodes[0].listtransactions, skip=-1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds missing test coverage for RPC errors that are thrown if invalid parameters are passed to `listtransactions`:

https://github.com/bitcoin/bitcoin/blob/887796a5ffcbafcd281b920f8d55fcb6e8347584/src/wallet/rpc/transactions.cpp#L508

https://github.com/bitcoin/bitcoin/blob/887796a5ffcbafcd281b920f8d55fcb6e8347584/src/wallet/rpc/transactions.cpp#L524

https://github.com/bitcoin/bitcoin/blob/887796a5ffcbafcd281b920f8d55fcb6e8347584/src/wallet/rpc/transactions.cpp#L526