### PR TITLE
Restore atoi64/GetIntArg saturating behavior

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -702,7 +702,7 @@ static RPCHelpMan getblocktemplate()
             std::string lpstr = lpval.get_str();
 
             hashWatchedChain = ParseHashV(lpstr.substr(0, 64), "longpollid");
-            nTransactionsUpdatedLastLP = LocaleIndependentAtoi<int64_t>(lpstr.substr(64));
+            nTransactionsUpdatedLastLP = LocaleIndependentAtoi64(lpstr.substr(64));
         }
         else
         {

--- a/src/test/fuzz/parse_numbers.cpp
+++ b/src/test/fuzz/parse_numbers.cpp
@@ -28,7 +28,7 @@ FUZZ_TARGET(parse_numbers)
     (void)ParseUInt32(random_string, &u32);
 
     int64_t i64;
-    (void)LocaleIndependentAtoi<int64_t>(random_string);
+    (void)LocaleIndependentAtoi64(random_string);
     (void)ParseFixedPoint(random_string, 3, &i64);
     (void)ParseInt64(random_string, &i64);
 

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -289,7 +289,7 @@ FUZZ_TARGET(string)
 
     {
         const int64_t atoi64_result = atoi64_legacy(random_string_1);
-        const int64_t locale_independent_atoi_result = LocaleIndependentAtoi<int64_t>(random_string_1);
+        const int64_t locale_independent_atoi_result = LocaleIndependentAtoi64(random_string_1);
         assert(atoi64_result == locale_independent_atoi_result || locale_independent_atoi_result == 0);
     }
 }

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -6,6 +6,7 @@
 #include <util/strencodings.h>
 #include <util/system.h>
 
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -143,6 +144,11 @@ BOOST_AUTO_TEST_CASE(intarg)
     ResetArgs("-foo -bar");
     BOOST_CHECK_EQUAL(m_local_args.GetIntArg("-foo", 11), 0);
     BOOST_CHECK_EQUAL(m_local_args.GetIntArg("-bar", 11), 0);
+
+    // Check under-/overflow behavior.
+    ResetArgs("-foo=-9223372036854775809 -bar=9223372036854775808");
+    BOOST_CHECK_EQUAL(m_local_args.GetIntArg("-foo", 0), std::numeric_limits<int64_t>::min());
+    BOOST_CHECK_EQUAL(m_local_args.GetIntArg("-bar", 0), std::numeric_limits<int64_t>::max());
 
     ResetArgs("-foo=11 -bar=12");
     BOOST_CHECK_EQUAL(m_local_args.GetIntArg("-foo", 0), 11);

--- a/src/util/moneystr.cpp
+++ b/src/util/moneystr.cpp
@@ -77,7 +77,7 @@ std::optional<CAmount> ParseMoney(const std::string& money_string)
         return std::nullopt;
     if (nUnits < 0 || nUnits > COIN)
         return std::nullopt;
-    int64_t nWhole = LocaleIndependentAtoi<int64_t>(strWhole);
+    int64_t nWhole = LocaleIndependentAtoi64(strWhole);
     CAmount value = nWhole * COIN + nUnits;
 
     if (!MoneyRange(value)) {

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -94,8 +94,11 @@ void SplitHostPort(std::string in, uint16_t& portOut, std::string& hostOut);
 // which provide parse error feedback.
 //
 // The goal of LocaleIndependentAtoi is to replicate the exact defined behaviour
-// of atoi and atoi64 as they behave under the "C" locale.
-template <typename T>
+// of atoi as it behaves under the "C" locale.
+//
+// Prevent use of LocaleIndependentAtoi for int64_t, since the function below
+// should be used for backwards compatibility with older versions of Bitcoin Core.
+template <typename T, typename std::enable_if<!std::is_same<T, int64_t>::value>::type* = nullptr>
 T LocaleIndependentAtoi(const std::string& str)
 {
     static_assert(std::is_integral<T>::value);
@@ -114,6 +117,21 @@ T LocaleIndependentAtoi(const std::string& str)
     }
     return result;
 }
+
+/**
+ * LocaleIndependentAtoi64 is provided for backwards compatibility reasons.
+ * Since its behavior differs from standard atoi functionality, it is not a
+ * template-specialization of the above function.
+ *
+ * New code should use ToIntegral or the ParseInt* functions which provide
+ * parse error feedback.
+ *
+ * This aims to replicate the exact behaviour of atoi64 in previous versions of
+ * Bitcoin Core. The old atoi64 utility function actually made use of `strtoll`
+ * in its implementation (or Microsoft's `_atoi64`), which saturates over- and
+ * underflows. That behavior is reproduced here.
+ */
+int64_t LocaleIndependentAtoi64(const std::string& str);
 
 /**
  * Tests if the given character is a decimal digit.

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -596,7 +596,7 @@ std::string ArgsManager::GetArg(const std::string& strArg, const std::string& st
 int64_t ArgsManager::GetIntArg(const std::string& strArg, int64_t nDefault) const
 {
     const util::SettingsValue value = GetSetting(strArg);
-    return value.isNull() ? nDefault : value.isFalse() ? 0 : value.isTrue() ? 1 : value.isNum() ? value.get_int64() : LocaleIndependentAtoi<int64_t>(value.get_str());
+    return value.isNull() ? nDefault : value.isFalse() ? 0 : value.isTrue() ? 1 : value.isNum() ? value.get_int64() : LocaleIndependentAtoi64(value.get_str());
 }
 
 bool ArgsManager::GetBoolArg(const std::string& strArg, bool fDefault) const

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -254,9 +254,9 @@ public:
         m_state = TxStateInterpretSerialized({serialized_block_hash, serializedIndex});
 
         const auto it_op = mapValue.find("n");
-        nOrderPos = (it_op != mapValue.end()) ? LocaleIndependentAtoi<int64_t>(it_op->second) : -1;
+        nOrderPos = (it_op != mapValue.end()) ? LocaleIndependentAtoi64(it_op->second) : -1;
         const auto it_ts = mapValue.find("timesmart");
-        nTimeSmart = (it_ts != mapValue.end()) ? static_cast<unsigned int>(LocaleIndependentAtoi<int64_t>(it_ts->second)) : 0;
+        nTimeSmart = (it_ts != mapValue.end()) ? static_cast<unsigned int>(LocaleIndependentAtoi64(it_ts->second)) : 0;
 
         mapValue.erase("fromaccount");
         mapValue.erase("spent");

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -43,6 +43,7 @@ KNOWN_VIOLATIONS=(
     "src/test/dbwrapper_tests.cpp:.*snprintf"
     "src/test/fuzz/locale.cpp"
     "src/test/fuzz/string.cpp"
+    "src/test/util_tests.cpp"
 )
 
 REGEXP_IGNORE_EXTERNAL_DEPENDENCIES="^src/(crypto/ctaes/|leveldb/|secp256k1/|minisketch/|tinyformat.h|univalue/)"


### PR DESCRIPTION
The new locale-independent atoi64 method introduced in #20452 behaves
differently for values passed which are greater than the uint64_t max.
This commit is proof of that (the attached test fails), and is meant to spur discussion 
on how to handle such an incompatibility.

The change as committed in #20542 may break some end-usages of
bitcoind, but more than that may have consensus implications as this
deserialization mechanism is used in CScript::ParseScript. ~~I think this
means it's possible that #20542 could have been an accidental soft fork?~~

Edit: `CScript::ParseScript` isn't consensus-critical, but is used in e.g. script descriptor parsing.