### PR TITLE
fs: consistently use fsbridge:: for ifstream / ofstream

### DIFF
--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -27,7 +27,7 @@ void GenerateTemplateResults(const std::vector<ankerl::nanobench::Result>& bench
         // nothing to write, bail out
         return;
     }
-    std::ofstream fout(filename);
+    fsbridge::ofstream fout{filename};
     if (fout.is_open()) {
         ankerl::nanobench::render(tpl, benchmarkResults, fout);
     } else {

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -158,7 +158,7 @@ static void RegisterLoad(const std::string& strInput)
     std::string key = strInput.substr(0, pos);
     std::string filename = strInput.substr(pos + 1, std::string::npos);
 
-    FILE *f = fopen(filename.c_str(), "r");
+    FILE *f = fsbridge::fopen(filename.c_str(), "r");
     if (!f) {
         std::string strErr = "Cannot open file " + filename;
         throw std::runtime_error(strErr);

--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -7,7 +7,6 @@
 #ifndef WIN32
 #include <cstring>
 #include <fcntl.h>
-#include <string>
 #include <sys/file.h>
 #include <sys/utsname.h>
 #include <unistd.h>
@@ -19,6 +18,9 @@
 #include <limits>
 #include <windows.h>
 #endif
+
+#include <cassert>
+#include <string>
 
 namespace fsbridge {
 

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -155,7 +155,7 @@ void PSBTOperationsDialog::saveTransaction() {
     if (filename.isEmpty()) {
         return;
     }
-    std::ofstream out(filename.toLocal8Bit().data(), std::ofstream::out | std::ofstream::binary);
+    fsbridge::ofstream out{filename.toLocal8Bit().data(), fsbridge::ofstream::out | fsbridge::ofstream::binary};
     out << ssTx.str();
     out.close();
     showStatus(tr("PSBT saved to disk."), StatusLevel::INFO);

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -500,7 +500,7 @@ void SendCoinsDialog::sendButtonClicked([[maybe_unused]] bool checked)
             if (filename.isEmpty()) {
                 return;
             }
-            std::ofstream out(filename.toLocal8Bit().data(), std::ofstream::out | std::ofstream::binary);
+            fsbridge::ofstream out{filename.toLocal8Bit().data(), fsbridge::ofstream::out | fsbridge::ofstream::binary};
             out << ssTx.str();
             out.close();
             Q_EMIT message(tr("PSBT saved"), "PSBT saved to disk", CClientUIInterface::MSG_INFORMATION);

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -210,7 +210,7 @@ void WalletFrame::gotoLoadPSBT(bool from_clipboard)
             Q_EMIT message(tr("Error"), tr("PSBT file must be smaller than 100 MiB"), CClientUIInterface::MSG_ERROR);
             return;
         }
-        std::ifstream in(filename.toLocal8Bit().data(), std::ios::binary);
+        fsbridge::ifstream in{filename.toLocal8Bit().data(), std::ios::binary};
         data = std::string(std::istreambuf_iterator<char>{in}, {});
     }
 

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -56,7 +56,7 @@ void initialize()
     }
     if (const char* out_path = std::getenv("WRITE_ALL_FUZZ_TARGETS_AND_ABORT")) {
         std::cout << "Writing all fuzz target names to '" << out_path << "'." << std::endl;
-        std::ofstream out_stream(out_path, std::ios::binary);
+        fsbridge::ofstream out_stream{out_path, std::ios::binary};
         for (const auto& t : FuzzTargets()) {
             if (std::get<2>(t.second)) continue;
             out_stream << t.first << std::endl;

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -923,7 +923,7 @@ BOOST_AUTO_TEST_CASE(script_build)
     }
 
 #ifdef UPDATE_JSON_TESTS
-    FILE* file = fopen("script_tests.json.gen", "w");
+    FILE* file = fsbridge::fopen("script_tests.json.gen", "w");
     fputs(strGen.c_str(), file);
     fclose(file);
 #endif

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -151,7 +151,7 @@ bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes)
 }
 
 std::streampos GetFileSize(const char* path, std::streamsize max) {
-    std::ifstream file(path, std::ios::binary);
+    fsbridge::ifstream file{path, std::ios::binary};
     file.ignore(max);
     return file.gcount();
 }


### PR DESCRIPTION
Two of these changes are part of #20744, but are ok to do now, and reduce the diff that will eventually need to be reviewed in that PR. See commit messages for details.