### PR TITLE
build: Update Guix build free space requirements

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -146,9 +146,12 @@ avail_KiB="$(df -Pk "$VERSION_BASE" | sed 1d | tr -s ' ' | cut -d' ' -f4)"
 total_required_KiB=0
 for host in $HOSTS; do
     case "$host" in
-        *darwin*) required_KiB=440000 ;;
-        *mingw*)  required_KiB=7600000 ;;
-        *)        required_KiB=6400000 ;;
+        *darwin*)       required_KiB=440000 ;;
+        *mingw*)        required_KiB=8700000 ;;
+        *x86_64-linux*) required_KiB=6100000 ;;
+        *arm-linux*)    required_KiB=4800000 ;;
+        *riscv64*)      required_KiB=6600000 ;;
+        *)              required_KiB=7400000 ;;
     esac
     total_required_KiB=$((total_required_KiB+required_KiB))
 done


### PR DESCRIPTION
After bumping Qt from 5.12 to 5.15 the actual disk space that are consumed by Guix builds (measured with a tweaked `guix-build` script):

- x86_64-linux-gnu -- 6080844 KiB
- arm-linux-gnueabihf -- 4775864 KiB
- aarch64-linux-gnu -- 7266380 KiB
- riscv64-linux-gnu -- 6583008 KiB
- powerpc64-linux-gnu -- 7330884 KiB
- powerpc64le-linux-gnu -- 7293340 KiB
- x86_64-w64-mingw32 -- 8667608 KiB
- x86_64-apple-darwin -- 430280 KiB

This PR adjusts the `required_KiB` variable values accordingly.