### PR TITLE
build, qt: Hardcode last modified timestamp in Qt RCC

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -13,6 +13,7 @@ $(package)_patches += dont_use_avx_android_x86_64.patch dont_hardcode_x86_64.pat
 $(package)_patches += fix_android_jni_static.patch dont_hardcode_pwd.patch
 $(package)_patches += qtbase-moc-ignore-gcc-macro.patch fix_limits_header.patch
 $(package)_patches += fix_bigsur_style.patch use_android_ndk23.patch
+$(package)_patches += rcc_hardcode_timestamp.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=d5788e86257b21d5323f1efd94376a213e091d1e5e03b45a95dd052b5f570db8
@@ -237,6 +238,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/fix_montery_include.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_bigsur_style.patch && \
   patch -p1 -i $($(package)_patch_dir)/use_android_ndk23.patch && \
+  patch -p1 -i $($(package)_patch_dir)/rcc_hardcode_timestamp.patch && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f $($(package)_patch_dir)/mac-qmake.conf qtbase/mkspecs/macx-clang-linux/qmake.conf && \

--- a/depends/patches/qt/rcc_hardcode_timestamp.patch
+++ b/depends/patches/qt/rcc_hardcode_timestamp.patch
@@ -1,0 +1,24 @@
+Hardcode last modified timestamp in Qt RCC
+
+This change allows the already built qt package to be reused even with
+the SOURCE_DATE_EPOCH variable set, e.g., for Guix builds.
+
+
+--- old/qtbase/src/tools/rcc/rcc.cpp
++++ new/qtbase/src/tools/rcc/rcc.cpp
+@@ -227,14 +227,7 @@ void RCCFileInfo::writeDataInfo(RCCResourceLibrary &lib)
+ 
+     if (lib.formatVersion() >= 2) {
+         // last modified time stamp
+-        const QDateTime lastModified = m_fileInfo.lastModified();
+-        quint64 lastmod = quint64(lastModified.isValid() ? lastModified.toMSecsSinceEpoch() : 0);
+-        static const quint64 sourceDate = 1000 * qgetenv("QT_RCC_SOURCE_DATE_OVERRIDE").toULongLong();
+-        if (sourceDate != 0)
+-            lastmod = sourceDate;
+-        static const quint64 sourceDate2 = 1000 * qgetenv("SOURCE_DATE_EPOCH").toULongLong();
+-        if (sourceDate2 != 0)
+-            lastmod = sourceDate2;
++        quint64 lastmod = quint64(1);
+         lib.writeNumber8(lastmod);
+         if (text || pass1)
+             lib.writeChar('\n');


### PR DESCRIPTION
Our Guix build system sets the [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/) and propagates it to the depends build subsystem. Its [default value](https://github.com/bitcoin/bitcoin/blob/master/contrib/guix/README.md#recognized-environment-variables) is the top commit timestamp.

After bumping Qt version up to 5.15.2, due to [this](https://github.com/qt/qtbase/commit/1ffcca4cc208c48ddb06b6a23abf1756f9724351) change, every time they are going to make new Guix builds for another branch/commit they must ensure that the `qt` package will be rebuilt from scratch. Otherwise, Bitcoin Core GUI binaries will be non-deterministic.

Such behavior makes working with Guix builds suboptimal.

This PR fixes the described issue by patching Qt RCC and hardcoding last modified timestamps with `1`.

It's worth to mention that this change is compatible with a possible future [improvement](https://github.com/bitcoin/bitcoin/pull/21995) which makes each dependency package reproducible.

A drawback of such an approach is not currently applied to our project, as it effectively makes [QML cache files](https://bugreports.qt.io/browse/QTBUG-57182) useless. I can't say it's a problem for the https://github.com/bitcoin-core/gui-qml project.

---

**A note for thinkers:** For now this change is enough as only Qt source contains `SOURCE_DATE_EPOCH`. But in general we should re-think about treating the `SOURCE_DATE_EPOCH` variable in the depends build subsystem. For instance, its default value could be the output of `git log --format=%at -1 -- depends`.

