### PR TITLE
test: use MiniWallet for p2p_compactblocks.py

### DIFF
--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -65,6 +65,8 @@ from test_framework.util import (
     assert_equal,
     softfork_active,
 )
+from test_framework.wallet import MiniWallet
+
 
 # TestP2PConn: A peer we use to send messages to bitcoind, and store responses.
 class TestP2PConn(P2PInterface):
@@ -150,9 +152,6 @@ class CompactBlocksTest(BitcoinTestFramework):
         ]]
         self.utxos = []
 
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
-
     def build_block_on_tip(self, node, segwit=False):
         block = create_block(tmpl=node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS))
         if segwit:
@@ -165,7 +164,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         block = self.build_block_on_tip(self.nodes[0])
         self.segwit_node.send_and_ping(msg_no_witness_block(block))
         assert int(self.nodes[0].getbestblockhash(), 16) == block.sha256
-        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY, self.nodes[0].getnewaddress(address_type="bech32"))
+        self.generate(self.wallet, COINBASE_MATURITY)
 
         total_value = block.vtx[0].vout[0].nValue
         out_value = total_value // 10
@@ -296,12 +295,10 @@ class CompactBlocksTest(BitcoinTestFramework):
         # Generate a bunch of transactions.
         self.generate(node, COINBASE_MATURITY + 1)
         num_transactions = 25
-        address = node.getnewaddress()
 
         segwit_tx_generated = False
         for _ in range(num_transactions):
-            txid = node.sendtoaddress(address, 0.1)
-            hex_tx = node.gettransaction(txid)["hex"]
+            hex_tx = self.wallet.send_self_transfer(from_node=self.nodes[0])['hex']
             tx = tx_from_hex(hex_tx)
             if not tx.wit.is_null():
                 segwit_tx_generated = True
@@ -843,8 +840,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         assert_highbandwidth_states(self.nodes[0], hb_to=True, hb_from=False)
 
     def run_test(self):
-        # Get the nodes out of IBD
-        self.generate(self.nodes[0], 1)
+        self.wallet = MiniWallet(self.nodes[0])
 
         # Setup the p2p connections
         self.segwit_node = self.nodes[0].add_p2p_connection(TestP2PConn(cmpct_version=2))


### PR DESCRIPTION
This PR enables one more of the non-wallet functional tests (p2p_compactblocks.py) to be run even with the Bitcoin Core wallet disabled by using the MiniWallet instead, as proposed in #20078.

The wallet RPCs calls (`getnewaddress`/`sendtoaddress`) can easily be substituted by generating/sending to the MiniWallet's internal address instead (`self.generate(self.wallet, ...)`/`self.wallet.send_self_transfer(...)`).