### PR TITLE
linearize: Fix the config item name about rpc port

### DIFF
--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -5,16 +5,16 @@ rpcpassword=somepassword
 host=127.0.0.1
 
 #mainnet default
-port=8332
+rpcport=8332
 
 #testnet default
-#port=18332
+#rpcport=18332
 
 #regtest default
-#port=18443
+#rpcport=18443
 
 #signet default
-#port=38332
+#rpcport=38332
 
 # bootstrap.dat hashlist settings (linearize-hashes)
 max_height=313000


### PR DESCRIPTION
The port numbers in the example-linearize.cfg are not the normal default listen port.

All of them are default RPC port.