### PR TITLE
doc: Remove TODO comment in tx_verify

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -4,15 +4,13 @@
 
 #include <consensus/tx_verify.h>
 
-#include <consensus/amount.h>
-#include <consensus/consensus.h>
-#include <primitives/transaction.h>
-#include <script/interpreter.h>
-#include <consensus/validation.h>
-
-// TODO remove the following dependencies
 #include <chain.h>
 #include <coins.h>
+#include <consensus/amount.h>
+#include <consensus/consensus.h>
+#include <consensus/validation.h>
+#include <primitives/transaction.h>
+#include <script/interpreter.h>
 #include <util/moneystr.h>
 
 bool IsFinalTx(const CTransaction &tx, int nBlockHeight, int64_t nBlockTime)


### PR DESCRIPTION
The comment has no clear motivation, so it seems better to remove it and fix it when there is a reason.

An alternative (if a fix isn't possible when there is a clear motivation) would be to create an issue thread for easier discussion.