### PR TITLE
test: check ban_duration and time_remaining after setting ban

### DIFF
--- a/test/functional/p2p_disconnect_ban.py
+++ b/test/functional/p2p_disconnect_ban.py
@@ -70,6 +70,15 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.nodes[1].setmocktime(old_time + 3)
         assert_equal(len(self.nodes[1].listbanned()), 3)
 
+        self.log.info("Test ban_duration and time_remaining")
+        for ban in self.nodes[1].listbanned():
+            if ban["address"] in ["127.0.0.0/32", "127.0.0.0/24"]:
+                assert_equal(ban["ban_duration"], 86400)
+                assert_equal(ban["time_remaining"], 86397)
+            elif ban["address"] == "2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/19":
+                assert_equal(ban["ban_duration"], 1000)
+                assert_equal(ban["time_remaining"], 997)
+
         self.restart_node(1)
 
         listAfterShutdown = self.nodes[1].listbanned()


### PR DESCRIPTION
This PR adds functional test coverage for `ban_duration` and `time_remaining` introduced in #21602