### PR TITLE
doc: Remove TODO from block fuzz test

### DIFF
--- a/src/test/fuzz/block.cpp
+++ b/src/test/fuzz/block.cpp
@@ -58,8 +58,6 @@ FUZZ_TARGET_INIT(block, initialize_block)
     (void)block.ToString();
     (void)BlockMerkleRoot(block);
     if (!block.vtx.empty()) {
-        // TODO: Avoid array index out of bounds error in BlockWitnessMerkleRoot
-        //       when block.vtx.empty().
         (void)BlockWitnessMerkleRoot(block);
     }
     (void)GetBlockWeight(block);


### PR DESCRIPTION
I don't see a reason to fix the TODO, as all call sites assume at least one tx in `vtx`. So remove it.