### PR TITLE
doc: Remove outdated scriptChange TODO comment

### DIFF
--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -665,8 +665,6 @@ static bool CreateTransactionInternal(
     }
 
     // Create change script that will be used if we need change
-    // TODO: pass in scriptChange instead of reservedest so
-    // change transaction isn't always pay-to-bitcoin-address
     CScript scriptChange;
 
     // coin control: send change to custom address


### PR DESCRIPTION
This was added in commit bf798734db4539a39edd6badf54a1c3aecf193e5 (raw multisig). Raw multisig isn't a thing, so remove the TODO.