### PR TITLE
Include patches for Guix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ src/qt/bitcoin-qt.includes
 
 # Only ignore unexpected patches
 *.patch
+!contrib/guix/patches/*.patch
 !depends/patches/**/*.patch
 
 #libtool object files


### PR DESCRIPTION
Fix .gitignore exclude the patches at 'contrib/guix/patches/'.