### PR TITLE
doc: Add gpg key import instructions for Windows

### DIFF
--- a/contrib/builder-keys/README.md
+++ b/contrib/builder-keys/README.md
@@ -19,13 +19,13 @@ gpg --refresh-keys
 To fetch keys of builders and active developers, feed the list of fingerprints
 of the primary keys into gpg:
 
-using \*NIX:
+On \*NIX:
 ```sh
 while read fingerprint keyholder_name; do gpg --keyserver hkps://keys.openpgp.org --recv-keys ${fingerprint}; done < ./keys.txt
 ```
 
 
-using Windows (requires Gpg4win >= 4.0.0):
+On Windows (requires Gpg4win >= 4.0.0):
 ```
 FOR /F "tokens=1" %i IN (keys.txt) DO gpg --keyserver hkps://keys.openpgp.org --recv-keys %i
 ```

--- a/contrib/builder-keys/README.md
+++ b/contrib/builder-keys/README.md
@@ -25,7 +25,7 @@ while read fingerprint keyholder_name; do gpg --keyserver hkps://keys.openpgp.or
 ```
 
 
-using Windows (tested with Gpg4win 4.0.0, and FAILS with Gp4win 3.1.13, so make sure you're up to date!):
+using Windows (requires Gpg4win >= 4.0.0):
 ```
 FOR /F "tokens=1" %i IN (keys.txt) DO gpg --keyserver hkps://keys.openpgp.org --recv-keys %i
 ```

--- a/contrib/builder-keys/README.md
+++ b/contrib/builder-keys/README.md
@@ -19,8 +19,15 @@ gpg --refresh-keys
 To fetch keys of builders and active developers, feed the list of fingerprints
 of the primary keys into gpg:
 
+using \*NIX:
 ```sh
 while read fingerprint keyholder_name; do gpg --keyserver hkps://keys.openpgp.org --recv-keys ${fingerprint}; done < ./keys.txt
+```
+
+
+using Windows (tested with Gpg4win 4.0.0, and FAILS with Gp4win 3.1.13, so make sure you're up to date!):
+```
+FOR /F "tokens=1" %i IN (keys.txt) DO gpg --keyserver hkps://keys.openpgp.org --recv-keys %i
 ```
 
 Add your key to the list if you provided Guix attestations for two major or


### PR DESCRIPTION
I propose this change so that Windows users can more easily import signers' keys.