### PR TITLE
test: clean up logs when there aren't perf subprocesses

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -317,11 +317,12 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
                 node.cleanup_on_exit = False
             self.log.info("Note: bitcoinds were not stopped and may still be running")
 
+        perf_active = any(bool(node.perf_available) for node in self.nodes)
         should_clean_up = (
             not self.options.nocleanup and
             not self.options.noshutdown and
             self.success != TestStatus.FAILED and
-            not self.options.perf
+            not perf_active
         )
         if should_clean_up:
             self.log.info("Cleaning up {} on exit".format(self.options.tmpdir))

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -138,6 +138,7 @@ class TestNode():
         self.cleanup_on_exit = True # Whether to kill the node when this object goes away
         # Cache perf subprocesses here by their data output filename.
         self.perf_subprocesses = {}
+        self.perf_available = False
 
         self.p2ps = []
         self.timeout_factor = timeout_factor
@@ -537,6 +538,7 @@ class TestNode():
         ]
         subp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         self.perf_subprocesses[profile_name] = subp
+        self.perf_available = True
 
         return subp
 


### PR DESCRIPTION
To check node performance during functional tests we can use `perf`. It generates profile data in the node's datadir, so after executing a test, node's datadir is not clean up. However, it only works in Linux, if you try to use `perf` in other systems for example, a warning message will be showed but the test will be executed normally. Besides that, the node's datadir won't be clean up because it understands you're using `perf` even if not working. This PR fixes it by checking if there are 'perf subprocesses' when deciding if the node's datadir should be clean up.

Example (master branch/macOS 12.0.1):
 ```
➜  bitcoin-core-dev git:(master) ✗ ./test/functional/feature_anchors.py --perf
2021-12-30T19:07:22.576000Z TestFramework (INFO): Initializing test directory /var/folders/7j/m0yjzmhj4ys9jgl353v2mqph0000gn/T/bitcoin_func_test_bkg26piv
2021-12-30T19:07:22.621000Z TestFramework.node0 (WARNING): Can't profile with perf; only available on Linux platforms
2021-12-30T19:07:23.169000Z TestFramework (INFO): When node starts, check if anchors.dat doesn't exist
2021-12-30T19:07:23.169000Z TestFramework (INFO): Add 2 block-relay-only connections to node
2021-12-30T19:07:23.446000Z TestFramework (INFO): Add 5 inbound connections to node
2021-12-30T19:07:24.011000Z TestFramework (INFO): Check node connections
2021-12-30T19:07:24.013000Z TestFramework (INFO): Stop node 0
2021-12-30T19:07:24.231000Z TestFramework (INFO): Check the addresses in anchors.dat
2021-12-30T19:07:24.232000Z TestFramework (INFO): Start node
2021-12-30T19:07:24.236000Z TestFramework.node0 (WARNING): Can't profile with perf; only available on Linux platforms
2021-12-30T19:07:24.758000Z TestFramework (INFO): When node starts, check if anchors.dat doesn't exist anymore
2021-12-30T19:07:24.814000Z TestFramework (INFO): Stopping nodes
2021-12-30T19:07:25.085000Z TestFramework (WARNING): Not cleaning up dir /var/folders/7j/m0yjzmhj4ys9jgl353v2mqph0000gn/T/bitcoin_func_test_bkg26piv due to perf data
2021-12-30T19:07:25.085000Z TestFramework (INFO): Tests successful
```

Example (this branch/macOS 12.0.1):
```
➜  bitcoin-core-dev git:(2021-12-fix-perf-clean-up) ✗ ./test/functional/feature_anchors.py --perf
2021-12-30T19:08:25.664000Z TestFramework (INFO): Initializing test directory /var/folders/7j/m0yjzmhj4ys9jgl353v2mqph0000gn/T/bitcoin_func_test_xl2qtsbz
2021-12-30T19:08:25.706000Z TestFramework.node0 (WARNING): Can't profile with perf; only available on Linux platforms
2021-12-30T19:08:26.261000Z TestFramework (INFO): When node starts, check if anchors.dat doesn't exist
2021-12-30T19:08:26.262000Z TestFramework (INFO): Add 2 block-relay-only connections to node
2021-12-30T19:08:26.538000Z TestFramework (INFO): Add 5 inbound connections to node
2021-12-30T19:08:27.110000Z TestFramework (INFO): Check node connections
2021-12-30T19:08:27.112000Z TestFramework (INFO): Stop node 0
2021-12-30T19:08:27.330000Z TestFramework (INFO): Check the addresses in anchors.dat
2021-12-30T19:08:27.331000Z TestFramework (INFO): Start node
2021-12-30T19:08:27.336000Z TestFramework.node0 (WARNING): Can't profile with perf; only available on Linux platforms
2021-12-30T19:08:27.870000Z TestFramework (INFO): When node starts, check if anchors.dat doesn't exist anymore
2021-12-30T19:08:27.927000Z TestFramework (INFO): Stopping nodes
2021-12-30T19:08:28.195000Z TestFramework (INFO): Cleaning up /var/folders/7j/m0yjzmhj4ys9jgl353v2mqph0000gn/T/bitcoin_func_test_xl2qtsbz on exit
2021-12-30T19:08:28.195000Z TestFramework (INFO): Tests successful
```