### PR TITLE
ci: Clone entire bitcoin-core/qa-assets repo only when run fuzzing

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -87,13 +87,17 @@ fi
 DOCKER_EXEC echo "Free disk space:"
 DOCKER_EXEC df -h
 
-if [ "$RUN_FUZZ_TESTS" = "true" ] || [ "$RUN_UNIT_TESTS" = "true" ] || [ "$RUN_UNIT_TESTS_SEQUENTIAL" = "true" ]; then
-  if [ ! -d "${DIR_QA_ASSETS}" ]; then
+if [ "$RUN_FUZZ_TESTS" = "true" ]; then
+  export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/
+  if [ ! -d "$DIR_FUZZ_IN" ]; then
     DOCKER_EXEC git clone --depth=1 https://github.com/bitcoin-core/qa-assets "${DIR_QA_ASSETS}"
   fi
-
-  export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/
+elif [ "$RUN_UNIT_TESTS" = "true" ] || [ "$RUN_UNIT_TESTS_SEQUENTIAL" = "true" ]; then
   export DIR_UNIT_TEST_DATA=${DIR_QA_ASSETS}/unit_test_data/
+  if [ ! -d "$DIR_UNIT_TEST_DATA" ]; then
+    DOCKER_EXEC mkdir -p "$DIR_UNIT_TEST_DATA"
+    DOCKER_EXEC curl --location --fail https://github.com/bitcoin-core/qa-assets/raw/main/unit_test_data/script_assets_test.json -o "${DIR_UNIT_TEST_DATA}/script_assets_test.json"
+  fi
 fi
 
 DOCKER_EXEC mkdir -p "${BASE_SCRATCH_DIR}/sanitizer-output/"


### PR DESCRIPTION
This PR speeds up CI tasks that run unit tests but do not run fuzzing.

On my machine:
```
$ time git clone --depth=1 https://github.com/bitcoin-core/qa-assets
Cloning into 'qa-assets'...
remote: Enumerating objects: 289750, done.
remote: Counting objects: 100% (289750/289750), done.
remote: Compressing objects: 100% (207687/207687), done.
remote: Total 289750 (delta 16863), reused 275449 (delta 12092), pack-reused 0
Receiving objects: 100% (289750/289750), 1.39 GiB | 4.79 MiB/s, done.
Resolving deltas: 100% (16863/16863), done.
Updating files: 100% (294515/294515), done.

real	7m43,417s
user	2m39,771s
sys	0m43,272s
```