### PR TITLE
build: use host_os instead of TARGET_OS in configure output

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1939,7 +1939,7 @@ echo "  gprof enabled   = $enable_gprof"
 echo "  werror          = $enable_werror"
 echo "  LTO             = $enable_lto"
 echo
-echo "  target os       = $TARGET_OS"
+echo "  target os       = $host_os"
 echo "  build os        = $build_os"
 echo
 echo "  CC              = $CC"


### PR DESCRIPTION
`TARGET_OS` was convenient, as a readable host name for most of our
targeted platforms, however unless we add more code to configure to
detect more hosts, it's easier just use `host_os` (it's also more
informative).

i.e FreeBSD master
```bash
  target os       =
  build os        = freebsd13.0
```

this PR:
```bash
  target os       = freebsd13.0
  build os        = freebsd13.0
```