### PR TITLE
doc: remove CC_FOR_BUILD from OpenBSD build doc

### DIFF
--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -25,8 +25,8 @@ See [dependencies.md](dependencies.md) for a complete overview.
 **Important**: From OpenBSD 6.2 onwards a C++11-supporting clang compiler is
 part of the base image, and while building it is necessary to make sure that
 this compiler is used and not ancient g++ 4.2.1. This is done by appending
-`CC=cc CC_FOR_BUILD=cc CXX=c++` to configuration commands. Mixing different
-compilers within the same executable will result in errors.
+`CC=cc CXX=c++` to configuration commands. Mixing different compilers within
+the same executable will result in errors.
 
 ### Building BerkeleyDB
 
@@ -84,7 +84,7 @@ To configure with wallet:
 
 To configure without wallet:
 ```bash
-./configure --disable-wallet --with-gui=no --disable-external-signer CC=cc CC_FOR_BUILD=cc CXX=c++ MAKE=gmake
+./configure --disable-wallet --with-gui=no --disable-external-signer CC=cc CXX=c++ MAKE=gmake
 ```
 
 To configure with GUI:


### PR DESCRIPTION
This is no-longer necessary after upstream libsecp256k1 changes that have been pulled into our repo.