### PR TITLE
Remove txmempool implicit-integer-sign-change sanitizer suppressions

### DIFF
--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -76,7 +76,6 @@ implicit-integer-sign-change:test/sighash_tests.cpp
 implicit-integer-sign-change:test/skiplist_tests.cpp
 implicit-integer-sign-change:test/streams_tests.cpp
 implicit-integer-sign-change:test/transaction_tests.cpp
-implicit-integer-sign-change:txmempool.cpp
 implicit-integer-sign-change:zmq/zmqpublishnotifier.cpp
 implicit-signed-integer-truncation,implicit-integer-sign-change:chain.h
 implicit-signed-integer-truncation,implicit-integer-sign-change:test/skiplist_tests.cpp


### PR DESCRIPTION
A file-wide suppression is problematic because it will wave through future violations, potentially bugs.

Fix that by using per-statement casts.

This refactor doesn't change behavior because the now explicit casts were previously done implicitly.

Similar to commit 8b5a4de904b414fb3a818732cd0a2c90b91bc275