### PR TITLE
refactor: Replace `struct update_lock_points` with lambda

### DIFF
--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -312,16 +312,6 @@ public:
     }
 };
 
-struct update_lock_points
-{
-    explicit update_lock_points(const LockPoints& _lp) : lp(_lp) { }
-
-    void operator() (CTxMemPoolEntry &e) { e.UpdateLockPoints(lp); }
-
-private:
-    const LockPoints& lp;
-};
-
 // Multi_index tag names
 struct descendant_score {};
 struct entry_time {};

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -376,7 +376,7 @@ void CChainState::MaybeUpdateMempoolForReorg(
             }
         }
         // CheckSequenceLocks updates lp. Update the mempool entry LockPoints.
-        if (!validLP) m_mempool->mapTx.modify(it, update_lock_points(lp));
+        if (!validLP) m_mempool->mapTx.modify(it, [lp](CTxMemPoolEntry& e) { e.UpdateLockPoints(lp); });
         return should_remove;
     };
 


### PR DESCRIPTION
This change makes code concise and improves it readability.