### PR TITLE
doc: Mark proprietary array optional

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1066,8 +1066,9 @@ static RPCHelpMan testmempoolaccept()
 
 static RPCHelpMan decodepsbt()
 {
-    return RPCHelpMan{"decodepsbt",
-                "\nReturn a JSON object representing the serialized, base64-encoded partially signed Bitcoin transaction.\n",
+    return RPCHelpMan{
+        "decodepsbt",
+        "Return a JSON object representing the serialized, base64-encoded partially signed Bitcoin transaction.",
                 {
                     {"psbt", RPCArg::Type::STR, RPCArg::Optional::NO, "The PSBT base64 string"},
                 },
@@ -1176,7 +1177,7 @@ static RPCHelpMan decodepsbt()
                                 {
                                     {RPCResult::Type::STR_HEX, "key", "(key-value pair) An unknown key-value pair"},
                                 }},
-                                {RPCResult::Type::ARR, "proprietary", "The input proprietary map",
+                                {RPCResult::Type::ARR, "proprietary", /*optional=*/true, "The input proprietary map",
                                 {
                                     {RPCResult::Type::OBJ, "", "",
                                     {
@@ -1217,7 +1218,7 @@ static RPCHelpMan decodepsbt()
                                 {
                                     {RPCResult::Type::STR_HEX, "key", "(key-value pair) An unknown key-value pair"},
                                 }},
-                                {RPCResult::Type::ARR, "proprietary", "The output proprietary map",
+                                {RPCResult::Type::ARR, "proprietary", /*optional=*/true, "The output proprietary map",
                                 {
                                     {RPCResult::Type::OBJ, "", "",
                                     {


### PR DESCRIPTION
The global one is returned all the time, but the input/output array is returned optionally