### PR TITLE
tests: use a cached datadir for wallet_descriptor.py

### DIFF
--- a/test/functional/wallet_descriptor.py
+++ b/test/functional/wallet_descriptor.py
@@ -14,7 +14,6 @@ from test_framework.util import (
 
 class WalletDescriptorTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
         self.num_nodes = 1
         self.extra_args = [['-keypool=100']]
         self.wallet_names = []


### PR DESCRIPTION
~~No need for a clean chain and the increased load of creating one.~~ <-- This made no sense