### PR TITLE
refactor: add thread safety lock assertion to WriteBlockIndexDB()

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -340,6 +340,7 @@ void BlockManager::Unload()
 
 bool BlockManager::WriteBlockIndexDB()
 {
+    AssertLockHeld(::cs_main);
     std::vector<std::pair<int, const CBlockFileInfo*>> vFiles;
     vFiles.reserve(m_dirty_fileinfo.size());
     for (std::set<int>::iterator it = m_dirty_fileinfo.begin(); it != m_dirty_fileinfo.end();) {


### PR DESCRIPTION
New helper function `BlockManager::WriteBlockIndexDB()` added in #23974 has a thread safety lock annotation in its declaration but is missing the corresponding run-time lock assertion in its definition.

Per doc/developer-notes.md: "Combine annotations in function declarations with run-time asserts in function definitions."
