### PR TITLE
assumeutxo: indexing changes

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -61,34 +61,36 @@ bool BaseIndex::Init()
     }
 
     LOCK(cs_main);
-    CChain& active_chain = m_chainstate->m_chain;
+    CChainState& index_chainstate = m_chainman->getChainstateForIndexing();
+    CChain& index_chain = index_chainstate.m_chain;
+
     if (locator.IsNull()) {
         m_best_block_index = nullptr;
     } else {
-        m_best_block_index = m_chainstate->FindForkInGlobalIndex(locator);
+        m_best_block_index = index_chainstate.FindForkInGlobalIndex(locator);
     }
-    m_synced = m_best_block_index.load() == active_chain.Tip();
+    m_synced = m_best_block_index.load() == index_chain.Tip();
     if (!m_synced) {
         bool prune_violation = false;
         if (!m_best_block_index) {
             // index is not built yet
             // make sure we have all block data back to the genesis
-            const CBlockIndex* block = active_chain.Tip();
+            const CBlockIndex* block = index_chain.Tip();
             while (block->pprev && (block->pprev->nStatus & BLOCK_HAVE_DATA)) {
                 block = block->pprev;
             }
-            prune_violation = block != active_chain.Genesis();
+            prune_violation = block != index_chain.Genesis();
         }
         // in case the index has a best block set and is not fully synced
         // check if we have the required blocks to continue building the index
         else {
             const CBlockIndex* block_to_test = m_best_block_index.load();
-            if (!active_chain.Contains(block_to_test)) {
+            if (!index_chain.Contains(block_to_test)) {
                 // if the bestblock is not part of the mainchain, find the fork
                 // and make sure we have all data down to the fork
-                block_to_test = active_chain.FindFork(block_to_test);
+                block_to_test = index_chain.FindFork(block_to_test);
             }
-            const CBlockIndex* block = active_chain.Tip();
+            const CBlockIndex* block = index_chain.Tip();
             prune_violation = true;
             // check backwards from the tip if we have all block data until we reach the indexes bestblock
             while (block_to_test && block && (block->nStatus & BLOCK_HAVE_DATA)) {
@@ -146,7 +148,8 @@ void BaseIndex::ThreadSync()
 
             {
                 LOCK(cs_main);
-                const CBlockIndex* pindex_next = NextSyncBlock(pindex, m_chainstate->m_chain);
+                CChain& index_chain = m_chainman->getChainstateForIndexing().m_chain;
+                const CBlockIndex* pindex_next = NextSyncBlock(pindex, index_chain);
                 if (!pindex_next) {
                     m_best_block_index = pindex;
                     m_synced = true;
@@ -209,7 +212,8 @@ bool BaseIndex::Commit()
 bool BaseIndex::CommitInternal(CDBBatch& batch)
 {
     LOCK(cs_main);
-    GetDB().WriteBestBlock(batch, m_chainstate->m_chain.GetLocator(m_best_block_index));
+    CChain& chain = m_chainman->getChainstateForIndexing().m_chain;
+    GetDB().WriteBestBlock(batch, chain.GetLocator(m_best_block_index));
     return true;
 }
 
@@ -235,9 +239,34 @@ bool BaseIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_ti
 
 void BaseIndex::BlockConnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex)
 {
+    return this->blockConnectedInternal(block, pindex, false);
+}
+
+void BaseIndex::BackgroundBlockConnected(
+    const std::shared_ptr<const CBlock>& block,
+    const CBlockIndex* pindex)
+{
+    this->blockConnectedInternal(block, pindex, true);
+}
+
+void BaseIndex::blockConnectedInternal(
+    const std::shared_ptr<const CBlock>& block,
+    const CBlockIndex* pindex,
+    bool from_background)
+{
+    // Ignore BlockConnected signals until we have fully indexed the chain.
     if (!m_synced) {
         return;
     }
+
+    bool bg_chainstates_in_use = m_chainman->hasBgChainstateInUse();
+
+    // Did we receive this event from a chain for which we can be sure
+    // that we have built indexes for all blocks beneath it?
+    //
+    // If we are receiving this event from an assumed-valid chain, then don't
+    // perform certain checks and don't update the m_best_block_index marker.
+    bool is_on_indexing_chain = !bg_chainstates_in_use || from_background;
 
     const CBlockIndex* best_block_index = m_best_block_index.load();
     if (!best_block_index) {
@@ -246,7 +275,7 @@ void BaseIndex::BlockConnected(const std::shared_ptr<const CBlock>& block, const
                        __func__, pindex->nHeight);
             return;
         }
-    } else {
+    } else if (is_on_indexing_chain) {
         // Ensure block connects to an ancestor of the current best block. This should be the case
         // most of the time, but may not be immediately after the sync thread catches up and sets
         // m_synced. Consider the case where there is a reorg and the blocks on the stale branch are
@@ -264,10 +293,31 @@ void BaseIndex::BlockConnected(const std::shared_ptr<const CBlock>& block, const
                        __func__, GetName());
             return;
         }
+    } else {
+        // Otherwise we're on an assumed-valid chain, so just ensure this block is
+        // contained in the active chain.
+        if (!m_chainman->ActiveChain().Contains(pindex)) {
+            LogPrintf("%s: WARNING: Block %s is not found on the known best chain; " /* Continued */
+                "not updating index\n",
+                __func__, pindex->GetBlockHash().ToString());
+            return;
+        }
     }
 
     if (WriteBlock(*block, pindex)) {
-        m_best_block_index = pindex;
+        // Since blocks may be submitted to this indexer out of order (i.e.
+        // earlier blocks from the background validation chainstate submitted
+        // *after* more recent blocks from the assumed-valid chainstate), only
+        // update m_best_block_index when pindex is on a chain where we can
+        // reasonably say that all blocks behind it have been indexed; in other
+        // words, when it's on a fully-validated chain.
+        //
+        // Once the background chain's use ends (i.e. we have validated the
+        // assumed-valid chain), we will update this in lockstep with the active
+        // chain and will have all historical index entries.
+        if (is_on_indexing_chain) {
+            m_best_block_index = pindex;
+        }
     } else {
         FatalError("%s: Failed to write block %s to index",
                    __func__, pindex->GetBlockHash().ToString());
@@ -281,30 +331,16 @@ void BaseIndex::ChainStateFlushed(const CBlockLocator& locator)
         return;
     }
 
-    const uint256& locator_tip_hash = locator.vHave.front();
-    const CBlockIndex* locator_tip_index;
-    {
-        LOCK(cs_main);
-        locator_tip_index = m_chainstate->m_blockman.LookupBlockIndex(locator_tip_hash);
-    }
-
-    if (!locator_tip_index) {
-        FatalError("%s: First block (hash=%s) in locator was not found",
-                   __func__, locator_tip_hash.ToString());
-        return;
-    }
-
     // This checks that ChainStateFlushed callbacks are received after BlockConnected. The check may fail
     // immediately after the sync thread catches up and sets m_synced. Consider the case where
     // there is a reorg and the blocks on the stale branch are in the ValidationInterface queue
     // backlog even after the sync thread has caught up to the new chain tip. In this unlikely
     // event, log a warning and let the queue clear.
     const CBlockIndex* best_block_index = m_best_block_index.load();
-    if (best_block_index->GetAncestor(locator_tip_index->nHeight) != locator_tip_index) {
-        LogPrintf("%s: WARNING: Locator contains block (hash=%s) not on known best " /* Continued */
-                  "chain (tip=%s); not writing index locator\n",
-                  __func__, locator_tip_hash.ToString(),
-                  best_block_index->GetBlockHash().ToString());
+    if (!m_chainman->ActiveChain().Contains(best_block_index)) {
+        LogPrintf("%s: WARNING: index progress marker (%s) not on known best " /* Continued */
+                  "chain; not writing marker\n",
+                  __func__, best_block_index->GetBlockHash().ToString());
         return;
     }
 
@@ -326,7 +362,7 @@ bool BaseIndex::BlockUntilSyncedToCurrentChain() const
         // Skip the queue-draining stuff if we know we're caught up with
         // m_chain.Tip().
         LOCK(cs_main);
-        const CBlockIndex* chain_tip = m_chainstate->m_chain.Tip();
+        const CBlockIndex* chain_tip = m_chainman->ActiveTip();
         const CBlockIndex* best_block_index = m_best_block_index.load();
         if (best_block_index->GetAncestor(chain_tip->nHeight) == chain_tip) {
             return true;
@@ -343,9 +379,9 @@ void BaseIndex::Interrupt()
     m_interrupt();
 }
 
-bool BaseIndex::Start(CChainState& active_chainstate)
+bool BaseIndex::Start(ChainstateManager& chainman)
 {
-    m_chainstate = &active_chainstate;
+    m_chainman = &chainman;
     // Need to register this ValidationInterface before running Init(), so that
     // callbacks are not missed if Init sets m_synced to true.
     RegisterValidationInterface(this);

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -272,7 +272,7 @@ bool CoinStatsIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* n
 
     {
         LOCK(cs_main);
-        CBlockIndex* iter_tip{m_chainstate->m_blockman.LookupBlockIndex(current_tip->GetBlockHash())};
+        CBlockIndex* iter_tip{m_chainman->m_blockman.LookupBlockIndex(current_tip->GetBlockHash())};
         const auto& consensus_params{Params().GetConsensus()};
 
         do {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1536,21 +1536,21 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         }
 
         g_txindex = std::make_unique<TxIndex>(cache_sizes.tx_index, false, fReindex);
-        if (!g_txindex->Start(chainman.ActiveChainstate())) {
+        if (!g_txindex->Start(chainman)) {
             return false;
         }
     }
 
     for (const auto& filter_type : g_enabled_filter_types) {
         InitBlockFilterIndex(filter_type, cache_sizes.filter_index, false, fReindex);
-        if (!GetBlockFilterIndex(filter_type)->Start(chainman.ActiveChainstate())) {
+        if (!GetBlockFilterIndex(filter_type)->Start(chainman)) {
             return false;
         }
     }
 
     if (args.GetBoolArg("-coinstatsindex", DEFAULT_COINSTATSINDEX)) {
         g_coin_stats_index = std::make_unique<CoinStatsIndex>(/* cache size */ 0, false, fReindex);
-        if (!g_coin_stats_index->Start(chainman.ActiveChainstate())) {
+        if (!g_coin_stats_index->Start(chainman)) {
             return false;
         }
     }

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -131,7 +131,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     // BlockUntilSyncedToCurrentChain should return false before index is started.
     BOOST_CHECK(!filter_index.BlockUntilSyncedToCurrentChain());
 
-    BOOST_REQUIRE(filter_index.Start(m_node.chainman->ActiveChainstate()));
+    BOOST_REQUIRE(filter_index.Start(*m_node.chainman));
 
     // Allow filter index to catch up with the block index.
     constexpr int64_t timeout_ms = 10 * 1000;

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -32,7 +32,7 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
     // is started.
     BOOST_CHECK(!coin_stats_index.BlockUntilSyncedToCurrentChain());
 
-    BOOST_REQUIRE(coin_stats_index.Start(m_node.chainman->ActiveChainstate()));
+    BOOST_REQUIRE(coin_stats_index.Start(*m_node.chainman));
 
     // Allow the CoinStatsIndex to catch up with the block index that is syncing
     // in a background thread.

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -28,7 +28,7 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
     // BlockUntilSyncedToCurrentChain should return false before txindex is started.
     BOOST_CHECK(!txindex.BlockUntilSyncedToCurrentChain());
 
-    BOOST_REQUIRE(txindex.Start(m_node.chainman->ActiveChainstate()));
+    BOOST_REQUIRE(txindex.Start(*m_node.chainman));
 
     // Allow tx index to catch up with the block index.
     constexpr int64_t timeout_ms = 10 * 1000;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4995,3 +4995,16 @@ void ChainstateManager::MaybeRebalanceCaches()
         }
     }
 }
+
+CBlockIndex* ChainstateManager::getSnapshotBaseBlock()
+{
+    auto blockhash_op = SnapshotBlockhash();
+    if (!blockhash_op) return nullptr;
+    return m_blockman.LookupBlockIndex(*blockhash_op);
+}
+
+std::optional<int> ChainstateManager::getSnapshotHeight()
+{
+    CBlockIndex* base = getSnapshotBaseBlock();
+    return base ? std::make_optional(base->nHeight) : std::nullopt;
+}

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2855,10 +2855,12 @@ bool CChainState::ActivateBestChain(BlockValidationState& state, std::shared_ptr
                 }
                 pindexNewTip = m_chain.Tip();
 
-                if (this == &m_chainman.ActiveChainstate()) {
-                    for (const PerBlockConnectTrace& trace : connectTrace.GetBlocksConnected()) {
-                        assert(trace.pblock && trace.pindex);
+                for (const PerBlockConnectTrace& trace : connectTrace.GetBlocksConnected()) {
+                    assert(trace.pblock && trace.pindex);
+                    if (this == &m_chainman.ActiveChainstate()) {
                         GetMainSignals().BlockConnected(trace.pblock, trace.pindex);
+                    } else {
+                        GetMainSignals().BackgroundBlockConnected(trace.pblock, trace.pindex);
                     }
                 }
             } while (!m_chain.Tip() || (starting_tip && CBlockIndexWorkComparator()(m_chain.Tip(), starting_tip)));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5008,3 +5008,13 @@ std::optional<int> ChainstateManager::getSnapshotHeight()
     CBlockIndex* base = getSnapshotBaseBlock();
     return base ? std::make_optional(base->nHeight) : std::nullopt;
 }
+
+CChainState& ChainstateManager::getChainstateForIndexing()
+{
+    return getSnapshotBaseBlock() ? *m_ibd_chainstate : *m_active_chainstate;
+}
+
+bool ChainstateManager::hasBgChainstateInUse()
+{
+    return this->SnapshotBlockhash() && !m_snapshot_validated;
+}

--- a/src/validation.h
+++ b/src/validation.h
@@ -822,6 +822,10 @@ private:
         CBlockIndex** ppindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     friend CChainState;
 
+    // Returns nullptr if no snapshot ahs been loaded.
+    CBlockIndex* getSnapshotBaseBlock() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    std::optional<int> getSnapshotHeight() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
 public:
     std::thread m_load_block;
     //! A single BlockManager instance is shared across each constructed

--- a/src/validation.h
+++ b/src/validation.h
@@ -968,6 +968,20 @@ public:
     //! ResizeCoinsCaches() as needed.
     void MaybeRebalanceCaches() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
+    //! @returns the chainstate that indexers should consult when ensuring that an
+    //!   index is synced with a chain where we can expect block index entries to have
+    //!   BLOCK_HAVE_DATA beneath the tip.
+    //!
+    //!   In other words, give us the chainstate for which we can reasonably expect
+    //!   that all blocks beneath the tip have been indexed. In practice this means
+    //!   when using an assumed-valid chainstate based upon a snapshot, return only the
+    //!   fully validated chain.
+    CChainState& getChainstateForIndexing() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    //! @returns true if we have more than one chainstate in use. This means that a
+    //! background validation chainstate is running.
+    bool hasBgChainstateInUse();
+
     ~ChainstateManager() {
         LOCK(::cs_main);
         UnloadBlockIndex(/* mempool */ nullptr, *this);

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -226,6 +226,18 @@ void CMainSignals::BlockConnected(const std::shared_ptr<const CBlock> &pblock, c
                           pindex->nHeight);
 }
 
+void CMainSignals::BackgroundBlockConnected(
+    const std::shared_ptr<const CBlock> &pblock,
+    const CBlockIndex *pindex)
+{
+    auto event = [pblock, pindex, this] {
+        m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.BackgroundBlockConnected(pblock, pindex); });
+    };
+    ENQUEUE_AND_LOG_EVENT(event, "%s: block hash=%s block height=%d", __func__,
+                          pblock->GetHash().ToString(),
+                          pindex->nHeight);
+}
+
 void CMainSignals::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex)
 {
     auto event = [pblock, pindex, this] {

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -89,13 +89,13 @@ protected:
      * but may not be called on every intermediate tip. If the latter behavior is desired,
      * subscribe to BlockConnected() instead.
      *
-     * Called on a background thread.
+     * Called on a background thread. Only called for the active chainstate.
      */
     virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}
     /**
      * Notifies listeners of a transaction having been added to mempool.
      *
-     * Called on a background thread.
+     * Called on a background thread. Only called for the active chainstate.
      */
     virtual void TransactionAddedToMempool(const CTransactionRef& tx, uint64_t mempool_sequence) {}
 
@@ -129,20 +129,20 @@ protected:
      * - BlockConnected(A)
      * - BlockConnected(B)
      *
-     * Called on a background thread.
+     * Called on a background thread. Only called for the active chainstate.
      */
     virtual void TransactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason, uint64_t mempool_sequence) {}
     /**
      * Notifies listeners of a block being connected.
      * Provides a vector of transactions evicted from the mempool as a result.
      *
-     * Called on a background thread.
+     * Called on a background thread. Only called for the active chainstate.
      */
     virtual void BlockConnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex) {}
     /**
      * Notifies listeners of a block being disconnected
      *
-     * Called on a background thread.
+     * Called on a background thread. Only called for the active chainstate.
      */
     virtual void BlockDisconnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex* pindex) {}
     /**
@@ -159,19 +159,24 @@ protected:
      * Provides a locator describing the best chain, which is likely useful for
      * storing current state on disk in client DBs.
      *
-     * Called on a background thread.
+     * Called on a background thread. Only called for the active chainstate.
      */
     virtual void ChainStateFlushed(const CBlockLocator &locator) {}
     /**
      * Notifies listeners of a block validation result.
      * If the provided BlockValidationState IsValid, the provided block
      * is guaranteed to be the current best block at the time the
-     * callback was generated (not necessarily now)
+     * callback was generated (not necessarily now).
+     *
+     * Only called for the active chainstate.
      */
     virtual void BlockChecked(const CBlock&, const BlockValidationState&) {}
     /**
      * Notifies listeners that a block which builds directly on our current tip
-     * has been received and connected to the headers tree, though not validated yet */
+     * has been received and connected to the headers tree, though not validated yet.
+     *
+     * Only called for the active chainstate.
+     */
     virtual void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& block) {};
     friend class CMainSignals;
 };

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -140,6 +140,15 @@ protected:
      */
     virtual void BlockConnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex) {}
     /**
+     * The equivalent of BlockConnected for non-active (i.e. background
+     * validation) chainstates.
+     *
+     * Called on a background thread.
+     */
+    virtual void BackgroundBlockConnected(
+        const std::shared_ptr<const CBlock> &block,
+        const CBlockIndex *pindex) {}
+    /**
      * Notifies listeners of a block being disconnected
      *
      * Called on a background thread. Only called for the active chainstate.
@@ -206,6 +215,7 @@ public:
     void TransactionAddedToMempool(const CTransactionRef&, uint64_t mempool_sequence);
     void TransactionRemovedFromMempool(const CTransactionRef&, MemPoolRemovalReason, uint64_t mempool_sequence);
     void BlockConnected(const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex);
+    void BackgroundBlockConnected(const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex);
     void BlockDisconnected(const std::shared_ptr<const CBlock> &, const CBlockIndex* pindex);
     void ChainStateFlushed(const CBlockLocator &);
     void BlockChecked(const CBlock&, const BlockValidationState&);


### PR DESCRIPTION
This is part of the [assumeutxo project](https://github.com/bitcoin/bitcoin/projects/11) (parent PR: #15606) 

---

This PR includes the necessary changes for indexing to work with the operation of a background validation chainstate. In short, it
- only emits existing ValidationInterface events for the active chain,
- introduces a BackgroundBlockConnected event for the background chain to support indexation, and
- removes assumptions in the indexing framework that indexation will happen sequentially.

More details below.

---

Adds BackgroundBlockConnected to the validationinterface and uses it in
index maintenance. Ensures that index building will work when part of
the chain is validated asynchronously in the background by a second
chainstate.

This changeset removes the guarantee that indexes will be built
sequentially, as none of the current indexes require this and it is no
longer easy to offer this guarantee when multiple chainstates are in
use.

Within BaseIndex, we only update `m_best_block_index` (which is
essentially the progress marker for how far along the indexing process
is) for chains which we can be certain that all blocks under a given
block on that chain have had indexing performed on them.  In other
words, we will not update `m_best_block_index` during a BlockConnected
event that comes from an active snapshot chain, i.e. a chain for which
some of the blocks underneath Tip() are not indexed.

Once background validation is completed and no background chainstates
are in use, the indexer will happily use BlockConnected events from the
active chain to update `m_best_block_index` as usual. No blocks from the
active chainstate will have been missed for indexing (despite not
previously updating m_best_block_index), so it is safe to perform this
transition without any extra behavior.

Some unnecessary logic from BaseIndex::ChainStateFlushed() is removed,
since the locator can no longer be assumed to be an ancestor of the
best_block_index (since the "best block" may be on a background chainstate
and the locator may have come from an assumed-valid tip well ahead of
it).