### PR TITLE
assumeutxo: net_processing changes

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -951,6 +951,11 @@ private:
     void ProcessBlockAvailability(NodeId nodeid) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     /** Update tracking information about which blocks a peer is assumed to have. */
     void UpdateBlockAvailability(NodeId nodeid, const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+    /**
+     * Allow the direct fetch of block data if our tip is recent within the past
+     * 200 minutes.
+     */
     bool CanDirectFetch() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /**

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2029,6 +2029,10 @@ void PeerManagerImpl::BlockChecked(const CBlock& block, const BlockValidationSta
     // 3. This is currently the best block we're aware of. We haven't updated
     //    the tip yet so we have no way to check this directly here. Instead we
     //    just check that there are currently no other blocks in flight.
+    //
+    // No need to consider the background validation chainstate's IBD status
+    // (if applicable) because any active chainstate not in IBD will allow
+    // us to judge block validity.
     else if (state.IsValid() &&
              !m_chainman.ActiveChainstate().IsInitialBlockDownload() &&
              mapBlocksInFlight.count(hash) == mapBlocksInFlight.size()) {
@@ -3765,6 +3769,9 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                 LogPrint(BCLog::NET, "got inv: %s  %s peer=%d\n", inv.ToString(), fAlreadyHave ? "have" : "new", pfrom.GetId());
 
                 AddKnownTx(*peer, inv.hash);
+                // Can ignore background validation chainstate IBD status here because
+                // as long as the active chainstate is out of IBD, we can consider
+                // TX validity.
                 if (!fAlreadyHave && !m_chainman.ActiveChainstate().IsInitialBlockDownload()) {
                     AddTxAnnouncement(pfrom, gtxid, current_time);
                 }
@@ -4037,6 +4044,8 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         // Stop processing the transaction early if we are still in IBD since we don't
         // have enough information to validate it yet. Sending unsolicited transactions
         // is not considered a protocol violation, so don't punish the peer.
+        //
+        // Can ignore background validation chainstate's IBD status here.
         if (m_chainman.ActiveChainstate().IsInitialBlockDownload()) return;
 
         CTransactionRef ptx;
@@ -4249,7 +4258,10 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
         const CBlockIndex* prev_block = m_chainman.m_blockman.LookupBlockIndex(cmpctblock.header.hashPrevBlock);
         if (!prev_block) {
-            // Doesn't connect (or is genesis), instead of DoSing in AcceptBlockHeader, request deeper headers
+            // Doesn't connect (or is genesis), instead of DoSing in AcceptBlockHeader, request deeper headers.
+            //
+            // Can ignore background chainstate (if applicable) for IsIBD because
+            // we will have a full headers chain by the time two chainstates are in use.
             if (!m_chainman.ActiveChainstate().IsInitialBlockDownload()) {
                 MaybeSendGetHeaders(pfrom, GetLocator(m_chainman.m_best_header), *peer);
             }
@@ -5321,6 +5333,9 @@ void PeerManagerImpl::MaybeSendFeefilter(CNode& pto, Peer& peer, std::chrono::mi
     CAmount currentFilter = m_mempool.GetMinFee().GetFeePerK();
     static FeeFilterRounder g_filter_rounder{CFeeRate{DEFAULT_MIN_RELAY_TX_FEE}};
 
+    // No need to consider background validation chainstate's IBD status
+    // (if applicable), since we will process tx-inv messages when the
+    // active chainstate is out of IBD (see comment below).
     if (m_chainman.ActiveChainstate().IsInitialBlockDownload()) {
         // Received tx-inv messages are discarded when the active
         // chainstate is in IBD, so tell the peer to not send them.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -423,8 +423,18 @@ struct CNodeState {
     const CBlockIndex* pindexBestKnownBlock{nullptr};
     //! The hash of the last unknown block this peer has announced.
     uint256 hashLastUnknownBlock{};
-    //! The last full block we both have.
-    const CBlockIndex* pindexLastCommonBlock{nullptr};
+
+    //! The last full block we both have (per chainstate).
+    //!
+    //! This is namespaced by chainstate to allow syncing two separate chainstates
+    //! simultaneously from a single peer.
+    //!
+    //! Nota bene: this is contingent on the ChainstateManager not destructing
+    //! any Chainstate objects which were in use at any point (e.g. a background
+    //! validation chainstate which has completed) until the end of
+    //! init.cpp:Shutdown(), else we'll have bad pointers here.
+    std::map<const Chainstate*, const CBlockIndex*> m_chainstate_to_last_common_block = {};
+
     //! The best header we have sent our peer.
     const CBlockIndex* pindexBestHeaderSent{nullptr};
     //! Whether we've started headers synchronization with this peer.
@@ -894,10 +904,15 @@ private:
 
     bool TipMayBeStale() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-    /** Update pindexLastCommonBlock and add not-in-flight missing successors to vBlocks, until it has
-     *  at most count entries.
+    /** Update m_chainstate_to_last_common_block and add not-in-flight missing successors
+     * to vBlocks, until it has at most count entries.
      */
-    void FindNextBlocksToDownload(const Peer& peer, unsigned int count, std::vector<const CBlockIndex*>& vBlocks, NodeId& nodeStaller) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    void FindNextBlocksToDownload(
+        const Chainstate& chainstate,
+        const Peer& peer,
+        unsigned int count,
+        std::vector<const CBlockIndex*>& vBlocks,
+        NodeId& nodeStaller) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> > mapBlocksInFlight GUARDED_BY(cs_main);
 
@@ -1301,7 +1316,12 @@ void PeerManagerImpl::UpdateBlockAvailability(NodeId nodeid, const uint256 &hash
     }
 }
 
-void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int count, std::vector<const CBlockIndex*>& vBlocks, NodeId& nodeStaller)
+void PeerManagerImpl::FindNextBlocksToDownload(
+    const Chainstate& chainstate,
+    const Peer& peer,
+    unsigned int count,
+    std::vector<const CBlockIndex*>& vBlocks,
+    NodeId& nodeStaller)
 {
     if (count == 0)
         return;
@@ -1313,31 +1333,44 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
     // Make sure pindexBestKnownBlock is up to date, we'll need it.
     ProcessBlockAvailability(peer.m_id);
 
-    if (state->pindexBestKnownBlock == nullptr || state->pindexBestKnownBlock->nChainWork < m_chainman.ActiveChain().Tip()->nChainWork || state->pindexBestKnownBlock->nChainWork < m_chainman.MinimumChainWork()) {
+    const CChain& our_chain = chainstate.m_chain;
+    const CBlockIndex* our_tip = our_chain.Tip();
+
+    if (state->pindexBestKnownBlock == nullptr
+            || state->pindexBestKnownBlock->nChainWork < our_tip->nChainWork
+            || state->pindexBestKnownBlock->nChainWork < m_chainman.MinimumChainWork()) {
         // This peer has nothing interesting.
         return;
     }
 
-    if (state->pindexLastCommonBlock == nullptr) {
+    if (!state->m_chainstate_to_last_common_block.count(&chainstate)) {
         // Bootstrap quickly by guessing a parent of our best tip is the forking point.
         // Guessing wrong in either direction is not a problem.
-        state->pindexLastCommonBlock = m_chainman.ActiveChain()[std::min(state->pindexBestKnownBlock->nHeight, m_chainman.ActiveChain().Height())];
+        //
+        // Namespace this by chainstate so that we can simultaneously sync two
+        // separate chainstates at different heights.
+        state->m_chainstate_to_last_common_block[&chainstate] = our_chain[
+            std::min(state->pindexBestKnownBlock->nHeight, our_chain.Height())];
     }
 
-    // If the peer reorganized, our previous pindexLastCommonBlock may not be an ancestor
+    const CBlockIndex*& last_common_block =  state->m_chainstate_to_last_common_block[&chainstate];
+
+    // If the peer reorganized, our previous m_chainstate_to_last_common_block may not be an ancestor
     // of its current tip anymore. Go back enough to fix that.
-    state->pindexLastCommonBlock = LastCommonAncestor(state->pindexLastCommonBlock, state->pindexBestKnownBlock);
-    if (state->pindexLastCommonBlock == state->pindexBestKnownBlock)
+    last_common_block = LastCommonAncestor(last_common_block, state->pindexBestKnownBlock);
+    if (last_common_block == state->pindexBestKnownBlock) {
         return;
+    }
 
     std::vector<const CBlockIndex*> vToFetch;
-    const CBlockIndex *pindexWalk = state->pindexLastCommonBlock;
+    const CBlockIndex *pindexWalk = last_common_block;
     // Never fetch further than the best block we know the peer has, or more than BLOCK_DOWNLOAD_WINDOW + 1 beyond the last
     // linked block we have in common with this peer. The +1 is so we can detect stalling, namely if we would be able to
     // download that next block if the window were 1 larger.
-    int nWindowEnd = state->pindexLastCommonBlock->nHeight + BLOCK_DOWNLOAD_WINDOW;
+    int nWindowEnd = pindexWalk->nHeight + BLOCK_DOWNLOAD_WINDOW;
     int nMaxHeight = std::min<int>(state->pindexBestKnownBlock->nHeight, nWindowEnd + 1);
     NodeId waitingfor = -1;
+
     while (pindexWalk->nHeight < nMaxHeight) {
         // Read up to 128 (or more, if more blocks than that are needed) successors of pindexWalk (towards
         // pindexBestKnownBlock) into vToFetch. We fetch 128, because CBlockIndex::GetAncestor may be as expensive
@@ -1352,7 +1385,7 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
 
         // Iterate over those blocks in vToFetch (in forward direction), adding the ones that
         // are not yet downloaded and not in flight to vBlocks. In the meantime, update
-        // pindexLastCommonBlock as long as all ancestors are already downloaded, or if it's
+        // m_chainstate_to_last_common_block as long as all ancestors are already downloaded, or if it's
         // already part of our chain (and therefore don't need it even if pruned).
         for (const CBlockIndex* pindex : vToFetch) {
             if (!pindex->IsValid(BLOCK_VALID_TREE)) {
@@ -1363,9 +1396,9 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
                 // We wouldn't download this block or its descendants from this peer.
                 return;
             }
-            if (pindex->nStatus & BLOCK_HAVE_DATA || m_chainman.ActiveChain().Contains(pindex)) {
+            if (pindex->nStatus & BLOCK_HAVE_DATA || our_chain.Contains(pindex)) {
                 if (pindex->HaveTxsDownloaded())
-                    state->pindexLastCommonBlock = pindex;
+                    last_common_block = pindex;
             } else if (!IsBlockRequested(pindex->GetBlockHash())) {
                 // The block is not already downloaded, and not yet in flight.
                 if (pindex->nHeight > nWindowEnd) {
@@ -1577,7 +1610,15 @@ bool PeerManagerImpl::GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) c
         if (state == nullptr)
             return false;
         stats.nSyncHeight = state->pindexBestKnownBlock ? state->pindexBestKnownBlock->nHeight : -1;
-        stats.nCommonHeight = state->pindexLastCommonBlock ? state->pindexLastCommonBlock->nHeight : -1;
+        stats.nCommonHeight = -1;
+
+        // Take the max common height with this peer across chainstates.
+        for (const auto& it : state->m_chainstate_to_last_common_block) {
+            const CBlockIndex* block = it.second;
+            if (block && block->nHeight > stats.nCommonHeight) {
+                stats.nCommonHeight = block->nHeight;
+            }
+        }
         for (const QueuedBlock& queue : state->vBlocksInFlight) {
             if (queue.pindex)
                 stats.vHeightInFlight.push_back(queue.pindex->nHeight);
@@ -1927,7 +1968,7 @@ void PeerManagerImpl::NewPoWValidBlock(const CBlockIndex *pindex, const std::sha
 
 /**
  * Update our best height and announce any block hashes which weren't previously
- * in m_chainman.ActiveChain() to our peers.
+ * in the active chain to our peers.
  */
 void PeerManagerImpl::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
 {
@@ -5808,21 +5849,44 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
         // Message: getdata (blocks)
         //
         std::vector<CInv> vGetData;
-        if (CanServeBlocks(*peer) && ((sync_blocks_and_headers_from_peer && !IsLimitedPeer(*peer)) || !m_chainman.ActiveChainstate().IsInitialBlockDownload()) && state.nBlocksInFlight < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
-            std::vector<const CBlockIndex*> vToDownload;
-            NodeId staller = -1;
-            FindNextBlocksToDownload(*peer, MAX_BLOCKS_IN_TRANSIT_PER_PEER - state.nBlocksInFlight, vToDownload, staller);
-            for (const CBlockIndex *pindex : vToDownload) {
-                uint32_t nFetchFlags = GetFetchFlags(*peer);
-                vGetData.push_back(CInv(MSG_BLOCK | nFetchFlags, pindex->GetBlockHash()));
-                BlockRequested(pto->GetId(), *pindex);
-                LogPrint(BCLog::NET, "Requesting block %s (%d) peer=%d\n", pindex->GetBlockHash().ToString(),
-                    pindex->nHeight, pto->GetId());
-            }
-            if (state.nBlocksInFlight == 0 && staller != -1) {
-                if (State(staller)->m_stalling_since == 0us) {
-                    State(staller)->m_stalling_since = current_time;
-                    LogPrint(BCLog::NET, "Stall started peer=%d\n", staller);
+
+        // The first chainstate in line for processing will likely exhaust this
+        // during IBD, but once it hits a tip capacity will trickle into subsequent
+        // chainstates.
+        unsigned int requests_available{
+            state.nBlocksInFlight >= MAX_BLOCKS_IN_TRANSIT_PER_PEER ?
+                0U :
+                static_cast<unsigned int>(MAX_BLOCKS_IN_TRANSIT_PER_PEER - state.nBlocksInFlight)};
+
+        const bool can_serve = CanServeBlocks(*peer);
+        const bool is_limited = IsLimitedPeer(*peer);
+
+        // It is more important to get to the network's tip
+        // quickly than do the background validation on the snapshot.
+        for (const auto* const chainstate : m_chainman.GetAll(/*assumed_first=*/true)) {
+            if (can_serve &&
+                    ((sync_blocks_and_headers_from_peer && !is_limited)
+                     || !chainstate->IsInitialBlockDownload())
+                    && state.nBlocksInFlight < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
+                std::vector<const CBlockIndex*> vToDownload;
+                NodeId staller = -1;
+                FindNextBlocksToDownload(*chainstate, *peer, requests_available, vToDownload, staller);
+                Assume(requests_available >= vToDownload.size());
+
+                for (const CBlockIndex *pindex : vToDownload) {
+                    uint32_t nFetchFlags = GetFetchFlags(*peer);
+                    vGetData.push_back(CInv(MSG_BLOCK | nFetchFlags, pindex->GetBlockHash()));
+                    BlockRequested(pto->GetId(), *pindex);
+                    LogPrint(BCLog::NET, "Requesting block %s (%d) peer=%d\n", pindex->GetBlockHash().ToString(),
+                        pindex->nHeight, pto->GetId());
+                    --requests_available;
+                }
+
+                if (state.nBlocksInFlight == 0 && staller != -1) {
+                    if (State(staller)->m_stalling_since == 0us) {
+                        State(staller)->m_stalling_since = current_time;
+                        LogPrint(BCLog::NET, "Stall started peer=%d\n", staller);
+                    }
                 }
             }
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5836,3 +5836,11 @@ bool ChainstateManager::ValidatedSnapshotCleanup()
     }
     return true;
 }
+
+
+bool ChainstateManager::IsAnyChainInIBD() const
+{
+    return
+        (m_snapshot_chainstate && m_snapshot_chainstate->IsInitialBlockDownload()) ||
+        (m_ibd_chainstate && m_ibd_chainstate->IsInitialBlockDownload());
+}

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4998,12 +4998,15 @@ std::optional<uint256> ChainstateManager::SnapshotBlockhash() const
     return std::nullopt;
 }
 
-std::vector<Chainstate*> ChainstateManager::GetAll()
+std::vector<Chainstate*> ChainstateManager::GetAll(bool assumed_first)
 {
     LOCK(::cs_main);
     std::vector<Chainstate*> out;
+    const auto chainstates = assumed_first ?
+        std::vector{m_snapshot_chainstate.get(), m_ibd_chainstate.get()} :
+        std::vector{m_ibd_chainstate.get(), m_snapshot_chainstate.get()};
 
-    for (Chainstate* cs : {m_ibd_chainstate.get(), m_snapshot_chainstate.get()}) {
+    for (Chainstate* cs : chainstates) {
         if (this->IsUsable(cs)) out.push_back(cs);
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4021,6 +4021,8 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
 {
     AssertLockNotHeld(cs_main);
 
+    Chainstate* chainstate = WITH_LOCK(::cs_main, return &this->GetChainstateForNewBlock(block->GetHash()));
+
     {
         CBlockIndex *pindex = nullptr;
         if (new_block) *new_block = false;
@@ -4038,7 +4040,8 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
         bool ret = CheckBlock(*block, state, GetConsensus());
         if (ret) {
             // Store to disk
-            ret = ActiveChainstate().AcceptBlock(block, state, &pindex, force_processing, nullptr, new_block, min_pow_checked);
+            ret = chainstate->AcceptBlock(
+                block, state, &pindex, force_processing, nullptr, new_block, min_pow_checked);
         }
         if (!ret) {
             GetMainSignals().BlockChecked(*block, state);
@@ -4046,10 +4049,12 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
         }
     }
 
-    NotifyHeaderTip(ActiveChainstate());
+    if (chainstate == &this->ActiveChainstate()) {
+        NotifyHeaderTip(*chainstate);
+    }
 
     BlockValidationState state; // Only used to report errors, not invalidity - ignore it
-    if (!ActiveChainstate().ActivateBestChain(state, block)) {
+    if (!chainstate->ActivateBestChain(state, block)) {
         return error("%s: ActivateBestChain failed (%s)", __func__, state.ToString());
     }
 
@@ -5541,6 +5546,28 @@ SnapshotCompletionResult ChainstateManager::MaybeCompleteSnapshotValidation(
     this->MaybeRebalanceCaches();
 
     return SnapshotCompletionResult::SUCCESS;
+}
+
+Chainstate& ChainstateManager::GetChainstateForNewBlock(const uint256& blockhash)
+{
+    AssertLockHeld(::cs_main);
+    // Early return to avoid unnecessary blockindex lookup when assumeutxo is not in use.
+    if (!m_snapshot_chainstate) {
+        return *Assert(m_ibd_chainstate);
+    }
+
+    const auto* pblock{m_blockman.LookupBlockIndex(blockhash)};
+    // If pblock is null, we haven't seen the header for this block.
+    // Because we expect to have received the headers for the IBD chain
+    // contents before receiving blocks, this means that any block for
+    // which we don't have headers should go in the snapshot chain.
+    //
+    // Note that searching the snapshot chain (as below) implicitly searches the ibd
+    // chain, since the former includes the latter.
+    if (pblock == nullptr || !m_snapshot_chainstate->m_chain.Contains(pblock)) {
+        return *m_snapshot_chainstate.get();
+    }
+    return *Assert(m_ibd_chainstate);
 }
 
 Chainstate& ChainstateManager::ActiveChainstate() const

--- a/src/validation.h
+++ b/src/validation.h
@@ -1176,6 +1176,9 @@ public:
     //! @sa node/chainstate:LoadChainstate()
     bool ValidatedSnapshotCleanup() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
+    //! Returns true if any chainstate in use is in initial block download.
+    bool IsAnyChainInIBD() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
     ~ChainstateManager();
 };
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -1014,7 +1014,9 @@ public:
     Chainstate& InitializeChainstate(CTxMemPool* mempool) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     //! Get all chainstates currently being used.
-    std::vector<Chainstate*> GetAll();
+    //!
+    //! @param assumed_first  If true, return any assumedvalid chainstates first.
+    std::vector<Chainstate*> GetAll(bool assumed_first = false);
 
     //! Construct and activate a Chainstate on the basis of UTXO snapshot data.
     //!

--- a/src/validation.h
+++ b/src/validation.h
@@ -1044,6 +1044,18 @@ public:
             [](bilingual_str msg) { AbortNode(msg.original, msg); })
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
+    //! Return the relevant chainstate for a new block.
+    //!
+    //! Because the use of UTXO snapshots requires the simultaneous maintenance
+    //! of two chainstates, when a new block message arrives we have to decide
+    //! which chain we should attempt to append it to.
+    //!
+    //! If our active chainstate hasn't seen the incoming blockhash, return that.
+    //! Otherwise, return the snapshot chainstate since we're receiving a block that
+    //! has been assumed valid.
+    Chainstate& GetChainstateForNewBlock(
+        const uint256& blockhash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
     //! The most-work chain.
     Chainstate& ActiveChainstate() const;
     CChain& ActiveChain() const EXCLUSIVE_LOCKS_REQUIRED(GetMutex()) { return ActiveChainstate().m_chain; }


### PR DESCRIPTION
This is part of the [assumeutxo project](https://github.com/bitcoin/bitcoin/projects/11) (parent PR: #27596) 

---

This PR includes the changes necessary to perform network functionality with multiple chainstates in use. Various pieces of net_processing logic have to be modified in order to support block download that is simultaneous across numerous chainstates.

Changes include

- Modify FindNextBlocksToDownload() to parameterize the chainstate
  being worked on.

- Change GetNodeStateStats to take the max nCommonHeight per peer across
  all chainstates.

- Add CNodeState::chainstate_to_last_common_block
  * we need this to allow handling for a single peer to distinguish
    between separate chainstates we're simultaneously downloading blocks for

- Share `requests_available` across chainstates when finding the next blocks
  to download (during calls to FindNextBlocksToDownload()).

---

This PR shares commit https://github.com/jamesob/bitcoin/commit/17906dd52543fb75d2c45de884799b35ec5721f4 with #24006, and is included here so that the two changes can be reviewed in parallel.

This PR excludes a small net_processing commit, https://github.com/jamesob/bitcoin/commit/3e6164d96f9a42ecbf34359f6fd1af5413346933, which will be proposed for merge after #24006 since it relies on the introduction of the `BackgroundBlockConnected()` validationinterface event that the indexing changes introduce.

---

Some commits here are best reviewed with `--ignore-space-change`.

Unit-testing net_processing is notoriously difficult and with that in mind I haven't included any unittests here, but in parallel with review of these changes I will attempt to write some tests. Note that this behavior is covered in the functional tests included in the parent PR: https://github.com/jamesob/bitcoin/commit/c4949f2daf05289e76123b3c705277bf735a79d6