### PR TITLE
[contrib] Displaying the time spent in the guix build

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+start_time=$(date +%s%N)
+
 export LC_ALL=C
 set -e -o pipefail
 
@@ -475,3 +478,7 @@ EOF
     )
 
 done
+
+end_time=$(date +%s%N)
+
+echo "Elapsed time: $(($(($end_time-$start_time))/1000000)) milliseconds (~$(($(($end_time-$start_time))/60000000000)) minutes)"


### PR DESCRIPTION
Add the function of displaying the time spent in the guix build.

Guix building process takes a long time in the normal desktop pc, and this value can help in the work about improving performance.

Example, after complete building process of guix-build:
...
Elapsed time: 120007 milliseconds (~2 minute)