### PR TITLE
rest: Use query parameters to control resource loading

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -47,17 +47,23 @@ The HTTP request and response are both handled entirely in-memory.
 With the /notxdetails/ option JSON response will only contain the transaction hash instead of the complete transaction details. The option only affects the JSON response.
 
 #### Blockheaders
-`GET /rest/headers/<COUNT>/<BLOCK-HASH>.<bin|hex|json>`
+`GET /rest/headers/<BLOCK-HASH>.<bin|hex|json>?count=<COUNT=5>`
 
 Given a block hash: returns <COUNT> amount of blockheaders in upward direction.
 Returns empty if the block doesn't exist or it isn't in the active chain.
 
+*Deprecated (but not removed) since 23.0:*
+`GET /rest/headers/<COUNT>/<BLOCK-HASH>.<bin|hex|json>`
+
 #### Blockfilter Headers
-`GET /rest/blockfilterheaders/<FILTERTYPE>/<COUNT>/<BLOCK-HASH>.<bin|hex|json>`
+`GET /rest/blockfilterheaders/<FILTERTYPE>/<BLOCK-HASH>.<bin|hex|json>?count=<COUNT=5>`
 
 Given a block hash: returns <COUNT> amount of blockfilter headers in upward
 direction for the filter type <FILTERTYPE>.
 Returns empty if the block doesn't exist or it isn't in the active chain.
+
+*Deprecated (but not removed) since 23.0:*
+`GET /rest/blockfilterheaders/<FILTERTYPE>/<COUNT>/<BLOCK-HASH>.<bin|hex|json>`
 
 #### Blockfilters
 `GET /rest/blockfilter/<FILTERTYPE>/<BLOCK-HASH>.<bin|hex|json>`

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -198,6 +198,7 @@ BITCOIN_CORE_H = \
   psbt.h \
   random.h \
   randomenv.h \
+  rest.h \
   reverse_iterator.h \
   rpc/blockchain.h \
   rpc/client.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -116,6 +116,7 @@ BITCOIN_TESTS =\
   test/prevector_tests.cpp \
   test/raii_event_tests.cpp \
   test/random_tests.cpp \
+  test/rest_tests.cpp \
   test/reverselock_tests.cpp \
   test/rpc_tests.cpp \
   test/sanity_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -95,6 +95,7 @@ BITCOIN_TESTS =\
   test/fs_tests.cpp \
   test/getarg_tests.cpp \
   test/hash_tests.cpp \
+  test/httpserver_tests.cpp \
   test/i2p_tests.cpp \
   test/interfaces_tests.cpp \
   test/key_io_tests.cpp \

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -83,6 +83,19 @@ public:
      */
     RequestMethod GetRequestMethod() const;
 
+    /** Get the query parameter value from request uri for a specified key.
+     * Throws std::runtime_error if key does not exist and no default_val is specified.
+     *
+     * If the query string contains duplicate keys, the first value is returned. Many web frameworks
+     * would instead parse this as an array of values, but this is not (yet) implemented as it is
+     * currently not needed in any of the endpoints.
+     *
+     * @param[in] key represents the query parameter of which the value is returned
+     * @param[in] default_val (optional) is returned if key is not in query string
+     * @throws std::runtime_error if key is not in query string and no default_val was provided
+     */
+    std::string GetQueryParameter(const std::string& key, const std::string& default_val = "") const;
+
     /**
      * Get the request header specified by hdr, or an empty string.
      * Return a pair (isPresent,string).
@@ -114,6 +127,22 @@ public:
      */
     void WriteReply(int nStatus, const std::string& strReply = "");
 };
+
+/** Get the query parameter value from request uri for a specified key.
+     * Throws std::runtime_error if key does not exist and no default_val is specified.
+     *
+     * If the query string contains duplicate keys, the first value is returned. Many web frameworks
+     * would instead parse this as an array of values, but this is not (yet) implemented as it is
+     * currently not needed in any of the endpoints.
+     *
+     * Helper function for HTTPRequest::GetQueryParamater.
+     *
+     * @param[in] uri is the entire request uri
+     * @param[in] key represents the query parameter of which the value is returned
+     * @param[in] default_val (optional) is returned if key is not in query string
+     * @throws std::runtime_error if key is not in query string and no default_val was provided
+     */
+std::string GetQueryParameterFromUri(const std::string& uri, const std::string& key, const std::string& default_val = "");
 
 /** Event handler closure.
  */

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -14,6 +14,7 @@
 #include <node/context.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
+#include <rest.h>
 #include <rpc/blockchain.h>
 #include <rpc/protocol.h>
 #include <rpc/server.h>
@@ -27,6 +28,7 @@
 #include <version.h>
 
 #include <any>
+#include <string>
 
 #include <boost/algorithm/string.hpp>
 
@@ -39,13 +41,6 @@ using node::ReadBlockFromDisk;
 
 static const size_t MAX_GETUTXOS_OUTPOINTS = 15; //allow a max of 15 outpoints to be queried at once
 static constexpr unsigned int MAX_REST_HEADERS_RESULTS = 2000;
-
-enum class RetFormat {
-    UNDEF,
-    BINARY,
-    HEX,
-    JSON,
-};
 
 static const struct {
     RetFormat rf;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -193,15 +193,27 @@ static bool rest_headers(const std::any& context,
     std::vector<std::string> path;
     boost::split(path, param, boost::is_any_of("/"));
 
-    if (path.size() != 2)
-        return RESTERR(req, HTTP_BAD_REQUEST, "No header count specified. Use /rest/headers/<count>/<hash>.<ext>.");
-
-    const auto parsed_count{ToIntegral<size_t>(path[0])};
-    if (!parsed_count.has_value() || *parsed_count < 1 || *parsed_count > MAX_REST_HEADERS_RESULTS) {
-        return RESTERR(req, HTTP_BAD_REQUEST, strprintf("Header count is invalid or out of acceptable range (1-%u): %s", MAX_REST_HEADERS_RESULTS, path[0]));
+    std::string raw_count {};
+    std::string hashStr {};
+    if (path.size() == 2) {
+        // deprecated path: /rest/headers/<count>/<hash>
+        hashStr = path[1];
+        raw_count = path[0];
+    }
+    else if (path.size() == 1) {
+        // new path with query parameter: /rest/headers/<hash>?count=<count>
+        hashStr = path[0];
+        raw_count = req->GetQueryParameter("count", "5");;
+    }
+    else {
+        return RESTERR(req, HTTP_BAD_REQUEST, "Invalid request. Use /rest/headers/<hash>.<ext>?count=<count>");
     }
 
-    std::string hashStr = path[1];
+    auto parsed_count = ToIntegral<size_t>(raw_count);
+    if (!parsed_count.has_value() || *parsed_count < 1 || *parsed_count > MAX_REST_HEADERS_RESULTS) {
+        return RESTERR(req, HTTP_BAD_REQUEST, strprintf("Header count is invalid or out of acceptable range (1-%u): %s", MAX_REST_HEADERS_RESULTS, raw_count));
+    }
+
     uint256 hash;
     if (!ParseHashStr(hashStr, hash))
         return RESTERR(req, HTTP_BAD_REQUEST, "Invalid hash: " + hashStr);
@@ -353,13 +365,30 @@ static bool rest_filter_header(const std::any& context, HTTPRequest* req, const 
 
     std::vector<std::string> uri_parts;
     boost::split(uri_parts, param, boost::is_any_of("/"));
-    if (uri_parts.size() != 3) {
-        return RESTERR(req, HTTP_BAD_REQUEST, "Invalid URI format. Expected /rest/blockfilterheaders/<filtertype>/<count>/<blockhash>");
+    std::string raw_count {};
+    size_t blockhash_index {};
+    if (uri_parts.size() == 3) {
+        // deprecated path: /rest/blockfilterheaders/<filtertype>/<count>/<blockhash>
+        blockhash_index = 2;
+        raw_count = uri_parts[1];
+    }
+    else if (uri_parts.size() == 2) {
+        // new path with query parameter: /rest/blockfilterheaders/<filtertype>/<blockhash>?count=<count>
+        blockhash_index = 1;
+        raw_count = req->GetQueryParameter("count", "5");
+    }
+    else {
+        return RESTERR(req, HTTP_BAD_REQUEST, "Invalid URI format. Expected /rest/blockfilterheaders/<filtertype>/<blockhash>.<ext>?count=<count>");
+    }
+
+    auto parsed_count = ToIntegral<size_t>(raw_count);
+    if (!parsed_count.has_value() || *parsed_count < 1 || *parsed_count > MAX_REST_HEADERS_RESULTS) {
+        return RESTERR(req, HTTP_BAD_REQUEST, strprintf("Header count is invalid or out of acceptable range (1-%u): %s", MAX_REST_HEADERS_RESULTS, raw_count));
     }
 
     uint256 block_hash;
-    if (!ParseHashStr(uri_parts[2], block_hash)) {
-        return RESTERR(req, HTTP_BAD_REQUEST, "Invalid hash: " + uri_parts[2]);
+    if (!ParseHashStr(uri_parts[blockhash_index], block_hash)) {
+        return RESTERR(req, HTTP_BAD_REQUEST, "Invalid hash: " + uri_parts[blockhash_index]);
     }
 
     BlockFilterType filtertype;
@@ -370,11 +399,6 @@ static bool rest_filter_header(const std::any& context, HTTPRequest* req, const 
     BlockFilterIndex* index = GetBlockFilterIndex(filtertype);
     if (!index) {
         return RESTERR(req, HTTP_BAD_REQUEST, "Index is not enabled for filtertype " + uri_parts[0]);
-    }
-
-    const auto parsed_count{ToIntegral<size_t>(uri_parts[1])};
-    if (!parsed_count.has_value() || *parsed_count < 1 || *parsed_count > MAX_REST_HEADERS_RESULTS) {
-        return RESTERR(req, HTTP_BAD_REQUEST, strprintf("Header count is invalid or out of acceptable range (1-%u): %s", MAX_REST_HEADERS_RESULTS, uri_parts[1]));
     }
 
     std::vector<const CBlockIndex*> headers;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -132,17 +132,20 @@ static ChainstateManager* GetChainman(const std::any& context, HTTPRequest* req)
     return node_context->chainman.get();
 }
 
-static RetFormat ParseDataFormat(std::string& param, const std::string& strReq)
+RetFormat ParseDataFormat(std::string& param, const std::string& strReq)
 {
-    const std::string::size_type pos = strReq.rfind('.');
-    if (pos == std::string::npos)
+    const std::string::size_type pos_format = strReq.rfind('.');
+    if (pos_format == std::string::npos)
     {
         param = strReq;
         return rf_names[0].rf;
     }
 
-    param = strReq.substr(0, pos);
-    const std::string suff(strReq, pos + 1);
+    // query string (optional, separated with '?') should not interfere with parsing param and data format
+    const std::string::size_type pos_querystr = strReq.rfind('?');
+    auto len_suff = (pos_querystr != std::string::npos) ? (pos_querystr - pos_format - 1) : std::string::npos;
+    param = strReq.substr(0, pos_format);
+    const std::string suff(strReq, pos_format + 1, len_suff);
 
     for (const auto& rf_name : rf_names) {
         if (suff == rf_name.name)

--- a/src/rest.h
+++ b/src/rest.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2015-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_REST_H
+#define BITCOIN_REST_H
+
+#include <string>
+
+enum class RetFormat {
+    UNDEF,
+    BINARY,
+    HEX,
+    JSON,
+};
+
+RetFormat ParseDataFormat(std::string& param, const std::string& strReq);
+
+#endif // BITCOIN_REST_H

--- a/src/test/httpserver_tests.cpp
+++ b/src/test/httpserver_tests.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2012-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <httpserver.h>
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(httpserver_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(test_query_parameters)
+{
+    std::string uri;
+
+    // No parameters
+    uri = "localhost:8080/rest/headers/someresource.json";
+    BOOST_CHECK_THROW(GetQueryParameterFromUri(uri, "p1"), std::runtime_error);
+    BOOST_CHECK_EQUAL(GetQueryParameterFromUri(uri, "p1", "defaultval"), "defaultval");
+
+    // Single parameter
+    uri = "localhost:8080/rest/endpoint/someresource.json?p1=v1";
+    BOOST_CHECK_EQUAL(GetQueryParameterFromUri(uri, "p1"), "v1");
+    BOOST_CHECK_THROW(GetQueryParameterFromUri(uri, "p2"), std::runtime_error);
+
+    // Multiple parameters
+    uri = "/rest/endpoint/someresource.json?p1=v1&p2=v2";
+    BOOST_CHECK_EQUAL(GetQueryParameterFromUri(uri, "p1"), "v1");
+    BOOST_CHECK_EQUAL(GetQueryParameterFromUri(uri, "p2"), "v2");
+
+    // If the query string contains duplicate keys, the first value is returned
+    uri = "/rest/endpoint/someresource.json?p1=v1&p1=v2";
+    BOOST_CHECK_EQUAL(GetQueryParameterFromUri(uri, "p1"), "v1");
+
+    // Invalid query string syntax is the same as not having parameters
+    uri = "/rest/endpoint/someresource.json&p1=v1&p2=v2";
+    BOOST_CHECK_THROW(GetQueryParameterFromUri(uri, "p1"), std::runtime_error);
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/rest_tests.cpp
+++ b/src/test/rest_tests.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2012-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <rest.h>
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+
+BOOST_FIXTURE_TEST_SUITE(rest_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(test_query_string)
+{
+    std::string param;
+    RetFormat rf;
+    // No query string
+    rf = ParseDataFormat(param, "/rest/endpoint/someresource.json");
+    BOOST_CHECK_EQUAL(param, "/rest/endpoint/someresource");
+    BOOST_CHECK_EQUAL(rf, RetFormat::JSON);
+
+    // Query string with single parameter
+    rf = ParseDataFormat(param, "/rest/endpoint/someresource.json?p1=v1");
+    BOOST_CHECK_EQUAL(param, "/rest/endpoint/someresource");
+    BOOST_CHECK_EQUAL(rf, RetFormat::JSON);
+
+    // Query string with multiple parameters
+    rf = ParseDataFormat(param, "/rest/endpoint/someresource.json?p1=v1&p2=v2");
+    BOOST_CHECK_EQUAL(param, "/rest/endpoint/someresource");
+    BOOST_CHECK_EQUAL(rf, RetFormat::JSON);
+
+    // Incorrectly formed query string will not be handled
+    rf = ParseDataFormat(param, "/rest/endpoint/someresource.json&p1=v1");
+    BOOST_CHECK_EQUAL(param, "/rest/endpoint/someresource.json&p1=v1");
+    BOOST_CHECK_EQUAL(rf, RetFormat::UNDEF);
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -49,12 +49,13 @@ class RESTTest (BitcoinTestFramework):
 
     def test_rest_request(self, uri, http_method='GET', req_type=ReqType.JSON, body='', status=200, ret_type=RetType.JSON):
         rest_uri = '/rest' + uri
-        if req_type == ReqType.JSON:
-            rest_uri += '.json'
-        elif req_type == ReqType.BIN:
-            rest_uri += '.bin'
-        elif req_type == ReqType.HEX:
-            rest_uri += '.hex'
+        query_string = ''
+        if '?' in rest_uri:
+            rest_uri, query_string = rest_uri.split('?')
+            query_string = '?' + query_string
+        if req_type in ReqType:
+            rest_uri += f'.{req_type.name.lower()}'
+        rest_uri = rest_uri + query_string
 
         conn = http.client.HTTPConnection(self.url.hostname, self.url.port)
         self.log.debug(f'{http_method} {rest_uri} {body}')


### PR DESCRIPTION
In RESTful APIs, [typically](https://rapidapi.com/blog/api-glossary/parameters/query/) path parameters  (e.g. `/some/unique/resource/`) are used to represent resources, and query parameters (e.g. `?sort=asc`) are used to control how these resources are being loaded through e.g. sorting, pagination, filtering, ...

As first [discussed in #17631](https://github.com/bitcoin/bitcoin/pull/17631#discussion_r733031180), the [current REST api](https://github.com/bitcoin/bitcoin/blob/master/doc/REST-interface.md) contains two endpoints `/headers/` and `/blockfilterheaders/` that rather unexpectedly use path parameters to control how many (filter) headers are returned in the response. While this is no critical issue, it is unintuitive and we are still early enough to easily phase this behaviour out and ensure new endpoints (if any) do not have to stick to non-standard behaviour for just internal consistency.

In this PR, a new `HTTPRequest::GetQueryParameter` method is introduced to easily parse query parameters, as well as two new `/headers/` and `/blockfilterheaders/` endpoints that use a count query parameter are introduced. The old path parameter-based endpoints are kept without too much overhead, but the documentation now points to the new query parameter-based endpoints as the default interface to encourage standardness.

## Behaviour change
### New endpoints and default values
`/headers/` and `/blockfilterheaders/` now have 2 new endpoints that contain query parameters (`?count=<count>`) instead of path parameters (`/<count>/`), as described in REST-interface.md. Since query parameters can easily have default values, I have set this at 5 for both endpoints.

**headers**
`GET /rest/headers/<BLOCK-HASH>.<bin|hex|json>?count=<COUNT=5>`
should now be used instead of
`GET /rest/headers/<COUNT>/<BLOCK-HASH>.<bin|hex|json>`

**blockfilterheaders**
`GET /rest/blockfilterheaders/<FILTERTYPE>/<BLOCK-HASH>.<bin|hex|json>?count=<COUNT=5>`
should now be used instead of
`GET /rest/blockfilterheaders/<FILTERTYPE>/<COUNT>/<BLOCK-HASH>.<bin|hex|json>`

### Some previously invalid API calls are now valid
API calls that contained query strings in the URI could not be parsed prior to this PR. This PR changes behaviour in that previously invalid calls (e.g. `GET /rest/headers/5/somehash.json?someunusedparam=foo`) would now become valid, as the query parameters are properly parsed, and discarded if unused. 
For example, prior to this PR, adding an irrelevant `someparam` parameter would be illegal:
```
GET /rest/headers/5/0000004c6aad0c89c1c060e8e116dcd849e0554935cd78ff9c6a398abeac6eda.json?someparam=true
->
Invalid hash: 0000004c6aad0c89c1c060e8e116dcd849e0554935cd78ff9c6a398abeac6eda.json?someparam=true
```
**This behaviour change affects all rest endpoints, not just the 2 new ones introduced here.**

*(Note: I'd be open to implementing additional logic to refuse requests containing unrecognized query parameters to minimize behaviour change, but for the endpoints that we currently have I don't really see the point for that added complexity. E.g. I don't see any scenarios where misspelling a parameter could lead to harmful outcomes)*

## To do
- [ ] update `doc/release-notes`

## Feedback
This is my first PR (hooray!). Please don't hold back on any feedback/comments/nits/... you may have, big or small, whether they are code, process, language, ... related. I welcome private messages too if there's anything you don't want to clutter the PR with. I'm here to learn and am grateful for everyone's input.
