### PR TITLE
build: Upgrade default msvc platform

### DIFF
--- a/build_msvc/msvc-autogen.py
+++ b/build_msvc/msvc-autogen.py
@@ -9,7 +9,7 @@ import argparse
 from shutil import copyfile
 
 SOURCE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
-DEFAULT_PLATFORM_TOOLSET = R'v142'
+DEFAULT_PLATFORM_TOOLSET = R'v143'
 
 libs = [
     'libbitcoin_cli',


### PR DESCRIPTION
Support Visual Studio 2022.

Pass the full compile at Windows 11 and vcpkg 2021.12.01.