### PR TITLE
Remove cs_main lock annotation from ChainstateManager.m_blockman

### DIFF
--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -273,7 +273,7 @@ FUZZ_TARGET_INIT(coins_view, initialize_coins_view)
                 CCoinsStats stats{CoinStatsHashType::HASH_SERIALIZED};
                 bool expected_code_path = false;
                 try {
-                    (void)GetUTXOStats(&coins_view_cache, WITH_LOCK(::cs_main, return std::ref(g_setup->m_node.chainman->m_blockman)), stats);
+                    (void)GetUTXOStats(&coins_view_cache, g_setup->m_node.chainman->m_blockman, stats);
                 } catch (const std::logic_error&) {
                     expected_code_path = true;
                 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4873,7 +4873,7 @@ bool ChainstateManager::PopulateAndValidateSnapshot(
     // about the snapshot_chainstate.
     CCoinsViewDB* snapshot_coinsdb = WITH_LOCK(::cs_main, return &snapshot_chainstate.CoinsDB());
 
-    if (!GetUTXOStats(snapshot_coinsdb, WITH_LOCK(::cs_main, return std::ref(m_blockman)), stats, breakpoint_fnc)) {
+    if (!GetUTXOStats(snapshot_coinsdb, m_blockman, stats, breakpoint_fnc)) {
         LogPrintf("[snapshot] failed to generate coins stats\n");
         return false;
     }

--- a/src/validation.h
+++ b/src/validation.h
@@ -828,7 +828,7 @@ public:
     std::thread m_load_block;
     //! A single BlockManager instance is shared across each constructed
     //! chainstate to avoid duplicating block metadata.
-    node::BlockManager m_blockman GUARDED_BY(::cs_main);
+    node::BlockManager m_blockman;
 
     /**
      * In order to efficiently track invalidity of headers, we keep the set of


### PR DESCRIPTION
`BlockManager` is a large data structure, and `cs_main` is not required to take its address or access every part of it. Individual `BlockManager` fields and methods which do require `cs_main` like `m_block_index` and `LookupBlockIndex` are already annotated separately, and these other annotations describe locking requirements more accurately and do a better job enforcing thread safety.

Since `cs_main` is not needed to access the address of the m_block object, this commit drops `cs_main` LOCK calls which were added pointlessly to satisfy this annotation in the past.

Code changes were made by dongcarl, I just wrote the commit description