### PR TITLE
test: MiniWallet: support default `from_node` for sending/creating txs

### DIFF
--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -114,7 +114,7 @@ class BIP65Test(BitcoinTestFramework):
         # create one invalid tx per CLTV failure reason (5 in total) and collect them
         invalid_cltv_txs = []
         for i in range(5):
-            spendtx = wallet.create_self_transfer(from_node=self.nodes[0])['tx']
+            spendtx = wallet.create_self_transfer()['tx']
             cltv_invalidate(spendtx, i)
             invalid_cltv_txs.append(spendtx)
 
@@ -145,7 +145,7 @@ class BIP65Test(BitcoinTestFramework):
 
         # create and test one invalid tx per CLTV failure reason (5 in total)
         for i in range(5):
-            spendtx = wallet.create_self_transfer(from_node=self.nodes[0])['tx']
+            spendtx = wallet.create_self_transfer()['tx']
             cltv_invalidate(spendtx, i)
 
             expected_cltv_reject_reason = [

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -104,7 +104,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
 
     def create_self_transfer_from_utxo(self, input_tx):
         utxo = self.miniwallet.get_utxo(txid=input_tx.rehash(), mark_as_spent=False)
-        tx = self.miniwallet.create_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo)['tx']
+        tx = self.miniwallet.create_self_transfer(utxo_to_spend=utxo)['tx']
         return tx
 
     def create_bip112special(self, input, txversion):
@@ -124,7 +124,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
     def send_generic_input_tx(self, coinbases):
         input_txid = self.nodes[0].getblock(coinbases.pop(), 2)['tx'][0]['txid']
         utxo_to_spend = self.miniwallet.get_utxo(txid=input_txid)
-        return self.miniwallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo_to_spend)['tx']
+        return self.miniwallet.send_self_transfer(utxo_to_spend=utxo_to_spend)['tx']
 
     def create_bip68txs(self, bip68inputs, txversion, locktime_delta=0):
         """Returns a list of bip68 transactions with different bits set."""

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -57,7 +57,7 @@ class BIP66Test(BitcoinTestFramework):
 
     def create_tx(self, input_txid):
         utxo_to_spend = self.miniwallet.get_utxo(txid=input_txid, mark_as_spent=False)
-        return self.miniwallet.create_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo_to_spend)['tx']
+        return self.miniwallet.create_self_transfer(utxo_to_spend=utxo_to_spend)['tx']
 
     def test_dersig_info(self, *, is_active):
         assert_equal(self.nodes[0].getblockchaininfo()['softforks']['bip66'],

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -114,7 +114,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         """Simple doublespend"""
         # we use MiniWallet to create a transaction template with inputs correctly set,
         # and modify the output (amount, scriptPubKey) according to our needs
-        tx_template = self.wallet.create_self_transfer(from_node=self.nodes[0])['tx']
+        tx_template = self.wallet.create_self_transfer()['tx']
 
         tx1a = deepcopy(tx_template)
         tx1a.vout = [CTxOut(1 * COIN, DUMMY_P2WPKH_SCRIPT)]
@@ -554,7 +554,6 @@ class ReplaceByFeeTest(BitcoinTestFramework):
 
         # Create an explicitly opt-in parent transaction
         optin_parent_tx = self.wallet.send_self_transfer(
-            from_node=self.nodes[0],
             utxo_to_spend=confirmed_utxo,
             sequence=BIP125_SEQUENCE_NUMBER,
             fee_rate=Decimal('0.01'),
@@ -562,7 +561,6 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         assert_equal(True, self.nodes[0].getmempoolentry(optin_parent_tx['txid'])['bip125-replaceable'])
 
         replacement_parent_tx = self.wallet.create_self_transfer(
-            from_node=self.nodes[0],
             utxo_to_spend=confirmed_utxo,
             sequence=BIP125_SEQUENCE_NUMBER,
             fee_rate=Decimal('0.02'),
@@ -577,7 +575,6 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         # Create an opt-out child tx spending the opt-in parent
         parent_utxo = self.wallet.get_utxo(txid=optin_parent_tx['txid'])
         optout_child_tx = self.wallet.send_self_transfer(
-            from_node=self.nodes[0],
             utxo_to_spend=parent_utxo,
             sequence=0xffffffff,
             fee_rate=Decimal('0.01'),
@@ -587,7 +584,6 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         assert_equal(True, self.nodes[0].getmempoolentry(optout_child_tx['txid'])['bip125-replaceable'])
 
         replacement_child_tx = self.wallet.create_self_transfer(
-            from_node=self.nodes[0],
             utxo_to_spend=parent_utxo,
             sequence=0xffffffff,
             fee_rate=Decimal('0.02'),
@@ -606,7 +602,6 @@ class ReplaceByFeeTest(BitcoinTestFramework):
 
         self.log.info('Check that the child tx can still be replaced (via a tx that also replaces the parent)')
         replacement_parent_tx = self.wallet.send_self_transfer(
-            from_node=self.nodes[0],
             utxo_to_spend=confirmed_utxo,
             sequence=0xffffffff,
             fee_rate=Decimal('0.03'),
@@ -616,7 +611,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         self.wallet.get_utxo(txid=optout_child_tx['txid'])
 
     def test_replacement_relay_fee(self):
-        tx = self.wallet.send_self_transfer(from_node=self.nodes[0])['tx']
+        tx = self.wallet.send_self_transfer()['tx']
 
         # Higher fee, higher feerate, different txid, but the replacement does not provide a relay
         # fee conforming to node's `incrementalrelayfee` policy of 1000 sat per KB.

--- a/test/functional/feature_txindex_compatibility.py
+++ b/test/functional/feature_txindex_compatibility.py
@@ -44,7 +44,7 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
         mini_wallet = MiniWallet(self.nodes[1])
         mini_wallet.rescan_utxos()
         spend_utxo = mini_wallet.get_utxo()
-        mini_wallet.send_self_transfer(from_node=self.nodes[1], utxo_to_spend=spend_utxo)
+        mini_wallet.send_self_transfer(utxo_to_spend=spend_utxo)
         self.generate(self.nodes[1], 1)
 
         self.log.info("Check legacy txindex")

--- a/test/functional/feature_utxo_set_hash.py
+++ b/test/functional/feature_utxo_set_hash.py
@@ -36,7 +36,7 @@ class UTXOSetHashTest(BitcoinTestFramework):
         blocks.pop(0)
 
         # Create a spending transaction and mine a block which includes it
-        txid = wallet.send_self_transfer(from_node=node)['txid']
+        txid = wallet.send_self_transfer()['txid']
         tx_block = self.generateblock(node, output=wallet.get_address(), transactions=[txid])
         blocks.append(from_hex(CBlock(), node.getblock(tx_block['hash'], False)))
 

--- a/test/functional/mempool_compatibility.py
+++ b/test/functional/mempool_compatibility.py
@@ -66,7 +66,7 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
         assert old_tx_hash in new_node.getrawmempool()
 
         self.log.info("Add unbroadcasted tx to mempool on new node and shutdown")
-        unbroadcasted_tx_hash = new_wallet.send_self_transfer(from_node=new_node)['txid']
+        unbroadcasted_tx_hash = new_wallet.send_self_transfer()['txid']
         assert unbroadcasted_tx_hash in new_node.getrawmempool()
         assert new_node.getmempoolentry(unbroadcasted_tx_hash)['unbroadcast']
         self.stop_node(1)

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -61,7 +61,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         self.generate(node, COINBASE_MATURITY - 1)
 
         self.log.info('Create a mempool tx that will be evicted')
-        tx_to_be_evicted_id = miniwallet.send_self_transfer(from_node=node, fee_rate=relayfee)["txid"]
+        tx_to_be_evicted_id = miniwallet.send_self_transfer(fee_rate=relayfee)["txid"]
 
         # Increase the tx fee rate to give the subsequent transactions a higher priority in the mempool
         # The tx has an approx. vsize of 65k, i.e. multiplying the previous fee rate (in sats/kvB)
@@ -85,7 +85,7 @@ class MempoolLimitTest(BitcoinTestFramework):
 
         # Deliberately try to create a tx with a fee less than the minimum mempool fee to assert that it does not get added to the mempool
         self.log.info('Create a mempool tx that will not pass mempoolminfee')
-        assert_raises_rpc_error(-26, "mempool min fee not met", miniwallet.send_self_transfer, from_node=node, fee_rate=relayfee, mempool_valid=False)
+        assert_raises_rpc_error(-26, "mempool min fee not met", miniwallet.send_self_transfer, fee_rate=relayfee, mempool_valid=False)
 
 
 if __name__ == '__main__':

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -70,7 +70,7 @@ class MempoolPersistTest(BitcoinTestFramework):
         self.log.debug("Send 5 transactions from node2 (to its own address)")
         tx_creation_time_lower = int(time.time())
         for _ in range(5):
-            last_txid = self.mini_wallet.send_self_transfer(from_node=self.nodes[2])["txid"]
+            last_txid = self.mini_wallet.send_self_transfer()["txid"]
         if self.is_sqlite_compiled():
             self.nodes[2].syncwithvalidationinterfacequeue()  # Flush mempool to wallet
             node2_balance = wallet_watch.getbalance()

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -45,14 +45,13 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         utxo_2 = wallet.get_utxo(txid=coinbase_txids[2])
         utxo_3 = wallet.get_utxo(txid=coinbase_txids[3])
         self.log.info("Create three transactions spending from coinbase utxos: spend_1, spend_2, spend_3")
-        spend_1 = wallet.create_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo_1)
-        spend_2 = wallet.create_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo_2)
-        spend_3 = wallet.create_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo_3)
+        spend_1 = wallet.create_self_transfer(utxo_to_spend=utxo_1)
+        spend_2 = wallet.create_self_transfer(utxo_to_spend=utxo_2)
+        spend_3 = wallet.create_self_transfer(utxo_to_spend=utxo_3)
 
         self.log.info("Create another transaction which is time-locked to two blocks in the future")
         utxo = wallet.get_utxo(txid=coinbase_txids[0])
         timelock_tx = wallet.create_self_transfer(
-            from_node=self.nodes[0],
             utxo_to_spend=utxo,
             mempool_valid=False,
             locktime=self.nodes[0].getblockcount() + 2
@@ -62,8 +61,8 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         assert_raises_rpc_error(-26, "non-final", self.nodes[0].sendrawtransaction, timelock_tx)
 
         self.log.info("Broadcast and mine spend_2 and spend_3")
-        wallet.sendrawtransaction(from_node=self.nodes[0], tx_hex=spend_2['hex'])
-        wallet.sendrawtransaction(from_node=self.nodes[0], tx_hex=spend_3['hex'])
+        wallet.sendrawtransaction(tx_hex=spend_2['hex'])
+        wallet.sendrawtransaction(tx_hex=spend_3['hex'])
         self.log.info("Generate a block")
         self.generate(self.nodes[0], 1)
         self.log.info("Check that time-locked transaction is still too immature to spend")
@@ -71,9 +70,9 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
 
         self.log.info("Create spend_2_1 and spend_3_1")
         spend_2_utxo = wallet.get_utxo(txid=spend_2['txid'])
-        spend_2_1 = wallet.create_self_transfer(from_node=self.nodes[0], utxo_to_spend=spend_2_utxo)
+        spend_2_1 = wallet.create_self_transfer(utxo_to_spend=spend_2_utxo)
         spend_3_utxo = wallet.get_utxo(txid=spend_3['txid'])
-        spend_3_1 = wallet.create_self_transfer(from_node=self.nodes[0], utxo_to_spend=spend_3_utxo)
+        spend_3_1 = wallet.create_self_transfer(utxo_to_spend=spend_3_utxo)
 
         self.log.info("Broadcast and mine spend_3_1")
         spend_3_1_id = self.nodes[0].sendrawtransaction(spend_3_1['hex'])

--- a/test/functional/mempool_resurrect.py
+++ b/test/functional/mempool_resurrect.py
@@ -33,9 +33,9 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         # Mine a new block
         # ... make sure all the transactions are confirmed again
         blocks = []
-        spends1_ids = [wallet.send_self_transfer(from_node=node)['txid'] for _ in range(3)]
+        spends1_ids = [wallet.send_self_transfer()['txid'] for _ in range(3)]
         blocks.extend(self.generate(node, 1))
-        spends2_ids = [wallet.send_self_transfer(from_node=node)['txid'] for _ in range(3)]
+        spends2_ids = [wallet.send_self_transfer()['txid'] for _ in range(3)]
         blocks.extend(self.generate(node, 1))
 
         spends_ids = set(spends1_ids + spends2_ids)

--- a/test/functional/mempool_spend_coinbase.py
+++ b/test/functional/mempool_spend_coinbase.py
@@ -37,10 +37,10 @@ class MempoolSpendCoinbaseTest(BitcoinTestFramework):
         utxo_mature = wallet.get_utxo(txid=coinbase_txid(chain_height - 100 + 1))
         utxo_immature = wallet.get_utxo(txid=coinbase_txid(chain_height - 100 + 2))
 
-        spend_mature_id = wallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo_mature)["txid"]
+        spend_mature_id = wallet.send_self_transfer(utxo_to_spend=utxo_mature)["txid"]
 
         # other coinbase should be too immature to spend
-        immature_tx = wallet.create_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo_immature, mempool_valid=False)
+        immature_tx = wallet.create_self_transfer(utxo_to_spend=utxo_immature, mempool_valid=False)
         assert_raises_rpc_error(-26,
                                 "bad-txns-premature-spend-of-coinbase",
                                 lambda: self.nodes[0].sendrawtransaction(immature_tx['hex']))

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -95,7 +95,7 @@ class MiningTest(BitcoinTestFramework):
         assert_equal(mining_info['pooledtx'], 0)
 
         self.log.info("getblocktemplate: Test default witness commitment")
-        txid = int(self.wallet.send_self_transfer(from_node=node)['wtxid'], 16)
+        txid = int(self.wallet.send_self_transfer()['wtxid'], 16)
         tmpl = node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
 
         # Check that default_witness_commitment is present.

--- a/test/functional/p2p_blocksonly.py
+++ b/test/functional/p2p_blocksonly.py
@@ -102,7 +102,7 @@ class P2PBlocksOnly(BitcoinTestFramework):
 
     def check_p2p_tx_violation(self):
         self.log.info('Check that txs from P2P are rejected and result in disconnect')
-        spendtx = self.miniwallet.create_self_transfer(from_node=self.nodes[0])
+        spendtx = self.miniwallet.create_self_transfer()
 
         with self.nodes[0].assert_debug_log(['transaction sent in violation of protocol peer=0']):
             self.nodes[0].p2ps[0].send_message(msg_tx(spendtx['tx']))

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -298,7 +298,7 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         segwit_tx_generated = False
         for _ in range(num_transactions):
-            hex_tx = self.wallet.send_self_transfer(from_node=self.nodes[0])['hex']
+            hex_tx = self.wallet.send_self_transfer()['hex']
             tx = tx_from_hex(hex_tx)
             if not tx.wit.is_null():
                 segwit_tx_generated = True

--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -136,7 +136,7 @@ class FilterTest(BitcoinTestFramework):
         filter_peer = P2PBloomFilter()
 
         self.log.debug("Create a tx relevant to the peer before connecting")
-        txid, _ = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=filter_peer.watch_script_pubkey, amount=9 * COIN)
+        txid, _ = self.wallet.send_to(scriptPubKey=filter_peer.watch_script_pubkey, amount=9 * COIN)
 
         self.log.debug("Send a mempool msg after connecting and check that the tx is received")
         self.nodes[0].add_p2p_connection(filter_peer)
@@ -147,7 +147,7 @@ class FilterTest(BitcoinTestFramework):
     def test_frelay_false(self, filter_peer):
         self.log.info("Check that a node with fRelay set to false does not receive invs until the filter is set")
         filter_peer.tx_received = False
-        self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=filter_peer.watch_script_pubkey, amount=9 * COIN)
+        self.wallet.send_to(scriptPubKey=filter_peer.watch_script_pubkey, amount=9 * COIN)
         # Sync to make sure the reason filter_peer doesn't receive the tx is not p2p delays
         filter_peer.sync_with_ping()
         assert not filter_peer.tx_received
@@ -176,21 +176,21 @@ class FilterTest(BitcoinTestFramework):
         self.log.info('Check that we not receive a tx if the filter does not match a mempool tx')
         filter_peer.merkleblock_received = False
         filter_peer.tx_received = False
-        self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=getnewdestination()[1], amount=7 * COIN)
+        self.wallet.send_to(scriptPubKey=getnewdestination()[1], amount=7 * COIN)
         filter_peer.sync_send_with_ping()
         assert not filter_peer.merkleblock_received
         assert not filter_peer.tx_received
 
         self.log.info('Check that we receive a tx if the filter matches a mempool tx')
         filter_peer.merkleblock_received = False
-        txid, _ = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=filter_peer.watch_script_pubkey, amount=9 * COIN)
+        txid, _ = self.wallet.send_to(scriptPubKey=filter_peer.watch_script_pubkey, amount=9 * COIN)
         filter_peer.wait_for_tx(txid)
         assert not filter_peer.merkleblock_received
 
         self.log.info('Check that after deleting filter all txs get relayed again')
         filter_peer.send_and_ping(msg_filterclear())
         for _ in range(5):
-            txid, _ = self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=getnewdestination()[1], amount=7 * COIN)
+            txid, _ = self.wallet.send_to(scriptPubKey=getnewdestination()[1], amount=7 * COIN)
             filter_peer.wait_for_tx(txid)
 
         self.log.info('Check that request for filtered blocks is ignored if no filter is set')

--- a/test/functional/p2p_leak_tx.py
+++ b/test/functional/p2p_leak_tx.py
@@ -36,7 +36,7 @@ class P2PLeakTxTest(BitcoinTestFramework):
         self.log.info("Running test up to {} times.".format(MAX_REPEATS))
         for i in range(MAX_REPEATS):
             self.log.info('Run repeat {}'.format(i + 1))
-            txid = miniwallet.send_self_transfer(from_node=gen_node)['wtxid']
+            txid = miniwallet.send_self_transfer()['wtxid']
 
             want_tx = msg_getdata()
             want_tx.inv.append(CInv(t=MSG_TX, h=int(txid, 16)))

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -443,7 +443,7 @@ class BlockchainTest(BitcoinTestFramework):
         fee_per_byte = Decimal('0.00000010')
         fee_per_kb = 1000 * fee_per_byte
 
-        self.wallet.send_self_transfer(fee_rate=fee_per_kb, from_node=node)
+        self.wallet.send_self_transfer(fee_rate=fee_per_kb)
         blockhash = self.generate(node, 1)[0]
 
         def assert_fee_not_in_block(verbosity):

--- a/test/functional/rpc_generateblock.py
+++ b/test/functional/rpc_generateblock.py
@@ -53,17 +53,17 @@ class GenerateBlockTest(BitcoinTestFramework):
 
         # Generate some extra mempool transactions to verify they don't get mined
         for _ in range(10):
-            miniwallet.send_self_transfer(from_node=node)
+            miniwallet.send_self_transfer()
 
         self.log.info('Generate block with txid')
-        txid = miniwallet.send_self_transfer(from_node=node)['txid']
+        txid = miniwallet.send_self_transfer()['txid']
         hash = self.generateblock(node, address, [txid])['hash']
         block = node.getblock(hash, 1)
         assert_equal(len(block['tx']), 2)
         assert_equal(block['tx'][1], txid)
 
         self.log.info('Generate block with raw tx')
-        rawtx = miniwallet.create_self_transfer(from_node=node)['hex']
+        rawtx = miniwallet.create_self_transfer()['hex']
         hash = self.generateblock(node, address, [rawtx])['hash']
 
         block = node.getblock(hash, 1)
@@ -72,9 +72,9 @@ class GenerateBlockTest(BitcoinTestFramework):
         assert_equal(node.getrawtransaction(txid=txid, verbose=False, blockhash=hash), rawtx)
 
         self.log.info('Fail to generate block with out of order txs')
-        txid1 = miniwallet.send_self_transfer(from_node=node)['txid']
+        txid1 = miniwallet.send_self_transfer()['txid']
         utxo1 = miniwallet.get_utxo(txid=txid1)
-        rawtx2 = miniwallet.create_self_transfer(from_node=node, utxo_to_spend=utxo1)['hex']
+        rawtx2 = miniwallet.create_self_transfer(utxo_to_spend=utxo1)['hex']
         assert_raises_rpc_error(-25, 'TestBlockValidity failed: bad-txns-inputs-missingorspent', self.generateblock, node, address, [rawtx2, txid1])
 
         self.log.info('Fail to generate block with txid not in mempool')

--- a/test/functional/rpc_mempool_entry_fee_fields_deprecation.py
+++ b/test/functional/rpc_mempool_entry_fee_fields_deprecation.py
@@ -29,7 +29,7 @@ class MempoolFeeFieldsDeprecationTest(BitcoinTestFramework):
 
         # we create the tx on the first node and wait until it syncs to node_deprecated
         # thus, any differences must be coming from getmempoolentry or getrawmempool
-        tx = self.wallet.send_self_transfer(from_node=self.nodes[0])
+        tx = self.wallet.send_self_transfer()
         self.nodes[1].sendrawtransaction(tx["hex"])
 
         deprecated_fields = ["ancestorfees", "descendantfees", "modifiedfee", "fee"]

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -79,7 +79,7 @@ class NetTest(BitcoinTestFramework):
     def test_getpeerinfo(self):
         self.log.info("Test getpeerinfo")
         # Create a few getpeerinfo last_block/last_transaction values.
-        self.wallet.send_self_transfer(from_node=self.nodes[0]) # Make a transaction so we can see it in the getpeerinfo results
+        self.wallet.send_self_transfer() # Make a transaction so we can see it in the getpeerinfo results
         self.generate(self.nodes[1], 1)
         time_now = int(time.time())
         peer_info = [x.getpeerinfo() for x in self.nodes]

--- a/test/functional/rpc_scantxoutset.py
+++ b/test/functional/rpc_scantxoutset.py
@@ -27,7 +27,7 @@ class ScantxoutsetTest(BitcoinTestFramework):
         # interpret strings as addresses, assume scriptPubKey otherwise
         if isinstance(destination, str):
             destination = address_to_scriptpubkey(destination)
-        self.wallet.send_to(from_node=self.nodes[0], scriptPubKey=destination, amount=int(COIN * amount))
+        self.wallet.send_to(scriptPubKey=destination, amount=int(COIN * amount))
 
     def run_test(self):
         self.wallet = MiniWallet(self.nodes[0])

--- a/test/functional/rpc_txoutproof.py
+++ b/test/functional/rpc_txoutproof.py
@@ -35,8 +35,8 @@ class MerkleBlockTest(BitcoinTestFramework):
         chain_height = self.nodes[1].getblockcount()
         assert_equal(chain_height, 105)
 
-        txid1 = miniwallet.send_self_transfer(from_node=self.nodes[0])['txid']
-        txid2 = miniwallet.send_self_transfer(from_node=self.nodes[0])['txid']
+        txid1 = miniwallet.send_self_transfer()['txid']
+        txid2 = miniwallet.send_self_transfer()['txid']
         # This will raise an exception because the transaction is not yet in a block
         assert_raises_rpc_error(-5, "Transaction not yet in block", self.nodes[0].gettxoutproof, [txid1])
 
@@ -53,7 +53,7 @@ class MerkleBlockTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].verifytxoutproof(self.nodes[0].gettxoutproof([txid1, txid2], blockhash)), txlist)
 
         txin_spent = miniwallet.get_utxo(txid=txid2)  # Get the change from txid2
-        tx3 = miniwallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=txin_spent)
+        tx3 = miniwallet.send_self_transfer(utxo_to_spend=txin_spent)
         txid3 = tx3['txid']
         self.generate(self.nodes[0], 1)
 

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -157,10 +157,10 @@ class MiniWallet:
     def send_self_transfer(self, **kwargs):
         """Create and send a tx with the specified fee_rate. Fee may be exact or at most one satoshi higher than needed."""
         tx = self.create_self_transfer(**kwargs)
-        self.sendrawtransaction(from_node=kwargs['from_node'], tx_hex=tx['hex'])
+        self.sendrawtransaction(from_node=kwargs.get('from_node'), tx_hex=tx['hex'])
         return tx
 
-    def send_to(self, *, from_node, scriptPubKey, amount, fee=1000):
+    def send_to(self, *, from_node=None, scriptPubKey, amount, fee=1000):
         """
         Create and send a tx with an output to a given scriptPubKey/amount,
         plus a change output to our internal address. To keep things simple, a
@@ -172,6 +172,7 @@ class MiniWallet:
 
         Returns a tuple (txid, n) referring to the created external utxo outpoint.
         """
+        from_node = from_node or self._test_node
         tx = self.create_self_transfer(from_node=from_node, fee_rate=0, mempool_valid=False)['tx']
         assert_greater_than_or_equal(tx.vout[0].nValue, amount + fee)
         tx.vout[0].nValue -= (amount + fee)           # change output -> MiniWallet
@@ -179,8 +180,9 @@ class MiniWallet:
         txid = self.sendrawtransaction(from_node=from_node, tx_hex=tx.serialize().hex())
         return txid, 1
 
-    def create_self_transfer(self, *, fee_rate=Decimal("0.003"), from_node, utxo_to_spend=None, mempool_valid=True, locktime=0, sequence=0):
+    def create_self_transfer(self, *, fee_rate=Decimal("0.003"), from_node=None, utxo_to_spend=None, mempool_valid=True, locktime=0, sequence=0):
         """Create and return a tx with the specified fee_rate. Fee may be exact or at most one satoshi higher than needed."""
+        from_node = from_node or self._test_node
         utxo_to_spend = utxo_to_spend or self.get_utxo()
         if self._priv_key is None:
             vsize = Decimal(104)  # anyone-can-spend
@@ -213,7 +215,8 @@ class MiniWallet:
             assert_equal(tx_info['fees']['base'], utxo_to_spend['value'] - Decimal(send_value) / COIN)
         return {'txid': tx_info['txid'], 'wtxid': tx_info['wtxid'], 'hex': tx_hex, 'tx': tx}
 
-    def sendrawtransaction(self, *, from_node, tx_hex):
+    def sendrawtransaction(self, *, from_node=None, tx_hex):
+        from_node = from_node or self._test_node
         txid = from_node.sendrawtransaction(tx_hex)
         self.scan_tx(from_node.decoderawtransaction(tx_hex))
         return txid

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -269,7 +269,7 @@ def test_bumpfee_with_descendant_fails(self, rbf_node, rbf_node_address, dest_ad
     parent_id = spend_one_input(rbf_node, miniwallet.get_address())
     tx = rbf_node.gettransaction(txid=parent_id, verbose=True)['decoded']
     miniwallet.scan_tx(tx)
-    miniwallet.send_self_transfer(from_node=rbf_node)
+    miniwallet.send_self_transfer()
     assert_raises_rpc_error(-8, "Transaction has descendants in the mempool", rbf_node.bumpfee, parent_id)
     self.clear_mempool()
 


### PR DESCRIPTION
In most functional tests using MiniWallet, the node that is used for the sending/creation  of transactions (parameter `from_node` to the methods `send_to`, `create_self_transfer`, `send_self_transfer` and `send_to`) is identical to the one passed to the MiniWallet instance (parameter `test_node`). This especially applies for tests with only one node `self.nodes[0]`.

This PR changes those methods to support a default `from_node` and applies it to all functional tests where it makes sense, i.e. passing `from_node` explicitely only remains if it differs from the wallet `test_node` or if it is important for readability (e.g. in `p2p_feefilter.py`, two different nodes are used intermittently).

The instances to tackle were identified via `git grep from_node= ./test/functional/*.py`.