### PR TITLE
p2p: delete anchors.dat after trying to connect to that peers

### DIFF
--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -233,3 +233,5 @@ std::vector<CAddress> ReadAnchors(const fs::path& anchors_db_path)
     fs::remove(anchors_db_path);
     return anchors;
 }
+
+void DeleteAnchorsFile(const fs::path& anchors_db_path) { fs::remove(anchors_db_path); }

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -230,7 +230,6 @@ std::vector<CAddress> ReadAnchors(const fs::path& anchors_db_path)
         anchors.clear();
     }
 
-    fs::remove(anchors_db_path);
     return anchors;
 }
 

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -24,6 +24,9 @@
 
 namespace {
 
+/** Anchor IP address database file name */
+const char* const ANCHORS_DATABASE_FILENAME = "anchors.dat";
+
 class DbNotFoundError : public std::exception
 {
     using std::exception::exception;
@@ -214,18 +217,20 @@ std::optional<bilingual_str> LoadAddrman(const NetGroupManager& netgroupman, con
     return std::nullopt;
 }
 
-void DumpAnchors(const fs::path& anchors_db_path, const std::vector<CAddress>& anchors)
+void DumpAnchors(const std::vector<CAddress>& anchors)
 {
+    const fs::path path{gArgs.GetDataDirNet() / ANCHORS_DATABASE_FILENAME};
     LOG_TIME_SECONDS(strprintf("Flush %d outbound block-relay-only peer addresses to anchors.dat", anchors.size()));
-    SerializeFileDB("anchors", anchors_db_path, anchors, CLIENT_VERSION | ADDRV2_FORMAT);
+    SerializeFileDB("anchors", path, anchors, CLIENT_VERSION | ADDRV2_FORMAT);
 }
 
-std::vector<CAddress> ReadAnchors(const fs::path& anchors_db_path)
+std::vector<CAddress> ReadAnchors()
 {
     std::vector<CAddress> anchors;
+    const fs::path path{gArgs.GetDataDirNet() / ANCHORS_DATABASE_FILENAME};
     try {
-        DeserializeFileDB(anchors_db_path, anchors, CLIENT_VERSION | ADDRV2_FORMAT);
-        LogPrintf("Loaded %i addresses from %s\n", anchors.size(), fs::quoted(fs::PathToString(anchors_db_path.filename())));
+        DeserializeFileDB(path, anchors, CLIENT_VERSION | ADDRV2_FORMAT);
+        LogPrintf("Loaded %i addresses from %s\n", anchors.size(), fs::quoted(fs::PathToString(path.filename())));
     } catch (const std::exception&) {
         anchors.clear();
     }
@@ -233,4 +238,8 @@ std::vector<CAddress> ReadAnchors(const fs::path& anchors_db_path)
     return anchors;
 }
 
-void DeleteAnchorsFile(const fs::path& anchors_db_path) { fs::remove(anchors_db_path); }
+void DeleteAnchorsFile()
+{
+    const fs::path path{gArgs.GetDataDirNet() / ANCHORS_DATABASE_FILENAME};
+    fs::remove(path);
+}

--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -59,12 +59,10 @@ std::optional<bilingual_str> LoadAddrman(const NetGroupManager& netgroupman, con
  */
 void DumpAnchors(const fs::path& anchors_db_path, const std::vector<CAddress>& anchors);
 
-/**
- * Read the anchor IP address database (anchors.dat)
- *
- * Deleting anchors.dat is intentional as it avoids renewed peering to anchors after
- * an unclean shutdown and thus potential exploitation of the anchor peer policy.
- */
+/** Read the anchor IP address database (anchors.dat) */
 std::vector<CAddress> ReadAnchors(const fs::path& anchors_db_path);
+
+/** Delete the anchor IP address database (anchors.dat) */
+void DeleteAnchorsFile(const fs::path& anchors_db_path);
 
 #endif // BITCOIN_ADDRDB_H

--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -57,12 +57,12 @@ std::optional<bilingual_str> LoadAddrman(const NetGroupManager& netgroupman, con
  * Anchors are last known outgoing block-relay-only peers that are
  * tried to re-connect to on startup.
  */
-void DumpAnchors(const fs::path& anchors_db_path, const std::vector<CAddress>& anchors);
+void DumpAnchors(const std::vector<CAddress>& anchors);
 
 /** Read the anchor IP address database (anchors.dat) */
-std::vector<CAddress> ReadAnchors(const fs::path& anchors_db_path);
+std::vector<CAddress> ReadAnchors();
 
 /** Delete the anchor IP address database (anchors.dat) */
-void DeleteAnchorsFile(const fs::path& anchors_db_path);
+void DeleteAnchorsFile();
 
 #endif // BITCOIN_ADDRDB_H

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1762,11 +1762,13 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
 
         const auto current_time{NodeClock::now()};
         int nTries = 0;
+        bool delete_anchors_file{false};
         while (!interruptNet)
         {
             if (anchor && !m_anchors.empty()) {
                 const CAddress addr = m_anchors.back();
                 m_anchors.pop_back();
+                if (m_anchors.empty()) delete_anchors_file = true;
                 if (!addr.IsValid() || IsLocal(addr) || !IsReachable(addr) ||
                     !HasAllDesirableServiceFlags(addr.nServices) ||
                     setConnected.count(m_netgroupman.GetGroup(addr))) continue;
@@ -1855,6 +1857,10 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
             }
 
             OpenNetworkConnection(addrConnect, (int)setConnected.size() >= std::min(nMaxConnections - 1, 2), &grant, nullptr, conn_type);
+        }
+
+        if (delete_anchors_file) {
+            DeleteAnchorsFile(gArgs.GetDataDirNet() / ANCHORS_DATABASE_FILENAME);
         }
     }
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -61,8 +61,6 @@
 /** Maximum number of block-relay-only anchor connections */
 static constexpr size_t MAX_BLOCK_RELAY_ONLY_ANCHORS = 2;
 static_assert (MAX_BLOCK_RELAY_ONLY_ANCHORS <= static_cast<size_t>(MAX_BLOCK_RELAY_ONLY_CONNECTIONS), "MAX_BLOCK_RELAY_ONLY_ANCHORS must not exceed MAX_BLOCK_RELAY_ONLY_CONNECTIONS.");
-/** Anchor IP address database file name */
-const char* const ANCHORS_DATABASE_FILENAME = "anchors.dat";
 
 // How often to dump addresses to peers.dat
 static constexpr std::chrono::minutes DUMP_PEERS_INTERVAL{15};
@@ -1861,7 +1859,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
 
         if (delete_anchors_file) {
             tried_connect_anchors = true;
-            DeleteAnchorsFile(gArgs.GetDataDirNet() / ANCHORS_DATABASE_FILENAME);
+            DeleteAnchorsFile();
         }
     }
 }
@@ -2300,12 +2298,12 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
 
     if (m_use_addrman_outgoing) {
         // Load addresses from anchors.dat
-        m_anchors = ReadAnchors(gArgs.GetDataDirNet() / ANCHORS_DATABASE_FILENAME);
+        m_anchors = ReadAnchors();
         if (m_anchors.size() > MAX_BLOCK_RELAY_ONLY_ANCHORS) {
             m_anchors.resize(MAX_BLOCK_RELAY_ONLY_ANCHORS);
         } else if (m_anchors.empty()) {
             tried_connect_anchors = true;
-            DeleteAnchorsFile(gArgs.GetDataDirNet() / ANCHORS_DATABASE_FILENAME);
+            DeleteAnchorsFile();
         }
         LogPrintf("%i block-relay-only anchors will be tried for connections.\n", m_anchors.size());
     }
@@ -2447,7 +2445,7 @@ void CConnman::StopNodes()
             }
 
             if (tried_connect_anchors) {
-                DumpAnchors(gArgs.GetDataDirNet() / ANCHORS_DATABASE_FILENAME, anchors_to_dump);
+                DumpAnchors(anchors_to_dump);
             }
         }
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2302,6 +2302,8 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
         m_anchors = ReadAnchors(gArgs.GetDataDirNet() / ANCHORS_DATABASE_FILENAME);
         if (m_anchors.size() > MAX_BLOCK_RELAY_ONLY_ANCHORS) {
             m_anchors.resize(MAX_BLOCK_RELAY_ONLY_ANCHORS);
+        } else if (m_anchors.empty()) {
+            DeleteAnchorsFile(gArgs.GetDataDirNet() / ANCHORS_DATABASE_FILENAME);
         }
         LogPrintf("%i block-relay-only anchors will be tried for connections.\n", m_anchors.size());
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1860,6 +1860,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
         }
 
         if (delete_anchors_file) {
+            tried_connect_anchors = true;
             DeleteAnchorsFile(gArgs.GetDataDirNet() / ANCHORS_DATABASE_FILENAME);
         }
     }
@@ -2303,6 +2304,7 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
         if (m_anchors.size() > MAX_BLOCK_RELAY_ONLY_ANCHORS) {
             m_anchors.resize(MAX_BLOCK_RELAY_ONLY_ANCHORS);
         } else if (m_anchors.empty()) {
+            tried_connect_anchors = true;
             DeleteAnchorsFile(gArgs.GetDataDirNet() / ANCHORS_DATABASE_FILENAME);
         }
         LogPrintf("%i block-relay-only anchors will be tried for connections.\n", m_anchors.size());
@@ -2443,7 +2445,10 @@ void CConnman::StopNodes()
             if (anchors_to_dump.size() > MAX_BLOCK_RELAY_ONLY_ANCHORS) {
                 anchors_to_dump.resize(MAX_BLOCK_RELAY_ONLY_ANCHORS);
             }
-            DumpAnchors(gArgs.GetDataDirNet() / ANCHORS_DATABASE_FILENAME, anchors_to_dump);
+
+            if (tried_connect_anchors) {
+                DumpAnchors(gArgs.GetDataDirNet() / ANCHORS_DATABASE_FILENAME, anchors_to_dump);
+            }
         }
     }
 

--- a/src/net.h
+++ b/src/net.h
@@ -1077,6 +1077,12 @@ private:
      */
     std::vector<CAddress> m_anchors;
 
+    /**
+    * Flag for checking if a connection with all peers from anchors.dat
+    * has been tried.
+    */
+    bool tried_connect_anchors{false};
+
     /** SipHasher seeds for deterministic randomness */
     const uint64_t nSeed0, nSeed1;
 

--- a/test/functional/feature_anchors.py
+++ b/test/functional/feature_anchors.py
@@ -76,7 +76,7 @@ class AnchorsTest(BitcoinTestFramework):
         self.start_node(0)
 
         self.log.info("When node starts, check if anchors.dat doesn't exist anymore")
-        assert not os.path.exists(node_anchors_path)
+        self.wait_until(lambda: not os.path.exists(node_anchors_path))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the current scenario, `anchors.dat` is deleted right after reading it, however, if my node stops before trying to connect to the anchors peers, it will create an empty `anchors.dat`. This PR changes it to delete `anchors.dat` after trying to connect to the peers from it. So, if my node stops (**in a clean way**) before trying to connect to that peers, the `anchors.dat` file will be preserved and a dump won't happen.