### PR TITLE
wallet: Use MTP for locktime checks, not adjusted time

### DIFF
--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -116,7 +116,7 @@ public:
     //! or one of its ancestors.
     virtual std::optional<int> findLocatorFork(const CBlockLocator& locator) = 0;
 
-    //! Check if transaction will be final given chain height current time.
+    //! Check if the transaction will be final in the block following the current chain tip.
     virtual bool checkFinalTx(const CTransaction& tx) = 0;
 
     //! Return whether node has the block and optionally return block metadata

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -489,7 +489,7 @@ public:
     bool checkFinalTx(const CTransaction& tx) override
     {
         LOCK(cs_main);
-        return CheckFinalTx(chainman().ActiveChain().Tip(), tx);
+        return CheckFinalTx(chainman().ActiveChain().Tip(), tx, STANDARD_LOCKTIME_VERIFY_FLAGS);
     }
     std::optional<int> findLocatorFork(const CBlockLocator& locator) override
     {

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -308,6 +308,7 @@ BASE_SCRIPTS = [
     'feature_coinstatsindex.py --legacy-wallet',
     'feature_coinstatsindex.py --descriptors',
     'wallet_orphanedreward.py',
+    'wallet_timelock.py',
     'p2p_node_network_limited.py',
     'p2p_permissions.py',
     'feature_blocksdir.py',

--- a/test/functional/wallet_timelock.py
+++ b/test/functional/wallet_timelock.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.messages import (
+    tx_from_hex,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE
+
+
+class WalletLocktimeTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+        mtp_tip = node.getblockheader(node.getbestblockhash())["mediantime"]
+        tx = node.sendtoaddress(ADDRESS_BCRT1_UNSPENDABLE, 5)
+        tx = node.getrawtransaction(tx)
+        tx = tx_from_hex(tx)
+        tx.nLockTime = mtp_tip - 1
+        tx = node.signrawtransactionwithwallet(tx.serialize().hex())["hex"]
+        self.generateblock(node, ADDRESS_BCRT1_UNSPENDABLE, [tx])
+        balance_before = node.getbalances()["mine"]["trusted"]
+        coin_before = node.listunspent(maxconf=1)
+        node.setmocktime(mtp_tip - 1)
+        assert_equal(node.getbalances()["mine"]["trusted"], balance_before)
+        assert_equal(node.listunspent(maxconf=1), coin_before)
+
+
+if __name__ == "__main__":
+    WalletLocktimeTest().main()


### PR DESCRIPTION
The "flags" parameter is used to decide whether to use MTP or network adjusted time. Make the wallet use MTP instead of adjusted time.

Otherwise this might calculate the wrong wallet balance or list the wrong coins.