### PR TITLE
bug fix: prevent UnicodeDecodeError when opening log file in feature_init.py

### DIFF
--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -93,7 +93,7 @@ class InitStressTest(BitcoinTestFramework):
             additional_lines = random.randint(1, num_total_logs)
             self.log.debug(f"Starting node and will exit after {additional_lines} lines")
             node.start(extra_args=['-txindex=1'])
-            logfile = open(node.debug_log_path, 'r', encoding='utf8')
+            logfile = open(node.debug_log_path, 'rb')
 
             MAX_SECS_TO_WAIT = 10
             start = time.time()


### PR DESCRIPTION
Should fix #23989 

To fix a bug, I modified `feature_init.py` to open the log file as a byte stream when opening it.
thank you.
