### PR TITLE
build: Point Guix to the current top of the "version-1.4.0" branch

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -239,7 +239,7 @@ SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git -c log.showSignature=false log --f
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://git.savannah.gnu.org/git/guix.git \
-                      --commit=fa17abf1af09570708daa28dd40ffbc932ebe25c \
+                      --commit=6ba510d76d6847065be725e958718002f3b13c7a \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \


### PR DESCRIPTION
On master (c561f2f06ed25f08f7776ac41aeb2999ebe79550) the commit in Guix repo from bitcoin/bitcoin#23778 seems unavailable:
```
$ git checkout fa17abf1af09570708daa28dd40ffbc932ebe25c
fatal: reference is not a tree: fa17abf1af09570708daa28dd40ffbc932ebe25c
```

This PR points Guix to the current top of the "version-1.4.0" branch.

Fixes #24040.