### PR TITLE
Bugfix: configure: bitcoin-{cli,tx,util} don't need UPnP, NAT-PMP, or ZMQ

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1349,7 +1349,7 @@ if test "$use_usdt" != "no"; then
   )
 fi
 
-if test "$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_util$build_bitcoind$bitcoin_enable_qt$use_bench$use_tests" = "nonononononono"; then
+if test "$build_bitcoind$bitcoin_enable_qt$use_bench$use_tests" = "nononono"; then
   use_upnp=no
   use_natpmp=no
   use_zmq=no


### PR DESCRIPTION
As with #23345, these other tools likewise don't use various deps.