### PR TITLE
guix: point to recent commit on the master branch

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -239,7 +239,7 @@ SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git -c log.showSignature=false log --f
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://git.savannah.gnu.org/git/guix.git \
-                      --commit=6ba510d76d6847065be725e958718002f3b13c7a \
+                      --commit=1ef7a03a148cf5f83ab1820444f6bd50d8e732d1 \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -397,6 +397,11 @@ thus should be able to compile on most platforms where these exist.")
                   (string-append indent
                                  "@unittest.skip(\"Disabled by Guix\")\n"
                                  line)))
+               (substitute* "tests/test_validate.py"
+                 (("^(.*)def test_revocation_mode_soft" line indent)
+                  (string-append indent
+                                 "@unittest.skip(\"Disabled by Guix\")\n"
+                                 line)))
                #t))
            (replace 'check
              (lambda _


### PR DESCRIPTION
Guix recently force pushed to their `version-1.4.0` branch, causing #24040. At the time #24042 pointed to the newest commit on that branch, fixing #24040, but it didn't actually build. Guix have now [temporarily removed](https://lists.gnu.org/archive/html/guix-devel/2022-01/msg00313.html) their `version-1.4.0` branch, while they incorporate additional fixes.

This PR updates our guix time-machine to point to a recent commit on the guix master branch, so that builds can resume for all hosts apart from Windows. Windows builds are broken due to what looks like an upstream issue, which  results in e failure to build the [`mingw-w64-x86_64-winpthreads package`](https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/mingw.scm#n137). The build fails with:
```bash
/gnu/store/4y5m9lb8k3qkb1y9m02sw9w9a6hacd16-bash-minimal-5.1.8/bin/bash ./libtool  --tag=CC   --mode=link x86_64-w64-mingw32-gcc -Wall -DWIN32_LEAN_AND_MEAN -g -O2 -no-undefined -version-info 1:0:0 -L./fakelib -Wc,-no-pthread  -o libwinpthread.la -rpath /gnu/store/2bglap5gk4db8lajaahg4d7361myw5qw-mingw-w64-x86_64-winpthreads-8.0.0/lib src/libwinpthread_la-barrier.lo src/libwinpthread_la-cond.lo src/libwinpthread_la-misc.lo src/libwinpthread_la-mutex.lo src/libwinpthread_la-rwlock.lo src/libwinpthread_la-spinlock.lo src/libwinpthread_la-thread.lo src/libwinpthread_la-ref.lo src/libwinpthread_la-sem.lo src/libwinpthread_la-sched.lo src/libwinpthread_la-clock.lo src/libwinpthread_la-nanosleep.lo src/version.lo  
libtool: link: x86_64-w64-mingw32-gcc -shared  src/.libs/libwinpthread_la-barrier.o src/.libs/libwinpthread_la-cond.o src/.libs/libwinpthread_la-misc.o src/.libs/libwinpthread_la-mutex.o src/.libs/libwinpthread_la-rwlock.o src/.libs/libwinpthread_la-spinlock.o src/.libs/libwinpthread_la-thread.o src/.libs/libwinpthread_la-ref.o src/.libs/libwinpthread_la-sem.o src/.libs/libwinpthread_la-sched.o src/.libs/libwinpthread_la-clock.o src/.libs/libwinpthread_la-nanosleep.o src/.libs/version.o   -L./fakelib  -g -O2 -no-pthread   -o .libs/libwinpthread-1.dll -Wl,--enable-auto-image-base -Xlinker --out-implib -Xlinker .libs/libwinpthread.dll.a
x86_64-w64-mingw32-ld: final link failed: bad value
collect2: error: ld returned 1 exit status
```

This info will be sent upstream. You can likely recreate the failure with `guix build mingw-w64-x86_64-winpthreads`.

Once Guix is at a point of tagging a 1.4.0 release commit (after re-branching and RCs), we can shift our time-machine to point to it. If a change is made upstream in relation to the Windows issue we are seeing, we will adjust our time-machine commit earlier.

Guix builds:
```bash
bash-5.1# find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
9bbaba7be551f871d940346dd8896908968e5403cdbaa9a990b98a5ef5d8a2c8  guix-build-85885919656a/output/aarch64-linux-gnu/SHA256SUMS.part
4da3c6589afb383e689c1569d9d0379dba3e6e18039f331c91da180b937b6b68  guix-build-85885919656a/output/aarch64-linux-gnu/bitcoin-85885919656a-aarch64-linux-gnu-debug.tar.gz
089c83b739149ea22809a6594aaec5b1df648d770e1086f17ab901e998b54dfd  guix-build-85885919656a/output/aarch64-linux-gnu/bitcoin-85885919656a-aarch64-linux-gnu.tar.gz
71db39d3e84f50a4146300271077bf9687ede8a15ee450d1b62270f362c6fa98  guix-build-85885919656a/output/arm-linux-gnueabihf/SHA256SUMS.part
6b6528e6077f403a53a12199a5dc98d5ea829380295aa768232d619417615465  guix-build-85885919656a/output/arm-linux-gnueabihf/bitcoin-85885919656a-arm-linux-gnueabihf-debug.tar.gz
4ce4d0c28d09bfd46492cd14f8d0a93c58ca827c2e5dcb7aadf74147b8aff7ea  guix-build-85885919656a/output/arm-linux-gnueabihf/bitcoin-85885919656a-arm-linux-gnueabihf.tar.gz
971b85090756ec9557792bfc7f47a013434d30ef41a19b6284c6efc425ce36bf  guix-build-85885919656a/output/dist-archive/bitcoin-85885919656a.tar.gz
64b9757d597f4665dc7b71f6ff3e52671ca2783a8834ef212dd795ff98350919  guix-build-85885919656a/output/powerpc64-linux-gnu/SHA256SUMS.part
5009332c4b7a23263a99e5f39a635d1193c7300672916abd6528112ba56c71c5  guix-build-85885919656a/output/powerpc64-linux-gnu/bitcoin-85885919656a-powerpc64-linux-gnu-debug.tar.gz
84f0e74abe3cf499480c16b371522c6ab958e5c234514c720e7b8915be4dc62d  guix-build-85885919656a/output/powerpc64-linux-gnu/bitcoin-85885919656a-powerpc64-linux-gnu.tar.gz
f73d0fe614caaa617aa2e65f59ccf689ddd2c484878ebd0649dd2e14b31b0329  guix-build-85885919656a/output/powerpc64le-linux-gnu/SHA256SUMS.part
0985d12c3aa1b7625a7369a4d4a8c7f92e1eaf4276c4457610f90d3c057a843e  guix-build-85885919656a/output/powerpc64le-linux-gnu/bitcoin-85885919656a-powerpc64le-linux-gnu-debug.tar.gz
e35a34bc9bf9bc8b9e760b7b9da897ed9bf669dc2a36cd3d5395dbb25683d057  guix-build-85885919656a/output/powerpc64le-linux-gnu/bitcoin-85885919656a-powerpc64le-linux-gnu.tar.gz
c1800ea2353feb984f05ea6f6faa6421b5f3764a036d335fbb18c6d313176e8b  guix-build-85885919656a/output/riscv64-linux-gnu/SHA256SUMS.part
17012337bfc124970dcb26fe0bef0eb0ec57eabaafdd0533828732e407199941  guix-build-85885919656a/output/riscv64-linux-gnu/bitcoin-85885919656a-riscv64-linux-gnu-debug.tar.gz
c9528178e2266ef7d2f49b6b6f65233c58c8f71d196d9347421f988ba4b662bd  guix-build-85885919656a/output/riscv64-linux-gnu/bitcoin-85885919656a-riscv64-linux-gnu.tar.gz
2e6c4fc18b866648e35ebece7c7c8f625833c4f37c1aae8b7d0bc0d5caca6f69  guix-build-85885919656a/output/x86_64-apple-darwin/SHA256SUMS.part
dcee189ad0b8dad71df9053db9c0e2f308c1742cb1638d60d515dafcf4cca8be  guix-build-85885919656a/output/x86_64-apple-darwin/bitcoin-85885919656a-osx-unsigned.dmg
d9366875d36c1993831548ca94de859cbdecca26b77877012456b63bf144558e  guix-build-85885919656a/output/x86_64-apple-darwin/bitcoin-85885919656a-osx-unsigned.tar.gz
6ddd041d2b359f1be5272e79d80deb7ed233289394cbc3436b4cc43853c9690f  guix-build-85885919656a/output/x86_64-apple-darwin/bitcoin-85885919656a-osx64.tar.gz
ef8ce6b349d886f23341dd034463b18d0c5298cf6b2d95632ae24ca98b1b51c8  guix-build-85885919656a/output/x86_64-linux-gnu/SHA256SUMS.part
ce5c2d681617ab1f2f20487ab0b73c48a436a3d313e7441d594a68f28a39a5d3  guix-build-85885919656a/output/x86_64-linux-gnu/bitcoin-85885919656a-x86_64-linux-gnu-debug.tar.gz
b364641aff6a1cde8b1bd950a50c74e9c49a09669d5597365de4da250b41aea6  guix-build-85885919656a/output/x86_64-linux-gnu/bitcoin-85885919656a-x86_64-linux-gnu.tar.gz
```