### PR TITLE
BIP-322 basic support

### DIFF
--- a/src/core_io.h
+++ b/src/core_io.h
@@ -31,6 +31,7 @@ enum class TxVerbosity {
 // core_read.cpp
 CScript ParseScript(const std::string& s);
 std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDecode = false);
+[[nodiscard]] bool DecodeTx(CMutableTransaction& tx, const std::vector<unsigned char>& tx_data, bool try_no_witness, bool try_witness);
 [[nodiscard]] bool DecodeHexTx(CMutableTransaction& tx, const std::string& hex_tx, bool try_no_witness = false, bool try_witness = true);
 [[nodiscard]] bool DecodeHexBlk(CBlock&, const std::string& strHexBlk);
 bool DecodeHexBlockHeader(CBlockHeader&, const std::string& hex_header);

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -121,7 +121,7 @@ static bool CheckTxScriptsSanity(const CMutableTransaction& tx)
     return true;
 }
 
-static bool DecodeTx(CMutableTransaction& tx, const std::vector<unsigned char>& tx_data, bool try_no_witness, bool try_witness)
+bool DecodeTx(CMutableTransaction& tx, const std::vector<unsigned char>& tx_data, bool try_no_witness, bool try_witness)
 {
     // General strategy:
     // - Decode both with extended serialization (which interprets the 0x0001 tag as a marker for

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -94,7 +94,7 @@ public:
     virtual bool getPubKey(const CScript& script, const CKeyID& address, CPubKey& pub_key) = 0;
 
     //! Sign message
-    virtual SigningResult signMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) = 0;
+    virtual SigningResult signMessage(const MessageSignatureFormat format, const std::string& message, const CTxDestination& address, std::string& str_sig) = 0;
 
     //! Return whether wallet has private key.
     virtual bool isSpendable(const CTxDestination& dest) = 0;

--- a/src/rpc/signmessage.cpp
+++ b/src/rpc/signmessage.cpp
@@ -49,9 +49,16 @@ static RPCHelpMan verifymessage()
                 throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to key");
             case MessageVerificationResult::ERR_MALFORMED_SIGNATURE:
                 throw JSONRPCError(RPC_TYPE_ERROR, "Malformed base64 encoding");
+            case MessageVerificationResult::ERR_POF:
+                throw JSONRPCError(RPC_TYPE_ERROR, "BIP-322 Proof of funds is not yet supported"); // TODO: get access to UTXO set / mempool to handle this, then remove this error code?
+            case MessageVerificationResult::INCONCLUSIVE:
+                return false; // TODO: switch to a string based result? mix bool and strings?
+            case MessageVerificationResult::ERR_INVALID:
             case MessageVerificationResult::ERR_PUBKEY_NOT_RECOVERED:
             case MessageVerificationResult::ERR_NOT_SIGNED:
                 return false;
+            case MessageVerificationResult::OK_TIMELOCKED:
+                // TODO: switch to string based result? mix bool and strings?
             case MessageVerificationResult::OK:
                 return true;
             }

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1658,6 +1658,10 @@ bool GenericTransactionSignatureChecker<T>::CheckECDSASignature(const std::vecto
     int nHashType = vchSig.back();
     vchSig.pop_back();
 
+    if (m_require_sighash_all && nHashType != SIGHASH_ALL) {
+        return false;
+    }
+
     // Witness sighashes need the amount.
     if (sigversion == SigVersion::WITNESS_V0 && amount < 0) return HandleMissingData(m_mdb);
 
@@ -1686,6 +1690,9 @@ bool GenericTransactionSignatureChecker<T>::CheckSchnorrSignature(Span<const uns
     uint8_t hashtype = SIGHASH_DEFAULT;
     if (sig.size() == 65) {
         hashtype = SpanPopBack(sig);
+        if (m_require_sighash_all && hashtype != SIGHASH_ALL) {
+            return set_error(serror, SCRIPT_ERR_SIG_HASHTYPE);
+        }
         if (hashtype == SIGHASH_DEFAULT) return set_error(serror, SCRIPT_ERR_SCHNORR_SIG_HASHTYPE);
     }
     uint256 sighash;

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -287,14 +287,15 @@ private:
     unsigned int nIn;
     const CAmount amount;
     const PrecomputedTransactionData* txdata;
+    bool m_require_sighash_all;
 
 protected:
     virtual bool VerifyECDSASignature(const std::vector<unsigned char>& vchSig, const CPubKey& vchPubKey, const uint256& sighash) const;
     virtual bool VerifySchnorrSignature(Span<const unsigned char> sig, const XOnlyPubKey& pubkey, const uint256& sighash) const;
 
 public:
-    GenericTransactionSignatureChecker(const T* txToIn, unsigned int nInIn, const CAmount& amountIn, MissingDataBehavior mdb) : txTo(txToIn), m_mdb(mdb), nIn(nInIn), amount(amountIn), txdata(nullptr) {}
-    GenericTransactionSignatureChecker(const T* txToIn, unsigned int nInIn, const CAmount& amountIn, const PrecomputedTransactionData& txdataIn, MissingDataBehavior mdb) : txTo(txToIn), m_mdb(mdb), nIn(nInIn), amount(amountIn), txdata(&txdataIn) {}
+    GenericTransactionSignatureChecker(const T* txToIn, unsigned int nInIn, const CAmount& amountIn, MissingDataBehavior mdb, bool require_sighash_all = false) : txTo(txToIn), m_mdb(mdb), nIn(nInIn), amount(amountIn), txdata(nullptr), m_require_sighash_all(require_sighash_all) {}
+    GenericTransactionSignatureChecker(const T* txToIn, unsigned int nInIn, const CAmount& amountIn, const PrecomputedTransactionData& txdataIn, MissingDataBehavior mdb, bool require_sighash_all = false) : txTo(txToIn), m_mdb(mdb), nIn(nInIn), amount(amountIn), txdata(&txdataIn), m_require_sighash_all(require_sighash_all) {}
     bool CheckECDSASignature(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const override;
     bool CheckSchnorrSignature(Span<const unsigned char> sig, Span<const unsigned char> pubkey, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* serror = nullptr) const override;
     bool CheckLockTime(const CScriptNum& nLockTime) const override;

--- a/src/test/fuzz/message.cpp
+++ b/src/test/fuzz/message.cpp
@@ -40,7 +40,7 @@ FUZZ_TARGET_INIT(message, initialize_message)
         }
     }
     {
-        (void)MessageHash(random_message);
+        (void)MessageHash(random_message, MessageSignatureFormat::LEGACY);
         (void)MessageVerify(fuzzed_data_provider.ConsumeRandomLengthString(1024), fuzzed_data_provider.ConsumeRandomLengthString(1024), random_message);
         (void)SigningResultString(fuzzed_data_provider.PickValueInArray({SigningResult::OK, SigningResult::PRIVATE_KEY_NOT_AVAILABLE, SigningResult::SIGNING_FAILED}));
     }

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -2718,6 +2718,29 @@ BOOST_AUTO_TEST_CASE(message_verify)
             "Hello World"),
         MessageVerificationResult::OK);
 
+    // 2-of-3 p2sh multisig BIP322 signature (created with the buidl-python library)
+    // Keys are defined as (HDRootWIF, bip322_path)
+    // Key1 (L4DksdGZ4KQJfcLHD5Dv25fu8Rxyv7hHi2RjZR4TYzr8c6h9VNrp, m/45'/0/0/1)
+    // Key2 (KzSRqnCVwjzY8id2X5oHEJWXkSHwKUYaAXusjwgkES8BuQPJnPNu, m/45'/0/0/3)
+    // Key3 (L1zt9Rw7HrU7jaguMbVzhiX8ffuVkmMis5wLHddXYuHWYf8u8uRj, m/45'/0/0/6)
+    // BIP322 includes signs from Key2 and Key3
+    BOOST_CHECK_EQUAL(
+        MessageVerify(
+            "3LnYoUkFrhyYP3V7rq3mhpwALz1XbCY9Uq",
+         "AAAAAAHNcfHaNfl8f/+ZC2gTr8aF+0KgppYjKM94egaNm/u1ZAAAAAD8AEcwRAIhAJ6hdj61vLDP+aFa30qUZQmrbBfE0kiOObYvt5nqPSxsAh9IrOKFwflfPRUcQ/5e0REkdFHVP2GGdUsMgDet+sNlAUcwRAIgH3eW/VyFDoXvCasd8qxgwj5NDVo0weXvM6qyGXLCR5YCIEwjbEV6fS6RWP6QsKOcMwvlGr1/SgdCC6pW4eH87/YgAUxpUiECKJfGy28imLcuAeNBLHCNv3NRP5jnJwFDNRXCYNY/vJ4hAv1RQtaZs7+vKqQeWl2rb/jd/gMxkEjUnjZdDGPDZkMLIQL65cH2X5O7LujjTLDL2l8Pxy0Y2UUR99u1qCfjdz7dklOuAAAAAAEAAAAAAAAAAAFqAAAAAA==",
+            "This will be a p2sh 2-of-3 multisig BIP 322 signed message"),
+        MessageVerificationResult::OK);
+
+    // 3-of-3 p2wsh multisig BIP322 signature (created with the buidl-python library)
+    // Keys are defined as (HDRootWIF, bip322_path)
+    // Key1 (L4DksdGZ4KQJfcLHD5Dv25fu8Rxyv7hHi2RjZR4TYzr8c6h9VNrp, m/45'/0/0/6)
+    // Key2 (KzSRqnCVwjzY8id2X5oHEJWXkSHwKUYaAXusjwgkES8BuQPJnPNu, m/45'/0/0/9)
+    // Key3 (L1zt9Rw7HrU7jaguMbVzhiX8ffuVkmMis5wLHddXYuHWYf8u8uRj, m/45'/0/0/11)
+    BOOST_CHECK_EQUAL(
+        MessageVerify(
+            "bc1qlqtuzpmazp2xmcutlwv0qvggdvem8vahkc333usey4gskug8nutsz53msw",    "BQBIMEUCIQDQoXvGKLH58exuujBOta+7+GN7vi0lKwiQxzBpuNuXuAIgIE0XYQlFDOfxbegGYYzlf+tqegleAKE6SXYIa1U+uCcBRzBEAiATegywVl6GWrG9jJuPpNwtgHKyVYCX2yfuSSDRFATAaQIgTLlU6reLQsSIrQSF21z3PtUO2yAUseUWGZqRUIE7VKoBSDBFAiEAgxtpidsU0Z4u/+5RB9cyeQtoCW5NcreLJmWXZ8kXCZMCIBR1sXoEinhZE4CF9P9STGIcMvCuZjY6F5F0XTVLj9SjAWlTIQP3dyWvTZjUENWJowMWBsQrrXCUs20Gu5YF79CG5Ga0XSEDwqI5GVBOuFkFzQOGH5eTExSAj2Z/LDV/hbcvAPQdlJMhA17FuuJd+4wGuj+ZbVxEsFapTKAOwyhfw9qpch52JKxbU64=",
+            "This will be a p2wsh 3-of-3 multisig BIP 322 signed message"),
+        MessageVerificationResult::OK);
 
     // Single key p2tr BIP322 signature (created with the buidl-python library)
     // PrivateKeyWIF L3VFeEujGtevx9w18HD1fhRbCH67Az2dpCymeRE1SoPK6XQtaN2k

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -2710,6 +2710,14 @@ BOOST_AUTO_TEST_CASE(message_verify)
             "Hello World"),
         MessageVerificationResult::OK);
 
+    // BIP322 signature created using buidl-python library with same parameters as test on line 2596
+    BOOST_CHECK_EQUAL(
+        MessageVerify(
+            "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l",
+         "AkgwRQIhAOzyynlqt93lOKJr+wmmxIens//zPzl9tqIOua93wO6MAiBi5n5EyAcPScOjf1lAqIUIQtr3zKNeavYabHyR8eGhowEhAsfxIAMZZEKUPYWI4BruhAQjzFT8FSFSajuFwrDL1Yhy",
+            "Hello World"),
+        MessageVerificationResult::OK);
+
     // wrong address
 
     BOOST_CHECK_EQUAL(

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -2718,6 +2718,25 @@ BOOST_AUTO_TEST_CASE(message_verify)
             "Hello World"),
         MessageVerificationResult::OK);
 
+
+    // Single key p2tr BIP322 signature (created with the buidl-python library)
+    // PrivateKeyWIF L3VFeEujGtevx9w18HD1fhRbCH67Az2dpCymeRE1SoPK6XQtaN2k
+    BOOST_CHECK_EQUAL(
+        MessageVerify(
+            "bc1ppv609nr0vr25u07u95waq5lucwfm6tde4nydujnu8npg4q75mr5sxq8lt3",
+            "AUHd69PrJQEv+oKTfZ8l+WROBHuy9HKrbFCJu7U1iK2iiEy1vMU5EfMtjc+VSHM7aU0SDbak5IUZRVno2P5mjSafAQ==",
+            "Hello World"),
+        MessageVerificationResult::OK);
+
+    // Same p2tr BIP322 signature as above (created with the buidl-python library)
+    // Signature should not verify against the message
+    BOOST_CHECK_EQUAL(
+        MessageVerify(
+            "bc1ppv609nr0vr25u07u95waq5lucwfm6tde4nydujnu8npg4q75mr5sxq8lt3",
+            "AUHd69PrJQEv+oKTfZ8l+WROBHuy9HKrbFCJu7U1iK2iiEy1vMU5EfMtjc+VSHM7aU0SDbak5IUZRVno2P5mjSafAQ==",
+            "Hello World - This should fail"),
+        MessageVerificationResult::ERR_INVALID);
+
     // wrong address
 
     BOOST_CHECK_EQUAL(

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -8,6 +8,8 @@
 #include <fs.h>
 #include <hash.h> // For Hash()
 #include <key.h>  // For CKey
+#include <key_io.h> // EncodeDestination
+#include <outputtype.h> // For BIP-322 tests
 #include <sync.h>
 #include <test/util/logging.h>
 #include <test/util/setup_common.h>
@@ -2605,6 +2607,38 @@ BOOST_AUTO_TEST_CASE(message_sign)
         "Sign with a valid private key");
 
     BOOST_CHECK_EQUAL(expected_signature, generated_signature);
+
+    // BIP-322 tests
+    // (no signing done here, as we need a wallet to do so)
+
+    auto pubkey = privkey.GetPubKey();
+    MessageVerificationResult mvr{MessageVerificationResult::OK};
+
+    // LEGACY pubkey type
+    auto dest_legacy = GetDestinationForKey(pubkey, OutputType::LEGACY);
+    BOOST_CHECK_EQUAL("15CRxFdyRpGZLW9w8HnHvVduizdL5jKNbs", EncodeDestination(dest_legacy));
+    auto txs_legacy = BIP322Txs::Create(dest_legacy, message, mvr);
+    if (!txs_legacy || mvr != MessageVerificationResult::OK) {
+        BOOST_FAIL("Failed to create BIP-322 txs for legacy address");
+    }
+
+    // P2SH_SEGWIT pubkey type
+    auto dest_p2sh_segwit = GetDestinationForKey(pubkey, OutputType::P2SH_SEGWIT);
+    BOOST_CHECK_EQUAL("35uijJkf4rcCnGzEZsn12YJenTHToDKpr2", EncodeDestination(dest_p2sh_segwit));
+    auto txs_p2sh_segwit = BIP322Txs::Create(dest_p2sh_segwit, message, mvr);
+    if (!txs_p2sh_segwit || mvr != MessageVerificationResult::OK) {
+        BOOST_FAIL("Failed to create BIP-322 txs for p2sh-segwit address");
+    }
+
+    // BECH32
+    auto dest_bech32 = GetDestinationForKey(pubkey, OutputType::BECH32);
+    BOOST_CHECK_EQUAL("bc1q9cy7s7nmzah0m6mt2ftmu6x723esjxqkkl4wsw", EncodeDestination(dest_bech32));
+    auto txs_bech32 = BIP322Txs::Create(dest_bech32, message, mvr);
+    if (!txs_bech32 || mvr != MessageVerificationResult::OK) {
+        BOOST_FAIL("Failed to create BIP-322 txs for bech32 address");
+    }
+
+    // TODO: BECH32M
 }
 
 BOOST_AUTO_TEST_CASE(message_verify)
@@ -2612,16 +2646,16 @@ BOOST_AUTO_TEST_CASE(message_verify)
     BOOST_CHECK_EQUAL(
         MessageVerify(
             "invalid address",
-            "signature should be irrelevant",
+            "AA==",
             "message too"),
         MessageVerificationResult::ERR_INVALID_ADDRESS);
 
     BOOST_CHECK_EQUAL(
         MessageVerify(
             "3B5fQsEXEaV8v6U3ejYc8XaKXAkyQj2MjV",
-            "signature should be irrelevant",
+            "AA==",
             "message too"),
-        MessageVerificationResult::ERR_ADDRESS_NO_KEY);
+        MessageVerificationResult::ERR_INVALID /* ERR_ADDRESS_NO_KEY */);
 
     BOOST_CHECK_EQUAL(
         MessageVerify(
@@ -2635,7 +2669,7 @@ BOOST_AUTO_TEST_CASE(message_verify)
             "1KqbBpLy5FARmTPD4VZnDDpYjkUvkr82Pm",
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
             "message should be irrelevant"),
-        MessageVerificationResult::ERR_PUBKEY_NOT_RECOVERED);
+        MessageVerificationResult::ERR_INVALID /* ERR_PUBKEY_NOT_RECOVERED */);
 
     BOOST_CHECK_EQUAL(
         MessageVerify(
@@ -2657,6 +2691,74 @@ BOOST_AUTO_TEST_CASE(message_verify)
             "IIcaIENoYW5jZWxsb3Igb24gYnJpbmsgb2Ygc2Vjb25kIGJhaWxvdXQgZm9yIGJhbmtzIAaHRtbCeDZINyavx14=",
             "Trust me"),
         MessageVerificationResult::OK);
+
+    // BIP-322 tests
+
+    // privkey: L3VFeEujGtevx9w18HD1fhRbCH67Az2dpCymeRE1SoPK6XQtaN2k
+
+    BOOST_CHECK_EQUAL(
+        MessageVerify(
+            "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l",
+            "AkcwRAIgM2gBAQqvZX15ZiysmKmQpDrG83avLIT492QBzLnQIxYCIBaTpOaD20qRlEylyxFSeEA2ba9YOixpX8z46TSDtS40ASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=",
+            ""),
+        MessageVerificationResult::OK);
+
+    BOOST_CHECK_EQUAL(
+        MessageVerify(
+            "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l",
+            "AkcwRAIgZRfIY3p7/DoVTty6YZbWS71bc5Vct9p9Fia83eRmw2QCICK/ENGfwLtptFluMGs2KsqoNSk89pO7F29zJLUx9a/sASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=",
+            "Hello World"),
+        MessageVerificationResult::OK);
+
+    // wrong address
+
+    BOOST_CHECK_EQUAL(
+        MessageVerify(
+            "bc1qkecg9ly2xwxqgdy9egpuy87qc9x26smpts562s",
+            "AkcwRAIgM2gBAQqvZX15ZiysmKmQpDrG83avLIT492QBzLnQIxYCIBaTpOaD20qRlEylyxFSeEA2ba9YOixpX8z46TSDtS40ASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=",
+            ""),
+        MessageVerificationResult::ERR_INVALID);
+
+    BOOST_CHECK_EQUAL(
+        MessageVerify(
+            "bc1qkecg9ly2xwxqgdy9egpuy87qc9x26smpts562s",
+            "AkcwRAIgZRfIY3p7/DoVTty6YZbWS71bc5Vct9p9Fia83eRmw2QCICK/ENGfwLtptFluMGs2KsqoNSk89pO7F29zJLUx9a/sASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=",
+            "Hello World"),
+        MessageVerificationResult::ERR_INVALID);
+
+    // wrong signature / message (signatures swapped)
+
+    BOOST_CHECK_EQUAL(
+        MessageVerify(
+            "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l",
+            "AkcwRAIgZRfIY3p7/DoVTty6YZbWS71bc5Vct9p9Fia83eRmw2QCICK/ENGfwLtptFluMGs2KsqoNSk89pO7F29zJLUx9a/sASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=",
+            ""),
+        MessageVerificationResult::ERR_INVALID);
+
+    BOOST_CHECK_EQUAL(
+        MessageVerify(
+            "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l",
+            "AkcwRAIgM2gBAQqvZX15ZiysmKmQpDrG83avLIT492QBzLnQIxYCIBaTpOaD20qRlEylyxFSeEA2ba9YOixpX8z46TSDtS40ASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=",
+            "Hello World"),
+        MessageVerificationResult::ERR_INVALID);
+
+    // invalid address
+
+    BOOST_CHECK_EQUAL(
+        MessageVerify(
+            "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx1l",
+            "AkcwRAIgM2gBAQqvZX15ZiysmKmQpDrG83avLIT492QBzLnQIxYCIBaTpOaD20qRlEylyxFSeEA2ba9YOixpX8z46TSDtS40ASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI=",
+            ""),
+        MessageVerificationResult::ERR_INVALID_ADDRESS);
+
+    // malformed signature
+
+    BOOST_CHECK_EQUAL(
+        MessageVerify(
+            "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l",
+            "AkcwRAIgClVQ8S9yX1h8YThlGElD9lOrQbOwbFDjkYb0ebfiq+oCIDHgb/X9WNalNNtqTXb465ufbv9JuLxcJf8qi7DP6yOXASECx/EgAxlkQpQ9hYjgGu6EBCPMVPwVIVJqO4XCsMvViHI",
+            ""),
+        MessageVerificationResult::ERR_MALFORMED_SIGNATURE);
 }
 
 BOOST_AUTO_TEST_CASE(message_hash)
@@ -2674,6 +2776,16 @@ BOOST_AUTO_TEST_CASE(message_hash)
 
     BOOST_CHECK_EQUAL(message_hash1, message_hash2);
     BOOST_CHECK_NE(message_hash1, signature_hash);
+
+    // BIP-322 tests
+
+    const uint256 signature_hash_0x = MessageHash("", MessageSignatureFormat::FULL);
+    const uint256 signature_hash_Hello_World = MessageHash("Hello World", MessageSignatureFormat::FULL);
+
+    std::vector<unsigned char> vec(signature_hash_0x.begin(), signature_hash_0x.end());
+    BOOST_CHECK_EQUAL("c90c269c4f8fcbe6880f72a721ddfbf1914268a794cbb21cfafee13770ae19f1", HexStr(vec));
+    vec = std::vector<unsigned char>(signature_hash_Hello_World.begin(), signature_hash_Hello_World.end());
+    BOOST_CHECK_EQUAL("f0eb03b1a75ac6d9847f55c624a99169b5dccba2a31f5b23bea77ba270de0a7a", HexStr(vec));
 }
 
 BOOST_AUTO_TEST_CASE(remove_prefix)

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -2670,7 +2670,7 @@ BOOST_AUTO_TEST_CASE(message_hash)
 
     const uint256 signature_hash = Hash(unsigned_tx);
     const uint256 message_hash1 = Hash(prefixed_message);
-    const uint256 message_hash2 = MessageHash(unsigned_tx);
+    const uint256 message_hash2 = MessageHash(unsigned_tx, MessageSignatureFormat::LEGACY);
 
     BOOST_CHECK_EQUAL(message_hash1, message_hash2);
     BOOST_CHECK_NE(message_hash1, signature_hash);

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -81,7 +81,7 @@ bool MessageSign(
  * Hashes a message for signing and verification in a manner that prevents
  * inadvertently signing a transaction.
  */
-uint256 MessageHash(const std::string& message);
+uint256 MessageHash(const std::string& message, MessageSignatureFormat format);
 
 std::string SigningResultString(const SigningResult res);
 

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -74,7 +74,7 @@ enum class SigningResult {
 };
 
 /** Verify a signed message.
- * @param[in] address Signer's bitcoin address, it must refer to a public key.
+ * @param[in] address Signer's bitcoin address.
  * @param[in] signature The signature in base64 format.
  * @param[in] message The message that was signed.
  * @return result code */

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -101,4 +101,19 @@ uint256 MessageHash(const std::string& message, MessageSignatureFormat format);
 
 std::string SigningResultString(const SigningResult res);
 
+/**
+ * Generate the BIP-322 tx corresponding to the given challenge
+ */
+class BIP322Txs {
+private:
+    template<class T1, class T2>
+    BIP322Txs(const T1& to_spend, const T2& to_sign) : m_to_spend{to_spend}, m_to_sign{to_sign} { }
+
+public:
+    static std::optional<BIP322Txs> Create(const CTxDestination& destination, const std::string& message, MessageVerificationResult& result, std::optional<const std::vector<unsigned char>> = std::nullopt);
+
+    const CTransaction m_to_spend;
+    const CTransaction m_to_sign;
+};
+
 #endif // BITCOIN_UTIL_MESSAGE_H

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -14,6 +14,17 @@ class CKey;
 
 extern const std::string MESSAGE_MAGIC;
 
+enum class MessageSignatureFormat {
+    //! Legacy format, which only works on legacy addresses
+    LEGACY,
+
+    //! Simple BIP-322 format, i.e. the script witness stack only
+    SIMPLE,
+
+    //! Full BIP-322 format, i.e. the serialized to_sign transaction in full
+    FULL,
+};
+
 /** The result of a signed message verification.
  * Message verification takes as an input:
  * - address (with whose private key the message is supposed to have been signed)
@@ -56,7 +67,7 @@ MessageVerificationResult MessageVerify(
     const std::string& signature,
     const std::string& message);
 
-/** Sign a message.
+/** Sign a message using legacy format.
  * @param[in] privkey Private key to sign with.
  * @param[in] message The message to sign.
  * @param[out] signature Signature, base64 encoded, only set if true is returned.

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -48,7 +48,23 @@ enum class MessageVerificationResult {
     ERR_NOT_SIGNED,
 
     //! The message verification was successful.
-    OK
+    OK,
+
+    //
+    // BIP-322 extensions
+    //
+
+    //! The message has set timelocks but is otherwise valid (BIP-322)
+    OK_TIMELOCKED,
+
+    //! The validator was unable to check the scripts (BIP-322)
+    INCONCLUSIVE,
+
+    //! Some check failed (BIP-322)
+    ERR_INVALID,
+
+    //! Proof of funds require the wallet-enabled verifier (BIP-322)
+    ERR_POF,
 };
 
 enum class SigningResult {

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -161,9 +161,9 @@ public:
         }
         return false;
     }
-    SigningResult signMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) override
+    SigningResult signMessage(const MessageSignatureFormat format, const std::string& message, const CTxDestination& address, std::string& str_sig) override
     {
-        return m_wallet->SignMessage(message, pkhash, str_sig);
+        return m_wallet->SignMessage(format, message, address, str_sig);
     }
     bool isSpendable(const CTxDestination& dest) override
     {

--- a/src/wallet/rpc/signmessage.cpp
+++ b/src/wallet/rpc/signmessage.cpp
@@ -50,13 +50,8 @@ RPCHelpMan signmessage()
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
             }
 
-            const PKHash* pkhash = std::get_if<PKHash>(&dest);
-            if (!pkhash) {
-                throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to key");
-            }
-
             std::string signature;
-            SigningResult err = pwallet->SignMessage(strMessage, *pkhash, signature);
+            SigningResult err = pwallet->SignMessage(MessageSignatureFormat::SIMPLE, strMessage, dest, signature);
             if (err == SigningResult::SIGNING_FAILED) {
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, SigningResultString(err));
             } else if (err != SigningResult::OK) {

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -238,7 +238,7 @@ public:
     /** Creates new signatures and adds them to the transaction. Returns whether all inputs were signed */
     virtual bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const { return false; }
     /** Sign a message with the given script */
-    virtual SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const { return SigningResult::SIGNING_FAILED; };
+    virtual SigningResult SignMessage(const MessageSignatureFormat format, const std::string& message, const CTxDestination& address, std::string& str_sig) const { return SigningResult::SIGNING_FAILED; };
     /** Adds script and derivation path information to a PSBT, and optionally signs it. */
     virtual TransactionError FillPSBT(PartiallySignedTransaction& psbt, const PrecomputedTransactionData& txdata, int sighash_type = SIGHASH_DEFAULT, bool sign = true, bool bip32derivs = false, int* n_signed = nullptr, bool finalize = true) const { return TransactionError::INVALID_PSBT; }
 
@@ -409,7 +409,7 @@ public:
     bool CanProvide(const CScript& script, SignatureData& sigdata) override;
 
     bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const override;
-    SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const override;
+    SigningResult SignMessage(const MessageSignatureFormat format, const std::string& message, const CTxDestination& address, std::string& str_sig) const override;
     TransactionError FillPSBT(PartiallySignedTransaction& psbt, const PrecomputedTransactionData& txdata, int sighash_type = SIGHASH_DEFAULT, bool sign = true, bool bip32derivs = false, int* n_signed = nullptr, bool finalize = true) const override;
 
     uint256 GetID() const override;
@@ -627,7 +627,7 @@ public:
     bool CanProvide(const CScript& script, SignatureData& sigdata) override;
 
     bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const override;
-    SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const override;
+    SigningResult SignMessage(const MessageSignatureFormat format, const std::string& message, const CTxDestination& address, std::string& str_sig) const override;
     TransactionError FillPSBT(PartiallySignedTransaction& psbt, const PrecomputedTransactionData& txdata, int sighash_type = SIGHASH_DEFAULT, bool sign = true, bool bip32derivs = false, int* n_signed = nullptr, bool finalize = true) const override;
 
     uint256 GetID() const override;

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -169,6 +169,8 @@ class ScriptPubKeyMan
 protected:
     WalletStorage& m_storage;
 
+    SigningResult SignMessageBIP322(MessageSignatureFormat format, const SigningProvider* keystore, const std::string& message, const CTxDestination& address, std::string& str_sig) const;
+
 public:
     explicit ScriptPubKeyMan(WalletStorage& storage) : m_storage(storage) {}
     virtual ~ScriptPubKeyMan() {};

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2104,14 +2104,14 @@ TransactionError CWallet::FillPSBT(PartiallySignedTransaction& psbtx, bool& comp
     return TransactionError::OK;
 }
 
-SigningResult CWallet::SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const
+SigningResult CWallet::SignMessage(const MessageSignatureFormat format, const std::string& message, const CTxDestination& address, std::string& str_sig) const
 {
     SignatureData sigdata;
-    CScript script_pub_key = GetScriptForDestination(pkhash);
+    CScript script_pub_key = GetScriptForDestination(address);
     for (const auto& spk_man_pair : m_spk_managers) {
         if (spk_man_pair.second->CanProvide(script_pub_key, sigdata)) {
             LOCK(cs_wallet);  // DescriptorScriptPubKeyMan calls IsLocked which can lock cs_wallet in a deadlocking order
-            return spk_man_pair.second->SignMessage(message, pkhash, str_sig);
+            return spk_man_pair.second->SignMessage(format, message, address, str_sig);
         }
     }
     return SigningResult::PRIVATE_KEY_NOT_AVAILABLE;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -545,7 +545,7 @@ public:
     bool SignTransaction(CMutableTransaction& tx) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     /** Sign the tx given the input coins and sighash. */
     bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const;
-    SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const;
+    SigningResult SignMessage(const MessageSignatureFormat format, const std::string& message, const CTxDestination& address, std::string& str_sig) const;
 
     /**
      * Fills out a PSBT with information from the wallet. Fills in UTXOs if we have


### PR DESCRIPTION
This PR enables support for [BIP-322](https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki), the sign/verify message upgrade.

Fixes #10542.

This PR is greatly simplified and is supposed to have one or more follow-up PRs to complete functionality.

In this PR:
* signing using single key (any type)
* verifying any signed message (auto-detects BIP-322 vs legacy)

Missing features/limitations:
* proof of funds (i.e. additional inputs) support
* multisig or other custom address type support (I need feedback on how to do this; I assume some psbt thing would be good?)
* (RPC) format is restricted to SIMPLE mode now; it may eventually be LEGACY, SIMPLE, or FULL. (In some cases, it will use FULL format but this is not selectable yet.)
* timelock support
