### PR TITLE
Fix implicit-integer-sign-change in arith_uint256

### DIFF
--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -96,7 +96,7 @@ base_uint<BITS>& base_uint<BITS>::operator/=(const base_uint& b)
     while (shift >= 0) {
         if (num >= div) {
             num -= div;
-            pn[shift / 32] |= (1 << (shift & 31)); // set a bit of the result.
+            pn[shift / 32] |= (1U << (shift & 31)); // set a bit of the result.
         }
         div >>= 1; // shift back.
         shift--;
@@ -236,7 +236,7 @@ uint32_t arith_uint256::GetCompact(bool fNegative) const
         nCompact >>= 8;
         nSize++;
     }
-    assert((nCompact & ~0x007fffff) == 0);
+    assert((nCompact & ~0x007fffffU) == 0);
     assert(nSize < 256);
     nCompact |= nSize << 24;
     nCompact |= (fNegative && (nCompact & 0x007fffff) ? 0x00800000 : 0);

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -62,7 +62,6 @@ unsigned-integer-overflow:txmempool.cpp
 unsigned-integer-overflow:util/strencodings.cpp
 unsigned-integer-overflow:validation.cpp
 implicit-integer-sign-change:addrman.h
-implicit-integer-sign-change:arith_uint256.cpp
 implicit-integer-sign-change:bech32.cpp
 implicit-integer-sign-change:common/bloom.cpp
 implicit-integer-sign-change:chain.cpp


### PR DESCRIPTION
This refactor doesn't change behaviour, but clarifies that the numbers being dealt with aren't supposed to be negative. This helps when reading the code and allows to remove a sanitizer suppression for the whole file.