### PR TITLE
refactor: replace RecursiveMutex `m_cs_callbacks_pending` with Mutex (and rename)

### DIFF
--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -136,7 +136,7 @@ bool CScheduler::AreThreadsServicingQueue() const
 void SingleThreadedSchedulerClient::MaybeScheduleProcessQueue()
 {
     {
-        LOCK(m_cs_callbacks_pending);
+        LOCK(m_callbacks_mutex);
         // Try to avoid scheduling too many copies here, but if we
         // accidentally have two ProcessQueue's scheduled at once its
         // not a big deal.
@@ -150,7 +150,7 @@ void SingleThreadedSchedulerClient::ProcessQueue()
 {
     std::function<void()> callback;
     {
-        LOCK(m_cs_callbacks_pending);
+        LOCK(m_callbacks_mutex);
         if (m_are_callbacks_running) return;
         if (m_callbacks_pending.empty()) return;
         m_are_callbacks_running = true;
@@ -167,7 +167,7 @@ void SingleThreadedSchedulerClient::ProcessQueue()
         ~RAIICallbacksRunning()
         {
             {
-                LOCK(instance->m_cs_callbacks_pending);
+                LOCK(instance->m_callbacks_mutex);
                 instance->m_are_callbacks_running = false;
             }
             instance->MaybeScheduleProcessQueue();
@@ -182,7 +182,7 @@ void SingleThreadedSchedulerClient::AddToProcessQueue(std::function<void()> func
     assert(m_pscheduler);
 
     {
-        LOCK(m_cs_callbacks_pending);
+        LOCK(m_callbacks_mutex);
         m_callbacks_pending.emplace_back(std::move(func));
     }
     MaybeScheduleProcessQueue();
@@ -194,13 +194,13 @@ void SingleThreadedSchedulerClient::EmptyQueue()
     bool should_continue = true;
     while (should_continue) {
         ProcessQueue();
-        LOCK(m_cs_callbacks_pending);
+        LOCK(m_callbacks_mutex);
         should_continue = !m_callbacks_pending.empty();
     }
 }
 
 size_t SingleThreadedSchedulerClient::CallbacksPending()
 {
-    LOCK(m_cs_callbacks_pending);
+    LOCK(m_callbacks_mutex);
     return m_callbacks_pending.size();
 }

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -119,7 +119,7 @@ class SingleThreadedSchedulerClient
 private:
     CScheduler* m_pscheduler;
 
-    RecursiveMutex m_callbacks_mutex;
+    Mutex m_callbacks_mutex;
     std::list<std::function<void()>> m_callbacks_pending GUARDED_BY(m_callbacks_mutex);
     bool m_are_callbacks_running GUARDED_BY(m_callbacks_mutex) = false;
 

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -119,9 +119,9 @@ class SingleThreadedSchedulerClient
 private:
     CScheduler* m_pscheduler;
 
-    RecursiveMutex m_cs_callbacks_pending;
-    std::list<std::function<void()>> m_callbacks_pending GUARDED_BY(m_cs_callbacks_pending);
-    bool m_are_callbacks_running GUARDED_BY(m_cs_callbacks_pending) = false;
+    RecursiveMutex m_callbacks_mutex;
+    std::list<std::function<void()>> m_callbacks_pending GUARDED_BY(m_callbacks_mutex);
+    bool m_are_callbacks_running GUARDED_BY(m_callbacks_mutex) = false;
 
     void MaybeScheduleProcessQueue();
     void ProcessQueue();


### PR DESCRIPTION
This PR is related to #19303 and gets rid of the RecursiveMutex `m_cs_callbacks_pending`. All of the critical sections (6 in total) only directly access the guarded elements, i.e. it is not possible that within one section another one is called, and we can use a regular Mutex:

https://github.com/bitcoin/bitcoin/blob/807169e10b4a18324356ed6ee4d69587b96a7c70/src/scheduler.cpp#L138-L145

https://github.com/bitcoin/bitcoin/blob/807169e10b4a18324356ed6ee4d69587b96a7c70/src/scheduler.cpp#L152-L160

https://github.com/bitcoin/bitcoin/blob/807169e10b4a18324356ed6ee4d69587b96a7c70/src/scheduler.cpp#L169-L172

https://github.com/bitcoin/bitcoin/blob/807169e10b4a18324356ed6ee4d69587b96a7c70/src/scheduler.cpp#L184-L187

https://github.com/bitcoin/bitcoin/blob/807169e10b4a18324356ed6ee4d69587b96a7c70/src/scheduler.cpp#L197-L199

https://github.com/bitcoin/bitcoin/blob/807169e10b4a18324356ed6ee4d69587b96a7c70/src/scheduler.cpp#L203-L206

Also, it is renamed to adapt to the (unwritten) naming convention to use the `_mutex` suffix rather than the `cs_` prefix.