### PR TITLE
doc: fix wording of alertnotify to match behaviour

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -392,7 +392,7 @@ void SetupServerArgs(ArgsManager& argsman)
 
     argsman.AddArg("-version", "Print version and exit", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #if HAVE_SYSTEM
-    argsman.AddArg("-alertnotify=<cmd>", "Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-alertnotify=<cmd>", "Execute command when an alert is raised (%s in cmd is replaced by message)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #endif
     argsman.AddArg("-assumevalid=<hex>", strprintf("If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet: %s, signet: %s)", defaultChainParams->GetConsensus().defaultAssumeValid.GetHex(), testnetChainParams->GetConsensus().defaultAssumeValid.GetHex(), signetChainParams->GetConsensus().defaultAssumeValid.GetHex()), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-blocksdir=<dir>", "Specify directory to hold blocks subdirectory for *.dat files (default: <datadir>)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);


### PR DESCRIPTION
The documentation of the `alertnotify` startup option no longer matches the implementation.

Currently the alert is only triggered by `DoWarning` (as part of `CChainstate::UpdateTip` when blocks containing unknown versionbits are detected on the network, indicating that there may be an upcoming softfork which you don't know about), but not when we see a "really long fork":

https://github.com/bitcoin/bitcoin/blob/2825c41a6121524bc647002cbb4258cbf701a14b/src/validation.cpp#L2418-L2433

I think it would be desirable in a follow-up PR to implement the logic to alert on a (really) long fork, but not to alert for "partition detection" (abnormally slow/fast blocks). `PartitionChecker` code was removed in ab8be98fdb25b678a8cd7e89adf06d1b1f6bdd62