### PR TITLE
util: Make base_uint::GetHex() and base_uint::SetHex() not depend on uint256

### DIFF
--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -146,13 +146,21 @@ double base_uint<BITS>::getdouble() const
 template <unsigned int BITS>
 std::string base_uint<BITS>::GetHex() const
 {
-    return ArithToUint256(*this).GetHex();
+    base_blob<BITS> b;
+    for (int x = 0; x < this->WIDTH; ++x) {
+        WriteLE32(b.begin() + x*4, this->pn[x]);
+    }
+    return b.GetHex();
 }
 
 template <unsigned int BITS>
 void base_uint<BITS>::SetHex(const char* psz)
 {
-    *this = UintToArith256(uint256S(psz));
+    base_blob<BITS> b;
+    b.SetHex(psz);
+    for (int x = 0; x < this->WIDTH; ++x) {
+        this->pn[x] = ReadLE32(b.begin() + x*4);
+    }
 }
 
 template <unsigned int BITS>
@@ -164,7 +172,7 @@ void base_uint<BITS>::SetHex(const std::string& str)
 template <unsigned int BITS>
 std::string base_uint<BITS>::ToString() const
 {
-    return (GetHex());
+    return GetHex();
 }
 
 template <unsigned int BITS>
@@ -183,20 +191,7 @@ unsigned int base_uint<BITS>::bits() const
 }
 
 // Explicit instantiations for base_uint<256>
-template base_uint<256>::base_uint(const std::string&);
-template base_uint<256>& base_uint<256>::operator<<=(unsigned int);
-template base_uint<256>& base_uint<256>::operator>>=(unsigned int);
-template base_uint<256>& base_uint<256>::operator*=(uint32_t b32);
-template base_uint<256>& base_uint<256>::operator*=(const base_uint<256>& b);
-template base_uint<256>& base_uint<256>::operator/=(const base_uint<256>& b);
-template int base_uint<256>::CompareTo(const base_uint<256>&) const;
-template bool base_uint<256>::EqualTo(uint64_t) const;
-template double base_uint<256>::getdouble() const;
-template std::string base_uint<256>::GetHex() const;
-template std::string base_uint<256>::ToString() const;
-template void base_uint<256>::SetHex(const char*);
-template void base_uint<256>::SetHex(const std::string&);
-template unsigned int base_uint<256>::bits() const;
+template class base_uint<256>;
 
 // This implementation directly uses shifts instead of going
 // through an intermediate MPI representation.

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -284,4 +284,6 @@ public:
 uint256 ArithToUint256(const arith_uint256 &);
 arith_uint256 UintToArith256(const uint256 &);
 
+extern template class base_uint<256>;
+
 #endif // BITCOIN_ARITH_UINT256_H


### PR DESCRIPTION
The current implementations of `SetHex()` and `GetHex()` in `base_uint` use `arith_uint256`'s implementations. Which means, any attempt to create anything other than `arith_uint256` (say `arith_uint512`) and using any of these functions (which is what I needed in my application) will just not work and will cause compilation errors (besides the immediate linking errors due to templates being in source files instantiated only for 256) because there's no viable conversion from `arith_uint256` and any of the other possible types. Besides that these function will yield wrong results even if the conversion is possible depending on the size. This is fixed in this PR.