### PR TITLE
doc: add information about status code 404 for some endpoints (rest)

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -31,6 +31,7 @@ Supported API
 `GET /rest/tx/<TX-HASH>.<bin|hex|json>`
 
 Given a transaction hash: returns a transaction in binary, hex-encoded binary, or JSON formats.
+Responds with 404 if the transaction doesn't exist.
 
 By default, this endpoint will only search the mempool.
 To query for a confirmed transaction, enable the transaction index via "txindex=1" command line / configuration option.
@@ -70,6 +71,7 @@ Responds with 404 if the block doesn't exist.
 `GET /rest/blockhashbyheight/<HEIGHT>.<bin|hex|json>`
 
 Given a height: returns hash of block in best-block-chain at height provided.
+Responds with 404 if block not found.
 
 #### Chaininfos
 `GET /rest/chaininfo.json`


### PR DESCRIPTION
This PR adds an explanation about status code 404 for 2 endpoints (`/rest/tx/ `and `/rest/blockhashbyheight/`) in`REST-interface.md`. There are other endpoints that already cover it.