### PR TITLE
net/p2p: change nScore and nBestScore data types to int64_t

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -134,13 +134,13 @@ bool GetLocal(CService& addr, const CNetAddr *paddrPeer)
     if (!fListen)
         return false;
 
-    int nBestScore = -1;
+    int64_t nBestScore = -1;
     int nBestReachability = -1;
     {
         LOCK(cs_mapLocalHost);
         for (const auto& entry : mapLocalHost)
         {
-            int nScore = entry.second.nScore;
+            int64_t nScore = entry.second.nScore;
             int nReachability = entry.first.GetReachabilityFrom(paddrPeer);
             if (nReachability > nBestReachability || (nReachability == nBestReachability && nScore > nBestScore))
             {
@@ -191,7 +191,7 @@ CAddress GetLocalAddress(const CNetAddr *paddrPeer, ServiceFlags nLocalServices)
     return ret;
 }
 
-static int GetnScore(const CService& addr)
+static int64_t GetnScore(const CService& addr)
 {
     LOCK(cs_mapLocalHost);
     const auto it = mapLocalHost.find(addr);
@@ -248,7 +248,7 @@ CService MaybeFlipIPv6toCJDNS(const CService& service)
 }
 
 // learn a new local address
-bool AddLocal(const CService& addr_, int nScore)
+bool AddLocal(const CService& addr_, int64_t nScore)
 {
     CService addr{MaybeFlipIPv6toCJDNS(addr_)};
 
@@ -276,7 +276,7 @@ bool AddLocal(const CService& addr_, int nScore)
     return true;
 }
 
-bool AddLocal(const CNetAddr &addr, int nScore)
+bool AddLocal(const CNetAddr &addr, int64_t nScore)
 {
     return AddLocal(CService(addr, GetListenPort()), nScore);
 }

--- a/src/net.h
+++ b/src/net.h
@@ -210,8 +210,8 @@ bool IsReachable(enum Network net);
 /** @returns true if the address is in a reachable network, false otherwise */
 bool IsReachable(const CNetAddr& addr);
 
-bool AddLocal(const CService& addr, int nScore = LOCAL_NONE);
-bool AddLocal(const CNetAddr& addr, int nScore = LOCAL_NONE);
+bool AddLocal(const CService& addr, int64_t nScore = LOCAL_NONE);
+bool AddLocal(const CNetAddr& addr, int64_t nScore = LOCAL_NONE);
 void RemoveLocal(const CService& addr);
 bool SeenLocal(const CService& addr);
 bool IsLocal(const CService& addr);
@@ -226,7 +226,7 @@ extern bool fListen;
 extern std::string strSubVersion;
 
 struct LocalServiceInfo {
-    int nScore;
+    int64_t nScore;
     uint16_t nPort;
 };
 


### PR DESCRIPTION
Changing nScore and nBestScore to a fixed-width integer guarantees to be the same size on any architecture and avoids UB.

Addresses issue:  #24049

