### PR TITLE
refactor: replace RecursiveMutex `m_cs_banned` with Mutex (and rename)

### DIFF
--- a/src/banman.h
+++ b/src/banman.h
@@ -86,13 +86,13 @@ private:
     //!clean unused entries (if bantime has expired)
     void SweepBanned();
 
-    RecursiveMutex m_cs_banned;
-    banmap_t m_banned GUARDED_BY(m_cs_banned);
-    bool m_is_dirty GUARDED_BY(m_cs_banned){false};
+    RecursiveMutex m_banned_mutex;
+    banmap_t m_banned GUARDED_BY(m_banned_mutex);
+    bool m_is_dirty GUARDED_BY(m_banned_mutex){false};
     CClientUIInterface* m_client_interface = nullptr;
     CBanDB m_ban_db;
     const int64_t m_default_ban_time;
-    CRollingBloomFilter m_discouraged GUARDED_BY(m_cs_banned) {50000, 0.000001};
+    CRollingBloomFilter m_discouraged GUARDED_BY(m_banned_mutex) {50000, 0.000001};
 };
 
 #endif // BITCOIN_BANMAN_H

--- a/src/banman.h
+++ b/src/banman.h
@@ -86,7 +86,7 @@ private:
     //!clean unused entries (if bantime has expired)
     void SweepBanned();
 
-    RecursiveMutex m_banned_mutex;
+    Mutex m_banned_mutex;
     banmap_t m_banned GUARDED_BY(m_banned_mutex);
     bool m_is_dirty GUARDED_BY(m_banned_mutex){false};
     CClientUIInterface* m_client_interface = nullptr;

--- a/src/banman.h
+++ b/src/banman.h
@@ -84,7 +84,8 @@ private:
     //!set the "dirty" flag for the banlist
     void SetBannedSetDirty(bool dirty = true);
     //!clean unused entries (if bantime has expired)
-    void SweepBanned();
+    bool SweepBanned();
+    void SweepBanned(bool isLockHeld) EXCLUSIVE_LOCKS_REQUIRED(m_banned_mutex);
 
     Mutex m_banned_mutex;
     banmap_t m_banned GUARDED_BY(m_banned_mutex);


### PR DESCRIPTION
This PR is related to #19303 and gets rid of the RecursiveMutex `m_cs_banned`.

The last commit prevents double lock for `m_banned_mutex` by changing `BanMan::GetBanned()` to lock it only after `BanMan::SweepBanned()` releases it.