### PR TITLE
build: specify hosts for qrencode package

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -137,7 +137,7 @@ include packages/packages.mk
 build_id:=$(shell env CC='$(build_CC)' CXX='$(build_CXX)' AR='$(build_AR)' RANLIB='$(build_RANLIB)' STRIP='$(build_STRIP)' SHA256SUM='$(build_SHA256SUM)' DEBUG='$(DEBUG)' ./gen_id '$(BUILD_ID_SALT)' 'GUIX_ENVIRONMENT=$(realpath $(GUIX_ENVIRONMENT))')
 $(host_arch)_$(host_os)_id:=$(shell env CC='$(host_CC)' CXX='$(host_CXX)' AR='$(host_AR)' RANLIB='$(host_RANLIB)' STRIP='$(host_STRIP)' SHA256SUM='$(build_SHA256SUM)' DEBUG='$(DEBUG)' ./gen_id '$(HOST_ID_SALT)' 'GUIX_ENVIRONMENT=$(realpath $(GUIX_ENVIRONMENT))')
 
-qrencode_packages_$(NO_QR) = $(qrencode_packages)
+qrencode_packages_$(NO_QR) = $(qrencode_$(host_os)_packages)
 
 qt_packages_$(NO_QT) = $(qt_packages) $(qt_$(host_os)_packages) $(qt_$(host_arch)_$(host_os)_packages) $(qrencode_packages_)
 

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,10 +1,12 @@
 packages:=boost libevent
 
-qrencode_packages = qrencode
+qrencode_linux_packages = qrencode
+qrencode_android_packages = qrencode
+qrencode_darwin_packages = qrencode
+qrencode_mingw32_packages = qrencode
 
 qt_linux_packages:=qt expat libxcb xcb_proto libXau xproto freetype fontconfig libxkbcommon libxcb_util libxcb_util_render libxcb_util_keysyms libxcb_util_image libxcb_util_wm
 qt_android_packages=qt
-
 qt_darwin_packages=qt
 qt_mingw32_packages=qt
 


### PR DESCRIPTION
Similar to how we specify the OS's we build Qt for, specify which OS's
we will build qrencode for (a qt dependency). This commit alone doesn't
change anything, but when we start supporting other OS's, i.e #23948,
where we wont support qt (or at least initially), it'll skip building
the qrencode package, which would be unused.

I'll rebase the other *BSD changes on top of this.