### PR TITLE
util: Fix mis-swapped `prettyIndent` and `indentLevel` arguments

### DIFF
--- a/src/util/settings.cpp
+++ b/src/util/settings.cpp
@@ -112,7 +112,7 @@ bool WriteSettings(const fs::path& path,
         errors.emplace_back(strprintf("Error: Unable to open settings file %s for writing", fs::PathToString(path)));
         return false;
     }
-    file << out.write(/* prettyIndent= */ 1, /* indentLevel= */ 4) << std::endl;
+    file << out.write(/* prettyIndent= */ 4, /* indentLevel= */ 1) << std::endl;
     file.close();
     return true;
 }


### PR DESCRIPTION
On master d0bf9bb6a539f151ec92725d20a2b6c22cb095a5:
```
$ cat settings.json
{
    "wallet": [
     "210803d"
    ]
   }
```

With this PR:
```
$ cat settings.json
{
    "wallet": [
        "210803d"
    ]
}
```