### PR TITLE
rest: Use query parameters to control resource loading

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -47,17 +47,23 @@ The HTTP request and response are both handled entirely in-memory.
 With the /notxdetails/ option JSON response will only contain the transaction hash instead of the complete transaction details. The option only affects the JSON response.
 
 #### Blockheaders
-`GET /rest/headers/<COUNT>/<BLOCK-HASH>.<bin|hex|json>`
+`GET /rest/headers/<BLOCK-HASH>.<bin|hex|json>?count=<COUNT=5>`
 
 Given a block hash: returns <COUNT> amount of blockheaders in upward direction.
 Returns empty if the block doesn't exist or it isn't in the active chain.
 
+*Deprecated (but not removed) since 24.0:*
+`GET /rest/headers/<COUNT>/<BLOCK-HASH>.<bin|hex|json>`
+
 #### Blockfilter Headers
-`GET /rest/blockfilterheaders/<FILTERTYPE>/<COUNT>/<BLOCK-HASH>.<bin|hex|json>`
+`GET /rest/blockfilterheaders/<FILTERTYPE>/<BLOCK-HASH>.<bin|hex|json>?count=<COUNT=5>`
 
 Given a block hash: returns <COUNT> amount of blockfilter headers in upward
 direction for the filter type <FILTERTYPE>.
 Returns empty if the block doesn't exist or it isn't in the active chain.
+
+*Deprecated (but not removed) since 24.0:*
+`GET /rest/blockfilterheaders/<FILTERTYPE>/<COUNT>/<BLOCK-HASH>.<bin|hex|json>`
 
 #### Blockfilters
 `GET /rest/blockfilter/<FILTERTYPE>/<BLOCK-HASH>.<bin|hex|json>`

--- a/doc/release-notes-24098.md
+++ b/doc/release-notes-24098.md
@@ -1,0 +1,22 @@
+Notable changes
+===============
+
+Updated REST APIs
+-----------------
+
+- The `/headers/` and `/blockfilterheaders/` endpoints have been updated to use
+  a query parameter instead of path parameter to specify the result count. The
+  count parameter is now optional, and defaults to 5 for both endpoints. The old
+  endpoints are still functional, and have no documented behaviour change.
+
+  For `/headers`, use
+  `GET /rest/headers/<BLOCK-HASH>.<bin|hex|json>?count=<COUNT=5>`
+  instead of
+  `GET /rest/headers/<COUNT>/<BLOCK-HASH>.<bin|hex|json>` (deprecated)
+
+  For `/blockfilterheaders/`, use
+  `GET /rest/blockfilterheaders/<FILTERTYPE>/<BLOCK-HASH>.<bin|hex|json>?count=<COUNT=5>`
+  instead of
+  `GET /rest/blockfilterheaders/<FILTERTYPE>/<COUNT>/<BLOCK-HASH>.<bin|hex|json>` (deprecated)
+
+  (#24098)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -198,6 +198,7 @@ BITCOIN_CORE_H = \
   psbt.h \
   random.h \
   randomenv.h \
+  rest.h \
   reverse_iterator.h \
   rpc/blockchain.h \
   rpc/client.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -116,6 +116,7 @@ BITCOIN_TESTS =\
   test/prevector_tests.cpp \
   test/raii_event_tests.cpp \
   test/random_tests.cpp \
+  test/rest_tests.cpp \
   test/reverselock_tests.cpp \
   test/rpc_tests.cpp \
   test/sanity_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -95,6 +95,7 @@ BITCOIN_TESTS =\
   test/fs_tests.cpp \
   test/getarg_tests.cpp \
   test/hash_tests.cpp \
+  test/httpserver_tests.cpp \
   test/i2p_tests.cpp \
   test/interfaces_tests.cpp \
   test/key_io_tests.cpp \

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -23,6 +23,7 @@
 
 #include <deque>
 #include <memory>
+#include <optional>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
@@ -30,11 +31,12 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#include <event2/thread.h>
 #include <event2/buffer.h>
 #include <event2/bufferevent.h>
-#include <event2/util.h>
+#include <event2/http.h>
 #include <event2/keyvalq_struct.h>
+#include <event2/thread.h>
+#include <event2/util.h>
 
 #include <support/events.h>
 
@@ -637,6 +639,37 @@ HTTPRequest::RequestMethod HTTPRequest::GetRequestMethod() const
         return UNKNOWN;
         break;
     }
+}
+
+std::optional<std::string> HTTPRequest::GetQueryParameter(const std::string& key) const
+{
+    const char* uri{evhttp_request_get_uri(req)};
+
+    return GetQueryParameterFromUri(uri, key);
+}
+
+std::optional<std::string> GetQueryParameterFromUri(const char* uri, const std::string& key)
+{
+    evhttp_uri* uri_parsed{evhttp_uri_parse(uri)};
+    const char* query{evhttp_uri_get_query(uri_parsed)};
+    std::optional<std::string> result;
+
+    if (query) {
+        // Parse the query string into a key-value queue and iterate over it
+        struct evkeyvalq params_q;
+        evhttp_parse_query_str(query, &params_q);
+
+        for (struct evkeyval* param{params_q.tqh_first}; param != nullptr; param = param->next.tqe_next) {
+            if (param->key == key) {
+                result = param->value;
+                break;
+            }
+        }
+        evhttp_clear_headers(&params_q);
+    }
+    evhttp_uri_free(uri_parsed);
+
+    return result;
 }
 
 void RegisterHTTPHandler(const std::string &prefix, bool exactMatch, const HTTPRequestHandler &handler)

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -5,8 +5,9 @@
 #ifndef BITCOIN_HTTPSERVER_H
 #define BITCOIN_HTTPSERVER_H
 
-#include <string>
 #include <functional>
+#include <optional>
+#include <string>
 
 static const int DEFAULT_HTTP_THREADS=4;
 static const int DEFAULT_HTTP_WORKQUEUE=16;
@@ -83,6 +84,17 @@ public:
      */
     RequestMethod GetRequestMethod() const;
 
+    /** Get the query parameter value from request uri for a specified key, or std::nullopt if the
+     * key is not found.
+     *
+     * If the query string contains duplicate keys, the first value is returned. Many web frameworks
+     * would instead parse this as an array of values, but this is not (yet) implemented as it is
+     * currently not needed in any of the endpoints.
+     *
+     * @param[in] key represents the query parameter of which the value is returned
+     */
+    std::optional<std::string> GetQueryParameter(const std::string& key) const;
+
     /**
      * Get the request header specified by hdr, or an empty string.
      * Return a pair (isPresent,string).
@@ -114,6 +126,20 @@ public:
      */
     void WriteReply(int nStatus, const std::string& strReply = "");
 };
+
+/** Get the query parameter value from request uri for a specified key, or std::nullopt if the key
+ * is not found.
+ *
+ * If the query string contains duplicate keys, the first value is returned. Many web frameworks
+ * would instead parse this as an array of values, but this is not (yet) implemented as it is
+ * currently not needed in any of the endpoints.
+ *
+ * Helper function for HTTPRequest::GetQueryParameter.
+ *
+ * @param[in] uri is the entire request uri
+ * @param[in] key represents the query parameter of which the value is returned
+ */
+std::optional<std::string> GetQueryParameterFromUri(const char* uri, const std::string& key);
 
 /** Event handler closure.
  */

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -135,23 +135,26 @@ static ChainstateManager* GetChainman(const std::any& context, HTTPRequest* req)
 
 RESTResponseFormat ParseDataFormat(std::string& param, const std::string& strReq)
 {
-    const std::string::size_type pos = strReq.rfind('.');
-    if (pos == std::string::npos)
-    {
-        param = strReq;
+    // Remove query string (if any, separated with '?') as it should not interfere with
+    // parsing param and data format
+    param = strReq.substr(0, strReq.rfind('?'));
+    const std::string::size_type pos_format{param.rfind('.')};
+
+    // No format string is found
+    if (pos_format == std::string::npos) {
         return rf_names[0].rf;
     }
 
-    param = strReq.substr(0, pos);
-    const std::string suff(strReq, pos + 1);
-
+    // Match format string to available formats
+    const std::string suffix(param, pos_format + 1);
     for (const auto& rf_name : rf_names) {
-        if (suff == rf_name.name)
+        if (suffix == rf_name.name) {
+            param.erase(pos_format);
             return rf_name.rf;
+        }
     }
 
-    /* If no suffix is found, return original string.  */
-    param = strReq;
+    // If no suffix is found, return RESTResponseFormat::UNDEF and original string without query string
     return rf_names[0].rf;
 }
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -3,6 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <rest.h>
+
 #include <blockfilter.h>
 #include <chain.h>
 #include <chainparams.h>
@@ -27,6 +29,7 @@
 #include <version.h>
 
 #include <any>
+#include <string>
 
 #include <boost/algorithm/string.hpp>
 
@@ -39,13 +42,6 @@ using node::ReadBlockFromDisk;
 
 static const size_t MAX_GETUTXOS_OUTPOINTS = 15; //allow a max of 15 outpoints to be queried at once
 static constexpr unsigned int MAX_REST_HEADERS_RESULTS = 2000;
-
-enum class RetFormat {
-    UNDEF,
-    BINARY,
-    HEX,
-    JSON,
-};
 
 static const struct {
     RetFormat rf;
@@ -137,7 +133,7 @@ static ChainstateManager* GetChainman(const std::any& context, HTTPRequest* req)
     return node_context->chainman.get();
 }
 
-static RetFormat ParseDataFormat(std::string& param, const std::string& strReq)
+RetFormat ParseDataFormat(std::string& param, const std::string& strReq)
 {
     const std::string::size_type pos = strReq.rfind('.');
     if (pos == std::string::npos)

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -44,13 +44,13 @@ static const size_t MAX_GETUTXOS_OUTPOINTS = 15; //allow a max of 15 outpoints t
 static constexpr unsigned int MAX_REST_HEADERS_RESULTS = 2000;
 
 static const struct {
-    RetFormat rf;
+    RESTResponseFormat rf;
     const char* name;
 } rf_names[] = {
-      {RetFormat::UNDEF, ""},
-      {RetFormat::BINARY, "bin"},
-      {RetFormat::HEX, "hex"},
-      {RetFormat::JSON, "json"},
+      {RESTResponseFormat::UNDEF, ""},
+      {RESTResponseFormat::BINARY, "bin"},
+      {RESTResponseFormat::HEX, "hex"},
+      {RESTResponseFormat::JSON, "json"},
 };
 
 struct CCoin {
@@ -133,7 +133,7 @@ static ChainstateManager* GetChainman(const std::any& context, HTTPRequest* req)
     return node_context->chainman.get();
 }
 
-RetFormat ParseDataFormat(std::string& param, const std::string& strReq)
+RESTResponseFormat ParseDataFormat(std::string& param, const std::string& strReq)
 {
     const std::string::size_type pos = strReq.rfind('.');
     if (pos == std::string::npos)
@@ -187,7 +187,7 @@ static bool rest_headers(const std::any& context,
     if (!CheckWarmup(req))
         return false;
     std::string param;
-    const RetFormat rf = ParseDataFormat(param, strURIPart);
+    const RESTResponseFormat rf = ParseDataFormat(param, strURIPart);
     std::vector<std::string> path;
     boost::split(path, param, boost::is_any_of("/"));
 
@@ -225,7 +225,7 @@ static bool rest_headers(const std::any& context,
     }
 
     switch (rf) {
-    case RetFormat::BINARY: {
+    case RESTResponseFormat::BINARY: {
         CDataStream ssHeader(SER_NETWORK, PROTOCOL_VERSION);
         for (const CBlockIndex *pindex : headers) {
             ssHeader << pindex->GetBlockHeader();
@@ -237,7 +237,7 @@ static bool rest_headers(const std::any& context,
         return true;
     }
 
-    case RetFormat::HEX: {
+    case RESTResponseFormat::HEX: {
         CDataStream ssHeader(SER_NETWORK, PROTOCOL_VERSION);
         for (const CBlockIndex *pindex : headers) {
             ssHeader << pindex->GetBlockHeader();
@@ -248,7 +248,7 @@ static bool rest_headers(const std::any& context,
         req->WriteReply(HTTP_OK, strHex);
         return true;
     }
-    case RetFormat::JSON: {
+    case RESTResponseFormat::JSON: {
         UniValue jsonHeaders(UniValue::VARR);
         for (const CBlockIndex *pindex : headers) {
             jsonHeaders.push_back(blockheaderToJSON(tip, pindex));
@@ -272,7 +272,7 @@ static bool rest_block(const std::any& context,
     if (!CheckWarmup(req))
         return false;
     std::string hashStr;
-    const RetFormat rf = ParseDataFormat(hashStr, strURIPart);
+    const RESTResponseFormat rf = ParseDataFormat(hashStr, strURIPart);
 
     uint256 hash;
     if (!ParseHashStr(hashStr, hash))
@@ -300,7 +300,7 @@ static bool rest_block(const std::any& context,
     }
 
     switch (rf) {
-    case RetFormat::BINARY: {
+    case RESTResponseFormat::BINARY: {
         CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
         ssBlock << block;
         std::string binaryBlock = ssBlock.str();
@@ -309,7 +309,7 @@ static bool rest_block(const std::any& context,
         return true;
     }
 
-    case RetFormat::HEX: {
+    case RESTResponseFormat::HEX: {
         CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
         ssBlock << block;
         std::string strHex = HexStr(ssBlock) + "\n";
@@ -318,7 +318,7 @@ static bool rest_block(const std::any& context,
         return true;
     }
 
-    case RetFormat::JSON: {
+    case RESTResponseFormat::JSON: {
         UniValue objBlock = blockToJSON(block, tip, pblockindex, tx_verbosity);
         std::string strJSON = objBlock.write() + "\n";
         req->WriteHeader("Content-Type", "application/json");
@@ -347,7 +347,7 @@ static bool rest_filter_header(const std::any& context, HTTPRequest* req, const 
     if (!CheckWarmup(req)) return false;
 
     std::string param;
-    const RetFormat rf = ParseDataFormat(param, strURIPart);
+    const RESTResponseFormat rf = ParseDataFormat(param, strURIPart);
 
     std::vector<std::string> uri_parts;
     boost::split(uri_parts, param, boost::is_any_of("/"));
@@ -413,7 +413,7 @@ static bool rest_filter_header(const std::any& context, HTTPRequest* req, const 
     }
 
     switch (rf) {
-    case RetFormat::BINARY: {
+    case RESTResponseFormat::BINARY: {
         CDataStream ssHeader{SER_NETWORK, PROTOCOL_VERSION};
         for (const uint256& header : filter_headers) {
             ssHeader << header;
@@ -424,7 +424,7 @@ static bool rest_filter_header(const std::any& context, HTTPRequest* req, const 
         req->WriteReply(HTTP_OK, binaryHeader);
         return true;
     }
-    case RetFormat::HEX: {
+    case RESTResponseFormat::HEX: {
         CDataStream ssHeader{SER_NETWORK, PROTOCOL_VERSION};
         for (const uint256& header : filter_headers) {
             ssHeader << header;
@@ -435,7 +435,7 @@ static bool rest_filter_header(const std::any& context, HTTPRequest* req, const 
         req->WriteReply(HTTP_OK, strHex);
         return true;
     }
-    case RetFormat::JSON: {
+    case RESTResponseFormat::JSON: {
         UniValue jsonHeaders(UniValue::VARR);
         for (const uint256& header : filter_headers) {
             jsonHeaders.push_back(header.GetHex());
@@ -457,7 +457,7 @@ static bool rest_block_filter(const std::any& context, HTTPRequest* req, const s
     if (!CheckWarmup(req)) return false;
 
     std::string param;
-    const RetFormat rf = ParseDataFormat(param, strURIPart);
+    const RESTResponseFormat rf = ParseDataFormat(param, strURIPart);
 
     // request is sent over URI scheme /rest/blockfilter/filtertype/blockhash
     std::vector<std::string> uri_parts;
@@ -513,7 +513,7 @@ static bool rest_block_filter(const std::any& context, HTTPRequest* req, const s
     }
 
     switch (rf) {
-    case RetFormat::BINARY: {
+    case RESTResponseFormat::BINARY: {
         CDataStream ssResp{SER_NETWORK, PROTOCOL_VERSION};
         ssResp << filter;
 
@@ -522,7 +522,7 @@ static bool rest_block_filter(const std::any& context, HTTPRequest* req, const s
         req->WriteReply(HTTP_OK, binaryResp);
         return true;
     }
-    case RetFormat::HEX: {
+    case RESTResponseFormat::HEX: {
         CDataStream ssResp{SER_NETWORK, PROTOCOL_VERSION};
         ssResp << filter;
 
@@ -531,7 +531,7 @@ static bool rest_block_filter(const std::any& context, HTTPRequest* req, const s
         req->WriteReply(HTTP_OK, strHex);
         return true;
     }
-    case RetFormat::JSON: {
+    case RESTResponseFormat::JSON: {
         UniValue ret(UniValue::VOBJ);
         ret.pushKV("filter", HexStr(filter.GetEncodedFilter()));
         std::string strJSON = ret.write() + "\n";
@@ -553,10 +553,10 @@ static bool rest_chaininfo(const std::any& context, HTTPRequest* req, const std:
     if (!CheckWarmup(req))
         return false;
     std::string param;
-    const RetFormat rf = ParseDataFormat(param, strURIPart);
+    const RESTResponseFormat rf = ParseDataFormat(param, strURIPart);
 
     switch (rf) {
-    case RetFormat::JSON: {
+    case RESTResponseFormat::JSON: {
         JSONRPCRequest jsonRequest;
         jsonRequest.context = context;
         jsonRequest.params = UniValue(UniValue::VARR);
@@ -579,10 +579,10 @@ static bool rest_mempool_info(const std::any& context, HTTPRequest* req, const s
     const CTxMemPool* mempool = GetMemPool(context, req);
     if (!mempool) return false;
     std::string param;
-    const RetFormat rf = ParseDataFormat(param, strURIPart);
+    const RESTResponseFormat rf = ParseDataFormat(param, strURIPart);
 
     switch (rf) {
-    case RetFormat::JSON: {
+    case RESTResponseFormat::JSON: {
         UniValue mempoolInfoObject = MempoolInfoToJSON(*mempool);
 
         std::string strJSON = mempoolInfoObject.write() + "\n";
@@ -602,10 +602,10 @@ static bool rest_mempool_contents(const std::any& context, HTTPRequest* req, con
     const CTxMemPool* mempool = GetMemPool(context, req);
     if (!mempool) return false;
     std::string param;
-    const RetFormat rf = ParseDataFormat(param, strURIPart);
+    const RESTResponseFormat rf = ParseDataFormat(param, strURIPart);
 
     switch (rf) {
-    case RetFormat::JSON: {
+    case RESTResponseFormat::JSON: {
         UniValue mempoolObject = MempoolToJSON(*mempool, true);
 
         std::string strJSON = mempoolObject.write() + "\n";
@@ -624,7 +624,7 @@ static bool rest_tx(const std::any& context, HTTPRequest* req, const std::string
     if (!CheckWarmup(req))
         return false;
     std::string hashStr;
-    const RetFormat rf = ParseDataFormat(hashStr, strURIPart);
+    const RESTResponseFormat rf = ParseDataFormat(hashStr, strURIPart);
 
     uint256 hash;
     if (!ParseHashStr(hashStr, hash))
@@ -643,7 +643,7 @@ static bool rest_tx(const std::any& context, HTTPRequest* req, const std::string
     }
 
     switch (rf) {
-    case RetFormat::BINARY: {
+    case RESTResponseFormat::BINARY: {
         CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
         ssTx << tx;
 
@@ -653,7 +653,7 @@ static bool rest_tx(const std::any& context, HTTPRequest* req, const std::string
         return true;
     }
 
-    case RetFormat::HEX: {
+    case RESTResponseFormat::HEX: {
         CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
         ssTx << tx;
 
@@ -663,7 +663,7 @@ static bool rest_tx(const std::any& context, HTTPRequest* req, const std::string
         return true;
     }
 
-    case RetFormat::JSON: {
+    case RESTResponseFormat::JSON: {
         UniValue objTx(UniValue::VOBJ);
         TxToUniv(*tx, hashBlock, objTx);
         std::string strJSON = objTx.write() + "\n";
@@ -683,7 +683,7 @@ static bool rest_getutxos(const std::any& context, HTTPRequest* req, const std::
     if (!CheckWarmup(req))
         return false;
     std::string param;
-    const RetFormat rf = ParseDataFormat(param, strURIPart);
+    const RESTResponseFormat rf = ParseDataFormat(param, strURIPart);
 
     std::vector<std::string> uriParts;
     if (param.length() > 1)
@@ -730,14 +730,14 @@ static bool rest_getutxos(const std::any& context, HTTPRequest* req, const std::
     }
 
     switch (rf) {
-    case RetFormat::HEX: {
+    case RESTResponseFormat::HEX: {
         // convert hex to bin, continue then with bin part
         std::vector<unsigned char> strRequestV = ParseHex(strRequestMutable);
         strRequestMutable.assign(strRequestV.begin(), strRequestV.end());
         [[fallthrough]];
     }
 
-    case RetFormat::BINARY: {
+    case RESTResponseFormat::BINARY: {
         try {
             //deserialize only if user sent a request
             if (strRequestMutable.size() > 0)
@@ -757,7 +757,7 @@ static bool rest_getutxos(const std::any& context, HTTPRequest* req, const std::
         break;
     }
 
-    case RetFormat::JSON: {
+    case RESTResponseFormat::JSON: {
         if (!fInputParsed)
             return RESTERR(req, HTTP_BAD_REQUEST, "Error: empty request");
         break;
@@ -811,7 +811,7 @@ static bool rest_getutxos(const std::any& context, HTTPRequest* req, const std::
     }
 
     switch (rf) {
-    case RetFormat::BINARY: {
+    case RESTResponseFormat::BINARY: {
         // serialize data
         // use exact same output as mentioned in Bip64
         CDataStream ssGetUTXOResponse(SER_NETWORK, PROTOCOL_VERSION);
@@ -823,7 +823,7 @@ static bool rest_getutxos(const std::any& context, HTTPRequest* req, const std::
         return true;
     }
 
-    case RetFormat::HEX: {
+    case RESTResponseFormat::HEX: {
         CDataStream ssGetUTXOResponse(SER_NETWORK, PROTOCOL_VERSION);
         ssGetUTXOResponse << chainman.ActiveChain().Height() << chainman.ActiveChain().Tip()->GetBlockHash() << bitmap << outs;
         std::string strHex = HexStr(ssGetUTXOResponse) + "\n";
@@ -833,7 +833,7 @@ static bool rest_getutxos(const std::any& context, HTTPRequest* req, const std::
         return true;
     }
 
-    case RetFormat::JSON: {
+    case RESTResponseFormat::JSON: {
         UniValue objGetUTXOResponse(UniValue::VOBJ);
 
         // pack in some essentials
@@ -873,7 +873,7 @@ static bool rest_blockhash_by_height(const std::any& context, HTTPRequest* req,
 {
     if (!CheckWarmup(req)) return false;
     std::string height_str;
-    const RetFormat rf = ParseDataFormat(height_str, str_uri_part);
+    const RESTResponseFormat rf = ParseDataFormat(height_str, str_uri_part);
 
     int32_t blockheight = -1; // Initialization done only to prevent valgrind false positive, see https://github.com/bitcoin/bitcoin/pull/18785
     if (!ParseInt32(height_str, &blockheight) || blockheight < 0) {
@@ -893,19 +893,19 @@ static bool rest_blockhash_by_height(const std::any& context, HTTPRequest* req,
         pblockindex = active_chain[blockheight];
     }
     switch (rf) {
-    case RetFormat::BINARY: {
+    case RESTResponseFormat::BINARY: {
         CDataStream ss_blockhash(SER_NETWORK, PROTOCOL_VERSION);
         ss_blockhash << pblockindex->GetBlockHash();
         req->WriteHeader("Content-Type", "application/octet-stream");
         req->WriteReply(HTTP_OK, ss_blockhash.str());
         return true;
     }
-    case RetFormat::HEX: {
+    case RESTResponseFormat::HEX: {
         req->WriteHeader("Content-Type", "text/plain");
         req->WriteReply(HTTP_OK, pblockindex->GetBlockHash().GetHex() + "\n");
         return true;
     }
-    case RetFormat::JSON: {
+    case RESTResponseFormat::JSON: {
         req->WriteHeader("Content-Type", "application/json");
         UniValue resp = UniValue(UniValue::VOBJ);
         resp.pushKV("blockhash", pblockindex->GetBlockHash().GetHex());

--- a/src/rest.h
+++ b/src/rest.h
@@ -14,6 +14,15 @@ enum class RESTResponseFormat {
     JSON,
 };
 
+/**
+ * Parse a URI to get the data format and URI without data format
+ * and query string.
+ *
+ * @param[out]  param   The strReq without the data format string and
+ *                      without the query string (if any).
+ * @param[in]   strReq  The URI to be parsed.
+ * @return      RESTResponseFormat that was parsed from the URI.
+ */
 RESTResponseFormat ParseDataFormat(std::string& param, const std::string& strReq);
 
 #endif // BITCOIN_REST_H

--- a/src/rest.h
+++ b/src/rest.h
@@ -7,13 +7,13 @@
 
 #include <string>
 
-enum class RetFormat {
+enum class RESTResponseFormat {
     UNDEF,
     BINARY,
     HEX,
     JSON,
 };
 
-RetFormat ParseDataFormat(std::string& param, const std::string& strReq);
+RESTResponseFormat ParseDataFormat(std::string& param, const std::string& strReq);
 
 #endif // BITCOIN_REST_H

--- a/src/rest.h
+++ b/src/rest.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2015-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_REST_H
+#define BITCOIN_REST_H
+
+#include <string>
+
+enum class RetFormat {
+    UNDEF,
+    BINARY,
+    HEX,
+    JSON,
+};
+
+RetFormat ParseDataFormat(std::string& param, const std::string& strReq);
+
+#endif // BITCOIN_REST_H

--- a/src/test/httpserver_tests.cpp
+++ b/src/test/httpserver_tests.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2012-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <httpserver.h>
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(httpserver_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(test_query_parameters)
+{
+    std::string uri {};
+
+    // No parameters
+    uri = "localhost:8080/rest/headers/someresource.json";
+    BOOST_CHECK(!GetQueryParameterFromUri(uri.c_str(), "p1").has_value());
+
+    // Single parameter
+    uri = "localhost:8080/rest/endpoint/someresource.json?p1=v1";
+    BOOST_CHECK_EQUAL(GetQueryParameterFromUri(uri.c_str(), "p1").value(), "v1");
+    BOOST_CHECK(!GetQueryParameterFromUri(uri.c_str(), "p2").has_value());
+
+    // Multiple parameters
+    uri = "/rest/endpoint/someresource.json?p1=v1&p2=v2";
+    BOOST_CHECK_EQUAL(GetQueryParameterFromUri(uri.c_str(), "p1").value(), "v1");
+    BOOST_CHECK_EQUAL(GetQueryParameterFromUri(uri.c_str(), "p2").value(), "v2");
+
+    // If the query string contains duplicate keys, the first value is returned
+    uri = "/rest/endpoint/someresource.json?p1=v1&p1=v2";
+    BOOST_CHECK_EQUAL(GetQueryParameterFromUri(uri.c_str(), "p1").value(), "v1");
+
+    // Invalid query string syntax is the same as not having parameters
+    uri = "/rest/endpoint/someresource.json&p1=v1&p2=v2";
+    BOOST_CHECK(!GetQueryParameterFromUri(uri.c_str(), "p1").has_value());
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/rest_tests.cpp
+++ b/src/test/rest_tests.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2012-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <rest.h>
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+
+BOOST_FIXTURE_TEST_SUITE(rest_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(test_query_string)
+{
+    std::string param;
+    RESTResponseFormat rf;
+    // No query string
+    rf = ParseDataFormat(param, "/rest/endpoint/someresource.json");
+    BOOST_CHECK_EQUAL(param, "/rest/endpoint/someresource");
+    BOOST_CHECK_EQUAL(rf, RESTResponseFormat::JSON);
+
+    // Query string with single parameter
+    rf = ParseDataFormat(param, "/rest/endpoint/someresource.bin?p1=v1");
+    BOOST_CHECK_EQUAL(param, "/rest/endpoint/someresource");
+    BOOST_CHECK_EQUAL(rf, RESTResponseFormat::BINARY);
+
+    // Query string with multiple parameters
+    rf = ParseDataFormat(param, "/rest/endpoint/someresource.hex?p1=v1&p2=v2");
+    BOOST_CHECK_EQUAL(param, "/rest/endpoint/someresource");
+    BOOST_CHECK_EQUAL(rf, RESTResponseFormat::HEX);
+
+    // Incorrectly formed query string will not be handled
+    rf = ParseDataFormat(param, "/rest/endpoint/someresource.json&p1=v1");
+    BOOST_CHECK_EQUAL(param, "/rest/endpoint/someresource.json&p1=v1");
+    BOOST_CHECK_EQUAL(rf, RESTResponseFormat::UNDEF);
+
+    // Omitted data format with query string should return UNDEF and hide query string
+    rf = ParseDataFormat(param, "/rest/endpoint/someresource?p1=v1");
+    BOOST_CHECK_EQUAL(param, "/rest/endpoint/someresource");
+    BOOST_CHECK_EQUAL(rf, RESTResponseFormat::UNDEF);
+
+    // Data format specified after query string
+    rf = ParseDataFormat(param, "/rest/endpoint/someresource?p1=v1.json");
+    BOOST_CHECK_EQUAL(param, "/rest/endpoint/someresource");
+    BOOST_CHECK_EQUAL(rf, RESTResponseFormat::UNDEF);
+}
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
In RESTful APIs, [typically](https://rapidapi.com/blog/api-glossary/parameters/query/) path parameters  (e.g. `/some/unique/resource/`) are used to represent resources, and query parameters (e.g. `?sort=asc`) are used to control how these resources are being loaded through e.g. sorting, pagination, filtering, ...

As first [discussed in #17631](https://github.com/bitcoin/bitcoin/pull/17631#discussion_r733031180), the [current REST api](https://github.com/bitcoin/bitcoin/blob/master/doc/REST-interface.md) contains two endpoints `/headers/` and `/blockfilterheaders/` that rather unexpectedly use path parameters to control how many (filter) headers are returned in the response. While this is no critical issue, it is unintuitive and we are still early enough to easily phase this behaviour out and ensure new endpoints (if any) do not have to stick to non-standard behaviour just for internal consistency.

In this PR, a new `HTTPRequest::GetQueryParameter` method is introduced to easily parse query parameters, as well as two new `/headers/` and `/blockfilterheaders/` endpoints that use a count query parameter are introduced. The old path parameter-based endpoints are kept without too much overhead, but the documentation now points to the new query parameter-based endpoints as the default interface to encourage standardness.

## Behaviour change
### New endpoints and default values
`/headers/` and `/blockfilterheaders/` now have 2 new endpoints that contain query parameters (`?count=<count>`) instead of path parameters (`/<count>/`), as described in REST-interface.md. Since query parameters can easily have default values, I have set this at 5 for both endpoints.

**headers**
`GET /rest/headers/<BLOCK-HASH>.<bin|hex|json>?count=<COUNT=5>`
should now be used instead of
`GET /rest/headers/<COUNT>/<BLOCK-HASH>.<bin|hex|json>`

**blockfilterheaders**
`GET /rest/blockfilterheaders/<FILTERTYPE>/<BLOCK-HASH>.<bin|hex|json>?count=<COUNT=5>`
should now be used instead of
`GET /rest/blockfilterheaders/<FILTERTYPE>/<COUNT>/<BLOCK-HASH>.<bin|hex|json>`

### Some previously invalid API calls are now valid
API calls that contained query strings in the URI could not be parsed prior to this PR. This PR changes behaviour in that previously invalid calls (e.g. `GET /rest/headers/5/somehash.json?someunusedparam=foo`) would now become valid, as the query parameters are properly parsed, and discarded if unused. 
For example, prior to this PR, adding an irrelevant `someparam` parameter would be illegal:
```
GET /rest/headers/5/0000004c6aad0c89c1c060e8e116dcd849e0554935cd78ff9c6a398abeac6eda.json?someparam=true
->
Invalid hash: 0000004c6aad0c89c1c060e8e116dcd849e0554935cd78ff9c6a398abeac6eda.json?someparam=true
```
**This behaviour change affects all rest endpoints, not just the 2 new ones introduced here.**

*(Note: I'd be open to implementing additional logic to refuse requests containing unrecognized query parameters to minimize behaviour change, but for the endpoints that we currently have I don't really see the point for that added complexity. E.g. I don't see any scenarios where misspelling a parameter could lead to harmful outcomes)*

## Using the REST API

To run the API HTTP server, start a bitcoind instance with the `-rest` flag enabled. To use the
`blockfilterheaders` endpoint, you'll also need to set `-blockfilterindex=1`: 
```
./bitcoind -signet -rest -blockfilterindex=1
```

As soon as bitcoind is fully up and running, you should be able to query the API, for example by
using curl on the command line: ```curl "127.0.0.1:38332/rest/chaininfo.json"```. 
To more easily parse the JSON output, you can also use tools like 'jq' or `json_pp`, e.g.:
```
curl -s "localhost:38332/rest/blockfilterheaders/basic/0000004c6aad0c89c1c060e8e116dcd849e0554935cd78ff9c6a398abeac6eda.json?count=2" | json_pp .
```

## To do
- [x] update `doc/release-notes`

## Feedback
This is my first PR (hooray!). Please don't hold back on any feedback/comments/nits/... you may have, big or small, whether they are code, process, language, ... related. I welcome private messages too if there's anything you don't want to clutter the PR with. I'm here to learn and am grateful for everyone's input.
