### PR TITLE
policy: treat P2TR outputs with invalid x-only pubkey as non-standard

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -73,6 +73,9 @@ bool IsStandard(const CScript& scriptPubKey, TxoutType& whichType)
     } else if (whichType == TxoutType::NULL_DATA &&
                (!fAcceptDatacarrier || scriptPubKey.size() > nMaxDatacarrierBytes)) {
           return false;
+    } else if (whichType == TxoutType::WITNESS_V1_TAPROOT &&
+               !XOnlyPubKey(vSolutions.front()).IsFullyValid()) {
+        return false;
     }
 
     return true;

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -59,7 +59,8 @@ FUZZ_TARGET_INIT(script, initialize_script)
     if (!is_standard_ret) {
         assert(which_type == TxoutType::NONSTANDARD ||
                which_type == TxoutType::NULL_DATA ||
-               which_type == TxoutType::MULTISIG);
+               which_type == TxoutType::MULTISIG ||
+               which_type == TxoutType::WITNESS_V1_TAPROOT);
     }
     if (which_type == TxoutType::NONSTANDARD) {
         assert(!is_standard_ret);

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -820,6 +820,17 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[0].scriptPubKey = CScript() << OP_1;
     CheckIsNotStandard(t, "scriptpubkey");
 
+    // TxoutType::WITNESS_V1_TAPROOT with invalid x-only pubkey (non-standard)
+    auto invalid_xpubkey{ParseHex("658204033e46a1fa8cceb84013cfe2d376ca72d5f595319497b95b08aa64a970")};
+    BOOST_CHECK(!XOnlyPubKey(invalid_xpubkey).IsFullyValid());
+    t.vout[0].scriptPubKey = CScript() << OP_1 << invalid_xpubkey;
+    CheckIsNotStandard(t, "scriptpubkey");
+
+    auto valid_xpubkey{ParseHex("a37c3903c8d0db6512e2b40b0dffa05e5a3ab73603ce8c9c4b7771e5412328f9")};
+    BOOST_CHECK(XOnlyPubKey(valid_xpubkey).IsFullyValid());
+    t.vout[0].scriptPubKey = CScript() << OP_1 << valid_xpubkey;
+    CheckIsStandard(t);
+
     // MAX_OP_RETURN_RELAY-byte TxoutType::NULL_DATA (standard)
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
     BOOST_CHECK_EQUAL(MAX_OP_RETURN_RELAY, t.vout[0].scriptPubKey.size());


### PR DESCRIPTION
P2TR outputs with an invalid x-only pubkey (i.e. one that is not on the secp256k1 curve) can obviously never be spent: https://suredbits.com/taproot-funds-burned-on-the-bitcoin-blockchain/ (https://twitter.com/Suredbits/status/1483804177507790863?s=20)
Treating transactions with such unspendable ouputs as non-standard is a measurement to prevent users from burning funds and bloating the UTXO set.
The x-only pubkey for the introduced unit tests are taken from the link above (invalid one) and the first ever taproot transaction in mainnet (valid one): https://twitter.com/Bitcoin/status/1459911733166829568

Further possible related improvements:
- treat bech32m (segwit v1) addresses as invalid if the encoded x-only pubkey is not on the curve (most importantly affects wallet sending RPCs, but also `verifyaddress`)
- mark these outputs as unspendable and remove them from the UTXO set (idea expressed by ajtowns on IRC)