### PR TITLE
Replace RecursiveMutex `cs_addrLocal` with Mutex, and rename it

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -553,12 +553,12 @@ std::string ConnectionTypeAsString(ConnectionType conn_type)
 
 CService CNode::GetAddrLocal() const
 {
-    LOCK(cs_addrLocal);
+    LOCK(m_addr_local_mutex);
     return addrLocal;
 }
 
 void CNode::SetAddrLocal(const CService& addrLocalIn) {
-    LOCK(cs_addrLocal);
+    LOCK(m_addr_local_mutex);
     if (addrLocal.IsValid()) {
         error("Addr local already set for node: %i. Refusing to change from %s to %s", id, addrLocal.ToString(), addrLocalIn.ToString());
     } else {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -553,11 +553,13 @@ std::string ConnectionTypeAsString(ConnectionType conn_type)
 
 CService CNode::GetAddrLocal() const
 {
+    AssertLockNotHeld(m_addr_local_mutex);
     LOCK(m_addr_local_mutex);
     return addrLocal;
 }
 
 void CNode::SetAddrLocal(const CService& addrLocalIn) {
+    AssertLockNotHeld(m_addr_local_mutex);
     LOCK(m_addr_local_mutex);
     if (addrLocal.IsValid()) {
         error("Addr local already set for node: %i. Refusing to change from %s to %s", id, addrLocal.ToString(), addrLocalIn.ToString());

--- a/src/net.h
+++ b/src/net.h
@@ -693,8 +693,8 @@ private:
     std::list<CNetMessage> vRecvMsg; // Used only by SocketHandler thread
 
     // Our address, as reported by the peer
-    CService addrLocal GUARDED_BY(cs_addrLocal);
-    mutable RecursiveMutex cs_addrLocal;
+    CService addrLocal GUARDED_BY(m_addr_local_mutex);
+    mutable RecursiveMutex m_addr_local_mutex;
 
     mapMsgCmdSize mapSendBytesPerMsgCmd GUARDED_BY(cs_vSend);
     mapMsgCmdSize mapRecvBytesPerMsgCmd GUARDED_BY(cs_vRecv);

--- a/src/net.h
+++ b/src/net.h
@@ -694,7 +694,7 @@ private:
 
     // Our address, as reported by the peer
     CService addrLocal GUARDED_BY(m_addr_local_mutex);
-    mutable RecursiveMutex m_addr_local_mutex;
+    mutable Mutex m_addr_local_mutex;
 
     mapMsgCmdSize mapSendBytesPerMsgCmd GUARDED_BY(cs_vSend);
     mapMsgCmdSize mapRecvBytesPerMsgCmd GUARDED_BY(cs_vRecv);

--- a/src/net.h
+++ b/src/net.h
@@ -618,9 +618,9 @@ public:
         return m_greatest_common_version;
     }
 
-    CService GetAddrLocal() const;
+    CService GetAddrLocal() const LOCKS_EXCLUDED(m_addr_local_mutex);
     //! May not be called more than once
-    void SetAddrLocal(const CService& addrLocalIn);
+    void SetAddrLocal(const CService& addrLocalIn) LOCKS_EXCLUDED(m_addr_local_mutex);
 
     CNode* AddRef()
     {


### PR DESCRIPTION
This PR is related to #19303 and gets rid of the `RecursiveMutex cs_addrLocal`.