### PR TITLE
build: force CRCCheck in Windows installer

### DIFF
--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -53,7 +53,7 @@ Var StartMenuGroup
 
 # Installer attributes
 InstallDir $PROGRAMFILES64\Bitcoin
-CRCCheck on
+CRCCheck force
 XPStyle on
 BrandingText " "
 ShowInstDetails show


### PR DESCRIPTION
Otherwise a user can pass `/NCRC` on the command line and bypass the
CRC check, meaning they could use a corrupted installer. I can't think of
a reason why we'd want to allow the use of corrupted installers.

[NSIS docs](https://nsis.sourceforge.io/Docs/Chapter4.html#acrccheck):
> Specifies whether or not the installer will perform a CRC on itself before allowing an install. Note that if the user uses /NCRC on the command line when executing the installer, and you didn't specify 'force', the CRC will not occur, and the user will be allowed to install a (potentially) corrupted installer.