### PR TITLE
build: pass win32-dll to LT_INIT()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,7 +100,7 @@ dnl sets RPATH for any directories in the dynamic linker search path.
 dnl See more: https://wiki.debian.org/RpathIssue
 LT_PREREQ([1.5.2])
 dnl Libtool init checks.
-LT_INIT([pic-only])
+LT_INIT([pic-only win32-dll])
 
 dnl Check/return PATH for base programs.
 AC_PATH_TOOL([AR], [ar])


### PR DESCRIPTION
This is the recommended way to support building PE DLLs with modern mingw 
toolchains and libtool. I made a similar change upstream in the secp256k1 
repo: https://github.com/bitcoin-core/secp256k1/pull/1022. Note that we already
pass `-no-undefined` to our libtool LDFLAGS.

> This option should be used if the package has been ported to build clean
> dlls on win32 platforms.
> If this macro is not used, libtool will assume that the package libraries
> are not dll clean and will build only static libraries on win32 hosts.

See:
https://www.gnu.org/software/libtool/manual/libtool.html#LT_005fINIT
https://www.gnu.org/software/gnulib/manual/html_node/Libtool-and-Windows.html
https://autotools.io/libtool/windows.html
https://github.com/bitcoin-core/secp256k1/issues/923

Guix Build:
```bash
bash-5.1# find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
a504bac1c81818e2fa7e14d4b1e2ddf665b9b79683fff4390ec1d76335157012  guix-build-80e78b6a0479/output/aarch64-linux-gnu/SHA256SUMS.part
ef9193402c261adb993f6644de3f49858acb6d120002505e0def4827b8772294  guix-build-80e78b6a0479/output/aarch64-linux-gnu/bitcoin-80e78b6a0479-aarch64-linux-gnu-debug.tar.gz
030961da6966a14d3dd7322dc7559dfdc0bdeb9f39d042f379c41bab98303d28  guix-build-80e78b6a0479/output/aarch64-linux-gnu/bitcoin-80e78b6a0479-aarch64-linux-gnu.tar.gz
c485e456d325cdd64111eefe36b007e7bcb9e5eb61b1ab752e601023f5853e55  guix-build-80e78b6a0479/output/arm-linux-gnueabihf/SHA256SUMS.part
ff0481c57a3ab15c9651ead7b77990c37af9360bfbc1f5285ad5f7d0c66f5acc  guix-build-80e78b6a0479/output/arm-linux-gnueabihf/bitcoin-80e78b6a0479-arm-linux-gnueabihf-debug.tar.gz
5f582e30bbdba9df175bf4c5d4aae64e2a1cf572086390ae6962d3ee9f0325a9  guix-build-80e78b6a0479/output/arm-linux-gnueabihf/bitcoin-80e78b6a0479-arm-linux-gnueabihf.tar.gz
e96c601af96e851a0351c6f8975feb47623a2dd5e3dd2c15bcdfe8435f845538  guix-build-80e78b6a0479/output/arm64-apple-darwin/SHA256SUMS.part
a50db7a8a9b6415842807644760110f2e01665b922b2762634d94e2b497cbd4a  guix-build-80e78b6a0479/output/arm64-apple-darwin/bitcoin-80e78b6a0479-arm64-apple-darwin.tar.gz
0f3707a2423483f84be5edff91f8e657cf71ab097d2550f4369760ac8c6a1644  guix-build-80e78b6a0479/output/arm64-apple-darwin/bitcoin-80e78b6a0479-osx-unsigned.dmg
33252a9895c013cfbea06444d6372a23cc555831e4675705b4d7d6b065f06cff  guix-build-80e78b6a0479/output/arm64-apple-darwin/bitcoin-80e78b6a0479-osx-unsigned.tar.gz
2ab70177c80c36e98018d07e2aece084c7d3d604e7dc12d2df2e1a077e06b983  guix-build-80e78b6a0479/output/dist-archive/bitcoin-80e78b6a0479.tar.gz
cc0237b05948472efa61f7d5a666d8e97b5abeb7f498f3f72d46ff69be38bcf4  guix-build-80e78b6a0479/output/powerpc64-linux-gnu/SHA256SUMS.part
b3778fd81bf4e432ad1590792673c91d09c8f8f43daef4cbe0852bca49e1ed57  guix-build-80e78b6a0479/output/powerpc64-linux-gnu/bitcoin-80e78b6a0479-powerpc64-linux-gnu-debug.tar.gz
bebe78f0e6a062d943c99470f12bfc520381acec40e0409915cc8d5dccbe5999  guix-build-80e78b6a0479/output/powerpc64-linux-gnu/bitcoin-80e78b6a0479-powerpc64-linux-gnu.tar.gz
350f7b22562d8b6642f37afb3e192d36dbcb360a361c8b834d0f7d50401667b8  guix-build-80e78b6a0479/output/powerpc64le-linux-gnu/SHA256SUMS.part
9a488fbd71c53092feda8dfccecc4ae7d10aa2efe48f99f150cb2322bb28c5e6  guix-build-80e78b6a0479/output/powerpc64le-linux-gnu/bitcoin-80e78b6a0479-powerpc64le-linux-gnu-debug.tar.gz
06d3c472171124d6ca92f95f7d5cb7fc4a523c25396dbbb9522cab920867d3db  guix-build-80e78b6a0479/output/powerpc64le-linux-gnu/bitcoin-80e78b6a0479-powerpc64le-linux-gnu.tar.gz
67d591d5f15933d56046d0b8208970dc812ddd240c14a4c3b635cdc256ae5205  guix-build-80e78b6a0479/output/riscv64-linux-gnu/SHA256SUMS.part
f9a853d703ac153748f3d9f60d4a74a72c75966dc1d3711b688ebd003ff9389c  guix-build-80e78b6a0479/output/riscv64-linux-gnu/bitcoin-80e78b6a0479-riscv64-linux-gnu-debug.tar.gz
07554223c5ab3b940f53f9483054023e639d4e9902810b3d5c1875fd390064ea  guix-build-80e78b6a0479/output/riscv64-linux-gnu/bitcoin-80e78b6a0479-riscv64-linux-gnu.tar.gz
294dc1274391b17fb750eac7c76e59c18e972ed3fbf8bccd53ba514843fbc59f  guix-build-80e78b6a0479/output/x86_64-apple-darwin/SHA256SUMS.part
cc5c1256ca57f80d5ecb93fe2ac477f90945206430545b0463813f7099804f47  guix-build-80e78b6a0479/output/x86_64-apple-darwin/bitcoin-80e78b6a0479-osx-unsigned.dmg
c5ff5cf7a8119981f8a1aa2306ff9e84c60e5c9845836eb2562941801495c7de  guix-build-80e78b6a0479/output/x86_64-apple-darwin/bitcoin-80e78b6a0479-osx-unsigned.tar.gz
5951712d82391ba0471f253a7f87701b464dad1a90bb1d91866b0c7c51164a8f  guix-build-80e78b6a0479/output/x86_64-apple-darwin/bitcoin-80e78b6a0479-osx64.tar.gz
28f84ed57769a642b1679acf90fdaad7ac489d59598d4a8a859021d39a32d878  guix-build-80e78b6a0479/output/x86_64-linux-gnu/SHA256SUMS.part
f7c37c47ffaec6fbca36c3c4897b2df2fa7dd5327cb860501eec9d9e987ea5c7  guix-build-80e78b6a0479/output/x86_64-linux-gnu/bitcoin-80e78b6a0479-x86_64-linux-gnu-debug.tar.gz
c7c6db897a604e5a85f37938b763538751a133bbab90e80904d4b7198b227d95  guix-build-80e78b6a0479/output/x86_64-linux-gnu/bitcoin-80e78b6a0479-x86_64-linux-gnu.tar.gz
80b1e0e249cefe8941ca0e1a563f479c5e4408da6f0aa02c127182a09310dd8c  guix-build-80e78b6a0479/output/x86_64-w64-mingw32/SHA256SUMS.part
e7f8b2cd0f0f465e80d96338dcc398306b321a9c99556ca1d39f094752702a21  guix-build-80e78b6a0479/output/x86_64-w64-mingw32/bitcoin-80e78b6a0479-win-unsigned.tar.gz
5191f309c758135fd597df6bc9ef9e2c2746947abb74b38c32e5b6e073fa0995  guix-build-80e78b6a0479/output/x86_64-w64-mingw32/bitcoin-80e78b6a0479-win64-debug.zip
1569de943ca054841141c700f1d4fca2658228b85eee1f44d201b0c881218ef0  guix-build-80e78b6a0479/output/x86_64-w64-mingw32/bitcoin-80e78b6a0479-win64-setup-unsigned.exe
c8d78aeedeeaf7af4d325d38fb5e2307965b0080ce08a8cde802afaaa73f157d  guix-build-80e78b6a0479/output/x86_64-w64-mingw32/bitcoin-80e78b6a0479-win64.zip
```