### PR TITLE
index: make indices robust against init aborts

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -211,6 +211,11 @@ bool BaseIndex::Commit()
 bool BaseIndex::CommitInternal(CDBBatch& batch)
 {
     LOCK(cs_main);
+    // Don't commit anything if we haven't indexed any block yet
+    // (this could happen if init is interrupted).
+    if (m_best_block_index == nullptr) {
+        return false;
+    }
     GetDB().WriteBestBlock(batch, m_chainstate->m_chain.GetLocator(m_best_block_index));
     return true;
 }

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -360,9 +360,9 @@ bool CoinStatsIndex::Init()
     if (pindex) {
         DBVal entry;
         if (!LookUpOne(*m_db, pindex, entry)) {
-            return false;
+            return error("%s: Cannot read current %s state; index may be corrupted",
+                         __func__, GetName());
         }
-
         m_transaction_output_count = entry.transaction_output_count;
         m_bogo_size = entry.bogo_size;
         m_total_amount = entry.total_amount;

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -64,6 +64,8 @@ class InitStressTest(BitcoinTestFramework):
             'addcon thread start',
             'loadblk thread start',
             'txindex thread start',
+            'block filter index thread start',
+            'coinstatsindex thread start',
             'msghand thread start',
             'net thread start',
             'addcon thread start',
@@ -74,7 +76,7 @@ class InitStressTest(BitcoinTestFramework):
         for terminate_line in lines_to_terminate_after:
             self.log.info(f"Starting node and will exit after line '{terminate_line}'")
             with node.wait_for_debug_log([terminate_line], ignore_case=True):
-                node.start(extra_args=['-txindex=1'])
+                node.start(extra_args=['-txindex=1', '-blockfilterindex=1', '-coinstatsindex=1'])
             self.log.debug("Terminating node after terminate line was found")
             sigterm_node()
 
@@ -109,7 +111,7 @@ class InitStressTest(BitcoinTestFramework):
             # investigate doing this later.
 
             node.assert_start_raises_init_error(
-                extra_args=['-txindex=1'],
+                extra_args=['-txindex=1', '-blockfilterindex=1', '-coinstatsindex=1'],
                 expected_msg=err_fragment,
                 match=ErrorMatch.PARTIAL_REGEX,
             )


### PR DESCRIPTION
When an index thread receives an interrupt during init before it got to index anything (so `m_best_block_index == nullptr` still), it will still try to commit previous "work" before stopping the thread. That means that `BaseIndex::CommitInternal()` calls `GetLocator(nullptr)`, which returns an locator to the tip ([code](https://github.com/bitcoin/bitcoin/blob/06b6369766137756648b3cb62c8f385cca234e69/src/chain.cpp#L31-L32)), and saves it to the index DB.
On the next startup, this locator will be read and it will be assumed that we have successfully synced the index to the tip, when in reality we have indexed nothing.
In the case of coinstatsindex, this would lead to a shutdown of bitcoind without any indication what went wrong. For the other indexes, there would be no immediate shutdown, but the index would be corrupt.

This PR fixes this by not committing when `m_best_block_index==nullptr`, and it also adds an error log message to the silent coinstatsindex shutdown path.

This is another small bug found by `feature_init.py` - the second commit enables blockfilterindex and coinstatsindex for this test, enabling coinstatsindex without the first commit would have led to frequent failures.