### PR TITLE
wallet: treat P2TR address with invalid x-only pubkey as invalid

### DIFF
--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -164,6 +164,12 @@ CTxDestination DecodeDestination(const std::string& str, const CChainParams& par
 
             if (version == 1 && data.size() == WITNESS_V1_TAPROOT_SIZE) {
                 static_assert(WITNESS_V1_TAPROOT_SIZE == WitnessV1Taproot::size());
+
+                if (!XOnlyPubKey(data).IsFullyValid()) {
+                    error_str = "Invalid x coordinate on the secp256k1 curve";
+                    return CNoDestination();
+                }
+
                 WitnessV1Taproot tap;
                 std::copy(data.begin(), data.end(), tap.begin());
                 return tap;

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -163,7 +163,13 @@ FUZZ_TARGET_INIT(script, initialize_script)
         const CTxDestination tx_destination_2{ConsumeTxDestination(fuzzed_data_provider)};
         const std::string encoded_dest{EncodeDestination(tx_destination_1)};
         const UniValue json_dest{DescribeAddress(tx_destination_1)};
-        Assert(tx_destination_1 == DecodeDestination(encoded_dest));
+
+        std::string error_msg;
+        auto destination = DecodeDestination(encoded_dest, error_msg);
+
+        if (error_msg.compare("Invalid x coordinate on the secp256k1 curve") == 0) return;
+
+        Assert(tx_destination_1 == destination);
         (void)GetKeyForDestination(/*store=*/{}, tx_destination_1);
         const CScript dest{GetScriptForDestination(tx_destination_1)};
         const bool valid{IsValidDestination(tx_destination_1)};

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -53,7 +53,11 @@ BOOST_AUTO_TEST_CASE(key_io_valid_parse)
             BOOST_CHECK_MESSAGE(!IsValidDestination(destination), "IsValid privkey as pubkey:" + strTest);
         } else {
             // Must be valid public key
-            destination = DecodeDestination(exp_base58string);
+            std::string error_msg;
+            destination = DecodeDestination(exp_base58string, error_msg);
+
+            if (error_msg.compare("Invalid x coordinate on the secp256k1 curve") == 0) continue;
+
             CScript script = GetScriptForDestination(destination);
             BOOST_CHECK_MESSAGE(IsValidDestination(destination), "!IsValid:" + strTest);
             BOOST_CHECK_EQUAL(HexStr(script), HexStr(exp_payload));


### PR DESCRIPTION
As suggested in https://github.com/bitcoin/bitcoin/pull/24106#issue-1108820339, this PR changes `DecodeDestination` to consider bech32m (segwit v1) addresses as invalid if the encoded x-only pubkey is not on the curve.
This prevents users from inadvertently burning funds.

This PR must not change policy or consensus rules and keep the current approach, where the user cannot send funds to invalid addresses.