### PR TITLE
refactor: replace RecursiveMutex `cs_vProcessMsg` with Mutex (and rename)

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1595,8 +1595,8 @@ void CConnman::SocketHandlerConnected(const std::vector<CNode*>& nodes,
                         nSizeAdded += it->m_raw_message_size;
                     }
                     {
-                        LOCK(pnode->cs_vProcessMsg);
-                        pnode->vProcessMsg.splice(pnode->vProcessMsg.end(), pnode->vRecvMsg, pnode->vRecvMsg.begin(), it);
+                        LOCK(pnode->m_process_msgs_mutex);
+                        pnode->m_process_msgs.splice(pnode->m_process_msgs.end(), pnode->vRecvMsg, pnode->vRecvMsg.begin(), it);
                         pnode->nProcessQueueSize += nSizeAdded;
                         pnode->fPauseRecv = pnode->nProcessQueueSize > nReceiveFloodSize;
                     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1595,6 +1595,7 @@ void CConnman::SocketHandlerConnected(const std::vector<CNode*>& nodes,
                         nSizeAdded += it->m_raw_message_size;
                     }
                     {
+                        AssertLockNotHeld(pnode->m_process_msgs_mutex);
                         LOCK(pnode->m_process_msgs_mutex);
                         pnode->m_process_msgs.splice(pnode->m_process_msgs.end(), pnode->vRecvMsg, pnode->vRecvMsg.begin(), it);
                         pnode->nProcessQueueSize += nSizeAdded;

--- a/src/net.h
+++ b/src/net.h
@@ -413,7 +413,7 @@ public:
     Mutex cs_hSocket;
     Mutex cs_vRecv;
 
-    RecursiveMutex m_process_msgs_mutex;
+    Mutex m_process_msgs_mutex;
     std::list<CNetMessage> m_process_msgs GUARDED_BY(m_process_msgs_mutex);
     size_t nProcessQueueSize{0};
 

--- a/src/net.h
+++ b/src/net.h
@@ -413,8 +413,8 @@ public:
     Mutex cs_hSocket;
     Mutex cs_vRecv;
 
-    RecursiveMutex cs_vProcessMsg;
-    std::list<CNetMessage> vProcessMsg GUARDED_BY(cs_vProcessMsg);
+    RecursiveMutex m_process_msgs_mutex;
+    std::list<CNetMessage> m_process_msgs GUARDED_BY(m_process_msgs_mutex);
     size_t nProcessQueueSize{0};
 
     RecursiveMutex cs_sendProcessing;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4140,13 +4140,13 @@ bool PeerManagerImpl::ProcessMessages(CNode* pfrom, std::atomic<bool>& interrupt
 
     std::list<CNetMessage> msgs;
     {
-        LOCK(pfrom->cs_vProcessMsg);
-        if (pfrom->vProcessMsg.empty()) return false;
+        LOCK(pfrom->m_process_msgs_mutex);
+        if (pfrom->m_process_msgs.empty()) return false;
         // Just take one message
-        msgs.splice(msgs.begin(), pfrom->vProcessMsg, pfrom->vProcessMsg.begin());
+        msgs.splice(msgs.begin(), pfrom->m_process_msgs, pfrom->m_process_msgs.begin());
         pfrom->nProcessQueueSize -= msgs.front().m_raw_message_size;
         pfrom->fPauseRecv = pfrom->nProcessQueueSize > m_connman.GetReceiveFloodSize();
-        fMoreWork = !pfrom->vProcessMsg.empty();
+        fMoreWork = !pfrom->m_process_msgs.empty();
     }
     CNetMessage& msg(msgs.front());
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -314,7 +314,7 @@ public:
     /** Implement NetEventsInterface */
     void InitializeNode(CNode* pnode) override;
     void FinalizeNode(const CNode& node) override;
-    bool ProcessMessages(CNode* pfrom, std::atomic<bool>& interrupt) override;
+    bool ProcessMessages(CNode* pfrom, std::atomic<bool>& interrupt) override LOCKS_EXCLUDED(pfrom->m_process_msgs_mutex);
     bool SendMessages(CNode* pto) override EXCLUSIVE_LOCKS_REQUIRED(pto->cs_sendProcessing);
 
     /** Implement PeerManager */
@@ -4140,6 +4140,7 @@ bool PeerManagerImpl::ProcessMessages(CNode* pfrom, std::atomic<bool>& interrupt
 
     std::list<CNetMessage> msgs;
     {
+        AssertLockNotHeld(pfrom->m_process_msgs_mutex);
         LOCK(pfrom->m_process_msgs_mutex);
         if (pfrom->m_process_msgs.empty()) return false;
         // Just take one message

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -22,6 +22,7 @@ void ConnmanTestMsg::NodeReceiveMsgBytes(CNode& node, Span<const uint8_t> msg_by
             nSizeAdded += it->m_raw_message_size;
         }
         {
+            AssertLockNotHeld(node.m_process_msgs_mutex);
             LOCK(node.m_process_msgs_mutex);
             node.m_process_msgs.splice(node.m_process_msgs.end(), node.vRecvMsg, node.vRecvMsg.begin(), it);
             node.nProcessQueueSize += nSizeAdded;

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -22,8 +22,8 @@ void ConnmanTestMsg::NodeReceiveMsgBytes(CNode& node, Span<const uint8_t> msg_by
             nSizeAdded += it->m_raw_message_size;
         }
         {
-            LOCK(node.cs_vProcessMsg);
-            node.vProcessMsg.splice(node.vProcessMsg.end(), node.vRecvMsg, node.vRecvMsg.begin(), it);
+            LOCK(node.m_process_msgs_mutex);
+            node.m_process_msgs.splice(node.m_process_msgs.end(), node.vRecvMsg, node.vRecvMsg.begin(), it);
             node.nProcessQueueSize += nSizeAdded;
             node.fPauseRecv = node.nProcessQueueSize > nReceiveFloodSize;
         }

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -40,7 +40,7 @@ struct ConnmanTestMsg : public CConnman {
 
     void ProcessMessagesOnce(CNode& node) { m_msgproc->ProcessMessages(&node, flagInterruptMsgProc); }
 
-    void NodeReceiveMsgBytes(CNode& node, Span<const uint8_t> msg_bytes, bool& complete) const;
+    void NodeReceiveMsgBytes(CNode& node, Span<const uint8_t> msg_bytes, bool& complete) const LOCKS_EXCLUDED(node.m_process_msgs_mutex);
 
     bool ReceiveMsgFrom(CNode& node, CSerializedNetMsg& ser_msg) const;
 };


### PR DESCRIPTION
This PR is related to #19303 and gets rid of the RecursiveMutex cs_vProcessMsg. Both of the critical sections only directly access the guarded elements, i.e. it is not possible that within one section another one is called, and we can use a regular Mutex:
https://github.com/bitcoin/bitcoin/blob/e3ce019667fba2ec50a59814a26566fb67fa9125/src/net.cpp#L1597-L1602
https://github.com/bitcoin/bitcoin/blob/e3ce019667fba2ec50a59814a26566fb67fa9125/src/net_processing.cpp#L4142-L4150
Also, it is renamed to adapt to the (unwritten) naming convention to use the `_mutex` suffix rather than the `cs_` prefix.