### PR TITLE
guix: Pointer Authentication and Branch Target Identification for aarch64 Linux

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -101,7 +101,7 @@ chain for " target " development."))
                                        #:key
                                        (base-gcc-for-libc linux-base-gcc)
                                        (base-kernel-headers base-linux-kernel-headers)
-                                       (base-libc glibc-2.31)
+                                       (base-libc glibc-2.33)
                                        (base-gcc linux-base-gcc))
   "Convenience wrapper around MAKE-CROSS-TOOLCHAIN with default values
 desirable for building Bitcoin Core release binaries."
@@ -451,11 +451,11 @@ inspecting signatures in Mach-O binaries.")
                  (("-rpath=") "-rpath-link="))
                #t))))))))
 
-(define-public glibc-2.31
-  (let ((commit "7b27c450c34563a28e634cccb399cd415e71ebfe"))
+(define-public glibc-2.33
+  (let ((commit "68cca6e1e8faac153c2f82dd3d1e2818d1b33f87"))
   (package
     (inherit glibc) ;; 2.39
-    (version "2.31")
+    (version "2.33")
     (source (origin
               (method git-fetch)
               (uri (git-reference
@@ -464,7 +464,7 @@ inspecting signatures in Mach-O binaries.")
               (file-name (git-file-name "glibc" commit))
               (sha256
                (base32
-                "017qdpr5id7ddb4lpkzj2li1abvw916m3fc6n7nw28z4h5qbv2n0"))
+                "16s2d933pcfd7h4vh8mcwzv8w05jrrg4mpsbi0rwkv7fy4gr76f5"))
               (patches (search-our-patches "glibc-guix-prefix.patch"
                                            "glibc-riscv-jumptarget.patch"))))
     (arguments
@@ -475,23 +475,13 @@ inspecting signatures in Mach-O binaries.")
             (list "--enable-stack-protector=all",
                   "--enable-cet",
                   "--enable-bind-now",
-                  "--disable-werror",
-                  "--disable-timezone-tools",
+                  "--enable-static-pie",
+                  "--disable-nscd",
                   "--disable-profile",
-                  building-on)))
-    ((#:phases phases)
-        `(modify-phases ,phases
-           (add-before 'configure 'set-etc-rpc-installation-directory
-             (lambda* (#:key outputs #:allow-other-keys)
-               ;; Install the rpc data base file under `$out/etc/rpc'.
-               ;; Otherwise build will fail with "Permission denied."
-               ;; Can be removed when we are building 2.32 or later.
-               (let ((out (assoc-ref outputs "out")))
-                 (substitute* "sunrpc/Makefile"
-                   (("^\\$\\(inst_sysconfdir\\)/rpc(.*)$" _ suffix)
-                    (string-append out "/etc/rpc" suffix "\n"))
-                   (("^install-others =.*$")
-                    (string-append "install-others = " out "/etc/rpc\n")))))))))))))
+                  "--disable-pt_chown",
+                  "--disable-timezone-tools",
+                  "--disable-werror",
+                  building-on))))))))
 
 ;; The sponge tool from moreutils.
 (define-public sponge

--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -34,11 +34,11 @@ import lief
 MAX_VERSIONS = {
 'GCC':       (7,0,0),
 'GLIBC': {
-    lief.ELF.ARCH.X86_64: (2,31),
-    lief.ELF.ARCH.ARM:    (2,31),
-    lief.ELF.ARCH.AARCH64:(2,31),
-    lief.ELF.ARCH.PPC64:  (2,31),
-    lief.ELF.ARCH.RISCV:  (2,31),
+    lief.ELF.ARCH.X86_64: (2,33),
+    lief.ELF.ARCH.ARM:    (2,33),
+    lief.ELF.ARCH.AARCH64:(2,33),
+    lief.ELF.ARCH.PPC64:  (2,33),
+    lief.ELF.ARCH.RISCV:  (2,33),
 },
 'LIBATOMIC': (1,0),
 'V':         (0,5,0),  # xkb (bitcoin-qt only)
@@ -47,7 +47,7 @@ MAX_VERSIONS = {
 # Ignore symbols that are exported as part of every executable
 IGNORE_EXPORTS = {
 'environ', '_environ', '__environ', '_fini', '_init', 'stdin',
-'stdout', 'stderr',
+'stdout', 'stderr', '__libc_single_threaded',
 }
 
 # Expected linker-loader names can be found here:


### PR DESCRIPTION
Arm Pointer Authentication (PAC) is a method of hardening code from Return Oriented Programming (ROP) attacks. It uses a tag in a pointer to sign and verify pointers. Branch Target Identification (BTI) is another code hardening method, where the branch/jump target is identified with a special landing pad instruction. Outside of some system support in glibc+kernel, packages gain the additional hardening by compiling with the `-mbranch-protection=flag` available in recent versions of GCC. In particular [-mbranch-protection=standard](https://gcc.gnu.org/onlinedocs/gcc-9.1.0/gcc/AArch64-Options.html) enables both BTI and PAC, with backwards compatible to `armv8.0` code sequences that activate on `v8.3` (PAC) & `v8.5` (BTI) enabled Arm machines. ([taken from Fedora](https://fedoraproject.org/wiki/Changes/Aarch64_PointerAuthentication)). 

Creation of a BTI enabled binary also requires that everything being linked in be BTI enabled. This means you currently cannot, for example, cross-compile using a Ubuntu based aarch64 toolchain, if you're wanting to use this feature. This can be shown using `-Wl,z,force-bti`, which will emit warnings for linked objects that are not BTI enabled (this is used in configure to detect when to disable using the flags). i.e:
```cpp
int main() { return 0; }
```

```bash
# aarch64-linux-gnu-g++ (Ubuntu 13.2.0-23ubuntu4) 13.2.0
aarch64-linux-gnu-g++ test.cpp -mbranch-protection=standard -Wl,-z,force-bti
/usr/lib/gcc-cross/aarch64-linux-gnu/13/../../../../aarch64-linux-gnu/bin/ld: /usr/lib/gcc-cross/aarch64-linux-gnu/13/../../../../aarch64-linux-gnu/lib/../lib/Scrt1.o: warning: BTI turned on by -z force-bti when all inputs do not have BTI in NOTE section.
```

Closes #19075.