### PR TITLE
p2p: Replace RecursiveMutex `m_tx_inventory_mutex` with Mutex and rename it

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -304,6 +304,13 @@ struct Peer {
             AssertLockNotHeld(m_tx_inventory_mutex);
             return WITH_LOCK(m_tx_inventory_mutex, return !m_tx_inventory_known_filter.contains(parent_txid));
         }
+
+        void SetSendMempool(bool value) EXCLUSIVE_LOCKS_REQUIRED(!m_tx_inventory_mutex)
+        {
+            AssertLockNotHeld(m_tx_inventory_mutex);
+            LOCK(m_tx_inventory_mutex);
+            m_send_mempool = value;
+        }
     };
 
     /* Initializes a TxRelay struct for this peer. Can be called at most once for a peer. */
@@ -3993,8 +4000,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         }
 
         if (auto tx_relay = peer->GetTxRelay(); tx_relay != nullptr) {
-            LOCK(tx_relay->m_tx_inventory_mutex);
-            tx_relay->m_send_mempool = true;
+            tx_relay->SetSendMempool(true);
         }
         return;
     }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -282,7 +282,7 @@ struct Peer {
         /** A bloom filter for which transactions to announce to the peer. See BIP37. */
         std::unique_ptr<CBloomFilter> m_bloom_filter PT_GUARDED_BY(m_bloom_filter_mutex) GUARDED_BY(m_bloom_filter_mutex){nullptr};
 
-        mutable RecursiveMutex m_tx_inventory_mutex;
+        mutable Mutex m_tx_inventory_mutex;
         /** A filter of all the txids and wtxids that the peer has announced to
          *  us or we have announced to the peer. We use this to avoid announcing
          *  the same txid/wtxid to a peer that already has the transaction. */


### PR DESCRIPTION
This PR is related to #19303 and gets rid of the `RecursiveMutex m_tx_inventory_mutex` and also adds `AssertLockNotHeld` macros combined with `LOCKS_EXCLUDED` thread safety annotations to avoid recursive locking.