### PR TITLE
build, qt: Fix Windows cross-compiling with Qt 5.15

### DIFF
--- a/ci/test/05_before_script.sh
+++ b/ci/test/05_before_script.sh
@@ -43,9 +43,6 @@ if [[ ${USE_MEMORY_SANITIZER} == "true" ]]; then
   CI_EXEC "contrib/install_db4.sh \$(pwd) --enable-umrw CC=clang CXX=clang++ CFLAGS='${MSAN_FLAGS}' CXXFLAGS='${MSAN_AND_LIBCXX_FLAGS}'"
 fi
 
-if [[ $HOST = *-mingw32 ]]; then
-  CI_EXEC update-alternatives --set "${HOST}-g++" \$\(which "${HOST}-g++-posix"\)
-fi
 if [ -z "$NO_DEPENDS" ]; then
   if [[ $DOCKER_NAME_TAG == *centos* ]]; then
     # CentOS has problems building the depends if the config shell is not explicitly set

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -163,6 +163,7 @@ $(package)_config_opts_mingw32 += -no-dbus
 $(package)_config_opts_mingw32 += -no-freetype
 $(package)_config_opts_mingw32 += -xplatform win32-g++
 $(package)_config_opts_mingw32 += "QMAKE_CFLAGS = '$($(package)_cflags) $($(package)_cppflags)'"
+$(package)_config_opts_mingw32 += "QMAKE_CXX = '$($(package)_cxx)'"
 $(package)_config_opts_mingw32 += "QMAKE_CXXFLAGS = '$($(package)_cflags) $($(package)_cppflags)'"
 $(package)_config_opts_mingw32 += "QMAKE_LFLAGS = '$($(package)_ldflags)'"
 $(package)_config_opts_mingw32 += -device-option CROSS_COMPILE="$(host)-"

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -48,8 +48,17 @@ Acquire the source in the usual way:
 ## Building for 64-bit Windows
 
 The first step is to install the mingw-w64 cross-compilation tool chain:
+  - on modern systems (Ubuntu 21.04 Hirsute Hippo or newer, Debian 11 Bullseye or newer):
 
-    sudo apt install g++-mingw-w64-x86-64
+```sh
+sudo apt install g++-mingw-w64-x86-64-posix
+```
+
+  - on older systems:
+
+```sh
+sudo apt install g++-mingw-w64-x86-64
+```
 
 Once the toolchain is installed the build steps are common:
 


### PR DESCRIPTION
While changes introduced in bitcoin/bitcoin#22093 worked fine with Qt 5.12, after bumping Qt up to 5.15 the cross-compiling of `qt` package for Windows fails with `error: ‘mutex’ in namespace ‘std’ does not name a type`.

The first commit fixes this bug.

The second commit cleans up a related CI script.

The third commit improves related docs (see https://github.com/bitcoin/bitcoin/pull/22093#discussion_r680911586).