### PR TITLE
index: Improve robustness of coinstatsindex at restart

### DIFF
--- a/src/index/base.h
+++ b/src/index/base.h
@@ -40,10 +40,10 @@ protected:
         DB(const fs::path& path, size_t n_cache_size,
            bool f_memory = false, bool f_wipe = false, bool f_obfuscate = false);
 
-        /// Read block locator of the chain that the txindex is in sync with.
+        /// Read block locator of the chain that the index is in sync with.
         bool ReadBestBlock(CBlockLocator& locator) const;
 
-        /// Write block locator of the chain that the txindex is in sync with.
+        /// Write block locator of the chain that the index is in sync with.
         void WriteBestBlock(CDBBatch& batch, const CBlockLocator& locator);
     };
 

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -363,6 +363,14 @@ bool CoinStatsIndex::Init()
             return error("%s: Cannot read current %s state; index may be corrupted",
                          __func__, GetName());
         }
+
+        uint256 out;
+        m_muhash.Finalize(out);
+        if (entry.muhash != out) {
+            return error("%s: Cannot read current %s state; index may be corrupted",
+                         __func__, GetName());
+        }
+
         m_transaction_output_count = entry.transaction_output_count;
         m_bogo_size = entry.bogo_size;
         m_total_amount = entry.total_amount;


### PR DESCRIPTION
This change lets the `coinstatsindex` fail loudly in case the internal `muhash` state differs from the last finalized output saved on disk, which would indicate that the `muhash` state somehow got out of sync. This should generally not happen since both are written to disk in a batch but #24076 seems to indicate that the might still be an issue.

Since #24076 so far can not be reproduced reliably, the issue should not be closed yet. Further investigation and testing needs to be done.