### PR TITLE
build: Fix zeromq package when cross-compiling

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -6,7 +6,8 @@ $(package)_sha256_hash=c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336
 $(package)_patches=remove_libstd_link.patch netbsd_kevent_void.patch
 
 define $(package)_set_vars
-  $(package)_config_opts=--without-docs --disable-shared --disable-curve --disable-curve-keygen --disable-perf
+  $(package)_config_opts = --without-docs --disable-shared
+  $(package)_config_opts += --disable-perf --disable-curve-keygen --disable-curve --disable-libbsd
   $(package)_config_opts += --without-libsodium --without-libgssapi_krb5 --without-pgm --without-norm --without-vmci
   $(package)_config_opts += --disable-libunwind --disable-radix-tree --without-gcov --disable-dependency-tracking
   $(package)_config_opts += --disable-Werror --disable-drafts --enable-option-checking

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336
 $(package)_patches=remove_libstd_link.patch netbsd_kevent_void.patch
 
 define $(package)_set_vars
-  $(package)_config_opts = --without-docs --disable-shared
+  $(package)_config_opts = --without-docs --disable-shared --disable-valgrind
   $(package)_config_opts += --disable-perf --disable-curve-keygen --disable-curve --disable-libbsd
   $(package)_config_opts += --without-libsodium --without-libgssapi_krb5 --without-pgm --without-norm --without-vmci
   $(package)_config_opts += --disable-libunwind --disable-radix-tree --without-gcov --disable-dependency-tracking

--- a/depends/patches/zeromq/netbsd_kevent_void.patch
+++ b/depends/patches/zeromq/netbsd_kevent_void.patch
@@ -10,7 +10,7 @@ diff --git a/configure.ac b/configure.ac
 index 1a571291..402f8b86 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -308,6 +308,27 @@ case "${host_os}" in
+@@ -307,6 +307,27 @@ case "${host_os}" in
          if test "x$libzmq_netbsd_has_atomic" = "xno"; then
              AC_DEFINE(ZMQ_FORCE_MUTEXES, 1, [Force to use mutexes])
          fi


### PR DESCRIPTION
Since v4.3.3 (https://github.com/zeromq/libzmq/commit/068385c951c0608edec6264d55ba9c4c923acccc) `libzmq` uses `libbsd` by default.

This PR disables `libbsd` explicitly, as it's not a part of our depends. Zeromq will fallback to its internal `strlcpy` implementation.

Otherwise, on systems with installed `libbsd-dev` package the `zeromq` package build system erroneously detects `libbsd` package from the host system:

```diff
--- a/libzmq.pc
+++ b/libzmq.pc
@@ -8,5 +8,5 @@
 Version: 4.3.4
 Libs: -L${libdir} -lzmq
 Libs.private:  -lpthread
-Requires.private: 
+Requires.private:  libbsd
 Cflags: -I${includedir} 
```

This causes the `configure` fails to detect the `zeromq` package:
```
configure: WARNING: libzmq version 4.x or greater not found, disabling
```

---

Other minor improvements:
- fixed `netbsd_kevent_void.patch` offset
- disabled valgrind as it's used in unit tests which we do not run:
```diff
--- a/zmq-configure-output
+++ b/zmq-configure-output
@@ -119,11 +119,6 @@
 checking whether the g++ -m64 linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
 checking dynamic linker characteristics... (cached) GNU/Linux ld.so
 checking how to hardcode library paths into programs... immediate
-checking for valgrind... valgrind
-checking for Valgrind tool memcheck... memcheck
-checking for Valgrind tool helgrind... helgrind
-checking for Valgrind tool drd... drd
-checking for Valgrind tool exp-sgcheck... exp-sgcheck
 checking linker version script flag... --version-script
 checking if version scripts can use complex wildcards... yes
 checking for working posix_memalign... yes
```