### PR TITLE
WIP: net/p2p:rename command*/Command/* to message*/Message* 

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -706,7 +706,7 @@ int V1TransportDeserializer::readHeader(Span<const uint8_t> msg_bytes)
 
     // reject messages larger than MAX_SIZE or MAX_PROTOCOL_MESSAGE_LENGTH
     if (hdr.nMessageSize > MAX_SIZE || hdr.nMessageSize > MAX_PROTOCOL_MESSAGE_LENGTH) {
-        LogPrint(BCLog::NET, "Header error: Size too large (%s, %u bytes), peer=%d\n", SanitizeString(hdr.GetCommand()), hdr.nMessageSize, m_node_id);
+        LogPrint(BCLog::NET, "Header error: Size too large (%s, %u bytes), peer=%d\n", SanitizeString(hdr.GetMessage()), hdr.nMessageSize, m_node_id);
         return -1;
     }
 
@@ -749,7 +749,7 @@ CNetMessage V1TransportDeserializer::GetMessage(const std::chrono::microseconds 
     CNetMessage msg(std::move(vRecv));
 
     // store command string, time, and sizes
-    msg.m_type = hdr.GetCommand();
+    msg.m_type = hdr.GetMessage();
     msg.m_time = time;
     msg.m_message_size = hdr.nMessageSize;
     msg.m_raw_message_size = hdr.nMessageSize + CMessageHeader::HEADER_SIZE;
@@ -767,9 +767,9 @@ CNetMessage V1TransportDeserializer::GetMessage(const std::chrono::microseconds 
                  HexStr(hdr.pchChecksum),
                  m_node_id);
         reject_message = true;
-    } else if (!hdr.IsCommandValid()) {
+    } else if (!hdr.IsMessageValid()) {
         LogPrint(BCLog::NET, "Header error: Invalid message type (%s, %u bytes), peer=%d\n",
-                 SanitizeString(hdr.GetCommand()), msg.m_message_size, m_node_id);
+                 SanitizeString(hdr.GetMessage()), msg.m_message_size, m_node_id);
         reject_message = true;
     }
 
@@ -3092,7 +3092,7 @@ void CaptureMessage(const CAddress& addr, const std::string& msg_type, const Spa
 
     ser_writedata64(f, now.count());
     f.write(msg_type.data(), msg_type.length());
-    for (auto i = msg_type.length(); i < CMessageHeader::COMMAND_SIZE; ++i) {
+    for (auto i = msg_type.length(); i < CMessageHeader::MESSAGE_SIZE; ++i) {
         f << uint8_t{'\0'};
     }
     uint32_t size = data.size();

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -87,30 +87,30 @@ const static std::string allNetMessageTypes[] = {
 };
 const static std::vector<std::string> allNetMessageTypesVec(std::begin(allNetMessageTypes), std::end(allNetMessageTypes));
 
-CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn, const char* pszCommand, unsigned int nMessageSizeIn)
+CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn, const char* pszMessage, unsigned int nMessageSizeIn)
 {
     memcpy(pchMessageStart, pchMessageStartIn, MESSAGE_START_SIZE);
 
-    // Copy the command name
+    // Copy the message name
     size_t i = 0;
-    for (; i < COMMAND_SIZE && pszCommand[i] != 0; ++i) pchCommand[i] = pszCommand[i];
-    assert(pszCommand[i] == 0); // Assert that the command name passed in is not longer than COMMAND_SIZE
+    for (; i < MESSAGE_SIZE && pszMessage[i] != 0; ++i) pchMessage[i] = pszMessage[i];
+    assert(pszMessage[i] == 0); // Assert that the message name passed in is not longer than MESSAGE_SIZE
 
     nMessageSize = nMessageSizeIn;
 }
 
-std::string CMessageHeader::GetCommand() const
+std::string CMessageHeader::GetMessage() const
 {
-    return std::string(pchCommand, pchCommand + strnlen(pchCommand, COMMAND_SIZE));
+    return std::string(pchMessage, pchMessage + strnlen(pchMessage, MESSAGE_SIZE));
 }
 
-bool CMessageHeader::IsCommandValid() const
+bool CMessageHeader::IsMessageValid() const
 {
     // Check the command string for errors
-    for (const char* p1 = pchCommand; p1 < pchCommand + COMMAND_SIZE; ++p1) {
+    for (const char* p1 = pchMessage; p1 < pchMessage + MESSAGE_SIZE; ++p1) {
         if (*p1 == 0) {
             // Must be all zeros after the first zero
-            for (; p1 < pchCommand + COMMAND_SIZE; ++p1) {
+            for (; p1 < pchMessage + MESSAGE_SIZE; ++p1) {
                 if (*p1 != 0) {
                     return false;
                 }
@@ -148,7 +148,7 @@ bool operator<(const CInv& a, const CInv& b)
     return (a.type < b.type || (a.type == b.type && a.hash < b.hash));
 }
 
-std::string CInv::GetCommand() const
+std::string CInv::GetMessage() const
 {
     std::string cmd;
     if (type & MSG_WITNESS_FLAG)
@@ -163,14 +163,14 @@ std::string CInv::GetCommand() const
     case MSG_FILTERED_BLOCK: return cmd.append(NetMsgType::MERKLEBLOCK);
     case MSG_CMPCT_BLOCK:    return cmd.append(NetMsgType::CMPCTBLOCK);
     default:
-        throw std::out_of_range(strprintf("CInv::GetCommand(): type=%d unknown type", type));
+        throw std::out_of_range(strprintf("CInv::GetMessage(): type=%d unknown type", type));
     }
 }
 
 std::string CInv::ToString() const
 {
     try {
-        return strprintf("%s %s", GetCommand(), hash.ToString());
+        return strprintf("%s %s", GetMessage(), hash.ToString());
     } catch(const std::out_of_range &) {
         return strprintf("0x%08x %s", type, hash.ToString());
     }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -31,28 +31,28 @@ class CMessageHeader
 {
 public:
     static constexpr size_t MESSAGE_START_SIZE = 4;
-    static constexpr size_t COMMAND_SIZE = 12;
+    static constexpr size_t MESSAGE_SIZE = 12;
     static constexpr size_t MESSAGE_SIZE_SIZE = 4;
     static constexpr size_t CHECKSUM_SIZE = 4;
-    static constexpr size_t MESSAGE_SIZE_OFFSET = MESSAGE_START_SIZE + COMMAND_SIZE;
+    static constexpr size_t MESSAGE_SIZE_OFFSET = MESSAGE_START_SIZE + MESSAGE_SIZE;
     static constexpr size_t CHECKSUM_OFFSET = MESSAGE_SIZE_OFFSET + MESSAGE_SIZE_SIZE;
-    static constexpr size_t HEADER_SIZE = MESSAGE_START_SIZE + COMMAND_SIZE + MESSAGE_SIZE_SIZE + CHECKSUM_SIZE;
+    static constexpr size_t HEADER_SIZE = MESSAGE_START_SIZE + MESSAGE_SIZE + MESSAGE_SIZE_SIZE + CHECKSUM_SIZE;
     typedef unsigned char MessageStartChars[MESSAGE_START_SIZE];
 
     explicit CMessageHeader() = default;
 
     /** Construct a P2P message header from message-start characters, a command and the size of the message.
-     * @note Passing in a `pszCommand` longer than COMMAND_SIZE will result in a run-time assertion error.
+     * @note Passing in a `pszMessage` longer than MESSAGE_SIZE will result in a run-time assertion error.
      */
-    CMessageHeader(const MessageStartChars& pchMessageStartIn, const char* pszCommand, unsigned int nMessageSizeIn);
+    CMessageHeader(const MessageStartChars& pchMessageStartIn, const char* pszMessage, unsigned int nMessageSizeIn);
 
-    std::string GetCommand() const;
-    bool IsCommandValid() const;
+    std::string GetMessage() const;
+    bool IsMessageValid() const;
 
-    SERIALIZE_METHODS(CMessageHeader, obj) { READWRITE(obj.pchMessageStart, obj.pchCommand, obj.nMessageSize, obj.pchChecksum); }
+    SERIALIZE_METHODS(CMessageHeader, obj) { READWRITE(obj.pchMessageStart, obj.pchMessage, obj.nMessageSize, obj.pchChecksum); }
 
     char pchMessageStart[MESSAGE_START_SIZE]{};
-    char pchCommand[COMMAND_SIZE]{};
+    char pchMessage[MESSAGE_SIZE]{};
     uint32_t nMessageSize{std::numeric_limits<uint32_t>::max()};
     uint8_t pchChecksum[CHECKSUM_SIZE]{};
 };
@@ -483,7 +483,7 @@ public:
 
     friend bool operator<(const CInv& a, const CInv& b);
 
-    std::string GetCommand() const;
+    std::string GetMessage() const;
     std::string ToString() const;
 
     // Single-message helper methods

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -99,7 +99,7 @@ FUZZ_TARGET_INIT(connman, initialize_connman)
             },
             [&] {
                 CSerializedNetMsg serialized_net_msg;
-                serialized_net_msg.m_type = fuzzed_data_provider.ConsumeRandomLengthString(CMessageHeader::COMMAND_SIZE);
+                serialized_net_msg.m_type = fuzzed_data_provider.ConsumeRandomLengthString(CMessageHeader::MESSAGE_SIZE);
                 serialized_net_msg.data = ConsumeRandomLengthByteVector(fuzzed_data_provider);
                 connman.PushMessage(&random_node, std::move(serialized_net_msg));
             },

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -247,7 +247,7 @@ FUZZ_TARGET_DESERIALIZE(service_deserialize, {
 FUZZ_TARGET_DESERIALIZE(messageheader_deserialize, {
     CMessageHeader mh;
     DeserializeFromFuzzingInput(buffer, mh);
-    (void)mh.IsCommandValid();
+    (void)mh.IsMessageValid();
 })
 FUZZ_TARGET_DESERIALIZE(address_deserialize_v1_notime, {
     CAddress a;

--- a/src/test/fuzz/p2p_transport_serialization.cpp
+++ b/src/test/fuzz/p2p_transport_serialization.cpp
@@ -70,7 +70,7 @@ FUZZ_TARGET_INIT(p2p_transport_serialization, initialize_p2p_transport_serializa
             const std::chrono::microseconds m_time{std::numeric_limits<int64_t>::max()};
             bool reject_message{false};
             CNetMessage msg = deserializer.GetMessage(m_time, reject_message);
-            assert(msg.m_type.size() <= CMessageHeader::COMMAND_SIZE);
+            assert(msg.m_type.size() <= CMessageHeader::MESSAGE_SIZE);
             assert(msg.m_raw_message_size <= mutable_msg_bytes.size());
             assert(msg.m_raw_message_size == CMessageHeader::HEADER_SIZE + msg.m_message_size);
             assert(msg.m_time == m_time);

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -73,7 +73,7 @@ void fuzz_target(FuzzBufferType buffer, const std::string& LIMIT_TO_MESSAGE_TYPE
     SetMockTime(1610000000); // any time to successfully reset ibd
     chainstate.ResetIbd();
 
-    const std::string random_message_type{fuzzed_data_provider.ConsumeBytesAsString(CMessageHeader::COMMAND_SIZE).c_str()};
+    const std::string random_message_type{fuzzed_data_provider.ConsumeBytesAsString(CMessageHeader::MESSAGE_SIZE).c_str()};
     if (!LIMIT_TO_MESSAGE_TYPE.empty() && random_message_type != LIMIT_TO_MESSAGE_TYPE) {
         return;
     }

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -53,7 +53,7 @@ FUZZ_TARGET_INIT(process_messages, initialize_process_messages)
     }
 
     LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000) {
-        const std::string random_message_type{fuzzed_data_provider.ConsumeBytesAsString(CMessageHeader::COMMAND_SIZE).c_str()};
+        const std::string random_message_type{fuzzed_data_provider.ConsumeBytesAsString(CMessageHeader::MESSAGE_SIZE).c_str()};
 
         const auto mock_time = ConsumeTime(fuzzed_data_provider);
         SetMockTime(mock_time);

--- a/src/test/fuzz/protocol.cpp
+++ b/src/test/fuzz/protocol.cpp
@@ -20,7 +20,7 @@ FUZZ_TARGET(protocol)
         return;
     }
     try {
-        (void)inv->GetCommand();
+        (void)inv->GetMessage();
     } catch (const std::out_of_range&) {
     }
     (void)inv->ToString();


### PR DESCRIPTION

-BEGIN VERIFY SCRIPT-
SED=$(which gsed)
export SED
echo $SED
export SRC=src
function s { git grep -l "$1" $SRC | xargs $SED -i "s/$1/$2/g"; }
function doit1 {
 s 'COMMAND_SIZE' 'MESSAGE_SIZE'
 s 'command name' 'message name'
 s 'pchCommand' 'pchMessage'
 s 'pszCommand' 'pszMessage'
}
function doit2 {
 s 'GetCommand' 'GetMessage'
}
export SRC=src && doit1
export SRC=src/net.h && doit1
export SRC=src/net.cpp && doit1
export SRC=src/protocol.h && doit1
export SRC=src/protocol.cpp && doit1
export SRC=src/test/fuzz/protocol.cpp && doit1
export SRC=src/test/fuzz/protocol.cpp && doit2
export SRC=src/test/fuzz/process_messages.cpp && doit1
export SRC=src/test/fuzz/process_messages.cpp && doit2
-END VERIFY SCRIPT-