### PR TITLE
mempool: Clear vTxHashes when mapTx is cleared

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -704,6 +704,7 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
 
 void CTxMemPool::_clear()
 {
+    vTxHashes.clear();
     mapTx.clear();
     mapNextTx.clear();
     totalTxSize = 0;


### PR DESCRIPTION
vTxHashes is a vector of all entries in mapTx, if you clear one you should clear the other, lest someone try to use the txiter in vTxHashes which would result in a segfault.