### PR TITLE
Avoid integer sanitizer warnings in chain.o

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -151,7 +151,7 @@ int64_t GetBlockProofEquivalentTime(const CBlockIndex& to, const CBlockIndex& fr
     if (r.bits() > 63) {
         return sign * std::numeric_limits<int64_t>::max();
     }
-    return sign * r.GetLow64();
+    return sign * int64_t(r.GetLow64());
 }
 
 /** Find the last common ancestor two blocks have.

--- a/src/chain.h
+++ b/src/chain.h
@@ -462,7 +462,7 @@ public:
     /** Return the maximal height in the chain. Is equal to chain.Tip() ? chain.Tip()->nHeight : -1. */
     int Height() const
     {
-        return vChain.size() - 1;
+        return int(vChain.size()) - 1;
     }
 
     /** Set/initialize a chain with a given tip. */

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -47,8 +47,6 @@ unsigned-integer-overflow:addrman.cpp
 unsigned-integer-overflow:arith_uint256.h
 unsigned-integer-overflow:bitcoin-tx.cpp
 unsigned-integer-overflow:common/bloom.cpp
-unsigned-integer-overflow:chain.cpp
-unsigned-integer-overflow:chain.h
 unsigned-integer-overflow:coins.cpp
 unsigned-integer-overflow:compressor.cpp
 unsigned-integer-overflow:core_write.cpp
@@ -64,8 +62,6 @@ unsigned-integer-overflow:validation.cpp
 implicit-integer-sign-change:addrman.h
 implicit-integer-sign-change:bech32.cpp
 implicit-integer-sign-change:common/bloom.cpp
-implicit-integer-sign-change:chain.cpp
-implicit-integer-sign-change:chain.h
 implicit-integer-sign-change:coins.h
 implicit-integer-sign-change:compat/stdin.cpp
 implicit-integer-sign-change:compressor.h
@@ -80,10 +76,8 @@ implicit-integer-sign-change:serialize.h
 implicit-integer-sign-change:test/streams_tests.cpp
 implicit-integer-sign-change:txmempool.cpp
 implicit-integer-sign-change:zmq/zmqpublishnotifier.cpp
-implicit-signed-integer-truncation,implicit-integer-sign-change:chain.h
 implicit-signed-integer-truncation:addrman.cpp
 implicit-signed-integer-truncation:addrman.h
-implicit-signed-integer-truncation:chain.h
 implicit-signed-integer-truncation:crypto/
 implicit-signed-integer-truncation:node/miner.cpp
 implicit-signed-integer-truncation:net.cpp


### PR DESCRIPTION
The two changes make the code more self-documenting and also allow to remove 5 file-wide suppressions for the module