### PR TITLE
refactor: move index class members from protected to private

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -378,7 +378,8 @@ IndexSummary BaseIndex::GetSummary() const
     return summary;
 }
 
-void BaseIndex::SetBestBlockIndex(const CBlockIndex* block) {
+void BaseIndex::SetBestBlockIndex(const CBlockIndex* block)
+{
     assert(!node::fPruneMode || AllowPrune());
 
     m_best_block_index = block;

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -26,6 +26,29 @@ struct IndexSummary {
  */
 class BaseIndex : public CValidationInterface
 {
+public:
+    /// Destructor interrupts sync thread if running and blocks until it exits.
+    virtual ~BaseIndex();
+
+    /// Blocks the current thread until the index is caught up to the current
+    /// state of the block chain. This only blocks if the index has gotten in
+    /// sync once and only needs to process blocks in the ValidationInterface
+    /// queue. If the index is catching up from far behind, this method does
+    /// not block and immediately returns false.
+    bool BlockUntilSyncedToCurrentChain() const LOCKS_EXCLUDED(::cs_main);
+
+    void Interrupt();
+
+    /// Start initializes the sync state and registers the instance as a
+    /// ValidationInterface so that it stays in sync with blockchain updates.
+    [[nodiscard]] bool Start(CChainState& active_chainstate);
+
+    /// Stops the instance from staying in sync with blockchain updates.
+    void Stop();
+
+    /// Get a summary of the index and its state.
+    IndexSummary GetSummary() const;
+
 protected:
     /**
      * The database stores a block locator of the chain the database is synced to
@@ -46,6 +69,14 @@ protected:
         /// Write block locator of the chain that the index is in sync with.
         void WriteBestBlock(CDBBatch& batch, const CBlockLocator& locator);
     };
+
+    CChainState* m_chainstate{nullptr};
+
+    void BlockConnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex) override;
+
+    void ChainStateFlushed(const CBlockLocator& locator) override;
+
+    const CBlockIndex* CurrentIndex() { return m_best_block_index.load(); };
 
 private:
     /// Whether the index is in sync with the main chain. The flag is flipped
@@ -76,27 +107,12 @@ private:
     /// getting corrupted.
     bool Commit();
 
-    virtual bool AllowPrune() const = 0;
-
-    virtual DB& GetDB() const = 0;
-
-    /// Write update index entries for a newly connected block.
-    virtual bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) { return true; }
-
     /// Update the internal best block index as well as the prune lock.
     void SetBestBlockIndex(const CBlockIndex* block);
 
-    /// Get the name of the index for display in logs.
-    virtual const char* GetIndexName() const = 0;
-
 protected:
-    CChainState* m_chainstate{nullptr};
-
-    void BlockConnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex) override;
-
-    void ChainStateFlushed(const CBlockLocator& locator) override;
-
-    const CBlockIndex* CurrentIndex() { return m_best_block_index.load(); };
+    // The following virtual functions can be overridden but the inherited base
+    // implementation is used by some of the child classes.
 
     /// Initialize internal state from the database and block index.
     [[nodiscard]] virtual bool Init();
@@ -109,28 +125,19 @@ protected:
     /// be an ancestor of the current best block.
     virtual bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip);
 
-public:
-    /// Destructor interrupts sync thread if running and blocks until it exits.
-    virtual ~BaseIndex();
+private:
+    // The following virtual functions are fully overridden, i.e. no inherited
+    // base implementation is used by the child classes.
 
-    /// Blocks the current thread until the index is caught up to the current
-    /// state of the block chain. This only blocks if the index has gotten in
-    /// sync once and only needs to process blocks in the ValidationInterface
-    /// queue. If the index is catching up from far behind, this method does
-    /// not block and immediately returns false.
-    bool BlockUntilSyncedToCurrentChain() const LOCKS_EXCLUDED(::cs_main);
+    virtual bool AllowPrune() const = 0;
 
-    void Interrupt();
+    virtual DB& GetDB() const = 0;
 
-    /// Start initializes the sync state and registers the instance as a
-    /// ValidationInterface so that it stays in sync with blockchain updates.
-    [[nodiscard]] bool Start(CChainState& active_chainstate);
+    /// Write update index entries for a newly connected block.
+    virtual bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) { return true; }
 
-    /// Stops the instance from staying in sync with blockchain updates.
-    void Stop();
-
-    /// Get a summary of the index and its state.
-    IndexSummary GetSummary() const;
+    /// Get the name of the index for display in logs.
+    virtual const char* GetIndexName() const = 0;
 };
 
 #endif // BITCOIN_INDEX_BASE_H

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -78,6 +78,8 @@ private:
 
     virtual bool AllowPrune() const = 0;
 
+    virtual DB& GetDB() const = 0;
+
     /// Write update index entries for a newly connected block.
     virtual bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) { return true; }
 
@@ -103,8 +105,6 @@ protected:
     /// Rewind index to an earlier chain tip during a chain reorg. The tip must
     /// be an ancestor of the current best block.
     virtual bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip);
-
-    virtual DB& GetDB() const = 0;
 
     /// Update the internal best block index as well as the prune lock.
     void SetBestBlockIndex(const CBlockIndex* block);

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -78,6 +78,9 @@ private:
 
     virtual bool AllowPrune() const = 0;
 
+    /// Get the name of the index for display in logs.
+    virtual const char* GetIndexName() const = 0;
+
 protected:
     CChainState* m_chainstate{nullptr};
 
@@ -102,9 +105,6 @@ protected:
     virtual bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip);
 
     virtual DB& GetDB() const = 0;
-
-    /// Get the name of the index for display in logs.
-    virtual const char* GetIndexName() const = 0;
 
     /// Update the internal best block index as well as the prune lock.
     void SetBestBlockIndex(const CBlockIndex* block);

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -83,6 +83,9 @@ private:
     /// Write update index entries for a newly connected block.
     virtual bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) { return true; }
 
+    /// Update the internal best block index as well as the prune lock.
+    void SetBestBlockIndex(const CBlockIndex* block);
+
     /// Get the name of the index for display in logs.
     virtual const char* GetIndexName() const = 0;
 
@@ -105,9 +108,6 @@ protected:
     /// Rewind index to an earlier chain tip during a chain reorg. The tip must
     /// be an ancestor of the current best block.
     virtual bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip);
-
-    /// Update the internal best block index as well as the prune lock.
-    void SetBestBlockIndex(const CBlockIndex* block);
 
 public:
     /// Destructor interrupts sync thread if running and blocks until it exits.

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -33,7 +33,7 @@ protected:
      * A locator is used instead of a simple hash of the chain tip because blocks
      * and block index entries may not be flushed to disk until after this database
      * is updated.
-    */
+     */
     class DB : public CDBWrapper
     {
     public:
@@ -78,6 +78,9 @@ private:
 
     virtual bool AllowPrune() const = 0;
 
+    /// Write update index entries for a newly connected block.
+    virtual bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) { return true; }
+
     /// Get the name of the index for display in logs.
     virtual const char* GetIndexName() const = 0;
 
@@ -92,9 +95,6 @@ protected:
 
     /// Initialize internal state from the database and block index.
     [[nodiscard]] virtual bool Init();
-
-    /// Write update index entries for a newly connected block.
-    virtual bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) { return true; }
 
     /// Virtual method called internally by Commit that can be overridden to atomically
     /// commit more index state.

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -104,7 +104,7 @@ protected:
     virtual DB& GetDB() const = 0;
 
     /// Get the name of the index for display in logs.
-    virtual const char* GetName() const = 0;
+    virtual const char* GetIndexName() const = 0;
 
     /// Update the internal best block index as well as the prune lock.
     void SetBestBlockIndex(const CBlockIndex* block);

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -116,7 +116,7 @@ bool BlockFilterIndex::Init()
         // further corruption.
         if (m_db->Exists(DB_FILTER_POS)) {
             return error("%s: Cannot read current %s state; index may be corrupted",
-                         __func__, GetName());
+                         __func__, GetIndexName());
         }
 
         // If the DB_FILTER_POS is not set, then initialize to the first location.

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -27,6 +27,7 @@ private:
     BlockFilterType m_filter_type;
     std::string m_name;
     std::unique_ptr<BaseIndex::DB> m_db;
+    BaseIndex::DB& GetDB() const override { return *m_db; }
 
     FlatFilePos m_next_filter_pos;
     std::unique_ptr<FlatFileSeq> m_filter_fileseq;
@@ -52,8 +53,6 @@ protected:
     bool CommitInternal(CDBBatch& batch) override;
 
     bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip) override;
-
-    BaseIndex::DB& GetDB() const override { return *m_db; }
 
 public:
     /** Constructs the index, which becomes available to be queried. */

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -40,6 +40,9 @@ private:
 
     bool AllowPrune() const override { return true; }
 
+    /// Write update index entries for a newly connected block.
+    bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) override;
+
     /// Get the name of the index for display in logs.
     const char* GetIndexName() const override { return m_name.c_str(); }
 
@@ -47,8 +50,6 @@ protected:
     bool Init() override;
 
     bool CommitInternal(CDBBatch& batch) override;
-
-    bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) override;
 
     bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip) override;
 

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -51,7 +51,7 @@ protected:
 
     BaseIndex::DB& GetDB() const override { return *m_db; }
 
-    const char* GetName() const override { return m_name.c_str(); }
+    const char* GetIndexName() const override { return m_name.c_str(); }
 
 public:
     /** Constructs the index, which becomes available to be queried. */

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -40,6 +40,9 @@ private:
 
     bool AllowPrune() const override { return true; }
 
+    /// Get the name of the index for display in logs.
+    const char* GetIndexName() const override { return m_name.c_str(); }
+
 protected:
     bool Init() override;
 
@@ -50,8 +53,6 @@ protected:
     bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip) override;
 
     BaseIndex::DB& GetDB() const override { return *m_db; }
-
-    const char* GetIndexName() const override { return m_name.c_str(); }
 
 public:
     /** Constructs the index, which becomes available to be queried. */

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -47,7 +47,6 @@ private:
     /// Get the name of the index for display in logs.
     const char* GetIndexName() const override { return m_name.c_str(); }
 
-protected:
     bool Init() override;
 
     bool CommitInternal(CDBBatch& batch) override;

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -348,7 +348,7 @@ bool CoinStatsIndex::Init()
         // failure, and starting the index would cause further corruption.
         if (m_db->Exists(DB_MUHASH)) {
             return error("%s: Cannot read current %s state; index may be corrupted",
-                         __func__, GetName());
+                         __func__, GetIndexName());
         }
     }
 
@@ -360,14 +360,14 @@ bool CoinStatsIndex::Init()
         DBVal entry;
         if (!LookUpOne(*m_db, pindex, entry)) {
             return error("%s: Cannot read current %s state; index may be corrupted",
-                         __func__, GetName());
+                         __func__, GetIndexName());
         }
 
         uint256 out;
         m_muhash.Finalize(out);
         if (entry.muhash != out) {
             return error("%s: Cannot read current %s state; index may be corrupted",
-                         __func__, GetName());
+                         __func__, GetIndexName());
         }
 
         m_transaction_output_count = entry.transaction_output_count;

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -19,6 +19,7 @@ class CoinStatsIndex final : public BaseIndex
 private:
     std::string m_name;
     std::unique_ptr<BaseIndex::DB> m_db;
+    BaseIndex::DB& GetDB() const override { return *m_db; }
 
     MuHash3072 m_muhash;
     uint64_t m_transaction_output_count{0};
@@ -50,8 +51,6 @@ protected:
     bool CommitInternal(CDBBatch& batch) override;
 
     bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip) override;
-
-    BaseIndex::DB& GetDB() const override { return *m_db; }
 
 public:
     // Constructs the index, which becomes available to be queried.

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -45,7 +45,6 @@ private:
     /// Get the name of the index for display in logs.
     const char* GetIndexName() const override { return "coinstatsindex"; }
 
-protected:
     bool Init() override;
 
     bool CommitInternal(CDBBatch& batch) override;

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -49,7 +49,7 @@ protected:
 
     BaseIndex::DB& GetDB() const override { return *m_db; }
 
-    const char* GetName() const override { return "coinstatsindex"; }
+    const char* GetIndexName() const override { return "coinstatsindex"; }
 
 public:
     // Constructs the index, which becomes available to be queried.

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -38,6 +38,9 @@ private:
 
     bool AllowPrune() const override { return true; }
 
+    /// Get the name of the index for display in logs.
+    const char* GetIndexName() const override { return "coinstatsindex"; }
+
 protected:
     bool Init() override;
 
@@ -48,8 +51,6 @@ protected:
     bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip) override;
 
     BaseIndex::DB& GetDB() const override { return *m_db; }
-
-    const char* GetIndexName() const override { return "coinstatsindex"; }
 
 public:
     // Constructs the index, which becomes available to be queried.

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -38,6 +38,9 @@ private:
 
     bool AllowPrune() const override { return true; }
 
+    /// Write update index entries for a newly connected block.
+    bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) override;
+
     /// Get the name of the index for display in logs.
     const char* GetIndexName() const override { return "coinstatsindex"; }
 
@@ -45,8 +48,6 @@ protected:
     bool Init() override;
 
     bool CommitInternal(CDBBatch& batch) override;
-
-    bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) override;
 
     bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip) override;
 

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -14,10 +14,8 @@
  */
 class TxIndex final : public BaseIndex
 {
-protected:
-    class DB;
-
 private:
+    class DB;
     const std::unique_ptr<DB> m_db;
     BaseIndex::DB& GetDB() const override;
 

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -27,7 +27,7 @@ protected:
 
     BaseIndex::DB& GetDB() const override;
 
-    const char* GetName() const override { return "txindex"; }
+    const char* GetIndexName() const override { return "txindex"; }
 
 public:
     /// Constructs the index, which becomes available to be queried.

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -22,12 +22,13 @@ private:
 
     bool AllowPrune() const override { return false; }
 
+    /// Write update index entries for a newly connected block.
+    bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) override;
+
     /// Get the name of the index for display in logs.
     const char* GetIndexName() const override { return "txindex"; }
 
 protected:
-    bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) override;
-
     BaseIndex::DB& GetDB() const override;
 
 public:

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -19,6 +19,7 @@ protected:
 
 private:
     const std::unique_ptr<DB> m_db;
+    BaseIndex::DB& GetDB() const override;
 
     bool AllowPrune() const override { return false; }
 
@@ -27,9 +28,6 @@ private:
 
     /// Get the name of the index for display in logs.
     const char* GetIndexName() const override { return "txindex"; }
-
-protected:
-    BaseIndex::DB& GetDB() const override;
 
 public:
     /// Constructs the index, which becomes available to be queried.

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -22,12 +22,13 @@ private:
 
     bool AllowPrune() const override { return false; }
 
+    /// Get the name of the index for display in logs.
+    const char* GetIndexName() const override { return "txindex"; }
+
 protected:
     bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) override;
 
     BaseIndex::DB& GetDB() const override;
-
-    const char* GetIndexName() const override { return "txindex"; }
 
 public:
     /// Constructs the index, which becomes available to be queried.

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -232,7 +232,8 @@ void BlockManager::FindFilesToPrune(std::set<int>& setFilesToPrune, uint64_t nPr
            nLastBlockWeCanPrune, count);
 }
 
-void BlockManager::UpdatePruneLock(const std::string& name, const PruneLockInfo& lock_info) {
+void BlockManager::UpdatePruneLock(const std::string& name, const PruneLockInfo& lock_info)
+{
     AssertLockHeld(::cs_main);
     m_prune_locks[name] = lock_info;
 }


### PR DESCRIPTION
Simplify the index base and child classes and improve encapsulation and clarity by making fully overridden virtual member functions `private`. In the child classes, this allows having only public and private members. This change also help contributors add virtual functions into the correct section. Also rename the `GetName()` getters to `GetIndexName()` for clarity and easier grepping/reviewing.

Some context:

A base class virtual function doesn't need to be accessible to be overridden, but it can only be `private` if fully overridden, e.g. no inherited base implementation is used by the child classes.

References:

- https://en.cppreference.com/w/cpp/language/virtual: "Base::vf does not need to be accessible or visible to be overridden. (Base::vf can be declared private, or Base can be inherited using private inheritance.)"

- "An implementation member should be protected if it provides an operation or data that a derived class will need to use in its own implementation. Otherwise, implementation members should be private." - C++ Primer (Lippman, Lajoie, Moo)

- Herb Sutter in http://www.gotw.ca/publications/mill18.htm: "Make virtual functions private, and only if derived classes need to invoke the base implementation of a virtual function, make the virtual function protected. Prefer to make interfaces non-virtual using the Template pattern."
