### PR TITLE
test: add functional test for `-maxtipage` parameter

### DIFF
--- a/test/functional/feature_maxtipage.py
+++ b/test/functional/feature_maxtipage.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test logic for setting nMaxTipAge on command line.
+
+Nodes don't consider themselves out of "initial block download" as long as
+their best known block header time is more than nMaxTipAge in the past.
+"""
+
+import time
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+DEFAULT_MAX_TIP_AGE = 24 * 60 * 60
+
+
+class MaxTipAgeTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+    def test_maxtipage(self, maxtipage, set_parameter=True):
+        node_miner = self.nodes[0]
+        node_ibd = self.nodes[1]
+
+        self.restart_node(1, [f'-maxtipage={maxtipage}'] if set_parameter else None)
+        self.connect_nodes(0, 1)
+
+        # tips older than maximum age -> stay in IBD
+        cur_time = int(time.time())
+        node_ibd.setmocktime(cur_time)
+        for delta in [5, 4, 3, 2, 1]:
+            node_miner.setmocktime(cur_time - maxtipage - delta)
+            self.generate(node_miner, 1)
+            assert_equal(node_ibd.getblockchaininfo()['initialblockdownload'], True)
+
+        # tip within maximum age -> leave IBD
+        node_miner.setmocktime(cur_time - maxtipage)
+        self.generate(node_miner, 1)
+        assert_equal(node_ibd.getblockchaininfo()['initialblockdownload'], False)
+
+    def run_test(self):
+        self.log.info("Test IBD with maximum tip age of 24 hours (default).")
+        self.test_maxtipage(DEFAULT_MAX_TIP_AGE, set_parameter=False)
+
+        for hours in [20, 10, 5, 2, 1]:
+            maxtipage = hours * 60 * 60
+            self.log.info(f"Test IBD with maximum tip age of {hours} hours (-maxtipage={maxtipage}).")
+            self.test_maxtipage(maxtipage)
+
+
+if __name__ == '__main__':
+    MaxTipAgeTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -198,6 +198,7 @@ BASE_SCRIPTS = [
     'wallet_keypool.py --legacy-wallet',
     'wallet_keypool.py --descriptors',
     'wallet_descriptor.py --descriptors',
+    'feature_maxtipage.py',
     'p2p_nobloomfilter_messages.py',
     'p2p_filter.py',
     'rpc_setban.py',


### PR DESCRIPTION
This PR adds a missing test for the `-maxtipage` parameter which controls what is the allowed maximum tip age for leaving IBD:
https://github.com/bitcoin/bitcoin/blob/792d0d8d512cf8ddca200317b74ce550c1a1a428/src/init.cpp#L540

Relevant code path in the `CChainState::IsInitialBlockDownload` method:
https://github.com/bitcoin/bitcoin/blob/792d0d8d512cf8ddca200317b74ce550c1a1a428/src/validation.cpp#L1479-L1480

The test is pretty simple and should be self-explanatory.