### PR TITLE
build: Replace `which` command with `command -v`

### DIFF
--- a/depends/hosts/mingw32.mk
+++ b/depends/hosts/mingw32.mk
@@ -1,4 +1,4 @@
-ifneq ($(shell which $(host)-g++-posix),)
+ifneq ($(shell $(SHELL) $(.SHELLFLAGS) "command -v $(host)-g++-posix"),)
 mingw32_CXX := $(host)-g++-posix
 endif
 


### PR DESCRIPTION
On some systems the `which` command can emit messages into stderr. For example, for `debianutils 5.5-1` package in Debian Sid:
```
# which cat  
/usr/bin/which: this version of `which' is deprecated; use `command -v' in scripts instead.
/bin/cat
```

Although such messages are harmless, they could distract developers needlessly (see bitcoin/bitcoin#24056).

Fixes bitcoin/bitcoin#24056.