### PR TITLE
Optimize Mempool Reorg logic using Epochs, improving memory usage and runtime.

### DIFF
--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -524,7 +524,7 @@ public:
 
     uint64_t CalculateDescendantMaximum(txiter entry) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 private:
-    typedef std::map<txiter, setEntries, CompareIteratorByHash> cacheMap;
+    typedef std::map<txiter, std::vector<txiter>, CompareIteratorByHash> cacheMap;
 
 
     void UpdateParent(txiter entry, txiter parent, bool add) EXCLUSIVE_LOCKS_REQUIRED(cs);


### PR DESCRIPTION
This is a follow up PR to #21464 which improves the memory usage and runtime of the reorg update logic. The main changes are:

1. Use std::vector<txiter> in cacheMap instead of std::set<txiter> which makes (iirc) entries go from > ~64 bytes to just 8 bytes
2.  Don't look up in cacheMap the updateIt N times, look it up once and directly write the vector with known length (saves resizing)
3. Use epochs to de-duplicate (saves N log N lookups)
4. trimming from setExclude in a hotter loop

