### PR TITLE
rpc: add require_checksum flag to deriveaddresses

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -82,6 +82,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendmany", 8, "fee_rate"},
     { "sendmany", 9, "verbose" },
     { "deriveaddresses", 1, "range" },
+    { "deriveaddresses", 2, "options" },
     { "scantxoutset", 1, "scanobjects" },
     { "addmultisigaddress", 0, "nrequired" },
     { "addmultisigaddress", 1, "keys" },


### PR DESCRIPTION
This allows a user to derive the addresses for some privkey without first having to derive the descriptor checksum.

Alternative to #24161.