### PR TITLE
Fix some race conditions in `BanMan::DumpBanlist()`

### DIFF
--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -7,6 +7,7 @@
 
 #include <netaddress.h>
 #include <node/ui_interface.h>
+#include <sync.h>
 #include <util/system.h>
 #include <util/time.h>
 #include <util/translation.h>
@@ -39,6 +40,9 @@ BanMan::~BanMan()
 
 void BanMan::DumpBanlist()
 {
+    static Mutex dump_mutex;
+    LOCK(dump_mutex);
+
     SweepBanned(); // clean unused entries (if bantime has expired)
 
     if (!BannedSetIsDirty()) return;

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -49,11 +49,12 @@ void BanMan::DumpBanlist()
         SweepBanned();
         if (!BannedSetIsDirty()) return;
         banmap = m_banned;
+        SetBannedSetDirty(false);
     }
 
     int64_t n_start = GetTimeMillis();
-    if (m_ban_db.Write(banmap)) {
-        SetBannedSetDirty(false);
+    if (!m_ban_db.Write(banmap)) {
+        SetBannedSetDirty(true);
     }
 
     LogPrint(BCLog::NET, "Flushed %d banned node addresses/subnets to disk  %dms\n", banmap.size(),

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -43,9 +43,11 @@ void BanMan::DumpBanlist()
     static Mutex dump_mutex;
     LOCK(dump_mutex);
 
-    SweepBanned(); // clean unused entries (if bantime has expired)
-
-    if (!BannedSetIsDirty()) return;
+    {
+        LOCK(m_cs_banned);
+        SweepBanned();
+        if (!BannedSetIsDirty()) return;
+    }
 
     int64_t n_start = GetTimeMillis();
 

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -43,16 +43,15 @@ void BanMan::DumpBanlist()
     static Mutex dump_mutex;
     LOCK(dump_mutex);
 
+    banmap_t banmap;
     {
         LOCK(m_cs_banned);
         SweepBanned();
         if (!BannedSetIsDirty()) return;
+        banmap = m_banned;
     }
 
     int64_t n_start = GetTimeMillis();
-
-    banmap_t banmap;
-    GetBanned(banmap);
     if (m_ban_db.Write(banmap)) {
         SetBannedSetDirty(false);
     }


### PR DESCRIPTION
This PR split from bitcoin/bitcoin#24097 with some additions. This makes the following switch from `RecursiveMutex` to `Mutex` a pure refactoring.

See details in commit messages.