### PR TITLE
build: Add --enable-c++20 option

### DIFF
--- a/ci/test/00_setup_env_native_asan.sh
+++ b/ci/test/00_setup_env_native_asan.sh
@@ -11,4 +11,4 @@ export PACKAGES="clang llvm python3-zmq qtbase5-dev qttools5-dev-tools libevent-
 export DOCKER_NAME_TAG=ubuntu:22.04
 export NO_DEPENDS=1
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=qt5 CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER' --with-sanitizers=address,integer,undefined CC=clang CXX=clang++"
+export BITCOIN_CONFIG="--enable-c++20 --enable-zmq --with-incompatible-bdb --with-gui=qt5 CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER' --with-sanitizers=address,integer,undefined CC=clang CXX=clang++"

--- a/configure.ac
+++ b/configure.ac
@@ -78,8 +78,18 @@ AC_ARG_WITH([seccomp],
   [seccomp_found=$withval],
   [seccomp_found=auto])
 
+AC_ARG_ENABLE([c++20],
+  [AS_HELP_STRING([--enable-c++20],
+  [enable compilation in c++20 mode (disabled by default)])],
+  [use_cxx20=$enableval],
+  [use_cxx20=no])
+
 dnl Require C++17 compiler (no GNU extensions)
+if test "$use_cxx20" = "no"; then
 AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
+else
+AX_CXX_COMPILE_STDCXX([20], [noext], [mandatory])
+fi
 
 dnl Check if -latomic is required for <std::atomic>
 CHECK_ATOMIC

--- a/src/fs.h
+++ b/src/fs.h
@@ -51,11 +51,25 @@ public:
     // Disallow std::string conversion method to avoid locale-dependent encoding on windows.
     std::string string() const = delete;
 
+    std::string u8string() const
+    {
+        const auto& utf8_str{std::filesystem::path::u8string()};
+        // utf8_str might either be std::string (C++17) or std::u8string
+        // (C++20). Convert both to std::string. This method can be removed
+        // after switching to C++20.
+        return std::string{utf8_str.begin(), utf8_str.end()};
+    }
+
     // Required for path overloads in <fstream>.
     // See https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=96e0367ead5d8dcac3bec2865582e76e2fbab190
     path& make_preferred() { std::filesystem::path::make_preferred(); return *this; }
     path filename() const { return std::filesystem::path::filename(); }
 };
+
+static inline path u8path(const std::string& utf8_str)
+{
+    return std::filesystem::u8path(utf8_str);
+}
 
 // Disallow implicit std::string conversion for absolute to avoid
 // locale-dependent encoding on windows.
@@ -116,8 +130,8 @@ static inline std::string PathToString(const path& path)
     // use here, because these methods encode the path using C++'s narrow
     // multibyte encoding, which on Windows corresponds to the current "code
     // page", which is unpredictable and typically not able to represent all
-    // valid paths. So std::filesystem::path::u8string() and
-    // std::filesystem::u8path() functions are used instead on Windows. On
+    // valid paths. So fs::path::u8string() and
+    // fs::u8path() functions are used instead on Windows. On
     // POSIX, u8string/u8path functions are not safe to use because paths are
     // not always valid UTF-8, so plain string methods which do not transform
     // the path there are used.

--- a/src/net.h
+++ b/src/net.h
@@ -99,14 +99,21 @@ struct AddedNodeInfo
 class CNodeStats;
 class CClientUIInterface;
 
-struct CSerializedNetMsg
-{
+struct CSerializedNetMsg {
     CSerializedNetMsg() = default;
     CSerializedNetMsg(CSerializedNetMsg&&) = default;
     CSerializedNetMsg& operator=(CSerializedNetMsg&&) = default;
-    // No copying, only moves.
+    // No implicit copying, only moves.
     CSerializedNetMsg(const CSerializedNetMsg& msg) = delete;
     CSerializedNetMsg& operator=(const CSerializedNetMsg&) = delete;
+
+    CSerializedNetMsg Copy() const
+    {
+        CSerializedNetMsg copy;
+        copy.data = data;
+        copy.m_type = m_type;
+        return copy;
+    }
 
     std::vector<unsigned char> data;
     std::string m_type;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1624,7 +1624,7 @@ void PeerManagerImpl::NewPoWValidBlock(const CBlockIndex *pindex, const std::sha
                     hashBlock.ToString(), pnode->GetId());
 
             const CSerializedNetMsg& ser_cmpctblock{lazy_ser.get()};
-            m_connman.PushMessage(pnode, CSerializedNetMsg{ser_cmpctblock.data, ser_cmpctblock.m_type});
+            m_connman.PushMessage(pnode, ser_cmpctblock.Copy());
             state.pindexBestHeaderSent = pindex;
         }
     });

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -111,7 +111,7 @@ static void Repeat(CScheduler& s, CScheduler::Function f, std::chrono::milliseco
 
 void CScheduler::scheduleEvery(CScheduler::Function f, std::chrono::milliseconds delta)
 {
-    scheduleFromNow([=] { Repeat(*this, f, delta); }, delta);
+    scheduleFromNow([this, f, delta] { Repeat(*this, f, delta); }, delta);
 }
 
 size_t CScheduler::getQueueInfo(std::chrono::system_clock::time_point& first,


### PR DESCRIPTION
This is for CI and devs only and doesn't change that C++17 is the standard we are currently using. The option `--enable-c++20` allows CI to check that the C++17 code in the repo is  also valid C++20. (There are some cases where valid C++17 doesn't compile under C++20).

Also, it allows developers to easily play with C++20 in the codebase.