### PR TITLE
p2p, rpc: Manual block-relay-only connections with addnode

### DIFF
--- a/doc/release-notes-24170.md
+++ b/doc/release-notes-24170.md
@@ -1,0 +1,8 @@
+RPC
+---
+
+- The RPC `addnode` and the `-addnode` bitcoind startup option now
+optionally support adding manual peers that are block-relay-only.
+On these connections, the node doesn't participate in transaction or
+address relay. See bitcoind and RPC help documentation for parameter
+semantics. (#24170)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1587,7 +1587,7 @@ int CConnman::GetExtraBlockRelayCount() const
     {
         LOCK(m_nodes_mutex);
         for (const CNode* pnode : m_nodes) {
-            if (pnode->fSuccessfullyConnected && !pnode->fDisconnect && pnode->IsBlockOnlyConn()) {
+            if (pnode->fSuccessfullyConnected && !pnode->fDisconnect && pnode->IsAutomaticBlockRelayConn()) {
                 ++block_relay_peers;
             }
         }
@@ -1713,7 +1713,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
             LOCK(m_nodes_mutex);
             for (const CNode* pnode : m_nodes) {
                 if (pnode->IsFullOutboundConn()) nOutboundFullRelay++;
-                if (pnode->IsBlockOnlyConn()) nOutboundBlockRelay++;
+                if (pnode->IsAutomaticBlockRelayConn()) nOutboundBlockRelay++;
 
                 // Make sure our persistent outbound slots to ipv4/ipv6 peers belong to different netgroups.
                 switch (pnode->m_conn_type) {
@@ -1908,12 +1908,12 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
     }
 }
 
-std::vector<CAddress> CConnman::GetCurrentBlockRelayOnlyConns() const
+std::vector<CAddress> CConnman::GetCurrentAutomaticBlockRelayConns() const
 {
     std::vector<CAddress> ret;
     LOCK(m_nodes_mutex);
     for (const CNode* pnode : m_nodes) {
-        if (pnode->IsBlockOnlyConn()) {
+        if (pnode->IsAutomaticBlockRelayConn()) {
             ret.push_back(pnode->addr);
         }
     }
@@ -2482,7 +2482,7 @@ void CConnman::StopNodes()
 
         if (m_use_addrman_outgoing) {
             // Anchor connections are only dumped during clean shutdown.
-            std::vector<CAddress> anchors_to_dump = GetCurrentBlockRelayOnlyConns();
+            std::vector<CAddress> anchors_to_dump = GetCurrentAutomaticBlockRelayConns();
             if (anchors_to_dump.size() > MAX_BLOCK_RELAY_ONLY_ANCHORS) {
                 anchors_to_dump.resize(MAX_BLOCK_RELAY_ONLY_ANCHORS);
             }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1079,6 +1079,7 @@ bool CConnman::AddConnection(const std::string& address, ConnectionType conn_typ
     switch (conn_type) {
     case ConnectionType::INBOUND:
     case ConnectionType::MANUAL:
+    case ConnectionType::MANUAL_BLOCK_RELAY:
         return false;
     case ConnectionType::OUTBOUND_FULL_RELAY:
         max_connections = m_max_outbound_full_relay;
@@ -1727,6 +1728,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
                     case ConnectionType::FEELER:
                         break;
                     case ConnectionType::MANUAL:
+                    case ConnectionType::MANUAL_BLOCK_RELAY:
                     case ConnectionType::OUTBOUND_FULL_RELAY:
                     case ConnectionType::BLOCK_RELAY:
                         CAddress address{pnode->addr};

--- a/src/net.h
+++ b/src/net.h
@@ -447,7 +447,7 @@ public:
     bool IsAutomaticOutboundOrBlockRelayConn() const {
         switch (m_conn_type) {
             case ConnectionType::OUTBOUND_FULL_RELAY:
-            case ConnectionType::BLOCK_RELAY:
+            case ConnectionType::AUTOMATIC_BLOCK_RELAY:
                 return true;
             case ConnectionType::INBOUND:
             case ConnectionType::MANUAL:
@@ -469,7 +469,7 @@ public:
     }
 
     bool IsAutomaticBlockRelayConn() const {
-        return m_conn_type == ConnectionType::BLOCK_RELAY;
+        return m_conn_type == ConnectionType::AUTOMATIC_BLOCK_RELAY;
     }
 
     bool IsFeelerConn() const {
@@ -502,7 +502,7 @@ public:
             case ConnectionType::FEELER:
                 return false;
             case ConnectionType::OUTBOUND_FULL_RELAY:
-            case ConnectionType::BLOCK_RELAY:
+            case ConnectionType::AUTOMATIC_BLOCK_RELAY:
             case ConnectionType::ADDR_FETCH:
                 return true;
         } // no default case, so the compiler can warn about missing cases
@@ -856,7 +856,7 @@ public:
      * Attempts to open a connection. Currently only used from tests.
      *
      * @param[in]   address     Address of node to try connecting to
-     * @param[in]   conn_type   ConnectionType::OUTBOUND, ConnectionType::BLOCK_RELAY,
+     * @param[in]   conn_type   ConnectionType::OUTBOUND, ConnectionType::AUTOMATIC_BLOCK_RELAY,
      *                          ConnectionType::ADDR_FETCH or ConnectionType::FEELER
      * @return      bool        Returns false if there are no available
      *                          slots for this connection:
@@ -1020,7 +1020,7 @@ private:
     std::unordered_set<Network> GetReachableEmptyNetworks() const;
 
     /**
-     * Return vector of current BLOCK_RELAY peers.
+     * Return vector of current AUTOMATIC_BLOCK_RELAY peers.
      */
     std::vector<CAddress> GetCurrentAutomaticBlockRelayConns() const;
 

--- a/src/net.h
+++ b/src/net.h
@@ -463,7 +463,7 @@ public:
         return m_conn_type == ConnectionType::MANUAL;
     }
 
-    bool IsBlockOnlyConn() const {
+    bool IsAutomaticBlockRelayConn() const {
         return m_conn_type == ConnectionType::BLOCK_RELAY;
     }
 
@@ -1006,7 +1006,7 @@ private:
     /**
      * Return vector of current BLOCK_RELAY peers.
      */
-    std::vector<CAddress> GetCurrentBlockRelayOnlyConns() const;
+    std::vector<CAddress> GetCurrentAutomaticBlockRelayConns() const;
 
     // Whether the node should be passed out in ForEach* callbacks
     static bool NodeFullyConnected(const CNode* pnode);

--- a/src/net.h
+++ b/src/net.h
@@ -735,7 +735,7 @@ public:
         bool bind_on_any;
         bool m_use_addrman_outgoing = true;
         std::vector<std::string> m_specified_outgoing;
-        std::vector<std::string> m_added_nodes;
+        std::vector<AddedNodeParams> m_added_nodes;
         bool m_i2p_accept_incoming;
     };
 
@@ -764,9 +764,7 @@ public:
         vWhitelistedRange = connOptions.vWhitelistedRange;
         {
             LOCK(m_added_nodes_mutex);
-            for (const auto& added_node : connOptions.m_added_nodes) {
-                m_added_nodes.push_back(AddedNodeParams{added_node, ConnectionType::MANUAL});
-            }
+            m_added_nodes = connOptions.m_added_nodes;
         }
         m_onion_binds = connOptions.onion_binds;
     }

--- a/src/net.h
+++ b/src/net.h
@@ -444,7 +444,7 @@ public:
         mapSendBytesPerMsgType[msg_type] += sent_bytes;
     }
 
-    bool IsOutboundOrBlockRelayConn() const {
+    bool IsAutomaticOutboundOrBlockRelayConn() const {
         switch (m_conn_type) {
             case ConnectionType::OUTBOUND_FULL_RELAY:
             case ConnectionType::BLOCK_RELAY:

--- a/src/net.h
+++ b/src/net.h
@@ -449,6 +449,7 @@ public:
             case ConnectionType::MANUAL:
             case ConnectionType::ADDR_FETCH:
             case ConnectionType::FEELER:
+            case ConnectionType::MANUAL_BLOCK_RELAY:
                 return false;
         } // no default case, so the compiler can warn about missing cases
 
@@ -479,10 +480,21 @@ public:
         return m_conn_type == ConnectionType::INBOUND;
     }
 
+    bool IsManualBlockRelayConn() const
+    {
+        return m_conn_type == ConnectionType::MANUAL_BLOCK_RELAY;
+    }
+
+    bool IsBlockRelayConn() const
+    {
+        return IsAutomaticBlockRelayConn() || IsManualBlockRelayConn();
+    }
+
     bool ExpectServicesFromConn() const {
         switch (m_conn_type) {
             case ConnectionType::INBOUND:
             case ConnectionType::MANUAL:
+            case ConnectionType::MANUAL_BLOCK_RELAY:
             case ConnectionType::FEELER:
                 return false;
             case ConnectionType::OUTBOUND_FULL_RELAY:

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -446,7 +446,7 @@ struct CNodeState {
       * Both are only in effect for outbound, non-manual, non-protected connections.
       * Any peer protected (m_protect = true) is not chosen for eviction. A peer is
       * marked as protected if all of these are true:
-      *   - its connection type is IsAutomaticBlockRelayConn() == false
+      *   - its connection type is OUTBOUND_FULL_RELAY
       *   - it gave us a valid connecting header
       *   - we haven't reached MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT yet
       *   - its chain tip has at least as much work as ours
@@ -1531,7 +1531,7 @@ void PeerManagerImpl::FinalizeNode(const CNode& node)
     }
     } // cs_main
     if (node.fSuccessfullyConnected && misbehavior == 0 &&
-        !node.IsAutomaticBlockRelayConn() && !node.IsInboundConn()) {
+        !node.IsBlockRelayConn() && !node.IsInboundConn()) {
         // Only change visible addrman state for full outbound peers.  We don't
         // call Connected() for feeler connections since they don't have
         // fSuccessfullyConnected set.
@@ -3282,7 +3282,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         // - fRelay=true (the peer wishes to receive transaction announcements)
         //   or we're offering NODE_BLOOM to this peer. NODE_BLOOM means that
         //   the peer may turn on transaction relay later.
-        if (!pfrom.IsAutomaticBlockRelayConn() &&
+        if (!pfrom.IsBlockRelayConn() &&
             !pfrom.IsFeelerConn() &&
             (fRelay || (peer->m_our_services & NODE_BLOOM))) {
             auto* const tx_relay = peer->SetTxRelay();
@@ -4839,7 +4839,7 @@ bool PeerManagerImpl::MaybeDiscourageAndDisconnect(CNode& pnode, Peer& peer)
         return false;
     }
 
-    if (pnode.IsManualConn()) {
+    if (pnode.IsManualConn() || pnode.IsManualBlockRelayConn()) {
         // We never disconnect or discourage manual peers for bad behavior
         LogPrintf("Warning: not punishing manually connected peer %d!\n", peer.m_id);
         return false;
@@ -5266,7 +5266,7 @@ void PeerManagerImpl::MaybeSendFeefilter(CNode& pto, Peer& peer, std::chrono::mi
     if (pto.HasPermission(NetPermissionFlags::ForceRelay)) return;
     // Don't send feefilter messages to outbound block-relay-only peers since they should never announce
     // transactions to us, regardless of feefilter state.
-    if (pto.IsAutomaticBlockRelayConn()) return;
+    if (pto.IsBlockRelayConn()) return;
 
     CAmount currentFilter = m_mempool.GetMinFee().GetFeePerK();
     static FeeFilterRounder g_filter_rounder{CFeeRate{DEFAULT_MIN_RELAY_TX_FEE}};
@@ -5325,7 +5325,7 @@ public:
 bool PeerManagerImpl::RejectIncomingTxs(const CNode& peer) const
 {
     // block-relay-only peers may never send txs to us
-    if (peer.IsAutomaticBlockRelayConn()) return true;
+    if (peer.IsBlockRelayConn()) return true;
     if (peer.IsFeelerConn()) return true;
     // In -blocksonly mode, peers need the 'relay' permission to send txs to us
     if (m_ignore_incoming_txs && !peer.HasPermission(NetPermissionFlags::Relay)) return true;
@@ -5337,7 +5337,7 @@ bool PeerManagerImpl::SetupAddressRelay(const CNode& node, Peer& peer)
     // We don't participate in addr relay with outbound block-relay-only
     // connections to prevent providing adversaries with the additional
     // information of addr traffic to infer the link.
-    if (node.IsAutomaticBlockRelayConn()) return false;
+    if (node.IsBlockRelayConn()) return false;
 
     if (!peer.m_addr_relay_enabled.exchange(true)) {
         // During version message processing (non-block-relay-only outbound peers)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2743,7 +2743,7 @@ void PeerManagerImpl::UpdatePeerStateForReceivedHeaders(CNode& pfrom, Peer& peer
             // until we have a headers chain that has at least
             // the minimum chain work, even if a peer has a chain past our tip,
             // as an anti-DoS measure.
-            if (pfrom.IsOutboundOrBlockRelayConn()) {
+            if (pfrom.IsAutomaticOutboundOrBlockRelayConn()) {
                 LogPrintf("Disconnecting outbound peer %d -- headers chain has insufficient work\n", pfrom.GetId());
                 pfrom.fDisconnect = true;
             }
@@ -4944,7 +4944,7 @@ void PeerManagerImpl::ConsiderEviction(CNode& pto, Peer& peer, std::chrono::seco
 
     CNodeState &state = *State(pto.GetId());
 
-    if (!state.m_chain_sync.m_protect && pto.IsOutboundOrBlockRelayConn() && state.fSyncStarted) {
+    if (!state.m_chain_sync.m_protect && pto.IsAutomaticOutboundOrBlockRelayConn() && state.fSyncStarted) {
         // This is an outbound peer subject to disconnection if they don't
         // announce a block with as much work as the current tip within
         // CHAIN_SYNC_TIMEOUT + HEADERS_RESPONSE_TIME seconds (note: if

--- a/src/node/connection_types.cpp
+++ b/src/node/connection_types.cpp
@@ -16,7 +16,7 @@ std::string ConnectionTypeAsString(ConnectionType conn_type)
         return "feeler";
     case ConnectionType::OUTBOUND_FULL_RELAY:
         return "outbound-full-relay";
-    case ConnectionType::BLOCK_RELAY:
+    case ConnectionType::AUTOMATIC_BLOCK_RELAY:
         return "block-relay-only";
     case ConnectionType::ADDR_FETCH:
         return "addr-fetch";

--- a/src/node/connection_types.cpp
+++ b/src/node/connection_types.cpp
@@ -20,6 +20,8 @@ std::string ConnectionTypeAsString(ConnectionType conn_type)
         return "block-relay-only";
     case ConnectionType::ADDR_FETCH:
         return "addr-fetch";
+    case ConnectionType::MANUAL_BLOCK_RELAY:
+        return "manual-block-relay";
     } // no default case, so the compiler can warn about missing cases
 
     assert(false);

--- a/src/node/connection_types.h
+++ b/src/node/connection_types.h
@@ -74,6 +74,18 @@ enum class ConnectionType {
      * AddrMan is empty.
      */
     ADDR_FETCH,
+
+    /**
+     * Manual-block-relay connections are manually added nodes (via -addnode)
+     * that behave like BLOCK_RELAY connections in that they don't participate in
+     * transaction and address relay, and also share the properties of MANUAL
+     * connections. When the node is connected to a privacy network such as
+     * Tor, manual block-relay-only connections to IPv4 or IPv6 nodes can be
+     * used for hardening against eclipse attacks, while at the same time
+     * making fingerprinting attacks more difficult and preserving a higher degree
+     * of privacy by not transmitting transactions and addresses over these links.
+     */
+    MANUAL_BLOCK_RELAY,
 };
 
 /** Convert ConnectionType enum to a string value */

--- a/src/node/connection_types.h
+++ b/src/node/connection_types.h
@@ -65,7 +65,7 @@ enum class ConnectionType {
      * addresses from our AddrMan if MAX_BLOCK_RELAY_ONLY_CONNECTIONS
      * isn't reached yet.
      */
-    BLOCK_RELAY,
+    AUTOMATIC_BLOCK_RELAY,
 
     /**
      * AddrFetch connections are short lived connections used to solicit
@@ -77,7 +77,7 @@ enum class ConnectionType {
 
     /**
      * Manual-block-relay connections are manually added nodes (via -addnode)
-     * that behave like BLOCK_RELAY connections in that they don't participate in
+     * that behave like AUTOMATIC_BLOCK_RELAY connections in that they don't participate in
      * transaction and address relay, and also share the properties of MANUAL
      * connections. When the node is connected to a privacy network such as
      * Tor, manual block-relay-only connections to IPv4 or IPv6 nodes can be

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -716,6 +716,9 @@ QString ConnectionTypeToQString(ConnectionType conn_type, bool prepend_direction
     case ConnectionType::FEELER: return prefix + QObject::tr("Feeler");
     //: Short-lived peer connection type that solicits known addresses from a peer.
     case ConnectionType::ADDR_FETCH: return prefix + QObject::tr("Address Fetch");
+    /*: Manually established connection type that does not participate in address
+        and transaction relay */
+    case ConnectionType::MANUAL_BLOCK_RELAY: return prefix + QObject::tr("Manual Block Relay");
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -709,7 +709,7 @@ QString ConnectionTypeToQString(ConnectionType conn_type, bool prepend_direction
     case ConnectionType::OUTBOUND_FULL_RELAY: return prefix + QObject::tr("Full Relay");
     /*: Peer connection type that relays network information about
         blocks and not transactions or addresses. */
-    case ConnectionType::BLOCK_RELAY: return prefix + QObject::tr("Block Relay");
+    case ConnectionType::AUTOMATIC_BLOCK_RELAY: return prefix + QObject::tr("Block Relay");
     //: Peer connection type established manually through one of several methods.
     case ConnectionType::MANUAL: return prefix + QObject::tr("Manual");
     //: Short-lived peer connection type that tests the aliveness of known addresses.

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -378,7 +378,7 @@ static RPCHelpMan addconnection()
     if (conn_type_in == "outbound-full-relay") {
         conn_type = ConnectionType::OUTBOUND_FULL_RELAY;
     } else if (conn_type_in == "block-relay-only") {
-        conn_type = ConnectionType::BLOCK_RELAY;
+        conn_type = ConnectionType::AUTOMATIC_BLOCK_RELAY;
     } else if (conn_type_in == "addr-fetch") {
         conn_type = ConnectionType::ADDR_FETCH;
     } else if (conn_type_in == "feeler") {

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -223,7 +223,7 @@ BOOST_AUTO_TEST_CASE(block_relay_only_eviction)
 
     // Add block-relay-only peers up to the limit
     for (int i = 0; i < max_outbound_block_relay; ++i) {
-        AddRandomOutboundPeer(id, vNodes, *peerLogic, *connman, ConnectionType::BLOCK_RELAY);
+        AddRandomOutboundPeer(id, vNodes, *peerLogic, *connman, ConnectionType::AUTOMATIC_BLOCK_RELAY);
     }
     peerLogic->CheckForStaleTipAndEvictPeers();
 
@@ -232,7 +232,7 @@ BOOST_AUTO_TEST_CASE(block_relay_only_eviction)
     }
 
     // Add an extra block-relay-only peer breaking the limit (mocks logic in ThreadOpenConnections)
-    AddRandomOutboundPeer(id, vNodes, *peerLogic, *connman, ConnectionType::BLOCK_RELAY);
+    AddRandomOutboundPeer(id, vNodes, *peerLogic, *connman, ConnectionType::AUTOMATIC_BLOCK_RELAY);
     peerLogic->CheckForStaleTipAndEvictPeers();
 
     // The extra peer should only get marked for eviction after MINIMUM_CONNECT_TIME

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -55,7 +55,7 @@ FUZZ_TARGET_INIT(connman, initialize_connman)
                 random_string = fuzzed_data_provider.ConsumeRandomLengthString(64);
             },
             [&] {
-                connman.AddNode(random_string);
+                connman.AddNode(random_string, fuzzed_data_provider.ConsumeBool() ? ConnectionType::MANUAL : ConnectionType::MANUAL_BLOCK_RELAY);
             },
             [&] {
                 connman.CheckIncomingNonce(fuzzed_data_provider.ConsumeIntegral<uint64_t>());

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
                                                             /*inbound_onion=*/false);
     BOOST_CHECK(pnode1->IsFullOutboundConn() == true);
     BOOST_CHECK(pnode1->IsManualConn() == false);
-    BOOST_CHECK(pnode1->IsBlockOnlyConn() == false);
+    BOOST_CHECK(pnode1->IsAutomaticBlockRelayConn() == false);
     BOOST_CHECK(pnode1->IsFeelerConn() == false);
     BOOST_CHECK(pnode1->IsAddrFetchConn() == false);
     BOOST_CHECK(pnode1->IsInboundConn() == false);
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
                                                             /*inbound_onion=*/false);
     BOOST_CHECK(pnode2->IsFullOutboundConn() == false);
     BOOST_CHECK(pnode2->IsManualConn() == false);
-    BOOST_CHECK(pnode2->IsBlockOnlyConn() == false);
+    BOOST_CHECK(pnode2->IsAutomaticBlockRelayConn() == false);
     BOOST_CHECK(pnode2->IsFeelerConn() == false);
     BOOST_CHECK(pnode2->IsAddrFetchConn() == false);
     BOOST_CHECK(pnode2->IsInboundConn() == true);
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
                                                             /*inbound_onion=*/false);
     BOOST_CHECK(pnode3->IsFullOutboundConn() == true);
     BOOST_CHECK(pnode3->IsManualConn() == false);
-    BOOST_CHECK(pnode3->IsBlockOnlyConn() == false);
+    BOOST_CHECK(pnode3->IsAutomaticBlockRelayConn() == false);
     BOOST_CHECK(pnode3->IsFeelerConn() == false);
     BOOST_CHECK(pnode3->IsAddrFetchConn() == false);
     BOOST_CHECK(pnode3->IsInboundConn() == false);
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
                                                             /*inbound_onion=*/true);
     BOOST_CHECK(pnode4->IsFullOutboundConn() == false);
     BOOST_CHECK(pnode4->IsManualConn() == false);
-    BOOST_CHECK(pnode4->IsBlockOnlyConn() == false);
+    BOOST_CHECK(pnode4->IsAutomaticBlockRelayConn() == false);
     BOOST_CHECK(pnode4->IsFeelerConn() == false);
     BOOST_CHECK(pnode4->IsAddrFetchConn() == false);
     BOOST_CHECK(pnode4->IsInboundConn() == true);

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -50,7 +50,7 @@ void ConnmanTestMsg::Handshake(CNode& node,
     assert(node.GetCommonVersion() == std::min(version, PROTOCOL_VERSION));
     CNodeStateStats statestats;
     assert(peerman.GetNodeStateStats(node.GetId(), statestats));
-    assert(statestats.m_relay_txs == (relay_txs && !node.IsBlockOnlyConn()));
+    assert(statestats.m_relay_txs == (relay_txs && !node.IsAutomaticBlockRelayConn()));
     assert(statestats.their_services == remote_services);
     if (successfully_connected) {
         CSerializedNetMsg msg_verack{mm.Make(NetMsgType::VERACK)};

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -50,7 +50,7 @@ void ConnmanTestMsg::Handshake(CNode& node,
     assert(node.GetCommonVersion() == std::min(version, PROTOCOL_VERSION));
     CNodeStateStats statestats;
     assert(peerman.GetNodeStateStats(node.GetId(), statestats));
-    assert(statestats.m_relay_txs == (relay_txs && !node.IsAutomaticBlockRelayConn()));
+    assert(statestats.m_relay_txs == (relay_txs && !node.IsBlockRelayConn()));
     assert(statestats.their_services == remote_services);
     if (successfully_connected) {
         CSerializedNetMsg msg_verack{mm.Make(NetMsgType::VERACK)};

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -83,6 +83,7 @@ constexpr ConnectionType ALL_CONNECTION_TYPES[]{
     ConnectionType::FEELER,
     ConnectionType::BLOCK_RELAY,
     ConnectionType::ADDR_FETCH,
+    ConnectionType::MANUAL_BLOCK_RELAY,
 };
 
 constexpr auto ALL_NETWORKS = std::array{

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -81,7 +81,7 @@ constexpr ConnectionType ALL_CONNECTION_TYPES[]{
     ConnectionType::OUTBOUND_FULL_RELAY,
     ConnectionType::MANUAL,
     ConnectionType::FEELER,
-    ConnectionType::BLOCK_RELAY,
+    ConnectionType::AUTOMATIC_BLOCK_RELAY,
     ConnectionType::ADDR_FETCH,
     ConnectionType::MANUAL_BLOCK_RELAY,
 };


### PR DESCRIPTION
This implements the suggestion from #23763 to introduce an option to establish block-relay-connections manually with the `-addnode` RPC.
Adding these can make sense for a node operator that wants to be connected to a anonymity networks like Tor or I2P, but also wants to have additional protection against eclipse attacks: Following the best chain can be more of an issue on anonymity networks because these are smaller and it can be easier to create a lot of sybil nodes there.

In that situation, manual block-relay-only connections to peers on clearnet networks can help us staying connected to the best chain, but in contrast to normal manual connections, transactions and addresses aren't transmitted on these links - in particular not our own address or transaction from our wallet. This increases privacy and will also make it harder to perform fingerprinting attacks (connecting our identities over different networks).

Manual Block-Relay connections:
- can be specified with `-addnode` RPC, both with the `add` and `onetry` command
- can be specified with the `-addnode` bitcoind arg (or in bitcoin.conf) with `<IP>=manual-block-relay`
- don't participate in transaction and address relay
- don't get discouraged / punished for misbehavior (but will still get disconnected for sending TX/tx-INV as automatic block-relay-only peers do)
- are not subject to outbound eviction logic (unlike automatic block-relay-only-peers)
