### PR TITLE
doc: Add pre-splitoff translation update to `release-process.md`

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -36,7 +36,8 @@ Release Process
   - This update should be reviewed with a reindex-chainstate with assumevalid=0 to catch any defect
      that causes rejection of blocks in the past history.
 - Clear the release notes and move them to the wiki (see "Write the release notes" below).
-- Translations on Transifex
+- Translations on Transifex:
+    - Pull translations from Transifex into the master branch.
     - Create [a new resource](https://www.transifex.com/bitcoin/bitcoin/content/) named after the major version with the slug `[bitcoin.qt-translation-<RRR>x]`, where `RRR` is the major branch number padded with zeros. Use `src/qt/locale/bitcoin_en.xlf` to create it.
     - In the project workflow settings, ensure that [Translation Memory Fill-up](https://docs.transifex.com/translation-memory/enabling-autofill) is enabled and that [Translation Memory Context Matching](https://docs.transifex.com/translation-memory/translation-memory-with-context) is disabled.
     - Update the Transifex slug in [`.tx/config`](/.tx/config) to the slug of the resource created in the first step. This identifies which resource the translations will be synchronized from.


### PR DESCRIPTION
This step is required to keep translations in the master branch updated.

Branches:
- 0.20 -- bitcoin/bitcoin#18492
- 0.21 -- bitcoin/bitcoin#20058, bitcoin/bitcoin#20256
- 22.x -- accidentally missed