### PR TITLE
fuzz: Speed up script fuzz target

### DIFF
--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -102,17 +102,6 @@ FUZZ_TARGET_INIT(script, initialize_script)
     (void)script.IsPushOnly();
     (void)script.GetSigOpCount(/* fAccurate= */ false);
 
-    (void)FormatScript(script);
-    (void)ScriptToAsmStr(script, false);
-    (void)ScriptToAsmStr(script, true);
-
-    UniValue o1(UniValue::VOBJ);
-    ScriptPubKeyToUniv(script, o1, true);
-    UniValue o2(UniValue::VOBJ);
-    ScriptPubKeyToUniv(script, o2, false);
-    UniValue o3(UniValue::VOBJ);
-    ScriptToUniv(script, o3);
-
     {
         const std::vector<uint8_t> bytes = ConsumeRandomLengthByteVector(fuzzed_data_provider);
         CompressedScript compressed_script;
@@ -178,4 +167,12 @@ FUZZ_TARGET_INIT(script, initialize_script)
             Assert(dest == GetScriptForDestination(tx_destination_2));
         }
     }
+
+    (void)FormatScript(script);
+    (void)ScriptToAsmStr(script, /*fAttemptSighashDecode=*/fuzzed_data_provider.ConsumeBool());
+
+    UniValue o1(UniValue::VOBJ);
+    ScriptPubKeyToUniv(script, o1, /*include_hex=*/fuzzed_data_provider.ConsumeBool());
+    UniValue o3(UniValue::VOBJ);
+    ScriptToUniv(script, o3);
 }


### PR DESCRIPTION
Currently the script fuzz target takes the longest time (5000 seconds, aka 80 minutes, see https://cirrus-ci.com/task/5651378755338240?logs=ci#L4501).

Fix this by making it twice as fast.

Instead of running all possible combinations for all fuzz inputs, consume a bool and decide at runtime which path to take.

I moved the new calls to the end to not invalidate existing fuzz inputs.