### PR TITLE
refactor: only use explicit reinterpret/const casts, not implicit

### DIFF
--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -50,7 +50,7 @@ bool SerializeFileDB(const std::string& prefix, const fs::path& path, const Data
 {
     // Generate random temporary filename
     uint16_t randv = 0;
-    GetRandBytes({(unsigned char*)&randv, sizeof(randv)});
+    GetRandBytes({reinterpret_cast<unsigned char*>(&randv), sizeof(randv)});
     std::string tmpfn = strprintf("%s.%04x", prefix, randv);
 
     // open temp output file, and associate with CAutoFile

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -137,7 +137,7 @@ std::string EncodeBase58Check(Span<const unsigned char> input)
     // add 4-byte hash check to the end
     std::vector<unsigned char> vch(input.begin(), input.end());
     uint256 hash = Hash(vch);
-    vch.insert(vch.end(), (unsigned char*)&hash, (unsigned char*)&hash + 4);
+    vch.insert(vch.end(), reinterpret_cast<unsigned char*>(&hash), reinterpret_cast<unsigned char*>(&hash) + 4);
     return EncodeBase58(vch);
 }
 

--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -86,7 +86,7 @@ static void SipHash_32b(benchmark::Bench& bench)
     uint256 x;
     uint64_t k1 = 0;
     bench.run([&] {
-        *((uint64_t*)x.begin()) = SipHashUint256(0, ++k1, x);
+        *(reinterpret_cast<uint64_t*>(x.begin())) = SipHashUint256(0, ++k1, x);
     });
 }
 

--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -68,7 +68,7 @@ static void VerifyScriptBench(benchmark::Bench& bench)
             txCredit.vout[0].scriptPubKey.data(),
             txCredit.vout[0].scriptPubKey.size(),
             txCredit.vout[0].nValue,
-            (const unsigned char*)stream.data(), stream.size(), 0, flags, nullptr);
+            reinterpret_cast<const unsigned char*>(stream.data()), stream.size(), 0, flags, nullptr);
         assert(csuccess == 1);
 #endif
     });

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -219,7 +219,7 @@ static void http_request_done(struct evhttp_request *req, void *ctx)
     if (buf)
     {
         size_t size = evbuffer_get_length(buf);
-        const char *data = (const char*)evbuffer_pullup(buf, size);
+        const char *data = reinterpret_cast<const char*>(evbuffer_pullup(buf, size));
         if (data)
             reply->body = std::string(data, size);
         evbuffer_drain(buf, size);
@@ -740,7 +740,7 @@ static UniValue CallRPC(BaseRequestHandler* rh, const std::string& strMethod, co
     }
 
     HTTPReply response;
-    raii_evhttp_request req = obtain_evhttp_request(http_request_done, (void*)&response);
+    raii_evhttp_request req = obtain_evhttp_request(http_request_done, reinterpret_cast<void*>(&response));
     if (req == nullptr) {
         throw std::runtime_error("create http request failed");
     }

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -32,7 +32,7 @@ void CBlockHeaderAndShortTxIDs::FillShortTxIDSelector() const {
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << header << nonce;
     CSHA256 hasher;
-    hasher.Write((unsigned char*)&(*stream.begin()), stream.end() - stream.begin());
+    hasher.Write(reinterpret_cast<const unsigned char*>(&(*stream.begin())), stream.end() - stream.begin());
     uint256 shorttxidhash;
     hasher.Finalize(shorttxidhash.begin());
     shorttxidk0 = shorttxidhash.GetUint64(0);

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -21,7 +21,7 @@ static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesi
     txNew.nVersion = 1;
     txNew.vin.resize(1);
     txNew.vout.resize(1);
-    txNew.vin[0].scriptSig = CScript() << 486604799 << CScriptNum(4) << std::vector<unsigned char>((const unsigned char*)pszTimestamp, (const unsigned char*)pszTimestamp + strlen(pszTimestamp));
+    txNew.vin[0].scriptSig = CScript() << 486604799 << CScriptNum(4) << std::vector<unsigned char>(reinterpret_cast<const unsigned char*>(pszTimestamp), reinterpret_cast<const unsigned char*>(pszTimestamp) + strlen(pszTimestamp));
     txNew.vout[0].nValue = genesisReward;
     txNew.vout[0].scriptPubKey = genesisOutputScript;
 

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -17,73 +17,73 @@
 uint16_t static inline ReadLE16(const unsigned char* ptr)
 {
     uint16_t x;
-    memcpy((char*)&x, ptr, 2);
+    memcpy(reinterpret_cast<char*>(&x), ptr, 2);
     return le16toh(x);
 }
 
 uint32_t static inline ReadLE32(const unsigned char* ptr)
 {
     uint32_t x;
-    memcpy((char*)&x, ptr, 4);
+    memcpy(reinterpret_cast<char*>(&x), ptr, 4);
     return le32toh(x);
 }
 
 uint64_t static inline ReadLE64(const unsigned char* ptr)
 {
     uint64_t x;
-    memcpy((char*)&x, ptr, 8);
+    memcpy(reinterpret_cast<char*>(&x), ptr, 8);
     return le64toh(x);
 }
 
 void static inline WriteLE16(unsigned char* ptr, uint16_t x)
 {
     uint16_t v = htole16(x);
-    memcpy(ptr, (char*)&v, 2);
+    memcpy(ptr, reinterpret_cast<char*>(&v), 2);
 }
 
 void static inline WriteLE32(unsigned char* ptr, uint32_t x)
 {
     uint32_t v = htole32(x);
-    memcpy(ptr, (char*)&v, 4);
+    memcpy(ptr, reinterpret_cast<char*>(&v), 4);
 }
 
 void static inline WriteLE64(unsigned char* ptr, uint64_t x)
 {
     uint64_t v = htole64(x);
-    memcpy(ptr, (char*)&v, 8);
+    memcpy(ptr, reinterpret_cast<char*>(&v), 8);
 }
 
 uint16_t static inline ReadBE16(const unsigned char* ptr)
 {
     uint16_t x;
-    memcpy((char*)&x, ptr, 2);
+    memcpy(reinterpret_cast<char*>(&x), ptr, 2);
     return be16toh(x);
 }
 
 uint32_t static inline ReadBE32(const unsigned char* ptr)
 {
     uint32_t x;
-    memcpy((char*)&x, ptr, 4);
+    memcpy(reinterpret_cast<char*>(&x), ptr, 4);
     return be32toh(x);
 }
 
 uint64_t static inline ReadBE64(const unsigned char* ptr)
 {
     uint64_t x;
-    memcpy((char*)&x, ptr, 8);
+    memcpy(reinterpret_cast<char*>(&x), ptr, 8);
     return be64toh(x);
 }
 
 void static inline WriteBE32(unsigned char* ptr, uint32_t x)
 {
     uint32_t v = htobe32(x);
-    memcpy(ptr, (char*)&v, 4);
+    memcpy(ptr, reinterpret_cast<char*>(&v), 4);
 }
 
 void static inline WriteBE64(unsigned char* ptr, uint64_t x)
 {
     uint64_t v = htobe64(x);
-    memcpy(ptr, (char*)&v, 8);
+    memcpy(ptr, reinterpret_cast<char*>(&v), 8);
 }
 
 /** Return the smallest number n such that (x >> n) == 0 (or 64 if the highest bit in x is set. */

--- a/src/crypto/hkdf_sha256_32.cpp
+++ b/src/crypto/hkdf_sha256_32.cpp
@@ -9,7 +9,7 @@
 
 CHKDF_HMAC_SHA256_L32::CHKDF_HMAC_SHA256_L32(const unsigned char* ikm, size_t ikmlen, const std::string& salt)
 {
-    CHMAC_SHA256((const unsigned char*)salt.data(), salt.size()).Write(ikm, ikmlen).Finalize(m_prk);
+    CHMAC_SHA256(reinterpret_cast<const unsigned char*>(salt.data()), salt.size()).Write(ikm, ikmlen).Finalize(m_prk);
 }
 
 void CHKDF_HMAC_SHA256_L32::Expand32(const std::string& info, unsigned char hash[OUTPUT_SIZE])
@@ -17,5 +17,5 @@ void CHKDF_HMAC_SHA256_L32::Expand32(const std::string& info, unsigned char hash
     // expand a 32byte key (single round)
     assert(info.size() <= 128);
     static const unsigned char one[1] = {1};
-    CHMAC_SHA256(m_prk, 32).Write((const unsigned char*)info.data(), info.size()).Write(one, 1).Finalize(hash);
+    CHMAC_SHA256(m_prk, 32).Write(reinterpret_cast<const unsigned char*>(info.data()), info.size()).Write(one, 1).Finalize(hash);
 }

--- a/src/crypto/sha256_x86_shani.cpp
+++ b/src/crypto/sha256_x86_shani.cpp
@@ -65,12 +65,12 @@ void inline __attribute__((always_inline)) Unshuffle(__m128i& s0, __m128i& s1)
 
 __m128i inline  __attribute__((always_inline)) Load(const unsigned char* in)
 {
-    return _mm_shuffle_epi8(_mm_loadu_si128((const __m128i*)in), _mm_load_si128((const __m128i*)MASK));
+    return _mm_shuffle_epi8(_mm_loadu_si128(reinterpret_cast<const __m128i*>(in)), _mm_load_si128(reinterpret_cast<const __m128i*>(MASK)));
 }
 
 void inline  __attribute__((always_inline)) Save(unsigned char* out, __m128i s)
 {
-    _mm_storeu_si128((__m128i*)out, _mm_shuffle_epi8(s, _mm_load_si128((const __m128i*)MASK)));
+    _mm_storeu_si128(reinterpret_cast<__m128i*>(out), _mm_shuffle_epi8(s, _mm_load_si128(reinterpret_cast<const __m128i*>(MASK))));
 }
 }
 
@@ -80,8 +80,8 @@ void Transform(uint32_t* s, const unsigned char* chunk, size_t blocks)
     __m128i m0, m1, m2, m3, s0, s1, so0, so1;
 
     /* Load state */
-    s0 = _mm_loadu_si128((const __m128i*)s);
-    s1 = _mm_loadu_si128((const __m128i*)(s + 4));
+    s0 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(s));
+    s1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(s + 4));
     Shuffle(s0, s1);
 
     while (blocks--) {
@@ -134,8 +134,8 @@ void Transform(uint32_t* s, const unsigned char* chunk, size_t blocks)
     }
 
     Unshuffle(s0, s1);
-    _mm_storeu_si128((__m128i*)s, s0);
-    _mm_storeu_si128((__m128i*)(s + 4), s1);
+    _mm_storeu_si128(reinterpret_cast<__m128i*>(s), s0);
+    _mm_storeu_si128(reinterpret_cast<__m128i*>(s + 4), s1);
 }
 }
 
@@ -147,8 +147,8 @@ void Transform_2way(unsigned char* out, const unsigned char* in)
     __m128i bm0, bm1, bm2, bm3, bs0, bs1, bso0, bso1;
 
     /* Transform 1 */
-    bs0 = as0 = _mm_load_si128((const __m128i*)INIT0);
-    bs1 = as1 = _mm_load_si128((const __m128i*)INIT1);
+    bs0 = as0 = _mm_load_si128(reinterpret_cast<const __m128i*>(INIT0));
+    bs1 = as1 = _mm_load_si128(reinterpret_cast<const __m128i*>(INIT1));
     am0 = Load(in);
     bm0 = Load(in + 64);
     QuadRound(as0, as1, am0, 0xe9b5dba5b5c0fbcfull, 0x71374491428a2f98ull);
@@ -217,10 +217,10 @@ void Transform_2way(unsigned char* out, const unsigned char* in)
     ShiftMessageC(bm1, bm2, bm3);
     QuadRound(as0, as1, am3, 0xc67178f2bef9A3f7ull, 0xa4506ceb90befffaull);
     QuadRound(bs0, bs1, bm3, 0xc67178f2bef9A3f7ull, 0xa4506ceb90befffaull);
-    as0 = _mm_add_epi32(as0, _mm_load_si128((const __m128i*)INIT0));
-    bs0 = _mm_add_epi32(bs0, _mm_load_si128((const __m128i*)INIT0));
-    as1 = _mm_add_epi32(as1, _mm_load_si128((const __m128i*)INIT1));
-    bs1 = _mm_add_epi32(bs1, _mm_load_si128((const __m128i*)INIT1));
+    as0 = _mm_add_epi32(as0, _mm_load_si128(reinterpret_cast<const __m128i*>(INIT0)));
+    bs0 = _mm_add_epi32(bs0, _mm_load_si128(reinterpret_cast<const __m128i*>(INIT0)));
+    as1 = _mm_add_epi32(as1, _mm_load_si128(reinterpret_cast<const __m128i*>(INIT1)));
+    bs1 = _mm_add_epi32(bs1, _mm_load_si128(reinterpret_cast<const __m128i*>(INIT1)));
 
     /* Transform 2 */
     aso0 = as0;
@@ -273,8 +273,8 @@ void Transform_2way(unsigned char* out, const unsigned char* in)
     bm1 = bs1;
 
     /* Transform 3 */
-    bs0 = as0 = _mm_load_si128((const __m128i*)INIT0);
-    bs1 = as1 = _mm_load_si128((const __m128i*)INIT1);
+    bs0 = as0 = _mm_load_si128(reinterpret_cast<const __m128i*>(INIT0));
+    bs1 = as1 = _mm_load_si128(reinterpret_cast<const __m128i*>(INIT1));
     QuadRound(as0, as1, am0, 0xe9b5dba5B5c0fbcfull, 0x71374491428a2f98ull);
     QuadRound(bs0, bs1, bm0, 0xe9b5dba5B5c0fbcfull, 0x71374491428a2f98ull);
     QuadRound(as0, as1, am1, 0xab1c5ed5923f82a4ull, 0x59f111f13956c25bull);
@@ -337,10 +337,10 @@ void Transform_2way(unsigned char* out, const unsigned char* in)
     ShiftMessageC(bm1, bm2, bm3);
     QuadRound(as0, as1, am3, 0xc67178f2bef9a3f7ull, 0xa4506ceb90befffaull);
     QuadRound(bs0, bs1, bm3, 0xc67178f2bef9a3f7ull, 0xa4506ceb90befffaull);
-    as0 = _mm_add_epi32(as0, _mm_load_si128((const __m128i*)INIT0));
-    bs0 = _mm_add_epi32(bs0, _mm_load_si128((const __m128i*)INIT0));
-    as1 = _mm_add_epi32(as1, _mm_load_si128((const __m128i*)INIT1));
-    bs1 = _mm_add_epi32(bs1, _mm_load_si128((const __m128i*)INIT1));
+    as0 = _mm_add_epi32(as0, _mm_load_si128(reinterpret_cast<const __m128i*>(INIT0)));
+    bs0 = _mm_add_epi32(bs0, _mm_load_si128(reinterpret_cast<const __m128i*>(INIT0)));
+    as1 = _mm_add_epi32(as1, _mm_load_si128(reinterpret_cast<const __m128i*>(INIT1)));
+    bs1 = _mm_add_epi32(bs1, _mm_load_si128(reinterpret_cast<const __m128i*>(INIT1)));
 
     /* Extract hash into out */
     Unshuffle(as0, as1);

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -74,12 +74,12 @@ public:
     {
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        leveldb::Slice slKey((const char*)ssKey.data(), ssKey.size());
+        leveldb::Slice slKey(reinterpret_cast<const char*>(ssKey.data()), ssKey.size());
 
         ssValue.reserve(DBWRAPPER_PREALLOC_VALUE_SIZE);
         ssValue << value;
         ssValue.Xor(dbwrapper_private::GetObfuscateKey(parent));
-        leveldb::Slice slValue((const char*)ssValue.data(), ssValue.size());
+        leveldb::Slice slValue(reinterpret_cast<const char*>(ssValue.data()), ssValue.size());
 
         batch.Put(slKey, slValue);
         // LevelDB serializes writes as:
@@ -99,7 +99,7 @@ public:
     {
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        leveldb::Slice slKey((const char*)ssKey.data(), ssKey.size());
+        leveldb::Slice slKey(reinterpret_cast<const char*>(ssKey.data()), ssKey.size());
 
         batch.Delete(slKey);
         // LevelDB serializes erases as:
@@ -138,7 +138,7 @@ public:
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        leveldb::Slice slKey((const char*)ssKey.data(), ssKey.size());
+        leveldb::Slice slKey(reinterpret_cast<const char*>(ssKey.data()), ssKey.size());
         piter->Seek(slKey);
     }
 
@@ -233,7 +233,7 @@ public:
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        leveldb::Slice slKey((const char*)ssKey.data(), ssKey.size());
+        leveldb::Slice slKey(reinterpret_cast<const char*>(ssKey.data()), ssKey.size());
 
         std::string strValue;
         leveldb::Status status = pdb->Get(readoptions, slKey, &strValue);
@@ -267,7 +267,7 @@ public:
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        leveldb::Slice slKey((const char*)ssKey.data(), ssKey.size());
+        leveldb::Slice slKey(reinterpret_cast<const char*>(ssKey.data()), ssKey.size());
 
         std::string strValue;
         leveldb::Status status = pdb->Get(readoptions, slKey, &strValue);
@@ -311,8 +311,8 @@ public:
         ssKey2.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey1 << key_begin;
         ssKey2 << key_end;
-        leveldb::Slice slKey1((const char*)ssKey1.data(), ssKey1.size());
-        leveldb::Slice slKey2((const char*)ssKey2.data(), ssKey2.size());
+        leveldb::Slice slKey1(reinterpret_cast<const char*>(ssKey1.data()), ssKey1.size());
+        leveldb::Slice slKey2(reinterpret_cast<const char*>(ssKey2.data()), ssKey2.size());
         uint64_t size = 0;
         leveldb::Range range(slKey1, slKey2);
         pdb->GetApproximateSizes(&range, 1, &size);
@@ -330,8 +330,8 @@ public:
         ssKey2.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey1 << key_begin;
         ssKey2 << key_end;
-        leveldb::Slice slKey1((const char*)ssKey1.data(), ssKey1.size());
-        leveldb::Slice slKey2((const char*)ssKey2.data(), ssKey2.size());
+        leveldb::Slice slKey1(reinterpret_cast<const char*>(ssKey1.data()), ssKey1.size());
+        leveldb::Slice slKey2(reinterpret_cast<const char*>(ssKey2.data()), ssKey2.size());
         pdb->CompactRange(&slKey1, &slKey2);
     }
 };

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -90,7 +90,7 @@ CHashWriter TaggedHash(const std::string& tag)
 {
     CHashWriter writer(SER_GETHASH, 0);
     uint256 taghash;
-    CSHA256().Write((const unsigned char*)tag.data(), tag.size()).Finalize(taghash.begin());
+    CSHA256().Write(reinterpret_cast<const unsigned char*>(tag.data()), tag.size()).Finalize(taghash.begin());
     writer << taghash << taghash;
     return writer;
 }

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -597,9 +597,8 @@ CService HTTPRequest::GetPeer() const
 #ifdef HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR
         evhttp_connection_get_peer(con, &address, &port);
 #else
-        evhttp_connection_get_peer(con, (char**)&address, &port);
+        evhttp_connection_get_peer(con, const_cast<char**>(reinterpret_cast<const char**>(&address)), &port);
 #endif // HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR
-
         peer = LookupNumeric(address, port);
     }
     return peer;

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -535,7 +535,7 @@ std::string HTTPRequest::ReadBody()
      * better to not copy into an intermediate string but use a stream
      * abstraction to consume the evbuffer on the fly in the parsing algorithm.
      */
-    const char* data = (const char*)evbuffer_pullup(buf, size);
+    const char* data = reinterpret_cast<const char*>(evbuffer_pullup(buf, size));
     if (!data) // returns nullptr in case of empty buffer
         return "";
     std::string rv(data, size);

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -191,7 +191,7 @@ CPubKey CKey::GetPubKey() const {
     CPubKey result;
     int ret = secp256k1_ec_pubkey_create(secp256k1_context_sign, &pubkey, begin());
     assert(ret);
-    secp256k1_ec_pubkey_serialize(secp256k1_context_sign, (unsigned char*)result.begin(), &clen, &pubkey, fCompressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED);
+    secp256k1_ec_pubkey_serialize(secp256k1_context_sign, const_cast<unsigned char*>(result.begin()), &clen, &pubkey, fCompressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED);
     assert(result.size() == clen);
     assert(result.IsValid());
     return result;
@@ -301,7 +301,7 @@ bool CKey::SignSchnorr(const uint256& hash, Span<unsigned char> sig, const uint2
 }
 
 bool CKey::Load(const CPrivKey &seckey, const CPubKey &vchPubKey, bool fSkipCheck=false) {
-    if (!ec_seckey_import_der(secp256k1_context_sign, (unsigned char*)begin(), seckey.data(), seckey.size()))
+    if (!ec_seckey_import_der(secp256k1_context_sign, const_cast<unsigned char*>(begin()), seckey.data(), seckey.size()))
         return false;
     fCompressed = vchPubKey.IsCompressed();
     fValid = true;
@@ -325,8 +325,8 @@ bool CKey::Derive(CKey& keyChild, ChainCode &ccChild, unsigned int nChild, const
         BIP32Hash(cc, nChild, 0, begin(), vout.data());
     }
     memcpy(ccChild.begin(), vout.data()+32, 32);
-    memcpy((unsigned char*)keyChild.begin(), begin(), 32);
-    bool ret = secp256k1_ec_seckey_tweak_add(secp256k1_context_sign, (unsigned char*)keyChild.begin(), vout.data());
+    memcpy(const_cast<unsigned char*>(keyChild.begin()), begin(), 32);
+    bool ret = secp256k1_ec_seckey_tweak_add(secp256k1_context_sign, const_cast<unsigned char*>(keyChild.begin()), vout.data());
     keyChild.fCompressed = true;
     keyChild.fValid = ret;
     return ret;

--- a/src/key.h
+++ b/src/key.h
@@ -75,7 +75,7 @@ public:
         if (size_t(pend - pbegin) != keydata.size()) {
             fValid = false;
         } else if (Check(&pbegin[0])) {
-            memcpy(keydata.data(), (unsigned char*)&pbegin[0], keydata.size());
+            memcpy(keydata.data(), reinterpret_cast<const unsigned char*>(&pbegin[0]), keydata.size());
             fValid = true;
             fCompressed = fCompressedIn;
         } else {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4481,7 +4481,7 @@ void PeerManagerImpl::MaybeSendPing(CNode& node_to, Peer& peer, std::chrono::mic
     if (pingSend) {
         uint64_t nonce = 0;
         while (nonce == 0) {
-            GetRandBytes({(unsigned char*)&nonce, sizeof(nonce)});
+            GetRandBytes({reinterpret_cast<unsigned char*>(&nonce), sizeof(nonce)});
         }
         peer.m_ping_queued = false;
         peer.m_ping_start = now;

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -173,7 +173,7 @@ bool CNetAddr::SetInternal(const std::string &name)
     }
     m_net = NET_INTERNAL;
     unsigned char hash[32] = {};
-    CSHA256().Write((const unsigned char*)name.data(), name.size()).Finalize(hash);
+    CSHA256().Write(reinterpret_cast<const unsigned char*>(name.data()), name.size()).Finalize(hash);
     m_addr.assign(hash, hash + ADDR_INTERNAL_SIZE);
     return true;
 }
@@ -838,10 +838,10 @@ bool CService::SetSockAddr(const struct sockaddr *paddr)
 {
     switch (paddr->sa_family) {
     case AF_INET:
-        *this = CService(*(const struct sockaddr_in*)paddr);
+        *this = CService(*reinterpret_cast<const struct sockaddr_in*>(paddr));
         return true;
     case AF_INET6:
-        *this = CService(*(const struct sockaddr_in6*)paddr);
+        *this = CService(*reinterpret_cast<const struct sockaddr_in6*>(paddr));
         return true;
     default:
         return false;
@@ -881,7 +881,7 @@ bool CService::GetSockAddr(struct sockaddr* paddr, socklen_t *addrlen) const
         if (*addrlen < (socklen_t)sizeof(struct sockaddr_in))
             return false;
         *addrlen = sizeof(struct sockaddr_in);
-        struct sockaddr_in *paddrin = (struct sockaddr_in*)paddr;
+        struct sockaddr_in *paddrin = reinterpret_cast<struct sockaddr_in*>(paddr);
         memset(paddrin, 0, *addrlen);
         if (!GetInAddr(&paddrin->sin_addr))
             return false;
@@ -893,7 +893,7 @@ bool CService::GetSockAddr(struct sockaddr* paddr, socklen_t *addrlen) const
         if (*addrlen < (socklen_t)sizeof(struct sockaddr_in6))
             return false;
         *addrlen = sizeof(struct sockaddr_in6);
-        struct sockaddr_in6 *paddrin6 = (struct sockaddr_in6*)paddr;
+        struct sockaddr_in6 *paddrin6 = reinterpret_cast<struct sockaddr_in6*>(paddr);
         memset(paddrin6, 0, *addrlen);
         if (!GetIn6Addr(&paddrin6->sin6_addr))
             return false;

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -488,13 +488,13 @@ std::unique_ptr<Sock> CreateSockTCP(const CService& address_family)
     // Create a sockaddr from the specified service.
     struct sockaddr_storage sockaddr;
     socklen_t len = sizeof(sockaddr);
-    if (!address_family.GetSockAddr((struct sockaddr*)&sockaddr, &len)) {
+    if (!address_family.GetSockAddr(reinterpret_cast<struct sockaddr*>(&sockaddr), &len)) {
         LogPrintf("Cannot create socket for %s: unsupported network\n", address_family.ToString());
         return nullptr;
     }
 
     // Create a TCP socket in the address family of the specified service.
-    SOCKET hSocket = socket(((struct sockaddr*)&sockaddr)->sa_family, SOCK_STREAM, IPPROTO_TCP);
+    SOCKET hSocket = socket(reinterpret_cast<struct sockaddr*>(&sockaddr)->sa_family, SOCK_STREAM, IPPROTO_TCP);
     if (hSocket == INVALID_SOCKET) {
         return nullptr;
     }
@@ -553,7 +553,7 @@ bool ConnectSocketDirectly(const CService &addrConnect, const Sock& sock, int nT
         LogPrintf("Cannot connect to %s: invalid socket\n", addrConnect.ToString());
         return false;
     }
-    if (!addrConnect.GetSockAddr((struct sockaddr*)&sockaddr, &len)) {
+    if (!addrConnect.GetSockAddr(reinterpret_cast<struct sockaddr*>(&sockaddr), &len)) {
         LogPrintf("Cannot connect to %s: unsupported network\n", addrConnect.ToString());
         return false;
     }
@@ -585,7 +585,7 @@ bool ConnectSocketDirectly(const CService &addrConnect, const Sock& sock, int nT
             // sockerr here.
             int sockerr;
             socklen_t sockerr_len = sizeof(sockerr);
-            if (sock.GetSockOpt(SOL_SOCKET, SO_ERROR, (sockopt_arg_type)&sockerr, &sockerr_len) ==
+            if (sock.GetSockOpt(SOL_SOCKET, SO_ERROR, reinterpret_cast<sockopt_arg_type>(&sockerr), &sockerr_len) ==
                 SOCKET_ERROR) {
                 LogPrintf("getsockopt() for %s failed: %s\n", addrConnect.ToString(), NetworkErrorString(WSAGetLastError()));
                 return false;

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -410,7 +410,7 @@ public:
         // necessary to switch to the (more efficient) directly allocated
         // representation (with capacity N and size <= N).
         iterator p = first;
-        char* endp = (char*)&(*end());
+        char* endp = reinterpret_cast<char*>(&(*end()));
         if (!std::is_trivially_destructible<T>::value) {
             while (p != last) {
                 (*p).~T();
@@ -420,7 +420,7 @@ public:
         } else {
             _size -= last - p;
         }
-        memmove(&(*first), &(*last), endp - ((char*)(&(*last))));
+        memmove(&(*first), &(*last), endp - (reinterpret_cast<char*>(&(*last))));
         return first;
     }
 

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -90,7 +90,7 @@ public:
     {
         int len = pend == pbegin ? 0 : GetLen(pbegin[0]);
         if (len && len == (pend - pbegin))
-            memcpy(vch, (unsigned char*)&pbegin[0], len);
+            memcpy(vch, reinterpret_cast<const unsigned char*>(&pbegin[0]), len);
         else
             Invalidate();
     }

--- a/src/span.h
+++ b/src/span.h
@@ -272,9 +272,9 @@ Span<std::byte> MakeWritableByteSpan(V&& v) noexcept
 }
 
 // Helper functions to safely cast to unsigned char pointers.
-inline unsigned char* UCharCast(char* c) { return (unsigned char*)c; }
+inline unsigned char* UCharCast(char* c) { return reinterpret_cast<unsigned char*>(c); }
 inline unsigned char* UCharCast(unsigned char* c) { return c; }
-inline const unsigned char* UCharCast(const char* c) { return (unsigned char*)c; }
+inline const unsigned char* UCharCast(const char* c) { return reinterpret_cast<const unsigned char*>(c); }
 inline const unsigned char* UCharCast(const unsigned char* c) { return c; }
 inline const unsigned char* UCharCast(const std::byte* c) { return reinterpret_cast<const unsigned char*>(c); }
 

--- a/src/streams.h
+++ b/src/streams.h
@@ -606,7 +606,7 @@ protected:
             readNow = nAvail;
         if (readNow == 0)
             return false;
-        size_t nBytes = fread((void*)&vchBuf[pos], 1, readNow, src);
+        size_t nBytes = fread(reinterpret_cast<void*>(&vchBuf[pos]), 1, readNow, src);
         if (nBytes == 0) {
             throw std::ios_base::failure(feof(src) ? "CBufferedFile::Fill: end of file" : "CBufferedFile::Fill: fread failed");
         }

--- a/src/sync.h
+++ b/src/sync.h
@@ -95,7 +95,7 @@ class LOCKABLE AnnotatedMixin : public PARENT
 {
 public:
     ~AnnotatedMixin() {
-        DeleteLock((void*)this);
+        DeleteLock(reinterpret_cast<void*>(this));
     }
 
     void lock() EXCLUSIVE_LOCK_FUNCTION()
@@ -198,7 +198,7 @@ public:
     class reverse_lock {
     public:
         explicit reverse_lock(UniqueLock& _lock, const char* _guardname, const char* _file, int _line) : lock(_lock), file(_file), line(_line) {
-            CheckLastCritical((void*)lock.mutex(), lockname, _guardname, _file, _line);
+            CheckLastCritical(reinterpret_cast<void*>(lock.mutex()), lockname, _guardname, _file, _line);
             lock.unlock();
             LeaveCritical();
             lock.swap(templock);
@@ -244,7 +244,7 @@ using DebugLock = UniqueLock<typename std::remove_reference<typename std::remove
 #define LEAVE_CRITICAL_SECTION(cs)                                          \
     {                                                                       \
         std::string lockname;                                               \
-        CheckLastCritical((void*)(&cs), lockname, #cs, __FILE__, __LINE__); \
+        CheckLastCritical(reinterpret_cast<void*>((&cs)), lockname, #cs, __FILE__, __LINE__); \
         (cs).unlock();                                                      \
         LeaveCritical();                                                    \
     }

--- a/src/test/allocator_tests.cpp
+++ b/src/test/allocator_tests.cpp
@@ -219,8 +219,8 @@ BOOST_AUTO_TEST_CASE(lockedpool_tests_live)
     void *a0 = pool.alloc(16);
     BOOST_CHECK(a0);
     // Test reading and writing the allocated memory
-    *((uint32_t*)a0) = 0x1234;
-    BOOST_CHECK(*((uint32_t*)a0) == 0x1234);
+    *reinterpret_cast<uint32_t*>(a0) = 0x1234;
+    BOOST_CHECK(*(reinterpret_cast<uint32_t*>(a0)) == 0x1234);
 
     pool.free(a0);
     try { // Test exception on double-free

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -33,7 +33,7 @@ static void TestVector(const Hasher &h, const In &in, const Out &out) {
     hash.resize(out.size());
     {
         // Test that writing the whole input string at once works.
-        Hasher(h).Write((const uint8_t*)in.data(), in.size()).Finalize(hash.data());
+        Hasher(h).Write(reinterpret_cast<const uint8_t*>(in.data()), in.size()).Finalize(hash.data());
         BOOST_CHECK(hash == out);
     }
     for (int i=0; i<32; i++) {
@@ -42,11 +42,11 @@ static void TestVector(const Hasher &h, const In &in, const Out &out) {
         size_t pos = 0;
         while (pos < in.size()) {
             size_t len = InsecureRandRange((in.size() - pos + 1) / 2 + 1);
-            hasher.Write((const uint8_t*)in.data() + pos, len);
+            hasher.Write(reinterpret_cast<const uint8_t*>(in.data()) + pos, len);
             pos += len;
             if (pos > 0 && pos + 2 * out.size() > in.size() && pos < in.size()) {
                 // Test that writing the rest at once to a copy of a hasher works.
-                Hasher(hasher).Write((const uint8_t*)in.data() + pos, in.size() - pos).Finalize(hash.data());
+                Hasher(hasher).Write(reinterpret_cast<const uint8_t*>(in.data()) + pos, in.size() - pos).Finalize(hash.data());
                 BOOST_CHECK(hash == out);
             }
         }

--- a/src/test/cuckoocache_tests.cpp
+++ b/src/test/cuckoocache_tests.cpp
@@ -61,7 +61,7 @@ static double test_cache(size_t megabytes, double load)
     uint32_t n_insert = static_cast<uint32_t>(load * (bytes / sizeof(uint256)));
     hashes.resize(n_insert);
     for (uint32_t i = 0; i < n_insert; ++i) {
-        uint32_t* ptr = (uint32_t*)hashes[i].begin();
+        uint32_t* ptr = reinterpret_cast<uint32_t*>(hashes[i].begin());
         for (uint8_t j = 0; j < 8; ++j)
             *(ptr++) = InsecureRand32();
     }
@@ -132,7 +132,7 @@ static void test_cache_erase(size_t megabytes)
     uint32_t n_insert = static_cast<uint32_t>(load * (bytes / sizeof(uint256)));
     hashes.resize(n_insert);
     for (uint32_t i = 0; i < n_insert; ++i) {
-        uint32_t* ptr = (uint32_t*)hashes[i].begin();
+        uint32_t* ptr = reinterpret_cast<uint32_t*>(hashes[i].begin());
         for (uint8_t j = 0; j < 8; ++j)
             *(ptr++) = InsecureRand32();
     }
@@ -195,7 +195,7 @@ static void test_cache_erase_parallel(size_t megabytes)
     uint32_t n_insert = static_cast<uint32_t>(load * (bytes / sizeof(uint256)));
     hashes.resize(n_insert);
     for (uint32_t i = 0; i < n_insert; ++i) {
-        uint32_t* ptr = (uint32_t*)hashes[i].begin();
+        uint32_t* ptr = reinterpret_cast<uint32_t*>(hashes[i].begin());
         for (uint8_t j = 0; j < 8; ++j)
             *(ptr++) = InsecureRand32();
     }
@@ -306,7 +306,7 @@ static void test_cache_generations()
             inserts.resize(n_insert);
             reads.reserve(n_insert / 2);
             for (uint32_t i = 0; i < n_insert; ++i) {
-                uint32_t* ptr = (uint32_t*)inserts[i].begin();
+                uint32_t* ptr = reinterpret_cast<uint32_t*>(inserts[i].begin());
                 for (uint8_t j = 0; j < 8; ++j)
                     *(ptr++) = InsecureRand32();
             }

--- a/src/test/fuzz/float.cpp
+++ b/src/test/fuzz/float.cpp
@@ -51,7 +51,7 @@ FUZZ_TARGET(float)
         if constexpr (std::numeric_limits<double>::is_iec559) {
             if (!std::isnan(d)) {
                 uint64_t encoded_in_memory;
-                std::copy((const unsigned char*)&d, (const unsigned char*)(&d + 1), (unsigned char*)&encoded_in_memory);
+                std::copy(reinterpret_cast<const unsigned char*>(&d), reinterpret_cast<const unsigned char*>(&d + 1), reinterpret_cast<unsigned char*>(&encoded_in_memory));
                 assert(encoded_in_memory == encoded);
             }
         }

--- a/src/test/fuzz/script_assets_test_minimizer.cpp
+++ b/src/test/fuzz/script_assets_test_minimizer.cpp
@@ -192,7 +192,7 @@ void test_init()
 FUZZ_TARGET_INIT_HIDDEN(script_assets_test_minimizer, test_init, /*hidden=*/true)
 {
     if (buffer.size() < 2 || buffer.back() != '\n' || buffer[buffer.size() - 2] != ',') return;
-    const std::string str((const char*)buffer.data(), buffer.size() - 2);
+    const std::string str(reinterpret_cast<const char*>(buffer.data()), buffer.size() - 2);
     try {
         Test(str);
     } catch (const std::runtime_error&) {

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -394,7 +394,7 @@ BOOST_AUTO_TEST_CASE(bip341_spk_test_vectors)
     using control_set = decltype(TaprootSpendData::scripts)::mapped_type;
 
     UniValue tests;
-    tests.read((const char*)json_tests::bip341_wallet_vectors, sizeof(json_tests::bip341_wallet_vectors));
+    tests.read(reinterpret_cast<const char*>(json_tests::bip341_wallet_vectors), sizeof(json_tests::bip341_wallet_vectors));
 
     const auto& vectors = tests["scriptPubKey"];
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1748,7 +1748,7 @@ BOOST_AUTO_TEST_CASE(script_assets_test)
 BOOST_AUTO_TEST_CASE(bip341_keypath_test_vectors)
 {
     UniValue tests;
-    tests.read((const char*)json_tests::bip341_wallet_vectors, sizeof(json_tests::bip341_wallet_vectors));
+    tests.read(reinterpret_cast<const char*>(json_tests::bip341_wallet_vectors), sizeof(json_tests::bip341_wallet_vectors));
 
     const auto& vectors = tests["keyPathSpending"];
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -340,7 +340,7 @@ public:
         test.SetupArgs({{"-value", flags}});
         const char* argv[] = {"ignored", arg};
         std::string error;
-        bool success = test.ParseParameters(arg ? 2 : 1, (char**)argv, error);
+        bool success = test.ParseParameters(arg ? 2 : 1, const_cast<char**>(argv), error);
 
         BOOST_CHECK_EQUAL(test.GetSetting("-value").write(), expect.setting.write());
         auto settings_list = test.GetSettingsList("-value");
@@ -445,13 +445,13 @@ BOOST_AUTO_TEST_CASE(util_ParseParameters)
     std::string error;
     LOCK(testArgs.cs_args);
     testArgs.SetupArgs({a, b, ccc, d});
-    BOOST_CHECK(testArgs.ParseParameters(0, (char**)argv_test, error));
+    BOOST_CHECK(testArgs.ParseParameters(0, const_cast<char**>(argv_test), error));
     BOOST_CHECK(testArgs.m_settings.command_line_options.empty() && testArgs.m_settings.ro_config.empty());
 
-    BOOST_CHECK(testArgs.ParseParameters(1, (char**)argv_test, error));
+    BOOST_CHECK(testArgs.ParseParameters(1, const_cast<char**>(argv_test), error));
     BOOST_CHECK(testArgs.m_settings.command_line_options.empty() && testArgs.m_settings.ro_config.empty());
 
-    BOOST_CHECK(testArgs.ParseParameters(7, (char**)argv_test, error));
+    BOOST_CHECK(testArgs.ParseParameters(7, const_cast<char**>(argv_test), error));
     // expectation: -ignored is ignored (program name argument),
     // -a, -b and -ccc end up in map, -d ignored because it is after
     // a non-option argument (non-GNU option parsing)
@@ -476,17 +476,17 @@ BOOST_AUTO_TEST_CASE(util_ParseInvalidParameters)
 
     const char* argv[] = {"ignored", "-registered"};
     std::string error;
-    BOOST_CHECK(test.ParseParameters(2, (char**)argv, error));
+    BOOST_CHECK(test.ParseParameters(2, const_cast<char**>(argv), error));
     BOOST_CHECK_EQUAL(error, "");
 
     argv[1] = "-unregistered";
-    BOOST_CHECK(!test.ParseParameters(2, (char**)argv, error));
+    BOOST_CHECK(!test.ParseParameters(2, const_cast<char**>(argv), error));
     BOOST_CHECK_EQUAL(error, "Invalid parameter -unregistered");
 
     // Make sure registered parameters prefixed with a chain name trigger errors.
     // (Previously, they were accepted and ignored.)
     argv[1] = "-test.registered";
-    BOOST_CHECK(!test.ParseParameters(2, (char**)argv, error));
+    BOOST_CHECK(!test.ParseParameters(2, const_cast<char**>(argv), error));
     BOOST_CHECK_EQUAL(error, "Invalid parameter -test.registered");
 }
 
@@ -497,7 +497,7 @@ static void TestParse(const std::string& str, bool expected_bool, int64_t expect
     std::string arg = "-value=" + str;
     const char* argv[] = {"ignored", arg.c_str()};
     std::string error;
-    BOOST_CHECK(test.ParseParameters(2, (char**)argv, error));
+    BOOST_CHECK(test.ParseParameters(2, const_cast<char**>(argv), error));
     BOOST_CHECK_EQUAL(test.GetBoolArg("-value", false), expected_bool);
     BOOST_CHECK_EQUAL(test.GetBoolArg("-value", true), expected_bool);
     BOOST_CHECK_EQUAL(test.GetIntArg("-value", 99998), expected_int);
@@ -559,7 +559,7 @@ BOOST_AUTO_TEST_CASE(util_GetBoolArg)
     std::string error;
     LOCK(testArgs.cs_args);
     testArgs.SetupArgs({a, b, c, d, e, f});
-    BOOST_CHECK(testArgs.ParseParameters(7, (char**)argv_test, error));
+    BOOST_CHECK(testArgs.ParseParameters(7, const_cast<char**>(argv_test), error));
 
     // Each letter should be set.
     for (const char opt : "abcdef")
@@ -596,7 +596,7 @@ BOOST_AUTO_TEST_CASE(util_GetBoolArgEdgeCases)
     const char *argv_test[] = {"ignored", "-nofoo", "-foo", "-nobar=0"};
     testArgs.SetupArgs({foo, bar});
     std::string error;
-    BOOST_CHECK(testArgs.ParseParameters(4, (char**)argv_test, error));
+    BOOST_CHECK(testArgs.ParseParameters(4, const_cast<char**>(argv_test), error));
 
     // This was passed twice, second one overrides the negative setting.
     BOOST_CHECK(!testArgs.IsArgNegated("-foo"));
@@ -608,7 +608,7 @@ BOOST_AUTO_TEST_CASE(util_GetBoolArgEdgeCases)
 
     // Config test
     const char *conf_test = "nofoo=1\nfoo=1\nnobar=0\n";
-    BOOST_CHECK(testArgs.ParseParameters(1, (char**)argv_test, error));
+    BOOST_CHECK(testArgs.ParseParameters(1, const_cast<char**>(argv_test), error));
     testArgs.ReadConfigString(conf_test);
 
     // This was passed twice, second one overrides the negative setting,
@@ -623,7 +623,7 @@ BOOST_AUTO_TEST_CASE(util_GetBoolArgEdgeCases)
     // Combined test
     const char *combo_test_args[] = {"ignored", "-nofoo", "-bar"};
     const char *combo_test_conf = "foo=1\nnobar=1\n";
-    BOOST_CHECK(testArgs.ParseParameters(3, (char**)combo_test_args, error));
+    BOOST_CHECK(testArgs.ParseParameters(3, const_cast<char**>(combo_test_args), error));
     testArgs.ReadConfigString(combo_test_conf);
 
     // Command line overrides, but doesn't erase old setting
@@ -883,38 +883,38 @@ BOOST_AUTO_TEST_CASE(util_GetChainName)
     const char* testnetconf = "testnet=1\nregtest=0\n[test]\nregtest=1";
     std::string error;
 
-    BOOST_CHECK(test_args.ParseParameters(0, (char**)argv_testnet, error));
+    BOOST_CHECK(test_args.ParseParameters(0, const_cast<char**>(argv_testnet), error));
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "main");
 
-    BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_testnet, error));
+    BOOST_CHECK(test_args.ParseParameters(2, const_cast<char**>(argv_testnet), error));
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
 
-    BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_regtest, error));
+    BOOST_CHECK(test_args.ParseParameters(2, const_cast<char**>(argv_regtest), error));
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "regtest");
 
-    BOOST_CHECK(test_args.ParseParameters(3, (char**)argv_test_no_reg, error));
+    BOOST_CHECK(test_args.ParseParameters(3, const_cast<char**>(argv_test_no_reg), error));
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
 
-    BOOST_CHECK(test_args.ParseParameters(3, (char**)argv_both, error));
+    BOOST_CHECK(test_args.ParseParameters(3, const_cast<char**>(argv_both), error));
     BOOST_CHECK_THROW(test_args.GetChainName(), std::runtime_error);
 
-    BOOST_CHECK(test_args.ParseParameters(0, (char**)argv_testnet, error));
+    BOOST_CHECK(test_args.ParseParameters(0, const_cast<char**>(argv_testnet), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
 
-    BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_testnet, error));
+    BOOST_CHECK(test_args.ParseParameters(2, const_cast<char**>(argv_testnet), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
 
-    BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_regtest, error));
+    BOOST_CHECK(test_args.ParseParameters(2, const_cast<char**>(argv_regtest), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_THROW(test_args.GetChainName(), std::runtime_error);
 
-    BOOST_CHECK(test_args.ParseParameters(3, (char**)argv_test_no_reg, error));
+    BOOST_CHECK(test_args.ParseParameters(3, const_cast<char**>(argv_test_no_reg), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
 
-    BOOST_CHECK(test_args.ParseParameters(3, (char**)argv_both, error));
+    BOOST_CHECK(test_args.ParseParameters(3, const_cast<char**>(argv_both), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_THROW(test_args.GetChainName(), std::runtime_error);
 
@@ -922,23 +922,23 @@ BOOST_AUTO_TEST_CASE(util_GetChainName)
     // [test] regtest=1 potentially relevant) doesn't break things
     test_args.SelectConfigNetwork("test");
 
-    BOOST_CHECK(test_args.ParseParameters(0, (char**)argv_testnet, error));
+    BOOST_CHECK(test_args.ParseParameters(0, const_cast<char**>(argv_testnet), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
 
-    BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_testnet, error));
+    BOOST_CHECK(test_args.ParseParameters(2, const_cast<char**>(argv_testnet), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
 
-    BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_regtest, error));
+    BOOST_CHECK(test_args.ParseParameters(2, const_cast<char**>(argv_regtest), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_THROW(test_args.GetChainName(), std::runtime_error);
 
-    BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_test_no_reg, error));
+    BOOST_CHECK(test_args.ParseParameters(2, const_cast<char**>(argv_test_no_reg), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
 
-    BOOST_CHECK(test_args.ParseParameters(3, (char**)argv_both, error));
+    BOOST_CHECK(test_args.ParseParameters(3, const_cast<char**>(argv_both), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_THROW(test_args.GetChainName(), std::runtime_error);
 }

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -479,7 +479,7 @@ void TorController::auth_cb(TorControlConnection& _conn, const TorControlReply& 
  */
 static std::vector<uint8_t> ComputeResponse(const std::string &key, const std::vector<uint8_t> &cookie,  const std::vector<uint8_t> &clientNonce, const std::vector<uint8_t> &serverNonce)
 {
-    CHMAC_SHA256 computeHash((const uint8_t*)key.data(), key.size());
+    CHMAC_SHA256 computeHash(reinterpret_cast<const uint8_t*>(key.data()), key.size());
     std::vector<uint8_t> computedHash(CHMAC_SHA256::OUTPUT_SIZE, 0);
     computeHash.Write(cookie.data(), cookie.size());
     computeHash.Write(clientNonce.data(), clientNonce.size());

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -43,7 +43,7 @@ void base_blob<BITS>::SetHex(const char* psz)
     size_t digits = 0;
     while (::HexDigit(psz[digits]) != -1)
         digits++;
-    unsigned char* p1 = (unsigned char*)m_data;
+    unsigned char* p1 = reinterpret_cast<unsigned char*>(m_data);
     unsigned char* pend = p1 + WIDTH;
     while (digits > 0 && p1 < pend) {
         *p1 = ::HexDigit(psz[--digits]);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1719,7 +1719,7 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
     // transaction).
     uint256 hashCacheEntry;
     CSHA256 hasher = g_scriptExecutionCacheHasher;
-    hasher.Write(tx.GetWitnessHash().begin(), 32).Write((unsigned char*)&flags, sizeof(flags)).Finalize(hashCacheEntry.begin());
+    hasher.Write(tx.GetWitnessHash().begin(), 32).Write(reinterpret_cast<unsigned char*>(&flags), sizeof(flags)).Finalize(hashCacheEntry.begin());
     AssertLockHeld(cs_main); //TODO: Remove this requirement by making CuckooCache not require external locks
     if (g_scriptExecutionCache.contains(hashCacheEntry, !cacheFullScriptStore)) {
         return true;

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -494,9 +494,9 @@ bool BerkeleyDatabase::Rewrite(const char* pszSkip)
                                 break;
                             }
                             if (pszSkip &&
-                                strncmp((const char*)ssKey.data(), pszSkip, std::min(ssKey.size(), strlen(pszSkip))) == 0)
+                                strncmp(reinterpret_cast<const char*>(ssKey.data()), pszSkip, std::min(ssKey.size(), strlen(pszSkip))) == 0)
                                 continue;
-                            if (strncmp((const char*)ssKey.data(), "\x07version", 8) == 0) {
+                            if (strncmp(reinterpret_cast<const char*>(ssKey.data()), "\x07version", 8) == 0) {
                                 // Update version:
                                 ssValue.clear();
                                 ssValue << CLIENT_VERSION;

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -24,7 +24,7 @@ int CCrypter::BytesToKeySHA512AES(const std::vector<unsigned char>& chSalt, cons
     unsigned char buf[CSHA512::OUTPUT_SIZE];
     CSHA512 di;
 
-    di.Write((const unsigned char*)strKeyData.data(), strKeyData.size());
+    di.Write(reinterpret_cast<const unsigned char*>(strKeyData.data()), strKeyData.size());
     di.Write(chSalt.data(), chSalt.size());
     di.Finalize(buf);
 

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -112,7 +112,7 @@ bool EncryptSecret(const CKeyingMaterial& vMasterKey, const CKeyingMaterial &vch
     memcpy(chIV.data(), &nIV, WALLET_CRYPTO_IV_SIZE);
     if(!cKeyCrypter.SetKey(vMasterKey, chIV))
         return false;
-    return cKeyCrypter.Encrypt(*((const CKeyingMaterial*)&vchPlaintext), vchCiphertext);
+    return cKeyCrypter.Encrypt(*(const_cast<CKeyingMaterial*>(&vchPlaintext)), vchCiphertext);
 }
 
 bool DecryptSecret(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char>& vchCiphertext, const uint256& nIV, CKeyingMaterial& vchPlaintext)

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -96,7 +96,7 @@ bool IsBDBFile(const fs::path& path)
 
     file.seekg(12, std::ios::beg); // Magic bytes start at offset 12
     uint32_t data = 0;
-    file.read((char*) &data, sizeof(data)); // Read 4 bytes of file to compare against magic
+    file.read(reinterpret_cast<char*>(&data), sizeof(data)); // Read 4 bytes of file to compare against magic
 
     // Berkeley DB Btree magic bytes, from:
     //  https://github.com/file/file/blob/5824af38469ec1ca9ac3ffd251e7afe9dc11e227/magic/Magdir/database#L74-L75

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2228,7 +2228,7 @@ uint256 DescriptorScriptPubKeyMan::GetID() const
     LOCK(cs_desc_man);
     std::string desc_str = m_wallet_descriptor.descriptor->ToString();
     uint256 id;
-    CSHA256().Write((unsigned char*)desc_str.data(), desc_str.size()).Finalize(id.begin());
+    CSHA256().Write(reinterpret_cast<unsigned char*>(desc_str.data()), desc_str.size()).Finalize(id.begin());
     return id;
 }
 

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -196,7 +196,7 @@ bool SQLiteDatabase::Verify(bilingual_str& error)
             error = strprintf(_("SQLiteDatabase: Failed to execute statement to verify database: %s"), sqlite3_errstr(ret));
             break;
         }
-        const char* msg = (const char*)sqlite3_column_text(stmt, 0);
+        const char* msg = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
         if (!msg) {
             error = strprintf(_("SQLiteDatabase: Failed to read database verification error: %s"), sqlite3_errstr(ret));
             break;


### PR DESCRIPTION
This PR converts 149 silent reinterpret_cast's into explicit reinterpret_cast's
This PR converts  33 silent const_cast's into explicit const_cast's

This PR is broken out from https://github.com/bitcoin/bitcoin/pull/23810, as it appears there is little appetite for the scope of change as outlined in that PR.

```
A C-style cast is equivalent to try casting in the following order:

    const_cast(...)
    static_cast(...)
    const_cast(static_cast(...))
    reinterpret_cast(...)
    const_cast(reinterpret_cast(...))

For a more thorough discussion, see "ES.49: If you must use a cast, use a named cast"
in the C++ Core Guidelines (Stroustrup & Sutter).
```

The PR resolves the most critical step of removing implicit c-style casts that act as reinterpret_casts or const_casts, additionally, this PR should be considerably less conflicting than it's predecessor. I at least hope that it is deemed the value will exceed the cost of conflicts.  

If there are any specific areas of the codebase that are heavily conflicting compared to others, I'd be happy to drop those sections of the PR for now.