### PR TITLE
test: Fix sanitizer suppresions in streams_tests

### DIFF
--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -162,14 +162,10 @@ BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
 {
     std::vector<std::byte> in;
     std::vector<char> expected_xor;
-    std::vector<unsigned char> key;
     CDataStream ds(in, 0, 0);
 
     // Degenerate case
-
-    key.push_back('\x00');
-    key.push_back('\x00');
-    ds.Xor(key);
+    ds.Xor({0x00, 0x00});
     BOOST_CHECK_EQUAL(
             std::string(expected_xor.begin(), expected_xor.end()),
             ds.str());
@@ -183,10 +179,8 @@ BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
 
     ds.clear();
     ds.insert(ds.begin(), in.begin(), in.end());
-    key.clear();
 
-    key.push_back('\xff');
-    ds.Xor(key);
+    ds.Xor({0xff});
     BOOST_CHECK_EQUAL(
             std::string(expected_xor.begin(), expected_xor.end()),
             ds.str());
@@ -203,11 +197,7 @@ BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
     ds.clear();
     ds.insert(ds.begin(), in.begin(), in.end());
 
-    key.clear();
-    key.push_back('\xff');
-    key.push_back('\x0f');
-
-    ds.Xor(key);
+    ds.Xor({0xff, 0x0f});
     BOOST_CHECK_EQUAL(
             std::string(expected_xor.begin(), expected_xor.end()),
             ds.str());
@@ -421,7 +411,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
                 size_t find = currentPos + InsecureRandRange(8);
                 if (find >= fileSize)
                     find = fileSize - 1;
-                bf.FindByte(static_cast<char>(find));
+                bf.FindByte(uint8_t(find));
                 // The value at each offset is the offset.
                 BOOST_CHECK_EQUAL(bf.GetPos(), find);
                 currentPos = find;

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -77,7 +77,6 @@ implicit-integer-sign-change:prevector.h
 implicit-integer-sign-change:script/bitcoinconsensus.cpp
 implicit-integer-sign-change:script/interpreter.cpp
 implicit-integer-sign-change:serialize.h
-implicit-integer-sign-change:test/streams_tests.cpp
 implicit-integer-sign-change:txmempool.cpp
 implicit-integer-sign-change:zmq/zmqpublishnotifier.cpp
 implicit-signed-integer-truncation,implicit-integer-sign-change:chain.h


### PR DESCRIPTION
Two changes (that also make sense on their own) to remove the file-wide sanitizer suppression:

* `FindByte` no longer takes a `char`, but an `uint8_t`, after commit 196b4599201dbce3e0317e9b98753fa6a244b82d.
* The `key` vector of unsigned chars can be removed and inlined as initializer-list. This avoids a bunch of verbose code like `clear()` and `push_back` of `char`s.