### PR TITLE
refactor: Use unsigned ignore() consistently

### DIFF
--- a/src/streams.h
+++ b/src/streams.h
@@ -362,12 +362,9 @@ public:
         nReadPos = nReadPosNext;
     }
 
-    void ignore(int nSize)
+    void ignore(size_t nSize)
     {
         // Ignore from the beginning of the buffer
-        if (nSize < 0) {
-            throw std::ios_base::failure("CDataStream::ignore(): nSize negative");
-        }
         unsigned int nReadPosNext = nReadPos + nSize;
         if (nReadPosNext >= vch.size())
         {

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -50,7 +50,6 @@ unsigned-integer-overflow:common/bloom.cpp
 unsigned-integer-overflow:chain.cpp
 unsigned-integer-overflow:chain.h
 unsigned-integer-overflow:coins.cpp
-unsigned-integer-overflow:compressor.cpp
 unsigned-integer-overflow:core_write.cpp
 unsigned-integer-overflow:crypto/
 unsigned-integer-overflow:hash.cpp
@@ -68,7 +67,6 @@ implicit-integer-sign-change:chain.cpp
 implicit-integer-sign-change:chain.h
 implicit-integer-sign-change:coins.h
 implicit-integer-sign-change:compat/stdin.cpp
-implicit-integer-sign-change:compressor.h
 implicit-integer-sign-change:crypto/
 implicit-integer-sign-change:key.cpp
 implicit-integer-sign-change:noui.cpp


### PR DESCRIPTION
Currently `CDataStream::ignore` takes a `signed` value. However all other `ignore()` functions take an `unsigned`. This causes integer sanitizer issues when an unsigned value is passed to `CDataStream::ignore`.

Fix this by accepting `unsigned` in all `ignore()` functions consistently.

Also, simplify the code to remove the confusing "nSize negative` exception and fallback to the more meaningful "end of data" exception.