### PR TITLE
test: Fix failfast option for functional test runner

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -532,8 +532,11 @@ def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=
 
     max_len_name = len(max(test_list, key=len))
     test_count = len(test_list)
+    all_passed = True
     i = 0
     while i < test_count:
+        if failfast and not all_passed:
+            break
         for test_result, testdir, stdout, stderr in job_queue.get_next():
             test_results.append(test_result)
             i += 1
@@ -543,6 +546,7 @@ def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=
             elif test_result.status == "Skipped":
                 logging.debug("%s skipped" % (done_str))
             else:
+                all_passed = False
                 print("%s failed, Duration: %s s\n" % (done_str, test_result.time))
                 print(BOLD[1] + 'stdout:\n' + BOLD[0] + stdout + '\n')
                 print(BOLD[1] + 'stderr:\n' + BOLD[0] + stderr + '\n')
@@ -576,7 +580,7 @@ def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=
     if not os.listdir(tmpdir):
         os.rmdir(tmpdir)
 
-    all_passed = all(map(lambda test_result: test_result.was_successful, test_results)) and coverage_passed
+    all_passed = all_passed and coverage_passed
 
     # Clean up dangling processes if any. This may only happen with --failfast option.
     # Killing the process group will also terminate the current process but that is


### PR DESCRIPTION
Fixes #23990

After #23799, the `--failfast` option in the test runner for the functional tests stopped working, because a second outer loop was introduced, which would have needed a `break` too for the test runner to fail immediately. This also led to the errors reported in #23990.

This provides a straightforward fix for that.
There is also #23995 which is a larger refactor, but that hasn't been updated in a while to fix the failfast issue.