### PR TITLE
Fix integer sanitizer suppressions in validation.cpp

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1787,8 +1787,9 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
                 error("DisconnectBlock(): transaction and undo data inconsistent");
                 return DISCONNECT_FAILED;
             }
-            for (unsigned int j = tx.vin.size(); j-- > 0;) {
-                const COutPoint &out = tx.vin[j].prevout;
+            for (unsigned int j = tx.vin.size(); j > 0;) {
+                --j;
+                const COutPoint& out = tx.vin[j].prevout;
                 int res = ApplyTxInUndo(std::move(txundo.vprevout[j]), view, out);
                 if (res == DISCONNECT_FAILED) return DISCONNECT_FAILED;
                 fClean = fClean && res != DISCONNECT_UNCLEAN;

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -57,7 +57,6 @@ unsigned-integer-overflow:pubkey.h
 unsigned-integer-overflow:script/interpreter.cpp
 unsigned-integer-overflow:txmempool.cpp
 unsigned-integer-overflow:util/strencodings.cpp
-unsigned-integer-overflow:validation.cpp
 implicit-integer-sign-change:addrman.h
 implicit-integer-sign-change:bech32.cpp
 implicit-integer-sign-change:compat/stdin.cpp


### PR DESCRIPTION
It doesn't seem ideal to have an integer sanitizer enabled, but then disable it for the whole validation.cpp file.

Fix it with a refactor and remove the suppression.