### PR TITLE
doc: Fix typos pointed out by lint-spelling

### DIFF
--- a/src/crypto/chacha_poly_aead.cpp
+++ b/src/crypto/chacha_poly_aead.cpp
@@ -73,7 +73,7 @@ bool ChaCha20Poly1305AEAD::Crypt(uint64_t seqnr_payload, uint64_t seqnr_aad, int
             return false;
         }
         memory_cleanse(expected_tag, sizeof(expected_tag));
-        // MAC has been successfully verified, make sure we don't covert it in decryption
+        // MAC has been successfully verified, make sure we don't convert it in decryption
         src_len -= POLY1305_TAGLEN;
     }
 

--- a/src/random.h
+++ b/src/random.h
@@ -89,7 +89,7 @@ constexpr auto GetRandMillis = GetRandomDuration<std::chrono::milliseconds>;
  * is memoryless and should be used for repeated network events (e.g. sending a
  * certain type of message) to minimize leaking information to observers.
  *
- * The probability of an event occuring before time x is 1 - e^-(x/a) where a
+ * The probability of an event occurring before time x is 1 - e^-(x/a) where a
  * is the average interval between events.
  * */
 std::chrono::microseconds GetExponentialRand(std::chrono::microseconds now, std::chrono::seconds average_interval);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -790,10 +790,10 @@ static RPCHelpMan getblockfrompeer()
 {
     return RPCHelpMan{
         "getblockfrompeer",
-        "Attempt to fetch block from a given peer.\n"
-        "\nWe must have the header for this block, e.g. using submitheader.\n"
-        "Subsequent calls for the same block and a new peer will cause the response from the previous peer to be ignored.\n"
-        "\nReturns an empty JSON object if the request was successfully scheduled.",
+        "Attempt to fetch block from a given peer.\n\n"
+        "We must have the header for this block, e.g. using submitheader.\n"
+        "Subsequent calls for the same block and a new peer will cause the response from the previous peer to be ignored.\n\n"
+        "Returns an empty JSON object if the request was successfully scheduled.",
         {
             {"block_hash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The block hash to try to fetch"},
             {"peer_id", RPCArg::Type::NUM, RPCArg::Optional::NO, "The peer to fetch it from (see getpeerinfo for peer IDs)"},

--- a/test/lint/lint-spelling.ignore-words.txt
+++ b/test/lint/lint-spelling.ignore-words.txt
@@ -1,6 +1,8 @@
 asend
+ba
 blockin
 cachable
+creat
 fo
 fpr
 hights


### PR DESCRIPTION
Occuring -> occurring (random.h)
Covert -> convert (chacha_poly_aead.cpp)
Fix `nWe` false positive in blockchain.cpp (https://github.com/bitcoin/bitcoin/pull/24203#issuecomment-1025116962)

Got it by linter, other ones are false positives.