### PR TITLE
init, test: improve network reachability test coverage and safety

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1301,6 +1301,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         }
         for (int n = 0; n < NET_MAX; n++) {
             enum Network net = (enum Network)n;
+            assert(IsReachable(net));
             if (!nets.count(net))
                 SetReachable(net, false);
         }

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -655,26 +655,31 @@ BOOST_AUTO_TEST_CASE(LimitedAndReachable_Network)
     BOOST_CHECK(IsReachable(NET_IPV6));
     BOOST_CHECK(IsReachable(NET_ONION));
     BOOST_CHECK(IsReachable(NET_I2P));
+    BOOST_CHECK(IsReachable(NET_CJDNS));
 
     SetReachable(NET_IPV4, false);
     SetReachable(NET_IPV6, false);
     SetReachable(NET_ONION, false);
     SetReachable(NET_I2P, false);
+    SetReachable(NET_CJDNS, false);
 
     BOOST_CHECK(!IsReachable(NET_IPV4));
     BOOST_CHECK(!IsReachable(NET_IPV6));
     BOOST_CHECK(!IsReachable(NET_ONION));
     BOOST_CHECK(!IsReachable(NET_I2P));
+    BOOST_CHECK(!IsReachable(NET_CJDNS));
 
     SetReachable(NET_IPV4, true);
     SetReachable(NET_IPV6, true);
     SetReachable(NET_ONION, true);
     SetReachable(NET_I2P, true);
+    SetReachable(NET_CJDNS, true);
 
     BOOST_CHECK(IsReachable(NET_IPV4));
     BOOST_CHECK(IsReachable(NET_IPV6));
     BOOST_CHECK(IsReachable(NET_ONION));
     BOOST_CHECK(IsReachable(NET_I2P));
+    BOOST_CHECK(IsReachable(NET_CJDNS));
 }
 
 BOOST_AUTO_TEST_CASE(LimitedAndReachable_NetworkCaseUnroutableAndInternal)

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -34,6 +34,7 @@ addnode connect to a CJDNS address
 - Test passing invalid -proxy
 - Test passing invalid -onion
 - Test passing -onlynet=onion without -proxy or -onion
+- Test passing -onlynet=onion with -onion=0 and with -noonion
 """
 
 import socket
@@ -328,6 +329,11 @@ class ProxyTest(BitcoinTestFramework):
         self.log.info("Test passing -onlynet=onion without -proxy or -onion raises expected init error")
         self.nodes[1].extra_args = ["-onlynet=onion"]
         self.nodes[1].assert_start_raises_init_error(expected_msg=msg)
+
+        self.log.info("Test passing -onlynet=onion with -onion=0/-noonion raises expected init error")
+        for arg in ["-onion=0", "-noonion"]:
+            self.nodes[1].extra_args = ["-onlynet=onion", arg]
+            self.nodes[1].assert_start_raises_init_error(expected_msg=msg)
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -33,6 +33,7 @@ addnode connect to a CJDNS address
 
 - Test passing invalid -proxy
 - Test passing invalid -onion
+- Test passing -onlynet=onion without -proxy or -onion
 """
 
 import socket
@@ -317,6 +318,15 @@ class ProxyTest(BitcoinTestFramework):
         self.log.info("Test passing invalid -onion raises expected init error")
         self.nodes[1].extra_args = ["-onion=xyz:abc"]
         msg = "Error: Invalid -onion address or hostname: 'xyz:abc'"
+        self.nodes[1].assert_start_raises_init_error(expected_msg=msg)
+
+        msg = (
+            "Error: Outbound connections restricted to Tor (-onlynet=onion) but "
+            "the proxy for reaching the Tor network is not provided (no -proxy= "
+            "and no -onion= given) or it is explicitly forbidden (-onion=0)"
+        )
+        self.log.info("Test passing -onlynet=onion without -proxy or -onion raises expected init error")
+        self.nodes[1].extra_args = ["-onlynet=onion"]
         self.nodes[1].assert_start_raises_init_error(expected_msg=msg)
 
 

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -263,12 +263,13 @@ class ProxyTest(BitcoinTestFramework):
 
         n2 = networks_dict(self.nodes[2].getnetworkinfo())
         assert_equal(NETWORKS, n2.keys())
+        proxy = f'{self.conf2.addr[0]}:{self.conf2.addr[1]}'
         for net in NETWORKS:
             if net == NET_I2P:
                 expected_proxy = ''
                 expected_randomize = False
             else:
-                expected_proxy = f'{self.conf2.addr[0]}:{self.conf2.addr[1]}'
+                expected_proxy = proxy
                 expected_randomize = True
             assert_equal(n2[net]['proxy'], expected_proxy)
             assert_equal(n2[net]['proxy_randomize_credentials'], expected_randomize)
@@ -279,11 +280,9 @@ class ProxyTest(BitcoinTestFramework):
         if self.have_ipv6:
             n3 = networks_dict(self.nodes[3].getnetworkinfo())
             assert_equal(NETWORKS, n3.keys())
+            proxy = f'[{self.conf3.addr[0]}]:{self.conf3.addr[1]}'
             for net in NETWORKS:
-                if net == NET_I2P or net == NET_ONION:
-                    expected_proxy = ''
-                else:
-                    expected_proxy = f'[{self.conf3.addr[0]}]:{self.conf3.addr[1]}'
+                expected_proxy = '' if net == NET_I2P or net == NET_ONION else proxy
                 assert_equal(n3[net]['proxy'], expected_proxy)
                 assert_equal(n3[net]['proxy_randomize_credentials'], False)
             assert_equal(n3['onion']['reachable'], False)

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -30,6 +30,8 @@ addnode connect to generic DNS name
 addnode connect to a CJDNS address
 
 - Test getnetworkinfo for each node
+
+- Test passing invalid -proxy
 """
 
 import socket
@@ -303,6 +305,13 @@ class ProxyTest(BitcoinTestFramework):
         assert_equal(n4['onion']['reachable'], True)
         assert_equal(n4['i2p']['reachable'], False)
         assert_equal(n4['cjdns']['reachable'], True)
+
+        self.stop_node(1)
+
+        self.log.info("Test passing invalid -proxy raises expected init error")
+        self.nodes[1].extra_args = ["-proxy=abc:def"]
+        msg = "Error: Invalid -proxy address or hostname: 'abc:def'"
+        self.nodes[1].assert_start_raises_init_error(expected_msg=msg)
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -32,6 +32,7 @@ addnode connect to a CJDNS address
 - Test getnetworkinfo for each node
 
 - Test passing invalid -proxy
+- Test passing invalid -onion
 """
 
 import socket
@@ -311,6 +312,11 @@ class ProxyTest(BitcoinTestFramework):
         self.log.info("Test passing invalid -proxy raises expected init error")
         self.nodes[1].extra_args = ["-proxy=abc:def"]
         msg = "Error: Invalid -proxy address or hostname: 'abc:def'"
+        self.nodes[1].assert_start_raises_init_error(expected_msg=msg)
+
+        self.log.info("Test passing invalid -onion raises expected init error")
+        self.nodes[1].extra_args = ["-onion=xyz:abc"]
+        msg = "Error: Invalid -onion address or hostname: 'xyz:abc'"
         self.nodes[1].assert_start_raises_init_error(expected_msg=msg)
 
 


### PR DESCRIPTION
Adds missing network reachability test coverage and an assertion during init, noticed while reviewing #22834:

- assert during init that each network reachability is  true by default
- add CJDNS to the `LimitedAndReachable_Network` unit tests
- hoist proxy out of two network loops in feature_proxy.py
- test that passing invalid `-proxy` raises expected init error
- test that passing invalid `-onion` raises expected init error
- test that passing `-onlynet=onion` without `-proxy` and `-onion` raises expected init error
- test that passing `-onlynet=onion` with `-onion=0` and with `-noonion` raises expected init error

