### PR TITLE
[22.x] guix: ignore additional failing certvalidator test

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -449,6 +449,11 @@ PKCS#8, PKCS#12, PKCS#5, X.509 and TSP.")
                   (string-append indent
                                  "@unittest.skip(\"Disabled by Guix\")\n"
                                  line)))
+               (substitute* "tests/test_validate.py"
+                 (("^(.*)def test_revocation_mode_soft" line indent)
+                  (string-append indent
+                                 "@unittest.skip(\"Disabled by Guix\")\n"
+                                 line)))
                #t))
            (replace 'check
              (lambda _


### PR DESCRIPTION
Backports https://github.com/bitcoin/bitcoin/commit/85885919656a3f606f3d7f208378aabe95f3f62d from #24057 so that from-scratch Guix builds for the Darwin host aren't broken due to a (very recently) expired certificate causing one of the python-certvalidator tests to fail. Kept separate from #23276 because that hasn't gotten review attention, and I don't think we should leave `22.x` Darwin Guix builds broken for any longer than we have to.

Fixes #24110.

```bash
======================================================================
ERROR: test_revocation_mode_soft (tests.test_validate.ValidateTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/guix-build-python-certvalidator-0.1-1.e5bdb4b.drv-0/source/tests/test_validate.py", line 85, in test_revocation_mode_soft
    validate_path(context, path)
  File "/tmp/guix-build-python-certvalidator-0.1-1.e5bdb4b.drv-0/source/tests/../certvalidator/validate.py", line 50, in validate_path
    return _validate_path(validation_context, path)
  File "/tmp/guix-build-python-certvalidator-0.1-1.e5bdb4b.drv-0/source/tests/../certvalidator/validate.py", line 358, in _validate_path
    raise PathValidationError(pretty_message(
certvalidator.errors.PathValidationError: The path could not be validated because the end-entity certificate expired 2022-01-14 12:00:00Z
```

Guix Build:
```bash
bash-5.1# find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
359755bffecc64b4c005c5cdee3824190f6b1759dbc6c20034476dcc06413959  guix-build-b7ecef1ddf0c/output/dist-archive/bitcoin-b7ecef1ddf0c.tar.gz
0c6700270ec75991d70a97cad77e22cc00553f812edb56c1bac5ef6421f963e1  guix-build-b7ecef1ddf0c/output/x86_64-apple-darwin/SHA256SUMS.part
87d4637a87959a304422550edf87feda3953d7305894154a6a2d413cc0dd2034  guix-build-b7ecef1ddf0c/output/x86_64-apple-darwin/bitcoin-b7ecef1ddf0c-osx-unsigned.dmg
9cabae32689bd5f93e7faaaf341827f1c4069a63ab6f74276564e47819343b6c  guix-build-b7ecef1ddf0c/output/x86_64-apple-darwin/bitcoin-b7ecef1ddf0c-osx-unsigned.tar.gz
bb5fb113bc022a305e49783d0ba48be90aca61e4a942beeb45206dbc5b91ca6e  guix-build-b7ecef1ddf0c/output/x86_64-apple-darwin/bitcoin-b7ecef1ddf0c-x86_64-apple-darwin.tar.gz
```