### PR TITLE
Fix unsigned integer overflow in tapscript validation weight calculation

### DIFF
--- a/src/script/script.h
+++ b/src/script/script.h
@@ -51,10 +51,10 @@ static const uint32_t LOCKTIME_MAX = 0xFFFFFFFFU;
 static constexpr unsigned int ANNEX_TAG = 0x50;
 
 // Validation weight per passing signature (Tapscript only, see BIP 342).
-static constexpr uint64_t VALIDATION_WEIGHT_PER_SIGOP_PASSED = 50;
+static constexpr int64_t VALIDATION_WEIGHT_PER_SIGOP_PASSED{50};
 
 // How much weight budget is added to the witness size (Tapscript only, see BIP 342).
-static constexpr uint64_t VALIDATION_WEIGHT_OFFSET = 50;
+static constexpr int64_t VALIDATION_WEIGHT_OFFSET{50};
 
 template <typename T>
 std::vector<unsigned char> ToByteVector(const T& in)


### PR DESCRIPTION
Change the tapscript validation weight constants from uint64_t to int64_t, since the type of m_validation_weight_left is also int64_t. Otherwise this will cause sanitizer warnings.

This should be safe because signed integer overflow isn't expected to happen.