### PR TITLE
zmq: Fix implicit-integer-sign-change

### DIFF
--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -209,9 +209,10 @@ bool CZMQPublishHashBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
 {
     uint256 hash = pindex->GetBlockHash();
     LogPrint(BCLog::ZMQ, "zmq: Publish hashblock %s to %s\n", hash.GetHex(), this->address);
-    char data[32];
-    for (unsigned int i = 0; i < 32; i++)
+    uint8_t data[32];
+    for (unsigned int i = 0; i < 32; i++) {
         data[31 - i] = hash.begin()[i];
+    }
     return SendZmqMessage(MSG_HASHBLOCK, data, 32);
 }
 
@@ -219,9 +220,10 @@ bool CZMQPublishHashTransactionNotifier::NotifyTransaction(const CTransaction &t
 {
     uint256 hash = transaction.GetHash();
     LogPrint(BCLog::ZMQ, "zmq: Publish hashtx %s to %s\n", hash.GetHex(), this->address);
-    char data[32];
-    for (unsigned int i = 0; i < 32; i++)
+    uint8_t data[32];
+    for (unsigned int i = 0; i < 32; i++) {
         data[31 - i] = hash.begin()[i];
+    }
     return SendZmqMessage(MSG_HASHTX, data, 32);
 }
 

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -73,7 +73,6 @@ implicit-integer-sign-change:script/interpreter.cpp
 implicit-integer-sign-change:serialize.h
 implicit-integer-sign-change:test/streams_tests.cpp
 implicit-integer-sign-change:txmempool.cpp
-implicit-integer-sign-change:zmq/zmqpublishnotifier.cpp
 implicit-signed-integer-truncation:addrman.cpp
 implicit-signed-integer-truncation:addrman.h
 implicit-signed-integer-truncation:crypto/


### PR DESCRIPTION
uint256::begin() returns unsigned data, so there is no reason to make it signed.

Fix that and remove the sanitizer suppression.