### PR TITLE
Fix implicit-integer-sign-change in bloom

### DIFF
--- a/src/common/bloom.cpp
+++ b/src/common/bloom.cpp
@@ -218,7 +218,7 @@ void CRollingBloomFilter::insert(Span<const unsigned char> vKey)
         /* FastMod works with the upper bits of h, so it is safe to ignore that the lower bits of h are already used for bit. */
         uint32_t pos = FastRange32(h, data.size());
         /* The lowest bit of pos is ignored, and set to zero for the first bit, and to one for the second. */
-        data[pos & ~1] = (data[pos & ~1] & ~(((uint64_t)1) << bit)) | ((uint64_t)(nGeneration & 1)) << bit;
+        data[pos & ~1U] = (data[pos & ~1U] & ~(((uint64_t)1) << bit)) | ((uint64_t)(nGeneration & 1)) << bit;
         data[pos | 1] = (data[pos | 1] & ~(((uint64_t)1) << bit)) | ((uint64_t)(nGeneration >> 1)) << bit;
     }
 }
@@ -230,7 +230,7 @@ bool CRollingBloomFilter::contains(Span<const unsigned char> vKey) const
         int bit = h & 0x3F;
         uint32_t pos = FastRange32(h, data.size());
         /* If the relevant bit is not set in either data[pos & ~1] or data[pos | 1], the filter does not contain vKey */
-        if (!(((data[pos & ~1] | data[pos | 1]) >> bit) & 1)) {
+        if (!(((data[pos & ~1U] | data[pos | 1]) >> bit) & 1)) {
             return false;
         }
     }

--- a/src/common/bloom.cpp
+++ b/src/common/bloom.cpp
@@ -218,8 +218,8 @@ void CRollingBloomFilter::insert(Span<const unsigned char> vKey)
         /* FastMod works with the upper bits of h, so it is safe to ignore that the lower bits of h are already used for bit. */
         uint32_t pos = FastRange32(h, data.size());
         /* The lowest bit of pos is ignored, and set to zero for the first bit, and to one for the second. */
-        data[pos & ~1U] = (data[pos & ~1U] & ~(((uint64_t)1) << bit)) | ((uint64_t)(nGeneration & 1)) << bit;
-        data[pos | 1] = (data[pos | 1] & ~(((uint64_t)1) << bit)) | ((uint64_t)(nGeneration >> 1)) << bit;
+        data[pos & ~1U] = (data[pos & ~1U] & ~(uint64_t{1} << bit)) | (uint64_t(nGeneration & 1)) << bit;
+        data[pos | 1] = (data[pos | 1] & ~(uint64_t{1} << bit)) | (uint64_t(nGeneration >> 1)) << bit;
     }
 }
 

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -60,7 +60,6 @@ unsigned-integer-overflow:util/strencodings.cpp
 unsigned-integer-overflow:validation.cpp
 implicit-integer-sign-change:addrman.h
 implicit-integer-sign-change:bech32.cpp
-implicit-integer-sign-change:common/bloom.cpp
 implicit-integer-sign-change:coins.h
 implicit-integer-sign-change:compat/stdin.cpp
 implicit-integer-sign-change:compressor.h


### PR DESCRIPTION
Signed values don't really make sense when using `std::vector::operator[]`.

Fix that and remove the suppression.