### PR TITLE
validation: don't re-acquire cs_main during IBD in CChainState::IsInitialBlockDownload()

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1578,7 +1578,7 @@ RPCHelpMan getblockchaininfo()
     obj.pushKV("time",                  (int64_t)tip->nTime);
     obj.pushKV("mediantime",            (int64_t)tip->GetMedianTimePast());
     obj.pushKV("verificationprogress",  GuessVerificationProgress(Params().TxData(), tip));
-    obj.pushKV("initialblockdownload",  active_chainstate.IsInitialBlockDownload());
+    obj.pushKV("initialblockdownload",  active_chainstate.IsIBD());
     obj.pushKV("chainwork",             tip->nChainWork.GetHex());
     obj.pushKV("size_on_disk", chainman.m_blockman.CalculateCurrentUsage());
     obj.pushKV("pruned",                node::fPruneMode);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -688,7 +688,7 @@ static RPCHelpMan getblocktemplate()
             throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, PACKAGE_NAME " is not connected!");
         }
 
-        if (active_chainstate.IsInitialBlockDownload()) {
+        if (active_chainstate.IsIBD()) {
             throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, PACKAGE_NAME " is in initial sync and waiting for blocks...");
         }
     }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -418,7 +418,7 @@ static RPCHelpMan setmocktime()
 
     // For now, don't change mocktime if we're in the middle of validation, as
     // this could have an effect on mempool time-based eviction, as well as
-    // IsCurrentForFeeEstimation() and IsInitialBlockDownload().
+    // IsCurrentForFeeEstimation() and IsIBD().
     // TODO: figure out the right way to synchronize around mocktime, and
     // ensure all call sites of GetTime() are accessing this safely.
     LOCK(cs_main);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1463,6 +1463,7 @@ void CChainState::InitCoinsCache(size_t cache_size_bytes)
 //
 bool CChainState::IsIBD() const
 {
+    AssertLockHeld(::cs_main);
     if (m_cached_finished_ibd.load(std::memory_order_relaxed))
         return false;
     if (fImporting || fReindex)
@@ -1480,6 +1481,7 @@ bool CChainState::IsIBD() const
 
 bool CChainState::IsInitialBlockDownload() const
 {
+    AssertLockNotHeld(::cs_main);
     // Optimization: pre-test latch before taking the lock.
     if (m_cached_finished_ibd.load(std::memory_order_relaxed)) {
         return false;

--- a/src/validation.h
+++ b/src/validation.h
@@ -676,13 +676,13 @@ public:
     void UnloadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /** Check whether we are doing an initial block download (synchronizing from disk or network) */
-    bool IsIBD() const;
+    bool IsIBD() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**
      * Same as `IsIBD()` above, but also locks mutex cs_main during initial
      * block download. Use only for callers not already holding the lock.
      */
-    bool IsInitialBlockDownload() const;
+    bool IsInitialBlockDownload() const LOCKS_EXCLUDED(::cs_main);
 
     /** Find the last common block of this chain and a locator. */
     CBlockIndex* FindForkInGlobalIndex(const CBlockLocator& locator) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/src/validation.h
+++ b/src/validation.h
@@ -676,6 +676,12 @@ public:
     void UnloadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /** Check whether we are doing an initial block download (synchronizing from disk or network) */
+    bool IsIBD() const;
+
+    /**
+     * Same as `IsIBD()` above, but also locks mutex cs_main during initial
+     * block download. Use only for callers not already holding the lock.
+     */
     bool IsInitialBlockDownload() const;
 
     /** Find the last common block of this chain and a locator. */


### PR DESCRIPTION
No longer re-acquire lock `cs_main` during IBD in `CChainState::IsInitialBlockDownload()`, as most of its callers already hold the lock. Have these callers invoke non-locking function `CChainState::IsIBD()` instead.  Apply thread safety analysis to the IBD functions. Retains the post-IBD optimization latch for the callers that do not hold the lock. Makes explicit which callers hold `cs_main`, and which do not.
