### PR TITLE
Fix unsigned integer overflow in LoadMempool

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4493,7 +4493,8 @@ bool LoadMempool(CTxMemPool& pool, CChainState& active_chainstate, FopenFn mocka
         }
         uint64_t num;
         file >> num;
-        while (num--) {
+        while (num) {
+            --num;
             CTransactionRef tx;
             int64_t nTime;
             int64_t nFeeDelta;


### PR DESCRIPTION
It doesn't seem ideal to have an integer sanitizer enabled, but then disable it for the whole validation.cpp file.

This removes one of the two violations.

This should be a refactor.