### PR TITLE
indexes: Stop using node internal types and locking cs_main, improve sync logic

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -217,6 +217,7 @@ add_library(bitcoin_node STATIC EXCLUDE_FROM_ALL
   node/blockmanager_args.cpp
   node/blockstorage.cpp
   node/caches.cpp
+  node/chain.cpp
   node/chainstate.cpp
   node/chainstatemanager_args.cpp
   node/coin.cpp

--- a/src/bench/index_blockfilter.cpp
+++ b/src/bench/index_blockfilter.cpp
@@ -49,6 +49,7 @@ static void BlockFilterIndexSync(benchmark::Bench& bench)
         assert(filter_index.Init());
         assert(!filter_index.BlockUntilSyncedToCurrentChain());
         filter_index.Sync();
+        assert(filter_index.BlockUntilSyncedToCurrentChain());
         filter_index.Interrupt();
         filter_index.Stop();
 

--- a/src/bench/index_blockfilter.cpp
+++ b/src/bench/index_blockfilter.cpp
@@ -49,6 +49,8 @@ static void BlockFilterIndexSync(benchmark::Bench& bench)
         assert(filter_index.Init());
         assert(!filter_index.BlockUntilSyncedToCurrentChain());
         filter_index.Sync();
+        filter_index.Interrupt();
+        filter_index.Stop();
 
         IndexSummary summary = filter_index.GetSummary();
         assert(summary.synced);

--- a/src/bench/index_blockfilter.cpp
+++ b/src/bench/index_blockfilter.cpp
@@ -14,6 +14,7 @@
 #include <pubkey.h>
 #include <script/script.h>
 #include <sync.h>
+#include <test/util/index.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <uint256.h>
@@ -48,8 +49,7 @@ static void BlockFilterIndexSync(benchmark::Bench& bench)
                                       /*n_cache_size=*/0, /*f_memory=*/false, /*f_wipe=*/true);
         assert(filter_index.Init());
         assert(!filter_index.BlockUntilSyncedToCurrentChain());
-        filter_index.Sync();
-        assert(filter_index.BlockUntilSyncedToCurrentChain());
+        IndexTester{filter_index}.Sync();
         filter_index.Interrupt();
         filter_index.Stop();
 

--- a/src/bench/index_blockfilter.cpp
+++ b/src/bench/index_blockfilter.cpp
@@ -14,6 +14,7 @@
 #include <pubkey.h>
 #include <script/script.h>
 #include <sync.h>
+#include <test/util/index.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
 #include <uint256.h>
@@ -48,8 +49,7 @@ static void BlockFilterIndexSync(benchmark::Bench& bench)
                                       /*n_cache_size=*/0, /*f_memory=*/false, /*f_wipe=*/true);
         assert(filter_index.Init());
         assert(!filter_index.BlockUntilSyncedToCurrentChain());
-        filter_index.Sync();
-        assert(filter_index.BlockUntilSyncedToCurrentChain());
+        IndexTester{filter_index}.SyncOnce();
         filter_index.Interrupt();
         filter_index.Stop();
 

--- a/src/bench/wallet_create_tx.cpp
+++ b/src/bench/wallet_create_tx.cpp
@@ -9,9 +9,10 @@
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
-#include <kernel/chain.h>
+#include <interfaces/types.h>
 #include <kernel/types.h>
 #include <node/blockstorage.h>
+#include <node/chain.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
 #include <primitives/block.h>
@@ -106,7 +107,7 @@ void generateFakeBlock(const CChainParams& params,
 
     // notify wallet
     const auto& pindex = WITH_LOCK(::cs_main, return context.chainman->ActiveChain().Tip());
-    wallet.blockConnected(ChainstateRole{}, kernel::MakeBlockInfo(pindex, &block));
+    wallet.blockConnected(ChainstateRole{}, node::MakeBlockInfo(pindex, &block));
 }
 
 struct PreSelectInputs {

--- a/src/common/interfaces.cpp
+++ b/src/common/interfaces.cpp
@@ -17,6 +17,7 @@ public:
     explicit CleanupHandler(std::function<void()> cleanup) : m_cleanup(std::move(cleanup)) {}
     ~CleanupHandler() override { if (!m_cleanup) return; m_cleanup(); m_cleanup = nullptr; }
     void disconnect() override { if (!m_cleanup) return; m_cleanup(); m_cleanup = nullptr; }
+    bool connected() override { return bool{m_cleanup}; }
     std::function<void()> m_cleanup;
 };
 
@@ -26,7 +27,7 @@ public:
     explicit SignalHandler(btcsignals::connection connection) : m_connection(std::move(connection)) {}
 
     void disconnect() override { m_connection.disconnect(); }
-
+    bool connected() override { return m_connection.connected(); }
     btcsignals::scoped_connection m_connection;
 };
 

--- a/src/common/interfaces.cpp
+++ b/src/common/interfaces.cpp
@@ -18,6 +18,7 @@ public:
     explicit CleanupHandler(std::function<void()> cleanup) : m_cleanup(std::move(cleanup)) {}
     ~CleanupHandler() override { if (!m_cleanup) return; m_cleanup(); m_cleanup = nullptr; }
     void disconnect() override { if (!m_cleanup) return; m_cleanup(); m_cleanup = nullptr; }
+    bool connected() override { return bool{m_cleanup}; }
     std::function<void()> m_cleanup;
 };
 
@@ -27,7 +28,7 @@ public:
     explicit SignalHandler(btcsignals::connection connection) : m_connection(std::move(connection)) {}
 
     void disconnect() override { m_connection.disconnect(); }
-
+    bool connected() override { return m_connection.connected(); }
     btcsignals::scoped_connection m_connection;
 };
 

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -54,6 +54,7 @@ constexpr auto SYNC_LOCATOR_WRITE_INTERVAL{30s};
 template <typename... Args>
 void BaseIndex::FatalErrorf(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args)
 {
+    Interrupt(); // Cancel the sync thread
     auto message = tfm::format(fmt, args...);
     node::AbortNode(m_chain->context()->shutdown_request, m_chain->context()->exit_status, Untranslated(message), m_chain->context()->warnings.get());
 }
@@ -79,6 +80,7 @@ public:
     void blockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block) override;
     void chainStateFlushed(const kernel::ChainstateRole& role, const CBlockLocator& locator) override;
     BaseIndex& m_index;
+    interfaces::Chain::NotifyOptions m_options = m_index.CustomOptions();
 };
 
 void BaseIndexNotifications::blockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block)
@@ -87,7 +89,7 @@ void BaseIndexNotifications::blockConnected(const kernel::ChainstateRole& role, 
 
     const CBlockIndex* pindex = &m_index.BlockIndex(block.hash);
     const CBlockIndex* best_block_index = m_index.m_best_block_index.load();
-    if (best_block_index && best_block_index != pindex->pprev && !m_index.Rewind(best_block_index, pindex->pprev)) {
+    if (!block.background_sync && best_block_index && best_block_index != pindex->pprev && !m_index.Rewind(best_block_index, pindex->pprev)) {
         m_index.FatalErrorf("Failed to rewind %s to a previous chain tip",
                    m_index.GetName());
         return;
@@ -95,6 +97,14 @@ void BaseIndexNotifications::blockConnected(const kernel::ChainstateRole& role, 
 
     // Dispatch block to child class; errors are logged internally and abort the node.
     if (!m_index.Append(block)) return;
+
+    if (block.background_sync) {
+        // Only update index best block between flushes if fully synced.
+        // Decision to let the best block pointer lag during sync seems a
+        // little arbitrary, but has been behavior since syncing was introduced
+        // in #13033, so preserving it in case anything depends on it.
+        return;
+    }
 
     // Setting the best block index is intentionally the last step of this
     // function, so BlockUntilSyncedToCurrentChain callers waiting for the
@@ -160,6 +170,7 @@ BaseIndex::~BaseIndex()
     //! handlers call pure virtual methods like GetName(), so if they are still
     //! being called at this point, they would segfault.
     LOCK(m_mutex);
+    assert(!m_notifications);
     assert(!m_handler);
 }
 
@@ -301,6 +312,11 @@ bool BaseIndex::Append(const interfaces::BlockInfo& new_block)
 
 void BaseIndex::Sync()
 {
+    auto notifications = WITH_LOCK(m_mutex, return m_notifications);
+    // If m_notifications is null, it means Stop() was called before the Sync
+    // thread was started, so just return without doing anything.
+    if (!notifications) return;
+
     const CBlockIndex* pindex = m_best_block_index.load();
     if (m_state == State::SYNCING) {
         auto last_log_time{NodeClock::now()};
@@ -347,7 +363,9 @@ void BaseIndex::Sync()
             }
             pindex = pindex_next;
 
-            if (!Append(node::MakeBlockInfo(pindex))) return; // error logged internally
+            interfaces::BlockInfo block_info = node::MakeBlockInfo(pindex);
+            block_info.background_sync = true;
+            notifications->blockConnected(ChainstateRole{}, block_info); // error logged internally
 
             auto current_time{NodeClock::now()};
             if (current_time - last_log_time >= SYNC_LOG_INTERVAL) {
@@ -449,6 +467,10 @@ bool BaseIndex::IgnoreBlockConnected(const ChainstateRole& role, const interface
         return true;
     }
 
+    if (block.background_sync) {
+        return false;
+    }
+
     const CBlockIndex* pindex = &BlockIndex(block.hash);
     const CBlockIndex* best_block_index = m_best_block_index.load();
     if (!best_block_index) {
@@ -538,6 +560,8 @@ bool BaseIndex::BlockUntilSyncedToCurrentChain() const
 void BaseIndex::Interrupt()
 {
     m_interrupt();
+    LOCK(m_mutex);
+    m_notifications.reset();
 }
 
 bool BaseIndex::StartBackgroundSync()
@@ -550,7 +574,12 @@ bool BaseIndex::StartBackgroundSync()
 
 void BaseIndex::Stop()
 {
-    WITH_LOCK(m_mutex, m_handler.reset());
+    {
+        m_interrupt();
+        LOCK(m_mutex);
+        m_notifications.reset();
+        m_handler.reset();
+    }
 
     if (m_thread_sync.joinable()) {
         m_thread_sync.join();

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -4,7 +4,6 @@
 
 #include <index/base.h>
 
-#include <chain.h>
 #include <common/args.h>
 #include <dbwrapper.h>
 #include <interfaces/chain.h>
@@ -13,7 +12,6 @@
 #include <kernel/types.h>
 #include <node/abort.h>
 #include <node/blockstorage.h>
-#include <node/chain.h>
 #include <node/context.h>
 #include <node/database_args.h>
 #include <node/interface_ui.h>
@@ -21,26 +19,18 @@
 #include <sync.h>
 #include <tinyformat.h>
 #include <uint256.h>
-#include <undo.h>
 #include <util/check.h>
 #include <util/fs.h>
 #include <util/log.h>
 #include <util/string.h>
-#include <util/thread.h>
-#include <util/threadinterrupt.h>
 #include <util/time.h>
 #include <util/translation.h>
-#include <validation.h>
-#include <validationinterface.h>
 
 #include <compare>
-#include <cstdint>
-#include <functional>
 #include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string>
-#include <thread>
 #include <utility>
 #include <vector>
 
@@ -48,7 +38,6 @@ using interfaces::BlockInfo;
 using interfaces::BlockRef;
 using interfaces::FoundBlock;
 using kernel::ChainstateRole;
-using node::MakeBlockInfo;
 
 constexpr uint8_t DB_BEST_BLOCK{'B'};
 
@@ -308,11 +297,6 @@ bool BaseIndex::Init()
         assert(!m_notifications);
     }
 
-    // m_chainstate member gives indexing code access to node internals. It is
-    // removed in followup https://github.com/bitcoin/bitcoin/pull/24230
-    m_chainstate = WITH_LOCK(::cs_main,
-                             return &m_chain->context()->chainman->ValidatedChainstate());
-
     const auto locator{GetDB().ReadBestBlock()};
     std::optional<BlockRef> block;
     if (!locator.IsNull()) {
@@ -511,12 +495,12 @@ std::optional<interfaces::BlockRef> BaseIndex::GetBestBlock() const
 
 void BaseIndex::SetBestBlock(const std::optional<interfaces::BlockRef>& block)
 {
-    assert(!m_chainstate->m_blockman.IsPruneMode() || AllowPrune());
+    assert(!m_chain->pruningEnabled() || AllowPrune());
 
     if (AllowPrune() && block) {
         node::PruneLockInfo prune_lock;
         prune_lock.height_first = block->height;
-        WITH_LOCK(::cs_main, m_chainstate->m_blockman.UpdatePruneLock(GetName(), prune_lock));
+        m_chain->updatePruneLock(GetName(), prune_lock);
     }
 
     // Intentionally set m_best_block as the last step in this function,

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -146,8 +146,11 @@ BaseIndex::BaseIndex(std::unique_ptr<interfaces::Chain> chain, std::string name,
 
 BaseIndex::~BaseIndex()
 {
-    Interrupt();
-    Stop();
+    //! Assert Stop() was called before this base destructor. Notification
+    //! handlers call pure virtual methods like GetName(), so if they are still
+    //! being called at this point, they would segfault.
+    LOCK(m_mutex);
+    assert(!m_handler);
 }
 
 // Read index best block, register for block connected and disconnected

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -106,8 +106,8 @@ BaseIndex::~BaseIndex()
 // Read index best block, register for block connected and disconnected
 // notifications, and determine where best block is relative to chain tip.
 //
-// If the chain tip and index best block are the same, `m_synced` will be set to
-// true so BlockConnected notifications will be processed after this call and
+// If the chain tip and index best block are the same, the UPDATING state will
+// be set so BlockConnected notifications will be processed after this call and
 // the index will update during node startup as the node::ImportBlocks()
 // function connects blocks. Otherwise the index will stay idle until
 // ImportBlocks() finishes and BaseIndex::StartBackgroundSync() is called later.
@@ -135,21 +135,21 @@ bool BaseIndex::Init()
     // removed in followup https://github.com/bitcoin/bitcoin/pull/24230
     m_chainstate = WITH_LOCK(::cs_main,
                              return &m_chain->context()->chainman->ValidatedChainstate());
-    // Register to validation interface before setting the 'm_synced' flag, so that
-    // callbacks are not missed once m_synced is true.
+    // Register to receive validation interface notifications. These
+    // notifications will be ignored until the UPDATING state is set, so
+    // there is no harm in registering too early. Registering any time before
+    // cs_main is released at the end of this function is early enough to avoid
+    // missing notifications.
     m_chain->context()->validation_signals->RegisterValidationInterface(this);
 
     const auto locator{GetDB().ReadBestBlock()};
-
-    LOCK(cs_main);
-    CChain& index_chain = m_chainstate->m_chain;
 
     if (locator.IsNull()) {
         SetBestBlockIndex(nullptr);
     } else {
         // Setting the best block to the locator's top block. If it is not part of the
         // best chain, we will rewind to the fork point during index sync
-        const CBlockIndex* locator_index{m_chainstate->m_blockman.LookupBlockIndex(locator.vHave.at(0))};
+        const CBlockIndex* locator_index{WITH_LOCK(::cs_main, return m_chainstate->m_blockman.LookupBlockIndex(locator.vHave.at(0)))};
         if (!locator_index) {
             return InitError(Untranslated(strprintf("best block of %s not found. Please rebuild the index.", GetName())));
         }
@@ -162,11 +162,25 @@ bool BaseIndex::Init()
         return false;
     }
 
-    // Note: this will latch to true immediately if the user starts up with an empty
-    // datadir and an index enabled. If this is the case, indexation will happen solely
-    // via `BlockConnected` signals until, possibly, the next restart.
-    m_synced = start_block == index_chain.Tip();
-    m_init = true;
+    {
+        LOCK(cs_main);
+        if (start_block != m_chainstate->m_chain.Tip()) {
+            // Set SYNCING state since the index is not at the chain tip, and a
+            // background sync is neccessary.
+            m_state = State::SYNCING;
+        } else {
+            // The index is caught up to the chain tip. We want to enter the
+            // UPDATING state to begin processing new BlockConnected notifications,
+            // but the shared validation queue may still contain stale notifications
+            // for older blocks. Enter SETTLING first so those are ignored.
+            m_state = State::SETTLING;
+            // Queue transition to UPDATING while holding cs_main, so if new
+            // blocks are connected now, the index will be in UPDATING state
+            // before their BlockConnected notifications are received.
+            m_chain->context()->validation_signals->CallFunctionInValidationInterfaceQueue([this] { m_state = State::UPDATING; });
+        }
+
+    }
     return true;
 }
 
@@ -230,7 +244,7 @@ bool BaseIndex::ProcessBlock(const CBlockIndex* pindex, const CBlock* block_data
 void BaseIndex::Sync()
 {
     const CBlockIndex* pindex = m_best_block_index.load();
-    if (!m_synced) {
+    if (m_state == State::SYNCING) {
         auto last_log_time{NodeClock::now()};
         auto last_locator_write_time{last_log_time};
         while (true) {
@@ -253,15 +267,22 @@ void BaseIndex::Sync()
                 // No need to handle errors in Commit. See rationale above.
                 Commit();
 
-                // If pindex is still the chain tip after committing, exit the
-                // sync loop. It is important for cs_main to be locked while
-                // setting m_synced = true, otherwise a new block could be
-                // attached while m_synced is still false, and it would not be
-                // indexed.
+                // After committing, if pindex is still the active chain tip,
+                // background sync is finished and we can switch to notification-
+                // based updates.
+                //
+                // Hold cs_main while checking for the next block and enqueueing
+                // the state transition. This ensures that if a new block is
+                // connected in this window, its notification will be delivered
+                // after we move to UPDATING and will not be missed. Set
+                // SETTLING state before transitioning to UPDATING, in case the
+                // notification queue contains BlockConnected notifications for
+                // older blocks which should be ignored.
                 LOCK(::cs_main);
                 pindex_next = NextSyncBlock(pindex, m_chainstate->m_chain);
                 if (!pindex_next) {
-                    m_synced = true;
+                    m_state = State::SETTLING;
+                    m_chain->context()->validation_signals->CallFunctionInValidationInterfaceQueue([this] { m_state = State::UPDATING; });
                     break;
                 }
             }
@@ -374,7 +395,7 @@ void BaseIndex::BlockConnected(const ChainstateRole& role, const std::shared_ptr
     }
 
     // Ignore BlockConnected signals until we have fully indexed the chain.
-    if (!m_synced) {
+    if (m_state != State::UPDATING) {
         return;
     }
 
@@ -386,50 +407,14 @@ void BaseIndex::BlockConnected(const ChainstateRole& role, const std::shared_ptr
             return;
         }
     } else {
-        // Ensure block connects to an ancestor of the current best block. This should be the case
-        // most of the time, but may not be immediately after the sync thread catches up and sets
-        // m_synced. Consider the case where there is a reorg and the blocks on the stale branch are
-        // in the ValidationInterface queue backlog even after the sync thread has caught up to the
-        // new chain tip. In this unlikely event, log a warning and let the queue clear.
-        //
+        // Ensure block connects to an ancestor of the current best block.
         // To allow handling reorgs, this only checks that the new block
         // connects to ancestor of the current best block, instead of checking
         // that it connects to directly to the current block. If there is a
         // reorg, Rewind call below will remove existing blocks from the index
         // before adding the new one.
-        //
-        // It's also possible for the new block to connect to an ancestor of the
-        // current best block without a reorg when the m_synced flag gets set to
-        // true too early. For example if the index is synced to height 100, and
-        // -reindex-chainstate option is used, there may be BlockConnected
-        // notifications for blocks 97, 98, 99, and 100 sitting in the
-        // notifications queue when m_synced gets set to true. When this
-        // happens, the Rewind call below will remove these blocks from the
-        // index before they are attached again.
-        //
-        // To summarize, there are 4 cases:
-        //
-        //   1. Normal case where new block connects directly to current block.
-        //      New block is just appended below.
-        //
-        //   2. Reorg case where new block connects to ancestor of current
-        //      block. The index is rewound and the new block is appended.
-        //
-        //   3. Race case where m_synced is set to true too early and the new
-        //      block is a previously indexed ancestor of the current block.
-        //      Index is rewound, and the block is appended a second time.
-        //
-        //   4. Race case where m_synced is set to true too early and
-        //      there has been a reorg, and the new block is from the stale
-        //      branch of the reorg. In this case the ancestor check here fails,
-        //      and logs a warning, and returns early ignoring the stale block.
-        if (best_block_index->GetAncestor(pindex->nHeight - 1) != pindex->pprev) {
-            LogWarning("Block %s does not connect to an ancestor of "
-                      "known best chain (tip=%s); not updating index",
-                      pindex->GetBlockHash().ToString(),
-                      best_block_index->GetBlockHash().ToString());
-            return;
-        }
+        assert(best_block_index->GetAncestor(pindex->nHeight - 1) == pindex->pprev);
+
         if (best_block_index != pindex->pprev && !Rewind(best_block_index, pindex->pprev)) {
             FatalErrorf("Failed to rewind %s to a previous chain tip",
                        GetName());
@@ -454,7 +439,7 @@ void BaseIndex::ChainStateFlushed(const ChainstateRole& role, const CBlockLocato
         return;
     }
 
-    if (!m_synced) {
+    if (m_state != State::UPDATING) {
         return;
     }
 
@@ -471,11 +456,16 @@ void BaseIndex::ChainStateFlushed(const ChainstateRole& role, const CBlockLocato
         return;
     }
 
-    // This checks that ChainStateFlushed callbacks are received after BlockConnected. The check may fail
-    // immediately after the sync thread catches up and sets m_synced. Consider the case where
-    // there is a reorg and the blocks on the stale branch are in the ValidationInterface queue
-    // backlog even after the sync thread has caught up to the new chain tip. In this unlikely
-    // event, log a warning and let the queue clear.
+    // Only commit if the locator points directly at the best block (the typical
+    // case), or if it points to an ancestor of the best block (if a reorg
+    // started or a block was invalidated).
+    //
+    // Otherwise, if the locator does not point to the best block or one of its
+    // ancestors, it means this ChainStateFlushed notification was queued ahead
+    // of relevant BlockConnected notifications from ConnectTrace in validation
+    // code. This can happen when -reindex-chainstate is used and many blocks
+    // are connected quickly. Ignore the flush event in this case since it's
+    // probably better not to commit when blocks are still in flight.
     const CBlockIndex* best_block_index = m_best_block_index.load();
     if (best_block_index->GetAncestor(locator_tip_index->nHeight) != locator_tip_index) {
         LogWarning("Locator contains block (hash=%s) not on known best "
@@ -495,7 +485,7 @@ bool BaseIndex::BlockUntilSyncedToCurrentChain() const
 {
     AssertLockNotHeld(cs_main);
 
-    if (!m_synced) {
+    if (m_state != State::UPDATING && m_state != State::SETTLING) {
         return false;
     }
 
@@ -522,7 +512,7 @@ void BaseIndex::Interrupt()
 
 bool BaseIndex::StartBackgroundSync()
 {
-    if (!m_init) throw std::logic_error("Error: Cannot start a non-initialized index");
+    if (m_state == State::INITIALIZING) throw std::logic_error("Error: Cannot start a non-initialized index");
 
     m_thread_sync = std::thread(&util::TraceThread, m_thread_name, [this] { Sync(); });
     return true;
@@ -543,7 +533,7 @@ IndexSummary BaseIndex::GetSummary() const
 {
     IndexSummary summary{};
     summary.name = GetName();
-    summary.synced = m_synced;
+    summary.synced = m_state == State::UPDATING || m_state == State::SETTLING;
     if (const auto& pindex = m_best_block_index.load()) {
         summary.best_block_height = pindex->nHeight;
         summary.best_block_hash = pindex->GetBlockHash();

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -12,6 +12,7 @@
 #include <kernel/types.h>
 #include <node/abort.h>
 #include <node/blockstorage.h>
+#include <node/chain.h>
 #include <node/context.h>
 #include <node/database_args.h>
 #include <node/interface_ui.h>
@@ -174,7 +175,7 @@ static const CBlockIndex* NextSyncBlock(const CBlockIndex* const pindex_prev, CC
 
 bool BaseIndex::ProcessBlock(const CBlockIndex* pindex, const CBlock* block_data)
 {
-    interfaces::BlockInfo block_info = kernel::MakeBlockInfo(pindex, block_data);
+    interfaces::BlockInfo block_info = node::MakeBlockInfo(pindex, block_data);
 
     CBlock block;
     if (!block_data) { // disk lookup if block data wasn't provided
@@ -311,7 +312,7 @@ bool BaseIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_ti
     CBlockUndo block_undo;
 
     for (const CBlockIndex* iter_tip = current_tip; iter_tip != new_tip; iter_tip = iter_tip->pprev) {
-        interfaces::BlockInfo block_info = kernel::MakeBlockInfo(iter_tip);
+        interfaces::BlockInfo block_info = node::MakeBlockInfo(iter_tip);
         if (CustomOptions().disconnect_data) {
             if (!m_chainstate->m_blockman.ReadBlock(block, *iter_tip)) {
                 LogError("Failed to read block %s from disk",

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -46,6 +46,7 @@
 
 using interfaces::BlockInfo;
 using kernel::ChainstateRole;
+using node::MakeBlockInfo;
 
 constexpr uint8_t DB_BEST_BLOCK{'B'};
 
@@ -78,30 +79,57 @@ class BaseIndexNotifications : public interfaces::Chain::Notifications
 {
 public:
     BaseIndexNotifications(BaseIndex& index) : m_index(index) {}
-    void blockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block) override;
-    void chainStateFlushed(const kernel::ChainstateRole& role, const CBlockLocator& locator) override;
-    void processBlock(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block, bool append);
+    void blockConnected(const ChainstateRole& role, const interfaces::BlockInfo& block) override;
+    void blockDisconnected(const interfaces::BlockInfo& block) override;
+    void chainStateFlushed(const ChainstateRole& role, const CBlockLocator& locator) override;
+    void processBlock(const ChainstateRole& role, const interfaces::BlockInfo& block, bool append);
     BaseIndex& m_index;
     interfaces::Chain::NotifyOptions m_options = m_index.CustomOptions();
     NodeClock::time_point m_last_log_time{NodeClock::now()};
     NodeClock::time_point m_last_locator_write_time{m_last_log_time};
+    //! If blocks are disconnected, m_rewind_start is set to track starting
+    //! point of the rewind and m_rewind_error is set to record any errors.
+    const CBlockIndex* m_rewind_start = nullptr;
+    bool m_rewind_error = false;
 };
 
-void BaseIndexNotifications::blockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block)
+void BaseIndexNotifications::blockConnected(const ChainstateRole& role, const interfaces::BlockInfo& block)
 {
     processBlock(role, block, /*append=*/true);
 }
 
-void BaseIndexNotifications::processBlock(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block, bool append)
+void BaseIndexNotifications::processBlock(const ChainstateRole& role, const interfaces::BlockInfo& block, bool append)
 {
+    // processBlock is called an extra time with append=false to notify about transition from SYNCING to UPDATING state.
+    if (!append && block.background_sync && m_index.m_state == BaseIndex::State::UPDATING) {
+        if (block.height >= 0) {
+            LogInfo("%s is enabled at height %d", m_index.GetName(), block.height);
+        } else {
+            LogInfo("%s is enabled", m_index.GetName());
+        }
+        return;
+    }
+
     if (m_index.IgnoreBlockConnected(role, block)) return;
 
     const CBlockIndex* pindex = &m_index.BlockIndex(block.hash);
     const CBlockIndex* best_block_index = m_index.m_best_block_index.load();
-    if (!block.background_sync && best_block_index && best_block_index != pindex->pprev && !m_index.Rewind(best_block_index, pindex->pprev)) {
+    // If a new block is being connected after blocks were rewound, reset the
+    // rewind state and handle any errors that happened while rewinding.
+    if (m_rewind_error) {
         m_index.FatalErrorf("Failed to rewind %s to a previous chain tip",
                    m_index.GetName());
         return;
+    } else if (m_rewind_start) {
+        assert(!best_block_index || best_block_index->GetAncestor(pindex->nHeight - 1) == pindex->pprev);
+        // Don't commit here - the committed index state must never be ahead of the
+        // flushed chainstate, otherwise unclean restarts would lead to index corruption.
+        // Pruning has a minimum of 288 blocks-to-keep and getting the index
+        // out of sync may be possible but a users fault.
+        // In case we reorg beyond the pruned depth, ReadBlock would
+        // throw and lead to a graceful shutdown
+        m_index.SetBestBlockIndex(pindex->pprev);
+        m_rewind_start = nullptr;
     }
 
     // Dispatch block to child class; errors are logged internally and abort the node.
@@ -147,7 +175,54 @@ void BaseIndexNotifications::processBlock(const kernel::ChainstateRole& role, co
     m_index.SetBestBlockIndex(pindex);
 }
 
-void BaseIndexNotifications::chainStateFlushed(const kernel::ChainstateRole& role, const CBlockLocator& locator)
+void BaseIndexNotifications::blockDisconnected(const interfaces::BlockInfo& block_info)
+{
+    // Make a mutable copy of the BlockInfo argument so block data can be
+    // attached below. This is temporary and removed in upcoming commits.
+    interfaces::BlockInfo block{block_info};
+
+    // During initial sync, ignore validation interface notifications, only
+    // process notifications from sync thread.
+    if (m_index.m_state != BaseIndex::State::UPDATING && !block.background_sync) return;
+
+    const CBlockIndex* pindex = &m_index.BlockIndex(block.hash);
+    if (!m_rewind_start) m_rewind_start = pindex;
+    if (m_rewind_error) return;
+
+    CBlock block_data;
+    if (m_options.disconnect_data && !block.data) {
+        if (!m_index.m_chainstate->m_blockman.ReadBlock(block_data, *pindex)) {
+            m_index.FatalErrorf("Failed to read block %s from disk",
+                        pindex->GetBlockHash().ToString());
+            m_rewind_error = true;
+            return;
+        } else {
+            block.data = &block_data;
+        }
+    }
+
+    CBlockUndo block_undo;
+    if (m_options.disconnect_undo_data && !block.undo_data && block.height > 0) {
+        if (!m_index.m_chainstate->m_blockman.ReadBlockUndo(block_undo, *pindex)) {
+            // If undo data can't be read, subsequent CustomRemove calls will be
+            // skipped, and will be a fatal error if there an attempt to connect
+            // a another block to the index.
+            m_rewind_error = true;
+            return;
+        }
+        block.undo_data = &block_undo;
+    }
+
+    // If one CustomRemove call fails, subsequent calls will be skipped,
+    // and there will be a fatal error if there an attempt to connect
+    // a another block to the index.
+    if (!m_index.CustomRemove(block)) {
+        m_rewind_error = true;
+        return;
+    }
+}
+
+void BaseIndexNotifications::chainStateFlushed(const ChainstateRole& role, const CBlockLocator& locator)
 {
     if (m_index.IgnoreChainStateFlushed(role, locator)) return;
 
@@ -357,37 +432,20 @@ void BaseIndex::Sync()
 
     const CBlockIndex* pindex = m_best_block_index.load();
     if (m_state == State::SYNCING) {
-        // Last block in the chain syncing to which is known to be flushed.
-        const CBlockIndex *last_flushed{nullptr};
-        // Return flush status of the block being indexed.
-        auto process_block = [&](bool append){
-            if (pindex) {
-                interfaces::BlockInfo block_info = node::MakeBlockInfo(pindex);
-                block_info.background_sync = true;
-                if (pindex == last_flushed) {
-                    block_info.status = BlockInfo::FLUSHED_TIP;
-                } else if (!last_flushed || last_flushed->GetAncestor(pindex->nHeight) == pindex) {
-                    block_info.status = BlockInfo::FLUSHED;
-                }
-                notifications->processBlock({}, block_info, append); // error logged internally
-            }
-        };
         while (true) {
             if (m_interrupt) {
                 LogInfo("%s: m_interrupt set; exiting ThreadSync", GetName());
-                // Call process_block a final time to commit latest state.
-                process_block(/*append=*/false);
+                // Call processBlock with append=false to commit latest state.
+                if (pindex) notifications->processBlock(ChainstateRole{}, MakeBlockInfo(pindex, nullptr, m_chainstate), /*append=*/false); // error logged internally
                 return;
             }
 
-            const CBlockIndex* pindex_next = WITH_LOCK(cs_main,
-                last_flushed = m_chainstate->GetLastFlushedBlock();
-                return NextSyncBlock(pindex, m_chainstate->m_chain));
+            const CBlockIndex* pindex_next = WITH_LOCK(cs_main, return NextSyncBlock(pindex, m_chainstate->m_chain));
             // If pindex_next is null, it means pindex is the chain tip, so
             // commit data indexed so far.
             if (!pindex_next) {
-                // Call process_block with append=false to force a commit.
-                process_block(/*append=*/false);
+                // Call processBlock with append=false to commit latest state.
+                notifications->processBlock(ChainstateRole{}, MakeBlockInfo(pindex, nullptr, m_chainstate), /*append=*/false); // error logged internally
 
                 // After committing, if pindex is still the active chain tip,
                 // background sync is finished and we can switch to notification-
@@ -402,22 +460,25 @@ void BaseIndex::Sync()
                 if (!pindex_next) {
                     m_state = State::UPDATING;
                     WITH_LOCK(m_mutex, if (m_handler) m_handler->connect());
+                    // Call processBlock a final time to log transition to UPDATING state.
+                    notifications->processBlock(ChainstateRole{}, MakeBlockInfo(pindex, nullptr, m_chainstate), /*append=*/false); // error logged internally
                     break;
                 }
             }
-            if (pindex_next->pprev != pindex && !Rewind(pindex, pindex_next->pprev)) {
-                FatalErrorf("Failed to rewind %s to a previous chain tip", GetName());
-                return;
+            if (pindex_next->pprev != pindex) {
+                const CBlockIndex* current_tip = pindex;
+                const CBlockIndex* new_tip = pindex_next->pprev;
+                for (const CBlockIndex* iter_tip = current_tip; iter_tip != new_tip; iter_tip = iter_tip->pprev) {
+                    CBlock block;
+                    interfaces::BlockInfo block_info = node::MakeBlockInfo(iter_tip);
+                    block_info.background_sync = true;
+                    notifications->blockDisconnected(block_info);
+                    if (m_interrupt) break;
+                }
             }
             pindex = pindex_next;
-            process_block(/*append=*/true);
+            notifications->processBlock(ChainstateRole{}, MakeBlockInfo(pindex, nullptr, m_chainstate), /*append=*/true);
         }
-    }
-
-    if (pindex) {
-        LogInfo("%s is enabled at height %d", GetName(), pindex->nHeight);
-    } else {
-        LogInfo("%s is enabled", GetName());
     }
 }
 
@@ -438,44 +499,6 @@ void BaseIndex::Commit(const CBlockLocator& locator)
     if (!ok) {
         LogError("Failed to commit latest %s state", GetName());
     }
-}
-
-bool BaseIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip)
-{
-    assert(current_tip->GetAncestor(new_tip->nHeight) == new_tip);
-
-    CBlock block;
-    CBlockUndo block_undo;
-
-    for (const CBlockIndex* iter_tip = current_tip; iter_tip != new_tip; iter_tip = iter_tip->pprev) {
-        interfaces::BlockInfo block_info = node::MakeBlockInfo(iter_tip);
-        if (CustomOptions().disconnect_data) {
-            if (!m_chainstate->m_blockman.ReadBlock(block, *iter_tip)) {
-                LogError("Failed to read block %s from disk",
-                         iter_tip->GetBlockHash().ToString());
-                return false;
-            }
-            block_info.data = &block;
-        }
-        if (CustomOptions().disconnect_undo_data && iter_tip->nHeight > 0) {
-            if (!m_chainstate->m_blockman.ReadBlockUndo(block_undo, *iter_tip)) {
-                return false;
-            }
-            block_info.undo_data = &block_undo;
-        }
-        if (!CustomRemove(block_info)) {
-            return false;
-        }
-    }
-
-    // Don't commit here - the committed index state must never be ahead of the
-    // flushed chainstate, otherwise unclean restarts would lead to index corruption.
-    // Pruning has a minimum of 288 blocks-to-keep and getting the index
-    // out of sync may be possible but a users fault.
-    // In case we reorg beyond the pruned depth, ReadBlock would
-    // throw and lead to a graceful shutdown
-    SetBestBlockIndex(new_tip);
-    return true;
 }
 
 bool BaseIndex::IgnoreBlockConnected(const ChainstateRole& role, const interfaces::BlockInfo& block)
@@ -505,8 +528,8 @@ bool BaseIndex::IgnoreBlockConnected(const ChainstateRole& role, const interface
         // To allow handling reorgs, this only checks that the new block
         // connects to ancestor of the current best block, instead of checking
         // that it connects to directly to the current block. If there is a
-        // reorg, Rewind call below will remove existing blocks from the index
-        // before adding the new one.
+        // reorg, blockDisconnected calls will have removed existing blocks from
+        // the index, but best_block_index will not have been updated yet.
         assert(best_block_index->GetAncestor(pindex->nHeight - 1) == pindex->pprev);
     }
     return false;

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -396,28 +396,6 @@ bool BaseIndex::IgnoreBlockConnected(const ChainstateRole& role, const interface
     if (!role.validated) {
         return true;
     }
-
-    if (block.state == BlockInfo::SYNCING) {
-        return false;
-    }
-
-    const CBlockIndex* pindex = &BlockIndex(block.hash);
-    const CBlockIndex* best_block_index = m_best_block_index.load();
-    if (!best_block_index) {
-        if (pindex->nHeight != 0) {
-            FatalErrorf("First block connected is not the genesis block (height=%d)",
-                       pindex->nHeight);
-            return true;
-        }
-    } else {
-        // Ensure block connects to an ancestor of the current best block.
-        // To allow handling reorgs, this only checks that the new block
-        // connects to ancestor of the current best block, instead of checking
-        // that it connects to directly to the current block. If there is a
-        // reorg, blockDisconnected calls will have removed existing blocks from
-        // the index, but best_block_index will not have been updated yet.
-        assert(best_block_index->GetAncestor(pindex->nHeight - 1) == pindex->pprev);
-    }
     return false;
 }
 
@@ -452,7 +430,7 @@ bool BaseIndex::IgnoreChainStateFlushed(const ChainstateRole& role, const CBlock
     // are connected quickly. Ignore the flush event in this case since it's
     // probably better not to commit when blocks are still in flight.
     const CBlockIndex* best_block_index = m_best_block_index.load();
-    if (best_block_index->GetAncestor(locator_tip_index->nHeight) != locator_tip_index) {
+    if (!best_block_index || best_block_index->GetAncestor(locator_tip_index->nHeight) != locator_tip_index) {
         LogWarning("Locator contains block (hash=%s) not on known best "
                   "chain (tip=%s); not writing index locator",
                   locator_tip_hash.ToString(),

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -8,6 +8,7 @@
 #include <common/args.h>
 #include <dbwrapper.h>
 #include <interfaces/chain.h>
+#include <interfaces/handler.h>
 #include <interfaces/types.h>
 #include <kernel/types.h>
 #include <node/abort.h>
@@ -57,6 +58,11 @@ void BaseIndex::FatalErrorf(util::ConstevalFormatString<sizeof...(Args)> fmt, co
     node::AbortNode(m_chain->context()->shutdown_request, m_chain->context()->exit_status, Untranslated(message), m_chain->context()->warnings.get());
 }
 
+const CBlockIndex& BaseIndex::BlockIndex(const uint256& hash)
+{
+   return WITH_LOCK(cs_main, return *Assert(m_chainstate->m_blockman.LookupBlockIndex(hash)));
+}
+
 CBlockLocator GetLocator(interfaces::Chain& chain, const uint256& block_hash)
 {
     CBlockLocator locator;
@@ -64,6 +70,25 @@ CBlockLocator GetLocator(interfaces::Chain& chain, const uint256& block_hash)
     assert(found);
     assert(!locator.IsNull());
     return locator;
+}
+
+class BaseIndexNotifications : public interfaces::Chain::Notifications
+{
+public:
+    BaseIndexNotifications(BaseIndex& index) : m_index(index) {}
+    void blockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block) override;
+    void chainStateFlushed(const kernel::ChainstateRole& role, const CBlockLocator& locator) override;
+    BaseIndex& m_index;
+};
+
+void BaseIndexNotifications::blockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block)
+{
+    m_index.BlockConnected(role, block);
+}
+
+void BaseIndexNotifications::chainStateFlushed(const kernel::ChainstateRole& role, const CBlockLocator& locator)
+{
+    m_index.ChainStateFlushed(role, locator);
 }
 
 BaseIndex::DB::DB(const fs::path& path, size_t n_cache_size, bool f_memory, bool f_wipe, bool f_obfuscate, bool f_bloom) :
@@ -135,12 +160,6 @@ bool BaseIndex::Init()
     // removed in followup https://github.com/bitcoin/bitcoin/pull/24230
     m_chainstate = WITH_LOCK(::cs_main,
                              return &m_chain->context()->chainman->ValidatedChainstate());
-    // Register to receive validation interface notifications. These
-    // notifications will be ignored until the UPDATING state is set, so
-    // there is no harm in registering too early. Registering any time before
-    // cs_main is released at the end of this function is early enough to avoid
-    // missing notifications.
-    m_chain->context()->validation_signals->RegisterValidationInterface(this);
 
     const auto locator{GetDB().ReadBestBlock()};
 
@@ -162,6 +181,9 @@ bool BaseIndex::Init()
         return false;
     }
 
+    // Register to receive validation interface notifications.
+    auto notifications = std::make_shared<BaseIndexNotifications>(*this);
+    auto handler = m_chain->attachChain(notifications, CustomOptions());
     {
         LOCK(cs_main);
         if (start_block != m_chainstate->m_chain.Tip()) {
@@ -171,16 +193,14 @@ bool BaseIndex::Init()
         } else {
             // The index is caught up to the chain tip. We want to enter the
             // UPDATING state to begin processing new BlockConnected notifications,
-            // but the shared validation queue may still contain stale notifications
-            // for older blocks. Enter SETTLING first so those are ignored.
-            m_state = State::SETTLING;
-            // Queue transition to UPDATING while holding cs_main, so if new
-            // blocks are connected now, the index will be in UPDATING state
-            // before their BlockConnected notifications are received.
-            m_chain->context()->validation_signals->CallFunctionInValidationInterfaceQueue([this] { m_state = State::UPDATING; });
+            m_state = State::UPDATING;
+            handler->connect();
         }
 
     }
+    LOCK(m_mutex);
+    m_notifications = std::move(notifications);
+    m_handler = std::move(handler);
     return true;
 }
 
@@ -208,12 +228,15 @@ static const CBlockIndex* NextSyncBlock(const CBlockIndex* const pindex_prev, CC
     return chain.Next(*Assert(fork));
 }
 
-bool BaseIndex::ProcessBlock(const CBlockIndex* pindex, const CBlock* block_data)
+bool BaseIndex::Append(const interfaces::BlockInfo& new_block)
 {
-    interfaces::BlockInfo block_info = node::MakeBlockInfo(pindex, block_data);
+    // Make a mutable copy of the BlockInfo argument so data and undo_data can
+    // be attached below. This is temporary and removed in upcoming commits.
+    interfaces::BlockInfo block_info{new_block};
+    const CBlockIndex* pindex = &BlockIndex(block_info.hash);
 
     CBlock block;
-    if (!block_data) { // disk lookup if block data wasn't provided
+    if (!block_info.data) { // disk lookup if block data wasn't provided
         if (!m_chainstate->m_blockman.ReadBlock(block, *pindex)) {
             FatalErrorf("Failed to read block %s from disk",
                         pindex->GetBlockHash().ToString());
@@ -274,15 +297,12 @@ void BaseIndex::Sync()
                 // Hold cs_main while checking for the next block and enqueueing
                 // the state transition. This ensures that if a new block is
                 // connected in this window, its notification will be delivered
-                // after we move to UPDATING and will not be missed. Set
-                // SETTLING state before transitioning to UPDATING, in case the
-                // notification queue contains BlockConnected notifications for
-                // older blocks which should be ignored.
+                // after we move to UPDATING and will not be missed.
                 LOCK(::cs_main);
                 pindex_next = NextSyncBlock(pindex, m_chainstate->m_chain);
                 if (!pindex_next) {
-                    m_state = State::SETTLING;
-                    m_chain->context()->validation_signals->CallFunctionInValidationInterfaceQueue([this] { m_state = State::UPDATING; });
+                    m_state = State::UPDATING;
+                    WITH_LOCK(m_mutex, if (m_handler) m_handler->connect());
                     break;
                 }
             }
@@ -292,8 +312,7 @@ void BaseIndex::Sync()
             }
             pindex = pindex_next;
 
-
-            if (!ProcessBlock(pindex)) return; // error logged internally
+            if (!Append(node::MakeBlockInfo(pindex))) return; // error logged internally
 
             auto current_time{NodeClock::now()};
             if (current_time - last_log_time >= SYNC_LOG_INTERVAL) {
@@ -384,7 +403,7 @@ bool BaseIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_ti
     return true;
 }
 
-void BaseIndex::BlockConnected(const ChainstateRole& role, const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex)
+void BaseIndex::BlockConnected(const ChainstateRole& role, const interfaces::BlockInfo& block_info)
 {
     // Ignore events from not fully validated chains to avoid out-of-order indexing.
     //
@@ -394,11 +413,7 @@ void BaseIndex::BlockConnected(const ChainstateRole& role, const std::shared_ptr
         return;
     }
 
-    // Ignore BlockConnected signals until we have fully indexed the chain.
-    if (m_state != State::UPDATING) {
-        return;
-    }
-
+    const CBlockIndex* pindex = &BlockIndex(block_info.hash);
     const CBlockIndex* best_block_index = m_best_block_index.load();
     if (!best_block_index) {
         if (pindex->nHeight != 0) {
@@ -423,7 +438,7 @@ void BaseIndex::BlockConnected(const ChainstateRole& role, const std::shared_ptr
     }
 
     // Dispatch block to child class; errors are logged internally and abort the node.
-    if (ProcessBlock(pindex, block.get())) {
+    if (Append(block_info)) {
         // Setting the best block index is intentionally the last step of this
         // function, so BlockUntilSyncedToCurrentChain callers waiting for the
         // best block index to be updated can rely on the block being fully
@@ -436,10 +451,6 @@ void BaseIndex::ChainStateFlushed(const ChainstateRole& role, const CBlockLocato
 {
     // Ignore events from not fully validated chains to avoid out-of-order indexing.
     if (!role.validated) {
-        return;
-    }
-
-    if (m_state != State::UPDATING) {
         return;
     }
 
@@ -485,7 +496,7 @@ bool BaseIndex::BlockUntilSyncedToCurrentChain() const
 {
     AssertLockNotHeld(cs_main);
 
-    if (m_state != State::UPDATING && m_state != State::SETTLING) {
+    if (m_state != State::UPDATING) {
         return false;
     }
 
@@ -520,9 +531,7 @@ bool BaseIndex::StartBackgroundSync()
 
 void BaseIndex::Stop()
 {
-    if (m_chain->context()->validation_signals) {
-        m_chain->context()->validation_signals->UnregisterValidationInterface(this);
-    }
+    WITH_LOCK(m_mutex, m_handler.reset());
 
     if (m_thread_sync.joinable()) {
         m_thread_sync.join();
@@ -533,7 +542,7 @@ IndexSummary BaseIndex::GetSummary() const
 {
     IndexSummary summary{};
     summary.name = GetName();
-    summary.synced = m_state == State::UPDATING || m_state == State::SETTLING;
+    summary.synced = m_state == State::UPDATING;
     if (const auto& pindex = m_best_block_index.load()) {
         summary.best_block_height = pindex->nHeight;
         summary.best_block_hash = pindex->GetBlockHash();

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -45,6 +45,7 @@
 #include <vector>
 
 using interfaces::BlockInfo;
+using interfaces::BlockRef;
 using interfaces::FoundBlock;
 using kernel::ChainstateRole;
 using node::MakeBlockInfo;
@@ -60,11 +61,6 @@ void BaseIndex::FatalErrorf(util::ConstevalFormatString<sizeof...(Args)> fmt, co
     Interrupt(); // Cancel the sync thread
     auto message = tfm::format(fmt, args...);
     node::AbortNode(m_chain->context()->shutdown_request, m_chain->context()->exit_status, Untranslated(message), m_chain->context()->warnings.get());
-}
-
-const CBlockIndex& BaseIndex::BlockIndex(const uint256& hash)
-{
-   return WITH_LOCK(cs_main, return *Assert(m_chainstate->m_blockman.LookupBlockIndex(hash)));
 }
 
 CBlockLocator GetLocator(interfaces::Chain& chain, const uint256& block_hash)
@@ -83,13 +79,19 @@ public:
     void blockConnected(const ChainstateRole& role, const interfaces::BlockInfo& block) override;
     void blockDisconnected(const interfaces::BlockInfo& block) override;
     void chainStateFlushed(const ChainstateRole& role, const CBlockLocator& locator) override;
+    void setBest(const interfaces::BlockRef& block)
+    {
+        assert(!block.hash.IsNull());
+        assert(block.height >= 0);
+        m_index.SetBestBlock(block);
+    }
     BaseIndex& m_index;
     interfaces::Chain::NotifyOptions m_options = m_index.CustomOptions();
     NodeClock::time_point m_last_log_time{NodeClock::now()};
     NodeClock::time_point m_last_locator_write_time{m_last_log_time};
     //! If blocks are disconnected, m_rewind_start is set to track starting
     //! point of the rewind and m_rewind_error is set to record any errors.
-    const CBlockIndex* m_rewind_start = nullptr;
+    std::optional<interfaces::BlockRef> m_rewind_start;
     bool m_rewind_error = false;
 };
 
@@ -115,8 +117,6 @@ void BaseIndexNotifications::blockConnected(const ChainstateRole& role, const in
 
     if (m_index.IgnoreBlockConnected(role, block)) return;
 
-    const CBlockIndex* pindex = &m_index.BlockIndex(block.hash);
-    const CBlockIndex* best_block_index = m_index.m_best_block_index.load();
     // If a new block is being connected after blocks were rewound, reset the
     // rewind state and handle any errors that happened while rewinding.
     if (m_rewind_error) {
@@ -124,15 +124,23 @@ void BaseIndexNotifications::blockConnected(const ChainstateRole& role, const in
                    m_index.GetName());
         return;
     } else if (m_rewind_start) {
-        assert(!best_block_index || best_block_index->GetAncestor(pindex->nHeight - 1) == pindex->pprev);
+        auto best_block = m_index.GetBestBlock();
+        // Assert m_best_block is null or is parent of new connected block, or is
+        // descendant of parent of new connected block.
+        if (best_block && best_block->hash != *block.prev_hash) {
+            uint256 best_ancestor_hash;
+            assert(m_index.m_chain->findAncestorByHeight(best_block->hash, block.height - 1, FoundBlock().hash(best_ancestor_hash)));
+            assert(best_ancestor_hash == *block.prev_hash);
+        }
+
         // Don't commit here - the committed index state must never be ahead of the
         // flushed chainstate, otherwise unclean restarts would lead to index corruption.
         // Pruning has a minimum of 288 blocks-to-keep and getting the index
         // out of sync may be possible but a users fault.
         // In case we reorg beyond the pruned depth, ReadBlock would
         // throw and lead to a graceful shutdown
-        m_index.SetBestBlockIndex(pindex->pprev);
-        m_rewind_start = nullptr;
+        setBest({*block.prev_hash, block.height-1});
+        m_rewind_start = std::nullopt;
     }
 
     // Dispatch block to child class; errors are logged internally and abort the node.
@@ -142,7 +150,7 @@ void BaseIndexNotifications::blockConnected(const ChainstateRole& role, const in
     if (block.state == BlockInfo::SYNCING) {
         current_time = NodeClock::now();
         if (current_time - m_last_log_time >= SYNC_LOG_INTERVAL) {
-            LogInfo("Syncing %s with block chain from height %d", m_index.GetName(), pindex->nHeight);
+            LogInfo("Syncing %s with block chain from height %d", m_index.GetName(), block.height);
             m_last_log_time = current_time;
         }
     }
@@ -175,7 +183,7 @@ void BaseIndexNotifications::blockConnected(const ChainstateRole& role, const in
     // function, so BlockUntilSyncedToCurrentChain callers waiting for the
     // best block index to be updated can rely on the block being fully
     // processed, and the index object being safe to delete.
-    m_index.SetBestBlockIndex(pindex);
+    setBest({block.hash, block.height});
 }
 
 void BaseIndexNotifications::blockDisconnected(const interfaces::BlockInfo& block)
@@ -185,8 +193,8 @@ void BaseIndexNotifications::blockDisconnected(const interfaces::BlockInfo& bloc
         return;
     }
 
-    const CBlockIndex* pindex = &m_index.BlockIndex(block.hash);
-    if (!m_rewind_start) m_rewind_start = pindex;
+    auto best_block = m_index.GetBestBlock();
+    if (!m_rewind_start) m_rewind_start = best_block;
     if (m_rewind_error) return;
 
     assert(!m_options.disconnect_data || block.data);
@@ -221,8 +229,8 @@ void BaseIndexNotifications::chainStateFlushed(const ChainstateRole& role, const
     // to see it is an ancestor of GetLastFlushedBlock(), because the
     // ChainstateFlushed notification is only sent by the node after it flushes,
     // so the block must have already been flushed to disk by the node.
-    const CBlockIndex* best_block = m_index.m_best_block_index.load();
-    m_index.Commit(best_block ? GetLocator(*m_index.m_chain, best_block->GetBlockHash()) : CBlockLocator{});
+    auto best_block = m_index.GetBestBlock();
+    m_index.Commit(best_block ? GetLocator(*m_index.m_chain, best_block->hash) : CBlockLocator{});
 }
 
 BaseIndex::DB::DB(const fs::path& path, size_t n_cache_size, bool f_memory, bool f_wipe, bool f_obfuscate, bool f_bloom) :
@@ -293,9 +301,9 @@ bool BaseIndex::Init()
 
     // May need reset if index is being restarted (e.g. after assumeutxo background validation)
     m_state = State::SYNCING;
-    m_best_block_index = nullptr;
     {
         LOCK(m_mutex);
+        m_best_block.reset();
         assert(!m_handler);
         assert(!m_notifications);
     }
@@ -306,22 +314,18 @@ bool BaseIndex::Init()
                              return &m_chain->context()->chainman->ValidatedChainstate());
 
     const auto locator{GetDB().ReadBestBlock()};
-
-    if (locator.IsNull()) {
-        SetBestBlockIndex(nullptr);
-    } else {
+    std::optional<BlockRef> block;
+    if (!locator.IsNull()) {
         // Setting the best block to the locator's top block. If it is not part of the
         // best chain, we will rewind to the fork point during index sync
-        const CBlockIndex* locator_index{WITH_LOCK(::cs_main, return m_chainstate->m_blockman.LookupBlockIndex(locator.vHave.at(0)))};
-        if (!locator_index) {
+        block.emplace(locator.vHave.at(0));
+        if (!m_chain->findBlock(block->hash, FoundBlock().height(block->height))) {
             return InitError(Untranslated(strprintf("best block of %s not found. Please rebuild the index.", GetName())));
         }
-        SetBestBlockIndex(locator_index);
     }
+    SetBestBlock(block);
 
     // Child init
-    const CBlockIndex* start_block = m_best_block_index.load();
-    auto block{start_block ? std::make_optional(interfaces::BlockRef{start_block->GetBlockHash(), start_block->nHeight}) : std::nullopt};
     if (!CustomInit(block)) {
         return false;
     }
@@ -393,13 +397,8 @@ bool BaseIndex::IgnoreChainStateFlushed(const ChainstateRole& role, const CBlock
     }
 
     const uint256& locator_tip_hash = locator.vHave.front();
-    const CBlockIndex* locator_tip_index;
-    {
-        LOCK(cs_main);
-        locator_tip_index = m_chainstate->m_blockman.LookupBlockIndex(locator_tip_hash);
-    }
-
-    if (!locator_tip_index) {
+    int locator_tip_height{-1};
+    if (!m_chain->findBlock(locator_tip_hash, FoundBlock().height(locator_tip_height))) {
         FatalErrorf("First block (hash=%s) in locator was not found",
                    locator_tip_hash.ToString());
         return true;
@@ -415,12 +414,15 @@ bool BaseIndex::IgnoreChainStateFlushed(const ChainstateRole& role, const CBlock
     // code. This can happen when -reindex-chainstate is used and many blocks
     // are connected quickly. Ignore the flush event in this case since it's
     // probably better not to commit when blocks are still in flight.
-    const CBlockIndex* best_block_index = m_best_block_index.load();
-    if (!best_block_index || best_block_index->GetAncestor(locator_tip_index->nHeight) != locator_tip_index) {
+    auto best_block = GetBestBlock();
+    uint256 ancestor;
+    if (!best_block ||
+        !m_chain->findAncestorByHeight(best_block->hash, locator_tip_height, FoundBlock().hash(ancestor)) ||
+        ancestor != locator_tip_hash) {
         LogWarning("Locator contains block (hash=%s) not on known best "
                   "chain (tip=%s); not writing index locator",
                   locator_tip_hash.ToString(),
-                  best_block_index->GetBlockHash().ToString());
+                  best_block ? best_block->hash.ToString() : "null");
         return true;
     }
 
@@ -436,14 +438,13 @@ bool BaseIndex::BlockUntilSyncedToCurrentChain() const
     }
 
     // best_block_index may be null if here this method is called immediately after Init().
-    if (const CBlockIndex* index = m_best_block_index.load()) {
-        interfaces::BlockRef best_block{index->GetBlockHash(), index->nHeight};
+    if (const auto best_block = GetBestBlock()) {
         // Skip the queue-draining stuff if we know we're caught up with
         // m_chain.Tip().
         interfaces::BlockRef tip;
         uint256 ancestor;
         if (m_chain->getTip(FoundBlock().hash(tip.hash).height(tip.height)) &&
-            m_chain->findAncestorByHeight(best_block.hash, tip.height, FoundBlock().hash(ancestor)) &&
+            m_chain->findAncestorByHeight(best_block->hash, tip.height, FoundBlock().hash(ancestor)) &&
             ancestor == tip.hash) {
             return true;
         }
@@ -492,9 +493,9 @@ IndexSummary BaseIndex::GetSummary() const
     IndexSummary summary{};
     summary.name = GetName();
     summary.synced = m_state == State::UPDATING;
-    if (const auto& pindex = m_best_block_index.load()) {
-        summary.best_block_height = pindex->nHeight;
-        summary.best_block_hash = pindex->GetBlockHash();
+    if (const auto best_block = GetBestBlock()) {
+        summary.best_block_height = best_block->height;
+        summary.best_block_hash = best_block->hash;
     } else {
         summary.best_block_height = 0;
         summary.best_block_hash = m_chain->getBlockHash(0);
@@ -502,23 +503,29 @@ IndexSummary BaseIndex::GetSummary() const
     return summary;
 }
 
-void BaseIndex::SetBestBlockIndex(const CBlockIndex* block)
+std::optional<interfaces::BlockRef> BaseIndex::GetBestBlock() const
+{
+    LOCK(m_mutex);
+    return m_best_block;
+}
+
+void BaseIndex::SetBestBlock(const std::optional<interfaces::BlockRef>& block)
 {
     assert(!m_chainstate->m_blockman.IsPruneMode() || AllowPrune());
 
     if (AllowPrune() && block) {
         node::PruneLockInfo prune_lock;
-        prune_lock.height_first = block->nHeight;
+        prune_lock.height_first = block->height;
         WITH_LOCK(::cs_main, m_chainstate->m_blockman.UpdatePruneLock(GetName(), prune_lock));
     }
 
-    // Intentionally set m_best_block_index as the last step in this function,
+    // Intentionally set m_best_block as the last step in this function,
     // after updating prune locks above, and after making any other references
     // to *this, so the BlockUntilSyncedToCurrentChain function (which checks
-    // m_best_block_index as an optimization) can be used to wait for the last
+    // m_best_block as an optimization) can be used to wait for the last
     // BlockConnected notification and safely assume that prune locks are
     // updated and that the index object is safe to delete.
-    m_best_block_index = block;
+    WITH_LOCK(m_mutex, m_best_block = block);
 }
 
 std::shared_ptr<interfaces::Chain::Notifications> BaseIndex::Notifications() const

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -103,11 +103,32 @@ BaseIndex::~BaseIndex()
     Stop();
 }
 
+// Read index best block, register for block connected and disconnected
+// notifications, and determine where best block is relative to chain tip.
+//
+// If the chain tip and index best block are the same, `m_synced` will be set to
+// true so BlockConnected notifications will be processed after this call and
+// the index will update during node startup as the node::ImportBlocks()
+// function connects blocks. Otherwise the index will stay idle until
+// ImportBlocks() finishes and BaseIndex::StartBackgroundSync() is called later.
+//
+// If the node is being started for the first time, or if -reindex or
+// -reindex-chainstate are used, the chain tip will be null at this point,
+// meaning that no blocks in the chain, even a genesis block. The best block
+// locator will also be null if -reindex is used or if the index is new, but
+// will be non-null if -reindex-chainstate is used. Therefore:
+//
+// * -reindex causes the index to rebuild as the chain is rebuilt
+// * -reindex-chainstate causes the index to be idle until the chainstate is
+//   rebuilt and BaseIndex::StartBackgroundSync is called later.
+//
+// This ensures indexes are synced in the most efficient way possible in each
+// case.
 bool BaseIndex::Init()
 {
     AssertLockNotHeld(cs_main);
 
-    // May need reset if index is being restarted.
+    // May need reset if index is being restarted (e.g. after assumeutxo background validation)
     m_interrupt.reset();
 
     // m_chainstate member gives indexing code access to node internals. It is
@@ -370,6 +391,38 @@ void BaseIndex::BlockConnected(const ChainstateRole& role, const std::shared_ptr
         // m_synced. Consider the case where there is a reorg and the blocks on the stale branch are
         // in the ValidationInterface queue backlog even after the sync thread has caught up to the
         // new chain tip. In this unlikely event, log a warning and let the queue clear.
+        //
+        // To allow handling reorgs, this only checks that the new block
+        // connects to ancestor of the current best block, instead of checking
+        // that it connects to directly to the current block. If there is a
+        // reorg, Rewind call below will remove existing blocks from the index
+        // before adding the new one.
+        //
+        // It's also possible for the new block to connect to an ancestor of the
+        // current best block without a reorg when the m_synced flag gets set to
+        // true too early. For example if the index is synced to height 100, and
+        // -reindex-chainstate option is used, there may be BlockConnected
+        // notifications for blocks 97, 98, 99, and 100 sitting in the
+        // notifications queue when m_synced gets set to true. When this
+        // happens, the Rewind call below will remove these blocks from the
+        // index before they are attached again.
+        //
+        // To summarize, there are 4 cases:
+        //
+        //   1. Normal case where new block connects directly to current block.
+        //      New block is just appended below.
+        //
+        //   2. Reorg case where new block connects to ancestor of current
+        //      block. The index is rewound and the new block is appended.
+        //
+        //   3. Race case where m_synced is set to true too early and the new
+        //      block is a previously indexed ancestor of the current block.
+        //      Index is rewound, and the block is appended a second time.
+        //
+        //   4. Race case where m_synced is set to true too early and
+        //      there has been a reorg, and the new block is from the stale
+        //      branch of the reorg. In this case the ancestor check here fails,
+        //      and logs a warning, and returns early ignoring the stale block.
         if (best_block_index->GetAncestor(pindex->nHeight - 1) != pindex->pprev) {
             LogWarning("Block %s does not connect to an ancestor of "
                       "known best chain (tip=%s); not updating index",

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -44,6 +44,7 @@
 #include <utility>
 #include <vector>
 
+using interfaces::BlockInfo;
 using kernel::ChainstateRole;
 
 constexpr uint8_t DB_BEST_BLOCK{'B'};
@@ -79,11 +80,19 @@ public:
     BaseIndexNotifications(BaseIndex& index) : m_index(index) {}
     void blockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block) override;
     void chainStateFlushed(const kernel::ChainstateRole& role, const CBlockLocator& locator) override;
+    void processBlock(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block, bool append);
     BaseIndex& m_index;
     interfaces::Chain::NotifyOptions m_options = m_index.CustomOptions();
+    NodeClock::time_point m_last_log_time{NodeClock::now()};
+    NodeClock::time_point m_last_locator_write_time{m_last_log_time};
 };
 
 void BaseIndexNotifications::blockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block)
+{
+    processBlock(role, block, /*append=*/true);
+}
+
+void BaseIndexNotifications::processBlock(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block, bool append)
 {
     if (m_index.IgnoreBlockConnected(role, block)) return;
 
@@ -96,14 +105,39 @@ void BaseIndexNotifications::blockConnected(const kernel::ChainstateRole& role, 
     }
 
     // Dispatch block to child class; errors are logged internally and abort the node.
-    if (!m_index.Append(block)) return;
+    if (append && !m_index.Append(block)) return;
 
+    NodeClock::time_point current_time{0s};
     if (block.background_sync) {
-        // Only update index best block between flushes if fully synced.
-        // Decision to let the best block pointer lag during sync seems a
-        // little arbitrary, but has been behavior since syncing was introduced
-        // in #13033, so preserving it in case anything depends on it.
-        return;
+        current_time = NodeClock::now();
+        if (current_time - m_last_log_time >= SYNC_LOG_INTERVAL) {
+            LogInfo("Syncing %s with block chain from height %d", m_index.GetName(), pindex->nHeight);
+            m_last_log_time = current_time;
+        }
+    }
+
+    // If currently syncing with the chain and adding old blocks, not new ones,
+    // decide whether to commit and update the best block pointer. Otherwise,
+    // when adding new blocks, always update the best block pointer, and don't
+    // commit until a chainstateFlush notification is received.
+    if (block.background_sync) {
+        // Commit if reached the last block flushed by the node, or if reached
+        // the end of sync and no more data is being appended, or if enough time
+        // has elapsed since the last commit.
+        if (block.status == BlockInfo::FLUSHED_TIP || (block.status == BlockInfo::FLUSHED && current_time - m_last_locator_write_time >= SYNC_LOCATOR_WRITE_INTERVAL)) {
+            auto locator = GetLocator(*m_index.m_chain, block.hash);
+            m_last_locator_write_time = current_time;
+            // No need to handle errors in Commit. If it fails, the error will be already be
+            // logged. The best way to recover is to continue, as index cannot be corrupted by
+            // a missed commit to disk for an advanced index state.
+            m_index.Commit(locator);
+        } else if (append) {
+            // Do not update index best block between commits if syncing.
+            // Decision to let the best block pointer lag during sync seems a
+            // little arbitrary, but has been behavior since syncing was introduced
+            // in #13033, so preserving it in case anything depends on it.
+            return;
+        }
     }
 
     // Setting the best block index is intentionally the last step of this
@@ -129,6 +163,10 @@ void BaseIndexNotifications::chainStateFlushed(const kernel::ChainstateRole& rol
     // been indexed yet. In general, calling GetLocator() here is safer than
     // trusting the locator argument, and this code was changed to stop saving
     // the locator argument in 4368384f1d26 from #14121.
+    // Note: it is safe to commit the best indexed block here without checking
+    // to see it is an ancestor of GetLastFlushedBlock(), because the
+    // ChainstateFlushed notification is only sent by the node after it flushes,
+    // so the block must have already been flushed to disk by the node.
     const CBlockIndex* best_block = m_index.m_best_block_index.load();
     m_index.Commit(best_block ? GetLocator(*m_index.m_chain, best_block->GetBlockHash()) : CBlockLocator{});
 }
@@ -319,27 +357,37 @@ void BaseIndex::Sync()
 
     const CBlockIndex* pindex = m_best_block_index.load();
     if (m_state == State::SYNCING) {
-        auto last_log_time{NodeClock::now()};
-        auto last_locator_write_time{last_log_time};
+        // Last block in the chain syncing to which is known to be flushed.
+        const CBlockIndex *last_flushed{nullptr};
+        // Return flush status of the block being indexed.
+        auto process_block = [&](bool append){
+            if (pindex) {
+                interfaces::BlockInfo block_info = node::MakeBlockInfo(pindex);
+                block_info.background_sync = true;
+                if (pindex == last_flushed) {
+                    block_info.status = BlockInfo::FLUSHED_TIP;
+                } else if (!last_flushed || last_flushed->GetAncestor(pindex->nHeight) == pindex) {
+                    block_info.status = BlockInfo::FLUSHED;
+                }
+                notifications->processBlock({}, block_info, append); // error logged internally
+            }
+        };
         while (true) {
             if (m_interrupt) {
                 LogInfo("%s: m_interrupt set; exiting ThreadSync", GetName());
-
-                SetBestBlockIndex(pindex);
-                // No need to handle errors in Commit. If it fails, the error will be already be
-                // logged. The best way to recover is to continue, as index cannot be corrupted by
-                // a missed commit to disk for an advanced index state.
-                Commit(pindex ? GetLocator(*m_chain, pindex->GetBlockHash()) : CBlockLocator{});
+                // Call process_block a final time to commit latest state.
+                process_block(/*append=*/false);
                 return;
             }
 
-            const CBlockIndex* pindex_next = WITH_LOCK(cs_main, return NextSyncBlock(pindex, m_chainstate->m_chain));
+            const CBlockIndex* pindex_next = WITH_LOCK(cs_main,
+                last_flushed = m_chainstate->GetLastFlushedBlock();
+                return NextSyncBlock(pindex, m_chainstate->m_chain));
             // If pindex_next is null, it means pindex is the chain tip, so
             // commit data indexed so far.
             if (!pindex_next) {
-                SetBestBlockIndex(pindex);
-                // No need to handle errors in Commit. See rationale above.
-                Commit(pindex ? GetLocator(*m_chain, pindex->GetBlockHash()) : CBlockLocator{});
+                // Call process_block with append=false to force a commit.
+                process_block(/*append=*/false);
 
                 // After committing, if pindex is still the active chain tip,
                 // background sync is finished and we can switch to notification-
@@ -362,23 +410,7 @@ void BaseIndex::Sync()
                 return;
             }
             pindex = pindex_next;
-
-            interfaces::BlockInfo block_info = node::MakeBlockInfo(pindex);
-            block_info.background_sync = true;
-            notifications->blockConnected(ChainstateRole{}, block_info); // error logged internally
-
-            auto current_time{NodeClock::now()};
-            if (current_time - last_log_time >= SYNC_LOG_INTERVAL) {
-                LogInfo("Syncing %s with block chain from height %d", GetName(), pindex->nHeight);
-                last_log_time = current_time;
-            }
-
-            if (current_time - last_locator_write_time >= SYNC_LOCATOR_WRITE_INTERVAL) {
-                SetBestBlockIndex(pindex);
-                last_locator_write_time = current_time;
-                // No need to handle errors in Commit. See rationale above.
-                Commit(pindex ? GetLocator(*m_chain, pindex->GetBlockHash()) : CBlockLocator{});
-            }
+            process_block(/*append=*/true);
         }
     }
 
@@ -396,17 +428,6 @@ void BaseIndex::Commit(const CBlockLocator& locator)
     // (this could happen if init is interrupted).
     bool ok = !locator.IsNull();
     if (ok) {
-        // Don't commit if the index best block is not an ancestor of the chainstate's last flushed
-        // block. Otherwise, after an unclean shutdown, the index could be
-        // persisted ahead of a chainstate it can no longer roll back to, which
-        // would corrupt indexes with state (e.g. coinstatsindex).
-        const CBlockIndex* index_tip = m_best_block_index.load();
-        const CBlockIndex* last_flushed = WITH_LOCK(::cs_main, return m_chainstate->GetLastFlushedBlock());
-        if (!last_flushed || last_flushed->GetAncestor(index_tip->nHeight) != index_tip) {
-            LogDebug(BCLog::COINDB, "Skipping commit, index is ahead of flushed chainstate (index height %d, last flush at height %d)",
-                    index_tip->nHeight, last_flushed ? last_flushed->nHeight : -1);
-            return;
-        }
         CDBBatch batch(GetDB());
         ok = CustomCommit(batch);
         if (ok) {

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -82,7 +82,6 @@ public:
     void blockConnected(const ChainstateRole& role, const interfaces::BlockInfo& block) override;
     void blockDisconnected(const interfaces::BlockInfo& block) override;
     void chainStateFlushed(const ChainstateRole& role, const CBlockLocator& locator) override;
-    void processBlock(const ChainstateRole& role, const interfaces::BlockInfo& block, bool append);
     BaseIndex& m_index;
     interfaces::Chain::NotifyOptions m_options = m_index.CustomOptions();
     NodeClock::time_point m_last_log_time{NodeClock::now()};
@@ -95,13 +94,16 @@ public:
 
 void BaseIndexNotifications::blockConnected(const ChainstateRole& role, const interfaces::BlockInfo& block)
 {
-    processBlock(role, block, /*append=*/true);
-}
+    if (!block.error.empty()) {
+        m_index.FatalErrorf("%s", block.error);
+        return;
+    }
 
-void BaseIndexNotifications::processBlock(const ChainstateRole& role, const interfaces::BlockInfo& block, bool append)
-{
-    // processBlock is called an extra time with append=false to notify about transition from SYNCING to UPDATING state.
-    if (!append && block.background_sync && m_index.m_state == BaseIndex::State::UPDATING) {
+    // blockConnected is called an extra time with no data and state=SYNCED to
+    // indicate the end of syncing.
+    if (block.state == BlockInfo::SYNCED) {
+        assert(!block.data);
+        m_index.m_state = BaseIndex::State::UPDATING;
         if (block.height >= 0) {
             LogInfo("%s is enabled at height %d", m_index.GetName(), block.height);
         } else {
@@ -133,10 +135,10 @@ void BaseIndexNotifications::processBlock(const ChainstateRole& role, const inte
     }
 
     // Dispatch block to child class; errors are logged internally and abort the node.
-    if (append && !m_index.Append(block)) return;
+    if (block.data && !m_index.Append(block)) return;
 
     NodeClock::time_point current_time{0s};
-    if (block.background_sync) {
+    if (block.state == BlockInfo::SYNCING) {
         current_time = NodeClock::now();
         if (current_time - m_last_log_time >= SYNC_LOG_INTERVAL) {
             LogInfo("Syncing %s with block chain from height %d", m_index.GetName(), pindex->nHeight);
@@ -148,7 +150,7 @@ void BaseIndexNotifications::processBlock(const ChainstateRole& role, const inte
     // decide whether to commit and update the best block pointer. Otherwise,
     // when adding new blocks, always update the best block pointer, and don't
     // commit until a chainstateFlush notification is received.
-    if (block.background_sync) {
+    if (block.state == BlockInfo::SYNCING) {
         // Commit if reached the last block flushed by the node, or if reached
         // the end of sync and no more data is being appended, or if enough time
         // has elapsed since the last commit.
@@ -159,7 +161,7 @@ void BaseIndexNotifications::processBlock(const ChainstateRole& role, const inte
             // logged. The best way to recover is to continue, as index cannot be corrupted by
             // a missed commit to disk for an advanced index state.
             m_index.Commit(locator);
-        } else if (append) {
+        } else if (block.data) {
             // Do not update index best block between commits if syncing.
             // Decision to let the best block pointer lag during sync seems a
             // little arbitrary, but has been behavior since syncing was introduced
@@ -181,26 +183,16 @@ void BaseIndexNotifications::blockDisconnected(const interfaces::BlockInfo& bloc
     // attached below. This is temporary and removed in upcoming commits.
     interfaces::BlockInfo block{block_info};
 
-    // During initial sync, ignore validation interface notifications, only
-    // process notifications from sync thread.
-    if (m_index.m_state != BaseIndex::State::UPDATING && !block.background_sync) return;
+    if (!block.error.empty()) {
+        m_index.FatalErrorf("%s", block.error);
+        return;
+    }
 
     const CBlockIndex* pindex = &m_index.BlockIndex(block.hash);
     if (!m_rewind_start) m_rewind_start = pindex;
     if (m_rewind_error) return;
 
-    CBlock block_data;
-    if (m_options.disconnect_data && !block.data) {
-        if (!m_index.m_chainstate->m_blockman.ReadBlock(block_data, *pindex)) {
-            m_index.FatalErrorf("Failed to read block %s from disk",
-                        pindex->GetBlockHash().ToString());
-            m_rewind_error = true;
-            return;
-        } else {
-            block.data = &block_data;
-        }
-    }
-
+    assert(!m_options.disconnect_data || block.data);
     CBlockUndo block_undo;
     if (m_options.disconnect_undo_data && !block.undo_data && block.height > 0) {
         if (!m_index.m_chainstate->m_blockman.ReadBlockUndo(block_undo, *pindex)) {
@@ -313,7 +305,13 @@ bool BaseIndex::Init()
     AssertLockNotHeld(cs_main);
 
     // May need reset if index is being restarted (e.g. after assumeutxo background validation)
-    m_interrupt.reset();
+    m_state = State::SYNCING;
+    m_best_block_index = nullptr;
+    {
+        LOCK(m_mutex);
+        assert(!m_handler);
+        assert(!m_notifications);
+    }
 
     // m_chainstate member gives indexing code access to node internals. It is
     // removed in followup https://github.com/bitcoin/bitcoin/pull/24230
@@ -336,152 +334,39 @@ bool BaseIndex::Init()
 
     // Child init
     const CBlockIndex* start_block = m_best_block_index.load();
-    if (!CustomInit(start_block ? std::make_optional(interfaces::BlockRef{start_block->GetBlockHash(), start_block->nHeight}) : std::nullopt)) {
+    auto block{start_block ? std::make_optional(interfaces::BlockRef{start_block->GetBlockHash(), start_block->nHeight}) : std::nullopt};
+    if (!CustomInit(block)) {
         return false;
     }
 
     // Register to receive validation interface notifications.
-    auto notifications = std::make_shared<BaseIndexNotifications>(*this);
-    auto handler = m_chain->attachChain(notifications, CustomOptions());
-    {
-        LOCK(cs_main);
-        if (start_block != m_chainstate->m_chain.Tip()) {
-            // Set SYNCING state since the index is not at the chain tip, and a
-            // background sync is neccessary.
-            m_state = State::SYNCING;
-        } else {
-            // The index is caught up to the chain tip. We want to enter the
-            // UPDATING state to begin processing new BlockConnected notifications,
-            m_state = State::UPDATING;
-            handler->connect();
-        }
-
-    }
+    auto options{CustomOptions()};
+    options.thread_name = m_thread_name;
+    auto notifications{std::make_shared<BaseIndexNotifications>(*this)};
+    auto handler = m_chain->attachChain(notifications, block ? std::make_optional(block->hash) : std::nullopt, options);
     LOCK(m_mutex);
     m_notifications = std::move(notifications);
     m_handler = std::move(handler);
+    // If handler is already sending notifications, set state to UPDATING to
+    // reflect this. The UPDATING state is only set here so methods like
+    // BlockUntilSyncedToCurrentChain() and GetSummary() are immediately usable,
+    // and this doesn't impact processing of notifications. (The state will
+    // actually already be UPDATING at this point if the first blockConnected
+    // notification was received.)
+    if (m_handler->connected()) m_state = State::UPDATING;
     return true;
 }
 
-static const CBlockIndex* NextSyncBlock(const CBlockIndex* const pindex_prev, CChain& chain) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+bool BaseIndex::Append(const interfaces::BlockInfo& block_info)
 {
-    AssertLockHeld(cs_main);
-
-    if (!pindex_prev) {
-        return chain.Genesis();
-    }
-
-    if (const auto* pindex{chain.Next(*pindex_prev)}) {
-        return pindex;
-    }
-
-    // If there is no next block, we might be synced
-    if (pindex_prev == chain.Tip()) {
-        return nullptr;
-    }
-
-    // Since block is not in the chain, return the next block in the chain AFTER the last common ancestor.
-    // Caller will be responsible for rewinding back to the common ancestor.
-    const auto* fork{chain.FindFork(*pindex_prev)};
-    // Common ancestor must exist (genesis).
-    return chain.Next(*Assert(fork));
-}
-
-bool BaseIndex::Append(const interfaces::BlockInfo& new_block)
-{
-    // Make a mutable copy of the BlockInfo argument so data and undo_data can
-    // be attached below. This is temporary and removed in upcoming commits.
-    interfaces::BlockInfo block_info{new_block};
-    const CBlockIndex* pindex = &BlockIndex(block_info.hash);
-
-    CBlock block;
-    if (!block_info.data) { // disk lookup if block data wasn't provided
-        if (!m_chainstate->m_blockman.ReadBlock(block, *pindex)) {
-            FatalErrorf("Failed to read block %s from disk",
-                        pindex->GetBlockHash().ToString());
-            return false;
-        }
-        block_info.data = &block;
-    }
-
-    CBlockUndo block_undo;
-    if (CustomOptions().connect_undo_data) {
-        if (pindex->nHeight > 0 && !m_chainstate->m_blockman.ReadBlockUndo(block_undo, *pindex)) {
-            FatalErrorf("Failed to read undo block data %s from disk",
-                        pindex->GetBlockHash().ToString());
-            return false;
-        }
-        block_info.undo_data = &block_undo;
-    }
-
     if (!CustomAppend(block_info)) {
         FatalErrorf("Failed to write block %s to index database",
-                    pindex->GetBlockHash().ToString());
+                    block_info.hash.ToString());
         return false;
     }
 
     return true;
 }
-
-void BaseIndex::Sync()
-{
-    auto notifications = WITH_LOCK(m_mutex, return m_notifications);
-    // If m_notifications is null, it means Stop() was called before the Sync
-    // thread was started, so just return without doing anything.
-    if (!notifications) return;
-
-    const CBlockIndex* pindex = m_best_block_index.load();
-    if (m_state == State::SYNCING) {
-        while (true) {
-            if (m_interrupt) {
-                LogInfo("%s: m_interrupt set; exiting ThreadSync", GetName());
-                // Call processBlock with append=false to commit latest state.
-                if (pindex) notifications->processBlock(ChainstateRole{}, MakeBlockInfo(pindex, nullptr, m_chainstate), /*append=*/false); // error logged internally
-                return;
-            }
-
-            const CBlockIndex* pindex_next = WITH_LOCK(cs_main, return NextSyncBlock(pindex, m_chainstate->m_chain));
-            // If pindex_next is null, it means pindex is the chain tip, so
-            // commit data indexed so far.
-            if (!pindex_next) {
-                // Call processBlock with append=false to commit latest state.
-                notifications->processBlock(ChainstateRole{}, MakeBlockInfo(pindex, nullptr, m_chainstate), /*append=*/false); // error logged internally
-
-                // After committing, if pindex is still the active chain tip,
-                // background sync is finished and we can switch to notification-
-                // based updates.
-                //
-                // Hold cs_main while checking for the next block and enqueueing
-                // the state transition. This ensures that if a new block is
-                // connected in this window, its notification will be delivered
-                // after we move to UPDATING and will not be missed.
-                LOCK(::cs_main);
-                pindex_next = NextSyncBlock(pindex, m_chainstate->m_chain);
-                if (!pindex_next) {
-                    m_state = State::UPDATING;
-                    WITH_LOCK(m_mutex, if (m_handler) m_handler->connect());
-                    // Call processBlock a final time to log transition to UPDATING state.
-                    notifications->processBlock(ChainstateRole{}, MakeBlockInfo(pindex, nullptr, m_chainstate), /*append=*/false); // error logged internally
-                    break;
-                }
-            }
-            if (pindex_next->pprev != pindex) {
-                const CBlockIndex* current_tip = pindex;
-                const CBlockIndex* new_tip = pindex_next->pprev;
-                for (const CBlockIndex* iter_tip = current_tip; iter_tip != new_tip; iter_tip = iter_tip->pprev) {
-                    CBlock block;
-                    interfaces::BlockInfo block_info = node::MakeBlockInfo(iter_tip);
-                    block_info.background_sync = true;
-                    notifications->blockDisconnected(block_info);
-                    if (m_interrupt) break;
-                }
-            }
-            pindex = pindex_next;
-            notifications->processBlock(ChainstateRole{}, MakeBlockInfo(pindex, nullptr, m_chainstate), /*append=*/true);
-        }
-    }
-}
-
 
 void BaseIndex::Commit(const CBlockLocator& locator)
 {
@@ -511,7 +396,7 @@ bool BaseIndex::IgnoreBlockConnected(const ChainstateRole& role, const interface
         return true;
     }
 
-    if (block.background_sync) {
+    if (block.state == BlockInfo::SYNCING) {
         return false;
     }
 
@@ -591,7 +476,8 @@ bool BaseIndex::BlockUntilSyncedToCurrentChain() const
         LOCK(cs_main);
         const CBlockIndex* chain_tip = m_chainstate->m_chain.Tip();
         const CBlockIndex* best_block_index = m_best_block_index.load();
-        if (best_block_index->GetAncestor(chain_tip->nHeight) == chain_tip) {
+        // best_block_index may be null if here this method is called immediately after Init().
+        if (best_block_index && best_block_index->GetAncestor(chain_tip->nHeight) == chain_tip) {
             return true;
         }
     }
@@ -603,31 +489,35 @@ bool BaseIndex::BlockUntilSyncedToCurrentChain() const
 
 void BaseIndex::Interrupt()
 {
-    m_interrupt();
     LOCK(m_mutex);
+    if (m_handler) m_handler->interrupt();
     m_notifications.reset();
 }
 
 bool BaseIndex::StartBackgroundSync()
 {
-    if (m_state == State::INITIALIZING) throw std::logic_error("Error: Cannot start a non-initialized index");
-
-    m_thread_sync = std::thread(&util::TraceThread, m_thread_name, [this] { Sync(); });
+    LOCK(m_mutex);
+    if (!m_handler) throw std::logic_error("Error: Cannot start a non-initialized index");
+    m_handler->connect();
     return true;
+}
+
+void BaseIndex::WaitForBackgroundSync()
+{
+    auto* handler{WITH_LOCK(m_mutex, return m_handler.get())};
+    if (!handler) throw std::logic_error("Error: Cannot wait for a stopped index");
+    handler->sync();
 }
 
 void BaseIndex::Stop()
 {
-    {
-        m_interrupt();
-        LOCK(m_mutex);
-        m_notifications.reset();
-        m_handler.reset();
-    }
-
-    if (m_thread_sync.joinable()) {
-        m_thread_sync.join();
-    }
+    Interrupt();
+    // Call handler destructor after releasing m_mutex. Locking the mutex is
+    // required to access m_handler, but the lock should not be held while
+    // destroying the handler, because the handler destructor waits for the last
+    // notification to be processed, so holding the lock would deadlock if that
+    // last notification also needs the lock.
+    auto handler = WITH_LOCK(m_mutex, return std::move(m_handler));
 }
 
 IndexSummary BaseIndex::GetSummary() const
@@ -662,4 +552,10 @@ void BaseIndex::SetBestBlockIndex(const CBlockIndex* block)
     // BlockConnected notification and safely assume that prune locks are
     // updated and that the index object is safe to delete.
     m_best_block_index = block;
+}
+
+std::shared_ptr<interfaces::Chain::Notifications> BaseIndex::Notifications() const
+{
+    LOCK(m_mutex);
+    return m_notifications;
 }

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -83,12 +83,34 @@ public:
 
 void BaseIndexNotifications::blockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block)
 {
-    m_index.BlockConnected(role, block);
+    if (m_index.IgnoreBlockConnected(role, block)) return;
+
+    const CBlockIndex* pindex = &m_index.BlockIndex(block.hash);
+    const CBlockIndex* best_block_index = m_index.m_best_block_index.load();
+    if (best_block_index && best_block_index != pindex->pprev && !m_index.Rewind(best_block_index, pindex->pprev)) {
+        m_index.FatalErrorf("Failed to rewind %s to a previous chain tip",
+                   m_index.GetName());
+        return;
+    }
+
+    // Dispatch block to child class; errors are logged internally and abort the node.
+    if (!m_index.Append(block)) return;
+
+    // Setting the best block index is intentionally the last step of this
+    // function, so BlockUntilSyncedToCurrentChain callers waiting for the
+    // best block index to be updated can rely on the block being fully
+    // processed, and the index object being safe to delete.
+    m_index.SetBestBlockIndex(pindex);
 }
 
 void BaseIndexNotifications::chainStateFlushed(const kernel::ChainstateRole& role, const CBlockLocator& locator)
 {
-    m_index.ChainStateFlushed(role, locator);
+    if (m_index.IgnoreChainStateFlushed(role, locator)) return;
+
+    // No need to handle errors in Commit. If it fails, the error will be already be logged. The
+    // best way to recover is to continue, as index cannot be corrupted by a missed commit to disk
+    // for an advanced index state.
+    m_index.Commit();
 }
 
 BaseIndex::DB::DB(const fs::path& path, size_t n_cache_size, bool f_memory, bool f_wipe, bool f_obfuscate, bool f_bloom) :
@@ -403,23 +425,23 @@ bool BaseIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_ti
     return true;
 }
 
-void BaseIndex::BlockConnected(const ChainstateRole& role, const interfaces::BlockInfo& block_info)
+bool BaseIndex::IgnoreBlockConnected(const ChainstateRole& role, const interfaces::BlockInfo& block)
 {
     // Ignore events from not fully validated chains to avoid out-of-order indexing.
     //
     // TODO at some point we could parameterize whether a particular index can be
     // built out of order, but for now just do the conservative simple thing.
     if (!role.validated) {
-        return;
+        return true;
     }
 
-    const CBlockIndex* pindex = &BlockIndex(block_info.hash);
+    const CBlockIndex* pindex = &BlockIndex(block.hash);
     const CBlockIndex* best_block_index = m_best_block_index.load();
     if (!best_block_index) {
         if (pindex->nHeight != 0) {
             FatalErrorf("First block connected is not the genesis block (height=%d)",
                        pindex->nHeight);
-            return;
+            return true;
         }
     } else {
         // Ensure block connects to an ancestor of the current best block.
@@ -429,29 +451,15 @@ void BaseIndex::BlockConnected(const ChainstateRole& role, const interfaces::Blo
         // reorg, Rewind call below will remove existing blocks from the index
         // before adding the new one.
         assert(best_block_index->GetAncestor(pindex->nHeight - 1) == pindex->pprev);
-
-        if (best_block_index != pindex->pprev && !Rewind(best_block_index, pindex->pprev)) {
-            FatalErrorf("Failed to rewind %s to a previous chain tip",
-                       GetName());
-            return;
-        }
     }
-
-    // Dispatch block to child class; errors are logged internally and abort the node.
-    if (Append(block_info)) {
-        // Setting the best block index is intentionally the last step of this
-        // function, so BlockUntilSyncedToCurrentChain callers waiting for the
-        // best block index to be updated can rely on the block being fully
-        // processed, and the index object being safe to delete.
-        SetBestBlockIndex(pindex);
-    }
+    return false;
 }
 
-void BaseIndex::ChainStateFlushed(const ChainstateRole& role, const CBlockLocator& locator)
+bool BaseIndex::IgnoreChainStateFlushed(const ChainstateRole& role, const CBlockLocator& locator)
 {
     // Ignore events from not fully validated chains to avoid out-of-order indexing.
     if (!role.validated) {
-        return;
+        return true;
     }
 
     const uint256& locator_tip_hash = locator.vHave.front();
@@ -464,7 +472,7 @@ void BaseIndex::ChainStateFlushed(const ChainstateRole& role, const CBlockLocato
     if (!locator_tip_index) {
         FatalErrorf("First block (hash=%s) in locator was not found",
                    locator_tip_hash.ToString());
-        return;
+        return true;
     }
 
     // Only commit if the locator points directly at the best block (the typical
@@ -483,13 +491,10 @@ void BaseIndex::ChainStateFlushed(const ChainstateRole& role, const CBlockLocato
                   "chain (tip=%s); not writing index locator",
                   locator_tip_hash.ToString(),
                   best_block_index->GetBlockHash().ToString());
-        return;
+        return true;
     }
 
-    // No need to handle errors in Commit. If it fails, the error will be already be logged. The
-    // best way to recover is to continue, as index cannot be corrupted by a missed commit to disk
-    // for an advanced index state.
-    Commit();
+    return false;
 }
 
 bool BaseIndex::BlockUntilSyncedToCurrentChain() const

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -110,7 +110,17 @@ void BaseIndexNotifications::chainStateFlushed(const kernel::ChainstateRole& rol
     // No need to handle errors in Commit. If it fails, the error will be already be logged. The
     // best way to recover is to continue, as index cannot be corrupted by a missed commit to disk
     // for an advanced index state.
-    m_index.Commit();
+    //
+    // Intentionally call GetLocator() here and do NOT pass the
+    // chainStateFlushed locator argument to Commit(). It is specifically not
+    // safe to use the chainStateFlushed locator here since d96c59cc5cd2 from
+    // #25740, which sends chainStateFlushed and blockConnected notifications
+    // out of order, so the locator sometimes points to a block which hasn't
+    // been indexed yet. In general, calling GetLocator() here is safer than
+    // trusting the locator argument, and this code was changed to stop saving
+    // the locator argument in 4368384f1d26 from #14121.
+    const CBlockIndex* best_block = m_index.m_best_block_index.load();
+    m_index.Commit(best_block ? GetLocator(*m_index.m_chain, best_block->GetBlockHash()) : CBlockLocator{});
 }
 
 BaseIndex::DB::DB(const fs::path& path, size_t n_cache_size, bool f_memory, bool f_wipe, bool f_obfuscate, bool f_bloom) :
@@ -303,7 +313,7 @@ void BaseIndex::Sync()
                 // No need to handle errors in Commit. If it fails, the error will be already be
                 // logged. The best way to recover is to continue, as index cannot be corrupted by
                 // a missed commit to disk for an advanced index state.
-                Commit();
+                Commit(pindex ? GetLocator(*m_chain, pindex->GetBlockHash()) : CBlockLocator{});
                 return;
             }
 
@@ -313,7 +323,7 @@ void BaseIndex::Sync()
             if (!pindex_next) {
                 SetBestBlockIndex(pindex);
                 // No need to handle errors in Commit. See rationale above.
-                Commit();
+                Commit(pindex ? GetLocator(*m_chain, pindex->GetBlockHash()) : CBlockLocator{});
 
                 // After committing, if pindex is still the active chain tip,
                 // background sync is finished and we can switch to notification-
@@ -349,7 +359,7 @@ void BaseIndex::Sync()
                 SetBestBlockIndex(pindex);
                 last_locator_write_time = current_time;
                 // No need to handle errors in Commit. See rationale above.
-                Commit();
+                Commit(pindex ? GetLocator(*m_chain, pindex->GetBlockHash()) : CBlockLocator{});
             }
         }
     }
@@ -361,11 +371,12 @@ void BaseIndex::Sync()
     }
 }
 
-void BaseIndex::Commit()
+
+void BaseIndex::Commit(const CBlockLocator& locator)
 {
     // Don't commit anything if we haven't indexed any block yet
     // (this could happen if init is interrupted).
-    bool ok = m_best_block_index != nullptr;
+    bool ok = !locator.IsNull();
     if (ok) {
         // Don't commit if the index best block is not an ancestor of the chainstate's last flushed
         // block. Otherwise, after an unclean shutdown, the index could be
@@ -381,7 +392,7 @@ void BaseIndex::Commit()
         CDBBatch batch(GetDB());
         ok = CustomCommit(batch);
         if (ok) {
-            GetDB().WriteBestBlock(batch, GetLocator(*m_chain, m_best_block_index.load()->GetBlockHash()));
+            GetDB().WriteBestBlock(batch, locator);
             GetDB().WriteBatch(batch);
         }
     }

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -45,6 +45,7 @@
 #include <vector>
 
 using interfaces::BlockInfo;
+using interfaces::FoundBlock;
 using kernel::ChainstateRole;
 using node::MakeBlockInfo;
 
@@ -470,20 +471,22 @@ bool BaseIndex::BlockUntilSyncedToCurrentChain() const
         return false;
     }
 
-    {
+    // best_block_index may be null if here this method is called immediately after Init().
+    if (const CBlockIndex* index = m_best_block_index.load()) {
+        interfaces::BlockRef best_block{index->GetBlockHash(), index->nHeight};
         // Skip the queue-draining stuff if we know we're caught up with
         // m_chain.Tip().
-        LOCK(cs_main);
-        const CBlockIndex* chain_tip = m_chainstate->m_chain.Tip();
-        const CBlockIndex* best_block_index = m_best_block_index.load();
-        // best_block_index may be null if here this method is called immediately after Init().
-        if (best_block_index && best_block_index->GetAncestor(chain_tip->nHeight) == chain_tip) {
+        interfaces::BlockRef tip;
+        uint256 ancestor;
+        if (m_chain->getTip(FoundBlock().hash(tip.hash).height(tip.height)) &&
+            m_chain->findAncestorByHeight(best_block.hash, tip.height, FoundBlock().hash(ancestor)) &&
+            ancestor == tip.hash) {
             return true;
         }
     }
 
     LogInfo("%s is catching up on block notifications", GetName());
-    m_chain->context()->validation_signals->SyncWithValidationInterfaceQueue();
+    m_chain->waitForPendingNotifications();
     return true;
 }
 

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -8,6 +8,7 @@
 #include <attributes.h>
 #include <dbwrapper.h>
 #include <interfaces/chain.h>
+#include <interfaces/types.h>
 #include <kernel/cs_main.h>
 #include <sync.h>
 #include <uint256.h>
@@ -33,9 +34,6 @@ struct IndexSummary {
     int best_block_height{0};
     uint256 best_block_hash;
 };
-namespace interfaces {
-struct BlockRef;
-}
 namespace util {
 template <unsigned int num_params>
 struct ConstevalFormatString;

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -26,7 +26,6 @@
 
 class BaseIndexNotifications;
 class CBlock;
-class CBlockIndex;
 class Chainstate;
 
 struct CBlockLocator;
@@ -108,7 +107,7 @@ private:
     ///
     /// - The m_best_block_index value is not consistent with the DB_BEST_BLOCK
     ///   value, which can be updated at other times.
-    std::atomic<const CBlockIndex*> m_best_block_index{nullptr};
+    std::optional<interfaces::BlockRef> m_best_block GUARDED_BY(m_mutex);
 
     /// Mutex to let m_notifications and m_handler be accessed from multiple
     /// threads (the sync thread and the init thread).
@@ -131,11 +130,6 @@ private:
 
     template <typename... Args>
     void FatalErrorf(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
-
-    /// Temporary helper function to convert block hashes to index pointers
-    /// while index code is being migrated to use interfaces::Chain methods
-    /// instead of index pointers.
-    const CBlockIndex& BlockIndex(const uint256& hash);
 
     /// Get chain notification handler.
     std::shared_ptr<interfaces::Chain::Notifications> Notifications() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
@@ -169,8 +163,10 @@ protected:
 
     virtual DB& GetDB() const = 0;
 
+    std::optional<interfaces::BlockRef> GetBestBlock() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
     /// Update the internal best block index as well as the prune lock.
-    void SetBestBlockIndex(const CBlockIndex* block);
+    void SetBestBlock(const std::optional<interfaces::BlockRef>& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
 public:
     BaseIndex(std::unique_ptr<interfaces::Chain> chain, std::string name, std::string thread_name);
@@ -187,7 +183,7 @@ public:
     /// sync once and only needs to process blocks in the ValidationInterface
     /// queue. If the index is catching up from far behind, this method does
     /// not block and immediately returns false.
-    bool BlockUntilSyncedToCurrentChain() const LOCKS_EXCLUDED(::cs_main);
+    bool BlockUntilSyncedToCurrentChain() const LOCKS_EXCLUDED(::cs_main) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     void Interrupt() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
@@ -205,7 +201,7 @@ public:
     void Stop() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Get a summary of the index and its state.
-    IndexSummary GetSummary() const;
+    IndexSummary GetSummary() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 };
 
 #endif // BITCOIN_INDEX_BASE_H

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -128,7 +128,7 @@ private:
     /// Will skip the commit if no block has been indexed yet or if the index's best block is
     /// ahead of the chainstate's last flushed block. This avoids persisting state an unclean shutdown
     /// could not roll back from. A later call commits when the chainstate has flushed far enough.
-    void Commit();
+    void Commit(const CBlockLocator& locator);
 
     /// Loop over disconnected blocks and call CustomRemove.
     bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip);

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -130,9 +130,6 @@ private:
     /// could not roll back from. A later call commits when the chainstate has flushed far enough.
     void Commit(const CBlockLocator& locator);
 
-    /// Loop over disconnected blocks and call CustomRemove.
-    bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip);
-
     virtual bool AllowPrune() const = 0;
 
     template <typename... Args>

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -8,27 +8,28 @@
 #include <attributes.h>
 #include <dbwrapper.h>
 #include <interfaces/chain.h>
-#include <interfaces/handler.h>
 #include <interfaces/types.h>
 #include <kernel/cs_main.h>
 #include <sync.h>
 #include <uint256.h>
 #include <util/fs.h>
-#include <util/threadinterrupt.h>
-#include <validationinterface.h>
 
 #include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
-#include <thread>
 
 class BaseIndexNotifications;
-class CBlock;
-class Chainstate;
-
 struct CBlockLocator;
+namespace interfaces {
+class Handler;
+}  // namespace interfaces
+namespace kernel {
+struct ChainstateRole;
+}  // namespace kernel
+
 struct IndexSummary {
     std::string name;
     bool synced{false};
@@ -138,7 +139,6 @@ private:
 
 protected:
     std::unique_ptr<interfaces::Chain> m_chain;
-    Chainstate* m_chainstate{nullptr};
     const std::string m_name;
     const std::string m_thread_name;
 

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -110,12 +110,9 @@ private:
     ///   value, which can be updated at other times.
     std::atomic<const CBlockIndex*> m_best_block_index{nullptr};
 
-    std::thread m_thread_sync;
-    CThreadInterrupt m_interrupt;
-
     /// Mutex to let m_notifications and m_handler be accessed from multiple
     /// threads (the sync thread and the init thread).
-    Mutex m_mutex;
+    mutable Mutex m_mutex;
     friend class BaseIndexNotifications;
     std::shared_ptr<BaseIndexNotifications> m_notifications GUARDED_BY(m_mutex);
     std::unique_ptr<interfaces::Handler> m_handler GUARDED_BY(m_mutex);
@@ -139,6 +136,11 @@ private:
     /// while index code is being migrated to use interfaces::Chain methods
     /// instead of index pointers.
     const CBlockIndex& BlockIndex(const uint256& hash);
+
+    /// Get chain notification handler.
+    std::shared_ptr<interfaces::Chain::Notifications> Notifications() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    friend class IndexTester;
 
 protected:
     std::unique_ptr<interfaces::Chain> m_chain;
@@ -196,13 +198,8 @@ public:
     /// Starts the initial sync process on a background thread.
     [[nodiscard]] bool StartBackgroundSync() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
-    /// \anchor index_sync
-    /// Sync the index with the block index starting from the current best block.
-    /// Intended to be run in its own thread, m_thread_sync, and can be
-    /// interrupted with m_interrupt. Once the index gets in sync, the UPDATING
-    /// state is set and the BlockConnected ValidationInterface callback takes
-    /// over and the sync thread exits.
-    void Sync() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    /// Wait for background sync to complete.
+    void WaitForBackgroundSync() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Stops the instance from staying in sync with blockchain updates.
     void Stop() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -175,7 +175,6 @@ protected:
 
 public:
     BaseIndex(std::unique_ptr<interfaces::Chain> chain, std::string name, std::string thread_name);
-    /// Destructor interrupts sync thread if running and blocks until it exits.
     virtual ~BaseIndex();
 
     /// Get the name of the index for display in logs.

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -74,16 +74,14 @@ protected:
     };
 
 private:
-    /// Whether the index has been initialized or not.
-    std::atomic<bool> m_init{false};
-    /// Whether the index is in sync with the main chain. The flag is flipped
-    /// from false to true once, after which point this starts processing
-    /// ValidationInterface notifications to stay in sync.
-    ///
-    /// Note that this will latch to true *immediately* upon startup if
-    /// `m_chainstate->m_chain` is empty, which will be the case upon startup
-    /// with an empty datadir if, e.g., `-txindex=1` is specified.
-    std::atomic<bool> m_synced{false};
+    /** Index synchronization state. */
+    enum class State : uint8_t {
+        INITIALIZING, //!< Constructed but Init() not yet called.
+        SYNCING,      //!< Catching up to the current chain tip in the background.
+        SETTLING,     //!< At tip; letting stale queued notifications pass before going live.
+        UPDATING,     //!< At tip; actively processing new block notifications.
+    };
+    std::atomic<State> m_state{State::INITIALIZING};
 
     /// The best block in the chain that the index is considered synced to, as
     /// reported by GetSummary. This field is not set in a consistent way and is
@@ -94,12 +92,12 @@ private:
     ///
     /// More specifically:
     ///
-    /// - During initial sync when m_synced is false, m_best_block_index is not
+    /// - During initial sync, in SYNCING state, m_best_block_index is not
     ///   updated when blocks are added to the index. It is only updated when
     ///   the data is committed (which is every 30 seconds, and at the end of
     ///   the sync, and any time after blocks are rewound).
     ///
-    /// - After initial sync when m_synced is true, m_best_block_index is set
+    /// - After initial sync, in UPDATING state, m_best_block_index is set
     ///   after each block is added to the index, whether or not the data is
     ///   committed.
     ///
@@ -188,8 +186,8 @@ public:
     /// \anchor index_sync
     /// Sync the index with the block index starting from the current best block.
     /// Intended to be run in its own thread, m_thread_sync, and can be
-    /// interrupted with m_interrupt. Once the index gets in sync, the m_synced
-    /// flag is set and the BlockConnected ValidationInterface callback takes
+    /// interrupted with m_interrupt. Once the index gets in sync, the UPDATING
+    /// state is set and the BlockConnected ValidationInterface callback takes
     /// over and the sync thread exits.
     void Sync();
 

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -149,9 +149,11 @@ protected:
     const std::string m_name;
     const std::string m_thread_name;
 
-    void BlockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block_info);
+    /// Return whether to ignore stale, out-of-sync block connected event
+    bool IgnoreBlockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block);
 
-    void ChainStateFlushed(const kernel::ChainstateRole& role, const CBlockLocator& locator);
+    /// Return whether to ignore stale, out-of-sync chain flushed event
+    bool IgnoreChainStateFlushed(const kernel::ChainstateRole& role, const CBlockLocator& locator);
 
     /// Initialize internal state from the database and block index.
     [[nodiscard]] virtual bool CustomInit(const std::optional<interfaces::BlockRef>& block) { return true; }

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -8,6 +8,7 @@
 #include <attributes.h>
 #include <dbwrapper.h>
 #include <interfaces/chain.h>
+#include <interfaces/handler.h>
 #include <interfaces/types.h>
 #include <kernel/cs_main.h>
 #include <sync.h>
@@ -23,6 +24,7 @@
 #include <string>
 #include <thread>
 
+class BaseIndexNotifications;
 class CBlock;
 class CBlockIndex;
 class Chainstate;
@@ -40,16 +42,16 @@ struct ConstevalFormatString;
 }
 
 /**
- * Base class for indices of blockchain data. This implements
- * CValidationInterface and ensures blocks are indexed sequentially according
- * to their position in the active chain.
+ * Base class for indices of blockchain data. This handles block connected and
+ * disconnected notifications and ensures blocks are indexed sequentially
+ * according to their position in the active chain.
  *
  * In the presence of multiple chainstates (i.e. if a UTXO snapshot is loaded),
  * only the background "IBD" chainstate will be indexed to avoid building the
  * index out of order. When the background chainstate completes validation, the
  * index will be reinitialized and indexing will continue.
  */
-class BaseIndex : public CValidationInterface
+class BaseIndex
 {
 protected:
     /**
@@ -78,7 +80,6 @@ private:
     enum class State : uint8_t {
         INITIALIZING, //!< Constructed but Init() not yet called.
         SYNCING,      //!< Catching up to the current chain tip in the background.
-        SETTLING,     //!< At tip; letting stale queued notifications pass before going live.
         UPDATING,     //!< At tip; actively processing new block notifications.
     };
     std::atomic<State> m_state{State::INITIALIZING};
@@ -112,6 +113,17 @@ private:
     std::thread m_thread_sync;
     CThreadInterrupt m_interrupt;
 
+    /// Mutex to let m_notifications and m_handler be accessed from multiple
+    /// threads (the sync thread and the init thread).
+    Mutex m_mutex;
+    friend class BaseIndexNotifications;
+    std::shared_ptr<BaseIndexNotifications> m_notifications GUARDED_BY(m_mutex);
+    std::unique_ptr<interfaces::Handler> m_handler GUARDED_BY(m_mutex);
+
+    /// Append new block to index. Will load block and undo data as needed, then
+    /// call CustomAppend.
+    bool Append(const interfaces::BlockInfo& new_block);
+
     /// Write the current index state (eg. chain block locator and subclass-specific items) to disk.
     /// Will skip the commit if no block has been indexed yet or if the index's best block is
     /// ahead of the chainstate's last flushed block. This avoids persisting state an unclean shutdown
@@ -121,12 +133,15 @@ private:
     /// Loop over disconnected blocks and call CustomRemove.
     bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip);
 
-    bool ProcessBlock(const CBlockIndex* pindex, const CBlock* block_data = nullptr);
-
     virtual bool AllowPrune() const = 0;
 
     template <typename... Args>
     void FatalErrorf(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args);
+
+    /// Temporary helper function to convert block hashes to index pointers
+    /// while index code is being migrated to use interfaces::Chain methods
+    /// instead of index pointers.
+    const CBlockIndex& BlockIndex(const uint256& hash);
 
 protected:
     std::unique_ptr<interfaces::Chain> m_chain;
@@ -134,9 +149,9 @@ protected:
     const std::string m_name;
     const std::string m_thread_name;
 
-    void BlockConnected(const kernel::ChainstateRole& role, const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex) override;
+    void BlockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block_info);
 
-    void ChainStateFlushed(const kernel::ChainstateRole& role, const CBlockLocator& locator) override;
+    void ChainStateFlushed(const kernel::ChainstateRole& role, const CBlockLocator& locator);
 
     /// Initialize internal state from the database and block index.
     [[nodiscard]] virtual bool CustomInit(const std::optional<interfaces::BlockRef>& block) { return true; }
@@ -178,10 +193,10 @@ public:
 
     /// Initializes the sync state and registers the instance to the
     /// validation interface so that it stays in sync with blockchain updates.
-    [[nodiscard]] bool Init();
+    [[nodiscard]] bool Init() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Starts the initial sync process on a background thread.
-    [[nodiscard]] bool StartBackgroundSync();
+    [[nodiscard]] bool StartBackgroundSync() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// \anchor index_sync
     /// Sync the index with the block index starting from the current best block.
@@ -189,10 +204,10 @@ public:
     /// interrupted with m_interrupt. Once the index gets in sync, the UPDATING
     /// state is set and the BlockConnected ValidationInterface callback takes
     /// over and the sync thread exits.
-    void Sync();
+    void Sync() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Stops the instance from staying in sync with blockchain updates.
-    void Stop();
+    void Stop() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Get a summary of the index and its state.
     IndexSummary GetSummary() const;

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -122,7 +122,7 @@ private:
 
     /// Append new block to index. Will load block and undo data as needed, then
     /// call CustomAppend.
-    bool Append(const interfaces::BlockInfo& new_block);
+    bool Append(const interfaces::BlockInfo& new_block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Write the current index state (eg. chain block locator and subclass-specific items) to disk.
     /// Will skip the commit if no block has been indexed yet or if the index's best block is
@@ -136,7 +136,7 @@ private:
     virtual bool AllowPrune() const = 0;
 
     template <typename... Args>
-    void FatalErrorf(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args);
+    void FatalErrorf(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Temporary helper function to convert block hashes to index pointers
     /// while index code is being migrated to use interfaces::Chain methods
@@ -150,10 +150,10 @@ protected:
     const std::string m_thread_name;
 
     /// Return whether to ignore stale, out-of-sync block connected event
-    bool IgnoreBlockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block);
+    bool IgnoreBlockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Return whether to ignore stale, out-of-sync chain flushed event
-    bool IgnoreChainStateFlushed(const kernel::ChainstateRole& role, const CBlockLocator& locator);
+    bool IgnoreChainStateFlushed(const kernel::ChainstateRole& role, const CBlockLocator& locator) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Initialize internal state from the database and block index.
     [[nodiscard]] virtual bool CustomInit(const std::optional<interfaces::BlockRef>& block) { return true; }
@@ -190,7 +190,7 @@ public:
     /// not block and immediately returns false.
     bool BlockUntilSyncedToCurrentChain() const LOCKS_EXCLUDED(::cs_main);
 
-    void Interrupt();
+    void Interrupt() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Initializes the sync state and registers the instance to the
     /// validation interface so that it stays in sync with blockchain updates.

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -129,7 +129,7 @@ private:
     /// Will skip the commit if no block has been indexed yet or if the index's best block is
     /// ahead of the chainstate's last flushed block. This avoids persisting state an unclean shutdown
     /// could not roll back from. A later call commits when the chainstate has flushed far enough.
-    void Commit();
+    void Commit(const CBlockLocator& locator);
 
     /// Loop over disconnected blocks and call CustomRemove.
     bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip);

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -75,16 +75,14 @@ protected:
     };
 
 private:
-    /// Whether the index has been initialized or not.
-    std::atomic<bool> m_init{false};
-    /// Whether the index is in sync with the main chain. The flag is flipped
-    /// from false to true once, after which point this starts processing
-    /// ValidationInterface notifications to stay in sync.
-    ///
-    /// Note that this will latch to true *immediately* upon startup if
-    /// `m_chainstate->m_chain` is empty, which will be the case upon startup
-    /// with an empty datadir if, e.g., `-txindex=1` is specified.
-    std::atomic<bool> m_synced{false};
+    /** Index synchronization state. */
+    enum class State : uint8_t {
+        INITIALIZING, //!< Constructed but Init() not yet called.
+        SYNCING,      //!< Catching up to the current chain tip in the background.
+        SETTLING,     //!< At tip; letting stale queued notifications pass before going live.
+        UPDATING,     //!< At tip; actively processing new block notifications.
+    };
+    std::atomic<State> m_state{State::INITIALIZING};
 
     /// The best block in the chain that the index is considered synced to, as
     /// reported by GetSummary. This field is not set in a consistent way and is
@@ -95,12 +93,12 @@ private:
     ///
     /// More specifically:
     ///
-    /// - During initial sync when m_synced is false, m_best_block_index is not
+    /// - During initial sync, in SYNCING state, m_best_block_index is not
     ///   updated when blocks are added to the index. It is only updated when
     ///   the data is committed (which is every 30 seconds, and at the end of
     ///   the sync, and any time after blocks are rewound).
     ///
-    /// - After initial sync when m_synced is true, m_best_block_index is set
+    /// - After initial sync, in UPDATING state, m_best_block_index is set
     ///   after each block is added to the index, whether or not the data is
     ///   committed.
     ///
@@ -189,8 +187,8 @@ public:
     /// \anchor index_sync
     /// Sync the index with the block index starting from the current best block.
     /// Intended to be run in its own thread, m_thread_sync, and can be
-    /// interrupted with m_interrupt. Once the index gets in sync, the m_synced
-    /// flag is set and the BlockConnected ValidationInterface callback takes
+    /// interrupted with m_interrupt. Once the index gets in sync, the UPDATING
+    /// state is set and the BlockConnected ValidationInterface callback takes
     /// over and the sync thread exits.
     void Sync();
 

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -176,7 +176,6 @@ protected:
 
 public:
     BaseIndex(std::unique_ptr<interfaces::Chain> chain, std::string name, std::string thread_name);
-    /// Destructor interrupts sync thread if running and blocks until it exits.
     virtual ~BaseIndex();
 
     /// Get the name of the index for display in logs.

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -123,7 +123,7 @@ private:
 
     /// Append new block to index. Will load block and undo data as needed, then
     /// call CustomAppend.
-    bool Append(const interfaces::BlockInfo& new_block);
+    bool Append(const interfaces::BlockInfo& new_block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Write the current index state (eg. chain block locator and subclass-specific items) to disk.
     /// Will skip the commit if no block has been indexed yet or if the index's best block is
@@ -137,7 +137,7 @@ private:
     virtual bool AllowPrune() const = 0;
 
     template <typename... Args>
-    void FatalErrorf(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args);
+    void FatalErrorf(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Temporary helper function to convert block hashes to index pointers
     /// while index code is being migrated to use interfaces::Chain methods
@@ -151,10 +151,10 @@ protected:
     const std::string m_thread_name;
 
     /// Return whether to ignore stale, out-of-sync block connected event
-    bool IgnoreBlockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block);
+    bool IgnoreBlockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Return whether to ignore stale, out-of-sync chain flushed event
-    bool IgnoreChainStateFlushed(const kernel::ChainstateRole& role, const CBlockLocator& locator);
+    bool IgnoreChainStateFlushed(const kernel::ChainstateRole& role, const CBlockLocator& locator) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Initialize internal state from the database and block index.
     [[nodiscard]] virtual bool CustomInit(const std::optional<interfaces::BlockRef>& block) { return true; }
@@ -191,7 +191,7 @@ public:
     /// not block and immediately returns false.
     bool BlockUntilSyncedToCurrentChain() const LOCKS_EXCLUDED(::cs_main);
 
-    void Interrupt();
+    void Interrupt() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Initializes the sync state and registers the instance to the
     /// validation interface so that it stays in sync with blockchain updates.

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -86,7 +86,30 @@ private:
     /// with an empty datadir if, e.g., `-txindex=1` is specified.
     std::atomic<bool> m_synced{false};
 
-    /// The last block in the chain that the index is in sync with.
+    /// The best block in the chain that the index is considered synced to, as
+    /// reported by GetSummary. This field is not set in a consistent way and is
+    /// hard to rely on. In some cases, this points to the last block that has
+    /// been added to the index even if the data was not committed. In other
+    /// cases, this pointer lags behind as blocks are added to the index, and is
+    /// only updated when the data is committed.
+    ///
+    /// More specifically:
+    ///
+    /// - During initial sync when m_synced is false, m_best_block_index is not
+    ///   updated when blocks are added to the index. It is only updated when
+    ///   the data is committed (which is every 30 seconds, and at the end of
+    ///   the sync, and any time after blocks are rewound).
+    ///
+    /// - After initial sync when m_synced is true, m_best_block_index is set
+    ///   after each block is added to the index, whether or not the data is
+    ///   committed.
+    ///
+    /// - When there is a reorg, m_best_block_index is not set as individual blocks
+    ///   are removed from the index, only after all blocks are removed and the
+    ///   data is committed.
+    ///
+    /// - The m_best_block_index value is not consistent with the DB_BEST_BLOCK
+    ///   value, which can be updated at other times.
     std::atomic<const CBlockIndex*> m_best_block_index{nullptr};
 
     std::thread m_thread_sync;

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -111,12 +111,9 @@ private:
     ///   value, which can be updated at other times.
     std::atomic<const CBlockIndex*> m_best_block_index{nullptr};
 
-    std::thread m_thread_sync;
-    CThreadInterrupt m_interrupt;
-
     /// Mutex to let m_notifications and m_handler be accessed from multiple
     /// threads (the sync thread and the init thread).
-    Mutex m_mutex;
+    mutable Mutex m_mutex;
     friend class BaseIndexNotifications;
     std::shared_ptr<BaseIndexNotifications> m_notifications GUARDED_BY(m_mutex);
     std::unique_ptr<interfaces::Handler> m_handler GUARDED_BY(m_mutex);
@@ -140,6 +137,11 @@ private:
     /// while index code is being migrated to use interfaces::Chain methods
     /// instead of index pointers.
     const CBlockIndex& BlockIndex(const uint256& hash);
+
+    /// Get chain notification handler.
+    std::shared_ptr<interfaces::Chain::Notifications> Notifications() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    friend class IndexTester;
 
 protected:
     std::unique_ptr<interfaces::Chain> m_chain;
@@ -197,13 +199,8 @@ public:
     /// Starts the initial sync process on a background thread.
     [[nodiscard]] bool StartBackgroundSync() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
-    /// \anchor index_sync
-    /// Sync the index with the block index starting from the current best block.
-    /// Intended to be run in its own thread, m_thread_sync, and can be
-    /// interrupted with m_interrupt. Once the index gets in sync, the UPDATING
-    /// state is set and the BlockConnected ValidationInterface callback takes
-    /// over and the sync thread exits.
-    void Sync() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    /// Wait for background sync to complete.
+    void WaitForBackgroundSync() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Stops the instance from staying in sync with blockchain updates.
     void Stop() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -131,9 +131,6 @@ private:
     /// could not roll back from. A later call commits when the chainstate has flushed far enough.
     void Commit(const CBlockLocator& locator);
 
-    /// Loop over disconnected blocks and call CustomRemove.
-    bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip);
-
     virtual bool AllowPrune() const = 0;
 
     template <typename... Args>

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -150,9 +150,11 @@ protected:
     const std::string m_name;
     const std::string m_thread_name;
 
-    void BlockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block_info);
+    /// Return whether to ignore stale, out-of-sync block connected event
+    bool IgnoreBlockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block);
 
-    void ChainStateFlushed(const kernel::ChainstateRole& role, const CBlockLocator& locator);
+    /// Return whether to ignore stale, out-of-sync chain flushed event
+    bool IgnoreChainStateFlushed(const kernel::ChainstateRole& role, const CBlockLocator& locator);
 
     /// Initialize internal state from the database and block index.
     [[nodiscard]] virtual bool CustomInit(const std::optional<interfaces::BlockRef>& block) { return true; }

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -8,6 +8,7 @@
 #include <attributes.h>
 #include <dbwrapper.h>
 #include <interfaces/chain.h>
+#include <interfaces/handler.h>
 #include <interfaces/types.h>
 #include <kernel/cs_main.h>
 #include <sync.h>
@@ -23,6 +24,7 @@
 #include <string>
 #include <thread>
 
+class BaseIndexNotifications;
 class CBlock;
 class CBlockIndex;
 class Chainstate;
@@ -40,16 +42,16 @@ struct ConstevalFormatString;
 }
 
 /**
- * Base class for indices of blockchain data. This implements
- * CValidationInterface and ensures blocks are indexed sequentially according
- * to their position in the active chain.
+ * Base class for indices of blockchain data. This handles block connected and
+ * disconnected notifications and ensures blocks are indexed sequentially
+ * according to their position in the active chain.
  *
  * In the presence of multiple chainstates (i.e. if a UTXO snapshot is loaded),
  * only the background "IBD" chainstate will be indexed to avoid building the
  * index out of order. When the background chainstate completes validation, the
  * index will be reinitialized and indexing will continue.
  */
-class BaseIndex : public CValidationInterface
+class BaseIndex
 {
 protected:
     /**
@@ -79,7 +81,6 @@ private:
     enum class State : uint8_t {
         INITIALIZING, //!< Constructed but Init() not yet called.
         SYNCING,      //!< Catching up to the current chain tip in the background.
-        SETTLING,     //!< At tip; letting stale queued notifications pass before going live.
         UPDATING,     //!< At tip; actively processing new block notifications.
     };
     std::atomic<State> m_state{State::INITIALIZING};
@@ -113,6 +114,17 @@ private:
     std::thread m_thread_sync;
     CThreadInterrupt m_interrupt;
 
+    /// Mutex to let m_notifications and m_handler be accessed from multiple
+    /// threads (the sync thread and the init thread).
+    Mutex m_mutex;
+    friend class BaseIndexNotifications;
+    std::shared_ptr<BaseIndexNotifications> m_notifications GUARDED_BY(m_mutex);
+    std::unique_ptr<interfaces::Handler> m_handler GUARDED_BY(m_mutex);
+
+    /// Append new block to index. Will load block and undo data as needed, then
+    /// call CustomAppend.
+    bool Append(const interfaces::BlockInfo& new_block);
+
     /// Write the current index state (eg. chain block locator and subclass-specific items) to disk.
     /// Will skip the commit if no block has been indexed yet or if the index's best block is
     /// ahead of the chainstate's last flushed block. This avoids persisting state an unclean shutdown
@@ -122,12 +134,15 @@ private:
     /// Loop over disconnected blocks and call CustomRemove.
     bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip);
 
-    bool ProcessBlock(const CBlockIndex* pindex, const CBlock* block_data = nullptr);
-
     virtual bool AllowPrune() const = 0;
 
     template <typename... Args>
     void FatalErrorf(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args);
+
+    /// Temporary helper function to convert block hashes to index pointers
+    /// while index code is being migrated to use interfaces::Chain methods
+    /// instead of index pointers.
+    const CBlockIndex& BlockIndex(const uint256& hash);
 
 protected:
     std::unique_ptr<interfaces::Chain> m_chain;
@@ -135,9 +150,9 @@ protected:
     const std::string m_name;
     const std::string m_thread_name;
 
-    void BlockConnected(const kernel::ChainstateRole& role, const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex) override;
+    void BlockConnected(const kernel::ChainstateRole& role, const interfaces::BlockInfo& block_info);
 
-    void ChainStateFlushed(const kernel::ChainstateRole& role, const CBlockLocator& locator) override;
+    void ChainStateFlushed(const kernel::ChainstateRole& role, const CBlockLocator& locator);
 
     /// Initialize internal state from the database and block index.
     [[nodiscard]] virtual bool CustomInit(const std::optional<interfaces::BlockRef>& block) { return true; }
@@ -179,10 +194,10 @@ public:
 
     /// Initializes the sync state and registers the instance to the
     /// validation interface so that it stays in sync with blockchain updates.
-    [[nodiscard]] bool Init();
+    [[nodiscard]] bool Init() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Starts the initial sync process on a background thread.
-    [[nodiscard]] bool StartBackgroundSync();
+    [[nodiscard]] bool StartBackgroundSync() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// \anchor index_sync
     /// Sync the index with the block index starting from the current best block.
@@ -190,10 +205,10 @@ public:
     /// interrupted with m_interrupt. Once the index gets in sync, the UPDATING
     /// state is set and the BlockConnected ValidationInterface callback takes
     /// over and the sync thread exits.
-    void Sync();
+    void Sync() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Stops the instance from staying in sync with blockchain updates.
-    void Stop();
+    void Stop() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Get a summary of the index and its state.
     IndexSummary GetSummary() const;

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -26,7 +26,6 @@
 
 class BaseIndexNotifications;
 class CBlock;
-class CBlockIndex;
 class Chainstate;
 
 struct CBlockLocator;
@@ -109,7 +108,7 @@ private:
     ///
     /// - The m_best_block_index value is not consistent with the DB_BEST_BLOCK
     ///   value, which can be updated at other times.
-    std::atomic<const CBlockIndex*> m_best_block_index{nullptr};
+    std::optional<interfaces::BlockRef> m_best_block GUARDED_BY(m_mutex);
 
     /// Mutex to let m_notifications and m_handler be accessed from multiple
     /// threads (the sync thread and the init thread).
@@ -132,11 +131,6 @@ private:
 
     template <typename... Args>
     void FatalErrorf(util::ConstevalFormatString<sizeof...(Args)> fmt, const Args&... args) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
-
-    /// Temporary helper function to convert block hashes to index pointers
-    /// while index code is being migrated to use interfaces::Chain methods
-    /// instead of index pointers.
-    const CBlockIndex& BlockIndex(const uint256& hash);
 
     /// Get chain notification handler.
     std::shared_ptr<interfaces::Chain::Notifications> Notifications() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
@@ -170,8 +164,10 @@ protected:
 
     virtual DB& GetDB() const = 0;
 
+    std::optional<interfaces::BlockRef> GetBestBlock() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
     /// Update the internal best block index as well as the prune lock.
-    void SetBestBlockIndex(const CBlockIndex* block);
+    void SetBestBlock(const std::optional<interfaces::BlockRef>& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
 public:
     BaseIndex(std::unique_ptr<interfaces::Chain> chain, std::string name, std::string thread_name);
@@ -188,7 +184,7 @@ public:
     /// sync once and only needs to process blocks in the ValidationInterface
     /// queue. If the index is catching up from far behind, this method does
     /// not block and immediately returns false.
-    bool BlockUntilSyncedToCurrentChain() const LOCKS_EXCLUDED(::cs_main);
+    bool BlockUntilSyncedToCurrentChain() const LOCKS_EXCLUDED(::cs_main) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     void Interrupt() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
@@ -206,7 +202,7 @@ public:
     void Stop() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /// Get a summary of the index and its state.
-    IndexSummary GetSummary() const;
+    IndexSummary GetSummary() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 };
 
 #endif // BITCOIN_INDEX_BASE_H

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -8,27 +8,28 @@
 #include <attributes.h>
 #include <dbwrapper.h>
 #include <interfaces/chain.h>
-#include <interfaces/handler.h>
 #include <interfaces/types.h>
 #include <kernel/cs_main.h>
 #include <sync.h>
 #include <uint256.h>
 #include <util/fs.h>
-#include <util/threadinterrupt.h>
-#include <validationinterface.h>
 
 #include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
-#include <thread>
 
 class BaseIndexNotifications;
-class CBlock;
-class Chainstate;
-
 struct CBlockLocator;
+namespace interfaces {
+class Handler;
+}  // namespace interfaces
+namespace kernel {
+struct ChainstateRole;
+}  // namespace kernel
+
 struct IndexSummary {
     std::string name;
     bool synced{false};
@@ -139,7 +140,6 @@ private:
 
 protected:
     std::unique_ptr<interfaces::Chain> m_chain;
-    Chainstate* m_chainstate{nullptr};
     const std::string m_name;
     const std::string m_thread_name;
 

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -5,7 +5,6 @@
 #include <index/blockfilterindex.h>
 
 #include <blockfilter.h>
-#include <chain.h>
 #include <common/args.h>
 #include <dbwrapper.h>
 #include <flatfile.h>

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -34,6 +34,8 @@
 #include <utility>
 #include <vector>
 
+using interfaces::FoundBlock;
+
 /* The index database stores three items for each block: the disk location of the encoded filter,
  * its dSHA256 hash, and the header. Those belonging to blocks on the active chain are indexed by
  * height, and those belonging to blocks that have been reorganized out of the active chain are
@@ -308,26 +310,26 @@ bool BlockFilterIndex::CustomRemove(const interfaces::BlockInfo& block)
     return true;
 }
 
-static bool LookupRange(CDBWrapper& db, const std::string& index_name, int start_height,
-                        const CBlockIndex* stop_index, std::vector<DBVal>& results)
+static bool LookupRange(CDBWrapper& db, const std::string& index_name, interfaces::Chain& chain, int start_height,
+                        const interfaces::BlockRef& stop, std::vector<DBVal>& results)
 {
     if (start_height < 0) {
         LogError("start height (%d) is negative", start_height);
         return false;
     }
-    if (start_height > stop_index->nHeight) {
+    if (start_height > stop.height) {
         LogError("start height (%d) is greater than stop height (%d)",
-                 start_height, stop_index->nHeight);
+                 start_height, stop.height);
         return false;
     }
 
-    size_t results_size = static_cast<size_t>(stop_index->nHeight - start_height + 1);
+    size_t results_size = static_cast<size_t>(stop.height - start_height + 1);
     std::vector<std::pair<uint256, DBVal>> values(results_size);
 
     index_util::DBHeightKey key(start_height);
     std::unique_ptr<CDBIterator> db_it(db.NewIterator());
     db_it->Seek(index_util::DBHeightKey(start_height));
-    for (int height = start_height; height <= stop_index->nHeight; ++height) {
+    for (int height = start_height; height <= stop.height; ++height) {
         if (!db_it->Valid() || !db_it->GetKey(key) || key.height != height) {
             return false;
         }
@@ -346,12 +348,13 @@ static bool LookupRange(CDBWrapper& db, const std::string& index_name, int start
 
     // Iterate backwards through block indexes collecting results in order to access the block hash
     // of each entry in case we need to look it up in the hash index.
-    for (const CBlockIndex* block_index = stop_index;
-         block_index && block_index->nHeight >= start_height;
-         block_index = block_index->pprev) {
-        uint256 block_hash = block_index->GetBlockHash();
-
-        size_t i = static_cast<size_t>(block_index->nHeight - start_height);
+    uint256 block_hash = stop.hash;
+    for (int block_height = stop.height; block_height >= start_height; --block_height) {
+        if (block_height < stop.height) {
+            bool found_hash = chain.findAncestorByHeight(block_hash, block_height, FoundBlock().hash(block_hash));
+            assert(found_hash);
+        }
+        size_t i = static_cast<size_t>(block_height - start_height);
         if (block_hash == values[i].first) {
             results[i] = std::move(values[i].second);
             continue;
@@ -367,10 +370,10 @@ static bool LookupRange(CDBWrapper& db, const std::string& index_name, int start
     return true;
 }
 
-bool BlockFilterIndex::LookupFilter(const CBlockIndex* block_index, BlockFilter& filter_out) const
+bool BlockFilterIndex::LookupFilter(const interfaces::BlockRef& block, BlockFilter& filter_out) const
 {
     DBVal entry;
-    if (!index_util::LookUpOne(*m_db, {block_index->GetBlockHash(), block_index->nHeight}, entry)) {
+    if (!index_util::LookUpOne(*m_db, {block.hash, block.height}, entry)) {
         return false;
     }
 
@@ -378,15 +381,15 @@ bool BlockFilterIndex::LookupFilter(const CBlockIndex* block_index, BlockFilter&
     return ReadFilterFromDisk(entry.pos, entry.hash, filter_out);
 }
 
-bool BlockFilterIndex::LookupFilterHeader(const CBlockIndex* block_index, uint256& header_out)
+bool BlockFilterIndex::LookupFilterHeader(const interfaces::BlockRef& block, uint256& header_out)
 {
     LOCK(m_cs_headers_cache);
 
-    bool is_checkpoint{block_index->nHeight % CFCHECKPT_INTERVAL == 0};
+    bool is_checkpoint{block.height % CFCHECKPT_INTERVAL == 0};
 
     if (is_checkpoint) {
         // Try to find the block in the headers cache if this is a checkpoint height.
-        auto header = m_headers_cache.find(block_index->GetBlockHash());
+        auto header = m_headers_cache.find(block.hash);
         if (header != m_headers_cache.end()) {
             header_out = header->second;
             return true;
@@ -394,25 +397,26 @@ bool BlockFilterIndex::LookupFilterHeader(const CBlockIndex* block_index, uint25
     }
 
     DBVal entry;
-    if (!index_util::LookUpOne(*m_db, {block_index->GetBlockHash(), block_index->nHeight}, entry)) {
+    if (!index_util::LookUpOne(*m_db, {block.hash, block.height}, entry)) {
         return false;
     }
 
     if (is_checkpoint &&
         m_headers_cache.size() < CF_HEADERS_CACHE_MAX_SZ) {
         // Add to the headers cache if this is a checkpoint height.
-        m_headers_cache.emplace(block_index->GetBlockHash(), entry.header);
+        m_headers_cache.emplace(block.hash, entry.header);
     }
 
     header_out = entry.header;
     return true;
 }
 
-bool BlockFilterIndex::LookupFilterRange(int start_height, const CBlockIndex* stop_index,
+bool BlockFilterIndex::LookupFilterRange(int start_height, const interfaces::BlockRef& stop_index,
                                          std::vector<BlockFilter>& filters_out) const
 {
     std::vector<DBVal> entries;
-    if (!LookupRange(*m_db, m_name, start_height, stop_index, entries)) {
+    assert(m_chain);
+    if (!LookupRange(*m_db, m_name, *m_chain, start_height, stop_index, entries)) {
         return false;
     }
 
@@ -429,12 +433,13 @@ bool BlockFilterIndex::LookupFilterRange(int start_height, const CBlockIndex* st
     return true;
 }
 
-bool BlockFilterIndex::LookupFilterHashRange(int start_height, const CBlockIndex* stop_index,
+bool BlockFilterIndex::LookupFilterHashRange(int start_height, const interfaces::BlockRef& stop_index,
                                              std::vector<uint256>& hashes_out) const
 
 {
     std::vector<DBVal> entries;
-    if (!LookupRange(*m_db, m_name, start_height, stop_index, entries)) {
+    assert(m_chain);
+    if (!LookupRange(*m_db, m_name, *m_chain, start_height, stop_index, entries)) {
         return false;
     }
 

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -106,6 +106,7 @@ interfaces::Chain::NotifyOptions BlockFilterIndex::CustomOptions()
 
 bool BlockFilterIndex::CustomInit(const std::optional<interfaces::BlockRef>& block)
 {
+    LOCK(m_filter_mutex);
     if (!m_db->Read(DB_FILTER_POS, m_next_filter_pos)) {
         // Check that the cause of the read failure is that the key does not exist. Any other errors
         // indicate database corruption or a disk failure, and starting the index would cause
@@ -135,6 +136,7 @@ bool BlockFilterIndex::CustomInit(const std::optional<interfaces::BlockRef>& blo
 
 bool BlockFilterIndex::CustomCommit(CDBBatch& batch)
 {
+    LOCK(m_filter_mutex);
     const FlatFilePos& pos = m_next_filter_pos;
 
     // Flush current filter file to disk.
@@ -267,6 +269,7 @@ bool BlockFilterIndex::CustomAppend(const interfaces::BlockInfo& block)
 
 bool BlockFilterIndex::Write(const BlockFilter& filter, uint32_t block_height, const uint256& filter_header)
 {
+    LOCK(m_filter_mutex);
     size_t bytes_written = WriteFilterToDisk(m_next_filter_pos, filter);
     if (bytes_written == 0) return false;
 
@@ -297,7 +300,7 @@ bool BlockFilterIndex::CustomRemove(const interfaces::BlockInfo& block)
     // The latest filter position gets written in Commit by the call to the BaseIndex::Rewind.
     // But since this creates new references to the filter, the position should get updated here
     // atomically as well in case Commit fails.
-    batch.Write(DB_FILTER_POS, m_next_filter_pos);
+    batch.Write(DB_FILTER_POS, WITH_LOCK(m_filter_mutex, return m_next_filter_pos));
     m_db->WriteBatch(batch);
 
     // Update cached header to the previous block hash
@@ -371,6 +374,7 @@ bool BlockFilterIndex::LookupFilter(const CBlockIndex* block_index, BlockFilter&
         return false;
     }
 
+    LOCK(m_filter_mutex);
     return ReadFilterFromDisk(entry.pos, entry.hash, filter_out);
 }
 
@@ -414,6 +418,7 @@ bool BlockFilterIndex::LookupFilterRange(int start_height, const CBlockIndex* st
 
     filters_out.resize(entries.size());
     auto filter_pos_it = filters_out.begin();
+    LOCK(m_filter_mutex);
     for (const auto& entry : entries) {
         if (!ReadFilterFromDisk(entry.pos, entry.hash, *filter_pos_it)) {
             return false;

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -84,17 +84,17 @@ public:
     BlockFilterType GetFilterType() const { return m_filter_type; }
 
     /** Get a single filter by block. */
-    bool LookupFilter(const CBlockIndex* block_index, BlockFilter& filter_out) const EXCLUSIVE_LOCKS_REQUIRED(!m_filter_mutex);
+    bool LookupFilter(const interfaces::BlockRef& block, BlockFilter& filter_out) const EXCLUSIVE_LOCKS_REQUIRED(!m_filter_mutex);
 
     /** Get a single filter header by block. */
-    bool LookupFilterHeader(const CBlockIndex* block_index, uint256& header_out) EXCLUSIVE_LOCKS_REQUIRED(!m_cs_headers_cache);
+    bool LookupFilterHeader(const interfaces::BlockRef& block, uint256& header_out) EXCLUSIVE_LOCKS_REQUIRED(!m_cs_headers_cache);
 
     /** Get a range of filters between two heights on a chain. */
-    bool LookupFilterRange(int start_height, const CBlockIndex* stop_index,
+    bool LookupFilterRange(int start_height, const interfaces::BlockRef& stop_index,
                            std::vector<BlockFilter>& filters_out) const EXCLUSIVE_LOCKS_REQUIRED(!m_filter_mutex);
 
     /** Get a range of filter hashes between two heights on a chain. */
-    bool LookupFilterHashRange(int start_height, const CBlockIndex* stop_index,
+    bool LookupFilterHashRange(int start_height, const interfaces::BlockRef& stop_index,
                                std::vector<uint256>& hashes_out) const;
 };
 

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -22,8 +22,10 @@
 #include <vector>
 
 class BlockFilter;
-class CBlockIndex;
 enum class BlockFilterType : uint8_t;
+namespace interfaces {
+struct BlockRef;
+}  // namespace interfaces
 
 static const char* const DEFAULT_BLOCKFILTERINDEX = "0";
 

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -43,11 +43,12 @@ private:
     BlockFilterType m_filter_type;
     std::unique_ptr<BaseIndex::DB> m_db;
 
-    FlatFilePos m_next_filter_pos;
-    std::unique_ptr<FlatFileSeq> m_filter_fileseq;
+    mutable Mutex m_filter_mutex;
+    FlatFilePos m_next_filter_pos GUARDED_BY(m_filter_mutex);
+    std::unique_ptr<FlatFileSeq> m_filter_fileseq GUARDED_BY(m_filter_mutex);
 
-    bool ReadFilterFromDisk(const FlatFilePos& pos, const uint256& hash, BlockFilter& filter) const;
-    size_t WriteFilterToDisk(FlatFilePos& pos, const BlockFilter& filter);
+    bool ReadFilterFromDisk(const FlatFilePos& pos, const uint256& hash, BlockFilter& filter) const EXCLUSIVE_LOCKS_REQUIRED(m_filter_mutex);
+    size_t WriteFilterToDisk(FlatFilePos& pos, const BlockFilter& filter) EXCLUSIVE_LOCKS_REQUIRED(m_filter_mutex);
 
     Mutex m_cs_headers_cache;
     /** cache of block hash to filter header, to avoid disk access when responding to getcfcheckpt. */
@@ -58,18 +59,18 @@ private:
 
     bool AllowPrune() const override { return true; }
 
-    bool Write(const BlockFilter& filter, uint32_t block_height, const uint256& filter_header);
+    bool Write(const BlockFilter& filter, uint32_t block_height, const uint256& filter_header) EXCLUSIVE_LOCKS_REQUIRED(!m_filter_mutex);
 
     std::optional<uint256> ReadFilterHeader(int height, const uint256& expected_block_hash);
 
 protected:
-    bool CustomInit(const std::optional<interfaces::BlockRef>& block) override;
+    bool CustomInit(const std::optional<interfaces::BlockRef>& block) override EXCLUSIVE_LOCKS_REQUIRED(!m_filter_mutex);
 
-    bool CustomCommit(CDBBatch& batch) override;
+    bool CustomCommit(CDBBatch& batch) override EXCLUSIVE_LOCKS_REQUIRED(!m_filter_mutex);
 
-    bool CustomAppend(const interfaces::BlockInfo& block) override;
+    bool CustomAppend(const interfaces::BlockInfo& block) override EXCLUSIVE_LOCKS_REQUIRED(!m_filter_mutex);
 
-    bool CustomRemove(const interfaces::BlockInfo& block) override;
+    bool CustomRemove(const interfaces::BlockInfo& block) override EXCLUSIVE_LOCKS_REQUIRED(!m_filter_mutex);
 
     BaseIndex::DB& GetDB() const LIFETIMEBOUND override { return *m_db; }
 
@@ -83,14 +84,14 @@ public:
     BlockFilterType GetFilterType() const { return m_filter_type; }
 
     /** Get a single filter by block. */
-    bool LookupFilter(const CBlockIndex* block_index, BlockFilter& filter_out) const;
+    bool LookupFilter(const CBlockIndex* block_index, BlockFilter& filter_out) const EXCLUSIVE_LOCKS_REQUIRED(!m_filter_mutex);
 
     /** Get a single filter header by block. */
     bool LookupFilterHeader(const CBlockIndex* block_index, uint256& header_out) EXCLUSIVE_LOCKS_REQUIRED(!m_cs_headers_cache);
 
     /** Get a range of filters between two heights on a chain. */
     bool LookupFilterRange(int start_height, const CBlockIndex* stop_index,
-                           std::vector<BlockFilter>& filters_out) const;
+                           std::vector<BlockFilter>& filters_out) const EXCLUSIVE_LOCKS_REQUIRED(!m_filter_mutex);
 
     /** Get a range of filter hashes between two heights on a chain. */
     bool LookupFilterHashRange(int start_height, const CBlockIndex* stop_index,

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -22,8 +22,10 @@
 #include <vector>
 
 class BlockFilter;
-class CBlockIndex;
 enum class BlockFilterType : uint8_t;
+namespace interfaces {
+struct BlockRef;
+}  // namespace interfaces
 
 inline constexpr const char* DEFAULT_BLOCKFILTERINDEX{"0"};
 

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -5,7 +5,6 @@
 #include <index/coinstatsindex.h>
 
 #include <arith_uint256.h>
-#include <chain.h>
 #include <chainparams.h>
 #include <coins.h>
 #include <common/args.h>

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -121,6 +121,7 @@ bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
 
         // Add the new utxos created from the block
         assert(block.data);
+        assert(block.undo_data);
         for (size_t i = 0; i < block.data->vtx.size(); ++i) {
             const auto& tx{block.data->vtx.at(i)};
             const bool is_coinbase{tx->IsCoinBase()};

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -234,13 +234,13 @@ bool CoinStatsIndex::CustomRemove(const interfaces::BlockInfo& block)
     return true;
 }
 
-std::optional<CCoinsStats> CoinStatsIndex::LookUpStats(const CBlockIndex& block_index) const
+std::optional<CCoinsStats> CoinStatsIndex::LookUpStats(const interfaces::BlockRef& block) const
 {
-    CCoinsStats stats{block_index.nHeight, block_index.GetBlockHash()};
+    CCoinsStats stats{block.height, block.hash};
     stats.index_used = true;
 
     DBVal entry;
-    if (!index_util::LookUpOne(*m_db, {block_index.GetBlockHash(), block_index.nHeight}, entry)) {
+    if (!index_util::LookUpOne(*m_db, block, entry)) {
         return std::nullopt;
     }
 

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -10,6 +10,7 @@
 #include <crypto/muhash.h>
 #include <index/base.h>
 #include <interfaces/chain.h>
+#include <interfaces/types.h>
 #include <uint256.h>
 
 #include <cstddef>

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -18,7 +18,6 @@
 #include <memory>
 #include <optional>
 
-class CBlockIndex;
 namespace kernel {
 struct CCoinsStats;
 }

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -69,8 +69,8 @@ public:
 
     interfaces::Chain::NotifyOptions CustomOptions() override;
 
-    // Look up stats for a specific block using CBlockIndex
-    std::optional<kernel::CCoinsStats> LookUpStats(const CBlockIndex& block_index) const;
+    // Look up stats for a specific block using hash and height
+    std::optional<kernel::CCoinsStats> LookUpStats(const interfaces::BlockRef& block) const;
 };
 
 /// The global UTXO set hash object.

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -10,6 +10,7 @@
 #include <index/base.h>
 #include <index/disktxpos.h>
 #include <interfaces/chain.h>
+#include <interfaces/types.h>
 #include <node/blockstorage.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -19,7 +19,6 @@
 #include <uint256.h>
 #include <util/fs.h>
 #include <util/log.h>
-#include <validation.h>
 
 #include <cassert>
 #include <cstdint>
@@ -66,8 +65,8 @@ void TxIndex::DB::WriteTxs(const std::vector<std::pair<Txid, CDiskTxPos>>& v_pos
     WriteBatch(batch);
 }
 
-TxIndex::TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
-    : BaseIndex(std::move(chain), "txindex", "txidx"), m_db(std::make_unique<TxIndex::DB>(n_cache_size, f_memory, f_wipe))
+TxIndex::TxIndex(std::unique_ptr<interfaces::Chain> chain, node::BlockManager& blockman, size_t n_cache_size, bool f_memory, bool f_wipe)
+    : BaseIndex(std::move(chain), "txindex", "txidx"), m_db(std::make_unique<TxIndex::DB>(n_cache_size, f_memory, f_wipe)), m_blockman(blockman)
 {}
 
 TxIndex::~TxIndex() = default;
@@ -98,7 +97,7 @@ bool TxIndex::FindTx(const Txid& tx_hash, uint256& block_hash, CTransactionRef& 
         return false;
     }
 
-    AutoFile file{m_chainstate->m_blockman.OpenBlockFile(postx, true)};
+    AutoFile file{m_blockman.OpenBlockFile(postx, true)};
     if (file.IsNull()) {
         LogError("OpenBlockFile failed");
         return false;

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -13,6 +13,8 @@
 #include <index/disktxpos.h>
 #include <index/txindex_key.h>
 #include <interfaces/chain.h>
+#include <interfaces/types.h>
+#include <kernel/cs_main.h>
 #include <node/blockstorage.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -25,7 +25,6 @@
 #include <uint256.h>
 #include <util/fs.h>
 #include <util/log.h>
-#include <validation.h>
 
 #include <algorithm>
 #include <array>
@@ -134,8 +133,8 @@ void TxIndex::DB::WriteTxs(const interfaces::BlockInfo& block)
     WriteBatch(batch);
 }
 
-TxIndex::TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
-    : BaseIndex(std::move(chain), "txindex", "txidx"), m_db(std::make_unique<TxIndex::DB>(n_cache_size, f_memory, f_wipe))
+TxIndex::TxIndex(std::unique_ptr<interfaces::Chain> chain, node::BlockManager& blockman, size_t n_cache_size, bool f_memory, bool f_wipe)
+    : BaseIndex(std::move(chain), "txindex", "txidx"), m_db(std::make_unique<TxIndex::DB>(n_cache_size, f_memory, f_wipe)), m_blockman(blockman)
 {
     if (m_db->m_has_legacy) {
         LogInfo("txindex contains entries in the legacy format, which uses excessive disk space. "
@@ -181,14 +180,16 @@ std::optional<TxIndexResult> TxIndex::FindTx(const Txid& tx_hash) const
                 continue;
             }
             LOCK(cs_main);
-            const CBlockIndex* block_index{m_chainstate->m_blockman.LookupBlockIndex(candidate_block_hash)};
+            const CBlockIndex* block_index{m_blockman.LookupBlockIndex(candidate_block_hash)};
             if (!block_index) {
                 LogWarning("Block index entry %s not found for txid %s", candidate_block_hash.ToString(), tx_hash.ToString());
                 continue;
             }
             if (!(block_index->nStatus & BLOCK_HAVE_DATA)) continue;
             const FlatFilePos tx_position{block_index->nFile, block_index->nDataPos + key.pos.tx_offset_in_block};
-            candidates.emplace_back(tx_position, candidate_block_hash, key.pos.block_seq, m_chainstate->m_chain.Contains(*block_index));
+            bool in_active_chain{false};
+            m_chain->findBlock(candidate_block_hash, interfaces::FoundBlock().inActiveChain(in_active_chain));
+            candidates.emplace_back(tx_position, candidate_block_hash, key.pos.block_seq, in_active_chain);
         }
     }
 
@@ -198,7 +199,7 @@ std::optional<TxIndexResult> TxIndex::FindTx(const Txid& tx_hash) const
     });
 
     for (const auto& candidate : candidates) {
-        AutoFile file{m_chainstate->m_blockman.OpenBlockFile(candidate.tx_position, /*fReadOnly=*/true)};
+        AutoFile file{m_blockman.OpenBlockFile(candidate.tx_position, /*fReadOnly=*/true)};
         if (file.IsNull()) {
             LogWarning("OpenBlockFile failed for txid %s", tx_hash.ToString());
             continue;
@@ -226,7 +227,7 @@ std::optional<TxIndexResult> TxIndex::FindLegacyTx(const Txid& tx_hash) const
         return std::nullopt;
     }
 
-    AutoFile file{m_chainstate->m_blockman.OpenBlockFile(postx, /*fReadOnly=*/true)};
+    AutoFile file{m_blockman.OpenBlockFile(postx, /*fReadOnly=*/true)};
     if (file.IsNull()) {
         LogError("OpenBlockFile failed");
         return std::nullopt;

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -16,6 +16,10 @@ namespace interfaces {
 class Chain;
 }
 
+namespace node {
+class BlockManager;
+} // namespace node
+
 static constexpr bool DEFAULT_TXINDEX{false};
 
 /**
@@ -30,6 +34,7 @@ protected:
 
 private:
     const std::unique_ptr<DB> m_db;
+    node::BlockManager& m_blockman;
 
     bool AllowPrune() const override { return false; }
 
@@ -40,7 +45,7 @@ protected:
 
 public:
     /// Constructs the index, which becomes available to be queried.
-    explicit TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit TxIndex(std::unique_ptr<interfaces::Chain> chain, node::BlockManager& blockman, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
     // Destructor is declared because this class contains a unique_ptr to an incomplete type.
     virtual ~TxIndex() override;

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -20,6 +20,10 @@ namespace txindex_tests {
 class TxIndexTest;
 }
 
+namespace node {
+class BlockManager;
+} // namespace node
+
 inline constexpr bool DEFAULT_TXINDEX{false};
 
 /// A found transaction and the hash of the block that contains it.
@@ -41,6 +45,7 @@ protected:
 private:
     friend class txindex_tests::TxIndexTest;
     const std::unique_ptr<DB> m_db;
+    node::BlockManager& m_blockman;
 
     bool AllowPrune() const override { return false; }
 
@@ -54,7 +59,7 @@ protected:
 
 public:
     /// Constructs the index, which becomes available to be queried.
-    explicit TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit TxIndex(std::unique_ptr<interfaces::Chain> chain, node::BlockManager& blockman, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
     // Destructor is declared because this class contains a unique_ptr to an incomplete type.
     virtual ~TxIndex() override;

--- a/src/index/txospenderindex.cpp
+++ b/src/index/txospenderindex.cpp
@@ -11,6 +11,7 @@
 #include <index/base.h>
 #include <index/disktxpos.h>
 #include <interfaces/chain.h>
+#include <interfaces/types.h>
 #include <logging.h>
 #include <node/blockstorage.h>
 #include <primitives/block.h>
@@ -21,7 +22,6 @@
 #include <tinyformat.h>
 #include <uint256.h>
 #include <util/fs.h>
-#include <validation.h>
 
 #include <cstddef>
 #include <cstdio>
@@ -61,8 +61,8 @@ struct DBKey {
     }
 };
 
-TxoSpenderIndex::TxoSpenderIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
-    : BaseIndex(std::move(chain), "txospenderindex", "txospenderidx"), m_db{std::make_unique<DB>(gArgs.GetDataDirNet() / "indexes" / "txospenderindex" / "db", n_cache_size, f_memory, f_wipe, /*f_obfuscate=*/false, /*f_bloom=*/false)}
+TxoSpenderIndex::TxoSpenderIndex(std::unique_ptr<interfaces::Chain> chain, node::BlockManager& blockman, size_t n_cache_size, bool f_memory, bool f_wipe)
+    : BaseIndex(std::move(chain), "txospenderindex", "txospenderidx"), m_db{std::make_unique<DB>(gArgs.GetDataDirNet() / "indexes" / "txospenderindex" / "db", n_cache_size, f_memory, f_wipe, /*f_obfuscate=*/false, /*f_bloom=*/false)}, m_blockman(blockman)
 {
     if (!m_db->Read("siphash_key", m_siphash_key)) {
         FastRandomContext rng(false);
@@ -143,7 +143,7 @@ bool TxoSpenderIndex::CustomRemove(const interfaces::BlockInfo& block)
 
 util::Expected<TxoSpender, std::string> TxoSpenderIndex::ReadTransaction(const CDiskTxPos& tx_pos) const
 {
-    AutoFile file{m_chainstate->m_blockman.OpenBlockFile(tx_pos, /*fReadOnly=*/true)};
+    AutoFile file{m_blockman.OpenBlockFile(tx_pos, /*fReadOnly=*/true)};
     if (file.IsNull()) {
         return util::Unexpected("cannot open block");
     }

--- a/src/index/txospenderindex.h
+++ b/src/index/txospenderindex.h
@@ -20,6 +20,9 @@
 #include <vector>
 
 struct CDiskTxPos;
+namespace node {
+class BlockManager;
+} // namespace node
 
 static constexpr bool DEFAULT_TXOSPENDERINDEX{false};
 
@@ -38,6 +41,7 @@ class TxoSpenderIndex final : public BaseIndex
 private:
     std::unique_ptr<BaseIndex::DB> m_db;
     std::pair<uint64_t, uint64_t> m_siphash_key;
+    node::BlockManager& m_blockman;
     bool AllowPrune() const override { return false; }
     void WriteSpenderInfos(const std::vector<std::pair<COutPoint, CDiskTxPos>>& items);
     void EraseSpenderInfos(const std::vector<std::pair<COutPoint, CDiskTxPos>>& items);
@@ -53,7 +57,7 @@ protected:
     BaseIndex::DB& GetDB() const override;
 
 public:
-    explicit TxoSpenderIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit TxoSpenderIndex(std::unique_ptr<interfaces::Chain> chain, node::BlockManager& blockman, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
     /**
      * Search the index for a transaction that spends the given outpoint.

--- a/src/index/txospenderindex.h
+++ b/src/index/txospenderindex.h
@@ -20,6 +20,9 @@
 #include <vector>
 
 struct CDiskTxPos;
+namespace node {
+class BlockManager;
+} // namespace node
 
 inline constexpr bool DEFAULT_TXOSPENDERINDEX{false};
 
@@ -38,6 +41,7 @@ class TxoSpenderIndex final : public BaseIndex
 private:
     std::unique_ptr<BaseIndex::DB> m_db;
     std::pair<uint64_t, uint64_t> m_siphash_key;
+    node::BlockManager& m_blockman;
     bool AllowPrune() const override { return false; }
     void WriteSpenderInfos(const std::vector<std::pair<COutPoint, CDiskTxPos>>& items);
     void EraseSpenderInfos(const std::vector<std::pair<COutPoint, CDiskTxPos>>& items);
@@ -53,7 +57,7 @@ protected:
     BaseIndex::DB& GetDB() const override;
 
 public:
-    explicit TxoSpenderIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit TxoSpenderIndex(std::unique_ptr<interfaces::Chain> chain, node::BlockManager& blockman, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
     /**
      * Search the index for a transaction that spends the given outpoint.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1924,12 +1924,12 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // ********************************************************* Step 8: start indexers
 
     if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
-        g_txindex = std::make_unique<TxIndex>(interfaces::MakeChain(node), index_cache_sizes.tx_index, false, do_reindex);
+        g_txindex = std::make_unique<TxIndex>(interfaces::MakeChain(node), chainman.m_blockman, index_cache_sizes.tx_index, false, do_reindex);
         node.indexes.emplace_back(g_txindex.get());
     }
 
     if (args.GetBoolArg("-txospenderindex", DEFAULT_TXOSPENDERINDEX)) {
-        g_txospenderindex = std::make_unique<TxoSpenderIndex>(interfaces::MakeChain(node), index_cache_sizes.txospender_index, false, do_reindex);
+        g_txospenderindex = std::make_unique<TxoSpenderIndex>(interfaces::MakeChain(node), chainman.m_blockman, index_cache_sizes.txospender_index, false, do_reindex);
         node.indexes.emplace_back(g_txospenderindex.get());
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1980,12 +1980,12 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // ********************************************************* Step 8: start indexers
 
     if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
-        g_txindex = std::make_unique<TxIndex>(interfaces::MakeChain(node), index_cache_sizes.tx_index, false, do_reindex);
+        g_txindex = std::make_unique<TxIndex>(interfaces::MakeChain(node), chainman.m_blockman, index_cache_sizes.tx_index, false, do_reindex);
         node.indexes.emplace_back(g_txindex.get());
     }
 
     if (args.GetBoolArg("-txospenderindex", DEFAULT_TXOSPENDERINDEX)) {
-        g_txospenderindex = std::make_unique<TxoSpenderIndex>(interfaces::MakeChain(node), index_cache_sizes.txospender_index, false, do_reindex);
+        g_txospenderindex = std::make_unique<TxoSpenderIndex>(interfaces::MakeChain(node), chainman.m_blockman, index_cache_sizes.txospender_index, false, do_reindex);
         node.indexes.emplace_back(g_txospenderindex.get());
     }
 

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -7,6 +7,7 @@
 
 #include <blockfilter.h>
 #include <common/settings.h>
+#include <interfaces/types.h>
 #include <kernel/chain.h> // IWYU pragma: export
 #include <node/types.h>
 #include <primitives/transaction.h>

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -40,6 +40,7 @@ struct ChainstateRole;
 } // namespace kernel
 namespace node {
 struct NodeContext;
+struct PruneLockInfo;
 } // namespace node
 
 namespace interfaces {
@@ -277,6 +278,12 @@ public:
 
     //! Relay dust fee setting (-dustrelayfee), reflecting lowest rate it's economical to spend.
     virtual CFeeRate relayDustFee() = 0;
+
+    //! Set or remove a prune lock.
+    virtual void updatePruneLock(const std::string& name, const node::PruneLockInfo& lock_info) = 0;
+
+    //! Check if pruning is enabled.
+    virtual bool pruningEnabled() = 0;
 
     //! Check if any block has been pruned.
     virtual bool havePruned() = 0;

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -326,6 +326,11 @@ public:
         bool disconnect_undo_data = false;
     };
 
+    //! Register handler for notifications. This is similar to
+    //! handleNotifications method below, but it accepts more options and delays
+    //! sending notifications until connect() is called on the returned handler.
+    virtual std::unique_ptr<Handler> attachChain(std::shared_ptr<Notifications> notifications, const NotifyOptions& options) = 0;
+
     //! Register handler for notifications.
     //! Some notifications are asynchronous and may still execute after the handler is disconnected.
     //! Use waitForNotifications() after the handler is disconnected to ensure all pending notifications

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -324,12 +324,18 @@ public:
         bool disconnect_data = false;
         //! Include undo data with block disconnected notifications.
         bool disconnect_undo_data = false;
+        //! Name to use for attachChain sync thread.
+        std::string thread_name;
     };
 
     //! Register handler for notifications. This is similar to
-    //! handleNotifications method below, but it accepts more options and delays
-    //! sending notifications until connect() is called on the returned handler.
-    virtual std::unique_ptr<Handler> attachChain(std::shared_ptr<Notifications> notifications, const NotifyOptions& options) = 0;
+    //! handleNotifications below, but it sends block connected and disconnected
+    //! notifications starting at a specified block instead of the chain tip. If
+    //! a starting block is not provided, this sends block connected
+    //! notifications starting from genesis. This also more accepts more options
+    //! than handleNotifications and, if not synced, delays sending
+    //! notifications until connect() is called on the returned handler.
+    virtual std::unique_ptr<Handler> attachChain(std::shared_ptr<Notifications> notifications, std::optional<uint256> start_block, const NotifyOptions& options) = 0;
 
     //! Register handler for notifications.
     //! Some notifications are asynchronous and may still execute after the handler is disconnected.

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -132,6 +132,9 @@ public:
     //! pruned), and contains transactions.
     virtual bool haveBlockOnDisk(int height) = 0;
 
+    //! Get tip information.
+    virtual bool getTip(const FoundBlock& block={}) = 0;
+
     //! Return height of the highest block on chain in common with the locator,
     //! which will either be the original block used to create the locator,
     //! or one of its ancestors.
@@ -342,6 +345,9 @@ public:
     //! Use waitForNotifications() after the handler is disconnected to ensure all pending notifications
     //! have been processed.
     virtual std::unique_ptr<Handler> handleNotifications(std::shared_ptr<Notifications> notifications) = 0;
+
+    //! Wait for pending notifications.
+    virtual void waitForPendingNotifications() = 0;
 
     //! Wait for pending notifications to be processed unless block hash points to the current
     //! chain tip.

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -41,6 +41,7 @@ struct ChainstateRole;
 namespace node {
 struct NodeContext;
 enum class TxBroadcast : uint8_t;
+struct PruneLockInfo;
 } // namespace node
 
 namespace interfaces {
@@ -276,6 +277,12 @@ public:
 
     //! Relay dust fee setting (-dustrelayfee), reflecting lowest rate it's economical to spend.
     virtual CFeeRate relayDustFee() = 0;
+
+    //! Set or remove a prune lock.
+    virtual void updatePruneLock(const std::string& name, const node::PruneLockInfo& lock_info) = 0;
+
+    //! Check if pruning is enabled.
+    virtual bool pruningEnabled() = 0;
 
     //! Check if any block has been pruned.
     virtual bool havePruned() = 0;

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -131,6 +131,9 @@ public:
     //! pruned), and contains transactions.
     virtual bool haveBlockOnDisk(int height) = 0;
 
+    //! Get tip information.
+    virtual bool getTip(const FoundBlock& block={}) = 0;
+
     //! Return height of the highest block on chain in common with the locator,
     //! which will either be the original block used to create the locator,
     //! or one of its ancestors.
@@ -341,6 +344,9 @@ public:
     //! Use waitForNotifications() after the handler is disconnected to ensure all pending notifications
     //! have been processed.
     virtual std::unique_ptr<Handler> handleNotifications(std::shared_ptr<Notifications> notifications) = 0;
+
+    //! Wait for pending notifications.
+    virtual void waitForPendingNotifications() = 0;
 
     //! Wait for pending notifications to be processed unless block hash points to the current
     //! chain tip.

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -8,6 +8,7 @@
 #include <blockfilter.h>
 #include <common/settings.h>
 #include <consensus/amount.h>
+#include <interfaces/types.h>
 #include <kernel/chain.h> // IWYU pragma: export
 #include <primitives/transaction.h>
 #include <util/expected.h>

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -323,12 +323,18 @@ public:
         bool disconnect_data = false;
         //! Include undo data with block disconnected notifications.
         bool disconnect_undo_data = false;
+        //! Name to use for attachChain sync thread.
+        std::string thread_name;
     };
 
     //! Register handler for notifications. This is similar to
-    //! handleNotifications method below, but it accepts more options and delays
-    //! sending notifications until connect() is called on the returned handler.
-    virtual std::unique_ptr<Handler> attachChain(std::shared_ptr<Notifications> notifications, const NotifyOptions& options) = 0;
+    //! handleNotifications below, but it sends block connected and disconnected
+    //! notifications starting at a specified block instead of the chain tip. If
+    //! a starting block is not provided, this sends block connected
+    //! notifications starting from genesis. This also more accepts more options
+    //! than handleNotifications and, if not synced, delays sending
+    //! notifications until connect() is called on the returned handler.
+    virtual std::unique_ptr<Handler> attachChain(std::shared_ptr<Notifications> notifications, std::optional<uint256> start_block, const NotifyOptions& options) = 0;
 
     //! Register handler for notifications.
     //! Some notifications are asynchronous and may still execute after the handler is disconnected.

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -325,6 +325,11 @@ public:
         bool disconnect_undo_data = false;
     };
 
+    //! Register handler for notifications. This is similar to
+    //! handleNotifications method below, but it accepts more options and delays
+    //! sending notifications until connect() is called on the returned handler.
+    virtual std::unique_ptr<Handler> attachChain(std::shared_ptr<Notifications> notifications, const NotifyOptions& options) = 0;
+
     //! Register handler for notifications.
     //! Some notifications are asynchronous and may still execute after the handler is disconnected.
     //! Use waitForNotifications() after the handler is disconnected to ensure all pending notifications

--- a/src/interfaces/handler.h
+++ b/src/interfaces/handler.h
@@ -22,7 +22,10 @@ class Handler
 public:
     virtual ~Handler() = default;
 
-    //! Disconnect the handler.
+    //! Connect the handler, start receiving notifications.
+    virtual void connect() {};
+
+    //! Disconnect the handler, stop receiving notifications.
     virtual void disconnect() = 0;
 };
 

--- a/src/interfaces/handler.h
+++ b/src/interfaces/handler.h
@@ -15,8 +15,7 @@ namespace btcsignals {
 namespace interfaces {
 
 //! Generic interface for managing an event handler or callback function
-//! registered with another interface. Has a single disconnect method to cancel
-//! the registration and prevent any future notifications.
+//! registered with another interface.
 class Handler
 {
 public:
@@ -27,6 +26,17 @@ public:
 
     //! Disconnect the handler, stop receiving notifications.
     virtual void disconnect() = 0;
+
+    //! Return whether handler is currently connected.
+    virtual bool connected() = 0;
+
+    //! Interrupt the handler, allowing it to disconnect more quickly. (Useful
+    //! to disconnect multiple handlers in parallel when disconnect is
+    //! blocking.)
+    virtual void interrupt() {};
+
+    //! Block until all current notifications are received.
+    virtual void sync() {};
 };
 
 //! Return handler wrapping a btcsignals connection.

--- a/src/interfaces/types.h
+++ b/src/interfaces/types.h
@@ -37,6 +37,13 @@ struct BlockInfo {
     // attaching to the chain. False if notification comes from the validation
     // interface queue.
     bool background_sync{false};
+    // Whether block data has been flushed and saved to disk yet. FLUSHED_TIP
+    // and FLUSHED both indicate that block data has been flushed, but
+    // FLUSHED_TIP additionally means this block is the *latest* block that's
+    // been flushed. FLUSHED_TIP is useful for chain clients that are syncing
+    // with the node and want to flush their state at the same points as the
+    // node, without flushing too frequently.
+    enum { UNFLUSHED, FLUSHED, FLUSHED_TIP } status{UNFLUSHED};
 
     BlockInfo(const uint256& hash LIFETIMEBOUND) : hash(hash) {}
 };

--- a/src/interfaces/types.h
+++ b/src/interfaces/types.h
@@ -33,6 +33,10 @@ struct BlockInfo {
     // The maximum time in the chain up to and including this block.
     // A timestamp that can only move forward.
     unsigned int chain_time_max{0};
+    // True if notification comes from a background sync thread while initially
+    // attaching to the chain. False if notification comes from the validation
+    // interface queue.
+    bool background_sync{false};
 
     BlockInfo(const uint256& hash LIFETIMEBOUND) : hash(hash) {}
 };

--- a/src/interfaces/types.h
+++ b/src/interfaces/types.h
@@ -33,10 +33,6 @@ struct BlockInfo {
     // The maximum time in the chain up to and including this block.
     // A timestamp that can only move forward.
     unsigned int chain_time_max{0};
-    // True if notification comes from a background sync thread while initially
-    // attaching to the chain. False if notification comes from the validation
-    // interface queue.
-    bool background_sync{false};
     // Whether block data has been flushed and saved to disk yet. FLUSHED_TIP
     // and FLUSHED both indicate that block data has been flushed, but
     // FLUSHED_TIP additionally means this block is the *latest* block that's
@@ -44,6 +40,12 @@ struct BlockInfo {
     // with the node and want to flush their state at the same points as the
     // node, without flushing too frequently.
     enum { UNFLUSHED, FLUSHED, FLUSHED_TIP } status{UNFLUSHED};
+    // Sync state. SYNCING or SYNCED if notification comes from a background
+    // sync thread while initially attaching to the chain, UPDATING if
+    // notification comes from the validation interface queue.
+    enum State { SYNCING, SYNCED, UPDATING } state{UPDATING};
+    //! Error string. If non-empty it indicates some block data could not be read and may be missing.
+    std::string error;
 
     BlockInfo(const uint256& hash LIFETIMEBOUND) : hash(hash) {}
 };

--- a/src/interfaces/types.h
+++ b/src/interfaces/types.h
@@ -7,12 +7,34 @@
 
 #include <uint256.h>
 
+#include <attributes.h>
+
+class CBlock;
+class CBlockUndo;
+class uint256;
+
 namespace interfaces {
 
 //! Hash/height pair to help track and identify blocks.
 struct BlockRef {
     uint256 hash;
     int height = -1;
+};
+
+//! Block data sent with blockConnected, blockDisconnected notifications.
+struct BlockInfo {
+    const uint256& hash;
+    const uint256* prev_hash = nullptr;
+    int height = -1;
+    int file_number = -1;
+    unsigned data_pos = 0;
+    const CBlock* data = nullptr;
+    const CBlockUndo* undo_data = nullptr;
+    // The maximum time in the chain up to and including this block.
+    // A timestamp that can only move forward.
+    unsigned int chain_time_max{0};
+
+    BlockInfo(const uint256& hash LIFETIMEBOUND) : hash(hash) {}
 };
 
 } // namespace interfaces

--- a/src/interfaces/types.h
+++ b/src/interfaces/types.h
@@ -5,7 +5,13 @@
 #ifndef BITCOIN_INTERFACES_TYPES_H
 #define BITCOIN_INTERFACES_TYPES_H
 
+#include <attributes.h>
 #include <uint256.h>
+
+#include <string>
+
+class CBlock;
+class CBlockUndo;
 
 namespace interfaces {
 
@@ -13,6 +19,22 @@ namespace interfaces {
 struct BlockRef {
     uint256 hash;
     int height = -1;
+};
+
+//! Block data sent with blockConnected, blockDisconnected notifications.
+struct BlockInfo {
+    const uint256& hash;
+    const uint256* prev_hash = nullptr;
+    int height = -1;
+    int file_number = -1;
+    unsigned data_pos = 0;
+    const CBlock* data = nullptr;
+    const CBlockUndo* undo_data = nullptr;
+    // The maximum time in the chain up to and including this block.
+    // A timestamp that can only move forward.
+    unsigned int chain_time_max{0};
+
+    BlockInfo(const uint256& hash LIFETIMEBOUND) : hash(hash) {}
 };
 
 } // namespace interfaces

--- a/src/kernel/chain.cpp
+++ b/src/kernel/chain.cpp
@@ -4,32 +4,11 @@
 
 #include <kernel/chain.h>
 
-#include <chain.h>
-#include <kernel/cs_main.h>
 #include <kernel/types.h>
-#include <sync.h>
-#include <uint256.h>
-
-class CBlock;
 
 using kernel::ChainstateRole;
 
 namespace kernel {
-interfaces::BlockInfo MakeBlockInfo(const CBlockIndex* index, const CBlock* data)
-{
-    interfaces::BlockInfo info{index ? *index->phashBlock : uint256::ZERO};
-    if (index) {
-        info.prev_hash = index->pprev ? index->pprev->phashBlock : nullptr;
-        info.height = index->nHeight;
-        info.chain_time_max = index->GetBlockTimeMax();
-        LOCK(::cs_main);
-        info.file_number = index->nFile;
-        info.data_pos = index->nDataPos;
-    }
-    info.data = data;
-    return info;
-}
-
 std::ostream& operator<<(std::ostream& os, const ChainstateRole& role) {
     if (!role.validated) {
         os << "assumedvalid";

--- a/src/kernel/chain.h
+++ b/src/kernel/chain.h
@@ -5,37 +5,10 @@
 #ifndef BITCOIN_KERNEL_CHAIN_H
 #define BITCOIN_KERNEL_CHAIN_H
 
-#include <attributes.h>
-
 #include <iostream>
-
-class CBlock;
-class CBlockIndex;
-class CBlockUndo;
-class uint256;
-
-namespace interfaces {
-//! Block data sent with blockConnected, blockDisconnected notifications.
-struct BlockInfo {
-    const uint256& hash;
-    const uint256* prev_hash = nullptr;
-    int height = -1;
-    int file_number = -1;
-    unsigned data_pos = 0;
-    const CBlock* data = nullptr;
-    const CBlockUndo* undo_data = nullptr;
-    // The maximum time in the chain up to and including this block.
-    // A timestamp that can only move forward.
-    unsigned int chain_time_max{0};
-
-    BlockInfo(const uint256& hash LIFETIMEBOUND) : hash(hash) {}
-};
-} // namespace interfaces
 
 namespace kernel {
 struct ChainstateRole;
-//! Return data from block index.
-interfaces::BlockInfo MakeBlockInfo(const CBlockIndex* block_index, const CBlock* data = nullptr);
 std::ostream& operator<<(std::ostream& os, const ChainstateRole& role);
 } // namespace kernel
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3371,7 +3371,7 @@ void PeerManagerImpl::ProcessGetCFilters(CNode& node, Peer& peer, DataStream& vR
     }
 
     std::vector<BlockFilter> filters;
-    if (!filter_index->LookupFilterRange(start_height, stop_index, filters)) {
+    if (!filter_index->LookupFilterRange(start_height, {stop_index->GetBlockHash(), stop_index->nHeight}, filters)) {
         LogDebug(BCLog::NET, "Failed to find block filter in index: filter_type=%s, start_height=%d, stop_hash=%s\n",
                      BlockFilterTypeName(filter_type), start_height, stop_hash.ToString());
         return;
@@ -3403,7 +3403,7 @@ void PeerManagerImpl::ProcessGetCFHeaders(CNode& node, Peer& peer, DataStream& v
     if (start_height > 0) {
         const CBlockIndex* const prev_block =
             stop_index->GetAncestor(static_cast<int>(start_height - 1));
-        if (!filter_index->LookupFilterHeader(prev_block, prev_header)) {
+        if (!filter_index->LookupFilterHeader({prev_block->GetBlockHash(), prev_block->nHeight}, prev_header)) {
             LogDebug(BCLog::NET, "Failed to find block filter header in index: filter_type=%s, block_hash=%s\n",
                          BlockFilterTypeName(filter_type), prev_block->GetBlockHash().ToString());
             return;
@@ -3411,7 +3411,7 @@ void PeerManagerImpl::ProcessGetCFHeaders(CNode& node, Peer& peer, DataStream& v
     }
 
     std::vector<uint256> filter_hashes;
-    if (!filter_index->LookupFilterHashRange(start_height, stop_index, filter_hashes)) {
+    if (!filter_index->LookupFilterHashRange(start_height, {stop_index->GetBlockHash(), stop_index->nHeight}, filter_hashes)) {
         LogDebug(BCLog::NET, "Failed to find block filter hashes in index: filter_type=%s, start_height=%d, stop_hash=%s\n",
                      BlockFilterTypeName(filter_type), start_height, stop_hash.ToString());
         return;
@@ -3449,7 +3449,7 @@ void PeerManagerImpl::ProcessGetCFCheckPt(CNode& node, Peer& peer, DataStream& v
         int height = (i + 1) * CFCHECKPT_INTERVAL;
         block_index = block_index->GetAncestor(height);
 
-        if (!filter_index->LookupFilterHeader(block_index, headers[i])) {
+        if (!filter_index->LookupFilterHeader({block_index->GetBlockHash(), block_index->nHeight}, headers[i])) {
             LogDebug(BCLog::NET, "Failed to find block filter header in index: filter_type=%s, block_hash=%s\n",
                          BlockFilterTypeName(filter_type), block_index->GetBlockHash().ToString());
             return;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3582,7 +3582,7 @@ void PeerManagerImpl::ProcessGetCFilters(CNode& node, Peer& peer, DataStream& vR
     }
 
     std::vector<BlockFilter> filters;
-    if (!filter_index->LookupFilterRange(start_height, stop_index, filters)) {
+    if (!filter_index->LookupFilterRange(start_height, {stop_index->GetBlockHash(), stop_index->nHeight}, filters)) {
         LogDebug(BCLog::NET, "Failed to find block filter in index: filter_type=%s, start_height=%d, stop_hash=%s\n",
                      BlockFilterTypeName(filter_type), start_height, stop_hash.ToString());
         return;
@@ -3614,7 +3614,7 @@ void PeerManagerImpl::ProcessGetCFHeaders(CNode& node, Peer& peer, DataStream& v
     if (start_height > 0) {
         const CBlockIndex* const prev_block =
             stop_index->GetAncestor(static_cast<int>(start_height - 1));
-        if (!filter_index->LookupFilterHeader(prev_block, prev_header)) {
+        if (!filter_index->LookupFilterHeader({prev_block->GetBlockHash(), prev_block->nHeight}, prev_header)) {
             LogDebug(BCLog::NET, "Failed to find block filter header in index: filter_type=%s, block_hash=%s\n",
                          BlockFilterTypeName(filter_type), prev_block->GetBlockHash().ToString());
             return;
@@ -3622,7 +3622,7 @@ void PeerManagerImpl::ProcessGetCFHeaders(CNode& node, Peer& peer, DataStream& v
     }
 
     std::vector<uint256> filter_hashes;
-    if (!filter_index->LookupFilterHashRange(start_height, stop_index, filter_hashes)) {
+    if (!filter_index->LookupFilterHashRange(start_height, {stop_index->GetBlockHash(), stop_index->nHeight}, filter_hashes)) {
         LogDebug(BCLog::NET, "Failed to find block filter hashes in index: filter_type=%s, start_height=%d, stop_hash=%s\n",
                      BlockFilterTypeName(filter_type), start_height, stop_hash.ToString());
         return;
@@ -3660,7 +3660,7 @@ void PeerManagerImpl::ProcessGetCFCheckPt(CNode& node, Peer& peer, DataStream& v
         int height = (i + 1) * CFCHECKPT_INTERVAL;
         block_index = block_index->GetAncestor(height);
 
-        if (!filter_index->LookupFilterHeader(block_index, headers[i])) {
+        if (!filter_index->LookupFilterHeader({block_index->GetBlockHash(), block_index->nHeight}, headers[i])) {
             LogDebug(BCLog::NET, "Failed to find block filter header in index: filter_type=%s, block_hash=%s\n",
                          BlockFilterTypeName(filter_type), block_index->GetBlockHash().ToString());
             return;

--- a/src/node/chain.cpp
+++ b/src/node/chain.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2022-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/chain.h>
+
+#include <interfaces/types.h>
+
+#include <chain.h>
+#include <kernel/cs_main.h>
+#include <sync.h>
+#include <uint256.h>
+
+class CBlock;
+
+namespace node {
+interfaces::BlockInfo MakeBlockInfo(const CBlockIndex* index, const CBlock* data)
+{
+    interfaces::BlockInfo info{index ? *index->phashBlock : uint256::ZERO};
+    if (index) {
+        info.prev_hash = index->pprev ? index->pprev->phashBlock : nullptr;
+        info.height = index->nHeight;
+        info.chain_time_max = index->GetBlockTimeMax();
+        LOCK(::cs_main);
+        info.file_number = index->nFile;
+        info.data_pos = index->nDataPos;
+    }
+    info.data = data;
+    return info;
+}
+} // namespace node

--- a/src/node/chain.cpp
+++ b/src/node/chain.cpp
@@ -65,6 +65,14 @@ bool ReadBlockData(node::BlockManager& blockman, const CBlockIndex& block, CBloc
             return false;
         }
     }
+    if (undo_data && block.nHeight > 0) {
+        if (blockman.ReadBlockUndo(*undo_data, block)) {
+            info.undo_data = undo_data;
+        } else {
+            info.error = strprintf("%s: Failed to read block %s undo data from disk", __func__, block.GetBlockHash().ToString());
+            return false;
+        }
+    }
     return true;
 }
 

--- a/src/node/chain.cpp
+++ b/src/node/chain.cpp
@@ -20,7 +20,6 @@
 class CBlock;
 
 using interfaces::BlockInfo;
-using kernel::ChainstateRole;
 
 namespace node {
 BlockInfo MakeBlockInfo(const CBlockIndex* index, const CBlock* data, const Chainstate* chainstate)

--- a/src/node/chain.cpp
+++ b/src/node/chain.cpp
@@ -68,77 +68,58 @@ bool ReadBlockData(node::BlockManager& blockman, const CBlockIndex& block, CBloc
     return true;
 }
 
-static const CBlockIndex* NextSyncBlock(const CBlockIndex* const pindex_prev, const CChain& chain) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+bool SyncChain(const Chainstate& chainstate, const CBlockIndex* block, const interfaces::Chain::NotifyOptions& options, std::shared_ptr<interfaces::Chain::Notifications> notifications, const CThreadInterrupt& interrupt, std::function<void(const CBlockIndex*)> on_sync)
 {
-    AssertLockHeld(cs_main);
-
-    if (!pindex_prev) {
-        return chain.Genesis();
-    }
-
-    if (const auto* pindex{chain.Next(*pindex_prev)}) {
-        return pindex;
-    }
-
-    // If there is no next block, we might be synced
-    if (pindex_prev == chain.Tip()) {
-        return nullptr;
-    }
-
-    // Since block is not in the chain, return the next block in the chain AFTER the last common ancestor.
-    // Caller will be responsible for rewinding back to the common ancestor.
-    const auto* fork{chain.FindFork(*pindex_prev)};
-    // Common ancestor must exist (genesis).
-    return chain.Next(*Assert(fork));
-}
-
-void SyncChain(const Chainstate& chainstate, const CBlockIndex* block, const interfaces::Chain::NotifyOptions& options, std::shared_ptr<interfaces::Chain::Notifications> notifications, const CThreadInterrupt& interrupt, std::function<void(const CBlockIndex*)> on_sync)
-{
-    assert(chainstate.m_chain.Tip());
-    const CBlockIndex* pindex = block;
-    std::optional<kernel::ChainstateRole> role;
     while (true) {
-        if (interrupt) {
-            LogInfo("%s: interrupt set; exiting sync", options.thread_name);
-            // Call blockConnected with no data to commit latest state.
-            if (role) notifications->blockConnected(*role, MakeBlockInfo(pindex, nullptr, &chainstate)); // error logged internally
-            return;
+        AssertLockNotHeld(::cs_main);
+        WAIT_LOCK(::cs_main, main_lock);
+
+        bool rewind = false;
+        if (!block) {
+            block = chainstate.m_chain.Genesis();
+        } else if (chainstate.m_chain.Contains(*block)) {
+            block = chainstate.m_chain.Next(*block);
+        } else {
+            rewind = true;
         }
 
-        const CBlockIndex* pindex_next = WITH_LOCK(cs_main,
-            role = chainstate.GetRole();
-            return NextSyncBlock(pindex, chainstate.m_chain));
-        // If pindex_next is null, it means pindex is the chain tip, so
-        // commit data indexed so far.
-        if (!pindex_next) {
-            // Call blockConnected with no data to commit latest state.
-            notifications->blockConnected(*role, MakeBlockInfo(pindex, nullptr, &chainstate)); // error logged internally
-            // If pindex is still the chain tip after committing, exit the sync
-            // loop. Call on_sync with cs_main so caller can handle it before
-            // new blocks are connected.
-            LOCK(::cs_main);
-            pindex_next = NextSyncBlock(pindex, chainstate.m_chain);
-            if (!pindex_next) {
-                if (on_sync) on_sync(pindex);
-                break;
+        auto role{chainstate.GetRole()};
+        if (block) {
+            // Read block data and send notifications.
+            BlockInfo block_info = MakeBlockInfo(block, nullptr, &chainstate);
+            REVERSE_LOCK(main_lock, ::cs_main);
+            CBlock data;
+            CBlockUndo undo_data;
+            ReadBlockData(chainstate.m_blockman, *block,
+                          !rewind || options.disconnect_data ? &data : nullptr,
+                          (!rewind && options.connect_undo_data) || (rewind && options.disconnect_undo_data) ? &undo_data : nullptr,
+                          block_info);
+            if (rewind) {
+                notifications->blockDisconnected(block_info);
+                block = Assert(block->pprev);
+            } else {
+                notifications->blockConnected(role, block_info);
+            }
+        } else {
+            block = chainstate.m_chain.Tip();
+        }
+
+        if (interrupt) return false;
+
+        if (block == chainstate.m_chain.Tip()) {
+            // Sent an extra notification when reaching the tip to signal that
+            // sync is likely finished, and allow the app to flush data.
+            {
+                BlockInfo block_info = MakeBlockInfo(block, nullptr, &chainstate);
+                REVERSE_LOCK(main_lock, ::cs_main);
+                notifications->blockConnected(role, block_info);
+            }
+            // If tip did not change, the sync is done.
+            if (block == chainstate.m_chain.Tip()) {
+                if (on_sync) on_sync(block);
+                return true;
             }
         }
-        if (pindex_next->pprev != pindex) {
-            for (const CBlockIndex* new_tip = pindex_next->pprev; pindex != new_tip && !interrupt; pindex = pindex->pprev) {
-                CBlock data;
-                CBlockUndo undo_data;
-                BlockInfo block = MakeBlockInfo(pindex, nullptr, &chainstate);
-                ReadBlockData(chainstate.m_blockman, *pindex, options.disconnect_data ? &data : nullptr, options.disconnect_undo_data ? &undo_data : nullptr, block);
-                notifications->blockDisconnected(block);
-            }
-            if (interrupt) continue;
-        }
-        pindex = pindex_next;
-        CBlock data;
-        CBlockUndo undo_data;
-        BlockInfo block = MakeBlockInfo(pindex, nullptr, &chainstate);
-        ReadBlockData(chainstate.m_blockman, *pindex, &data, options.connect_undo_data ? &undo_data : nullptr, block);
-        notifications->blockConnected(*role, block); // error logged internally
     }
 }
 } // namespace node

--- a/src/node/chain.cpp
+++ b/src/node/chain.cpp
@@ -10,13 +10,16 @@
 #include <kernel/cs_main.h>
 #include <sync.h>
 #include <uint256.h>
+#include <validation.h>
 
 class CBlock;
 
+using interfaces::BlockInfo;
+
 namespace node {
-interfaces::BlockInfo MakeBlockInfo(const CBlockIndex* index, const CBlock* data)
+BlockInfo MakeBlockInfo(const CBlockIndex* index, const CBlock* data, const Chainstate* chainstate)
 {
-    interfaces::BlockInfo info{index ? *index->phashBlock : uint256::ZERO};
+    BlockInfo info{index ? *index->phashBlock : uint256::ZERO};
     if (index) {
         info.prev_hash = index->pprev ? index->pprev->phashBlock : nullptr;
         info.height = index->nHeight;
@@ -24,6 +27,15 @@ interfaces::BlockInfo MakeBlockInfo(const CBlockIndex* index, const CBlock* data
         LOCK(::cs_main);
         info.file_number = index->nFile;
         info.data_pos = index->nDataPos;
+        if (chainstate) {
+            info.background_sync = true;
+            const CBlockIndex* last_flushed{chainstate->GetLastFlushedBlock()};
+            if (index == last_flushed) {
+                info.status = BlockInfo::FLUSHED_TIP;
+            } else if (!last_flushed || last_flushed->GetAncestor(index->nHeight) == index) {
+                info.status = BlockInfo::FLUSHED;
+            }
+        }
     }
     info.data = data;
     return info;

--- a/src/node/chain.cpp
+++ b/src/node/chain.cpp
@@ -4,17 +4,23 @@
 
 #include <node/chain.h>
 
-#include <interfaces/types.h>
-
 #include <chain.h>
+#include <interfaces/chain.h>
+#include <interfaces/types.h>
+#include <kernel/chain.h>
 #include <kernel/cs_main.h>
+#include <kernel/types.h>
+#include <node/blockstorage.h>
 #include <sync.h>
 #include <uint256.h>
+#include <undo.h>
+#include <util/threadinterrupt.h>
 #include <validation.h>
 
 class CBlock;
 
 using interfaces::BlockInfo;
+using kernel::ChainstateRole;
 
 namespace node {
 BlockInfo MakeBlockInfo(const CBlockIndex* index, const CBlock* data, const Chainstate* chainstate)
@@ -28,7 +34,7 @@ BlockInfo MakeBlockInfo(const CBlockIndex* index, const CBlock* data, const Chai
         info.file_number = index->nFile;
         info.data_pos = index->nDataPos;
         if (chainstate) {
-            info.background_sync = true;
+            info.state = BlockInfo::SYNCING;
             const CBlockIndex* last_flushed{chainstate->GetLastFlushedBlock()};
             if (index == last_flushed) {
                 info.status = BlockInfo::FLUSHED_TIP;
@@ -39,5 +45,100 @@ BlockInfo MakeBlockInfo(const CBlockIndex* index, const CBlock* data, const Chai
     }
     info.data = data;
     return info;
+}
+
+bool ReadBlockData(node::BlockManager& blockman, const CBlockIndex& block, CBlock* data, CBlockUndo* undo_data, BlockInfo& info)
+{
+    if (data) {
+        if (blockman.ReadBlock(*data, block)) {
+            info.data = data;
+        } else {
+            info.error = strprintf("Failed to read block %s from disk", block.GetBlockHash().ToString());
+            return false;
+        }
+    }
+    if (undo_data) {
+        if (block.nHeight == 0 || blockman.ReadBlockUndo(*undo_data, block)) {
+            info.undo_data = undo_data;
+        } else {
+            info.error = strprintf("Failed to read block %s undo data from disk", block.GetBlockHash().ToString());
+            return false;
+        }
+    }
+    return true;
+}
+
+static const CBlockIndex* NextSyncBlock(const CBlockIndex* const pindex_prev, const CChain& chain) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    AssertLockHeld(cs_main);
+
+    if (!pindex_prev) {
+        return chain.Genesis();
+    }
+
+    if (const auto* pindex{chain.Next(*pindex_prev)}) {
+        return pindex;
+    }
+
+    // If there is no next block, we might be synced
+    if (pindex_prev == chain.Tip()) {
+        return nullptr;
+    }
+
+    // Since block is not in the chain, return the next block in the chain AFTER the last common ancestor.
+    // Caller will be responsible for rewinding back to the common ancestor.
+    const auto* fork{chain.FindFork(*pindex_prev)};
+    // Common ancestor must exist (genesis).
+    return chain.Next(*Assert(fork));
+}
+
+void SyncChain(const Chainstate& chainstate, const CBlockIndex* block, const interfaces::Chain::NotifyOptions& options, std::shared_ptr<interfaces::Chain::Notifications> notifications, const CThreadInterrupt& interrupt, std::function<void(const CBlockIndex*)> on_sync)
+{
+    assert(chainstate.m_chain.Tip());
+    const CBlockIndex* pindex = block;
+    std::optional<kernel::ChainstateRole> role;
+    while (true) {
+        if (interrupt) {
+            LogInfo("%s: interrupt set; exiting sync", options.thread_name);
+            // Call blockConnected with no data to commit latest state.
+            if (role) notifications->blockConnected(*role, MakeBlockInfo(pindex, nullptr, &chainstate)); // error logged internally
+            return;
+        }
+
+        const CBlockIndex* pindex_next = WITH_LOCK(cs_main,
+            role = chainstate.GetRole();
+            return NextSyncBlock(pindex, chainstate.m_chain));
+        // If pindex_next is null, it means pindex is the chain tip, so
+        // commit data indexed so far.
+        if (!pindex_next) {
+            // Call blockConnected with no data to commit latest state.
+            notifications->blockConnected(*role, MakeBlockInfo(pindex, nullptr, &chainstate)); // error logged internally
+            // If pindex is still the chain tip after committing, exit the sync
+            // loop. Call on_sync with cs_main so caller can handle it before
+            // new blocks are connected.
+            LOCK(::cs_main);
+            pindex_next = NextSyncBlock(pindex, chainstate.m_chain);
+            if (!pindex_next) {
+                if (on_sync) on_sync(pindex);
+                break;
+            }
+        }
+        if (pindex_next->pprev != pindex) {
+            for (const CBlockIndex* new_tip = pindex_next->pprev; pindex != new_tip && !interrupt; pindex = pindex->pprev) {
+                CBlock data;
+                CBlockUndo undo_data;
+                BlockInfo block = MakeBlockInfo(pindex, nullptr, &chainstate);
+                ReadBlockData(chainstate.m_blockman, *pindex, options.disconnect_data ? &data : nullptr, options.disconnect_undo_data ? &undo_data : nullptr, block);
+                notifications->blockDisconnected(block);
+            }
+            if (interrupt) continue;
+        }
+        pindex = pindex_next;
+        CBlock data;
+        CBlockUndo undo_data;
+        BlockInfo block = MakeBlockInfo(pindex, nullptr, &chainstate);
+        ReadBlockData(chainstate.m_blockman, *pindex, &data, options.connect_undo_data ? &undo_data : nullptr, block);
+        notifications->blockConnected(*role, block); // error logged internally
+    }
 }
 } // namespace node

--- a/src/node/chain.h
+++ b/src/node/chain.h
@@ -7,13 +7,14 @@
 
 class CBlock;
 class CBlockIndex;
+class Chainstate;
 namespace interfaces {
 struct BlockInfo;
 } // namespace interfaces
 
 namespace node {
 //! Return data from block index.
-interfaces::BlockInfo MakeBlockInfo(const CBlockIndex* block_index, const CBlock* data = nullptr);
+interfaces::BlockInfo MakeBlockInfo(const CBlockIndex* block_index, const CBlock* data = nullptr, const Chainstate* chainstate = nullptr);
 } // namespace node
 
 #endif // BITCOIN_NODE_CHAIN_H

--- a/src/node/chain.h
+++ b/src/node/chain.h
@@ -31,7 +31,27 @@ interfaces::BlockInfo MakeBlockInfo(const CBlockIndex* block_index, const CBlock
 bool ReadBlockData(BlockManager& blockman, const CBlockIndex& block, CBlock* data, CBlockUndo* undo_data, interfaces::BlockInfo& info);
 
 //! Send blockConnected and blockDisconnected notifications needed to sync from
-//! a specified block to the chain tip.
+//! a specified block to the chain tip. This sync function locks the ::cs_main
+//! mutex intermittently, releasing it while sending notifications and reading
+//! block data, so it follows the tip if the tip changes, and follows any
+//! reorgs.
+//!
+//! At the of sync this sends two special notifications to the client:
+//!
+//! - A special blockConnected notification with data=null, called without
+//!   cs_main locked. Called one or more times.
+//! - A call to the on_sync callback, called with cs_main locked, called exactly
+//!   once.
+//!
+//! Purpose of the first notification is to let application flush data at the
+//! end of the sync. Because this is potentially expensive it is called without
+//! cs_main locked. And it may potentially be called multiple times if new
+//! blocks are connected while the callback is processed.
+//!
+//! Purpose of the second notification is to let the client register for new
+//! blockconnected events. This has to been done with cs_main locked so no new
+//! blocks can be connected while registering, which could lead to missed
+//! notifications.
 //!
 //! @param chainstate - chain to sync to
 //! @param block - starting block to sync from
@@ -39,10 +59,9 @@ bool ReadBlockData(BlockManager& blockman, const CBlockIndex& block, CBlock* dat
 //! @param notifications - object to send notifications to
 //! @param interrupt - flag to interrupt the sync
 //! @param on_sync - optional callback invoked when reaching the chain tip
-//!                  while cs_main is still held, before sending a final
-//!                  blockConnected notification. This can be used to
-//!                  synchronously register for new notifications.
-void SyncChain(const Chainstate& chainstate, const CBlockIndex* block, const interfaces::Chain::NotifyOptions& options, std::shared_ptr<interfaces::Chain::Notifications> notifications, const CThreadInterrupt& interrupt, std::function<void(const CBlockIndex*)> on_sync);
+//!                  while cs_main is still held.
+//! @return true if synced, false if interrupted
+bool SyncChain(const Chainstate& chainstate, const CBlockIndex* block, const interfaces::Chain::NotifyOptions& options, std::shared_ptr<interfaces::Chain::Notifications> notifications, const CThreadInterrupt& interrupt, std::function<void(const CBlockIndex*)> on_sync);
 } // namespace node
 
 #endif // BITCOIN_NODE_CHAIN_H

--- a/src/node/chain.h
+++ b/src/node/chain.h
@@ -5,16 +5,44 @@
 #ifndef BITCOIN_NODE_CHAIN_H
 #define BITCOIN_NODE_CHAIN_H
 
+#include <functional>
+
+#include <interfaces/chain.h>
+
 class CBlock;
 class CBlockIndex;
+class CBlockUndo;
+class CThreadInterrupt;
 class Chainstate;
 namespace interfaces {
 struct BlockInfo;
 } // namespace interfaces
 
 namespace node {
+class BlockManager;
+
 //! Return data from block index.
+//! By default assumes data for an UPDATING notification and the block is not
+//! flushed. But if chainstate is provided, this assumes a SYNCING notification
+//! and flush status will be looked up in the ChainState.
 interfaces::BlockInfo MakeBlockInfo(const CBlockIndex* block_index, const CBlock* data = nullptr, const Chainstate* chainstate = nullptr);
+
+//! Read block data and/or undo data from disk and update BlockInfo with pointers and errors.
+bool ReadBlockData(BlockManager& blockman, const CBlockIndex& block, CBlock* data, CBlockUndo* undo_data, interfaces::BlockInfo& info);
+
+//! Send blockConnected and blockDisconnected notifications needed to sync from
+//! a specified block to the chain tip.
+//!
+//! @param chainstate - chain to sync to
+//! @param block - starting block to sync from
+//! @param options - notification options
+//! @param notifications - object to send notifications to
+//! @param interrupt - flag to interrupt the sync
+//! @param on_sync - optional callback invoked when reaching the chain tip
+//!                  while cs_main is still held, before sending a final
+//!                  blockConnected notification. This can be used to
+//!                  synchronously register for new notifications.
+void SyncChain(const Chainstate& chainstate, const CBlockIndex* block, const interfaces::Chain::NotifyOptions& options, std::shared_ptr<interfaces::Chain::Notifications> notifications, const CThreadInterrupt& interrupt, std::function<void(const CBlockIndex*)> on_sync);
 } // namespace node
 
 #endif // BITCOIN_NODE_CHAIN_H

--- a/src/node/chain.h
+++ b/src/node/chain.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2022-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_CHAIN_H
+#define BITCOIN_NODE_CHAIN_H
+
+class CBlock;
+class CBlockIndex;
+namespace interfaces {
+struct BlockInfo;
+} // namespace interfaces
+
+namespace node {
+//! Return data from block index.
+interfaces::BlockInfo MakeBlockInfo(const CBlockIndex* block_index, const CBlock* data = nullptr);
+} // namespace node
+
+#endif // BITCOIN_NODE_CHAIN_H

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -672,6 +672,12 @@ public:
         const CBlockIndex* block{chainman().ActiveChain()[height]};
         return block && ((block->nStatus & BLOCK_HAVE_DATA) != 0) && block->nTx > 0;
     }
+    bool getTip(const FoundBlock& block) override
+    {
+        WAIT_LOCK(cs_main, lock);
+        const CChain& active = chainman().ActiveChain();
+        return FillBlock(active.Tip(), block, lock, active, chainman().m_blockman);
+    }
     std::optional<int> findLocatorFork(const CBlockLocator& locator) override
     {
         LOCK(::cs_main);
@@ -899,6 +905,10 @@ public:
         LOCK(cs_main);
         Chainstate& chainstate{chainman().CurrentChainstate()};
         return std::make_unique<NotificationsHandlerImpl>(validation_signals(), chainstate, std::move(notifications));
+    }
+    void waitForPendingNotifications() override
+    {
+        validation_signals().SyncWithValidationInterfaceQueue();
     }
     void waitForNotificationsIfTipChanged(const uint256& old_tip) override
     {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -34,6 +34,7 @@
 #include <netaddress.h>
 #include <netbase.h>
 #include <node/blockstorage.h>
+#include <node/chain.h>
 #include <node/coin.h>
 #include <node/context.h>
 #include <node/interface_ui.h>
@@ -479,11 +480,11 @@ public:
     }
     void BlockConnected(const ChainstateRole& role, const std::shared_ptr<const CBlock>& block, const CBlockIndex* index) override
     {
-        m_notifications->blockConnected(role, kernel::MakeBlockInfo(index, block.get()));
+        m_notifications->blockConnected(role, MakeBlockInfo(index, block.get()));
     }
     void BlockDisconnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* index) override
     {
-        m_notifications->blockDisconnected(kernel::MakeBlockInfo(index, block.get()));
+        m_notifications->blockDisconnected(MakeBlockInfo(index, block.get()));
     }
     void UpdatedBlockTip(const CBlockIndex* index, const CBlockIndex* fork_index, bool is_ibd) override
     {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -26,10 +26,12 @@
 #include <interfaces/types.h>
 #include <kernel/context.h>
 #include <key.h>
+#include <kernel/types.h>
 #include <logging.h>
 #include <mapport.h>
 #include <net.h>
 #include <net_processing.h>
+#include <util/threadinterrupt.h>
 #include <net_types.h>
 #include <netaddress.h>
 #include <netbase.h>
@@ -59,12 +61,14 @@
 #include <sync.h>
 #include <txmempool.h>
 #include <uint256.h>
+#include <undo.h>
 #include <univalue.h>
 #include <util/btcsignals.h>
 #include <util/check.h>
 #include <util/result.h>
 #include <util/signalinterrupt.h>
 #include <util/string.h>
+#include <util/thread.h>
 #include <util/time.h>
 #include <util/translation.h>
 #include <validation.h>
@@ -80,10 +84,12 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <thread>
 #include <tuple>
 #include <utility>
 #include <vector>
 
+using interfaces::BlockInfo;
 using interfaces::BlockRef;
 using interfaces::BlockTemplate;
 using interfaces::BlockTip;
@@ -467,8 +473,8 @@ bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<Rec
 class NotificationsProxy : public CValidationInterface
 {
 public:
-    explicit NotificationsProxy(std::shared_ptr<Chain::Notifications> notifications, bool connected)
-        : m_notifications{std::move(notifications)}, m_connected{connected} {}
+    explicit NotificationsProxy(Chainstate& chainstate, std::shared_ptr<Chain::Notifications> notifications, Chain::NotifyOptions options)
+        : m_chainstate{chainstate}, m_notifications{std::move(notifications)}, m_options{std::move(options)} {}
     virtual ~NotificationsProxy() = default;
     void TransactionAddedToMempool(const NewMempoolTransactionInfo& tx, uint64_t mempool_sequence) override
     {
@@ -480,11 +486,17 @@ public:
     }
     void BlockConnected(const ChainstateRole& role, const std::shared_ptr<const CBlock>& block, const CBlockIndex* index) override
     {
-        m_notifications->blockConnected(role, MakeBlockInfo(index, block.get()));
+        interfaces::BlockInfo block_info = MakeBlockInfo(index, block.get());
+        CBlockUndo undo_data;
+        if (m_options.connect_undo_data) ReadBlockData(m_chainstate.m_blockman, *Assert(index), /*data=*/nullptr, &undo_data, block_info);
+        m_notifications->blockConnected(role, block_info);
     }
     void BlockDisconnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* index) override
     {
-        m_notifications->blockDisconnected(MakeBlockInfo(index, block.get()));
+        interfaces::BlockInfo block_info = MakeBlockInfo(index, block.get());
+        CBlockUndo undo_data;
+        if (m_options.disconnect_undo_data) ReadBlockData(m_chainstate.m_blockman, *Assert(index), /*data=*/nullptr, &undo_data, block_info);
+        m_notifications->blockDisconnected(block_info);
     }
     void UpdatedBlockTip(const CBlockIndex* index, const CBlockIndex* fork_index, bool is_ibd) override
     {
@@ -494,18 +506,66 @@ public:
     {
         m_notifications->chainStateFlushed(role, locator);
     }
+    static void RegisterSynced(std::shared_ptr<NotificationsProxy> self, ValidationSignals& signals, const CBlockIndex* sync_block) EXCLUSIVE_LOCKS_REQUIRED (::cs_main)
+    {
+        AssertLockHeld(::cs_main);
+        // Instead of registering for notifications immediately, which could
+        // cause older BlockConnected notifications currently in the queue to be
+        // received, enqueue the registration so only notifications from new
+        // blocks connected after this call will be received.
+        //
+        // cs_main should also be held during this call to prevent new blocks
+        // from being connected before this and notifications being missed.
+        signals.CallFunctionInValidationInterfaceQueue([self, &signals, sync_block] {
+            // Send initial notification with state = SYNCED indicating the block currently synced to.
+            BlockInfo block = MakeBlockInfo(sync_block, nullptr, &self->m_chainstate);
+            block.state = BlockInfo::SYNCED;
+            self->m_notifications->blockConnected(WITH_LOCK(::cs_main, return self->m_chainstate.GetRole()), block);
+            // Register for new notifications unless disconnect() has been called.
+            if (WITH_LOCK(self->m_mutex, return self->m_connected)) {
+                signals.RegisterSharedValidationInterface(self);
+            }
+        });
+    }
+
+    Chainstate& m_chainstate;
     std::shared_ptr<Chain::Notifications> m_notifications;
+    Chain::NotifyOptions m_options;
     Mutex m_mutex;
-    bool m_connected GUARDED_BY(m_mutex);
+    bool m_connected GUARDED_BY(m_mutex) {false};
 };
+
+using SyncFn = std::function<void(const CThreadInterrupt& interrupt, std::function<void(const CBlockIndex*)> on_sync)>;
 
 class NotificationsHandlerImpl : public Handler
 {
 public:
-    explicit NotificationsHandlerImpl(ValidationSignals& signals, std::shared_ptr<Chain::Notifications> notifications, bool connected = true)
-        : m_signals{signals}, m_proxy{std::make_shared<NotificationsProxy>(std::move(notifications), connected)}
+    explicit NotificationsHandlerImpl(ValidationSignals& signals, Chainstate& chainstate, std::shared_ptr<Chain::Notifications> notifications, const Chain::NotifyOptions& options = {}, BlockInfo::State state = BlockInfo::UPDATING, const CBlockIndex* start_block = nullptr)
+        : m_signals{signals}, m_chainstate{chainstate}, m_proxy{std::make_shared<NotificationsProxy>(chainstate, std::move(notifications), std::move(options))}, m_start_block{start_block}
     {
-        if (connected) m_signals.RegisterSharedValidationInterface(m_proxy);
+        // If syncing is not needed, set connected=true and register for
+        // notifications right away. If syncing is needed (state == SYNCING), do
+        // not do anything until connect() is called. It would be simpler to
+        // just always connect, but indexes rely on being able to call connect()
+        // later to delay syncing if they are not in sync with the chainstate
+        // initially (e.g. if -reindex-chainstate is used) so they do not start
+        // syncing with the chainstate until it is up-to-date. More typically
+        // though, indexes start off already synced to the chainstate tip (state
+        // == SYNCED), and connect here to start receiving notifications and be
+        // updated in parallel with chainstate.
+        if (state == BlockInfo::SYNCED || state == BlockInfo::UPDATING) {
+            WITH_LOCK(m_proxy->m_mutex, m_proxy->m_connected = true);
+            if (state == BlockInfo::SYNCED) {
+                // If synced at a particular block send a notification and
+                // register via the queue to make sure stale notications from
+                // earlier blocks are not sent.
+                m_proxy->RegisterSynced(m_proxy, signals, m_start_block);
+            } else {
+                // If not synced at any block just register now.
+                assert(!m_start_block);
+                signals.RegisterSharedValidationInterface(m_proxy);
+            }
+        }
     }
     ~NotificationsHandlerImpl() override { disconnect(); }
     void connect() override
@@ -514,33 +574,41 @@ public:
         LOCK(m_proxy->m_mutex);
         if (!m_proxy->m_connected) {
             m_proxy->m_connected = true;
-            // Instead of registering for notifications immediately, which could
-            // cause older BlockConnected notifications currently in the queue
-            // to be received, enqueue the registration so only new
-            // notifications from new blocks connected after this call will be
-            // received.
-            //
-            // cs_main should also be held during this call to prevent new
-            // blocks from being connected now and notifications being missed.
-            m_signals.CallFunctionInValidationInterfaceQueue([proxy = m_proxy, signals = &m_signals] {
-                LOCK(proxy->m_mutex);
-                if (proxy->m_connected) signals->RegisterSharedValidationInterface(proxy);
+            assert(!m_sync_thread.joinable());
+            m_sync_thread = std::thread(&util::TraceThread, m_proxy->m_options.thread_name, [proxy = m_proxy, signals = &m_signals, chainstate = &m_chainstate, start_block = m_start_block, interrupt = &m_interrupt] {
+                SyncChain(*chainstate, start_block, proxy->m_options, proxy->m_notifications, *interrupt, [proxy, signals](const CBlockIndex* end_block) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
+                    AssertLockHeld(::cs_main);
+                    proxy->RegisterSynced(proxy, *signals, end_block);
+                });
             });
         }
     }
     void disconnect() override
     {
+        m_interrupt();
         if (m_proxy) {
-            LOCK(m_proxy->m_mutex);
-            if (m_proxy->m_connected) {
-                m_proxy->m_connected = false;
-                m_signals.UnregisterSharedValidationInterface(m_proxy);
-            }
+            WITH_LOCK(m_proxy->m_mutex, m_proxy->m_connected = false);
+            m_signals.UnregisterSharedValidationInterface(m_proxy);
             m_proxy.reset();
         }
+        if (m_sync_thread.joinable()) m_sync_thread.join();
+    }
+    bool connected() override
+    {
+        return m_proxy && WITH_LOCK(m_proxy->m_mutex, return m_proxy->m_connected);
+    }
+    void interrupt() override { m_interrupt(); }
+    void sync() override
+    {
+        if (m_sync_thread.joinable()) m_sync_thread.join();
+        m_signals.SyncWithValidationInterfaceQueue();
     }
     ValidationSignals& m_signals;
+    Chainstate& m_chainstate;
     std::shared_ptr<NotificationsProxy> m_proxy;
+    const CBlockIndex* m_start_block;
+    std::thread m_sync_thread;
+    CThreadInterrupt m_interrupt;
 };
 
 class RpcHandlerImpl : public Handler
@@ -575,6 +643,8 @@ public:
             ::tableRPC.removeCommand(m_command.name, &m_command);
         }
     }
+
+    bool connected() override { return m_wrapped_command; }
 
     ~RpcHandlerImpl() override { disconnect(); }
 
@@ -816,14 +886,19 @@ public:
     {
         ::uiInterface.ShowProgress(title, progress, resume_possible);
     }
-    std::unique_ptr<Handler> attachChain(std::shared_ptr<Notifications> notifications, const NotifyOptions& options) override
+    std::unique_ptr<Handler> attachChain(std::shared_ptr<Notifications> notifications, std::optional<uint256> start_block, const NotifyOptions& options) override
     {
         LOCK(cs_main);
-        return std::make_unique<NotificationsHandlerImpl>(validation_signals(), notifications, /*connected=*/false);
+        Chainstate& chainstate{chainman().ValidatedChainstate()};
+        const CBlockIndex* start_index{start_block ? Assert(chainman().m_blockman.LookupBlockIndex(*start_block)) : nullptr};
+        BlockInfo::State state{start_index == chainstate.m_chain.Tip() ? BlockInfo::SYNCED : BlockInfo::SYNCING};
+        return std::make_unique<NotificationsHandlerImpl>(validation_signals(), chainstate, std::move(notifications), options, state, start_index);
     }
     std::unique_ptr<Handler> handleNotifications(std::shared_ptr<Notifications> notifications) override
     {
-        return std::make_unique<NotificationsHandlerImpl>(validation_signals(), std::move(notifications));
+        LOCK(cs_main);
+        Chainstate& chainstate{chainman().CurrentChainstate()};
+        return std::make_unique<NotificationsHandlerImpl>(validation_signals(), chainstate, std::move(notifications));
     }
     void waitForNotificationsIfTipChanged(const uint256& old_tip) override
     {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -719,7 +719,7 @@ public:
 
         BlockFilter filter;
         const CBlockIndex* index{WITH_LOCK(::cs_main, return chainman().m_blockman.LookupBlockIndex(block_hash))};
-        if (index == nullptr || !block_filter_index->LookupFilter(index, filter)) return std::nullopt;
+        if (index == nullptr || !block_filter_index->LookupFilter({index->GetBlockHash(), index->nHeight}, filter)) return std::nullopt;
         return filter.GetFilter().MatchAny(filter_set);
     }
     bool findBlock(const uint256& hash, const FoundBlock& block) override

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -506,6 +506,22 @@ public:
     {
         m_notifications->chainStateFlushed(role, locator);
     }
+    static void connect(std::shared_ptr<NotificationsProxy> self, ValidationSignals& signals) EXCLUSIVE_LOCKS_REQUIRED(!self->m_mutex)
+    {
+        LOCK(self->m_mutex);
+        if (self->m_state == INIT || self->m_state == CONNECTING) {
+            signals.RegisterSharedValidationInterface(self);
+            self->m_state = CONNECTED;
+        }
+    }
+    static void disconnect(std::shared_ptr<NotificationsProxy> self, ValidationSignals& signals) EXCLUSIVE_LOCKS_REQUIRED(!self->m_mutex)
+    {
+        LOCK(self->m_mutex);
+        if (self->m_state == CONNECTED) {
+            signals.UnregisterSharedValidationInterface(self);
+        }
+        self->m_state = DISCONNECTED;
+    }
     static void RegisterSynced(std::shared_ptr<NotificationsProxy> self, ValidationSignals& signals, const CBlockIndex* sync_block) EXCLUSIVE_LOCKS_REQUIRED (::cs_main)
     {
         AssertLockHeld(::cs_main);
@@ -521,10 +537,7 @@ public:
             BlockInfo block = MakeBlockInfo(sync_block, nullptr, &self->m_chainstate);
             block.state = BlockInfo::SYNCED;
             self->m_notifications->blockConnected(WITH_LOCK(::cs_main, return self->m_chainstate.GetRole()), block);
-            // Register for new notifications unless disconnect() has been called.
-            if (WITH_LOCK(self->m_mutex, return self->m_connected)) {
-                signals.RegisterSharedValidationInterface(self);
-            }
+            self->connect(self, signals);
         });
     }
 
@@ -532,10 +545,20 @@ public:
     std::shared_ptr<Chain::Notifications> m_notifications;
     Chain::NotifyOptions m_options;
     Mutex m_mutex;
-    bool m_connected GUARDED_BY(m_mutex) {false};
+    //! State reflecting whether proxy is registered to receive notifications
+    //! from validationinterface, and whether the handler is connected to
+    //! receive notifications from the proxy. The implementation needs to avoid
+    //! registering the proxy if the handler is disconnected first, and avoid
+    //! unregistering the proxy if it wasn't registered first. State needs to be
+    //! guarded by mutex because connect() is called from a
+    //! CallFunctionInValidationInterfaceQueue callback in validationinterface
+    //! thread, and disconnect() is called from the application thread which
+    //! owns the handler, and the two calls could happen at any time in any
+    //! order.
+    enum State { INIT, CONNECTING, CONNECTED, DISCONNECTED } m_state GUARDED_BY(m_mutex) = INIT;
 };
 
-using SyncFn = std::function<void(const CThreadInterrupt& interrupt, std::function<void(const CBlockIndex*)> on_sync)>;
+using SyncFn = std::function<void(std::shared_ptr<NotificationsProxy>, const CThreadInterrupt& interrupt)>;
 
 class NotificationsHandlerImpl : public Handler
 {
@@ -543,7 +566,7 @@ public:
     explicit NotificationsHandlerImpl(ValidationSignals& signals, Chainstate& chainstate, std::shared_ptr<Chain::Notifications> notifications, const Chain::NotifyOptions& options = {}, BlockInfo::State state = BlockInfo::UPDATING, const CBlockIndex* start_block = nullptr)
         : m_signals{signals}, m_chainstate{chainstate}, m_proxy{std::make_shared<NotificationsProxy>(chainstate, std::move(notifications), std::move(options))}, m_start_block{start_block}
     {
-        // If syncing is not needed, set connected=true and register for
+        // If syncing is not needed, set connecting or connecting state and register for
         // notifications right away. If syncing is needed (state == SYNCING), do
         // not do anything until connect() is called. It would be simpler to
         // just always connect, but indexes rely on being able to call connect()
@@ -554,7 +577,7 @@ public:
         // == SYNCED), and connect here to start receiving notifications and be
         // updated in parallel with chainstate.
         if (state == BlockInfo::SYNCED || state == BlockInfo::UPDATING) {
-            WITH_LOCK(m_proxy->m_mutex, m_proxy->m_connected = true);
+            WITH_LOCK(m_proxy->m_mutex, m_proxy->m_state = NotificationsProxy::CONNECTING);
             if (state == BlockInfo::SYNCED) {
                 // If synced at a particular block send a notification and
                 // register via the queue to make sure stale notications from
@@ -563,7 +586,7 @@ public:
             } else {
                 // If not synced at any block just register now.
                 assert(!m_start_block);
-                signals.RegisterSharedValidationInterface(m_proxy);
+                m_proxy->connect(m_proxy, signals);
             }
         }
     }
@@ -572,8 +595,8 @@ public:
     {
         assert(m_proxy);
         LOCK(m_proxy->m_mutex);
-        if (!m_proxy->m_connected) {
-            m_proxy->m_connected = true;
+        if (m_proxy->m_state == NotificationsProxy::INIT) {
+            m_proxy->m_state = NotificationsProxy::CONNECTING;
             assert(!m_sync_thread.joinable());
             m_sync_thread = std::thread(&util::TraceThread, m_proxy->m_options.thread_name, [proxy = m_proxy, signals = &m_signals, chainstate = &m_chainstate, start_block = m_start_block, interrupt = &m_interrupt] {
                 SyncChain(*chainstate, start_block, proxy->m_options, proxy->m_notifications, *interrupt, [proxy, signals](const CBlockIndex* end_block) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
@@ -587,15 +610,14 @@ public:
     {
         m_interrupt();
         if (m_proxy) {
-            WITH_LOCK(m_proxy->m_mutex, m_proxy->m_connected = false);
-            m_signals.UnregisterSharedValidationInterface(m_proxy);
+            m_proxy->disconnect(m_proxy, m_signals);
             m_proxy.reset();
         }
         if (m_sync_thread.joinable()) m_sync_thread.join();
     }
     bool connected() override
     {
-        return m_proxy && WITH_LOCK(m_proxy->m_mutex, return m_proxy->m_connected);
+        return m_proxy && WITH_LOCK(m_proxy->m_mutex, return m_proxy->m_state == NotificationsProxy::CONNECTING || m_proxy->m_state == NotificationsProxy::CONNECTED);
     }
     void interrupt() override { m_interrupt(); }
     void sync() override
@@ -894,6 +916,22 @@ public:
     }
     std::unique_ptr<Handler> attachChain(std::shared_ptr<Notifications> notifications, std::optional<uint256> start_block, const NotifyOptions& options) override
     {
+        // Lock cs_main while finding forks and determining which blocks to
+        // rescan. Release cs_main while processing blocks and while calling
+        // RegisterSharedValidationInterface in the notifications thread.
+        //
+        // To prevent older, stale notifications currently in the validation
+        // queue from being received, it is important to not to register for
+        // notifications immediately, but to delay registration with
+        // CallFunctionInValidationInterfaceQueue, registering the notification
+        // proxy inside the queue, so older notifications in the queue before it
+        // get processed before the proxy is registered.
+        //
+        // To prevent new notifications that may be happening in the background
+        // from being lost, it is important to keep cs_main locked while calling
+        // CallFunctionInValidationInterfaceQueue, so the new notifications will
+        // be added to the queue after the queue entry which connects the proxy.
+        AssertLockNotHeld(::cs_main);
         LOCK(cs_main);
         Chainstate& chainstate{chainman().ValidatedChainstate()};
         const CBlockIndex* start_index{start_block ? Assert(chainman().m_blockman.LookupBlockIndex(*start_block)) : nullptr};

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -467,8 +467,8 @@ bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<Rec
 class NotificationsProxy : public CValidationInterface
 {
 public:
-    explicit NotificationsProxy(std::shared_ptr<Chain::Notifications> notifications)
-        : m_notifications(std::move(notifications)) {}
+    explicit NotificationsProxy(std::shared_ptr<Chain::Notifications> notifications, bool connected)
+        : m_notifications{std::move(notifications)}, m_connected{connected} {}
     virtual ~NotificationsProxy() = default;
     void TransactionAddedToMempool(const NewMempoolTransactionInfo& tx, uint64_t mempool_sequence) override
     {
@@ -495,21 +495,47 @@ public:
         m_notifications->chainStateFlushed(role, locator);
     }
     std::shared_ptr<Chain::Notifications> m_notifications;
+    Mutex m_mutex;
+    bool m_connected GUARDED_BY(m_mutex);
 };
 
 class NotificationsHandlerImpl : public Handler
 {
 public:
-    explicit NotificationsHandlerImpl(ValidationSignals& signals, std::shared_ptr<Chain::Notifications> notifications)
-        : m_signals{signals}, m_proxy{std::make_shared<NotificationsProxy>(std::move(notifications))}
+    explicit NotificationsHandlerImpl(ValidationSignals& signals, std::shared_ptr<Chain::Notifications> notifications, bool connected = true)
+        : m_signals{signals}, m_proxy{std::make_shared<NotificationsProxy>(std::move(notifications), connected)}
     {
-        m_signals.RegisterSharedValidationInterface(m_proxy);
+        if (connected) m_signals.RegisterSharedValidationInterface(m_proxy);
     }
     ~NotificationsHandlerImpl() override { disconnect(); }
+    void connect() override
+    {
+        assert(m_proxy);
+        LOCK(m_proxy->m_mutex);
+        if (!m_proxy->m_connected) {
+            m_proxy->m_connected = true;
+            // Instead of registering for notifications immediately, which could
+            // cause older BlockConnected notifications currently in the queue
+            // to be received, enqueue the registration so only new
+            // notifications from new blocks connected after this call will be
+            // received.
+            //
+            // cs_main should also be held during this call to prevent new
+            // blocks from being connected now and notifications being missed.
+            m_signals.CallFunctionInValidationInterfaceQueue([proxy = m_proxy, signals = &m_signals] {
+                LOCK(proxy->m_mutex);
+                if (proxy->m_connected) signals->RegisterSharedValidationInterface(proxy);
+            });
+        }
+    }
     void disconnect() override
     {
         if (m_proxy) {
-            m_signals.UnregisterSharedValidationInterface(m_proxy);
+            LOCK(m_proxy->m_mutex);
+            if (m_proxy->m_connected) {
+                m_proxy->m_connected = false;
+                m_signals.UnregisterSharedValidationInterface(m_proxy);
+            }
             m_proxy.reset();
         }
     }
@@ -789,6 +815,11 @@ public:
     void showProgress(const std::string& title, int progress, bool resume_possible) override
     {
         ::uiInterface.ShowProgress(title, progress, resume_possible);
+    }
+    std::unique_ptr<Handler> attachChain(std::shared_ptr<Notifications> notifications, const NotifyOptions& options) override
+    {
+        LOCK(cs_main);
+        return std::make_unique<NotificationsHandlerImpl>(validation_signals(), notifications, /*connected=*/false);
     }
     std::unique_ptr<Handler> handleNotifications(std::shared_ptr<Notifications> notifications) override
     {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -25,8 +25,8 @@
 #include <interfaces/rpc.h>
 #include <interfaces/types.h>
 #include <kernel/context.h>
-#include <key.h>
 #include <kernel/types.h>
+#include <key.h>
 #include <logging.h>
 #include <mapport.h>
 #include <net.h>
@@ -563,7 +563,7 @@ using SyncFn = std::function<void(std::shared_ptr<NotificationsProxy>, const CTh
 class NotificationsHandlerImpl : public Handler
 {
 public:
-    explicit NotificationsHandlerImpl(ValidationSignals& signals, Chainstate& chainstate, std::shared_ptr<Chain::Notifications> notifications, const Chain::NotifyOptions& options = {}, BlockInfo::State state = BlockInfo::UPDATING, const CBlockIndex* start_block = nullptr)
+    explicit NotificationsHandlerImpl(ValidationSignals& signals, Chainstate& chainstate, std::shared_ptr<Chain::Notifications> notifications, Chain::NotifyOptions options = {}, BlockInfo::State state = BlockInfo::UPDATING, const CBlockIndex* start_block = nullptr)
         : m_signals{signals}, m_chainstate{chainstate}, m_proxy{std::make_shared<NotificationsProxy>(chainstate, std::move(notifications), std::move(options))}, m_start_block{start_block}
     {
         // If syncing is not needed, set connecting or connecting state and register for
@@ -890,6 +890,15 @@ public:
     {
         if (!m_node.mempool) return CFeeRate{DUST_RELAY_TX_FEE};
         return m_node.mempool->m_opts.dust_relay_feerate;
+    }
+    void updatePruneLock(const std::string& name, const PruneLockInfo& lock_info) override
+    {
+        LOCK(cs_main);
+        m_node.chainman->m_blockman.UpdatePruneLock(name, lock_info);
+    }
+    bool pruningEnabled() override
+    {
+        return chainman().m_blockman.IsPruneMode();
     }
     bool havePruned() override
     {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -508,6 +508,24 @@ public:
     {
         m_notifications->chainStateFlushed(role, locator);
     }
+    static bool connect(std::shared_ptr<NotificationsProxy> self, ValidationSignals& signals) EXCLUSIVE_LOCKS_REQUIRED(!self->m_mutex)
+    {
+        LOCK(self->m_mutex);
+        if (self->m_state == INIT || self->m_state == CONNECTING) {
+            signals.RegisterSharedValidationInterface(self);
+            self->m_state = CONNECTED;
+            return true;
+        }
+        return false;
+    }
+    static void disconnect(std::shared_ptr<NotificationsProxy> self, ValidationSignals& signals) EXCLUSIVE_LOCKS_REQUIRED(!self->m_mutex)
+    {
+        LOCK(self->m_mutex);
+        if (self->m_state == CONNECTED) {
+            signals.UnregisterSharedValidationInterface(self);
+        }
+        self->m_state = DISCONNECTED;
+    }
     static void RegisterSynced(std::shared_ptr<NotificationsProxy> self, ValidationSignals& signals, const CBlockIndex* sync_block) EXCLUSIVE_LOCKS_REQUIRED (::cs_main)
     {
         AssertLockHeld(::cs_main);
@@ -519,13 +537,15 @@ public:
         // cs_main should also be held during this call to prevent new blocks
         // from being connected before this and notifications being missed.
         signals.CallFunctionInValidationInterfaceQueue([self, &signals, sync_block] {
-            // Send initial notification with state = SYNCED indicating the block currently synced to.
-            BlockInfo block = MakeBlockInfo(sync_block, nullptr, &self->m_chainstate);
-            block.state = BlockInfo::SYNCED;
-            self->m_notifications->blockConnected(WITH_LOCK(::cs_main, return self->m_chainstate.GetRole()), block);
-            // Register for new notifications unless disconnect() has been called.
-            if (WITH_LOCK(self->m_mutex, return self->m_connected)) {
-                signals.RegisterSharedValidationInterface(self);
+            // Register first, and only send the notification if connect()
+            // succeeds. If the handler was already disconnected, connect()
+            // returns false and the blockConnected() call is skipped, avoiding
+            // a notification (and use of the handler) after it is torn down.
+            if (self->connect(self, signals)) {
+                // Send initial notification with state = SYNCED indicating the block currently synced to.
+                BlockInfo block = MakeBlockInfo(sync_block, nullptr, &self->m_chainstate);
+                block.state = BlockInfo::SYNCED;
+                self->m_notifications->blockConnected(WITH_LOCK(::cs_main, return self->m_chainstate.GetRole()), block);
             }
         });
     }
@@ -534,10 +554,20 @@ public:
     std::shared_ptr<Chain::Notifications> m_notifications;
     Chain::NotifyOptions m_options;
     Mutex m_mutex;
-    bool m_connected GUARDED_BY(m_mutex) {false};
+    //! State reflecting whether proxy is registered to receive notifications
+    //! from validationinterface, and whether the handler is connected to
+    //! receive notifications from the proxy. The implementation needs to avoid
+    //! registering the proxy if the handler is disconnected first, and avoid
+    //! unregistering the proxy if it wasn't registered first. State needs to be
+    //! guarded by mutex because connect() is called from a
+    //! CallFunctionInValidationInterfaceQueue callback in validationinterface
+    //! thread, and disconnect() is called from the application thread which
+    //! owns the handler, and the two calls could happen at any time in any
+    //! order.
+    enum State { INIT, CONNECTING, CONNECTED, DISCONNECTED } m_state GUARDED_BY(m_mutex) = INIT;
 };
 
-using SyncFn = std::function<void(const CThreadInterrupt& interrupt, std::function<void(const CBlockIndex*)> on_sync)>;
+using SyncFn = std::function<void(std::shared_ptr<NotificationsProxy>, const CThreadInterrupt& interrupt)>;
 
 class NotificationsHandlerImpl : public Handler
 {
@@ -545,7 +575,7 @@ public:
     explicit NotificationsHandlerImpl(ValidationSignals& signals, Chainstate& chainstate, std::shared_ptr<Chain::Notifications> notifications, const Chain::NotifyOptions& options = {}, BlockInfo::State state = BlockInfo::UPDATING, const CBlockIndex* start_block = nullptr)
         : m_signals{signals}, m_chainstate{chainstate}, m_proxy{std::make_shared<NotificationsProxy>(chainstate, std::move(notifications), std::move(options))}, m_start_block{start_block}
     {
-        // If syncing is not needed, set connected=true and register for
+        // If syncing is not needed, set connecting or connecting state and register for
         // notifications right away. If syncing is needed (state == SYNCING), do
         // not do anything until connect() is called. It would be simpler to
         // just always connect, but indexes rely on being able to call connect()
@@ -556,7 +586,7 @@ public:
         // == SYNCED), and connect here to start receiving notifications and be
         // updated in parallel with chainstate.
         if (state == BlockInfo::SYNCED || state == BlockInfo::UPDATING) {
-            WITH_LOCK(m_proxy->m_mutex, m_proxy->m_connected = true);
+            WITH_LOCK(m_proxy->m_mutex, m_proxy->m_state = NotificationsProxy::CONNECTING);
             if (state == BlockInfo::SYNCED) {
                 // If synced at a particular block send a notification and
                 // register via the queue to make sure stale notications from
@@ -565,7 +595,7 @@ public:
             } else {
                 // If not synced at any block just register now.
                 assert(!m_start_block);
-                signals.RegisterSharedValidationInterface(m_proxy);
+                m_proxy->connect(m_proxy, signals);
             }
         }
     }
@@ -574,8 +604,8 @@ public:
     {
         assert(m_proxy);
         LOCK(m_proxy->m_mutex);
-        if (!m_proxy->m_connected) {
-            m_proxy->m_connected = true;
+        if (m_proxy->m_state == NotificationsProxy::INIT) {
+            m_proxy->m_state = NotificationsProxy::CONNECTING;
             assert(!m_sync_thread.joinable());
             m_sync_thread = std::thread(&util::TraceThread, m_proxy->m_options.thread_name, [proxy = m_proxy, signals = &m_signals, chainstate = &m_chainstate, start_block = m_start_block, interrupt = &m_interrupt] {
                 SyncChain(*chainstate, start_block, proxy->m_options, proxy->m_notifications, *interrupt, [proxy, signals](const CBlockIndex* end_block) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
@@ -589,15 +619,14 @@ public:
     {
         m_interrupt();
         if (m_proxy) {
-            WITH_LOCK(m_proxy->m_mutex, m_proxy->m_connected = false);
-            m_signals.UnregisterSharedValidationInterface(m_proxy);
+            m_proxy->disconnect(m_proxy, m_signals);
             m_proxy.reset();
         }
         if (m_sync_thread.joinable()) m_sync_thread.join();
     }
     bool connected() override
     {
-        return m_proxy && WITH_LOCK(m_proxy->m_mutex, return m_proxy->m_connected);
+        return m_proxy && WITH_LOCK(m_proxy->m_mutex, return m_proxy->m_state == NotificationsProxy::CONNECTING || m_proxy->m_state == NotificationsProxy::CONNECTED);
     }
     void interrupt() override { m_interrupt(); }
     void sync() override
@@ -896,6 +925,22 @@ public:
     }
     std::unique_ptr<Handler> attachChain(std::shared_ptr<Notifications> notifications, std::optional<uint256> start_block, const NotifyOptions& options) override
     {
+        // Lock cs_main while finding forks and determining which blocks to
+        // rescan. Release cs_main while processing blocks and while calling
+        // RegisterSharedValidationInterface in the notifications thread.
+        //
+        // To prevent older, stale notifications currently in the validation
+        // queue from being received, it is important to not to register for
+        // notifications immediately, but to delay registration with
+        // CallFunctionInValidationInterfaceQueue, registering the notification
+        // proxy inside the queue, so older notifications in the queue before it
+        // get processed before the proxy is registered.
+        //
+        // To prevent new notifications that may be happening in the background
+        // from being lost, it is important to keep cs_main locked while calling
+        // CallFunctionInValidationInterfaceQueue, so the new notifications will
+        // be added to the queue after the queue entry which connects the proxy.
+        AssertLockNotHeld(::cs_main);
         LOCK(cs_main);
         Chainstate& chainstate{chainman().ValidatedChainstate()};
         const CBlockIndex* start_index{start_block ? Assert(chainman().m_blockman.LookupBlockIndex(*start_block)) : nullptr};

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -26,10 +26,12 @@
 #include <interfaces/types.h>
 #include <kernel/context.h>
 #include <key.h>
+#include <kernel/types.h>
 #include <logging.h>
 #include <mapport.h>
 #include <net.h>
 #include <net_processing.h>
+#include <util/threadinterrupt.h>
 #include <net_types.h>
 #include <netaddress.h>
 #include <netbase.h>
@@ -59,6 +61,7 @@
 #include <sync.h>
 #include <txmempool.h>
 #include <uint256.h>
+#include <undo.h>
 #include <univalue.h>
 #include <util/btcsignals.h>
 #include <util/check.h>
@@ -67,6 +70,7 @@
 #include <util/result.h>
 #include <util/signalinterrupt.h>
 #include <util/string.h>
+#include <util/thread.h>
 #include <util/time.h>
 #include <util/translation.h>
 #include <validation.h>
@@ -82,10 +86,12 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <thread>
 #include <tuple>
 #include <utility>
 #include <vector>
 
+using interfaces::BlockInfo;
 using interfaces::BlockRef;
 using interfaces::BlockTemplate;
 using interfaces::BlockTip;
@@ -469,8 +475,8 @@ bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<Rec
 class NotificationsProxy : public CValidationInterface
 {
 public:
-    explicit NotificationsProxy(std::shared_ptr<Chain::Notifications> notifications, bool connected)
-        : m_notifications{std::move(notifications)}, m_connected{connected} {}
+    explicit NotificationsProxy(Chainstate& chainstate, std::shared_ptr<Chain::Notifications> notifications, Chain::NotifyOptions options)
+        : m_chainstate{chainstate}, m_notifications{std::move(notifications)}, m_options{std::move(options)} {}
     virtual ~NotificationsProxy() = default;
     void TransactionAddedToMempool(const NewMempoolTransactionInfo& tx, uint64_t mempool_sequence) override
     {
@@ -482,11 +488,17 @@ public:
     }
     void BlockConnected(const ChainstateRole& role, const std::shared_ptr<const CBlock>& block, const CBlockIndex* index) override
     {
-        m_notifications->blockConnected(role, MakeBlockInfo(index, block.get()));
+        interfaces::BlockInfo block_info = MakeBlockInfo(index, block.get());
+        CBlockUndo undo_data;
+        if (m_options.connect_undo_data) ReadBlockData(m_chainstate.m_blockman, *Assert(index), /*data=*/nullptr, &undo_data, block_info);
+        m_notifications->blockConnected(role, block_info);
     }
     void BlockDisconnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* index) override
     {
-        m_notifications->blockDisconnected(MakeBlockInfo(index, block.get()));
+        interfaces::BlockInfo block_info = MakeBlockInfo(index, block.get());
+        CBlockUndo undo_data;
+        if (m_options.disconnect_undo_data) ReadBlockData(m_chainstate.m_blockman, *Assert(index), /*data=*/nullptr, &undo_data, block_info);
+        m_notifications->blockDisconnected(block_info);
     }
     void UpdatedBlockTip(const CBlockIndex* index, const CBlockIndex* fork_index, bool is_ibd) override
     {
@@ -496,18 +508,66 @@ public:
     {
         m_notifications->chainStateFlushed(role, locator);
     }
+    static void RegisterSynced(std::shared_ptr<NotificationsProxy> self, ValidationSignals& signals, const CBlockIndex* sync_block) EXCLUSIVE_LOCKS_REQUIRED (::cs_main)
+    {
+        AssertLockHeld(::cs_main);
+        // Instead of registering for notifications immediately, which could
+        // cause older BlockConnected notifications currently in the queue to be
+        // received, enqueue the registration so only notifications from new
+        // blocks connected after this call will be received.
+        //
+        // cs_main should also be held during this call to prevent new blocks
+        // from being connected before this and notifications being missed.
+        signals.CallFunctionInValidationInterfaceQueue([self, &signals, sync_block] {
+            // Send initial notification with state = SYNCED indicating the block currently synced to.
+            BlockInfo block = MakeBlockInfo(sync_block, nullptr, &self->m_chainstate);
+            block.state = BlockInfo::SYNCED;
+            self->m_notifications->blockConnected(WITH_LOCK(::cs_main, return self->m_chainstate.GetRole()), block);
+            // Register for new notifications unless disconnect() has been called.
+            if (WITH_LOCK(self->m_mutex, return self->m_connected)) {
+                signals.RegisterSharedValidationInterface(self);
+            }
+        });
+    }
+
+    Chainstate& m_chainstate;
     std::shared_ptr<Chain::Notifications> m_notifications;
+    Chain::NotifyOptions m_options;
     Mutex m_mutex;
-    bool m_connected GUARDED_BY(m_mutex);
+    bool m_connected GUARDED_BY(m_mutex) {false};
 };
+
+using SyncFn = std::function<void(const CThreadInterrupt& interrupt, std::function<void(const CBlockIndex*)> on_sync)>;
 
 class NotificationsHandlerImpl : public Handler
 {
 public:
-    explicit NotificationsHandlerImpl(ValidationSignals& signals, std::shared_ptr<Chain::Notifications> notifications, bool connected = true)
-        : m_signals{signals}, m_proxy{std::make_shared<NotificationsProxy>(std::move(notifications), connected)}
+    explicit NotificationsHandlerImpl(ValidationSignals& signals, Chainstate& chainstate, std::shared_ptr<Chain::Notifications> notifications, const Chain::NotifyOptions& options = {}, BlockInfo::State state = BlockInfo::UPDATING, const CBlockIndex* start_block = nullptr)
+        : m_signals{signals}, m_chainstate{chainstate}, m_proxy{std::make_shared<NotificationsProxy>(chainstate, std::move(notifications), std::move(options))}, m_start_block{start_block}
     {
-        if (connected) m_signals.RegisterSharedValidationInterface(m_proxy);
+        // If syncing is not needed, set connected=true and register for
+        // notifications right away. If syncing is needed (state == SYNCING), do
+        // not do anything until connect() is called. It would be simpler to
+        // just always connect, but indexes rely on being able to call connect()
+        // later to delay syncing if they are not in sync with the chainstate
+        // initially (e.g. if -reindex-chainstate is used) so they do not start
+        // syncing with the chainstate until it is up-to-date. More typically
+        // though, indexes start off already synced to the chainstate tip (state
+        // == SYNCED), and connect here to start receiving notifications and be
+        // updated in parallel with chainstate.
+        if (state == BlockInfo::SYNCED || state == BlockInfo::UPDATING) {
+            WITH_LOCK(m_proxy->m_mutex, m_proxy->m_connected = true);
+            if (state == BlockInfo::SYNCED) {
+                // If synced at a particular block send a notification and
+                // register via the queue to make sure stale notications from
+                // earlier blocks are not sent.
+                m_proxy->RegisterSynced(m_proxy, signals, m_start_block);
+            } else {
+                // If not synced at any block just register now.
+                assert(!m_start_block);
+                signals.RegisterSharedValidationInterface(m_proxy);
+            }
+        }
     }
     ~NotificationsHandlerImpl() override { disconnect(); }
     void connect() override
@@ -516,33 +576,41 @@ public:
         LOCK(m_proxy->m_mutex);
         if (!m_proxy->m_connected) {
             m_proxy->m_connected = true;
-            // Instead of registering for notifications immediately, which could
-            // cause older BlockConnected notifications currently in the queue
-            // to be received, enqueue the registration so only new
-            // notifications from new blocks connected after this call will be
-            // received.
-            //
-            // cs_main should also be held during this call to prevent new
-            // blocks from being connected now and notifications being missed.
-            m_signals.CallFunctionInValidationInterfaceQueue([proxy = m_proxy, signals = &m_signals] {
-                LOCK(proxy->m_mutex);
-                if (proxy->m_connected) signals->RegisterSharedValidationInterface(proxy);
+            assert(!m_sync_thread.joinable());
+            m_sync_thread = std::thread(&util::TraceThread, m_proxy->m_options.thread_name, [proxy = m_proxy, signals = &m_signals, chainstate = &m_chainstate, start_block = m_start_block, interrupt = &m_interrupt] {
+                SyncChain(*chainstate, start_block, proxy->m_options, proxy->m_notifications, *interrupt, [proxy, signals](const CBlockIndex* end_block) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
+                    AssertLockHeld(::cs_main);
+                    proxy->RegisterSynced(proxy, *signals, end_block);
+                });
             });
         }
     }
     void disconnect() override
     {
+        m_interrupt();
         if (m_proxy) {
-            LOCK(m_proxy->m_mutex);
-            if (m_proxy->m_connected) {
-                m_proxy->m_connected = false;
-                m_signals.UnregisterSharedValidationInterface(m_proxy);
-            }
+            WITH_LOCK(m_proxy->m_mutex, m_proxy->m_connected = false);
+            m_signals.UnregisterSharedValidationInterface(m_proxy);
             m_proxy.reset();
         }
+        if (m_sync_thread.joinable()) m_sync_thread.join();
+    }
+    bool connected() override
+    {
+        return m_proxy && WITH_LOCK(m_proxy->m_mutex, return m_proxy->m_connected);
+    }
+    void interrupt() override { m_interrupt(); }
+    void sync() override
+    {
+        if (m_sync_thread.joinable()) m_sync_thread.join();
+        m_signals.SyncWithValidationInterfaceQueue();
     }
     ValidationSignals& m_signals;
+    Chainstate& m_chainstate;
     std::shared_ptr<NotificationsProxy> m_proxy;
+    const CBlockIndex* m_start_block;
+    std::thread m_sync_thread;
+    CThreadInterrupt m_interrupt;
 };
 
 class RpcHandlerImpl : public Handler
@@ -577,6 +645,8 @@ public:
             ::tableRPC.removeCommand(m_command.name, &m_command);
         }
     }
+
+    bool connected() override { return m_wrapped_command; }
 
     ~RpcHandlerImpl() override { disconnect(); }
 
@@ -818,14 +888,19 @@ public:
     {
         ::uiInterface.ShowProgress(title, progress, resume_possible);
     }
-    std::unique_ptr<Handler> attachChain(std::shared_ptr<Notifications> notifications, const NotifyOptions& options) override
+    std::unique_ptr<Handler> attachChain(std::shared_ptr<Notifications> notifications, std::optional<uint256> start_block, const NotifyOptions& options) override
     {
         LOCK(cs_main);
-        return std::make_unique<NotificationsHandlerImpl>(validation_signals(), notifications, /*connected=*/false);
+        Chainstate& chainstate{chainman().ValidatedChainstate()};
+        const CBlockIndex* start_index{start_block ? Assert(chainman().m_blockman.LookupBlockIndex(*start_block)) : nullptr};
+        BlockInfo::State state{start_index == chainstate.m_chain.Tip() ? BlockInfo::SYNCED : BlockInfo::SYNCING};
+        return std::make_unique<NotificationsHandlerImpl>(validation_signals(), chainstate, std::move(notifications), options, state, start_index);
     }
     std::unique_ptr<Handler> handleNotifications(std::shared_ptr<Notifications> notifications) override
     {
-        return std::make_unique<NotificationsHandlerImpl>(validation_signals(), std::move(notifications));
+        LOCK(cs_main);
+        Chainstate& chainstate{chainman().CurrentChainstate()};
+        return std::make_unique<NotificationsHandlerImpl>(validation_signals(), chainstate, std::move(notifications));
     }
     void waitForNotificationsIfTipChanged(const uint256& old_tip) override
     {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -674,6 +674,12 @@ public:
         const CBlockIndex* block{chainman().ActiveChain()[height]};
         return block && ((block->nStatus & BLOCK_HAVE_DATA) != 0) && block->nTx > 0;
     }
+    bool getTip(const FoundBlock& block) override
+    {
+        WAIT_LOCK(cs_main, lock);
+        const CChain& active = chainman().ActiveChain();
+        return FillBlock(active.Tip(), block, lock, active, chainman().m_blockman);
+    }
     std::optional<int> findLocatorFork(const CBlockLocator& locator) override
     {
         LOCK(::cs_main);
@@ -901,6 +907,10 @@ public:
         LOCK(cs_main);
         Chainstate& chainstate{chainman().CurrentChainstate()};
         return std::make_unique<NotificationsHandlerImpl>(validation_signals(), chainstate, std::move(notifications));
+    }
+    void waitForPendingNotifications() override
+    {
+        validation_signals().SyncWithValidationInterfaceQueue();
     }
     void waitForNotificationsIfTipChanged(const uint256& old_tip) override
     {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -34,6 +34,7 @@
 #include <netaddress.h>
 #include <netbase.h>
 #include <node/blockstorage.h>
+#include <node/chain.h>
 #include <node/coin.h>
 #include <node/context.h>
 #include <node/interface_ui.h>
@@ -481,11 +482,11 @@ public:
     }
     void BlockConnected(const ChainstateRole& role, const std::shared_ptr<const CBlock>& block, const CBlockIndex* index) override
     {
-        m_notifications->blockConnected(role, kernel::MakeBlockInfo(index, block.get()));
+        m_notifications->blockConnected(role, MakeBlockInfo(index, block.get()));
     }
     void BlockDisconnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* index) override
     {
-        m_notifications->blockDisconnected(kernel::MakeBlockInfo(index, block.get()));
+        m_notifications->blockDisconnected(MakeBlockInfo(index, block.get()));
     }
     void UpdatedBlockTip(const CBlockIndex* index, const CBlockIndex* fork_index, bool is_ibd) override
     {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -469,8 +469,8 @@ bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<Rec
 class NotificationsProxy : public CValidationInterface
 {
 public:
-    explicit NotificationsProxy(std::shared_ptr<Chain::Notifications> notifications)
-        : m_notifications(std::move(notifications)) {}
+    explicit NotificationsProxy(std::shared_ptr<Chain::Notifications> notifications, bool connected)
+        : m_notifications{std::move(notifications)}, m_connected{connected} {}
     virtual ~NotificationsProxy() = default;
     void TransactionAddedToMempool(const NewMempoolTransactionInfo& tx, uint64_t mempool_sequence) override
     {
@@ -497,21 +497,47 @@ public:
         m_notifications->chainStateFlushed(role, locator);
     }
     std::shared_ptr<Chain::Notifications> m_notifications;
+    Mutex m_mutex;
+    bool m_connected GUARDED_BY(m_mutex);
 };
 
 class NotificationsHandlerImpl : public Handler
 {
 public:
-    explicit NotificationsHandlerImpl(ValidationSignals& signals, std::shared_ptr<Chain::Notifications> notifications)
-        : m_signals{signals}, m_proxy{std::make_shared<NotificationsProxy>(std::move(notifications))}
+    explicit NotificationsHandlerImpl(ValidationSignals& signals, std::shared_ptr<Chain::Notifications> notifications, bool connected = true)
+        : m_signals{signals}, m_proxy{std::make_shared<NotificationsProxy>(std::move(notifications), connected)}
     {
-        m_signals.RegisterSharedValidationInterface(m_proxy);
+        if (connected) m_signals.RegisterSharedValidationInterface(m_proxy);
     }
     ~NotificationsHandlerImpl() override { disconnect(); }
+    void connect() override
+    {
+        assert(m_proxy);
+        LOCK(m_proxy->m_mutex);
+        if (!m_proxy->m_connected) {
+            m_proxy->m_connected = true;
+            // Instead of registering for notifications immediately, which could
+            // cause older BlockConnected notifications currently in the queue
+            // to be received, enqueue the registration so only new
+            // notifications from new blocks connected after this call will be
+            // received.
+            //
+            // cs_main should also be held during this call to prevent new
+            // blocks from being connected now and notifications being missed.
+            m_signals.CallFunctionInValidationInterfaceQueue([proxy = m_proxy, signals = &m_signals] {
+                LOCK(proxy->m_mutex);
+                if (proxy->m_connected) signals->RegisterSharedValidationInterface(proxy);
+            });
+        }
+    }
     void disconnect() override
     {
         if (m_proxy) {
-            m_signals.UnregisterSharedValidationInterface(m_proxy);
+            LOCK(m_proxy->m_mutex);
+            if (m_proxy->m_connected) {
+                m_proxy->m_connected = false;
+                m_signals.UnregisterSharedValidationInterface(m_proxy);
+            }
             m_proxy.reset();
         }
     }
@@ -791,6 +817,11 @@ public:
     void showProgress(const std::string& title, int progress, bool resume_possible) override
     {
         ::uiInterface.ShowProgress(title, progress, resume_possible);
+    }
+    std::unique_ptr<Handler> attachChain(std::shared_ptr<Notifications> notifications, const NotifyOptions& options) override
+    {
+        LOCK(cs_main);
+        return std::make_unique<NotificationsHandlerImpl>(validation_signals(), notifications, /*connected=*/false);
     }
     std::unique_ptr<Handler> handleNotifications(std::shared_ptr<Notifications> notifications) override
     {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -728,7 +728,7 @@ public:
 
         BlockFilter filter;
         const CBlockIndex* index{WITH_LOCK(::cs_main, return chainman().m_blockman.LookupBlockIndex(block_hash))};
-        if (index == nullptr || !block_filter_index->LookupFilter(index, filter)) return std::nullopt;
+        if (index == nullptr || !block_filter_index->LookupFilter({index->GetBlockHash(), index->nHeight}, filter)) return std::nullopt;
         return filter.GetFilter().MatchAny(filter_set);
     }
     bool findBlock(const uint256& hash, const FoundBlock& block) override

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -25,8 +25,8 @@
 #include <interfaces/rpc.h>
 #include <interfaces/types.h>
 #include <kernel/context.h>
-#include <key.h>
 #include <kernel/types.h>
+#include <key.h>
 #include <logging.h>
 #include <mapport.h>
 #include <net.h>
@@ -572,7 +572,7 @@ using SyncFn = std::function<void(std::shared_ptr<NotificationsProxy>, const CTh
 class NotificationsHandlerImpl : public Handler
 {
 public:
-    explicit NotificationsHandlerImpl(ValidationSignals& signals, Chainstate& chainstate, std::shared_ptr<Chain::Notifications> notifications, const Chain::NotifyOptions& options = {}, BlockInfo::State state = BlockInfo::UPDATING, const CBlockIndex* start_block = nullptr)
+    explicit NotificationsHandlerImpl(ValidationSignals& signals, Chainstate& chainstate, std::shared_ptr<Chain::Notifications> notifications, Chain::NotifyOptions options = {}, BlockInfo::State state = BlockInfo::UPDATING, const CBlockIndex* start_block = nullptr)
         : m_signals{signals}, m_chainstate{chainstate}, m_proxy{std::make_shared<NotificationsProxy>(chainstate, std::move(notifications), std::move(options))}, m_start_block{start_block}
     {
         // If syncing is not needed, set connecting or connecting state and register for
@@ -899,6 +899,15 @@ public:
     {
         if (!m_node.mempool) return CFeeRate{DUST_RELAY_TX_FEE};
         return m_node.mempool->m_opts.dust_relay_feerate;
+    }
+    void updatePruneLock(const std::string& name, const PruneLockInfo& lock_info) override
+    {
+        LOCK(cs_main);
+        m_node.chainman->m_blockman.UpdatePruneLock(name, lock_info);
+    }
+    bool pruningEnabled() override
+    {
+        return chainman().m_blockman.IsPruneMode();
     }
     bool havePruned() override
     {

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -567,7 +567,7 @@ static bool rest_filter_header(const std::any& context, HTTPRequest* req, const 
     filter_headers.reserve(*parsed_count);
     for (const CBlockIndex* pindex : headers) {
         uint256 filter_header;
-        if (!index->LookupFilterHeader(pindex, filter_header)) {
+        if (!index->LookupFilterHeader({pindex->GetBlockHash(), pindex->nHeight}, filter_header)) {
             std::string errmsg = "Filter not found.";
 
             if (!index_ready) {
@@ -665,7 +665,7 @@ static bool rest_block_filter(const std::any& context, HTTPRequest* req, const s
     bool index_ready = index->BlockUntilSyncedToCurrentChain();
 
     BlockFilter filter;
-    if (!index->LookupFilter(block_index, filter)) {
+    if (!index->LookupFilter({block_index->GetBlockHash(), block_index->nHeight}, filter)) {
         std::string errmsg = "Filter not found.";
 
         if (!block_was_connected) {

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -583,7 +583,7 @@ static bool rest_filter_header(const std::any& context, HTTPRequest* req, const 
     filter_headers.reserve(*parsed_count);
     for (const CBlockIndex* pindex : headers) {
         uint256 filter_header;
-        if (!index->LookupFilterHeader(pindex, filter_header)) {
+        if (!index->LookupFilterHeader({pindex->GetBlockHash(), pindex->nHeight}, filter_header)) {
             std::string errmsg = "Filter not found.";
 
             if (!index_ready) {
@@ -685,7 +685,7 @@ static bool rest_block_filter(const std::any& context, HTTPRequest* req, const s
     bool index_ready = index->BlockUntilSyncedToCurrentChain();
 
     BlockFilter filter;
-    if (!index->LookupFilter(block_index, filter)) {
+    if (!index->LookupFilter({block_index->GetBlockHash(), block_index->nHeight}, filter)) {
         std::string errmsg = "Filter not found.";
 
         if (!block_was_connected) {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1001,10 +1001,10 @@ static std::optional<kernel::CCoinsStats> GetUTXOStats(const CCoinsViewDB& view,
     // Use CoinStatsIndex if it is requested and available and a hash_type of Muhash or None was requested
     if ((hash_type == kernel::CoinStatsHashType::MUHASH || hash_type == kernel::CoinStatsHashType::NONE) && g_coin_stats_index && index_requested) {
         if (pindex) {
-            return g_coin_stats_index->LookUpStats(*pindex);
+            return g_coin_stats_index->LookUpStats({pindex->GetBlockHash(), pindex->nHeight});
         } else {
             CBlockIndex& block_index = *CHECK_NONFATAL(WITH_LOCK(::cs_main, return blockman.LookupBlockIndex(view.GetBestBlock())));
-            return g_coin_stats_index->LookUpStats(block_index);
+            return g_coin_stats_index->LookUpStats({block_index.GetBlockHash(), block_index.nHeight});
         }
     }
 
@@ -2680,7 +2680,7 @@ static RPCMethod scanblocks()
                     WITH_LOCK(::cs_main, return chainman.ActiveChain()[start_block + amount_per_chunk]) :
                     stop_block;
 
-            if (index->LookupFilterRange(start_block, end_range, filters)) {
+            if (index->LookupFilterRange(start_block, {end_range->GetBlockHash(), end_range->nHeight}, filters)) {
                 for (const BlockFilter& filter : filters) {
                     // compare the elements-set with each filter
                     if (filter.GetFilter().MatchAny(needle_set)) {
@@ -3009,8 +3009,8 @@ static RPCMethod getblockfilter()
 
     BlockFilter filter;
     uint256 filter_header;
-    if (!index->LookupFilter(block_index, filter) ||
-        !index->LookupFilterHeader(block_index, filter_header)) {
+    if (!index->LookupFilter({block_index->GetBlockHash(), block_index->nHeight}, filter) ||
+        !index->LookupFilterHeader({block_index->GetBlockHash(), block_index->nHeight}, filter_header)) {
         int err_code;
         std::string errmsg = "Filter not found.";
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1001,10 +1001,10 @@ static std::optional<kernel::CCoinsStats> GetUTXOStats(const CCoinsViewDB& view,
     // Use CoinStatsIndex if it is requested and available and a hash_type of Muhash or None was requested
     if ((hash_type == kernel::CoinStatsHashType::MUHASH || hash_type == kernel::CoinStatsHashType::NONE) && g_coin_stats_index && index_requested) {
         if (pindex) {
-            return g_coin_stats_index->LookUpStats(*pindex);
+            return g_coin_stats_index->LookUpStats({pindex->GetBlockHash(), pindex->nHeight});
         } else {
             CBlockIndex& block_index = *CHECK_NONFATAL(WITH_LOCK(::cs_main, return blockman.LookupBlockIndex(view.GetBestBlock())));
-            return g_coin_stats_index->LookUpStats(block_index);
+            return g_coin_stats_index->LookUpStats({block_index.GetBlockHash(), block_index.nHeight});
         }
     }
 
@@ -2685,7 +2685,7 @@ static RPCMethod scanblocks()
                     WITH_LOCK(::cs_main, return chainman.ActiveChain()[start_block + amount_per_chunk]) :
                     stop_block;
 
-            if (index->LookupFilterRange(start_block, end_range, filters)) {
+            if (index->LookupFilterRange(start_block, {end_range->GetBlockHash(), end_range->nHeight}, filters)) {
                 for (const BlockFilter& filter : filters) {
                     // compare the elements-set with each filter
                     if (filter.GetFilter().MatchAny(needle_set)) {
@@ -3014,8 +3014,8 @@ static RPCMethod getblockfilter()
 
     BlockFilter filter;
     uint256 filter_header;
-    if (!index->LookupFilter(block_index, filter) ||
-        !index->LookupFilterHeader(block_index, filter_header)) {
+    if (!index->LookupFilter({block_index->GetBlockHash(), block_index->nHeight}, filter) ||
+        !index->LookupFilterHeader({block_index->GetBlockHash(), block_index->nHeight}, filter_header)) {
         int err_code;
         std::string errmsg = "Filter not found.";
 

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -27,6 +27,7 @@
 #include <util/any.h>
 #include <util/check.h>
 #include <util/time.h>
+#include <validationinterface.h>
 
 #include <cstdint>
 #include <limits>

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -37,6 +37,13 @@ BOOST_FIXTURE_TEST_CASE(baseindex_no_commit_ahead_of_flush, TestChain100Setup)
         // Reload index to see which block data was actually committed.
         BOOST_REQUIRE(index.Init());
         BOOST_CHECK_EQUAL(index.GetSummary().best_block_height, expected_commit_height);
+        // Drain any pending scheduler callbacks from Init so they run while index is
+        // alive. Without this, callbacks enqueued by connect() during Init could fire
+        // after the stack frame unwinds and index is freed.
+        // TODO: The handler destructor (NotificationsHandlerImpl::disconnect) should
+        // ensure any in-flight scheduler callback from RegisterSynced completes
+        // before returning, so the callback cannot access m_index after it is freed.
+        m_node.chain->context()->validation_signals->SyncWithValidationInterfaceQueue();
         index.Stop();
     };
 

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -27,7 +27,8 @@ BOOST_FIXTURE_TEST_CASE(baseindex_no_commit_ahead_of_flush, TestChain100Setup)
     auto sync_index = [&](bool do_flush, int expected_sync_height, int expected_commit_height) {
         CoinStatsIndex index{interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB};
         BOOST_REQUIRE(index.Init());
-        index.Sync();
+        BOOST_CHECK(index.StartBackgroundSync());
+        index.WaitForBackgroundSync();
         if (do_flush) {
             chainstate.ForceFlushStateToDisk();
             m_node.chain->context()->validation_signals->SyncWithValidationInterfaceQueue();

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -51,9 +51,9 @@ static const std::vector<std::pair<std::string, IndexFactory>> INDEX_FACTORIES{
     {"coinstatsindex", [](node::NodeContext& node) -> std::unique_ptr<BaseIndex> {
         return std::make_unique<CoinStatsIndex>(interfaces::MakeChain(node), /*n_cache_size=*/1_MiB); }},
     {"txindex", [](node::NodeContext& node) -> std::unique_ptr<BaseIndex> {
-        return std::make_unique<TxIndex>(interfaces::MakeChain(node), /*n_cache_size=*/1_MiB); }},
+        return std::make_unique<TxIndex>(interfaces::MakeChain(node), Assert(node.chainman)->m_blockman, /*n_cache_size=*/1_MiB); }},
     {"txospenderindex", [](node::NodeContext& node) -> std::unique_ptr<BaseIndex> {
-        return std::make_unique<TxoSpenderIndex>(interfaces::MakeChain(node), /*n_cache_size=*/1_MiB); }},
+        return std::make_unique<TxoSpenderIndex>(interfaces::MakeChain(node), Assert(node.chainman)->m_blockman, /*n_cache_size=*/1_MiB); }},
     {"blockfilterindex", [](node::NodeContext& node) -> std::unique_ptr<BaseIndex> {
         return std::make_unique<BlockFilterIndex>(interfaces::MakeChain(node), BlockFilterType::BASIC, /*n_cache_size=*/1_MiB); }},
 };

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -85,7 +85,13 @@ BOOST_FIXTURE_TEST_CASE(baseindex_no_commit_ahead_of_flush, TestChain100Setup)
             BOOST_REQUIRE(index->Init());
             BOOST_CHECK_EQUAL(index->GetSummary().best_block_height, expected_commit_height);
 
-            // Drain in-flight validation callbacks before destroying the index.
+            // Deliver the reload's queued notifications before destroying the
+            // index, as the node does before stopping indexes; otherwise the
+            // reload's queued SYNCED notification would fire on the freed
+            // index. Note: this is removed in a later change adding a
+            // WaitForCurrentCallback() call to
+            // NotificationsHandlerImpl::disconnect() to ensure no notifications
+            // notifications can be received after disconnect() returns.
             m_node.chain->context()->validation_signals->SyncWithValidationInterfaceQueue();
             // shutdown sequence (c.f. Shutdown() in init.cpp)
             index->Stop();

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -21,6 +21,7 @@
 #include <primitives/block.h>
 #include <script/script.h>
 #include <sync.h>
+#include <test/util/index.h>
 #include <test/util/mining.h>
 #include <test/util/setup_common.h>
 #include <test/util/time.h>
@@ -95,7 +96,7 @@ BOOST_FIXTURE_TEST_CASE(baseindex_no_commit_ahead_of_flush, TestChain100Setup)
         auto sync_index = [&](bool do_flush, int expected_sync_height, int expected_commit_height) {
             auto index{make_index(m_node)};
             BOOST_REQUIRE(index->Init());
-            index->Sync();
+            IndexTester{*index}.Sync();
             if (do_flush) {
                 chainstate.ForceFlushStateToDisk();
                 m_node.chain->context()->validation_signals->SyncWithValidationInterfaceQueue();
@@ -157,7 +158,7 @@ BOOST_FIXTURE_TEST_CASE(index_unclean_shutdown, TestChain100Setup)
         {
             auto index{make_index(m_node)};
             BOOST_REQUIRE(index->Init());
-            index->Sync();
+            IndexTester{*index}.Sync();
             std::shared_ptr<const CBlock> new_block;
             CBlockIndex* new_block_index = nullptr;
             {
@@ -186,7 +187,7 @@ BOOST_FIXTURE_TEST_CASE(index_unclean_shutdown, TestChain100Setup)
             BOOST_REQUIRE(index->Init());
             // Make sure the index reloads from the pre-crash commit.
             BOOST_CHECK_EQUAL(index->GetSummary().best_block_height, tip_height);
-            BOOST_REQUIRE(index->StartBackgroundSync());
+            IndexTester{*index}.Sync();
             index->Stop();
         }
     }
@@ -234,6 +235,10 @@ BOOST_FIXTURE_TEST_CASE(index_reorg_crash, TestChain100Setup)
 
     IndexReorgCrash index{interfaces::MakeChain(m_node), blocker, blocking_height, m_clock};
     BOOST_REQUIRE(index.Init());
+    // This test drives the background sync directly (StartBackgroundSync without an
+    // immediate WaitForBackgroundSync) instead of IndexTester::Sync(): it needs the
+    // sync running concurrently so it can trigger a reorg while the index is still
+    // mid-sync, whereas IndexTester::Sync() blocks until the sync has finished.
     BOOST_REQUIRE(index.StartBackgroundSync());
 
     auto func_wait_until = [&](int height, std::chrono::milliseconds timeout) {

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -61,13 +61,34 @@ static const std::vector<std::pair<std::string, IndexFactory>> INDEX_FACTORIES{
 // concrete index is being used.
 BOOST_AUTO_TEST_SUITE(baseindex_tests)
 
-// Test that the index does not commit ahead of the chainstate's last
-// flushed block. If it did, a subsequent unclean shutdown would corrupt
-// the index, because during reverting it would require blocks that were
+// Test that the index commits up to, but never ahead of, the chainstate's last
+// flushed block. Committing ahead of the flush would corrupt the index on an
+// unclean shutdown: on the next startup the index would be ahead of the chainstate
+// and, when reverting to catch back up, would need undo data for blocks that were
 // never flushed to disk.
+//
+// History of the end-of-sync commit behavior this exercises:
+//   - Originally the index committed at the chain tip at the end of a background
+//     sync unconditionally. That could commit ahead of the flushed chainstate and
+//     cause the corruption described above.
+//   - PR #34897 (commit 3679f1ecf5e "index: Don't commit ahead of the flushed
+//     chainstate") fixed the corruption by skipping the end-of-sync commit whenever
+//     the index best block was ahead of the flushed best block. Safe, but it can
+//     leave the index committed behind the flush point, i.e. stale on disk.
+//   - Current code commits at the flushed best block instead: up to the flush,
+//     never ahead. That avoids both the corruption (not ahead) and the staleness
+//     (not needlessly behind).
 BOOST_FIXTURE_TEST_CASE(baseindex_no_commit_ahead_of_flush, TestChain100Setup)
 {
     Chainstate& chainstate = Assert(m_node.chainman)->ActiveChainstate();
+    // Chainstate's last-flushed best block height, which (per the behavior history
+    // above) is the height each index is expected to commit at the end of sync.
+    // It is declared outside the loop because all the indexes share the same node
+    // chainstate: a flush performed while testing one index is still in effect when
+    // testing the next. So an index's expected commit height depends on flushes done
+    // by earlier iterations, not just its own -- only the first index (before any
+    // flush) is expected to commit nothing (flushed_height == 0).
+    int flushed_height{0};
     for (const auto& [index_name, make_index] : INDEX_FACTORIES) {
         BOOST_TEST_INFO_SCOPE(index_name);
         const int tip_height{WITH_LOCK(cs_main, return m_node.chainman->ActiveChain().Tip()->nHeight)};
@@ -97,23 +118,27 @@ BOOST_FIXTURE_TEST_CASE(baseindex_no_commit_ahead_of_flush, TestChain100Setup)
             index->Stop();
         };
 
-        // Part 1: Sync, then "crash" (stop without flushing). Models a node that
-        // started up, had its index catch up, but never flushed before going down.
-        // The end-of-sync Commit() runs at the chain tip but m_last_flushed_block
-        // is null, so it is skipped.
-        sync_index(false, tip_height, 0);
+        // Part 1: Sync, then "crash" (stop without flushing this round). Models a
+        // node that started up, had its index catch up, but never flushed before
+        // going down. At the end of sync the index commits up to the chainstate's
+        // last flushed block -- never ahead of it. For the first index that is
+        // genesis (flushed_height == 0, so nothing is committed); for later indexes
+        // it is the height flushed by a previous iteration.
+        sync_index(false, tip_height, flushed_height);
 
-        // Part 2: Restart cleanly. Sync, force a chainstate flush, and drain the
-        // validation queue so the index's ChainStateFlushed callback runs.
-        // Now m_last_flushed_block == tip and the index can commit.
+        // Part 2: Restart cleanly. Sync, force a chainstate flush at the tip, and
+        // drain the validation queue so the index's ChainStateFlushed callback runs.
+        // Now the last flushed block == tip and the index can commit at the tip.
         sync_index(true, tip_height, tip_height);
+        flushed_height = tip_height;
 
-        // Part 3: Connect a new block on the chain without flushing
-        // (m_last_flushed_block stays at tip_height). For a real node this would
-        // happen in parallel with Sync(). Here we do it before Sync() to make the
-        // race state deterministic.
+        // Part 3: Connect a new block on the chain without flushing (the last
+        // flushed block stays at flushed_height). For a real node this would happen
+        // in parallel with Sync(). Here we do it before Sync() to make the race
+        // state deterministic. The index syncs the new block but still only commits
+        // up to flushed_height, not ahead of the flush.
         CreateAndProcessBlock({}, CScript() << OP_TRUE);
-        sync_index(false, tip_height + 1, tip_height);
+        sync_index(false, tip_height + 1, flushed_height);
     }
 }
 

--- a/src/test/baseindex_tests.cpp
+++ b/src/test/baseindex_tests.cpp
@@ -151,7 +151,8 @@ BOOST_FIXTURE_TEST_CASE(index_unclean_shutdown, TestChain100Setup)
             // Send block connected notification, then stop the index without
             // sending a chainstate flushed notification. Prior to #24138, this
             // would cause the index to be corrupted and fail to reload.
-            ValidationInterfaceTest::BlockConnected(ChainstateRole{}, *index, new_block, new_block_index);
+            m_node.validation_signals->BlockConnected(ChainstateRole{}, new_block, new_block_index);
+            m_node.validation_signals->SyncWithValidationInterfaceQueue();
             index->Stop();
         }
 

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -165,8 +165,8 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
 
     // BlockUntilSyncedToCurrentChain should return false before index is started.
     BOOST_CHECK(!filter_index.BlockUntilSyncedToCurrentChain());
-
-    filter_index.Sync();
+    BOOST_CHECK(filter_index.StartBackgroundSync());
+    filter_index.WaitForBackgroundSync();
 
     // Check that filter index has all blocks that were in the chain before it started.
     {

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -65,10 +65,10 @@ static bool CheckFilterLookups(BlockFilterIndex& filter_index, const CBlockIndex
     std::vector<BlockFilter> filters;
     std::vector<uint256> filter_hashes;
 
-    BOOST_CHECK(filter_index.LookupFilter(block_index, filter));
-    BOOST_CHECK(filter_index.LookupFilterHeader(block_index, filter_header));
-    BOOST_CHECK(filter_index.LookupFilterRange(block_index->nHeight, block_index, filters));
-    BOOST_CHECK(filter_index.LookupFilterHashRange(block_index->nHeight, block_index,
+    BOOST_CHECK(filter_index.LookupFilter({block_index->GetBlockHash(), block_index->nHeight}, filter));
+    BOOST_CHECK(filter_index.LookupFilterHeader({block_index->GetBlockHash(), block_index->nHeight}, filter_header));
+    BOOST_CHECK(filter_index.LookupFilterRange(block_index->nHeight, {block_index->GetBlockHash(), block_index->nHeight}, filters));
+    BOOST_CHECK(filter_index.LookupFilterHashRange(block_index->nHeight, {block_index->GetBlockHash(), block_index->nHeight},
                                                    filter_hashes));
 
     BOOST_CHECK_EQUAL(filters.size(), 1U);
@@ -155,10 +155,10 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         for (const CBlockIndex* block_index = m_node.chainman->ActiveChain().Genesis();
              block_index != nullptr;
              block_index = m_node.chainman->ActiveChain().Next(*block_index)) {
-            BOOST_CHECK(!filter_index.LookupFilter(block_index, filter));
-            BOOST_CHECK(!filter_index.LookupFilterHeader(block_index, filter_header));
-            BOOST_CHECK(!filter_index.LookupFilterRange(block_index->nHeight, block_index, filters));
-            BOOST_CHECK(!filter_index.LookupFilterHashRange(block_index->nHeight, block_index,
+            BOOST_CHECK(!filter_index.LookupFilter({block_index->GetBlockHash(), block_index->nHeight}, filter));
+            BOOST_CHECK(!filter_index.LookupFilterHeader({block_index->GetBlockHash(), block_index->nHeight}, filter_header));
+            BOOST_CHECK(!filter_index.LookupFilterRange(block_index->nHeight, {block_index->GetBlockHash(), block_index->nHeight}, filters));
+            BOOST_CHECK(!filter_index.LookupFilterHashRange(block_index->nHeight, {block_index->GetBlockHash(), block_index->nHeight},
                                                             filter_hashes));
         }
     }
@@ -278,8 +278,8 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         LOCK(cs_main);
         tip = m_node.chainman->ActiveChain().Tip();
     }
-    BOOST_CHECK(filter_index.LookupFilterRange(0, tip, filters));
-    BOOST_CHECK(filter_index.LookupFilterHashRange(0, tip, filter_hashes));
+    BOOST_CHECK(filter_index.LookupFilterRange(0, {tip->GetBlockHash(), tip->nHeight}, filters));
+    BOOST_CHECK(filter_index.LookupFilterHashRange(0, {tip->GetBlockHash(), tip->nHeight}, filter_hashes));
 
     assert(tip->nHeight >= 0);
     BOOST_CHECK_EQUAL(filters.size(), tip->nHeight + 1U);

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -14,6 +14,7 @@
 #include <sync.h>
 #include <test/util/blockfilter.h>
 #include <test/util/common.h>
+#include <test/util/index.h>
 #include <test/util/mining.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
@@ -99,8 +100,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, TestChain100Setup)
 
     // BlockUntilSyncedToCurrentChain should return false before index is started.
     BOOST_CHECK(!filter_index.BlockUntilSyncedToCurrentChain());
-
-    filter_index.Sync();
+    IndexTester{filter_index}.Sync();
 
     // Check that filter index has all blocks that were in the chain before it started.
     {

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -51,10 +51,10 @@ static bool CheckFilterLookups(BlockFilterIndex& filter_index, const CBlockIndex
     std::vector<BlockFilter> filters;
     std::vector<uint256> filter_hashes;
 
-    BOOST_CHECK(filter_index.LookupFilter(block_index, filter));
-    BOOST_CHECK(filter_index.LookupFilterHeader(block_index, filter_header));
-    BOOST_CHECK(filter_index.LookupFilterRange(block_index->nHeight, block_index, filters));
-    BOOST_CHECK(filter_index.LookupFilterHashRange(block_index->nHeight, block_index,
+    BOOST_CHECK(filter_index.LookupFilter({block_index->GetBlockHash(), block_index->nHeight}, filter));
+    BOOST_CHECK(filter_index.LookupFilterHeader({block_index->GetBlockHash(), block_index->nHeight}, filter_header));
+    BOOST_CHECK(filter_index.LookupFilterRange(block_index->nHeight, {block_index->GetBlockHash(), block_index->nHeight}, filters));
+    BOOST_CHECK(filter_index.LookupFilterHashRange(block_index->nHeight, {block_index->GetBlockHash(), block_index->nHeight},
                                                    filter_hashes));
 
     BOOST_CHECK_EQUAL(filters.size(), 1U);
@@ -90,10 +90,10 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, TestChain100Setup)
         for (const CBlockIndex* block_index = m_node.chainman->ActiveChain().Genesis();
              block_index != nullptr;
              block_index = m_node.chainman->ActiveChain().Next(*block_index)) {
-            BOOST_CHECK(!filter_index.LookupFilter(block_index, filter));
-            BOOST_CHECK(!filter_index.LookupFilterHeader(block_index, filter_header));
-            BOOST_CHECK(!filter_index.LookupFilterRange(block_index->nHeight, block_index, filters));
-            BOOST_CHECK(!filter_index.LookupFilterHashRange(block_index->nHeight, block_index,
+            BOOST_CHECK(!filter_index.LookupFilter({block_index->GetBlockHash(), block_index->nHeight}, filter));
+            BOOST_CHECK(!filter_index.LookupFilterHeader({block_index->GetBlockHash(), block_index->nHeight}, filter_header));
+            BOOST_CHECK(!filter_index.LookupFilterRange(block_index->nHeight, {block_index->GetBlockHash(), block_index->nHeight}, filters));
+            BOOST_CHECK(!filter_index.LookupFilterHashRange(block_index->nHeight, {block_index->GetBlockHash(), block_index->nHeight},
                                                             filter_hashes));
         }
     }
@@ -212,8 +212,8 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, TestChain100Setup)
         LOCK(cs_main);
         tip = m_node.chainman->ActiveChain().Tip();
     }
-    BOOST_CHECK(filter_index.LookupFilterRange(0, tip, filters));
-    BOOST_CHECK(filter_index.LookupFilterHashRange(0, tip, filter_hashes));
+    BOOST_CHECK(filter_index.LookupFilterRange(0, {tip->GetBlockHash(), tip->nHeight}, filters));
+    BOOST_CHECK(filter_index.LookupFilterHashRange(0, {tip->GetBlockHash(), tip->nHeight}, filter_hashes));
 
     assert(tip->nHeight >= 0);
     BOOST_CHECK_EQUAL(filters.size(), tip->nHeight + 1U);

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -43,7 +43,7 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
     }
 
     // CoinStatsIndex should not be found before it is started.
-    BOOST_CHECK(!coin_stats_index.LookUpStats(*block_index));
+    BOOST_CHECK(!coin_stats_index.LookUpStats({block_index->GetBlockHash(), block_index->nHeight}));
 
     // BlockUntilSyncedToCurrentChain should return false before CoinStatsIndex
     // is started.
@@ -57,10 +57,10 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
         LOCK(cs_main);
         genesis_block_index = m_node.chainman->ActiveChain().Genesis();
     }
-    BOOST_CHECK(coin_stats_index.LookUpStats(*genesis_block_index));
+    BOOST_CHECK(coin_stats_index.LookUpStats({genesis_block_index->GetBlockHash(), genesis_block_index->nHeight}));
 
     // Check that CoinStatsIndex updates with new blocks.
-    BOOST_CHECK(coin_stats_index.LookUpStats(*block_index));
+    BOOST_CHECK(coin_stats_index.LookUpStats({block_index->GetBlockHash(), block_index->nHeight}));
 
     const CScript script_pub_key{CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG};
     std::vector<CMutableTransaction> noTxns;
@@ -74,7 +74,7 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
         LOCK(cs_main);
         new_block_index = m_node.chainman->ActiveChain().Tip();
     }
-    BOOST_CHECK(coin_stats_index.LookUpStats(*new_block_index));
+    BOOST_CHECK(coin_stats_index.LookUpStats({new_block_index->GetBlockHash(), new_block_index->nHeight}));
 
     BOOST_CHECK(block_index != new_block_index);
 

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -48,8 +48,8 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
     // BlockUntilSyncedToCurrentChain should return false before CoinStatsIndex
     // is started.
     BOOST_CHECK(!coin_stats_index.BlockUntilSyncedToCurrentChain());
-
-    coin_stats_index.Sync();
+    BOOST_CHECK(coin_stats_index.StartBackgroundSync());
+    coin_stats_index.WaitForBackgroundSync();
 
     // Check that CoinStatsIndex works for genesis block.
     const CBlockIndex* genesis_block_index;
@@ -91,7 +91,8 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_unclean_shutdown, TestChain100Setup)
     {
         CoinStatsIndex index{interfaces::MakeChain(m_node), 1_MiB};
         BOOST_REQUIRE(index.Init());
-        index.Sync();
+        BOOST_CHECK(index.StartBackgroundSync());
+        index.WaitForBackgroundSync();
         std::shared_ptr<const CBlock> new_block;
         CBlockIndex* new_block_index = nullptr;
         {

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -110,7 +110,8 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_unclean_shutdown, TestChain100Setup)
         // Send block connected notification, then stop the index without
         // sending a chainstate flushed notification. Prior to #24138, this
         // would cause the index to be corrupted and fail to reload.
-        ValidationInterfaceTest::BlockConnected(ChainstateRole{}, index, new_block, new_block_index);
+        m_node.validation_signals->BlockConnected(ChainstateRole{}, new_block, new_block_index);
+        m_node.validation_signals->SyncWithValidationInterfaceQueue();
         index.Stop();
     }
 

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -19,6 +19,7 @@
 #include <test/util/validation.h>
 #include <util/check.h>
 #include <validation.h>
+#include <validationinterface.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -37,7 +37,7 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
     }
 
     // CoinStatsIndex should not be found before it is started.
-    BOOST_CHECK(!coin_stats_index.LookUpStats(*block_index));
+    BOOST_CHECK(!coin_stats_index.LookUpStats({block_index->GetBlockHash(), block_index->nHeight}));
 
     // BlockUntilSyncedToCurrentChain should return false before CoinStatsIndex
     // is started.
@@ -51,10 +51,10 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
         LOCK(cs_main);
         genesis_block_index = m_node.chainman->ActiveChain().Genesis();
     }
-    BOOST_CHECK(coin_stats_index.LookUpStats(*genesis_block_index));
+    BOOST_CHECK(coin_stats_index.LookUpStats({genesis_block_index->GetBlockHash(), genesis_block_index->nHeight}));
 
     // Check that CoinStatsIndex updates with new blocks.
-    BOOST_CHECK(coin_stats_index.LookUpStats(*block_index));
+    BOOST_CHECK(coin_stats_index.LookUpStats({block_index->GetBlockHash(), block_index->nHeight}));
 
     const CScript script_pub_key{CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG};
     std::vector<CMutableTransaction> noTxns;
@@ -68,7 +68,7 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
         LOCK(cs_main);
         new_block_index = m_node.chainman->ActiveChain().Tip();
     }
-    BOOST_CHECK(coin_stats_index.LookUpStats(*new_block_index));
+    BOOST_CHECK(coin_stats_index.LookUpStats({new_block_index->GetBlockHash(), new_block_index->nHeight}));
 
     BOOST_CHECK(block_index != new_block_index);
 

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -11,6 +11,7 @@
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <sync.h>
+#include <test/util/index.h>
 #include <test/util/setup_common.h>
 #include <util/check.h>
 #include <validation.h>
@@ -42,7 +43,7 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
     // is started.
     BOOST_CHECK(!coin_stats_index.BlockUntilSyncedToCurrentChain());
 
-    coin_stats_index.Sync();
+    IndexTester{coin_stats_index}.Sync();
 
     // Check that CoinStatsIndex works for genesis block.
     const CBlockIndex* genesis_block_index;

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -15,6 +15,7 @@
 #include <test/util/setup_common.h>
 #include <util/check.h>
 #include <validation.h>
+#include <validationinterface.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -6,9 +6,11 @@
 #include <chainparams.h>
 #include <index/txindex.h>
 #include <interfaces/chain.h>
+#include <node/context.h>
 #include <test/util/setup_common.h>
 #include <util/byte_units.h>
 #include <validation.h>
+#include <validationinterface.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -16,7 +18,7 @@ BOOST_AUTO_TEST_SUITE(txindex_tests)
 
 BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
 {
-    TxIndex txindex(interfaces::MakeChain(m_node), 1_MiB, true);
+    TxIndex txindex(interfaces::MakeChain(m_node), m_node.chainman->m_blockman, 1_MiB, true);
     BOOST_REQUIRE(txindex.Init());
 
     CTransactionRef tx_disk;

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -29,8 +29,8 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
 
     // BlockUntilSyncedToCurrentChain should return false before txindex is started.
     BOOST_CHECK(!txindex.BlockUntilSyncedToCurrentChain());
-
-    txindex.Sync();
+    BOOST_CHECK(txindex.StartBackgroundSync());
+    txindex.WaitForBackgroundSync();
 
     // Check that txindex excludes genesis block transactions.
     const CBlock& genesis_block = Params().GenesisBlock();

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -21,6 +21,7 @@
 #include <script/script.h>
 #include <streams.h>
 #include <sync.h>
+#include <test/util/index.h>
 #include <test/util/setup_common.h>
 #include <util/byte_units.h>
 #include <util/check.h>
@@ -145,8 +146,7 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
 
     // BlockUntilSyncedToCurrentChain should return false before txindex is started.
     BOOST_CHECK(!txindex.BlockUntilSyncedToCurrentChain());
-
-    txindex.Sync();
+    IndexTester{txindex}.Sync();
 
     // Check that txindex excludes genesis block transactions.
     const CBlock& genesis_block = Params().GenesisBlock();
@@ -180,7 +180,7 @@ BOOST_FIXTURE_TEST_CASE(txindex_collision_scan_path, TestChain100Setup)
     // database, as it would on a node whose index was created by this version.
     TxIndex txindex(interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB, /*f_memory=*/false);
     BOOST_REQUIRE(txindex.Init());
-    txindex.Sync();
+    IndexTester{txindex}.Sync();
 
     CDBWrapper& db{TxIndexTest::GetDB(txindex)};
     const SipHasher13UJ hasher{ReadHasher(db)};
@@ -241,7 +241,7 @@ BOOST_FIXTURE_TEST_CASE(txindex_legacy_fallback, TestChain100Setup)
 
     TxIndex txindex(interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB, /*f_memory=*/false);
     BOOST_REQUIRE(txindex.Init());
-    txindex.Sync();
+    IndexTester{txindex}.Sync();
 
     // Drop the hashed entries so only the legacy row remains, then confirm the
     // lookup succeeds through the fallback.
@@ -282,7 +282,7 @@ BOOST_FIXTURE_TEST_CASE(txindex_reorg_keeps_stale_entries, TestChain100Setup)
 {
     TxIndex txindex(interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB, /*f_memory=*/true);
     BOOST_REQUIRE(txindex.Init());
-    txindex.Sync();
+    IndexTester{txindex}.Sync();
 
     const CScript coinbase_script{CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG};
 

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -17,6 +17,7 @@
 #include <interfaces/chain.h>
 #include <key.h>
 #include <node/blockstorage.h>
+#include <node/context.h>
 #include <primitives/block.h>
 #include <script/script.h>
 #include <streams.h>
@@ -27,6 +28,7 @@
 #include <util/check.h>
 #include <util/strencodings.h>
 #include <validation.h>
+#include <validationinterface.h>
 
 #include <cstdint>
 #include <memory>
@@ -136,7 +138,7 @@ BOOST_AUTO_TEST_CASE(txindex_hash_prefix)
 
 BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
 {
-    TxIndex txindex(interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB, /*f_memory=*/true);
+    TxIndex txindex(interfaces::MakeChain(m_node), m_node.chainman->m_blockman, /*n_cache_size=*/1_MiB, /*f_memory=*/true);
     BOOST_REQUIRE(txindex.Init());
 
     // Transaction should not be found in the index before it is started.
@@ -178,7 +180,7 @@ BOOST_FIXTURE_TEST_CASE(txindex_collision_scan_path, TestChain100Setup)
 {
     // On-disk, so the legacy-entry probe at construction runs against a fresh
     // database, as it would on a node whose index was created by this version.
-    TxIndex txindex(interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB, /*f_memory=*/false);
+    TxIndex txindex(interfaces::MakeChain(m_node), m_node.chainman->m_blockman, /*n_cache_size=*/1_MiB, /*f_memory=*/false);
     BOOST_REQUIRE(txindex.Init());
     IndexTester{txindex}.Sync();
 
@@ -239,7 +241,7 @@ BOOST_FIXTURE_TEST_CASE(txindex_legacy_fallback, TestChain100Setup)
         db.Write(txindex::LegacyTxKey(legacy_txid), legacy_pos);
     }
 
-    TxIndex txindex(interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB, /*f_memory=*/false);
+    TxIndex txindex(interfaces::MakeChain(m_node), m_node.chainman->m_blockman, /*n_cache_size=*/1_MiB, /*f_memory=*/false);
     BOOST_REQUIRE(txindex.Init());
     IndexTester{txindex}.Sync();
 
@@ -267,7 +269,7 @@ BOOST_FIXTURE_TEST_CASE(txindex_locator_upgrade, TestChain100Setup)
     CBlockLocator legacy_locator{{legacy_hash}}, new_locator{{new_hash}};
     { CDBWrapper{DBParams{.path = gArgs.GetDataDirNet() / "indexes" / "txindex", .cache_bytes = 1_MiB}}.Write(uint8_t{'B'}, legacy_locator); }
 
-    TxIndex txindex(interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB, /*f_memory=*/false);
+    TxIndex txindex(interfaces::MakeChain(m_node), m_node.chainman->m_blockman, /*n_cache_size=*/1_MiB, /*f_memory=*/false);
     BOOST_CHECK(TxIndexTest::ReadBestBlock(txindex).vHave == legacy_locator.vHave);
 
     TxIndexTest::WriteBestBlock(txindex, new_locator);
@@ -280,7 +282,7 @@ BOOST_FIXTURE_TEST_CASE(txindex_locator_upgrade, TestChain100Setup)
 
 BOOST_FIXTURE_TEST_CASE(txindex_reorg_keeps_stale_entries, TestChain100Setup)
 {
-    TxIndex txindex(interfaces::MakeChain(m_node), /*n_cache_size=*/1_MiB, /*f_memory=*/true);
+    TxIndex txindex(interfaces::MakeChain(m_node), m_node.chainman->m_blockman, /*n_cache_size=*/1_MiB, /*f_memory=*/true);
     BOOST_REQUIRE(txindex.Init());
     IndexTester{txindex}.Sync();
 

--- a/src/test/txospenderindex_tests.cpp
+++ b/src/test/txospenderindex_tests.cpp
@@ -50,7 +50,7 @@ BOOST_FIXTURE_TEST_CASE(txospenderindex_initial_sync, TestChain100Setup)
     BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return m_node.chainman->ActiveTip()->GetBlockHash()), tip_hash);
 
     // Now we concluded the setup phase, run index
-    TxoSpenderIndex txospenderindex(interfaces::MakeChain(m_node), 1 << 20, true);
+    TxoSpenderIndex txospenderindex(interfaces::MakeChain(m_node), m_node.chainman->m_blockman, 1 << 20, true);
     BOOST_REQUIRE(txospenderindex.Init());
     BOOST_CHECK(!txospenderindex.BlockUntilSyncedToCurrentChain()); // false when not synced
     BOOST_CHECK_NE(txospenderindex.GetSummary().best_block_hash, tip_hash);

--- a/src/test/txospenderindex_tests.cpp
+++ b/src/test/txospenderindex_tests.cpp
@@ -6,6 +6,7 @@
 #include <test/util/common.h>
 #include <test/util/setup_common.h>
 #include <validation.h>
+#include <validationinterface.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -59,7 +60,8 @@ BOOST_FIXTURE_TEST_CASE(txospenderindex_initial_sync, TestChain100Setup)
         BOOST_CHECK(!txospenderindex.FindSpender(outpoint).value());
     }
 
-    txospenderindex.Sync();
+    BOOST_CHECK(txospenderindex.StartBackgroundSync());
+    txospenderindex.WaitForBackgroundSync();
     BOOST_CHECK_EQUAL(txospenderindex.GetSummary().best_block_hash, tip_hash);
 
     for (size_t i = 0; i < spent.size(); i++) {

--- a/src/test/txospenderindex_tests.cpp
+++ b/src/test/txospenderindex_tests.cpp
@@ -4,8 +4,10 @@
 
 #include <index/txospenderindex.h>
 #include <test/util/common.h>
+#include <test/util/index.h>
 #include <test/util/setup_common.h>
 #include <validation.h>
+#include <validationinterface.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -59,7 +61,7 @@ BOOST_FIXTURE_TEST_CASE(txospenderindex_initial_sync, TestChain100Setup)
         BOOST_CHECK(!txospenderindex.FindSpender(outpoint).value());
     }
 
-    txospenderindex.Sync();
+    IndexTester{txospenderindex}.Sync();
     BOOST_CHECK_EQUAL(txospenderindex.GetSummary().best_block_hash, tip_hash);
 
     for (size_t i = 0; i < spent.size(); i++) {

--- a/src/test/txospenderindex_tests.cpp
+++ b/src/test/txospenderindex_tests.cpp
@@ -51,7 +51,7 @@ BOOST_FIXTURE_TEST_CASE(txospenderindex_initial_sync, TestChain100Setup)
     BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return m_node.chainman->ActiveTip()->GetBlockHash()), tip_hash);
 
     // Now we concluded the setup phase, run index
-    TxoSpenderIndex txospenderindex(interfaces::MakeChain(m_node), 1 << 20, true);
+    TxoSpenderIndex txospenderindex(interfaces::MakeChain(m_node), m_node.chainman->m_blockman, 1 << 20, true);
     BOOST_REQUIRE(txospenderindex.Init());
     BOOST_CHECK(!txospenderindex.BlockUntilSyncedToCurrentChain()); // false when not synced
     BOOST_CHECK_NE(txospenderindex.GetSummary().best_block_hash, tip_hash);

--- a/src/test/util/CMakeLists.txt
+++ b/src/test/util/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(test_util STATIC EXCLUDE_FROM_ALL
   blockfilter.cpp
   coins.cpp
   coverage.cpp
+  index.cpp
   json.cpp
   logging.cpp
   mining.cpp

--- a/src/test/util/index.cpp
+++ b/src/test/util/index.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/util/index.h>
+
+#include <chain.h>
+#include <index/base.h>
+#include <kernel/types.h>
+#include <node/chain.h>
+#include <validation.h>
+
+using interfaces::BlockInfo;
+using kernel::ChainstateRole;
+using node::MakeBlockInfo;
+using node::SyncChain;
+
+void IndexTester::Sync()
+{
+    CThreadInterrupt interrupt;
+    SyncChain(*Assert(m_index.m_chainstate), m_index.m_best_block_index, m_index.CustomOptions(), m_index.Notifications(), interrupt, nullptr);
+    BlockInfo block = MakeBlockInfo(m_index.m_best_block_index, nullptr, m_index.m_chainstate);
+    block.state = BlockInfo::SYNCED;
+    m_index.Notifications()->blockConnected(ChainstateRole{}, block);
+}

--- a/src/test/util/index.cpp
+++ b/src/test/util/index.cpp
@@ -18,8 +18,12 @@ using node::SyncChain;
 void IndexTester::Sync()
 {
     CThreadInterrupt interrupt;
-    SyncChain(*Assert(m_index.m_chainstate), m_index.m_best_block_index, m_index.CustomOptions(), m_index.Notifications(), interrupt, nullptr);
-    BlockInfo block = MakeBlockInfo(m_index.m_best_block_index, nullptr, m_index.m_chainstate);
+    CBlockIndex* best_block{nullptr};
+    if (std::optional<interfaces::BlockRef> block{m_index.GetBestBlock()}) {
+        best_block = WITH_LOCK(::cs_main, return m_index.m_chainstate->m_blockman.LookupBlockIndex(block->hash));
+    }
+    SyncChain(*Assert(m_index.m_chainstate), best_block, m_index.CustomOptions(), m_index.Notifications(), interrupt, nullptr);
+    BlockInfo block = MakeBlockInfo(best_block, nullptr, m_index.m_chainstate);
     block.state = BlockInfo::SYNCED;
     m_index.Notifications()->blockConnected(ChainstateRole{}, block);
 }

--- a/src/test/util/index.cpp
+++ b/src/test/util/index.cpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/util/index.h>
+
+#include <chain.h>
+#include <index/base.h>
+#include <kernel/types.h>
+#include <node/chain.h>
+#include <util/check.h>
+#include <validation.h>
+
+using interfaces::BlockInfo;
+using kernel::ChainstateRole;
+using node::MakeBlockInfo;
+using node::SyncChain;
+
+void IndexTester::Sync()
+{
+    Assert(m_index.StartBackgroundSync());
+    m_index.WaitForBackgroundSync();
+}
+
+void IndexTester::SyncOnce()
+{
+    CThreadInterrupt interrupt;
+    SyncChain(*Assert(m_index.m_chainstate), m_index.m_best_block_index, m_index.CustomOptions(), m_index.Notifications(), interrupt, nullptr);
+    BlockInfo block = MakeBlockInfo(m_index.m_best_block_index, nullptr, m_index.m_chainstate);
+    block.state = BlockInfo::SYNCED;
+    m_index.Notifications()->blockConnected(ChainstateRole{}, block);
+}

--- a/src/test/util/index.cpp
+++ b/src/test/util/index.cpp
@@ -25,8 +25,12 @@ void IndexTester::Sync()
 void IndexTester::SyncOnce()
 {
     CThreadInterrupt interrupt;
-    SyncChain(*Assert(m_index.m_chainstate), m_index.m_best_block_index, m_index.CustomOptions(), m_index.Notifications(), interrupt, nullptr);
-    BlockInfo block = MakeBlockInfo(m_index.m_best_block_index, nullptr, m_index.m_chainstate);
+    CBlockIndex* best_block{nullptr};
+    if (std::optional<interfaces::BlockRef> block{m_index.GetBestBlock()}) {
+        best_block = WITH_LOCK(::cs_main, return m_index.m_chainstate->m_blockman.LookupBlockIndex(block->hash));
+    }
+    SyncChain(*Assert(m_index.m_chainstate), best_block, m_index.CustomOptions(), m_index.Notifications(), interrupt, nullptr);
+    BlockInfo block = MakeBlockInfo(best_block, nullptr, m_index.m_chainstate);
     block.state = BlockInfo::SYNCED;
     m_index.Notifications()->blockConnected(ChainstateRole{}, block);
 }

--- a/src/test/util/index.cpp
+++ b/src/test/util/index.cpp
@@ -8,7 +8,9 @@
 #include <index/base.h>
 #include <kernel/types.h>
 #include <node/chain.h>
+#include <node/context.h>
 #include <util/check.h>
+#include <util/threadinterrupt.h>
 #include <validation.h>
 
 using interfaces::BlockInfo;
@@ -24,13 +26,14 @@ void IndexTester::Sync()
 
 void IndexTester::SyncOnce()
 {
+    Chainstate& chainstate{WITH_LOCK(::cs_main, return m_index.m_chain->context()->chainman->ValidatedChainstate())};
     CThreadInterrupt interrupt;
     CBlockIndex* best_block{nullptr};
     if (std::optional<interfaces::BlockRef> block{m_index.GetBestBlock()}) {
-        best_block = WITH_LOCK(::cs_main, return m_index.m_chainstate->m_blockman.LookupBlockIndex(block->hash));
+        best_block = WITH_LOCK(::cs_main, return chainstate.m_blockman.LookupBlockIndex(block->hash));
     }
-    SyncChain(*Assert(m_index.m_chainstate), best_block, m_index.CustomOptions(), m_index.Notifications(), interrupt, nullptr);
-    BlockInfo block = MakeBlockInfo(best_block, nullptr, m_index.m_chainstate);
+    SyncChain(chainstate, best_block, m_index.CustomOptions(), m_index.Notifications(), interrupt, nullptr);
+    BlockInfo block = MakeBlockInfo(best_block, nullptr, &chainstate);
     block.state = BlockInfo::SYNCED;
     m_index.Notifications()->blockConnected(ChainstateRole{}, block);
 }

--- a/src/test/util/index.h
+++ b/src/test/util/index.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_UTIL_INDEX_H
+#define BITCOIN_TEST_UTIL_INDEX_H
+
+class BaseIndex;
+
+class IndexTester
+{
+public:
+    IndexTester(BaseIndex& index) : m_index{index} {}
+
+    //! Sync index in foreground without creating background thread.
+    void Sync();
+
+    BaseIndex& m_index;
+};
+
+#endif // BITCOIN_TEST_UTIL_INDEX_H

--- a/src/test/util/index.h
+++ b/src/test/util/index.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_UTIL_INDEX_H
+#define BITCOIN_TEST_UTIL_INDEX_H
+
+class BaseIndex;
+
+class IndexTester
+{
+public:
+    IndexTester(BaseIndex& index) : m_index{index} {}
+
+    //! Bring the index up to the current chain tip and leave it connected, so it
+    //! keeps indexing blocks that are connected afterwards (as on a running node).
+    //! Internally this runs the index's background sync (StartBackgroundSync +
+    //! WaitForBackgroundSync): a sync thread is created and joined within this
+    //! call, so individual tests don't have to manage one. This is the method
+    //! tests should normally use.
+    void Sync();
+
+    //! Bring the index up to the current chain tip once, synchronously in the
+    //! foreground, and leave it disconnected: blocks connected after this returns
+    //! are NOT indexed. Intended for the sync benchmark, where a deterministic
+    //! foreground sync with no background thread is wanted.
+    void SyncOnce();
+
+    BaseIndex& m_index;
+};
+
+#endif // BITCOIN_TEST_UTIL_INDEX_H

--- a/src/test/util/validation.cpp
+++ b/src/test/util/validation.cpp
@@ -43,14 +43,6 @@ void TestChainstateManager::JumpOutOfIbd()
     Assert(!IsInitialBlockDownload());
 }
 
-void ValidationInterfaceTest::BlockConnected(
-    const ChainstateRole& role,
-    CValidationInterface& obj,
-    const std::shared_ptr<const CBlock>& block,
-    const CBlockIndex* pindex)
-{
-    obj.BlockConnected(role, block, pindex);
-}
 void TestChainstateManager::InvalidBlockFound(CBlockIndex* pindex, const BlockValidationState& state)
 {
     struct TestChainstate : public Chainstate {

--- a/src/test/util/validation.cpp
+++ b/src/test/util/validation.cpp
@@ -10,8 +10,6 @@
 #include <validation.h>
 #include <validationinterface.h>
 
-using kernel::ChainstateRole;
-
 void TestBlockManager::CleanupForFuzzing()
 {
     m_dirty_blockindex.clear();

--- a/src/test/util/validation.cpp
+++ b/src/test/util/validation.cpp
@@ -56,14 +56,6 @@ void TestChainstateManager::JumpOutOfIbd()
     Assert(!IsInitialBlockDownload());
 }
 
-void ValidationInterfaceTest::BlockConnected(
-    const ChainstateRole& role,
-    CValidationInterface& obj,
-    const std::shared_ptr<const CBlock>& block,
-    const CBlockIndex* pindex)
-{
-    obj.BlockConnected(role, block, pindex);
-}
 void TestChainstateManager::InvalidBlockFound(CBlockIndex* pindex, const BlockValidationState& state)
 {
     struct TestChainstate : public Chainstate {

--- a/src/test/util/validation.cpp
+++ b/src/test/util/validation.cpp
@@ -23,7 +23,6 @@
 #include <utility>
 #include <vector>
 
-using kernel::ChainstateRole;
 
 void TestBlockManager::CleanupForFuzzing()
 {

--- a/src/test/util/validation.h
+++ b/src/test/util/validation.h
@@ -10,7 +10,6 @@
 namespace node {
 class BlockManager;
 }
-class CValidationInterface;
 
 struct TestBlockManager : public node::BlockManager {
     /** Test-only method to clear internal state for fuzzing */
@@ -29,16 +28,6 @@ struct TestChainstateManager : public ChainstateManager {
     void InvalidChainFound(CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     CBlockIndex* FindMostWorkChain() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     void ResetBestInvalid() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-};
-
-class ValidationInterfaceTest
-{
-public:
-    static void BlockConnected(
-        const kernel::ChainstateRole& role,
-        CValidationInterface& obj,
-        const std::shared_ptr<const CBlock>& block,
-        const CBlockIndex* pindex);
 };
 
 #endif // BITCOIN_TEST_UTIL_VALIDATION_H

--- a/src/test/util/validation.h
+++ b/src/test/util/validation.h
@@ -19,7 +19,6 @@
 namespace node {
 class BlockManager;
 }
-class CValidationInterface;
 class FakeNodeClock;
 struct TestingSetup;
 
@@ -49,16 +48,6 @@ struct TestChainstateManager : public ChainstateManager {
     void InvalidChainFound(CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     CBlockIndex* FindMostWorkChain() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     void ResetBestInvalid() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-};
-
-class ValidationInterfaceTest
-{
-public:
-    static void BlockConnected(
-        const kernel::ChainstateRole& role,
-        CValidationInterface& obj,
-        const std::shared_ptr<const CBlock>& block,
-        const CBlockIndex* pindex);
 };
 
 std::vector<std::pair<COutPoint, CAmount>> ResetChainmanAndMempool(TestingSetup& setup, FakeNodeClock& node_clock);

--- a/src/util/btcsignals.h
+++ b/src/util/btcsignals.h
@@ -138,6 +138,11 @@ public:
         m_conn.disconnect();
     }
 
+    bool connected() const
+    {
+        return m_conn.connected();
+    }
+
     ~scoped_connection()
     {
         disconnect();

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -159,7 +159,6 @@ protected:
      */
     virtual void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& block) {};
     friend class ValidationSignals;
-    friend class ValidationInterfaceTest;
 };
 
 class ValidationSignalsImpl;

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -162,7 +162,6 @@ protected:
      */
     virtual void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& block) {};
     friend class ValidationSignals;
-    friend class ValidationInterfaceTest;
 };
 
 class ValidationSignalsImpl;

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -61,7 +61,12 @@ class InitTest(BitcoinTestFramework):
                 os.kill(node.process.pid, signal.CTRL_BREAK_EVENT)
             else:
                 node.process.terminate()
-            assert_equal(0, node.process.wait())
+            # Don't check exit code returned by wait(). Normally exit code will
+            # be 0, but if the process is killed early, before the bitcoind
+            # signal handler is installed, it will exit with other values like
+            # SIGTERM (-15) on linux or STATUS_DLL_INIT_FAILED (0xc0000142) on
+            # windows.
+            node.process.wait()
 
         reindex_log_line = b'Reindexing block file blk00000.dat'
         lines_to_terminate_after = [
@@ -90,9 +95,24 @@ class InitTest(BitcoinTestFramework):
             lines_to_terminate_after.append(b'Verifying wallet')
         lines_to_terminate_after.append(reindex_log_line)
 
+        index_threads = [
+            b'txidx thread start',
+            b'blkfltbscidx thread start',
+            b'coinstatsidx thread start',
+            b'txospenderidx thread start',
+        ]
+        log_start_byte = node.debug_log_size(mode="rb")
         for terminate_line in lines_to_terminate_after:
             self.log.info(f"Starting node and will terminate after line {terminate_line}")
-            with node.busy_wait_for_debug_log([terminate_line]):
+            # Index thread start messages are only printed if index is behind
+            # the current chain tip at startup and needs to sync. If the index
+            # is already in sync during startup no messages will be printed.
+            # Set `start_byte` below for this reason to look for the index
+            # thread start messages, starting earlier, from the begining of this
+            # test, in case the node was not killed quickly enough and an index
+            # was already synced by the time this test was looking for its
+            # thread start message.
+            with node.busy_wait_for_debug_log([terminate_line], start_byte=log_start_byte if terminate_line in index_threads else None):
                 extra_args = [*ALL_INDEX_ARGS]
                 if terminate_line == reindex_log_line:
                     extra_args += ['-reindex']

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -62,7 +62,12 @@ class InitTest(BitcoinTestFramework):
                 os.kill(node.process.pid, signal.CTRL_BREAK_EVENT)
             else:
                 node.process.terminate()
-            assert_equal(0, node.process.wait())
+            # Don't check exit code returned by wait(). Normally exit code will
+            # be 0, but if the process is killed early, before the bitcoind
+            # signal handler is installed, it will exit with other values like
+            # SIGTERM (-15) on linux or STATUS_DLL_INIT_FAILED (0xc0000142) on
+            # windows.
+            node.process.wait()
 
         reindex_log_line = b'Reindexing block file blk00000.dat'
         lines_to_terminate_after = [
@@ -91,9 +96,24 @@ class InitTest(BitcoinTestFramework):
             lines_to_terminate_after.append(b'Verifying wallet')
         lines_to_terminate_after.append(reindex_log_line)
 
+        index_threads = [
+            b'txidx thread start',
+            b'blkfltbscidx thread start',
+            b'coinstatsidx thread start',
+            b'txospenderidx thread start',
+        ]
+        log_start_byte = node.debug_log_size(mode="rb")
         for terminate_line in lines_to_terminate_after:
             self.log.info(f"Starting node and will terminate after line {terminate_line}")
-            with node.busy_wait_for_debug_log([terminate_line]):
+            # Index thread start messages are only printed if index is behind
+            # the current chain tip at startup and needs to sync. If the index
+            # is already in sync during startup no messages will be printed.
+            # Set `start_byte` below for this reason to look for the index
+            # thread start messages, starting earlier, from the begining of this
+            # test, in case the node was not killed quickly enough and an index
+            # was already synced by the time this test was looking for its
+            # thread start message.
+            with node.busy_wait_for_debug_log([terminate_line], start_byte=log_start_byte if terminate_line in index_threads else None):
                 extra_args = [*ALL_INDEX_ARGS]
                 if terminate_line == reindex_log_line:
                     extra_args += ['-reindex']

--- a/test/functional/rpc_gettxspendingprevout.py
+++ b/test/functional/rpc_gettxspendingprevout.py
@@ -195,9 +195,9 @@ class GetTxSpendingPrevoutTest(BitcoinTestFramework):
         assert tx1["txid"] not in node0_mempool
         assert tx2["txid"] not in node0_mempool
 
-        # tx2 is not in the mempool anymore, but still in txospender index which has not been rewound yet
+        # tx2 is not in the mempool anymore, and txospenderindex has already been rewound by blockDisconnected
         result = node0.gettxspendingprevout([prevout(tx1['txid'], vout=0)], return_spending_tx=True)
-        assert_equal(result, [spent_out_in_block(tx1['txid'], vout=0, spending_tx_id=tx2["txid"], blockhash=blockhash, spending_tx=tx2['hex'])])
+        assert_equal(result, [unspent_out(tx1['txid'], vout=0)])
 
         txinfo = node0.getrawtransaction(tx2["txid"], verbose = True, blockhash = blockhash)
         assert_equal(txinfo["confirmations"], 0)

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -612,7 +612,7 @@ class TestNode():
                                     f'not found in log:\n\n{join_log(log)}\n\n')
 
     @contextlib.contextmanager
-    def busy_wait_for_debug_log(self, expected_msgs, timeout=60):
+    def busy_wait_for_debug_log(self, expected_msgs, timeout=60, *, start_byte=None):
         """
         Block until we see a particular debug log message fragment or until we exceed the timeout.
         """
@@ -624,7 +624,7 @@ class TestNode():
 
         while True:
             with open(self.debug_log_path, "rb") as dl:
-                dl.seek(prev_size)
+                dl.seek(start_byte if start_byte is not None else prev_size)
                 log = dl.read()
 
             while remaining_expected and remaining_expected[-1] in log:

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -644,7 +644,7 @@ class TestNode():
                                     f'not found in log:\n\n{join_log(log)}\n\n')
 
     @contextlib.contextmanager
-    def busy_wait_for_debug_log(self, expected_msgs, timeout=60):
+    def busy_wait_for_debug_log(self, expected_msgs, timeout=60, *, start_byte=None):
         """
         Block until we see a particular debug log message fragment or until we exceed the timeout.
         """
@@ -656,7 +656,7 @@ class TestNode():
 
         while True:
             with open(self.debug_log_path, "rb") as dl:
-                dl.seek(prev_size)
+                dl.seek(start_byte if start_byte is not None else prev_size)
                 log = dl.read()
 
             while remaining_expected and remaining_expected[-1] in log:


### PR DESCRIPTION
This PR lets indexing code mostly run outside of the node process. It also improves indexing sync logic, which is moved out of indexing code to a new [`node::SyncChain()`](https://github.com/ryanofsky/bitcoin/blob/cf6d99bed842361fb06986780097fb80c9e879e4/src/node/chain.h#L21-L36) function.

Almost all the commits in this PR are small refactoring changes that move code from `src/index/` to `src/node/`, or replace references to node types like `CBlockIndex`, `CChain`, `CChainState` in index code. There are only two commits affecting indexing sync logic which make complicated or substantive changes:

- [`8862eddeb68b` indexes: Rewrite chain sync logic, simplify index sync code](https://github.com/bitcoin/bitcoin/pull/24230/commits/8862eddeb68b8871421e8aa4e69c7fa567df4da5)
- [`f458cf8a4ce1` indexes: Initialize indexes without holding cs_main](https://github.com/bitcoin/bitcoin/pull/24230/commits/f458cf8a4ce1c9a21633439122df929dbee53946)

The commit messages have more details about these and other changes. Followups to this PR will reuse indexing sync code for wallets (#15719, #11756) and let indexes run in separate processes (#10102)