### PR TITLE
depends: fix capnp's descriptor for make download

### DIFF
--- a/depends/packages/capnp.mk
+++ b/depends/packages/capnp.mk
@@ -1,6 +1,7 @@
 package=capnp
 $(package)_version=$(native_$(package)_version)
 $(package)_download_path=$(native_$(package)_download_path)
+$(package)_download_file=$(native_$(package)_download_file)
 $(package)_file_name=$(native_$(package)_file_name)
 $(package)_sha256_hash=$(native_$(package)_sha256_hash)
 $(package)_dependencies=native_$(package)


### PR DESCRIPTION
The non-native capnp was trying to fetch the wrong file.
Without this, "make -C depends MULTIPROCESS=1 download" is broken.

Presumably it breaks with the download target because the dependency graph is flattened. It manages to work if native_capnp is encountered first because it will then be found in the cache.