### PR TITLE
Re-enable windows path tests disabled by #20744

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -71,12 +71,9 @@ BOOST_AUTO_TEST_CASE(util_datadir)
     args.ClearPathCache();
     BOOST_CHECK_EQUAL(dd_norm, args.GetDataDirBase());
 
-#ifndef WIN32
-    // Windows does not consider "datadir/.//" to be a valid directory path.
     args.ForceSetArg("-datadir", fs::PathToString(dd_norm) + "/.//");
     args.ClearPathCache();
     BOOST_CHECK_EQUAL(dd_norm, args.GetDataDirBase());
-#endif
 }
 
 BOOST_AUTO_TEST_CASE(util_check)

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -253,7 +253,7 @@ fs::path StripRedundantLastElementsOfPath(const fs::path& path)
         result = result.parent_path();
     }
 
-    assert(fs::equivalent(result, path));
+    assert(fs::equivalent(result, path.lexically_normal()));
     return result;
 }
 } // namespace

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -31,11 +31,13 @@ bool VerifyWallets(WalletContext& context)
         fs::path wallet_dir = fs::PathFromString(args.GetArg("-walletdir", ""));
         std::error_code error;
         // The canonical path cleans the path, preventing >1 Berkeley environment instances for the same directory
+        // It also lets the fs::exists and fs::is_directory checks below pass on windows, since they return false
+        // if a path has trailing slashes, and it strips trailing slashes.
         fs::path canonical_wallet_dir = fs::canonical(wallet_dir, error);
-        if (error || !fs::exists(wallet_dir)) {
+        if (error || !fs::exists(canonical_wallet_dir)) {
             chain.initError(strprintf(_("Specified -walletdir \"%s\" does not exist"), fs::PathToString(wallet_dir)));
             return false;
-        } else if (!fs::is_directory(wallet_dir)) {
+        } else if (!fs::is_directory(canonical_wallet_dir)) {
             chain.initError(strprintf(_("Specified -walletdir \"%s\" is not a directory"), fs::PathToString(wallet_dir)));
             return false;
         // The canonical path transforms relative paths into absolute ones, so we check the non-canonical version

--- a/src/wallet/test/init_tests.cpp
+++ b/src/wallet/test/init_tests.cpp
@@ -73,8 +73,6 @@ BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_no_trailing)
     BOOST_CHECK_EQUAL(walletdir, expected_path);
 }
 
-#ifndef WIN32
-// Windows does not consider "datadir/wallets//" to be a valid directory path.
 BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_no_trailing2)
 {
     SetWalletDir(m_walletdir_path_cases["trailing2"]);
@@ -84,7 +82,6 @@ BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_no_trailing2)
     fs::path expected_path = fs::canonical(m_walletdir_path_cases["default"]);
     BOOST_CHECK_EQUAL(walletdir, expected_path);
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()
 } // namespace wallet


### PR DESCRIPTION
Reenable some broken tests as discussed https://github.com/bitcoin/bitcoin/pull/20744#discussion_r798651736 and https://github.com/bitcoin/bitcoin/pull/20744#discussion_r798678137

Fix windows test cases broken in #20744, by passing normalized path arguments to fs::equivalent, fs::exists, and fs::is_directory, instead of non-normalized arguments. Also re-enable the tests.

It is possible these changes also fix real init behavior on windows when -datadir or -walletdir paths with trailing dots or dashes are used, but it's not clear because I only tested on wine.