### PR TITLE
[22.x] build: Bump depends packages (zmq, libXau)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -105,7 +105,7 @@ task:
   name: '32-bit + dash [gui] [CentOS 8]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
-    image: centos:8
+    image: quay.io/centos/centos:stream8
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
     PACKAGE_MANAGER_INSTALL: "yum install -y"

--- a/ci/test/00_setup_env_i686_centos.sh
+++ b/ci/test/00_setup_env_i686_centos.sh
@@ -7,9 +7,9 @@
 export LC_ALL=C.UTF-8
 
 export HOST=i686-pc-linux-gnu
-export CONTAINER_NAME=ci_i686_centos_8
-export DOCKER_NAME_TAG=centos:8
-export DOCKER_PACKAGES="gcc-c++ glibc-devel.x86_64 libstdc++-devel.x86_64 glibc-devel.i686 libstdc++-devel.i686 ccache libtool make git python3 python3-zmq which patch lbzip2 dash rsync coreutils bison"
+export CONTAINER_NAME=ci_i686_centos
+export DOCKER_NAME_TAG=quay.io/centos/centos:stream8
+export DOCKER_PACKAGES="gcc-c++ glibc-devel.x86_64 libstdc++-devel.x86_64 glibc-devel.i686 libstdc++-devel.i686 ccache libtool make git python3 python3-zmq which patch lbzip2 xz procps-ng dash rsync coreutils bison"
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-reduce-exports"
 export CONFIG_SHELL="/bin/dash"

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -62,7 +62,7 @@ if [ -n "$DPKG_ADD_ARCH" ]; then
   DOCKER_EXEC dpkg --add-architecture "$DPKG_ADD_ARCH"
 fi
 
-if [[ $DOCKER_NAME_TAG == centos* ]]; then
+if [[ $DOCKER_NAME_TAG == *centos* ]]; then
   ${CI_RETRY_EXE} DOCKER_EXEC dnf -y install epel-release
   ${CI_RETRY_EXE} DOCKER_EXEC dnf -y --allowerasing install $DOCKER_PACKAGES $PACKAGES
 elif [ "$CI_USE_APT_INSTALL" != "no" ]; then

--- a/ci/test/05_before_script.sh
+++ b/ci/test/05_before_script.sh
@@ -45,7 +45,7 @@ if [[ $HOST = *-mingw32 ]]; then
   DOCKER_EXEC update-alternatives --set $HOST-g++ \$\(which $HOST-g++-posix\)
 fi
 if [ -z "$NO_DEPENDS" ]; then
-  if [[ $DOCKER_NAME_TAG == centos* ]]; then
+  if [[ $DOCKER_NAME_TAG == *centos* ]]; then
     # CentOS has problems building the depends if the config shell is not explicitly set
     # (i.e. for libevent a Makefile with an empty SHELL variable is generated, leading to
     #  an error as the first command is executed)

--- a/ci/test/05_before_script.sh
+++ b/ci/test/05_before_script.sh
@@ -49,7 +49,7 @@ if [ -z "$NO_DEPENDS" ]; then
     # CentOS has problems building the depends if the config shell is not explicitly set
     # (i.e. for libevent a Makefile with an empty SHELL variable is generated, leading to
     #  an error as the first command is executed)
-    SHELL_OPTS="LC_ALL=en_US.UTF-8 CONFIG_SHELL=/bin/bash"
+    SHELL_OPTS="LC_ALL=en_US.UTF-8 CONFIG_SHELL=/bin/dash"
   else
     SHELL_OPTS="CONFIG_SHELL="
   fi

--- a/depends/packages/libXau.mk
+++ b/depends/packages/libXau.mk
@@ -1,8 +1,8 @@
 package=libXau
-$(package)_version=1.0.8
+$(package)_version=1.0.9
 $(package)_download_path=https://xorg.freedesktop.org/releases/individual/lib/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=fdd477320aeb5cdd67272838722d6b7d544887dfe7de46e1e7cc0c27c2bea4f2
+$(package)_sha256_hash=ccf8cbf0dbf676faa2ea0a6d64bcc3b6746064722b606c8c52917ed00dcb73ec
 $(package)_dependencies=xproto
 
 # When updating this package, check the default value of

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -3,7 +3,7 @@ $(package)_version=4.3.1
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d835cd21eb
-$(package)_patches=remove_libstd_link.patch
+$(package)_patches=remove_libstd_link.patch fix_dash_compat.patch
 
 define $(package)_set_vars
   $(package)_config_opts=--without-docs --disable-shared --disable-curve --disable-curve-keygen --disable-perf
@@ -17,10 +17,12 @@ endef
 
 define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/remove_libstd_link.patch && \
+  patch -p1 < $($(package)_patch_dir)/fix_dash_compat.patch && \
   cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub config
 endef
 
 define $(package)_config_cmds
+  ./autogen.sh && \
   $($(package)_autoconf)
 endef
 

--- a/depends/patches/zeromq/fix_dash_compat.patch
+++ b/depends/patches/zeromq/fix_dash_compat.patch
@@ -1,0 +1,71 @@
+commit 9a397666d28ca5f3c0d8233be3d39b2206555f45
+Author: Alain Kalker <a.c.kalker@gmail.com>
+Date:   Wed May 22 01:30:54 2019 +0200
+
+    acinclude.m4, configure.ac: Fix several non-portable uses of `test`
+    
+    Fixes #3517
+
+diff --git a/acinclude.m4 b/acinclude.m4
+index 036a30a0..4f5ae3c2 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -1058,12 +1058,12 @@ AC_DEFUN([LIBZMQ_CHECK_POLLER], [{
+         [AS_HELP_STRING([--with-api-poller],
+         [choose zmq_poll(er)_* API polling system manually. Valid values are 'poll', 'select', or 'auto'. [default=auto]])])
+ 
+-    if test "x$with_poller" == "x"; then
++    if test "x$with_poller" = "x"; then
+         pollers=auto
+     else
+         pollers=$with_poller
+     fi
+-    if test "$pollers" == "auto"; then
++    if test "$pollers" = "auto"; then
+         # We search for pollers in this order
+         pollers="kqueue epoll devpoll pollset poll select"
+     fi
+@@ -1145,13 +1145,13 @@ AC_DEFUN([LIBZMQ_CHECK_POLLER], [{
+     if test $poller_found -eq 0; then
+         AC_MSG_ERROR([None of '$pollers' are valid pollers on this platform])
+     fi
+-    if test "x$with_api_poller" == "x"; then
++    if test "x$with_api_poller" = "x"; then
+         with_api_poller=auto
+     fi
+-	if test "x$with_api_poller" == "xauto"; then
+-		if test $poller == "select"; then
++	if test "x$with_api_poller" = "xauto"; then
++		if test $poller = "select"; then
+ 			api_poller=select
+-		elif test $poller == "wepoll"; then
++		elif test $poller = "wepoll"; then
+ 			api_poller=select
+ 		else		
+ 			api_poller=poll
+@@ -1159,10 +1159,10 @@ AC_DEFUN([LIBZMQ_CHECK_POLLER], [{
+ 	else
+ 		api_poller=$with_api_poller
+ 	fi
+-	if test "$api_poller" == "select"; then
++	if test "$api_poller" = "select"; then
+ 		AC_MSG_NOTICE([Using 'select' zmq_poll(er)_* API polling system])
+ 		AC_DEFINE(ZMQ_POLL_BASED_ON_SELECT, 1, [Use 'select' zmq_poll(er)_* API polling system])
+-	elif test "$api_poller" == "poll"; then
++	elif test "$api_poller" = "poll"; then
+ 		AC_MSG_NOTICE([Using 'poll' zmq_poll(er)_* API polling system])
+ 		AC_DEFINE(ZMQ_POLL_BASED_ON_POLL, 1, [Use 'poll' zmq_poll(er)_* API polling system])
+ 	else
+diff --git a/configure.ac b/configure.ac
+index 5c4e1e45..65bb4e0d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -143,7 +143,7 @@ AC_ARG_ENABLE(address-sanitizer, [AS_HELP_STRING([--enable-address-sanitizer=yes
+                   [Build with GCC Address Sanitizer instrumentation])],
+                   [ZMQ_ASAN="$enableval"])
+ 
+-if test "x${ZMQ_ASAN}" == "xyes"; then
++if test "x${ZMQ_ASAN}" = "xyes"; then
+     CFLAGS="${CFLAGS} -fsanitize=address"
+     CXXFLAGS="${CXXFLAGS} -fsanitize=address"
+ 


### PR DESCRIPTION
Backports #24212 to the 22.x branch. Included a bump to libXau and an additional commit for zeromq to fix dash compatibility.