### PR TITLE
upstream: Update minisketch subtree

### DIFF
--- a/src/minisketch.cpp
+++ b/src/minisketch.cpp
@@ -63,9 +63,9 @@ enum class FieldImpl {
 #endif
 };
 
+#ifdef HAVE_CLMUL
 static inline bool EnableClmul()
 {
-#ifdef HAVE_CLMUL
 #ifdef _MSC_VER
     int regs[4];
     __cpuid(regs, 1);
@@ -74,10 +74,8 @@ static inline bool EnableClmul()
     uint32_t eax, ebx, ecx, edx;
     return (__get_cpuid(1, &eax, &ebx, &ecx, &edx) && (ecx & 0x2));
 #endif
-#else
-    return false;
-#endif
 }
+#endif
 
 Sketch* Construct(int bits, int impl)
 {


### PR DESCRIPTION
Marco mentioned issues running the native valgrind job (it sets `-Werror`) on arm64 hardware due to compile errors:
```bash
minisketch/src/minisketch.cpp:66:20: error: unused function 'EnableClmul' [-Werror,-Wunused-function]
```

Pull the subtree to fix this. The only change here is https://github.com/sipa/minisketch/pull/58.