### PR TITLE
util: Avoid buggy std::filesystem:::create_directories() call

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -443,12 +443,16 @@ const fs::path& ArgsManager::GetDataDir(bool net_specific) const
     } else {
         path = GetDefaultDataDir();
     }
-    if (net_specific)
-        path /= fs::PathFromString(BaseParams().DataDir());
 
-    if (fs::create_directories(path)) {
-        // This is the first run, create wallets subdirectory too
+    if (!fs::exists(path)) {
         fs::create_directories(path / "wallets");
+    }
+
+    if (net_specific && !BaseParams().DataDir().empty()) {
+        path /= fs::PathFromString(BaseParams().DataDir());
+        if (!fs::exists(path)) {
+            fs::create_directories(path / "wallets");
+        }
     }
 
     path = StripRedundantLastElementsOfPath(path);


### PR DESCRIPTION
Compiled with some libstdc++ versions (e.g., on Ubuntu 20.04) [`std::filesystem:::create_directories()`](https://en.cppreference.com/w/cpp/filesystem/create_directory) call [fails](https://github.com/bitcoin/bitcoin/issues/24257#issue-1123753243) to handle symbol links properly.

No behavior change in comparison to the [pre-20744](https://github.com/bitcoin/bitcoin/commit/c194293883fbb656779102309b2cb3e60889feff) master branch.

Fixes bitcoin/bitcoin#24257.