### PR TITLE
util: if `DataDir` is a symbolic link, manually follow it

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -443,6 +443,15 @@ const fs::path& ArgsManager::GetDataDir(bool net_specific) const
     } else {
         path = GetDefaultDataDir();
     }
+
+    if (fs::is_symlink(path)) {
+        path = fs::read_symlink(path);
+        if (!fs::is_directory(path)) {
+            path = "";
+            return path;
+        }
+    }
+
     if (net_specific)
         path /= fs::PathFromString(BaseParams().DataDir());
 


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/24257

```
$~/btc-things/bitcoin$ ln -s /media/DATA/Bitcoin /home/me/.bitcoin
$~/btc-things/bitcoin$ ./bitcoind 
************************
EXCEPTION: NSt10filesystem7__cxx1116filesystem_errorE       
filesystem error: cannot create directories: Not a directory [/home/me/.bitcoin]  
```

Another related fix attempt can be found here https://github.com/bitcoin/bitcoin/pull/24266