### PR TITLE
Add bitcoin_config.h to build_msvc/.gitignore

### DIFF
--- a/build_msvc/.gitignore
+++ b/build_msvc/.gitignore
@@ -21,6 +21,8 @@ libbitcoin_zmq/libbitcoin_zmq.vcxproj
 bench_bitcoin/bench_bitcoin.vcxproj
 libtest_util/libtest_util.vcxproj
 
+/bitcoin_config.h
+
 */Win32
 libbitcoin_qt/QtGeneratedFiles/*
 test_bitcoin-qt/QtGeneratedFiles/*


### PR DESCRIPTION
`bitcoin_config.h` is auto-generated by the `msvc-autogen.py` script.