### PR TITLE
build: Fix `make deploy` for Windows when building out of source tree

### DIFF
--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -72,14 +72,14 @@ ShowUninstDetails show
 Section -Main SEC0000
     SetOutPath $INSTDIR
     SetOverwrite on
-    File @abs_top_srcdir@/release/@BITCOIN_GUI_NAME@@EXEEXT@
+    File @abs_top_builddir@/release/@BITCOIN_GUI_NAME@@EXEEXT@
     File /oname=COPYING.txt @abs_top_srcdir@/COPYING
     File /oname=readme.txt @abs_top_srcdir@/doc/README_windows.txt
     SetOutPath $INSTDIR\daemon
-    File @abs_top_srcdir@/release/@BITCOIN_DAEMON_NAME@@EXEEXT@
-    File @abs_top_srcdir@/release/@BITCOIN_CLI_NAME@@EXEEXT@
-    File @abs_top_srcdir@/release/@BITCOIN_TX_NAME@@EXEEXT@
-    File @abs_top_srcdir@/release/@BITCOIN_WALLET_TOOL_NAME@@EXEEXT@
+    File @abs_top_builddir@/release/@BITCOIN_DAEMON_NAME@@EXEEXT@
+    File @abs_top_builddir@/release/@BITCOIN_CLI_NAME@@EXEEXT@
+    File @abs_top_builddir@/release/@BITCOIN_TX_NAME@@EXEEXT@
+    File @abs_top_builddir@/release/@BITCOIN_WALLET_TOOL_NAME@@EXEEXT@
     SetOutPath $INSTDIR\doc
     File /r /x Makefile* @abs_top_srcdir@/doc\*.*
     SetOutPath $INSTDIR


### PR DESCRIPTION
On master (1e7564eca8a688f39c75540877ec3bdfdde766b1):
```
$ make distclean
$ mkdir ../build
$ cd ../build
$ CONFIG_SITE=$PWD/../bitcoin/depends/x86_64-w64-mingw32/share/config.site ../bitcoin/configure
$ make
$ make deploy
...
File: "/home/hebasto/GitHub/build/../bitcoin/release/bitcoin-qt.exe" -> no files found.
Usage: File [/nonfatal] [/a] ([/r] [/x filespec [...]] filespec [...] |
   /oname=outfile one_file_only)
Error in script "<stdin>" on line 75 -- aborting creation process
error: could not build bitcoin-22.99.0-win64-setup.exe
built bitcoin-22.99.0-win64-setup.exe
```

This PR fixes this bug.