### PR TITLE
docs: Move explanation of hardened key syntax closer to KEY section

### DIFF
--- a/doc/descriptors.md
+++ b/doc/descriptors.md
@@ -90,11 +90,11 @@ Descriptors consist of several types of expressions. The top level expression is
     - Optionally followed by a single `/*` or `/*'` final step to denote all (direct) unhardened or hardened children.
     - The usage of hardened derivation steps requires providing the private key.
 
+(Anywhere a `'` suffix is permitted to denote hardened derivation, the suffix `h` can be used instead.)
+
 `TREE` expressions:
 - any `SCRIPT` expression
 - An open brace `{`, a `TREE` expression, a comma `,`, a `TREE` expression, and a closing brace `}`
-
-(Anywhere a `'` suffix is permitted to denote hardened derivation, the suffix `h` can be used instead.)
 
 `ADDR` expressions are any type of supported address:
 - P2PKH addresses (base58, of the form `1...` for mainnet or `[nm]...` for testnet). Note that P2PKH addresses in descriptors cannot be used for P2PK outputs (use the `pk` function instead).


### PR DESCRIPTION
The line about "(Anywhere a `'` suffix is permitted to denote hardened derivation, the suffix `h` can be used instead.)" belongs with the section on KEY expressions, not following the unrelated TREE section.
