### PR TITLE
build: Add `show-%` target for multi-line variables and debug info

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -1,8 +1,16 @@
 .NOTPARALLEL :
 
 # Pattern rule to print variables, e.g. make print-top_srcdir
+# To print multi-line variables and/or additional debug info, use show-%
 print-%: FORCE
 	@echo '$*'='$($*)'
+
+show-% : FORCE
+	$(info - name:   $*)
+	$(info - origin: $(origin $*))
+	$(info - flavor: $(flavor $*))
+	$(info - value, printed from the new line:)
+	$(info $($*))
 
 # When invoking a sub-make, keep only the command line variable definitions
 # matching the pattern in the filter function.

--- a/depends/packages.md
+++ b/depends/packages.md
@@ -54,7 +54,7 @@ After defining the main identifiers, build variables may be added or customized
 before running the build commands. They should be added to a function called
 $(package)_set_vars. For example:
 
-    define $(package)_set_vars
+    define $(package)_set_vars :=
     ...
     endef
 

--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b857327
 $(package)_build_subdir=build_unix
 $(package)_patches=clang_cxx_11.patch
 
-define $(package)_set_vars
+define $(package)_set_vars :=
 $(package)_config_opts=--disable-shared --enable-cxx --disable-replication --enable-option-checking
 $(package)_config_opts_mingw32=--enable-mingw
 $(package)_config_opts_linux=--with-pic

--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -7,7 +7,7 @@ $(package)_sha256_hash=f79b8f904b749e3e0d20afeadecf8249c55b2e32d4ebb089ae378df47
 # -D_DEFAULT_SOURCE defines __USE_MISC, which exposes additional
 # definitions in endian.h, which are required for a working
 # endianess check in configure when building with -flto.
-define $(package)_set_vars
+define $(package)_set_vars :=
   $(package)_config_opts=--disable-shared --without-docbook --without-tests --without-examples
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
   $(package)_config_opts += --without-xmlwf

--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=cf0c30807d08f6a28ab46c61b8dbd55c97d2f292cf88f3a07d3384687
 $(package)_dependencies=freetype expat
 $(package)_patches=gperf_header_regen.patch
 
-define $(package)_set_vars
+define $(package)_set_vars :=
   $(package)_config_opts=--disable-docs --disable-static --disable-libxml2 --disable-iconv
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 endef

--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -4,7 +4,7 @@ $(package)_download_path=https://download.savannah.gnu.org/releases/$(package)
 $(package)_file_name=$(package)-$($(package)_version).tar.xz
 $(package)_sha256_hash=8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7
 
-define $(package)_set_vars
+define $(package)_set_vars :=
   $(package)_config_opts=--without-zlib --without-png --without-harfbuzz --without-bzip2 --disable-static
   $(package)_config_opts += --enable-option-checking --without-brotli
   $(package)_config_opts_linux=--with-pic

--- a/depends/packages/libXau.mk
+++ b/depends/packages/libXau.mk
@@ -7,7 +7,7 @@ $(package)_dependencies=xproto
 
 # When updating this package, check the default value of
 # --disable-xthreads. It is currently enabled.
-define $(package)_set_vars
+define $(package)_set_vars :=
   $(package)_config_opts=--disable-shared --disable-lint-library --without-lint
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
   $(package)_config_opts_linux=--with-pic

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -7,7 +7,7 @@ $(package)_sha256_hash=92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346
 # When building for Windows, we set _WIN32_WINNT to target the same Windows
 # version as we do in configure. Due to quirks in libevents build system, this
 # is also required to enable support for ipv6. See #19375.
-define $(package)_set_vars
+define $(package)_set_vars :=
   $(package)_config_opts=--disable-shared --disable-openssl --disable-libevent-regress --disable-samples
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
   $(package)_config_opts_release=--disable-debug-mode

--- a/depends/packages/libnatpmp.mk
+++ b/depends/packages/libnatpmp.mk
@@ -4,7 +4,7 @@ $(package)_download_path=https://github.com/miniupnp/libnatpmp/archive
 $(package)_file_name=$($(package)_version).tar.gz
 $(package)_sha256_hash=543b460aab26acf91e11d15e17d8798f845304199eea2d76c2f444ec749c5383
 
-define $(package)_set_vars
+define $(package)_set_vars :=
   $(package)_build_opts=CC="$($(package)_cc)"
   $(package)_build_opts_mingw32=CPPFLAGS=-DNATPMP_STATICLIB
   $(package)_build_opts_darwin=LIBTOOL="$($(package)_libtool)"

--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=a55ed6db98d43469801262d81dc2572ed124edc3db31059d4e9916eb9
 $(package)_dependencies=xcb_proto libXau
 $(package)_patches = remove_pthread_stubs.patch
 
-define $(package)_set_vars
+define $(package)_set_vars :=
 $(package)_config_opts=--disable-static --disable-devel-docs --without-doxygen --without-launchd
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 # Disable unneeded extensions.

--- a/depends/packages/libxcb_util.mk
+++ b/depends/packages/libxcb_util.mk
@@ -5,7 +5,7 @@ $(package)_file_name=xcb-util-$($(package)_version).tar.bz2
 $(package)_sha256_hash=46e49469cb3b594af1d33176cd7565def2be3fa8be4371d62271fabb5eae50e9
 $(package)_dependencies=libxcb
 
-define $(package)_set_vars
+define $(package)_set_vars :=
 $(package)_config_opts = --disable-shared --disable-devel-docs --without-doxygen
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 $(package)_config_opts += --with-pic

--- a/depends/packages/libxcb_util_image.mk
+++ b/depends/packages/libxcb_util_image.mk
@@ -5,7 +5,7 @@ $(package)_file_name=xcb-util-image-$($(package)_version).tar.bz2
 $(package)_sha256_hash=2db96a37d78831d643538dd1b595d7d712e04bdccf8896a5e18ce0f398ea2ffc
 $(package)_dependencies=libxcb libxcb_util
 
-define $(package)_set_vars
+define $(package)_set_vars :=
 $(package)_config_opts=--disable-static --disable-devel-docs --without-doxygen
 $(package)_config_opts+= --disable-dependency-tracking --enable-option-checking
 endef

--- a/depends/packages/libxcb_util_keysyms.mk
+++ b/depends/packages/libxcb_util_keysyms.mk
@@ -5,7 +5,7 @@ $(package)_file_name=xcb-util-keysyms-$($(package)_version).tar.bz2
 $(package)_sha256_hash=0ef8490ff1dede52b7de533158547f8b454b241aa3e4dcca369507f66f216dd9
 $(package)_dependencies=libxcb xproto
 
-define $(package)_set_vars
+define $(package)_set_vars :=
 $(package)_config_opts=--disable-static --disable-devel-docs --without-doxygen
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 endef

--- a/depends/packages/libxcb_util_render.mk
+++ b/depends/packages/libxcb_util_render.mk
@@ -5,7 +5,7 @@ $(package)_file_name=xcb-util-renderutil-$($(package)_version).tar.bz2
 $(package)_sha256_hash=c6e97e48fb1286d6394dddb1c1732f00227c70bd1bedb7d1acabefdd340bea5b
 $(package)_dependencies=libxcb
 
-define $(package)_set_vars
+define $(package)_set_vars :=
 $(package)_config_opts=--disable-static --disable-devel-docs --without-doxygen
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 endef

--- a/depends/packages/libxcb_util_wm.mk
+++ b/depends/packages/libxcb_util_wm.mk
@@ -5,7 +5,7 @@ $(package)_file_name=xcb-util-wm-$($(package)_version).tar.bz2
 $(package)_sha256_hash=28bf8179640eaa89276d2b0f1ce4285103d136be6c98262b6151aaee1d3c2a3f
 $(package)_dependencies=libxcb
 
-define $(package)_set_vars
+define $(package)_set_vars :=
 $(package)_config_opts=--disable-static --disable-devel-docs --without-doxygen
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 endef

--- a/depends/packages/libxkbcommon.mk
+++ b/depends/packages/libxkbcommon.mk
@@ -9,7 +9,7 @@ $(package)_dependencies=libxcb
 # with GCC 12.1+. Work around that by turning errors back into warnings.
 # This workaround would be dropped if the package was updated, as that would require
 # a different build system (Meson)
-define $(package)_set_vars
+define $(package)_set_vars :=
 $(package)_config_opts = --enable-option-checking --disable-dependency-tracking
 $(package)_config_opts += --disable-static --disable-docs
 $(package)_cflags += -Wno-error=array-bounds

--- a/depends/packages/miniupnpc.mk
+++ b/depends/packages/miniupnpc.mk
@@ -5,7 +5,7 @@ $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=888fb0976ba61518276fe1eda988589c700a3f2a69d71089260d75562afd3687
 $(package)_patches=dont_leak_info.patch
 
-define $(package)_set_vars
+define $(package)_set_vars :=
 $(package)_build_opts=CC="$($(package)_cc)"
 $(package)_build_opts_darwin=LIBTOOL="$($(package)_libtool)"
 $(package)_build_opts_mingw32=-f Makefile.mingw

--- a/depends/packages/native_cctools.mk
+++ b/depends/packages/native_cctools.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=6b73269efdf5c58a070e7357b66ee760501388549d6a12b423723f458
 $(package)_build_subdir=cctools
 $(package)_dependencies=native_libtapi
 
-define $(package)_set_vars
+define $(package)_set_vars :=
   $(package)_config_opts=--target=$(host) --enable-lto-support
   $(package)_config_opts+=--with-llvm-config=$(llvm_config_prog)
   $(package)_ldflags+=-Wl,-rpath=\\$$$$$$$$\$$$$$$$$ORIGIN/../lib

--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -4,7 +4,7 @@ $(package)_download_path=https://fukuchi.org/works/qrencode/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=efe5188b1ddbcbf98763b819b146be6a90481aac30cfc8d858ab78a19cde1fa5
 
-define $(package)_set_vars
+define $(package)_set_vars :=
 $(package)_config_opts=--disable-shared --without-tools --without-tests --disable-sdltest
 $(package)_config_opts += --disable-gprof --disable-gcov --disable-mudflap
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -32,7 +32,7 @@ $(package)_qttools_sha256_hash=6d0778b71b2742cb527561791d1d3d255366163d54a10f78c
 $(package)_extra_sources  = $($(package)_qttranslations_file_name)
 $(package)_extra_sources += $($(package)_qttools_file_name)
 
-define $(package)_set_vars
+define $(package)_set_vars :=
 $(package)_config_opts_release = -release
 $(package)_config_opts_release += -silent
 $(package)_config_opts_debug = -debug

--- a/depends/packages/sqlite.mk
+++ b/depends/packages/sqlite.mk
@@ -4,7 +4,7 @@ $(package)_download_path=https://sqlite.org/2022/
 $(package)_file_name=sqlite-autoconf-$($(package)_version).tar.gz
 $(package)_sha256_hash=5af07de982ba658fd91a03170c945f99c971f6955bc79df3266544373e39869c
 
-define $(package)_set_vars
+define $(package)_set_vars :=
 $(package)_config_opts=--disable-shared --disable-readline --disable-dynamic-extensions --enable-option-checking
 $(package)_config_opts_linux=--with-pic
 $(package)_config_opts_freebsd=--with-pic

--- a/depends/packages/xproto.mk
+++ b/depends/packages/xproto.mk
@@ -4,7 +4,7 @@ $(package)_download_path=https://xorg.freedesktop.org/releases/individual/proto
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=c6f9747da0bd3a95f86b17fb8dd5e717c8f3ab7f0ece3ba1b247899ec1ef7747
 
-define $(package)_set_vars
+define $(package)_set_vars :=
 $(package)_config_opts=--without-fop --without-xmlto --without-xsltproc --disable-specs
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 endef

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -5,7 +5,7 @@ $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5
 $(package)_patches=remove_libstd_link.patch netbsd_kevent_void.patch
 
-define $(package)_set_vars
+define $(package)_set_vars :=
   $(package)_config_opts = --without-docs --disable-shared --disable-valgrind
   $(package)_config_opts += --disable-perf --disable-curve-keygen --disable-curve --disable-libbsd
   $(package)_config_opts += --without-libsodium --without-libgssapi_krb5 --without-pgm --without-norm --without-vmci


### PR DESCRIPTION
This PR is a continuation of bitcoin/bitcoin#17087.

Our depends builds system uses a bunch of variables which values consist of some lines, i.e., multi-line variables.

During debugging it is annoying that `print-%` is unable to handle such variables:
```
$ cd depends
$ make print-sqlite_set_vars
/bin/sh: 1: Syntax error: Unterminated quoted string
make: *** [Makefile:5: print-sqlite_set_vars] Error 2
```

This PR adds `show-%` target which prints multi-line variable value and its origin and flavor as well:
```
$ cd depends
$ make show-sqlite_set_vars
- name:   sqlite_set_vars
- origin: file
- flavor: simple
- value, printed from the new line:
sqlite_config_opts=--disable-shared --disable-readline --disable-dynamic-extensions --enable-option-checking
sqlite_config_opts_linux=--with-pic
sqlite_config_opts_freebsd=--with-pic
sqlite_config_opts_netbsd=--with-pic
sqlite_config_opts_openbsd=--with-pic
```

For connoisseurs suggesting `make show-qt_set_vars` :)

---

Other useful examples of usage:
```
$ make show-CC
- name:   CC
- origin: default
- flavor: recursive
- value, printed from the new line:
cc
```

```
$ make show-CC CC=clang
- name:   CC
- origin: command line
- flavor: recursive
- value, printed from the new line:
clang
```

```
$ CC=clang make show-CC
- name:   CC
- origin: environment
- flavor: recursive
- value, printed from the new line:
clang
```

```
$ make show-host
- name:   host
- origin: file
- flavor: simple
- value, printed from the new line:
x86_64-pc-linux-gnu
```

---

Please note that it is unwanted to just modify the `print-%` rule as it is used in [scripts](https://github.com/bitcoin/bitcoin/blob/5034b7fa3b97c1cbaf93b337d462777f3e25d256/contrib/guix/guix-build#L130).