### PR TITLE
build, refactor: Drop redundant `$(package)_download_file` assignments

### DIFF
--- a/depends/packages/native_clang.mk
+++ b/depends/packages/native_clang.mk
@@ -2,11 +2,9 @@ package=native_clang
 $(package)_version=10.0.1
 $(package)_download_path=https://github.com/llvm/llvm-project/releases/download/llvmorg-$($(package)_version)
 ifneq (,$(findstring aarch64,$(BUILD)))
-$(package)_download_file=clang+llvm-$($(package)_version)-aarch64-linux-gnu.tar.xz
 $(package)_file_name=clang+llvm-$($(package)_version)-aarch64-linux-gnu.tar.xz
 $(package)_sha256_hash=90dc69a4758ca15cd0ffa45d07fbf5bf4309d47d2c7745a9f0735ecffde9c31f
 else
-$(package)_download_file=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 $(package)_file_name=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
 $(package)_sha256_hash=48b83ef827ac2c213d5b64f5ad7ed082c8bcb712b46644e0dc5045c6f462c231
 endif

--- a/depends/packages/native_libtapi.mk
+++ b/depends/packages/native_libtapi.mk
@@ -1,7 +1,6 @@
 package=native_libtapi
 $(package)_version=664b8414f89612f2dfd35a9b679c345aa5389026
 $(package)_download_path=https://github.com/tpoechtrager/apple-libtapi/archive
-$(package)_download_file=$($(package)_version).tar.gz
 $(package)_file_name=$($(package)_version).tar.gz
 $(package)_sha256_hash=62e419c12d1c9fad67cc1cd523132bc00db050998337c734c15bc8d73cc02b61
 


### PR DESCRIPTION
No need to specify `$(package)_download_file` when it is equal to `$(package)_file_name`.

Historically, before bitcoin/bitcoin#19817, distinct `$(package)_download_file` and `$(package)_file_name` were used for better portability (I guess) by removing `+` characters from a file name.

The only package which still use file renaming is `native_capnp`: https://github.com/bitcoin/bitcoin/blob/eca694a4e78d54ce4e29b388b3e81b06e55c2293/depends/packages/native_capnp.mk#L3-L5