### PR TITLE
 Revert "ci: Run fuzzer task for the master branch only" 

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -237,7 +237,6 @@ task:
 
 task:
   name: '[fuzzer,address,undefined,integer, no depends] [focal]'
-  only_if: $CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH || $CIRRUS_BASE_BRANCH == $CIRRUS_DEFAULT_BRANCH
   << : *GLOBAL_TASK_TEMPLATE
   container:
     image: ubuntu:focal

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -236,10 +236,10 @@ task:
     MAKEJOBS: "-j4"  # Avoid excessive memory use
 
 task:
-  name: '[fuzzer,address,undefined,integer, no depends] [focal]'
+  name: '[fuzzer,address,undefined,integer, no depends] [jammy]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
-    image: ubuntu:focal
+    image: ubuntu:jammy
     cpu: 4  # Increase CPU and memory to avoid timeout
     memory: 16G
   env:

--- a/ci/test/00_setup_env_native_fuzz.sh
+++ b/ci/test/00_setup_env_native_fuzz.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export DOCKER_NAME_TAG="ubuntu:20.04"
+export DOCKER_NAME_TAG="ubuntu:22.04"
 export CONTAINER_NAME=ci_native_fuzz
 export PACKAGES="clang llvm python3 libevent-dev bsdmainutils libboost-dev libboost-test-dev libsqlite3-dev"
 export NO_DEPENDS=1

--- a/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
+++ b/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export DOCKER_NAME_TAG="ubuntu:20.04"
+export DOCKER_NAME_TAG="ubuntu:22.04"
 export CONTAINER_NAME=ci_native_fuzz_valgrind
 export PACKAGES="clang llvm python3 libevent-dev bsdmainutils libboost-dev libboost-test-dev libsqlite3-dev valgrind"
 export NO_DEPENDS=1


### PR DESCRIPTION
This reverts commit 5a9e255e5a324e7aa0b63a9634aa3cfda9a300bd.

I think we should attempt to maintain the fuzz tasks for release branches as well.

If it is too difficult for one branch, it could make sense to disable it for that branch, but not for all branches unconditionally.

Also, bump to jammy.