### PR TITLE
(Refactor) QA: wallet_basic: Split wtx expected_fields over multiple lines to minimise merge conflicts

### DIFF
--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -508,8 +508,19 @@ class WalletTest(BitcoinTestFramework):
                                  "amount":   baz["amount"],
                                  "category": baz["category"],
                                  "vout":     baz["vout"]}
-        expected_fields = frozenset({'amount', 'bip125-replaceable', 'confirmations', 'details', 'fee',
-                                     'hex', 'time', 'timereceived', 'trusted', 'txid', 'walletconflicts'})
+        expected_fields = frozenset({
+            'amount',
+            'bip125-replaceable',
+            'confirmations',
+            'details',
+            'fee',
+            'hex',
+            'time',
+            'timereceived',
+            'trusted',
+            'txid',
+            'walletconflicts',
+        })
         verbose_field = "decoded"
         expected_verbose_fields = expected_fields | {verbose_field}
 


### PR DESCRIPTION
This list seems to be high risk of, and trivial to reduce merge conflicts for.