### PR TITLE
Remove std::move from fs wrapper to work around -D_LIBCPP_DEBUG=1 bug

### DIFF
--- a/src/fs.h
+++ b/src/fs.h
@@ -32,9 +32,9 @@ public:
     using std::filesystem::path::path;
 
     // Allow path objects arguments for compatibility.
-    path(std::filesystem::path path) : std::filesystem::path::path(std::move(path)) {}
-    path& operator=(std::filesystem::path path) { std::filesystem::path::operator=(std::move(path)); return *this; }
-    path& operator/=(std::filesystem::path path) { std::filesystem::path::operator/=(std::move(path)); return *this; }
+    path(std::filesystem::path path) : std::filesystem::path::path{path} {}
+    path& operator=(std::filesystem::path path) { std::filesystem::path::operator=(path); return *this; }
+    path& operator/=(std::filesystem::path path) { std::filesystem::path::operator/=(path); return *this; }
 
     // Allow literal string arguments, which are safe as long as the literals are ASCII.
     path(const char* c) : std::filesystem::path(c) {}


### PR DESCRIPTION
Fix #24290 