### PR TITLE
fuzz: Avoid unsigned integer overflow in FormatParagraph

### DIFF
--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -145,7 +145,8 @@ FUZZ_TARGET(string)
     (void)CopyrightHolders(random_string_1);
     FeeEstimateMode fee_estimate_mode;
     (void)FeeModeFromString(random_string_1, fee_estimate_mode);
-    (void)FormatParagraph(random_string_1, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 1000), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 1000));
+    const auto width{fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 1000)};
+    (void)FormatParagraph(random_string_1, width, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, width));
     (void)FormatSubVersion(random_string_1, fuzzed_data_provider.ConsumeIntegral<int>(), random_string_vector);
     (void)GetDescriptorChecksum(random_string_1);
     (void)HelpExampleCli(random_string_1, random_string_2);

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -328,6 +328,7 @@ bool ParseUInt64(const std::string& str, uint64_t* out)
 
 std::string FormatParagraph(const std::string& in, size_t width, size_t indent)
 {
+    assert(width >= indent);
     std::stringstream out;
     size_t ptr = 0;
     size_t indented = 0;


### PR DESCRIPTION
`FormatParagraph` is only ever called with compile time constant arguments, so I don't see the need for fuzzing it.

Though, keep it for now, but avoid the unsigned integer overflow with this patch.