### PR TITLE
validation, refactor: UnloadBlockIndex and ChainstateManager::Reset thread safety cleanups

### DIFF
--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -180,7 +180,7 @@ ChainTestingSetup::~ChainTestingSetup()
     m_node.banman.reset();
     m_node.addrman.reset();
     m_node.args = nullptr;
-    UnloadBlockIndex(m_node.mempool.get(), *m_node.chainman);
+    WITH_LOCK(::cs_main, UnloadBlockIndex(m_node.mempool.get(), *m_node.chainman));
     m_node.mempool.reset();
     m_node.scheduler.reset();
     m_node.chainman->Reset();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -183,7 +183,6 @@ ChainTestingSetup::~ChainTestingSetup()
     WITH_LOCK(::cs_main, UnloadBlockIndex(m_node.mempool.get(), *m_node.chainman));
     m_node.mempool.reset();
     m_node.scheduler.reset();
-    m_node.chainman->Reset();
     m_node.chainman.reset();
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4028,7 +4028,7 @@ void CChainState::UnloadBlockIndex() {
 // block index state
 void UnloadBlockIndex(CTxMemPool* mempool, ChainstateManager& chainman)
 {
-    LOCK(cs_main);
+    AssertLockHeld(::cs_main);
     chainman.Unload();
     pindexBestHeader = nullptr;
     if (mempool) mempool->clear();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5009,15 +5009,6 @@ void ChainstateManager::Unload()
     m_best_invalid = nullptr;
 }
 
-void ChainstateManager::Reset()
-{
-    LOCK(::cs_main);
-    m_ibd_chainstate.reset();
-    m_snapshot_chainstate.reset();
-    m_active_chainstate = nullptr;
-    m_snapshot_validated = false;
-}
-
 void ChainstateManager::MaybeRebalanceCaches()
 {
     if (m_ibd_chainstate && !m_snapshot_chainstate) {

--- a/src/validation.h
+++ b/src/validation.h
@@ -138,7 +138,7 @@ extern CBlockIndex *pindexBestHeader;
 extern const std::vector<std::string> CHECKLEVEL_DOC;
 
 /** Unload database information */
-void UnloadBlockIndex(CTxMemPool* mempool, ChainstateManager& chainman);
+void UnloadBlockIndex(CTxMemPool* mempool, ChainstateManager& chainman) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 /** Run instances of script checking worker threads */
 void StartScriptCheckWorkerThreads(int threads_num);
 /** Stop all of the script checking worker threads */

--- a/src/validation.h
+++ b/src/validation.h
@@ -985,17 +985,13 @@ public:
     //! Unload block index and chain data before shutdown.
     void Unload() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
-    //! Clear (deconstruct) chainstate data.
-    void Reset();
-
     //! Check to see if caches are out of balance and if so, call
     //! ResizeCoinsCaches() as needed.
     void MaybeRebalanceCaches() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     ~ChainstateManager() {
         LOCK(::cs_main);
-        UnloadBlockIndex(/* mempool */ nullptr, *this);
-        Reset();
+        UnloadBlockIndex(/*mempool=*/nullptr, *this);
     }
 };
 


### PR DESCRIPTION
Thread safety refactoring seen in #24177:
- replace re-acquiring lock cs_main with a thread safety annotation in UnloadBlockIndex()
- remove ChainstateManager::Reset(), as it is currently unused (can be reintroduced in the test utilities if needed for unit testing)
