### PR TITLE
guix: point to latest upstream master

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -239,7 +239,7 @@ SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git -c log.showSignature=false log --f
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://git.savannah.gnu.org/git/guix.git \
-                      --commit=1ef7a03a148cf5f83ab1820444f6bd50d8e732d1 \
+                      --commit=a9a59c464c1114db4b29004f4071355effe76977 \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \


### PR DESCRIPTION
Now that Carls fix for binutils and compressed debug sections has been
merged into Guix, point our time-machine to the latest commit on Guix
master. The Windows builds don't yet work with this change, but we are
now at the point of compiling our own code..

There must be a difference in the Guix environment, compared to, for
example, compiling using GCC 10.3 on Ubuntu Hirsute, which currently works.

Opening this PR for testing / discussion:
```bash
Making all in src
make[1]: Entering directory '/distsrc-base/distsrc-f6ff8d8604f6-x86_64-w64-mingw32/src'
make[2]: Entering directory '/distsrc-base/distsrc-f6ff8d8604f6-x86_64-w64-mingw32/src'
  CXX      bitcoind-bitcoind.o
  CXX      libbitcoin_node_a-addrdb.o
  CXX      libbitcoin_node_a-addrman.o
  CXX      libbitcoin_node_a-banman.o
  GEN      bitcoind-res.o
  CXX      libbitcoin_node_a-blockencodings.o
  CXX      libbitcoin_node_a-blockfilter.o
  CXX      libbitcoin_node_a-chain.o
  CXX      libbitcoin_node_a-dbwrapper.o
  CXX      libbitcoin_node_a-deploymentstatus.o
  CXX      libbitcoin_node_a-flatfile.o
  CXX      libbitcoin_node_a-httprpc.o
  CXX      libbitcoin_node_a-httpserver.o
  CXX      libbitcoin_node_a-i2p.o
  CXX      libbitcoin_node_a-init.o
  CXX      libbitcoin_node_a-mapport.o
  CXX      libbitcoin_node_a-net.o
  CXX      libbitcoin_node_a-net_processing.o
  CXX      libbitcoin_node_a-noui.o
  CXX      libbitcoin_node_a-pow.o
  CXX      libbitcoin_node_a-rest.o
  CXX      libbitcoin_node_a-shutdown.o
In file included from init.cpp:78:
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream: In instantiation of 'std::basic_ofstream<_CharT, _Traits>::basic_ofstream(const _Path&, std::ios_base::openmode) [with _Path = fs::path; _Require = fs::path; _CharT = char; _Traits = std::char_traits<char>; std::ios_base::openmode = std::ios_base::openmode]':
init.cpp:143:40:   required from here
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:844:38: error: no matching function for call to 'std::basic_ofstream<char>::basic_ofstream(const value_type*, std::ios_base::openmode&)'
  844 |  : basic_ofstream(__s.c_str(), __mode)
      |                                      ^
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:850:7: note: candidate: 'std::basic_ofstream<_CharT, _Traits>::basic_ofstream(std::basic_ofstream<_CharT, _Traits>&&) [with _CharT = char; _Traits = std::char_traits<char>]'
  850 |       basic_ofstream(basic_ofstream&& __rhs)
      |       ^~~~~~~~~~~~~~
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:850:7: note:   candidate expects 1 argument, 2 provided
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:842:2: note: candidate: 'template<class _Path, class _Require> std::basic_ofstream<_CharT, _Traits>::basic_ofstream(const _Path&, std::ios_base::openmode) [with _Path = _Path; _Require = _Require; _CharT = char; _Traits = std::char_traits<char>]'
  842 |  basic_ofstream(const _Path& __s,
      |  ^~~~~~~~~~~~~~
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:842:2: note:   template argument deduction/substitution failed:
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:841:32: error: request for member 'make_preferred' in 'std::declval<const wchar_t*&>()', which is of non-class type 'const wchar_t*'
  841 |       template<typename _Path, typename _Require = _If_fs_path<_Path>>
      |                                ^~~~~~~~
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:825:7: note: candidate: 'std::basic_ofstream<_CharT, _Traits>::basic_ofstream(const string&, std::ios_base::openmode) [with _CharT = char; _Traits = std::char_traits<char>; std::string = std::__cxx11::basic_string<char>; std::ios_base::openmode = std::ios_base::openmode]'
  825 |       basic_ofstream(const std::string& __s,
      |       ^~~~~~~~~~~~~~
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:825:41: note:   no known conversion for argument 1 from 'const value_type*' {aka 'const wchar_t*'} to 'const string&' {aka 'const std::__cxx11::basic_string<char>&'}
  825 |       basic_ofstream(const std::string& __s,
      |                      ~~~~~~~~~~~~~~~~~~~^~~
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:790:7: note: candidate: 'std::basic_ofstream<_CharT, _Traits>::basic_ofstream(const char*, std::ios_base::openmode) [with _CharT = char; _Traits = std::char_traits<char>; std::ios_base::openmode = std::ios_base::openmode]'
  790 |       basic_ofstream(const char* __s,
      |       ^~~~~~~~~~~~~~
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:790:34: note:   no known conversion for argument 1 from 'const value_type*' {aka 'const wchar_t*'} to 'const char*'
  790 |       basic_ofstream(const char* __s,
      |                      ~~~~~~~~~~~~^~~
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:779:7: note: candidate: 'std::basic_ofstream<_CharT, _Traits>::basic_ofstream() [with _CharT = char; _Traits = std::char_traits<char>]'
  779 |       basic_ofstream(): __ostream_type(), _M_filebuf()
      |       ^~~~~~~~~~~~~~
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:779:7: note:   candidate expects 0 arguments, 2 provided
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:844:38: error: no matching function for call to 'std::basic_ofstream<char>::basic_ofstream(const value_type*, std::ios_base::openmode&)'
  844 |  : basic_ofstream(__s.c_str(), __mode)
      |                                      ^
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:850:7: note: candidate: 'std::basic_ofstream<_CharT, _Traits>::basic_ofstream(std::basic_ofstream<_CharT, _Traits>&&) [with _CharT = char; _Traits = std::char_traits<char>]'
  850 |       basic_ofstream(basic_ofstream&& __rhs)
      |       ^~~~~~~~~~~~~~
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:850:7: note:   candidate expects 1 argument, 2 provided
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:842:2: note: candidate: 'template<class _Path, class _Require> std::basic_ofstream<_CharT, _Traits>::basic_ofstream(const _Path&, std::ios_base::openmode) [with _Path = _Path; _Require = _Require; _CharT = char; _Traits = std::char_traits<char>]'
  842 |  basic_ofstream(const _Path& __s,
      |  ^~~~~~~~~~~~~~
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:842:2: note:   template argument deduction/substitution failed:
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:841:32: error: request for member 'make_preferred' in 'std::declval<const wchar_t*&>()', which is of non-class type 'const wchar_t*'
  841 |       template<typename _Path, typename _Require = _If_fs_path<_Path>>
      |                                ^~~~~~~~
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:825:7: note: candidate: 'std::basic_ofstream<_CharT, _Traits>::basic_ofstream(const string&, std::ios_base::openmode) [with _CharT = char; _Traits = std::char_traits<char>; std::string = std::__cxx11::basic_string<char>; std::ios_base::openmode = std::ios_base::openmode]'
  825 |       basic_ofstream(const std::string& __s,
      |       ^~~~~~~~~~~~~~
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:825:41: note:   no known conversion for argument 1 from 'const value_type*' {aka 'const wchar_t*'} to 'const string&' {aka 'const std::__cxx11::basic_string<char>&'}
  825 |       basic_ofstream(const std::string& __s,
      |                      ~~~~~~~~~~~~~~~~~~~^~~
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:790:7: note: candidate: 'std::basic_ofstream<_CharT, _Traits>::basic_ofstream(const char*, std::ios_base::openmode) [with _CharT = char; _Traits = std::char_traits<char>; std::ios_base::openmode = std::ios_base::openmode]'
  790 |       basic_ofstream(const char* __s,
      |       ^~~~~~~~~~~~~~
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:790:34: note:   no known conversion for argument 1 from 'const value_type*' {aka 'const wchar_t*'} to 'const char*'
  790 |       basic_ofstream(const char* __s,
      |                      ~~~~~~~~~~~~^~~
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:779:7: note: candidate: 'std::basic_ofstream<_CharT, _Traits>::basic_ofstream() [with _CharT = char; _Traits = std::char_traits<char>]'
  779 |       basic_ofstream(): __ostream_type(), _M_filebuf()
      |       ^~~~~~~~~~~~~~
/gnu/store/k3bs5211ca8hy7hzkj83caiakmj3sh36-gcc-cross-x86_64-w64-mingw32-10.3.0/include/c++/fstream:779:7: note:   candidate expects 0 arguments, 2 provided
  CXX      libbitcoin_node_a-signet.o
  CXX      libbitcoin_node_a-timedata.o
  CXX      libbitcoin_node_a-torcontrol.o
  CXX      libbitcoin_node_a-txdb.o
make[2]: *** [Makefile:9653: libbitcoin_node_a-init.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/distsrc-base/distsrc-f6ff8d8604f6-x86_64-w64-mingw32/src'
make[1]: *** [Makefile:17461: all-recursive] Error 1
make[1]: Leaving directory '/distsrc-base/distsrc-f6ff8d8604f6-x86_64-w64-mingw32/src'
make: *** [Makefile:816: all-recursive] Error 1
```

Related to #24055.