### PR TITLE
test: Remove unused integer sanitizer suppressions

### DIFF
--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -43,7 +43,6 @@ shift-base:test/fuzz/crypto_diff_fuzz_chacha20.cpp
 # contains files in which we expect unsigned integer overflows to occur. The
 # list is used to suppress -fsanitize=integer warnings when running our CI UBSan
 # job.
-unsigned-integer-overflow:addrman.cpp
 unsigned-integer-overflow:arith_uint256.h
 unsigned-integer-overflow:common/bloom.cpp
 unsigned-integer-overflow:coins.cpp
@@ -57,7 +56,6 @@ unsigned-integer-overflow:pubkey.h
 unsigned-integer-overflow:script/interpreter.cpp
 unsigned-integer-overflow:txmempool.cpp
 unsigned-integer-overflow:util/strencodings.cpp
-implicit-integer-sign-change:addrman.h
 implicit-integer-sign-change:bech32.cpp
 implicit-integer-sign-change:compat/stdin.cpp
 implicit-integer-sign-change:compressor.h
@@ -70,7 +68,6 @@ implicit-integer-sign-change:script/interpreter.cpp
 implicit-integer-sign-change:serialize.h
 implicit-integer-sign-change:txmempool.cpp
 implicit-signed-integer-truncation:addrman.cpp
-implicit-signed-integer-truncation:addrman.h
 implicit-signed-integer-truncation:crypto/
 implicit-unsigned-integer-truncation:crypto/
 shift-base:arith_uint256.cpp


### PR DESCRIPTION
Looks like they are not needed anymore. Maybe due to commit 7de2cf9b258590ffefd724abe0d4458f282b95c3 ?