### PR TITLE
Docs: [policy] Remove outdated confusing comment

### DIFF
--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -24,35 +24,40 @@ enum class FeeEstimateMode {
 };
 
 /**
- * Fee rate in satoshis per kilobyte: CAmount / kB
+ * Fee rate in satoshis per kilovirtualbyte: CAmount / kvB
  */
 class CFeeRate
 {
 private:
-    CAmount nSatoshisPerK; // unit is satoshis-per-1,000-bytes
+    /** Fee rate in sat/kvB (satoshis per 1000 virtualbytes) */
+    CAmount nSatoshisPerK;
 
 public:
-    /** Fee rate of 0 satoshis per kB */
+    /** Fee rate of 0 satoshis per kvB */
     CFeeRate() : nSatoshisPerK(0) { }
     template<typename I>
     explicit CFeeRate(const I _nSatoshisPerK): nSatoshisPerK(_nSatoshisPerK) {
         // We've previously had bugs creep in from silent double->int conversion...
         static_assert(std::is_integral<I>::value, "CFeeRate should be used without floats");
     }
-    /** Constructor for a fee rate in satoshis per kvB (sat/kvB).
+
+    /**
+     * Construct a fee rate from a fee in satoshis and a vsize in vB.
      *
-     *  Passing a num_bytes value of COIN (1e8) returns a fee rate in satoshis per vB (sat/vB),
-     *  e.g. (nFeePaid * 1e8 / 1e3) == (nFeePaid / 1e5),
-     *  where 1e5 is the ratio to convert from BTC/kvB to sat/vB.
+     * param@[in]   nFeePaid    The fee paid by a transaction, in satoshis
+     * param@[in]   num_bytes   The vsize of a transaction, in vbytes
      */
     CFeeRate(const CAmount& nFeePaid, uint32_t num_bytes);
+
     /**
-     * Return the fee in satoshis for the given size in bytes.
-     * If the calculated fee would have fractional satoshis, then the returned fee will always be rounded up to the nearest satoshi.
+     * Return the fee in satoshis for the given vsize in vbytes.
+     * If the calculated fee would have fractional satoshis, then the
+     * returned fee will always be rounded up to the nearest satoshi.
      */
     CAmount GetFee(uint32_t num_bytes) const;
+
     /**
-     * Return the fee in satoshis for a size of 1000 bytes
+     * Return the fee in satoshis for a vsize of 1000 vbytes
      */
     CAmount GetFeePerK() const { return GetFee(1000); }
     friend bool operator<(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK < b.nSatoshisPerK; }


### PR DESCRIPTION
This comment described how the constructor of CFeeRate was previously indirectly used to parse fee rate arguments from RPCs. The command line input was actually in sat/vB but due to the use of AmountFromValue() it got converted to BTC/vB which then got rectified in the constructor by creating a CFeeRate from that given value and COIN as the transaction size. Since this usage pattern was removed from the codebase some months ago, the comment is now obsolete.
