### PR TITLE
build: Fix Guix build for Windows

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -239,7 +239,7 @@ SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git -c log.showSignature=false log --f
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://git.savannah.gnu.org/git/guix.git \
-                      --commit=1ef7a03a148cf5f83ab1820444f6bd50d8e732d1 \
+                      --commit=f97fe92b570b01ed1b03abd4f3ec89bf20ebc9db \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -8,7 +8,6 @@
 #include <test/util/setup_common.h>
 
 #include <chrono>
-#include <fstream>
 #include <functional>
 #include <iostream>
 #include <map>
@@ -30,7 +29,7 @@ void GenerateTemplateResults(const std::vector<ankerl::nanobench::Result>& bench
         // nothing to write, bail out
         return;
     }
-    std::ofstream fout{file};
+    fsbridge::ofstream fout{file};
     if (fout.is_open()) {
         ankerl::nanobench::render(tpl, benchmarkResults, fout);
         std::cout << "Created " << file << std::endl;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -75,7 +75,6 @@
 #include <condition_variable>
 #include <cstdint>
 #include <cstdio>
-#include <fstream>
 #include <functional>
 #include <set>
 #include <string>
@@ -140,7 +139,7 @@ static fs::path GetPidFile(const ArgsManager& args)
 
 [[nodiscard]] static bool CreatePidFile(const ArgsManager& args)
 {
-    std::ofstream file{GetPidFile(args)};
+    fsbridge::ofstream file{GetPidFile(args)};
     if (file) {
 #ifdef WIN32
         tfm::format(file, "%d\n", GetCurrentProcessId());

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -68,7 +68,6 @@
 #include <cassert>
 #include <chrono>
 #include <exception>
-#include <fstream>
 #include <string>
 #include <vector>
 
@@ -431,7 +430,7 @@ bool openBitcoinConf()
     fs::path pathConfig = GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME));
 
     /* Create the file */
-    std::ofstream configFile{pathConfig, std::ios_base::app};
+    fsbridge::ofstream configFile{pathConfig, std::ios_base::app};
 
     if (!configFile.good())
         return false;
@@ -591,7 +590,7 @@ fs::path static GetAutostartFilePath()
 
 bool GetStartOnSystemStartup()
 {
-    std::ifstream optionFile{GetAutostartFilePath()};
+    fsbridge::ifstream optionFile{GetAutostartFilePath()};
     if (!optionFile.good())
         return false;
     // Scan through file for "Hidden=true":
@@ -622,7 +621,7 @@ bool SetStartOnSystemStartup(bool fAutoStart)
 
         fs::create_directories(GetAutostartDir());
 
-        std::ofstream optionFile{GetAutostartFilePath(), std::ios_base::out | std::ios_base::trunc};
+        fsbridge::ofstream optionFile{GetAutostartFilePath(), std::ios_base::out | std::ios_base::trunc};
         if (!optionFile.good())
             return false;
         std::string chain = gArgs.GetChainName();

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -16,7 +16,6 @@
 #include <qt/optionsmodel.h>
 #include <util/strencodings.h>
 
-#include <fstream>
 #include <iostream>
 #include <string>
 
@@ -161,7 +160,7 @@ void PSBTOperationsDialog::saveTransaction() {
     if (filename.isEmpty()) {
         return;
     }
-    std::ofstream out{filename.toLocal8Bit().data(), std::ofstream::out | std::ofstream::binary};
+    fsbridge::ofstream out{filename.toLocal8Bit().data(), fsbridge::ofstream::out | fsbridge::ofstream::binary};
     out << ssTx.str();
     out.close();
     showStatus(tr("PSBT saved to disk."), StatusLevel::INFO);

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -19,6 +19,7 @@
 #include <qt/sendcoinsentry.h>
 
 #include <chainparams.h>
+#include <fs.h>
 #include <interfaces/node.h>
 #include <key_io.h>
 #include <node/ui_interface.h>
@@ -31,7 +32,6 @@
 
 #include <array>
 #include <chrono>
-#include <fstream>
 #include <memory>
 
 #include <QFontMetrics>
@@ -512,7 +512,7 @@ void SendCoinsDialog::sendButtonClicked([[maybe_unused]] bool checked)
             if (filename.isEmpty()) {
                 return;
             }
-            std::ofstream out{filename.toLocal8Bit().data(), std::ofstream::out | std::ofstream::binary};
+            fsbridge::ofstream out{filename.toLocal8Bit().data(), fsbridge::ofstream::out | fsbridge::ofstream::binary};
             out << ssTx.str();
             out.close();
             Q_EMIT message(tr("PSBT saved"), "PSBT saved to disk", CClientUIInterface::MSG_INFORMATION);

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -15,7 +15,6 @@
 #include <util/system.h>
 
 #include <cassert>
-#include <fstream>
 #include <string>
 
 #include <QApplication>
@@ -213,7 +212,7 @@ void WalletFrame::gotoLoadPSBT(bool from_clipboard)
             Q_EMIT message(tr("Error"), tr("PSBT file must be smaller than 100 MiB"), CClientUIInterface::MSG_ERROR);
             return;
         }
-        std::ifstream in{filename.toLocal8Bit().data(), std::ios::binary};
+        fsbridge::ifstream in{filename.toLocal8Bit().data(), std::ios::binary};
         data = std::string(std::istreambuf_iterator<char>{in}, {});
     }
 

--- a/src/rpc/request.cpp
+++ b/src/rpc/request.cpp
@@ -6,13 +6,11 @@
 #include <rpc/request.h>
 
 #include <fs.h>
-
 #include <random.h>
 #include <rpc/protocol.h>
 #include <util/system.h>
 #include <util/strencodings.h>
 
-#include <fstream>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -88,7 +86,7 @@ bool GenerateAuthCookie(std::string *cookie_out)
     /** the umask determines what permissions are used to create this file -
      * these are set to 077 in init.cpp unless overridden with -sysperms.
      */
-    std::ofstream file;
+    fsbridge::ofstream file;
     fs::path filepath_tmp = GetAuthCookieFile(true);
     file.open(filepath_tmp);
     if (!file.is_open()) {
@@ -112,7 +110,7 @@ bool GenerateAuthCookie(std::string *cookie_out)
 
 bool GetAuthCookie(std::string *cookie_out)
 {
-    std::ifstream file;
+    fsbridge::ifstream file;
     std::string cookie;
     fs::path filepath = GetAuthCookieFile();
     file.open(filepath);

--- a/src/test/fs_tests.cpp
+++ b/src/test/fs_tests.cpp
@@ -9,7 +9,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <fstream>
 #include <ios>
 #include <string>
 
@@ -49,37 +48,37 @@ BOOST_AUTO_TEST_CASE(fsbridge_fstream)
     fs::path tmpfile1 = tmpfolder / "fs_tests_₿_🏃";
     fs::path tmpfile2 = tmpfolder / "fs_tests_₿_🏃";
     {
-        std::ofstream file{tmpfile1};
+        fsbridge::ofstream file{tmpfile1};
         file << "bitcoin";
     }
     {
-        std::ifstream file{tmpfile2};
+        fsbridge::ifstream file{tmpfile2};
         std::string input_buffer;
         file >> input_buffer;
         BOOST_CHECK_EQUAL(input_buffer, "bitcoin");
     }
     {
-        std::ifstream file{tmpfile1, std::ios_base::in | std::ios_base::ate};
+        fsbridge::ifstream file{tmpfile1, std::ios_base::in | std::ios_base::ate};
         std::string input_buffer;
         file >> input_buffer;
         BOOST_CHECK_EQUAL(input_buffer, "");
     }
     {
-        std::ofstream file{tmpfile2, std::ios_base::out | std::ios_base::app};
+        fsbridge::ofstream file{tmpfile2, std::ios_base::out | std::ios_base::app};
         file << "tests";
     }
     {
-        std::ifstream file{tmpfile1};
+        fsbridge::ifstream file{tmpfile1};
         std::string input_buffer;
         file >> input_buffer;
         BOOST_CHECK_EQUAL(input_buffer, "bitcointests");
     }
     {
-        std::ofstream file{tmpfile2, std::ios_base::out | std::ios_base::trunc};
+        fsbridge::ofstream file{tmpfile2, std::ios_base::out | std::ios_base::trunc};
         file << "bitcoin";
     }
     {
-        std::ifstream file{tmpfile1};
+        fsbridge::ifstream file{tmpfile1};
         std::string input_buffer;
         file >> input_buffer;
         BOOST_CHECK_EQUAL(input_buffer, "bitcoin");

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -13,7 +13,6 @@
 
 #include <cstdint>
 #include <exception>
-#include <fstream>
 #include <functional>
 #include <map>
 #include <memory>
@@ -84,7 +83,7 @@ void initialize()
     }
     if (const char* out_path = std::getenv("WRITE_ALL_FUZZ_TARGETS_AND_ABORT")) {
         std::cout << "Writing all fuzz target names to '" << out_path << "'." << std::endl;
-        std::ofstream out_stream{out_path, std::ios::binary};
+        fsbridge::ofstream out_stream{out_path, std::ios::binary};
         for (const auto& t : FuzzTargets()) {
             if (std::get<2>(t.second)) continue;
             out_stream << t.first << std::endl;

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -25,7 +25,6 @@
 #endif
 
 #include <cstdint>
-#include <fstream>
 #include <string>
 #include <vector>
 
@@ -1728,7 +1727,7 @@ BOOST_AUTO_TEST_CASE(script_assets_test)
     bool exists = fs::exists(path);
     BOOST_WARN_MESSAGE(exists, "File $DIR_UNIT_TEST_DATA/script_assets_test.json not found, skipping script_assets_test");
     if (!exists) return;
-    std::ifstream file{path};
+    fsbridge::ifstream file{path};
     BOOST_CHECK(file.is_open());
     file.seekg(0, std::ios::end);
     size_t length = file.tellg();

--- a/src/test/settings_tests.cpp
+++ b/src/test/settings_tests.cpp
@@ -15,7 +15,6 @@
 #include <util/string.h>
 #include <util/system.h>
 
-#include <fstream>
 #include <map>
 #include <string>
 #include <system_error>
@@ -42,7 +41,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::pair<std::string, u
 
 inline void WriteText(const fs::path& path, const std::string& text)
 {
-    std::ofstream file;
+    fsbridge::ofstream file;
     file.open(path);
     file << text;
 }

--- a/src/util/settings.cpp
+++ b/src/util/settings.cpp
@@ -8,7 +8,6 @@
 #include <tinyformat.h>
 #include <univalue.h>
 
-#include <fstream>
 #include <map>
 #include <string>
 #include <vector>
@@ -69,7 +68,7 @@ bool ReadSettings(const fs::path& path, std::map<std::string, SettingsValue>& va
     // Ok for file to not exist
     if (!fs::exists(path)) return true;
 
-    std::ifstream file;
+    fsbridge::ifstream file;
     file.open(path);
     if (!file.is_open()) {
       errors.emplace_back(strprintf("%s. Please check permissions.", fs::PathToString(path)));
@@ -112,7 +111,7 @@ bool WriteSettings(const fs::path& path,
     for (const auto& value : values) {
         out.__pushKV(value.first, value.second);
     }
-    std::ofstream file;
+    fsbridge::ofstream file;
     file.open(path);
     if (file.fail()) {
         errors.emplace_back(strprintf("Error: Unable to open settings file %s for writing", fs::PathToString(path)));

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -69,7 +69,6 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <univalue.h>
 
-#include <fstream>
 #include <map>
 #include <memory>
 #include <optional>
@@ -152,7 +151,7 @@ bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes)
 }
 
 std::streampos GetFileSize(const char* path, std::streamsize max) {
-    std::ifstream file{path, std::ios::binary};
+    fsbridge::ifstream file{path, std::ios::binary};
     file.ignore(max);
     return file.gcount();
 }
@@ -900,7 +899,7 @@ bool ArgsManager::ReadConfigFiles(std::string& error, bool ignore_invalid_keys)
     }
 
     const std::string confPath = GetArg("-conf", BITCOIN_CONF_FILENAME);
-    std::ifstream stream{GetConfigFile(confPath)};
+    fsbridge::ifstream stream{GetConfigFile(confPath)};
 
     // not ok to have a config file specified that cannot be opened
     if (IsArgSet("-conf") && !stream.good()) {
@@ -947,7 +946,7 @@ bool ArgsManager::ReadConfigFiles(std::string& error, bool ignore_invalid_keys)
             const size_t default_includes = add_includes({});
 
             for (const std::string& conf_file_name : conf_file_names) {
-                std::ifstream conf_file_stream{GetConfigFile(conf_file_name)};
+                fsbridge::ifstream conf_file_stream{GetConfigFile(conf_file_name)};
                 if (conf_file_stream.good()) {
                     if (!ReadConfigStream(conf_file_stream, conf_file_name, error, ignore_invalid_keys)) {
                         return false;

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -9,7 +9,6 @@
 #include <wallet/db.h>
 
 #include <exception>
-#include <fstream>
 #include <string>
 #include <system_error>
 #include <vector>
@@ -90,7 +89,7 @@ bool IsBDBFile(const fs::path& path)
     if (ec) LogPrintf("%s: %s %s\n", __func__, ec.message(), fs::PathToString(path));
     if (size < 4096) return false;
 
-    std::ifstream file{path, std::ios::binary};
+    fsbridge::ifstream file{path, std::ios::binary};
     if (!file.is_open()) return false;
 
     file.seekg(12, std::ios::beg); // Magic bytes start at offset 12
@@ -114,7 +113,7 @@ bool IsSQLiteFile(const fs::path& path)
     if (ec) LogPrintf("%s: %s %s\n", __func__, ec.message(), fs::PathToString(path));
     if (size < 512) return false;
 
-    std::ifstream file{path, std::ios::binary};
+    fsbridge::ifstream file{path, std::ios::binary};
     if (!file.is_open()) return false;
 
     // Magic is at beginning and is 16 bytes long

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -9,7 +9,6 @@
 #include <wallet/wallet.h>
 
 #include <algorithm>
-#include <fstream>
 #include <memory>
 #include <string>
 #include <utility>
@@ -34,7 +33,7 @@ bool DumpWallet(CWallet& wallet, bilingual_str& error)
         error = strprintf(_("File %s already exists. If you are sure this is what you want, move it out of the way first."), fs::PathToString(path));
         return false;
     }
-    std::ofstream dump_file;
+    fsbridge::ofstream dump_file;
     dump_file.open(path);
     if (dump_file.fail()) {
         error = strprintf(_("Unable to open %s for writing"), fs::PathToString(path));
@@ -129,7 +128,7 @@ bool CreateFromDump(const std::string& name, const fs::path& wallet_path, biling
         error = strprintf(_("Dump file %s does not exist."), fs::PathToString(dump_path));
         return false;
     }
-    std::ifstream dump_file{dump_path};
+    fsbridge::ifstream dump_file{dump_path};
 
     // Compute the checksum
     CHashWriter hasher(0, 0);

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -22,7 +22,6 @@
 #include <wallet/wallet.h>
 
 #include <cstdint>
-#include <fstream>
 #include <tuple>
 #include <string>
 
@@ -524,7 +523,7 @@ RPCHelpMan importwallet()
 
         EnsureWalletIsUnlocked(*pwallet);
 
-        std::ifstream file;
+        fsbridge::ifstream file;
         file.open(fs::u8path(request.params[0].get_str()), std::ios::in | std::ios::ate);
         if (!file.is_open()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot open wallet dump file");
@@ -732,7 +731,7 @@ RPCHelpMan dumpwallet()
         throw JSONRPCError(RPC_INVALID_PARAMETER, filepath.u8string() + " already exists. If you are sure this is what you want, move it out of the way first");
     }
 
-    std::ofstream file;
+    fsbridge::ofstream file;
     file.open(filepath);
     if (!file.is_open())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot open wallet dump file");

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -8,7 +8,6 @@
 #include <test/util/setup_common.h>
 #include <wallet/bdb.h>
 
-#include <fstream>
 #include <memory>
 #include <string>
 
@@ -27,7 +26,7 @@ BOOST_AUTO_TEST_CASE(getwalletenv_file)
     std::string test_name = "test_name.dat";
     const fs::path datadir = gArgs.GetDataDirNet();
     fs::path file_path = datadir / test_name;
-    std::ofstream f{file_path};
+    fsbridge::ofstream f{file_path};
     f.close();
 
     std::string filename;

--- a/src/wallet/test/init_test_fixture.cpp
+++ b/src/wallet/test/init_test_fixture.cpp
@@ -7,7 +7,6 @@
 #include <util/check.h>
 #include <util/system.h>
 
-#include <fstream>
 #include <string>
 
 #include <wallet/test/init_test_fixture.h>
@@ -36,7 +35,7 @@ InitWalletDirTestingSetup::InitWalletDirTestingSetup(const std::string& chainNam
     fs::create_directories(m_walletdir_path_cases["default"]);
     fs::create_directories(m_walletdir_path_cases["custom"]);
     fs::create_directories(m_walletdir_path_cases["relative"]);
-    std::ofstream f{m_walletdir_path_cases["file"]};
+    fsbridge::ofstream f{m_walletdir_path_cases["file"]};
     f.close();
 }
 


### PR DESCRIPTION
This PR adds ugly crutches to avoid `{i,o}fstream` errors when cross-compiling for Windows in the Guix environment.

I'm not happy with this solution, but it ~works~.

#### Guix builds:
```
$ find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
157830ddd10f50a21ebbb7d54708c46b37b0a19739d09b2ae2d75ff8bc62b5ee  guix-build-fe054cf4abbd/output/dist-archive/bitcoin-fe054cf4abbd.tar.gz
291ffabfdbca6880c4ac83589a23c90df4d481d8fd5d068ecaf61f772e644d69  guix-build-fe054cf4abbd/output/x86_64-w64-mingw32/SHA256SUMS.part
93544c07d29126500fda993b6892013ea5fc84a0ee9aaf02e04c434f1b4d2540  guix-build-fe054cf4abbd/output/x86_64-w64-mingw32/bitcoin-fe054cf4abbd-win-unsigned.tar.gz
b6502582afea382950c2b3382058bdf504d8c82d9f4b4ac3da3e6c68c6d19aae  guix-build-fe054cf4abbd/output/x86_64-w64-mingw32/bitcoin-fe054cf4abbd-win64-debug.zip
f03f7049d032a153d32326726c29bf3119da461dac8c720c1548d497d7037622  guix-build-fe054cf4abbd/output/x86_64-w64-mingw32/bitcoin-fe054cf4abbd-win64-setup-unsigned.exe
3540d07ce1e6106dce59fe401f7fb33211885b05d3a607268580a5de88f71ae3  guix-build-fe054cf4abbd/output/x86_64-w64-mingw32/bitcoin-fe054cf4abbd-win64.zip
```

Fixes bitcoin/bitcoin#24055.