### PR TITLE
 addrman: Log too low compat value 

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -246,12 +246,18 @@ void AddrManImpl::Unserialize(Stream& s_)
 
     uint8_t compat;
     s >> compat;
+    if (compat < INCOMPATIBILITY_BASE) {
+        throw std::ios_base::failure(strprintf(
+            "Corrupted addrman database: The compat value (%u) "
+            "is lower than the expected minimum value %u.",
+            compat, INCOMPATIBILITY_BASE));
+    }
     const uint8_t lowest_compatible = compat - INCOMPATIBILITY_BASE;
     if (lowest_compatible > FILE_FORMAT) {
         throw InvalidAddrManVersionError(strprintf(
             "Unsupported format of addrman database: %u. It is compatible with formats >=%u, "
             "but the maximum supported by this version of %s is %u.",
-            uint8_t{format}, uint8_t{lowest_compatible}, PACKAGE_NAME, uint8_t{FILE_FORMAT}));
+            uint8_t{format}, lowest_compatible, PACKAGE_NAME, uint8_t{FILE_FORMAT}));
     }
 
     s >> nKey;

--- a/test/functional/feature_addrman.py
+++ b/test/functional/feature_addrman.py
@@ -68,6 +68,17 @@ class AddrmanTest(BitcoinTestFramework):
             self.start_node(0, extra_args=["-checkaddrman=1"])
         assert_equal(self.nodes[0].getnodeaddresses(), [])
 
+        self.log.info("Check that addrman with negative lowest_compatible cannot be read")
+        self.stop_node(0)
+        write_addrman(peers_dat, lowest_compatible=-32)
+        self.nodes[0].assert_start_raises_init_error(
+            expected_msg=init_error(
+                "Corrupted addrman database: The compat value \\(0\\) is lower "
+                "than the expected minimum value 32.: (.+)"
+            ),
+            match=ErrorMatch.FULL_REGEX,
+        )
+
         self.log.info("Check that addrman from future is overwritten with new addrman")
         self.stop_node(0)
         write_addrman(peers_dat, lowest_compatible=111)

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -62,7 +62,6 @@ implicit-integer-sign-change:script/bitcoinconsensus.cpp
 implicit-integer-sign-change:script/interpreter.cpp
 implicit-integer-sign-change:serialize.h
 implicit-integer-sign-change:txmempool.cpp
-implicit-signed-integer-truncation:addrman.cpp
 implicit-signed-integer-truncation:crypto/
 implicit-unsigned-integer-truncation:crypto/
 shift-base:arith_uint256.cpp


### PR DESCRIPTION
Before this patch, when writing a negative `lowest_compatible` value, it would be read as a positive value. For example `-32` will be read as `224`. There is generally nothing wrong with that. Though, similarly there shouldn't be anything wrong with refusing to read a negative value. I find the code after this patch more logical than before. Also, this allows dropping a file-wide sanitizer suppression.

In practice none of this should ever happen. Bitcoin Core would never write a negative `lowest_compatible` in normal operation, unless the file storage is later corrupted by external influence.