### PR TITLE
refactor: Avoid unsigned integer overflow in core_write

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -65,7 +65,7 @@ std::string FormatScript(const CScript& script)
         ret += strprintf("0x%x ", HexStr(std::vector<uint8_t>(it2, script.end())));
         break;
     }
-    return ret.substr(0, ret.size() - 1);
+    return ret.substr(0, ret.empty() ? ret.npos : ret.size() - 1);
 }
 
 const std::map<unsigned char, std::string> mapSigHashTypes = {

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -47,7 +47,6 @@ unsigned-integer-overflow:arith_uint256.h
 unsigned-integer-overflow:common/bloom.cpp
 unsigned-integer-overflow:coins.cpp
 unsigned-integer-overflow:compressor.cpp
-unsigned-integer-overflow:core_write.cpp
 unsigned-integer-overflow:crypto/
 unsigned-integer-overflow:hash.cpp
 unsigned-integer-overflow:policy/fees.cpp


### PR DESCRIPTION
Also, I find the new code a bit easier to understand.