### PR TITLE
test: refactor: remove unneeded bytes<->hex conversions in `byte_to_base58`

### DIFF
--- a/test/functional/test_framework/address.py
+++ b/test/functional/test_framework/address.py
@@ -55,17 +55,15 @@ def create_deterministic_address_bcrt1_p2tr_op_true():
 
 def byte_to_base58(b, version):
     result = ''
-    str = b.hex()
-    str = chr(version).encode('latin-1').hex() + str
-    checksum = hash256(bytes.fromhex(str)).hex()
-    str += checksum[:8]
-    value = int('0x' + str, 0)
+    b = bytes([version]) + b  # prepend version
+    b += hash256(b)[:4]       # append checksum
+    value = int.from_bytes(b, 'big')
     while value > 0:
         result = chars[value % 58] + result
         value //= 58
-    while (str[:2] == '00'):
+    while b[0] == 0:
         result = chars[0] + result
-        str = str[2:]
+        b = b[1:]
     return result
 
 


### PR DESCRIPTION
It seems like the only reason for using hex strings in this method was to have a convenient way to convert to an integer from the input data interpreted as big-endian. In Python3 we have `int.from_bytes(..., 'big')` for that purpose, hence there is no need for that anymore and we can simply operate on bytes only.