### PR TITLE
build: minor cleanups to native_clang package 

### DIFF
--- a/depends/packages/native_clang.mk
+++ b/depends/packages/native_clang.mk
@@ -16,15 +16,10 @@ endef
 define $(package)_stage_cmds
   mkdir -p $($(package)_staging_prefix_dir)/lib/clang/$($(package)_version)/include && \
   mkdir -p $($(package)_staging_prefix_dir)/bin && \
-  mkdir -p $($(package)_staging_prefix_dir)/include && \
   cp bin/clang $($(package)_staging_prefix_dir)/bin/ && \
   cp -P bin/clang++ $($(package)_staging_prefix_dir)/bin/ && \
   cp bin/dsymutil $($(package)_staging_prefix_dir)/bin/$(host)-dsymutil && \
   cp bin/llvm-config $($(package)_staging_prefix_dir)/bin/ && \
   cp lib/libLTO.so $($(package)_staging_prefix_dir)/lib/ && \
   cp -rf lib/clang/$($(package)_version)/include/* $($(package)_staging_prefix_dir)/lib/clang/$($(package)_version)/include/
-endef
-
-define $(package)_postprocess_cmds
-  rmdir include
 endef

--- a/depends/packages/native_clang.mk
+++ b/depends/packages/native_clang.mk
@@ -21,5 +21,5 @@ define $(package)_stage_cmds
   cp bin/dsymutil $($(package)_staging_prefix_dir)/bin/$(host)-dsymutil && \
   cp bin/llvm-config $($(package)_staging_prefix_dir)/bin/ && \
   cp lib/libLTO.so $($(package)_staging_prefix_dir)/lib/ && \
-  cp -rf lib/clang/$($(package)_version)/include/* $($(package)_staging_prefix_dir)/lib/clang/$($(package)_version)/include/
+  cp -r lib/clang/$($(package)_version)/include/* $($(package)_staging_prefix_dir)/lib/clang/$($(package)_version)/include/
 endef


### PR DESCRIPTION
Pulled out of #21778.

Guix build:
```bash
bash-5.1# find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
b7fc20b23d2270f0bf39859fc2d9b75c687a0cceaf287b3871d872e8e7aaaeb6  guix-build-4255b4669359/output/arm64-apple-darwin/SHA256SUMS.part
bd31487de1f49fd84b1eb37c744ea55b1268d729ec4715e7cb50a768b147628e  guix-build-4255b4669359/output/arm64-apple-darwin/bitcoin-4255b4669359-arm64-apple-darwin.tar.gz
6eca741ecd7e35e5d917442326e8f64e2f745cb0cf8573e616fb1fc388d3376f  guix-build-4255b4669359/output/arm64-apple-darwin/bitcoin-4255b4669359-osx-unsigned.dmg
b54797d350e00a597478dadb3c7372d15306c095f63cc3e5257a3b1851856614  guix-build-4255b4669359/output/arm64-apple-darwin/bitcoin-4255b4669359-osx-unsigned.tar.gz
af212f87138950a398e2cd1c3ebc69bbe90126ac916a735d5a24a91864e0a164  guix-build-4255b4669359/output/dist-archive/bitcoin-4255b4669359.tar.gz
d25ab8698524f283958e32cbdfaa14d344d905f972c66987ff27286cb2abcdfa  guix-build-4255b4669359/output/x86_64-apple-darwin/SHA256SUMS.part
39f069317efff319aea55d6f929ee4cd5e4c04cfb5cf84ea1e6500b18e368be3  guix-build-4255b4669359/output/x86_64-apple-darwin/bitcoin-4255b4669359-osx-unsigned.dmg
dc755eff3cb4e628637f68c3e31a28ae41bbece1339067a2c0042f39899a275c  guix-build-4255b4669359/output/x86_64-apple-darwin/bitcoin-4255b4669359-osx-unsigned.tar.gz
d084f798f08cb175272ae420a68df3fa69c3b2be2fbe972c929dd4d4214039f7  guix-build-4255b4669359/output/x86_64-apple-darwin/bitcoin-4255b4669359-osx64.tar.gz
```