### PR TITLE
doc: release-process: Specify remote name in "git fetch"

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -97,7 +97,7 @@ Checkout the Bitcoin Core version you'd like to build:
 pushd ./bitcoin
 SIGNER='(your builder key, ie bluematt, sipa, etc)'
 VERSION='(new version without v-prefix, e.g. 0.20.0)'
-git fetch "v${VERSION}"
+git fetch origin "v${VERSION}"
 git checkout "v${VERSION}"
 popd
 ```


### PR DESCRIPTION
Avoids "does not appear to be a git repository" error.

Fixes #24329
