### PR TITLE
rpc: Improve RPC help by explicitly mentioning output types

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1037,7 +1037,7 @@ static RPCHelpMan getblock()
                                             {RPCResult::Type::STR, "asm", "The asm"},
                                             {RPCResult::Type::STR, "hex", "The hex"},
                                             {RPCResult::Type::STR, "address", /* optional */ true, "The Bitcoin address (only if a well-defined address exists)"},
-                                            {RPCResult::Type::STR, "type", "The type, eg 'pubkeyhash'"},
+                                            {RPCResult::Type::STR, "type", "The type (one of: " + GetAllOutputTypes() + ")"},
                                         }},
                                     }},
                                 }},

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -542,16 +542,6 @@ static RPCHelpMan decoderawtransaction()
     };
 }
 
-static std::string GetAllOutputTypes()
-{
-    std::vector<std::string> ret;
-    using U = std::underlying_type<TxoutType>::type;
-    for (U i = (U)TxoutType::NONSTANDARD; i <= (U)TxoutType::WITNESS_UNKNOWN; ++i) {
-        ret.emplace_back(GetTxnOutputType(static_cast<TxoutType>(i)));
-    }
-    return Join(ret, ", ");
-}
-
 static RPCHelpMan decodescript()
 {
     return RPCHelpMan{

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -21,6 +21,16 @@
 const std::string UNIX_EPOCH_TIME = "UNIX epoch time";
 const std::string EXAMPLE_ADDRESS[2] = {"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl", "bc1q02ad21edsxd23d32dfgqqsz4vv4nmtfzuklhy3"};
 
+std::string GetAllOutputTypes()
+{
+    std::vector<std::string> ret;
+    using U = std::underlying_type<TxoutType>::type;
+    for (U i = (U)TxoutType::NONSTANDARD; i <= (U)TxoutType::WITNESS_UNKNOWN; ++i) {
+        ret.emplace_back(GetTxnOutputType(static_cast<TxoutType>(i)));
+    }
+    return Join(ret, ", ");
+}
+
 void RPCTypeCheck(const UniValue& params,
                   const std::list<UniValueType>& typesExpected,
                   bool fAllowNull)

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -39,6 +39,13 @@ class CPubKey;
 class CScript;
 struct Sections;
 
+/**
+ * Gets all existing output types formatted for RPC help sections.
+ *
+ * @return Comma separated string representing output type names.
+ */
+std::string GetAllOutputTypes();
+
 /** Wrapper for UniValue::VType, which includes typeAny:
  * Used to denote don't care type. */
 struct UniValueType {


### PR DESCRIPTION
This PR attempts to replicate https://github.com/bitcoin/bitcoin/blob/0ccf9b2e5594581deef2f60174c3651a57f93b64/src/rpc/rawtransaction.cpp#L547 to one other place (at the moment) so that users have better idea what RPC methods can actually return.

I created this PR as a follow-up to the idea mentioned here https://github.com/bitcoin/bitcoin/pull/23320#discussion_r732458112 (resolved).