### PR TITLE
util: Add missing unlinkat to syscall sandbox

### DIFF
--- a/src/util/syscall_sandbox.cpp
+++ b/src/util/syscall_sandbox.cpp
@@ -600,6 +600,7 @@ public:
         allowed_syscalls.insert(__NR_statfs);          // get filesystem statistics
         allowed_syscalls.insert(__NR_statx);           // get file status (extended)
         allowed_syscalls.insert(__NR_unlink);          // delete a name and possibly the file it refers to
+        allowed_syscalls.insert(__NR_unlinkat);        // delete relative to a directory file descriptor
     }
 
     void AllowFutex()


### PR DESCRIPTION
This will be needed for g++-12 (after libstdc++6 12-20220206).

Steps to reproduce:

```
gdb --args ./src/bitcoind -sandbox=log-and-abort -regtest
./src/bitcoin-cli -regtest -named createwallet wallet_name=a descriptors=false
./src/bitcoin-cli -regtest stop
```

BT:

```
Thread 1 "b-shutoff" received signal SIGSYS, Bad system call.
0x00007ffff79564f7 in unlinkat () from /lib/x86_64-linux-gnu/libc.so.6
(gdb) bt
#0  0x00007ffff79564f7 in unlinkat () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007ffff7cc7335 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#2  0x00007ffff7cc94e3 in std::filesystem::remove_all(std::filesystem::__cxx11::path const&) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#3  0x00005555559d4918 in wallet::BerkeleyEnvironment::Flush (this=0x7fffc4005160, fShutdown=<optimized out>) at /usr/include/c++/12/bits/fs_path.h:595
#4  0x000055555592c058 in wallet::StopWallets (context=...) at /usr/include/c++/12/bits/shared_ptr_base.h:1665
#5  0x00005555556617ca in Shutdown (node=...) at ./src/init.cpp:293
#6  0x000055555563ada6 in AppInit (argv=<optimized out>, argc=<optimized out>, node=...) at ./src/bitcoind.cpp:249
#7  main (argc=<optimized out>, argv=<optimized out>) at ./src/bitcoind.cpp:273
