### PR TITLE
test: remove `import socket` in test_ipv6_local

### DIFF
--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -144,7 +144,6 @@ def test_ipv6_local():
     '''
     Check for (local) IPv6 support.
     '''
-    import socket
     # By using SOCK_DGRAM this will not actually make a connection, but it will
     # fail if there is no route to IPv6 localhost.
     have_ipv6 = True


### PR DESCRIPTION
Since this module (`socket`) is imported at the top of file, there is no need to import it again within the function.