### PR TITLE
init: Add bounds checking to -port

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1235,6 +1235,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // is not yet setup and may end up being set up twice if we
     // need to reindex later.
 
+    auto nListenPort = args.GetIntArg("-port", Params().GetDefaultPort());
+    if (nListenPort <= 0 || nListenPort > 65535) {
+        return InitError(strprintf(_("Invalid -port: %d"), nListenPort));
+    }
+
     fListen = args.GetBoolArg("-listen", DEFAULT_LISTEN);
     fDiscover = args.GetBoolArg("-discover", true);
     const bool ignores_incoming_txs{args.GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY)};


### PR DESCRIPTION
Specifying ports outside of the bounds of 1 - 65535 give unexpected behaviors:
* 0 assigns a random port
* less than 0 underflows
* greater than 65535 overflows and then assigns a random port

This patch alerts the user that port numbers in these ranges are invalid.