### PR TITLE
doc: Release process: fix broken link to Guix building docs

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -118,7 +118,7 @@ details.
 ### Build and attest to build outputs:
 
 Follow the relevant Guix README.md sections:
-- [Performing a build](/contrib/guix/README.md#performing-a-build)
+- [Building](/contrib/guix/README.md#building)
 - [Attesting to build outputs](/contrib/guix/README.md#attesting-to-build-outputs)
 
 ### Verify other builders' signatures to your own. (Optional)


### PR DESCRIPTION
Not 100% sure whether this link was always broken or if the Guix docs renamed the heading at some point.  Either way, seems good to fix it.