### PR TITLE
build: Fix Guix build for Windows (attempt 2)

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -239,7 +239,7 @@ SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git -c log.showSignature=false log --f
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://git.savannah.gnu.org/git/guix.git \
-                      --commit=1ef7a03a148cf5f83ab1820444f6bd50d8e732d1 \
+                      --commit=ae03f401381e956c4c41b4cf495cbde964fa43d0 \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -162,13 +162,17 @@ desirable for building Bitcoin Core release binaries."
 (define (make-gcc-with-pthreads gcc)
   (package-with-extra-configure-variable gcc "--enable-threads" "posix"))
 
+;; Required to support std::filesystem for mingw-w64 target.
+(define (make-gcc-without-newlib gcc)
+  (package-with-extra-configure-variable gcc "--with-newlib" "no"))
+
 (define (make-mingw-pthreads-cross-toolchain target)
   "Create a cross-compilation toolchain package for TARGET"
   (let* ((xbinutils (cross-binutils target))
          (pthreads-xlibc mingw-w64-x86_64-winpthreads)
          (pthreads-xgcc (make-gcc-with-pthreads
                          (cross-gcc target
-                                    #:xgcc (make-ssp-fixed-gcc base-gcc)
+                                    #:xgcc (make-gcc-without-newlib (make-ssp-fixed-gcc base-gcc))
                                     #:xbinutils xbinutils
                                     #:libc pthreads-xlibc))))
     ;; Define a meta-package that propagates the resulting XBINUTILS, XLIBC, and


### PR DESCRIPTION
Fixes bitcoin/bitcoin#24055.
Replaces bitcoin/bitcoin#24300.

#### Guix builds:
```
$ find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
d807189a8b5721892395968a86acd47f0cff2c7e76e75e6e927045ba339ba1dc  guix-build-b3617a99c141/output/aarch64-linux-gnu/SHA256SUMS.part
a1c89935c5d5c57df428a360168944d1be83fc00324a903a0a68c284fa4d71cf  guix-build-b3617a99c141/output/aarch64-linux-gnu/bitcoin-b3617a99c141-aarch64-linux-gnu-debug.tar.gz
2936adc6d4425f297c2eee310fa8a90b51209289474d10a5a320346c9b4fb90a  guix-build-b3617a99c141/output/aarch64-linux-gnu/bitcoin-b3617a99c141-aarch64-linux-gnu.tar.gz
10420ef9e7001f7dbe009261925db81ee94764bb42514f28d0aa429de37c81d6  guix-build-b3617a99c141/output/arm-linux-gnueabihf/SHA256SUMS.part
00b762833139e0d7b470570e30dfe10c427f78a5bd498207b8750695b307fcfe  guix-build-b3617a99c141/output/arm-linux-gnueabihf/bitcoin-b3617a99c141-arm-linux-gnueabihf-debug.tar.gz
2084c431e262a49cf18a2346e1465f73ccb8c320cfda3aa918439f371c1fec9c  guix-build-b3617a99c141/output/arm-linux-gnueabihf/bitcoin-b3617a99c141-arm-linux-gnueabihf.tar.gz
752b769cbee5b04a4ae1fff0db5d8521b76df68e20c966bad141e9c65de3d196  guix-build-b3617a99c141/output/arm64-apple-darwin/SHA256SUMS.part
708a39f525ea225cce71d53120df411c808a5f5a29e9c3498646ab7e5d5ab14d  guix-build-b3617a99c141/output/arm64-apple-darwin/bitcoin-b3617a99c141-arm64-apple-darwin.tar.gz
cc60ed18529d0656feb87189c69f2fbe048b2b37ac11952d9290dd0f8576ea97  guix-build-b3617a99c141/output/arm64-apple-darwin/bitcoin-b3617a99c141-osx-unsigned.dmg
5e10d7f0ab7352995ceb7959b5b371615e06904f9a857d59229dd5e1b7f5825e  guix-build-b3617a99c141/output/arm64-apple-darwin/bitcoin-b3617a99c141-osx-unsigned.tar.gz
b44e8a11279d3fe29cc4d72f3ac1b3da1f11608636b4a9c8653272bf6be5ed92  guix-build-b3617a99c141/output/dist-archive/bitcoin-b3617a99c141.tar.gz
c467e2371a88fd2fbcd98c9413f47f1ddc81183ac9f0674182a7af208df18e31  guix-build-b3617a99c141/output/powerpc64-linux-gnu/SHA256SUMS.part
2de931fe54aaf6fdaac9aa2595d7f4901eeba80ab1185249c2bc2141318a9811  guix-build-b3617a99c141/output/powerpc64-linux-gnu/bitcoin-b3617a99c141-powerpc64-linux-gnu-debug.tar.gz
2d2cf5236d41d9dbe2480e19a94107c726dce3c52bfa8672e3f41ada7a8acd61  guix-build-b3617a99c141/output/powerpc64-linux-gnu/bitcoin-b3617a99c141-powerpc64-linux-gnu.tar.gz
2815de278610cc7aa3d365af3834ed77e49cf6695dc9e2ffdbc3ccd6cc8362fc  guix-build-b3617a99c141/output/powerpc64le-linux-gnu/SHA256SUMS.part
fd13b01363a44c03dd52b1193b2690efdaa358c2bcdc31c43e83c96e06c2bc05  guix-build-b3617a99c141/output/powerpc64le-linux-gnu/bitcoin-b3617a99c141-powerpc64le-linux-gnu-debug.tar.gz
796bd23f314e6edb429d893e7ffafc7c4d6b51c0febe1faaa192085435aeb0bb  guix-build-b3617a99c141/output/powerpc64le-linux-gnu/bitcoin-b3617a99c141-powerpc64le-linux-gnu.tar.gz
c1e449e6ac3e78682d613d8bcebf97bce5ed69a865cfdc939cf6d290a3a5c7ef  guix-build-b3617a99c141/output/riscv64-linux-gnu/SHA256SUMS.part
c3e6380e81229779ad60fa1c1fa856d6af46c1cab9a87abe296694be0b42b405  guix-build-b3617a99c141/output/riscv64-linux-gnu/bitcoin-b3617a99c141-riscv64-linux-gnu-debug.tar.gz
1351e7755ace57cdbcb66f2673733f31d3b90063e414a0eeb1f0c71b19ca3b88  guix-build-b3617a99c141/output/riscv64-linux-gnu/bitcoin-b3617a99c141-riscv64-linux-gnu.tar.gz
1af14acc6e7210286d09618e9e43b93707540eac9ee48226a6a2d69ab10dfe24  guix-build-b3617a99c141/output/x86_64-apple-darwin/SHA256SUMS.part
e76b872e075604916ad60fa50989bba81080ecad9a12e8793a2628713bc816fd  guix-build-b3617a99c141/output/x86_64-apple-darwin/bitcoin-b3617a99c141-osx-unsigned.dmg
2755d5766efc86f360909b01206e4594f5049e7aed17bc8ba3781a375acc28cf  guix-build-b3617a99c141/output/x86_64-apple-darwin/bitcoin-b3617a99c141-osx-unsigned.tar.gz
335a08ee376c51692e9e24f4dd0a71fc24af2b15f3acd4ef2881ecb882fc708f  guix-build-b3617a99c141/output/x86_64-apple-darwin/bitcoin-b3617a99c141-osx64.tar.gz
0ed78a1a1e22e8d20de9aeff052f57f0ada1eb536d541d28318223120610614b  guix-build-b3617a99c141/output/x86_64-linux-gnu/SHA256SUMS.part
d07dfb39d9fd65ed2514eae7697a25f43ece18efdd1255a592feb0e6eb0510e4  guix-build-b3617a99c141/output/x86_64-linux-gnu/bitcoin-b3617a99c141-x86_64-linux-gnu-debug.tar.gz
c427792751e83edbc48a4ed05278b70d888b957b77d8e7d9e298da47d2351bab  guix-build-b3617a99c141/output/x86_64-linux-gnu/bitcoin-b3617a99c141-x86_64-linux-gnu.tar.gz
f24d5d065cebd214a948600adc97cdc1535ad3411e07ec66d3af2007586518e9  guix-build-b3617a99c141/output/x86_64-w64-mingw32/SHA256SUMS.part
de196c52b6767a84c36d0d8c304ad46060dfd27accbc0812dd29600449385ab2  guix-build-b3617a99c141/output/x86_64-w64-mingw32/bitcoin-b3617a99c141-win-unsigned.tar.gz
f6795755776c06fcc42482f2aaeedc0d45f11396a7766423bc8ee408feb203b8  guix-build-b3617a99c141/output/x86_64-w64-mingw32/bitcoin-b3617a99c141-win64-debug.zip
76e75bb47277ae9f4a1b3116f98a91ed7291705c6c87456d9fa10a98448818d3  guix-build-b3617a99c141/output/x86_64-w64-mingw32/bitcoin-b3617a99c141-win64-setup-unsigned.exe
615cb51c1536ff809025a580e3542da5eba02041676a37a21dbe11e1ac5f97c2  guix-build-b3617a99c141/output/x86_64-w64-mingw32/bitcoin-b3617a99c141-win64.zip
```