### PR TITLE
fuzz: Split script formatting from script fuzz target

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -294,6 +294,7 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/script_bitcoin_consensus.cpp \
  test/fuzz/script_descriptor_cache.cpp \
  test/fuzz/script_flags.cpp \
+ test/fuzz/script_format.cpp \
  test/fuzz/script_interpreter.cpp \
  test/fuzz/script_ops.cpp \
  test/fuzz/script_sigcache.cpp \

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -167,12 +167,4 @@ FUZZ_TARGET_INIT(script, initialize_script)
             Assert(dest == GetScriptForDestination(tx_destination_2));
         }
     }
-
-    (void)FormatScript(script);
-    (void)ScriptToAsmStr(script, /*fAttemptSighashDecode=*/fuzzed_data_provider.ConsumeBool());
-
-    UniValue o1(UniValue::VOBJ);
-    ScriptPubKeyToUniv(script, o1, /*include_hex=*/fuzzed_data_provider.ConsumeBool());
-    UniValue o3(UniValue::VOBJ);
-    ScriptToUniv(script, o3);
 }

--- a/src/test/fuzz/script_format.cpp
+++ b/src/test/fuzz/script_format.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2019-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <core_io.h>
+#include <script/script.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <univalue.h>
+
+void initialize_script_format()
+{
+    SelectParams(CBaseChainParams::REGTEST);
+}
+
+FUZZ_TARGET_INIT(script_format, initialize_script_format)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const CScript script{ConsumeScript(fuzzed_data_provider)};
+
+    (void)FormatScript(script);
+    (void)ScriptToAsmStr(script, /*fAttemptSighashDecode=*/fuzzed_data_provider.ConsumeBool());
+
+    UniValue o1(UniValue::VOBJ);
+    ScriptPubKeyToUniv(script, o1, /*include_hex=*/fuzzed_data_provider.ConsumeBool());
+    UniValue o3(UniValue::VOBJ);
+    ScriptToUniv(script, o3);
+}


### PR DESCRIPTION
This is a follow-up to commit 9237bdaac196951a437accaefa65638149b25978.

The target was improved a bit, but is still taking enormously long. See for example 4096 seconds in https://cirrus-ci.com/task/5153886888525824?logs=ci#L4451.

Most of the time is spent formatting the script. See the flamegraph: ![flame](https://user-images.githubusercontent.com/6399679/154052491-ad868078-42e6-4d85-9c77-c2e7e8291a9f.png)

Thus, I suggest to split up the formatting into a new target. This will:

* Allow more fuzz cycles in the `script` target when exploring the search space with the fuzz engine
* Hopefully allow to reduce the fuzz inputs in `qa-assets` without losing coverage

