### PR TITLE
Primitives: Correct CTransaction deserialization docstring

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -181,7 +181,7 @@ struct CMutableTransaction;
  * - std::vector<CTxIn> vin
  * - std::vector<CTxOut> vout
  * - if (flags & 1):
- *   - CTxWitness wit;
+ *   - CScriptWitness scriptWitness; (deserialized into CTxIn)
  * - uint32_t nLockTime
  */
 template<typename Stream, typename TxType>


### PR DESCRIPTION
Since https://github.com/bitcoin/bitcoin/pull/8589 CTxWitness was removed and instead replaced with CScriptWitness inside each CTxIn.
