### PR TITLE
RPC: Return external_signer command in getwalletinfo

### DIFF
--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -57,7 +57,7 @@ static RPCHelpMan getwalletinfo()
                             {RPCResult::Type::NUM, "progress", "scanning progress percentage [0.0, 1.0]"},
                         }},
                         {RPCResult::Type::BOOL, "descriptors", "whether this wallet uses descriptors for scriptPubKey management"},
-                        {RPCResult::Type::BOOL, "external_signer", "whether this wallet is configured to use an external signer such as a hardware wallet"},
+                        {RPCResult::Type::STR, "external_signer", /*optional=*/true, "external signing tool used for this wallet if it is configured to use external signer"},
                     }},
                 },
                 RPCExamples{
@@ -118,7 +118,10 @@ static RPCHelpMan getwalletinfo()
         obj.pushKV("scanning", false);
     }
     obj.pushKV("descriptors", pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
-    obj.pushKV("external_signer", pwallet->IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER));
+    if (pwallet->IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER)) {
+        const std::string signer_command = gArgs.GetArg("-signer", "");
+        obj.pushKV("external_signer", signer_command);
+    }
     return obj;
 },
     };

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -72,12 +72,12 @@ class WalletSignerTest(BitcoinTestFramework):
 
         self.nodes[1].createwallet(wallet_name='hww', disable_private_keys=True, descriptors=True, external_signer=True)
         hww = self.nodes[1].get_wallet_rpc('hww')
-        assert_equal(hww.getwalletinfo()["external_signer"], True)
+        assert_equal(hww.getwalletinfo()["external_signer"], self.mock_signer_path())
 
         # Flag can't be set afterwards (could be added later for non-blank descriptor based watch-only wallets)
         self.nodes[1].createwallet(wallet_name='not_hww', disable_private_keys=True, descriptors=True, external_signer=False)
         not_hww = self.nodes[1].get_wallet_rpc('not_hww')
-        assert_equal(not_hww.getwalletinfo()["external_signer"], False)
+        assert("external_signer" not in not_hww.getwalletinfo())
         assert_raises_rpc_error(-8, "Wallet flag is immutable: external_signer", not_hww.setwalletflag, "external_signer", True)
 
         # assert_raises_rpc_error(-4, "Multiple signers found, please specify which to use", wallet_name='not_hww', disable_private_keys=True, descriptors=True, external_signer=True)


### PR DESCRIPTION
Alternative / follow-up to #24307. As was proposed by @luke-jr (https://github.com/bitcoin/bitcoin/pull/24307#issuecomment-1037577925):

> Seems like this should probably be a string indicating the external signer program...

`"external_signer"` is changed from bool to optional string and is returned only if `WALLET_FLAG_EXTERNAL_SIGNER` is set. Will return empty string if wallet is configured to use external signer but Core is started without `-signer`.