### PR TITLE
Descriptor unit tests and simplifications

### DIFF
--- a/src/script/descriptor.h
+++ b/src/script/descriptor.h
@@ -105,14 +105,11 @@ struct Descriptor {
      *  This is true for all descriptors except ones that use `raw` or `addr` constructions. */
     virtual bool IsSolvable() const = 0;
 
-    /** Convert the descriptor back to a string, undoing parsing. */
-    virtual std::string ToString() const = 0;
-
     /** Whether this descriptor will return one scriptPubKey or multiple (aka is or is not combo) */
     virtual bool IsSingleType() const = 0;
 
-    /** Convert the descriptor to a private string. For missing private keys the public key will be emitted. */
-    virtual std::string ToPrivateString(const SigningProvider& provider) const = 0;
+    /** Convert the descriptor to a string. For missing private keys the public key will be emitted. */
+    virtual std::string ToString(const SigningProvider* provider = nullptr) const = 0;
 
     /** Convert the descriptor to a normalized string. Normalized descriptors have the xpub at the last hardened step. This fails if the provided provider does not have the private keys to derive that xpub. */
     virtual bool ToNormalizedString(const SigningProvider& provider, std::string& out, const DescriptorCache* cache = nullptr) const = 0;

--- a/src/script/descriptor.h
+++ b/src/script/descriptor.h
@@ -111,8 +111,8 @@ struct Descriptor {
     /** Whether this descriptor will return one scriptPubKey or multiple (aka is or is not combo) */
     virtual bool IsSingleType() const = 0;
 
-    /** Convert the descriptor to a private string. This fails if the provided provider does not have the relevant private keys. */
-    virtual bool ToPrivateString(const SigningProvider& provider, std::string& out) const = 0;
+    /** Convert the descriptor to a private string. For missing private keys the public key will be emitted. */
+    virtual std::string ToPrivateString(const SigningProvider& provider) const = 0;
 
     /** Convert the descriptor to a normalized string. Normalized descriptors have the xpub at the last hardened step. This fails if the provided provider does not have the private keys to derive that xpub. */
     virtual bool ToNormalizedString(const SigningProvider& provider, std::string& out, const DescriptorCache* cache = nullptr) const = 0;

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -163,10 +163,10 @@ void DoCheck(const std::string& prv, const std::string& pub, const std::string& 
     // priv parsing should result back in the private version.
     BOOST_CHECK(EqualDescriptor(pub, parse_priv->ToString()));
     BOOST_CHECK(EqualDescriptor(pub, parse_pub->ToString()));
-    BOOST_CHECK(EqualDescriptor(pub, parse_priv->ToPrivateString(keys_pub)));
-    BOOST_CHECK(EqualDescriptor(pub, parse_pub->ToPrivateString(keys_pub)));
-    BOOST_CHECK(EqualDescriptor(prv, parse_priv->ToPrivateString(keys_priv)));
-    BOOST_CHECK(EqualDescriptor(prv, parse_pub->ToPrivateString(keys_priv)));
+    BOOST_CHECK(EqualDescriptor(pub, parse_priv->ToString(&keys_pub)));
+    BOOST_CHECK(EqualDescriptor(pub, parse_pub->ToString(&keys_pub)));
+    BOOST_CHECK(EqualDescriptor(prv, parse_priv->ToString(&keys_priv)));
+    BOOST_CHECK(EqualDescriptor(prv, parse_pub->ToString(&keys_priv)));
 
     // Check that private can produce the normalized descriptors
     std::string norm1;

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2323,7 +2323,8 @@ bool DescriptorScriptPubKeyMan::GetDescriptorString(std::string& out, const bool
         // For the private version, always return the master key to avoid
         // exposing child private keys. The risk implications of exposing child
         // private keys together with the parent xpub may be non-obvious for users.
-        return m_wallet_descriptor.descriptor->ToPrivateString(provider, out);
+        out = m_wallet_descriptor.descriptor->ToPrivateString(provider);
+        return true;
     }
 
     return m_wallet_descriptor.descriptor->ToNormalizedString(provider, out, &m_wallet_descriptor.cache);

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2323,7 +2323,7 @@ bool DescriptorScriptPubKeyMan::GetDescriptorString(std::string& out, const bool
         // For the private version, always return the master key to avoid
         // exposing child private keys. The risk implications of exposing child
         // private keys together with the parent xpub may be non-obvious for users.
-        out = m_wallet_descriptor.descriptor->ToPrivateString(provider);
+        out = m_wallet_descriptor.descriptor->ToString(&provider);
         return true;
     }
 

--- a/test/functional/wallet_listdescriptors.py
+++ b/test/functional/wallet_listdescriptors.py
@@ -103,7 +103,7 @@ class ListDescriptorsTest(BitcoinTestFramework):
             'desc': descsum_create('wpkh(' + xpub_acc + ')'),
             'timestamp': 1296688602,
         }])
-        assert_raises_rpc_error(-4, 'Can\'t get descriptor string', watch_only_wallet.listdescriptors, True)
+        assert_equal(watch_only_wallet.listdescriptors(True), watch_only_wallet.listdescriptors(False))
 
         self.log.info('Test non-active non-range combo descriptor')
         node.createwallet(wallet_name='w4', blank=True, descriptors=True)


### PR DESCRIPTION
Builds on top of #24343.

Adds additional tests, and makes `ToPrivateString()` always succeed, using pubkeys in case privkeys are unavailable.