### PR TITLE
wallet: Do not match legacy addresses for change type

### DIFF
--- a/src/wallet/test/availablecoins_tests.cpp
+++ b/src/wallet/test/availablecoins_tests.cpp
@@ -98,7 +98,7 @@ BOOST_FIXTURE_TEST_CASE(BasicOutputTypesTest, AvailableCoinsTestingSetup)
     BOOST_ASSERT(dest.HasRes());
     AddTx(CRecipient{{GetScriptForDestination(dest.GetObj())}, 4 * COIN, /*fSubtractFeeFromAmount=*/true});
     available_coins = AvailableCoins(*wallet);
-    BOOST_CHECK_EQUAL(available_coins.legacy.size(), 2U);
+    BOOST_CHECK_EQUAL(available_coins.legacy.size(), 1U);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2088,7 +2088,6 @@ OutputType CWallet::TransactionChangeType(const std::optional<OutputType>& chang
     bool any_tr{false};
     bool any_wpkh{false};
     bool any_sh{false};
-    bool any_pkh{false};
 
     for (const auto& recipient : vecSend) {
         std::vector<std::vector<uint8_t>> dummy;
@@ -2099,8 +2098,6 @@ OutputType CWallet::TransactionChangeType(const std::optional<OutputType>& chang
             any_wpkh = true;
         } else if (type == TxoutType::SCRIPTHASH) {
             any_sh = true;
-        } else if (type == TxoutType::PUBKEYHASH) {
-            any_pkh = true;
         }
     }
 
@@ -2119,11 +2116,6 @@ OutputType CWallet::TransactionChangeType(const std::optional<OutputType>& chang
         // Currently sh_wpkh is the only type supported by the P2SH_SEGWIT spkman
         // As of 2021 about 80% of all SH are wrapping WPKH, so use that
         return OutputType::P2SH_SEGWIT;
-    }
-    const bool has_legacy_spkman(GetScriptPubKeyMan(OutputType::LEGACY, /*internal=*/true));
-    if (has_legacy_spkman && any_pkh) {
-        // Currently pkh is the only type supported by the LEGACY spkman
-        return OutputType::LEGACY;
     }
 
     if (has_bech32m_spkman) {


### PR DESCRIPTION
We've long since moved away from using the legacy address type unless the user explicitly wants it, so we should not re-introduce using it as change automatically.