### PR TITLE
refactor: remove duplicate code from BlockAssembler

### DIFF
--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -266,13 +266,9 @@ int BlockAssembler::UpdatePackagesForAdded(const CTxMemPool::setEntries& already
             modtxiter mit = mapModifiedTx.find(desc);
             if (mit == mapModifiedTx.end()) {
                 CTxMemPoolModifiedEntry modEntry(desc);
-                modEntry.nSizeWithAncestors -= it->GetTxSize();
-                modEntry.nModFeesWithAncestors -= it->GetModifiedFee();
-                modEntry.nSigOpCostWithAncestors -= it->GetSigOpCost();
-                mapModifiedTx.insert(modEntry);
-            } else {
-                mapModifiedTx.modify(mit, update_for_parent_inclusion(it));
+                mit = mapModifiedTx.insert(modEntry).first;
             }
+            mapModifiedTx.modify(mit, update_for_parent_inclusion(it));
         }
     }
     return nDescendantsUpdated;


### PR DESCRIPTION
Found while reminding myself how transactions are chosen for blocks. Take it or leave it!