### PR TITLE
util: Add missing rseq to syscall sandbox

### DIFF
--- a/src/util/syscall_sandbox.cpp
+++ b/src/util/syscall_sandbox.cpp
@@ -68,6 +68,10 @@ bool g_syscall_sandbox_log_violation_before_terminating{false};
 #define __NR_copy_file_range 326
 #endif
 
+#ifndef  __NR_rseq
+#define __NR_rseq 334
+#endif
+
 // This list of syscalls in LINUX_SYSCALLS is only used to map syscall numbers to syscall names in
 // order to be able to print user friendly error messages which include the syscall name in addition
 // to the syscall number.
@@ -327,6 +331,7 @@ const std::map<uint32_t, std::string> LINUX_SYSCALLS{
     {__NR_request_key, "request_key"},
     {__NR_restart_syscall, "restart_syscall"},
     {__NR_rmdir, "rmdir"},
+    {__NR_rseq, "rseq"},
     {__NR_rt_sigaction, "rt_sigaction"},
     {__NR_rt_sigpending, "rt_sigpending"},
     {__NR_rt_sigprocmask, "rt_sigprocmask"},
@@ -723,6 +728,7 @@ public:
         allowed_syscalls.insert(__NR_fork);       // create a child process
         allowed_syscalls.insert(__NR_tgkill);     // send a signal to a thread
         allowed_syscalls.insert(__NR_wait4);      // wait for process to change state, BSD style
+        allowed_syscalls.insert(__NR_rseq);       // register restartable sequence for thread
     }
 
     void AllowScheduling()


### PR DESCRIPTION
Fixes #24368.