### PR TITLE
bench: Avoid deprecated use of volatile +=

### DIFF
--- a/src/bench/examples.cpp
+++ b/src/bench/examples.cpp
@@ -13,7 +13,7 @@ static void Trig(benchmark::Bench& bench)
 {
     double d = 0.01;
     bench.run([&] {
-        sum += sin(d);
+        sum = sum + sin(d);
         d += 0.000001;
     });
 }


### PR DESCRIPTION
Deprecated in C++20 according to https://eel.is/c++draft/expr.ass#6 .

```
bench/examples.cpp:16:13: warning: compound assignment with ‘volatile’-qualified left operand is deprecated [-Wvolatile]
   16 |         sum += sin(d);
      |         ~~~~^~~~~~~~~
```

While C++20 is currently unsupported, I don't see any downside to a minor fixup to an example benchmark. This will also make a hypothetical C++20 patch smaller.