### PR TITLE
Do not use `LocalTestingSetup` in getarg_tests test file.

### DIFF
--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -14,22 +14,13 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
 
-namespace getarg_tests{
-    class LocalTestingSetup : BasicTestingSetup {
-        protected:
-        void SetupArgs(const std::vector<std::pair<std::string, unsigned int>>& args);
-        void ResetArgs(const std::string& strArg);
-        ArgsManager m_local_args;
-    };
-}
+BOOST_FIXTURE_TEST_SUITE(getarg_tests, BasicTestingSetup)
 
-BOOST_FIXTURE_TEST_SUITE(getarg_tests, LocalTestingSetup)
-
-void LocalTestingSetup :: ResetArgs(const std::string& strArg)
+void ResetArgs(ArgsManager& local_args, const std::string& strArg)
 {
     std::vector<std::string> vecArg;
     if (strArg.size())
-      boost::split(vecArg, strArg, IsSpace, boost::token_compress_on);
+        boost::split(vecArg, strArg, IsSpace, boost::token_compress_on);
 
     // Insert dummy executable name:
     vecArg.insert(vecArg.begin(), "testbitcoin");
@@ -40,264 +31,275 @@ void LocalTestingSetup :: ResetArgs(const std::string& strArg)
         vecChar.push_back(s.c_str());
 
     std::string error;
-    BOOST_CHECK(m_local_args.ParseParameters(vecChar.size(), vecChar.data(), error));
+    BOOST_CHECK(local_args.ParseParameters(vecChar.size(), vecChar.data(), error));
 }
 
-void LocalTestingSetup :: SetupArgs(const std::vector<std::pair<std::string, unsigned int>>& args)
+void SetupArgs(ArgsManager& local_args, const std::vector<std::pair<std::string, unsigned int>>& args)
 {
-    m_local_args.ClearArgs();
     for (const auto& arg : args) {
-        m_local_args.AddArg(arg.first, "", arg.second, OptionsCategory::OPTIONS);
+        local_args.AddArg(arg.first, "", arg.second, OptionsCategory::OPTIONS);
     }
 }
 
 BOOST_AUTO_TEST_CASE(boolarg)
 {
+    ArgsManager local_args;
+
     const auto foo = std::make_pair("-foo", ArgsManager::ALLOW_ANY);
-    SetupArgs({foo});
-    ResetArgs("-foo");
-    BOOST_CHECK(m_local_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(m_local_args.GetBoolArg("-foo", true));
+    SetupArgs(local_args, {foo});
+    ResetArgs(local_args, "-foo");
+    BOOST_CHECK(local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(local_args.GetBoolArg("-foo", true));
 
-    BOOST_CHECK(!m_local_args.GetBoolArg("-fo", false));
-    BOOST_CHECK(m_local_args.GetBoolArg("-fo", true));
+    BOOST_CHECK(!local_args.GetBoolArg("-fo", false));
+    BOOST_CHECK(local_args.GetBoolArg("-fo", true));
 
-    BOOST_CHECK(!m_local_args.GetBoolArg("-fooo", false));
-    BOOST_CHECK(m_local_args.GetBoolArg("-fooo", true));
+    BOOST_CHECK(!local_args.GetBoolArg("-fooo", false));
+    BOOST_CHECK(local_args.GetBoolArg("-fooo", true));
 
-    ResetArgs("-foo=0");
-    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", true));
+    ResetArgs(local_args, "-foo=0");
+    BOOST_CHECK(!local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!local_args.GetBoolArg("-foo", true));
 
-    ResetArgs("-foo=1");
-    BOOST_CHECK(m_local_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(m_local_args.GetBoolArg("-foo", true));
+    ResetArgs(local_args, "-foo=1");
+    BOOST_CHECK(local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(local_args.GetBoolArg("-foo", true));
 
     // New 0.6 feature: auto-map -nosomething to !-something:
-    ResetArgs("-nofoo");
-    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", true));
+    ResetArgs(local_args, "-nofoo");
+    BOOST_CHECK(!local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!local_args.GetBoolArg("-foo", true));
 
-    ResetArgs("-nofoo=1");
-    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", true));
+    ResetArgs(local_args, "-nofoo=1");
+    BOOST_CHECK(!local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!local_args.GetBoolArg("-foo", true));
 
-    ResetArgs("-foo -nofoo");  // -nofoo should win
-    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", true));
+    ResetArgs(local_args, "-foo -nofoo"); // -nofoo should win
+    BOOST_CHECK(!local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!local_args.GetBoolArg("-foo", true));
 
-    ResetArgs("-foo=1 -nofoo=1");  // -nofoo should win
-    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", true));
+    ResetArgs(local_args, "-foo=1 -nofoo=1"); // -nofoo should win
+    BOOST_CHECK(!local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!local_args.GetBoolArg("-foo", true));
 
-    ResetArgs("-foo=0 -nofoo=0");  // -nofoo=0 should win
-    BOOST_CHECK(m_local_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(m_local_args.GetBoolArg("-foo", true));
+    ResetArgs(local_args, "-foo=0 -nofoo=0"); // -nofoo=0 should win
+    BOOST_CHECK(local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(local_args.GetBoolArg("-foo", true));
 
     // New 0.6 feature: treat -- same as -:
-    ResetArgs("--foo=1");
-    BOOST_CHECK(m_local_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(m_local_args.GetBoolArg("-foo", true));
+    ResetArgs(local_args, "--foo=1");
+    BOOST_CHECK(local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(local_args.GetBoolArg("-foo", true));
 
-    ResetArgs("--nofoo=1");
-    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", false));
-    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", true));
-
+    ResetArgs(local_args, "--nofoo=1");
+    BOOST_CHECK(!local_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!local_args.GetBoolArg("-foo", true));
 }
 
 BOOST_AUTO_TEST_CASE(stringarg)
 {
+    ArgsManager local_args;
+
     const auto foo = std::make_pair("-foo", ArgsManager::ALLOW_ANY);
     const auto bar = std::make_pair("-bar", ArgsManager::ALLOW_ANY);
-    SetupArgs({foo, bar});
-    ResetArgs("");
-    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", ""), "");
-    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", "eleven"), "eleven");
+    SetupArgs(local_args, {foo, bar});
+    ResetArgs(local_args, "");
+    BOOST_CHECK_EQUAL(local_args.GetArg("-foo", ""), "");
+    BOOST_CHECK_EQUAL(local_args.GetArg("-foo", "eleven"), "eleven");
 
-    ResetArgs("-foo -bar");
-    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", ""), "");
-    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", "eleven"), "");
+    ResetArgs(local_args, "-foo -bar");
+    BOOST_CHECK_EQUAL(local_args.GetArg("-foo", ""), "");
+    BOOST_CHECK_EQUAL(local_args.GetArg("-foo", "eleven"), "");
 
-    ResetArgs("-foo=");
-    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", ""), "");
-    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", "eleven"), "");
+    ResetArgs(local_args, "-foo=");
+    BOOST_CHECK_EQUAL(local_args.GetArg("-foo", ""), "");
+    BOOST_CHECK_EQUAL(local_args.GetArg("-foo", "eleven"), "");
 
-    ResetArgs("-foo=11");
-    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", ""), "11");
-    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", "eleven"), "11");
+    ResetArgs(local_args, "-foo=11");
+    BOOST_CHECK_EQUAL(local_args.GetArg("-foo", ""), "11");
+    BOOST_CHECK_EQUAL(local_args.GetArg("-foo", "eleven"), "11");
 
-    ResetArgs("-foo=eleven");
-    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", ""), "eleven");
-    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", "eleven"), "eleven");
-
+    ResetArgs(local_args, "-foo=eleven");
+    BOOST_CHECK_EQUAL(local_args.GetArg("-foo", ""), "eleven");
+    BOOST_CHECK_EQUAL(local_args.GetArg("-foo", "eleven"), "eleven");
 }
 
 BOOST_AUTO_TEST_CASE(intarg)
 {
+    ArgsManager local_args;
+
     const auto foo = std::make_pair("-foo", ArgsManager::ALLOW_ANY);
     const auto bar = std::make_pair("-bar", ArgsManager::ALLOW_ANY);
-    SetupArgs({foo, bar});
-    ResetArgs("");
-    BOOST_CHECK_EQUAL(m_local_args.GetIntArg("-foo", 11), 11);
-    BOOST_CHECK_EQUAL(m_local_args.GetIntArg("-foo", 0), 0);
+    SetupArgs(local_args, {foo, bar});
+    ResetArgs(local_args, "");
+    BOOST_CHECK_EQUAL(local_args.GetIntArg("-foo", 11), 11);
+    BOOST_CHECK_EQUAL(local_args.GetIntArg("-foo", 0), 0);
 
-    ResetArgs("-foo -bar");
-    BOOST_CHECK_EQUAL(m_local_args.GetIntArg("-foo", 11), 0);
-    BOOST_CHECK_EQUAL(m_local_args.GetIntArg("-bar", 11), 0);
+    ResetArgs(local_args, "-foo -bar");
+    BOOST_CHECK_EQUAL(local_args.GetIntArg("-foo", 11), 0);
+    BOOST_CHECK_EQUAL(local_args.GetIntArg("-bar", 11), 0);
 
     // Check under-/overflow behavior.
-    ResetArgs("-foo=-9223372036854775809 -bar=9223372036854775808");
-    BOOST_CHECK_EQUAL(m_local_args.GetIntArg("-foo", 0), std::numeric_limits<int64_t>::min());
-    BOOST_CHECK_EQUAL(m_local_args.GetIntArg("-bar", 0), std::numeric_limits<int64_t>::max());
+    ResetArgs(local_args, "-foo=-9223372036854775809 -bar=9223372036854775808");
+    BOOST_CHECK_EQUAL(local_args.GetIntArg("-foo", 0), std::numeric_limits<int64_t>::min());
+    BOOST_CHECK_EQUAL(local_args.GetIntArg("-bar", 0), std::numeric_limits<int64_t>::max());
 
-    ResetArgs("-foo=11 -bar=12");
-    BOOST_CHECK_EQUAL(m_local_args.GetIntArg("-foo", 0), 11);
-    BOOST_CHECK_EQUAL(m_local_args.GetIntArg("-bar", 11), 12);
+    ResetArgs(local_args, "-foo=11 -bar=12");
+    BOOST_CHECK_EQUAL(local_args.GetIntArg("-foo", 0), 11);
+    BOOST_CHECK_EQUAL(local_args.GetIntArg("-bar", 11), 12);
 
-    ResetArgs("-foo=NaN -bar=NotANumber");
-    BOOST_CHECK_EQUAL(m_local_args.GetIntArg("-foo", 1), 0);
-    BOOST_CHECK_EQUAL(m_local_args.GetIntArg("-bar", 11), 0);
+    ResetArgs(local_args, "-foo=NaN -bar=NotANumber");
+    BOOST_CHECK_EQUAL(local_args.GetIntArg("-foo", 1), 0);
+    BOOST_CHECK_EQUAL(local_args.GetIntArg("-bar", 11), 0);
 }
 
 BOOST_AUTO_TEST_CASE(patharg)
 {
+    ArgsManager local_args;
+
     const auto dir = std::make_pair("-dir", ArgsManager::ALLOW_ANY);
-    SetupArgs({dir});
-    ResetArgs("");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), fs::path{});
+    SetupArgs(local_args, {dir});
+    ResetArgs(local_args, "");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), fs::path{});
 
     const fs::path root_path{"/"};
-    ResetArgs("-dir=/");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), root_path);
+    ResetArgs(local_args, "-dir=/");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), root_path);
 
-    ResetArgs("-dir=/.");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), root_path);
+    ResetArgs(local_args, "-dir=/.");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), root_path);
 
-    ResetArgs("-dir=/./");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), root_path);
+    ResetArgs(local_args, "-dir=/./");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), root_path);
 
-    ResetArgs("-dir=/.//");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), root_path);
+    ResetArgs(local_args, "-dir=/.//");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), root_path);
 
 #ifdef WIN32
     const fs::path win_root_path{"C:\\"};
-    ResetArgs("-dir=C:\\");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), win_root_path);
+    ResetArgs(local_args, "-dir=C:\\");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), win_root_path);
 
-    ResetArgs("-dir=C:/");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), win_root_path);
+    ResetArgs(local_args, "-dir=C:/");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), win_root_path);
 
-    ResetArgs("-dir=C:\\\\");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), win_root_path);
+    ResetArgs(local_args, "-dir=C:\\\\");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), win_root_path);
 
-    ResetArgs("-dir=C:\\.");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), win_root_path);
+    ResetArgs(local_args, "-dir=C:\\.");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), win_root_path);
 
-    ResetArgs("-dir=C:\\.\\");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), win_root_path);
+    ResetArgs(local_args, "-dir=C:\\.\\");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), win_root_path);
 
-    ResetArgs("-dir=C:\\.\\\\");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), win_root_path);
+    ResetArgs(local_args, "-dir=C:\\.\\\\");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), win_root_path);
 #endif
 
     const fs::path absolute_path{"/home/user/.bitcoin"};
-    ResetArgs("-dir=/home/user/.bitcoin");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), absolute_path);
+    ResetArgs(local_args, "-dir=/home/user/.bitcoin");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), absolute_path);
 
-    ResetArgs("-dir=/root/../home/user/.bitcoin");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), absolute_path);
+    ResetArgs(local_args, "-dir=/root/../home/user/.bitcoin");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), absolute_path);
 
-    ResetArgs("-dir=/home/./user/.bitcoin");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), absolute_path);
+    ResetArgs(local_args, "-dir=/home/./user/.bitcoin");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), absolute_path);
 
-    ResetArgs("-dir=/home/user/.bitcoin/");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), absolute_path);
+    ResetArgs(local_args, "-dir=/home/user/.bitcoin/");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), absolute_path);
 
-    ResetArgs("-dir=/home/user/.bitcoin//");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), absolute_path);
+    ResetArgs(local_args, "-dir=/home/user/.bitcoin//");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), absolute_path);
 
-    ResetArgs("-dir=/home/user/.bitcoin/.");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), absolute_path);
+    ResetArgs(local_args, "-dir=/home/user/.bitcoin/.");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), absolute_path);
 
-    ResetArgs("-dir=/home/user/.bitcoin/./");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), absolute_path);
+    ResetArgs(local_args, "-dir=/home/user/.bitcoin/./");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), absolute_path);
 
-    ResetArgs("-dir=/home/user/.bitcoin/.//");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), absolute_path);
+    ResetArgs(local_args, "-dir=/home/user/.bitcoin/.//");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), absolute_path);
 
     const fs::path relative_path{"user/.bitcoin"};
-    ResetArgs("-dir=user/.bitcoin");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), relative_path);
+    ResetArgs(local_args, "-dir=user/.bitcoin");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), relative_path);
 
-    ResetArgs("-dir=somewhere/../user/.bitcoin");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), relative_path);
+    ResetArgs(local_args, "-dir=somewhere/../user/.bitcoin");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), relative_path);
 
-    ResetArgs("-dir=user/./.bitcoin");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), relative_path);
+    ResetArgs(local_args, "-dir=user/./.bitcoin");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), relative_path);
 
-    ResetArgs("-dir=user/.bitcoin/");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), relative_path);
+    ResetArgs(local_args, "-dir=user/.bitcoin/");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), relative_path);
 
-    ResetArgs("-dir=user/.bitcoin//");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), relative_path);
+    ResetArgs(local_args, "-dir=user/.bitcoin//");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), relative_path);
 
-    ResetArgs("-dir=user/.bitcoin/.");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), relative_path);
+    ResetArgs(local_args, "-dir=user/.bitcoin/.");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), relative_path);
 
-    ResetArgs("-dir=user/.bitcoin/./");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), relative_path);
+    ResetArgs(local_args, "-dir=user/.bitcoin/./");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), relative_path);
 
-    ResetArgs("-dir=user/.bitcoin/.//");
-    BOOST_CHECK_EQUAL(m_local_args.GetPathArg("-dir"), relative_path);
+    ResetArgs(local_args, "-dir=user/.bitcoin/.//");
+    BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), relative_path);
 }
 
 BOOST_AUTO_TEST_CASE(doubledash)
 {
+    ArgsManager local_args;
+
     const auto foo = std::make_pair("-foo", ArgsManager::ALLOW_ANY);
     const auto bar = std::make_pair("-bar", ArgsManager::ALLOW_ANY);
-    SetupArgs({foo, bar});
-    ResetArgs("--foo");
-    BOOST_CHECK_EQUAL(m_local_args.GetBoolArg("-foo", false), true);
+    SetupArgs(local_args, {foo, bar});
+    ResetArgs(local_args, "--foo");
+    BOOST_CHECK_EQUAL(local_args.GetBoolArg("-foo", false), true);
 
-    ResetArgs("--foo=verbose --bar=1");
-    BOOST_CHECK_EQUAL(m_local_args.GetArg("-foo", ""), "verbose");
-    BOOST_CHECK_EQUAL(m_local_args.GetIntArg("-bar", 0), 1);
+    ResetArgs(local_args, "--foo=verbose --bar=1");
+    BOOST_CHECK_EQUAL(local_args.GetArg("-foo", ""), "verbose");
+    BOOST_CHECK_EQUAL(local_args.GetIntArg("-bar", 0), 1);
 }
 
 BOOST_AUTO_TEST_CASE(boolargno)
 {
+    ArgsManager local_args;
+
     const auto foo = std::make_pair("-foo", ArgsManager::ALLOW_ANY);
     const auto bar = std::make_pair("-bar", ArgsManager::ALLOW_ANY);
-    SetupArgs({foo, bar});
-    ResetArgs("-nofoo");
-    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", true));
-    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", false));
+    SetupArgs(local_args, {foo, bar});
+    ResetArgs(local_args, "-nofoo");
+    BOOST_CHECK(!local_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(!local_args.GetBoolArg("-foo", false));
 
-    ResetArgs("-nofoo=1");
-    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", true));
-    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", false));
+    ResetArgs(local_args, "-nofoo=1");
+    BOOST_CHECK(!local_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(!local_args.GetBoolArg("-foo", false));
 
-    ResetArgs("-nofoo=0");
-    BOOST_CHECK(m_local_args.GetBoolArg("-foo", true));
-    BOOST_CHECK(m_local_args.GetBoolArg("-foo", false));
+    ResetArgs(local_args, "-nofoo=0");
+    BOOST_CHECK(local_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(local_args.GetBoolArg("-foo", false));
 
-    ResetArgs("-foo --nofoo"); // --nofoo should win
-    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", true));
-    BOOST_CHECK(!m_local_args.GetBoolArg("-foo", false));
+    ResetArgs(local_args, "-foo --nofoo"); // --nofoo should win
+    BOOST_CHECK(!local_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(!local_args.GetBoolArg("-foo", false));
 
-    ResetArgs("-nofoo -foo"); // foo always wins:
-    BOOST_CHECK(m_local_args.GetBoolArg("-foo", true));
-    BOOST_CHECK(m_local_args.GetBoolArg("-foo", false));
+    ResetArgs(local_args, "-nofoo -foo"); // foo always wins:
+    BOOST_CHECK(local_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(local_args.GetBoolArg("-foo", false));
 }
 
 BOOST_AUTO_TEST_CASE(logargs)
 {
+    ArgsManager local_args;
+
     const auto okaylog_bool = std::make_pair("-okaylog-bool", ArgsManager::ALLOW_ANY);
     const auto okaylog_negbool = std::make_pair("-okaylog-negbool", ArgsManager::ALLOW_ANY);
     const auto okaylog = std::make_pair("-okaylog", ArgsManager::ALLOW_ANY);
     const auto dontlog = std::make_pair("-dontlog", ArgsManager::ALLOW_ANY | ArgsManager::SENSITIVE);
-    SetupArgs({okaylog_bool, okaylog_negbool, okaylog, dontlog});
-    ResetArgs("-okaylog-bool -nookaylog-negbool -okaylog=public -dontlog=private");
+    SetupArgs(local_args, {okaylog_bool, okaylog_negbool, okaylog, dontlog});
+    ResetArgs(local_args, "-okaylog-bool -nookaylog-negbool -okaylog=public -dontlog=private");
 
     // Everything logged to debug.log will also append to str
     std::string str;
@@ -307,7 +309,7 @@ BOOST_AUTO_TEST_CASE(logargs)
         });
 
     // Log the arguments
-    m_local_args.LogArgs();
+    local_args.LogArgs();
 
     LogInstance().DeleteCallback(print_connection);
     // Check that what should appear does, and what shouldn't doesn't.


### PR DESCRIPTION
Avoid using a test fixture in getarg_tests for better readability. Change was implemented by _kiminuo_ and posted https://github.com/bitcoin/bitcoin/pull/24306#issuecomment-1036643216