### PR TITLE
refactor: make bind() and listen() mockable/testable

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2396,8 +2396,7 @@ bool CConnman::BindListenPort(const CService& addrBind, bilingual_str& strError,
 #endif
     }
 
-    if (::bind(sock->Get(), (struct sockaddr*)&sockaddr, len) == SOCKET_ERROR)
-    {
+    if (sock->Bind(reinterpret_cast<struct sockaddr*>(&sockaddr), len) == SOCKET_ERROR) {
         int nErr = WSAGetLastError();
         if (nErr == WSAEADDRINUSE)
             strError = strprintf(_("Unable to bind to %s on this computer. %s is probably already running."), addrBind.ToString(), PACKAGE_NAME);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2408,7 +2408,7 @@ bool CConnman::BindListenPort(const CService& addrBind, bilingual_str& strError,
     LogPrintf("Bound to %s\n", addrBind.ToString());
 
     // Listen for incoming connections
-    if (listen(sock->Get(), SOMAXCONN) == SOCKET_ERROR)
+    if (sock->Listen(SOMAXCONN) == SOCKET_ERROR)
     {
         strError = strprintf(_("Error: Listening for incoming connections failed (listen returned error %s)"), NetworkErrorString(WSAGetLastError()));
         LogPrintf("%s\n", strError.original);

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -180,6 +180,25 @@ int FuzzedSock::Bind(const sockaddr*, socklen_t) const
     return 0;
 }
 
+int FuzzedSock::Listen(int) const
+{
+    // Have a permanent error at listen_errnos[0] because when the fuzzed data is exhausted
+    // SetFuzzedErrNo() will always set the global errno to listen_errnos[0]. We want to
+    // avoid this method returning -1 and setting errno to a temporary error (like EAGAIN)
+    // repeatedly because proper code should retry on temporary errors, leading to an
+    // infinite loop.
+    constexpr std::array listen_errnos{
+        EADDRINUSE,
+        EINVAL,
+        EOPNOTSUPP,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, listen_errnos);
+        return -1;
+    }
+    return 0;
+}
+
 std::unique_ptr<Sock> FuzzedSock::Accept(sockaddr* addr, socklen_t* addr_len) const
 {
     constexpr std::array accept_errnos{

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -64,6 +64,8 @@ public:
 
     int Connect(const sockaddr*, socklen_t) const override;
 
+    int Bind(const sockaddr*, socklen_t) const override;
+
     std::unique_ptr<Sock> Accept(sockaddr* addr, socklen_t* addr_len) const override;
 
     int GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const override;

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -66,6 +66,8 @@ public:
 
     int Bind(const sockaddr*, socklen_t) const override;
 
+    int Listen(int backlog) const override;
+
     std::unique_ptr<Sock> Accept(sockaddr* addr, socklen_t* addr_len) const override;
 
     int GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const override;

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -127,6 +127,8 @@ public:
 
     int Connect(const sockaddr*, socklen_t) const override { return 0; }
 
+    int Bind(const sockaddr*, socklen_t) const override { return 0; }
+
     std::unique_ptr<Sock> Accept(sockaddr* addr, socklen_t* addr_len) const override
     {
         if (addr != nullptr) {

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -129,6 +129,8 @@ public:
 
     int Bind(const sockaddr*, socklen_t) const override { return 0; }
 
+    int Listen(int) const override { return 0; }
+
     std::unique_ptr<Sock> Accept(sockaddr* addr, socklen_t* addr_len) const override
     {
         if (addr != nullptr) {

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -79,6 +79,11 @@ int Sock::Bind(const sockaddr* addr, socklen_t addr_len) const
     return bind(m_socket, addr, addr_len);
 }
 
+int Sock::Listen(int backlog) const
+{
+    return listen(m_socket, backlog);
+}
+
 std::unique_ptr<Sock> Sock::Accept(sockaddr* addr, socklen_t* addr_len) const
 {
 #ifdef WIN32

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -74,6 +74,11 @@ int Sock::Connect(const sockaddr* addr, socklen_t addr_len) const
     return connect(m_socket, addr, addr_len);
 }
 
+int Sock::Bind(const sockaddr* addr, socklen_t addr_len) const
+{
+    return bind(m_socket, addr, addr_len);
+}
+
 std::unique_ptr<Sock> Sock::Accept(sockaddr* addr, socklen_t* addr_len) const
 {
 #ifdef WIN32

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -98,6 +98,12 @@ public:
     [[nodiscard]] virtual int Connect(const sockaddr* addr, socklen_t addr_len) const;
 
     /**
+     * bind(2) wrapper. Equivalent to `bind(this->Get(), addr, addr_len)`. Code that uses this
+     * wrapper can be unit tested if this method is overridden by a mock Sock implementation.
+     */
+    [[nodiscard]] virtual int Bind(const sockaddr* addr, socklen_t addr_len) const;
+
+    /**
      * accept(2) wrapper. Equivalent to `std::make_unique<Sock>(accept(this->Get(), addr, addr_len))`.
      * Code that uses this wrapper can be unit tested if this method is overridden by a mock Sock
      * implementation.

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -104,6 +104,12 @@ public:
     [[nodiscard]] virtual int Bind(const sockaddr* addr, socklen_t addr_len) const;
 
     /**
+     * listen(2) wrapper. Equivalent to `listen(this->Get(), backlog)`. Code that uses this
+     * wrapper can be unit tested if this method is overridden by a mock Sock implementation.
+     */
+    [[nodiscard]] virtual int Listen(int backlog) const;
+
+    /**
      * accept(2) wrapper. Equivalent to `std::make_unique<Sock>(accept(this->Get(), addr, addr_len))`.
      * Code that uses this wrapper can be unit tested if this method is overridden by a mock Sock
      * implementation.


### PR DESCRIPTION
_This is a piece of #21878, chopped off to ease review._

Add new methods `Sock::Bind()` and `Sock::Listen()` that wrap `bind()` and `listen()`.
This will help to increase `Sock` usage and make more code mockable.
