### PR TITLE
test: Run symlink regression tests on Windows

### DIFF
--- a/src/test/fs_tests.cpp
+++ b/src/test/fs_tests.cpp
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(rename)
     fs::remove(path2);
 }
 
-#ifndef WIN32
+#ifndef __MINGW64__ // no symlinks on mingw
 BOOST_AUTO_TEST_CASE(create_directories)
 {
     // Test fs::create_directories workaround.
@@ -174,6 +174,6 @@ BOOST_AUTO_TEST_CASE(create_directories)
     fs::remove(symlink);
     fs::remove(dir);
 }
-#endif // WIN32
+#endif // __MINGW64__
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/feature_dirsymlinks.py
+++ b/test/functional/feature_dirsymlinks.py
@@ -6,9 +6,8 @@
 """
 
 import os
-import sys
 
-from test_framework.test_framework import BitcoinTestFramework, SkipTest
+from test_framework.test_framework import BitcoinTestFramework
 
 
 def rename_and_link(*, from_name, to_name):
@@ -16,24 +15,27 @@ def rename_and_link(*, from_name, to_name):
     os.symlink(to_name, from_name)
     assert os.path.islink(from_name) and os.path.isdir(from_name)
 
-class SymlinkTest(BitcoinTestFramework):
-    def skip_test_if_missing_module(self):
-        if sys.platform == 'win32':
-            raise SkipTest("Symlinks test skipped on Windows")
 
+class SymlinkTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
 
     def run_test(self):
+        dir_new_blocks = self.nodes[0].chain_path / "new_blocks"
+        dir_new_chainstate = self.nodes[0].chain_path / "new_chainstate"
         self.stop_node(0)
 
-        rename_and_link(from_name=os.path.join(self.nodes[0].datadir, self.chain, "blocks"),
-                        to_name=os.path.join(self.nodes[0].datadir, self.chain, "newblocks"))
-        rename_and_link(from_name=os.path.join(self.nodes[0].datadir, self.chain, "chainstate"),
-                        to_name=os.path.join(self.nodes[0].datadir, self.chain, "newchainstate"))
+        rename_and_link(
+            from_name=self.nodes[0].chain_path / "blocks",
+            to_name=dir_new_blocks,
+        )
+        rename_and_link(
+            from_name=self.nodes[0].chain_path / "chainstate",
+            to_name=dir_new_chainstate,
+        )
 
         self.start_node(0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     SymlinkTest().main()


### PR DESCRIPTION
Seems odd to add tests, but not run them on the platform that needs them most.