### PR TITLE
build: upgrade depends Boost to 1.77.0

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,8 +1,8 @@
 package=boost
-$(package)_version=1.71.0
+$(package)_version=1.77.0
 $(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/$($(package)_version)/source/
 $(package)_file_name=boost_$(subst .,_,$($(package)_version)).tar.bz2
-$(package)_sha256_hash=d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee
+$(package)_sha256_hash=fc9f85fc030e233142908241af7a846e60630aa7388de9a5fafb1f3a26840854
 
 define $(package)_stage_cmds
   mkdir -p $($(package)_staging_prefix_dir)/include && \

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -6,7 +6,7 @@ These are the dependencies currently used by Bitcoin Core. You can find instruct
 | Dependency | Version used | Minimum required | CVEs | Shared | [Bundled Qt library](https://doc.qt.io/qt-5/configure-options.html#third-party-libraries) |
 | --- | --- | --- | --- | --- | --- |
 | Berkeley DB | [4.8.30](https://www.oracle.com/technetwork/database/database-technologies/berkeleydb/downloads/index.html) | 4.8.x | No |  |  |
-| Boost | [1.71.0](https://www.boost.org/users/download/) | [1.64.0](https://github.com/bitcoin/bitcoin/pull/22320) | No |  |  |
+| Boost | [1.77.0](https://www.boost.org/users/download/) | [1.64.0](https://github.com/bitcoin/bitcoin/pull/22320) | No |  |  |
 | Clang<sup>[ \* ](#note1)</sup> |  | [7.0](https://releases.llvm.org/download.html) (C++17 & std::filesystem support) |  |  |  |
 | Fontconfig | [2.12.6](https://www.freedesktop.org/software/fontconfig/release/) |  | No | Yes |  |
 | FreeType | [2.11.0](https://download.savannah.gnu.org/releases/freetype) |  | No |  | [Yes](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/qt.mk) (Android only) |


### PR DESCRIPTION
This primarily improves support for external signing, as it includes
multiple bugfixes for Boost Process. As well as various improvements to
the multi-index library.

#23340 rebased.

Guix build:
```bash
bash-5.1# find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
b5186404303e2a6573a6df404f943f6d172d4965bd9a78d7f9d1f7cf7080b774  guix-build-4bba7ab2ffc3/output/aarch64-linux-gnu/SHA256SUMS.part
9d03756665fac8cb1e3af6623b8cede3032bad6cbc15739db5145c4813f0c2f9  guix-build-4bba7ab2ffc3/output/aarch64-linux-gnu/bitcoin-4bba7ab2ffc3-aarch64-linux-gnu-debug.tar.gz
32897b5fda018d4fe57f65234da9620202de0b774ae4fa454309460ee451ef98  guix-build-4bba7ab2ffc3/output/aarch64-linux-gnu/bitcoin-4bba7ab2ffc3-aarch64-linux-gnu.tar.gz
f64304b16fbfaf7a7330842bf8f535acacdcdd36ddf185f5dfcdbe184f05571f  guix-build-4bba7ab2ffc3/output/arm-linux-gnueabihf/SHA256SUMS.part
f5cb4c742edf42aec2f64f97c727a8e325050d465ea58ff9c22f8b5b31073879  guix-build-4bba7ab2ffc3/output/arm-linux-gnueabihf/bitcoin-4bba7ab2ffc3-arm-linux-gnueabihf-debug.tar.gz
0f834947a3eb2d802ba4d1d6dbd26fea9d3453bd8c2dedb06fcfbf1498b45433  guix-build-4bba7ab2ffc3/output/arm-linux-gnueabihf/bitcoin-4bba7ab2ffc3-arm-linux-gnueabihf.tar.gz
389feef0bf716dd7ea7d72d755f999dbd2d3160f895a606ad6f4a14e97083a47  guix-build-4bba7ab2ffc3/output/arm64-apple-darwin/SHA256SUMS.part
a9c791b6bcc2bbeff0c94f71dbd9967676559297e089079216253e303acd82cb  guix-build-4bba7ab2ffc3/output/arm64-apple-darwin/bitcoin-4bba7ab2ffc3-arm64-apple-darwin.tar.gz
55cdef30941f3fc4716bae5be1230b529b171c5e2cd0c18cc57a15206d742a13  guix-build-4bba7ab2ffc3/output/arm64-apple-darwin/bitcoin-4bba7ab2ffc3-osx-unsigned.dmg
5343499bd15ae59627d3b33259ac7ccec8c841c8bc27cd1a47b41389fae48ac3  guix-build-4bba7ab2ffc3/output/arm64-apple-darwin/bitcoin-4bba7ab2ffc3-osx-unsigned.tar.gz
fbb99e7f3d5249b92c90ba312ac769adfc9813fb70468decd09f722826f48119  guix-build-4bba7ab2ffc3/output/dist-archive/bitcoin-4bba7ab2ffc3.tar.gz
c5f466eb462dccea8daa10307ff140844f38097b198282600528acd486915e97  guix-build-4bba7ab2ffc3/output/powerpc64-linux-gnu/SHA256SUMS.part
174c75cbf16f3ca593d1c684b597eb8dac483dc10ae3cd46cbff61d3f70e70a5  guix-build-4bba7ab2ffc3/output/powerpc64-linux-gnu/bitcoin-4bba7ab2ffc3-powerpc64-linux-gnu-debug.tar.gz
1e6692f4876ba13847cd3722c6e2cd3ee886ebede6b12dffa01b1dbc55186358  guix-build-4bba7ab2ffc3/output/powerpc64-linux-gnu/bitcoin-4bba7ab2ffc3-powerpc64-linux-gnu.tar.gz
dac7f60b99dfb96daf8c3c9a0b98d4ecc3a7ecf7ad6a8dfb879cb61aa4f2e429  guix-build-4bba7ab2ffc3/output/powerpc64le-linux-gnu/SHA256SUMS.part
4cef32efcd9fa591a53ea5354d63e9d6c0d663ae7748599b34427f17ef462f1c  guix-build-4bba7ab2ffc3/output/powerpc64le-linux-gnu/bitcoin-4bba7ab2ffc3-powerpc64le-linux-gnu-debug.tar.gz
d5ac47db91eb0232075a1138cc0ae212516e4f7fa022b2de181533d411a0d507  guix-build-4bba7ab2ffc3/output/powerpc64le-linux-gnu/bitcoin-4bba7ab2ffc3-powerpc64le-linux-gnu.tar.gz
7eb67ea46c7ade1f51928648e664bc2295a96ae0e3f144cf6903f277334b228f  guix-build-4bba7ab2ffc3/output/riscv64-linux-gnu/SHA256SUMS.part
b97d248731573ef3911f4d2750409615a940f975d9c4de783c76beb897a4dd53  guix-build-4bba7ab2ffc3/output/riscv64-linux-gnu/bitcoin-4bba7ab2ffc3-riscv64-linux-gnu-debug.tar.gz
7d2b0cef4cc83dbf54cd1af18fe4cb7b7ea408747e30993c20e1012b1b628373  guix-build-4bba7ab2ffc3/output/riscv64-linux-gnu/bitcoin-4bba7ab2ffc3-riscv64-linux-gnu.tar.gz
a45eb59edc5a1e8742dd9fce1a9916b43ab2894ff8f3c62d5110a9afa35cf9e9  guix-build-4bba7ab2ffc3/output/x86_64-apple-darwin/SHA256SUMS.part
504efd5c1131407a3e3120e77a1abe1e183727d995e7cb944c9c8089518314a0  guix-build-4bba7ab2ffc3/output/x86_64-apple-darwin/bitcoin-4bba7ab2ffc3-osx-unsigned.dmg
0f14f26d2074de96d078ea31ef249a6f9ba2db1fec86856496fca5ab2f517cb7  guix-build-4bba7ab2ffc3/output/x86_64-apple-darwin/bitcoin-4bba7ab2ffc3-osx-unsigned.tar.gz
574aab5513038a80c6cac16eb927d7dcec27b880ffd313c6b56272ed577e2df3  guix-build-4bba7ab2ffc3/output/x86_64-apple-darwin/bitcoin-4bba7ab2ffc3-osx64.tar.gz
ec7861c9840c2888022a81d5fbb807284c07f603053ba9cc200c103e26379e7f  guix-build-4bba7ab2ffc3/output/x86_64-linux-gnu/SHA256SUMS.part
9d1d2fb313d15048ae6b10b9c50942a00ef8c65c367b25656810b3819fdc95ff  guix-build-4bba7ab2ffc3/output/x86_64-linux-gnu/bitcoin-4bba7ab2ffc3-x86_64-linux-gnu-debug.tar.gz
d668065e2de147d352914f0d2f5769051f0ec0a29ce208979758724fe556cc04  guix-build-4bba7ab2ffc3/output/x86_64-linux-gnu/bitcoin-4bba7ab2ffc3-x86_64-linux-gnu.tar.gz
aa1f2ce87f707d28c137775830da128bd2b49b20eb258ff46a78f1ada1516480  guix-build-4bba7ab2ffc3/output/x86_64-w64-mingw32/SHA256SUMS.part
bcf3f19575662dadf3f77ca0bd5d4a3268314fd97c46f88679af1977d83863c5  guix-build-4bba7ab2ffc3/output/x86_64-w64-mingw32/bitcoin-4bba7ab2ffc3-win-unsigned.tar.gz
c8d64700e03757a5f46ec04dc7e2cdf9435ebdee9e6cea5789475ca86461f912  guix-build-4bba7ab2ffc3/output/x86_64-w64-mingw32/bitcoin-4bba7ab2ffc3-win64-debug.zip
92bd0cb7a43551e89910e8fabfb2915da03835ac074331436e1f159760ed8d19  guix-build-4bba7ab2ffc3/output/x86_64-w64-mingw32/bitcoin-4bba7ab2ffc3-win64-setup-unsigned.exe
e414c9a500ebf49ef1f2625c6763b945a13d5f1d1c56463f642f325e054f87ed  guix-build-4bba7ab2ffc3/output/x86_64-w64-mingw32/bitcoin-4bba7ab2ffc3-win64.zip
```