### PR TITLE
build: remove boost dep from libmultiprocess

### DIFF
--- a/depends/packages/libmultiprocess.mk
+++ b/depends/packages/libmultiprocess.mk
@@ -3,7 +3,7 @@ $(package)_version=$(native_$(package)_version)
 $(package)_download_path=$(native_$(package)_download_path)
 $(package)_file_name=$(native_$(package)_file_name)
 $(package)_sha256_hash=$(native_$(package)_sha256_hash)
-$(package)_dependencies=native_$(package) boost capnp
+$(package)_dependencies=native_$(package) capnp
 
 define $(package)_config_cmds
   $($(package)_cmake)


### PR DESCRIPTION
Looks like this hasn't been needed since https://github.com/chaincodelabs/libmultiprocess/pull/25 and was just missed in #19160.