### PR TITLE
test: Remove suppression no longer needed with headers-only Boost.Test

### DIFF
--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -22,10 +22,6 @@ deadlock:sync_tests::potential_deadlock_detected
 race:src/qt/test/*
 deadlock:src/qt/test/*
 
-# Race in src/test/main.cpp
-# Can be removed once upgraded to boost test 1.74 in depends
-race:validation_chainstatemanager_tests
-
 # External libraries
 deadlock:libdb
 race:libzmq


### PR DESCRIPTION
It appears, that moving to [headers-only](https://github.com/bitcoin/bitcoin/pull/24301) Boost.Test makes the removed suppression unneeded even without [bumping](https://github.com/bitcoin/bitcoin/pull/24383) boost version.