### PR TITLE
build: Fix configuring depends with cmake

### DIFF
--- a/depends/hosts/mingw32.mk
+++ b/depends/hosts/mingw32.mk
@@ -13,4 +13,4 @@ mingw32_debug_CXXFLAGS=$(mingw32_debug_CFLAGS)
 
 mingw32_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC
 
-mingw_cmake_system=Windows
+mingw32_cmake_system=Windows


### PR DESCRIPTION
This PR fixes bitcoin/bitcoin#24389.

On master (28aa0e3ca0a6cfeb5b2b63929d4bc58de6ee6f02) configuring of the `libmultiprocess` package for the `x86_64-w64-mingw32` target fails:
```
$ cd depends
$ make libmultiprocess_configured MULTIPROCESS=1 HOST=x86_64-w64-mingw32
Configuring libmultiprocess...
CMake Warning:
  No source or binary directory provided.  Both will be assumed to be the
  same as the current working directory, but note that this warning will
  become a fatal error in future CMake releases.


-- The CXX compiler identification is GNU 9.3.0
-- Check for working CXX compiler: /usr/bin/x86_64-w64-mingw32-g++-posix
-- Check for working CXX compiler: /usr/bin/x86_64-w64-mingw32-g++-posix -- broken
CMake Error at /usr/share/cmake-3.16/Modules/CMakeTestCXXCompiler.cmake:53 (message):
  The C++ compiler

    "/usr/bin/x86_64-w64-mingw32-g++-posix"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: /home/hebasto/GitHub/bitcoin/depends/work/build/x86_64-w64-mingw32/libmultiprocess/d576d975debdc9090bd2582f83f49c76c0061698-f496b1e64cb/CMakeFiles/CMakeTmp
    
    Run Build Command(s):/usr/bin/make cmTC_93273/fast && make[1]: Entering directory '/home/hebasto/GitHub/bitcoin/depends/work/build/x86_64-w64-mingw32/libmultiprocess/d576d975debdc9090bd2582f83f49c76c0061698-f496b1e64cb/CMakeFiles/CMakeTmp'
    /usr/bin/make -f CMakeFiles/cmTC_93273.dir/build.make CMakeFiles/cmTC_93273.dir/build
    make[2]: Entering directory '/home/hebasto/GitHub/bitcoin/depends/work/build/x86_64-w64-mingw32/libmultiprocess/d576d975debdc9090bd2582f83f49c76c0061698-f496b1e64cb/CMakeFiles/CMakeTmp'
    Building CXX object CMakeFiles/cmTC_93273.dir/testCXXCompiler.cxx.o
    /usr/bin/x86_64-w64-mingw32-g++-posix    -I/home/hebasto/GitHub/bitcoin/depends/x86_64-w64-mingw32/include     -pipe -O2    -o CMakeFiles/cmTC_93273.dir/testCXXCompiler.cxx.o -c /home/hebasto/GitHub/bitcoin/depends/work/build/x86_64-w64-mingw32/libmultiprocess/d576d975debdc9090bd2582f83f49c76c0061698-f496b1e64cb/CMakeFiles/CMakeTmp/testCXXCompiler.cxx
    Linking CXX executable cmTC_93273
    /usr/bin/cmake -E cmake_link_script CMakeFiles/cmTC_93273.dir/link.txt --verbose=1
    /usr/bin/x86_64-w64-mingw32-g++-posix  -I/home/hebasto/GitHub/bitcoin/depends/x86_64-w64-mingw32/include     -pipe -O2   -L/home/hebasto/GitHub/bitcoin/depends/x86_64-w64-mingw32/lib  -rdynamic CMakeFiles/cmTC_93273.dir/testCXXCompiler.cxx.o  -o cmTC_93273 
    x86_64-w64-mingw32-g++-posix: error: unrecognized command line option ‘-rdynamic’
    make[2]: *** [CMakeFiles/cmTC_93273.dir/build.make:87: cmTC_93273] Error 1
    make[2]: Leaving directory '/home/hebasto/GitHub/bitcoin/depends/work/build/x86_64-w64-mingw32/libmultiprocess/d576d975debdc9090bd2582f83f49c76c0061698-f496b1e64cb/CMakeFiles/CMakeTmp'
    make[1]: *** [Makefile:121: cmTC_93273/fast] Error 2
    make[1]: Leaving directory '/home/hebasto/GitHub/bitcoin/depends/work/build/x86_64-w64-mingw32/libmultiprocess/d576d975debdc9090bd2582f83f49c76c0061698-f496b1e64cb/CMakeFiles/CMakeTmp'
    
    

  

  CMake will not be able to correctly generate this project.
Call Stack (most recent call first):
  CMakeLists.txt:6 (project)


-- Configuring incomplete, errors occurred!
See also "/home/hebasto/GitHub/bitcoin/depends/work/build/x86_64-w64-mingw32/libmultiprocess/d576d975debdc9090bd2582f83f49c76c0061698-f496b1e64cb/CMakeFiles/CMakeOutput.log".
See also "/home/hebasto/GitHub/bitcoin/depends/work/build/x86_64-w64-mingw32/libmultiprocess/d576d975debdc9090bd2582f83f49c76c0061698-f496b1e64cb/CMakeFiles/CMakeError.log".
make: *** [funcs.mk:283: /home/hebasto/GitHub/bitcoin/depends/work/build/x86_64-w64-mingw32/libmultiprocess/d576d975debdc9090bd2582f83f49c76c0061698-f496b1e64cb/./.stamp_configured] Error 1

```

The reason of that failure is the unset `-DCMAKE_SYSTEM_NAME` flag:
```
$ make print-libmultiprocess_cmake MULTIPROCESS=1 HOST=x86_64-w64-mingw32
libmultiprocess_cmake=env CC="x86_64-w64-mingw32-gcc" CFLAGS="  -I/home/hebasto/GitHub/bitcoin/depends/x86_64-w64-mingw32/include     -pipe -O2    " CXX="x86_64-w64-mingw32-g++-posix" CXXFLAGS="  -I/home/hebasto/GitHub/bitcoin/depends/x86_64-w64-mingw32/include     -pipe -O2    " LDFLAGS="  -L/home/hebasto/GitHub/bitcoin/depends/x86_64-w64-mingw32/lib    " cmake -DCMAKE_INSTALL_PREFIX:PATH="/home/hebasto/GitHub/bitcoin/depends/x86_64-w64-mingw32" -DCMAKE_SYSTEM_NAME= -DCMAKE_C_COMPILER_TARGET=x86_64-w64-mingw32 -DCMAKE_CXX_COMPILER_TARGET=x86_64-w64-mingw32
```

This PR fixes this error:
```
$ make libmultiprocess_configured MULTIPROCESS=1 HOST=x86_64-w64-mingw32
$ # no errors
```