### PR TITLE
refactor: Avoid implicit-integer-sign-change in bech32.cpp

### DIFF
--- a/src/bech32.cpp
+++ b/src/bech32.cpp
@@ -284,10 +284,11 @@ inline unsigned char LowerCase(unsigned char c)
 }
 
 /** Return indices of invalid characters in a Bech32 string. */
-bool CheckCharacters(const std::string& str, std::vector<int>& errors) {
+bool CheckCharacters(const std::string& str, std::vector<int>& errors)
+{
     bool lower = false, upper = false;
     for (size_t i = 0; i < str.size(); ++i) {
-        unsigned char c = str[i];
+        unsigned char c{(unsigned char)(str[i])};
         if (c >= 'a' && c <= 'z') {
             if (upper) {
                 errors.push_back(i);

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -53,7 +53,6 @@ unsigned-integer-overflow:policy/fees.cpp
 unsigned-integer-overflow:prevector.h
 unsigned-integer-overflow:script/interpreter.cpp
 unsigned-integer-overflow:txmempool.cpp
-implicit-integer-sign-change:bech32.cpp
 implicit-integer-sign-change:compat/stdin.cpp
 implicit-integer-sign-change:compressor.h
 implicit-integer-sign-change:crypto/

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -51,15 +51,12 @@ unsigned-integer-overflow:crypto/
 unsigned-integer-overflow:hash.cpp
 unsigned-integer-overflow:policy/fees.cpp
 unsigned-integer-overflow:prevector.h
-unsigned-integer-overflow:pubkey.h
 unsigned-integer-overflow:script/interpreter.cpp
 unsigned-integer-overflow:txmempool.cpp
-unsigned-integer-overflow:util/strencodings.cpp
 implicit-integer-sign-change:bech32.cpp
 implicit-integer-sign-change:compat/stdin.cpp
 implicit-integer-sign-change:compressor.h
 implicit-integer-sign-change:crypto/
-implicit-integer-sign-change:key.cpp
 implicit-integer-sign-change:policy/fees.cpp
 implicit-integer-sign-change:prevector.h
 implicit-integer-sign-change:script/bitcoinconsensus.cpp


### PR DESCRIPTION
Clarifies sign conversion and allows to remove a file-wide suppression.

Also, includes an unrelated commit to remove unused suppressions.