### PR TITLE
refactor: Remove confusing P1008R1 violation in ATMPArgs

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -528,9 +528,26 @@ public:
                             /* m_package_submission */ true,
             };
         }
-        // No default ctor to avoid exposing details to clients and allowing the possibility of
+
+    private:
+        // Private ctor to avoid exposing details to clients and allowing the possibility of
         // mixing up the order of the arguments. Use static functions above instead.
-        ATMPArgs() = delete;
+        ATMPArgs(const CChainParams& chainparams,
+                 int64_t accept_time,
+                 bool bypass_limits,
+                 std::vector<COutPoint>& coins_to_uncache,
+                 bool test_accept,
+                 bool allow_bip125_replacement,
+                 bool package_submission)
+            : m_chainparams{chainparams},
+              m_accept_time{accept_time},
+              m_bypass_limits{bypass_limits},
+              m_coins_to_uncache{coins_to_uncache},
+              m_test_accept{test_accept},
+              m_allow_bip125_replacement{allow_bip125_replacement},
+              m_package_submission{package_submission}
+        {
+        }
     };
 
     // Single transaction acceptance


### PR DESCRIPTION
The `= delete` doesn't achieve the stated goal and it is also redundant, since it is not possible to default construct the `ATMPArgs` type.

This can be tested with:

```diff
diff --git a/src/validation.cpp b/src/validation.cpp
index 2813b62462..1c939c0b8a 100644
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -519,6 +519,7 @@ public:
         /** Parameters for child-with-unconfirmed-parents package validation. */
         static ATMPArgs PackageChildWithParents(const CChainParams& chainparams, int64_t accept_time,
                                                 std::vector<COutPoint>& coins_to_uncache) {
+            ATMPArgs{};
             return ATMPArgs{/* m_chainparams */ chainparams,
                             /* m_accept_time */ accept_time,
                             /* m_bypass_limits */ false,
```

Which fails on current master *and* this pull with the following error:

```
validation.cpp:525:22: error: reference member of type 'const CChainParams &' uninitialized
            ATMPArgs{};
                    ~^
validation.cpp:470:29: note: uninitialized reference member is here
        const CChainParams& m_chainparams;
                            ^
1 error generated.
```

Further reading (optional):
* http://open-std.org/JTC1/SC22/WG21/docs/papers/2018/p1008r1.pdf