### PR TITLE
test: Fix Wambiguous-reversed-operator compiler warnings

### DIFF
--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -137,7 +137,7 @@ public:
      * - vvNew entries refer to the same addresses
      * - vvTried entries refer to the same addresses
      */
-    bool operator==(const AddrManDeterministic& other)
+    bool operator==(const AddrManDeterministic& other) const
     {
         LOCK2(m_impl->cs, other.m_impl->cs);
 

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -38,13 +38,13 @@ public:
         READWRITE(obj.txval);
     }
 
-    bool operator==(const CSerializeMethodsTestSingle& rhs)
+    bool operator==(const CSerializeMethodsTestSingle& rhs) const
     {
-        return  intval == rhs.intval && \
-                boolval == rhs.boolval && \
-                stringval == rhs.stringval && \
-                strcmp(charstrval, rhs.charstrval) == 0 && \
-                *txval == *rhs.txval;
+        return intval == rhs.intval &&
+               boolval == rhs.boolval &&
+               stringval == rhs.stringval &&
+               strcmp(charstrval, rhs.charstrval) == 0 &&
+               *txval == *rhs.txval;
     }
 };
 


### PR DESCRIPTION
Add a missing const to avoid the C++20 clang **compiler warning**:

```
test/fuzz/addrman.cpp:325:22: error: ISO C++20 considers use of overloaded operator '==' (with operand types 'AddrManDeterministic' and 'AddrManDeterministic') to be ambiguous despite there being a unique best viable function [-Werror,-Wambiguous-reversed-operator]
    assert(addr_man1 == addr_man2);
           ~~~~~~~~~ ^  ~~~~~~~~~
/usr/include/assert.h:93:27: note: expanded from macro 'assert'
     (static_cast <bool> (expr)                                         \
                          ^~~~
test/fuzz/addrman.cpp:140:10: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
    bool operator==(const AddrManDeterministic& other)
         ^
1 error generated.
```

This patch also fixes the **compile error** if the first operand is `const`:

```
test/fuzz/addrman.cpp:326:23: error: invalid operands to binary expression ('const AddrManDeterministic' and 'AddrManDeterministic')
    assert(addr_man_1 == addr_man2);
           ~~~~~~~~~~ ^  ~~~~~~~~~
/usr/include/assert.h:90:27: note: expanded from macro 'assert'
     (static_cast <bool> (expr)                                         \
                          ^~~~
test/fuzz/addrman.cpp:140:10: note: candidate function not viable: 'this' argument has type 'const AddrManDeterministic', but method is not marked const
    bool operator==(const AddrManDeterministic& other)
         ^
1 error generated.
