### PR TITLE
fees: make the class FeeFilterRounder thread-safe

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -1010,8 +1010,10 @@ FeeFilterRounder::FeeFilterRounder(const CFeeRate& minIncrementalFee)
 CAmount FeeFilterRounder::round(CAmount currentMinFee)
 {
     std::set<double>::iterator it = feeset.lower_bound(currentMinFee);
-    if ((it != feeset.begin() && insecure_rand.rand32() % 3 != 0) || it == feeset.end()) {
-        it--;
+    if (it == feeset.end() ||
+        (it != feeset.begin() &&
+         WITH_LOCK(m_insecure_rand_mutex, return insecure_rand.rand32()) % 3 != 0)) {
+        --it;
     }
     return static_cast<CAmount>(*it);
 }

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -297,13 +297,13 @@ private:
 
 public:
     /** Create new FeeFilterRounder */
-    explicit FeeFilterRounder(const CFeeRate& minIncrementalFee);
+    explicit FeeFilterRounder(const CFeeRate& min_incremental_fee);
 
     /** Quantize a minimum fee for privacy purpose before broadcast. */
     CAmount round(CAmount currentMinFee);
 
 private:
-    const std::set<double> feeset;
+    const std::set<double> m_fee_set;
     Mutex m_insecure_rand_mutex;
     FastRandomContext insecure_rand GUARDED_BY(m_insecure_rand_mutex);
 };

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -299,12 +299,13 @@ public:
     /** Create new FeeFilterRounder */
     explicit FeeFilterRounder(const CFeeRate& minIncrementalFee);
 
-    /** Quantize a minimum fee for privacy purpose before broadcast. Not thread-safe due to use of FastRandomContext */
+    /** Quantize a minimum fee for privacy purpose before broadcast. */
     CAmount round(CAmount currentMinFee);
 
 private:
     std::set<double> feeset;
-    FastRandomContext insecure_rand;
+    Mutex m_insecure_rand_mutex;
+    FastRandomContext insecure_rand GUARDED_BY(m_insecure_rand_mutex);
 };
 
 #endif // BITCOIN_POLICY_FEES_H

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -303,7 +303,7 @@ public:
     CAmount round(CAmount currentMinFee);
 
 private:
-    std::set<double> feeset;
+    const std::set<double> feeset;
     Mutex m_insecure_rand_mutex;
     FastRandomContext insecure_rand GUARDED_BY(m_insecure_rand_mutex);
 };


### PR DESCRIPTION
Make the class `FeeFilterRounder` thread-safe so that its methods can be called concurrently by different threads on the same object. Currently it has just one method (`round()`).

The second commit is optional, but it improves readability, showing that the `feeset` member will never be changed, thus does not need protection from concurrent access.