### PR TITLE
doc: Avoid ADL for function calls

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -105,6 +105,28 @@ code.
   - `nullptr` is preferred over `NULL` or `(void*)0`.
   - `static_assert` is preferred over `assert` where possible. Generally; compile-time checking is preferred over run-time checking.
 
+For function calls a namespace should be specified explicitly, unless such functions have been declared within it.
+Otherwise, [argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl), also known as ADL, could be
+triggered that makes code harder to maintain and reason about:
+```c++
+#include <filesystem>
+
+namespace fs {
+class path : public std::filesystem::path
+{
+};
+// The intention is to disallow this function.
+bool exists(const fs::path& p) = delete;
+} // namespace fs
+
+int main()
+{
+    //fs::path p; // error
+    std::filesystem::path p; // compiled
+    exists(p); // ADL being used for unqualified name lookup
+}
+```
+
 Block style example:
 ```c++
 int g_count = 0;


### PR DESCRIPTION
It happened two times recently, when [ADL](https://en.cppreference.com/w/cpp/language/adl) popped up unexpectedly and brought some confusion:
- https://github.com/bitcoin/bitcoin/pull/24338/files#r805989994
> Any idea why this even compiles?
- https://www.erisian.com.au/bitcoin-core-dev/log-2022-02-18.html#l-51:
> 2022-02-18T03:24:14  \<dongcarl\> Does anyone know why this compiles? https://github.com/dongcarl/bitcoin/commit/6d3d2caa3751f968f72d19fa84f001472fb26749
> 2022-02-18T03:24:14  \<dongcarl\> GetUTXOStatsWithHasher and MakeUTXOHasher are both in the `kernel::` namespace and I never added a `using` declaration on top...
> 2022-02-18T03:25:53  \<sipa\> https://en.cppreference.com/w/cpp/language/adl ?

Let's document our intention to avoid similar cases in the future.