### PR TITLE
Chainparams update for 23.x

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -166,10 +166,10 @@ public:
         };
 
         chainTxData = ChainTxData{
-            // Data from RPC: getchaintxstats 4096 00000000000000000008a89e854d57e5667df88f1cdef6fde2fbca1de5b639ad
-            /* nTime    */ 1626697539,
-            /* nTxCount */ 656509474,
-            /* dTxRate  */ 2.424920418708139,
+            // Data from RPC: getchaintxstats 4096 000000000000000000052d314a259755ca65944e68df6b12a067ea8f1f5a7091
+            /* nTime    */ 1645542140,
+            /* nTxCount */ 712531200,
+            /* dTxRate  */ 2.891036496010309,
         };
     }
 };
@@ -261,10 +261,10 @@ public:
         };
 
         chainTxData = ChainTxData{
-            // Data from RPC: getchaintxstats 4096 0000000000004ae2f3896ca8ecd41c460a35bf6184e145d91558cece1c688a76
-            /* nTime    */ 1625727096,
-            /* nTxCount */ 60408943,
-            /* dTxRate  */ 0.08379062270367649,
+            // Data from RPC: getchaintxstats 4096 00000000d18cfe81cbeea665076807789bd8f831d557632e635bc6e3c003069e
+            /* nTime    */ 1645635119,
+            /* nTxCount */ 62226341,
+            /* dTxRate  */ 0.07717997442177152,
         };
     }
 };
@@ -291,10 +291,10 @@ public:
             m_assumed_blockchain_size = 1;
             m_assumed_chain_state_size = 0;
             chainTxData = ChainTxData{
-                // Data from RPC: getchaintxstats 4096 000000187d4440e5bff91488b700a140441e089a8aaea707414982460edbfe54
-                /* nTime    */ 1626696658,
-                /* nTxCount */ 387761,
-                /* dTxRate  */ 0.04035946932424404,
+                // Data from RPC: getchaintxstats 4096 0000003d9144c56ac110ae04a0c271a0acce2f14f426b39fdf0d938c96d2eb09
+                /* nTime    */ 1645631279,
+                /* nTxCount */ 1257429,
+                /* dTxRate  */ 0.1389638742514995,
             };
         } else {
             const auto signet_challenge = args.GetArgs("-signetchallenge");

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -91,8 +91,8 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1628640000; // August 11th, 2021
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 709632; // Approximately November 12th, 2021
 
-        consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000001fa4663bbbe19f82de910280");
-        consensus.defaultAssumeValid = uint256S("0x00000000000000000008a89e854d57e5667df88f1cdef6fde2fbca1de5b639ad"); // 691719
+        consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000002927cdceccbd5209e81e80db");
+        consensus.defaultAssumeValid = uint256S("0x000000000000000000052d314a259755ca65944e68df6b12a067ea8f1f5a7091"); // 724466
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -210,8 +210,8 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1628640000; // August 11th, 2021
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
-        consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000005180c3bd8290da33a1a");
-        consensus.defaultAssumeValid = uint256S("0x0000000000004ae2f3896ca8ecd41c460a35bf6184e145d91558cece1c688a76"); // 2010000
+        consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000064728c7be6fe4b2f961");
+        consensus.defaultAssumeValid = uint256S("0x00000000000163cfb1f97c4e4098a3692c8053ad9cab5ad9c86b338b5c00b8b7"); // 2143398
 
         pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;
@@ -286,8 +286,8 @@ public:
             vSeeds.emplace_back("178.128.221.177");
             vSeeds.emplace_back("v7ajjeirttkbnt32wpy3c6w3emwnfr3fkla7hpxcfokr3ysd3kqtzmqd.onion:38333");
 
-            consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000000000008546553c03");
-            consensus.defaultAssumeValid = uint256S("0x000000187d4440e5bff91488b700a140441e089a8aaea707414982460edbfe54"); // 47200
+            consensus.nMinimumChainWork = uint256S("0x000000000000000000000000000000000000000000000000000000de26b0e471");
+            consensus.defaultAssumeValid = uint256S("0x00000112852484b5fe3451572368f93cfd2723279af3464e478aee35115256ef"); // 78788
             m_assumed_blockchain_size = 1;
             m_assumed_chain_state_size = 0;
             chainTxData = ChainTxData{

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -105,7 +105,7 @@ public:
         pchMessageStart[3] = 0xd9;
         nDefaultPort = 8333;
         nPruneAfterHeight = 100000;
-        m_assumed_blockchain_size = 420;
+        m_assumed_blockchain_size = 460;
         m_assumed_chain_state_size = 6;
 
         genesis = CreateGenesisBlock(1231006505, 2083236893, 0x1d00ffff, 1, 50 * COIN);


### PR DESCRIPTION
Update chain parameters for upcoming major release. See [doc/release-process.md](https://github.com/bitcoin/bitcoin/blob/master/doc/release-process.md) for review instructions.

- `m_assumed_blockchain_size`, `m_assumed_chain_state_size`:

```
bitcoin$ du -h .
105M    ./blocks/index
415G    ./blocks
4.5G    ./chainstate
420G    .
bitcoin$ python3
Python 3.9.10 (main, Jan 16 2022, 17:12:18)
[GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 420 * 1.1
462.00000000000006
>>> 5 * 1.1
5.5
```

- `chainTxData`:
```
cli getchaintxstats 4096 000000000000000000052d314a259755ca65944e68df6b12a067ea8f1f5a7091
{
  "time": 1645542140,
  "txcount": 712531200,
  "window_final_block_hash": "000000000000000000052d314a259755ca65944e68df6b12a067ea8f1f5a7091",
  "window_final_block_height": 724466,
  "window_block_count": 4096,
  "window_tx_count": 6950257,
  "window_interval": 2404071,
  "txrate": 2.891036496010309
}
```

- `nMinimumChainWork`, `defaultAssumeValid`:

```
$ cli getblockhash 724466 # was two from the tip at the time
000000000000000000052d314a259755ca65944e68df6b12a067ea8f1f5a7091
$ cli getblockheader 000000000000000000052d314a259755ca65944e68df6b12a067ea8f1f5a7091
{
  "hash": "000000000000000000052d314a259755ca65944e68df6b12a067ea8f1f5a7091",
  "confirmations": 3,
  "height": 724466,
  "version": 939515908,
  "versionHex": "37ffe004",
  "merkleroot": "35a08d9647972e7c3ec39ee7f4ab434f03445de7c446a4d1acc1254b4546bbbe",
  "time": 1645542140,
  "mediantime": 1645539567,
  "nonce": 188699556,
  "bits": "170a1078",
  "difficulty": 27967152532434.23,
  "chainwork": "00000000000000000000000000000000000000002927cdceccbd5209e81e80db",
  "nTx": 1948,
  "previousblockhash": "000000000000000000075e26c23c2ecec4e34699411ccd712ff6f2d252f65a78",
  "nextblockhash": "0000000000000000000905369cd69f68323e3e8da2933a78bea0b2cdb8baa89f"
}
```
