### PR TITLE
util: improve bitcoin-wallet exit codes

### DIFF
--- a/contrib/devtools/gen-manpages.py
+++ b/contrib/devtools/gen-manpages.py
@@ -36,7 +36,7 @@ versions = []
 for relpath in BINARIES:
     abspath = os.path.join(builddir, relpath)
     try:
-        r = subprocess.run([abspath, '--version'], stdout=subprocess.PIPE, universal_newlines=True)
+        r = subprocess.run([abspath, '--version'], stdout=subprocess.PIPE, check=True, universal_newlines=True)
     except IOError:
         print(f'{abspath} not found or not an executable', file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
Refactors `bitcoin-wallet` so that it doesn't return a non-zero exit code by default, and makes the option handling more inline with the other binaries. i.e outputting `Error: too few parameters` if you don't pass any options.

Fixing this means we can check the process output in `gen-manpages.py`; which addresses the remaining [review comment](https://github.com/bitcoin/bitcoin/pull/24263#discussion_r806126705) from #24263.