### PR TITLE
test: Check error for non-existent directory symlink

### DIFF
--- a/src/test/fs_tests.cpp
+++ b/src/test/fs_tests.cpp
@@ -171,8 +171,14 @@ BOOST_AUTO_TEST_CASE(create_directories)
     BOOST_CHECK(fs::is_directory(symlink));
     BOOST_CHECK(!fs::create_directories(symlink));
 
-    fs::remove(symlink);
     fs::remove(dir);
+    BOOST_CHECK(!fs::exists(symlink));
+    BOOST_CHECK(fs::is_symlink(symlink));
+    BOOST_CHECK(!fs::is_directory(symlink));
+    // Next check is disabled due to a bug in libc++-11
+    // See https://github.com/bitcoin/bitcoin/pull/24432#issuecomment-1049060318
+    // BOOST_CHECK_THROW(fs::create_directories(symlink), fs::filesystem_error);
+    fs::remove(symlink);
 }
 #endif // __MINGW64__
 


### PR DESCRIPTION
Add a test for the case where the symlink points to a non-existing directory. This confirms the behaviour is identical to the one in v22.0 (using boost):

```
 node0 stderr ************************
EXCEPTION: N5boost10filesystem16filesystem_errorE       
boost::filesystem::create_directory: File exists: "/tmp/bitcoin_func_test_jozyx4wp/node0/regtest/blocks"       
bitcoin in AppInit() 
