### PR TITLE
fuzz: Limit script_format to 100kB

### DIFF
--- a/src/test/fuzz/script_format.cpp
+++ b/src/test/fuzz/script_format.cpp
@@ -3,7 +3,9 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <consensus/consensus.h>
 #include <core_io.h>
+#include <policy/policy.h>
 #include <script/script.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
@@ -19,6 +21,9 @@ FUZZ_TARGET_INIT(script_format, initialize_script_format)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const CScript script{ConsumeScript(fuzzed_data_provider)};
+    if (script.size() > MAX_STANDARD_TX_WEIGHT / WITNESS_SCALE_FACTOR) {
+        return;
+    }
 
     (void)FormatScript(script);
     (void)ScriptToAsmStr(script, /*fAttemptSighashDecode=*/fuzzed_data_provider.ConsumeBool());


### PR DESCRIPTION
The target is still one of the slowest ones, but doesn't seem incredibly important. Especially for sizes larger than the standard tx size.

Fix that by limiting the script size.