### PR TITLE
Guix: Fix building for i686-linux-gnu

### DIFF
--- a/contrib/devtools/security-check.py
+++ b/contrib/devtools/security-check.py
@@ -111,6 +111,14 @@ def check_ELF_separate_code(binary):
                 return False
     return True
 
+def control_flow_instruction_for(binary):
+    assert lief.ARCHITECTURES.X86 == binary.abstract.header.architecture
+    if binary.abstract.header.is_32:
+        return [243, 15, 30, 251]  # endbr32
+    if binary.abstract.header.is_64:
+        return [243, 15, 30, 250]  # endbr64
+    raise RuntimeError('unknown control flow instruction')
+
 def check_ELF_control_flow(binary) -> bool:
     '''
     Check for control flow instrumentation
@@ -118,7 +126,7 @@ def check_ELF_control_flow(binary) -> bool:
     main = binary.get_function_address('main')
     content = binary.get_content_from_virtual_address(main, 4, lief.Binary.VA_TYPES.AUTO)
 
-    if content == [243, 15, 30, 250]: # endbr64
+    if content == control_flow_instruction_for(binary):
         return True
     return False
 
@@ -147,7 +155,7 @@ def check_PE_control_flow(binary) -> bool:
 
     content = binary.get_content_from_virtual_address(virtual_address, 4, lief.Binary.VA_TYPES.VA)
 
-    if content == [243, 15, 30, 250]: # endbr64
+    if content == control_flow_instruction_for(binary):
         return True
     return False
 
@@ -189,7 +197,7 @@ def check_MACHO_control_flow(binary) -> bool:
     '''
     content = binary.get_content_from_virtual_address(binary.entrypoint, 4, lief.Binary.VA_TYPES.AUTO)
 
-    if content == [243, 15, 30, 250]: # endbr64
+    if content == control_flow_instruction_for(binary):
         return True
     return False
 

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -37,7 +37,14 @@ LIEF_ELF_ARCH_RISCV = lief.ELF.ARCH(243)
 # See https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html for more info.
 
 MAX_VERSIONS = {
-'GCC':       (4,8,0),
+'GCC': {
+    lief.ELF.ARCH.i386:   (7,0,0),  # requires Debian 10, Ubuntu 18.04
+    lief.ELF.ARCH.x86_64: (4,8,0),
+    lief.ELF.ARCH.ARM:    (4,8,0),
+    lief.ELF.ARCH.AARCH64:(4,8,0),
+    lief.ELF.ARCH.PPC64:  (4,8,0),
+    LIEF_ELF_ARCH_RISCV:  (4,8,0),
+},
 'GLIBC': {
     lief.ELF.ARCH.i386:   (2,18),
     lief.ELF.ARCH.x86_64: (2,18),

--- a/contrib/devtools/test-symbol-check.py
+++ b/contrib/devtools/test-symbol-check.py
@@ -6,6 +6,7 @@
 Test script for symbol-check.py
 '''
 import os
+import re
 import subprocess
 from typing import List
 import unittest
@@ -59,9 +60,10 @@ class TestSymbolChecks(unittest.TestCase):
                 }
         ''')
 
-        self.assertEqual(call_symbol_check(cc, source, executable, ['-lm']),
-                (1, executable + ': symbol nextup from unsupported version GLIBC_2.24(3)\n' +
-                    executable + ': failed IMPORTED_SYMBOLS'))
+        result = call_symbol_check(cc, source, executable, ['-lm'])
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], 1)
+        self.assertTrue(re.match(rf'^{executable}: symbol nextup from unsupported version GLIBC_2\.24\(\d+\)\n{executable}: failed IMPORTED_SYMBOLS', result[1]))
 
         # -lutil is part of the libc6 package so a safe bet that it's installed
         # it's also out of context enough that it's unlikely to ever become a real dependency


### PR DESCRIPTION
This seems to be what is needed to get i686-linux-gnu Guix builds working.

Since we don't officially provide i686-linux-gnu release binaries, I'm not sure if this is wanted for Core. Considering the need to reintroduce `--enable-glibc-back-compat`, I would guess we don't want it. But at the same time, our Guix stuff presently has incomplete/broken i686 support, so maybe others might disagree and think it's worth keeping. (I'm keeping it in Knots for now, so might as well offer it for Core here too.)

Note that for `__divmoddi4`, I have reintroduced it with a very simple (copyright-immune?) replacement similar to the one used by LLVM. Prior versions (0.17-0.21) using it had copied GPL 3 code from GCC.

Previous versions had also used this `__divmoddi4` substitution concept for ARM. As far as I can tell, it was never needed for ARM. While ARM uses a similar method, the equivalent libgcc functions it calls appear to be older than on x86-32.

Also note we cannot use the "build with an older library" trick for `__divmoddi4` because it is part of GCC, not glibc, and we require a fairly new GCC to build at all, at this point.