### PR TITLE
test: Correctly decode UTF-8 literal string paths

### DIFF
--- a/src/test/fs_tests.cpp
+++ b/src/test/fs_tests.cpp
@@ -46,8 +46,8 @@ BOOST_AUTO_TEST_CASE(fsbridge_fstream)
 {
     fs::path tmpfolder = m_args.GetDataDirBase();
     // tmpfile1 should be the same as tmpfile2
-    fs::path tmpfile1 = tmpfolder / "fs_tests_₿_🏃";
-    fs::path tmpfile2 = tmpfolder / "fs_tests_₿_🏃";
+    fs::path tmpfile1 = tmpfolder / fs::u8path("fs_tests_₿_🏃");
+    fs::path tmpfile2 = tmpfolder / fs::u8path("fs_tests_₿_🏃");
     {
         std::ofstream file{tmpfile1};
         file << "bitcoin";
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(fsbridge_fstream)
     }
     {
         // Join an absolute path and a relative path.
-        fs::path p = fsbridge::AbsPathJoin(tmpfolder, "fs_tests_₿_🏃");
+        fs::path p = fsbridge::AbsPathJoin(tmpfolder, fs::u8path("fs_tests_₿_🏃"));
         BOOST_CHECK(p.is_absolute());
         BOOST_CHECK_EQUAL(tmpfile1, p);
     }


### PR DESCRIPTION
Call `fs::u8path()` to convert some UTF-8 string literals to paths, instead of relying on the implicit conversion. Fake Macro pointed out in https://github.com/bitcoin/bitcoin/pull/24306#discussion_r818566106 that `fs_tests` are incorrectly decoding some literal UTF-8 paths using the current windows codepage, instead of treating them as UTF-8. This could cause test failures depending what environment windows tests are run under.

The `fs::path` class exists to avoid problems like this, but because it is lenient with `const char*` conversions, under assumption that they are ["safe as long as the literals are ASCII"](https://github.com/bitcoin/bitcoin/blob/727b0cb59259ac63c627b09b503faada1a89bfb8/src/fs.h#L39), bugs like this are still possible.

If we think this is a concern, followup options to try to prevent this bug in the future are:

0. Do nothing
1. Improve the "safe as long as the literals are ASCII" comment. Make it clear that non-ASCII strings are invalid.
2. Drop the implicit `const char*` conversion functions. This would be nice because it would simplifify the `fs::path` class a little, while making it safer. Drawback is that it would require some more verbosity from callers. For example, instead of `GetDataDirNet() / "mempool.dat"` they would have to write `GetDataDirNet() / fs::u8path("mempool.dat")`
3. Keep the implicit `const char*` conversion functions, but make them call `fs::u8path()` internally. Change the "safe as long as the literals are *ASCII*" comment to "safe as long as the literals are *UTF-8*".

I'd be happy with 0, 1, or 2. I'd be a little resistant to 3 even though it was would add more safety, because it would slightly increase complexity, and because I think it would encourage representing paths as strings, when I think there are so many footguns associated with paths as strings, that it's best to convert strings to paths at the earliest point possible, and convert paths to strings at the latest point possible.