### PR TITLE
fuzz: execute each file in dir without fuzz engine

### DIFF
--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -10,7 +10,9 @@
 #include <test/util/setup_common.h>
 #include <util/check.h>
 #include <util/sock.h>
+#include <util/time.h>
 
+#include <csignal>
 #include <cstdint>
 #include <exception>
 #include <fstream>
@@ -59,6 +61,7 @@ void FuzzFrameworkRegisterTarget(std::string_view name, TypeTestOneInput target,
     Assert(it_ins.second);
 }
 
+static std::string_view g_fuzz_target;
 static TypeTestOneInput* g_test_one_input{nullptr};
 
 void initialize()
@@ -92,9 +95,12 @@ void initialize()
         should_abort = true;
     }
     Assert(!should_abort);
-    std::string_view fuzz_target{Assert(std::getenv("FUZZ"))};
-    const auto it = FuzzTargets().find(fuzz_target);
-    Assert(it != FuzzTargets().end());
+    g_fuzz_target = Assert(std::getenv("FUZZ"));
+    const auto it = FuzzTargets().find(g_fuzz_target);
+    if (it == FuzzTargets().end()) {
+        std::cerr << "No fuzzer for " << g_fuzz_target << "." << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
     Assert(!g_test_one_input);
     g_test_one_input = &std::get<0>(it->second);
     std::get<1>(it->second)();
@@ -109,6 +115,35 @@ static bool read_stdin(std::vector<uint8_t>& data)
         data.insert(data.end(), buffer, buffer + length);
     }
     return length == 0;
+}
+#endif
+
+#if defined(PROVIDE_FUZZ_MAIN_FUNCTION) && !defined(__AFL_LOOP)
+static bool read_file(fs::path p, std::vector<uint8_t>& data)
+{
+    uint8_t buffer[1024];
+    FILE* f = fsbridge::fopen(p, "rb");
+    if (f == nullptr) return false;
+    do {
+        const size_t length = fread(buffer, sizeof(uint8_t), sizeof(buffer), f);
+        if (ferror(f)) return false;
+        data.insert(data.end(), buffer, buffer + length);
+    } while (!feof(f));
+    fclose(f);
+    return true;
+}
+#endif
+
+#if defined(PROVIDE_FUZZ_MAIN_FUNCTION) && !defined(__AFL_LOOP)
+static fs::path g_input_path;
+void signal_handler(int signal)
+{
+    if (signal == SIGABRT) {
+        std::cerr << "Error processing input " << g_input_path << std::endl;
+    } else {
+        std::cerr << "Unexpected signal " << signal << " received\n";
+    }
+    std::_Exit(EXIT_FAILURE);
 }
 #endif
 
@@ -151,10 +186,37 @@ int main(int argc, char** argv)
     }
 #else
     std::vector<uint8_t> buffer;
-    if (!read_stdin(buffer)) {
+    if (argc <= 1) {
+        if (!read_stdin(buffer)) {
+            return 0;
+        }
+        test_one_input(buffer);
         return 0;
     }
-    test_one_input(buffer);
+    std::signal(SIGABRT, signal_handler);
+    int64_t start_time = GetTimeSeconds();
+    int tested = 0;
+    for (int i = 1; i < argc; ++i) {
+        fs::path input_path(*(argv + i));
+        if (fs::is_directory(input_path)) {
+            for (fs::directory_iterator it(input_path); it != fs::directory_iterator(); ++it) {
+                if (!fs::is_regular_file(it->path())) continue;
+                g_input_path = it->path();
+                Assert(read_file(it->path(), buffer));
+                test_one_input(buffer);
+                ++tested;
+                buffer.clear();
+            }
+        } else {
+            g_input_path = input_path;
+            Assert(read_file(input_path, buffer));
+            test_one_input(buffer);
+            ++tested;
+            buffer.clear();
+        }
+    }
+    int64_t end_time = GetTimeSeconds();
+    std::cout << g_fuzz_target << ": succeeded against " << tested << " files in " << (end_time - start_time) << "s." << std::endl;
 #endif
     return 0;
 }


### PR DESCRIPTION
Phony fuzzing (phuzzing)! Run the fuzz testing code against known inputs to detect errors. Advantage is you can easily test using the existing qa-assets datasets without having to compile with fuzzing enabled; disadvantage is that it doesn't do any actual fuzzing.

Example usage:

```
$ for a in ${QA_ASSETS}/fuzz_seed_corpus/*; do echo ${a##*/}; done | xargs -P8 -I {} /bin/sh -c "FUZZ={} test/fuzz/fuzz ${QA_ASSETS}/fuzz_seed_corpus/{}"
No fuzzer for address_deserialize.
No fuzzer for addrdb.
No fuzzer for banentry_deserialize.
addition_overflow: succeeded against 848 files in 0s.
asmap: succeeded against 981 files in 0s.
checkqueue: succeeded against 211 files in 0s.
...
```

(`-P8` says run 8 of the tasks in parallel)

If there are failures, the first one will be reported and the program will abort with output like:

```
fuzz: test/fuzz/versionbits.cpp:336: void (anonymous namespace)::versionbits_fuzz_target(FuzzBufferType): Assertion `exp_state != ThresholdState::FAILED' failed.
Error processing seed "corpus/versionbits/35345ae8e722234095810b1117a29b63af7621af"
```

Rebase of #22763, which was a rebase of #21496, but also reports the name of the fuzzer and the time taken.

Fixes #21461