### PR TITLE
[22.x] fs: Make compatible with boost 1.78

### DIFF
--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -22,7 +22,7 @@ bool VerifyWallets(interfaces::Chain& chain)
         fs::path wallet_dir = gArgs.GetArg("-walletdir", "");
         boost::system::error_code error;
         // The canonical path cleans the path, preventing >1 Berkeley environment instances for the same directory
-        fs::path canonical_wallet_dir = fs::canonical(wallet_dir, error);
+        fs::path canonical_wallet_dir = fs::canonical(wallet_dir, error).remove_trailing_separator();
         if (error || !fs::exists(wallet_dir)) {
             chain.initError(strprintf(_("Specified -walletdir \"%s\" does not exist"), wallet_dir.string()));
             return false;

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -141,7 +141,7 @@ class MultiWalletTest(BitcoinTestFramework):
 
         # should raise rpc error if wallet path can't be created
         err_code = -4 if self.options.descriptors else -1
-        assert_raises_rpc_error(err_code, "boost::filesystem::create_directory:", self.nodes[0].createwallet, "w8/bad")
+        assert_raises_rpc_error(err_code, "boost::filesystem::create_director", self.nodes[0].createwallet, "w8/bad")
 
         # check that all requested wallets were created
         self.stop_node(0)


### PR DESCRIPTION
Backports #24104 to the `22.x` branch to fix the build with Boost 1.78.0.