### PR TITLE
Bugfix: util: Correctly handle Number value types in GetArg/GetBoolArg

### DIFF
--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -100,22 +100,22 @@ BOOST_AUTO_TEST_CASE(setting_args)
     BOOST_CHECK_EQUAL(args.GetSetting("foo").write(), "99");
     BOOST_CHECK_EQUAL(args.GetArg("foo", "default"), "99");
     BOOST_CHECK_EQUAL(args.GetIntArg("foo", 100), 99);
-    BOOST_CHECK_THROW(args.GetBoolArg("foo", true), std::runtime_error);
-    BOOST_CHECK_THROW(args.GetBoolArg("foo", false), std::runtime_error);
+    BOOST_CHECK_EQUAL(args.GetBoolArg("foo", true), true);
+    BOOST_CHECK_EQUAL(args.GetBoolArg("foo", false), true);
 
     set_foo(3.25);
     BOOST_CHECK_EQUAL(args.GetSetting("foo").write(), "3.25");
     BOOST_CHECK_EQUAL(args.GetArg("foo", "default"), "3.25");
     BOOST_CHECK_THROW(args.GetIntArg("foo", 100), std::runtime_error);
-    BOOST_CHECK_THROW(args.GetBoolArg("foo", true), std::runtime_error);
-    BOOST_CHECK_THROW(args.GetBoolArg("foo", false), std::runtime_error);
+    BOOST_CHECK_EQUAL(args.GetBoolArg("foo", true), true);
+    BOOST_CHECK_EQUAL(args.GetBoolArg("foo", false), true);
 
     set_foo(0);
     BOOST_CHECK_EQUAL(args.GetSetting("foo").write(), "0");
     BOOST_CHECK_EQUAL(args.GetArg("foo", "default"), "0");
     BOOST_CHECK_EQUAL(args.GetIntArg("foo", 100), 0);
-    BOOST_CHECK_THROW(args.GetBoolArg("foo", true), std::runtime_error);
-    BOOST_CHECK_THROW(args.GetBoolArg("foo", false), std::runtime_error);
+    BOOST_CHECK_EQUAL(args.GetBoolArg("foo", true), false);
+    BOOST_CHECK_EQUAL(args.GetBoolArg("foo", false), false);
 
     set_foo(true);
     BOOST_CHECK_EQUAL(args.GetSetting("foo").write(), "true");

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -664,9 +664,21 @@ std::optional<bool> ArgsManager::GetBoolArg(const std::string& strArg) const
 
 std::optional<bool> SettingToBool(const util::SettingsValue& value)
 {
-    if (value.isNull()) return std::nullopt;
-    if (value.isBool()) return value.get_bool();
-    return InterpretBool(value.get_str());
+    switch (value.getType()) {
+        case UniValue::VNULL:
+            return std::nullopt;
+        case UniValue::VBOOL:
+            return value.get_bool();
+        case UniValue::VOBJ:
+        case UniValue::VARR:
+            // Throws an exception
+            value.get_str();
+            assert(false);
+        case UniValue::VSTR:
+        case UniValue::VNUM:
+            return InterpretBool(value.getValStr());
+    }
+    assert(false);
 }
 
 bool SettingToBool(const util::SettingsValue& value, bool fDefault)


### PR DESCRIPTION
Currently, Number values can cause ~~GetArg/~~ GetBoolArg to throw an exception, which most of the code isn't expecting (eg #24457).

AFAIK it isn't possible to normally get Numbers in settings right now, but ~~that's expected to change with #15936 (which could create downgrading issues without this fixed), and in any case~~ it isn't a great idea to randomly crash because of a logically-value settings.json value anyway.

This *doesn't* fix Get\*Arg from throwing in the case it encounters an Array or Object. It's not obvious how to handle those scenarios. However, the function~~s~~ touched are refactored to explicitly clarify that those scenarios will throw.

~~NOTE: Based on 0.20 branch-point, so a clean merge to everything newer. For testing, you will probably want to merge onto 23.x or master.~~