### PR TITLE
[23.x] guix: use same commit for codesigning time-machine

### DIFF
--- a/contrib/guix/guix-codesign
+++ b/contrib/guix/guix-codesign
@@ -227,7 +227,7 @@ SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git -c log.showSignature=false log --f
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://git.savannah.gnu.org/git/guix.git \
-                      --commit=aa34d4d28dfe25ba47d5800d05000fb7221788c0 \
+                      --commit=ae03f401381e956c4c41b4cf495cbde964fa43d0 \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \


### PR DESCRIPTION
The time machines should be updated in lockstep. Backports #24484.

Github-Pull: #24484
Rebased-From: 29862bdd402112a98d5da08cb9909bd427b955ad