### PR TITLE
ci: Bump vcpkg to the latest version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -82,7 +82,7 @@ task:
   env:
     PATH: 'C:\jom;C:\Python39;C:\Python39\Scripts;C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin;%PATH%'
     PYTHONUTF8: 1
-    CI_VCPKG_TAG: '2021.05.12'
+    CI_VCPKG_TAG: '2022.02.23'
     VCPKG_DOWNLOADS: 'C:\Users\ContainerAdministrator\AppData\Local\vcpkg\downloads'
     VCPKG_DEFAULT_BINARY_CACHE: 'C:\Users\ContainerAdministrator\AppData\Local\vcpkg\archives'
     QT_DOWNLOAD_URL: 'https://download.qt.io/official_releases/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.zip'


### PR DESCRIPTION
It seems reasonable to run a CI task against the most recent dependencies.

Dependency changes:
- boost 1.75.0 -> 1.78.0
- double-conversion 3.1.5 -> 3.2.0
- sqlite3 3.35.4 -> 3.37.2