### PR TITLE
tests: Ensure sorted/multi_a descriptors always generate different addrs

### DIFF
--- a/test/functional/wallet_taproot.py
+++ b/test/functional/wallet_taproot.py
@@ -429,10 +429,10 @@ class WalletTaprootTest(BitcoinTestFramework):
             lambda k1, k2: (key(H_POINT), [multi_a(1, [k1, k2], True)])
         )
         self.do_test(
-            "tr(H,multi_a(1,XPUB,XPRV))",
-            "tr($H,multi_a(1,$1/*,$2/*))",
+            "tr(H,{H,multi_a(1,XPUB,XPRV)})",
+            "tr($H,{pk($H),multi_a(1,$1/*,$2/*)})",
             [False, True],
-            lambda k1, k2: (key(H_POINT), [multi_a(1, [k1, k2])])
+            lambda k1, k2: (key(H_POINT), [pk(H_POINT), [multi_a(1, [k1, k2])]])
         )
         self.do_test(
             "tr(H,sortedmulti_a(1,XPUB,XPRV,XPRV))",


### PR DESCRIPTION
Sometimes the multi_a and sortedmulti_a descriptors will produce some of the same addresses in the tests. This causes the wallets to start generating addresses at a different index as they detect that one of the addresses is used. This subsequently causes a test failure.

To avoid this problem, use descriptors that will produce unique addresses by putting one of the multi_a in a different branch.