### PR TITLE
Add missing fs::u8path wrap

### DIFF
--- a/src/fs.h
+++ b/src/fs.h
@@ -57,6 +57,11 @@ public:
     path filename() const { return std::filesystem::path::filename(); }
 };
 
+static inline path u8path(const std::string& utf8_str)
+{
+    return std::filesystem::u8path(utf8_str);
+}
+
 // Disallow implicit std::string conversion for absolute to avoid
 // locale-dependent encoding on windows.
 static inline path absolute(const path& p)
@@ -116,8 +121,8 @@ static inline std::string PathToString(const path& path)
     // use here, because these methods encode the path using C++'s narrow
     // multibyte encoding, which on Windows corresponds to the current "code
     // page", which is unpredictable and typically not able to represent all
-    // valid paths. So std::filesystem::path::u8string() and
-    // std::filesystem::u8path() functions are used instead on Windows. On
+    // valid paths. So fs::path::u8string() and
+    // fs::u8path() functions are used instead on Windows. On
     // POSIX, u8string/u8path functions are not safe to use because paths are
     // not always valid UTF-8, so plain string methods which do not transform
     // the path there are used.


### PR DESCRIPTION
Without the wrap, paths can flee the "fs-jail".

For example, the following compiles on current master:

```diff
diff --git a/src/test/fs_tests.cpp b/src/test/fs_tests.cpp
index 5875f0218f..04eef9f5c6 100644
--- a/src/test/fs_tests.cpp
+++ b/src/test/fs_tests.cpp
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_CASE(fsbridge_pathtostring)
 {
     std::string u8_str = "fs_tests_₿_🏃";
     BOOST_CHECK_EQUAL(fs::PathToString(fs::PathFromString(u8_str)), u8_str);
-    BOOST_CHECK_EQUAL(fs::u8path(u8_str).u8string(), u8_str);
+    BOOST_CHECK_EQUAL(fs::u8path(u8_str).string(), u8_str);
     BOOST_CHECK_EQUAL(fs::PathFromString(u8_str).u8string(), u8_str);
     BOOST_CHECK_EQUAL(fs::PathToString(fs::u8path(u8_str)), u8_str);
 #ifndef WIN32
```

After this pull, it will fail, as expected:

```
test/fs_tests.cpp:22:42: error: attempt to use a deleted function
    BOOST_CHECK_EQUAL(fs::u8path(u8_str).string(), u8_str);
                                         ^
./fs.h:52:17: note: 'string' has been explicitly marked deleted here
    std::string string() const = delete;
                ^
1 error generated.
make[2]: *** [Makefile:17833: test/test_bitcoin-fs_tests.o] Error 1
