### PR TITLE
guix: only use native GCC 7 toolchain for Linux builds

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -593,24 +593,30 @@ inspecting signatures in Mach-O binaries.")
         ;; Git
         git
         ;; Tests
-        lief
-        ;; Native gcc 7 toolchain
-        gcc-toolchain-7
-        (list gcc-toolchain-7 "static"))
+        lief)
   (let ((target (getenv "HOST")))
     (cond ((string-suffix? "-mingw32" target)
            ;; Windows
-           (list zip
+           (list ;; Native GCC 10 toolchain
+                 gcc-toolchain-10
+                 (list gcc-toolchain-10 "static")
+                 zip
                  (make-mingw-pthreads-cross-toolchain "x86_64-w64-mingw32")
                  (make-nsis-for-gcc-10 nsis-x86_64)
                  osslsigncode))
           ((string-contains target "-linux-")
-           (list (cond ((string-contains target "riscv64-")
+           (list ;; Native GCC 7 toolchain
+                 gcc-toolchain-7
+                 (list gcc-toolchain-7 "static")
+                 (cond ((string-contains target "riscv64-")
                         (make-bitcoin-cross-toolchain target
                                                       #:base-libc glibc-2.27/bitcoin-patched
                                                       #:base-kernel-headers linux-libre-headers-4.19))
                        (else
                         (make-bitcoin-cross-toolchain target)))))
           ((string-contains target "darwin")
-           (list clang-toolchain-10 binutils cmake xorriso python-signapple))
+           (list ;; Native GCC 10 toolchain
+                 gcc-toolchain-10
+                 (list gcc-toolchain-10 "static")
+                 clang-toolchain-10 binutils cmake xorriso python-signapple))
           (else '())))))


### PR DESCRIPTION
The macOS and Windows builds do not require a GCC 7 toolchain, and this
is actually causing build issues, i.e #24211. So switch to using a GCC
10 native toolchain for both. We can't switch to using a GCC 7+ native
toolchain for Linux without patching around glibc build issues (something
to look at for a future change).

Fixes #24211.

Guix Builds (on x86_64):
```bash
bash-5.1# find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
6fece1c8ed69bd724c76dfd768f03b1d43c9dfb1767f0fad743fb3e068ce8f7f  guix-build-bb12870bac23/output/aarch64-linux-gnu/SHA256SUMS.part
555c1245581eff3013a2b56a3c7acb2923de9117dd5d108d4b7954e22f386dd1  guix-build-bb12870bac23/output/aarch64-linux-gnu/bitcoin-bb12870bac23-aarch64-linux-gnu-debug.tar.gz
e8f10a3791a4245566dab8253b76dcac3354bdfad9b9575743e937b52e364494  guix-build-bb12870bac23/output/aarch64-linux-gnu/bitcoin-bb12870bac23-aarch64-linux-gnu.tar.gz
c4339db89259e5a8e5666fc807c198a49162d500c2143f8a1dc86e6e7ca32bbc  guix-build-bb12870bac23/output/arm-linux-gnueabihf/SHA256SUMS.part
6123682411cbb16bfa41d31cb4a9673744ad8c09b6f8586a4dfda08bc5f7a682  guix-build-bb12870bac23/output/arm-linux-gnueabihf/bitcoin-bb12870bac23-arm-linux-gnueabihf-debug.tar.gz
3dcd70f65dd3dfd7385ac6715244fb6c696257e622220310abae7279cbd2a3a4  guix-build-bb12870bac23/output/arm-linux-gnueabihf/bitcoin-bb12870bac23-arm-linux-gnueabihf.tar.gz
47c5235cce1e3e2e88a461e48e54a29dffb7ac0d8b57955f4e6977273af113f3  guix-build-bb12870bac23/output/arm64-apple-darwin/SHA256SUMS.part
3584eec693b82b1b4e81094132a9a5e3ebf4a72a3c3cfe9914f24da62c2e2014  guix-build-bb12870bac23/output/arm64-apple-darwin/bitcoin-bb12870bac23-arm64-apple-darwin.tar.gz
4a6e561abfc3f69e57a05fc278d75b6f58f82dec50b9b3acbf9745706be91d60  guix-build-bb12870bac23/output/arm64-apple-darwin/bitcoin-bb12870bac23-osx-unsigned.dmg
36a88bc090927493ed31635e1412dc01a81fb034d612c21ebb8b8602b7529ad2  guix-build-bb12870bac23/output/arm64-apple-darwin/bitcoin-bb12870bac23-osx-unsigned.tar.gz
d77871d97198c521fc54cf4ea547c0ee723bfe94036bf40987837e529a59b4e9  guix-build-bb12870bac23/output/dist-archive/bitcoin-bb12870bac23.tar.gz
b676ae5d37fdac267c82bcc57d76e25694f2ee2292f4d012648a0e496104f48d  guix-build-bb12870bac23/output/powerpc64-linux-gnu/SHA256SUMS.part
00cad11e137030b1165437a91d4e9f2827b1abe54b5ff14709abeab0a33711b8  guix-build-bb12870bac23/output/powerpc64-linux-gnu/bitcoin-bb12870bac23-powerpc64-linux-gnu-debug.tar.gz
e715686469924452e1d35b93a64aa1fe1a85f5592757e8c24feda03db821fc48  guix-build-bb12870bac23/output/powerpc64-linux-gnu/bitcoin-bb12870bac23-powerpc64-linux-gnu.tar.gz
20547e405ab88d84a228563ec7aaa965515b2714f65cc16f3288f8c885fe39db  guix-build-bb12870bac23/output/powerpc64le-linux-gnu/SHA256SUMS.part
707d2f14a7b73cc73710297d4d8f1773864c27a5e44ef45a97c0437ce4b291e0  guix-build-bb12870bac23/output/powerpc64le-linux-gnu/bitcoin-bb12870bac23-powerpc64le-linux-gnu-debug.tar.gz
6930ddbb6d5aebfd901ec30ad68749338265d43b73ad11015a320af37620d6e9  guix-build-bb12870bac23/output/powerpc64le-linux-gnu/bitcoin-bb12870bac23-powerpc64le-linux-gnu.tar.gz
2af7a3a50622ed1b2b271b655b8319f1b34f605f97381a66ee4625c1864cc3e2  guix-build-bb12870bac23/output/riscv64-linux-gnu/SHA256SUMS.part
0e9e0878e446af7cd33782cf6d8a0cfb163b1ade7c87d5a6c6d7c315436bbb31  guix-build-bb12870bac23/output/riscv64-linux-gnu/bitcoin-bb12870bac23-riscv64-linux-gnu-debug.tar.gz
6c8994f11fadbfda8fc9c57deeaf67568b8368084c7959a56aabde89c99033d1  guix-build-bb12870bac23/output/riscv64-linux-gnu/bitcoin-bb12870bac23-riscv64-linux-gnu.tar.gz
5214d7276030ea9721b2f8ed715308d2e3bf46158ddc030c7aa6f40098e3bc9b  guix-build-bb12870bac23/output/x86_64-apple-darwin/SHA256SUMS.part
5783948617c4b0f7b47642b0045d5c648318bfc454a5d93db1a7ccb066ed17e2  guix-build-bb12870bac23/output/x86_64-apple-darwin/bitcoin-bb12870bac23-osx-unsigned.dmg
3a26d5e127fd2a723601fe14855b49cdb39c6fe6f407ca0d84a833eac6e4f47d  guix-build-bb12870bac23/output/x86_64-apple-darwin/bitcoin-bb12870bac23-osx-unsigned.tar.gz
92e341ec48c74a5a0a9b7af6665a400bb12f6b35b983f2c9f8fd1819e390b57e  guix-build-bb12870bac23/output/x86_64-apple-darwin/bitcoin-bb12870bac23-osx64.tar.gz
056a78e9f0aaed10aa7d734746d3adb27bb8ea0856829e7fedd2cb02f1234c62  guix-build-bb12870bac23/output/x86_64-linux-gnu/SHA256SUMS.part
77a493b1e5409d422b2006d46bf9de1e151485fc65680e4d4dd07c28a0264c51  guix-build-bb12870bac23/output/x86_64-linux-gnu/bitcoin-bb12870bac23-x86_64-linux-gnu-debug.tar.gz
ccef5699e8a6153dbf35deb35f9d63439a5ef19234b9923840fe23780d41a983  guix-build-bb12870bac23/output/x86_64-linux-gnu/bitcoin-bb12870bac23-x86_64-linux-gnu.tar.gz
0d64b0f1797f2b25eb7be65045f25b0297409250e8cc298a711a790b69534066  guix-build-bb12870bac23/output/x86_64-w64-mingw32/SHA256SUMS.part
471d48dd50c7f3a3ebffd68aceb7537613e581acc55ad5dd3c15e8095027c322  guix-build-bb12870bac23/output/x86_64-w64-mingw32/bitcoin-bb12870bac23-win-unsigned.tar.gz
be7af6c54a52b58f696a9cabda21ec9c9748150b5874b21d4377199db7d70b7b  guix-build-bb12870bac23/output/x86_64-w64-mingw32/bitcoin-bb12870bac23-win64-debug.zip
d522c2b27638f99b6faacb7f478e4908cfc01ca86c71f17c34cbc395d47c4504  guix-build-bb12870bac23/output/x86_64-w64-mingw32/bitcoin-bb12870bac23-win64-setup-unsigned.exe
43a038525f2383fdb9ed7f0d0d709d7f353933f3bf066779bc27503282acc0c5  guix-build-bb12870bac23/output/x86_64-w64-mingw32/bitcoin-bb12870bac23-win64.zip
```

Guix Builds (on arm64 [skipping aarch64 HOST](https://github.com/bitcoin/bitcoin/issues/22458)):
```bash
root@3b26b9608b88:/bitcoin# find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
9da540efe1e32ea74c1da5b9d17436d4de75f5d2b370d09cfdb06b044b3c816a  guix-build-bb12870bac23/output/arm-linux-gnueabihf/SHA256SUMS.part
ade319778d571de3727600d2bbbccbdb35cdaa138f2a941e0be58d94899b2ce5  guix-build-bb12870bac23/output/arm-linux-gnueabihf/bitcoin-bb12870bac23-arm-linux-gnueabihf-debug.tar.gz
1bd1790c002a40b6db1378f5344e7e34df0cd0fd7f29dbe98db5397b52b9dde9  guix-build-bb12870bac23/output/arm-linux-gnueabihf/bitcoin-bb12870bac23-arm-linux-gnueabihf.tar.gz
e457b5f6a30d713faa521969d2f8b56e3176f63c3e116c4d149b63f9fa0de80f  guix-build-bb12870bac23/output/arm64-apple-darwin/SHA256SUMS.part
13f1b769c6af61ee4ef057f36715d63390c42ae29fae301f6cf65bdf644c6adf  guix-build-bb12870bac23/output/arm64-apple-darwin/bitcoin-bb12870bac23-arm64-apple-darwin.tar.gz
278c0c1134aed42e575d8af2c328a26e88765f0b0686e06cea1c884bd821cd28  guix-build-bb12870bac23/output/arm64-apple-darwin/bitcoin-bb12870bac23-osx-unsigned.dmg
6b5602fe63b9fb546ba0897bf5563714fad83e4c3a0cb285ed4961ec1a5e488d  guix-build-bb12870bac23/output/arm64-apple-darwin/bitcoin-bb12870bac23-osx-unsigned.tar.gz
d77871d97198c521fc54cf4ea547c0ee723bfe94036bf40987837e529a59b4e9  guix-build-bb12870bac23/output/dist-archive/bitcoin-bb12870bac23.tar.gz
0292906278db266a67f5c780af12a2c91ec62007c6a72e6c8b37463701d838cb  guix-build-bb12870bac23/output/powerpc64-linux-gnu/SHA256SUMS.part
83362d3d84b00674359df9300729e1a2b3cf14cf2b9b71b9bb46fe9610ab0e6d  guix-build-bb12870bac23/output/powerpc64-linux-gnu/bitcoin-bb12870bac23-powerpc64-linux-gnu-debug.tar.gz
3d5a538d28ccb97a239da358d1390add1d20e4c4d89e873a29aed3f92728e532  guix-build-bb12870bac23/output/powerpc64-linux-gnu/bitcoin-bb12870bac23-powerpc64-linux-gnu.tar.gz
8eb7194b2019b5ddb12f88fee8a76d8923bd0883de817c3bf396ea16e5b0543e  guix-build-bb12870bac23/output/powerpc64le-linux-gnu/SHA256SUMS.part
3ec4a6cff3c974a1603276e5d75bc398522d543b6f9770a74c9a7acf6dc79c82  guix-build-bb12870bac23/output/powerpc64le-linux-gnu/bitcoin-bb12870bac23-powerpc64le-linux-gnu-debug.tar.gz
5b5eeb539362d6664a007d4856b5779a55ab714a96134749b5cfe870a4b5a7f9  guix-build-bb12870bac23/output/powerpc64le-linux-gnu/bitcoin-bb12870bac23-powerpc64le-linux-gnu.tar.gz
3201f796777a9fc029dddc085489afcf14b68cf77b0511d3b52cc336fb58baad  guix-build-bb12870bac23/output/riscv64-linux-gnu/SHA256SUMS.part
a46286b4d94de7189c93682d37c8bd3910f5ca2f612fc939b6e8ff3e56a4feff  guix-build-bb12870bac23/output/riscv64-linux-gnu/bitcoin-bb12870bac23-riscv64-linux-gnu-debug.tar.gz
e88fd7b312879fd7dc254674532535a05efaeb7167145541440289d45ec9ba17  guix-build-bb12870bac23/output/riscv64-linux-gnu/bitcoin-bb12870bac23-riscv64-linux-gnu.tar.gz
31659aa39146ad25631cc2030b415bec6892fa9cffebfd8c6da2d9b0c552773b  guix-build-bb12870bac23/output/x86_64-apple-darwin/SHA256SUMS.part
5783948617c4b0f7b47642b0045d5c648318bfc454a5d93db1a7ccb066ed17e2  guix-build-bb12870bac23/output/x86_64-apple-darwin/bitcoin-bb12870bac23-osx-unsigned.dmg
7a75daff1427fa8839f35ce84fda19c95a6c82365937dc67f988bc8853fc1948  guix-build-bb12870bac23/output/x86_64-apple-darwin/bitcoin-bb12870bac23-osx-unsigned.tar.gz
92e341ec48c74a5a0a9b7af6665a400bb12f6b35b983f2c9f8fd1819e390b57e  guix-build-bb12870bac23/output/x86_64-apple-darwin/bitcoin-bb12870bac23-osx64.tar.gz
bbc0c2fc3b142191ea5403095b9da1691073375b178e06eea68736c3a4b8477f  guix-build-bb12870bac23/output/x86_64-linux-gnu/SHA256SUMS.part
121fc43297b045af7fbe3904a1df94ff55e4908344eb97d48e50091216ecfdc2  guix-build-bb12870bac23/output/x86_64-linux-gnu/bitcoin-bb12870bac23-x86_64-linux-gnu-debug.tar.gz
b2fbab5153a52f82390c67e6a14187eb791a3f052cedca0183b81e939932618f  guix-build-bb12870bac23/output/x86_64-linux-gnu/bitcoin-bb12870bac23-x86_64-linux-gnu.tar.gz
4ffca23b6d93ed888b7ac5a54eb1c06bd04f304f336361655033796f3117d145  guix-build-bb12870bac23/output/x86_64-w64-mingw32/SHA256SUMS.part
471d48dd50c7f3a3ebffd68aceb7537613e581acc55ad5dd3c15e8095027c322  guix-build-bb12870bac23/output/x86_64-w64-mingw32/bitcoin-bb12870bac23-win-unsigned.tar.gz
b226fe0f139bc2c4773e67784fc928874cba2ec0322d5da9a60fe5e6fd440f95  guix-build-bb12870bac23/output/x86_64-w64-mingw32/bitcoin-bb12870bac23-win64-debug.zip
d522c2b27638f99b6faacb7f478e4908cfc01ca86c71f17c34cbc395d47c4504  guix-build-bb12870bac23/output/x86_64-w64-mingw32/bitcoin-bb12870bac23-win64-setup-unsigned.exe
a435f9e1637281a8c6b174ec5dbc729ae35cca64928a42e435d57fb3292b9f3f  guix-build-bb12870bac23/output/x86_64-w64-mingw32/bitcoin-bb12870bac23-win64.zip
```