### PR TITLE
test: refactor: use `random.sample` for choosing random keys in wallet_taproot.py

### DIFF
--- a/test/functional/wallet_taproot.py
+++ b/test/functional/wallet_taproot.py
@@ -208,19 +208,6 @@ class WalletTaprootTest(BitcoinTestFramework):
         pass
 
     @staticmethod
-    def rand_keys(n):
-        ret = []
-        idxes = set()
-        for _ in range(n):
-            while True:
-                i = random.randrange(len(KEYS))
-                if not i in idxes:
-                    break
-            idxes.add(i)
-            ret.append(KEYS[i])
-        return ret
-
-    @staticmethod
     def make_desc(pattern, privmap, keys, pub_only = False):
         pat = pattern.replace("$H", H_POINT)
         for i in range(len(privmap)):
@@ -332,7 +319,7 @@ class WalletTaprootTest(BitcoinTestFramework):
 
     def do_test(self, comment, pattern, privmap, treefn):
         nkeys = len(privmap)
-        keys = self.rand_keys(nkeys * 4)
+        keys = random.sample(KEYS, nkeys * 4)
         self.do_test_addr(comment, pattern, privmap, treefn, keys[0:nkeys])
         self.do_test_sendtoaddress(comment, pattern, privmap, treefn, keys[0:nkeys], keys[nkeys:2*nkeys])
         self.do_test_psbt(comment, pattern, privmap, treefn, keys[2*nkeys:3*nkeys], keys[3*nkeys:4*nkeys])


### PR DESCRIPTION
The Python3 standard library method `random.sample` has the exact same functionality as the helper method `rand_keys(...)` (that is, random sampling without replacement) on a generic set or sequence, i.e. we can simply replace it. See https://docs.python.org/3/library/random.html#random.sample
Note that this is also safer: in case that the sample size `k` is larger than the population count, `random.sample` throws an error:
```
$ python3
Python 3.8.12 (default, Sep 26 2021, 13:12:50)
[Clang 11.1.0 ] on openbsd7
Type "help", "copyright", "credits" or "license" for more information.
>>> import random
>>> random.sample([23, 42], 3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.8/random.py", line 363, in sample
    raise ValueError("Sample larger than population or is negative")
ValueError: Sample larger than population or is negative
```
while the custom method would get stuck in an endless loop.