### PR TITLE
test: add script to mutate cpp files

### DIFF
--- a/test/mutation/consts.py
+++ b/test/mutation/consts.py
@@ -1,0 +1,34 @@
+FILES = [
+    "src/wallet/coinselection.cpp",
+    # "src/wallet/spend.cpp",
+    # "src/net.cpp",
+    # "src/wallet/feebumper.cpp",
+    # "src/script/interpreter.cpp"
+]
+
+REPLACE_OPERATORS = [
+             [" > ", " < "], [" < ", " > "], [" >= ", " > "],
+             [" >= ", " <= "], [" <= ", " > "], [" == ", " != "],
+             [" != ", " == "], [" + ", " - "],  [" - ", " + "],
+             [" && ", " || "], [" || ", " && "], [" / ", " * "],
+             [" += ", " -= "], [" -= ", " += "], [" % ", " * "],
+             [" /= ", " *= "], [" *= ", " /= "], [" * ", " / "],
+             [" break", " continue"], [" continue", " break"],
+             ["std::all_of", "std::any_of"], ["std::any_of", "std::all_of"],
+             ["std::min", "std::max"], ["std::max", "std::min"], ["std::begin", "std::end"],
+             ["std::end", "std::begin"], ["true", "false"], ["false", "true"]]
+
+REPLACEMENT_IN_REGEX = ["LESS_THAN", "RANDOM_INT", "GREATER_THAN"]
+
+REGEX_OPERATORS = [[r"at(\(.*\))", r"at(0)"], [r"CAmount\s+(\w+)\s*=\s*([0-9]+)", r"CAmount \1 = RANDOM_INT"],
+                   [r"CAmount\s+(\w+)\s*=\s*([0-9]+)", r"CAmount \1 = LESS_THAN"],
+                   [r"CAmount{+(\w+)}", r"CAmount{RANDOM_INT}"], [r"int\s+(\w+)\s*=\s*([0-9]+)", r"int \1 = RANDOM_INT"],
+                   [r"int\s+(\w+)\s*=\s*([0-9]+)", r"int \1 = LESS_THAN"], [r"int\s+(\w+)\s*=\s*([0-9]+)", r"int \1 = GREATER_THAN"],
+                   [r"int32_t\s+(\w+)\s*=\s*([0-9]+)", r"int32_t \1 = LESS_THAN"], [r"int32_t\s+(\w+)\s*=\s*([0-9]+)", r"int32_t \1 = GREATER_THAN"],
+                   [r"int64_t\s+(\w+)\s*=\s*([0-9]+)", r"int64_t \1 = RANDOM_INT"], [r"int64_t\s+(\w+)\s*=\s*([0-9]+)", r"int64_t \1 = GREATER_THAN"],
+                   [r"bool\s+(\w+)\s*=\s+(.*)", r"bool \1 = true;"], [r"int64_t\s+(\w+)\s*=\s*([0-9]+)", r"int64_t \1 = LESS_THAN"],
+                   [r"bool\s+(\w+)\s*=\s+(.*)", r"bool \1 = false;"], [r"std::chrono::seconds (\w+){+(\w+)}", r"std::chrono::seconds \1{RANDOM_INT}"],
+                   [r"int32_t\s+(\w+)\s*=\s*([0-9]+)", r"int32_t \1 = RANDOM_INT"], [r"const\s+size_t\s+(\w+)\s*=\s*([0-9]+)", r"const size_t \1 = RANDOM_INT"],
+                   [r"(^\s*)(\S+.*)\n", r"\1\2\n\1break;\n"], [r"(^\s*)(\S+.*)\n", r"\1\2\n\1continue;\n"],
+                   [r"std::chrono::seconds (\w+){+(\w+)}", r"std::chrono::seconds \1{RANDOM_INT}"],
+                   [r"std::chrono::seconds (\w+)\s*=\s*(.*)", r"std::chrono::seconds \1 = RANDOM_INT;"]]

--- a/test/mutation/gen-mutators.py
+++ b/test/mutation/gen-mutators.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import pathlib
+import re
+import consts
+from utils import mkdir_mutation_folder, replace_value
+
+
+FILES = consts.FILES
+REGEX_OPERATORS = consts.REGEX_OPERATORS
+REPLACE_OPERATORS = consts.REPLACE_OPERATORS
+REPLACEMENT_IN_REGEX = consts.REPLACEMENT_IN_REGEX
+
+BASE_PATH = str(pathlib.Path().resolve())
+BASE_MUT = f'{BASE_PATH}/test/mutation/mutators'
+
+
+def mutate(file_to_mutate):
+    input_file = f'{BASE_PATH}/{file_to_mutate}'
+
+    file_name = file_to_mutate.split('/')
+    file_name = file_name[len(file_name) - 1].split('.')[0]
+
+    with open(input_file, 'r', encoding="utf8") as source_code:
+        source_code = source_code.readlines()
+        num_lines = len(source_code)
+
+    OPERATORS = REGEX_OPERATORS + REPLACE_OPERATORS
+    i = 0
+
+    for operator in OPERATORS:
+        lines_num_list = list(range(1, num_lines - 1))
+        for line_num in lines_num_list:
+            lines = source_code.copy()
+            line_before_mutation = lines[line_num]
+
+            if line_before_mutation.lstrip().startswith(("//", "*", "assert", "/*")):
+                continue
+
+            if operator in REGEX_OPERATORS:
+                if re.search(operator[0], line_before_mutation):
+                    print(f"Before: {line_before_mutation}")
+                    operator_sub = operator[1]
+                    res = [op for op in REPLACEMENT_IN_REGEX if(op in operator[1])]
+                    if bool(res):
+                        operator_sub = replace_value(res[0], operator[0], operator[1], line_before_mutation)
+                        if not operator_sub:
+                            continue
+                    line_mutated = re.sub(operator[0], operator_sub, line_before_mutation)
+                    lines[line_num] = f'{line_before_mutation[:-len(line_before_mutation.lstrip())]}{line_mutated}'
+                else:
+                    continue
+            elif operator in REPLACE_OPERATORS:
+                if operator[0] in line_before_mutation:
+                    print(f"Before: {line_before_mutation}")
+                    line_mutated = line_before_mutation.replace(operator[0], operator[1])
+                    lines[line_num] = f'{line_before_mutation[:-len(line_before_mutation.lstrip())]}{line_mutated}'
+                else:
+                    continue
+
+            mutator_file = f'{BASE_MUT}/{file_name}.mutant.{i}.cpp'
+            with open(mutator_file, 'w', encoding="utf8") as file:
+                print(f"After: {line_mutated}")
+                file.writelines(lines)
+                i = i + 1
+
+
+if __name__ == "__main__":
+    mkdir_mutation_folder()
+
+    for file in FILES:
+        mutate(file)

--- a/test/mutation/utils.py
+++ b/test/mutation/utils.py
@@ -1,0 +1,32 @@
+import os
+import re
+import pathlib
+import random
+
+
+BASE_PATH = str(pathlib.Path().resolve())
+
+
+def replace_value(code, regex_to_search, regex_to_mutate, to_be_mutated):
+    search_regex = re.search(regex_to_search, to_be_mutated)
+    if code == "RANDOM_INT":
+        regex_to_mutate = regex_to_mutate.replace("RANDOM_INT", str(random.randint(0, 3000)))
+    elif code == "LESS_THAN":
+        search_regex = re.search(regex_to_search, to_be_mutated)
+        if int(search_regex.group(2)) == 0:
+            print(search_regex.group(1))
+            return False
+        new_value = str(int(int(search_regex.group(2)) * 0.7))
+        regex_to_mutate = regex_to_mutate.replace("LESS_THAN", new_value)
+    else:
+        search_regex = re.search(regex_to_search, to_be_mutated)
+        new_value = str(int(int(search_regex.group(2)) * 1.3))
+        regex_to_mutate = regex_to_mutate.replace("GREATER_THAN", new_value)
+
+    return regex_to_mutate
+
+
+def mkdir_mutation_folder():
+    path = os.path.join(BASE_PATH, 'test/mutation/mutators')
+    if not os.path.isdir(f'{BASE_PATH}/test/mutation/mutators'):
+        os.mkdir(path)


### PR DESCRIPTION
I've been researching mutation testing and how we could use it here since we already have other automated tests. So, I created a Python script to mutate our cpp files. I created these scripts focused on mutating Bitcoin Core, this is not a general cpp one, so it mutates specific Core stuff like `CAmount{}` and other ones. 

In `test/mutation/consts.py` you can find the operators and you can set what files you'd like to mutate:
```py
FILES = [
    "src/wallet/coinselection.cpp",
    # "src/wallet/spend.cpp",
    # "src/net.cpp",
    # "src/wallet/feebumper.cpp",
    # "src/script/interpreter.cpp"
]
```

This script mutates some consts by incresing/decreasing their value, e.g:
```
from:
const CAmount fee = 100;


to:
const CAmount fee = 75;
or 
const CAmount fee = 130;
```

All the mutators are saved in `test/mutation/mutators`, it generates one file per mutator. 

Feel free to suggest anything, NACKs are welcome, I opened this PR because I use it a lot and I think it might be useful here.

