### PR TITLE
ci: use compiler version in ccache compiler check

### DIFF
--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -56,6 +56,7 @@ export DEBIAN_FRONTEND=noninteractive
 export CCACHE_SIZE=${CCACHE_SIZE:-100M}
 export CCACHE_TEMPDIR=${CCACHE_TEMPDIR:-/tmp/.ccache-temp}
 export CCACHE_COMPRESS=${CCACHE_COMPRESS:-1}
+export CCACHE_COMPILERCHECK=${CCACHE_COMPILERCHECK:-"%compiler% -v"}
 # The cache dir.
 # This folder exists on the ci host and ci guest. Changes are propagated back and forth.
 export CCACHE_DIR=${CCACHE_DIR:-$BASE_SCRATCH_DIR/.ccache}


### PR DESCRIPTION
> compiler_check (CCACHE_COMPILERCHECK)
By default, ccache includes the modification time (“mtime”) and size of the compiler in the hash to ensure that results retrieved from the cache are accurate. If compiler plugins are used, these plugins will also be added to the hash. This option can be used to select another strategy.

https://ccache.dev/manual/latest.html#_configuration_options

Since platforms like CI install toolchains on every run, ccache's default option for using mtime causes ccache to not utilize the cache. This PR uses a several years old environment variable to use the version output from the compiler instead.