### PR TITLE
guix: use the latest version of signapple

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -352,7 +352,7 @@ thus should be able to compile on most platforms where these exist.")
              #t)))))))
 
 (define-public python-certvalidator
-  (let ((commit "e5bdb4bfcaa09fa0af355eb8867d00dfeecba08c"))
+  (let ((commit "a145bf25eb75a9f014b3e7678826132efbba6213"))
     (package
       (name "python-certvalidator")
       (version (git-version "0.1" "1" commit))
@@ -365,7 +365,7 @@ thus should be able to compile on most platforms where these exist.")
          (file-name (git-file-name name commit))
          (sha256
           (base32
-           "18pvxkvpkfkzgvfylv0kx65pmxfcv1hpsg03cip93krfvrrl4c75"))))
+           "1qw2k7xis53179lpqdqyylbcmp76lj7sagp883wmxg5i7chhc96k"))))
       (build-system python-build-system)
       (propagated-inputs
        `(("python-asn1crypto" ,python-asn1crypto)
@@ -398,11 +398,6 @@ thus should be able to compile on most platforms where these exist.")
                                  line)))
                (substitute* "tests/test_validate.py"
                  (("^(.*)def test_revocation_mode_hard" line indent)
-                  (string-append indent
-                                 "@unittest.skip(\"Disabled by Guix\")\n"
-                                 line)))
-               (substitute* "tests/test_validate.py"
-                 (("^(.*)def test_revocation_mode_soft" line indent)
                   (string-append indent
                                  "@unittest.skip(\"Disabled by Guix\")\n"
                                  line)))

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -485,7 +485,7 @@ and endian independent.")
     (license license:expat)))
 
 (define-public python-signapple
-  (let ((commit "b084cbbf44d5330448ffce0c7d118f75781b64bd"))
+  (let ((commit "9f42f3c8295d4107ee7a22e523ec17449a936f43"))
     (package
       (name "python-signapple")
       (version (git-version "0.1" "1" commit))
@@ -498,7 +498,7 @@ and endian independent.")
          (file-name (git-file-name name commit))
          (sha256
           (base32
-           "0k7inccl2mzac3wq4asbr0kl8s4cghm8982z54kfascqg45shv01"))))
+           "0j1sqi0g8k2z5y56iayh5pw9yyq1r6ry3q5zy0cdy2sispiwvdnp"))))
       (build-system python-build-system)
       (propagated-inputs
        `(("python-asn1crypto" ,python-asn1crypto)


### PR DESCRIPTION
Update our signapple and python-certvalidator dependencies to the latest available versions. The latest signapple includes [improvements for signing M1 binaries](https://github.com/achow101/signapple/commit/bf4d906220a23f905ea8c371a50b1178796327ba) and [better error output](https://github.com/achow101/signapple/commit/9f42f3c8295d4107ee7a22e523ec17449a936f43) when applying signatures (i.e applying the wrong signature type to a binary).

Guix Build (x86_64):
```bash
bash-5.1# find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
53d4207c9aaa3fd1a596796566d88e9d77bbf4bc85a1772e2f6cc5c5ebd9eca8  guix-build-40894f677168/output/aarch64-linux-gnu/SHA256SUMS.part
4a472d63838e6b27317cb3d2bea72a9b4e5c6ee70b4b0e5191b343e3daad73cf  guix-build-40894f677168/output/aarch64-linux-gnu/bitcoin-40894f677168-aarch64-linux-gnu-debug.tar.gz
45307531316cc4b7915cff2764af1e713711f0ac1dbce55f5a5c9434a080a29d  guix-build-40894f677168/output/aarch64-linux-gnu/bitcoin-40894f677168-aarch64-linux-gnu.tar.gz
57fbc2a5ccb4ac77ce6bfba073d0bc4d561cdbe552abd0d322dbd52bce7f9392  guix-build-40894f677168/output/arm-linux-gnueabihf/SHA256SUMS.part
d30b9a815a87af37814a7b8ccb39551fafe9f9d587182a154e14597393417e41  guix-build-40894f677168/output/arm-linux-gnueabihf/bitcoin-40894f677168-arm-linux-gnueabihf-debug.tar.gz
7b103a83aa181374941785427a96a15063ae757f15913b7a7b1401d70da781a3  guix-build-40894f677168/output/arm-linux-gnueabihf/bitcoin-40894f677168-arm-linux-gnueabihf.tar.gz
b5c9eed6a1b9e728217c1e9d96af6d11332f4d6b74f5482d972fccb2e6c35a2b  guix-build-40894f677168/output/arm64-apple-darwin/SHA256SUMS.part
81915be1d32a6fb81b45f0f128ecc68e0bba75c5c719d5bf3d5e4f512f436631  guix-build-40894f677168/output/arm64-apple-darwin/bitcoin-40894f677168-arm64-apple-darwin.tar.gz
185643a4bdf915c3968c1265c3aedb3f8865904cddaaee1bf02c8ce08cb7d8cc  guix-build-40894f677168/output/arm64-apple-darwin/bitcoin-40894f677168-osx-unsigned.dmg
d9de7d15ebca380ec65e39f362a051994d515944665e535929fead0c1b6d6b56  guix-build-40894f677168/output/arm64-apple-darwin/bitcoin-40894f677168-osx-unsigned.tar.gz
ca94146ac95f623ba5b63d52dfc8b5909fd9a1a406fff447cad83b059b191a49  guix-build-40894f677168/output/dist-archive/bitcoin-40894f677168.tar.gz
e1637718b3d605896c9cfb8c309207acc8ac406acb2d9a3b6d8c83edba196c7c  guix-build-40894f677168/output/powerpc64-linux-gnu/SHA256SUMS.part
559f5376dd7a5c59b620f2e64290c265ef1a70c0cdc94c5d7468e3d51b418c12  guix-build-40894f677168/output/powerpc64-linux-gnu/bitcoin-40894f677168-powerpc64-linux-gnu-debug.tar.gz
44f34dfc2fddeabfbb75b301d7cd9282283aa4c1b1f60815536eaa40c8faf136  guix-build-40894f677168/output/powerpc64-linux-gnu/bitcoin-40894f677168-powerpc64-linux-gnu.tar.gz
d4904f60f22656abaf1b1e933cf321207dbf1902149f68a4857909c38b0d861c  guix-build-40894f677168/output/powerpc64le-linux-gnu/SHA256SUMS.part
76e76b99721cec1d382a190d3fd5315e8b70e07686681f30ace13f7f252ac2b7  guix-build-40894f677168/output/powerpc64le-linux-gnu/bitcoin-40894f677168-powerpc64le-linux-gnu-debug.tar.gz
4c3e5d1f62c21fe2dc47ceba3fa067ef7d3c1fa1914a6d37a8ba1262a82c54f1  guix-build-40894f677168/output/powerpc64le-linux-gnu/bitcoin-40894f677168-powerpc64le-linux-gnu.tar.gz
816f2d6b0705ec5e07a408ed3a97a07066189b9a89489e7ce67b4cb73a503bb9  guix-build-40894f677168/output/riscv64-linux-gnu/SHA256SUMS.part
42a9b52da8829a77cde4bae92b81f914c1da81cc39c6312b17dcdc13b2ea5273  guix-build-40894f677168/output/riscv64-linux-gnu/bitcoin-40894f677168-riscv64-linux-gnu-debug.tar.gz
b8e1ee469c77860998d4eb71166f22d83ad2487573b4b59600f42f25926431ed  guix-build-40894f677168/output/riscv64-linux-gnu/bitcoin-40894f677168-riscv64-linux-gnu.tar.gz
bd5b059d432b7f387f47feff4feaf6730d13cfed68298cdcf7282fb1a4e5a9e7  guix-build-40894f677168/output/x86_64-apple-darwin/SHA256SUMS.part
ff7a2b16ea40cf60c9ddb88eef60c36354b72f3ea1e9cac2609d876ad3d85149  guix-build-40894f677168/output/x86_64-apple-darwin/bitcoin-40894f677168-osx-unsigned.dmg
71416640e454374a2165992c4e9caf11ffc2129ef1e7fa15c26bf8d712e4c20c  guix-build-40894f677168/output/x86_64-apple-darwin/bitcoin-40894f677168-osx-unsigned.tar.gz
82755c00fd33f1c5afa40ef3148e3d802c387b4b64593215f54362167d43eb95  guix-build-40894f677168/output/x86_64-apple-darwin/bitcoin-40894f677168-osx64.tar.gz
824c65decc1169c94d68eaf2c91fec9d76a14521daffcf0ef4cf952c0ca2f27e  guix-build-40894f677168/output/x86_64-linux-gnu/SHA256SUMS.part
dbff4685658ab2e26bb90ed3a454559a41bb579730f13012335f52fd8e7f664c  guix-build-40894f677168/output/x86_64-linux-gnu/bitcoin-40894f677168-x86_64-linux-gnu-debug.tar.gz
32e9f8988b7e6f663d38f84160e00580adeb1915367afefed0a44c76ffcc4ab8  guix-build-40894f677168/output/x86_64-linux-gnu/bitcoin-40894f677168-x86_64-linux-gnu.tar.gz
e3d09fa9e5054f4801ec1ebb530f0990b9675a3e99ffee6bb36b524f37acca13  guix-build-40894f677168/output/x86_64-w64-mingw32/SHA256SUMS.part
3ed8d3f5d9d935d015429962d305781cefcc7bd2616fda105f4f14a088f5e9a4  guix-build-40894f677168/output/x86_64-w64-mingw32/bitcoin-40894f677168-win-unsigned.tar.gz
bf55846641b6877c5d8415ecbd172a061c7dc822b119247a0f6594d4bd1a8d90  guix-build-40894f677168/output/x86_64-w64-mingw32/bitcoin-40894f677168-win64-debug.zip
70a10d7d0843bb4b2dde80a0d0d1543e26d9eb7a38185adf3b51001e107f414e  guix-build-40894f677168/output/x86_64-w64-mingw32/bitcoin-40894f677168-win64-setup-unsigned.exe
264a12164944ec803e330248365704b7ca47b9ed81882f73c3c6ec71a65806e0  guix-build-40894f677168/output/x86_64-w64-mingw32/bitcoin-40894f677168-win64.zip
```