### PR TITLE
fix CI: bitcoin-chainstate: Lock `cs_main` to `UnloadBlockIndex`

### DIFF
--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -256,7 +256,7 @@ epilogue:
     }
     GetMainSignals().UnregisterBackgroundSignalScheduler();
 
-    UnloadBlockIndex(nullptr, chainman);
+    WITH_LOCK(::cs_main, UnloadBlockIndex(nullptr, chainman));
 
     init::UnsetGlobals();
 }


### PR DESCRIPTION
This was introduced because of a silent merge conflict.
