### PR TITLE
guix: Drop unneeded openssl dependency for signapple

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -506,8 +506,7 @@ and endian independent.")
          ("python-certvalidator" ,python-certvalidator)
          ("python-elfesteem" ,python-elfesteem)
          ("python-requests" ,python-requests)
-         ("python-macholib" ,python-macholib)
-         ("libcrypto" ,openssl)))
+         ("python-macholib" ,python-macholib)))
       ;; There are no tests, but attempting to run python setup.py test leads to
       ;; problems, just disable the test
       (arguments '(#:tests? #f))


### PR DESCRIPTION
`openssl` is not mentioned as a dependency in the https://github.com/achow101/signapple repo.

#### GUIX builds on `x86_64`:
```
$ find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
533f65e86f038ede9a665472279fc7569a3c9323c8c9c8f751ec1cb03d181638  guix-build-e857f0bb55b1/output/arm64-apple-darwin/SHA256SUMS.part
835b1b48d139f76213a7289d09bfa05e32d14a5351f8f9b6624059db5c621479  guix-build-e857f0bb55b1/output/arm64-apple-darwin/bitcoin-e857f0bb55b1-arm64-apple-darwin.tar.gz
076b385ec3aa21045a9d3269848ba20ec5e3150bf1e6a6a4f9cb940087588b72  guix-build-e857f0bb55b1/output/arm64-apple-darwin/bitcoin-e857f0bb55b1-osx-unsigned.dmg
9cd50f1fb66b817f76a7dda5db29cab1abe68a8eba5f0192c7e7350ebc160313  guix-build-e857f0bb55b1/output/arm64-apple-darwin/bitcoin-e857f0bb55b1-osx-unsigned.tar.gz
af674d14f616526de8737cf79ab4f4dff81a9737bebf92fd45ebd17b99b560a1  guix-build-e857f0bb55b1/output/dist-archive/bitcoin-e857f0bb55b1.tar.gz
ebea43c2fd7f7883055219c99c96bab5b77c82060d5e977de9be9639fe343cd8  guix-build-e857f0bb55b1/output/x86_64-apple-darwin/SHA256SUMS.part
9d4a93f1a82224b901fabe04081fa15e19692c91b5b53f17af5cab468b1185fe  guix-build-e857f0bb55b1/output/x86_64-apple-darwin/bitcoin-e857f0bb55b1-osx-unsigned.dmg
df3fc3644b4ce51a58b8f527594b5351af1b6f468d3dd929a901094bdec8adeb  guix-build-e857f0bb55b1/output/x86_64-apple-darwin/bitcoin-e857f0bb55b1-osx-unsigned.tar.gz
7f665e8dcb485c71da70cfcff12547dfc801d09dae3133a5e79d5dba2e1b4048  guix-build-e857f0bb55b1/output/x86_64-apple-darwin/bitcoin-e857f0bb55b1-osx64.tar.gz
```