### PR TITLE
[23.x] Second round signapple backports (M1)

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -490,7 +490,7 @@ and endian independent.")
     (license license:expat)))
 
 (define-public python-signapple
-  (let ((commit "b084cbbf44d5330448ffce0c7d118f75781b64bd"))
+  (let ((commit "0777ce58e61b0e6be753a5f524149d6d47905186"))
     (package
       (name "python-signapple")
       (version (git-version "0.1" "1" commit))
@@ -503,7 +503,7 @@ and endian independent.")
          (file-name (git-file-name name commit))
          (sha256
           (base32
-           "0k7inccl2mzac3wq4asbr0kl8s4cghm8982z54kfascqg45shv01"))))
+           "19axspyyfqbrfw2r53c17mi9bvm8zsb39mz8v9h7c173qkm3x5ym"))))
       (build-system python-build-system)
       (propagated-inputs
        `(("python-asn1crypto" ,python-asn1crypto)

--- a/contrib/macdeploy/detached-sig-create.sh
+++ b/contrib/macdeploy/detached-sig-create.sh
@@ -8,9 +8,11 @@ set -e
 
 ROOTDIR=dist
 BUNDLE="${ROOTDIR}/Bitcoin-Qt.app"
+BINARY="${BUNDLE}/Contents/MacOS/Bitcoin-Qt"
 SIGNAPPLE=signapple
 TEMPDIR=sign.temp
-OUT=signature-osx.tar.gz
+ARCH=$(${SIGNAPPLE} info ${BINARY} | head -n 1 | cut -d " " -f 1)
+OUT="signature-osx-${ARCH}.tar.gz"
 OUTROOT=osx/dist
 
 if [ -z "$1" ]; then


### PR DESCRIPTION
This backports additional signapple and macOS codesigning changes from #24506 for 23.x (skipping #24503, which is an interim signapple update, and the certvalidator change, which is not strictly necessary), and should complete the changes required to perform M1 codesigning for the 23.x release.