### PR TITLE
build, ci: Fix MSVC builds and other improvements

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -130,6 +130,7 @@ task:
     reupload_on_changes: true
     fingerprint_script:
       - echo %CI_VCPKG_TAG%
+      - type build_msvc\vcpkg.json
       - msbuild -version
     populate_script:
       - mkdir %VCPKG_DEFAULT_BINARY_CACHE%

--- a/build_msvc/vcpkg.json
+++ b/build_msvc/vcpkg.json
@@ -8,7 +8,6 @@
     "boost-signals2",
     "boost-test",
     "sqlite3",
-    "double-conversion",
     {
       "name": "libevent",
       "features": ["thread"]

--- a/build_msvc/vcpkg.json
+++ b/build_msvc/vcpkg.json
@@ -14,5 +14,13 @@
       "features": ["thread"]
     },
     "zeromq"
+  ],
+  "builtin-baseline": "b86c0c35b88e2bf3557ff49dc831689c2f085090",
+  "overrides": [
+    {
+      "name": "zeromq",
+      "version": "4.3.4",
+      "port-version": 3
+    }
   ]
 }


### PR DESCRIPTION
The current MSVC builds are broken due to the bug in the `zeromq` [port](https://github.com/microsoft/vcpkg/pull/22681#issuecomment-1061312320). From [IRC](https://bitcoin-irc.chaincode.com/bitcoin-core-dev/2022-03-08#787145):

> \<sipsorcery> Looks like it's a problem downloading the zeromq dependency from https://patch-diff.githubusercontent.com/raw/zeromq/libzmq/pull/4311.diff
> \<dhruv> sipsorcery: I'm definitely misunderstanding, i actually have no clue which file the CI is failing to download. I'll DM you more details.
> \<sipsorcery> It's saying the hash of the patch file has changed.
> \<dhruv> so we'd need to verify that the change is not malicious and then commit the new hash?
> \<sipsorcery> No that dependency is managed by the vcpkg repo. Seems they might be working on it https://github.com/microsoft/vcpkg/pull/22681#issuecomment-1061312320
> \<dhruv> ok, thanks

This PR fixes this issue with specifying the previous port version [explicitly](https://github.com/microsoft/vcpkg/blob/master/docs/users/versioning.md).

The current CI task does not fail due to the cached binaries.

---

The second commit makes vcpkg binary cache invalid if dependencies changed.

The third commit drops `double-conversion` from dependencies as Qt is configured as follows:
```
Configure summary:

Build type: win32-msvc (x86_64, CPU features: sse sse2)
Compiler: msvc 193131104
Configuration: sse2 aesni sse3 ssse3 sse4_1 sse4_2 avx avx2 avx512f avx512bw avx512cd avx512dq avx512er avx512ifma avx512pf avx512vbmi avx512vl compile_examples f16c largefile msvc_mp precompile_header rdrnd rdseed shani silent x86SimdAlways release c++11 c++14 c++17 c++1z concurrent no-pkg-config static static_runtime stl
Build options:
...
Qt Core:
  DoubleConversion ....................... yes
    Using system DoubleConversion ........ no
...
```