### PR TITLE
doc: update multisig-tutorial.md to descriptor wallet by default

### DIFF
--- a/doc/multisig-tutorial.md
+++ b/doc/multisig-tutorial.md
@@ -29,7 +29,7 @@ These three wallets should not be used directly for privacy reasons (public key 
 ```bash
 for ((n=1;n<=3;n++))
 do
- ./src/bitcoin-cli -signet -named createwallet wallet_name="participant_${n}" descriptors=true
+ ./src/bitcoin-cli -signet createwallet "participant_${n}"
 done
 ```
 
@@ -109,7 +109,7 @@ Then import the descriptors created in the previous step using the `importdescri
 After that, `getwalletinfo` can be used to check if the wallet was created successfully.
 
 ```bash
-./src/bitcoin-cli -signet -named createwallet wallet_name="multisig_wallet_01" disable_private_keys=true blank=true descriptors=true
+./src/bitcoin-cli -signet -named createwallet wallet_name="multisig_wallet_01" disable_private_keys=true blank=true
 
 ./src/bitcoin-cli  -signet -rpcwallet="multisig_wallet_01" importdescriptors "$multisig_desc"
 


### PR DESCRIPTION
Follow-up to #24281 and https://github.com/bitcoin/bitcoin/pull/24281#issuecomment-1033996386. The default wallet type was changed to descriptor wallets in #23002.