### PR TITLE
guix: only check for the macOS SDK once

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -121,7 +121,7 @@ else
 fi
 
 ################
-# When building for darwin, the macOS SDK should exists
+# When building for darwin, the macOS SDK should exist
 ################
 
 for host in $HOSTS; do
@@ -130,6 +130,7 @@ for host in $HOSTS; do
             OSX_SDK="$(make -C "${PWD}/depends" --no-print-directory HOST="$host" print-OSX_SDK | sed 's@^[^=]\+=@@g')"
             if [ -e "$OSX_SDK" ]; then
                 echo "Found macOS SDK at '${OSX_SDK}', using..."
+                break
             else
                 echo "macOS SDK does not exist at '${OSX_SDK}', please place the extracted, untarred SDK there to perform darwin builds, exiting..."
                 exit 1


### PR DESCRIPTION
If we are building for both macOS HOSTS, there's no need to check and
print that the SDK exists two times.

Currently a Guix build for both HOSTS will print:
```bash
./contrib/guix/guix-build
Found macOS SDK at '/SDKs/Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers', using...
Found macOS SDK at '/SDKs/Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers', using...
Checking that we can connect to the guix-daemon...
```