### PR TITLE
build: Fix Boost.Process detection on macOS arm64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1446,6 +1446,8 @@ if test "$use_external_signer" != "no"; then
     ;;
     *)
       AC_MSG_CHECKING([whether Boost.Process can be used])
+      TEMP_CPPFLAGS="$CPPFLAGS"
+      CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
       TEMP_LDFLAGS="$LDFLAGS"
       dnl Boost 1.73 and older require the following workaround.
       LDFLAGS="$LDFLAGS $PTHREAD_CFLAGS"
@@ -1453,6 +1455,7 @@ if test "$use_external_signer" != "no"; then
         [have_boost_process="yes"],
         [have_boost_process="no"])
       LDFLAGS="$TEMP_LDFLAGS"
+      CPPFLAGS="$TEMP_CPPFLAGS"
       AC_MSG_RESULT([$have_boost_process])
       if test "$have_boost_process" = "yes"; then
         use_external_signer="yes"


### PR DESCRIPTION
Could be tested as follows:
```
% brew install boost@1.76
% ./autogen.sh
% ./configure --with-boost='/opt/homebrew/opt/boost@1.76'
```