### PR TITLE
doc: remove Boost LDFLAGS from netBSD build docs

### DIFF
--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -57,7 +57,6 @@ With wallet:
 ./configure --with-gui=no CPPFLAGS="-I/usr/pkg/include" \
     LDFLAGS="-L/usr/pkg/lib" \
     BOOST_CPPFLAGS="-I/usr/pkg/include" \
-    BOOST_LDFLAGS="-L/usr/pkg/lib" \
     BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
     BDB_CFLAGS="-I${BDB_PREFIX}/include" \
     MAKE=gmake
@@ -70,7 +69,6 @@ Without wallet:
     CPPFLAGS="-I/usr/pkg/include" \
     LDFLAGS="-L/usr/pkg/lib" \
     BOOST_CPPFLAGS="-I/usr/pkg/include" \
-    BOOST_LDFLAGS="-L/usr/pkg/lib" \
     MAKE=gmake
 ```
 


### PR DESCRIPTION
We no-longer link against any Boost libs, so we shouldn't need to use
any Boost linker flags.