### PR TITLE
build: don't install deprecated libevent headers

### DIFF
--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -36,5 +36,6 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm lib/*.la
+  rm lib/*.la && \
+  rm include/ev*.h
 endef


### PR DESCRIPTION
We don't use the deprecated headers now, and never should do in the
future, so there is no need for them to exist in depends.

The headers themselves are just full of includes for the newer headers.