### PR TITLE
rpc: rename getdeploymentinfo status-next to status_next

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1481,7 +1481,7 @@ static void SoftForkDescPushBack(const CBlockIndex* blockindex, UniValue& softfo
     // BIP9 status
     bip9.pushKV("status", get_state_name(current_state));
     bip9.pushKV("since", g_versionbitscache.StateSinceHeight(blockindex->pprev, consensusParams, id));
-    bip9.pushKV("status-next", get_state_name(next_state));
+    bip9.pushKV("status_next", get_state_name(next_state));
 
     // BIP9 signalling status, if applicable
     if (has_signal) {
@@ -1623,7 +1623,7 @@ const std::vector<RPCResult> RPCHelpForDeployment{
         {RPCResult::Type::NUM, "min_activation_height", "minimum height of blocks for which the rules may be enforced"},
         {RPCResult::Type::STR, "status", "status of deployment at specified block (one of \"defined\", \"started\", \"locked_in\", \"active\", \"failed\")"},
         {RPCResult::Type::NUM, "since", "height of the first block to which the status applies"},
-        {RPCResult::Type::STR, "status-next", "status of deployment at the next block"},
+        {RPCResult::Type::STR, "status_next", "status of deployment at the next block"},
         {RPCResult::Type::OBJ, "statistics", /*optional=*/true, "numeric statistics about signalling for a softfork (only for \"started\" and \"locked_in\" status)",
         {
             {RPCResult::Type::NUM, "period", "the length in blocks of the signalling period"},

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -200,7 +200,7 @@ class BlockchainTest(BitcoinTestFramework):
                     'timeout': 0x7fffffffffffffff,  # testdummy does not have a timeout so is set to the max int64 value
                     'min_activation_height': 0,
                     'status': 'started',
-                    'status-next': status_next,
+                    'status_next': status_next,
                     'since': 144,
                     'statistics': {
                         'period': 144,
@@ -220,7 +220,7 @@ class BlockchainTest(BitcoinTestFramework):
                     'timeout': 9223372036854775807,
                     'min_activation_height': 0,
                     'status': 'active',
-                    'status-next': 'active',
+                    'status_next': 'active',
                     'since': 0,
                 },
                 'height': 0,


### PR DESCRIPTION
Rename the `status-next` field to `status_next` in getdeploymentinfo before the RPC is released in v23.

Before
```
Result:
{                                       (json object)
  "hash" : "str",                       (string) requested block hash (or tip)
  "height" : n,                         (numeric) requested block height (or tip)
  "deployments" : {                     (json object)
    "xxxx" : {                          (json object) name of the deployment
      "type" : "str",                   (string) one of "buried", "bip9"
      "height" : n,                     (numeric, optional) height of the first block which the rules are or will be enforced (only for "buried" type, or "bip9" type with "active" status)
      "active" : true|false,            (boolean) true if the rules are enforced for the mempool and the next block
      "bip9" : {                        (json object, optional) status of bip9 softforks (only for "bip9" type)
        "bit" : n,                      (numeric, optional) the bit (0-28) in the block version field used to signal this softfork (only for "started" and "locked_in" status)
        "start_time" : xxx,             (numeric) the minimum median time past of a block at which the bit gains its meaning
        "timeout" : xxx,                (numeric) the median time past of a block at which the deployment is considered failed if not yet locked in
        "min_activation_height" : n,    (numeric) minimum height of blocks for which the rules may be enforced
        "status" : "str",               (string) status of deployment at specified block (one of "defined", "started", "locked_in", "active", "failed")
        "since" : n,                    (numeric) height of the first block to which the status applies
        "status-next" : "str",          (string) status of deployment at the next block
        "statistics" : {                (json object, optional) numeric statistics about signalling for a softfork (only for "started" and "locked_in" status)
          "period" : n,                 (numeric) the length in blocks of the signalling period
          "threshold" : n,              (numeric, optional) the number of blocks with the version bit set required to activate the feature (only for "started" status)
          "elapsed" : n,                (numeric) the number of blocks elapsed since the beginning of the current period
          "count" : n,                  (numeric) the number of blocks with the version bit set in the current period
          "possible" : true|false       (boolean, optional) returns false if there are not enough blocks left in this period to pass activation threshold (only for "started" status)
        },
        "signalling" : "str"            (string) indicates blocks that signalled with a # and blocks that did not with a -
      }
    }
  }
}
```
After
```
Result:
{                                       (json object)
  "hash" : "str",                       (string) requested block hash (or tip)
  "height" : n,                         (numeric) requested block height (or tip)
  "deployments" : {                     (json object)
    "xxxx" : {                          (json object) name of the deployment
      "type" : "str",                   (string) one of "buried", "bip9"
      "height" : n,                     (numeric, optional) height of the first block which the rules are or will be enforced (only for "buried" type, or "bip9" type with "active" status)
      "active" : true|false,            (boolean) true if the rules are enforced for the mempool and the next block
      "bip9" : {                        (json object, optional) status of bip9 softforks (only for "bip9" type)
        "bit" : n,                      (numeric, optional) the bit (0-28) in the block version field used to signal this softfork (only for "started" and "locked_in" status)
        "start_time" : xxx,             (numeric) the minimum median time past of a block at which the bit gains its meaning
        "timeout" : xxx,                (numeric) the median time past of a block at which the deployment is considered failed if not yet locked in
        "min_activation_height" : n,    (numeric) minimum height of blocks for which the rules may be enforced
        "status" : "str",               (string) status of deployment at specified block (one of "defined", "started", "locked_in", "active", "failed")
        "since" : n,                    (numeric) height of the first block to which the status applies
        "status_next" : "str",          (string) status of deployment at the next block
        "statistics" : {                (json object, optional) numeric statistics about signalling for a softfork (only for "started" and "locked_in" status)
          "period" : n,                 (numeric) the length in blocks of the signalling period
          "threshold" : n,              (numeric, optional) the number of blocks with the version bit set required to activate the feature (only for "started" status)
          "elapsed" : n,                (numeric) the number of blocks elapsed since the beginning of the current period
          "count" : n,                  (numeric) the number of blocks with the version bit set in the current period
          "possible" : true|false       (boolean, optional) returns false if there are not enough blocks left in this period to pass activation threshold (only for "started" status)
        },
        "signalling" : "str"            (string) indicates blocks that signalled with a # and blocks that did not with a -
      }
    }
  }
}
```
