### PR TITLE
Use designated initializers

### DIFF
--- a/build_msvc/common.init.vcxproj.in
+++ b/build_msvc/common.init.vcxproj.in
@@ -90,7 +90,7 @@
       <AdditionalOptions>/utf-8 /Zc:__cplusplus /std:c++17 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4018;4244;4267;4334;4715;4805;4834</DisableSpecificWarnings>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <PreprocessorDefinitions>_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;_SILENCE_CXX17_OLD_ALLOCATOR_MEMBERS_DEPRECATION_WARNING;ZMQ_STATIC;NOMINMAX;WIN32;HAVE_CONFIG_H;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CONSOLE;_WIN32_WINNT=0x0601;_WIN32_IE=0x0501;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>DISABLE_DESIGNATED_INITIALIZER_ERRORS;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;_SILENCE_CXX17_OLD_ALLOCATOR_MEMBERS_DEPRECATION_WARNING;ZMQ_STATIC;NOMINMAX;WIN32;HAVE_CONFIG_H;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CONSOLE;_WIN32_WINNT=0x0601;_WIN32_IE=0x0501;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\src;..\..\src\minisketch\include;..\..\src\univalue\include;..\..\src\secp256k1\include;..\..\src\leveldb\include;..\..\src\leveldb\helpers\memenv;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -254,6 +254,7 @@ BITCOIN_CORE_H = \
   util/bip32.h \
   util/bytevectorhash.h \
   util/check.h \
+  util/designator.h \
   util/epochguard.h \
   util/error.h \
   util/fastrange.h \

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -25,6 +25,7 @@
 #include <protocol.h>
 #include <random.h>
 #include <scheduler.h>
+#include <util/designator.h>
 #include <util/sock.h>
 #include <util/strencodings.h>
 #include <util/syscall_sandbox.h>
@@ -1101,12 +1102,20 @@ bool CConnman::AttemptToEvictConnection()
                 continue;
             if (node->fDisconnect)
                 continue;
-            NodeEvictionCandidate candidate = {node->GetId(), node->m_connected, node->m_min_ping_time,
-                                               node->m_last_block_time, node->m_last_tx_time,
-                                               HasAllDesirableServiceFlags(node->nServices),
-                                               node->m_relays_txs.load(), node->m_bloom_filter_loaded.load(),
-                                               node->nKeyedNetGroup, node->m_prefer_evict, node->addr.IsLocal(),
-                                               node->ConnectedThroughNetwork()};
+            NodeEvictionCandidate candidate{
+                Desig(id) node->GetId(),
+                Desig(m_connected) node->m_connected,
+                Desig(m_min_ping_time) node->m_min_ping_time,
+                Desig(m_last_block_time) node->m_last_block_time,
+                Desig(m_last_tx_time) node->m_last_tx_time,
+                Desig(fRelevantServices) HasAllDesirableServiceFlags(node->nServices),
+                Desig(m_relay_txs) node->m_relays_txs.load(),
+                Desig(fBloomFilter) node->m_bloom_filter_loaded.load(),
+                Desig(nKeyedNetGroup) node->nKeyedNetGroup,
+                Desig(prefer_evict) node->m_prefer_evict,
+                Desig(m_is_local) node->addr.IsLocal(),
+                Desig(m_network) node->ConnectedThroughNetwork(),
+            };
             vEvictionCandidates.push_back(candidate);
         }
     }

--- a/src/util/designator.h
+++ b/src/util/designator.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_DESIGNATOR_H
+#define BITCOIN_UTIL_DESIGNATOR_H
+
+/**
+ * Designated initializers can be used to avoid ordering mishaps in aggregate
+ * initialization. However, they do not prevent uninitialized members. The
+ * checks can be disabled by defining DISABLE_DESIGNATED_INITIALIZER_ERRORS.
+ * This should only be needed on MSVC 2019. MSVC 2022 supports them with the
+ * option "/std:c++20"
+ */
+#ifndef DISABLE_DESIGNATED_INITIALIZER_ERRORS
+#define Desig(field_name) .field_name =
+#else
+#define Desig(field_name)
+#endif
+
+#endif // BITCOIN_UTIL_DESIGNATOR_H


### PR DESCRIPTION
Designated initializers are supported since gcc 4.7 (Our minimum required is 8) and clang 3 (Our minimum required is 7). They work out of the box with C++17, and only msvc requires the C++20 flag to be set. I don't expect any of our msvc users will run into issues due to this. See also https://bitcoin.jonasschnelli.ch/ircmeetings/logs/bitcoin-core-dev/2022/bitcoin-core-dev.2022-03-10-19.00.log.html#l-114