### PR TITLE
test: use MiniWallet for feature_maxuploadtarget.py

### DIFF
--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -13,10 +13,19 @@ if uploadtarget has been reached.
 from collections import defaultdict
 import time
 
-from test_framework.messages import CInv, MSG_BLOCK, msg_getdata
+from test_framework.messages import (
+    CInv,
+    MSG_BLOCK,
+    msg_getdata,
+)
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, mine_large_block
+from test_framework.util import (
+    assert_equal,
+    mine_large_block,
+)
+from test_framework.wallet import MiniWallet
+
 
 class TestP2PConn(P2PInterface):
     def __init__(self):
@@ -41,12 +50,6 @@ class MaxUploadTest(BitcoinTestFramework):
         ]]
         self.supports_cli = False
 
-        # Cache for utxos, as the listunspent may take a long time later in the test
-        self.utxo_cache = []
-
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
-
     def run_test(self):
         # Before we connect anything, we first set the time on the node
         # to be in the past, otherwise things break because the CNode
@@ -55,7 +58,8 @@ class MaxUploadTest(BitcoinTestFramework):
         self.nodes[0].setmocktime(old_time)
 
         # Generate some old blocks
-        self.generate(self.nodes[0], 130)
+        self.wallet = MiniWallet(self.nodes[0])
+        self.generate(self.wallet, 130)
 
         # p2p_conns[0] will only request old blocks
         # p2p_conns[1] will only request new blocks
@@ -66,7 +70,7 @@ class MaxUploadTest(BitcoinTestFramework):
             p2p_conns.append(self.nodes[0].add_p2p_connection(TestP2PConn()))
 
         # Now mine a big block
-        mine_large_block(self, self.nodes[0], self.utxo_cache)
+        mine_large_block(self, self.wallet, self.nodes[0])
 
         # Store the hash; we'll request this later
         big_old_block = self.nodes[0].getbestblockhash()
@@ -77,7 +81,7 @@ class MaxUploadTest(BitcoinTestFramework):
         self.nodes[0].setmocktime(int(time.time()) - 2*60*60*24)
 
         # Mine one more block, so that the prior block looks old
-        mine_large_block(self, self.nodes[0], self.utxo_cache)
+        mine_large_block(self, self.wallet, self.nodes[0])
 
         # We'll be requesting this new block too
         big_new_block = self.nodes[0].getbestblockhash()


### PR DESCRIPTION
This PR enables one more of the non-wallet functional tests (feature_maxuploadtarget.py) to be run even with the Bitcoin Core wallet disabled by using the MiniWallet instead, as proposed in https://github.com/bitcoin/bitcoin/issues/20078. Note that the adapted helper function `mine_large_block` is currently only is used in this test, i.e. there was no need to change any others.