### PR TITLE
ci: Integrate ccache into MSVC build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -85,6 +85,8 @@ task:
     CI_VCPKG_TAG: '2022.02.23'
     VCPKG_DOWNLOADS: 'C:\Users\ContainerAdministrator\AppData\Local\vcpkg\downloads'
     VCPKG_DEFAULT_BINARY_CACHE: 'C:\Users\ContainerAdministrator\AppData\Local\vcpkg\archives'
+    CCACHE_DIR: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
+    WRAPPED_CL: 'C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build\ci\test\wrapped-cl.bat'
     QT_DOWNLOAD_URL: 'https://download.qt.io/official_releases/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.zip'
     QT_LOCAL_PATH: 'C:\qt-everywhere-src-5.15.2.zip'
     QT_SOURCE_DIR: 'C:\qt-everywhere-src-5.15.2'
@@ -134,9 +136,13 @@ task:
       - msbuild -version
     populate_script:
       - mkdir %VCPKG_DEFAULT_BINARY_CACHE%
-  install_python_script:
+  ccache_cache:
+    folder: '%CCACHE_DIR%'
+  install_tools_script:
+    - choco install --yes --no-progress ccache
     - choco install --yes --no-progress python3 --version=3.9.6
     - pip install zmq
+    - ccache --version
     - python -VV
   install_vcpkg_script:
     - cd ..
@@ -148,9 +154,12 @@ task:
     - .\vcpkg integrate install
     - .\vcpkg version
   build_script:
+    - '%x64_NATIVE_TOOLS%'
     - cd %CIRRUS_WORKING_DIR%
+    - ccache --zero-stats
     - python build_msvc\msvc-autogen.py
-    - msbuild build_msvc\bitcoin.sln -property:Configuration=Release -maxCpuCount -verbosity:minimal -noLogo
+    - msbuild build_msvc\bitcoin.sln -property:CLToolExe=%WRAPPED_CL% -property:Configuration=Release -maxCpuCount -verbosity:minimal -noLogo
+    - ccache --show-stats
   unit_tests_script:
     - src\test_bitcoin.exe -l test_suite
     - src\bench_bitcoin.exe > NUL

--- a/ci/test/wrapped-cl.bat
+++ b/ci/test/wrapped-cl.bat
@@ -1,0 +1,1 @@
+ccache cl %*


### PR DESCRIPTION
[ccache 4.6](https://ccache.dev/releasenotes.html#_ccache_4_6):
> Added support for caching calls to Microsoft Visual C++ (MSVC)

Integrated into our native Windows CI task.

[On master](url) (c109e7d51c9c5614aafce184c63b52ad2e859eb2):
![Screenshot from 2022-03-12 10-17-58](https://user-images.githubusercontent.com/32963518/158012098-7ac9d441-2eb0-481e-bcc5-3700c1ce2b15.png)

[This PR](https://cirrus-ci.com/task/6572984340054016):
![Screenshot from 2022-03-12 10-25-33](https://user-images.githubusercontent.com/32963518/158012361-d6bf88bc-f98d-4771-8b4f-31bf5673d085.png)

```
Summary:
  Hits:             222 /  222 (100.0 %)
    Direct:         222 /  222 (100.0 %)
    Preprocessed:     0 /    0
  Misses:             0
    Direct:           0
    Preprocessed:     0
  Errors:             7
  Uncacheable:        9
Primary storage:
  Hits:             444 /  444 (100.0 %)
  Misses:             0
  Cache size (GB): 0.04 / 5.00 (0.86 %)

Use the -v/--verbose option for more details.
```