### PR TITLE
guix: Use $HOST instead of generic osx{64} for macOS artifacts

### DIFF
--- a/contrib/guix/guix-codesign
+++ b/contrib/guix/guix-codesign
@@ -155,7 +155,7 @@ unsigned_tarball_for_host() {
             echo "$(outdir_for_host "$1")/${DISTNAME}-win-unsigned.tar.gz"
             ;;
         *darwin*)
-            echo "$(outdir_for_host "$1")/${DISTNAME}-osx-unsigned.tar.gz"
+            echo "$(outdir_for_host "$1")/${DISTNAME}-${1}-unsigned.tar.gz"
             ;;
         *)
             exit 1

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -348,10 +348,10 @@ mkdir -p "$DISTSRC"
                 find . -print0 \
                     | sort --zero-terminated \
                     | tar --create --no-recursion --mode='u+rw,go+r-w,a+X' --null --files-from=- \
-                    | gzip -9n > "${OUTDIR}/${DISTNAME}-osx-unsigned.tar.gz" \
-                    || ( rm -f "${OUTDIR}/${DISTNAME}-osx-unsigned.tar.gz" && exit 1 )
+                    | gzip -9n > "${OUTDIR}/${DISTNAME}-${HOST}-unsigned.tar.gz" \
+                    || ( rm -f "${OUTDIR}/${DISTNAME}-${HOST}-unsigned.tar.gz" && exit 1 )
             )
-            make deploy ${V:+V=1} OSX_DMG="${OUTDIR}/${DISTNAME}-osx-unsigned.dmg"
+            make deploy ${V:+V=1} OSX_DMG="${OUTDIR}/${DISTNAME}-${HOST}-unsigned.dmg"
             ;;
     esac
     (
@@ -423,8 +423,8 @@ mkdir -p "$DISTSRC"
                 find "${DISTNAME}" -print0 \
                     | sort --zero-terminated \
                     | tar --create --no-recursion --mode='u+rw,go+r-w,a+X' --null --files-from=- \
-                    | gzip -9n > "${OUTDIR}/${DISTNAME}-${HOST//x86_64-apple-darwin/osx64}.tar.gz" \
-                    || ( rm -f "${OUTDIR}/${DISTNAME}-${HOST//x86_64-apple-darwin/osx64}.tar.gz" && exit 1 )
+                    | gzip -9n > "${OUTDIR}/${DISTNAME}-${HOST}.tar.gz" \
+                    || ( rm -f "${OUTDIR}/${DISTNAME}-${HOST}.tar.gz" && exit 1 )
                 ;;
         esac
     )  # $DISTSRC/installed

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -439,8 +439,8 @@ mkdir -p "$DISTSRC"
                 find . -print0 \
                     | sort --zero-terminated \
                     | tar --create --no-recursion --mode='u+rw,go+r-w,a+X' --null --files-from=- \
-                    | gzip -9n > "${OUTDIR}/${DISTNAME}-win-unsigned.tar.gz" \
-                    || ( rm -f "${OUTDIR}/${DISTNAME}-win-unsigned.tar.gz" && exit 1 )
+                    | gzip -9n > "${OUTDIR}/${DISTNAME}-win64-unsigned.tar.gz" \
+                    || ( rm -f "${OUTDIR}/${DISTNAME}-win64-unsigned.tar.gz" && exit 1 )
             )
             ;;
     esac

--- a/contrib/guix/libexec/codesign.sh
+++ b/contrib/guix/libexec/codesign.sh
@@ -91,7 +91,7 @@ mkdir -p "$DISTSRC"
                       -- -volume_date all_file_dates ="$SOURCE_DATE_EPOCH"
 
             # Compress uncompressed.dmg and output to OUTDIR
-            ./dmg dmg uncompressed.dmg "${OUTDIR}/${DISTNAME}-osx-signed.dmg"
+            ./dmg dmg uncompressed.dmg "${OUTDIR}/${DISTNAME}-${HOST}-signed.dmg"
             ;;
         *)
             exit 1

--- a/contrib/guix/libexec/codesign.sh
+++ b/contrib/guix/libexec/codesign.sh
@@ -91,7 +91,7 @@ mkdir -p "$DISTSRC"
                       -- -volume_date all_file_dates ="$SOURCE_DATE_EPOCH"
 
             # Compress uncompressed.dmg and output to OUTDIR
-            ./dmg dmg uncompressed.dmg "${OUTDIR}/${DISTNAME}-${HOST}-signed.dmg"
+            ./dmg dmg uncompressed.dmg "${OUTDIR}/${DISTNAME}-${HOST}.dmg"
             ;;
         *)
             exit 1


### PR DESCRIPTION
On master (f94784f5bcfd0adf5d20f9631cde454348b4ff71) and 23.x branches some GUIX artifacts for `x86_64` and `arm64` macOS have indistinguishable names:
```
d34646cbaf05e03195eb1e426f72fb471fe2d87ab18c9a656600089597703a38  bitcoin-23.0rc2-arm64-apple-darwin.tar.gz
968767b39442e179e5976b948112a0904374eb4cfb9cba22863408a70a1d99f9  bitcoin-23.0rc2-osx-unsigned.dmg
d8a7037d5bb845a214e45a52abcf9119bfbe72a76d6370e9560c18fda74a70db  bitcoin-23.0rc2-osx-unsigned.tar.gz
71092f37985d556bdd25d33fb8571e13664eacadda90efcf21eaa1ba8a32eabd  bitcoin-23.0rc2-osx-unsigned.dmg
cb10c49b486085b89393955a7a168c32e2f2a4911f2b8d44494bd8f2bd0acf2f  bitcoin-23.0rc2-osx-unsigned.tar.gz
6d4c44726cd45711c4cb7257c6b46731be1446fc85e79ac86f2def19be45ced3  bitcoin-23.0rc2-osx64.tar.gz
```

With this PR:
```
$ find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
054c3765381b6d59c6ad8e5e3cbbdd23e330bd579f88b399f78f296d1a4536d0  guix-build-53dd6165b899/output/arm64-apple-darwin/SHA256SUMS.part
18750c1ff71d014fe5f976da738bfa04a4cd02af6b0d575def8d83160552de2d  guix-build-53dd6165b899/output/arm64-apple-darwin/bitcoin-53dd6165b899-arm64-apple-darwin-unsigned.dmg
fa2b16684060202d1918c658b446909ee10999a8b9a85018ca2f6a09eaa11c8e  guix-build-53dd6165b899/output/arm64-apple-darwin/bitcoin-53dd6165b899-arm64-apple-darwin-unsigned.tar.gz
b865000eb4b291a51d1920eec63dcbc9b47dedb1cc7fda0af3ab9b321db36b82  guix-build-53dd6165b899/output/arm64-apple-darwin/bitcoin-53dd6165b899-arm64-apple-darwin.tar.gz
dd88ce6660754987abf95fc2c4d09f6d2248f12ecee4ef2c03f4fa74bbd8e3ae  guix-build-53dd6165b899/output/dist-archive/bitcoin-53dd6165b899.tar.gz
fb1871c134e079aa970c5317cad258540e2642cc7ff60a794c85651c85fc6fc4  guix-build-53dd6165b899/output/x86_64-apple-darwin/SHA256SUMS.part
b1f4c04f7dbd85798ed7cd76fd7948299dfb5653c6c68df0b0839be1c1b295dd  guix-build-53dd6165b899/output/x86_64-apple-darwin/bitcoin-53dd6165b899-x86_64-apple-darwin-unsigned.dmg
f1f8b2774ba3028d6cdde509076614067a6affc0fa176fdbb03829109ae47022  guix-build-53dd6165b899/output/x86_64-apple-darwin/bitcoin-53dd6165b899-x86_64-apple-darwin-unsigned.tar.gz
20b9386a81e70f848db7c4f14bcb6cf2fbc1dc17aad1b9a2e6f04ac6fa86a4c9  guix-build-53dd6165b899/output/x86_64-apple-darwin/bitcoin-53dd6165b899-x86_64-apple-darwin.tar.gz
6f764a8fe876359d3c377fd934eb6595cc06d746980e07320565566abe9409f9  guix-build-53dd6165b899/output/x86_64-w64-mingw32/SHA256SUMS.part
446b24b2e01608d3dc09db29545db2cdb716c161b19356f4fae930d3ebb299f8  guix-build-53dd6165b899/output/x86_64-w64-mingw32/bitcoin-53dd6165b899-win64-debug.zip
d1660e6839a1358ae2d164958b551b81338cca9b740b3dc314397a35b17ba2a6  guix-build-53dd6165b899/output/x86_64-w64-mingw32/bitcoin-53dd6165b899-win64-setup-unsigned.exe
4ab0d948f3864f0d5d220c570b57a02e040f936a8f6b9dba3b4688c80667def9  guix-build-53dd6165b899/output/x86_64-w64-mingw32/bitcoin-53dd6165b899-win64-unsigned.tar.gz
481177329998fcbb71ab1fc9542a6ffcea623cebddf567981cfa76a7320ec115  guix-build-53dd6165b899/output/x86_64-w64-mingw32/bitcoin-53dd6165b899-win64.zip
```

Also naming of Windows artifacts has been improved.