### PR TITLE
contrib: fix signet miner (sighash mismatch)

### DIFF
--- a/contrib/signet/miner
+++ b/contrib/signet/miner
@@ -8,7 +8,7 @@ import base64
 import json
 import logging
 import math
-import os.path
+import os
 import re
 import struct
 import sys
@@ -493,10 +493,11 @@ def do_generate(args):
         logging.debug("Mining block delta=%s start=%s mine=%s", seconds_to_hms(mine_time-bestheader["time"]), mine_time, is_mine)
         mined_blocks += 1
         psbt = generate_psbt(tmpl, reward_spk, blocktime=mine_time)
-        psbt_signed = json.loads(args.bcli("-stdin", "walletprocesspsbt", input=psbt.encode('utf8')))
+        input_stream = os.linesep.join([psbt, "true", "ALL"]).encode('utf8')
+        psbt_signed = json.loads(args.bcli("-stdin", "walletprocesspsbt", input=input_stream))
         if not psbt_signed.get("complete",False):
             logging.debug("Generated PSBT: %s" % (psbt,))
-            sys.stderr.write("PSBT signing failed")
+            sys.stderr.write("PSBT signing failed\n")
             return 1
         block, signet_solution = do_decode_psbt(psbt_signed["psbt"])
         block = finish_block(block, signet_solution, args.grind_cmd)


### PR DESCRIPTION
gruve-p reported that the signet miner doesn't work anymore (see https://github.com/bitcoin/bitcoin/issues/24501#issuecomment-1062088351), failing with the following error of the `walletprocesspsbt` RPC:

```
error code: -22
error message:
Specified sighash value does not match value stored in PSBT
.....
subprocess.CalledProcessError: Command '['bitcoin-cli', '-signet', '-stdin', 'walletprocesspsbt']' returned non-zero exit status 22
```

PSBT signing was changed to use SIGHASH_DEFAULT by default in #22514. The signet miner script sets the sighash type of the created PSBT to SIGHASH_ALL (3 is the per-input type PSBT_IN_SIGHASH_TYPE, following a little-endian 32 unsigned integer of the sighash type):

https://github.com/bitcoin/bitcoin/blob/e04720ec3336e3df7fce522e3b1da972aa65ff62/contrib/signet/miner#L169-L170

hence this leads to a sighash mismatch when the `walletprocesspsbt` RPC is called. Fix this by explicitly passing the correct sighash type. The same change was needed in one of our functional tests, see commit d3992669df826899a3de78a77a366dab46028026.

Note that instead of feeding the PSBT via `-stdin` it is directly passed as parameter, as I couldn't figure out a way to pass multiple parameters otherwise (separating by newline also didn't work).
