### PR TITLE
[POC] build: Use "build ID" instead of "debug link" to specify debug info

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -970,6 +970,8 @@ if test "$TARGET_OS" = "darwin"; then
   AX_CHECK_LINK_FLAG([-Wl,-bind_at_load], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,-bind_at_load"], [], [$LDFLAG_WERROR])
 fi
 
+AX_CHECK_LINK_FLAG([-Wl,--build-id=0xfedcba9876543210], [LDFLAGS="$LDFLAGS -Wl,--build-id=0xfedcba9876543210"], [AC_MSG_ERROR([linker did not accept --build-id flag])], [$LDFLAG_WERROR])
+
 AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h sys/select.h sys/prctl.h sys/sysctl.h vm/vm_param.h sys/vmmeter.h sys/resources.h])
 
 AC_CHECK_DECLS([getifaddrs, freeifaddrs],[CHECK_SOCKET],,

--- a/contrib/devtools/split-debug.sh.in
+++ b/contrib/devtools/split-debug.sh.in
@@ -7,4 +7,3 @@ fi
 @OBJCOPY@ --enable-deterministic-archives -p --only-keep-debug $1 $3
 @OBJCOPY@ --enable-deterministic-archives -p --strip-debug $1 $2
 @STRIP@ --enable-deterministic-archives -p -s $2
-@OBJCOPY@ --enable-deterministic-archives -p --add-gnu-debuglink=$3 $2


### PR DESCRIPTION
This PR makes GUIX built executables, except for the GUI (TBD), architecture agnostic.

Close bitcoin/bitcoin#21194 ?