### PR TITLE
Remove unused feebumper code

### DIFF
--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -233,12 +233,6 @@ Result CreateRateBumpTransaction(CWallet& wallet, const uint256& txid, const CCo
 
     // Write back transaction
     mtx = CMutableTransaction(*tx_new);
-    // Mark new tx not replaceable, if requested.
-    if (!coin_control.m_signal_bip125_rbf.value_or(wallet.m_signal_rbf)) {
-        for (auto& input : mtx.vin) {
-            if (input.nSequence < 0xfffffffe) input.nSequence = 0xfffffffe;
-        }
-    }
 
     return Result::OK;
 }


### PR DESCRIPTION
This was accidentally added in commit 0ea47ba7b38cc4b2b9175347cb5cd48fcd08da48. Presumably due to a copy-paste error, as `CreateTransaction` already takes care of the rbf-signal.