### PR TITLE
doc: Clarify that CheckSequenceLocksAtTip is a validation function

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -273,7 +273,7 @@ PackageMempoolAcceptResult ProcessNewPackage(CChainState& active_chainstate, CTx
                                                    const Package& txns, bool test_accept)
                                                    EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-/* Transaction policy functions */
+/* Mempool validation helper functions */
 
 /**
  * Check if transaction will be final in the next block to be created.


### PR DESCRIPTION
It has been pointed out that a bug in this function can prevent block template creation. ( https://github.com/bitcoin/bitcoin/pull/24080#issuecomment-1065148776 ) So it seems that the scope of this function is more than "policy". Rename it back to "validation", to partially revert commit fa4e30b0f36f2e7a09db7d30dca9008ed9dbcb35.