### PR TITLE
build: Drop redundant checks for ranlib and strip tools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -108,8 +108,6 @@ LT_INIT([pic-only win32-dll])
 
 dnl Check/return PATH for base programs.
 AC_PATH_TOOL([AR], [ar])
-AC_PATH_TOOL([RANLIB], [ranlib])
-AC_PATH_TOOL([STRIP], [strip])
 AC_PATH_TOOL([GCOV], [gcov])
 AC_PATH_TOOL([LLVM_COV], [llvm-cov])
 AC_PATH_PROG([LCOV], [lcov])


### PR DESCRIPTION
These checks are handled by the `LT_INIT` macro.

Inspired by bitcoin-core/secp256k1#1088.

On master (f3e0ace8ecd84009a23da6b0de47f01d79c45772):
```
$ ./configure --with-incompatible-bdb 2>&1 | grep -n -E 'ranlib\.\.\.|strip\.\.\.'
56:checking for strip... strip
57:checking for ranlib... ranlib
102:checking for ranlib... /usr/bin/ranlib
103:checking for strip... /usr/bin/strip
380:checking for strip... strip
381:checking for ranlib... ranlib
```
With this PR:
```
$ ./configure --with-incompatible-bdb 2>&1 | grep -n -E 'ranlib\.\.\.|strip\.\.\.'
56:checking for strip... strip
57:checking for ranlib... ranlib
377:checking for strip... strip
378:checking for ranlib... ranlib
$ CONFIG_SITE=$PWD/depends/x86_64-apple-darwin/share/config.site ./configure 2>&1 | grep -n -E 'ranlib\.\.\.|strip\.\.\.'
8:checking for x86_64-apple-darwin-strip... /home/hebasto/GitHub/bitcoin/depends/x86_64-apple-darwin/native/bin/x86_64-apple-darwin-strip
61:checking for x86_64-apple-darwin-strip... (cached) /home/hebasto/GitHub/bitcoin/depends/x86_64-apple-darwin/native/bin/x86_64-apple-darwin-strip
62:checking for x86_64-apple-darwin-ranlib... /home/hebasto/GitHub/bitcoin/depends/x86_64-apple-darwin/native/bin/x86_64-apple-darwin-ranlib
188:checking whether the linker accepts -Wl,-dead_strip... yes
367:checking for x86_64-apple-darwin-strip... /home/hebasto/GitHub/bitcoin/depends/x86_64-apple-darwin/native/bin/x86_64-apple-darwin-strip
411:checking for x86_64-apple-darwin-strip... (cached) /home/hebasto/GitHub/bitcoin/depends/x86_64-apple-darwin/native/bin/x86_64-apple-darwin-strip
412:checking for x86_64-apple-darwin-ranlib... /home/hebasto/GitHub/bitcoin/depends/x86_64-apple-darwin/native/bin/x86_64-apple-darwin-ranlib
```

#### Guix builds on `x86_64`:
```
...
```