### PR TITLE
p2p: Prevent block index fingerprinting by sending additional getheaders messages

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -1167,6 +1167,13 @@ private:
     friend struct ConnmanTestMsg;
 };
 
+/**
+ * Get a unique identifier for the network (e.g. Tor, IPv4/6) of a connection.
+ * The id is derived from the connection's network and local socket (address
+ * and port).
+ */
+uint64_t GetUniqueNetworkID(const CConnman& connman, const CNode& node);
+
 /** Dump binary message to file, with timestamp */
 void CaptureMessageToFile(const CAddress& addr,
                           const std::string& msg_type,


### PR DESCRIPTION
The block index might contain stale blocks that are not part of the main chain. If a malicious peer is able to probe a node's block index for certain stale blocks then it can use this information to fingerprint the node.

When receiving headers (either through a `cmpctblock` or `headers` messages) a node will send `getheaders` if the predecessor of the first header does not exist. This leaks information from the block index if the predecessor of the header is a stale block because no `getheaders` will be sent in that case revealing that the stale block exists in the index.

This PR prevents this fingerprinting by sending additional `getheaders` messages in cases where not doing so leaks the existence of stale blocks. To determine when additional messages should be send, we introduce the `PeerManagerImpl::m_chain_tips_sets` map which keeps track of seen chain tips per network, effectively creating a per network view of the node's global block index.  We only try to accept new headers if they connect to anything in our global index and they connect to our active chain or to a chain that was previously sent to us by a peer on the same network. We send a `getheaders` message should these conditions not be met.