### PR TITLE
ci: Temporarily use clang-13 to work around clang-14 TSan bug

### DIFF
--- a/ci/test/00_setup_env_native_tsan.sh
+++ b/ci/test/00_setup_env_native_tsan.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_tsan
 export DOCKER_NAME_TAG=ubuntu:22.04
-export PACKAGES="clang llvm libc++abi-dev libc++-dev python3-zmq"
-export DEP_OPTS="CC=clang CXX='clang++ -stdlib=libc++'"
+export PACKAGES="clang-13 llvm-13 libc++abi-13-dev libc++-13-dev python3-zmq"
+export DEP_OPTS="CC=clang-13 CXX='clang++-13 -stdlib=libc++'"
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-zmq CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER' CXXFLAGS='-g' --with-sanitizers=thread CC=clang CXX='clang++ -stdlib=libc++'"
+export BITCOIN_CONFIG="--enable-zmq CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER' CXXFLAGS='-g' --with-sanitizers=thread CC=clang-13 CXX='clang++-13 -stdlib=libc++'"


### PR DESCRIPTION
There is an increase in intermittent issues in the TSan task. The increase correlates with Ubuntu Jammy's bump of `clang` from `clang-13` to `clang-14`.

Temporarily work around that.