### PR TITLE
Update signapple for platform identifier fix

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -485,7 +485,7 @@ and endian independent.")
     (license license:expat)))
 
 (define-public python-signapple
-  (let ((commit "0777ce58e61b0e6be753a5f524149d6d47905186"))
+  (let ((commit "8a945a2e7583be2665cf3a6a89d665b70ecd1ab6"))
     (package
       (name "python-signapple")
       (version (git-version "0.1" "1" commit))
@@ -498,7 +498,7 @@ and endian independent.")
          (file-name (git-file-name name commit))
          (sha256
           (base32
-           "19axspyyfqbrfw2r53c17mi9bvm8zsb39mz8v9h7c173qkm3x5ym"))))
+           "0fr1hangvfyiwflca6jg5g8zvg3jc9qr7vd2c12ff89pznf38dlg"))))
       (build-system python-build-system)
       (propagated-inputs
        `(("python-asn1crypto" ,python-asn1crypto)


### PR DESCRIPTION
Apparently #23134 is caused by the platform identifier field being set to the incorrect value in our code signatures. The problem has been resolved in signapple, and so guix should point to the latest commit containing the fix.

I suppose guix does not strictly need to have this; only the macOS code signer will need to have the fix.

Fixes #23134