### PR TITLE
doc: mention that BDB is for the legacy wallet in build-osx.md

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -68,29 +68,21 @@ git clone https://github.com/bitcoin/bitcoin.git
 #### Wallet Dependencies
 
 It is not necessary to build wallet functionality to run `bitcoind` or  `bitcoin-qt`.
-To enable legacy wallets, you must install `berkeley-db@4`.
-To enable [descriptor wallets](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md), `sqlite` is required.
-Skip `berkeley-db@4` if you intend to *exclusively* use descriptor wallets.
+
+###### Descriptor Wallet Support
+
+`sqlite` is required to support for descriptor wallets.
+
+macOS ships with a useable `sqlite` package, meaning you don't need to
+install anything.
 
 ###### Legacy Wallet Support
 
-`berkeley-db@4` is required to enable support for legacy wallets.
+`berkeley-db@4` is only required to support for legacy wallets.
 Skip if you don't intend to use legacy wallets.
 
 ``` bash
 brew install berkeley-db@4
-```
-
-###### Descriptor Wallet Support
-
-Note: Apple has included a useable `sqlite` package since macOS 10.14.
-You may not need to install this package.
-
-`sqlite` is required to enable support for descriptor wallets.
-Skip if you don't intend to use descriptor wallets.
-
-``` bash
-brew install sqlite
 ```
 ---
 

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -4,7 +4,7 @@ These are the dependencies used by Bitcoin Core.
 You can find installation instructions in the `build-*.md` file for your platform.
 "Runtime" and "Version Used" are both in reference to the release binaries.
 
-| Compiler | Minimum required |
+| Dependency | Minimum required |
 | --- | --- |
 | [Autoconf](https://www.gnu.org/software/autoconf/) | [2.69](https://github.com/bitcoin/bitcoin/pull/17769) |
 | [Automake](https://www.gnu.org/software/automake/) | [1.13](https://github.com/bitcoin/bitcoin/pull/18290) |


### PR DESCRIPTION
Re-order legacy and descriptor wallet section.
Installing sqlite isn't required (the version pre-installed on macOS is just as good as what will be installed via `brew`).
Remove prelude that pointlessly repeats the same info.

Basically the macOS version of #23446.

Includes a small fixup from #23565.