### PR TITLE
doc: Delete old line of code that was commented out

### DIFF
--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -68,7 +68,6 @@ BOOST_AUTO_TEST_CASE(psbt_updater_test)
     // Try to sign the mutated input
     SignatureData sigdata;
     BOOST_CHECK(m_wallet.FillPSBT(psbtx, complete, SIGHASH_ALL, true, true) != TransactionError::OK);
-    //BOOST_CHECK(spk_man->FillPSBT(psbtx, PrecomputePSBTData(psbtx), SIGHASH_ALL, true, true) != TransactionError::OK);
 }
 
 BOOST_AUTO_TEST_CASE(parse_hd_keypath)


### PR DESCRIPTION
In #23288 MarcoFalke [highlighted](https://github.com/bitcoin/bitcoin/pull/23288/files#r739817055) an old BOOST_CHECK that was commented out and replaced by a different BOOST_CHECK. I think this can be deleted and wasn't deliberately left in by achow101. 
