### PR TITLE
guix: remove mingw-w64 std::filesystem workaround

### DIFF
--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -51,7 +51,7 @@ fi
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://git.savannah.gnu.org/git/guix.git \
-                      --commit=ae03f401381e956c4c41b4cf495cbde964fa43d0 \
+                      --commit=34e9eae68c9583acce5abc4100add3d88932a5ae \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -162,17 +162,13 @@ desirable for building Bitcoin Core release binaries."
 (define (make-gcc-with-pthreads gcc)
   (package-with-extra-configure-variable gcc "--enable-threads" "posix"))
 
-;; Required to support std::filesystem for mingw-w64 target.
-(define (make-gcc-without-newlib gcc)
-  (package-with-extra-configure-variable gcc "--with-newlib" "no"))
-
 (define (make-mingw-pthreads-cross-toolchain target)
   "Create a cross-compilation toolchain package for TARGET"
   (let* ((xbinutils (cross-binutils target))
          (pthreads-xlibc mingw-w64-x86_64-winpthreads)
          (pthreads-xgcc (make-gcc-with-pthreads
                          (cross-gcc target
-                                    #:xgcc (make-gcc-without-newlib (make-ssp-fixed-gcc base-gcc))
+                                    #:xgcc (make-ssp-fixed-gcc base-gcc)
                                     #:xbinutils xbinutils
                                     #:libc pthreads-xlibc))))
     ;; Define a meta-package that propagates the resulting XBINUTILS, XLIBC, and


### PR DESCRIPTION
Now that https://issues.guix.gnu.org/54212 has been merged upstream, we can bump our time-machine, and then no-longer need to maintain a workaround to use `std::filesystem` for Windows builds.

Guix build on `x86_64`:
```bash
8edd06c2dbd4533c9f1b0e445cda1c2692b7d5e28e9d4c9262100dc1b4160448  guix-build-946b86cf5735/output/aarch64-linux-gnu/SHA256SUMS.part
aca0eb632d73d08272a76837a9d15ab6df602cc95fd8d67d459881c823531816  guix-build-946b86cf5735/output/aarch64-linux-gnu/bitcoin-946b86cf5735-aarch64-linux-gnu-debug.tar.gz
5795e2893a81d2a260e7290a9204e63f78e7994cae54277a0ae952fd977108b3  guix-build-946b86cf5735/output/aarch64-linux-gnu/bitcoin-946b86cf5735-aarch64-linux-gnu.tar.gz
90dc12f37f9b66a553be3251374da04f022fd98a871a8d0b122f69ff4fdc5a3d  guix-build-946b86cf5735/output/arm-linux-gnueabihf/SHA256SUMS.part
d03dbb12963328afe050c212dac6c42f5f34ce6f36d5a22f6b262ed17acd00fa  guix-build-946b86cf5735/output/arm-linux-gnueabihf/bitcoin-946b86cf5735-arm-linux-gnueabihf-debug.tar.gz
d02cac8b56285bec488d3f4ac92174ee1a25a3f75d069a9e54a872905fcab311  guix-build-946b86cf5735/output/arm-linux-gnueabihf/bitcoin-946b86cf5735-arm-linux-gnueabihf.tar.gz
14122032ce024eec843552d6fb6eefad4eb849a0bfac1f7679f0723e7aa69d7d  guix-build-946b86cf5735/output/arm64-apple-darwin/SHA256SUMS.part
a2392b37cde87f1a9db599197e7516f31024b88e86699a6bdc9bc0e95edcd450  guix-build-946b86cf5735/output/arm64-apple-darwin/bitcoin-946b86cf5735-arm64-apple-darwin-unsigned.dmg
8b3596ff5dda6f978f7d19ed33b29357226f17449db65058676b911d110b2fb8  guix-build-946b86cf5735/output/arm64-apple-darwin/bitcoin-946b86cf5735-arm64-apple-darwin-unsigned.tar.gz
94baa2dae8c7b920fdd3e78097084c4550cb9441769b851924671265b032724b  guix-build-946b86cf5735/output/arm64-apple-darwin/bitcoin-946b86cf5735-arm64-apple-darwin.tar.gz
ee13d5669928c2d09e1091871c3e1a4e4fe7e2aa76ef0cfb472cac26fe304372  guix-build-946b86cf5735/output/dist-archive/bitcoin-946b86cf5735.tar.gz
b757ff56eb2b4b6c07ea1b784a5d72e2d6dce53a6b15068e6b10beb101068d9b  guix-build-946b86cf5735/output/powerpc64-linux-gnu/SHA256SUMS.part
b6f29f9a3d1e78e37a56da3a98fd74037a622070f8d5f3e677db3714f2f0ab90  guix-build-946b86cf5735/output/powerpc64-linux-gnu/bitcoin-946b86cf5735-powerpc64-linux-gnu-debug.tar.gz
fa575269b25154ad9d258bfe4c89d9c083d199084229a9c2c44235d22e0499de  guix-build-946b86cf5735/output/powerpc64-linux-gnu/bitcoin-946b86cf5735-powerpc64-linux-gnu.tar.gz
ee73c68dfa2923da17553aee26e9c26c1e9b5ecfae0f032e6cac56f951ea7353  guix-build-946b86cf5735/output/powerpc64le-linux-gnu/SHA256SUMS.part
9eb4d47506765b7d2e93cdf1ef5e53a2f53e22a318cbd7d5d7a9f97de292e2e7  guix-build-946b86cf5735/output/powerpc64le-linux-gnu/bitcoin-946b86cf5735-powerpc64le-linux-gnu-debug.tar.gz
5541f70c5d5e935d5c71e2aef3995e0df76202782d296b81c692c05250d3ba6c  guix-build-946b86cf5735/output/powerpc64le-linux-gnu/bitcoin-946b86cf5735-powerpc64le-linux-gnu.tar.gz
46dbe4710fbb962a8a8c8a2d60e3fd7a53fc0ea47096f776de9b2d865b6dcd99  guix-build-946b86cf5735/output/riscv64-linux-gnu/SHA256SUMS.part
3dbcb703d699e400a6d23082e545e52ac6d3100d54bf0f544216940c0f336e24  guix-build-946b86cf5735/output/riscv64-linux-gnu/bitcoin-946b86cf5735-riscv64-linux-gnu-debug.tar.gz
b2dc20a418192478e9b892dcaec982bf23899a5742bb33791ed9e621d4b2bd87  guix-build-946b86cf5735/output/riscv64-linux-gnu/bitcoin-946b86cf5735-riscv64-linux-gnu.tar.gz
a25c379f2c81be647491b10fa50486c780bf0096f437e4db351d32ccf235ad7d  guix-build-946b86cf5735/output/x86_64-apple-darwin/SHA256SUMS.part
c017523424767593daaf4037598683ffa360c4142df4986b9548e42b125587a5  guix-build-946b86cf5735/output/x86_64-apple-darwin/bitcoin-946b86cf5735-x86_64-apple-darwin-unsigned.dmg
a6e1e5bb358ec7f8f4f5289225ea07f6d3bef417da90756c7eb748a2e9a9276d  guix-build-946b86cf5735/output/x86_64-apple-darwin/bitcoin-946b86cf5735-x86_64-apple-darwin-unsigned.tar.gz
95283762bafa08106c841cb43a19b18a541fdae7cb759f13a2e9bf81ac24b176  guix-build-946b86cf5735/output/x86_64-apple-darwin/bitcoin-946b86cf5735-x86_64-apple-darwin.tar.gz
56876f95dc4ce82b35f1206ef4093962431887f5a0eac28abfbfdacab68b55f7  guix-build-946b86cf5735/output/x86_64-linux-gnu/SHA256SUMS.part
8305d7b92b30fd8a14ea44459d673c077ec8971aeaa79cb6331c4f9fccd51f0f  guix-build-946b86cf5735/output/x86_64-linux-gnu/bitcoin-946b86cf5735-x86_64-linux-gnu-debug.tar.gz
a6f1e12fd15e0eb6ef8e1182ecf564b587a0d2b77f799570bdcbad747617d202  guix-build-946b86cf5735/output/x86_64-linux-gnu/bitcoin-946b86cf5735-x86_64-linux-gnu.tar.gz
79cd3e1b9a6cbb06bb19f24cb03d02a5e87f1c96c42648d0397bf6edca912114  guix-build-946b86cf5735/output/x86_64-w64-mingw32/SHA256SUMS.part
c119dd7bebfd76d9692c37efa150862feb98256a1ec6e2fcedf85dbaf185a47d  guix-build-946b86cf5735/output/x86_64-w64-mingw32/bitcoin-946b86cf5735-win64-debug.zip
a48af7b53c9c863ced4d7b9864f91f4f4a54cc63275858427fb7636f90f464fe  guix-build-946b86cf5735/output/x86_64-w64-mingw32/bitcoin-946b86cf5735-win64-setup-unsigned.exe
2ebd813a39299a687f4cfd0e60b76808f9e8fee5a60a16e84148d3f0b3da6128  guix-build-946b86cf5735/output/x86_64-w64-mingw32/bitcoin-946b86cf5735-win64-unsigned.tar.gz
c628444e07c18ff13db76cb5a51386d77be8135ca7fe80a4d1b97b07e4f34baf  guix-build-946b86cf5735/output/x86_64-w64-mingw32/bitcoin-946b86cf5735-win64.zip
```

Guix build on `aarch64`:
```bash
83f7387975d043e29a994d4d8e9bbdd65c8ba2002a1ca97fe76a61ad2333d37e  guix-build-946b86cf5735/output/arm-linux-gnueabihf/SHA256SUMS.part
8791579ecc7c0799bd53be7c0bdab18eb4bae2fb06ed41d0aa77e28ee0dde487  guix-build-946b86cf5735/output/arm-linux-gnueabihf/bitcoin-946b86cf5735-arm-linux-gnueabihf-debug.tar.gz
28d6a41d7ccb88197ef75e1e83d202a0a11caefde3a6f86ed9186d9e19c2c682  guix-build-946b86cf5735/output/arm-linux-gnueabihf/bitcoin-946b86cf5735-arm-linux-gnueabihf.tar.gz
0c34bfb74a3ff7b2f69967e00ac02af145b7af3f539e7b5f817e8453b49efdb8  guix-build-946b86cf5735/output/arm64-apple-darwin/SHA256SUMS.part
57357182b3630fa7b02cefab2b662944d2f226d8c739f934fd15e669b11de01a  guix-build-946b86cf5735/output/arm64-apple-darwin/bitcoin-946b86cf5735-arm64-apple-darwin-unsigned.dmg
f5d761f3b5d98c830ec7247ad2ec42e9d6fbe723539b0c47f4a91c2e8a7214c7  guix-build-946b86cf5735/output/arm64-apple-darwin/bitcoin-946b86cf5735-arm64-apple-darwin-unsigned.tar.gz
fb2ab7cfc7a9f01b1507ec08775ac8f7267cfbeb28d13f4b62f15cbd81ef15fe  guix-build-946b86cf5735/output/arm64-apple-darwin/bitcoin-946b86cf5735-arm64-apple-darwin.tar.gz
ee13d5669928c2d09e1091871c3e1a4e4fe7e2aa76ef0cfb472cac26fe304372  guix-build-946b86cf5735/output/dist-archive/bitcoin-946b86cf5735.tar.gz
a269e7ef2bac18e7bbdf8488023fa1dd202d5b7cd18f4127b122b9fa82cd9317  guix-build-946b86cf5735/output/powerpc64-linux-gnu/SHA256SUMS.part
9b5ad80352b9d211dd8e3b2d7ac5b304a83aaaa43e54a96f4ec6e130d37415e5  guix-build-946b86cf5735/output/powerpc64-linux-gnu/bitcoin-946b86cf5735-powerpc64-linux-gnu-debug.tar.gz
4b7c09ebe7b729957f345629acb8ce0c3966ed17d8a4cc3da6401100dd29c05b  guix-build-946b86cf5735/output/powerpc64-linux-gnu/bitcoin-946b86cf5735-powerpc64-linux-gnu.tar.gz
abc357d83966bf3f2dba201786b315cf673da197c1e3e2ee56e99e5e44df32a6  guix-build-946b86cf5735/output/powerpc64le-linux-gnu/SHA256SUMS.part
d057eb88fb33363345026e2fe39881dff65c06cd1266427ef018befa4f21d5a7  guix-build-946b86cf5735/output/powerpc64le-linux-gnu/bitcoin-946b86cf5735-powerpc64le-linux-gnu-debug.tar.gz
9067057d983ed79acaf252fc7ca8cbe89dbad92280a95f079a417a20a7fe1f83  guix-build-946b86cf5735/output/powerpc64le-linux-gnu/bitcoin-946b86cf5735-powerpc64le-linux-gnu.tar.gz
cd05ef28fbaad0512edc012a124f32079b8fe831d7c7882f0f8a754756712bc3  guix-build-946b86cf5735/output/riscv64-linux-gnu/SHA256SUMS.part
2dcdb32faa687ed14956338c4876ea2a4a113c52cdf835eb4e66cbcd98e6ebdc  guix-build-946b86cf5735/output/riscv64-linux-gnu/bitcoin-946b86cf5735-riscv64-linux-gnu-debug.tar.gz
940c6404d506c353256018eea9b77560f618c75e1becae1ac262149b2f30d01a  guix-build-946b86cf5735/output/riscv64-linux-gnu/bitcoin-946b86cf5735-riscv64-linux-gnu.tar.gz
a980ef922b3af77ee7d9118b7db1d0893bdc1dbdf7c39d076f5dc4e368296447  guix-build-946b86cf5735/output/x86_64-apple-darwin/SHA256SUMS.part
c017523424767593daaf4037598683ffa360c4142df4986b9548e42b125587a5  guix-build-946b86cf5735/output/x86_64-apple-darwin/bitcoin-946b86cf5735-x86_64-apple-darwin-unsigned.dmg
090479eecdd7169184f29009eb498dd498d504a4d642ae034ec82210cd08dca2  guix-build-946b86cf5735/output/x86_64-apple-darwin/bitcoin-946b86cf5735-x86_64-apple-darwin-unsigned.tar.gz
95283762bafa08106c841cb43a19b18a541fdae7cb759f13a2e9bf81ac24b176  guix-build-946b86cf5735/output/x86_64-apple-darwin/bitcoin-946b86cf5735-x86_64-apple-darwin.tar.gz
a94a4ed02ff71ca6a5594cb3aed7f600cfacf40fa14ceb3dd8af6a251502bea4  guix-build-946b86cf5735/output/x86_64-linux-gnu/SHA256SUMS.part
04b1e08c5482b5fd37b360e2950775626838a7c2429bcceec3d082615b52c300  guix-build-946b86cf5735/output/x86_64-linux-gnu/bitcoin-946b86cf5735-x86_64-linux-gnu-debug.tar.gz
0e0d8260f3898a59e23878fc17f47e20af0b2e35f628196df3977ca53418ad19  guix-build-946b86cf5735/output/x86_64-linux-gnu/bitcoin-946b86cf5735-x86_64-linux-gnu.tar.gz
942aced6e2a6df3c0f31d2040db2a61b51b4014fc6530410eb5ece5a6b05f11d  guix-build-946b86cf5735/output/x86_64-w64-mingw32/SHA256SUMS.part
a8119d7db4dcde912dfff27d2690da0935e08a2996f0282715afd9ea7cde11f8  guix-build-946b86cf5735/output/x86_64-w64-mingw32/bitcoin-946b86cf5735-win64-debug.zip
a48af7b53c9c863ced4d7b9864f91f4f4a54cc63275858427fb7636f90f464fe  guix-build-946b86cf5735/output/x86_64-w64-mingw32/bitcoin-946b86cf5735-win64-setup-unsigned.exe
2ebd813a39299a687f4cfd0e60b76808f9e8fee5a60a16e84148d3f0b3da6128  guix-build-946b86cf5735/output/x86_64-w64-mingw32/bitcoin-946b86cf5735-win64-unsigned.tar.gz
7aa5627bb706654734525b7ef76736fe24b8f314e5a20f850ea6a0dca1559d1f  guix-build-946b86cf5735/output/x86_64-w64-mingw32/bitcoin-946b86cf5735-win64.zip
```