### PR TITLE
ci: add ci/scratch dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,5 @@ osx_volname
 dist/
 
 /guix-build-*
+
+/ci/scratch/


### PR DESCRIPTION
Not sure if I'm missing some context as to why this isn't already ignored?
