### PR TITLE
Change -maxtimeadjustment default from 70 minutes to 0

### DIFF
--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -74,7 +74,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
     // a timing cleanup that strengthens it in a number of other ways.
     //
     if (g_time_offsets.size() >= 5 && g_time_offsets.size() % 2 == 1) {
-        int64_t nMedian = g_time_offsets.median();
+        const int64_t nMedian{g_time_offsets.median()};
         std::vector<int64_t> vSorted = g_time_offsets.sorted();
         // Only let other nodes change our time by so much
         int64_t max_adjustment = std::max<int64_t>(0, gArgs.GetIntArg("-maxtimeadjustment", DEFAULT_MAX_TIME_ADJUSTMENT));
@@ -104,7 +104,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
             for (const int64_t n : vSorted) {
                 log_message += strprintf("%+d  ", n);
             }
-            log_message += strprintf("|  median offset = %+d  (%+d minutes)", nTimeOffset, nTimeOffset / 60);
+            log_message += strprintf("|  median offset = %+d seconds (%+d minutes)", nMedian, nMedian / 60);
             LogPrint(BCLog::NET, "%s\n", log_message);
         }
     }

--- a/src/timedata.h
+++ b/src/timedata.h
@@ -10,7 +10,7 @@
 #include <stdint.h>
 #include <vector>
 
-static const int64_t DEFAULT_MAX_TIME_ADJUSTMENT = 70 * 60;
+static constexpr int64_t DEFAULT_MAX_TIME_ADJUSTMENT{0};
 
 class CNetAddr;
 


### PR DESCRIPTION
Following the core dev IRC discussion today, this is a straightforward step per the suggestion at https://www.erisian.com.au/bitcoin-core-dev/log-2022-03-17.html#l-652.  Users can still opt in to adjusted time by setting `-maxtimeadjustment` with a value greater than zero. This allows gaining feedback as to what extent user space depends on adjusted time.

If we want to remove the adjusted time code down the road, it makes sense to give users the fallback option to use adjusted time for a release or two. This also reduces our code reversion risk in the case that users rely on it. The release notes would describe the change and suggest that the option is being deprecated for future removal.

See #7573 and #4521 for further context.