### PR TITLE
test, lint: check bash version before executing codespell

### DIFF
--- a/test/lint/lint-spelling.sh
+++ b/test/lint/lint-spelling.sh
@@ -12,6 +12,9 @@ export LC_ALL=C
 if ! command -v codespell > /dev/null; then
     echo "Skipping spell check linting since codespell is not installed."
     exit 0
+elif [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+    echo "Skipping spell check linting since your bash version is less than 4."
+    exit 0
 fi
 
 IGNORE_WORDS_FILE=test/lint/lint-spelling.ignore-words.txt


### PR DESCRIPTION
When executing `lint-spelling.sh` I noticed `mapfile` command wasn't working so it wasn't ignoring the files that should be ignored giving me some false flags. I noticed the problem is the version of bash, `mapfile` was introduced in bash 4 and my machine had the 3 one. So, I added a verification to skip it if the version of bash is less than 4.

