### PR TITLE
build: remove unused QMAKE_* VARs

### DIFF
--- a/depends/patches/qt/mac-qmake.conf
+++ b/depends/patches/qt/mac-qmake.conf
@@ -19,6 +19,4 @@ QMAKE_MAC_SDK.macosx.PlatformPath = /phony
 !host_build: QMAKE_LFLAGS += -target $${MAC_TARGET}
 QMAKE_AR = $${CROSS_COMPILE}ar cq
 QMAKE_RANLIB=$${CROSS_COMPILE}ranlib
-QMAKE_LIBTOOL=$${CROSS_COMPILE}libtool
-QMAKE_INSTALL_NAME_TOOL=$${CROSS_COMPILE}install_name_tool
 load(qt_config)


### PR DESCRIPTION
As far as I can gather Qts build system doesn't respect either of these
variables (there is a `QMAKE_LIBTOOL_LIBDIR`).

Guix Build:
```bash
bash-5.1# find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
dd12aaea98cfaa85a7d4b2e0cd8c4c01766ad47cb2d41a516073b7e0304ccab1  guix-build-3a463992b981/output/aarch64-linux-gnu/SHA256SUMS.part
7107fce198c238c6b88a58574be5cfd77ac2aa8176488738671c4873a21e1efe  guix-build-3a463992b981/output/aarch64-linux-gnu/bitcoin-3a463992b981-aarch64-linux-gnu-debug.tar.gz
2fe573897994e9dbb4a5123045e86ed3fefbf3381eddb5f17f2034aecb5adb80  guix-build-3a463992b981/output/aarch64-linux-gnu/bitcoin-3a463992b981-aarch64-linux-gnu.tar.gz
250246aef50a752d56a63a58978cd95555a4e4447b83577615e85cfee30003b6  guix-build-3a463992b981/output/arm-linux-gnueabihf/SHA256SUMS.part
4e07018fcb47d0674b4dc598c23179f05124e9cf70e8dd229ef74542d3b106a3  guix-build-3a463992b981/output/arm-linux-gnueabihf/bitcoin-3a463992b981-arm-linux-gnueabihf-debug.tar.gz
649115440ff109d427718aa8468ef65f50ac50edf5722c233dad2fb9e90d4af6  guix-build-3a463992b981/output/arm-linux-gnueabihf/bitcoin-3a463992b981-arm-linux-gnueabihf.tar.gz
3f5dae095c718854ae2de1dcbc88a91b14cdb13adb9a7bd5e2a08bf006a1bca9  guix-build-3a463992b981/output/arm64-apple-darwin/SHA256SUMS.part
e8f546db5bc14452a50041d46711160d4f4d4fd7b93092a20cdb96a3549f92d2  guix-build-3a463992b981/output/arm64-apple-darwin/bitcoin-3a463992b981-arm64-apple-darwin-unsigned.dmg
5f1c9695d1ef286b8b779b8ae76af8dfe45d31ce9b081122d1d5594c21c73de2  guix-build-3a463992b981/output/arm64-apple-darwin/bitcoin-3a463992b981-arm64-apple-darwin-unsigned.tar.gz
5eccb71d8c0c0b0806bf8858079d7a8b626d23446ba6b09920b0118debea6b88  guix-build-3a463992b981/output/arm64-apple-darwin/bitcoin-3a463992b981-arm64-apple-darwin.tar.gz
59c52d0190ad6182ffb5ca7124d05e9a18df4472db2662fe4dada7636f0b93c4  guix-build-3a463992b981/output/dist-archive/bitcoin-3a463992b981.tar.gz
bb5b090610c2200223fbb3ac18bd274f3ac5cbbf0b122b520645b1945f03e7f1  guix-build-3a463992b981/output/powerpc64-linux-gnu/SHA256SUMS.part
4e76e3e933ac1cad56ef8a970c7dc617a57bbd46d1c13554455f6ed72114d7d3  guix-build-3a463992b981/output/powerpc64-linux-gnu/bitcoin-3a463992b981-powerpc64-linux-gnu-debug.tar.gz
2039d619824f4678367e71ca1a09c2dcd01ba4fca0151193235e991fec927cf2  guix-build-3a463992b981/output/powerpc64-linux-gnu/bitcoin-3a463992b981-powerpc64-linux-gnu.tar.gz
9023d223c41a82907b5cea5f011b16b9ac83155d7c152315576339dd78d2ed7b  guix-build-3a463992b981/output/powerpc64le-linux-gnu/SHA256SUMS.part
35d374257124b4c8bc59f938dbc9428f4c45fd38a45e29f9afa4c31fb129c593  guix-build-3a463992b981/output/powerpc64le-linux-gnu/bitcoin-3a463992b981-powerpc64le-linux-gnu-debug.tar.gz
aee514d913c905c153ec06a20521fa5698096e94e124f2262a16bba3bf7dc0fb  guix-build-3a463992b981/output/powerpc64le-linux-gnu/bitcoin-3a463992b981-powerpc64le-linux-gnu.tar.gz
39ca1e06c8ef5086055242286e58c096965494ce050b7780171492fcbc6c78e1  guix-build-3a463992b981/output/riscv64-linux-gnu/SHA256SUMS.part
f92412fdf3566518dc16a03a24eaa00e82550ad0f7f0ef14e2d4772f69ff8496  guix-build-3a463992b981/output/riscv64-linux-gnu/bitcoin-3a463992b981-riscv64-linux-gnu-debug.tar.gz
11c0a55d760f422135c3a5c9e3b7acdec4a1e001dde47e4830f9a64e39cea13c  guix-build-3a463992b981/output/riscv64-linux-gnu/bitcoin-3a463992b981-riscv64-linux-gnu.tar.gz
c0a4bfb7f3b62bbe9b3e0e8dc05395e72d31a151038a5278acf78c5f3abd1b30  guix-build-3a463992b981/output/x86_64-apple-darwin/SHA256SUMS.part
3c6a8e2b91b66cbdbf811251e95ae2a68604fc0f442695211727b6f740e303f9  guix-build-3a463992b981/output/x86_64-apple-darwin/bitcoin-3a463992b981-x86_64-apple-darwin-unsigned.dmg
2d0b0b0615d83ef4c876fd99628e2d21b57acef0f1dc2ee175d0c0c3786dc63c  guix-build-3a463992b981/output/x86_64-apple-darwin/bitcoin-3a463992b981-x86_64-apple-darwin-unsigned.tar.gz
e4c123cc6c848d342154cf6f47518465ab0238e8779f5d253095cf429eb2cafb  guix-build-3a463992b981/output/x86_64-apple-darwin/bitcoin-3a463992b981-x86_64-apple-darwin.tar.gz
4f6801b93e458f59611e40d725eb910720ef91cb6dc5052f8b314df2b892e5f8  guix-build-3a463992b981/output/x86_64-linux-gnu/SHA256SUMS.part
5a60dab96f4db45facd0d0f126803f3af864eb0fe6bfdb338deb89a28d22c857  guix-build-3a463992b981/output/x86_64-linux-gnu/bitcoin-3a463992b981-x86_64-linux-gnu-debug.tar.gz
949185ab779c0f7199a468fb384636de30e8f689173c797dec0ab51eb67e6120  guix-build-3a463992b981/output/x86_64-linux-gnu/bitcoin-3a463992b981-x86_64-linux-gnu.tar.gz
ffc2e51b928c6f76ee678cbf8291c5dce00a221c5241d88fcd449dbdfc2b0861  guix-build-3a463992b981/output/x86_64-w64-mingw32/SHA256SUMS.part
2ba59ab5a27249ab06a396401633ff9fb688b02fb364a39edad4d3120e3f02aa  guix-build-3a463992b981/output/x86_64-w64-mingw32/bitcoin-3a463992b981-win64-debug.zip
17378a06f3ae08cd50f840bf8279b4a54ef587da69080ad59a5948799af47eda  guix-build-3a463992b981/output/x86_64-w64-mingw32/bitcoin-3a463992b981-win64-setup-unsigned.exe
89e1929c669e9d62dae804f65a886eae8ff7fdf7fe8ba965c57ba9ebaf84e7ff  guix-build-3a463992b981/output/x86_64-w64-mingw32/bitcoin-3a463992b981-win64-unsigned.tar.gz
7ec3021e84296632182261d3017a9e25c4573013d61fb2a13c9ec46ef35a1e59  guix-build-3a463992b981/output/x86_64-w64-mingw32/bitcoin-3a463992b981-win64.zip
```