### PR TITLE
guix: Map guix store prefixes to /usr for cross-architecture reproducibility of linux binaries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -106,6 +106,10 @@ dnl OpenBSD ships with 2.4.2
 LT_PREREQ([2.4.2])
 dnl Libtool init checks.
 LT_INIT([pic-only win32-dll])
+_LT_TAGVAR(hardcode_libdir_flag_spec, )=""
+_LT_TAGVAR(hardcode_libdir_flag_spec, CXX)=""
+_LT_TAGVAR(hardcode_into_libs, )="no"
+_LT_TAGVAR(hardcode_into_libs, CXX)="no"
 
 dnl Check/return PATH for base programs.
 AC_PATH_TOOL([AR], [ar])

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -147,7 +147,10 @@ desirable for building Bitcoin Core release binaries."
                         base-gcc))
 
 (define (make-gcc-with-pthreads gcc)
-  (package-with-extra-configure-variable gcc "--enable-threads" "posix"))
+  (package-with-extra-configure-variable
+    (package-with-extra-patches gcc
+      (search-our-patches "gcc-10-remap-guix-store.patch"))
+    "--enable-threads" "posix"))
 
 (define (make-mingw-w64-cross-gcc cross-gcc)
   (package-with-extra-patches cross-gcc

--- a/contrib/guix/patches/gcc-10-remap-guix-store.patch
+++ b/contrib/guix/patches/gcc-10-remap-guix-store.patch
@@ -1,0 +1,39 @@
+From 5209c558df9849193a4e03429ee548b92eaa59ca Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Tue, 22 Mar 2022 13:58:42 -0400
+Subject: [PATCH] guix: remap guix store paths to /usr
+
+---
+ libgcc/Makefile.in  | 2 ++
+ libgcc/configure.ac | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/libgcc/Makefile.in b/libgcc/Makefile.in
+index 851e7657d07..847536f1b88 100644
+--- a/libgcc/Makefile.in
++++ b/libgcc/Makefile.in
+@@ -87,6 +87,8 @@ CFLAGS = @CFLAGS@
+ RANLIB = @RANLIB@
+ LN_S = @LN_S@
+ 
++CFLAGS+=$(find /gnu/store -maxdepth 1 -mindepth 1 -type d -exec echo -n " -ffile-prefix-map={}=/usr" \;)
++
+ PWD_COMMAND = $${PWDCMD-pwd}
+ 
+ # Flags to pass to a recursive make.
+diff --git a/libgcc/configure.ac b/libgcc/configure.ac
+index bff6e54f22e..f91024fd0e1 100644
+--- a/libgcc/configure.ac
++++ b/libgcc/configure.ac
+@@ -420,6 +420,8 @@ esac
+ ;;
+ esac
+ 
++CFLAGS=$(find /gnu/store -maxdepth 1 -mindepth 1 -type d -exec echo -n " -ffile-prefix-map={}=/usr" \;)
++
+ case ${host} in
+ # At present, we cannot turn -mfloat128 on via #pragma GCC target, so just
+ # check if we have VSX (ISA 2.06) support to build the software libraries, and
+-- 
+2.35.1
+


### PR DESCRIPTION
The non-reproducibility observed in binaries built on different architectures appears to come from guix store paths being present in the debug info. These guix store paths appear to differ depending on the architecture. These paths can be mapped to `/usr` using the GCC option `-ffile-prefix-map`. As the paths will change as the package versions change, we use `find` to search for all guix store paths to build a `CFLAGS` that has all guix store paths mapped to `/usr`.

Some glibc code ends up in our binaries as well and these also contain debug info with guix store paths. So glibc is also patched to map guix store paths to `/usr`

Alternative to #24569