### PR TITLE
build: Fix ccache behavior when cross-compiling for darwin hosts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1657,6 +1657,21 @@ AC_MSG_RESULT($build_bitcoin_libs)
 
 AC_LANG_POP
 
+dnl Add a ccache to a compiler invocation string
+dnl
+dnl   ADD_CCACHE[COMPILER_NAME]
+dnl
+dnl The ccache fails if a compiler invocation string is prepended with the "env"
+dnl command. In such cases the environment variables ENVIRONMENT_C{C,XX} must be
+dnl set to a full "env" command with its options.
+AC_DEFUN([ADD_CCACHE], [
+  if test "$ENVIRONMENT_$1" = ""; then
+    $1="$ac_cv_path_CCACHE $$1"
+  else
+    $1=$(echo $$1 | ${SED} -e "s|\($ENVIRONMENT_$1\)|\1 $ac_cv_path_CCACHE|")
+  fi
+])
+
 if test "$use_ccache" != "no"; then
   AC_MSG_CHECKING([if ccache should be used])
   if test "$CCACHE" = ""; then
@@ -1667,8 +1682,8 @@ if test "$use_ccache" != "no"; then
     fi
   else
     use_ccache=yes
-    CC="$ac_cv_path_CCACHE $CC"
-    CXX="$ac_cv_path_CCACHE $CXX"
+    ADD_CCACHE([CC])
+    ADD_CCACHE([CXX])
   fi
   AC_MSG_RESULT($use_ccache)
   if test "$use_ccache" = "yes"; then

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -217,7 +217,9 @@ $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_
 	@mkdir -p $(@D)
 	sed -e 's|@HOST@|$(host)|' \
             -e 's|@CC@|$(host_CC)|' \
+            -e 's|@ENVIRONMENT_CC@|$(ENVIRONMENT_CC)|' \
             -e 's|@CXX@|$(host_CXX)|' \
+            -e 's|@ENVIRONMENT_CXX@|$(ENVIRONMENT_CXX)|' \
             -e 's|@AR@|$(host_AR)|' \
             -e 's|@RANLIB@|$(host_RANLIB)|' \
             -e 's|@NM@|$(host_NM)|' \

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -95,9 +95,13 @@ LDFLAGS="-L${depends_prefix}/lib ${LDFLAGS}"
 if test -n "@CC@" -a -z "${CC}"; then
   CC="@CC@"
 fi
+ENVIRONMENT_CC='@ENVIRONMENT_CC@'
+
 if test -n "@CXX@" -a -z "${CXX}"; then
   CXX="@CXX@"
 fi
+ENVIRONMENT_CXX='@ENVIRONMENT_CXX@'
+
 PYTHONPATH="${depends_prefix}/native/lib/python3/dist-packages${PYTHONPATH:+${PATH_SEPARATOR}}${PYTHONPATH}"
 
 if test -n "@AR@"; then

--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -90,18 +90,17 @@ $(foreach TOOL,$(cctools_TOOLS),$(eval darwin_$(TOOL) = $$(build_prefix)/bin/$$(
 #         include search paths, as that would be wrong in general but would also
 #         break #include_next's.
 #
-darwin_CC=env -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH \
-              -u OBJC_INCLUDE_PATH -u OBJCPLUS_INCLUDE_PATH -u CPATH \
-              -u LIBRARY_PATH \
-            $(clang_prog) --target=$(host) -mmacosx-version-min=$(OSX_MIN_VERSION) \
+ENVIRONMENT_CC := env -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH \
+                      -u OBJC_INCLUDE_PATH -u OBJCPLUS_INCLUDE_PATH \
+                      -u CPATH -u LIBRARY_PATH
+darwin_CC = $(ENVIRONMENT_CC) $(clang_prog) --target=$(host) -mmacosx-version-min=$(OSX_MIN_VERSION) \
               -B$(build_prefix)/bin -mlinker-version=$(LD64_VERSION) \
               -isysroot$(OSX_SDK) \
               -Xclang -internal-externc-isystem$(clang_resource_dir)/include \
               -Xclang -internal-externc-isystem$(OSX_SDK)/usr/include
-darwin_CXX=env -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH \
-               -u OBJC_INCLUDE_PATH -u OBJCPLUS_INCLUDE_PATH -u CPATH \
-               -u LIBRARY_PATH \
-             $(clangxx_prog) --target=$(host) -mmacosx-version-min=$(OSX_MIN_VERSION) \
+
+ENVIRONMENT_CXX := $(ENVIRONMENT_CC)
+darwin_CXX = $(ENVIRONMENT_CXX) $(clangxx_prog) --target=$(host) -mmacosx-version-min=$(OSX_MIN_VERSION) \
                -B$(build_prefix)/bin -mlinker-version=$(LD64_VERSION) \
                -isysroot$(OSX_SDK) \
                -stdlib=libc++ \


### PR DESCRIPTION
For `darwin` hosts we [use](https://github.com/bitcoin/bitcoin/blob/ae005a647ffa1d457c5c7a0528cb29f3b1937b96/depends/hosts/darwin.mk#L93-L110) the `env` command to run a compiler in a modified environment which in turn makes `ccache` effectively no-op. On master (ae005a647ffa1d457c5c7a0528cb29f3b1937b96):
```
$ cat /etc/os-release | grep VERSION=
VERSION="22.04 (Jammy Jellyfish)"
$ ccache --version | head -1
ccache version 4.5.1
$ make -C depends HOST=x86_64-apple-darwin
$ ./autogen.sh
$ CONFIG_SITE=$PWD/depends/x86_64-apple-darwin/share/config.site ./configure 
$ make clean
$ ccache --zero-stats
$ make
$ ccache --show-stats -v
Summary:
  Cache directory:       /home/hebasto/.cache/ccache
  Primary config:        /home/hebasto/.config/ccache/ccache.conf
  Secondary config:      /etc/ccache.conf
  Stats updated:         Sun Mar 20 12:33:01 2022
  Hits:                      0 /    0
    Direct:                  0 /    0
    Preprocessed:            0 /    0
  Misses:                    0
    Direct:                  0
    Preprocessed:            0
  Uncacheable:             734
Primary storage:
  Hits:                      0 /    0
  Misses:                    0
  Cache size (GB):        1.69 / 5.00 (33.87 %)
  Files:                 11790
Uncacheable:
  Called for linking:       14
  Multiple source files:   720
```

With this PR:
```
$ make -C depends HOST=x86_64-apple-darwin
$ ./autogen.sh
$ CONFIG_SITE=$PWD/depends/x86_64-apple-darwin/share/config.site ./configure 
$ make clean
$ make
$ make clean
$ ccache --zero-stats
$ make
$ ccache --show-stats 
Summary:
  Hits:             720 /  720 (100.0 %)
    Direct:         720 /  720 (100.0 %)
    Preprocessed:     0 /    0
  Misses:             0
    Direct:           0
    Preprocessed:     0
  Uncacheable:       14
Primary storage:
  Hits:            1440 / 1440 (100.0 %)
  Misses:             0
  Cache size (GB): 1.74 / 5.00 (34.80 %)

Use the -v/--verbose option for more details.
```

Fixes bitcoin/bitcoin#21552.

---

Also this PR improves efficiency of the "macOS 10.15" CI task:
- master (e09cf64c48286176e7d080edfe901f47baa0a418), https://cirrus-ci.com/task/6266307669655552:
![Screenshot from 2022-03-20 18-26-25](https://user-images.githubusercontent.com/32963518/159174705-77a68251-6366-45e8-a097-fd2b4089f511.png)

- this PR, https://cirrus-ci.com/task/6033477492539392:
![Screenshot from 2022-03-20 18-27-35](https://user-images.githubusercontent.com/32963518/159174752-620c6dca-d992-49fe-adf0-95a19be13518.png)
