### PR TITLE
index: reset indexes when running reindex-chainstate

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1542,21 +1542,21 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             return InitError(*error);
         }
 
-        g_txindex = std::make_unique<TxIndex>(cache_sizes.tx_index, false, fReindex);
+        g_txindex = std::make_unique<TxIndex>(cache_sizes.tx_index, /*f_memory=*/false, /*f_wipe=*/fReindex || fReindexChainState);
         if (!g_txindex->Start(chainman.ActiveChainstate())) {
             return false;
         }
     }
 
     for (const auto& filter_type : g_enabled_filter_types) {
-        InitBlockFilterIndex(filter_type, cache_sizes.filter_index, false, fReindex);
+        InitBlockFilterIndex(filter_type, cache_sizes.filter_index, /*f_memory=*/false, /*f_wipe=*/fReindex || fReindexChainState);
         if (!GetBlockFilterIndex(filter_type)->Start(chainman.ActiveChainstate())) {
             return false;
         }
     }
 
     if (args.GetBoolArg("-coinstatsindex", DEFAULT_COINSTATSINDEX)) {
-        g_coin_stats_index = std::make_unique<CoinStatsIndex>(/* cache size */ 0, false, fReindex);
+        g_coin_stats_index = std::make_unique<CoinStatsIndex>(/*n_cache_size=*/0, /*f_memory=*/false, /*f_wipe=*/fReindex || fReindexChainState);
         if (!g_coin_stats_index->Start(chainman.ActiveChainstate())) {
             return false;
         }

--- a/test/functional/feature_coinstatsindex.py
+++ b/test/functional/feature_coinstatsindex.py
@@ -231,6 +231,18 @@ class CoinStatsIndexTest(BitcoinTestFramework):
         res10 = index_node.gettxoutsetinfo('muhash')
         assert(res8['txouts'] < res10['txouts'])
 
+        self.log.info("Test that the index works with -reindex")
+
+        self.restart_node(1, extra_args=["-coinstatsindex", "-reindex"])
+        res11 = index_node.gettxoutsetinfo('muhash')
+        assert_equal(res11, res10)
+
+        self.log.info("Test that the index works with -reindex-chainstate")
+
+        self.restart_node(1, extra_args=["-coinstatsindex", "-reindex-chainstate"])
+        res12 = index_node.gettxoutsetinfo('muhash')
+        assert_equal(res12, res10)
+
     def _test_use_index_option(self):
         self.log.info("Test use_index option for nodes running the index")
 


### PR DESCRIPTION
This resets the index dbs when running `-reindex-chainstate` as was previously done only for `-reindex`.

It fixes two bugs with `-reindex-chainstate` in conjunction with the indices:
1. `coinstatsindex` gets corrupted:
`reindex-chainstate`  leads to `BlockConnected()` signals to the index for each block that is reprocessed:
If the index db is not reset, the running hash `DB_MUHASH` is not reset either and it will include data from each block twice after the reindexing, so the MuHash will be incorrect. I added a test for this that fails on master.

2. `blockfilterindex` duplicates the flatfile data:
It has a variable `DB_FILTER_POS` for the current position which would not get reset. As a result, the filterdata would be written twice to disk in succession.

`txindex` has no running variable like the other two indexes, but I think that conceptually it makes sense to reset the index db here as well.