### PR TITLE
rpc: Exclude descriptor when address is excluded

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -153,7 +153,9 @@ void ScriptPubKeyToUniv(const CScript& scriptPubKey, UniValue& out, bool include
     CTxDestination address;
 
     out.pushKV("asm", ScriptToAsmStr(scriptPubKey));
-    out.pushKV("desc", InferDescriptor(scriptPubKey, DUMMY_SIGNING_PROVIDER)->ToString());
+    if (include_address) {
+        out.pushKV("desc", InferDescriptor(scriptPubKey, DUMMY_SIGNING_PROVIDER)->ToString());
+    }
     if (include_hex) out.pushKV("hex", HexStr(scriptPubKey));
 
     std::vector<std::vector<unsigned char>> solns;

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1121,6 +1121,7 @@ static RPCHelpMan decodepsbt()
                                     {RPCResult::Type::OBJ, "scriptPubKey", "",
                                     {
                                         {RPCResult::Type::STR, "asm", "The asm"},
+                                        {RPCResult::Type::STR, "desc", "Inferred descriptor for the output"},
                                         {RPCResult::Type::STR_HEX, "hex", "The hex"},
                                         {RPCResult::Type::STR, "type", "The type, eg 'pubkeyhash'"},
                                         {RPCResult::Type::STR, "address", /*optional=*/true, "The Bitcoin address (only if a well-defined address exists)"},


### PR DESCRIPTION
I don't think output descriptors should be used to describe redeem scripts and witness scripts.

Fix this by excluding them when it doesn't make sense.

This should only affect the `decodepsbt` RPC.

Found by https://github.com/bitcoin/bitcoin/pull/23083