### PR TITLE
test: use MiniWallet for mempool_package_onemore.py

### DIFF
--- a/test/functional/mempool_package_onemore.py
+++ b/test/functional/mempool_package_onemore.py
@@ -7,74 +7,68 @@
    size.
 """
 
-from decimal import Decimal
-
-from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    chain_transaction,
 )
+from test_framework.wallet import MiniWallet
+
 
 MAX_ANCESTORS = 25
 MAX_DESCENDANTS = 25
+
 
 class MempoolPackagesTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.extra_args = [["-maxorphantx=1000"]]
 
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
+    def chain_tx(self, utxos_to_spend, *, num_outputs=1):
+        return self.wallet.send_self_transfer_multi(
+            from_node=self.nodes[0],
+            utxos_to_spend=utxos_to_spend,
+            num_outputs=num_outputs)['new_utxos']
 
     def run_test(self):
-        # Mine some blocks and have them mature.
-        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
-        utxo = self.nodes[0].listunspent(10)
-        txid = utxo[0]['txid']
-        vout = utxo[0]['vout']
-        value = utxo[0]['amount']
+        self.wallet = MiniWallet(self.nodes[0])
+        self.wallet.rescan_utxos()
 
-        fee = Decimal("0.0002")
         # MAX_ANCESTORS transactions off a confirmed tx should be fine
         chain = []
+        utxo = self.wallet.get_utxo()
         for _ in range(4):
-            (txid, sent_value) = chain_transaction(self.nodes[0], [txid], [vout], value, fee, 2)
-            vout = 0
-            value = sent_value
-            chain.append([txid, value])
+            utxo, utxo2 = self.chain_tx([utxo], num_outputs=2)
+            chain.append(utxo2)
         for _ in range(MAX_ANCESTORS - 4):
-            (txid, sent_value) = chain_transaction(self.nodes[0], [txid], [0], value, fee, 1)
-            value = sent_value
-            chain.append([txid, value])
-        (second_chain, second_chain_value) = chain_transaction(self.nodes[0], [utxo[1]['txid']], [utxo[1]['vout']], utxo[1]['amount'], fee, 1)
+            utxo, = self.chain_tx([utxo])
+            chain.append(utxo)
+        second_chain, = self.chain_tx([self.wallet.get_utxo()])
 
         # Check mempool has MAX_ANCESTORS + 1 transactions in it
         assert_equal(len(self.nodes[0].getrawmempool()), MAX_ANCESTORS + 1)
 
         # Adding one more transaction on to the chain should fail.
-        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many unconfirmed ancestors [limit: 25]", chain_transaction, self.nodes[0], [txid], [0], value, fee, 1)
+        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many unconfirmed ancestors [limit: 25]", self.chain_tx, [utxo])
         # ...even if it chains on from some point in the middle of the chain.
-        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many descendants", chain_transaction, self.nodes[0], [chain[2][0]], [1], chain[2][1], fee, 1)
-        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many descendants", chain_transaction, self.nodes[0], [chain[1][0]], [1], chain[1][1], fee, 1)
+        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many descendants", self.chain_tx, [chain[2]])
+        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many descendants", self.chain_tx, [chain[1]])
         # ...even if it chains on to two parent transactions with one in the chain.
-        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many descendants", chain_transaction, self.nodes[0], [chain[0][0], second_chain], [1, 0], chain[0][1] + second_chain_value, fee, 1)
+        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many descendants", self.chain_tx, [chain[0], second_chain])
         # ...especially if its > 40k weight
-        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many descendants", chain_transaction, self.nodes[0], [chain[0][0]], [1], chain[0][1], fee, 350)
+        assert_raises_rpc_error(-26, "too-long-mempool-chain, too many descendants", self.chain_tx, [chain[0]], num_outputs=350)
         # But not if it chains directly off the first transaction
-        (replacable_txid, replacable_orig_value) = chain_transaction(self.nodes[0], [chain[0][0]], [1], chain[0][1], fee, 1)
+        replacable_tx = self.wallet.send_self_transfer_multi(from_node=self.nodes[0], utxos_to_spend=[chain[0]])['tx']
         # and the second chain should work just fine
-        chain_transaction(self.nodes[0], [second_chain], [0], second_chain_value, fee, 1)
+        self.chain_tx([second_chain])
 
         # Make sure we can RBF the chain which used our carve-out rule
-        second_tx_outputs = {self.nodes[0].getrawtransaction(replacable_txid, True)["vout"][0]['scriptPubKey']['address']: replacable_orig_value - (Decimal(1) / Decimal(100))}
-        second_tx = self.nodes[0].createrawtransaction([{'txid': chain[0][0], 'vout': 1}], second_tx_outputs)
-        signed_second_tx = self.nodes[0].signrawtransactionwithwallet(second_tx)
-        self.nodes[0].sendrawtransaction(signed_second_tx['hex'])
+        replacable_tx.vout[0].nValue -= 1000000
+        self.nodes[0].sendrawtransaction(replacable_tx.serialize().hex())
 
         # Finally, check that we added two transactions
         assert_equal(len(self.nodes[0].getrawmempool()), MAX_ANCESTORS + 3)
+
 
 if __name__ == '__main__':
     MempoolPackagesTest().main()

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -188,6 +188,46 @@ class MiniWallet:
         txid = self.sendrawtransaction(from_node=from_node, tx_hex=tx.serialize().hex())
         return txid, 1
 
+    def send_self_transfer_multi(self, **kwargs):
+        """
+        Create and send a transaction that spends the given UTXOs and creates a
+        certain number of outputs with equal amounts.
+
+        Returns a dictionary with
+            - txid
+            - serialized transaction in hex format
+            - transaction as CTransaction instance
+            - list of newly created UTXOs, ordered by vout index
+        """
+        tx = self.create_self_transfer_multi(**kwargs)
+        txid = self.sendrawtransaction(from_node=kwargs['from_node'], tx_hex=tx.serialize().hex())
+        return {'new_utxos': [self.get_utxo(txid=txid, vout=vout) for vout in range(len(tx.vout))],
+                'txid': txid, 'hex': tx.serialize().hex(), 'tx': tx}
+
+    def create_self_transfer_multi(self, *, from_node, utxos_to_spend, num_outputs=1, fee_per_output=1000):
+        """
+        Create and return a transaction that spends the given UTXOs and creates a
+        certain number of outputs with equal amounts.
+        """
+        # create simple tx template (1 input, 1 output)
+        tx = self.create_self_transfer(fee_rate=0, from_node=from_node, utxo_to_spend=utxos_to_spend[0], mempool_valid=False)['tx']
+
+        # duplicate inputs, witnesses and outputs
+        tx.vin = [deepcopy(tx.vin[0]) for _ in range(len(utxos_to_spend))]
+        tx.wit.vtxinwit = [deepcopy(tx.wit.vtxinwit[0]) for _ in range(len(utxos_to_spend))]
+        tx.vout = [deepcopy(tx.vout[0]) for _ in range(num_outputs)]
+
+        # adapt input prevouts
+        for i, utxo in enumerate(utxos_to_spend):
+            tx.vin[i] = CTxIn(COutPoint(int(utxo['txid'], 16), utxo['vout']))
+
+        # adapt output amounts (use fixed fee per output)
+        inputs_value_total = sum([int(COIN * utxo['value']) for utxo in utxos_to_spend])
+        outputs_value_total = inputs_value_total - fee_per_output * num_outputs
+        for i in range(num_outputs):
+            tx.vout[i].nValue = outputs_value_total // num_outputs
+        return tx
+
     def create_self_transfer(self, *, fee_rate=Decimal("0.003"), from_node=None, utxo_to_spend=None, mempool_valid=True, locktime=0, sequence=0):
         """Create and return a tx with the specified fee_rate. Fee may be exact or at most one satoshi higher than needed."""
         from_node = from_node or self._test_node


### PR DESCRIPTION
This PR enables one more of the non-wallet functional tests (mempool_package_onemore.py) to be run even with the Bitcoin Core wallet disabled by using the MiniWallet instead, as proposed in https://github.com/bitcoin/bitcoin/issues/20078. For this purpose helper methods `MiniWallet.{create,send}_self_transfer_multi` are introduced which serve as a replacement for `chain_transaction`. With this, it should be also quite straight-forward to change the larger related test `mempool_packages.py` to use MiniWallet.