### PR TITLE
Re-enable C++20 aggregate initialization for CSerializedNetMsg

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -100,13 +100,6 @@ class CNodeStats;
 class CClientUIInterface;
 
 struct CSerializedNetMsg {
-    CSerializedNetMsg() = default;
-    CSerializedNetMsg(CSerializedNetMsg&&) = default;
-    CSerializedNetMsg& operator=(CSerializedNetMsg&&) = default;
-    // No implicit copying, only moves.
-    CSerializedNetMsg(const CSerializedNetMsg& msg) = delete;
-    CSerializedNetMsg& operator=(const CSerializedNetMsg&) = delete;
-
     CSerializedNetMsg Copy() const
     {
         CSerializedNetMsg copy;
@@ -117,7 +110,11 @@ struct CSerializedNetMsg {
 
     std::vector<unsigned char> data;
     std::string m_type;
+
+    // No implicit copying, only moves.
+    DISABLE_IMPLICIT_COPIES();
 };
+static_assert(!std::is_copy_constructible_v<CSerializedNetMsg>);
 
 /** Different types of connections to a peer. This enum encapsulates the
  * information we have available at the time of opening or accepting the

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -8,4 +8,20 @@
 template <class>
 inline constexpr bool ALWAYS_FALSE{false};
 
+struct Disable_Implicit_Copies {
+    Disable_Implicit_Copies() = default;
+    Disable_Implicit_Copies(Disable_Implicit_Copies&&) = default;
+    Disable_Implicit_Copies& operator=(Disable_Implicit_Copies&&) = default;
+};
+
+/**
+ * Helper to disable implicit copies.
+ *
+ * This can be used on types that are expensive to copy, and cheap to move.
+ *
+ * To use, place this as the last line into a class or struct.
+ */
+#define DISABLE_IMPLICIT_COPIES() \
+    Disable_Implicit_Copies _disable_implicit_copies {}
+
 #endif // BITCOIN_UTIL_TYPES_H


### PR DESCRIPTION
I think this is a nice macro that can be used to disable implicit copies, but allow moves.

This is also required in the context of C++20 to re-enable aggregate initialization, which have been disabled in commit 213e98ca826eb25c7d6e26729c6a3de6521614ba. This pull request is inspired by section 3.3 of the paper http://open-std.org/JTC1/SC22/WG21/docs/papers/2018/p1008r1.pdf