### PR TITLE
build: require libtool 2.4.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -96,10 +96,8 @@ fi
 AC_PROG_OBJCXX
 ])
 
-dnl Since libtool 1.5.2 (released 2004-01-25), on Linux libtool no longer
-dnl sets RPATH for any directories in the dynamic linker search path.
-dnl See more: https://wiki.debian.org/RpathIssue
-LT_PREREQ([1.5.2])
+dnl OpenBSD ships with 2.4.2
+LT_PREREQ([2.4.2])
 dnl Libtool init checks.
 LT_INIT([pic-only win32-dll])
 


### PR DESCRIPTION
Every system we support has 2.4.6 available, except for OpenBSD, which
[currently ships with 2.4.2](https://github.com/openbsd/ports/blob/master/devel/libtool/Makefile) (released 2011). For now, set our minimum
required version to that.

After a 7 year hitus, 2.4.7 has also very recently been released:
https://savannah.gnu.org/forum/forum.php?forum_id=10139.

Partially motivated by comments in https://github.com/bitcoin/bitcoin/pull/24615.

See also: https://repology.org/project/libtool/versions