### PR TITLE
doc: rewrite OpenBSD build docs for 7.0

### DIFF
--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,123 +1,133 @@
-OpenBSD build guide
-======================
-(updated for OpenBSD 6.9)
+# OpenBSD Build Guide
 
-This guide describes how to build bitcoind, bitcoin-qt, and command-line utilities on OpenBSD.
+**Updated for OpenBSD [7.0](https://www.openbsd.org/70.html)**
 
-Preparation
--------------
+This guide describes how to build bitcoind, command-line utilities, and GUI on OpenBSD.
 
-Run the following as root to install the base dependencies for building:
+## Preparation
+
+### 1. Install Required Dependencies
+Run the following as root to install the base dependencies for building.
 
 ```bash
-pkg_add git gmake libevent libtool boost
-pkg_add qt5 # (optional for enabling the GUI)
-pkg_add autoconf # (select highest version, e.g. 2.69)
-pkg_add automake # (select highest version, e.g. 1.16)
-pkg_add python # (select highest version, e.g. 3.8)
-pkg_add bash
-
-git clone https://github.com/bitcoin/bitcoin.git
+pkg_add bash git gmake libevent libtool boost
+# Select the newest version of the follow packages:
+pkg_add autoconf automake python
 ```
 
 See [dependencies.md](dependencies.md) for a complete overview.
 
-**Important**: From OpenBSD 6.2 onwards a C++11-supporting clang compiler is
-part of the base image, and while building it is necessary to make sure that
-this compiler is used and not ancient g++ 4.2.1. This is done by appending
-`CC=cc CXX=c++` to configuration commands. Mixing different compilers within
-the same executable will result in errors.
-
-### Building BerkeleyDB
-
-BerkeleyDB is only necessary for the wallet functionality. To skip this, pass
-`--disable-wallet` to `./configure` and skip to the next section.
-
-It is recommended to use Berkeley DB 4.8. You cannot use the BerkeleyDB library
-from ports, for the same reason as boost above (g++/libstd++ incompatibility).
-If you have to build it yourself, you can use [the installation script included
-in contrib/](/contrib/install_db4.sh) like so:
-
-```bash
-./contrib/install_db4.sh `pwd` CC=cc CXX=c++
+### 2. Clone Bitcoin Repo
+Clone the Bitcoin Core repository to a directory. All build scripts and commands will run from this directory.
+``` bash
+git clone https://github.com/bitcoin/bitcoin.git
 ```
 
-from the root of the repository. Then set `BDB_PREFIX` for the next section:
+### 3. Install Optional Dependencies
+
+#### Wallet Dependencies
+
+It is not necessary to build wallet functionality to run either `bitcoind` or `bitcoin-qt`.
+
+###### Descriptor Wallet Support
+
+`sqlite3` is required to support [descriptor wallets](descriptors.md).
+
+``` bash
+pkg_add install sqlite3
+```
+
+###### Legacy Wallet Support
+BerkeleyDB is only required to support legacy wallets.
+
+It is recommended to use Berkeley DB 4.8. You cannot use the BerkeleyDB library
+from ports. However you can build it yourself, [using the installation script included in contrib/](/contrib/install_db4.sh), like so, from the root of the repository.
+
+```bash
+./contrib/install_db4.sh `pwd`
+```
+
+Then set `BDB_PREFIX`:
 
 ```bash
 export BDB_PREFIX="$PWD/db4"
 ```
 
-### Building Bitcoin Core
+#### GUI Dependencies
+###### Qt5
+
+Bitcoin Core includes a GUI built with the cross-platform Qt Framework. To compile the GUI, Qt 5 is required.
+
+```bash
+pkg_add qt5
+```
+
+## Building Bitcoin Core
 
 **Important**: Use `gmake` (the non-GNU `make` will exit with an error).
 
 Preparation:
 ```bash
 
-# Replace this with the autoconf version that you installed. Include only
-# the major and minor parts of the version: use "2.69" for "autoconf-2.69p2".
-export AUTOCONF_VERSION=2.69
-
-# Replace this with the automake version that you installed. Include only
-# the major and minor parts of the version: use "1.16" for "automake-1.16.1".
+# Adapt the following for the version you installed (major.minor only):
+export AUTOCONF_VERSION=2.71
 export AUTOMAKE_VERSION=1.16
 
 ./autogen.sh
 ```
-Make sure `BDB_PREFIX` is set to the appropriate path from the above steps.
+
+### 1. Configuration
 
 Note that building with external signer support currently fails on OpenBSD,
 hence you have to explicitly disable it by passing the parameter
-`--disable-external-signer` to the configure script.
-(Background: the feature requires the header-only library boost::process, which
-is available on OpenBSD 6.9 via Boost 1.72.0, but contains certain system calls
-and preprocessor defines like `waitid()` and `WEXITED` that are not available.)
+`--disable-external-signer` to the configure script. The feature requires the
+header-only library boost::process, which is available on OpenBSD, but contains
+certain system calls and preprocessor defines like `waitid()` and `WEXITED` that
+are not available.
 
-To configure with wallet:
+There are many ways to configure Bitcoin Core, here are a few common examples:
+
+##### Descriptor Wallet and GUI:
+This enables the GUI and descriptor wallet support, assuming `sqlite` and `qt5` are installed.
+
 ```bash
-./configure --with-gui=no --disable-external-signer CC=cc CXX=c++ \
+./configure --disable-external-signer MAKE=gmake
+```
+
+##### Descriptor & Legacy Wallet. No GUI:
+This enables support for both wallet types and disables the GUI:
+
+```bash
+./configure --disable-external-signer --with-gui=no \
     BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
     BDB_CFLAGS="-I${BDB_PREFIX}/include" \
     MAKE=gmake
 ```
 
-To configure without wallet:
+### 2. Compile
+**Important**: Use `gmake` (the non-GNU `make` will exit with an error).
+
 ```bash
-./configure --disable-wallet --with-gui=no --disable-external-signer CC=cc CXX=c++ MAKE=gmake
+gmake # use "-j N" for N parallel jobs
+gmake check # Run tests if Python 3 is available
 ```
 
-To configure with GUI:
-```bash
-./configure --with-gui=yes --disable-external-signer CC=cc CXX=c++ \
-    BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
-    BDB_CFLAGS="-I${BDB_PREFIX}/include" \
-    MAKE=gmake
-```
-
-Build and run the tests:
-```bash
-gmake # use "-j N" here for N parallel jobs
-gmake check
-```
-
-Resource limits
--------------------
+## Resource limits
 
 If the build runs into out-of-memory errors, the instructions in this section
 might help.
 
 The standard ulimit restrictions in OpenBSD are very strict:
-
-    data(kbytes)         1572864
+```bash
+data(kbytes)         1572864
+```
 
 This is, unfortunately, in some cases not enough to compile some `.cpp` files in the project,
 (see issue [#6658](https://github.com/bitcoin/bitcoin/issues/6658)).
 If your user is in the `staff` group the limit can be raised with:
-
-    ulimit -d 3000000
-
+```bash
+ulimit -d 3000000
+```
 The change will only affect the current shell and processes spawned by it. To
 make the change system-wide, change `datasize-cur` and `datasize-max` in
 `/etc/login.conf`, and reboot.
-


### PR DESCRIPTION
Removes redundant notes for setting `CC` &`CXX` now that Clang is well and truly the base compiler. See: https://www.openbsd.org/70.html
> Disabled base-gcc on amd64.

Cleans up the wallet docs, i.e #23446.

Make the notes more similar to the FreeBSD notes.