### PR TITLE
refactor: Fix coinselection.h include, Make COutput a struct

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -16,10 +16,11 @@
 #include <qt/platformstyle.h>
 #include <qt/walletmodel.h>
 
-#include <wallet/coincontrol.h>
 #include <interfaces/node.h>
 #include <key_io.h>
 #include <policy/policy.h>
+#include <wallet/coincontrol.h>
+#include <wallet/coinselection.h>
 #include <wallet/wallet.h>
 
 #include <QApplication>

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -19,9 +19,7 @@ static constexpr CAmount MIN_CHANGE{COIN / 100};
 static const CAmount MIN_FINAL_CHANGE = MIN_CHANGE/2;
 
 /** A UTXO under consideration for use in funding a new transaction. */
-class COutput
-{
-public:
+struct COutput {
     /** The outpoint identifying this UTXO */
     COutPoint outpoint;
 
@@ -67,21 +65,22 @@ public:
     CAmount long_term_fee{0};
 
     COutput(const COutPoint& outpoint, const CTxOut& txout, int depth, int input_bytes, bool spendable, bool solvable, bool safe, int64_t time, bool from_me)
-        : outpoint(outpoint),
-        txout(txout),
-        depth(depth),
-        input_bytes(input_bytes),
-        spendable(spendable),
-        solvable(solvable),
-        safe(safe),
-        time(time),
-        from_me(from_me),
-        effective_value(txout.nValue)
+        : outpoint{outpoint},
+          txout{txout},
+          depth{depth},
+          input_bytes{input_bytes},
+          spendable{spendable},
+          solvable{solvable},
+          safe{safe},
+          time{time},
+          from_me{from_me},
+          effective_value{txout.nValue}
     {}
 
     std::string ToString() const;
 
-    bool operator<(const COutput& rhs) const {
+    bool operator<(const COutput& rhs) const
+    {
         return outpoint < rhs.outpoint;
     }
 };

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -20,7 +20,6 @@
 #include <util/system.h>
 #include <util/ui_change_type.h>
 #include <validationinterface.h>
-#include <wallet/coinselection.h>
 #include <wallet/crypter.h>
 #include <wallet/scriptpubkeyman.h>
 #include <wallet/transaction.h>
@@ -112,7 +111,6 @@ constexpr CAmount HIGH_MAX_TX_FEE{100 * HIGH_TX_FEE_PER_KB};
 static constexpr size_t DUMMY_NESTED_P2WPKH_INPUT_SIZE = 91;
 
 class CCoinControl;
-class COutput;
 class CWalletTx;
 class ReserveDestination;
 


### PR DESCRIPTION
* Fix include (see commit message)
* `{}`-init, see https://github.com/bitcoin/bitcoin/pull/24091#discussion_r831193284
* `struct`, see https://github.com/bitcoin/bitcoin/pull/24091#discussion_r831192702