### PR TITLE
build: remove unneeded configure $*val setting

### DIFF
--- a/build-aux/m4/bitcoin_find_bdb48.m4
+++ b/build-aux/m4/bitcoin_find_bdb48.m4
@@ -6,8 +6,8 @@ AC_DEFUN([BITCOIN_FIND_BDB48],[
   AC_ARG_VAR([BDB_CFLAGS], [C compiler flags for BerkeleyDB, bypasses autodetection])
   AC_ARG_VAR([BDB_LIBS], [Linker flags for BerkeleyDB, bypasses autodetection])
 
-  if test "$use_bdb" = "no"; then
-    use_bdb=no
+  if test "$with_bdb" = "no"; then
+    with_bdb=no
   elif test "$BDB_CFLAGS" = ""; then
     AC_MSG_CHECKING([for Berkeley DB C++ headers])
     BDB_CPPFLAGS=
@@ -46,7 +46,7 @@ AC_DEFUN([BITCOIN_FIND_BDB48],[
       ],[])
     done
     if test "$bdbpath" = "X"; then
-      use_bdb=no
+      with_bdb=no
       AC_MSG_RESULT([no])
       AC_MSG_WARN([libdb_cxx headers missing])
       AC_MSG_WARN(AC_PACKAGE_NAME[ requires this library for BDB (legacy) wallet support])
@@ -56,26 +56,26 @@ AC_DEFUN([BITCOIN_FIND_BDB48],[
       AC_ARG_WITH([incompatible-bdb],[AS_HELP_STRING([--with-incompatible-bdb], [allow using a bdb version other than 4.8])],[
         AC_MSG_WARN([Found Berkeley DB other than 4.8])
         AC_MSG_WARN([BDB (legacy) wallets opened by this build will not be portable!])
-        use_bdb=yes
+        with_bdb=yes
       ],[
         AC_MSG_WARN([Found Berkeley DB other than 4.8])
         AC_MSG_WARN([BDB (legacy) wallets opened by this build would not be portable!])
         AC_MSG_WARN([If this is intended, pass --with-incompatible-bdb])
         AC_MSG_WARN([Passing --without-bdb will suppress this warning])
-        use_bdb=no
+        with_bdb=no
       ])
     else
       BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdb48path}],db_cxx)
       bdbpath="${bdb48path}"
-      use_bdb=yes
+      with_bdb=yes
     fi
   else
     BDB_CPPFLAGS=${BDB_CFLAGS}
   fi
   AC_SUBST(BDB_CPPFLAGS)
 
-  if test "$use_bdb" = "no"; then
-    use_bdb=no
+  if test "$with_bdb" = "no"; then
+    with_bdb=no
   elif test "$BDB_LIBS" = ""; then
     # TODO: Ideally this could find the library version and make sure it matches the headers being used
     for searchlib in db_cxx-4.8 db_cxx db4_cxx; do
@@ -90,8 +90,8 @@ AC_DEFUN([BITCOIN_FIND_BDB48],[
         AC_MSG_WARN([Passing --without-bdb will suppress this warning])
     fi
   fi
-  if test "$use_bdb" != "no"; then
+  if test "$with_bdb" != "no"; then
     AC_DEFINE([USE_BDB], [1], [Define if BDB support should be compiled in])
-    use_bdb=yes
+    with_bdb=yes
   fi
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -294,10 +294,10 @@ AM_CONDITIONAL([ENABLE_MAN], [test "$enable_man" != "no"])
 
 dnl Enable debug
 AC_ARG_ENABLE([debug],
-    [AS_HELP_STRING([--enable-debug],
-                    [use compiler flags and macros suited for debugging (default is no)])],
-    [enable_debug=$enableval],
-    [enable_debug=no])
+  [AS_HELP_STRING([--enable-debug],
+  [use compiler flags and macros suited for debugging (default is no)])],
+  [],
+  [enable_debug=no])
 
 dnl Enable different -fsanitize options
 AC_ARG_WITH([sanitizers],

--- a/configure.ac
+++ b/configure.ac
@@ -230,9 +230,9 @@ dnl too much, so that it becomes difficult to spot Bitcoin Core warnings
 dnl or if they cause a build failure with --enable-werror.
 AC_ARG_ENABLE([suppress-external-warnings],
   [AS_HELP_STRING([--enable-suppress-external-warnings],
-                  [Suppress warnings from external headers (default is no)])],
-  [suppress_external_warnings=$enableval],
-  [suppress_external_warnings=no])
+  [Suppress warnings from external headers (default is no)])],
+  [],
+  [enable_suppress_external_warnings=no])
 
 AC_ARG_ENABLE([lcov],
   [AS_HELP_STRING([--enable-lcov],
@@ -454,7 +454,7 @@ if test "$CXXFLAGS_overridden" = "no"; then
   AX_CHECK_COMPILE_FLAG([-Wunreachable-code-loop-increment], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wunreachable-code-loop-increment"], [], [$CXXFLAG_WERROR])
   AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wimplicit-fallthrough"], [], [$CXXFLAG_WERROR])
 
-  if test "$suppress_external_warnings" != "no" ; then
+  if test "$enable_suppress_external_warnings" != "no" ; then
     AX_CHECK_COMPILE_FLAG([-Wdocumentation], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wdocumentation"], [], [$CXXFLAG_WERROR])
   fi
 
@@ -463,7 +463,7 @@ if test "$CXXFLAGS_overridden" = "no"; then
   dnl set the -Wno-foo case if it works.
   AX_CHECK_COMPILE_FLAG([-Wunused-parameter], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-unused-parameter"], [], [$CXXFLAG_WERROR])
   AX_CHECK_COMPILE_FLAG([-Wself-assign], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-self-assign"], [], [$CXXFLAG_WERROR])
-  if test "$suppress_external_warnings" != "yes" ; then
+  if test "$enable_suppress_external_warnings" != "yes" ; then
     AX_CHECK_COMPILE_FLAG([-Wdeprecated-copy], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-deprecated-copy"], [], [$CXXFLAG_WERROR])
   fi
 fi
@@ -748,7 +748,7 @@ case $host in
              dnl explicitly.
              if test "$use_upnp" != "no" && $BREW list --versions miniupnpc >/dev/null; then
                miniupnpc_prefix=$($BREW --prefix miniupnpc 2>/dev/null)
-               if test "$suppress_external_warnings" != "no"; then
+               if test "$enable_suppress_external_warnings" != "no"; then
                  CORE_CPPFLAGS="$CORE_CPPFLAGS -isystem $miniupnpc_prefix/include"
                else
                  CORE_CPPFLAGS="$CORE_CPPFLAGS -I$miniupnpc_prefix/include"
@@ -757,7 +757,7 @@ case $host in
              fi
              if test "$use_natpmp" != "no" && $BREW list --versions libnatpmp >/dev/null; then
                libnatpmp_prefix=$($BREW --prefix libnatpmp 2>/dev/null)
-               if test "$suppress_external_warnings" != "no"; then
+               if test "$enable_suppress_external_warnings" != "no"; then
                  CORE_CPPFLAGS="$CORE_CPPFLAGS -isystem $libnatpmp_prefix/include"
                else
                  CORE_CPPFLAGS="$CORE_CPPFLAGS -I$libnatpmp_prefix/include"
@@ -1307,7 +1307,7 @@ else
 
   dnl Keep a copy of the original $QT_INCLUDES and use it when invoking qt's moc
   QT_INCLUDES_UNSUPPRESSED=$QT_INCLUDES
-  if test "$suppress_external_warnings" != "no" ; then
+  if test "$enable_suppress_external_warnings" != "no" ; then
     QT_INCLUDES=SUPPRESS_WARNINGS($QT_INCLUDES)
     QT_DBUS_INCLUDES=SUPPRESS_WARNINGS($QT_DBUS_INCLUDES)
     QT_TEST_INCLUDES=SUPPRESS_WARNINGS($QT_TEST_INCLUDES)
@@ -1337,7 +1337,7 @@ if test "$enable_wallet" != "no"; then
     dnl Check for libdb_cxx only if wallet enabled
     if test "$use_bdb" != "no"; then
       BITCOIN_FIND_BDB48
-      if test "$suppress_external_warnings" != "no" ; then
+      if test "$enable_suppress_external_warnings" != "no" ; then
         BDB_CPPFLAGS=SUPPRESS_WARNINGS($BDB_CPPFLAGS)
       fi
     fi
@@ -1543,7 +1543,7 @@ if test "$build_bitcoin_cli$build_bitcoind$bitcoin_enable_qt$use_tests$use_bench
     PKG_CHECK_MODULES([EVENT_PTHREADS], [libevent_pthreads >= 2.1.8], [], [AC_MSG_ERROR([libevent_pthreads version 2.1.8 or greater not found.])])
   fi
 
-  if test "$suppress_external_warnings" != "no"; then
+  if test "$enable_suppress_external_warnings" != "no"; then
     EVENT_CFLAGS=SUPPRESS_WARNINGS($EVENT_CFLAGS)
   fi
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -306,10 +306,10 @@ AC_ARG_WITH([sanitizers],
 
 dnl Enable gprof profiling
 AC_ARG_ENABLE([gprof],
-    [AS_HELP_STRING([--enable-gprof],
-                    [use gprof profiling compiler flags (default is no)])],
-    [enable_gprof=$enableval],
-    [enable_gprof=no])
+  [AS_HELP_STRING([--enable-gprof],
+  [use gprof profiling compiler flags (default is no)])],
+  [],
+  [enable_gprof=no])
 
 dnl Turn warnings into errors
 AC_ARG_ENABLE([werror],

--- a/configure.ac
+++ b/configure.ac
@@ -135,8 +135,8 @@ AC_ARG_WITH([sqlite],
 AC_ARG_WITH([bdb],
   [AS_HELP_STRING([--without-bdb],
   [disable bdb wallet support (default is enabled if wallet is enabled)])],
-  [use_bdb=$withval],
-  [use_bdb=auto])
+  [],
+  [with_bdb=auto])
 
 AC_ARG_ENABLE([usdt],
   [AS_HELP_STRING([--enable-usdt],
@@ -730,7 +730,7 @@ case $host in
          dnl It's safe to add these paths even if the functionality is disabled by
          dnl the user (--without-wallet or --without-gui for example).
 
-         if test "$use_bdb" != "no" && $BREW list --versions berkeley-db@4 >/dev/null && test "$BDB_CFLAGS" = "" && test "$BDB_LIBS" = ""; then
+         if test "$with_bdb" != "no" && $BREW list --versions berkeley-db@4 >/dev/null && test "$BDB_CFLAGS" = "" && test "$BDB_LIBS" = ""; then
            bdb_prefix=$($BREW --prefix berkeley-db@4 2>/dev/null)
            dnl This must precede the call to BITCOIN_FIND_BDB48 below.
            BDB_CFLAGS="-I$bdb_prefix/include"
@@ -1340,7 +1340,7 @@ fi
 
 if test "$enable_wallet" != "no"; then
     dnl Check for libdb_cxx only if wallet enabled
-    if test "$use_bdb" != "no"; then
+    if test "$with_bdb" != "no"; then
       BITCOIN_FIND_BDB48
       if test "$enable_suppress_external_warnings" != "no" ; then
         BDB_CPPFLAGS=SUPPRESS_WARNINGS($BDB_CPPFLAGS)
@@ -1368,7 +1368,7 @@ if test "$enable_wallet" != "no"; then
     AC_MSG_RESULT([$use_sqlite])
 
     dnl Disable wallet if both --without-bdb and --without-sqlite
-    if test "$use_bdb$use_sqlite" = "nono"; then
+    if test "$with_bdb$use_sqlite" = "nono"; then
         if test "$enable_wallet" = "yes"; then
             AC_MSG_ERROR([wallet functionality requested but no BDB or SQLite support available.])
         fi
@@ -1831,7 +1831,7 @@ AM_CONDITIONAL([TARGET_LINUX], [test "$TARGET_OS" = "linux"])
 AM_CONDITIONAL([TARGET_WINDOWS], [test "$TARGET_OS" = "windows"])
 AM_CONDITIONAL([ENABLE_WALLET], [test "$enable_wallet" = "yes"])
 AM_CONDITIONAL([USE_SQLITE], [test "$use_sqlite" = "yes"])
-AM_CONDITIONAL([USE_BDB], [test "$use_bdb" = "yes"])
+AM_CONDITIONAL([USE_BDB], [test "$with_bdb" = "yes"])
 AM_CONDITIONAL([ENABLE_TESTS], [test "$BUILD_TEST" = "yes"])
 AM_CONDITIONAL([ENABLE_FUZZ], [test "$enable_fuzz" = "yes"])
 AM_CONDITIONAL([ENABLE_FUZZ_BINARY], [test "$enable_fuzz_binary" = "yes"])
@@ -1983,7 +1983,7 @@ echo "  with libs       = $build_bitcoin_libs"
 echo "  with wallet     = $enable_wallet"
 if test "$enable_wallet" != "no"; then
     echo "    with sqlite   = $use_sqlite"
-    echo "    with bdb      = $use_bdb"
+    echo "    with bdb      = $with_bdb"
 fi
 echo "  with gui / qt   = $bitcoin_enable_qt"
 if test $bitcoin_enable_qt != "no"; then

--- a/configure.ac
+++ b/configure.ac
@@ -169,15 +169,16 @@ AC_ARG_ENABLE([natpmp-default],
               [use_natpmp_default=no])
 
 AC_ARG_ENABLE(tests,
-    AS_HELP_STRING([--disable-tests],[do not compile tests (default is to compile)]),
-    [use_tests=$enableval],
-    [use_tests=yes])
+  AS_HELP_STRING([--disable-tests],
+  [do not compile tests (default is to compile)]),
+  [],
+  [enable_tests=yes])
 
 AC_ARG_ENABLE(gui-tests,
   AS_HELP_STRING([--disable-gui-tests],
   [do not compile GUI tests (default is to compile if GUI and tests enabled)]),
   [],
-  [enable_gui_tests=$use_tests])
+  [enable_gui_tests=$enable_tests])
 
 AC_ARG_ENABLE(bench,
   AS_HELP_STRING([--disable-bench],
@@ -1388,7 +1389,7 @@ if test "$enable_usdt" != "no"; then
 fi
 AM_CONDITIONAL([ENABLE_USDT_TRACEPOINTS], [test "$use_usdt" = "yes"])
 
-if test "$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_util$build_bitcoind$bitcoin_enable_qt$enable_bench$use_tests" = "nonononononono"; then
+if test "$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_util$build_bitcoind$bitcoin_enable_qt$enable_bench$enable_tests" = "nonononononono"; then
   use_upnp=no
   use_natpmp=no
   enable_zmq=no
@@ -1430,7 +1431,7 @@ if test "$use_natpmp" != "no"; then
                    [have_natpmp=no])
 fi
 
-if test "$build_bitcoin_wallet$build_bitcoin_cli$build_bitcoin_tx$build_bitcoind$bitcoin_enable_qt$use_tests$enable_bench" = "nonononononono"; then
+if test "$build_bitcoin_wallet$build_bitcoin_cli$build_bitcoin_tx$build_bitcoind$bitcoin_enable_qt$enable_tests$enable_bench" = "nonononononono"; then
   use_boost=no
 else
   use_boost=yes
@@ -1532,7 +1533,7 @@ if test "$enable_reduce_exports" = "yes"; then
   AX_CHECK_LINK_FLAG([-Wl,--exclude-libs,ALL], [RELDFLAGS="-Wl,--exclude-libs,ALL"], [], [$LDFLAG_WERROR])
 fi
 
-if test "$use_tests" = "yes"; then
+if test "$enable_tests" = "yes"; then
 
   if test "$HEXDUMP" = ""; then
     AC_MSG_ERROR([hexdump is required for tests])
@@ -1541,7 +1542,7 @@ fi
 
 dnl libevent check
 
-if test "$build_bitcoin_cli$build_bitcoind$bitcoin_enable_qt$use_tests$enable_bench" != "nonononono"; then
+if test "$build_bitcoin_cli$build_bitcoind$bitcoin_enable_qt$enable_tests$enable_bench" != "nonononono"; then
   PKG_CHECK_MODULES([EVENT], [libevent >= 2.1.8], [use_libevent=yes], [AC_MSG_ERROR([libevent version 2.1.8 or greater not found.])])
   if test "$TARGET_OS" != "windows"; then
     PKG_CHECK_MODULES([EVENT_PTHREADS], [libevent_pthreads >= 2.1.8], [], [AC_MSG_ERROR([libevent_pthreads version 2.1.8 or greater not found.])])
@@ -1801,7 +1802,7 @@ fi
 AM_CONDITIONAL([ENABLE_ZMQ], [test "$enable_zmq" = "yes"])
 
 AC_MSG_CHECKING([whether to build test_bitcoin])
-if test "$use_tests" = "yes"; then
+if test "$enable_tests" = "yes"; then
   if test "$enable_fuzz" = "yes"; then
     AC_MSG_RESULT([no, because fuzzing is enabled])
   else
@@ -1820,7 +1821,7 @@ else
   AC_MSG_RESULT([no])
 fi
 
-if test "$build_bitcoin_wallet$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_libs$build_bitcoind$bitcoin_enable_qt$enable_bench$use_tests" = "nononononononono"; then
+if test "$build_bitcoin_wallet$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_libs$build_bitcoind$bitcoin_enable_qt$enable_bench$enable_tests" = "nononononononono"; then
   AC_MSG_ERROR([No targets! Please specify at least one of: --with-utils --with-libs --with-daemon --with-gui --enable-bench or --enable-tests])
 fi
 
@@ -1990,7 +1991,7 @@ if test $bitcoin_enable_qt != "no"; then
 fi
 echo "  with zmq        = $enable_zmq"
 if test $enable_fuzz = "no"; then
-    echo "  with test       = $use_tests"
+    echo "  with test       = $enable_tests"
 else
     echo "  with test       = not building test_bitcoin because fuzzing is enabled"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -215,8 +215,8 @@ AC_ARG_ENABLE([hardening],
 AC_ARG_ENABLE([reduce-exports],
   [AS_HELP_STRING([--enable-reduce-exports],
   [attempt to reduce exported symbols in the resulting executables (default is no)])],
-  [use_reduce_exports=$enableval],
-  [use_reduce_exports=no])
+  [],
+  [enable_reduce_exports=no])
 
 AC_ARG_ENABLE([ccache],
   [AS_HELP_STRING([--disable-ccache],
@@ -1065,7 +1065,7 @@ AC_COMPILE_IFELSE([AC_LANG_SOURCE([
   ],
   [
     AC_MSG_RESULT([no])
-    if test "$use_reduce_exports" = "yes"; then
+    if test "$enable_reduce_exports" = "yes"; then
       AC_MSG_ERROR([Cannot find a working visibility attribute. Use --disable-reduce-exports.])
     fi
   ]
@@ -1523,7 +1523,7 @@ use_syscall_sandbox=$with_seccomp
 AM_CONDITIONAL([ENABLE_SYSCALL_SANDBOX], [test "$use_syscall_sandbox" != "no"])
 
 dnl Check for reduced exports
-if test "$use_reduce_exports" = "yes"; then
+if test "$enable_reduce_exports" = "yes"; then
   AX_CHECK_COMPILE_FLAG([-fvisibility=hidden], [CORE_CXXFLAGS="$CORE_CXXFLAGS -fvisibility=hidden"],
   [AC_MSG_ERROR([Cannot set hidden symbol visibility. Use --disable-reduce-exports.])], [$CXXFLAG_WERROR])
   AX_CHECK_LINK_FLAG([-Wl,--exclude-libs,ALL], [RELDFLAGS="-Wl,--exclude-libs,ALL"], [], [$LDFLAG_WERROR])
@@ -1811,7 +1811,7 @@ else
 fi
 
 AC_MSG_CHECKING([whether to reduce exports])
-if test "$use_reduce_exports" = "yes"; then
+if test "$enable_reduce_exports" = "yes"; then
   AC_MSG_RESULT([yes])
 else
   AC_MSG_RESULT([no])

--- a/configure.ac
+++ b/configure.ac
@@ -221,8 +221,8 @@ AC_ARG_ENABLE([reduce-exports],
 AC_ARG_ENABLE([ccache],
   [AS_HELP_STRING([--disable-ccache],
   [do not use ccache for building (default is to use if found)])],
-  [use_ccache=$enableval],
-  [use_ccache=auto])
+  [],
+  [enable_ccache=auto])
 
 dnl Suppress warnings from external headers (e.g. Boost, Qt).
 dnl May be useful if warnings from external headers clutter the build output
@@ -1670,21 +1670,21 @@ AC_MSG_RESULT($build_bitcoin_libs)
 
 AC_LANG_POP
 
-if test "$use_ccache" != "no"; then
+if test "$enable_ccache" != "no"; then
   AC_MSG_CHECKING([if ccache should be used])
   if test "$CCACHE" = ""; then
-    if test "$use_ccache" = "yes"; then
+    if test "$enable_ccache" = "yes"; then
       AC_MSG_ERROR([ccache not found.]);
     else
-      use_ccache=no
+      enable_ccache=no
     fi
   else
-    use_ccache=yes
+    enable_ccache=yes
     CC="$ac_cv_path_CCACHE $CC"
     CXX="$ac_cv_path_CCACHE $CXX"
   fi
-  AC_MSG_RESULT($use_ccache)
-  if test "$use_ccache" = "yes"; then
+  AC_MSG_RESULT($enable_ccache)
+  if test "$enable_ccache" = "yes"; then
     AX_CHECK_COMPILE_FLAG([-fdebug-prefix-map=A=B], [DEBUG_CXXFLAGS="$DEBUG_CXXFLAGS -fdebug-prefix-map=\$(abs_top_srcdir)=."], [], [$CXXFLAG_WERROR])
     AX_CHECK_PREPROC_FLAG([-fmacro-prefix-map=A=B], [DEBUG_CPPFLAGS="$DEBUG_CPPFLAGS -fmacro-prefix-map=\$(abs_top_srcdir)=."], [], [$CXXFLAG_WERROR])
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -123,7 +123,7 @@ AC_ARG_VAR([PYTHONPATH], [Augments the default search path for python module fil
 AC_ARG_ENABLE([wallet],
   [AS_HELP_STRING([--disable-wallet],
   [disable wallet (enabled by default)])],
-  [enable_wallet=$enableval],
+  [],
   [enable_wallet=auto])
 
 AC_ARG_WITH([sqlite],

--- a/configure.ac
+++ b/configure.ac
@@ -237,14 +237,14 @@ AC_ARG_ENABLE([suppress-external-warnings],
 AC_ARG_ENABLE([lcov],
   [AS_HELP_STRING([--enable-lcov],
   [enable lcov testing (default is no)])],
-  [use_lcov=$enableval],
-  [use_lcov=no])
+  [],
+  [enable_lcov=no])
 
 AC_ARG_ENABLE([lcov-branch-coverage],
   [AS_HELP_STRING([--enable-lcov-branch-coverage],
   [enable lcov testing branch coverage (default is no)])],
-  [use_lcov_branch=yes],
-  [use_lcov_branch=no])
+  [],
+  [enable_lcov_branch_coverage=no])
 
 AC_ARG_ENABLE([threadlocal],
   [AS_HELP_STRING([--enable-threadlocal],
@@ -818,7 +818,7 @@ if test "$use_extended_functional_tests" != "no"; then
   AC_SUBST(EXTENDED_FUNCTIONAL_TESTS, --extended)
 fi
 
-if test "$use_lcov" = "yes"; then
+if test "$enable_lcov" = "yes"; then
   if test "$LCOV" = ""; then
     AC_MSG_ERROR([lcov testing requested but lcov not found])
   fi
@@ -866,7 +866,7 @@ if test "$use_lcov" = "yes"; then
   CORE_CXXFLAGS="$CORE_CXXFLAGS -Og -O0"
 fi
 
-if test "$use_lcov_branch" != "no"; then
+if test "$enable_lcov_branch_coverage" != "no"; then
   AC_SUBST(LCOV_OPTS, "$LCOV_OPTS --rc lcov_branch_coverage=1")
 fi
 
@@ -1835,7 +1835,7 @@ AM_CONDITIONAL([ENABLE_QT], [test "$bitcoin_enable_qt" = "yes"])
 AM_CONDITIONAL([ENABLE_QT_TESTS], [test "$BUILD_TEST_QT" = "yes"])
 AM_CONDITIONAL([ENABLE_BENCH], [test "$use_bench" = "yes"])
 AM_CONDITIONAL([USE_QRCODE], [test "$use_qr" = "yes"])
-AM_CONDITIONAL([USE_LCOV], [test "$use_lcov" = "yes"])
+AM_CONDITIONAL([USE_LCOV], [test "$enable_lcov" = "yes"])
 AM_CONDITIONAL([USE_LIBEVENT], [test "$use_libevent" = "yes"])
 AM_CONDITIONAL([HARDEN], [test "$use_hardening" = "yes"])
 AM_CONDITIONAL([ENABLE_SSE42], [test "$enable_sse42" = "yes"])

--- a/configure.ac
+++ b/configure.ac
@@ -157,16 +157,16 @@ AC_ARG_ENABLE([upnp-default],
   [use_upnp_default=no])
 
 AC_ARG_WITH([natpmp],
-            [AS_HELP_STRING([--with-natpmp],
-                            [enable NAT-PMP (default is yes if libnatpmp is found)])],
-            [use_natpmp=$withval],
-            [use_natpmp=auto])
+  [AS_HELP_STRING([--with-natpmp],
+  [enable NAT-PMP (default is yes if libnatpmp is found)])],
+  [],
+  [with_natpmp=auto])
 
 AC_ARG_ENABLE([natpmp-default],
-              [AS_HELP_STRING([--enable-natpmp-default],
-                              [if NAT-PMP is enabled, turn it on at startup (default is no)])],
-              [use_natpmp_default=$enableval],
-              [use_natpmp_default=no])
+  [AS_HELP_STRING([--enable-natpmp-default],
+  [if NAT-PMP is enabled, turn it on at startup (default is no)])],
+  [],
+  [enable_natpmp_default=no])
 
 AC_ARG_ENABLE(tests,
   AS_HELP_STRING([--disable-tests],
@@ -760,7 +760,7 @@ case $host in
                fi
                CORE_LDFLAGS="$CORE_LDFLAGS -L$miniupnpc_prefix/lib"
              fi
-             if test "$use_natpmp" != "no" && $BREW list --versions libnatpmp >/dev/null; then
+             if test "$with_natpmp" != "no" && $BREW list --versions libnatpmp >/dev/null; then
                libnatpmp_prefix=$($BREW --prefix libnatpmp 2>/dev/null)
                if test "$enable_suppress_external_warnings" != "no"; then
                  CORE_CPPFLAGS="$CORE_CPPFLAGS -isystem $libnatpmp_prefix/include"
@@ -1299,7 +1299,7 @@ if test "$enable_fuzz" = "yes"; then
   enable_bench=no
   enable_external_signer=no
   use_upnp=no
-  use_natpmp=no
+  with_natpmp=no
   enable_zmq=no
   enable_fuzz_binary=yes
 
@@ -1391,7 +1391,7 @@ AM_CONDITIONAL([ENABLE_USDT_TRACEPOINTS], [test "$use_usdt" = "yes"])
 
 if test "$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_util$build_bitcoind$bitcoin_enable_qt$enable_bench$enable_tests" = "nonononononono"; then
   use_upnp=no
-  use_natpmp=no
+  with_natpmp=no
   enable_zmq=no
 fi
 
@@ -1425,7 +1425,7 @@ fi
 fi
 
 dnl Check for libnatpmp (optional).
-if test "$use_natpmp" != "no"; then
+if test "$with_natpmp" != "no"; then
   AC_CHECK_HEADERS([natpmp.h],
                    [AC_CHECK_LIB([natpmp], [initnatpmp], [NATPMP_LIBS=-lnatpmp], [have_natpmp=no])],
                    [have_natpmp=no])
@@ -1736,22 +1736,22 @@ fi
 dnl Enable NAT-PMP support.
 AC_MSG_CHECKING([whether to build with support for NAT-PMP])
 if test "$have_natpmp" = "no"; then
-  if test "$use_natpmp" = "yes"; then
+  if test "$with_natpmp" = "yes"; then
      AC_MSG_ERROR([NAT-PMP requested but cannot be built. Use --without-natpmp])
   fi
   AC_MSG_RESULT([no])
-  use_natpmp=no
+  with_natpmp=no
 else
-  if test "$use_natpmp" != "no"; then
+  if test "$with_natpmp" != "no"; then
     AC_MSG_RESULT([yes])
     AC_MSG_CHECKING([whether to build with NAT-PMP enabled by default])
-    use_natpmp=yes
+    with_natpmp=yes
     natpmp_setting=0
-    if test "$use_natpmp_default" != "no"; then
-      use_natpmp_default=yes
+    if test "$enable_natpmp_default" != "no"; then
+      enable_natpmp_default=yes
       natpmp_setting=1
     fi
-    AC_MSG_RESULT($use_natpmp_default)
+    AC_MSG_RESULT($enable_natpmp_default)
     AC_DEFINE_UNQUOTED([USE_NATPMP], [$natpmp_setting], [NAT-PMP support not compiled if undefined, otherwise value (0 or 1) determines default state])
     if test "$TARGET_OS" = "windows"; then
       NATPMP_CPPFLAGS="-DSTATICLIB -DNATPMP_STATICLIB"
@@ -1850,7 +1850,7 @@ AM_CONDITIONAL([ENABLE_ARM_CRC], [test "$enable_arm_crc" = "yes"])
 AM_CONDITIONAL([ENABLE_ARM_SHANI], [test "$enable_arm_shani" = "yes"])
 AM_CONDITIONAL([USE_ASM], [test "$enable_asm" = "yes"])
 AM_CONDITIONAL([WORDS_BIGENDIAN], [test "$ac_cv_c_bigendian" = "yes"])
-AM_CONDITIONAL([USE_NATPMP], [test "$use_natpmp" = "yes"])
+AM_CONDITIONAL([USE_NATPMP], [test "$with_natpmp" = "yes"])
 AM_CONDITIONAL([USE_UPNP], [test "$use_upnp" = "yes"])
 
 dnl for minisketch
@@ -1998,7 +1998,7 @@ fi
 echo "  with fuzz binary = $enable_fuzz_binary"
 echo "  with bench      = $enable_bench"
 echo "  with upnp       = $use_upnp"
-echo "  with natpmp     = $use_natpmp"
+echo "  with natpmp     = $with_natpmp"
 echo "  use asm         = $enable_asm"
 echo "  USDT tracing    = $enable_usdt"
 echo "  sanitizers      = $with_sanitizers"

--- a/configure.ac
+++ b/configure.ac
@@ -203,8 +203,8 @@ AC_ARG_ENABLE([fuzz-binary],
 AC_ARG_WITH([qrencode],
   [AS_HELP_STRING([--with-qrencode],
   [enable QR code support (default is yes if qt is enabled and libqrencode is found)])],
-  [use_qr=$withval],
-  [use_qr=auto])
+  [],
+  [with_qrencode=auto])
 
 AC_ARG_ENABLE([hardening],
   [AS_HELP_STRING([--disable-hardening],
@@ -1571,7 +1571,7 @@ fi
 
 dnl QR Code encoding library check
 
-if test "$use_qr" != "no"; then
+if test "$with_qrencode" != "no"; then
   BITCOIN_QT_CHECK([PKG_CHECK_MODULES([QR], [libqrencode], [have_qrencode=yes], [have_qrencode=no])])
 fi
 
@@ -1770,17 +1770,17 @@ if test "$bitcoin_enable_qt" != "no"; then
   dnl enable qr support
   AC_MSG_CHECKING([whether to build GUI with support for QR codes])
   if test "$have_qrencode" = "no"; then
-    if test "$use_qr" = "yes"; then
+    if test "$with_qrencode" = "yes"; then
       AC_MSG_ERROR([QR support requested but cannot be built. Use --without-qrencode])
     fi
-    use_qr=no
+    with_qrencode=no
   else
-    if test "$use_qr" != "no"; then
+    if test "$with_qrencode" != "no"; then
       AC_DEFINE([USE_QRCODE], [1], [Define if QR support should be compiled in])
-      use_qr=yes
+      with_qrencode=yes
     fi
   fi
-  AC_MSG_RESULT([$use_qr])
+  AC_MSG_RESULT([$with_qrencode])
 
   if test "$XGETTEXT" = ""; then
     AC_MSG_WARN([xgettext is required to update qt translations])
@@ -1834,7 +1834,7 @@ AM_CONDITIONAL([ENABLE_FUZZ_BINARY], [test "$enable_fuzz_binary" = "yes"])
 AM_CONDITIONAL([ENABLE_QT], [test "$bitcoin_enable_qt" = "yes"])
 AM_CONDITIONAL([ENABLE_QT_TESTS], [test "$BUILD_TEST_QT" = "yes"])
 AM_CONDITIONAL([ENABLE_BENCH], [test "$use_bench" = "yes"])
-AM_CONDITIONAL([USE_QRCODE], [test "$use_qr" = "yes"])
+AM_CONDITIONAL([USE_QRCODE], [test "$with_qrencode" = "yes"])
 AM_CONDITIONAL([USE_LCOV], [test "$enable_lcov" = "yes"])
 AM_CONDITIONAL([USE_LIBEVENT], [test "$use_libevent" = "yes"])
 AM_CONDITIONAL([HARDEN], [test "$enable_hardening" = "yes"])
@@ -1983,7 +1983,7 @@ if test "$enable_wallet" != "no"; then
 fi
 echo "  with gui / qt   = $bitcoin_enable_qt"
 if test $bitcoin_enable_qt != "no"; then
-    echo "    with qr       = $use_qr"
+    echo "    with qr       = $with_qrencode"
 fi
 echo "  with zmq        = $enable_zmq"
 if test $enable_fuzz = "no"; then

--- a/configure.ac
+++ b/configure.ac
@@ -147,14 +147,14 @@ AC_ARG_ENABLE([usdt],
 AC_ARG_WITH([miniupnpc],
   [AS_HELP_STRING([--with-miniupnpc],
   [enable UPNP (default is yes if libminiupnpc is found)])],
-  [use_upnp=$withval],
-  [use_upnp=auto])
+  [],
+  [with_miniupnpc=auto])
 
 AC_ARG_ENABLE([upnp-default],
   [AS_HELP_STRING([--enable-upnp-default],
   [if UPNP is enabled, turn it on at startup (default is no)])],
-  [use_upnp_default=$enableval],
-  [use_upnp_default=no])
+  [],
+  [enable_upnp_default=no])
 
 AC_ARG_WITH([natpmp],
   [AS_HELP_STRING([--with-natpmp],
@@ -751,7 +751,7 @@ case $host in
              dnl Therefore, as we do not use pkg-config to detect miniupnpc and libnatpmp
              dnl packages, we should set the CPPFLAGS and LDFLAGS variables for them
              dnl explicitly.
-             if test "$use_upnp" != "no" && $BREW list --versions miniupnpc >/dev/null; then
+             if test "$with_miniupnpc" != "no" && $BREW list --versions miniupnpc >/dev/null; then
                miniupnpc_prefix=$($BREW --prefix miniupnpc 2>/dev/null)
                if test "$enable_suppress_external_warnings" != "no"; then
                  CORE_CPPFLAGS="$CORE_CPPFLAGS -isystem $miniupnpc_prefix/include"
@@ -1298,7 +1298,7 @@ if test "$enable_fuzz" = "yes"; then
   bitcoin_enable_qt_dbus=no
   enable_bench=no
   enable_external_signer=no
-  use_upnp=no
+  with_miniupnpc=no
   with_natpmp=no
   enable_zmq=no
   enable_fuzz_binary=yes
@@ -1390,13 +1390,13 @@ fi
 AM_CONDITIONAL([ENABLE_USDT_TRACEPOINTS], [test "$use_usdt" = "yes"])
 
 if test "$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_util$build_bitcoind$bitcoin_enable_qt$enable_bench$enable_tests" = "nonononononono"; then
-  use_upnp=no
+  with_miniupnpc=no
   with_natpmp=no
   enable_zmq=no
 fi
 
 dnl Check for libminiupnpc (optional)
-if test "$use_upnp" != "no"; then
+if test "$with_miniupnpc" != "no"; then
   AC_CHECK_HEADERS(
     [miniupnpc/miniupnpc.h miniupnpc/upnpcommands.h miniupnpc/upnperrors.h],
     [AC_CHECK_LIB([miniupnpc], [upnpDiscover], [MINIUPNPC_LIBS=-lminiupnpc], [have_miniupnpc=no])],
@@ -1708,22 +1708,22 @@ fi
 dnl enable upnp support
 AC_MSG_CHECKING([whether to build with support for UPnP])
 if test "$have_miniupnpc" = "no"; then
-  if test "$use_upnp" = "yes"; then
+  if test "$with_miniupnpc" = "yes"; then
      AC_MSG_ERROR([UPnP requested but cannot be built. Use --without-miniupnpc])
   fi
   AC_MSG_RESULT([no])
-  use_upnp=no
+  with_miniupnpc=no
 else
-  if test "$use_upnp" != "no"; then
+  if test "$with_miniupnpc" != "no"; then
     AC_MSG_RESULT([yes])
     AC_MSG_CHECKING([whether to build with UPnP enabled by default])
-    use_upnp=yes
+    with_miniupnpc=yes
     upnp_setting=0
-    if test "$use_upnp_default" != "no"; then
-      use_upnp_default=yes
+    if test "$enable_upnp_default" != "no"; then
+      enable_upnp_default=yes
       upnp_setting=1
     fi
-    AC_MSG_RESULT([$use_upnp_default])
+    AC_MSG_RESULT([$enable_upnp_default])
     AC_DEFINE_UNQUOTED([USE_UPNP],[$upnp_setting],[UPnP support not compiled if undefined, otherwise value (0 or 1) determines default state])
     if test "$TARGET_OS" = "windows"; then
       MINIUPNPC_CPPFLAGS="-DSTATICLIB -DMINIUPNP_STATICLIB"
@@ -1851,7 +1851,7 @@ AM_CONDITIONAL([ENABLE_ARM_SHANI], [test "$enable_arm_shani" = "yes"])
 AM_CONDITIONAL([USE_ASM], [test "$enable_asm" = "yes"])
 AM_CONDITIONAL([WORDS_BIGENDIAN], [test "$ac_cv_c_bigendian" = "yes"])
 AM_CONDITIONAL([USE_NATPMP], [test "$with_natpmp" = "yes"])
-AM_CONDITIONAL([USE_UPNP], [test "$use_upnp" = "yes"])
+AM_CONDITIONAL([USE_UPNP], [test "$with_miniupnpc" = "yes"])
 
 dnl for minisketch
 AM_CONDITIONAL([ENABLE_CLMUL], [test "$enable_clmul" = "yes"])
@@ -1997,7 +1997,7 @@ else
 fi
 echo "  with fuzz binary = $enable_fuzz_binary"
 echo "  with bench      = $enable_bench"
-echo "  with upnp       = $use_upnp"
+echo "  with upnp       = $with_miniupnpc"
 echo "  with natpmp     = $with_natpmp"
 echo "  use asm         = $enable_asm"
 echo "  USDT tracing    = $enable_usdt"

--- a/configure.ac
+++ b/configure.ac
@@ -265,8 +265,8 @@ fi
 AC_ARG_ENABLE([zmq],
   [AS_HELP_STRING([--disable-zmq],
   [disable ZMQ notifications])],
-  [use_zmq=$enableval],
-  [use_zmq=yes])
+  [],
+  [enable_zmq=yes])
 
 AC_ARG_WITH([libmultiprocess],
   [AS_HELP_STRING([--with-libmultiprocess=yes|no|auto],
@@ -1296,7 +1296,7 @@ if test "$enable_fuzz" = "yes"; then
   enable_external_signer=no
   use_upnp=no
   use_natpmp=no
-  use_zmq=no
+  enable_zmq=no
   enable_fuzz_binary=yes
 
   AX_CHECK_PREPROC_FLAG([-DABORT_ON_FAILED_ASSUME], [DEBUG_CPPFLAGS="$DEBUG_CPPFLAGS -DABORT_ON_FAILED_ASSUME"], [], [$CXXFLAG_WERROR])
@@ -1388,7 +1388,7 @@ AM_CONDITIONAL([ENABLE_USDT_TRACEPOINTS], [test "$use_usdt" = "yes"])
 if test "$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_util$build_bitcoind$bitcoin_enable_qt$use_bench$use_tests" = "nonononononono"; then
   use_upnp=no
   use_natpmp=no
-  use_zmq=no
+  enable_zmq=no
 fi
 
 dnl Check for libminiupnpc (optional)
@@ -1577,17 +1577,17 @@ fi
 
 dnl ZMQ check
 
-if test "$use_zmq" = "yes"; then
+if test "$enable_zmq" = "yes"; then
   PKG_CHECK_MODULES([ZMQ], [libzmq >= 4],
     AC_DEFINE([ENABLE_ZMQ], [1], [Define to 1 to enable ZMQ functions]),
     [AC_DEFINE([ENABLE_ZMQ], [0], [Define to 1 to enable ZMQ functions])
     AC_MSG_WARN([libzmq version 4.x or greater not found, disabling])
-    use_zmq=no])
+    enable_zmq=no])
 else
   AC_DEFINE_UNQUOTED([ENABLE_ZMQ], [0], [Define to 1 to enable ZMQ functions])
 fi
 
-if test "$use_zmq" = "yes"; then
+if test "$enable_zmq" = "yes"; then
   dnl Assume libzmq was built for static linking
   case $host in
     *mingw*)
@@ -1795,7 +1795,7 @@ if test "$bitcoin_enable_qt" != "no"; then
   fi
 fi
 
-AM_CONDITIONAL([ENABLE_ZMQ], [test "$use_zmq" = "yes"])
+AM_CONDITIONAL([ENABLE_ZMQ], [test "$enable_zmq" = "yes"])
 
 AC_MSG_CHECKING([whether to build test_bitcoin])
 if test "$use_tests" = "yes"; then
@@ -1985,7 +1985,7 @@ echo "  with gui / qt   = $bitcoin_enable_qt"
 if test $bitcoin_enable_qt != "no"; then
     echo "    with qr       = $use_qr"
 fi
-echo "  with zmq        = $use_zmq"
+echo "  with zmq        = $enable_zmq"
 if test $enable_fuzz = "no"; then
     echo "  with test       = $use_tests"
 else

--- a/configure.ac
+++ b/configure.ac
@@ -249,8 +249,8 @@ AC_ARG_ENABLE([lcov-branch-coverage],
 AC_ARG_ENABLE([threadlocal],
   [AS_HELP_STRING([--enable-threadlocal],
   [enable features that depend on the c++ thread_local keyword (currently just thread names in debug logs). (default is to enable if there is platform support)])],
-  [use_thread_local=$enableval],
-  [use_thread_local=auto])
+  [],
+  [enable_threadlocal=auto])
 
 AC_ARG_ENABLE([asm],
   [AS_HELP_STRING([--disable-asm],
@@ -1083,7 +1083,7 @@ AC_COMPILE_IFELSE([AC_LANG_SOURCE([
   [AC_MSG_RESULT([no])]
 )
 
-if test "$use_thread_local" = "yes" || test "$use_thread_local" = "auto"; then
+if test "$enable_threadlocal" = "yes" || test "$enable_threadlocal" = "auto"; then
   TEMP_LDFLAGS="$LDFLAGS"
   LDFLAGS="$TEMP_LDFLAGS $PTHREAD_CFLAGS"
   AC_MSG_CHECKING([for thread_local support])

--- a/configure.ac
+++ b/configure.ac
@@ -174,9 +174,10 @@ AC_ARG_ENABLE(tests,
     [use_tests=yes])
 
 AC_ARG_ENABLE(gui-tests,
-    AS_HELP_STRING([--disable-gui-tests],[do not compile GUI tests (default is to compile if GUI and tests enabled)]),
-    [use_gui_tests=$enableval],
-    [use_gui_tests=$use_tests])
+  AS_HELP_STRING([--disable-gui-tests],
+  [do not compile GUI tests (default is to compile if GUI and tests enabled)]),
+  [],
+  [enable_gui_tests=$use_tests])
 
 AC_ARG_ENABLE(bench,
   AS_HELP_STRING([--disable-bench],
@@ -1789,7 +1790,7 @@ if test "$bitcoin_enable_qt" != "no"; then
   fi
 
   AC_MSG_CHECKING([whether to build test_bitcoin-qt])
-  if test "$use_gui_tests$bitcoin_enable_qt_test" = "yesyes"; then
+  if test "$enable_gui_tests$bitcoin_enable_qt_test" = "yesyes"; then
     AC_MSG_RESULT([yes])
     BUILD_TEST_QT="yes"
   else

--- a/configure.ac
+++ b/configure.ac
@@ -320,9 +320,9 @@ AC_ARG_ENABLE([werror],
     [enable_werror=no])
 
 AC_ARG_ENABLE([external-signer],
-    [AS_HELP_STRING([--enable-external-signer],[compile external signer support (default is yes, requires Boost::Process)])],
-    [use_external_signer=$enableval],
-    [use_external_signer=auto])
+  [AS_HELP_STRING([--enable-external-signer],[compile external signer support (default is yes, requires Boost::Process)])],
+  [],
+  [enable_external_signer=auto])
 
 AC_ARG_ENABLE([lto],
     [AS_HELP_STRING([--enable-lto],[build using LTO (default is no)])],
@@ -1293,7 +1293,7 @@ if test "$enable_fuzz" = "yes"; then
   bitcoin_enable_qt_test=no
   bitcoin_enable_qt_dbus=no
   use_bench=no
-  use_external_signer=no
+  enable_external_signer=no
   use_upnp=no
   use_natpmp=no
   use_zmq=no
@@ -1449,16 +1449,16 @@ if test "$use_boost" = "yes"; then
   fi
 fi
 
-if test "$use_external_signer" != "no"; then
+if test "$enable_external_signer" != "no"; then
   case $host in
     *mingw*)
       dnl Boost Process uses Boost Filesystem when targeting Windows. Also,
       dnl since Boost 1.71.0, Process does not work with mingw-w64 without
       dnl workarounds. See 67669ab425b52a2b6be3d2f3b3b7e3939b676a2c.
-      if test "$use_external_signer" = "yes"; then
+      if test "$enable_external_signer" = "yes"; then
         AC_MSG_ERROR([External signing is not supported on Windows])
       fi
-      use_external_signer="no";
+      enable_external_signer="no";
     ;;
     *)
       AC_MSG_CHECKING([whether Boost.Process can be used])
@@ -1479,18 +1479,18 @@ if test "$use_external_signer" != "no"; then
       CXXFLAGS="$TEMP_CXXFLAGS"
       AC_MSG_RESULT([$have_boost_process])
       if test "$have_boost_process" = "yes"; then
-        use_external_signer="yes"
+        enable_external_signer="yes"
         AC_DEFINE([ENABLE_EXTERNAL_SIGNER], [1], [Define if external signer support is enabled])
       else
-        if test "$use_external_signer" = "yes"; then
+        if test "$enable_external_signer" = "yes"; then
           AC_MSG_ERROR([External signing is not supported for this Boost version])
         fi
-        use_external_signer="no";
+        enable_external_signer="no";
       fi
     ;;
   esac
 fi
-AM_CONDITIONAL([ENABLE_EXTERNAL_SIGNER], [test "$use_external_signer" = "yes"])
+AM_CONDITIONAL([ENABLE_EXTERNAL_SIGNER], [test "$enable_external_signer" = "yes"])
 
 dnl Do not compile with syscall sandbox support when compiling under the sanitizers.
 dnl The sanitizers introduce use of syscalls that are not typically used in bitcoind
@@ -1972,7 +1972,7 @@ esac
 
 echo
 echo "Options used to compile and link:"
-echo "  external signer = $use_external_signer"
+echo "  external signer = $enable_external_signer"
 echo "  multiprocess    = $build_multiprocess"
 echo "  with syscall sandbox = $use_syscall_sandbox"
 echo "  with libs       = $build_bitcoin_libs"

--- a/configure.ac
+++ b/configure.ac
@@ -179,9 +179,10 @@ AC_ARG_ENABLE(gui-tests,
     [use_gui_tests=$use_tests])
 
 AC_ARG_ENABLE(bench,
-    AS_HELP_STRING([--disable-bench],[do not compile benchmarks (default is to compile)]),
-    [use_bench=$enableval],
-    [use_bench=yes])
+  AS_HELP_STRING([--disable-bench],
+  [do not compile benchmarks (default is to compile)]),
+  [],
+  [enable_bench=yes])
 
 AC_ARG_ENABLE([extended-functional-tests],
   AS_HELP_STRING([--enable-extended-functional-tests],
@@ -1293,7 +1294,7 @@ if test "$enable_fuzz" = "yes"; then
   bitcoin_enable_qt=no
   bitcoin_enable_qt_test=no
   bitcoin_enable_qt_dbus=no
-  use_bench=no
+  enable_bench=no
   enable_external_signer=no
   use_upnp=no
   use_natpmp=no
@@ -1386,7 +1387,7 @@ if test "$enable_usdt" != "no"; then
 fi
 AM_CONDITIONAL([ENABLE_USDT_TRACEPOINTS], [test "$use_usdt" = "yes"])
 
-if test "$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_util$build_bitcoind$bitcoin_enable_qt$use_bench$use_tests" = "nonononononono"; then
+if test "$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_util$build_bitcoind$bitcoin_enable_qt$enable_bench$use_tests" = "nonononononono"; then
   use_upnp=no
   use_natpmp=no
   enable_zmq=no
@@ -1428,7 +1429,7 @@ if test "$use_natpmp" != "no"; then
                    [have_natpmp=no])
 fi
 
-if test "$build_bitcoin_wallet$build_bitcoin_cli$build_bitcoin_tx$build_bitcoind$bitcoin_enable_qt$use_tests$use_bench" = "nonononononono"; then
+if test "$build_bitcoin_wallet$build_bitcoin_cli$build_bitcoin_tx$build_bitcoind$bitcoin_enable_qt$use_tests$enable_bench" = "nonononononono"; then
   use_boost=no
 else
   use_boost=yes
@@ -1539,7 +1540,7 @@ fi
 
 dnl libevent check
 
-if test "$build_bitcoin_cli$build_bitcoind$bitcoin_enable_qt$use_tests$use_bench" != "nonononono"; then
+if test "$build_bitcoin_cli$build_bitcoind$bitcoin_enable_qt$use_tests$enable_bench" != "nonononono"; then
   PKG_CHECK_MODULES([EVENT], [libevent >= 2.1.8], [use_libevent=yes], [AC_MSG_ERROR([libevent version 2.1.8 or greater not found.])])
   if test "$TARGET_OS" != "windows"; then
     PKG_CHECK_MODULES([EVENT_PTHREADS], [libevent_pthreads >= 2.1.8], [], [AC_MSG_ERROR([libevent_pthreads version 2.1.8 or greater not found.])])
@@ -1818,7 +1819,7 @@ else
   AC_MSG_RESULT([no])
 fi
 
-if test "$build_bitcoin_wallet$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_libs$build_bitcoind$bitcoin_enable_qt$use_bench$use_tests" = "nononononononono"; then
+if test "$build_bitcoin_wallet$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_libs$build_bitcoind$bitcoin_enable_qt$enable_bench$use_tests" = "nononononononono"; then
   AC_MSG_ERROR([No targets! Please specify at least one of: --with-utils --with-libs --with-daemon --with-gui --enable-bench or --enable-tests])
 fi
 
@@ -1834,7 +1835,7 @@ AM_CONDITIONAL([ENABLE_FUZZ], [test "$enable_fuzz" = "yes"])
 AM_CONDITIONAL([ENABLE_FUZZ_BINARY], [test "$enable_fuzz_binary" = "yes"])
 AM_CONDITIONAL([ENABLE_QT], [test "$bitcoin_enable_qt" = "yes"])
 AM_CONDITIONAL([ENABLE_QT_TESTS], [test "$BUILD_TEST_QT" = "yes"])
-AM_CONDITIONAL([ENABLE_BENCH], [test "$use_bench" = "yes"])
+AM_CONDITIONAL([ENABLE_BENCH], [test "$enable_bench" = "yes"])
 AM_CONDITIONAL([USE_QRCODE], [test "$with_qrencode" = "yes"])
 AM_CONDITIONAL([USE_LCOV], [test "$enable_lcov" = "yes"])
 AM_CONDITIONAL([USE_LIBEVENT], [test "$use_libevent" = "yes"])
@@ -1993,7 +1994,7 @@ else
     echo "  with test       = not building test_bitcoin because fuzzing is enabled"
 fi
 echo "  with fuzz binary = $enable_fuzz_binary"
-echo "  with bench      = $use_bench"
+echo "  with bench      = $enable_bench"
 echo "  with upnp       = $use_upnp"
 echo "  with natpmp     = $use_natpmp"
 echo "  use asm         = $enable_asm"

--- a/configure.ac
+++ b/configure.ac
@@ -184,9 +184,10 @@ AC_ARG_ENABLE(bench,
     [use_bench=yes])
 
 AC_ARG_ENABLE([extended-functional-tests],
-    AS_HELP_STRING([--enable-extended-functional-tests],[enable expensive functional tests when using lcov (default no)]),
-    [use_extended_functional_tests=$enableval],
-    [use_extended_functional_tests=no])
+  AS_HELP_STRING([--enable-extended-functional-tests],
+  [enable expensive functional tests when using lcov (default no)]),
+  [],
+  [enable_extended_functional_tests=no])
 
 AC_ARG_ENABLE([fuzz],
   AS_HELP_STRING([--enable-fuzz],
@@ -814,7 +815,7 @@ case $host in
      ;;
 esac
 
-if test "$use_extended_functional_tests" != "no"; then
+if test "$enable_extended_functional_tests" != "no"; then
   AC_SUBST(EXTENDED_FUNCTIONAL_TESTS, --extended)
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -271,19 +271,19 @@ AC_ARG_ENABLE([zmq],
 AC_ARG_WITH([libmultiprocess],
   [AS_HELP_STRING([--with-libmultiprocess=yes|no|auto],
   [Build with libmultiprocess library. (default: auto, i.e. detect with pkg-config)])],
-  [with_libmultiprocess=$withval],
+  [],
   [with_libmultiprocess=auto])
 
 AC_ARG_WITH([mpgen],
   [AS_HELP_STRING([--with-mpgen=yes|no|auto|PREFIX],
   [Build with libmultiprocess codegen tool. Useful to specify different libmultiprocess host system library and build system codegen tool prefixes when cross-compiling (default is host system libmultiprocess prefix)])],
-  [with_mpgen=$withval],
+  [],
   [with_mpgen=auto])
 
 AC_ARG_ENABLE([multiprocess],
   [AS_HELP_STRING([--enable-multiprocess],
   [build multiprocess bitcoin-node, bitcoin-wallet, and bitcoin-gui executables in addition to monolithic bitcoind and bitcoin-qt executables. Requires libmultiprocess library. Experimental (default is no)])],
-  [enable_multiprocess=$enableval],
+  [],
   [enable_multiprocess=no])
 
 AC_ARG_ENABLE(man,

--- a/configure.ac
+++ b/configure.ac
@@ -301,9 +301,8 @@ AC_ARG_ENABLE([debug],
 
 dnl Enable different -fsanitize options
 AC_ARG_WITH([sanitizers],
-    [AS_HELP_STRING([--with-sanitizers],
-                    [comma separated list of extra sanitizers to build with (default is none enabled)])],
-    [use_sanitizers=$withval])
+  [AS_HELP_STRING([--with-sanitizers],
+  [comma separated list of extra sanitizers to build with (default is none enabled)])])
 
 dnl Enable gprof profiling
 AC_ARG_ENABLE([gprof],
@@ -389,13 +388,13 @@ if test "$enable_lto" = "yes"; then
   AX_CHECK_LINK_FLAG([-flto], [LTO_LDFLAGS="$LTO_LDFLAGS -flto"], [AC_MSG_ERROR([link failed with -flto])], [$CXXFLAG_WERROR])
 fi
 
-if test "$use_sanitizers" != ""; then
+if test "$with_sanitizers" != ""; then
   dnl First check if the compiler accepts flags. If an incompatible pair like
   dnl -fsanitize=address,thread is used here, this check will fail. This will also
   dnl fail if a bad argument is passed, e.g. -fsanitize=undfeined
   AX_CHECK_COMPILE_FLAG(
-    [-fsanitize=$use_sanitizers],
-    [SANITIZER_CXXFLAGS="-fsanitize=$use_sanitizers"],
+    [-fsanitize=$with_sanitizers],
+    [SANITIZER_CXXFLAGS="-fsanitize=$with_sanitizers"],
     [AC_MSG_ERROR([compiler did not accept requested flags])])
 
   dnl Some compilers (e.g. GCC) require additional libraries like libasan,
@@ -404,8 +403,8 @@ if test "$use_sanitizers" != ""; then
   dnl the sanitize flags are supported by the compiler but the actual sanitizer
   dnl libs are missing.
   AX_CHECK_LINK_FLAG(
-    [-fsanitize=$use_sanitizers],
-    [SANITIZER_LDFLAGS="-fsanitize=$use_sanitizers"],
+    [-fsanitize=$with_sanitizers],
+    [SANITIZER_LDFLAGS="-fsanitize=$with_sanitizers"],
     [AC_MSG_ERROR([linker did not accept requested flags, you are missing required libraries])],
     [],
     [AC_LANG_PROGRAM([[
@@ -1495,7 +1494,7 @@ AM_CONDITIONAL([ENABLE_EXTERNAL_SIGNER], [test "$enable_external_signer" = "yes"
 dnl Do not compile with syscall sandbox support when compiling under the sanitizers.
 dnl The sanitizers introduce use of syscalls that are not typically used in bitcoind
 dnl (such as execve when the sanitizers execute llvm-symbolizer).
-if test "$use_sanitizers" != ""; then
+if test "$with_sanitizers" != ""; then
   AC_MSG_WARN([Specifying --with-sanitizers forces --without-seccomp since the sanitizers introduce use of syscalls not allowed by the bitcoind syscall sandbox (-sandbox=<mode>).])
   with_seccomp=no
 fi
@@ -1997,7 +1996,7 @@ echo "  with upnp       = $use_upnp"
 echo "  with natpmp     = $use_natpmp"
 echo "  use asm         = $use_asm"
 echo "  USDT tracing    = $use_usdt"
-echo "  sanitizers      = $use_sanitizers"
+echo "  sanitizers      = $with_sanitizers"
 echo "  debug enabled   = $enable_debug"
 echo "  gprof enabled   = $enable_gprof"
 echo "  werror          = $enable_werror"

--- a/configure.ac
+++ b/configure.ac
@@ -209,8 +209,8 @@ AC_ARG_WITH([qrencode],
 AC_ARG_ENABLE([hardening],
   [AS_HELP_STRING([--disable-hardening],
   [do not attempt to harden the resulting executables (default is to harden when possible)])],
-  [use_hardening=$enableval],
-  [use_hardening=auto])
+  [],
+  [enable_hardening=auto])
 
 AC_ARG_ENABLE([reduce-exports],
   [AS_HELP_STRING([--enable-reduce-exports],
@@ -902,10 +902,10 @@ if test "$enable_gprof" = "yes"; then
     dnl we simply make them mutually exclusive here. Additionally, hardened toolchains may force
     dnl -pie by default, in which case it needs to be turned off with -no-pie.
 
-    if test "$use_hardening" = "yes"; then
+    if test "$enable_hardening" = "yes"; then
         AC_MSG_ERROR([gprof profiling is not compatible with hardening. Reconfigure with --disable-hardening or --disable-gprof])
     fi
-    use_hardening=no
+    enable_hardening=no
     AX_CHECK_COMPILE_FLAG([-pg],[GPROF_CXXFLAGS="-pg"],
         [AC_MSG_ERROR([gprof profiling requested but not available])], [$CXXFLAG_WERROR])
 
@@ -923,8 +923,8 @@ dnl All versions of gcc that we commonly use for building are subject to bug
 dnl https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90348. To work around that, set
 dnl -fstack-reuse=none for all gcc builds. (Only gcc understands this flag)
 AX_CHECK_COMPILE_FLAG([-fstack-reuse=none], [HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fstack-reuse=none"])
-if test "$use_hardening" != "no"; then
-  use_hardening=yes
+if test "$enable_hardening" != "no"; then
+  enable_hardening=yes
   AX_CHECK_COMPILE_FLAG([-Wstack-protector], [HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -Wstack-protector"])
   AX_CHECK_COMPILE_FLAG([-fstack-protector-all], [HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fstack-protector-all"])
 
@@ -1837,7 +1837,7 @@ AM_CONDITIONAL([ENABLE_BENCH], [test "$use_bench" = "yes"])
 AM_CONDITIONAL([USE_QRCODE], [test "$use_qr" = "yes"])
 AM_CONDITIONAL([USE_LCOV], [test "$enable_lcov" = "yes"])
 AM_CONDITIONAL([USE_LIBEVENT], [test "$use_libevent" = "yes"])
-AM_CONDITIONAL([HARDEN], [test "$use_hardening" = "yes"])
+AM_CONDITIONAL([HARDEN], [test "$enable_hardening" = "yes"])
 AM_CONDITIONAL([ENABLE_SSE42], [test "$enable_sse42" = "yes"])
 AM_CONDITIONAL([ENABLE_SSE41], [test "$enable_sse41" = "yes"])
 AM_CONDITIONAL([ENABLE_AVX2], [test "$enable_avx2" = "yes"])

--- a/configure.ac
+++ b/configure.ac
@@ -189,16 +189,16 @@ AC_ARG_ENABLE([extended-functional-tests],
     [use_extended_functional_tests=no])
 
 AC_ARG_ENABLE([fuzz],
-    AS_HELP_STRING([--enable-fuzz],
-    [build for fuzzing (default no). enabling this will disable all other targets and override --{enable,disable}-fuzz-binary]),
-    [enable_fuzz=$enableval],
-    [enable_fuzz=no])
+  AS_HELP_STRING([--enable-fuzz],
+  [build for fuzzing (default no). enabling this will disable all other targets and override --{enable,disable}-fuzz-binary]),
+  [],
+  [enable_fuzz=no])
 
 AC_ARG_ENABLE([fuzz-binary],
-    AS_HELP_STRING([--enable-fuzz-binary],
-    [enable building of fuzz binary (default yes).]),
-    [enable_fuzz_binary=$enableval],
-    [enable_fuzz_binary=yes])
+  AS_HELP_STRING([--enable-fuzz-binary],
+  [enable building of fuzz binary (default yes).]),
+  [],
+  [enable_fuzz_binary=yes])
 
 AC_ARG_WITH([qrencode],
   [AS_HELP_STRING([--with-qrencode],

--- a/configure.ac
+++ b/configure.ac
@@ -287,9 +287,10 @@ AC_ARG_ENABLE([multiprocess],
   [enable_multiprocess=no])
 
 AC_ARG_ENABLE(man,
-    [AS_HELP_STRING([--disable-man],
-                    [do not install man pages (default is to install)])],,
-    enable_man=yes)
+  [AS_HELP_STRING([--disable-man],
+  [do not install man pages (default is to install)])],
+  [],
+  [enable_man=yes])
 AM_CONDITIONAL([ENABLE_MAN], [test "$enable_man" != "no"])
 
 dnl Enable debug

--- a/configure.ac
+++ b/configure.ac
@@ -67,12 +67,6 @@ case $host in
   ;;
 esac
 
-AC_ARG_WITH([seccomp],
-  [AS_HELP_STRING([--with-seccomp],
-  [enable experimental syscall sandbox feature (-sandbox), default is yes if seccomp-bpf is detected under Linux x86_64])],
-  [seccomp_found=$withval],
-  [seccomp_found=auto])
-
 AC_ARG_ENABLE([c++20],
   [AS_HELP_STRING([--enable-c++20],
   [enable compilation in c++20 mode (disabled by default)])],
@@ -334,6 +328,12 @@ AC_ARG_ENABLE([lto],
     [AS_HELP_STRING([--enable-lto],[build using LTO (default is no)])],
     [enable_lto=$enableval],
     [enable_lto=no])
+
+AC_ARG_WITH([seccomp],
+  [AS_HELP_STRING([--with-seccomp],
+  [enable experimental syscall sandbox feature (-sandbox), default is yes if seccomp-bpf is detected under Linux x86_64])],
+  [],
+  [with_seccomp=auto])
 
 AC_LANG_PUSH([C++])
 
@@ -1497,9 +1497,9 @@ dnl The sanitizers introduce use of syscalls that are not typically used in bitc
 dnl (such as execve when the sanitizers execute llvm-symbolizer).
 if test "$use_sanitizers" != ""; then
   AC_MSG_WARN([Specifying --with-sanitizers forces --without-seccomp since the sanitizers introduce use of syscalls not allowed by the bitcoind syscall sandbox (-sandbox=<mode>).])
-  seccomp_found=no
+  with_seccomp=no
 fi
-if test "$seccomp_found" != "no"; then
+if test "$with_seccomp" != "no"; then
   AC_MSG_CHECKING([for seccomp-bpf (Linux x86-64)])
   AC_PREPROC_IFELSE([AC_LANG_PROGRAM([[
       @%:@include <linux/seccomp.h>
@@ -1509,17 +1509,17 @@ if test "$seccomp_found" != "no"; then
       #endif
     ]])],[
       AC_MSG_RESULT([yes])
-      seccomp_found="yes"
+      with_seccomp="yes"
       AC_DEFINE([USE_SYSCALL_SANDBOX], [1], [Define this symbol to build with syscall sandbox support.])
     ],[
       AC_MSG_RESULT([no])
-      seccomp_found="no"
+      with_seccomp="no"
   ])
 fi
 dnl Currently only enable -sandbox=<mode> feature if seccomp is found.
 dnl In the future, sandboxing could be also be supported with other
 dnl sandboxing mechanisms besides seccomp.
-use_syscall_sandbox=$seccomp_found
+use_syscall_sandbox=$with_seccomp
 AM_CONDITIONAL([ENABLE_SYSCALL_SANDBOX], [test "$use_syscall_sandbox" != "no"])
 
 dnl Check for reduced exports
@@ -1974,7 +1974,7 @@ echo
 echo "Options used to compile and link:"
 echo "  external signer = $use_external_signer"
 echo "  multiprocess    = $build_multiprocess"
-echo "  with experimental syscall sandbox support = $use_syscall_sandbox"
+echo "  with syscall sandbox = $use_syscall_sandbox"
 echo "  with libs       = $build_bitcoin_libs"
 echo "  with wallet     = $enable_wallet"
 if test "$enable_wallet" != "no"; then

--- a/configure.ac
+++ b/configure.ac
@@ -129,8 +129,8 @@ AC_ARG_ENABLE([wallet],
 AC_ARG_WITH([sqlite],
   [AS_HELP_STRING([--with-sqlite=yes|no|auto],
   [enable sqlite wallet support (default: auto, i.e., enabled if wallet is enabled and sqlite is found)])],
-  [use_sqlite=$withval],
-  [use_sqlite=auto])
+  [],
+  [with_sqlite=auto])
 
 AC_ARG_WITH([bdb],
   [AS_HELP_STRING([--without-bdb],
@@ -737,7 +737,7 @@ case $host in
            BDB_LIBS="-L$bdb_prefix/lib -ldb_cxx-4.8"
          fi
 
-         if test "$use_sqlite" != "no" && $BREW list --versions sqlite3 >/dev/null; then
+         if test "$with_sqlite" != "no" && $BREW list --versions sqlite3 >/dev/null; then
            export PKG_CONFIG_PATH="$($BREW --prefix sqlite3 2>/dev/null)/lib/pkgconfig:$PKG_CONFIG_PATH"
          fi
 
@@ -1348,27 +1348,27 @@ if test "$enable_wallet" != "no"; then
     fi
 
     dnl Check for sqlite3
-    if test "$use_sqlite" != "no"; then
+    if test "$with_sqlite" != "no"; then
       PKG_CHECK_MODULES([SQLITE], [sqlite3 >= 3.7.17], [have_sqlite=yes], [have_sqlite=no])
     fi
     AC_MSG_CHECKING([whether to build wallet with support for sqlite])
-    if test "$use_sqlite" = "no"; then
-      use_sqlite=no
+    if test "$with_sqlite" = "no"; then
+      with_sqlite=no
     elif test "$have_sqlite" = "no"; then
-      if test "$use_sqlite" = "yes"; then
+      if test "$with_sqlite" = "yes"; then
         AC_MSG_ERROR([sqlite support requested but cannot be built. Use --without-sqlite])
       fi
-      use_sqlite=no
+      with_sqlite=no
     else
-      if test "$use_sqlite" != "no"; then
+      if test "$with_sqlite" != "no"; then
         AC_DEFINE([USE_SQLITE],[1],[Define if sqlite support should be compiled in])
-        use_sqlite=yes
+        with_sqlite=yes
       fi
     fi
-    AC_MSG_RESULT([$use_sqlite])
+    AC_MSG_RESULT([$with_sqlite])
 
     dnl Disable wallet if both --without-bdb and --without-sqlite
-    if test "$with_bdb$use_sqlite" = "nono"; then
+    if test "$with_bdb$with_sqlite" = "nono"; then
         if test "$enable_wallet" = "yes"; then
             AC_MSG_ERROR([wallet functionality requested but no BDB or SQLite support available.])
         fi
@@ -1830,7 +1830,7 @@ AM_CONDITIONAL([BUILD_DARWIN], [test "$BUILD_OS" = "darwin"])
 AM_CONDITIONAL([TARGET_LINUX], [test "$TARGET_OS" = "linux"])
 AM_CONDITIONAL([TARGET_WINDOWS], [test "$TARGET_OS" = "windows"])
 AM_CONDITIONAL([ENABLE_WALLET], [test "$enable_wallet" = "yes"])
-AM_CONDITIONAL([USE_SQLITE], [test "$use_sqlite" = "yes"])
+AM_CONDITIONAL([USE_SQLITE], [test "$with_sqlite" = "yes"])
 AM_CONDITIONAL([USE_BDB], [test "$with_bdb" = "yes"])
 AM_CONDITIONAL([ENABLE_TESTS], [test "$BUILD_TEST" = "yes"])
 AM_CONDITIONAL([ENABLE_FUZZ], [test "$enable_fuzz" = "yes"])
@@ -1982,7 +1982,7 @@ echo "  with syscall sandbox = $use_syscall_sandbox"
 echo "  with libs       = $build_bitcoin_libs"
 echo "  with wallet     = $enable_wallet"
 if test "$enable_wallet" != "no"; then
-    echo "    with sqlite   = $use_sqlite"
+    echo "    with sqlite   = $with_sqlite"
     echo "    with bdb      = $with_bdb"
 fi
 echo "  with gui / qt   = $bitcoin_enable_qt"

--- a/configure.ac
+++ b/configure.ac
@@ -313,10 +313,10 @@ AC_ARG_ENABLE([gprof],
 
 dnl Turn warnings into errors
 AC_ARG_ENABLE([werror],
-    [AS_HELP_STRING([--enable-werror],
-                    [Treat compiler warnings as errors (default is no)])],
-    [enable_werror=$enableval],
-    [enable_werror=no])
+  [AS_HELP_STRING([--enable-werror],
+  [Treat compiler warnings as errors (default is no)])],
+  [],
+  [enable_werror=no])
 
 AC_ARG_ENABLE([external-signer],
   [AS_HELP_STRING([--enable-external-signer],[compile external signer support (default is yes, requires Boost::Process)])],

--- a/configure.ac
+++ b/configure.ac
@@ -141,8 +141,8 @@ AC_ARG_WITH([bdb],
 AC_ARG_ENABLE([usdt],
   [AS_HELP_STRING([--enable-usdt],
   [enable tracepoints for Userspace, Statically Defined Tracing (default is yes if sys/sdt.h is found)])],
-  [use_usdt=$enableval],
-  [use_usdt=yes])
+  [],
+  [enable_usdt=yes])
 
 AC_ARG_WITH([miniupnpc],
   [AS_HELP_STRING([--with-miniupnpc],
@@ -1371,7 +1371,7 @@ if test "$enable_wallet" != "no"; then
     fi
 fi
 
-if test "$use_usdt" != "no"; then
+if test "$enable_usdt" != "no"; then
   AC_MSG_CHECKING([whether Userspace, Statically Defined Tracing tracepoints are supported])
   AC_COMPILE_IFELSE([
     AC_LANG_PROGRAM(
@@ -1379,7 +1379,7 @@ if test "$use_usdt" != "no"; then
       [DTRACE_PROBE("context", "event");]
     )],
     [AC_MSG_RESULT([yes]); AC_DEFINE([ENABLE_TRACING], [1], [Define to 1 to enable tracepoints for Userspace, Statically Defined Tracing])],
-    [AC_MSG_RESULT([no]); use_usdt=no;]
+    [AC_MSG_RESULT([no]); enable_usdt=no;]
   )
 fi
 AM_CONDITIONAL([ENABLE_USDT_TRACEPOINTS], [test "$use_usdt" = "yes"])
@@ -1995,7 +1995,7 @@ echo "  with bench      = $use_bench"
 echo "  with upnp       = $use_upnp"
 echo "  with natpmp     = $use_natpmp"
 echo "  use asm         = $use_asm"
-echo "  USDT tracing    = $use_usdt"
+echo "  USDT tracing    = $enable_usdt"
 echo "  sanitizers      = $with_sanitizers"
 echo "  debug enabled   = $enable_debug"
 echo "  gprof enabled   = $enable_gprof"

--- a/configure.ac
+++ b/configure.ac
@@ -255,10 +255,10 @@ AC_ARG_ENABLE([threadlocal],
 AC_ARG_ENABLE([asm],
   [AS_HELP_STRING([--disable-asm],
   [disable assembly routines (enabled by default)])],
-  [use_asm=$enableval],
-  [use_asm=yes])
+  [],
+  [enable_asm=yes])
 
-if test "$use_asm" = "yes"; then
+if test "$enable_asm" = "yes"; then
   AC_DEFINE([USE_ASM], [1], [Define this symbol to build in assembly routines])
 fi
 
@@ -476,7 +476,7 @@ enable_sse41=no
 enable_avx2=no
 enable_x86_shani=no
 
-if test "$use_asm" = "yes"; then
+if test "$enable_asm" = "yes"; then
 
 dnl Check for optional instruction set support. Enabling these does _not_ imply that all code will
 dnl be compiled with them, rather that specific objects/libs may use them after checking for runtime
@@ -1843,7 +1843,7 @@ AM_CONDITIONAL([ENABLE_AVX2], [test "$enable_avx2" = "yes"])
 AM_CONDITIONAL([ENABLE_X86_SHANI], [test "$enable_x86_shani" = "yes"])
 AM_CONDITIONAL([ENABLE_ARM_CRC], [test "$enable_arm_crc" = "yes"])
 AM_CONDITIONAL([ENABLE_ARM_SHANI], [test "$enable_arm_shani" = "yes"])
-AM_CONDITIONAL([USE_ASM], [test "$use_asm" = "yes"])
+AM_CONDITIONAL([USE_ASM], [test "$enable_asm" = "yes"])
 AM_CONDITIONAL([WORDS_BIGENDIAN], [test "$ac_cv_c_bigendian" = "yes"])
 AM_CONDITIONAL([USE_NATPMP], [test "$use_natpmp" = "yes"])
 AM_CONDITIONAL([USE_UPNP], [test "$use_upnp" = "yes"])
@@ -1994,7 +1994,7 @@ echo "  with fuzz binary = $enable_fuzz_binary"
 echo "  with bench      = $use_bench"
 echo "  with upnp       = $use_upnp"
 echo "  with natpmp     = $use_natpmp"
-echo "  use asm         = $use_asm"
+echo "  use asm         = $enable_asm"
 echo "  USDT tracing    = $enable_usdt"
 echo "  sanitizers      = $with_sanitizers"
 echo "  debug enabled   = $enable_debug"

--- a/configure.ac
+++ b/configure.ac
@@ -324,9 +324,9 @@ AC_ARG_ENABLE([external-signer],
   [enable_external_signer=auto])
 
 AC_ARG_ENABLE([lto],
-    [AS_HELP_STRING([--enable-lto],[build using LTO (default is no)])],
-    [enable_lto=$enableval],
-    [enable_lto=no])
+  [AS_HELP_STRING([--enable-lto],[build using LTO (default is no)])],
+  [],
+  [enable_lto=no])
 
 AC_ARG_WITH([seccomp],
   [AS_HELP_STRING([--with-seccomp],


### PR DESCRIPTION
Setting these values has been redundant since autoconf ~2.60, and we
require 2.69. Should not change behaviour. Includes minor formatting
improvements.

secp256k1 also recently made the same change:
https://github.com/bitcoin-core/secp256k1/pull/1079.