### PR TITLE
init: add missing cs_main lock

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1541,7 +1541,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // ********************************************************* Step 8: start indexers
     if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
-        if (const auto error{CheckLegacyTxindex(*Assert(chainman.m_blockman.m_block_tree_db))}) {
+        if (const auto error{WITH_LOCK(cs_main, return CheckLegacyTxindex(*Assert(chainman.m_blockman.m_block_tree_db)))}) {
             return InitError(*error);
         }
 


### PR DESCRIPTION
`BlockManager::m_block_tree_db` is protected by `cs_main`, so take the
`cs_main` lock while accessing it.