### PR TITLE
refactor: remove unused boost include in bitcoin-util.cpp

### DIFF
--- a/src/bitcoin-util.cpp
+++ b/src/bitcoin-util.cpp
@@ -22,8 +22,6 @@
 #include <memory>
 #include <thread>
 
-#include <boost/algorithm/string.hpp>
-
 static const int CONTINUE_EXECUTION=-1;
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;


### PR DESCRIPTION
This header was included since the introduction of bitcoin-util in
commit 13762bcc9618138dd28b53c2031defdc9d762d26, but boost was
actually never used (see `git log -S boost ./src/bitcoin-util.cpp`).

Cherry-picked out of #22953, which currently needs rebase. This commit could just be merged on its own.