### PR TITLE
[WIP] [kernelheaders 1/n] Cleave LevelDB headers from our header tree

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -221,6 +221,25 @@ bool CDBWrapper::doExists(const CDataStream& ssKey) const
     return doRawGet(ssKey, strValue);
 }
 
+size_t CDBWrapper::doEstimateSizes(const CDataStream& begin_key, const CDataStream& end_key) const
+{
+    leveldb::Slice slKey1((const char*)begin_key.data(), begin_key.size());
+    leveldb::Slice slKey2((const char*)end_key.data(), end_key.size());
+
+    uint64_t size = 0;
+    leveldb::Range range(slKey1, slKey2);
+    pdb->GetApproximateSizes(&range, 1, &size);
+    return size;
+}
+
+void CDBWrapper::doCompactRange(const CDataStream& begin_key, const CDataStream& end_key) const
+{
+    leveldb::Slice slKey1((const char*)begin_key.data(), begin_key.size());
+    leveldb::Slice slKey2((const char*)end_key.data(), end_key.size());
+
+    pdb->CompactRange(&slKey1, &slKey2);
+}
+
 bool CDBWrapper::WriteBatch(CDBBatch& batch, bool fSync)
 {
     const bool log_memory = LogAcceptCategory(BCLog::LEVELDB);

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -18,12 +18,10 @@ class DBIteratorImpl
 {
 private:
     const CDBWrapper& parent;
-    leveldb::Iterator *piter;
+    std::unique_ptr<leveldb::Iterator> piter;
 
 public:
     explicit DBIteratorImpl(const CDBWrapper& _parent, leveldb::Iterator* _piter);
-
-    ~DBIteratorImpl();
 
     void doSeek(const CDataStream& key);
     CDataStream doGetKey();
@@ -43,8 +41,6 @@ DBIteratorImpl::DBIteratorImpl(const CDBWrapper& _parent, leveldb::Iterator* _pi
     : parent(_parent), piter(_piter){};
 
 CDBIterator::~CDBIterator() = default;
-
-DBIteratorImpl::~DBIteratorImpl() { delete piter; }
 
 void CDBIterator::doSeek(const CDataStream& key)
 {

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -4,15 +4,19 @@
 
 #include <dbwrapper.h>
 
-#include <memory>
 #include <random.h>
+#include <streams.h>
 
 #include <leveldb/cache.h>
+#include <leveldb/db.h>
 #include <leveldb/env.h>
 #include <leveldb/filter_policy.h>
+#include <leveldb/write_batch.h>
 #include <memenv.h>
-#include <stdint.h>
+
 #include <algorithm>
+#include <memory>
+#include <stdint.h>
 
 /** These should be considered an implementation detail of the specific database.
  */

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -260,11 +260,6 @@ DBWrapperImpl::~DBWrapperImpl()
 
 CDBWrapper::~CDBWrapper() = default;
 
-bool CDBWrapper::doRawGet(const CDataStream& ssKey, std::string& strValue) const
-{
-    return m_impl->doRawGet(ssKey, strValue);
-}
-
 bool DBWrapperImpl::doRawGet(const CDataStream& ssKey, std::string& strValue) const
 {
     leveldb::Slice slKey((const char*)ssKey.data(), ssKey.size());

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -161,7 +161,7 @@ public:
 
     size_t DynamicMemoryUsage() const;
 
-    CDBIterator *NewIterator();
+    std::unique_ptr<CDBIterator> NewIterator();
 
     bool IsEmpty();
 
@@ -374,14 +374,14 @@ size_t DBWrapperImpl::DynamicMemoryUsage() const
     return parsed.value();
 }
 
-CDBIterator* CDBWrapper::NewIterator()
+std::unique_ptr<CDBIterator> CDBWrapper::NewIterator()
 {
     return m_impl->NewIterator();
 }
 
-CDBIterator* DBWrapperImpl::NewIterator()
+std::unique_ptr<CDBIterator> DBWrapperImpl::NewIterator()
 {
-    return new CDBIterator(m_parent, pdb->NewIterator(iteroptions));
+    return std::make_unique<CDBIterator>(m_parent, pdb->NewIterator(iteroptions));
 }
 
 // Prefixed with null character to avoid collisions with other keys

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -14,6 +14,15 @@
 #include <stdint.h>
 #include <algorithm>
 
+/** These should be considered an implementation detail of the specific database.
+ */
+namespace dbwrapper_private {
+
+/** Handle database error by throwing dbwrapper_error exception.
+ */
+void HandleError(const leveldb::Status& status);
+};
+
 class DBBatchImpl
 {
 private:

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -268,6 +268,11 @@ size_t CDBWrapper::DynamicMemoryUsage() const
     return parsed.value();
 }
 
+CDBIterator* CDBWrapper::NewIterator()
+{
+    return new CDBIterator(*this, pdb->NewIterator(iteroptions));
+}
+
 // Prefixed with null character to avoid collisions with other keys
 //
 // We must use a string constructor which specifies length so that we copy

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -165,6 +165,10 @@ public:
 
     bool IsEmpty();
 
+    /**
+     * Returns a string (consisting of 8 random bytes) suitable for use as an
+     * obfuscating XOR key.
+     */
     std::vector<unsigned char> CreateObfuscateKey() const;
 
     // Removed from interface later when pimpl'd
@@ -392,15 +396,6 @@ CDBIterator* DBWrapperImpl::NewIterator()
 const std::string DBWrapperImpl::OBFUSCATE_KEY_KEY("\000obfuscate_key", 14);
 
 const unsigned int DBWrapperImpl::OBFUSCATE_KEY_NUM_BYTES = 8;
-
-/**
- * Returns a string (consisting of 8 random bytes) suitable for use as an
- * obfuscating XOR key.
- */
-std::vector<unsigned char> CDBWrapper::CreateObfuscateKey() const
-{
-    return m_impl->CreateObfuscateKey();
-}
 
 std::vector<unsigned char> DBWrapperImpl::CreateObfuscateKey() const
 {

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -178,9 +178,6 @@ class CDBWrapper
 {
     friend const std::vector<unsigned char>& dbwrapper_private::GetObfuscateKey(const CDBWrapper &w);
 private:
-    // Removed from interface later when pimpl'd
-    bool doRawGet(const CDataStream& ssKey, std::string& strValue) const;
-
     std::optional<CDataStream> doGet(const CDataStream& ssKey) const;
 
     bool doExists(const CDataStream& ssKey) const;

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -32,10 +32,6 @@ class DBWrapperImpl;
  */
 namespace dbwrapper_private {
 
-/** Handle database error by throwing dbwrapper_error exception.
- */
-void HandleError(const leveldb::Status& status);
-
 /** Work around circular dependency, as well as for testing in dbwrapper_tests.
  * Database obfuscation should be considered an implementation detail of the
  * specific database.

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -178,8 +178,6 @@ class CDBWrapper
 {
     friend const std::vector<unsigned char>& dbwrapper_private::GetObfuscateKey(const CDBWrapper &w);
 private:
-    std::vector<unsigned char> CreateObfuscateKey() const;
-
     // Removed from interface later when pimpl'd
     bool doRawGet(const CDataStream& ssKey, std::string& strValue) const;
 

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -219,6 +219,9 @@ private:
 
     bool doExists(const CDataStream& ssKey) const;
 
+    size_t doEstimateSizes(const CDataStream& begin_key, const CDataStream& end_key) const;
+
+    void doCompactRange(const CDataStream& begin_key, const CDataStream& end_key) const;
 public:
     /**
      * @param[in] path        Location in the filesystem where leveldb data will be stored.
@@ -305,13 +308,9 @@ public:
         ssKey2.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey1 << key_begin;
         ssKey2 << key_end;
-        leveldb::Slice slKey1((const char*)ssKey1.data(), ssKey1.size());
-        leveldb::Slice slKey2((const char*)ssKey2.data(), ssKey2.size());
-        uint64_t size = 0;
-        leveldb::Range range(slKey1, slKey2);
-        pdb->GetApproximateSizes(&range, 1, &size);
-        return size;
-    }
+
+        return doEstimateSizes(ssKey1, ssKey2);
+     }
 
     /**
      * Compact a certain range of keys in the database.
@@ -324,9 +323,8 @@ public:
         ssKey2.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey1 << key_begin;
         ssKey2 << key_end;
-        leveldb::Slice slKey1((const char*)ssKey1.data(), ssKey1.size());
-        leveldb::Slice slKey2((const char*)ssKey2.data(), ssKey2.size());
-        pdb->CompactRange(&slKey1, &slKey2);
+
+        return doCompactRange(ssKey1, ssKey2);
     }
 };
 

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -13,9 +13,6 @@
 #include <util/strencodings.h>
 #include <util/system.h>
 
-#include <leveldb/db.h>
-#include <leveldb/write_batch.h>
-
 static const size_t DBWRAPPER_PREALLOC_KEY_SIZE = 64;
 static const size_t DBWRAPPER_PREALLOC_VALUE_SIZE = 1024;
 

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -127,12 +127,10 @@ private:
     CDataStream doGetValue();
 
 public:
-
     /**
-     * @param[in] _parent          Parent CDBWrapper instance.
-     * @param[in] _piter           The original leveldb iterator.
+     * @param[in] impl          DBIteratorImpl instance.
      */
-    CDBIterator(const CDBWrapper &_parent, leveldb::Iterator *_piter);
+    CDBIterator(std::unique_ptr<DBIteratorImpl> impl);
     ~CDBIterator();
 
     bool Valid() const;

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -44,17 +44,16 @@ const std::vector<unsigned char>& GetObfuscateKey(const CDBWrapper &w);
 
 };
 
+class DBBatchImpl;
+
 /** Batch of changes queued to be written to a CDBWrapper */
 class CDBBatch
 {
     friend class DBWrapperImpl;
 
+protected:
+    const std::unique_ptr<DBBatchImpl> m_impl;
 private:
-    const CDBWrapper &parent;
-    leveldb::WriteBatch batch;
-
-    size_t size_estimate;
-
     void doWrite(CDataStream& key, CDataStream& value);
     void doErase(CDataStream& key);
 
@@ -63,6 +62,7 @@ public:
      * @param[in] _parent   CDBWrapper that this batch is to be submitted to
      */
     explicit CDBBatch(const CDBWrapper &_parent);
+    ~CDBBatch();
 
     void Clear();
 

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -255,7 +255,7 @@ public:
     // Get an estimate of LevelDB memory usage (in bytes).
     size_t DynamicMemoryUsage() const;
 
-    CDBIterator* NewIterator();
+    std::unique_ptr<CDBIterator> NewIterator();
 
     /**
      * Return true if the database managed by this class contains no entries.

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -115,12 +115,13 @@ public:
     size_t SizeEstimate() const { return size_estimate; }
 };
 
+class DBIteratorImpl;
+
 class CDBIterator
 {
+protected:
+    const std::unique_ptr<DBIteratorImpl> m_impl;
 private:
-    const CDBWrapper &parent;
-    leveldb::Iterator *piter;
-
     void doSeek(const CDataStream& key);
     CDataStream doGetKey();
     CDataStream doGetValue();

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -55,48 +55,16 @@ private:
 
     size_t size_estimate;
 
-    void doWrite(CDataStream& key, CDataStream& value)
-    {
-        leveldb::Slice slKey((const char*)key.data(), key.size());
+    void doWrite(CDataStream& key, CDataStream& value);
+    void doErase(CDataStream& key);
 
-        value.Xor(dbwrapper_private::GetObfuscateKey(parent));
-        leveldb::Slice slValue((const char*)value.data(), value.size());
-
-        batch.Put(slKey, slValue);
-
-        // LevelDB serializes writes as:
-        // - byte: header
-        // - varint: key length (1 byte up to 127B, 2 bytes up to 16383B, ...)
-        // - byte[]: key
-        // - varint: value length
-        // - byte[]: value
-        // The formula below assumes the key and value are both less than 16k.
-        size_estimate += 3 + (slKey.size() > 127) + slKey.size() + (slValue.size() > 127) + slValue.size();
-    }
-
-    void doErase(CDataStream& key)
-    {
-        leveldb::Slice slKey((const char*)key.data(), key.size());
-        batch.Delete(slKey);
-
-        // LevelDB serializes erases as:
-        // - byte: header
-        // - varint: key length
-        // - byte[]: key
-        // The formula below assumes the key is less than 16kB.
-        size_estimate += 2 + (slKey.size() > 127) + slKey.size();
-    }
 public:
     /**
      * @param[in] _parent   CDBWrapper that this batch is to be submitted to
      */
-    explicit CDBBatch(const CDBWrapper &_parent) : parent(_parent), size_estimate(0) { };
+    explicit CDBBatch(const CDBWrapper &_parent);
 
-    void Clear()
-    {
-        batch.Clear();
-        size_estimate = 0;
-    }
+    void Clear();
 
     template <typename K, typename V>
     void Write(const K& key, const V& value)
@@ -122,7 +90,7 @@ public:
         doErase(ssKey);
     }
 
-    size_t SizeEstimate() const { return size_estimate; }
+    size_t SizeEstimate() const;
 };
 
 class DBIteratorImpl;

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -121,25 +121,9 @@ private:
     const CDBWrapper &parent;
     leveldb::Iterator *piter;
 
-    void doSeek(const CDataStream& key)
-    {
-        leveldb::Slice slKey((const char*)key.data(), key.size());
-        piter->Seek(slKey);
-    }
-
-    CDataStream doGetKey()
-    {
-        leveldb::Slice slKey = piter->key();
-        return CDataStream{MakeByteSpan(slKey), SER_DISK, CLIENT_VERSION};
-    }
-
-    CDataStream doGetValue()
-    {
-        leveldb::Slice slValue = piter->value();
-        CDataStream ssValue{MakeByteSpan(slValue), SER_DISK, CLIENT_VERSION};
-        ssValue.Xor(dbwrapper_private::GetObfuscateKey(parent));
-        return ssValue;
-    }
+    void doSeek(const CDataStream& key);
+    CDataStream doGetKey();
+    CDataStream doGetValue();
 
 public:
 
@@ -147,8 +131,7 @@ public:
      * @param[in] _parent          Parent CDBWrapper instance.
      * @param[in] _piter           The original leveldb iterator.
      */
-    CDBIterator(const CDBWrapper &_parent, leveldb::Iterator *_piter) :
-        parent(_parent), piter(_piter) { };
+    CDBIterator(const CDBWrapper &_parent, leveldb::Iterator *_piter);
     ~CDBIterator();
 
     bool Valid() const;
@@ -183,10 +166,7 @@ public:
         return true;
     }
 
-    unsigned int GetValueSize() {
-        return piter->value().size();
-    }
-
+    unsigned int GetValueSize();
 };
 
 class CDBWrapper

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -26,6 +26,7 @@ public:
 };
 
 class CDBWrapper;
+class DBWrapperImpl;
 
 /** These should be considered an implementation detail of the specific database.
  */
@@ -46,7 +47,7 @@ const std::vector<unsigned char>& GetObfuscateKey(const CDBWrapper &w);
 /** Batch of changes queued to be written to a CDBWrapper */
 class CDBBatch
 {
-    friend class CDBWrapper;
+    friend class DBWrapperImpl;
 
 private:
     const CDBWrapper &parent;
@@ -177,39 +178,6 @@ class CDBWrapper
 {
     friend const std::vector<unsigned char>& dbwrapper_private::GetObfuscateKey(const CDBWrapper &w);
 private:
-    //! custom environment this database is using (may be nullptr in case of default environment)
-    leveldb::Env* penv;
-
-    //! database options used
-    leveldb::Options options;
-
-    //! options used when reading from the database
-    leveldb::ReadOptions readoptions;
-
-    //! options used when iterating over values of the database
-    leveldb::ReadOptions iteroptions;
-
-    //! options used when writing to the database
-    leveldb::WriteOptions writeoptions;
-
-    //! options used when sync writing to the database
-    leveldb::WriteOptions syncoptions;
-
-    //! the database itself
-    leveldb::DB* pdb;
-
-    //! the name of this database
-    std::string m_name;
-
-    //! a key used for optional XOR-obfuscation of the database
-    std::vector<unsigned char> obfuscate_key;
-
-    //! the key under which the obfuscation key is stored
-    static const std::string OBFUSCATE_KEY_KEY;
-
-    //! the length of the obfuscate key in number of bytes
-    static const unsigned int OBFUSCATE_KEY_NUM_BYTES;
-
     std::vector<unsigned char> CreateObfuscateKey() const;
 
     // Removed from interface later when pimpl'd
@@ -222,6 +190,8 @@ private:
     size_t doEstimateSizes(const CDataStream& begin_key, const CDataStream& end_key) const;
 
     void doCompactRange(const CDataStream& begin_key, const CDataStream& end_key) const;
+protected:
+    const std::unique_ptr<DBWrapperImpl> m_impl;
 public:
     /**
      * @param[in] path        Location in the filesystem where leveldb data will be stored.

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -290,10 +290,7 @@ public:
     // Get an estimate of LevelDB memory usage (in bytes).
     size_t DynamicMemoryUsage() const;
 
-    CDBIterator *NewIterator()
-    {
-        return new CDBIterator(*this, pdb->NewIterator(iteroptions));
-    }
+    CDBIterator* NewIterator();
 
     /**
      * Return true if the database managed by this class contains no entries.

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -197,8 +197,8 @@ class CCoinsViewDBCursor: public CCoinsViewCursor
 public:
     // Prefer using CCoinsViewDB::Cursor() since we want to perform some
     // cache warmup on instantiation.
-    CCoinsViewDBCursor(CDBIterator* pcursorIn, const uint256&hashBlockIn):
-        CCoinsViewCursor(hashBlockIn), pcursor(pcursorIn) {}
+    CCoinsViewDBCursor(std::unique_ptr<CDBIterator> pcursorIn, const uint256&hashBlockIn):
+        CCoinsViewCursor(hashBlockIn), pcursor(std::move(pcursorIn)) {}
     ~CCoinsViewDBCursor() {}
 
     bool GetKey(COutPoint &key) const override;


### PR DESCRIPTION
**This PR is not based on anything other than `master`.**

We `#include` LevelDB headers in `dbwrapper.h`, which means that anything that `#include`'s or transitively `#include`'s `dbwrapper.h` will also pull in the LevelDB headers:

https://github.com/bitcoin/bitcoin/blob/2f0f056e08cd5a1435120592a9ecd212fcdb915b/src/dbwrapper.h#L16-L17

This PR's changes allow us to remove these LevelDB header `#include`'s in `dbwrapper.h` and have them be in `dbwrapper.cpp` instead. We achieve this mainly by:

- Using private non-virtual interfaces (private `doFoo`'s) to:
  - Move `LevelDB`-specific code out of the header,
  - While keeping templatized serialization logic in the header
- Using the pimpl idiom to move `LevelDB`-specific member variables out of the header

Coincidentally, this PR also makes obfuscation an implementation detail of the database, as described in this code comment:

https://github.com/bitcoin/bitcoin/blob/2f0f056e08cd5a1435120592a9ecd212fcdb915b/src/dbwrapper.h#L39-L42
