### PR TITLE
refactor: fix wallet and related named args

### DIFF
--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -58,21 +58,21 @@ static void CoinSelection(benchmark::Bench& bench)
     // Create coins
     std::vector<COutput> coins;
     for (const auto& wtx : wtxs) {
-        coins.emplace_back(COutPoint(wtx->GetHash(), 0), wtx->tx->vout.at(0), /*depth=*/ 6 * 24, GetTxSpendSize(wallet, *wtx, 0), /*spendable=*/ true, /*solvable=*/ true, /*safe=*/ true, wtx->GetTxTime(), /*from_me=*/ true);
+        coins.emplace_back(COutPoint(wtx->GetHash(), 0), wtx->tx->vout.at(0), /*depth=*/6 * 24, GetTxSpendSize(wallet, *wtx, 0), /*spendable=*/true, /*solvable=*/true, /*safe=*/true, wtx->GetTxTime(), /*from_me=*/true);
     }
 
     const CoinEligibilityFilter filter_standard(1, 6, 0);
     FastRandomContext rand{};
     const CoinSelectionParams coin_selection_params{
         rand,
-        /* change_output_size= */ 34,
-        /* change_spend_size= */ 148,
+        /*change_output_size=*/ 34,
+        /*change_spend_size=*/ 148,
         /*min_change_target=*/ CHANGE_LOWER,
-        /* effective_feerate= */ CFeeRate(0),
-        /* long_term_feerate= */ CFeeRate(0),
-        /* discard_feerate= */ CFeeRate(0),
-        /* tx_noinputs_size= */ 0,
-        /* avoid_partial= */ false,
+        /*effective_feerate=*/ CFeeRate(0),
+        /*long_term_feerate=*/ CFeeRate(0),
+        /*discard_feerate=*/ CFeeRate(0),
+        /*tx_noinputs_size=*/ 0,
+        /*avoid_partial=*/ false,
     };
     bench.run([&] {
         auto result = AttemptSelection(wallet, 1003 * COIN, filter_standard, coins, coin_selection_params);

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -148,14 +148,14 @@ inline std::vector<OutputGroup>& KnapsackGroupOutputs(const std::vector<COutput>
     FastRandomContext rand{};
     CoinSelectionParams coin_selection_params{
         rand,
-        /* change_output_size= */ 0,
-        /* change_spend_size= */ 0,
+        /*change_output_size=*/ 0,
+        /*change_spend_size=*/ 0,
         /*min_change_target=*/ CENT,
-        /* effective_feerate= */ CFeeRate(0),
-        /* long_term_feerate= */ CFeeRate(0),
-        /* discard_feerate= */ CFeeRate(0),
-        /* tx_noinputs_size= */ 0,
-        /* avoid_partial= */ false,
+        /*effective_feerate=*/ CFeeRate(0),
+        /*long_term_feerate=*/ CFeeRate(0),
+        /*discard_feerate=*/ CFeeRate(0),
+        /*tx_noinputs_size=*/ 0,
+        /*avoid_partial=*/ false,
     };
     static std::vector<OutputGroup> static_groups;
     static_groups = GroupOutputs(wallet, coins, coin_selection_params, filter, /*positive_only=*/false);
@@ -293,14 +293,14 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     // Make sure that effective value is working in AttemptSelection when BnB is used
     CoinSelectionParams coin_selection_params_bnb{
         rand,
-        /* change_output_size= */ 0,
-        /* change_spend_size= */ 0,
+        /*change_output_size=*/ 0,
+        /*change_spend_size=*/ 0,
         /*min_change_target=*/ 0,
-        /* effective_feerate= */ CFeeRate(3000),
-        /* long_term_feerate= */ CFeeRate(1000),
-        /* discard_feerate= */ CFeeRate(1000),
-        /* tx_noinputs_size= */ 0,
-        /* avoid_partial= */ false,
+        /*effective_feerate=*/ CFeeRate(3000),
+        /*long_term_feerate=*/ CFeeRate(1000),
+        /*discard_feerate=*/ CFeeRate(1000),
+        /*tx_noinputs_size=*/ 0,
+        /*avoid_partial=*/ false,
     };
     {
         std::unique_ptr<CWallet> wallet = std::make_unique<CWallet>(m_node.chain.get(), "", m_args, CreateMockWalletDatabase());
@@ -717,14 +717,14 @@ BOOST_AUTO_TEST_CASE(SelectCoins_test)
         // Perform selection
         CoinSelectionParams cs_params{
             rand,
-            /* change_output_size= */ 34,
-            /* change_spend_size= */ 148,
+            /*change_output_size=*/ 34,
+            /*change_spend_size=*/ 148,
             /*min_change_target=*/ CENT,
-            /* effective_feerate= */ CFeeRate(0),
-            /* long_term_feerate= */ CFeeRate(0),
-            /* discard_feerate= */ CFeeRate(0),
-            /* tx_noinputs_size= */ 0,
-            /* avoid_partial= */ false,
+            /*effective_feerate=*/ CFeeRate(0),
+            /*long_term_feerate=*/ CFeeRate(0),
+            /*discard_feerate=*/ CFeeRate(0),
+            /*tx_noinputs_size=*/ 0,
+            /*avoid_partial=*/ false,
         };
         CCoinControl cc;
         const auto result = SelectCoins(*wallet, coins, target, cc, cs_params);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -339,7 +339,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 BOOST_FIXTURE_TEST_CASE(coin_mark_dirty_immature_credit, TestChain100Setup)
 {
     CWallet wallet(m_node.chain.get(), "", m_args, CreateDummyWalletDatabase());
-    CWalletTx wtx{m_coinbase_txns.back(), TxStateConfirmed{m_node.chainman->ActiveChain().Tip()->GetBlockHash(), m_node.chainman->ActiveChain().Height(), /*position_in_block=*/0}};
+    CWalletTx wtx{m_coinbase_txns.back(), TxStateConfirmed{m_node.chainman->ActiveChain().Tip()->GetBlockHash(), m_node.chainman->ActiveChain().Height(), /*index=*/0}};
 
     LOCK(wallet.cs_wallet);
     wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
@@ -373,7 +373,7 @@ static int64_t AddTx(ChainstateManager& chainman, CWallet& wallet, uint32_t lock
         block = &inserted.first->second;
         block->nTime = blockTime;
         block->phashBlock = &hash;
-        state = TxStateConfirmed{hash, block->nHeight, /*position_in_block=*/0};
+        state = TxStateConfirmed{hash, block->nHeight, /*index=*/0};
     }
     return wallet.AddToWallet(MakeTransactionRef(tx), state, [&](CWalletTx& wtx, bool /* new_tx */) {
         // Assign wtx.m_state to simplify test and avoid the need to simulate
@@ -540,7 +540,7 @@ public:
         wallet->SetLastBlockProcessed(wallet->GetLastBlockHeight() + 1, m_node.chainman->ActiveChain().Tip()->GetBlockHash());
         auto it = wallet->mapWallet.find(tx->GetHash());
         BOOST_CHECK(it != wallet->mapWallet.end());
-        it->second.m_state = TxStateConfirmed{m_node.chainman->ActiveChain().Tip()->GetBlockHash(), m_node.chainman->ActiveChain().Height(), /*position_in_block=*/1};
+        it->second.m_state = TxStateConfirmed{m_node.chainman->ActiveChain().Tip()->GetBlockHash(), m_node.chainman->ActiveChain().Height(), /*index=*/1};
         return it->second;
     }
 


### PR DESCRIPTION
Should be one of the last changes split from #24661.

Motivation:
> Incorrect named args are source of bugs, like https://github.com/bitcoin/bitcoin/pull/22979.

> To allow them being checked by clang-tidy, use a format it can understand.