### PR TITLE
Add and use ForEachWallet

### DIFF
--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -141,9 +141,9 @@ bool LoadWallets(WalletContext& context)
 
 void StartWallets(WalletContext& context, CScheduler& scheduler)
 {
-    for (const std::shared_ptr<CWallet>& pwallet : GetWallets(context)) {
-        pwallet->postInitProcess();
-    }
+    ForEachWallet(context, [](CWallet& wallet) {
+        wallet.postInitProcess();
+    });
 
     // Schedule periodic wallet flushes and tx rebroadcasts
     if (context.args->GetBoolArg("-flushwallet", DEFAULT_FLUSHWALLET)) {
@@ -154,16 +154,16 @@ void StartWallets(WalletContext& context, CScheduler& scheduler)
 
 void FlushWallets(WalletContext& context)
 {
-    for (const std::shared_ptr<CWallet>& pwallet : GetWallets(context)) {
-        pwallet->Flush();
-    }
+    ForEachWallet(context, [](CWallet& wallet) {
+        wallet.Flush();
+    });
 }
 
 void StopWallets(WalletContext& context)
 {
-    for (const std::shared_ptr<CWallet>& pwallet : GetWallets(context)) {
-        pwallet->Close();
-    }
+    ForEachWallet(context, [](CWallet& wallet) {
+        wallet.Close();
+    });
 }
 
 void UnloadWallets(WalletContext& context)

--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -64,12 +64,11 @@ std::shared_ptr<CWallet> GetWalletForJSONRPCRequest(const JSONRPCRequest& reques
         return pwallet;
     }
 
-    std::vector<std::shared_ptr<CWallet>> wallets = GetWallets(context);
-    if (wallets.size() == 1) {
-        return wallets[0];
-    }
+    size_t count{0};
+    auto wallet = GetDefaultWallet(context, count);
+    if (wallet) return wallet;
 
-    if (wallets.empty()) {
+    if (count == 0) {
         throw JSONRPCError(
             RPC_WALLET_NOT_FOUND, "No wallet is loaded. Load a wallet using loadwallet or create a new one with createwallet. (Note: A default wallet is no longer automatically created)");
     }

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -183,10 +183,10 @@ static RPCHelpMan listwallets()
     UniValue obj(UniValue::VARR);
 
     WalletContext& context = EnsureWalletContext(request.context);
-    for (const std::shared_ptr<CWallet>& wallet : GetWallets(context)) {
-        LOCK(wallet->cs_wallet);
-        obj.push_back(wallet->GetName());
-    }
+    ForEachWallet(context, [&](CWallet& wallet) {
+        LOCK(wallet.cs_wallet);
+        obj.push_back(wallet.GetName());
+    });
 
     return obj;
 },

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -151,6 +151,13 @@ std::vector<std::shared_ptr<CWallet>> GetWallets(WalletContext& context)
     return context.wallets;
 }
 
+std::shared_ptr<CWallet> GetDefaultWallet(WalletContext& context, size_t& count)
+{
+    LOCK(context.wallets_mutex);
+    count = context.wallets.size();
+    return count == 1 ? context.wallets[0] : nullptr;
+}
+
 std::shared_ptr<CWallet> GetWallet(WalletContext& context, const std::string& name)
 {
     LOCK(context.wallets_mutex);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -145,6 +145,14 @@ bool RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet
     return RemoveWallet(context, wallet, load_on_start, warnings);
 }
 
+void ForEachWallet(WalletContext& context, const WalletFn& fn)
+{
+    LOCK(context.wallets_mutex);
+    for (const auto& wallet : context.wallets) {
+        fn(*wallet);
+    }
+}
+
 std::vector<std::shared_ptr<CWallet>> GetWallets(WalletContext& context)
 {
     LOCK(context.wallets_mutex);
@@ -1916,9 +1924,9 @@ void CWallet::ResendWalletTransactions()
 
 void MaybeResendWalletTxs(WalletContext& context)
 {
-    for (const std::shared_ptr<CWallet>& pwallet : GetWallets(context)) {
-        pwallet->ResendWalletTransactions();
-    }
+    ForEachWallet(context, [](CWallet& wallet) {
+        wallet.ResendWalletTransactions();
+    });
 }
 
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -62,6 +62,7 @@ bool AddWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet);
 bool RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet, std::optional<bool> load_on_start, std::vector<bilingual_str>& warnings);
 bool RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet, std::optional<bool> load_on_start);
 std::vector<std::shared_ptr<CWallet>> GetWallets(WalletContext& context);
+std::shared_ptr<CWallet> GetDefaultWallet(WalletContext& context, size_t& count);
 std::shared_ptr<CWallet> GetWallet(WalletContext& context, const std::string& name);
 std::shared_ptr<CWallet> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings);
 std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -61,6 +61,8 @@ void UnloadWallet(std::shared_ptr<CWallet>&& wallet);
 bool AddWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet);
 bool RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet, std::optional<bool> load_on_start, std::vector<bilingual_str>& warnings);
 bool RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet, std::optional<bool> load_on_start);
+using WalletFn = std::function<void(CWallet&)>;
+void ForEachWallet(WalletContext& context, const WalletFn& fn);
 std::vector<std::shared_ptr<CWallet>> GetWallets(WalletContext& context);
 std::shared_ptr<CWallet> GetDefaultWallet(WalletContext& context, size_t& count);
 std::shared_ptr<CWallet> GetWallet(WalletContext& context, const std::string& name);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1045,8 +1045,8 @@ void MaybeCompactWalletDB(WalletContext& context)
         return;
     }
 
-    for (const std::shared_ptr<CWallet>& pwallet : GetWallets(context)) {
-        WalletDatabase& dbh = pwallet->GetDatabase();
+    ForEachWallet(context, [](CWallet& wallet) {
+        WalletDatabase& dbh = wallet.GetDatabase();
 
         unsigned int nUpdateCounter = dbh.nUpdateCounter;
 
@@ -1060,7 +1060,7 @@ void MaybeCompactWalletDB(WalletContext& context)
                 dbh.nLastFlushed = nUpdateCounter;
             }
         }
-    }
+    });
 
     fOneThread = false;
 }


### PR DESCRIPTION
There can be implicit wallet unload on `GetWallets` call site. With this 
change  concurrent wallet unload is not possible and shared ownership is 
not extended to `GetWallets`'s caller scope.