### PR TITLE
ci: Clean package manager cache on CentOS

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -193,7 +193,7 @@ task:
     image: quay.io/centos/centos:stream8
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
-    PACKAGE_MANAGER_INSTALL: "yum install -y"
+    PACKAGE_MANAGER_INSTALL: "rm -r /var/cache/dnf && dnf install -y"
     FILE_ENV: "./ci/test/00_setup_env_i686_centos.sh"
 
 task:


### PR DESCRIPTION
Fixes https://api.cirrus-ci.com/v1/task/6340911251587072/logs/merge_base.log:
```
Errors during downloading metadata for repository 'extras':
...
```