### PR TITLE
test: Check an invalid -i2psam will raise an init error

### DIFF
--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -33,6 +33,7 @@ addnode connect to a CJDNS address
 
 - Test passing invalid -proxy
 - Test passing invalid -onion
+- Test passing invalid -i2psam
 - Test passing -onlynet=onion without -proxy or -onion
 - Test passing -onlynet=onion with -onion=0 and with -noonion
 """
@@ -319,6 +320,11 @@ class ProxyTest(BitcoinTestFramework):
         self.log.info("Test passing invalid -onion raises expected init error")
         self.nodes[1].extra_args = ["-onion=xyz:abc"]
         msg = "Error: Invalid -onion address or hostname: 'xyz:abc'"
+        self.nodes[1].assert_start_raises_init_error(expected_msg=msg)
+
+        self.log.info("Test passing invalid -i2psam raises expected init error")
+        self.nodes[1].extra_args = ["-i2psam=def:xyz"]
+        msg = "Error: Invalid -i2psam address or hostname: 'def:xyz'"
         self.nodes[1].assert_start_raises_init_error(expected_msg=msg)
 
         msg = (


### PR DESCRIPTION
This PR adds test coverage (at `feature_proxy.py`) for the following init error:

https://github.com/bitcoin/bitcoin/blob/2f0f056e08cd5a1435120592a9ecd212fcdb915b/src/init.cpp#L1791

It starts the node with an invalid -i2psam (`-i2psam=invalidhere`) and test if it raises an error when initializing.