### PR TITLE
util: Add inotify_rm_watch to syscall sandbox (AllowFileSystem)

### DIFF
--- a/src/util/syscall_sandbox.cpp
+++ b/src/util/syscall_sandbox.cpp
@@ -592,6 +592,7 @@ public:
         allowed_syscalls.insert(__NR_getcwd);          // get current working directory
         allowed_syscalls.insert(__NR_getdents);        // get directory entries
         allowed_syscalls.insert(__NR_getdents64);      // get directory entries
+        allowed_syscalls.insert(__NR_inotify_rm_watch);// remove an existing watch from an inotify instance
         allowed_syscalls.insert(__NR_linkat);          // create relative to a directory file descriptor
         allowed_syscalls.insert(__NR_lstat);           // get file status
         allowed_syscalls.insert(__NR_mkdir);           // create a directory


### PR DESCRIPTION
This PR fixes the current master (3297f5c11c72dd83479ff8335e047555e3f8cb3b) when running `bitcoin-qt` on Ubuntu 22.04 and quitting:
```
$ ./src/qt/bitcoin-qt -signet -sandbox=log-and-abort
Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway.
ERROR: The syscall "inotify_rm_watch" (syscall number 255) is not allowed by the syscall sandbox in thread "main". Please report.
terminate called without an active exception
Aborted (core dumped)
```

Also see https://github.com/bitcoin/bitcoin/pull/24659#discussion_r835747166