### PR TITLE
test: -peerblockfilters without -blockfilterindex raises an error

### DIFF
--- a/test/functional/p2p_blockfilters.py
+++ b/test/functional/p2p_blockfilters.py
@@ -244,6 +244,12 @@ class CompactFiltersTest(BitcoinTestFramework):
             peer_0.send_message(request)
             peer_0.wait_for_disconnect()
 
+        self.log.info("Test -peerblockfilters without -blockfilterindex raises an error")
+        self.stop_node(0)
+        self.nodes[0].extra_args = ["-peerblockfilters"]
+        msg = "Error: Cannot set -peerblockfilters without -blockfilterindex."
+        self.nodes[0].assert_start_raises_init_error(expected_msg=msg)
+
 
 def compute_last_header(prev_header, hashes):
     """Compute the last filter header from a starting header and a sequence of filter hashes."""


### PR DESCRIPTION
This PR adds test coverage for the following init error:
https://github.com/bitcoin/bitcoin/blob/2a3e8fb3592e42300ec96c9f6724e15346e30ea7/src/init.cpp#L850

Setting -peerblockfilters without -blockfilterindex should raise an error when initializing.