### PR TITLE
Add concrete steps in doc/cjdns.md to easily find a friend

### DIFF
--- a/doc/cjdns.md
+++ b/doc/cjdns.md
@@ -23,17 +23,37 @@ somewhat centralized. I2P connections have a source address and I2P is slow.
 CJDNS is fast but does not hide the sender and the recipient from intermediate
 routers.
 
-## Installing CJDNS and connecting to the network
+## Installing CJDNS and finding a peer to connect to the network
 
 To install and set up CJDNS, follow the instructions at
 https://github.com/cjdelisle/cjdns#cjdns.
 
-Don't skip steps
+You need to initiate an outbound connection to a peer on the CJDNS network
+before it will work with your Bitcoin Core node. This is described in steps
 ["2. Find a friend"](https://github.com/cjdelisle/cjdns#2-find-a-friend) and
 ["3. Connect your node to your friend's
-node"](https://github.com/cjdelisle/cjdns#3-connect-your-node-to-your-friends-node).
-You need to be connected to the CJDNS network before it will work with your
-Bitcoin Core node.
+node"](https://github.com/cjdelisle/cjdns#3-connect-your-node-to-your-friends-node)
+in the CJDNS documentation.
+
+One quick way to accomplish these two steps is to query for available public
+peers on [Hyperboria](https://github.com/hyperboria) by running the following:
+
+```
+git clone https://github.com/hyperboria/peers hyperboria-peers
+cd hyperboria-peers
+./testAvailable.py
+```
+
+For each peer, the `./testAvailable.py` script prints the filename of the peer's
+credentials followed by the ping result.
+
+Choose one or several peers, copy their credentials from their respective files,
+paste them into the relevant IPv4 or IPv6 "connectTo" JSON object in the
+`cjdroute.conf` file you created in step ["1. Generate a new configuration
+file"](https://github.com/cjdelisle/cjdns#1-generate-a-new-configuration-file),
+and save the file.
+
+## Launching CJDNS
 
 Typically, CJDNS might be launched from its directory with
 `sudo ./cjdroute < cjdroute.conf` and it sheds permissions after setting up the

--- a/doc/cjdns.md
+++ b/doc/cjdns.md
@@ -10,7 +10,8 @@ CJDNS is like a distributed, shared VPN with multiple entry points where every
 participant can reach any other participant. All participants use addresses from
 the `fc00::/8` network (reserved IPv6 range). Installation and configuration is
 done outside of Bitcoin Core, similarly to a VPN (either in the host/OS or on
-the network router).
+the network router). See https://github.com/cjdelisle/cjdns#readme and
+https://github.com/hyperboria/docs#hyperboriadocs for more information.
 
 Compared to IPv4/IPv6, CJDNS provides end-to-end encryption and protects nodes
 from traffic analysis and filtering.
@@ -26,7 +27,7 @@ routers.
 ## Installing CJDNS and finding a peer to connect to the network
 
 To install and set up CJDNS, follow the instructions at
-https://github.com/cjdelisle/cjdns#cjdns.
+https://github.com/cjdelisle/cjdns#how-to-install-cjdns.
 
 You need to initiate an outbound connection to a peer on the CJDNS network
 before it will work with your Bitcoin Core node. This is described in steps


### PR DESCRIPTION
and improve the informational links.  CJDNS functions with a friend-of-a-friend topology and a key hurdle to getting started is to find a public peer and set up an outbound connection to it. This update makes doing it much easier for people getting started. 

Credit to Vasil Dimov for an [IRC suggestion in October 2021](https://www.erisian.com.au/bitcoin-core-dev/log-2021-10-04.html#l-469) and to stickies-v for IRC discussions this week and the [testing guide](https://github.com/bitcoin-core/bitcoin-devwiki/wiki/23.0-Release-Candidate-Testing-Guide) that led me to redo these steps, provide feedback at https://github.com/bitcoin/bitcoin/issues/24706 and refine the added documentation here.