### PR TITLE
wallet: reduce coin selection iterations

### DIFF
--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -521,9 +521,7 @@ std::optional<SelectionResult> SelectCoins(const CWallet& wallet, const std::vec
         // Pre-selected inputs already cover the target amount.
         if (value_to_select <= 0) return std::make_optional(SelectionResult(nTargetValue));
 
-        // If possible, fund the transaction with confirmed UTXOs only. Prefer at least six
-        // confirmations on outputs received from other wallets and only spend confirmed change.
-        if (auto r1{AttemptSelection(wallet, value_to_select, CoinEligibilityFilter(1, 6, 0), vCoins, coin_selection_params)}) return r1;
+        // If possible, fund the transaction with confirmed UTXOs only.
         if (auto r2{AttemptSelection(wallet, value_to_select, CoinEligibilityFilter(1, 1, 0), vCoins, coin_selection_params)}) return r2;
 
         // Fall back to using zero confirmation change (but with as few ancestors in the mempool as


### PR DESCRIPTION
Remove coin selection iteration requiring 6 confs
    
It's not clear what purpose we serve with this additional iteration of coin selection that restricts foreign UTXOs to at least six confirmations.
    
If the wallet hasn't been used in a long time, requiring six confirmations or one is equivalent. If the wallet has just received
    funds, the important distinction is still between confirmed and    unconfirmed UTXOs: we haven't had any reorgs of more than a single block    in multiple years, and the ones we had have been benign—the differences    of included transactions between blocks at the same height is generally    minuscule and can be explained by transaction relay latency or the rate    of block template updates. The risk of a UTXO getting reorged out due to    requiring a single confirmation instead of six can be discounted and    doesn't suffice to instigate a full additional coin selection iteration.