### PR TITLE
build, test: Fix test logfile name

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -390,14 +390,14 @@ endif
 		grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | \
 		cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1) \
 		from $<
-	$(AM_V_at)$(TEST_BINARY) \
-		--catch_system_errors=no -l test_suite -t "$$(\
+	$(AM_V_at)export TEST_LOGFILE=$(abs_builddir)/$$(\
+	  echo $< | grep -E -o "(wallet/test/.*\.cpp|test/.*\.cpp)" | $(SED) -e s/\.cpp/.log/ \
+	) && \
+	$(TEST_BINARY) --catch_system_errors=no -l test_suite -t "$$(\
 			cat $< | \
 			grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | \
 			cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1\
-		)" -- DEBUG_LOG_OUT > $(abs_builddir)/$$(\
-			echo $< | grep -E -o "(wallet/test/.*\.cpp|test/.*\.cpp)" | $(SED) -e s/\.cpp/.log/\
-		) 2>&1 || (cat $<.log && false)
+	)" -- DEBUG_LOG_OUT > "$$TEST_LOGFILE" 2>&1 || (cat "$$TEST_LOGFILE" && false)
 
 %.json.h: %.json
 	@$(MKDIR_P) $(@D)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -386,17 +386,17 @@ endif
 
 %.cpp.test: %.cpp
 	@echo Running tests: $$(\
-		cat $< | \
-		grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | \
-		cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1) \
-		from $<
+	  cat $< | \
+	  grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | \
+	  cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1\
+	) from $<
 	$(AM_V_at)export TEST_LOGFILE=$(abs_builddir)/$$(\
 	  echo $< | grep -E -o "(wallet/test/.*\.cpp|test/.*\.cpp)" | $(SED) -e s/\.cpp/.log/ \
 	) && \
 	$(TEST_BINARY) --catch_system_errors=no -l test_suite -t "$$(\
-			cat $< | \
-			grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | \
-			cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1\
+	  cat $< | \
+	  grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | \
+	  cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1\
 	)" -- DEBUG_LOG_OUT > "$$TEST_LOGFILE" 2>&1 || (cat "$$TEST_LOGFILE" && false)
 
 %.json.h: %.json


### PR DESCRIPTION
Recently merged bitcoin/bitcoin#19385 was flawed as it tries to `cat` a non-existed logfile:
- https://github.com/bitcoin/bitcoin/pull/19385#discussion_r835300701
- https://github.com/bitcoin/bitcoin/pull/19385#issuecomment-1082748549

Closes bitcoin/bitcoin#17224.