### PR TITLE
rpc: Fix documentation assertion for `getrawtransaction`

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -138,6 +138,7 @@ static RPCHelpMan getrawtransaction()
                          RPCResult::Type::STR, "data", "The serialized, hex-encoded data for 'txid'"
                      },
                      RPCResult{"if verbose is set to true",
+                         // When updating this documentation, update `decoderawtransaction` in the same way.
                          RPCResult::Type::OBJ, "", "",
                          {
                              {RPCResult::Type::BOOL, "in_active_chain", /*optional=*/true, "Whether specified block is in the active chain or not (only present with explicit \"blockhash\" argument)"},
@@ -153,31 +154,32 @@ static RPCHelpMan getrawtransaction()
                              {
                                  {RPCResult::Type::OBJ, "", "",
                                  {
-                                     {RPCResult::Type::STR_HEX, "txid", "The transaction id"},
-                                     {RPCResult::Type::NUM, "vout", "The output number"},
-                                     {RPCResult::Type::OBJ, "scriptSig", "The script",
+                                     {RPCResult::Type::STR_HEX, "coinbase", /*optional=*/true, "The coinbase value (only if coinbase transaction)"},
+                                     {RPCResult::Type::STR_HEX, "txid", /*optional=*/true, "The transaction id (if not coinbase transaction)"},
+                                     {RPCResult::Type::NUM, "vout", /*optional=*/true, "The output number (if not coinbase transaction)"},
+                                     {RPCResult::Type::OBJ, "scriptSig", /*optional=*/true, "The script (if not coinbase transaction)",
                                      {
                                          {RPCResult::Type::STR, "asm", "asm"},
                                          {RPCResult::Type::STR_HEX, "hex", "hex"},
                                      }},
-                                     {RPCResult::Type::NUM, "sequence", "The script sequence number"},
                                      {RPCResult::Type::ARR, "txinwitness", /*optional=*/true, "",
                                      {
                                          {RPCResult::Type::STR_HEX, "hex", "hex-encoded witness data (if any)"},
                                      }},
+                                     {RPCResult::Type::NUM, "sequence", "The script sequence number"},
                                  }},
                              }},
                              {RPCResult::Type::ARR, "vout", "",
                              {
                                  {RPCResult::Type::OBJ, "", "",
                                  {
-                                     {RPCResult::Type::NUM, "value", "The value in " + CURRENCY_UNIT},
+                                     {RPCResult::Type::STR_AMOUNT, "value", "The value in " + CURRENCY_UNIT},
                                      {RPCResult::Type::NUM, "n", "index"},
                                      {RPCResult::Type::OBJ, "scriptPubKey", "",
                                      {
                                          {RPCResult::Type::STR, "asm", "the asm"},
                                          {RPCResult::Type::STR, "desc", "Inferred descriptor for the output"},
-                                         {RPCResult::Type::STR, "hex", "the hex"},
+                                         {RPCResult::Type::STR_HEX, "hex", "the hex"},
                                          {RPCResult::Type::STR, "type", "The type, eg 'pubkeyhash'"},
                                          {RPCResult::Type::STR, "address", /*optional=*/true, "The Bitcoin address (only if a well-defined address exists)"},
                                      }},
@@ -321,21 +323,22 @@ static RPCHelpMan decoderawtransaction()
                 RPCResult{
                     RPCResult::Type::OBJ, "", "",
                     {
+                        // When updating this documentation, update `getrawtransaction` in the same way.
                         {RPCResult::Type::STR_HEX, "txid", "The transaction id"},
                         {RPCResult::Type::STR_HEX, "hash", "The transaction hash (differs from txid for witness transactions)"},
-                        {RPCResult::Type::NUM, "size", "The transaction size"},
+                        {RPCResult::Type::NUM, "size", "The serialized transaction size"},
                         {RPCResult::Type::NUM, "vsize", "The virtual transaction size (differs from size for witness transactions)"},
-                        {RPCResult::Type::NUM, "weight", "The transaction's weight (between vsize*4 - 3 and vsize*4)"},
+                        {RPCResult::Type::NUM, "weight", "The transaction's weight (between vsize*4-3 and vsize*4)"},
                         {RPCResult::Type::NUM, "version", "The version"},
                         {RPCResult::Type::NUM_TIME, "locktime", "The lock time"},
                         {RPCResult::Type::ARR, "vin", "",
                         {
                             {RPCResult::Type::OBJ, "", "",
                             {
-                                {RPCResult::Type::STR_HEX, "coinbase", /*optional=*/true, ""},
-                                {RPCResult::Type::STR_HEX, "txid", /*optional=*/true, "The transaction id"},
-                                {RPCResult::Type::NUM, "vout", /*optional=*/true, "The output number"},
-                                {RPCResult::Type::OBJ, "scriptSig", /*optional=*/true, "The script",
+                                {RPCResult::Type::STR_HEX, "coinbase", /*optional=*/true, "The coinbase value (only if coinbase transaction)"},
+                                {RPCResult::Type::STR_HEX, "txid", /*optional=*/true, "The transaction id (if not coinbase transaction)"},
+                                {RPCResult::Type::NUM, "vout", /*optional=*/true, "The output number (if not coinbase transaction)"},
+                                {RPCResult::Type::OBJ, "scriptSig", /*optional=*/true, "The script (if not coinbase transaction)",
                                 {
                                     {RPCResult::Type::STR, "asm", "asm"},
                                     {RPCResult::Type::STR_HEX, "hex", "hex"},
@@ -351,7 +354,7 @@ static RPCHelpMan decoderawtransaction()
                         {
                             {RPCResult::Type::OBJ, "", "",
                             {
-                                {RPCResult::Type::NUM, "value", "The value in " + CURRENCY_UNIT},
+                                {RPCResult::Type::STR_AMOUNT, "value", "The value in " + CURRENCY_UNIT},
                                 {RPCResult::Type::NUM, "n", "index"},
                                 {RPCResult::Type::OBJ, "scriptPubKey", "",
                                 {


### PR DESCRIPTION
When `getrawtransaction` is successfully used on a coinbase transaction, there is an assertion error. This is very unlikely but happens in the `interface_usdt_utxocache.py` test in #24358.

This does the following:

- Add missing "coinbase" documentation.

- Synchronize documentation between `getrawtransaction` and  `decoderawtransaction`, the two users of `TxToUniv` that have detailed   documentation. `decodepsbt` and `getblock` also uses it but fortunately elides this block.

- Change "vout[].amount" to `STR_AMOUNT` for consistency.

- Add maintainer comment to keep the two places synchronized. It might  be possible to get smarter with deduplication, but there are some  extra fields that prevent the obvious way.