### PR TITLE
ci: Bump msan to clang-14

### DIFF
--- a/ci/test/00_setup_env_native_fuzz_with_msan.sh
+++ b/ci/test/00_setup_env_native_fuzz_with_msan.sh
@@ -13,7 +13,7 @@ LIBCXX_FLAGS="-nostdinc++ -stdlib=libc++ -L${LIBCXX_DIR}lib -lc++abi -I${LIBCXX_
 export MSAN_AND_LIBCXX_FLAGS="${MSAN_FLAGS} ${LIBCXX_FLAGS}"
 
 export CONTAINER_NAME="ci_native_msan"
-export PACKAGES="clang-12 llvm-12 cmake"
+export PACKAGES="cmake gpg gpg-agent lsb-release wget software-properties-common"
 # BDB generates false-positives and will be removed in future
 export DEP_OPTS="NO_BDB=1 NO_QT=1 CC='clang' CXX='clang++' CFLAGS='${MSAN_FLAGS}' CXXFLAGS='${MSAN_AND_LIBCXX_FLAGS}' libevent_cflags='${MSAN_FLAGS}' sqlite_cflags='${MSAN_FLAGS}' zeromq_cxxflags='-std=c++17 ${MSAN_AND_LIBCXX_FLAGS}'"
 export GOAL="install"

--- a/ci/test/00_setup_env_native_msan.sh
+++ b/ci/test/00_setup_env_native_msan.sh
@@ -13,7 +13,7 @@ LIBCXX_FLAGS="-nostdinc++ -stdlib=libc++ -L${LIBCXX_DIR}lib -lc++abi -I${LIBCXX_
 export MSAN_AND_LIBCXX_FLAGS="${MSAN_FLAGS} ${LIBCXX_FLAGS}"
 
 export CONTAINER_NAME="ci_native_msan"
-export PACKAGES="clang-12 llvm-12 cmake"
+export PACKAGES="cmake gpg gpg-agent lsb-release wget software-properties-common"
 # BDB generates false-positives and will be removed in future
 export DEP_OPTS="NO_BDB=1 NO_QT=1 CC='clang' CXX='clang++' CFLAGS='${MSAN_FLAGS}' CXXFLAGS='${MSAN_AND_LIBCXX_FLAGS}' libevent_cflags='${MSAN_FLAGS}' sqlite_cflags='${MSAN_FLAGS}' zeromq_cxxflags='-std=c++17 ${MSAN_AND_LIBCXX_FLAGS}'"
 export GOAL="install"

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -103,10 +103,13 @@ fi
 CI_EXEC mkdir -p "${BASE_SCRATCH_DIR}/sanitizer-output/"
 
 if [[ ${USE_MEMORY_SANITIZER} == "true" ]]; then
-  CI_EXEC "update-alternatives --install /usr/bin/clang++ clang++ \$(which clang++-12) 100"
-  CI_EXEC "update-alternatives --install /usr/bin/clang clang \$(which clang-12) 100"
+  CI_EXEC wget "https://apt.llvm.org/llvm.sh"
+  CI_EXEC chmod +x ./llvm.sh
+  CI_EXEC ./llvm.sh 14
+  CI_EXEC "update-alternatives --install /usr/bin/clang++ clang++ \$(which clang++-14) 100"
+  CI_EXEC "update-alternatives --install /usr/bin/clang clang \$(which clang-14) 100"
   CI_EXEC "mkdir -p ${BASE_SCRATCH_DIR}/msan/build/"
-  CI_EXEC "git clone --depth=1 https://github.com/llvm/llvm-project -b llvmorg-12.0.0 ${BASE_SCRATCH_DIR}/msan/llvm-project"
+  CI_EXEC "git clone --depth=1 https://github.com/llvm/llvm-project -b llvmorg-14.0.0 ${BASE_SCRATCH_DIR}/msan/llvm-project"
   CI_EXEC "cd ${BASE_SCRATCH_DIR}/msan/build/ && cmake -DLLVM_ENABLE_PROJECTS='libcxx;libcxxabi' -DCMAKE_BUILD_TYPE=Release -DLLVM_USE_SANITIZER=MemoryWithOrigins -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_TARGETS_TO_BUILD=X86 ../llvm-project/llvm/"
   CI_EXEC "cd ${BASE_SCRATCH_DIR}/msan/build/ && make $MAKEJOBS cxx"
 fi


### PR DESCRIPTION
Run the latest sanitizers to get the most implemented features. Similar to commit 74b011bbfa3b607606cc7c0ce6e2d22cfd07605a, but no longer using system packages, as other Ubuntu/Debian fail to run msan on Bitcoin Core and Focal doesn't ship with clang-14.