### PR TITLE
build: Disable AVX2 code path on mingw builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -554,8 +554,12 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
     #include <stdint.h>
     #include <immintrin.h>
   ]],[[
+#ifdef __MINGW64__
+#error AVX2 is disabled in Windows gcc builds (see https://github.com/bitcoin/bitcoin/issues/24726).
+#else
     __m256i l = _mm256_set1_epi32(0);
     return _mm256_extract_epi32(l, 7);
+#endif
   ]])],
  [ AC_MSG_RESULT([yes]); enable_avx2=yes; AC_DEFINE([ENABLE_AVX2], [1], [Define this symbol to build code that uses AVX2 intrinsics]) ],
  [ AC_MSG_RESULT([no])]


### PR DESCRIPTION
The stack is 16 byte aligned according to the ABI, but gcc assumes 32 byte alignment during ~~register spilling~~ write of function arguments (doesn't re-align the stack pointer), resulting in ~50% chance of a crash.

Avoid this issue by disabling detection of AVX2 compiler support when
compiling with mingw-w64. This should be enough, none of the other extended instruction sets uses 256 bit types.

Newer systems will use SHANI for SHA256 acceleration, older ones will fall back to one of the other (maybe a little slower) optimized implementations.

Upstream bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54412

Fixes #24726.