### PR TITLE
util/check: avoid unused parameter warnings

### DIFF
--- a/src/util/check.h
+++ b/src/util/check.h
@@ -51,7 +51,7 @@ void assertion_fail(const char* file, int line, const char* func, const char* as
 
 /** Helper for Assert()/Assume() */
 template <bool IS_ASSERT, typename T>
-T&& inline_assertion_check(T&& val, const char* file, int line, const char* func, const char* assertion)
+T&& inline_assertion_check(T&& val, [[maybe_unused]] const char* file, [[maybe_unused]] int line, [[maybe_unused]] const char* func, [[maybe_unused]] const char* assertion)
 {
     if constexpr (IS_ASSERT
 #ifdef ABORT_ON_FAILED_ASSUME


### PR DESCRIPTION
Add `[[maybe_unused]]` annotations to avoid warnings from gcc 9.4 and earlier which don't analyse `if constexpr` properly.
