### PR TITLE
build: Fix "ERR: Unsigned tarballs do not exist"

### DIFF
--- a/contrib/guix/guix-codesign
+++ b/contrib/guix/guix-codesign
@@ -152,7 +152,7 @@ outdir_for_host() {
 unsigned_tarball_for_host() {
     case "$1" in
         *mingw*)
-            echo "$(outdir_for_host "$1")/${DISTNAME}-win-unsigned.tar.gz"
+            echo "$(outdir_for_host "$1")/${DISTNAME}-win64-unsigned.tar.gz"
             ;;
         *darwin*)
             echo "$(outdir_for_host "$1")/${DISTNAME}-${1}-unsigned.tar.gz"


### PR DESCRIPTION
This was missed in 53dd6165b8994301d638298906b006032e0bbe48 (bitcoin/bitcoin#24549).