### PR TITLE
build: remove faketime unsetting and comments from configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,14 +42,9 @@ AH_TOP([#ifndef BITCOIN_CONFIG_H])
 AH_TOP([#define BITCOIN_CONFIG_H])
 AH_BOTTOM([#endif //BITCOIN_CONFIG_H])
 
-dnl faketime breaks configure and is only needed for make. Disable it here.
-unset FAKETIME
-
 dnl Automake init set-up and checks
 AM_INIT_AUTOMAKE([1.13 no-define subdir-objects foreign])
 
-dnl faketime messes with timestamps and causes configure to be re-run.
-dnl --disable-maintainer-mode can be used to bypass this.
 AM_MAINTAINER_MODE([enable])
 
 dnl make the compilation flags quiet unless V=1 is used


### PR DESCRIPTION
We no-longer use [`faketime`](https://github.com/wolfcw/libfaketime) (it used to be required in gitian), so as far as I'm aware, there is no need for us to unset `FAKETIME` or mention it in our build docs.