### PR TITLE
test: Fix intermittent test failure in wallet_listreceivedby.py

### DIFF
--- a/test/functional/wallet_listreceivedby.py
+++ b/test/functional/wallet_listreceivedby.py
@@ -26,9 +26,6 @@ class ReceivedByTest(BitcoinTestFramework):
         self.skip_if_no_cli()
 
     def run_test(self):
-        # Generate block to get out of IBD
-        self.generate(self.nodes[0], 1)
-
         # save the number of coinbase reward addresses so far
         num_cb_reward_addresses = len(self.nodes[1].listreceivedbyaddress(minconf=0, include_empty=True, include_watchonly=True))
 
@@ -172,7 +169,7 @@ class ReceivedByTest(BitcoinTestFramework):
         address = self.nodes[0].getnewaddress(label)
 
         reward = Decimal("25")
-        self.generatetoaddress(self.nodes[0], 1, address, sync_fun=self.no_op)
+        self.generatetoaddress(self.nodes[0], 1, address)
         hash = self.nodes[0].getbestblockhash()
 
         self.log.info("getreceivedbyaddress returns nothing with defaults")
@@ -212,7 +209,7 @@ class ReceivedByTest(BitcoinTestFramework):
                             {"label": label, "amount": reward})
 
         self.log.info("Generate 100 more blocks")
-        self.generate(self.nodes[0], COINBASE_MATURITY, sync_fun=self.no_op)
+        self.generate(self.nodes[0], COINBASE_MATURITY)
 
         self.log.info("getreceivedbyaddress returns reward with defaults")
         balance = self.nodes[0].getreceivedbyaddress(address)


### PR DESCRIPTION
* Remove not needed "Generate block to get out of IBD"
* Sync blocks where possible to avoid incoming blocks on the p2p `msghand` thread while blocks are mined in the RPC thread. See https://github.com/bitcoin/bitcoin/issues/24730 for discussion.

