### PR TITLE
doc: remove incorrect mention of PR_GET_NAME

### DIFF
--- a/src/util/threadnames.cpp
+++ b/src/util/threadnames.cpp
@@ -16,7 +16,7 @@
 #include <util/threadnames.h>
 
 #ifdef HAVE_SYS_PRCTL_H
-#include <sys/prctl.h> // For prctl, PR_SET_NAME, PR_GET_NAME
+#include <sys/prctl.h>
 #endif
 
 //! Set the thread's name at the process level. Does not affect the

--- a/src/util/threadnames.cpp
+++ b/src/util/threadnames.cpp
@@ -6,7 +6,9 @@
 #include <config/bitcoin-config.h>
 #endif
 
+#include <string>
 #include <thread>
+#include <utility>
 
 #if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
 #include <pthread.h>


### PR DESCRIPTION
By removing the whole comment. These `#include // For` comments are near impossible
to maintain, pollute diffs, and generally don't add a lot of value.

While here, also add the missing `std::` includes.