### PR TITLE
refactor: use ternary when creating RPC param variables

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -269,9 +269,7 @@ static RPCHelpMan waitfornewblock()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    int timeout = 0;
-    if (!request.params[0].isNull())
-        timeout = request.params[0].get_int();
+    const int timeout{request.params[0].isNull() ? 0 : request.params[0].get_int()};
 
     CUpdatedBlock block;
     {
@@ -312,12 +310,9 @@ static RPCHelpMan waitforblock()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    int timeout = 0;
+    const int timeout{request.params[1].isNull() ? 0 : request.params[1].get_int()};
 
     uint256 hash(ParseHashV(request.params[0], "blockhash"));
-
-    if (!request.params[1].isNull())
-        timeout = request.params[1].get_int();
 
     CUpdatedBlock block;
     {
@@ -359,12 +354,9 @@ static RPCHelpMan waitforblockheight()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    int timeout = 0;
+    const int timeout {request.params[1].isNull() ? 0 : request.params[1].get_int()};
 
     int height = request.params[0].get_int();
-
-    if (!request.params[1].isNull())
-        timeout = request.params[1].get_int();
 
     CUpdatedBlock block;
     {
@@ -535,9 +527,7 @@ static RPCHelpMan getblockheader()
 {
     uint256 hash(ParseHashV(request.params[0], "hash"));
 
-    bool fVerbose = true;
-    if (!request.params[1].isNull())
-        fVerbose = request.params[1].get_bool();
+    const bool fVerbose{request.params[1].isNull() ? true : request.params[1].get_bool()};
 
     const CBlockIndex* pblockindex;
     const CBlockIndex* tip;
@@ -996,9 +986,7 @@ static RPCHelpMan gettxout()
     uint256 hash(ParseHashV(request.params[0], "txid"));
     int n = request.params[1].get_int();
     COutPoint out(hash, n);
-    bool fMempool = true;
-    if (!request.params[2].isNull())
-        fMempool = request.params[2].get_bool();
+    const bool fMempool{request.params[2].isNull() ? true : request.params[2].get_bool()};
 
     Coin coin;
     CChainState& active_chainstate = chainman.ActiveChainstate();
@@ -2191,10 +2179,7 @@ static RPCHelpMan getblockfilter()
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
     uint256 block_hash = ParseHashV(request.params[0], "blockhash");
-    std::string filtertype_name = "basic";
-    if (!request.params[1].isNull()) {
-        filtertype_name = request.params[1].get_str();
-    }
+    const std::string filtertype_name = {request.params[1].isNull() ? "basic" : request.params[1].get_str()};
 
     BlockFilterType filtertype;
     if (!BlockFilterTypeByName(filtertype_name, filtertype)) {

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -411,14 +411,9 @@ static RPCHelpMan getrawmempool()
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    bool fVerbose = false;
-    if (!request.params[0].isNull())
-        fVerbose = request.params[0].get_bool();
+    const bool fVerbose{request.params[0].isNull() ? false : request.params[0].get_bool()};
 
-    bool include_mempool_sequence = false;
-    if (!request.params[1].isNull()) {
-        include_mempool_sequence = request.params[1].get_bool();
-    }
+    const bool include_mempool_sequence{request.params[1].isNull() ? false : request.params[1].get_bool()};
 
     return MempoolToJSON(EnsureAnyMemPool(request.context), fVerbose, include_mempool_sequence);
 },
@@ -449,9 +444,7 @@ static RPCHelpMan getmempoolancestors()
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    bool fVerbose = false;
-    if (!request.params[1].isNull())
-        fVerbose = request.params[1].get_bool();
+    const bool fVerbose{request.params[1].isNull() ? false : request.params[1].get_bool()};
 
     uint256 hash = ParseHashV(request.params[0], "parameter 1");
 
@@ -513,9 +506,7 @@ static RPCHelpMan getmempooldescendants()
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    bool fVerbose = false;
-    if (!request.params[1].isNull())
-        fVerbose = request.params[1].get_bool();
+    const bool fVerbose{request.params[1].isNull() ? false : request.params[1].get_bool()};
 
     uint256 hash = ParseHashV(request.params[0], "parameter 1");
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1206,10 +1206,8 @@ static RPCHelpMan estimaterawfee()
 
     unsigned int max_target = fee_estimator.HighestTargetTracked(FeeEstimateHorizon::LONG_HALFLIFE);
     unsigned int conf_target = ParseConfirmTarget(request.params[0], max_target);
-    double threshold = 0.95;
-    if (!request.params[1].isNull()) {
-        threshold = request.params[1].get_real();
-    }
+    const double threshold{request.params[1].isNull() ? 0.95 : request.params[1].get_real()};
+
     if (threshold < 0 || threshold > 1) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid threshold");
     }

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -286,12 +286,10 @@ static RPCHelpMan addnode()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    std::string strCommand;
-    if (!request.params[1].isNull())
-        strCommand = request.params[1].get_str();
+    const std::string strCommand{request.params[1].isNull() ? "" : request.params[1].get_str()};
+
     if (strCommand != "onetry" && strCommand != "add" && strCommand != "remove") {
-        throw std::runtime_error(
-            self.ToString());
+        throw std::runtime_error(self.ToString());
     }
 
     NodeContext& node = EnsureAnyNodeContext(request.context);
@@ -683,9 +681,8 @@ static RPCHelpMan setban()
                 },
         [&](const RPCHelpMan& help, const JSONRPCRequest& request) -> UniValue
 {
-    std::string strCommand;
-    if (!request.params[1].isNull())
-        strCommand = request.params[1].get_str();
+    const std::string strCommand{request.params[1].isNull() ? "" : request.params[1].get_str()};
+
     if (strCommand != "add" && strCommand != "remove") {
         throw std::runtime_error(help.ToString());
     }
@@ -718,13 +715,10 @@ static RPCHelpMan setban()
             throw JSONRPCError(RPC_CLIENT_NODE_ALREADY_ADDED, "Error: IP/Subnet already banned");
         }
 
-        int64_t banTime = 0; //use standard bantime if not specified
-        if (!request.params[2].isNull())
-            banTime = request.params[2].get_int64();
+        //use standard bantime if not specified
+        const int64_t banTime{request.params[2].isNull() ? 0 : request.params[2].get_int64()};
 
-        bool absolute = false;
-        if (request.params[3].isTrue())
-            absolute = true;
+        const bool absolute{request.params[3].isTrue() ? true : false};
 
         if (isSubnet) {
             node.banman->Ban(subNet, banTime, absolute);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -303,10 +303,7 @@ static RPCHelpMan createrawtransaction()
         }, true
     );
 
-    bool rbf = false;
-    if (!request.params[3].isNull()) {
-        rbf = request.params[3].isTrue();
-    }
+    const bool rbf{request.params[3].isNull() ? false : request.params[3].isTrue()};
     CMutableTransaction rawTx = ConstructTransaction(request.params[0], request.params[1], request.params[2], rbf);
 
     return EncodeHexTx(CTransaction(rawTx));
@@ -342,8 +339,8 @@ static RPCHelpMan decoderawtransaction()
 
     CMutableTransaction mtx;
 
-    bool try_witness = request.params[1].isNull() ? true : request.params[1].get_bool();
-    bool try_no_witness = request.params[1].isNull() ? true : !request.params[1].get_bool();
+    const bool try_witness{request.params[1].isNull() ? true : request.params[1].get_bool()};
+    const bool try_no_witness{request.params[1].isNull() ? true : !request.params[1].get_bool()};
 
     if (!DecodeHexTx(mtx, request.params[0].get_str(), try_no_witness, try_witness)) {
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
@@ -1229,7 +1226,7 @@ static RPCHelpMan finalizepsbt()
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("TX decode failed %s", error));
     }
 
-    bool extract = request.params[1].isNull() || (!request.params[1].isNull() && request.params[1].get_bool());
+    const bool extract{request.params[1].isNull() || (!request.params[1].isNull() && request.params[1].get_bool())};
 
     CMutableTransaction mtx;
     bool complete = FinalizeAndExtractPSBT(psbtx, mtx);
@@ -1277,10 +1274,8 @@ static RPCHelpMan createpsbt()
         }, true
     );
 
-    bool rbf = false;
-    if (!request.params[3].isNull()) {
-        rbf = request.params[3].isTrue();
-    }
+    const bool rbf{request.params[3].isNull() ? false : request.params[3].isTrue()};
+
     CMutableTransaction rawTx = ConstructTransaction(request.params[0], request.params[1], request.params[2], rbf);
 
     // Make a blank psbt
@@ -1334,11 +1329,11 @@ static RPCHelpMan converttopsbt()
 
     // parse hex string from parameter
     CMutableTransaction tx;
-    bool permitsigdata = request.params[1].isNull() ? false : request.params[1].get_bool();
-    bool witness_specified = !request.params[2].isNull();
-    bool iswitness = witness_specified ? request.params[2].get_bool() : false;
-    const bool try_witness = witness_specified ? iswitness : true;
-    const bool try_no_witness = witness_specified ? !iswitness : true;
+    const bool permitsigdata{request.params[1].isNull() ? false : request.params[1].get_bool()};
+    const bool witness_specified{!request.params[2].isNull()};
+    const bool iswitness{witness_specified ? request.params[2].get_bool() : false};
+    const bool try_witness{witness_specified ? iswitness : true};
+    const bool try_no_witness{witness_specified ? !iswitness : true};
     if (!DecodeHexTx(tx, request.params[0].get_str(), try_no_witness, try_witness)) {
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
     }

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -133,20 +133,16 @@ RPCHelpMan importprivkey()
     EnsureLegacyScriptPubKeyMan(*pwallet, true);
 
     WalletRescanReserver reserver(*pwallet);
-    bool fRescan = true;
+
+    // Whether to perform rescan after import
+    const bool fRescan{request.params[2].isNull() ? true : request.params[2].get_bool()};
     {
         LOCK(pwallet->cs_wallet);
 
         EnsureWalletIsUnlocked(*pwallet);
 
-        std::string strSecret = request.params[0].get_str();
-        std::string strLabel = "";
-        if (!request.params[1].isNull())
-            strLabel = request.params[1].get_str();
-
-        // Whether to perform rescan after import
-        if (!request.params[2].isNull())
-            fRescan = request.params[2].get_bool();
+        const std::string strSecret = request.params[0].get_str();
+        const std::string strLabel{request.params[1].isNull() ? "" : request.params[1].get_str()};
 
         if (fRescan && pwallet->chain().havePruned()) {
             // Exit early and print an error.
@@ -230,14 +226,10 @@ RPCHelpMan importaddress()
 
     EnsureLegacyScriptPubKeyMan(*pwallet, true);
 
-    std::string strLabel;
-    if (!request.params[1].isNull())
-        strLabel = request.params[1].get_str();
+    const std::string strLabel{request.params[1].isNull() ? "" : request.params[1].get_str()};
 
     // Whether to perform rescan after import
-    bool fRescan = true;
-    if (!request.params[2].isNull())
-        fRescan = request.params[2].get_bool();
+    const bool fRescan{request.params[2].isNull() ? true : request.params[2].get_bool()};
 
     if (fRescan && pwallet->chain().havePruned()) {
         // Exit early and print an error.
@@ -252,9 +244,7 @@ RPCHelpMan importaddress()
     }
 
     // Whether to import a p2sh version, too
-    bool fP2SH = false;
-    if (!request.params[3].isNull())
-        fP2SH = request.params[3].get_bool();
+    const bool fP2SH{request.params[3].isNull() ? false : request.params[3].get_bool()};
 
     {
         LOCK(pwallet->cs_wallet);
@@ -424,14 +414,10 @@ RPCHelpMan importpubkey()
 
     EnsureLegacyScriptPubKeyMan(*pwallet, true);
 
-    std::string strLabel;
-    if (!request.params[1].isNull())
-        strLabel = request.params[1].get_str();
+    const std::string strLabel{request.params[1].isNull() ? "" : request.params[1].get_str()};
 
     // Whether to perform rescan after import
-    bool fRescan = true;
-    if (!request.params[2].isNull())
-        fRescan = request.params[2].get_bool();
+    const bool fRescan{request.params[2].isNull() ? true : request.params[2].get_bool()};
 
     if (fRescan && pwallet->chain().havePruned()) {
         // Exit early and print an error.
@@ -1771,7 +1757,7 @@ RPCHelpMan listdescriptors()
         throw JSONRPCError(RPC_WALLET_ERROR, "listdescriptors is not available for non-descriptor wallets");
     }
 
-    const bool priv = !request.params[0].isNull() && request.params[0].get_bool();
+    const bool priv{!request.params[0].isNull() && request.params[0].get_bool()};
     if (priv) {
         EnsureWalletIsUnlocked(*wallet);
     }

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -38,9 +38,7 @@ static CAmount GetReceived(const CWallet& wallet, const UniValue& params, bool b
     }
 
     // Minimum confirmations
-    int min_depth = 1;
-    if (!params[1].isNull())
-        min_depth = params[1].get_int();
+    const int min_depth{params[1].isNull() ? 1 : params[1].get_int()};
 
     const bool include_immature_coinbase{params[2].isNull() ? false : params[2].get_bool()};
 
@@ -198,10 +196,7 @@ RPCHelpMan getbalance()
         throw JSONRPCError(RPC_METHOD_DEPRECATED, "dummy first argument must be excluded or set to \"*\".");
     }
 
-    int min_depth = 0;
-    if (!request.params[1].isNull()) {
-        min_depth = request.params[1].get_int();
-    }
+    const int min_depth{request.params[1].isNull() ? 0 : request.params[1].get_int()};
 
     bool include_watchonly = ParseIncludeWatchonly(request.params[2], *pwallet);
 
@@ -293,7 +288,7 @@ RPCHelpMan lockunspent()
 
     RPCTypeCheckArgument(request.params[0], UniValue::VBOOL);
 
-    bool fUnlock = request.params[0].get_bool();
+    const bool fUnlock{request.params[0].get_bool()};
 
     const bool persistent{request.params[2].isNull() ? false : request.params[2].get_bool()};
 

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -279,10 +279,7 @@ RPCHelpMan sendtoaddress()
     if (!request.params[3].isNull() && !request.params[3].get_str().empty())
         mapValue["to"] = request.params[3].get_str();
 
-    bool fSubtractFeeFromAmount = false;
-    if (!request.params[4].isNull()) {
-        fSubtractFeeFromAmount = request.params[4].get_bool();
-    }
+    const bool fSubtractFeeFromAmount{request.params[4].isNull() ? false : request.params[4].get_bool()};
 
     CCoinControl coin_control;
     if (!request.params[5].isNull()) {
@@ -827,8 +824,8 @@ RPCHelpMan fundrawtransaction()
 
     // parse hex string from parameter
     CMutableTransaction tx;
-    bool try_witness = request.params[2].isNull() ? true : request.params[2].get_bool();
-    bool try_no_witness = request.params[2].isNull() ? true : !request.params[2].get_bool();
+    const bool try_witness{request.params[2].isNull() ? true : request.params[2].get_bool()};
+    const bool try_no_witness{request.params[2].isNull() ? true : !request.params[2].get_bool()};
     if (!DecodeHexTx(tx, request.params[0].get_str(), try_no_witness, try_witness)) {
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
     }
@@ -1528,10 +1525,10 @@ RPCHelpMan walletprocesspsbt()
     int nHashType = ParseSighashString(request.params[2]);
 
     // Fill transaction with our data and also sign
-    bool sign = request.params[1].isNull() ? true : request.params[1].get_bool();
-    bool bip32derivs = request.params[3].isNull() ? true : request.params[3].get_bool();
-    bool finalize = request.params[4].isNull() ? true : request.params[4].get_bool();
-    bool complete = true;
+    const bool sign{request.params[1].isNull() ? true : request.params[1].get_bool()};
+    const bool bip32derivs{request.params[3].isNull() ? true : request.params[3].get_bool()};
+    const bool finalize{request.params[4].isNull() ? true : request.params[4].get_bool()};
+    bool complete{true};
 
     if (sign) EnsureWalletIsUnlocked(*pwallet);
 
@@ -1673,8 +1670,8 @@ RPCHelpMan walletcreatefundedpsbt()
     PartiallySignedTransaction psbtx(rawTx);
 
     // Fill transaction with out data but don't sign
-    bool bip32derivs = request.params[4].isNull() ? true : request.params[4].get_bool();
-    bool complete = true;
+    const bool bip32derivs{request.params[4].isNull() ? true : request.params[4].get_bool()};
+    bool complete{true};
     const TransactionError err{wallet.FillPSBT(psbtx, complete, 1, false, bip32derivs)};
     if (err != TransactionError::OK) {
         throw JSONRPCTransactionError(err);

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -71,14 +71,10 @@ struct tallyitem
 static UniValue ListReceived(const CWallet& wallet, const UniValue& params, const bool by_label, const bool include_immature_coinbase) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
     // Minimum confirmations
-    int nMinDepth = 1;
-    if (!params[0].isNull())
-        nMinDepth = params[0].get_int();
+    const int nMinDepth{params[0].isNull() ? 1 : params[0].get_int()};
 
     // Whether to include empty labels
-    bool fIncludeEmpty = false;
-    if (!params[1].isNull())
-        fIncludeEmpty = params[1].get_bool();
+    const bool fIncludeEmpty{params[1].isNull() ? false : params[1].get_bool()};
 
     isminefilter filter = ISMINE_SPENDABLE;
 
@@ -511,12 +507,9 @@ RPCHelpMan listtransactions()
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Label argument must be a valid label name or \"*\".");
         }
     }
-    int nCount = 10;
-    if (!request.params[1].isNull())
-        nCount = request.params[1].get_int();
-    int nFrom = 0;
-    if (!request.params[2].isNull())
-        nFrom = request.params[2].get_int();
+    int nCount{request.params[1].isNull() ? 10 : request.params[1].get_int()};
+    int nFrom{request.params[2].isNull() ? 0 : request.params[2].get_int()};
+
     isminefilter filter = ISMINE_SPENDABLE;
 
     if (ParseIncludeWatchonly(request.params[3], *pwallet)) {
@@ -625,7 +618,6 @@ RPCHelpMan listsinceblock()
 
     std::optional<int> height;    // Height of the specified block or the common ancestor, if the block provided was in a deactivated chain.
     std::optional<int> altheight; // Height of the specified block, even if it's in a deactivated chain.
-    int target_confirms = 1;
     isminefilter filter = ISMINE_SPENDABLE;
 
     uint256 blockId;
@@ -638,21 +630,19 @@ RPCHelpMan listsinceblock()
         }
     }
 
-    if (!request.params[1].isNull()) {
-        target_confirms = request.params[1].get_int();
+    int target_confirms{request.params[1].isNull() ? 1 : request.params[1].get_int()};
 
-        if (target_confirms < 1) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter");
-        }
+    if (target_confirms < 1) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter");
     }
 
     if (ParseIncludeWatchonly(request.params[2], wallet)) {
         filter |= ISMINE_WATCH_ONLY;
     }
 
-    bool include_removed = (request.params[3].isNull() || request.params[3].get_bool());
+    const bool include_removed{request.params[3].isNull() || request.params[3].get_bool()};
 
-    int depth = height ? wallet.GetLastBlockHeight() + 1 - *height : -1;
+    const int depth{height ? wallet.GetLastBlockHeight() + 1 - *height : -1};
 
     UniValue transactions(UniValue::VARR);
 
@@ -771,7 +761,7 @@ RPCHelpMan gettransaction()
         filter |= ISMINE_WATCH_ONLY;
     }
 
-    bool verbose = request.params[2].isNull() ? false : request.params[2].get_bool();
+    const bool verbose{request.params[2].isNull() ? false : request.params[2].get_bool()};
 
     UniValue entry(UniValue::VOBJ);
     auto it = pwallet->mapWallet.find(hash);

--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -17,8 +17,8 @@ static const std::string WALLET_ENDPOINT_BASE = "/wallet/";
 const std::string HELP_REQUIRING_PASSPHRASE{"\nRequires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.\n"};
 
 bool GetAvoidReuseFlag(const CWallet& wallet, const UniValue& param) {
-    bool can_avoid_reuse = wallet.IsWalletFlagSet(WALLET_FLAG_AVOID_REUSE);
-    bool avoid_reuse = param.isNull() ? can_avoid_reuse : param.get_bool();
+    const bool can_avoid_reuse{wallet.IsWalletFlagSet(WALLET_FLAG_AVOID_REUSE)};
+    const bool avoid_reuse{param.isNull() ? can_avoid_reuse : param.get_bool()};
 
     if (avoid_reuse && !can_avoid_reuse) {
         throw JSONRPCError(RPC_WALLET_ERROR, "wallet does not have the \"avoid reuse\" feature enabled");

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -269,8 +269,8 @@ static RPCHelpMan setwalletflag()
     std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
     if (!pwallet) return NullUniValue;
 
-    std::string flag_str = request.params[0].get_str();
-    bool value = request.params[1].isNull() || request.params[1].get_bool();
+    const std::string flag_str{request.params[0].get_str()};
+    const bool value{request.params[1].isNull() || request.params[1].get_bool()};
 
     if (!WALLET_FLAG_MAP.count(flag_str)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Unknown wallet flag: %s", flag_str));
@@ -497,10 +497,7 @@ static RPCHelpMan sethdseed()
 
     EnsureWalletIsUnlocked(*pwallet);
 
-    bool flush_key_pool = true;
-    if (!request.params[0].isNull()) {
-        flush_key_pool = request.params[0].get_bool();
-    }
+    const bool flush_key_pool{request.params[0].isNull() ? true : request.params[0].get_bool()};
 
     CPubKey master_pub_key;
     if (request.params[1].isNull()) {
@@ -557,10 +554,8 @@ static RPCHelpMan upgradewallet()
 
     EnsureWalletIsUnlocked(*pwallet);
 
-    int version = 0;
-    if (!request.params[0].isNull()) {
-        version = request.params[0].get_int();
-    }
+    const int version{request.params[0].isNull() ? 0 : request.params[0].get_int()};
+
     bilingual_str error;
     const int previous_version{pwallet->GetVersion()};
     const bool wallet_upgraded{pwallet->UpgradeWallet(version, error)};


### PR DESCRIPTION
A style we are already using in some RPC code. i.e:
https://github.com/bitcoin/bitcoin/blob/55ea6fd2506b84f553c0bd42f48a9cc4393bab47/src/rpc/blockchain.cpp#L864-L866
More concise (about half the lines of code).
Variables that should be made `const`, can be made `const`.
I'd argue that this:
```cpp
    const bool fVerbose{request.params[0].isNull() ? false : request.params[0].get_bool()};

    const bool include_mempool_sequence{request.params[1].isNull() ? false : request.params[1].get_bool()};
```
is easier to read / reason about, than:
```cpp
    bool fVerbose = false;
    if (!request.params[0].isNull())
        fVerbose = request.params[0].get_bool();

    bool include_mempool_sequence = false;
    if (!request.params[1].isNull()) {
        include_mempool_sequence = request.params[1].get_bool();
    }
```