### PR TITLE
refactor: remove macOS MAP_ANONYMOUS work around

### DIFF
--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -235,12 +235,6 @@ PosixLockedPageAllocator::PosixLockedPageAllocator()
 #endif
 }
 
-// Some systems (at least OS X) do not define MAP_ANONYMOUS yet and define
-// MAP_ANON which is deprecated
-#ifndef MAP_ANONYMOUS
-#define MAP_ANONYMOUS MAP_ANON
-#endif
-
 void *PosixLockedPageAllocator::AllocateLocked(size_t len, bool *lockingSuccess)
 {
     void *addr;


### PR DESCRIPTION
This was added to support compilation on macOS 10.10, our minimum
required macOS is now 10.15. macOS has also supported it since 10.11.

See https://github.com/bitcoin/bitcoin/pull/9063.

macOS 12.3 manpage for mmap:
```bash
     MAP_ANONYMOUS     Synonym for MAP_ANON.

     MAP_ANON          Map anonymous memory not associated with any specific file. 
```