### PR TITLE
doc: Add bash dependency of lint tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -303,6 +303,13 @@ Use the `-v` option for verbose output.
 
 #### Dependencies
 
+##### Bash
+
+Several lint tests require a `bash` shell version 4 or higher.
+macOS systems require upgrading the system provided `bash`.
+
+##### Python
+
 | Lint test | Dependency |
 |-----------|:----------:|
 | [`lint-python.sh`](lint/lint-python.sh) | [flake8](https://gitlab.com/pycqa/flake8)

--- a/test/lint/lint-python-dead-code.sh
+++ b/test/lint/lint-python-dead-code.sh
@@ -11,6 +11,9 @@ export LC_ALL=C
 if ! command -v vulture > /dev/null; then
     echo "Skipping Python dead code linting since vulture is not installed. Install by running \"pip3 install vulture\""
     exit 0
+elif [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+    echo "Skipping Python dead code linting since your bash version is less than 4."
+    exit 0
 fi
 
 # --min-confidence 100 will only report code that is guaranteed to be unused within the analyzed files.

--- a/test/lint/lint-python.sh
+++ b/test/lint/lint-python.sh
@@ -88,6 +88,9 @@ if ! command -v flake8 > /dev/null; then
 elif PYTHONWARNINGS="ignore" flake8 --version | grep -q "Python 2"; then
     echo "Skipping Python linting since flake8 is running under Python 2. Install the Python 3 version of flake8."
     exit 0
+elif [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+    echo "Skipping Python linting since your bash version is less than 4."
+    exit 0
 fi
 
 EXIT_CODE=0

--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -18,6 +18,9 @@ EXIT_CODE=0
 if ! command -v shellcheck > /dev/null; then
     echo "Skipping shell linting since shellcheck is not installed."
     exit $EXIT_CODE
+elif [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+    echo "Skipping shell linting since your bash version is less than 4."
+    exit $EXIT_CODE
 fi
 
 SHELLCHECK_CMD=(shellcheck --external-sources --check-sourced --source-path=SCRIPTDIR)

--- a/test/lint/lint-spelling.sh
+++ b/test/lint/lint-spelling.sh
@@ -12,6 +12,9 @@ export LC_ALL=C
 if ! command -v codespell > /dev/null; then
     echo "Skipping spell check linting since codespell is not installed."
     exit 0
+elif [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+    echo "Skipping spell check linting since your bash version is less than 4."
+    exit 0
 fi
 
 IGNORE_WORDS_FILE=test/lint/lint-spelling.ignore-words.txt


### PR DESCRIPTION
This issue has already been the topic of #24610.

macOS, sadly, does not ship with a bash version that is compatible with all lint tests since they now include the usage of `mapfile`. `mapfile` was introduced in `bash` 4.0 but macOS still uses 3.x because the newer version changed their license from GPL2 to GPL3. macOS has changed the default shell to `zsh` but that doesn't help since bash 3.x is still installed and will be used due to the shebang. Also, `zsh` does not have `mapfile` the same way `bash` has. Confusingly, the `zsh` version of the command does something completely different than the `bash` version.

Including guard code was rejected in #24610 and I guess this is probably reasonable since only a hand full of developers will ever run into this. But I think it should still be mentioned in the docs.