### PR TITLE
refactor: Remove ParseHex(const char*) from public interface

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -114,7 +114,7 @@ static const unsigned char ParseHex_expected[65] = {
     0xde, 0x5c, 0x38, 0x4d, 0xf7, 0xba, 0x0b, 0x8d, 0x57, 0x8a, 0x4c, 0x70, 0x2b, 0x6b, 0xf1, 0x1d,
     0x5f
 };
-BOOST_AUTO_TEST_CASE(util_ParseHex)
+BOOST_AUTO_TEST_CASE(parse_hex)
 {
     std::vector<unsigned char> result;
     std::vector<unsigned char> expected(ParseHex_expected, ParseHex_expected + sizeof(ParseHex_expected));
@@ -129,6 +129,14 @@ BOOST_AUTO_TEST_CASE(util_ParseHex)
     // Leading space must be supported (used in BerkeleyEnvironment::Salvage)
     result = ParseHex(" 89 34 56 78");
     BOOST_CHECK(result.size() == 4 && result[0] == 0x89 && result[1] == 0x34 && result[2] == 0x56 && result[3] == 0x78);
+
+    // Embedded null is treated as end
+    const std::string with_embedded_null{" 11 "s
+                                         " \0 "
+                                         " 22 "s};
+    BOOST_CHECK_EQUAL(with_embedded_null.size(), 11);
+    result = ParseHex(with_embedded_null);
+    BOOST_CHECK(result.size() == 1 && result[0] == 0x11);
 
     // Stop parsing at invalid value
     result = ParseHex("1234 invalid 1234");

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -81,8 +81,9 @@ bool IsHexNumber(const std::string& str)
     return (str.size() > starting_location);
 }
 
-std::vector<unsigned char> ParseHex(const char* psz)
+std::vector<unsigned char> ParseHex(const std::string& str)
 {
+    const char* psz{str.c_str()};
     std::vector<unsigned char> vch;
     while (true) {
         while (IsSpace(*psz)) {
@@ -101,11 +102,6 @@ std::vector<unsigned char> ParseHex(const char* psz)
         vch.push_back(n);
     }
     return vch;
-}
-
-std::vector<unsigned char> ParseHex(const std::string& str)
-{
-    return ParseHex(str.c_str());
 }
 
 void SplitHostPort(std::string in, uint16_t& portOut, std::string& hostOut)

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -83,19 +83,20 @@ bool IsHexNumber(const std::string& str)
 
 std::vector<unsigned char> ParseHex(const char* psz)
 {
-    // convert hex dump to vector
     std::vector<unsigned char> vch;
-    while (true)
-    {
-        while (IsSpace(*psz))
+    while (true) {
+        while (IsSpace(*psz)) {
             psz++;
+        }
         signed char c = HexDigit(*psz++);
-        if (c == (signed char)-1)
+        if (c == (signed char)-1) {
             break;
+        }
         auto n{uint8_t(c << 4)};
         c = HexDigit(*psz++);
-        if (c == (signed char)-1)
+        if (c == (signed char)-1) {
             break;
+        }
         n |= c;
         vch.push_back(n);
     }

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -54,7 +54,7 @@ enum class ByteUnit : uint64_t {
 * @return           A new string without unsafe chars
 */
 std::string SanitizeString(const std::string& str, int rule = SAFE_CHARS_DEFAULT);
-std::vector<unsigned char> ParseHex(const char* psz);
+/** Parse the hex string into bytes. Ignores whitespace. */
 std::vector<unsigned char> ParseHex(const std::string& str);
 signed char HexDigit(char c);
 /* Returns true if each character in str is a hex character, and has an even


### PR DESCRIPTION
This is a refactor (with added test), needed for:

* https://github.com/bitcoin/bitcoin/pull/23595
* https://github.com/bitcoin/bitcoin/pull/18061
* Some bugfixes I am working on, but are blocked on this