### PR TITLE
build: specify cmake build dir for multiprocess depends build

### DIFF
--- a/depends/packages/libmultiprocess.mk
+++ b/depends/packages/libmultiprocess.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=$(native_$(package)_sha256_hash)
 $(package)_dependencies=native_$(package) capnp
 
 define $(package)_config_cmds
-  $($(package)_cmake)
+  $($(package)_cmake) .
 endef
 
 define $(package)_build_cmds

--- a/depends/packages/native_libmultiprocess.mk
+++ b/depends/packages/native_libmultiprocess.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=9f8b055c8bba755dc32fe799b67c20b91e7b13e67cadafbc54c0f1def
 $(package)_dependencies=native_capnp
 
 define $(package)_config_cmds
-  $($(package)_cmake)
+  $($(package)_cmake) .
 endef
 
 define $(package)_build_cmds


### PR DESCRIPTION
When no build dir is specified, cmake will warn:
```bash
Preprocessing libmultiprocess...
Configuring libmultiprocess...
CMake Warning:
  No source or binary directory provided.  Both will be assumed to be the
  same as the current working directory, but note that this warning will
  become a fatal error in future CMake releases.
```

It's unclear if this will actually ever become an error, but it's also easy
enough to just supply the directory, and save this maybe breaking in
future.