### PR TITLE
Disable the syscall sandbox for bitcoin-qt and remove gui-related syscalls 

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -792,7 +792,7 @@ bool AppInitBasicSetup(const ArgsManager& args)
     return true;
 }
 
-bool AppInitParameterInteraction(const ArgsManager& args)
+bool AppInitParameterInteraction(const ArgsManager& args, bool use_syscall_sandbox)
 {
     const CChainParams& chainparams = Params();
     // ********************************************************* Step 2: parameter interactions
@@ -1057,6 +1057,9 @@ bool AppInitParameterInteraction(const ArgsManager& args)
         }
         if (!SetupSyscallSandbox(log_syscall_violation_before_terminating)) {
             return InitError(Untranslated("Installation of the syscall sandbox failed."));
+        }
+        if (use_syscall_sandbox) {
+            SetSyscallSandboxPolicy(SyscallSandboxPolicy::INITIALIZATION);
         }
         LogPrintf("Experimental syscall sandbox enabled (-sandbox=%s): bitcoind will terminate if an unexpected (not allowlisted) syscall is invoked.\n", sandbox_arg);
     }

--- a/src/init.h
+++ b/src/init.h
@@ -41,7 +41,7 @@ bool AppInitBasicSetup(const ArgsManager& args);
  * @note This can be done before daemonization. Do not call Shutdown() if this function fails.
  * @pre Parameters should be parsed and config file should be read, AppInitBasicSetup should have been called.
  */
-bool AppInitParameterInteraction(const ArgsManager& args);
+bool AppInitParameterInteraction(const ArgsManager& args, bool use_syscall_sandbox = true);
 /**
  * Initialization sanity checks: ecc init, sanity checks, dir lock.
  * @note This can be done before daemonization. Do not call Shutdown() if this function fails.

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -90,7 +90,7 @@ public:
     uint32_t getLogCategories() override { return LogInstance().GetCategoryMask(); }
     bool baseInitialize() override
     {
-        return AppInitBasicSetup(gArgs) && AppInitParameterInteraction(gArgs) && AppInitSanityChecks() &&
+        return AppInitBasicSetup(gArgs) && AppInitParameterInteraction(gArgs, /*use_syscall_sandbox=*/false) && AppInitSanityChecks() &&
                AppInitLockDataDirectory() && AppInitInterfaces(*m_context);
     }
     bool appInitMain(interfaces::BlockAndHeaderTipInfo* tip_info) override

--- a/src/util/syscall_sandbox.cpp
+++ b/src/util/syscall_sandbox.cpp
@@ -823,7 +823,6 @@ bool SetupSyscallSandbox(bool log_syscall_violation_before_terminating)
             return false;
         }
     }
-    SetSyscallSandboxPolicy(SyscallSandboxPolicy::INITIALIZATION);
     return true;
 }
 

--- a/src/util/syscall_sandbox.cpp
+++ b/src/util/syscall_sandbox.cpp
@@ -592,8 +592,6 @@ public:
         allowed_syscalls.insert(__NR_getcwd);          // get current working directory
         allowed_syscalls.insert(__NR_getdents);        // get directory entries
         allowed_syscalls.insert(__NR_getdents64);      // get directory entries
-        allowed_syscalls.insert(__NR_inotify_rm_watch);// remove an existing watch from an inotify instance
-        allowed_syscalls.insert(__NR_linkat);          // create relative to a directory file descriptor
         allowed_syscalls.insert(__NR_lstat);           // get file status
         allowed_syscalls.insert(__NR_mkdir);           // create a directory
         allowed_syscalls.insert(__NR_newfstatat);      // get file status

--- a/src/util/syscall_sandbox.h
+++ b/src/util/syscall_sandbox.h
@@ -45,9 +45,6 @@ void SetSyscallSandboxPolicy(SyscallSandboxPolicy syscall_policy);
 
 #if defined(USE_SYSCALL_SANDBOX)
 //! Setup and enable the experimental syscall sandbox for the running process.
-//!
-//! SetSyscallSandboxPolicy(SyscallSandboxPolicy::INITIALIZATION) is called as part of
-//! SetupSyscallSandbox(...).
 [[nodiscard]] bool SetupSyscallSandbox(bool log_syscall_violation_before_terminating);
 
 //! Invoke a disallowed syscall. Use for testing purposes.


### PR DESCRIPTION
It is basically impossible (and a bit out of scope) for us to maintain a sandbox for the qt library. I am not sure if it is possible to only sandbox a few threads in a process, but I doubt this will add no practical benefit anyway, so I am disabling the sandbox for the whole bitcoin-qt process.

See also https://github.com/bitcoin/bitcoin/pull/24690#issuecomment-1084372400