### PR TITLE
configure.ac: disable FORTIFY_SOURCE for asan/msan/tsan

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -939,12 +939,24 @@ if test "$use_hardening" != "no"; then
   dnl When enable_debug is yes, all optimizations are disabled.
   dnl However, FORTIFY_SOURCE requires that there is some level of optimization, otherwise it does nothing and just creates a compiler warning.
   dnl Since FORTIFY_SOURCE is a no-op without optimizations, do not enable it when enable_debug is yes.
+  dnl FORTIFY_SOURCE is also disabled for msan/asan/tsan builds since they do not work well together.
   if test "$enable_debug" != "yes"; then
     AX_CHECK_PREPROC_FLAG([-D_FORTIFY_SOURCE=2],[
       AX_CHECK_PREPROC_FLAG([-U_FORTIFY_SOURCE],[
         HARDENED_CPPFLAGS="$HARDENED_CPPFLAGS -U_FORTIFY_SOURCE"
       ])
-      HARDENED_CPPFLAGS="$HARDENED_CPPFLAGS -D_FORTIFY_SOURCE=2"
+
+      case $use_sanitizers in
+        *memory*)
+          ;;
+        *address*)
+          ;;
+        *thread*)
+          ;;
+        *)
+          HARDENED_CPPFLAGS="$HARDENED_CPPFLAGS -D_FORTIFY_SOURCE=2"
+          ;;
+      esac
     ])
   fi
 


### PR DESCRIPTION
This can cause trouble with these specific sanitizers according to https://github.com/google/sanitizers/issues/247#issuecomment-242238980 . The MSAN CI build already disables hardening, as there can be false positives there due to lack of instrumentation on the fortified functions (e.g. __memcpy_chk), but there's no reason the other hardening checks (stack-smashing protection, and more) can't be enabled if this is the culprit.  Also affects ASAN and TSAN, though I do not know how as I only encountered a problem with MSAN. This patch will disable source fortification when `--with-sanitizers` is used with these sanitizers, but if `-fsanitize` is used instead, then this patch will be bypassed.