### PR TITLE
refactor: Use [[maybe_unused]] attribute

### DIFF
--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -586,13 +586,9 @@ std::string SHA256AutoDetect()
     bool have_sse4 = false;
     bool have_xsave = false;
     bool have_avx = false;
-    bool have_avx2 = false;
-    bool have_x86_shani = false;
-    bool enabled_avx = false;
-
-    (void)have_avx2;
-    (void)have_x86_shani;
-    (void)enabled_avx;
+    [[maybe_unused]] bool have_avx2 = false;
+    [[maybe_unused]] bool have_x86_shani = false;
+    [[maybe_unused]] bool enabled_avx = false;
 
     uint32_t eax, ebx, ecx, edx;
     GetCPUID(1, 0, eax, ebx, ecx, edx);

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -590,10 +590,6 @@ std::string SHA256AutoDetect()
     bool have_x86_shani = false;
     bool enabled_avx = false;
 
-    (void)AVXEnabled;
-    (void)have_sse4;
-    (void)have_avx;
-    (void)have_xsave;
     (void)have_avx2;
     (void)have_x86_shani;
     (void)enabled_avx;
@@ -641,7 +637,7 @@ std::string SHA256AutoDetect()
         ret += ",avx2(8way)";
     }
 #endif
-#endif
+#endif // defined(USE_ASM) && defined(HAVE_GETCPUID)
 
 #if defined(ENABLE_ARM_SHANI) && !defined(BUILD_BITCOIN_INTERNAL)
     bool have_arm_shani = false;


### PR DESCRIPTION
This change is required for bitcoin/bitcoin#24773 as it prevents MSVC yelling about "warning C4551: function call missing argument list".

But it is useful by itself as it makes code more concise and readable.