### PR TITLE
Enable HW-accelerated implementations of SHA256 for MSVC builds

### DIFF
--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -149,7 +149,7 @@ include(CheckSourceCompilesWithFlags)
 
 # Check for SSE4.1 intrinsics.
 if(MSVC)
-  set(AVX2_CXXFLAGS /arch:SSE4.2)
+  set(SSE41_CXXFLAGS "")
 else()
   set(SSE41_CXXFLAGS -msse4.1)
 endif()
@@ -169,7 +169,7 @@ check_cxx_source_compiles_with_flags("
 
 # Check for AVX2 intrinsics.
 if(MSVC)
-  set(AVX2_CXXFLAGS /arch:AVX2)
+  set(AVX2_CXXFLAGS "")
 else()
   set(AVX2_CXXFLAGS -mavx -mavx2)
 endif()
@@ -185,37 +185,43 @@ check_cxx_source_compiles_with_flags("
   CXXFLAGS ${AVX2_CXXFLAGS}
 )
 
-if(NOT MSVC)
-  # Check for x86 SHA-NI intrinsics.
+# Check for x86 SHA-NI intrinsics.
+if(MSVC)
+  set(X86_SHANI_CXXFLAGS "")
+else()
   set(X86_SHANI_CXXFLAGS -msse4 -msha)
-  check_cxx_source_compiles_with_flags("
-    #include <immintrin.h>
-
-    int main()
-    {
-      __m128i i = _mm_set1_epi32(0);
-      __m128i j = _mm_set1_epi32(1);
-      __m128i k = _mm_set1_epi32(2);
-      return _mm_extract_epi32(_mm_sha256rnds2_epu32(i, j, k), 0);
-    }
-    " HAVE_X86_SHANI
-    CXXFLAGS ${X86_SHANI_CXXFLAGS}
-  )
-
-  # Check for ARMv8 SHA-NI intrinsics.
-  set(ARM_SHANI_CXXFLAGS -march=armv8-a+crypto)
-  check_cxx_source_compiles_with_flags("
-    #include <arm_neon.h>
-
-    int main()
-    {
-      uint32x4_t a, b, c;
-      vsha256h2q_u32(a, b, c);
-      vsha256hq_u32(a, b, c);
-      vsha256su0q_u32(a, b);
-      vsha256su1q_u32(a, b, c);
-    }
-    " HAVE_ARM_SHANI
-    CXXFLAGS ${ARM_SHANI_CXXFLAGS}
-  )
 endif()
+check_cxx_source_compiles_with_flags("
+  #include <immintrin.h>
+
+  int main()
+  {
+    __m128i i = _mm_set1_epi32(0);
+    __m128i j = _mm_set1_epi32(1);
+    __m128i k = _mm_set1_epi32(2);
+    return _mm_extract_epi32(_mm_sha256rnds2_epu32(i, j, k), 0);
+  }
+  " HAVE_X86_SHANI
+  CXXFLAGS ${X86_SHANI_CXXFLAGS}
+)
+
+# Check for ARMv8 SHA-NI intrinsics.
+if(MSVC)
+  set(ARM_SHANI_CXXFLAGS "")
+else()
+  set(ARM_SHANI_CXXFLAGS -march=armv8-a+crypto)
+endif()
+check_cxx_source_compiles_with_flags("
+  #include <arm_neon.h>
+
+  int main()
+  {
+    uint32x4_t a, b, c;
+    vsha256h2q_u32(a, b, c);
+    vsha256hq_u32(a, b, c);
+    vsha256su0q_u32(a, b);
+    vsha256su1q_u32(a, b, c);
+  }
+  " HAVE_ARM_SHANI
+  CXXFLAGS ${ARM_SHANI_CXXFLAGS}
+)

--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -145,25 +145,29 @@ check_cxx_source_compiles("
   " HAVE_SYSCTL_ARND
 )
 
-if(NOT MSVC)
-  include(CheckSourceCompilesWithFlags)
+include(CheckSourceCompilesWithFlags)
 
-  # Check for SSE4.1 intrinsics.
+# Check for SSE4.1 intrinsics.
+if(MSVC)
+  set(AVX2_CXXFLAGS /arch:SSE4.2)
+else()
   set(SSE41_CXXFLAGS -msse4.1)
-  check_cxx_source_compiles_with_flags("
-    #include <immintrin.h>
+endif()
+check_cxx_source_compiles_with_flags("
+  #include <immintrin.h>
 
-    int main()
-    {
-      __m128i a = _mm_set1_epi32(0);
-      __m128i b = _mm_set1_epi32(1);
-      __m128i r = _mm_blend_epi16(a, b, 0xFF);
-      return _mm_extract_epi32(r, 3);
-    }
-    " HAVE_SSE41
-    CXXFLAGS ${SSE41_CXXFLAGS}
-  )
+  int main()
+  {
+    __m128i a = _mm_set1_epi32(0);
+    __m128i b = _mm_set1_epi32(1);
+    __m128i r = _mm_blend_epi16(a, b, 0xFF);
+    return _mm_extract_epi32(r, 3);
+  }
+  " HAVE_SSE41
+  CXXFLAGS ${SSE41_CXXFLAGS}
+)
 
+if(NOT MSVC)
   # Check for AVX2 intrinsics.
   set(AVX2_CXXFLAGS -mavx -mavx2)
   check_cxx_source_compiles_with_flags("

--- a/cmake/introspection.cmake
+++ b/cmake/introspection.cmake
@@ -167,21 +167,25 @@ check_cxx_source_compiles_with_flags("
   CXXFLAGS ${SSE41_CXXFLAGS}
 )
 
-if(NOT MSVC)
-  # Check for AVX2 intrinsics.
+# Check for AVX2 intrinsics.
+if(MSVC)
+  set(AVX2_CXXFLAGS /arch:AVX2)
+else()
   set(AVX2_CXXFLAGS -mavx -mavx2)
-  check_cxx_source_compiles_with_flags("
-    #include <immintrin.h>
+endif()
+check_cxx_source_compiles_with_flags("
+  #include <immintrin.h>
 
-    int main()
-    {
-      __m256i l = _mm256_set1_epi32(0);
-      return _mm256_extract_epi32(l, 7);
-    }
-    " HAVE_AVX2
-    CXXFLAGS ${AVX2_CXXFLAGS}
-  )
+  int main()
+  {
+    __m256i l = _mm256_set1_epi32(0);
+    return _mm256_extract_epi32(l, 7);
+  }
+  " HAVE_AVX2
+  CXXFLAGS ${AVX2_CXXFLAGS}
+)
 
+if(NOT MSVC)
   # Check for x86 SHA-NI intrinsics.
   set(X86_SHANI_CXXFLAGS -msse4 -msha)
   check_cxx_source_compiles_with_flags("

--- a/src/compat/cpuid.h
+++ b/src/compat/cpuid.h
@@ -23,4 +23,22 @@ void static inline GetCPUID(uint32_t leaf, uint32_t subleaf, uint32_t& a, uint32
 }
 
 #endif // defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
+
+#if defined(_MSC_VER) && defined(_M_X64)
+#define HAVE_GETCPUID
+
+#include <intrin.h>
+
+void static inline GetCPUID(uint32_t leaf, uint32_t subleaf, uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d)
+{
+    int regs[4];
+    __cpuidex(regs, leaf, subleaf);
+    a = regs[0];
+    b = regs[1];
+    c = regs[2];
+    d = regs[3];
+}
+
+#endif  // defined(_MSC_VER) && defined(_M_X64)
+
 #endif // BITCOIN_COMPAT_CPUID_H

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -578,6 +578,15 @@ bool AVXEnabled()
     return (a & 6) == 6;
 }
 #endif
+
+#if defined(_MSC_VER) && defined(_M_X64)
+#include <intrin.h>
+bool AVXEnabled()
+{
+    auto a = _xgetbv(_XCR_XFEATURE_ENABLED_MASK);
+    return (a & 6) == 6;
+}
+#endif  // defined(_MSC_VER) && defined(_M_X64)
 #endif // DISABLE_OPTIMIZED_SHA256
 } // namespace
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -77,7 +77,7 @@ inline int64_t GetPerformanceCounter() noexcept
 #endif
 }
 
-#ifdef HAVE_GETCPUID
+#if defined(HAVE_GETCPUID) && !defined(_MSC_VER)
 bool g_rdrand_supported = false;
 bool g_rdseed_supported = false;
 constexpr uint32_t CPUID_F1_ECX_RDRAND = 0x40000000;


### PR DESCRIPTION
This PR enables AVX2, SSE4.1 and x86 SHA-NI hardware-accelerated implementations of SHA256 to replace the "standard" default implementation when building on Windows.

**Testing Note:** At runtime, the SHA-NI implementation is dynamically selected and available only if the CPU has the `sha_ni` flag set.

Here are the benchmark results on my machine using "Release" binaries:

- the master branch @ 47da4f9b716d11294d4fb0f30b04a7bcf128cc14:
```
> build\bin\Release\bench_bitcoin.exe -filter="SHA256.*_SHANI"

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               11.35 |       88,074,183.58 |    0.3% |      0.01 | `SHA256D64_1024_SHANI using the 'standard' SHA256 implementation`
|               13.07 |       76,522,397.95 |    0.4% |      0.01 | `SHA256_32b_SHANI using the 'standard' SHA256 implementation`
|                4.26 |      234,554,580.85 |    0.9% |      0.05 | `SHA256_SHANI using the 'standard' SHA256 implementation`

> build\bin\Release\bench_bitcoin.exe -filter="SHA256D64_1024.*"

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               11.29 |       88,586,104.35 |    0.3% |      0.01 | `SHA256D64_1024_AVX2 using the 'standard' SHA256 implementation`
|               11.36 |       88,062,348.83 |    0.9% |      0.01 | `SHA256D64_1024_SHANI using the 'standard' SHA256 implementation`
|               11.33 |       88,275,862.07 |    0.9% |      0.01 | `SHA256D64_1024_SSE4 using the 'standard' SHA256 implementation`
|               11.33 |       88,263,973.06 |    0.8% |      0.01 | `SHA256D64_1024_STANDARD using the 'standard' SHA256 implementation`
```

- this PR:

```
> build\bin\Release\bench_bitcoin.exe -filter="SHA256.*_SHANI"

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                1.27 |      790,145,684.72 |    0.5% |      0.01 | `SHA256D64_1024_SHANI using the 'x86_shani(1way;2way)' SHA256 implementation`
|                1.97 |      508,638,668.32 |    0.8% |      0.01 | `SHA256_32b_SHANI using the 'x86_shani(1way;2way)' SHA256 implementation`
|                0.63 |    1,587,301,587.30 |    0.5% |      0.01 | `SHA256_SHANI using the 'x86_shani(1way;2way)' SHA256 implementation`

> build\bin\Release\bench_bitcoin.exe -filter="SHA256D64_1024.*"

|             ns/byte |              byte/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|                4.02 |      248,878,761.99 |    0.3% |      0.01 | `SHA256D64_1024_AVX2 using the 'standard;sse41(4way);avx2(8way)' SHA256 implementation`
|                1.27 |      787,950,595.69 |    0.8% |      0.01 | `SHA256D64_1024_SHANI using the 'x86_shani(1way;2way)' SHA256 implementation`
|                7.00 |      142,826,631.80 |    0.8% |      0.01 | `SHA256D64_1024_SSE4 using the 'standard;sse41(4way)' SHA256 implementation`
|               11.23 |       89,055,578.20 |    1.0% |      0.01 | `SHA256D64_1024_STANDARD using the 'standard' SHA256 implementation`
```