### PR TITLE
build: Do not modify `common.init.vcxproj` directly

### DIFF
--- a/build_msvc/.gitignore
+++ b/build_msvc/.gitignore
@@ -22,6 +22,7 @@ bench_bitcoin/bench_bitcoin.vcxproj
 libtest_util/libtest_util.vcxproj
 
 /bitcoin_config.h
+/common.init.vcxproj
 
 */Win32
 libbitcoin_qt/QtGeneratedFiles/*

--- a/build_msvc/common.init.vcxproj.in
+++ b/build_msvc/common.init.vcxproj.in
@@ -39,7 +39,7 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <LinkIncremental>false</LinkIncremental>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>@TOOLSET@</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <GenerateManifest>No</GenerateManifest>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
@@ -49,7 +49,7 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <LinkIncremental>true</LinkIncremental>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>@TOOLSET@</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>

--- a/build_msvc/msvc-autogen.py
+++ b/build_msvc/msvc-autogen.py
@@ -50,13 +50,6 @@ def parse_makefile(makefile):
                     lib_sources[current_lib] = []
                     break
 
-def set_common_properties(toolset):
-    with open(os.path.join(SOURCE_DIR, '../build_msvc/common.init.vcxproj'), 'r', encoding='utf-8') as rfile:
-        s = rfile.read()
-        s = re.sub('<PlatformToolset>.*?</PlatformToolset>', '<PlatformToolset>'+toolset+'</PlatformToolset>', s)
-    with open(os.path.join(SOURCE_DIR, '../build_msvc/common.init.vcxproj'), 'w', encoding='utf-8',newline='\n') as wfile:
-        wfile.write(s)
-
 def parse_config_into_btc_config():
     def find_between( s, first, last ):
         try:
@@ -99,11 +92,11 @@ def set_properties(vcxproj_filename, placeholder, content):
 
 def main():
     parser = argparse.ArgumentParser(description='Bitcoin-core msbuild configuration initialiser.')
-    parser.add_argument('-toolset', nargs='?',help='Optionally sets the msbuild platform toolset, e.g. v142 for Visual Studio 2019.'
+    parser.add_argument('-toolset', nargs='?', default=DEFAULT_PLATFORM_TOOLSET,
+        help='Optionally sets the msbuild platform toolset, e.g. v142 for Visual Studio 2019.'
          ' default is %s.'%DEFAULT_PLATFORM_TOOLSET)
     args = parser.parse_args()
-    if args.toolset:
-        set_common_properties(args.toolset)
+    set_properties(os.path.join(SOURCE_DIR, '../build_msvc/common.init.vcxproj'), '@TOOLSET@', args.toolset)
 
     for makefile_name in os.listdir(SOURCE_DIR):
         if 'Makefile' in makefile_name:
@@ -115,7 +108,7 @@ def main():
             content += '    <ClCompile Include="..\\..\\src\\' + source_filename + '">\n'
             content += '      <ObjectFileName>$(IntDir)' + object_filename + '</ObjectFileName>\n'
             content += '    </ClCompile>\n'
-        set_properties(vcxproj_filename, '@SOURCE_FILES@\n', content):
+        set_properties(vcxproj_filename, '@SOURCE_FILES@\n', content)
     parse_config_into_btc_config()
     copyfile(os.path.join(SOURCE_DIR,'../build_msvc/bitcoin_config.h'), os.path.join(SOURCE_DIR, 'config/bitcoin-config.h'))
     copyfile(os.path.join(SOURCE_DIR,'../build_msvc/libsecp256k1_config.h'), os.path.join(SOURCE_DIR, 'secp256k1/src/libsecp256k1-config.h'))

--- a/build_msvc/msvc-autogen.py
+++ b/build_msvc/msvc-autogen.py
@@ -92,6 +92,11 @@ def parse_config_into_btc_config():
     with open(os.path.join(SOURCE_DIR,'../build_msvc/bitcoin_config.h'), "w", encoding="utf8") as btc_config:
         btc_config.writelines(template)
 
+def set_properties(vcxproj_filename, placeholder, content):
+    with open(vcxproj_filename + '.in', 'r', encoding='utf-8') as vcxproj_in_file:
+        with open(vcxproj_filename, 'w', encoding='utf-8') as vcxproj_file:
+            vcxproj_file.write(vcxproj_in_file.read().replace(placeholder, content))
+
 def main():
     parser = argparse.ArgumentParser(description='Bitcoin-core msbuild configuration initialiser.')
     parser.add_argument('-toolset', nargs='?',help='Optionally sets the msbuild platform toolset, e.g. v142 for Visual Studio 2019.'
@@ -110,10 +115,7 @@ def main():
             content += '    <ClCompile Include="..\\..\\src\\' + source_filename + '">\n'
             content += '      <ObjectFileName>$(IntDir)' + object_filename + '</ObjectFileName>\n'
             content += '    </ClCompile>\n'
-        with open(vcxproj_filename + '.in', 'r', encoding='utf-8') as vcxproj_in_file:
-            with open(vcxproj_filename, 'w', encoding='utf-8') as vcxproj_file:
-                vcxproj_file.write(vcxproj_in_file.read().replace(
-                    '@SOURCE_FILES@\n', content))
+        set_properties(vcxproj_filename, '@SOURCE_FILES@\n', content):
     parse_config_into_btc_config()
     copyfile(os.path.join(SOURCE_DIR,'../build_msvc/bitcoin_config.h'), os.path.join(SOURCE_DIR, 'config/bitcoin-config.h'))
     copyfile(os.path.join(SOURCE_DIR,'../build_msvc/libsecp256k1_config.h'), os.path.join(SOURCE_DIR, 'secp256k1/src/libsecp256k1-config.h'))


### PR DESCRIPTION
When building with MSVC, and using a non-default toolset, the following command
```
>python build_msvc\msvc-autogen.py -toolset v143
```
actually modifies the source tree:
```diff
>git diff
warning: LF will be replaced by CRLF in build_msvc/common.init.vcxproj.
The file will have its original line endings in your working directory
diff --git a/build_msvc/common.init.vcxproj b/build_msvc/common.init.vcxproj
index 0cbe2effd..44b7efff3 100644
--- a/build_msvc/common.init.vcxproj
+++ b/build_msvc/common.init.vcxproj
@@ -39,7 +39,7 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <LinkIncremental>false</LinkIncremental>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <GenerateManifest>No</GenerateManifest>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
@@ -49,7 +49,7 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <LinkIncremental>true</LinkIncremental>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>

```

This PR fixes this bug.