### PR TITLE
refactor: Get rid of `boost/algorithm/string.hpp`

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -31,7 +31,8 @@
 #include <memory>
 #include <stdio.h>
 
-#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
 
 static bool fCreateBlank;
 static std::map<std::string,UniValue> registers;

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -23,7 +23,8 @@
 #include <set>
 #include <string>
 
-#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
 
 /** WWW-Authenticate to present with 401 Unauthorized response */
 static const char* WWW_AUTH_HEADER_DATA = "Basic realm=\"jsonrpc\"";

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -32,7 +32,8 @@
 #include <any>
 #include <string>
 
-#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
 
 #include <univalue.h>
 

--- a/src/test/fuzz/script_assets_test_minimizer.cpp
+++ b/src/test/fuzz/script_assets_test_minimizer.cpp
@@ -12,7 +12,9 @@
 #include <univalue.h>
 #include <util/strencodings.h>
 
-#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/split.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_FIXTURE_TEST_SUITE(getarg_tests, BasicTestingSetup)

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -14,7 +14,8 @@
 
 #include <any>
 
-#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <univalue.h>

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -26,7 +26,8 @@
 #include <tuple>
 #include <string>
 
-#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
 
 #include <univalue.h>
 

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -49,7 +49,6 @@ if [[ ${INCLUDED_CPP_FILES} != "" ]]; then
 fi
 
 EXPECTED_BOOST_INCLUDES=(
-    boost/algorithm/string.hpp
     boost/algorithm/string/classification.hpp
     boost/algorithm/string/replace.hpp
     boost/algorithm/string/split.hpp


### PR DESCRIPTION
This PR replaces the `boost/algorithm/string.hpp` header with more granular ones which are already used in the codebase.

Such granulation, for example, guarantees that the `boost/algorithm/string/trim.hpp` header is not included indirectly, which in turn allows to remove `boost::algorithm::trim*` calls from the `test/lint/lint-locale-dependence.sh` linter.