### PR TITLE
doc: Add gpg key import instructions for Windows

### DIFF
--- a/contrib/builder-keys/README.md
+++ b/contrib/builder-keys/README.md
@@ -19,8 +19,14 @@ gpg --refresh-keys
 To fetch keys of builders and active developers, feed the list of fingerprints
 of the primary keys into gpg:
 
+On \*NIX:
 ```sh
 while read fingerprint keyholder_name; do gpg --keyserver hkps://keys.openpgp.org --recv-keys ${fingerprint}; done < ./keys.txt
+```
+
+On Windows (requires Gpg4win >= 4.0.0):
+```
+FOR /F "tokens=1" %i IN (keys.txt) DO gpg --keyserver hkps://keys.openpgp.org --recv-keys %i
 ```
 
 Add your key to the list if you provided Guix attestations for two major or


### PR DESCRIPTION
This is a single commit to replace the three commits from #23916 

I propose this change so that Windows users can more easily import signers' keys.