### PR TITLE
doc: update RPC argument and field naming guideline in developer notes

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -1220,7 +1220,10 @@ A few guidelines for introducing and reviewing new RPC interfaces:
 
   - *Rationale*: Consistency with the existing interface.
 
-- Argument naming: use snake case `fee_delta` (and not, e.g. camel case `feeDelta`)
+- Argument and field naming: please consider whether there is already a naming
+  style or spelling convention in the API for the type of object in question
+  (`blockhash`, for example), and if so, try to use that. If not, use snake case
+  `fee_delta` (and not, e.g. `feedelta` or camel case `feeDelta`).
 
   - *Rationale*: Consistency with the existing interface.
 


### PR DESCRIPTION
Clarify the doc per the IRC discussion today at https://www.erisian.com.au/bitcoin-core-dev/log-2022-04-08.html#l-229.
