### PR TITLE
build: Getting ready to Qt 6 (4/n). Improve `build-aux/m4/bitcoin_qt.m4`

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -364,6 +364,36 @@ AC_DEFUN([_BITCOIN_QT_CHECK_STATIC_LIBS], [
   fi
 ])
 
+dnl Internal. Check whether Qt application can be initialized.
+dnl
+dnl _BITCOIN_QT_CHECK_APP(APPLICATION_CLASS)
+dnl ----------------------------------------
+dnl
+dnl dnl Requires: QT_INCLUDES and QT_LIBS must be populated as necessary.
+dnl Inputs: $1: QCoreApplication, QGuiApplication, or QApplication.
+AC_DEFUN([_BITCOIN_QT_CHECK_APP], [
+  AC_MSG_CHECKING([for $1 initialization])
+  TEMP_CPPFLAGS="$CPPFLAGS"
+  TEMP_CXXFLAGS="$CXXFLAGS"
+  TEMP_LIBS="$LIBS"
+  CPPFLAGS="$QT_INCLUDES $CORE_CPPFLAGS $CPPFLAGS"
+  CXXFLAGS="$QT_PIE_FLAGS $CORE_CXXFLAGS $CXXFLAGS"
+  LIBS="$QT_LIBS"
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+      #include <$1>
+    ]],
+    [[
+      int argc = 1;
+      const char* argv = "core";
+      $1 app(argc, const_cast<char**>(&argv));
+    ]])],
+    [AC_MSG_RESULT([yes])],
+    [AC_MSG_RESULT([no]); BITCOIN_QT_FAIL([$1 failed to initialize])])
+  CPPFLAGS="$TEMP_CPPFLAGS"
+  CXXFLAGS="$TEMP_CXXFLAGS"
+  LIBS="$TEMP_LIBS"
+])
+
 dnl Internal. Find Qt libraries using pkg-config.
 dnl
 dnl _BITCOIN_QT_FIND_LIBS
@@ -375,14 +405,17 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS],[
   BITCOIN_QT_CHECK([
     PKG_CHECK_MODULES([QT_CORE], [${qt_lib_prefix}Core${qt_lib_suffix} $qt_version], [QT_INCLUDES="$QT_CORE_CFLAGS $QT_INCLUDES" QT_LIBS="$QT_CORE_LIBS $QT_LIBS"],
                       [BITCOIN_QT_FAIL([${qt_lib_prefix}Core${qt_lib_suffix} $qt_version not found])])
+    _BITCOIN_QT_CHECK_APP([QCoreApplication])
   ])
   BITCOIN_QT_CHECK([
     PKG_CHECK_MODULES([QT_GUI], [${qt_lib_prefix}Gui${qt_lib_suffix} $qt_version], [QT_INCLUDES="$QT_GUI_CFLAGS $QT_INCLUDES" QT_LIBS="$QT_GUI_LIBS $QT_LIBS"],
                       [BITCOIN_QT_FAIL([${qt_lib_prefix}Gui${qt_lib_suffix} $qt_version not found])])
+    _BITCOIN_QT_CHECK_APP([QGuiApplication])
   ])
   BITCOIN_QT_CHECK([
     PKG_CHECK_MODULES([QT_WIDGETS], [${qt_lib_prefix}Widgets${qt_lib_suffix} $qt_version], [QT_INCLUDES="$QT_WIDGETS_CFLAGS $QT_INCLUDES" QT_LIBS="$QT_WIDGETS_LIBS $QT_LIBS"],
                       [BITCOIN_QT_FAIL([${qt_lib_prefix}Widgets${qt_lib_suffix} $qt_version not found])])
+    _BITCOIN_QT_CHECK_APP([QApplication])
   ])
   BITCOIN_QT_CHECK([
     PKG_CHECK_MODULES([QT_NETWORK], [${qt_lib_prefix}Network${qt_lib_suffix} $qt_version], [QT_INCLUDES="$QT_NETWORK_CFLAGS $QT_INCLUDES" QT_LIBS="$QT_NETWORK_LIBS $QT_LIBS"],

--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -313,12 +313,12 @@ AC_DEFUN([_BITCOIN_QT_IS_STATIC],[
 
 dnl Internal. Check if the link-requirements for a static plugin are met.
 dnl
-dnl _BITCOIN_QT_CHECK_STATIC_PLUGIN(PLUGIN, LIBRARIES)
-dnl --------------------------------------------------
+dnl _BITCOIN_QT_CHECK_STATIC_PLUGIN(PLUGIN_NAME, PLUGIN_LIBRARY)
+dnl ------------------------------------------------------------
 dnl
 dnl Requires: INCLUDES and LIBS must be populated as necessary.
 dnl Inputs: $1: A static plugin name.
-dnl Inputs: $2: The libraries that resolve $1.
+dnl Inputs: $2: The library that resolves $1.
 dnl Output: QT_LIBS is prepended or configure exits.
 AC_DEFUN([_BITCOIN_QT_CHECK_STATIC_PLUGIN], [
   AC_MSG_CHECKING([for $1 ($2)])
@@ -329,7 +329,7 @@ AC_DEFUN([_BITCOIN_QT_CHECK_STATIC_PLUGIN], [
       Q_IMPORT_PLUGIN($1)
     ]])],
     [AC_MSG_RESULT([yes]); QT_LIBS="$2${qt_lib_suffix} $QT_LIBS"],
-    [AC_MSG_RESULT([no]); BITCOIN_QT_FAIL([$1 not found.])])
+    [AC_MSG_RESULT([no]); BITCOIN_QT_FAIL([$1 not found])])
   LIBS="$CHECK_STATIC_PLUGINS_TEMP_LIBS"
 ])
 

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -17,6 +17,10 @@ ac_tool_prefix="${host_alias}-"
 if test -z "$with_boost"; then
   with_boost="$depends_prefix"
 fi
+
+if test -z "$with_qt_libdir"; then
+  with_qt_libdir="${depends_prefix}/lib"
+fi
 if test -z "$with_qt_plugindir"; then
   with_qt_plugindir="${depends_prefix}/plugins"
 fi


### PR DESCRIPTION
This PR adds a test macro `_BITCOIN_QT_CHECK_APP`, which ensures that Qt resource system object (`*.rcc`) have being compiled and linked properly. Found it such checks very useful while working on bitcoin/bitcoin#24798.

Here are examples from `configure` logs:
- successful check:
```
...
checking for Qt5Core >= 5.11.3... yes
checking for QCoreApplication initialization... yes
checking for Qt5Gui >= 5.11.3... yes
checking for QGuiApplication initialization... yes
checking for Qt5Widgets >= 5.11.3... yes
checking for QApplication initialization... yes
checking for Qt5Network >= 5.11.3... yes
checking for Qt5Test >= 5.11.3... yes
checking for Qt5DBus >= 5.11.3... yes
...
```

- failed check:
```
...
checking for QCoreApplication initialization... no
configure: WARNING: QCoreApplication failed to initialize.; bitcoin-qt frontend will not be built
checking whether to build Bitcoin Core GUI... no
...
```

The fourth commit may fix build in some weird setups, but it is definitely required for Qt 6.