### PR TITLE
refactor: remove preset coins in linear time with remove-erase idiom

### DIFF
--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -490,12 +490,15 @@ std::optional<SelectionResult> SelectCoins(const CWallet& wallet, const std::vec
     }
 
     // remove preset inputs from vCoins so that Coin Selection doesn't pick them.
-    for (std::vector<COutput>::iterator it = vCoins.begin(); it != vCoins.end() && coin_control.HasSelected();)
-    {
-        if (preset_coins.count(it->outpoint))
-            it = vCoins.erase(it);
-        else
-            ++it;
+    if (coin_control.HasSelected()) {
+        std::vector<COutput>::iterator last_good = vCoins.begin();
+        for (std::vector<COutput>::iterator it = vCoins.begin(); it != vCoins.end(); ++it) {
+            if (!preset_coins.count(it->outpoint)) {
+                std::iter_swap(last_good, it);
+                last_good++;
+            }
+        }
+        vCoins.erase(last_good, vCoins.end());
     }
 
     unsigned int limit_ancestor_count = 0;


### PR DESCRIPTION
This is a followup to pr #24814. 

This pr implements the filtering of coins without an additional vector using the remove-erase idiom as discussed in #24814 

