### PR TITLE
net: Fix undefined behavior in socket address handling

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -428,7 +428,7 @@ static CAddress GetBindAddress(SOCKET sock)
     socklen_t sockaddr_bind_len = sizeof(sockaddr_bind);
     if (sock != INVALID_SOCKET) {
         if (!getsockname(sock, (struct sockaddr*)&sockaddr_bind, &sockaddr_bind_len)) {
-            addr_bind.SetSockAddr((const struct sockaddr*)&sockaddr_bind);
+            addr_bind.SetSockAddr(sockaddr_bind);
         } else {
             LogPrint(BCLog::NET, "Warning: getsockname failed\n");
         }
@@ -1139,7 +1139,7 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
         return;
     }
 
-    if (!addr.SetSockAddr((const struct sockaddr*)&sockaddr)) {
+    if (!addr.SetSockAddr(sockaddr)) {
         LogPrintf("Warning: Unknown socket family\n");
     } else {
         addr = CAddress{MaybeFlipIPv6toCJDNS(addr), NODE_NONE};
@@ -2389,7 +2389,7 @@ bool CConnman::BindListenPort(const CService& addrBind, bilingual_str& strError,
     // Create socket for listening for incoming connections
     struct sockaddr_storage sockaddr;
     socklen_t len = sizeof(sockaddr);
-    if (!addrBind.GetSockAddr((struct sockaddr*)&sockaddr, &len))
+    if (!addrBind.GetSockAddr(&sockaddr, &len))
     {
         strError = strprintf(Untranslated("Error: Bind address family for %s not supported"), addrBind.ToString());
         LogPrintf("%s\n", strError.original);
@@ -2485,15 +2485,15 @@ void Discover()
             if (strcmp(ifa->ifa_name, "lo0") == 0) continue;
             if (ifa->ifa_addr->sa_family == AF_INET)
             {
-                struct sockaddr_in* s4 = (struct sockaddr_in*)(ifa->ifa_addr);
-                CNetAddr addr(s4->sin_addr);
+                struct sockaddr_in s4 = LoadSockaddrIPv4(*ifa->ifa_addr);
+                CNetAddr addr(s4.sin_addr);
                 if (AddLocal(addr, LOCAL_IF))
                     LogPrintf("%s: IPv4 %s: %s\n", __func__, ifa->ifa_name, addr.ToString());
             }
             else if (ifa->ifa_addr->sa_family == AF_INET6)
             {
-                struct sockaddr_in6* s6 = (struct sockaddr_in6*)(ifa->ifa_addr);
-                CNetAddr addr(s6->sin6_addr);
+                struct sockaddr_in6 s6 = LoadSockaddrIPv6(*ifa->ifa_addr);
+                CNetAddr addr(s6.sin6_addr);
                 if (AddLocal(addr, LOCAL_IF))
                     LogPrintf("%s: IPv6 %s: %s\n", __func__, ifa->ifa_name, addr.ToString());
             }

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -529,8 +529,8 @@ public:
     CService(const struct in_addr& ipv4Addr, uint16_t port);
     explicit CService(const struct sockaddr_in& addr);
     uint16_t GetPort() const;
-    bool GetSockAddr(struct sockaddr* paddr, socklen_t* addrlen) const;
-    bool SetSockAddr(const struct sockaddr* paddr);
+    bool GetSockAddr(struct sockaddr_storage* paddr, socklen_t* addrlen) const;
+    bool SetSockAddr(const struct sockaddr_storage& addr);
     friend bool operator==(const CService& a, const CService& b);
     friend bool operator!=(const CService& a, const CService& b) { return !(a == b); }
     friend bool operator<(const CService& a, const CService& b);
@@ -576,5 +576,34 @@ private:
     const uint64_t m_salt_k0;
     const uint64_t m_salt_k1;
 };
+
+/**
+ * Read the generic sockaddr struct `src` safely. Use these
+ * instead of casting `src` and accessing its fields.
+ */
+sockaddr_in LoadSockaddrIPv4(const sockaddr& src);
+sockaddr_in LoadSockaddrIPv4(const sockaddr_storage& src);
+sockaddr_in6 LoadSockaddrIPv6(const sockaddr& src);
+sockaddr_in6 LoadSockaddrIPv6(const sockaddr_storage& src);
+
+/**
+ * Overwrite the provided generic sockaddr struct `ptr` safely. Use these
+ * instead of casting `ptr` and dereferencing it.
+ */
+template <typename T>
+void StoreSockaddrIPv4(const sockaddr_in& src, T* ptr, socklen_t *addrlen) {
+    constexpr size_t sz4 = sizeof(sockaddr_in);
+    assert(*addrlen >= sz4);
+    *addrlen = sz4;
+    std::memcpy(ptr, &src, sz4);
+}
+
+template <typename T>
+void StoreSockaddrIPv6(const sockaddr_in6& src, T* ptr, socklen_t *addrlen) {
+    constexpr size_t sz6 = sizeof(sockaddr_in6);
+    assert(*addrlen >= sz6);
+    *addrlen = sz6;
+    std::memcpy(ptr, &src, sz6);
+}
 
 #endif // BITCOIN_NETADDRESS_H

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -135,10 +135,12 @@ public:
             const socklen_t write_len = static_cast<socklen_t>(sizeof(sockaddr_in));
             if (*addr_len >= write_len) {
                 *addr_len = write_len;
-                sockaddr_in* addr_in = reinterpret_cast<sockaddr_in*>(addr);
-                addr_in->sin_family = AF_INET;
-                memset(&addr_in->sin_addr, 0x05, sizeof(addr_in->sin_addr));
-                addr_in->sin_port = htons(6789);
+                sockaddr_in addr_in;
+                memset(&addr_in, 0, sizeof(addr_in));
+                addr_in.sin_family = AF_INET;
+                memset(&addr_in.sin_addr, 0x05, sizeof(addr_in.sin_addr));
+                addr_in.sin_port = htons(6789);
+                StoreSockaddrIPv4(addr_in, addr, addr_len);
             }
         }
         return std::make_unique<StaticContentsSock>("");

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -142,7 +142,7 @@ bool TorControlConnection::Connect(const std::string& tor_control_center, const 
 
     struct sockaddr_storage control_address;
     socklen_t control_address_len = sizeof(control_address);
-    if (!control_service.GetSockAddr(reinterpret_cast<struct sockaddr*>(&control_address), &control_address_len)) {
+    if (!control_service.GetSockAddr(&control_address, &control_address_len)) {
         LogPrintf("tor: Error parsing socket address %s\n", tor_control_center);
         return false;
     }


### PR DESCRIPTION
Fixes #22613

The fix is pretty simple – it's legal to `memcpy` between these types, you just can't dereference members after a `reinterpret_cast`. The `memcpys` will be optimised away in any half decent compiler.

I chose to switch `GetSockAddr/SetSockAddr` to accept `sockaddr_storage` rather than `sockaddr` so we can be sure we're never reading/writing out of bounds. Essentially, `struct sockaddr*` is old junk that we never want to deal with. Only hand those to the C APIs.