### PR TITLE
tidy: add include-what-you-use

### DIFF
--- a/ci/test/00_setup_env_native_tidy.sh
+++ b/ci/test/00_setup_env_native_tidy.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 export DOCKER_NAME_TAG="ubuntu:22.04"
 export CONTAINER_NAME=ci_native_tidy
-export PACKAGES="clang llvm clang-tidy bear libevent-dev libboost-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev systemtap-sdt-dev libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libqrencode-dev libsqlite3-dev libdb++-dev"
+export PACKAGES="clang libclang-dev llvm-dev clang-tidy bear cmake libevent-dev libboost-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev systemtap-sdt-dev libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libqrencode-dev libsqlite3-dev libdb++-dev"
 export NO_DEPENDS=1
 export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -111,6 +111,13 @@ if [[ ${USE_MEMORY_SANITIZER} == "true" ]]; then
   CI_EXEC "cd ${BASE_SCRATCH_DIR}/msan/build/ && make $MAKEJOBS cxx"
 fi
 
+if [[ "${RUN_TIDY}" == "true" ]]; then
+  CI_EXEC "mkdir -p ${BASE_SCRATCH_DIR}/iwyu/build/"
+  CI_EXEC "git clone --depth=1 https://github.com/include-what-you-use/include-what-you-use -b clang_14 ${BASE_SCRATCH_DIR}/iwyu/include-what-you-use"
+  CI_EXEC "cd ${BASE_SCRATCH_DIR}/iwyu/build && cmake -G 'Unix Makefiles' -DCMAKE_PREFIX_PATH=/usr/lib/llvm-14 ../include-what-you-use"
+  CI_EXEC "cd ${BASE_SCRATCH_DIR}/iwyu/build && make install $MAKEJOBS"
+fi
+
 if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
   echo "Create $BASE_ROOT_DIR"
   CI_EXEC rsync -a /ro_base/ "$BASE_ROOT_DIR"

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -37,6 +37,8 @@ fi
 if [ "${RUN_TIDY}" = "true" ]; then
   export P_CI_DIR="${BASE_BUILD_DIR}/bitcoin-$HOST/src/"
   CI_EXEC run-clang-tidy "${MAKEJOBS}"
+  export P_CI_DIR="${BASE_BUILD_DIR}/bitcoin-$HOST/"
+  CI_EXEC "python3 ${BASE_SCRATCH_DIR}/iwyu/include-what-you-use/iwyu_tool.py src/compat src/init -p . ${MAKEJOBS} -- -Xiwyu --cxx17ns -Xiwyu --mapping_file=${BASE_BUILD_DIR}/bitcoin-$HOST/contrib/devtools/iwyu/bitcoin.core.imp"
 fi
 
 if [ "$RUN_SECURITY_TESTS" = "true" ]; then

--- a/configure.ac
+++ b/configure.ac
@@ -1934,6 +1934,7 @@ AC_CONFIG_LINKS([contrib/devtools/security-check.py:contrib/devtools/security-ch
 AC_CONFIG_LINKS([contrib/devtools/symbol-check.py:contrib/devtools/symbol-check.py])
 AC_CONFIG_LINKS([contrib/devtools/test-security-check.py:contrib/devtools/test-security-check.py])
 AC_CONFIG_LINKS([contrib/devtools/test-symbol-check.py:contrib/devtools/test-symbol-check.py])
+AC_CONFIG_LINKS([contrib/devtools/iwyu/bitcoin.core.imp:contrib/devtools/iwyu/bitcoin.core.imp])
 AC_CONFIG_LINKS([contrib/filter-lcov.py:contrib/filter-lcov.py])
 AC_CONFIG_LINKS([contrib/macdeploy/background.tiff:contrib/macdeploy/background.tiff])
 AC_CONFIG_LINKS([src/.clang-tidy:src/.clang-tidy])

--- a/contrib/devtools/iwyu/bitcoin.core.imp
+++ b/contrib/devtools/iwyu/bitcoin.core.imp
@@ -1,0 +1,6 @@
+# Fixups / upstreamed changes
+[
+  { include: [ "<bits/termios-c_lflag.h>", private, "<termios.h>", public ] },
+  { include: [ "<bits/termios-struct.h>", private, "<termios.h>", public ] },
+  { include: [ "<bits/termios-tcflow.h>", private, "<termios.h>", public ] },
+]

--- a/src/compat/byteswap.h
+++ b/src/compat/byteswap.h
@@ -9,7 +9,7 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <stdint.h>
+#include <cstdint>
 
 #if defined(HAVE_BYTESWAP_H)
 #include <byteswap.h>

--- a/src/compat/cpuid.h
+++ b/src/compat/cpuid.h
@@ -10,6 +10,8 @@
 
 #include <cpuid.h>
 
+#include <cstdint>
+
 // We can't use cpuid.h's __get_cpuid as it does not support subleafs.
 void static inline GetCPUID(uint32_t leaf, uint32_t subleaf, uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d)
 {

--- a/src/compat/endian.h
+++ b/src/compat/endian.h
@@ -11,7 +11,7 @@
 
 #include <compat/byteswap.h>
 
-#include <stdint.h>
+#include <cstdint>
 
 #if defined(HAVE_ENDIAN_H)
 #include <endian.h>

--- a/src/compat/glibcxx_sanity.cpp
+++ b/src/compat/glibcxx_sanity.cpp
@@ -5,6 +5,7 @@
 #include <list>
 #include <locale>
 #include <stdexcept>
+#include <string>
 
 namespace
 {

--- a/src/compat/stdin.cpp
+++ b/src/compat/stdin.cpp
@@ -2,22 +2,18 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include <config/bitcoin-config.h>
-#endif
+#include <compat/stdin.h>
 
-#include <cstdio>       // for fileno(), stdin
+#include <cstdio>
 
 #ifdef WIN32
-#include <windows.h>    // for SetStdinEcho()
-#include <io.h>         // for isatty()
+#include <windows.h>
+#include <io.h>
 #else
-#include <termios.h>    // for SetStdinEcho()
-#include <unistd.h>     // for SetStdinEcho(), isatty()
-#include <poll.h>       // for StdinReady()
+#include <termios.h>
+#include <unistd.h>
+#include <poll.h>
 #endif
-
-#include <compat/stdin.h>
 
 // https://stackoverflow.com/questions/1413445/reading-a-password-from-stdcin
 void SetStdinEcho(bool enable)

--- a/src/init/bitcoin-gui.cpp
+++ b/src/init/bitcoin-gui.cpp
@@ -9,6 +9,7 @@
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
 #include <node/context.h>
+#include <util/check.h>
 #include <util/system.h>
 
 #include <memory>

--- a/src/init/bitcoin-node.cpp
+++ b/src/init/bitcoin-node.cpp
@@ -9,6 +9,7 @@
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
 #include <node/context.h>
+#include <util/check.h>
 #include <util/system.h>
 
 #include <memory>

--- a/src/init/bitcoin-qt.cpp
+++ b/src/init/bitcoin-qt.cpp
@@ -8,6 +8,7 @@
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
 #include <node/context.h>
+#include <util/check.h>
 #include <util/system.h>
 
 #include <memory>

--- a/src/init/bitcoin-wallet.cpp
+++ b/src/init/bitcoin-wallet.cpp
@@ -4,6 +4,8 @@
 
 #include <interfaces/init.h>
 
+#include <memory>
+
 namespace interfaces {
 std::unique_ptr<Init> MakeWalletInit(int argc, char* argv[], int& exit_status)
 {

--- a/src/init/bitcoind.cpp
+++ b/src/init/bitcoind.cpp
@@ -8,6 +8,7 @@
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
 #include <node/context.h>
+#include <util/check.h>
 #include <util/system.h>
 
 #include <memory>

--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -9,16 +9,21 @@
 #include <clientversion.h>
 #include <compat/sanity.h>
 #include <crypto/sha256.h>
+#include <fs.h>
 #include <key.h>
 #include <logging.h>
 #include <node/ui_interface.h>
 #include <pubkey.h>
 #include <random.h>
+#include <tinyformat.h>
 #include <util/system.h>
 #include <util/time.h>
 #include <util/translation.h>
 
+#include <algorithm>
 #include <memory>
+#include <string>
+#include <vector>
 
 static std::unique_ptr<ECCVerifyHandle> globalVerifyHandle;
 


### PR DESCRIPTION
We recently added a [`clang-tidy` job](https://github.com/bitcoin/bitcoin/blob/master/ci/test/00_setup_env_native_tidy.sh) to the CI, which generates a compilation database. We can leverage that now existing database to begin running [include-what-you-use](https://include-what-you-use.org/) over the codebase.

This PR demonstrates using a mapping_file to indicate fixups / includes that may differ from IWYU suggestions. In this case, I've added some fixups for glibc includes that I've [upstreamed changes for](https://github.com/include-what-you-use/include-what-you-use/pull/1026):
```bash
# Fixups / upstreamed changes
[
  { include: [ "<bits/termios-c_lflag.h>", private, "<termios.h>", public ] },
  { include: [ "<bits/termios-struct.h>", private, "<termios.h>", public ] },
  { include: [ "<bits/termios-tcflow.h>", private, "<termios.h>", public ] },
]
```

The include "fixing" commits of this PR:
* Adds missing includes.
* Swaps C headers for their C++ counterparts.
* Removes the pointless / unmaintainable `//for abc, xyz` comments. When using IWYU, if anyone wants to see / generate those comments, to see why something is included, it is trivial to do so (IWYU outputs them by default). i.e:
```cpp
// The full include-list for compat/stdin.cpp:
#include <compat/stdin.h>
#include <poll.h>                  // for poll, pollfd, POLLIN
#include <termios.h>               // for tcgetattr, tcsetattr
#include <unistd.h>                // for isatty, STDIN_FILENO
```

TODO:
- [ ] Qt mapping_file. There is one in the IWYU repo, but it's for Qt 5.11. Needs testing.
- [ ] Boost mapping_file. There is one in the IWYU repo, but it's for Boost 1.75. Needs testing.

I'm not suggesting we turn this on the for entire codebase, or immediately go-nuts refactoring all includes. However I think our dependency includes are now slim enough, and our CI infrastructure in place such that we can start doing this in some capacity, and just automate away include fixups / refactorings etc.