### PR TITLE
refactor: consensus/tx_verify.{h,cpp} tidy-ups

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -40,6 +40,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
   export P_CI_DIR="${BASE_BUILD_DIR}/bitcoin-$HOST/"
   CI_EXEC "python3 ${DIR_IWYU}/include-what-you-use/iwyu_tool.py"\
           " src/compat"\
+          " src/consensus/tx_verify.cpp"\
           " src/init"\
           " src/policy/feerate.cpp"\
           " src/policy/packages.cpp"\

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -7,7 +7,8 @@
 
 #include <consensus/amount.h>
 
-#include <stdint.h>
+#include <cstdint>
+#include <utility>
 #include <vector>
 
 class CBlockIndex;
@@ -58,7 +59,7 @@ int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& i
  * Check if transaction is final and can be included in a block with the
  * specified height and time. Consensus critical.
  */
-bool IsFinalTx(const CTransaction &tx, int nBlockHeight, int64_t nBlockTime);
+bool IsFinalTx(const CTransaction& tx, int nBlockHeight, int64_t nBlockTime);
 
 /**
  * Calculates the block height and previous block's median time past at
@@ -66,13 +67,14 @@ bool IsFinalTx(const CTransaction &tx, int nBlockHeight, int64_t nBlockTime);
  * Also removes from the vector of input heights any entries which did not
  * correspond to sequence locked inputs as they do not affect the calculation.
  */
-std::pair<int, int64_t> CalculateSequenceLocks(const CTransaction &tx, int flags, std::vector<int>& prevHeights, const CBlockIndex& block);
+std::pair<int, int64_t> CalculateSequenceLocks(const CTransaction& tx, int flags, std::vector<int>& prevHeights, const CBlockIndex& block);
 
-bool EvaluateSequenceLocks(const CBlockIndex& block, std::pair<int, int64_t> lockPair);
+bool EvaluateSequenceLocks(const CBlockIndex& block, const std::pair<int, int64_t>& lock_pair);
+
 /**
  * Check if transaction is final per BIP 68 sequence numbers and can be included in a block.
  * Consensus critical. Takes as input a list of heights at which tx's inputs (in order) confirmed.
  */
-bool SequenceLocks(const CTransaction &tx, int flags, std::vector<int>& prevHeights, const CBlockIndex& block);
+bool SequenceLocks(const CTransaction& tx, int flags, std::vector<int>& prevHeights, const CBlockIndex& block);
 
 #endif // BITCOIN_CONSENSUS_TX_VERIFY_H


### PR DESCRIPTION
1. Fix lockpair in-param passing in EvaluateSequenceLocks() and other tidy-ups:
    
      - pass lockPair by reference to const instead of by value, per
        https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-in
    
      - make nBlockTime const
    
      - rename lockPair to lock_pair
    
      - rename nBlockTime to block_time
    
      - add brackets to conditionals
    
2. add consensus/tx_verify.{h,cpp} to the iwyu (include what you use) CI checks, along with missing include headers to satisfy the checks 
    
3. apply clang-format to consensus/tx_verify.{h,cpp}

