### PR TITLE
Revert "Do not consider blocked networks local"

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -294,9 +294,6 @@ bool AddLocal(const CService& addr_, int nScore)
     if (!fDiscover && nScore < LOCAL_MANUAL)
         return false;
 
-    if (!IsReachable(addr))
-        return false;
-
     LogPrintf("AddLocal(%s,%i)\n", addr.ToString(), nScore);
 
     {


### PR DESCRIPTION
This reverts commit 1653f97c8f3c37cd96e03cf397c31c5caf81af08.

The output of `bitcoin-cli -netinfo` does not show local addresses for networks that the node itself would not make connections to, however the node might still receive incoming connections on addresses not shown by `-netinfo`. I would have expected `-netinfo` to list all local addresses that can receive incoming connections.

This can be observed when running a node that listens on multiple networks but also uses `-onlynet`. The local addresses of the networks **not** specified by `-onlynet` will be excluded from the output of `-netinfo`.