### PR TITLE
init: Prevent -noproxy and -proxy=0 from interacting with other settings

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -660,7 +660,8 @@ void InitParameterInteraction(ArgsManager& args)
             LogPrintf("%s: parameter interaction: -connect set -> setting -listen=0\n", __func__);
     }
 
-    if (args.IsArgSet("-proxy")) {
+    std::string proxy_arg = args.GetArg("-proxy", "");
+    if (proxy_arg != "" && proxy_arg != "0") {
         // to protect privacy, do not listen by default if a default proxy server is specified
         if (args.SoftSetBoolArg("-listen", false))
             LogPrintf("%s: parameter interaction: -proxy set -> setting -listen=0\n", __func__);


### PR DESCRIPTION
Prevent `-noproxy` and `-proxy=0` settings from interacting with `-listen`, `-upnp`, and `-natpmp` settings.

These settings started being handled inconsistently in the `AppInitMain` and `InitParameterInteraction` functions starting in commit baf05075fae2cc2625a2a74b35cc66902f3cbfa3 from #6272:

https://github.com/bitcoin/bitcoin/blob/baf05075fae2cc2625a2a74b35cc66902f3cbfa3/src/init.cpp#L990-L991
https://github.com/bitcoin/bitcoin/blob/baf05075fae2cc2625a2a74b35cc66902f3cbfa3/src/init.cpp#L687

This commit changes both functions to handle proxy arguments the same way so
there are not side effects from specifying a proxy=0 setting.

This change was originally part of #24830 but really is independent and makes more sense as a separate PR