### PR TITLE
build, windows: Use Direct2D plugin

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -146,7 +146,7 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
       dnl Linking against wtsapi32 is required. See #17749 and
       dnl https://bugreports.qt.io/browse/QTBUG-27097.
       AX_CHECK_LINK_FLAG([-lwtsapi32], [QT_LIBS="$QT_LIBS -lwtsapi32"], [AC_MSG_ERROR([could not link against -lwtsapi32])])
-      _BITCOIN_QT_CHECK_STATIC_PLUGIN([QWindowsIntegrationPlugin], [-lqwindows])
+      _BITCOIN_QT_CHECK_STATIC_PLUGIN([QWindowsDirect2DIntegrationPlugin], [-lqdirect2d])
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QWindowsVistaStylePlugin], [-lqwindowsvistastyle])
       AC_DEFINE([QT_QPA_PLATFORM_WINDOWS], [1], [Define this symbol if the qt platform is windows])
     elif test "$TARGET_OS" = "linux"; then

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -161,6 +161,10 @@ PE_ALLOWED_LIBRARIES = {
 'VERSION.dll', # version checking
 'WINMM.dll', # WinMM audio API
 'WTSAPI32.dll',
+# Direct2D plugin
+'d2d1.dll',
+'d3d11.dll',
+'DWrite.dll',
 }
 
 def check_version(max_versions, version, arch) -> bool:

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -175,6 +175,11 @@ $(package)_config_opts_mingw32 += "QMAKE_CXXFLAGS = '$($(package)_cflags) $($(pa
 $(package)_config_opts_mingw32 += "QMAKE_LFLAGS = '$($(package)_ldflags)'"
 $(package)_config_opts_mingw32 += -device-option CROSS_COMPILE="$(host)-"
 $(package)_config_opts_mingw32 += -pch
+# The default "windows" platform backend being compiled
+# with GCC 10 in Guix environment is broken.
+# See https://github.com/bitcoin-core/gui/issues/582
+$(package)_config_opts_mingw32 += -direct2d
+$(package)_config_opts_mingw32 += -qpa direct2d
 
 $(package)_config_opts_android = -xplatform android-clang
 $(package)_config_opts_android += -android-sdk $(ANDROID_SDK)

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -61,8 +61,8 @@
 #if defined(QT_QPA_PLATFORM_XCB)
 Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
 #elif defined(QT_QPA_PLATFORM_WINDOWS)
-Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
-Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin);
+Q_IMPORT_PLUGIN(QWindowsDirect2DIntegrationPlugin)
+Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin)
 #elif defined(QT_QPA_PLATFORM_COCOA)
 Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
 Q_IMPORT_PLUGIN(QMacStylePlugin);

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -33,7 +33,7 @@ Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin);
 #if defined(QT_QPA_PLATFORM_XCB)
 Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
 #elif defined(QT_QPA_PLATFORM_WINDOWS)
-Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
+Q_IMPORT_PLUGIN(QWindowsDirect2DIntegrationPlugin)
 #elif defined(QT_QPA_PLATFORM_COCOA)
 Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
 #elif defined(QT_QPA_PLATFORM_ANDROID)


### PR DESCRIPTION
The default "windows" platform backend being compiled with GCC 10 in Guix environment is [broken](https://github.com/bitcoin-core/gui/issues/582).

This PR switches Windows backend to Direct2D.

Pros:
- closes bitcoin-core/gui#582
- Direct2D is a mature API

Cons:
- does not work in `wine` on my Ubuntu 22.04 out-of-the-box

The "direct2d" platform plugin has been available [since](https://github.com/qt/qtbase/commit/b9362903b339e57362a7a3296904504521d0e26f) Qt 5.3.

#### Guix hashes on `x86_64`:
```
$ find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
5dbba767a2f8b9bacdd0920bfbf88c3bd415348a65eaa570c1485a2a425b2113  guix-build-388709b9f415/output/dist-archive/bitcoin-388709b9f415.tar.gz
56c30459eb35d493e35284e7668c74ff00c164296a8aa3aeb1b2d4bcabd40eb3  guix-build-388709b9f415/output/x86_64-w64-mingw32/SHA256SUMS.part
fff3ab1b46cce21f97b5d00269e9e189fc1ff43ea4df2ca0007c5642b11be060  guix-build-388709b9f415/output/x86_64-w64-mingw32/bitcoin-388709b9f415-win64-debug.zip
203a72ccd040906e96b5d7b32c4b173b8903dc3cf63d6dae0032c7ac21f67472  guix-build-388709b9f415/output/x86_64-w64-mingw32/bitcoin-388709b9f415-win64-setup-unsigned.exe
4d18037c3e0ad6eb8c4f53a3c286fd05b12c219f1f64c5c3f627a461d255ac9e  guix-build-388709b9f415/output/x86_64-w64-mingw32/bitcoin-388709b9f415-win64-unsigned.tar.gz
5e7aa77f60f4f1bbe2404034dfacc7b58d5cd30d21bc8e56c987bb52a96f70b6  guix-build-388709b9f415/output/x86_64-w64-mingw32/bitcoin-388709b9f415-win64.zip
```