### PR TITLE
test: use MiniWallet for mining_prioritisetransaction.py

### DIFF
--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -7,12 +7,12 @@
 from decimal import Decimal
 
 from test_framework.blocktools import COINBASE_MATURITY
-from test_framework.messages import COIN
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_greater_than,
     assert_raises_rpc_error,
+    create_lots_of_big_transactions,
     gen_return_txouts,
 )
 from test_framework.wallet import MiniWallet
@@ -28,16 +28,6 @@ class MempoolLimitTest(BitcoinTestFramework):
             "-spendzeroconfchange=0",
         ]]
         self.supports_cli = False
-
-    def send_large_txs(self, node, miniwallet, txouts, fee, tx_batch_size):
-        for _ in range(tx_batch_size):
-            tx = miniwallet.create_self_transfer(from_node=node, fee_rate=0, mempool_valid=False)['tx']
-            for txout in txouts:
-                tx.vout.append(txout)
-            tx.vout[0].nValue -= int(fee * COIN)
-            res = node.testmempoolaccept([tx.serialize().hex()])[0]
-            assert_equal(res['fees']['base'], fee)
-            miniwallet.sendrawtransaction(from_node=node, tx_hex=tx.serialize().hex())
 
     def run_test(self):
         txouts = gen_return_txouts()
@@ -71,7 +61,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         self.log.info("Fill up the mempool with txs with higher fee rate")
         for batch_of_txid in range(num_of_batches):
             fee = (batch_of_txid + 1) * base_fee
-            self.send_large_txs(node, miniwallet, txouts, fee, tx_batch_size)
+            create_lots_of_big_transactions(miniwallet, node, fee, tx_batch_size, txouts)
 
         self.log.info('The tx should be evicted by now')
         # The number of transactions created should be greater than the ones present in the mempool

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -575,13 +575,8 @@ def mine_large_block(test_framework, mini_wallet, node):
     # generate a 66k transaction,
     # and 14 of them is close to the 1MB block limit
     txouts = gen_return_txouts()
-    from .messages import COIN
-    fee = 100 * int(node.getnetworkinfo()["relayfee"] * COIN)
-    for _ in range(14):
-        tx = mini_wallet.create_self_transfer(from_node=node, fee_rate=0, mempool_valid=False)['tx']
-        tx.vout[0].nValue -= fee
-        tx.vout.extend(txouts)
-        mini_wallet.sendrawtransaction(from_node=node, tx_hex=tx.serialize().hex())
+    fee = 100 * node.getnetworkinfo()["relayfee"]
+    create_lots_of_big_transactions(mini_wallet, node, fee, 14, txouts)
     test_framework.generate(node, 1)
 
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -552,24 +552,22 @@ def gen_return_txouts():
 
 # Create a spend of each passed-in utxo, splicing in "txouts" to each raw
 # transaction to make it large.  See gen_return_txouts() above.
-def create_lots_of_big_transactions(node, txouts, utxos, num, fee):
-    addr = node.getnewaddress()
+def create_lots_of_big_transactions(mini_wallet, node, fee, tx_batch_size, txouts, utxos=None):
+    from .messages import COIN
+    fee_sats = int(fee * COIN)
     txids = []
-    from .messages import tx_from_hex
-    for _ in range(num):
-        t = utxos.pop()
-        inputs = [{"txid": t["txid"], "vout": t["vout"]}]
-        outputs = {}
-        change = t['amount'] - fee
-        outputs[addr] = satoshi_round(change)
-        rawtx = node.createrawtransaction(inputs, outputs)
-        tx = tx_from_hex(rawtx)
-        for txout in txouts:
-            tx.vout.append(txout)
-        newtx = tx.serialize().hex()
-        signresult = node.signrawtransactionwithwallet(newtx, None, "NONE")
-        txid = node.sendrawtransaction(signresult["hex"], 0)
-        txids.append(txid)
+    use_internal_utxos = utxos is None
+    for _ in range(tx_batch_size):
+        tx = mini_wallet.create_self_transfer(
+                from_node=node,
+                utxo_to_spend=None if use_internal_utxos else utxos.pop(),
+                fee_rate=0,
+                mempool_valid=False)['tx']
+        tx.vout[0].nValue -= fee_sats
+        tx.vout.extend(txouts)
+        res = node.testmempoolaccept([tx.serialize().hex()])[0]
+        assert_equal(res['fees']['base'], fee)
+        txids.append(node.sendrawtransaction(tx.serialize().hex()))
     return txids
 
 


### PR DESCRIPTION
This PR enables one more of the non-wallet functional tests (mining_prioritisetransaction.py) to be run even with the Bitcoin Code wallet by using the MiniWallet instead, as proposed in #20078. Note that the adapted helper function `create_lots_of_big_transactions` is currently only used in this test, i.e. there was no need to change any others.