### PR TITLE
Remove not needed ArithToUint256 roundtrips in tests

### DIFF
--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -24,22 +24,19 @@ template<unsigned int BITS>
 class base_uint
 {
 protected:
+    static_assert(BITS / 32 > 0 && BITS % 32 == 0, "Template parameter BITS must be a positive multiple of 32.");
     static constexpr int WIDTH = BITS / 32;
     uint32_t pn[WIDTH];
 public:
 
     base_uint()
     {
-        static_assert(BITS/32 > 0 && BITS%32 == 0, "Template parameter BITS must be a positive multiple of 32.");
-
         for (int i = 0; i < WIDTH; i++)
             pn[i] = 0;
     }
 
     base_uint(const base_uint& b)
     {
-        static_assert(BITS/32 > 0 && BITS%32 == 0, "Template parameter BITS must be a positive multiple of 32.");
-
         for (int i = 0; i < WIDTH; i++)
             pn[i] = b.pn[i];
     }
@@ -53,8 +50,6 @@ public:
 
     base_uint(uint64_t b)
     {
-        static_assert(BITS/32 > 0 && BITS%32 == 0, "Template parameter BITS must be a positive multiple of 32.");
-
         pn[0] = (unsigned int)b;
         pn[1] = (unsigned int)(b >> 32);
         for (int i = 2; i < WIDTH; i++)

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -4,7 +4,6 @@
 
 // Unit tests for denial-of-service detection/prevention code
 
-#include <arith_uint256.h>
 #include <banman.h>
 #include <chainparams.h>
 #include <net.h>
@@ -464,7 +463,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
     // ecdsa_signature_parse_der_lax are executed during this test.
     // Specifically branches that run only when an ECDSA
     // signature's R and S values have leading zeros.
-    g_insecure_rand_ctx = FastRandomContext(ArithToUint256(arith_uint256(33)));
+    g_insecure_rand_ctx = FastRandomContext{uint256{33}};
 
     TxOrphanageTest orphanage;
     CKey key;

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <arith_uint256.h>
 #include <consensus/merkle.h>
 #include <merkleblock.h>
 #include <serialize.h>
@@ -107,13 +106,13 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
 
 BOOST_AUTO_TEST_CASE(pmt_malleability)
 {
-    std::vector<uint256> vTxid = {
-        ArithToUint256(1), ArithToUint256(2),
-        ArithToUint256(3), ArithToUint256(4),
-        ArithToUint256(5), ArithToUint256(6),
-        ArithToUint256(7), ArithToUint256(8),
-        ArithToUint256(9), ArithToUint256(10),
-        ArithToUint256(9), ArithToUint256(10),
+    std::vector<uint256> vTxid{
+        uint256{1}, uint256{2},
+        uint256{3}, uint256{4},
+        uint256{5}, uint256{6},
+        uint256{7}, uint256{8},
+        uint256{9}, uint256{10},
+        uint256{9}, uint256{10},
     };
     std::vector<bool> vMatch = {false, false, false, false, false, false, false, false, false, true, true, false};
 


### PR DESCRIPTION
No need to go from `arith_uint256`->`uint256` when a `uint256` can be constructed right away.