### PR TITLE
rpc, wallet: Keep the same response from `RPCHelpMan setwalletflag()` regardless of whether the flag is false or true

### DIFF
--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -299,6 +299,8 @@ static RPCHelpMan setwalletflag()
 
     if (flag && value && WALLET_FLAG_CAVEATS.count(flag)) {
         res.pushKV("warnings", WALLET_FLAG_CAVEATS.at(flag));
+    } else {
+        res.pushKV("warnings", "");
     }
 
     return res;


### PR DESCRIPTION
`RPCHelpMan setwalletflag()` returns a different structure in response according to the value of the flag. This causes an error since the structure is well defined in RPCResult.
This PR  changes the answer to use the same structure in both cases.

In master branch:
```
$ bitcoin-cli -regtest setwalletflag "avoid_reuse" true
{
  "flag_name": "avoid_reuse",
  "flag_state": true,
  "warnings": "You need to rescan the blockchain in order to correctly mark used destinations in the past. Until this is done, some destinations may be considered unused, even if the opposite is the case."
}

$ bitcoin-cli -regtest setwalletflag "avoid_reuse" false
error code: -1
error message:
Internal bug detected: 'std::any_of(m_results.m_results.begin(), m_results.m_results.end(), [ret](const RPCResult& res) { return res.MatchesType(ret); })'
rpc/util.cpp:587 (HandleRequest)
You may report this issue here: https://github.com/bitcoin/bitcoin/issues
```
In PR branch:
```
$ bitcoin-cli -regtest setwalletflag "avoid_reuse" true
{
  "flag_name": "avoid_reuse",
  "flag_state": true,
  "warnings": "You need to rescan the blockchain in order to correctly mark used destinations in the past. Until this is done, some destinations may be considered unused, even if the opposite is the case."
}

$ bitcoin-cli -regtest setwalletflag "avoid_reuse" false
{
  "flag_name": "avoid_reuse",
  "flag_state": false,
  "warnings": ""
}
```
