### PR TITLE
[Draft / POC] Silent Payments

### DIFF
--- a/build_msvc/libsecp256k1/libsecp256k1.vcxproj
+++ b/build_msvc/libsecp256k1/libsecp256k1.vcxproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>ENABLE_MODULE_RECOVERY;ENABLE_MODULE_EXTRAKEYS;ENABLE_MODULE_SCHNORRSIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ENABLE_MODULE_ECDH;ENABLE_MODULE_RECOVERY;ENABLE_MODULE_EXTRAKEYS;ENABLE_MODULE_SCHNORRSIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\src\secp256k1;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4146;4244;4267;4334</DisableSpecificWarnings>
     </ClCompile>

--- a/configure.ac
+++ b/configure.ac
@@ -1989,7 +1989,7 @@ CPPFLAGS_TEMP="$CPPFLAGS"
 unset CPPFLAGS
 CPPFLAGS="$CPPFLAGS_TEMP"
 
-ac_configure_args="${ac_configure_args} --disable-shared --with-pic --enable-benchmark=no --enable-module-recovery --disable-module-ecdh"
+ac_configure_args="${ac_configure_args} --disable-shared --with-pic --enable-benchmark=no --enable-module-recovery --enable-module-ecdh"
 AC_CONFIG_SUBDIRS([src/secp256k1])
 
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -249,6 +249,7 @@ BITCOIN_CORE_H = \
   rpc/server.h \
   rpc/server_util.h \
   rpc/util.h \
+  silentpayment.h \
   scheduler.h \
   script/descriptor.h \
   script/keyorigin.h \
@@ -433,6 +434,7 @@ libbitcoin_node_a_SOURCES = \
   rpc/server_util.cpp \
   rpc/signmessage.cpp \
   rpc/txoutproof.cpp \
+  silentpayment.cpp \
   script/sigcache.cpp \
   shutdown.cpp \
   signet.cpp \
@@ -473,6 +475,7 @@ endif
 libbitcoin_wallet_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS) $(BDB_CPPFLAGS) $(SQLITE_CFLAGS)
 libbitcoin_wallet_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_wallet_a_SOURCES = \
+  silentpayment.cpp \
   wallet/coincontrol.cpp \
   wallet/context.cpp \
   wallet/crypter.cpp \

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -46,6 +46,7 @@ bench_bench_bitcoin_SOURCES = \
   bench/rollingbloom.cpp \
   bench/rpc_blockchain.cpp \
   bench/rpc_mempool.cpp \
+  bench/silentpayment.cpp \
   bench/strencodings.cpp \
   bench/util_time.cpp \
   bench/verify_script.cpp

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -180,8 +180,9 @@ BITCOIN_TESTS += \
   wallet/test/ismine_tests.cpp \
   wallet/test/rpc_util_tests.cpp \
   wallet/test/scriptpubkeyman_tests.cpp \
-  wallet/test/walletload_tests.cpp \
-  wallet/test/group_outputs_tests.cpp
+  wallet/test/group_outputs_tests.cpp \
+  wallet/test/silentpayment_tests.cpp \
+  wallet/test/walletload_tests.cpp
 
 FUZZ_SUITE_LD_COMMON +=\
  $(SQLITE_LIBS) \

--- a/src/bech32.cpp
+++ b/src/bech32.cpp
@@ -370,11 +370,13 @@ std::string Encode(Encoding encoding, const std::string& hrp, const data& values
 }
 
 /** Decode a Bech32 or Bech32m string. */
-DecodeResult Decode(const std::string& str) {
+DecodeResult Decode(const std::string& str, bool silent) {
+    std::size_t max_size = silent ? 114 : 90;
+
     std::vector<int> errors;
     if (!CheckCharacters(str, errors)) return {};
     size_t pos = str.rfind('1');
-    if (str.size() > 90 || pos == str.npos || pos == 0 || pos + 7 > str.size()) {
+    if (str.size() > max_size || pos == str.npos || pos == 0 || pos + 7 > str.size()) {
         return {};
     }
     data values(str.size() - 1 - pos);

--- a/src/bech32.h
+++ b/src/bech32.h
@@ -43,7 +43,7 @@ struct DecodeResult
 };
 
 /** Decode a Bech32 or Bech32m string. */
-DecodeResult Decode(const std::string& str);
+DecodeResult Decode(const std::string& str, bool silent = false);
 
 /** Return the positions of errors in a Bech32 string. */
 std::pair<std::string, std::vector<int>> LocateErrors(const std::string& str);

--- a/src/bench/silentpayment.cpp
+++ b/src/bench/silentpayment.cpp
@@ -1,0 +1,124 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+
+#include <random.h>
+#include <secp256k1.h>
+#include <secp256k1_ecdh.h>
+#include <secp256k1_extrakeys.h>
+#include <silentpayment.h>
+#include <test/util/setup_common.h>
+
+static void SumXOnlyPublicKeys(benchmark::Bench& bench, size_t key_count)
+{
+    ECC_Start();
+
+    std::vector<CPubKey> sender_pub_keys;
+    std::vector<XOnlyPubKey> sender_x_only_pub_keys;
+
+    // non-taproot inputs
+    for(size_t i =0; i < key_count; i++) {
+        CKey senderkey;
+        senderkey.MakeNewKey(true);
+        CPubKey senderPubkey = senderkey.GetPubKey();
+        sender_pub_keys.push_back(senderPubkey);
+    }
+
+    // taproot inputs
+    for(size_t i =0; i < key_count; i++) {
+        CKey senderkey;
+        senderkey.MakeNewKey(true);
+        sender_x_only_pub_keys.push_back(XOnlyPubKey{senderkey.GetPubKey()});
+    }
+
+    bench.run([&] {
+        CPubKey sum_tx_pubkeys{silentpayment::Recipient::CombinePublicKeys(sender_pub_keys, sender_x_only_pub_keys)};
+        assert(sum_tx_pubkeys.IsFullyValid());
+    });
+
+    ECC_Stop();
+}
+
+static void ECDHPerformance(benchmark::Bench& bench, int32_t pool_size)
+{
+    ECC_Start();
+
+    auto txid1 = uint256S("0x00000000000002dc756eebf4f49723ed8d30cc28a5f108eb94b1ba88ac4f9c22");
+    uint32_t vout1 = 4;
+
+    auto txid2 = uint256S("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+    uint32_t vout2 = 7;
+
+    std::vector<COutPoint> tx_outpoints;
+    tx_outpoints.emplace_back(txid1, vout1);
+    tx_outpoints.emplace_back(txid2, vout2);
+
+    std::vector<std::tuple<CKey, bool>> sender_secret_keys;
+
+    CKey senderkey1;
+    senderkey1.MakeNewKey(true);
+    CPubKey senderPubkey1 = senderkey1.GetPubKey();
+    sender_secret_keys.push_back({senderkey1, false});
+
+    CKey senderkey2;
+    senderkey2.MakeNewKey(true);
+    XOnlyPubKey senderPubkey2 = XOnlyPubKey(senderkey2.GetPubKey());
+    sender_secret_keys.push_back({senderkey2, true});
+
+    CKey recipient_spend_seckey;
+    recipient_spend_seckey.MakeNewKey(true);
+
+    auto silent_recipient = silentpayment::Recipient(recipient_spend_seckey, pool_size);
+    CPubKey sum_tx_pubkeys{silentpayment::Recipient::CombinePublicKeys({senderPubkey1}, {senderPubkey2})};
+
+    bench.run([&] {
+        silent_recipient.SetSenderPublicKey(sum_tx_pubkeys, tx_outpoints);
+
+        for (int32_t identifier = 0; identifier < pool_size; identifier++) {
+            const auto&[recipient_scan_pubkey, recipient_spend_pubkey]{silent_recipient.GetAddress(identifier)};
+
+            silentpayment::Sender silent_sender{
+                sender_secret_keys,
+                tx_outpoints,
+                recipient_scan_pubkey
+            };
+
+            XOnlyPubKey sender_tweaked_pubkey = silent_sender.Tweak(recipient_spend_pubkey);
+            const auto [recipient_priv_key, recipient_pub_key] = silent_recipient.Tweak(identifier);
+
+            assert(sender_tweaked_pubkey == recipient_pub_key);
+        }
+    });
+
+    ECC_Stop();
+}
+
+static void SumXOnlyPublicKeys_1(benchmark::Bench& bench)
+{
+    SumXOnlyPublicKeys(bench, 1);
+}
+static void SumXOnlyPublicKeys_10(benchmark::Bench& bench)
+{
+    SumXOnlyPublicKeys(bench, 10);
+}
+static void SumXOnlyPublicKeys_100(benchmark::Bench& bench)
+{
+    SumXOnlyPublicKeys(bench, 100);
+}
+static void SumXOnlyPublicKeys_1000(benchmark::Bench& bench)
+{
+    SumXOnlyPublicKeys(bench, 1000);
+}
+
+static void ECDHPerformance_100(benchmark::Bench& bench)
+{
+    ECDHPerformance(bench, 100);
+}
+
+BENCHMARK(SumXOnlyPublicKeys_1, benchmark::PriorityLevel::HIGH);
+BENCHMARK(SumXOnlyPublicKeys_10, benchmark::PriorityLevel::HIGH);
+BENCHMARK(SumXOnlyPublicKeys_100, benchmark::PriorityLevel::HIGH);
+BENCHMARK(SumXOnlyPublicKeys_1000, benchmark::PriorityLevel::HIGH);
+BENCHMARK(ECDHPerformance_100, benchmark::PriorityLevel::HIGH);

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -155,6 +155,9 @@ public:
     //! or contents.
     virtual bool findBlock(const uint256& hash, const FoundBlock& block={}) = 0;
 
+    //! Return the undo information for a block hash
+    virtual bool getUndoBlock(const uint256& block_hash, CBlockUndo& blockUndo) = 0;
+
     //! Find first block in the chain with timestamp >= the given time
     //! and height >= than the given height, return false if there is no block
     //! with a high enough timestamp and height. Optionally return block

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -12,6 +12,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <pubkey.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string>

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -147,6 +147,7 @@ public:
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x88, 0xAD, 0xE4};
 
         bech32_hrp = "bc";
+	silent_payment_hrp = "sp";
 
         vFixedSeeds = std::vector<uint8_t>(std::begin(chainparams_seed_main), std::end(chainparams_seed_main));
 
@@ -255,6 +256,7 @@ public:
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
 
         bech32_hrp = "tb";
+	silent_payment_hrp = "tsp";
 
         vFixedSeeds = std::vector<uint8_t>(std::begin(chainparams_seed_test), std::end(chainparams_seed_test));
 
@@ -380,6 +382,7 @@ public:
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
 
         bech32_hrp = "tb";
+	silent_payment_hrp = "tsp";
 
         fDefaultConsistencyChecks = false;
         fRequireStandard = true;
@@ -508,6 +511,7 @@ public:
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
 
         bech32_hrp = "bcrt";
+	silent_payment_hrp = "sprt";
     }
 };
 

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -120,6 +120,7 @@ public:
     const std::vector<std::string>& DNSSeeds() const { return vSeeds; }
     const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
     const std::string& Bech32HRP() const { return bech32_hrp; }
+    const std::string& SilentPaymentHRP() const { return silent_payment_hrp; }
     const std::vector<uint8_t>& FixedSeeds() const { return vFixedSeeds; }
     const CCheckpointData& Checkpoints() const { return checkpointData; }
 
@@ -172,6 +173,7 @@ protected:
     std::vector<std::string> vSeeds;
     std::vector<unsigned char> base58Prefixes[MAX_BASE58_TYPES];
     std::string bech32_hrp;
+    std::string silent_payment_hrp;
     std::string strNetworkID;
     CBlock genesis;
     std::vector<uint8_t> vFixedSeeds;

--- a/src/key.h
+++ b/src/key.h
@@ -101,6 +101,14 @@ public:
     //! Negate private key
     bool Negate();
 
+    //! Tweak a secret key by adding tweak to it.
+    CKey AddTweak(const unsigned char *tweak32) const;
+
+    //! Tweak a secret key by adding tweak to it.
+    CKey MultiplyTweak(const unsigned char *tweak32) const;
+
+    std::array<unsigned char,32> ECDH(const CPubKey& pubkey) const;
+
     /**
      * Convert the private key to a CPrivKey (serialized OpenSSL private key data).
      * This is expensive.
@@ -144,6 +152,8 @@ public:
      *                              Merkle root of the script tree).
      */
     bool SignSchnorr(const uint256& hash, Span<unsigned char> sig, const uint256* merkle_root, const uint256& aux) const;
+
+    bool TweakCKey(const uint256* merkle_root, CKey& key) const;
 
     //! Derive BIP32 child key.
     [[nodiscard]] bool Derive(CKey& keyChild, ChainCode &ccChild, unsigned int nChild, const ChainCode& cc) const;

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -278,6 +278,22 @@ std::string EncodeDestination(const CTxDestination& dest)
     return std::visit(DestinationEncoder(Params()), dest);
 }
 
+std::string EncodeSilentDestination(const XOnlyPubKey& scan_pubkey, const XOnlyPubKey& spend_pubkey)
+{
+    // The data_in is scan_pubkey + spend_pubkey
+    std::vector<unsigned char> data_in = {};
+    std::vector<unsigned char> data_out = {};
+
+    data_in.insert(data_in.end(), scan_pubkey.begin(), scan_pubkey.end());
+    data_in.insert(data_in.end(), spend_pubkey.begin(), spend_pubkey.end());
+
+    ConvertBits<8, 5, true>([&](unsigned char c) { data_out.push_back(c); }, data_in.begin(), data_in.end());
+
+    std::string hrp = Params().SilentPaymentHRP();
+
+    return bech32::Encode(bech32::Encoding::BECH32M, hrp, data_out);
+}
+
 CTxDestination DecodeDestination(const std::string& str, std::string& error_msg, std::vector<int>* error_locations)
 {
     return DecodeDestination(str, Params(), error_msg, error_locations);
@@ -298,4 +314,47 @@ bool IsValidDestinationString(const std::string& str, const CChainParams& params
 bool IsValidDestinationString(const std::string& str)
 {
     return IsValidDestinationString(str, Params());
+}
+
+std::pair<XOnlyPubKey, XOnlyPubKey> DecodeSilentData(const std::vector<unsigned char>& data)
+{
+    if (data.size() != 64) {
+        return {XOnlyPubKey(), XOnlyPubKey()};
+    }
+
+    std::vector<unsigned char> scan_pubkey_data(data.begin(), data.begin() + 32);
+    XOnlyPubKey scan_pubkey{scan_pubkey_data};
+
+    std::vector<unsigned char> spend_pubkey_data(data.begin() + 32, data.end());
+    XOnlyPubKey spend_pubkey{spend_pubkey_data};
+
+    return {scan_pubkey, spend_pubkey};
+}
+
+std::vector<unsigned char> DecodeSilentAddress(const std::string& str)
+{
+    const auto& params{Params()};
+
+    const auto& silent_payment_hrp = params.SilentPaymentHRP();
+    auto dest_silent_payment_hrp = ToLower(std::string_view(str).substr(0, params.SilentPaymentHRP().size()));
+
+    if (dest_silent_payment_hrp != silent_payment_hrp) {
+        return {};
+    }
+
+    std::vector<unsigned char> data;
+    data.clear();
+    const auto dec = bech32::Decode(str, /*silent*/true);
+    auto dec_silent_payment_hrp = dec.hrp.substr(0, params.SilentPaymentHRP().size());
+
+    if (dec.encoding != bech32::Encoding::BECH32M || dec.data.empty() || dec.hrp != silent_payment_hrp) {
+        return {};
+    }
+
+    data.reserve(((dec.data.size() - 1) * 5) / 8);
+    if (ConvertBits<5, 8, false>([&](unsigned char c) { data.push_back(c); }, dec.data.begin(), dec.data.end())) {
+        return data;
+    }
+
+    return {};
 }

--- a/src/key_io.h
+++ b/src/key_io.h
@@ -13,6 +13,8 @@
 
 #include <string>
 
+const int32_t SILENT_ADDRESS_MAXIMUM_IDENTIFIER = 99;
+
 CKey DecodeSecret(const std::string& str);
 std::string EncodeSecret(const CKey& key);
 
@@ -22,8 +24,13 @@ CExtPubKey DecodeExtPubKey(const std::string& str);
 std::string EncodeExtPubKey(const CExtPubKey& extpubkey);
 
 std::string EncodeDestination(const CTxDestination& dest);
+std::string EncodeSilentDestination(const XOnlyPubKey& scan_pubkey, const XOnlyPubKey& spend_pubkey);
 CTxDestination DecodeDestination(const std::string& str);
 CTxDestination DecodeDestination(const std::string& str, std::string& error_msg, std::vector<int>* error_locations = nullptr);
+
+std::pair<XOnlyPubKey, XOnlyPubKey> DecodeSilentData(const std::vector<unsigned char>& data);
+std::vector<unsigned char> DecodeSilentAddress(const std::string& str);
+
 bool IsValidDestinationString(const std::string& str);
 bool IsValidDestinationString(const std::string& str, const CChainParams& params);
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -34,6 +34,7 @@
 #include <policy/settings.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
+#include <pubkey.h>
 #include <rpc/protocol.h>
 #include <rpc/server.h>
 #include <shutdown.h>

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -559,6 +559,13 @@ public:
         WAIT_LOCK(cs_main, lock);
         return FillBlock(chainman().m_blockman.LookupBlockIndex(hash), block, lock, chainman().ActiveChain());
     }
+    bool getUndoBlock(const uint256& block_hash, CBlockUndo& undoBlock) override
+    {
+        WAIT_LOCK(cs_main, lock);
+        const CBlockIndex* pindex{chainman().m_blockman.LookupBlockIndex(block_hash)};
+        if (!node::UndoReadFromDisk(undoBlock, pindex)) return false;
+        return true;
+    }
     bool findFirstBlockWithTimeAndHeight(int64_t min_time, int min_height, const FoundBlock& block) override
     {
         WAIT_LOCK(cs_main, lock);

--- a/src/outputtype.cpp
+++ b/src/outputtype.cpp
@@ -21,6 +21,7 @@ static const std::string OUTPUT_TYPE_STRING_P2SH_SEGWIT = "p2sh-segwit";
 static const std::string OUTPUT_TYPE_STRING_BECH32 = "bech32";
 static const std::string OUTPUT_TYPE_STRING_BECH32M = "bech32m";
 static const std::string OUTPUT_TYPE_STRING_UNKNOWN = "unknown";
+static const std::string OUTPUT_TYPE_STRING_SILENT_PAYMENT = "silent-payment";
 
 std::optional<OutputType> ParseOutputType(const std::string& type)
 {
@@ -34,6 +35,8 @@ std::optional<OutputType> ParseOutputType(const std::string& type)
         return OutputType::BECH32M;
     } else if (type == OUTPUT_TYPE_STRING_UNKNOWN) {
         return OutputType::UNKNOWN;
+    } else if (type == OUTPUT_TYPE_STRING_SILENT_PAYMENT) {
+        return OutputType::SILENT_PAYMENT;
     }
     return std::nullopt;
 }
@@ -46,6 +49,7 @@ const std::string& FormatOutputType(OutputType type)
     case OutputType::BECH32: return OUTPUT_TYPE_STRING_BECH32;
     case OutputType::BECH32M: return OUTPUT_TYPE_STRING_BECH32M;
     case OutputType::UNKNOWN: return OUTPUT_TYPE_STRING_UNKNOWN;
+    case OutputType::SILENT_PAYMENT: return OUTPUT_TYPE_STRING_SILENT_PAYMENT;
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }
@@ -66,7 +70,8 @@ CTxDestination GetDestinationForKey(const CPubKey& key, OutputType type)
         }
     }
     case OutputType::BECH32M:
-    case OutputType::UNKNOWN: {} // This function should never be used with BECH32M or UNKNOWN, so let it assert
+    case OutputType::UNKNOWN: // This function should never be used with BECH32M or UNKNOWN, so let it assert
+    case OutputType::SILENT_PAYMENT: {} // This function should never be used with SILENT_PAYMENT, so let it assert
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }
@@ -105,7 +110,8 @@ CTxDestination AddAndGetDestinationForScript(FillableSigningProvider& keystore, 
         }
     }
     case OutputType::BECH32M:
-    case OutputType::UNKNOWN: {} // This function should not be used for BECH32M or UNKNOWN, so let it assert
+    case OutputType::UNKNOWN: // This function should not be used for BECH32M or UNKNOWN, so let it assert
+    case OutputType::SILENT_PAYMENT: {} // This function should never be used with SILENT_PAYMENT, so let it assert
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }

--- a/src/outputtype.h
+++ b/src/outputtype.h
@@ -20,6 +20,7 @@ enum class OutputType {
     BECH32,
     BECH32M,
     UNKNOWN,
+    SILENT_PAYMENT,
 };
 
 static constexpr auto OUTPUT_TYPES = std::array{
@@ -27,6 +28,7 @@ static constexpr auto OUTPUT_TYPES = std::array{
     OutputType::P2SH_SEGWIT,
     OutputType::BECH32,
     OutputType::BECH32M,
+    OutputType::SILENT_PAYMENT,
 };
 
 std::optional<OutputType> ParseOutputType(const std::string& str);

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -51,11 +51,13 @@ std::string CTxIn::ToString() const
     return str;
 }
 
-CTxOut::CTxOut(const CAmount& nValueIn, CScript scriptPubKeyIn)
-{
-    nValue = nValueIn;
-    scriptPubKey = scriptPubKeyIn;
-}
+CTxOut::CTxOut(const CAmount& nValueIn, const CScript& scriptPubKeyIn) :
+    nValue{nValueIn}, scriptPubKey{scriptPubKeyIn} { }
+
+CTxOut::CTxOut(const CAmount& nValueIn, const CScript& scriptPubKeyIn, bool silentpayment) :
+    nValue{nValueIn},
+    scriptPubKey{scriptPubKeyIn},
+    m_silentpayment{silentpayment} { }
 
 std::string CTxOut::ToString() const
 {

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -159,13 +159,16 @@ class CTxOut
 public:
     CAmount nValue;
     CScript scriptPubKey;
+    bool m_silentpayment{false};
 
     CTxOut()
     {
         SetNull();
     }
 
-    CTxOut(const CAmount& nValueIn, CScript scriptPubKeyIn);
+    CTxOut(const CAmount& nValueIn, const CScript& scriptPubKeyIn);
+
+    CTxOut(const CAmount& nValueIn, const CScript& scriptPubKeyIn, bool silentpayment);
 
     SERIALIZE_METHODS(CTxOut, obj) { READWRITE(obj.nValue, obj.scriptPubKey); }
 
@@ -173,6 +176,7 @@ public:
     {
         nValue = -1;
         scriptPubKey.clear();
+        m_silentpayment = false;
     }
 
     bool IsNull() const
@@ -192,6 +196,12 @@ public:
     }
 
     std::string ToString() const;
+};
+
+struct SilentTxOut
+{
+    CTxOut tx_out;
+    int32_t identifier;
 };
 
 struct CMutableTransaction;

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -211,6 +211,9 @@ public:
      */
     static bool CheckLowS(const std::vector<unsigned char>& vchSig);
 
+    //! Add a number of public keys together.
+    static CPubKey Combine(std::vector<CPubKey> pubkeys);
+
     //! Recover a public key from a compact signature.
     bool RecoverCompact(const uint256& hash, const std::vector<unsigned char>& vchSig);
 
@@ -271,6 +274,9 @@ public:
     /** Construct a Taproot tweaked output point with this point as internal key. */
     std::optional<std::pair<XOnlyPubKey, bool>> CreateTapTweak(const uint256* merkle_root) const;
 
+    /** Tweak an x-only public key by adding the generator multiplied with tweak32 to it. */
+    XOnlyPubKey AddTweak(const unsigned char *tweak32) const;
+
     /** Returns a list of CKeyIDs for the CPubKeys that could have been used to create this XOnlyPubKey.
      * This is needed for key lookups since keys are indexed by CKeyID.
      */
@@ -286,6 +292,13 @@ public:
     bool operator==(const XOnlyPubKey& other) const { return m_keydata == other.m_keydata; }
     bool operator!=(const XOnlyPubKey& other) const { return m_keydata != other.m_keydata; }
     bool operator<(const XOnlyPubKey& other) const { return m_keydata < other.m_keydata; }
+
+    CPubKey ConvertToCompressedPubKey(bool even = true) const
+    {
+        std::vector<unsigned char> vch(std::begin(m_keydata), std::end(m_keydata));
+        vch.insert(vch.begin(), even ? 2 : 3);
+        return CPubKey(vch.begin(), vch.end());
+    }
 
     //! Implement serialization without length prefixes since it is a fixed length
     SERIALIZE_METHODS(XOnlyPubKey, obj) { READWRITE(obj.m_keydata); }

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -213,6 +213,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "createwallet", 5, "descriptors"},
     { "createwallet", 6, "load_on_startup"},
     { "createwallet", 7, "external_signer"},
+    { "createwallet", 8, "silent_payment"},
     { "restorewallet", 2, "load_on_startup"},
     { "loadwallet", 1, "load_on_startup"},
     { "unloadwallet", 1, "load_on_startup"},

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -99,6 +99,8 @@ void AddOutputs(CMutableTransaction& rawTx, const UniValue& outputs_in)
     std::set<CTxDestination> destinations;
     bool has_data{false};
 
+    std::set<std::vector<unsigned char>> silent_data;
+
     for (const std::string& name_ : outputs.getKeys()) {
         if (name_ == "data") {
             if (has_data) {
@@ -110,19 +112,39 @@ void AddOutputs(CMutableTransaction& rawTx, const UniValue& outputs_in)
             CTxOut out(0, CScript() << OP_RETURN << data);
             rawTx.vout.push_back(out);
         } else {
-            CTxDestination destination = DecodeDestination(name_);
-            if (!IsValidDestination(destination)) {
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Bitcoin address: ") + name_);
+
+            auto data = DecodeSilentAddress(name_);
+            auto [scan_pubkey, spend_pubkey] = DecodeSilentData(data);
+
+            CTxOut out;
+
+            if (scan_pubkey.IsFullyValid() && spend_pubkey.IsFullyValid()) {
+
+                if (!silent_data.insert(data).second) {
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid parameter, duplicated address: ") + name_);
+                }
+                // this scriptPubKey is the identifier + pubkey
+                // This is not a valid pubkey but will be changed to a P2TR when creating the transaction
+                CScript scriptPubKey = CScript(std::begin(data), std::end(data));
+                CAmount nAmount = AmountFromValue(outputs[name_]);
+                out = {nAmount, scriptPubKey, true};
+            }
+            else {
+                CTxDestination destination = DecodeDestination(name_);
+
+                if (!IsValidDestination(destination)) {
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Bitcoin address: ") + name_);
+                }
+
+                if (!destinations.insert(destination).second) {
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid parameter, duplicated address: ") + name_);
+                }
+
+                CScript scriptPubKey = GetScriptForDestination(destination);
+                CAmount nAmount = AmountFromValue(outputs[name_]);
+                out = {nAmount, scriptPubKey};
             }
 
-            if (!destinations.insert(destination).second) {
-                throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid parameter, duplicated address: ") + name_);
-            }
-
-            CScript scriptPubKey = GetScriptForDestination(destination);
-            CAmount nAmount = AmountFromValue(outputs[name_]);
-
-            CTxOut out(nAmount, scriptPubKey);
             rawTx.vout.push_back(out);
         }
     }

--- a/src/rpc/rawtransaction_util.h
+++ b/src/rpc/rawtransaction_util.h
@@ -5,17 +5,20 @@
 #ifndef BITCOIN_RPC_RAWTRANSACTION_UTIL_H
 #define BITCOIN_RPC_RAWTRANSACTION_UTIL_H
 
+#include <vector>
 #include <map>
 #include <string>
 #include <optional>
 
 struct bilingual_str;
+class CTxOut;
 class FillableSigningProvider;
 class UniValue;
 struct CMutableTransaction;
 class Coin;
 class COutPoint;
 class SigningProvider;
+struct SilentTxOut;
 
 /**
  * Sign a transaction with the given keystore and previous transactions

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -112,6 +112,12 @@ std::pair<int64_t, int64_t> ParseDescriptorRange(const UniValue& value);
 /** Evaluate a descriptor given as a string, or as a {"desc":...,"range":...} object, with default range of 1000. */
 std::vector<CScript> EvalDescriptorStringOrObject(const UniValue& scanobject, FlatSigningProvider& provider);
 
+std::tuple<std::string, std::pair<int64_t, int64_t>> EvalDescriptorStringOrObject(const UniValue& scanobject);
+
+std::vector<CScript> DescriptorToScripts(const std::string& desc_str, std::pair<int64_t, int64_t> range, FlatSigningProvider& provider);
+
+std::vector<CKey> DescriptorToKeys(const std::string& desc_str, std::pair<int64_t, int64_t> range, FlatSigningProvider& provider);
+
 /** Returns, given services flags, a list of humanly readable (known) network services */
 UniValue GetServicesNames(ServiceFlags services);
 

--- a/src/silentpayment.cpp
+++ b/src/silentpayment.cpp
@@ -1,0 +1,336 @@
+#include <silentpayment.h>
+
+#include <arith_uint256.h>
+#include <coins.h>
+#include <crypto/hmac_sha512.h>
+#include <key_io.h>
+#include <undo.h>
+namespace silentpayment {
+
+Recipient::Recipient(const CKey& spend_seckey, size_t pool_size)
+{
+    std::vector<std::pair<CKey, XOnlyPubKey>> spend_keys;
+
+    unsigned char scan_seckey_bytes[32];
+    CSHA256().Write(spend_seckey.begin(), 32).Finalize(scan_seckey_bytes);
+
+    CKey scan_key;
+    scan_key.Set(std::begin(scan_seckey_bytes), std::end(scan_seckey_bytes), true);
+
+    m_scan_pubkey = XOnlyPubKey(scan_key.GetPubKey());
+
+    m_negated_scan_seckey = scan_key;
+    if (scan_key.GetPubKey().data()[0] == 3) {
+        m_negated_scan_seckey.Negate();
+    }
+
+    for(size_t identifier = 0; identifier < pool_size; identifier++) {
+
+        CKey spend_seckey1{spend_seckey};
+        if (spend_seckey.GetPubKey().data()[0] == 3) {
+            spend_seckey1.Negate();
+        }
+
+        arith_uint256 tweak;
+        tweak = tweak + identifier;
+
+        CKey spend_seckey2 = spend_seckey1.AddTweak(ArithToUint256(tweak).data());
+
+        CKey tweaked_spend_seckey{spend_seckey2};
+        if (spend_seckey2.GetPubKey().data()[0] == 3) {
+            tweaked_spend_seckey.Negate();
+        }
+
+        spend_keys.push_back(std::make_pair(tweaked_spend_seckey, XOnlyPubKey{tweaked_spend_seckey.GetPubKey()}));
+    }
+
+    m_spend_keys = spend_keys;
+}
+
+void Recipient::SetSenderPublicKey(const CPubKey& sender_public_key, const uint256& outpoint_hash)
+{
+    auto tweaked_scan_seckey = m_negated_scan_seckey.MultiplyTweak(outpoint_hash.begin());
+
+    std::array<unsigned char, 32> result = tweaked_scan_seckey.ECDH(sender_public_key);
+
+    std::copy(std::begin(result), std::end(result), std::begin(m_shared_secret));
+}
+
+void Recipient::SetSenderPublicKey(const CPubKey& sender_public_key, const std::vector<COutPoint>& tx_outpoints)
+{
+    const auto& [truncated_hash, outpoint_hash] = HashOutpoints(tx_outpoints);
+    (void) truncated_hash; //not used here
+
+    SetSenderPublicKey(sender_public_key, outpoint_hash);
+}
+
+std::tuple<CKey,XOnlyPubKey> Recipient::Tweak(const int32_t& identifier) const
+{
+    const auto& [seckey, xonly_pubkey]{m_spend_keys.at(identifier)};
+
+    const auto& result_xonly_pubkey{xonly_pubkey.AddTweak(m_shared_secret)};
+
+    const auto& result_seckey{seckey.AddTweak(m_shared_secret)};
+
+    return {result_seckey, result_xonly_pubkey};
+}
+
+std::pair<XOnlyPubKey,XOnlyPubKey> Recipient::GetAddress(const int32_t& identifier) const
+{
+    const auto& [_, spend_pubkey]{m_spend_keys.at(identifier)};
+    return {m_scan_pubkey, spend_pubkey};
+}
+
+int32_t Recipient::GetIdentifier(const XOnlyPubKey& spend_pubkey) const
+{
+    for(std::size_t i = 0; i < spend_pubkey.size(); i++) {
+        const auto& [_, pubkey] = m_spend_keys.at(i);
+        if (pubkey == spend_pubkey) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+CPubKey Recipient::CombinePublicKeys(const std::vector<CPubKey>& sender_public_keys, const std::vector<XOnlyPubKey>& sender_x_only_public_key)
+{
+    std::vector<CPubKey> v_pubkeys;
+
+    v_pubkeys.insert(v_pubkeys.end(), sender_public_keys.begin(), sender_public_keys.end());
+
+    for (auto& xpubkey : sender_x_only_public_key) {
+        v_pubkeys.push_back(xpubkey.ConvertToCompressedPubKey());
+    }
+
+    return CPubKey::Combine(v_pubkeys);
+}
+
+CPubKey Recipient::CombinePublicKeys(const CTransaction &tx, const std::vector<Coin>& coins)
+{
+    CPubKey sum_sender_pubkeys;
+
+    std::vector<XOnlyPubKey> input_xonly_pubkeys;
+    std::vector<CPubKey> input_pubkeys;
+
+    for (size_t i = 0; i < tx.vin.size(); i++)
+    {
+        const CTxIn& txin{tx.vin.at(i)};
+        const Coin& prev_coin{coins.at(i)};
+
+        // TODO: confirm that txin.scriptSig unlocks prev_coin.out.scriptPubKey
+
+        const auto& pubkey_variant{ExtractPubkeyFromInput(prev_coin, txin)};
+
+        if (std::holds_alternative<CPubKey>(pubkey_variant)) {
+            const auto& pubkey{std::get<CPubKey>(pubkey_variant)};
+            if (pubkey.IsFullyValid()) {
+                input_pubkeys.push_back(pubkey);
+            }
+        } else if (std::holds_alternative<XOnlyPubKey>(pubkey_variant)) {
+            const auto& pubkey{std::get<XOnlyPubKey>(pubkey_variant)};
+            if (pubkey.IsFullyValid()) {
+                input_xonly_pubkeys.push_back(pubkey);
+            }
+        }
+    }
+
+    // Currently Silent Payment scheme uses all keys. If not possible to
+    // retrieve all keys, it is not a SP transaction.
+    if ((input_pubkeys.size() + input_xonly_pubkeys.size()) == tx.vin.size()) {
+        sum_sender_pubkeys = CombinePublicKeys(input_pubkeys, input_xonly_pubkeys);
+    }
+
+    return sum_sender_pubkeys;
+}
+
+XOnlyPubKey Sender::Tweak(const XOnlyPubKey spend_xonly_pubkey) const
+{
+    return spend_xonly_pubkey.AddTweak(m_shared_secret);
+}
+
+
+Sender::Sender(const std::vector<std::tuple<CKey, bool>>& sender_secret_keys, const std::vector<COutPoint>& tx_outpoints, const XOnlyPubKey& recipient_scan_xonly_pubkey)
+{
+    const auto& [seckey, is_taproot] = sender_secret_keys.at(0);
+
+    CKey sum_seckey{seckey};
+
+    if (is_taproot && sum_seckey.GetPubKey()[0] == 3) {
+        sum_seckey.Negate();
+    }
+
+    if (sender_secret_keys.size() > 1) {
+        for (size_t i = 1; i < sender_secret_keys.size(); i++) {
+            const auto& [sender_seckey, sender_is_taproot] = sender_secret_keys.at(i);
+
+            auto temp_key{sender_seckey};
+            if (sender_is_taproot && sender_seckey.GetPubKey()[0] == 3) {
+                temp_key.Negate();
+            }
+
+            sum_seckey = sum_seckey.AddTweak(temp_key.begin());
+        }
+    }
+
+    CPubKey recipient_scan_pubkey = recipient_scan_xonly_pubkey.ConvertToCompressedPubKey();
+
+    const auto& [truncated_hash, outpoint_hash] = HashOutpoints(tx_outpoints);
+    (void) truncated_hash; //not used here
+
+    auto tweaked_sum_seckey = sum_seckey.MultiplyTweak(outpoint_hash.begin());
+    std::array<unsigned char, 32> result = tweaked_sum_seckey.ECDH(recipient_scan_pubkey);
+
+    std::copy(std::begin(result), std::end(result), std::begin(m_shared_secret));
+}
+
+std::pair<std::array<uint8_t, 8>, uint256> HashOutpoints(const std::vector<COutPoint>& tx_outpoints)
+{
+    uint256 result_hash;
+
+    auto hash256 = CSHA256();
+
+    for (const auto& outpoint: tx_outpoints) {
+        hash256 = hash256.Write(std::begin(outpoint.hash), outpoint.hash.size());
+
+        uint256 hash_n = uint256(outpoint.n);
+        hash256 = hash256.Write(std::begin(hash_n), hash_n.size());
+    }
+
+    hash256.Finalize(result_hash.begin());
+
+    std::array<uint8_t, 8> truncated_hash;
+
+    for (std::size_t i{ 0 }; i < truncated_hash.size(); ++i) {
+        truncated_hash[i] = result_hash.data()[i];
+    }
+
+    uint256 final_hash;
+    CSHA256().Write(truncated_hash.data(), truncated_hash.size()).Finalize(final_hash.begin());
+
+    return {truncated_hash, final_hash};
+}
+
+std::variant<CPubKey, XOnlyPubKey> ExtractPubkeyFromInput(const Coin& prevCoin, const CTxIn& txin)
+{
+    // scriptPubKey being spent by this input
+    CScript scriptPubKey = prevCoin.out.scriptPubKey;
+
+    if (scriptPubKey.IsPayToWitnessScriptHash()) {
+        return CPubKey(); // returns an invalid pubkey
+    }
+
+    // Vector of parsed pubkeys and hashes
+    std::vector<std::vector<unsigned char>> solutions;
+
+    TxoutType whichType = Solver(scriptPubKey, solutions);
+
+    if (whichType == TxoutType::NONSTANDARD ||
+    whichType == TxoutType::MULTISIG ||
+    whichType == TxoutType::WITNESS_UNKNOWN ) {
+        return CPubKey(); // returns an invalid pubkey
+    }
+
+    const CScript scriptSig = txin.scriptSig;
+    const CScriptWitness scriptWitness = txin.scriptWitness;
+
+    // TODO: Condition not tested
+    if (whichType == TxoutType::PUBKEY) {
+
+        CPubKey pubkey = CPubKey(solutions[0]);
+        assert(pubkey.IsFullyValid());
+        return pubkey;
+    }
+
+    else if (whichType == TxoutType::PUBKEYHASH) {
+
+        int sigSize = static_cast<int>(scriptSig[0]);
+        int pubKeySize = static_cast<int>(scriptSig[sigSize + 1]);
+        auto serializedPubKey = std::vector<unsigned char>(scriptSig.begin() + sigSize + 2, scriptSig.end());
+        assert(serializedPubKey.size() == (size_t) pubKeySize);
+
+        CPubKey pubkey = CPubKey(serializedPubKey);
+        assert(pubkey.IsFullyValid());
+
+        return pubkey;
+
+    }
+
+    else if (whichType == TxoutType::WITNESS_V0_KEYHASH || scriptPubKey.IsPayToScriptHash()) {
+        if (scriptWitness.stack.size() != 2) return CPubKey(); // returns an invalid pubkey
+
+        if (scriptWitness.stack.at(1).size() != 33) {
+            return CPubKey();
+        }
+
+        CPubKey pubkey = CPubKey(scriptWitness.stack.at(1));
+        assert(pubkey.IsFullyValid());
+
+        return pubkey;
+    }
+
+    else if (whichType == TxoutType::WITNESS_V1_TAPROOT) {
+
+        XOnlyPubKey pubkey = XOnlyPubKey(solutions[0]);
+        assert(pubkey.IsFullyValid());
+        return pubkey;
+    }
+
+    return CPubKey(); // returns an invalid pubkey
+}
+
+std::vector<std::tuple<uint256, CPubKey, uint256, std::array<uint8_t, 8>>> GetSilentPaymentKeysPerBlock(const uint256& block_hash, const CBlockUndo& blockUndo, const std::vector<CTransactionRef> vtx)
+{
+    std::vector<std::tuple<uint256, CPubKey, uint256, std::array<uint8_t, 8>>>  items; // <tx_hash, sum of public keys of transaction inputs, hash of the outpoints >
+
+    for (const auto& tx : vtx) {
+
+        if (tx->IsCoinBase()) {
+            continue;
+        }
+
+        std::unordered_set<TxoutType> tx_vout_types;
+        for (auto& vout : tx->vout) {
+            std::vector<std::vector<unsigned char>> solutions;
+            TxoutType whichType = Solver(vout.scriptPubKey, solutions);
+            tx_vout_types.insert(whichType);
+        }
+
+        // Silent Payments require that the recipients use Taproot address
+        // so one output at least must be Taproot
+        if (tx_vout_types.find(TxoutType::WITNESS_V1_TAPROOT) == tx_vout_types.end()) {
+            continue;
+        }
+
+        auto it = std::find_if(vtx.cbegin(), vtx.cend(), [tx](CTransactionRef t){ return *t == *tx; });
+        // TODO: redundant verification ?
+        if (it == vtx.end()) {
+            continue;
+        }
+
+        // -1 as blockundo does not have coinbase tx
+        const auto& undoTX = blockUndo.vtxundo.at(it - vtx.begin() - 1);
+
+        assert(tx->vin.size() == undoTX.vprevout.size());
+
+        std::vector<COutPoint> tx_outpoints;
+
+        std::vector<Coin> coins;
+        for (size_t i = 0; i < tx->vin.size(); i++)
+        {
+            coins.push_back(undoTX.vprevout[i]);
+            tx_outpoints.push_back(tx->vin[i].prevout);
+        }
+
+        CPubKey sum_tx_pubkeys = silentpayment::Recipient::CombinePublicKeys(*tx, coins);
+
+        const auto& [truncated_hash, outpoint_hash] = HashOutpoints(tx_outpoints);
+        (void) truncated_hash; //not used here
+
+        if (sum_tx_pubkeys.IsFullyValid()) {
+            items.emplace_back(tx->GetHash(), sum_tx_pubkeys, outpoint_hash, truncated_hash);
+        }
+    }
+
+    return items;
+}
+} // namespace silentpayment

--- a/src/silentpayment.h
+++ b/src/silentpayment.h
@@ -1,0 +1,45 @@
+#ifndef BITCOIN_SILENTPAYMENT_H
+#define BITCOIN_SILENTPAYMENT_H
+
+#include <coins.h>
+#include <key_io.h>
+#include <undo.h>
+
+namespace silentpayment {
+
+class Recipient {
+    protected:
+        CKey m_negated_scan_seckey;
+        unsigned char m_shared_secret[32];
+        std::vector<std::pair<CKey, XOnlyPubKey>> m_spend_keys;
+        XOnlyPubKey m_scan_pubkey;
+
+    public:
+        Recipient(const CKey& spend_seckey, size_t pool_size);
+        void SetSenderPublicKey(const CPubKey& sender_public_key, const uint256& outpoint_hash);
+        void SetSenderPublicKey(const CPubKey& sender_public_key, const std::vector<COutPoint>& tx_outpoints);
+        std::tuple<CKey,XOnlyPubKey> Tweak(const int32_t& identifier) const;
+        std::pair<XOnlyPubKey,XOnlyPubKey> GetAddress(const int32_t& identifier) const;
+        int32_t GetIdentifier(const XOnlyPubKey& spend_pubkey) const;
+
+        static CPubKey CombinePublicKeys(const std::vector<CPubKey>& sender_public_keys, const std::vector<XOnlyPubKey>& sender_x_only_public_key);
+        static CPubKey CombinePublicKeys(const CTransaction& tx, const std::vector<Coin>& coins);
+}; // class Recipient
+
+class Sender {
+    protected:
+        unsigned char m_shared_secret[32];
+
+    public:
+        Sender(const std::vector<std::tuple<CKey, bool>>& sender_secret_keys, const std::vector<COutPoint>& tx_outpoints, const XOnlyPubKey& recipient_scan_xonly_pubkey);
+        XOnlyPubKey Tweak(const XOnlyPubKey spend_xonly_pubkey) const;
+};  // class Sender
+
+std::pair<std::array<uint8_t, 8>, uint256> HashOutpoints(const std::vector<COutPoint>& tx_outpoints);
+/** Extract Pubkey from an input according to the transaction type **/
+std::variant<CPubKey, XOnlyPubKey> ExtractPubkeyFromInput(const Coin& prevCoin, const CTxIn& txin);
+/** For each transaction in the block, return <txid, sum_public_keys, outpoint_hash, truncated_hash> **/
+std::vector<std::tuple<uint256, CPubKey, uint256, std::array<uint8_t, 8>>> GetSilentPaymentKeysPerBlock(const uint256& block_hash, const CBlockUndo& blockUndo, const std::vector<CTransactionRef> vtx);
+} // namespace silentpayment
+
+#endif // BITCOIN_SILENTPAYMENT_H

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -172,6 +172,7 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "waitforblock",
     "waitforblockheight",
     "waitfornewblock",
+    "getsilentpaymentblockdata"
 };
 
 std::string ConsumeScalarRPCArgument(FuzzedDataProvider& fuzzed_data_provider)

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -1490,10 +1490,17 @@ static UniValue ProcessDescriptorImport(CWallet& wallet, const UniValue& data, c
                 }
             }
         }
+	// Can only have sp at the top level
+	bool isSP = (descriptor.rfind("sp(", 0) == 0);
 
         // Active descriptors must be ranged
         if (active && !parsed_desc->IsRange()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Active descriptors must be ranged");
+        }
+
+        if (isSP && data.exists("next_index"))
+        {
+            next_index = data["next_index"].getInt<int64_t>();
         }
 
         // Ranged descriptors should not have a label
@@ -1840,6 +1847,9 @@ RPCHelpMan listdescriptors()
             spk.pushKV("range", range);
             spk.pushKV("next", info.next_index);
             spk.pushKV("next_index", info.next_index);
+        }
+        if (info.descriptor.rfind("sp(", 0) == 0) {
+            spk.pushKV("next", info.next_index);
         }
         descriptors.push_back(spk);
     }

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -1717,6 +1717,9 @@ RPCHelpMan walletcreatefundedpsbt()
     const UniValue &replaceable_arg = options["replaceable"];
     const bool rbf{replaceable_arg.isNull() ? wallet.m_signal_rbf : replaceable_arg.get_bool()};
     CMutableTransaction rawTx = ConstructTransaction(request.params[0], request.params[1], request.params[2], rbf);
+
+    CheckSilentPayment(*pwallet, rawTx);
+
     CCoinControl coin_control;
     // Automatically select coins, unless at least one is manually selected. Can
     // be overridden by options.add_inputs.

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -1169,6 +1169,28 @@ static RPCHelpMan bumpfee_helper(std::string method_name)
     };
 }
 
+static void CheckSilentPayment(const CWallet &pwallet, const CMutableTransaction& tx)
+{
+    bool is_silent_payment{false};
+
+    for (const auto& out : tx.vout) {
+        if (out.m_silentpayment) {
+            is_silent_payment = true;
+            break;
+        }
+    }
+
+    if (is_silent_payment) {
+        if (!pwallet.IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "Only descriptor wallets support silent payments.");
+        }
+        if (pwallet.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) || pwallet.IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER) ) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "Silent payments require access to private keys to build transactions.");
+        }
+        EnsureWalletIsUnlocked(pwallet);
+    }
+}
+
 RPCHelpMan bumpfee() { return bumpfee_helper("bumpfee"); }
 RPCHelpMan psbtbumpfee() { return bumpfee_helper("psbtbumpfee"); }
 
@@ -1261,11 +1283,13 @@ RPCHelpMan send()
             InterpretFeeEstimationInstructions(/*conf_target=*/request.params[1], /*estimate_mode=*/request.params[2], /*fee_rate=*/request.params[3], options);
             PreventOutdatedOptions(options);
 
-
             CAmount fee;
             int change_position;
             bool rbf{options.exists("replaceable") ? options["replaceable"].get_bool() : pwallet->m_signal_rbf};
             CMutableTransaction rawTx = ConstructTransaction(options["inputs"], request.params[0], options["locktime"], rbf);
+
+            CheckSilentPayment(*pwallet, rawTx);
+
             CCoinControl coin_control;
             // Automatically select coins, unless at least one is manually selected. Can
             // be overridden by options.add_inputs.

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -59,6 +59,7 @@ static RPCHelpMan getwalletinfo()
                         }, /*skip_type_check=*/true},
                         {RPCResult::Type::BOOL, "descriptors", "whether this wallet uses descriptors for scriptPubKey management"},
                         {RPCResult::Type::BOOL, "external_signer", "whether this wallet is configured to use an external signer such as a hardware wallet"},
+                        {RPCResult::Type::BOOL, "silent_payment", "whether this supports silent payments"},
                     }},
                 },
                 RPCExamples{
@@ -120,6 +121,7 @@ static RPCHelpMan getwalletinfo()
     }
     obj.pushKV("descriptors", pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
     obj.pushKV("external_signer", pwallet->IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER));
+    obj.pushKV("silent_payment", pwallet->IsWalletFlagSet(WALLET_FLAG_SILENT_PAYMENT));
     return obj;
 },
     };

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -802,6 +802,7 @@ RPCHelpMan newkeypool();
 RPCHelpMan getaddressesbylabel();
 RPCHelpMan listlabels();
 RPCHelpMan getsilentaddress();
+RPCHelpMan listsilentaddresses();
 #ifdef ENABLE_EXTERNAL_SIGNER
 RPCHelpMan walletdisplayaddress();
 #endif // ENABLE_EXTERNAL_SIGNER
@@ -887,6 +888,7 @@ Span<const CRPCCommand> GetWalletRPCCommands()
         {"wallet", &getreceivedbyaddress},
         {"wallet", &getreceivedbylabel},
         {"wallet", &getsilentaddress},
+        {"wallet", &listsilentaddresses},
         {"wallet", &gettransaction},
         {"wallet", &getunconfirmedbalance},
         {"wallet", &getbalances},

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -332,6 +332,7 @@ static RPCHelpMan createwallet()
                                                                        " support for creating and opening legacy wallets will be removed in the future."},
             {"load_on_startup", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged."},
             {"external_signer", RPCArg::Type::BOOL, RPCArg::Default{false}, "Use an external signer such as a hardware wallet. Requires -signer to be configured. Wallet creation will fail if keys cannot be fetched. Requires disable_private_keys and descriptors set to true."},
+            {"silent_payment", RPCArg::Type::BOOL, RPCArg::Default{false}, "Experimental. Indicates that the wallet supports Silent Payments. This means a more complex scanning logic"},
         },
         RPCResult{
             RPCResult::Type::OBJ, "", "",
@@ -391,6 +392,12 @@ static RPCHelpMan createwallet()
     }
 #endif
 
+    bool silent_payment = !request.params[8].isNull() && request.params[8].get_bool();
+
+    if (silent_payment) {
+        flags |= WALLET_FLAG_SILENT_PAYMENT;
+    }
+
     DatabaseOptions options;
     DatabaseStatus status;
     ReadDatabaseArgs(*context.args, options);
@@ -399,7 +406,7 @@ static RPCHelpMan createwallet()
     options.create_passphrase = passphrase;
     bilingual_str error;
     std::optional<bool> load_on_start = request.params[6].isNull() ? std::nullopt : std::optional<bool>(request.params[6].get_bool());
-    const std::shared_ptr<CWallet> wallet = CreateWallet(context, request.params[0].get_str(), load_on_start, options, status, error, warnings);
+    const std::shared_ptr<CWallet> wallet = CreateWallet(context, request.params[0].get_str(), load_on_start, options, status, error, warnings, silent_payment);
     if (!wallet) {
         RPCErrorCode code = status == DatabaseStatus::FAILED_ENCRYPT ? RPC_WALLET_ENCRYPTION_FAILED : RPC_WALLET_ERROR;
         throw JSONRPCError(code, error.original);
@@ -784,6 +791,7 @@ static RPCHelpMan migratewallet()
 
 // addresses
 RPCHelpMan getaddressinfo();
+RPCHelpMan decodesilentaddress();
 RPCHelpMan getnewaddress();
 RPCHelpMan getrawchangeaddress();
 RPCHelpMan setlabel();
@@ -793,6 +801,7 @@ RPCHelpMan keypoolrefill();
 RPCHelpMan newkeypool();
 RPCHelpMan getaddressesbylabel();
 RPCHelpMan listlabels();
+RPCHelpMan getsilentaddress();
 #ifdef ENABLE_EXTERNAL_SIGNER
 RPCHelpMan walletdisplayaddress();
 #endif // ENABLE_EXTERNAL_SIGNER
@@ -871,11 +880,13 @@ Span<const CRPCCommand> GetWalletRPCCommands()
         {"wallet", &encryptwallet},
         {"wallet", &getaddressesbylabel},
         {"wallet", &getaddressinfo},
+        {"wallet", &decodesilentaddress},
         {"wallet", &getbalance},
         {"wallet", &getnewaddress},
         {"wallet", &getrawchangeaddress},
         {"wallet", &getreceivedbyaddress},
         {"wallet", &getreceivedbylabel},
+        {"wallet", &getsilentaddress},
         {"wallet", &gettransaction},
         {"wallet", &getunconfirmedbalance},
         {"wallet", &getbalances},

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2760,6 +2760,38 @@ std::tuple<CKey,bool> DescriptorScriptPubKeyMan::GetPrivKeyForSilentPayment(cons
     }
 }
 
+std::vector<std::tuple<CKey, int32_t>> DescriptorScriptPubKeyMan::VerifySilentPaymentAddress(
+    const std::vector<std::tuple<CScript, XOnlyPubKey>>& tx_output_pub_keys,
+    const CPubKey& sender_pub_key,
+    const std::vector<COutPoint>& tx_outpoints)
+{
+    LOCK(cs_desc_man);
+
+    std::vector<std::tuple<CKey, int32_t>> raw_tr_keys;
+
+    LoadSilentRecipient();
+
+    assert(m_silent_recipient != nullptr);
+
+    m_silent_recipient->SetSenderPublicKey(sender_pub_key, tx_outpoints);
+
+    for(const auto& [outputScriptPubKey, outputPubKey] : tx_output_pub_keys) {
+
+        for (int32_t identifier = 0; identifier <= m_wallet_descriptor.next_index; identifier++) {
+            const auto [silent_priv_key, silent_pub_key] = m_silent_recipient->Tweak(identifier);
+
+            if (silent_pub_key == outputPubKey) {
+                raw_tr_keys.emplace_back(silent_priv_key, identifier);
+                WalletLogPrintf("Silent scriptPubKey identified: %s\n", HexStr(outputScriptPubKey));
+                break;
+            }
+        }
+
+    }
+
+    return raw_tr_keys;
+}
+
 bool DescriptorScriptPubKeyMan::HasWalletDescriptor(const WalletDescriptor& desc) const
 {
     LOCK(cs_desc_man);

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2717,6 +2717,49 @@ int32_t DescriptorScriptPubKeyMan::RetrieveSilentIdentifier(const XOnlyPubKey& s
     return m_silent_recipient->GetIdentifier(spend_key);
 }
 
+std::tuple<CKey,bool> DescriptorScriptPubKeyMan::GetPrivKeyForSilentPayment(const CScript& scriptPubKey, const bool onlyTaproot) const
+{
+    std::vector<std::vector<unsigned char>> solutions;
+    TxoutType whichType = Solver(scriptPubKey, solutions);
+
+    std::unique_ptr<FlatSigningProvider> coin_keys = GetSigningProvider(scriptPubKey, true);
+    if (!coin_keys || coin_keys->keys.size() != 1) {
+        return {}; // returns an invalid private key
+    }
+
+    const auto& [_, key] = *coin_keys->keys.begin();
+    (void) _;
+
+    // Tweak the private key as GetSigningProvider returns the original key.
+    // Taproot addresses / scriptPubKeys use tweaked public key, not the original key.
+    if (whichType == TxoutType::WITNESS_V1_TAPROOT) {
+
+
+        auto pubKeyFromScriptPubKey = XOnlyPubKey(solutions[0]);
+
+        // this means it is a "rawtr" output
+        if (XOnlyPubKey(key.GetPubKey()) == pubKeyFromScriptPubKey) {
+            return {key, true};
+        }
+
+        TaprootSpendData spenddata;
+        coin_keys->GetTaprootSpendData(pubKeyFromScriptPubKey, spenddata);
+
+        CKey priv_key;
+        if(!key.TweakCKey(&spenddata.merkle_root, priv_key)) return {};
+
+        assert(XOnlyPubKey(priv_key.GetPubKey()) ==  pubKeyFromScriptPubKey);
+
+        return {priv_key, true};
+    } else if (onlyTaproot) {
+        return {}; // returns an invalid private key
+    } else if (whichType == TxoutType::NONSTANDARD || whichType == TxoutType::MULTISIG || whichType == TxoutType::WITNESS_UNKNOWN ) {
+        return {}; // returns an invalid private key
+    } else {
+        return {key, false};
+    }
+}
+
 bool DescriptorScriptPubKeyMan::HasWalletDescriptor(const WalletDescriptor& desc) const
 {
     LOCK(cs_desc_man);

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1984,6 +1984,7 @@ util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination(const 
     }
     {
         LOCK(cs_desc_man);
+
         assert(m_wallet_descriptor.descriptor->IsSingleType()); // This is a combo descriptor which should not be an active descriptor
         std::optional<OutputType> desc_addr_type = m_wallet_descriptor.descriptor->GetOutputType();
         assert(desc_addr_type);
@@ -2335,6 +2336,11 @@ bool DescriptorScriptPubKeyMan::CanGetAddresses(bool internal) const
     // We can only give out addresses from descriptors that are single type (not combo), ranged,
     // and either have cached keys or can generate more keys (ignoring encryption)
     LOCK(cs_desc_man);
+
+    if (m_wallet_descriptor.descriptor->GetOutputType() == OutputType::SILENT_PAYMENT &&
+        m_wallet_descriptor.next_index <= SILENT_ADDRESS_MAXIMUM_IDENTIFIER)
+        return true;
+
     return m_wallet_descriptor.descriptor->IsSingleType() &&
            m_wallet_descriptor.descriptor->IsRange() &&
            (HavePrivateKeys() || m_wallet_descriptor.next_index < m_wallet_descriptor.range_end);

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2285,6 +2285,9 @@ bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(const CExtKey& master_
         // so if we get to this point something is wrong
         assert(false);
     }
+    case OutputType::SILENT_PAYMENT: {
+        return false;
+    }
     } // no default case, so the compiler can warn about missing cases
     assert(!desc_prefix.empty());
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -649,6 +649,7 @@ public:
 
     void LoadSilentRecipient();
     int32_t RetrieveSilentIdentifier(const XOnlyPubKey& spend_key);
+    std::tuple<CKey,bool> GetPrivKeyForSilentPayment(const CScript& scriptPubKey, const bool onlyTaproot) const;
 
     bool HasWalletDescriptor(const WalletDescriptor& desc) const;
     void UpdateWalletDescriptor(WalletDescriptor& descriptor);

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -9,6 +9,7 @@
 #include <script/descriptor.h>
 #include <script/signingprovider.h>
 #include <script/standard.h>
+#include <silentpayment.h>
 #include <util/error.h>
 #include <util/message.h>
 #include <util/result.h>
@@ -555,6 +556,8 @@ private:
     KeyMap m_map_keys GUARDED_BY(cs_desc_man);
     CryptedKeyMap m_map_crypted_keys GUARDED_BY(cs_desc_man);
 
+    std::unique_ptr<silentpayment::Recipient> m_silent_recipient{nullptr};
+
     //! keeps track of whether Unlock has run a thorough check before
     bool m_decryption_thoroughly_checked = false;
 
@@ -591,6 +594,7 @@ public:
     mutable RecursiveMutex cs_desc_man;
 
     util::Result<CTxDestination> GetNewDestination(const OutputType type) override;
+    util::Result<std::tuple<int32_t,XOnlyPubKey,XOnlyPubKey>> GetSilentAddress();
     isminetype IsMine(const CScript& script) const override;
 
     bool CheckDecryptionKey(const CKeyingMaterial& master_key, bool accept_no_keys = false) override;
@@ -642,6 +646,9 @@ public:
 
     bool AddKey(const CKeyID& key_id, const CKey& key);
     bool AddCryptedKey(const CKeyID& key_id, const CPubKey& pubkey, const std::vector<unsigned char>& crypted_key);
+
+    void LoadSilentRecipient();
+    int32_t RetrieveSilentIdentifier(const XOnlyPubKey& spend_key);
 
     bool HasWalletDescriptor(const WalletDescriptor& desc) const;
     void UpdateWalletDescriptor(WalletDescriptor& descriptor);

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -650,6 +650,8 @@ public:
     void LoadSilentRecipient();
     int32_t RetrieveSilentIdentifier(const XOnlyPubKey& spend_key);
     std::tuple<CKey,bool> GetPrivKeyForSilentPayment(const CScript& scriptPubKey, const bool onlyTaproot) const;
+    std::vector<std::tuple<CKey, int32_t>> VerifySilentPaymentAddress(const std::vector<std::tuple<CScript, XOnlyPubKey>>& txOutputPubKeys, const CPubKey& senderPubKey, const std::vector<COutPoint>& tx_outpoints);
+
 
     bool HasWalletDescriptor(const WalletDescriptor& desc) const;
     void UpdateWalletDescriptor(WalletDescriptor& descriptor);

--- a/src/wallet/test/silentpayment_tests.cpp
+++ b/src/wallet/test/silentpayment_tests.cpp
@@ -1,0 +1,217 @@
+#include <test/util/setup_common.h>
+#include <silentpayment.h>
+
+#include <boost/test/unit_test.hpp>
+
+namespace wallet {
+BOOST_FIXTURE_TEST_SUITE(silentpayment_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(silent_addresses)
+{
+    auto txid1 = uint256S("0x00000000000002dc756eebf4f49723ed8d30cc28a5f108eb94b1ba88ac4f9c22");
+    uint32_t vout1 = 4;
+
+    auto txid2 = uint256S("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+    uint32_t vout2 = 7;
+
+    std::vector<COutPoint> tx_outpoints;
+    tx_outpoints.emplace_back(txid1, vout1);
+    tx_outpoints.emplace_back(txid2, vout2);
+
+    std::vector<std::tuple<CKey, bool>> sender_secret_keys;
+    std::vector<CPubKey> sender_pub_keys;
+    std::vector<XOnlyPubKey> sender_x_only_pub_keys;
+
+    // non-taproot inputs
+    for(size_t i =0; i < 34; i++) {
+        CKey senderkey;
+        senderkey.MakeNewKey(true);
+        CPubKey senderPubkey = senderkey.GetPubKey();
+
+        sender_secret_keys.emplace_back(senderkey, false);
+        sender_pub_keys.emplace_back(senderPubkey);
+    }
+
+    // taproot inputs
+    for(size_t i =0; i < 45; i++) {
+        CKey senderkey;
+        senderkey.MakeNewKey(true);
+
+        sender_secret_keys.emplace_back(senderkey, true);
+        sender_x_only_pub_keys.emplace_back(senderkey.GetPubKey());
+    }
+
+    CKey recipient_spend_seckey;
+    recipient_spend_seckey.MakeNewKey(true);
+
+    auto silent_recipient = silentpayment::Recipient(recipient_spend_seckey, 440);
+
+    CPubKey combined_tx_pubkeys{silentpayment::Recipient::CombinePublicKeys(sender_pub_keys, sender_x_only_pub_keys)};
+
+    silent_recipient.SetSenderPublicKey(combined_tx_pubkeys, tx_outpoints);
+
+    for (int32_t identifier = 0; identifier < 234; identifier++) {
+        const auto&[recipient_scan_pubkey, recipient_spend_pubkey]{silent_recipient.GetAddress(identifier)};
+
+        silentpayment::Sender silent_sender{
+            sender_secret_keys,
+            tx_outpoints,
+            recipient_scan_pubkey
+        };
+
+        XOnlyPubKey sender_tweaked_pubkey = silent_sender.Tweak(recipient_spend_pubkey);
+        const auto [recipient_priv_key, recipient_pub_key] = silent_recipient.Tweak(identifier);
+
+        BOOST_CHECK(XOnlyPubKey{recipient_priv_key.GetPubKey()} == recipient_pub_key);
+        BOOST_CHECK(sender_tweaked_pubkey == recipient_pub_key);
+    }
+
+}
+
+class TestRecipient: public silentpayment::Recipient {
+    public:
+        TestRecipient(const CKey& spend_seckey, size_t pool_size) : Recipient(spend_seckey, pool_size) {}
+        CKey GetNegatedScanSecKey() { return m_negated_scan_seckey; }
+        std::vector<std::pair<CKey, XOnlyPubKey>> GetSpendKeys() { return m_spend_keys; }
+        XOnlyPubKey GetScanPubkey() { return m_scan_pubkey; }
+        std::array<unsigned char, 32> GetSharedSecret() {
+            std::array<unsigned char, 32> result;
+            std::copy(std::begin(m_shared_secret), std::end(m_shared_secret), std::begin(result));
+            return result;
+        }
+};
+
+class TestSender: public silentpayment::Sender {
+    public:
+        TestSender(const std::vector<std::tuple<CKey, bool>>& sender_secret_keys, const std::vector<COutPoint>& tx_outpoints, const XOnlyPubKey& recipient_scan_xonly_pubkey) :
+            Sender(sender_secret_keys, tx_outpoints, recipient_scan_xonly_pubkey) {}
+        std::array<unsigned char, 32> GetSharedSecret() {
+            std::array<unsigned char, 32> result;
+            std::copy(std::begin(m_shared_secret), std::end(m_shared_secret), std::begin(result));
+            return result;
+    }
+};
+
+BOOST_AUTO_TEST_CASE(silent_addresses2)
+{
+    std::vector<std::tuple<CKey, bool>> sender_secret_keys;
+    std::vector<CPubKey> sender_pub_keys;
+    std::vector<XOnlyPubKey> sender_x_only_pub_keys;
+
+    const std::vector<std::pair<std::string, bool>> sender_keys = {
+        {"KxeDWuvKtXfBxLGmP6ZT4crvbamCnicJg2xgkgESSLURYyr6kVvu", false},
+        {"L3nddfqwDWmAeskCjWwLnnF5ZFt1BZXFxNav92eA3sS7kKbh3nT3", false},
+        {"KyAWmQjXmkNL8xFaFc3Kp4S4SJSqYmGfvdePvuGwpsb7YyWAW5wS", true},
+        {"KzrGQWApg8wpX4pCQM1chMrJhgSfzmwS8fZLfUDujA73sJNgreeF", true},
+    };
+
+    for (const auto& [wif, is_taproot]: sender_keys) {
+        CKey senderkey = DecodeSecret(wif);
+
+        sender_secret_keys.emplace_back(senderkey, is_taproot);
+        if (is_taproot) {
+            sender_x_only_pub_keys.emplace_back(senderkey.GetPubKey());
+        } else {
+            sender_pub_keys.emplace_back(senderkey.GetPubKey());
+        }
+    }
+
+    CKey recipient_spend_seckey = DecodeSecret("L4mGgWaqFknPASp5cwrAbqhEcLuHqDMzm4UjJyAo1A7f85XPiGVU");
+
+    auto silent_recipient = TestRecipient(recipient_spend_seckey, 5);
+
+    BOOST_CHECK(EncodeSecret(silent_recipient.GetNegatedScanSecKey()) == "L2HBwB2tkUdGeb2KWx2EaUWD1YjW8u4eZ7uXJfJA8u3ibkrPtvh5");
+    BOOST_CHECK(HexStr(silent_recipient.GetScanPubkey()) == "bfa2fb9b2d094a039d4b5bf76a159d028f15a8350d5c957651d6dc00af4ccf41");
+
+    const std::vector<std::pair<std::string, std::string>> spend_keys = {
+        {"KxFnFy2MjkfxGYbLWXbLztcbM5T5qQnaRaWcnCT9fySCB8XXVfRw","aef5a67267768f18f8efc327ca7add15d2bb9fcd6b6f4911424565eb6db0ae63"},
+        {"L4jKwLMPDuMhwJzVv3GYbtNdqRng7Zf9tGqfCj277ATejavame9C","3246572723b9aa4c601f2b5a277e9af81b61ca53de8ad88eedfb563dec8c2fce"},
+        {"KxKfkKVFoTXJipEVvLkazoFntugKGiCGB9nkzgkXTxkCx7nbQ9p4","c2ece65cae45f7475f99a911754189ac2aa999eba8691eab3adb51d711f73cd2"},
+        {"L4fSSytVACWMV3MLWE7JbyjSHbZSgGFU8hZWzEijKB9dxbeSUA6b","8bc5214b98ad9491ba96b0c2dbb1b9ebf45849e599ac143e487246d783da56e9"},
+        {"L4dVhof38M5gFuXkoKXgc2QqWgSpxcYdFuvSsza3RBVda73d52bA","c1547a55f2f4fd3bd7dbc94ba751bc0b6108be7ff0b6b995826db2dd0aebddba"},
+    };
+
+    size_t idx = 0;
+    for(const auto& [spend_seckey, spend_pubkey]: silent_recipient.GetSpendKeys()) {
+
+        const auto& [seckey, pubkey] = spend_keys.at(idx++);
+
+        BOOST_CHECK(EncodeSecret(spend_seckey) == seckey);
+        BOOST_CHECK(HexStr(spend_pubkey) == pubkey);
+    }
+
+    CPubKey combined_tx_pubkeys{silentpayment::Recipient::CombinePublicKeys(sender_pub_keys, sender_x_only_pub_keys)};
+
+    BOOST_CHECK(HexStr(combined_tx_pubkeys) == "031ea6a65ac33fd26dd296299dbce0b40b8105af395c68655bc303a943f0f75025");
+
+    auto txid1 = uint256S("0x00000000000002dc756eebf4f49723ed8d30cc28a5f108eb94b1ba88ac4f9c22");
+    uint32_t vout1 = 4;
+
+    auto txid2 = uint256S("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+    uint32_t vout2 = 7;
+
+    std::vector<COutPoint> tx_outpoints;
+    tx_outpoints.emplace_back(txid1, vout1);
+    tx_outpoints.emplace_back(txid2, vout2);
+
+    const auto& [truncated_hash, outpoint_hash] = silentpayment::HashOutpoints(tx_outpoints);
+
+    BOOST_CHECK(HexStr(outpoint_hash) == "db30d92d7e60ff38f4ad821d2d94996c0151f0706178d081254732808a9066f5");
+    BOOST_CHECK(HexStr(truncated_hash) == "bd37fdb110dc3df7");
+
+    silent_recipient.SetSenderPublicKey(combined_tx_pubkeys, tx_outpoints);
+
+    auto _recipient_shared_secret = silent_recipient.GetSharedSecret();
+
+    CKey recipient_shared_secret;
+    recipient_shared_secret.Set(std::begin(_recipient_shared_secret), std::end(_recipient_shared_secret), true);
+
+    BOOST_CHECK(EncodeSecret(recipient_shared_secret) == "Kx2qKiKqFMSRerYZeEUz1d9MRpKATczVXuJinaJZcAPgaTPaJC5v");
+
+    int32_t identifier = 0;
+
+    const auto&[recipient_scan_pubkey, recipient_spend_pubkey]{silent_recipient.GetAddress(identifier)};
+
+    TestSender silent_sender{
+        sender_secret_keys,
+        tx_outpoints,
+        recipient_scan_pubkey
+    };
+
+    auto _silent_shared_secret = silent_sender.GetSharedSecret();
+
+    CKey silent_shared_secret;
+    silent_shared_secret.Set(std::begin(_silent_shared_secret), std::end(_silent_shared_secret), true);
+
+    BOOST_CHECK(recipient_shared_secret == silent_shared_secret);
+
+    const std::vector<std::pair<std::string, std::string>> results = {
+        {"1669506efdf338f5610a6b3314b7a0ad40940383f3314b0af6f4ab9708fd00f9","Ky4uQ2E3aRqnCASaN4Z27EebvH3kSU527w5ewdQbRtMmiDLWqgyr"},
+        {"6ceda6fddc975987b642ef3d589b9028ad0b977316fcdc1ad0d7f92c42b60477","L5YT5PZ54aXXrvqjmaEDiEQeQdPLicwbadQhN9yYs5PEGfjzwEqY"},
+        {"6669869ddb5b0e10e47f3ff76d5258172c7f6b1305993a51072d0354e196d0d3","Ky8ntNgwe8h8eS5jmsiG79HoU7GysmUhsWMoA7hyDsfnVCZP7cvJ"},
+    };
+
+    for (int32_t identifier = 0; identifier < 3; identifier++) {
+        const auto&[recipient_scan_pubkey, recipient_spend_pubkey]{silent_recipient.GetAddress(identifier)};
+
+        TestSender silent_sender{
+            sender_secret_keys,
+            tx_outpoints,
+            recipient_scan_pubkey
+        };
+
+        XOnlyPubKey sender_tweaked_pubkey = silent_sender.Tweak(recipient_spend_pubkey);
+        const auto [recipient_priv_key, recipient_pub_key] = silent_recipient.Tweak(identifier);
+
+        BOOST_CHECK(XOnlyPubKey{recipient_priv_key.GetPubKey()} == recipient_pub_key);
+        BOOST_CHECK(sender_tweaked_pubkey == recipient_pub_key);
+
+        const auto& [expected_pubkey, expected_prvkey] = results.at(identifier);
+
+        BOOST_CHECK(expected_pubkey == HexStr(sender_tweaked_pubkey));
+        BOOST_CHECK(expected_prvkey == EncodeSecret(recipient_priv_key));
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -656,7 +656,7 @@ BOOST_FIXTURE_TEST_CASE(BasicOutputTypesTest, ListCoinsTest)
     //   2. One UTXO from the change, due to payment address matching logic
 
     for (const auto& out_type : OUTPUT_TYPES) {
-        if (out_type == OutputType::UNKNOWN) continue;
+        if (out_type == OutputType::UNKNOWN || out_type == OutputType::SILENT_PAYMENT) continue;
         expected_coins_sizes[out_type] = 2U;
         TestCoinsResult(*this, out_type, 1 * COIN, expected_coins_sizes);
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3526,6 +3526,25 @@ std::vector<WalletDescriptor> CWallet::GetWalletDescriptors(const CScript& scrip
     return descs;
 }
 
+util::Result<WalletDescriptor> CWallet::GetWalletDescriptor(const OutputType type, const bool internal) const
+{
+    LOCK(cs_wallet);
+    auto spk_man = GetScriptPubKeyMan(type, false /* internal */);
+
+    if (!spk_man) {
+        return util::Error{strprintf(_("Error: No %s addresses available."), FormatOutputType(type))};
+    }
+
+    const auto desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man);
+
+    if (!desc_spk_man) {
+        return util::Error{strprintf(_("Error: No descriptor scriptpubkeymanager for this output type"))};
+    }
+
+    LOCK(desc_spk_man->cs_desc_man);
+    return desc_spk_man->GetWalletDescriptor();
+}
+
 LegacyScriptPubKeyMan* CWallet::GetLegacyScriptPubKeyMan() const
 {
     if (IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3588,6 +3588,7 @@ void CWallet::SetupDescriptorScriptPubKeyMans(const CExtKey& master_key)
 
     for (bool internal : {false, true}) {
         for (OutputType t : OUTPUT_TYPES) {
+            if (t == OutputType::SILENT_PAYMENT) continue;
             auto spk_manager = std::unique_ptr<DescriptorScriptPubKeyMan>(new DescriptorScriptPubKeyMan(*this, m_keypool_size));
             if (IsCrypted()) {
                 if (IsLocked()) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -58,6 +58,11 @@ const std::map<uint64_t,std::string> WALLET_FLAG_CAVEATS{
         "destinations in the past. Until this is done, some destinations may "
         "be considered unused, even if the opposite is the case."
     },
+    {WALLET_FLAG_SILENT_PAYMENT,
+        "By enabling this flag, the wallet will start to check for silent transactions. "
+        "For previous transactions, a rescan is required."
+        "This flag significantly increases scan and verification time."
+    }
 };
 
 bool AddWalletSetting(interfaces::Chain& chain, const std::string& wallet_name)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1839,6 +1839,26 @@ int64_t CWallet::RescanFromTime(int64_t startTime, const WalletRescanReserver& r
     return startTime;
 }
 
+std::map<uint256, CPubKey> CWallet::GetSilentPaymentKeysPerBlock(const uint256& block_hash, const std::vector<CTransactionRef> vtx)
+{
+    CBlockUndo blockUndo;
+    if (!chain().getUndoBlock(block_hash, blockUndo)) {
+        return {};
+    }
+
+    std::map<uint256, CPubKey> items;
+
+    for(const auto& [txid, sum_tx_pubkeys, full_hash, truncated_hash]: silentpayment::GetSilentPaymentKeysPerBlock(block_hash, blockUndo, vtx))
+    {
+	// the hashes are not used here
+	(void)full_hash;
+	(void)truncated_hash;
+        items.emplace(txid, sum_tx_pubkeys);
+    }
+
+    return items;
+}
+
 /**
  * Scan the block chain (starting in start_block) for transactions
  * from or to us. If fUpdate is true, found transactions that already

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1209,70 +1209,224 @@ bool CWallet::LoadToWallet(const uint256& hash, const UpdateWalletTxFn& fill_wtx
     return true;
 }
 
-bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxState& state, bool fUpdate, bool rescanning_old_block)
+bool CWallet::HandleNewTxBelongingToMe(const CTransaction& tx, const SyncTxState& state, bool rescanning_old_block)
 {
-    const CTransaction& tx = *ptx;
-    {
-        AssertLockHeld(cs_wallet);
+    AssertLockHeld(cs_wallet);
 
-        if (auto* conf = std::get_if<TxStateConfirmed>(&state)) {
-            for (const CTxIn& txin : tx.vin) {
-                std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(txin.prevout);
-                while (range.first != range.second) {
-                    if (range.first->second != tx.GetHash()) {
-                        WalletLogPrintf("Transaction %s (in block %s) conflicts with wallet transaction %s (both spend %s:%i)\n", tx.GetHash().ToString(), conf->confirmed_block_hash.ToString(), range.first->second.ToString(), range.first->first.hash.ToString(), range.first->first.n);
-                        MarkConflicted(conf->confirmed_block_hash, conf->confirmed_block_height, range.first->second);
-                    }
-                    range.first++;
+    /* Check if any keys in the wallet keypool that were supposed to be unused
+        * have appeared in a new transaction. If so, remove those keys from the keypool.
+        * This can happen when restoring an old wallet backup that does not contain
+        * the mostly recently created transactions from newer versions of the wallet.
+        */
+
+    // loop though all outputs
+    for (const CTxOut& txout: tx.vout) {
+        for (const auto& spk_man : GetScriptPubKeyMans(txout.scriptPubKey)) {
+            for (auto &dest : spk_man->MarkUnusedAddresses(txout.scriptPubKey)) {
+                // If internal flag is not defined try to infer it from the ScriptPubKeyMan
+                if (!dest.internal.has_value()) {
+                    dest.internal = IsInternalScriptPubKeyMan(spk_man);
+                }
+
+                // skip if can't determine whether it's a receiving address or not
+                if (!dest.internal.has_value()) continue;
+
+                // If this is a receiving address and it's not in the address book yet
+                // (e.g. it wasn't generated on this node or we're restoring from backup)
+                // add it to the address book for proper transaction accounting
+                if (!*dest.internal && !FindAddressBookEntry(dest.dest, /* allow_change= */ false)) {
+                    SetAddressBook(dest.dest, "", "receive");
                 }
             }
-        }
-
-        bool fExisted = mapWallet.count(tx.GetHash()) != 0;
-        if (fExisted && !fUpdate) return false;
-        if (fExisted || IsMine(tx) || IsFromMe(tx))
-        {
-            /* Check if any keys in the wallet keypool that were supposed to be unused
-             * have appeared in a new transaction. If so, remove those keys from the keypool.
-             * This can happen when restoring an old wallet backup that does not contain
-             * the mostly recently created transactions from newer versions of the wallet.
-             */
-
-            // loop though all outputs
-            for (const CTxOut& txout: tx.vout) {
-                for (const auto& spk_man : GetScriptPubKeyMans(txout.scriptPubKey)) {
-                    for (auto &dest : spk_man->MarkUnusedAddresses(txout.scriptPubKey)) {
-                        // If internal flag is not defined try to infer it from the ScriptPubKeyMan
-                        if (!dest.internal.has_value()) {
-                            dest.internal = IsInternalScriptPubKeyMan(spk_man);
-                        }
-
-                        // skip if can't determine whether it's a receiving address or not
-                        if (!dest.internal.has_value()) continue;
-
-                        // If this is a receiving address and it's not in the address book yet
-                        // (e.g. it wasn't generated on this node or we're restoring from backup)
-                        // add it to the address book for proper transaction accounting
-                        if (!*dest.internal && !FindAddressBookEntry(dest.dest, /* allow_change= */ false)) {
-                            SetAddressBook(dest.dest, "", "receive");
-                        }
-                    }
-                }
-            }
-
-            // Block disconnection override an abandoned tx as unconfirmed
-            // which means user may have to call abandontransaction again
-            TxState tx_state = std::visit([](auto&& s) -> TxState { return s; }, state);
-            CWalletTx* wtx = AddToWallet(MakeTransactionRef(tx), tx_state, /*update_wtx=*/nullptr, /*fFlushOnClose=*/false, rescanning_old_block);
-            if (!wtx) {
-                // Can only be nullptr if there was a db write error (missing db, read-only db or a db engine internal writing error).
-                // As we only store arriving transaction in this process, and we don't want an inconsistent state, let's throw an error.
-                throw std::runtime_error("DB error adding transaction to wallet, write failed");
-            }
-            return true;
         }
     }
-    return false;
+
+    // Block disconnection override an abandoned tx as unconfirmed
+    // which means user may have to call abandontransaction again
+    TxState tx_state = std::visit([](auto&& s) -> TxState { return s; }, state);
+    CWalletTx* wtx = AddToWallet(MakeTransactionRef(tx), tx_state, /*update_wtx=*/nullptr, /*fFlushOnClose=*/false, rescanning_old_block);
+    if (!wtx) {
+        // Can only be nullptr if there was a db write error (missing db, read-only db or a db engine internal writing error).
+        // As we only store arriving transaction in this process, and we don't want an inconsistent state, let's throw an error.
+        throw std::runtime_error("DB error adding transaction to wallet, write failed");
+    }
+    return true;
+}
+
+bool CWallet::AddSilentScriptKeyMan(
+    const CTransaction& tx, const SyncTxState& state, bool rescanning_old_block, const std::vector<std::tuple<CKey, int32_t>>& rawTrKeys)
+{
+    WalletLogPrintf("Silent Transaction identified: %s.\n", tx.GetHash().ToString());
+
+    for(const auto& [key, identifier]: rawTrKeys) {
+
+        std::string desc = "rawtr(" + EncodeSecret(key) + ")";
+        std::string checksum = GetDescriptorChecksum(desc);
+
+        auto timestamp = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+        std::string desc_check = desc + "#" + checksum;
+
+        FlatSigningProvider keys;
+        std::string error;
+        auto parsed_desc = Parse(desc_check, keys, error, /* require_checksum = */ true);
+        assert(parsed_desc);
+
+        int64_t range_start = 0, range_end = 1, next_index = 0;
+
+        // Need to ExpandPrivate to check if private keys are available for all pubkeys
+        FlatSigningProvider expand_keys;
+        std::vector<CScript> scripts;
+        assert(parsed_desc->Expand(0, keys, scripts, expand_keys));
+        parsed_desc->ExpandPrivate(0, keys, expand_keys);
+
+        WalletDescriptor w_desc(std::move(parsed_desc), timestamp, range_start, range_end, next_index);
+
+        std::string label;
+
+        if (m_silent_address_book.count(identifier)) {
+            auto entry = m_silent_address_book[identifier];
+            label = entry.m_label;
+        } else {
+            std::stringstream ss;
+            ss << identifier;
+            label = ss.str();
+        }
+
+        auto existing_spk_manager = GetDescriptorScriptPubKeyMan(w_desc);
+        if (!existing_spk_manager) {
+            auto spk_manager = AddWalletDescriptor(w_desc, keys, label, false);
+            assert(spk_manager != nullptr);
+        }
+    }
+
+    return HandleNewTxBelongingToMe(tx, state, rescanning_old_block);
+}
+
+bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxState& state, const std::map<uint256, CPubKey>& tweakData, bool fUpdate, bool rescanning_old_block, bool taproot_active)
+{
+    const CTransaction& tx = *ptx;
+
+    AssertLockHeld(cs_wallet);
+
+    std::vector<std::tuple<CKey, int32_t>> rawTrKeys;
+
+    if (auto* conf = std::get_if<TxStateConfirmed>(&state)) {
+        for (const CTxIn& txin : tx.vin) {
+            std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(txin.prevout);
+            while (range.first != range.second) {
+                if (range.first->second != tx.GetHash()) {
+                    WalletLogPrintf("Transaction %s (in block %s) conflicts with wallet transaction %s (both spend %s:%i)\n", tx.GetHash().ToString(), conf->confirmed_block_hash.ToString(), range.first->second.ToString(), range.first->first.hash.ToString(), range.first->first.n);
+                    MarkConflicted(conf->confirmed_block_hash, conf->confirmed_block_height, range.first->second);
+                }
+                range.first++;
+            }
+        }
+    }
+
+    bool fExisted = mapWallet.count(tx.GetHash()) != 0;
+    if (fExisted && !fUpdate) return false;
+
+    bool ret = (fExisted || IsMine(tx) || IsFromMe(tx)) ? HandleNewTxBelongingToMe(tx, state, rescanning_old_block) : false;
+    if (IsWalletFlagSet(WALLET_FLAG_SILENT_PAYMENT) && taproot_active) {
+        if (VerifySilentPayment(tx, rawTrKeys, tweakData)) {
+            ret = AddSilentScriptKeyMan(tx, state, rescanning_old_block, rawTrKeys) || ret;
+        }
+    }
+    return ret;
+}
+
+Coin CWallet::FindPreviousCoin(const CTxIn& txin) const
+{
+    // Find the UTXO being spent in UTXO Set to learn the transaction type
+    std::map<COutPoint, Coin> coins;
+    coins[txin.prevout];
+    chain().findCoins(coins);
+
+    auto pos = coins.find(txin.prevout);
+
+    Coin coin = pos->second;
+
+    // TODO: can more than one txin.prevout be in the mempool (RBF) ?
+    pos++;
+    assert( pos == coins.end() );
+
+    return coin;
+}
+
+ bool CWallet::VerifySilentPayment(const CTransaction& tx, std::vector<std::tuple<CKey, int32_t>>& rawTrKeys, const std::map<uint256, CPubKey>& tweakData)
+{
+    AssertLockHeld(cs_wallet);
+
+    if (tx.IsCoinBase() || tx.vin.empty()) return false;
+
+    if (!IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) return false;
+
+    std::vector<std::tuple<CScript, XOnlyPubKey>> outputPubKeys;
+
+    for (auto& vout : tx.vout) {
+
+        if (IsMine(vout)) {
+            continue;
+        }
+
+        std::vector<std::vector<unsigned char>> solutions;
+        TxoutType whichType = Solver(vout.scriptPubKey, solutions);
+
+        // Silent Payments require that the recipients use Taproot address
+        if (whichType != TxoutType::WITNESS_V1_TAPROOT) {
+            continue;
+        }
+
+        auto xOnlyPubKey = XOnlyPubKey(solutions[0]);
+
+        if (!xOnlyPubKey.IsFullyValid()) {
+            continue;
+        }
+
+        outputPubKeys.emplace_back(vout.scriptPubKey, xOnlyPubKey);
+    }
+
+    if (outputPubKeys.empty()) {
+        return false;
+    }
+
+    std::vector<Coin> coins;
+    std::vector<COutPoint> tx_outpoints;
+
+    for (const CTxIn& txin : tx.vin) {
+        coins.push_back(FindPreviousCoin(txin));
+        tx_outpoints.push_back(txin.prevout);
+    }
+
+    CPubKey sum_sender_pubkeys{silentpayment::Recipient::CombinePublicKeys(tx, coins)};
+
+    if (!sum_sender_pubkeys.IsFullyValid()) {
+        auto it = tweakData.find(tx.GetHash());
+        if (it == tweakData.end()) return false;
+        auto pubkeys_from_index = it->second;
+        if (!pubkeys_from_index.IsFullyValid()) {
+            return false;
+        }
+        sum_sender_pubkeys = pubkeys_from_index;
+    }
+
+    for (ScriptPubKeyMan* spkm : GetActiveScriptPubKeyMans()) {
+        DescriptorScriptPubKeyMan* desc_spkm = dynamic_cast<DescriptorScriptPubKeyMan*>(spkm);
+
+        std::string desc_str;
+        bool res_get_desc = desc_spkm->GetDescriptorString(desc_str, false);
+
+        // There must be only one SP descriptor
+        if (res_get_desc && desc_str.rfind("sp(", 0) != 0) {
+            continue;
+        }
+
+        rawTrKeys = desc_spkm->VerifySilentPaymentAddress(outputPubKeys, sum_sender_pubkeys, tx_outpoints);
+    }
+
+    return !rawTrKeys.empty();
 }
 
 bool CWallet::TransactionCanBeAbandoned(const uint256& hashTx) const
@@ -1401,9 +1555,9 @@ void CWallet::MarkConflicted(const uint256& hashBlock, int conflicting_height, c
     }
 }
 
-void CWallet::SyncTransaction(const CTransactionRef& ptx, const SyncTxState& state, bool update_tx, bool rescanning_old_block)
+void CWallet::SyncTransaction(const CTransactionRef& ptx, const SyncTxState& state, const std::map<uint256, CPubKey>& tweakData, bool update_tx, bool rescanning_old_block, bool taproot_active)
 {
-    if (!AddToWalletIfInvolvingMe(ptx, state, update_tx, rescanning_old_block))
+    if (!AddToWalletIfInvolvingMe(ptx, state, tweakData, update_tx, rescanning_old_block, taproot_active))
         return; // Not one of ours
 
     // If a transaction changes 'conflicted' state, that changes the balance
@@ -1466,8 +1620,12 @@ void CWallet::blockConnected(const interfaces::BlockInfo& block)
 
     m_last_block_processed_height = block.height;
     m_last_block_processed = block.hash;
+    std::map<uint256, CPubKey> tweakData;
+    if (IsWalletFlagSet(WALLET_FLAG_SILENT_PAYMENT)) {
+        tweakData = GetSilentPaymentKeysPerBlock(block.hash, block.data->vtx);
+    }
     for (size_t index = 0; index < block.data->vtx.size(); index++) {
-        SyncTransaction(block.data->vtx[index], TxStateConfirmed{block.hash, block.height, static_cast<int>(index)});
+        SyncTransaction(block.data->vtx[index], TxStateConfirmed{block.hash, block.height, static_cast<int>(index)}, tweakData);
         transactionRemovedFromMempool(block.data->vtx[index], MemPoolRemovalReason::BLOCK);
     }
 }
@@ -1848,11 +2006,10 @@ std::map<uint256, CPubKey> CWallet::GetSilentPaymentKeysPerBlock(const uint256& 
 
     std::map<uint256, CPubKey> items;
 
-    for(const auto& [txid, sum_tx_pubkeys, full_hash, truncated_hash]: silentpayment::GetSilentPaymentKeysPerBlock(block_hash, blockUndo, vtx))
+    for(const auto& [txid, sum_tx_pubkeys, hash_outpoints, truncated_hash]: silentpayment::GetSilentPaymentKeysPerBlock(block_hash, blockUndo, vtx))
     {
-	// the hashes are not used here
-	(void)full_hash;
-	(void)truncated_hash;
+        (void) hash_outpoints; // not used
+        (void) truncated_hash; // not used
         items.emplace(txid, sum_tx_pubkeys);
     }
 
@@ -1907,6 +2064,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
     double progress_end = chain().guessVerificationProgress(end_hash);
     double progress_current = progress_begin;
     int block_height = start_height;
+    Consensus::Params consensus = Params().GetConsensus();
     while (!fAbortRescan && !chain().shutdownRequested()) {
         if (progress_end - progress_begin > 0.0) {
             m_scanning_progress = (progress_current - progress_begin) / (progress_end - progress_begin);
@@ -1924,7 +2082,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
         }
 
         bool fetch_block{true};
-        if (fast_rescan_filter) {
+        if (!IsWalletFlagSet(WALLET_FLAG_SILENT_PAYMENT) && fast_rescan_filter) {
             fast_rescan_filter->UpdateIfNeeded();
             auto matches_block{fast_rescan_filter->MatchesBlock(block_hash)};
             if (matches_block.has_value()) {
@@ -1961,8 +2119,15 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
                     result.status = ScanResult::FAILURE;
                     break;
                 }
+
+                std::map<uint256, CPubKey> tweakData;
+                bool taproot_active{block_height >= consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height};
+                if (IsWalletFlagSet(WALLET_FLAG_SILENT_PAYMENT) && taproot_active) {
+                    tweakData = GetSilentPaymentKeysPerBlock(block_hash, block.vtx);
+                }
+
                 for (size_t posInBlock = 0; posInBlock < block.vtx.size(); ++posInBlock) {
-                    SyncTransaction(block.vtx[posInBlock], TxStateConfirmed{block_hash, block_height, static_cast<int>(posInBlock)}, fUpdate, /*rescanning_old_block=*/true);
+                    SyncTransaction(block.vtx[posInBlock], TxStateConfirmed{block_hash, block_height, static_cast<int>(posInBlock)}, tweakData, fUpdate, /*rescanning_old_block=*/true, taproot_active);
                 }
                 // scan succeeded, record block as most recent successfully scanned
                 result.last_scanned_block = block_hash;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -130,10 +130,12 @@ static constexpr uint64_t KNOWN_WALLET_FLAGS =
     |   WALLET_FLAG_LAST_HARDENED_XPUB_CACHED
     |   WALLET_FLAG_DISABLE_PRIVATE_KEYS
     |   WALLET_FLAG_DESCRIPTORS
-    |   WALLET_FLAG_EXTERNAL_SIGNER;
+    |   WALLET_FLAG_EXTERNAL_SIGNER
+    |   WALLET_FLAG_SILENT_PAYMENT;
 
 static constexpr uint64_t MUTABLE_WALLET_FLAGS =
-        WALLET_FLAG_AVOID_REUSE;
+        WALLET_FLAG_AVOID_REUSE
+    |   WALLET_FLAG_SILENT_PAYMENT;
 
 static const std::map<std::string,WalletFlags> WALLET_FLAG_MAP{
     {"avoid_reuse", WALLET_FLAG_AVOID_REUSE},
@@ -142,7 +144,8 @@ static const std::map<std::string,WalletFlags> WALLET_FLAG_MAP{
     {"last_hardened_xpub_cached", WALLET_FLAG_LAST_HARDENED_XPUB_CACHED},
     {"disable_private_keys", WALLET_FLAG_DISABLE_PRIVATE_KEYS},
     {"descriptor_wallet", WALLET_FLAG_DESCRIPTORS},
-    {"external_signer", WALLET_FLAG_EXTERNAL_SIGNER}
+    {"external_signer", WALLET_FLAG_EXTERNAL_SIGNER},
+    {"silent_payment", WALLET_FLAG_SILENT_PAYMENT}
 };
 
 extern const std::map<uint64_t,std::string> WALLET_FLAG_CAVEATS;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -236,6 +236,7 @@ struct CRecipient
     CScript scriptPubKey;
     CAmount nAmount;
     bool fSubtractFeeFromAmount;
+    bool m_silentpayment{false};
 };
 
 class WalletRescanReserver; //forward declarations for ScanForWalletTransactions/RescanFromTime

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -861,6 +861,9 @@ public:
     //! Get the wallet descriptors for a script.
     std::vector<WalletDescriptor> GetWalletDescriptors(const CScript& script) const;
 
+    //! Get the wallet descriptor for an output type.
+    util::Result<WalletDescriptor> GetWalletDescriptor(const OutputType type, const bool internal) const;
+
     //! Get the LegacyScriptPubKeyMan which is used for all types, internal, and external.
     LegacyScriptPubKeyMan* GetLegacyScriptPubKeyMan() const;
     LegacyScriptPubKeyMan* GetOrCreateLegacyScriptPubKeyMan();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -68,7 +68,7 @@ std::vector<std::shared_ptr<CWallet>> GetWallets(WalletContext& context);
 std::shared_ptr<CWallet> GetDefaultWallet(WalletContext& context, size_t& count);
 std::shared_ptr<CWallet> GetWallet(WalletContext& context, const std::string& name);
 std::shared_ptr<CWallet> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings);
-std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings);
+std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings, const bool silent_payment = false);
 std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings);
 std::unique_ptr<interfaces::Handler> HandleLoadWallet(WalletContext& context, LoadWalletFn load_wallet);
 void NotifyWalletLoaded(WalletContext& context, const std::shared_ptr<CWallet>& wallet);
@@ -223,6 +223,12 @@ public:
         m_change = false;
         m_label = label;
     }
+};
+
+struct SilentAddressBookEntry
+{
+    std::string m_label;
+    std::string m_address;
 };
 
 struct CRecipient
@@ -404,6 +410,7 @@ public:
     int64_t nOrderPosNext GUARDED_BY(cs_wallet) = 0;
 
     std::map<CTxDestination, CAddressBookData> m_address_book GUARDED_BY(cs_wallet);
+    std::map<int32_t, SilentAddressBookEntry> m_silent_address_book GUARDED_BY(cs_wallet);
     const CAddressBookData* FindAddressBookEntry(const CTxDestination&, bool allow_change = false) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /** Set of Coins owned by this wallet that we won't try to spend from. A
@@ -682,7 +689,8 @@ public:
      */
     void MarkDestinationsDirty(const std::set<CTxDestination>& destinations) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    util::Result<CTxDestination> GetNewDestination(const OutputType type, const std::string label);
+    util::Result<CTxDestination> GetNewDestination(const OutputType& type, const std::string& label);
+    util::Result<std::pair<std::string, int32_t>> GetSilentDestination(const std::string& label);
     util::Result<CTxDestination> GetNewChangeDestination(const OutputType type);
 
     isminetype IsMine(const CTxDestination& dest) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
@@ -704,6 +712,9 @@ public:
     DBErrors ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256>& vHashOut) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     bool SetAddressBook(const CTxDestination& address, const std::string& strName, const std::string& purpose);
+
+    bool SetSilentAddressBook(int32_t identifier, const std::string& silent_address, const std::string& label) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool SetSilentAddressBook(const XOnlyPubKey& spend_pubkey, const std::string& silent_address, const std::string& label) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     bool DelAddressBook(const CTxDestination& address);
 
@@ -781,7 +792,7 @@ public:
     bool MarkReplaced(const uint256& originalHash, const uint256& newHash);
 
     /* Initializes the wallet, returns a new CWallet instance or a null pointer in case of an error */
-    static std::shared_ptr<CWallet> Create(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, uint64_t wallet_creation_flags, bilingual_str& error, std::vector<bilingual_str>& warnings);
+    static std::shared_ptr<CWallet> Create(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, uint64_t wallet_creation_flags, bilingual_str& error, std::vector<bilingual_str>& warnings, const bool silent_payment = false);
 
     /**
      * Wallet post-init setup
@@ -920,8 +931,8 @@ public:
     void DeactivateScriptPubKeyMan(uint256 id, OutputType type, bool internal);
 
     //! Create new DescriptorScriptPubKeyMans and add them to the wallet
-    void SetupDescriptorScriptPubKeyMans(const CExtKey& master_key) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    void SetupDescriptorScriptPubKeyMans() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void SetupDescriptorScriptPubKeyMans(const CExtKey& master_key, bool silent_payment = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void SetupDescriptorScriptPubKeyMans(bool silent_payment = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Return the DescriptorScriptPubKeyMan for a WalletDescriptor if it is already in the wallet
     DescriptorScriptPubKeyMan* GetDescriptorScriptPubKeyMan(const WalletDescriptor& desc) const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -549,6 +549,7 @@ public:
         //! USER_ABORT.
         uint256 last_failed_block;
     };
+    std::map<uint256, CPubKey> GetSilentPaymentKeysPerBlock(const uint256& block_hash, const std::vector<CTransactionRef> vtx);
     ScanResult ScanForWalletTransactions(const uint256& start_block, int start_height, std::optional<int> max_height, const WalletRescanReserver& reserver, bool fUpdate, const bool save_progress);
     void transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason) override;
     /** Set the next time this wallet should resend transactions to 12-36 hours from now, ~1 day on average. */

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -44,6 +44,8 @@ const std::string KEY{"key"};
 const std::string LOCKED_UTXO{"lockedutxo"};
 const std::string MASTER_KEY{"mkey"};
 const std::string MINVERSION{"minversion"};
+const std::string SILENT_IDENTIFIER_LABEL{"silentidentifierlabel"};
+const std::string SILENT_IDENTIFIER_ADDRESS{"silentidentifieraddress"};
 const std::string NAME{"name"};
 const std::string OLD_KEY{"wkey"};
 const std::string ORDERPOSNEXT{"orderposnext"};
@@ -65,6 +67,15 @@ const std::unordered_set<std::string> LEGACY_TYPES{CRYPTED_KEY, CSCRIPT, DEFAULT
 //
 // WalletBatch
 //
+
+bool WalletBatch::WriteSilentIdentifier(const int32_t& identifier, const std::string& label, const std::string& address)
+{
+    if (!WriteIC(std::make_pair(DBKeys::SILENT_IDENTIFIER_LABEL, identifier), label)) {
+        return false;
+    }
+
+    return WriteIC(std::make_pair(DBKeys::SILENT_IDENTIFIER_ADDRESS, identifier), address);
+}
 
 bool WalletBatch::WriteName(const std::string& strAddress, const std::string& strName)
 {
@@ -338,7 +349,19 @@ ReadKeyValue(CWallet* pwallet, DataStream& ssKey, CDataStream& ssValue,
             wss.unexpected_legacy_entry = true;
             return false;
         }
-        if (strType == DBKeys::NAME) {
+        if (strType == DBKeys::SILENT_IDENTIFIER_LABEL) {
+            int32_t identifier;
+            ssKey >> identifier;
+            std::string label;
+            ssValue >> label;
+            pwallet->m_silent_address_book[identifier].m_label = label;
+        } else if (strType == DBKeys::SILENT_IDENTIFIER_ADDRESS) {
+            int32_t identifier;
+            ssKey >> identifier;
+            std::string address;
+            ssValue >> address;
+            pwallet->m_silent_address_book[identifier].m_address = address;
+        } else if (strType == DBKeys::NAME) {
             std::string strAddress;
             ssKey >> strAddress;
             std::string label;

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -223,6 +223,8 @@ public:
     WalletBatch(const WalletBatch&) = delete;
     WalletBatch& operator=(const WalletBatch&) = delete;
 
+    bool WriteSilentIdentifier(const int32_t& identifier, const std::string& label, const std::string& address);
+
     bool WriteName(const std::string& strAddress, const std::string& strName);
     bool EraseName(const std::string& strAddress);
 

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -67,6 +67,10 @@ enum WalletFlags : uint64_t {
 
     //! Indicates that the wallet needs an external signer
     WALLET_FLAG_EXTERNAL_SIGNER = (1ULL << 35),
+
+    //! Indicates that the wallet supports Silent Payments
+    //! This means a more complex scanning logic
+    WALLET_FLAG_SILENT_PAYMENT = (1ULL << 36),
 };
 
 //! Get the path of the wallet directory.

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -772,10 +772,10 @@ class RPCOverloadWrapper():
     def createwallet_passthrough(self, *args, **kwargs):
         return self.__getattr__("createwallet")(*args, **kwargs)
 
-    def createwallet(self, wallet_name, disable_private_keys=None, blank=None, passphrase='', avoid_reuse=None, descriptors=None, load_on_startup=None, external_signer=None):
+    def createwallet(self, wallet_name, disable_private_keys=None, blank=None, passphrase='', avoid_reuse=None, descriptors=None, load_on_startup=None, external_signer=None, silent_payment=None):
         if descriptors is None:
             descriptors = self.descriptors
-        return self.__getattr__('createwallet')(wallet_name, disable_private_keys, blank, passphrase, avoid_reuse, descriptors, load_on_startup, external_signer)
+        return self.__getattr__('createwallet')(wallet_name, disable_private_keys, blank, passphrase, avoid_reuse, descriptors, load_on_startup, external_signer, silent_payment)
 
     def importprivkey(self, privkey, label=None, rescan=None):
         wallet_info = self.getwalletinfo()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -92,6 +92,14 @@ BASE_SCRIPTS = [
     # Scripts that are run by default.
     # Longest test should go first, to favor running tests in parallel
     # vv Tests less than 5m vv
+    'wallet_silentpayment_tx.py',
+    'wallet_silentpayment_misc.py',
+    'wallet_silentpayment_labels.py',
+    'wallet_silentpayment_identifier.py',
+    'wallet_silentpayment_psbt_send_many_addr.py',
+    'wallet_silentpayment_blockfilterindex.py',
+    'wallet_silentpayment_addr_reuse.py',
+    'wallet_silentpayment_addresses.py',
     'feature_fee_estimation.py',
     'feature_taproot.py',
     'feature_block.py',

--- a/test/functional/wallet_silentpayment_addr_reuse.py
+++ b/test/functional/wallet_silentpayment_addr_reuse.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.blocktools import COINBASE_MATURITY
+
+
+class SilentAddressReuseTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+        self.skip_if_no_sqlite()
+
+    def init_wallet(self, *, node):
+        pass
+
+    def run_test(self):
+        self.nodes[0].createwallet(wallet_name=f'miner_wallet', descriptors=True)
+        miner_wallet = self.nodes[0].get_wallet_rpc(f'miner_wallet')
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 10, miner_wallet.getnewaddress())
+
+        print(miner_wallet.getbalances())
+
+        self.nodes[0].createwallet(wallet_name=f'sender_wallet', descriptors=True)
+        sender_wallet = self.nodes[0].get_wallet_rpc(f'sender_wallet')
+        sender_address = sender_wallet.getnewaddress()
+
+        miner_wallet.send(outputs=[{sender_address: 5}])
+        miner_wallet.send(outputs=[{sender_address: 7}])
+
+        self.generate(self.nodes[0], 8, sync_fun=self.no_op)
+
+        print(sender_wallet.getbalances())
+
+        self.nodes[0].createwallet(wallet_name=f'silent_wallet', descriptors=True, silent_payment=True)
+        silent_wallet = self.nodes[0].get_wallet_rpc(f'silent_wallet')
+
+        silent_address = silent_wallet.getsilentaddress()['address']
+
+        sender_wallet.send(outputs=[{silent_address: 4}])
+        sender_wallet.send(outputs=[{silent_address: 6}])
+
+        self.generate(self.nodes[0], 8, sync_fun=self.no_op)
+
+        utxos = silent_wallet.listunspent()
+
+        assert len(utxos) == 2
+
+        assert utxos[0]['address'] != utxos[1]['address']
+        assert utxos[0]['scriptPubKey'] != utxos[1]['scriptPubKey']
+
+
+if __name__ == '__main__':
+    SilentAddressReuseTest().main()
+

--- a/test/functional/wallet_silentpayment_addresses.py
+++ b/test/functional/wallet_silentpayment_addresses.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+
+
+class SilentAddressesTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [["-txindex=1"]]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+        self.skip_if_no_sqlite()
+
+    def init_wallet(self, *, node):
+        pass
+
+    def run_test(self):
+        self.nodes[0].createwallet(wallet_name=f'silent_wallet', descriptors=True, blank=True)
+
+        sp_desc = "sp(cP8cbSymcBmE36ghaM1FFEUdCvphVeeYFvnyiHMSWVEa9i6jB2Th)#p39n508k"
+
+        silent_wallet = self.nodes[0].get_wallet_rpc(f'silent_wallet')
+        ret = silent_wallet.importdescriptors([{'desc': sp_desc, 'timestamp': 0, 'active': True}])
+        assert ret[0]['success']
+
+        sil_addr_01 = silent_wallet.getsilentaddress()['address']
+        sil_addr_02 = silent_wallet.getsilentaddress('1')['address']
+        sil_addr_03 = silent_wallet.getsilentaddress('2')['address']
+        sil_addr_04 = silent_wallet.getsilentaddress('3')['address']
+        sil_addr_05 = silent_wallet.getsilentaddress('4')['address']
+        sil_addr_06 = silent_wallet.getsilentaddress('5')['address']
+
+        assert_equal(sil_addr_01, "sprt168nnqa3fxvm0fqextvv3j8kzc2nx4u84u07hxtpgdkkswrrtqwl2thhzr9ze7cr4nlz7ragedagakt4u288vga50gjrp4vd23krsgtq67qrmt")
+        assert_equal(sil_addr_02, "sprt168nnqa3fxvm0fqextvv3j8kzc2nx4u84u07hxtpgdkkswrrtqwltul72dwazf904zkytg29xnxwycfn2nwez45cscvsj3zgwdtgf4fglcq4ml")
+        assert_equal(sil_addr_03, "sprt168nnqa3fxvm0fqextvv3j8kzc2nx4u84u07hxtpgdkkswrrtqwlp6q7ql2u6rxfv6kt8qre26rn3cpmc3jyw8d6zatvaqrw3hszp8kqvrwnt6")
+        assert_equal(sil_addr_04, "sprt168nnqa3fxvm0fqextvv3j8kzc2nx4u84u07hxtpgdkkswrrtqwlrmcmqpqtlrhypawsd5wm0uzxgthaazkmz28zk28yl69zc8s38p3qangva0")
+        assert_equal(sil_addr_05, "sprt168nnqa3fxvm0fqextvv3j8kzc2nx4u84u07hxtpgdkkswrrtqwlt8tjeraq5ygdemakam9eux8d9qrp3ex285z4nfvnx9kcfaq0l22qtltc29")
+        assert_equal(sil_addr_06, "sprt168nnqa3fxvm0fqextvv3j8kzc2nx4u84u07hxtpgdkkswrrtqwlgcqk508uxj3ekneu9k9q4jnwalyds69lun7kclz2sy38musrdnycxaw9s3")
+
+        ret = silent_wallet.decodesilentaddress(sil_addr_01)
+        assert_equal(ret["scan_pubkey"], "d1e73076293336f483265b19191ec2c2a66af0f5e3fd732c286dad070c6b03be")
+        assert_equal(ret["spend_pubkey"], "a5dee219459f60759fc5e1f5196f51db2ebc51cec4768f44861ab1aa8d87042c")
+
+        ret = silent_wallet.decodesilentaddress(sil_addr_02)
+        assert_equal(ret["scan_pubkey"], "d1e73076293336f483265b19191ec2c2a66af0f5e3fd732c286dad070c6b03be")
+        assert_equal(ret["spend_pubkey"], "be7fca6bba2495f51588b428a6999c4c266a9bb22ad310c32128890e6ad09aa5")
+
+        ret = silent_wallet.decodesilentaddress(sil_addr_03)
+        assert_equal(ret["scan_pubkey"], "d1e73076293336f483265b19191ec2c2a66af0f5e3fd732c286dad070c6b03be")
+        assert_equal(ret["spend_pubkey"], "1d03c0fab9a1992cd596700f2ad0e71c07788c88e3b742ead9d00dd1bc0413d8")
+
+        ret = silent_wallet.decodesilentaddress(sil_addr_04)
+        assert_equal(ret["scan_pubkey"], "d1e73076293336f483265b19191ec2c2a66af0f5e3fd732c286dad070c6b03be")
+        assert_equal(ret["spend_pubkey"], "3de3600817f1dc81eba0da3b6fe08c85dfbd15b6251c5651c9fd14583c2270c4")
+
+        ret = silent_wallet.decodesilentaddress(sil_addr_05)
+        assert_equal(ret["scan_pubkey"], "d1e73076293336f483265b19191ec2c2a66af0f5e3fd732c286dad070c6b03be")
+        assert_equal(ret["spend_pubkey"], "b3ae591f414221b9df6ddd973c31da500c31c9947a0ab34b2662db09e81ff528")
+
+        ret = silent_wallet.decodesilentaddress(sil_addr_06)
+        assert_equal(ret["scan_pubkey"], "d1e73076293336f483265b19191ec2c2a66af0f5e3fd732c286dad070c6b03be")
+        assert_equal(ret["spend_pubkey"], "8c02d479f86947369e785b141594dddf91b0d17fc9fad8f8950244fbe406d993")
+
+
+if __name__ == '__main__':
+    SilentAddressesTest().main()

--- a/test/functional/wallet_silentpayment_blockfilterindex.py
+++ b/test/functional/wallet_silentpayment_blockfilterindex.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.util import (
+    assert_equal,
+)
+
+import random
+import string
+
+
+class SilentIdentifierSimple(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        # Test compatibility with PR #25957
+        self.extra_args = [["-blockfilterindex"]]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+        self.skip_if_no_sqlite()
+
+    def init_wallet(self, *, node):
+        pass
+
+    def random_string(self, n):
+        return ''.join(random.choice(string.ascii_lowercase) for _ in range(n))
+
+    def one_wallet(self, sender_wallet):
+        self.nodes[0].createwallet(wallet_name=f'recipient_wallet_01', descriptors=True, silent_payment=True)
+        recipient_wallet_01 = self.nodes[0].get_wallet_rpc(f'recipient_wallet_01')
+
+        label01 = self.random_string(8)
+        recv_addr_01 = recipient_wallet_01.getsilentaddress()['address']
+        recv_addr_02 = recipient_wallet_01.getsilentaddress(label01)['address']
+
+        outputs = [{recv_addr_01: 3}, {recv_addr_02: 2}]
+
+        sender_wallet.send(outputs=outputs)
+
+        self.generatetoaddress(self.nodes[0], 1, sender_wallet.getnewaddress())
+
+        recipient_wallet_01_utxos = recipient_wallet_01.listunspent()
+        assert_equal(len(recipient_wallet_01_utxos), 2)
+        assert label01 in [utxo['label'] for utxo in recipient_wallet_01_utxos]
+
+    def two_wallets(self, sender_wallet):
+        self.nodes[0].createwallet(wallet_name=f'recipient_wallet_02', descriptors=True, silent_payment=True)
+        recipient_wallet_02 = self.nodes[0].get_wallet_rpc(f'recipient_wallet_02')
+
+        self.nodes[0].createwallet(wallet_name=f'recipient_wallet_03', descriptors=True, silent_payment=True)
+        recipient_wallet_03 = self.nodes[0].get_wallet_rpc(f'recipient_wallet_03')
+
+        label01 = self.random_string(8)
+        recv_addr_01 = recipient_wallet_02.getsilentaddress()['address']
+        recv_addr_02 = recipient_wallet_02.getsilentaddress(label01)['address']
+
+        label02 = self.random_string(8)
+        recv_addr_03 = recipient_wallet_03.getsilentaddress()['address']
+        recv_addr_04 = recipient_wallet_03.getsilentaddress(label02)['address']
+
+        outputs = [{recv_addr_01: 1}, {recv_addr_02: 2}, {recv_addr_03: 3}, {recv_addr_04: 4}]
+
+        assert sender_wallet.send(outputs=outputs)['complete']
+
+        self.generatetoaddress(self.nodes[0], 1, sender_wallet.getnewaddress())
+
+        recipient_wallet_02_utxos = recipient_wallet_02.listunspent()
+        assert_equal(len(recipient_wallet_02_utxos), 2)
+        assert label01 in [utxo['label'] for utxo in recipient_wallet_02_utxos]
+
+        recipient_wallet_03_utxos = recipient_wallet_03.listunspent()
+        assert_equal(len(recipient_wallet_03_utxos), 2)
+        assert label02 in [utxo['label'] for utxo in recipient_wallet_03_utxos]
+
+    def test_block_filter(self, sender_wallet):
+        self.nodes[0].createwallet(wallet_name=f'recipient_wallet_04', descriptors=True, silent_payment=True)
+        recipient_wallet_04 = self.nodes[0].get_wallet_rpc(f'recipient_wallet_04')
+
+        label01 = self.random_string(8)
+        recv_addr_01 = recipient_wallet_04.getsilentaddress()['address']
+        recv_addr_02 = recipient_wallet_04.getsilentaddress(label01)['address']
+
+        self.nodes[0].unloadwallet(f'recipient_wallet_04')
+
+        for i in range(50):
+            outputs = [{recv_addr_01: 1}, {recv_addr_02: 2}]
+            assert sender_wallet.send(outputs=outputs)['complete']
+            self.generatetoaddress(self.nodes[0], 1, sender_wallet.getnewaddress())
+
+        self.nodes[0].loadwallet(f'recipient_wallet_04')
+        recipient_wallet_04 = self.nodes[0].get_wallet_rpc(f'recipient_wallet_04')
+
+        assert_equal(recipient_wallet_04.getbalance(), 150)
+        assert_equal(len(recipient_wallet_04.listunspent()), 100)
+
+    def run_test(self):
+        self.nodes[0].createwallet(wallet_name=f'sender_wallet', descriptors=True)
+        sender_wallet = self.nodes[0].get_wallet_rpc(f'sender_wallet')
+
+        self.generatetoaddress(self.nodes[0], 1, sender_wallet.getnewaddress('', 'bech32'))
+        self.generatetoaddress(self.nodes[0], 1, sender_wallet.getnewaddress('', 'bech32'))
+        self.generatetoaddress(self.nodes[0], 1, sender_wallet.getnewaddress('', 'bech32m'))
+        self.generatetoaddress(self.nodes[0], 1, sender_wallet.getnewaddress('', 'legacy'))
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 10, "bcrt1qjqmxmkpmxt80xz4y3746zgt0q3u3ferr34acd5")
+
+        self.one_wallet(sender_wallet)
+        self.two_wallets(sender_wallet)
+        self.test_block_filter(sender_wallet)
+
+
+if __name__ == '__main__':
+    SilentIdentifierSimple().main()

--- a/test/functional/wallet_silentpayment_identifier.py
+++ b/test/functional/wallet_silentpayment_identifier.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.util import (
+    assert_equal,
+)
+
+import random
+import string
+
+
+class SilentIdentifierTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [["-txindex=1"]]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+        self.skip_if_no_sqlite()
+
+    def init_wallet(self, *, node):
+        pass
+
+    def random_string(self, n):
+        return ''.join(random.choice(string.ascii_lowercase) for _ in range(n))
+
+    def test_identifier(self):
+        self.nodes[0].createwallet(wallet_name=f'sender_wallet', descriptors=True)
+        sender_wallet = self.nodes[0].get_wallet_rpc(f'sender_wallet')
+
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 10, sender_wallet.getnewaddress())
+
+        self.nodes[0].createwallet(wallet_name=f'recipient_wallet_01', descriptors=True, silent_payment=True)
+        recipient_wallet_01 = self.nodes[0].get_wallet_rpc(f'recipient_wallet_01')
+
+        self.nodes[0].createwallet(wallet_name=f'recipient_wallet_02', descriptors=True, silent_payment=True)
+        recipient_wallet_02 = self.nodes[0].get_wallet_rpc(f'recipient_wallet_02')
+
+        self.nodes[0].createwallet(wallet_name=f'recipient_wallet_03', descriptors=True, silent_payment=True)
+        recipient_wallet_03 = self.nodes[0].get_wallet_rpc(f'recipient_wallet_03')
+
+        label01 = self.random_string(8)
+        recv_addr_01 = recipient_wallet_01.getsilentaddress()['address']
+        recv_addr_02 = recipient_wallet_01.getsilentaddress(label01)['address']
+
+        label02 = self.random_string(8)
+        recv_addr_03 = recipient_wallet_02.getsilentaddress()['address']
+        recv_addr_04 = recipient_wallet_02.getsilentaddress(label02)['address']
+
+        # generate a large index
+        recipient_wallet_03.getsilentaddress()['address']
+        for _ in range(85):
+            recipient_wallet_03.getsilentaddress(self.random_string(8))['address']
+
+        label03 = self.random_string(8)
+        recv_addr_05 = recipient_wallet_03.getsilentaddress(label03)['address']
+
+        outputs = [{recv_addr_01: 3}, {recv_addr_02: 2}, {recv_addr_03: 4}, {recv_addr_04: 6},
+            {recv_addr_05: 7}]
+
+        sender_wallet.send(outputs=outputs)
+
+        self.generatetoaddress(self.nodes[0], 1, sender_wallet.getnewaddress())
+
+        recipient_wallet_01_utxos = recipient_wallet_01.listunspent()
+        assert_equal(len(recipient_wallet_01_utxos), 2)
+        assert label01 in [utxo['label'] for utxo in recipient_wallet_01_utxos]
+
+        recipient_wallet_02_utxos = recipient_wallet_02.listunspent()
+        assert_equal(len(recipient_wallet_02_utxos), 2)
+        assert label02 in [utxo['label'] for utxo in recipient_wallet_02_utxos]
+
+        recipient_wallet_03_utxos = recipient_wallet_03.listunspent()
+        assert_equal(len(recipient_wallet_03_utxos), 1)
+        assert label03 in [utxo['label'] for utxo in recipient_wallet_03_utxos]
+
+        # Test if importing wallet descriptors will fetch all UTXOs
+        desc_to_import = []
+
+        for wallet in [recipient_wallet_01, recipient_wallet_02, recipient_wallet_03]:
+            for desc in wallet.listdescriptors(True)['descriptors']:
+                if (desc['desc'].startswith("sp(")):
+                    desc_to_import.append(
+                        {"desc": desc['desc'],
+                        "timestamp": desc['timestamp'],
+                        "next_index": desc["next"],
+                        "active": True}
+                    )
+
+        self.nodes[0].createwallet(wallet_name='backup_wallet', descriptors=True, blank=True)
+        backup_wallet = self.nodes[0].get_wallet_rpc('backup_wallet')
+
+        for desc in desc_to_import:
+            result = backup_wallet.importdescriptors([desc])
+            assert_equal(result[0]['success'], True)
+
+        backup_wallet_utxos = backup_wallet.listunspent()
+        assert_equal(len(backup_wallet_utxos), 5)
+
+        # Wallets with imported descriptors have no way of knowing what the original labels are,
+        # so they use the identifier as labels
+        backup_wallet_utxos = [utxo['label'] for utxo in backup_wallet_utxos]
+        assert '0' in backup_wallet_utxos
+        assert '1' in backup_wallet_utxos
+        assert '86' in backup_wallet_utxos
+
+        # Test scantxoutset using identifiers
+        desc_param =  [{"desc": desc['desc'], "range": desc['next_index']} for desc in desc_to_import]
+        result = self.nodes[0].scantxoutset("start", desc_param)
+        assert result['success']
+        assert_equal(len(result['unspents']), 5)
+
+    def run_test(self):
+        self.test_identifier()
+
+
+if __name__ == '__main__':
+    SilentIdentifierTest().main()

--- a/test/functional/wallet_silentpayment_labels.py
+++ b/test/functional/wallet_silentpayment_labels.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_raises_rpc_error,
+    assert_equal,
+)
+
+import random
+import string
+
+
+class SilentLabelTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+        self.skip_if_no_sqlite()
+
+    def init_wallet(self, *, node):
+        pass
+
+    def random_string(self, n):
+        return ''.join(random.choice(string.ascii_lowercase) for _ in range(n))
+
+    def test_address_label(self):
+        self.nodes[0].createwallet(wallet_name='sp_wallet_01', descriptors=True, silent_payment=True)
+        sp_wallet_01 = self.nodes[0].get_wallet_rpc('sp_wallet_01')
+
+        existing_labels = []
+
+        ret = sp_wallet_01.listsilentaddresses()
+        assert_equal(ret['wallet_name'], 'sp_wallet_01')
+        assert_equal(ret['silent_addresses'], [])
+
+        assert_raises_rpc_error(-4, "Error: Use `getsilentaddress` RPC to generate silent payment address",
+                sp_wallet_01.getnewaddress, address_type='silent-payment')
+
+        self.log.info("Confirm that calling getsilentaddress without the label parameter will generate same address.")
+        assert_equal(sp_wallet_01.getsilentaddress()['address'], sp_wallet_01.getsilentaddress()['address'])
+
+        self.log.info("Confirm that calling getsilentaddress with different labels will generate different address.")
+        label01 = self.random_string(8)
+        label02 = self.random_string(8)
+
+        assert_equal(sp_wallet_01.getsilentaddress(label01)['address'], sp_wallet_01.getsilentaddress(label01)['address'])
+        assert sp_wallet_01.getsilentaddress(label01)['address'] != sp_wallet_01.getsilentaddress(label02)['address']
+
+        labels = sp_wallet_01.listlabels()
+        assert label01 in labels
+        assert label02 in labels
+
+        assert_equal(sp_wallet_01.listlabels(), sp_wallet_01.listlabels('silent-payment'))
+
+        assert_equal(len(sp_wallet_01.getaddressesbylabel()), 3)
+        assert_equal(len(sp_wallet_01.getaddressesbylabel(label01)), 1)
+        assert_equal(len(sp_wallet_01.getaddressesbylabel(label02)), 1)
+
+        identifier = 3
+
+        existing_labels.append('')
+        existing_labels.append(label01)
+        existing_labels.append(label02)
+
+        for _ in range(96):
+            label = self.random_string(8)
+            existing_labels.append(label)
+            addr = sp_wallet_01.getsilentaddress(label)['address']
+
+            ret = sp_wallet_01.decodesilentaddress(addr)
+            assert_equal(identifier,ret['identifier'])
+
+            identifier = identifier + 1
+
+        label = self.random_string(8)
+        assert_raises_rpc_error(-4, "No addresses available", sp_wallet_01.getsilentaddress, label=label)
+
+        ret = sp_wallet_01.listsilentaddresses()
+        assert_equal(ret['wallet_name'], 'sp_wallet_01')
+
+        identifier = 0
+
+        for addr in ret['silent_addresses']:
+            assert_equal(addr['label'], existing_labels[identifier])
+            ret = sp_wallet_01.decodesilentaddress(addr['address'])
+            assert_equal(identifier,ret['identifier'])
+
+            identifier = identifier + 1
+
+    def run_test(self):
+        self.test_address_label()
+
+
+if __name__ == '__main__':
+    SilentLabelTest().main()
+

--- a/test/functional/wallet_silentpayment_misc.py
+++ b/test/functional/wallet_silentpayment_misc.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.util import (
+    assert_raises_rpc_error,
+    assert_equal
+)
+from test_framework.descriptors import descsum_create
+from test_framework.key import (
+    ECKey,
+    compute_xonly_pubkey,
+)
+from test_framework.wallet_util import bytes_to_wif
+
+
+class SilentTransactioTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 3
+        self.extra_args = [[], ["-txindex=1"], []]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+        self.skip_if_no_sqlite()
+
+    def init_wallet(self, *, node):
+        pass
+
+    def invalid_create_wallet(self):
+        self.log.info("Testing the creation of invalid wallets")
+
+        if self.is_bdb_compiled():
+            assert_raises_rpc_error(-4, "Only descriptor wallets support silent payments.",
+                self.nodes[1].createwallet, wallet_name='invalid_wallet', descriptors=False, silent_payment=True)
+
+        assert_raises_rpc_error(-4, "Silent payments require the ability to store private keys.",
+            self.nodes[1].createwallet, wallet_name='invalid_wallet', descriptors=True, disable_private_keys=True, silent_payment=True)
+
+        if self.is_external_signer_compiled():
+            assert_raises_rpc_error(-4, "Silent payments require the ability to store private keys.",
+                self.nodes[1].createwallet, wallet_name='invalid_wallet',  descriptors=True, disable_private_keys=True, external_signer=True, silent_payment=True)
+
+        assert_raises_rpc_error(-4, "Silent payment verification requires access to private keys. Cannot be used with encrypted wallets.",
+            self.nodes[1].createwallet, wallet_name='invalid_wallet', descriptors=True, passphrase="passphrase", silent_payment=True)
+
+    def watch_only_wallet_send(self):
+        self.log.info("Testing if a watch only wallet is not able to send silent transaction")
+
+        self.nodes[0].createwallet(wallet_name='watch_only_wallet', descriptors=True, disable_private_keys=True, blank=True)
+        watch_only_wallet = self.nodes[0].get_wallet_rpc('watch_only_wallet')
+
+        desc_import = [{
+            "desc": descsum_create("wpkh(tpubD6NzVbkrYhZ4YNXVQbNhMK1WqguFsUXceaVJKbmno2aZ3B6QfbMeraaYvnBSGpV3vxLyTTK9DYT1yoEck4XUScMzXoQ2U2oSmE2JyMedq3H/0/*)"),
+            "timestamp": "now",
+            "internal": False,
+            "active": True,
+            "keypool": True,
+            "range": [0, 100],
+            "watchonly": True,
+        }]
+
+        watch_only_wallet.importdescriptors(desc_import)
+
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 10, watch_only_wallet.getnewaddress())
+
+        self.log.info("Watch-only wallets cannot send coins using silent_payment option")
+        outputs = [{"sprt1nnspl0k3p5atkj88lsk703dv0nwczz440huq9dhzdj5un2aa76t2ptnk3pl2tg6v080uq2nvylqq8398zu6422n2lzaz403tpuq44egxa4t46": 15}]
+
+        assert_raises_rpc_error(-4, "Silent payments require access to private keys to build transactions.",
+            watch_only_wallet.send, outputs=outputs)
+
+    def encrypted_wallet_send(self):
+        self.log.info("Testing if encrypted SP wallet")
+
+        self.nodes[0].createwallet(wallet_name='encrypted_wallet', descriptors=True, passphrase='passphrase')
+        encrypted_wallet = self.nodes[0].get_wallet_rpc('encrypted_wallet')
+
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 10, encrypted_wallet.getnewaddress())
+
+        self.log.info("encrypted wallets must be able to send coins after decryption")
+        outputs = [{"bcrt1pk0yzk76w2p55ykyjyfeq99td069c257se9nwugl7cl5geadq944spyc330": 15}]
+
+        # send RPC can be run without decrypting the wallet and it must generate a incomplete PSBT
+        tx = encrypted_wallet.send(outputs=outputs, options={"add_to_wallet": False})
+        assert not tx['complete']
+
+        # but when silent_payment option is enabled, wallet must be decrypted
+        outputs = [{"sprt1nnspl0k3p5atkj88lsk703dv0nwczz440huq9dhzdj5un2aa76t9jt4nlxwucu9lzw75yxl74x9vq6jl7v33064hrx8kd0q5rgvjctq354m7t": 15}]
+        assert_raises_rpc_error(-13, "Please enter the wallet passphrase with walletpassphrase first.",
+            encrypted_wallet.send, outputs=outputs)
+
+        encrypted_wallet.walletpassphrase('passphrase', 20)
+
+        tx = encrypted_wallet.send(outputs=outputs)
+        assert tx['complete']
+
+    def test_addressinfo(self):
+        self.log.info("Testing decodesilentaddress RPC")
+        self.nodes[1].createwallet(wallet_name='sp_addr_info_01', descriptors=True, silent_payment=True)
+        sp_addr_info_01 = self.nodes[1].get_wallet_rpc('sp_addr_info_01')
+
+        addr01 = sp_addr_info_01.getsilentaddress()['address']
+
+        assert_raises_rpc_error(-5, "Use `decodesilentaddress` RPC to get information about silent addresses.",
+            sp_addr_info_01.getaddressinfo, addr01)
+
+        addr01_info = sp_addr_info_01.decodesilentaddress(addr01)
+        assert_equal(addr01_info['identifier'], 0)
+
+        for i in range(20):
+            sp_addr_info_01.getsilentaddress(str(i))['address']
+
+        addr01 = sp_addr_info_01.getsilentaddress(str(21))['address']
+        addr01_info = sp_addr_info_01.decodesilentaddress(addr01)
+        assert_equal(addr01_info['identifier'], 21)
+
+        for i in range(22,67):
+            sp_addr_info_01.getsilentaddress(str(i))['address']
+
+        addr01 = sp_addr_info_01.getsilentaddress(str(67))['address']
+        addr01_info = sp_addr_info_01.decodesilentaddress(addr01)
+        assert_equal(addr01_info['identifier'], 67)
+
+    def test_sp_descriptor(self):
+        self.log.info("Testing if SP descriptor works as expected")
+
+        self.nodes[1].createwallet(wallet_name='sp_wallet_01', descriptors=True, silent_payment=True)
+        sp_wallet_01 = self.nodes[1].get_wallet_rpc('sp_wallet_01')
+
+        wallet_has_sp_desc = False
+
+        sp_pub = ''
+
+        for desc in sp_wallet_01.listdescriptors()['descriptors']:
+            if "sp(" in desc['desc']:
+                sp_pub = desc['desc']
+                wallet_has_sp_desc = True
+
+        assert wallet_has_sp_desc
+
+        self.nodes[1].createwallet(wallet_name='sp_wallet_02', descriptors=True, blank=True)
+        sp_wallet_02 = self.nodes[1].get_wallet_rpc('sp_wallet_02')
+
+        result = sp_wallet_02.importdescriptors([{"desc": sp_pub, "timestamp": "now"}])
+        assert_equal(result[0]['success'], False)
+        assert_equal(result[0]['error']['code'], -4)
+        assert_equal(result[0]['error']['message'], "Cannot import Silent Payment descriptor without private keys provided.")
+
+        ranged_xpriv = "sp(tprv8ZgxMBicQKsPeKADhpai31FxDicMkXH29nNwuq7rK8m8w6cvwEyMCynLbXLZBYxrVdZLsopaMGwLUvNUwkx4GHcGNgpcUAGcfEVVEzjUYvb/42'/1'/0'/1/*)#l5qfzdxa"
+
+        result = sp_wallet_02.importdescriptors([{"desc": ranged_xpriv, "timestamp": "now"}])
+        assert_equal(result[0]['success'], False)
+        assert_equal(result[0]['error']['code'], -5)
+        assert_equal(result[0]['error']['message'], "Silent Payment descriptors cannot be ranged.")
+
+        xpriv = "sp(cMcfPtLYsvQAUrP1Xw3uWYvtnNH1pSJ1jWbgTxL5yqwkgfbmaSkx)#vutc4cze"
+
+        result = sp_wallet_02.importdescriptors([{"desc": xpriv, "timestamp": "now"}])
+        assert_equal(result[0]['success'], True)
+
+        # This will fail because "active = True" was not present in descriptor
+        assert_raises_rpc_error(-4, "Error: This wallet has no available keys", sp_wallet_02.getsilentaddress)
+
+        eckey = ECKey()
+        eckey.generate()
+        privkey = bytes_to_wif(eckey.get_bytes())
+        pubkey = compute_xonly_pubkey(eckey.get_bytes())[0].hex()
+
+        xpriv1 = "sp(cNSWZfhJWf1uYcsMKZxN94SgNiM8xQPhGyGaEkyCSR1GtSweLkdr)#vs4h975j"
+        xpriv2 = "sp(cS1NMRiK87hdpzzNJgiYcdABjCPGxbBAdCrHoosqzjfeQY4z85rn)#dh4rsd8m"
+        xpriv3 = descsum_create("sp(" + privkey + ")")
+
+        result = sp_wallet_02.importdescriptors([
+            {"desc": xpriv1, "timestamp": "now", "active": True},
+            {"desc": xpriv2, "timestamp": "now", "active": True},
+            {"desc": xpriv3, "timestamp": "now", "active": True}
+        ])
+        assert_equal(result[0]['success'], True)
+        assert_equal(result[1]['success'], True)
+        assert_equal(result[2]['success'], True)
+
+        for desc in sp_wallet_02.listdescriptors(True)['descriptors']:
+            if desc['desc'] == xpriv3:
+                assert desc['active']
+            else:
+                assert not desc['active']
+
+        sp_addr = sp_wallet_02.getsilentaddress()['address']
+        assert_raises_rpc_error(-5, "Use `decodesilentaddress` RPC to get information about silent addresses.",
+            sp_wallet_02.getaddressinfo, sp_addr)
+
+        addr_info = sp_wallet_02.decodesilentaddress(sp_addr)
+
+        assert_equal(addr_info['address'], sp_addr)
+        assert_equal(addr_info['identifier'], 0)
+        assert_equal(addr_info['label'], '')
+        assert_equal(addr_info['spend_pubkey'], pubkey)
+
+    def test_big_transaction_multiple_wallets(self):
+        self.log.info("Testing a big transaction to SP wallet")
+
+        self.nodes[0].createwallet(wallet_name='mw_01', descriptors=True)
+        mw_01 = self.nodes[0].get_wallet_rpc('mw_01')
+
+        self.nodes[1].createwallet(wallet_name='mw_02', descriptors=True, silent_payment=True)
+        mw_02 = self.nodes[1].get_wallet_rpc('mw_02')
+
+        self.nodes[1].createwallet(wallet_name='mw_03', descriptors=True, silent_payment=True)
+        mw_03 = self.nodes[1].get_wallet_rpc('mw_03')
+
+        self.nodes[1].createwallet(wallet_name='mw_04', descriptors=True)
+        mw_04 = self.nodes[1].get_wallet_rpc('mw_04')
+
+        self.nodes[1].createwallet(wallet_name='mw_05', descriptors=True, silent_payment=True)
+        mw_05 = self.nodes[1].get_wallet_rpc('mw_05')
+
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 15, mw_01.getnewaddress())
+
+        recv_addr_01 = mw_02.getsilentaddress()['address']
+        recv_addr_02 = mw_02.getnewaddress('', 'bech32m')
+        recv_addr_03 = mw_02.getnewaddress('', 'bech32')
+
+        recv_addr_04 = mw_03.getsilentaddress()['address']
+        recv_addr_05 = mw_03.getnewaddress('', 'legacy')
+
+        recv_addr_06 = mw_04.getnewaddress('', 'legacy')
+        recv_addr_07 = mw_04.getnewaddress('', 'bech32m')
+        recv_addr_08 = mw_04.getnewaddress('', 'p2sh-segwit')
+
+        recv_addr_09 = mw_05.getsilentaddress()['address']
+        recv_addr_10 = mw_05.getnewaddress('', 'p2sh-segwit')
+        recv_addr_11 = mw_05.getnewaddress('', 'bech32m')
+        recv_addr_12 = mw_05.getnewaddress('', 'bech32')
+        recv_addr_13 = mw_05.getnewaddress('', 'legacy')
+
+        outputs = [{recv_addr_01: 2}, {recv_addr_02: 3}, {recv_addr_03: 1}, {recv_addr_04: 2}, {recv_addr_05: 1},
+            {recv_addr_06: 4}, {recv_addr_07: 3}, {recv_addr_08: 2}, {recv_addr_09: 5}, {recv_addr_10: 4},
+            {recv_addr_11: 2}, {recv_addr_12: 1}, {recv_addr_13: 2}]
+
+        ret = mw_01.send(outputs)
+
+        assert ret['complete']
+
+        self.sync_mempools()
+
+        assert_equal(len(mw_02.listunspent(0)), 3)
+        assert_equal(len(mw_03.listunspent(0)), 2)
+        assert_equal(len(mw_04.listunspent(0)), 3)
+        assert_equal(len(mw_05.listunspent(0)), 5)
+
+    def test_backup_sp_descriptor(self):
+        self.log.info("Testing SP descriptor backup")
+
+        self.nodes[0].createwallet(wallet_name='sender_bk_01', descriptors=True)
+        sender_bk_01 = self.nodes[0].get_wallet_rpc('sender_bk_01')
+
+        self.nodes[1].createwallet(wallet_name='receiver_bk_01', descriptors=True, silent_payment=True)
+        receiver_bk_01 = self.nodes[1].get_wallet_rpc('receiver_bk_01')
+
+        assert receiver_bk_01.getwalletinfo()['silent_payment']
+
+        receiver_sp_address = receiver_bk_01.getsilentaddress()['address']
+
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY, sender_bk_01.getnewaddress())
+        self.generate(self.nodes[0], COINBASE_MATURITY)
+
+        ret1 = sender_bk_01.send({receiver_sp_address: 2})
+        assert ret1['complete']
+
+        ret2 = sender_bk_01.send({receiver_sp_address: 3})
+        assert ret2['complete']
+
+        ret3 = sender_bk_01.send({receiver_sp_address: 5})
+        assert ret3['complete']
+
+        self.generate(self.nodes[0], 7)
+
+        self.sync_all()
+
+        assert_equal(len(receiver_bk_01.listunspent()), 3)
+
+        for utxo in receiver_bk_01.listunspent(0):
+            assert utxo['desc'].startswith('rawtr(')
+
+        sp_priv = ''
+
+        for desc in receiver_bk_01.listdescriptors(True)['descriptors']:
+            if "sp(" in desc['desc']:
+                sp_priv = desc['desc']
+
+        assert sp_priv != ''
+
+        self.nodes[1].createwallet(wallet_name='receiver_bk_02', descriptors=True, blank=True)
+        receiver_bk_02 = self.nodes[1].get_wallet_rpc('receiver_bk_02')
+
+        ret = receiver_bk_02.importdescriptors([{'desc': sp_priv, 'timestamp': 0, 'active': True}])
+
+        assert ret[0]['success']
+        assert receiver_bk_02.getwalletinfo()['silent_payment']
+
+        assert_equal(len(receiver_bk_02.listunspent()), 3)
+
+    def test_load_silent_wallet(self):
+        self.log.info("Testing wallet loading after receveing transactions")
+
+        self.nodes[0].createwallet(wallet_name='load_sender_wallet_01', descriptors=True)
+        load_sender_wallet_01 = self.nodes[0].get_wallet_rpc('load_sender_wallet_01')
+
+        self.nodes[1].createwallet(wallet_name='load_recipient_wallet_01', descriptors=True, silent_payment=True)
+        load_recipient_wallet_01 = self.nodes[1].get_wallet_rpc('load_recipient_wallet_01')
+
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 25, load_sender_wallet_01.getnewaddress())
+
+        sp_recv_addr = load_recipient_wallet_01.getsilentaddress()['address']
+
+        self.nodes[1].unloadwallet('load_recipient_wallet_01')
+
+        silent_tx_ids = []
+
+        for _ in range(1,5):
+
+            outputs = [{sp_recv_addr: 5}]
+
+            silent_tx_ids.append(load_sender_wallet_01.send(outputs=outputs)['txid'])
+
+            self.generate(self.nodes[0], 1)
+
+        self.sync_all()
+
+        self.nodes[1].loadwallet('load_recipient_wallet_01')
+
+        listunspent = [u['txid'] for u in load_recipient_wallet_01.listunspent(0)]
+
+        assert len(listunspent) == len(silent_tx_ids)
+
+        for txid in silent_tx_ids:
+            assert txid in listunspent
+
+    # it makes no sense for users to send themselves silent payments, but that should work anyway.
+    def test_self_sp_transfer(self):
+
+        self.log.info("Testing self transfer")
+
+        self.nodes[1].createwallet(wallet_name='self_sender_wallet_01', descriptors=True, silent_payment=True)
+        self_sender_wallet_01 = self.nodes[1].get_wallet_rpc('self_sender_wallet_01')
+
+        self.generatetoaddress(self.nodes[1], 1, self_sender_wallet_01.getnewaddress())
+
+        self.generate(self.nodes[1], COINBASE_MATURITY)
+
+        sp_recv_addr = self_sender_wallet_01.getsilentaddress()['address']
+
+        ret = self_sender_wallet_01.send([{sp_recv_addr: 0.2}])
+
+        assert ret['complete']
+
+        assert_equal(len(self_sender_wallet_01.listunspent(0)), 2)
+
+    def test_scantxoutset(self):
+        self.log.info("Testing  SP scantxoutset")
+        self.nodes[0].createwallet(wallet_name='scan_sender_wallet_02', descriptors=True)
+        scan_sender_wallet_02 = self.nodes[0].get_wallet_rpc('scan_sender_wallet_02')
+
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 10, scan_sender_wallet_02.getnewaddress())
+
+        self.nodes[2].createwallet(wallet_name='recipient_wallet_03', descriptors=True, silent_payment=True, blank=True)
+        recipient_wallet_03 = self.nodes[2].get_wallet_rpc('recipient_wallet_03')
+
+        desc_import = [{
+            "desc": "sp(cQq73sG9nQN1bUNneZHKiYV3jhnED7Y3oNUdLHoHrpZdJD51uaRD)#9llg6xjm",
+            "timestamp": "now",
+            "internal": False,
+            "active": True,
+        }]
+
+        self.log.info("send multiple silent transactions to test scantxoutset")
+        for amount in [2.75, 3.98, 2.30]:
+
+            recipient_wallet_03.importdescriptors(desc_import)
+
+            recv_addr_03 = recipient_wallet_03.getsilentaddress()['address']
+
+            outputs = [{recv_addr_03: amount}]
+
+            silent_tx_ret = scan_sender_wallet_02.send(outputs=outputs)
+
+            self.sync_mempools()
+
+            silent_utxo = [x for x in recipient_wallet_03.listunspent(0) if x['txid'] == silent_tx_ret['txid']][0]
+
+            assert silent_utxo['address'] != recv_addr_03
+
+            self.generate(self.nodes[0], 7)
+
+            self.sync_all()
+
+        self.wait_until(lambda: all(i["synced"] for i in self.nodes[0].getindexinfo().values()))
+
+        utxos = recipient_wallet_03.listunspent()
+
+        scan_result = self.nodes[1].scantxoutset("start", [desc_import[0]["desc"]])
+
+        self.log.info("check if silent scantxoutset and listunspent have the same result for the same descriptor")
+        assert len(scan_result["unspents"]) == len(utxos)
+
+        for scan_tx in scan_result["unspents"]:
+            assert len([x for x in utxos if x['txid'] == scan_tx['txid']]) == 1
+
+
+    def run_test(self):
+        self.invalid_create_wallet()
+        self.watch_only_wallet_send()
+        self.encrypted_wallet_send()
+        self.test_self_sp_transfer()
+        self.test_sp_descriptor()
+        self.test_big_transaction_multiple_wallets()
+        self.test_backup_sp_descriptor()
+        self.test_load_silent_wallet()
+        self.test_scantxoutset()
+        self.test_addressinfo()
+
+
+if __name__ == '__main__':
+    SilentTransactioTest().main()

--- a/test/functional/wallet_silentpayment_psbt_send_many_addr.py
+++ b/test/functional/wallet_silentpayment_psbt_send_many_addr.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.util import (
+    assert_equal,
+)
+
+import random
+import string
+
+
+class SilentPSBTTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+        self.skip_if_no_sqlite()
+
+    def init_wallet(self, *, node):
+        pass
+
+    def random_string(self, n):
+        return ''.join(random.choice(string.ascii_lowercase) for _ in range(n))
+
+    def test_psbt(self):
+        sender_wallet = self.nodes[0].get_wallet_rpc(f'sender_wallet')
+
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 10, sender_wallet.getnewaddress())
+
+        self.nodes[0].createwallet(wallet_name=f'silent_wallet_01', descriptors=True, silent_payment=True)
+        silent_wallet_01 = self.nodes[0].get_wallet_rpc(f'silent_wallet_01')
+
+        label01 = self.random_string(8)
+        recv_addr_01 = silent_wallet_01.getsilentaddress()['address']
+        recv_addr_02 = silent_wallet_01.getsilentaddress(label01)['address']
+
+        psbt = sender_wallet.walletcreatefundedpsbt(inputs=[], outputs={recv_addr_01: 70, recv_addr_02: 90})['psbt']
+
+        signed_tx = sender_wallet.walletprocesspsbt(psbt=psbt, finalize=False)['psbt']
+        final_tx = self.nodes[0].finalizepsbt(signed_tx)['hex']
+        self.nodes[0].sendrawtransaction(final_tx)
+
+        self.generatetoaddress(self.nodes[0], 1, sender_wallet.getnewaddress())
+
+        silent_wallet_01_utxos = silent_wallet_01.listunspent()
+        assert_equal(len(silent_wallet_01_utxos), 2)
+
+    def test_sendmany(self):
+        sender_wallet = self.nodes[0].get_wallet_rpc(f'sender_wallet')
+
+        self.nodes[0].createwallet(wallet_name=f'silent_wallet_02', descriptors=True, silent_payment=True)
+        silent_wallet_02 = self.nodes[0].get_wallet_rpc(f'silent_wallet_02')
+
+        label01 = self.random_string(8)
+        recv_addr_01 = silent_wallet_02.getsilentaddress()['address']
+        recv_addr_02 = silent_wallet_02.getsilentaddress(label01)['address']
+
+        sender_wallet.sendmany(dummy="", amounts={recv_addr_01: 1.1,recv_addr_02: 3.3})
+
+        self.generatetoaddress(self.nodes[0], 1, sender_wallet.getnewaddress())
+
+        silent_wallet_02_utxos = silent_wallet_02.listunspent()
+        assert_equal(len(silent_wallet_02_utxos), 2)
+
+    def test_sendtoaddress(self):
+        sender_wallet = self.nodes[0].get_wallet_rpc(f'sender_wallet')
+
+        self.nodes[0].createwallet(wallet_name=f'silent_wallet_03', descriptors=True, silent_payment=True)
+        silent_wallet_03 = self.nodes[0].get_wallet_rpc(f'silent_wallet_03')
+
+        recv_addr_01 = silent_wallet_03.getsilentaddress()['address']
+
+        sender_wallet.sendtoaddress(address=recv_addr_01,  amount=1.1)
+
+        self.generatetoaddress(self.nodes[0], 1, sender_wallet.getnewaddress())
+
+        silent_wallet_03_utxo = silent_wallet_03.listunspent()
+        assert_equal(len(silent_wallet_03_utxo), 1)
+
+
+    def run_test(self):
+        self.nodes[0].createwallet(wallet_name=f'sender_wallet', descriptors=True)
+        self.test_psbt()
+        self.test_sendmany()
+        self.test_sendtoaddress()
+
+        height = self.nodes[0].getblockcount()
+        blockhash = self.nodes[0].getblockhash(height)
+        blockdata = self.nodes[0].getsilentpaymentblockdata(blockhash)
+        # TODO: improve this validation
+        assert_equal(blockdata['total_tx'], 1)
+
+
+if __name__ == '__main__':
+    SilentPSBTTest().main()

--- a/test/functional/wallet_silentpayment_tx.py
+++ b/test/functional/wallet_silentpayment_tx.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.util import assert_equal
+
+
+class SilentTransactioTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 3
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+        self.skip_if_no_sqlite()
+
+    def init_wallet(self, *, node):
+        pass
+
+    def test_transactions(self):
+        for input_type in ['bech32m', 'bech32', 'p2sh-segwit', 'legacy']:
+
+            self.nodes[0].createwallet(wallet_name=f'sender_wallet_{input_type}', descriptors=True)
+            sender_wallet = self.nodes[0].get_wallet_rpc(f'sender_wallet_{input_type}')
+
+            self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 10, sender_wallet.getnewaddress())
+
+            self.nodes[1].createwallet(wallet_name=f'recipient_wallet_01_{input_type}', descriptors=True, silent_payment=True)
+            recipient_wallet_01 = self.nodes[1].get_wallet_rpc(f'recipient_wallet_01_{input_type}')
+
+            self.nodes[2].createwallet(wallet_name=f'recipient_wallet_02_{input_type}', descriptors=True, silent_payment=True)
+            recipient_wallet_02 = self.nodes[2].get_wallet_rpc(f'recipient_wallet_02_{input_type}')
+
+            # sender wallet sends coins to itself using input_type address
+            # The goal is to use the output of this tx as silent transaction inputs
+            sen_addr_02 = sender_wallet.getnewaddress('', input_type)
+            tx_id_01 = sender_wallet.send({sen_addr_02: 50})['txid']
+
+            self.generate(self.nodes[0], 7)
+
+            tx_01 = [x for x in sender_wallet.listunspent(0) if x['txid'] == tx_id_01]
+            input_data = [x for x in tx_01 if x['address'] == sen_addr_02][0]
+
+            # use two addresses so that one can be spent on a normal tx and the other on a normal transaction
+            recv_addr_01 = recipient_wallet_01.getsilentaddress()['address']
+            recv_addr_02 = recipient_wallet_01.getnewaddress('', input_type)
+            recv_addr_03 = recipient_wallet_02.getsilentaddress()['address']
+
+            self.log.info("[%s] create silent transaction", input_type)
+            inputs = [{"txid": input_data["txid"], "vout":input_data["vout"]}]
+            outputs = [{recv_addr_01: 15}, {recv_addr_02: 15}, {recv_addr_03: 15}]
+            options= {"inputs": inputs }
+
+            silent_tx_ret = sender_wallet.send(outputs=outputs, options=options)
+
+            self.sync_mempools()
+
+            wallet_01_utxos = [x for x in recipient_wallet_01.listunspent(0) if x['txid'] == silent_tx_ret['txid']]
+
+            silent_txid = ''
+            silent_vout = ''
+
+            self.log.info("[%s] confirm that transaction has a different address than the original", input_type)
+            assert_equal(len(wallet_01_utxos), 2)
+            for utxo in wallet_01_utxos:
+                if utxo['desc'].startswith('rawtr('):
+                    silent_txid = utxo["txid"]
+                    silent_vout = utxo["vout"]
+                    assert utxo['address'] != recv_addr_01
+                else:
+                    assert utxo['address'] == recv_addr_02
+
+            recv_addr_04 = recipient_wallet_02.getnewaddress('', input_type)
+
+            self.log.info("[%s] spend the silent output to a normal address", input_type)
+            normal_inputs = [{"txid": silent_txid, "vout":silent_vout}]
+            normal_outputs = [{recv_addr_04: 10}]
+            normal_options = {"inputs": normal_inputs}
+
+            normal_tx_ret = recipient_wallet_01.send(outputs=normal_outputs, options=normal_options)
+
+            self.log.info("[%s] spend the silent output to another", input_type)
+            wallet_02_utxos = [x for x in recipient_wallet_02.listunspent(0) if x['txid'] == silent_tx_ret['txid']]
+            assert_equal(len(wallet_02_utxos), 1)
+            assert wallet_02_utxos[0]['desc'].startswith('rawtr(')
+            assert wallet_02_utxos[0]['address'] != recv_addr_03
+
+            recv_addr_05 = recipient_wallet_01.getsilentaddress()['address']
+            assert_equal(recv_addr_01, recv_addr_05)
+
+            silent_inputs = [{"txid": wallet_02_utxos[0]["txid"], "vout":wallet_02_utxos[0]["vout"]}]
+            silent_outputs = [{recv_addr_05: 10}]
+            silent_options = {"inputs": silent_inputs}
+
+            silent_tx_ret = recipient_wallet_02.send(outputs=silent_outputs, options=silent_options)
+
+            self.sync_mempools()
+
+            normal_tx = [x for x in recipient_wallet_02.listunspent(0) if x['txid'] == normal_tx_ret['txid']][0]
+            silent_tx = [x for x in recipient_wallet_01.listunspent(0) if x['txid'] == silent_tx_ret['txid']][0]
+
+            self.log.info("[%s] confirm the silent output was spent correctly", input_type)
+            assert normal_tx['address'] == recv_addr_04
+
+            assert silent_tx['address'] != recv_addr_05
+            assert silent_tx['desc'].startswith('rawtr(')
+
+    def run_test(self):
+        self.test_transactions()
+
+
+if __name__ == '__main__':
+    SilentTransactioTest().main()


### PR DESCRIPTION
This PR proposes an early version of [Silent Payment](https://gist.github.com/RubenSomsen/c43b79517e7cb701ebf77eec6dbb46b8) (author:@RubenSomsen).
In this scheme, the recipient generates a public address, but the sender tweaks the address and the recipient detects the payment by verifying all transactions on the blockchain. An example use case would be private donations.

The purpose of this PR is not a final version, but to start the discussion and get benchmarks based on a real implementation.

This version is built on top of [#994](https://github.com/bitcoin-core/secp256k1/pull/994) (bitcoin-core/secp256k1) for x-only ECDH support and #23480 (bitcoin/bitcoin) for `rawtr()`. Each new silent transaction detected is stored in wallet as a `rawtr()` descriptor. 

In this implementation, the sender can tweak the recipient address by passing the `silent_payment` option to send RPC. The transaction output will be different from the address entered.

For example `./src/bitcoin-cli -regtest -named send outputs="[{\"bcrt1pwlh5xuyrpgfunwyww8cfu78yfs2yqyevl7yturavahh5kgxwdd2q5hzgfu\": 1.1}]" fee_rate=1 options="{ \"silent_payment\": true}"`.

will generate `vout` with completely unrelated outputs:

```
"vout": [
    {
      "value": 1.10000000,
      "n": 0,
      "scriptPubKey": {
        "desc": "rawtr(65b19890c5ca40edb816d26f5f48cd9f3ed51121613b1c2405adc1a6dbbc824a)#8myx9tcu",
        "address": "bcrt1pvkce3yx9efqwmwqk6fh47jxdnuld2yfpvya3cfq94hq6dkausf9qrfjkgz",

      }
    },
    {
      "value": 2.02499835,
      "n": 1,
      "scriptPubKey": {
        "desc": "rawtr(c45cb3d500bbf8f0c8841e8e011b008781d826c16ee348edb822c0f97419bc4d)#26hcce63",
        "address": "bcrt1pc3wt84gqh0u0pjyyr68qzxcqs7qasfkpdm353mdcytq0jaqeh3xsuvlykg",
      }
    }
  ]
```

Any wallet, as long as it has access to private keys, can send silent payments. Thus, this excludes watch-only wallets or wallets with external signers .

But the recipient's wallet needs a new flag called `SILENT_PAYMENT`. This flag allows an additional scan that verifies that the wallet keys match the silent payment scheme. When it detects a silent payment that belongs to the wallet, it is stored in a `rawtr()` descriptor.

`./src/bitcoin-cli -regtest -named createwallet wallet_name="recipient" silent_payment=true`

Therefore, scanning each address for each transaction is potentially prohibitive overhead, so the node can be initialized with `keypool=1` or a descriptor with range [0,1] can be imported into a blank wallet. Until there is more benchmark data, it is the safest option. The proposal recommends one static address.

I've been running some silent payments on signet using wallets with default keypool and default range, I haven't noticed any relevant performance drops on the signet node.
Apparently this implementation is working as expected but I can't guarantee that the scheme is implemented correctly or safely, so I'm opening this PR for reviews, modifications and improvements.

There is a new functional test (`test/functional/wallet_silentpayment.py`) that can help to better understand the implementation.