### PR TITLE
mempool: reduce lookups, insertions to cache in UpdateForDescendants

### DIFF
--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -831,10 +831,13 @@ private:
      *     for any descendant
      * @param[in] ancestor_count_limit the max number of ancestor transactions
      *     allowed for any descendant
+     * @param[in] skipLookup whether or not a lookup in cachedDescendants can be
+     *     skipped since there are no children of updateIt in setExclude.
      */
     void UpdateForDescendants(txiter updateIt, cacheMap& cachedDescendants,
                               const std::set<uint256>& setExclude, std::set<uint256>& descendants_to_remove,
-                              uint64_t ancestor_size_limit, uint64_t ancestor_count_limit) EXCLUSIVE_LOCKS_REQUIRED(cs);
+                              uint64_t ancestor_size_limit, uint64_t ancestor_count_limit,
+                              bool skipLookup) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Update ancestors of hash to add/remove it as a descendant transaction. */
     void UpdateAncestorsOf(bool add, txiter hash, setEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Set ancestor state for an entry */


### PR DESCRIPTION
Before this commit, the stageEntries loop could skip a cache lookup since it was done on the grand-children of updateIt initially and not the direct children. This commit changes the logic so that the cache is queried even for the children of updateIt. Additionally, if updateIt has no children in setExclude, it is possible to avoid the cache lookups. And if updateIt has no parents, it is possible to avoid cache insertions.

- If `updateIt` has no children in `setExclude`, then there's no need to check the cache for any descendants as only entries in `setExclude` get into the cache.
- If `updateIt` has no parents, then a subsequent iteration of the loop in `UpdateTransactionsFromBlock` won't use the cache entry for `updateIt`.

Prior to this commit, if we had the following tx chain (tx0 is the ancestor of all):
```
tx0 <- tx1 <- tx2 <- [tx3, not in setExclude]
```
then the `stageEntries.empty` loop would only query the cache when `updateIt` was tx0. When `updateIt` is tx2 or tx1, the cache would not be queried since one "generation" of descendants is effectively skipped for lookup.