### PR TITLE
refactor: update CBlockIndex::nChainTx to be uint64_t

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -183,14 +183,13 @@ public:
     unsigned int nTx{0};
 
     //! (memory only) Number of transactions in the chain up to and including this block.
-    //! This value will be non-zero only if and only if transactions for this block and all its parents are available.
-    //! Change to 64-bit type before 2024 (assuming worst case of 60 byte transactions).
+    //! This value will be non-zero if, and only if, transactions for this block and all its parents are available.
     //!
     //! Note: this value is faked during use of a UTXO snapshot because we don't
     //! have the underlying block data available during snapshot load.
     //! @sa AssumeutxoData
     //! @sa ActivateSnapshot
-    unsigned int nChainTx{0};
+    uint64_t nChainTx{0};
 
     //! Verification status of this block. See enum BlockStatus
     //!

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -45,7 +45,7 @@ struct AssumeutxoData {
     //!
     //! We need to hardcode the value here because this is computed cumulatively using block data,
     //! which we do not necessarily have at the time of snapshot load.
-    const unsigned int nChainTx;
+    const uint64_t nChainTx;
 };
 
 using MapAssumeutxo = std::map<int, const AssumeutxoData>;
@@ -58,7 +58,7 @@ using MapAssumeutxo = std::map<int, const AssumeutxoData>;
  */
 struct ChainTxData {
     int64_t nTime;    //!< UNIX timestamp of last known number of transactions
-    int64_t nTxCount; //!< total number of transactions between genesis and that timestamp
+    uint64_t nTxCount; //!< total number of transactions between genesis and that timestamp
     double dTxRate;   //!< estimated number of transactions per second after that timestamp
 };
 

--- a/src/node/utxo_snapshot.h
+++ b/src/node/utxo_snapshot.h
@@ -26,8 +26,7 @@ public:
     SnapshotMetadata() { }
     SnapshotMetadata(
         const uint256& base_blockhash,
-        uint64_t coins_count,
-        unsigned int nchaintx) :
+        uint64_t coins_count) :
             m_base_blockhash(base_blockhash),
             m_coins_count(coins_count) { }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1624,11 +1624,11 @@ static RPCHelpMan getchaintxstats()
 
     const CBlockIndex* pindexPast = pindex->GetAncestor(pindex->nHeight - blockcount);
     int nTimeDiff = pindex->GetMedianTimePast() - pindexPast->GetMedianTimePast();
-    int nTxDiff = pindex->nChainTx - pindexPast->nChainTx;
+    uint64_t nTxDiff = pindex->nChainTx - pindexPast->nChainTx;
 
     UniValue ret(UniValue::VOBJ);
     ret.pushKV("time", (int64_t)pindex->nTime);
-    ret.pushKV("txcount", (int64_t)pindex->nChainTx);
+    ret.pushKV("txcount", pindex->nChainTx);
     ret.pushKV("window_final_block_hash", pindex->GetBlockHash().GetHex());
     ret.pushKV("window_final_block_height", pindex->nHeight);
     ret.pushKV("window_block_count", blockcount);
@@ -2345,7 +2345,7 @@ UniValue CreateUTXOSnapshot(
         tip->nHeight, tip->GetBlockHash().ToString(),
         fs::PathToString(path), fs::PathToString(temppath)));
 
-    SnapshotMetadata metadata{tip->GetBlockHash(), stats.coins_count, tip->nChainTx};
+    SnapshotMetadata metadata{tip->GetBlockHash(), stats.coins_count};
 
     afile << metadata;
 
@@ -2372,9 +2372,7 @@ UniValue CreateUTXOSnapshot(
     result.pushKV("base_height", tip->nHeight);
     result.pushKV("path", path.u8string());
     result.pushKV("txoutset_hash", stats.hashSerialized.ToString());
-    // Cast required because univalue doesn't have serialization specified for
-    // `unsigned int`, nChainTx's type.
-    result.pushKV("nchaintx", uint64_t{tip->nChainTx});
+    result.pushKV("nchaintx", tip->nChainTx);
     return result;
 }
 

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -71,7 +71,7 @@ FUZZ_TARGET_INIT(utxo_snapshot, initialize_chain)
         Assert(*chainman.ActiveChainstate().m_from_snapshot_blockhash ==
                *chainman.SnapshotBlockhash());
         const auto& coinscache{chainman.ActiveChainstate().CoinsTip()};
-        int64_t chain_tx{};
+        uint64_t chain_tx{0};
         for (const auto& block : *g_chain) {
             Assert(coinscache.HaveCoin(COutPoint{block->vtx.at(0)->GetHash(), 0}));
             const auto* index{chainman.m_blockman.LookupBlockIndex(block->GetHash())};


### PR DESCRIPTION
There was a comment with the `CBlockIndex::nChainTx` data member:
"Change to 64-bit type before 2024 (assuming worst case of 60 byte transactions)."

As of when this PR was created, there were only around 750,000,000 transactions in the main best chain. That's only in the ballpark of 20% of the range of a 32-bit unsigned int. So, you might think that this is early. But, since I was looking up the references and already doing most of the work, I figured that I'd propose it now. In the least this commit resolves and removes a comment that might otherwise scare more people into doing the same research that I did, thus saving people time.

I went through all the references to this member and made updates to make the data types line up better where there were differences.

I also removed a small amount of dead code from SnapshotMetadata, see (https://github.com/bitcoin/bitcoin/pull/21681#issue-858110318).