### PR TITLE
Isolate the storage abstraction layer from the application/serialization layer

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -146,8 +146,11 @@ BITCOIN_CORE_H = \
   consensus/tx_verify.h \
   core_io.h \
   core_memusage.h \
+  cowbytes.h \
   cuckoocache.h \
   dbwrapper.h \
+  db/idb.h \
+  db/leveldbimpl.h \
   deploymentinfo.h \
   deploymentstatus.h \
   external_signer.h \
@@ -345,6 +348,7 @@ libbitcoin_node_a_SOURCES = \
   chain.cpp \
   consensus/tx_verify.cpp \
   dbwrapper.cpp \
+  db/leveldbimpl.cpp \
   deploymentstatus.cpp \
   flatfile.cpp \
   httprpc.cpp \
@@ -598,6 +602,7 @@ libbitcoin_common_a_SOURCES = \
   compressor.cpp \
   core_read.cpp \
   core_write.cpp \
+  cowbytes.cpp \
   deploymentinfo.cpp \
   external_signer.cpp \
   init/common.cpp \
@@ -860,7 +865,9 @@ libbitcoinkernel_la_SOURCES = \
   consensus/tx_check.cpp \
   consensus/tx_verify.cpp \
   core_read.cpp \
+  cowbytes.cpp \
   dbwrapper.cpp \
+  db/leveldbimpl.cpp \
   deploymentinfo.cpp \
   deploymentstatus.cpp \
   flatfile.cpp \

--- a/src/cowbytes.cpp
+++ b/src/cowbytes.cpp
@@ -1,0 +1,17 @@
+#include <cowbytes.h>
+
+CowBytes::CowBytes(Span<const std::byte> data) : m_data(data)
+{
+}
+
+CowBytes::CowBytes(std::string data) : m_data(std::move(data))
+{
+}
+
+Span<const std::byte> CowBytes::GetSpan() const
+{
+    if (m_data.valueless_by_exception()) {
+        return Span<const std::byte>();
+    }
+    return std::visit([](const auto& d) { return MakeByteSpan(d); }, m_data);
+}

--- a/src/cowbytes.h
+++ b/src/cowbytes.h
@@ -1,0 +1,24 @@
+#ifndef BITCOIN_COWBYTES_H
+#define BITCOIN_COWBYTES_H
+
+#include <variant>
+#include <vector>
+#include <string>
+
+#include <span.h>
+
+/**
+ * @brief The CowBytes class; a class that represents either bytes owned by its object or a thin wrapper (span) around an already owned bytes with no owner
+ */
+class CowBytes
+{
+    std::variant<std::string, Span<const std::byte>> m_data;
+
+public:
+    explicit CowBytes(Span<const std::byte> data);
+    explicit CowBytes(std::string data);
+
+    Span<const std::byte> GetSpan() const;
+};
+
+#endif // BITCOIN_COWBYTES_H

--- a/src/db/idb.h
+++ b/src/db/idb.h
@@ -1,0 +1,137 @@
+#ifndef BITCOIN_DB_IDB_H
+#define BITCOIN_DB_IDB_H
+
+#include <cowbytes.h>
+#include <fs.h>
+#include <map>
+#include <optional>
+#include <vector>
+
+using DBByteSpan = Span<const std::byte>;
+
+class IDBBatch
+{
+public:
+    /**
+     * @brief Clear cleans all the contents of the batch and resets the size estimates, if any
+     */
+    virtual void Clear() = 0;
+
+    /**
+     * @brief Write data to the batch; the operation has no effect on the database until flushed
+     */
+    virtual void Write(const DBByteSpan& key, const DBByteSpan& value) = 0;
+
+    /**
+     * @brief Erase data from the database with a given key; the operation has no effect on the database until flushed
+     */
+    virtual void Erase(const DBByteSpan& key) = 0;
+
+    /**
+     * @return an estimate of the size of the data held in the batch
+     */
+    virtual size_t SizeEstimate() const = 0;
+
+    /**
+     * @brief FlushToParent apply the changes of the batch to the database
+     */
+    virtual bool FlushToParent(bool fSync) = 0;
+
+    virtual ~IDBBatch() {}
+};
+
+class IDBIterator
+{
+public:
+    /**
+     * @return true if the iterator points to a value in the database, false otherwise
+     */
+    virtual bool Valid() const = 0;
+
+    /**
+     * @brief SeekToFirst moves the iterator pointer to the very first value in the key/value store/database
+     */
+    virtual void SeekToFirst() = 0;
+
+    /**
+     * @brief Seek moves the iterator pointer to the first entry with prefix `key`
+     */
+    virtual void Seek(const DBByteSpan& key) = 0;
+
+    /**
+     * @brief Next moves the iterator to the next key/value pair, assuming the iterator is valid
+     */
+    virtual void Next() = 0;
+
+    /**
+     * @return the key under the current iterator position, if the iterator is valid, otherwise std::nullopt
+     */
+    virtual std::optional<CowBytes> GetKey() = 0;
+
+    /**
+     * @return the value under the current iterator position, if the iterator is valid, otherwise std::nullopt
+     */
+    virtual std::optional<CowBytes> GetValue() = 0;
+
+    /**
+     * @return the size of the value under the current iterator position
+     */
+    virtual uint32_t GetValueSize() = 0;
+
+    virtual ~IDBIterator() {}
+};
+
+class IDB
+{
+public:
+    enum class Index : int {
+        DB_MAIN_INDEX = 0,
+    };
+
+    /**
+     * @return the approximate memory usage of the database; 0 can be either an error or that feature is not supported
+     */
+    virtual size_t DynamicMemoryUsage() const = 0;
+
+    /**
+     * @return Copy-on-write bytes of the value read from the database if reading the value is a success, otherwise std::nullopt
+     * Under a database operation batch/transaction, the unowned data is valid only until the transaction is over
+     */
+    virtual std::optional<CowBytes>
+    Read(IDB::Index dbindex, const DBByteSpan& key, std::size_t offset = 0,
+         const std::optional<std::size_t>& size = std::nullopt) const = 0;
+
+    /**
+     * @return true if writing the key/value pair to the database is a success, false otherwise
+     */
+    virtual bool Write(IDB::Index dbindex, const DBByteSpan& key, const DBByteSpan& value, bool fSync = false) = 0;
+
+    /**
+     * @return true if the key doesn't exist or was deleted, false otherwiseCowBytes (db access failed, etc)
+     */
+    virtual bool Erase(IDB::Index dbindex, const DBByteSpan& key, bool fSync) = 0;
+
+    /**
+     * @return true if the key exists in the database, false otherwise
+     */
+    virtual bool Exists(IDB::Index dbindex, const DBByteSpan& key) const = 0;
+
+    /**
+     * @return true if the database has zero key/value pairs
+     */
+    virtual bool IsEmpty() const = 0;
+
+    /**
+     * @return the estimated size of the keys in the range [key_begin, key_end), a left-closed interval
+     */
+    virtual size_t EstimateSize(const DBByteSpan& key_begin, const DBByteSpan& key_end) const = 0;
+
+    /**
+     * @return a new uninitialized iterator; must use Seek() or similar methods to initialize it
+     */
+    virtual std::unique_ptr<IDBIterator> NewIterator() = 0;
+
+    virtual ~IDB() {}
+};
+
+#endif // BITCOIN_DB_IDB_H

--- a/src/db/leveldbimpl.cpp
+++ b/src/db/leveldbimpl.cpp
@@ -1,0 +1,350 @@
+#include <db/leveldbimpl.h>
+
+#include <logging.h>
+#include <util/strencodings.h>
+#include <memenv.h>
+#include <leveldb/cache.h>
+#include <leveldb/env.h>
+#include <leveldb/filter_policy.h>
+#include <util/system.h>
+
+class CBitcoinLevelDBLogger : public leveldb::Logger {
+public:
+    // This code is adapted from posix_logger.h, which is why it is using vsprintf.
+    // Please do not do this in normal code
+    void Logv(const char * format, va_list ap) override {
+        if (!LogAcceptCategory(BCLog::LEVELDB)) {
+            return;
+        }
+        char buffer[500];
+        for (int iter = 0; iter < 2; iter++) {
+            char* base;
+            int bufsize;
+            if (iter == 0) {
+                bufsize = sizeof(buffer);
+                base = buffer;
+            }
+            else {
+                bufsize = 30000;
+                base = new char[bufsize];
+            }
+            char* p = base;
+            char* limit = base + bufsize;
+
+            // Print the message
+            if (p < limit) {
+                va_list backup_ap;
+                va_copy(backup_ap, ap);
+                // Do not use vsnprintf elsewhere in bitcoin source code, see above.
+                p += vsnprintf(p, limit - p, format, backup_ap);
+                va_end(backup_ap);
+            }
+
+            // Truncate to available space if necessary
+            if (p >= limit) {
+                if (iter == 0) {
+                    continue;       // Try again with larger buffer
+                }
+                else {
+                    p = limit - 1;
+                }
+            }
+
+            // Add newline if necessary
+            if (p == base || p[-1] != '\n') {
+                *p++ = '\n';
+            }
+
+            assert(p <= limit);
+            base[std::min(bufsize - 1, (int)(p - base))] = '\0';
+            LogPrintf("leveldb: %s", base);  /* Continued */
+            if (base != buffer) {
+                delete[] base;
+            }
+            break;
+        }
+    }
+};
+
+static void SetMaxOpenFiles(leveldb::Options *options) {
+    // On most platforms the default setting of max_open_files (which is 1000)
+    // is optimal. On Windows using a large file count is OK because the handles
+    // do not interfere with select() loops. On 64-bit Unix hosts this value is
+    // also OK, because up to that amount LevelDB will use an mmap
+    // implementation that does not use extra file descriptors (the fds are
+    // closed after being mmap'ed).
+    //
+    // Increasing the value beyond the default is dangerous because LevelDB will
+    // fall back to a non-mmap implementation when the file count is too large.
+    // On 32-bit Unix host we should decrease the value because the handles use
+    // up real fds, and we want to avoid fd exhaustion issues.
+    //
+    // See PR #12495 for further discussion.
+
+    int default_open_files = options->max_open_files;
+#ifndef WIN32
+    if (sizeof(void*) < 8) {
+        options->max_open_files = 64;
+    }
+#endif
+    LogPrint(BCLog::LEVELDB, "LevelDB using max_open_files=%d (default=%d)\n",
+             options->max_open_files, default_open_files);
+}
+
+static leveldb::Options GetOptions(size_t nCacheSize)
+{
+    leveldb::Options options;
+    options.block_cache = leveldb::NewLRUCache(nCacheSize / 2);
+    options.write_buffer_size = nCacheSize / 4; // up to two write buffers may be held in memory simultaneously
+    options.filter_policy = leveldb::NewBloomFilterPolicy(10);
+    options.compression = leveldb::kNoCompression;
+    options.info_log = new CBitcoinLevelDBLogger();
+    if (leveldb::kMajorVersion > 1 || (leveldb::kMajorVersion == 1 && leveldb::kMinorVersion >= 16)) {
+        // LevelDB versions before 1.16 consider short writes to be corruption. Only trigger error
+        // on corruption in later versions.
+        options.paranoid_checks = true;
+    }
+    SetMaxOpenFiles(&options);
+    return options;
+}
+
+CLevelDBImpl::CLevelDBImpl(const fs::path& path, size_t nCacheSize, bool fMemory, bool fWipe)
+    : m_name{fs::PathToString(path.stem())}
+{
+    penv = nullptr;
+    readoptions.verify_checksums = true;
+    iteroptions.verify_checksums = true;
+    iteroptions.fill_cache = false;
+    syncoptions.sync = true;
+    options = GetOptions(nCacheSize);
+    options.create_if_missing = true;
+    if (fMemory) {
+        penv = leveldb::NewMemEnv(leveldb::Env::Default());
+        options.env = penv;
+    } else {
+        if (fWipe) {
+            LogPrintf("Wiping LevelDB in %s\n", fs::PathToString(path));
+            leveldb::Status result = leveldb::DestroyDB(fs::PathToString(path), options);
+            dbwrapper_private::HandleError(result);
+        }
+        TryCreateDirectories(path);
+        LogPrintf("Opening LevelDB in %s\n", fs::PathToString(path));
+    }
+    // PathToString() return value is safe to pass to leveldb open function,
+    // because on POSIX leveldb passes the byte string directly to ::open(), and
+    // on Windows it converts from UTF-8 to UTF-16 before calling ::CreateFileW
+    // (see env_posix.cc and env_windows.cc).
+    leveldb::Status status = leveldb::DB::Open(options, fs::PathToString(path), &pdb);
+    dbwrapper_private::HandleError(status);
+    LogPrintf("Opened LevelDB successfully\n");
+
+    if (gArgs.GetBoolArg("-forcecompactdb", false)) {
+        LogPrintf("Starting database compaction of %s\n", fs::PathToString(path));
+        pdb->CompactRange(nullptr, nullptr);
+        LogPrintf("Finished database compaction of %s\n", fs::PathToString(path));
+    }
+}
+
+CLevelDBImpl::~CLevelDBImpl()
+{
+    delete pdb;
+    pdb = nullptr;
+    delete options.filter_policy;
+    options.filter_policy = nullptr;
+    delete options.info_log;
+    options.info_log = nullptr;
+    delete options.block_cache;
+    options.block_cache = nullptr;
+    delete penv;
+    options.env = nullptr;
+}
+
+namespace dbwrapper_private {
+
+void HandleError(const leveldb::Status& status)
+{
+    if (status.ok())
+        return;
+    const std::string errmsg = "Fatal LevelDB error: " + status.ToString();
+    LogPrintf("%s\n", errmsg);
+    LogPrintf("You can use -debug=leveldb to get more complete diagnostic messages\n");
+    throw dbwrapper_error(errmsg);
+}
+
+} // namespace dbwrapper_private
+
+std::optional<CowBytes> CLevelDBImpl::Read(Index /*dbindex*/, const DBByteSpan &key, std::size_t offset, const std::optional<std::size_t> &size) const
+{
+    leveldb::Slice slKey((const char*)key.data(), key.size());
+
+    std::string strValue;
+    leveldb::Status status = pdb->Get(readoptions, slKey, &strValue);
+    if (!status.ok()) {
+        if (status.IsNotFound())
+            return std::nullopt;
+        LogPrintf("LevelDB read failure: %s\n", status.ToString());
+        dbwrapper_private::HandleError(status);
+    }
+    if(size) {
+        return std::make_optional(CowBytes(strValue.substr(offset, *size)));
+    } else {
+        return std::make_optional(CowBytes(strValue.substr(offset)));
+    }
+}
+
+bool CLevelDBImpl::Write(Index /*dbindex*/, const DBByteSpan &key, const DBByteSpan &value, bool fSync)
+{
+    CLevelDBBatch batch(*this);
+    batch.Write(key, value);
+    return batch.FlushToParent(fSync);
+}
+
+size_t CLevelDBImpl::DynamicMemoryUsage() const
+{
+    std::string memory;
+    std::optional<size_t> parsed;
+    if (!pdb->GetProperty("leveldb.approximate-memory-usage", &memory) || !(parsed = ToIntegral<size_t>(memory))) {
+        LogPrint(BCLog::LEVELDB, "Failed to get approximate-memory-usage property\n");
+        return 0;
+    }
+    return parsed.value();
+}
+
+bool CLevelDBImpl::Erase(Index /*dbindex*/, const DBByteSpan &key, bool fSync)
+{
+    CLevelDBBatch batch(*this);
+    batch.Erase(key);
+    return batch.FlushToParent(fSync);
+}
+
+bool CLevelDBImpl::IsEmpty() const
+{
+    std::unique_ptr<IDBIterator> it(const_cast<CLevelDBImpl*>(this)->NewIterator());
+    it->SeekToFirst();
+    return !(it->Valid());
+}
+
+std::unique_ptr<IDBIterator> CLevelDBImpl::NewIterator()
+{
+    return std::make_unique<CLevelDBIterator>(*this);
+}
+
+size_t CLevelDBImpl::EstimateSize(const DBByteSpan &key_begin, const DBByteSpan &key_end) const
+{
+    leveldb::Slice slKey1((const char*)key_begin.data(), key_begin.size());
+    leveldb::Slice slKey2((const char*)key_end.data(), key_end.size());
+    uint64_t size = 0;
+    leveldb::Range range(slKey1, slKey2);
+    pdb->GetApproximateSizes(&range, 1, &size);
+    return size;
+}
+
+bool CLevelDBImpl::Exists(Index /*dbindex*/, const DBByteSpan &key) const
+{
+    leveldb::Slice slKey((const char*)key.data(), key.size());
+
+    std::string strValue;
+    leveldb::Status status = pdb->Get(readoptions, slKey, &strValue);
+    if (!status.ok()) {
+        if (status.IsNotFound())
+            return false;
+        LogPrintf("LevelDB read failure: %s\n", status.ToString());
+        dbwrapper_private::HandleError(status);
+    }
+    return true;
+}
+
+void CLevelDBBatch::Clear()
+{
+    batch.Clear();
+    size_estimate = 0;
+}
+
+void CLevelDBBatch::Write(const DBByteSpan &key, const DBByteSpan &value)
+{
+    leveldb::Slice slKey((const char*)key.data(), key.size());
+    leveldb::Slice slValue((const char*)value.data(), value.size());
+
+    batch.Put(slKey, slValue);
+    // LevelDB serializes writes as:
+    // - byte: header
+    // - varint: key length (1 byte up to 127B, 2 bytes up to 16383B, ...)
+    // - byte[]: key
+    // - varint: value length
+    // - byte[]: value
+    // The formula below assumes the key and value are both less than 16k.
+    size_estimate += 3 + (slKey.size() > 127) + slKey.size() + (slValue.size() > 127) + slValue.size();
+}
+
+void CLevelDBBatch::Erase(const DBByteSpan &key)
+{
+    leveldb::Slice slKey((const char*)key.data(), key.size());
+
+    batch.Delete(slKey);
+    // LevelDB serializes erases as:
+    // - byte: header
+    // - varint: key length
+    // - byte[]: key
+    // The formula below assumes the key is less than 16kB.
+    size_estimate += 2 + (slKey.size() > 127) + slKey.size();
+}
+
+bool CLevelDBBatch::FlushToParent(bool fSync)
+{
+    const bool log_memory = LogAcceptCategory(BCLog::LEVELDB);
+    double mem_before = 0;
+    if (log_memory) {
+        mem_before = parent.DynamicMemoryUsage() / 1024.0 / 1024;
+    }
+    leveldb::Status status = parent.pdb->Write(fSync ? parent.syncoptions : parent.writeoptions, &this->batch);
+    dbwrapper_private::HandleError(status);
+    if (log_memory) {
+        double mem_after = parent.DynamicMemoryUsage() / 1024.0 / 1024;
+                    LogPrint(BCLog::LEVELDB, "WriteBatch memory usage: db=%s, before=%.1fMiB, after=%.1fMiB\n",
+                             parent.m_name, mem_before, mem_after);
+    }
+    return true;
+}
+
+size_t CLevelDBBatch::SizeEstimate() const { return size_estimate; }
+
+
+
+uint32_t CLevelDBIterator::GetValueSize() {
+    return piter->value().size();
+}
+
+CLevelDBIterator::~CLevelDBIterator()
+{
+}
+
+bool CLevelDBIterator::Valid() const
+{
+    return piter->Valid();
+}
+
+void CLevelDBIterator::SeekToFirst()
+{
+    piter->SeekToFirst();
+}
+
+void CLevelDBIterator::Seek(const DBByteSpan &key) {
+    leveldb::Slice slKey((const char*)key.data(), key.size());
+    piter->Seek(slKey);
+}
+
+void CLevelDBIterator::Next()
+{
+    return piter->Next();
+}
+
+std::optional<CowBytes> CLevelDBIterator::GetKey() {
+    // TODO(Sam): Maybe check Valid() first? Let's see what other devs think about this
+    leveldb::Slice slKey = piter->key();
+    return std::make_optional(CowBytes(MakeByteSpan(slKey)));
+}
+
+std::optional<CowBytes> CLevelDBIterator::GetValue() {
+    leveldb::Slice slValue = piter->value();
+    return std::make_optional(CowBytes(MakeByteSpan(slValue)));
+}

--- a/src/db/leveldbimpl.h
+++ b/src/db/leveldbimpl.h
@@ -1,0 +1,119 @@
+#ifndef BITCOIN_DB_LEVELDBIMPL_H
+#define BITCOIN_DB_LEVELDBIMPL_H
+
+#include <db/idb.h>
+#include <leveldb/db.h>
+#include <leveldb/write_batch.h>
+
+class CLevelDBImpl;
+
+namespace dbwrapper_private {
+
+/** Handle database error by throwing dbwrapper_error exception.
+ */
+void HandleError(const leveldb::Status& status);
+
+};
+
+class dbwrapper_error : public std::runtime_error
+{
+public:
+    explicit dbwrapper_error(const std::string& msg) : std::runtime_error(msg) {}
+};
+
+
+class CLevelDBImpl : public IDB
+{
+    friend class CLevelDBBatch;
+    friend class CLevelDBIterator;
+
+    //! custom environment this database is using (may be nullptr in case of default environment)
+    leveldb::Env* penv;
+
+    //! database options used
+    leveldb::Options options;
+
+    //! options used when reading from the database
+    leveldb::ReadOptions readoptions;
+
+    //! options used when iterating over values of the database
+    leveldb::ReadOptions iteroptions;
+
+    //! options used when writing to the database
+    leveldb::WriteOptions writeoptions;
+
+    //! options used when sync writing to the database
+    leveldb::WriteOptions syncoptions;
+
+    //! the database itself
+    leveldb::DB* pdb;
+
+    //! the name of this database
+    std::string m_name;
+
+    std::vector<unsigned char> CreateObfuscateKey() const;
+
+public:
+    explicit CLevelDBImpl(const fs::path& path, size_t nCacheSize, bool fMemory, bool fWipe);
+    ~CLevelDBImpl();
+
+    std::optional<CowBytes> Read(Index dbindex, const DBByteSpan &key, std::size_t offset = 0, const std::optional<std::size_t> &size = std::nullopt) const override;
+    bool Write(Index dbindex, const DBByteSpan &key, const DBByteSpan &value, bool fSync = false) override;
+    size_t DynamicMemoryUsage() const override;
+    bool Erase(Index dbindex, const DBByteSpan &key, bool fSync) override;
+    bool IsEmpty() const override;
+    std::unique_ptr<IDBIterator> NewIterator() override;
+    size_t EstimateSize(const DBByteSpan &key_begin, const DBByteSpan &key_end) const override;
+    bool Exists(Index dbindex, const DBByteSpan &key) const override;
+};
+
+/** Batch of changes queued to be written to a CDBWrapper */
+class CLevelDBBatch : public IDBBatch
+{
+    friend class CLevelDBImpl;
+
+private:
+    CLevelDBImpl &parent;
+    leveldb::WriteBatch batch;
+
+    size_t size_estimate;
+
+public:
+    /**
+     * @param[in] _parent   CDBWrapper that this batch is to be submitted to
+     */
+    explicit CLevelDBBatch(CLevelDBImpl &_parent) : parent(_parent), size_estimate(0) { };
+    virtual ~CLevelDBBatch() {}
+
+    void Clear() override;
+    void Write(const DBByteSpan& key, const DBByteSpan& value) override;
+    void Erase(const DBByteSpan& key) override;
+    bool FlushToParent(bool fSync) override;
+    size_t SizeEstimate() const override;
+};
+
+class CLevelDBIterator : public IDBIterator
+{
+private:
+    const CLevelDBImpl &parent;
+    std::unique_ptr<leveldb::Iterator> piter;
+
+public:
+
+    /**
+     * @param[in] _parent          Parent CLevelDBImpl instance.
+     */
+    explicit CLevelDBIterator(const CLevelDBImpl &_parent) : parent(_parent), piter(parent.pdb->NewIterator(parent.iteroptions)) { };
+    virtual ~CLevelDBIterator();
+
+    bool Valid() const override;
+    void SeekToFirst() override;
+    void Seek(const DBByteSpan& key) override;
+    void Next() override;
+    std::optional<CowBytes> GetKey() override;
+    std::optional<CowBytes> GetValue() override;
+    uint32_t GetValueSize() override;
+
+};
+
+#endif // BITCOIN_DB_LEVELDBIMPL_H

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -7,148 +7,13 @@
 #include <memory>
 #include <random.h>
 
-#include <leveldb/cache.h>
-#include <leveldb/env.h>
-#include <leveldb/filter_policy.h>
 #include <memenv.h>
 #include <stdint.h>
 #include <algorithm>
 
-class CBitcoinLevelDBLogger : public leveldb::Logger {
-public:
-    // This code is adapted from posix_logger.h, which is why it is using vsprintf.
-    // Please do not do this in normal code
-    void Logv(const char * format, va_list ap) override {
-            if (!LogAcceptCategory(BCLog::LEVELDB)) {
-                return;
-            }
-            char buffer[500];
-            for (int iter = 0; iter < 2; iter++) {
-                char* base;
-                int bufsize;
-                if (iter == 0) {
-                    bufsize = sizeof(buffer);
-                    base = buffer;
-                }
-                else {
-                    bufsize = 30000;
-                    base = new char[bufsize];
-                }
-                char* p = base;
-                char* limit = base + bufsize;
-
-                // Print the message
-                if (p < limit) {
-                    va_list backup_ap;
-                    va_copy(backup_ap, ap);
-                    // Do not use vsnprintf elsewhere in bitcoin source code, see above.
-                    p += vsnprintf(p, limit - p, format, backup_ap);
-                    va_end(backup_ap);
-                }
-
-                // Truncate to available space if necessary
-                if (p >= limit) {
-                    if (iter == 0) {
-                        continue;       // Try again with larger buffer
-                    }
-                    else {
-                        p = limit - 1;
-                    }
-                }
-
-                // Add newline if necessary
-                if (p == base || p[-1] != '\n') {
-                    *p++ = '\n';
-                }
-
-                assert(p <= limit);
-                base[std::min(bufsize - 1, (int)(p - base))] = '\0';
-                LogPrintf("leveldb: %s", base);  /* Continued */
-                if (base != buffer) {
-                    delete[] base;
-                }
-                break;
-            }
-    }
-};
-
-static void SetMaxOpenFiles(leveldb::Options *options) {
-    // On most platforms the default setting of max_open_files (which is 1000)
-    // is optimal. On Windows using a large file count is OK because the handles
-    // do not interfere with select() loops. On 64-bit Unix hosts this value is
-    // also OK, because up to that amount LevelDB will use an mmap
-    // implementation that does not use extra file descriptors (the fds are
-    // closed after being mmap'ed).
-    //
-    // Increasing the value beyond the default is dangerous because LevelDB will
-    // fall back to a non-mmap implementation when the file count is too large.
-    // On 32-bit Unix host we should decrease the value because the handles use
-    // up real fds, and we want to avoid fd exhaustion issues.
-    //
-    // See PR #12495 for further discussion.
-
-    int default_open_files = options->max_open_files;
-#ifndef WIN32
-    if (sizeof(void*) < 8) {
-        options->max_open_files = 64;
-    }
-#endif
-    LogPrint(BCLog::LEVELDB, "LevelDB using max_open_files=%d (default=%d)\n",
-             options->max_open_files, default_open_files);
-}
-
-static leveldb::Options GetOptions(size_t nCacheSize)
-{
-    leveldb::Options options;
-    options.block_cache = leveldb::NewLRUCache(nCacheSize / 2);
-    options.write_buffer_size = nCacheSize / 4; // up to two write buffers may be held in memory simultaneously
-    options.filter_policy = leveldb::NewBloomFilterPolicy(10);
-    options.compression = leveldb::kNoCompression;
-    options.info_log = new CBitcoinLevelDBLogger();
-    if (leveldb::kMajorVersion > 1 || (leveldb::kMajorVersion == 1 && leveldb::kMinorVersion >= 16)) {
-        // LevelDB versions before 1.16 consider short writes to be corruption. Only trigger error
-        // on corruption in later versions.
-        options.paranoid_checks = true;
-    }
-    SetMaxOpenFiles(&options);
-    return options;
-}
-
 CDBWrapper::CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory, bool fWipe, bool obfuscate)
-    : m_name{fs::PathToString(path.stem())}
 {
-    penv = nullptr;
-    readoptions.verify_checksums = true;
-    iteroptions.verify_checksums = true;
-    iteroptions.fill_cache = false;
-    syncoptions.sync = true;
-    options = GetOptions(nCacheSize);
-    options.create_if_missing = true;
-    if (fMemory) {
-        penv = leveldb::NewMemEnv(leveldb::Env::Default());
-        options.env = penv;
-    } else {
-        if (fWipe) {
-            LogPrintf("Wiping LevelDB in %s\n", fs::PathToString(path));
-            leveldb::Status result = leveldb::DestroyDB(fs::PathToString(path), options);
-            dbwrapper_private::HandleError(result);
-        }
-        TryCreateDirectories(path);
-        LogPrintf("Opening LevelDB in %s\n", fs::PathToString(path));
-    }
-    // PathToString() return value is safe to pass to leveldb open function,
-    // because on POSIX leveldb passes the byte string directly to ::open(), and
-    // on Windows it converts from UTF-8 to UTF-16 before calling ::CreateFileW
-    // (see env_posix.cc and env_windows.cc).
-    leveldb::Status status = leveldb::DB::Open(options, fs::PathToString(path), &pdb);
-    dbwrapper_private::HandleError(status);
-    LogPrintf("Opened LevelDB successfully\n");
-
-    if (gArgs.GetBoolArg("-forcecompactdb", false)) {
-        LogPrintf("Starting database compaction of %s\n", fs::PathToString(path));
-        pdb->CompactRange(nullptr, nullptr);
-        LogPrintf("Finished database compaction of %s\n", fs::PathToString(path));
-    }
+    impl = InternalDBFactories::MakeDBImpl(GetSelectedDBType(), path, nCacheSize, fMemory, fWipe);
 
     // The base-case obfuscation key, which is a noop.
     obfuscate_key = std::vector<unsigned char>(OBFUSCATE_KEY_NUM_BYTES, '\000');
@@ -172,44 +37,26 @@ CDBWrapper::CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory, bo
 
 CDBWrapper::~CDBWrapper()
 {
-    delete pdb;
-    pdb = nullptr;
-    delete options.filter_policy;
-    options.filter_policy = nullptr;
-    delete options.info_log;
-    options.info_log = nullptr;
-    delete options.block_cache;
-    options.block_cache = nullptr;
-    delete penv;
-    options.env = nullptr;
 }
 
-bool CDBWrapper::WriteBatch(CDBBatch& batch, bool fSync)
+bool CDBWrapper::WriteBatch(CDBBatch &batch, bool fSync)
 {
-    const bool log_memory = LogAcceptCategory(BCLog::LEVELDB);
-    double mem_before = 0;
-    if (log_memory) {
-        mem_before = DynamicMemoryUsage() / 1024.0 / 1024;
-    }
-    leveldb::Status status = pdb->Write(fSync ? syncoptions : writeoptions, &batch.batch);
-    dbwrapper_private::HandleError(status);
-    if (log_memory) {
-        double mem_after = DynamicMemoryUsage() / 1024.0 / 1024;
-        LogPrint(BCLog::LEVELDB, "WriteBatch memory usage: db=%s, before=%.1fMiB, after=%.1fMiB\n",
-                 m_name, mem_before, mem_after);
-    }
-    return true;
+    return batch.FlushToParent(fSync);
 }
 
 size_t CDBWrapper::DynamicMemoryUsage() const
 {
-    std::string memory;
-    std::optional<size_t> parsed;
-    if (!pdb->GetProperty("leveldb.approximate-memory-usage", &memory) || !(parsed = ToIntegral<size_t>(memory))) {
-        LogPrint(BCLog::LEVELDB, "Failed to get approximate-memory-usage property\n");
-        return 0;
-    }
-    return parsed.value();
+    return impl->DynamicMemoryUsage();
+}
+
+CDBIterator *CDBWrapper::NewIterator()
+{
+    return new CDBIterator(*this);
+}
+
+IDB *CDBWrapper::GetRawDB()
+{
+    return impl.get();
 }
 
 // Prefixed with null character to avoid collisions with other keys
@@ -231,29 +78,16 @@ std::vector<unsigned char> CDBWrapper::CreateObfuscateKey() const
     return ret;
 }
 
-bool CDBWrapper::IsEmpty()
-{
-    std::unique_ptr<CDBIterator> it(NewIterator());
-    it->SeekToFirst();
-    return !(it->Valid());
-}
-
-CDBIterator::~CDBIterator() { delete piter; }
+CDBIterator::~CDBIterator() { }
 bool CDBIterator::Valid() const { return piter->Valid(); }
 void CDBIterator::SeekToFirst() { piter->SeekToFirst(); }
 void CDBIterator::Next() { piter->Next(); }
 
-namespace dbwrapper_private {
-
-void HandleError(const leveldb::Status& status)
-{
-    if (status.ok())
-        return;
-    const std::string errmsg = "Fatal LevelDB error: " + status.ToString();
-    LogPrintf("%s\n", errmsg);
-    LogPrintf("You can use -debug=leveldb to get more complete diagnostic messages\n");
-    throw dbwrapper_error(errmsg);
+uint32_t CDBIterator::GetValueSize() {
+    return piter->GetValueSize();
 }
+
+namespace dbwrapper_private {
 
 const std::vector<unsigned char>& GetObfuscateKey(const CDBWrapper &w)
 {
@@ -261,3 +95,42 @@ const std::vector<unsigned char>& GetObfuscateKey(const CDBWrapper &w)
 }
 
 } // namespace dbwrapper_private
+
+std::unique_ptr<IDB> InternalDBFactories::MakeDBImpl(DatabaseBackend tp, const fs::path &path, size_t nCacheSize, bool fMemory, bool fWipe) {
+    switch (tp) {
+    case DatabaseBackend::LevelDB:
+        return std::make_unique<CLevelDBImpl>(path, nCacheSize, fMemory, fWipe);
+    }
+    throw std::runtime_error(strprintf("Unrecognized database type: %d", static_cast<int>(tp)));
+}
+
+std::unique_ptr<IDBBatch> InternalDBFactories::MakeDBBatchImpl(DatabaseBackend tp, CDBWrapper &parent) {
+    switch (tp) {
+    case DatabaseBackend::LevelDB:
+        return std::make_unique<CLevelDBBatch>(*static_cast<CLevelDBImpl*>(parent.GetRawDB()));
+    }
+    throw std::runtime_error(strprintf("Unrecognized database type: %d", static_cast<int>(tp)));
+}
+
+std::unique_ptr<IDBIterator> InternalDBFactories::MakeDBIteratorImpl(DatabaseBackend tp, CDBWrapper &parent)
+{
+    switch (tp) {
+    case DatabaseBackend::LevelDB:
+        return std::make_unique<CLevelDBIterator>(*static_cast<CLevelDBImpl*>(parent.GetRawDB()));
+    }
+    throw std::runtime_error(strprintf("Unrecognized database type: %d", static_cast<int>(tp)));
+}
+
+CDBBatch::CDBBatch(CDBWrapper &_parent) : parent(_parent), ssKey(SER_DISK, CLIENT_VERSION), ssValue(SER_DISK, CLIENT_VERSION), batch_impl(InternalDBFactories::MakeDBBatchImpl(GetSelectedDBType(), parent)) { }
+
+void CDBBatch::Clear()
+{
+    batch_impl->Clear();
+}
+
+size_t CDBBatch::SizeEstimate() const { return batch_impl->SizeEstimate(); }
+
+bool CDBBatch::FlushToParent(bool fSync)
+{
+    return batch_impl->FlushToParent(fSync);
+}

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -13,193 +13,59 @@
 #include <util/strencodings.h>
 #include <util/system.h>
 
-#include <leveldb/db.h>
-#include <leveldb/write_batch.h>
+#include <db/leveldbimpl.h>
 
 static const size_t DBWRAPPER_PREALLOC_KEY_SIZE = 64;
 static const size_t DBWRAPPER_PREALLOC_VALUE_SIZE = 1024;
 
-class dbwrapper_error : public std::runtime_error
-{
-public:
-    explicit dbwrapper_error(const std::string& msg) : std::runtime_error(msg) {}
-};
+static const char* LEVELDB_SELECTOR = "leveldb";
 
 class CDBWrapper;
+class CDBBatch;
+class CDBIterator;
 
 /** These should be considered an implementation detail of the specific database.
  */
 namespace dbwrapper_private {
-
-/** Handle database error by throwing dbwrapper_error exception.
- */
-void HandleError(const leveldb::Status& status);
 
 /** Work around circular dependency, as well as for testing in dbwrapper_tests.
  * Database obfuscation should be considered an implementation detail of the
  * specific database.
  */
 const std::vector<unsigned char>& GetObfuscateKey(const CDBWrapper &w);
-
 };
 
-/** Batch of changes queued to be written to a CDBWrapper */
-class CDBBatch
-{
-    friend class CDBWrapper;
-
-private:
-    const CDBWrapper &parent;
-    leveldb::WriteBatch batch;
-
-    CDataStream ssKey;
-    CDataStream ssValue;
-
-    size_t size_estimate;
-
-public:
-    /**
-     * @param[in] _parent   CDBWrapper that this batch is to be submitted to
-     */
-    explicit CDBBatch(const CDBWrapper &_parent) : parent(_parent), ssKey(SER_DISK, CLIENT_VERSION), ssValue(SER_DISK, CLIENT_VERSION), size_estimate(0) { };
-
-    void Clear()
-    {
-        batch.Clear();
-        size_estimate = 0;
-    }
-
-    template <typename K, typename V>
-    void Write(const K& key, const V& value)
-    {
-        ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
-        ssKey << key;
-        leveldb::Slice slKey((const char*)ssKey.data(), ssKey.size());
-
-        ssValue.reserve(DBWRAPPER_PREALLOC_VALUE_SIZE);
-        ssValue << value;
-        ssValue.Xor(dbwrapper_private::GetObfuscateKey(parent));
-        leveldb::Slice slValue((const char*)ssValue.data(), ssValue.size());
-
-        batch.Put(slKey, slValue);
-        // LevelDB serializes writes as:
-        // - byte: header
-        // - varint: key length (1 byte up to 127B, 2 bytes up to 16383B, ...)
-        // - byte[]: key
-        // - varint: value length
-        // - byte[]: value
-        // The formula below assumes the key and value are both less than 16k.
-        size_estimate += 3 + (slKey.size() > 127) + slKey.size() + (slValue.size() > 127) + slValue.size();
-        ssKey.clear();
-        ssValue.clear();
-    }
-
-    template <typename K>
-    void Erase(const K& key)
-    {
-        ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
-        ssKey << key;
-        leveldb::Slice slKey((const char*)ssKey.data(), ssKey.size());
-
-        batch.Delete(slKey);
-        // LevelDB serializes erases as:
-        // - byte: header
-        // - varint: key length
-        // - byte[]: key
-        // The formula below assumes the key is less than 16kB.
-        size_estimate += 2 + (slKey.size() > 127) + slKey.size();
-        ssKey.clear();
-    }
-
-    size_t SizeEstimate() const { return size_estimate; }
+enum class DatabaseBackend {
+    LevelDB,
 };
 
-class CDBIterator
+static DatabaseBackend GetSelectedDBType()
 {
-private:
-    const CDBWrapper &parent;
-    leveldb::Iterator *piter;
-
-public:
-
-    /**
-     * @param[in] _parent          Parent CDBWrapper instance.
-     * @param[in] _piter           The original leveldb iterator.
-     */
-    CDBIterator(const CDBWrapper &_parent, leveldb::Iterator *_piter) :
-        parent(_parent), piter(_piter) { };
-    ~CDBIterator();
-
-    bool Valid() const;
-
-    void SeekToFirst();
-
-    template<typename K> void Seek(const K& key) {
-        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
-        ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
-        ssKey << key;
-        leveldb::Slice slKey((const char*)ssKey.data(), ssKey.size());
-        piter->Seek(slKey);
-    }
-
-    void Next();
-
-    template<typename K> bool GetKey(K& key) {
-        leveldb::Slice slKey = piter->key();
-        try {
-            CDataStream ssKey{MakeByteSpan(slKey), SER_DISK, CLIENT_VERSION};
-            ssKey >> key;
-        } catch (const std::exception&) {
-            return false;
+    static std::string selectedDatabaseStr = gArgs.GetArg("-dbbackend", LEVELDB_SELECTOR);
+    static const auto selectorFunc = [&]() {
+        if (selectedDatabaseStr == LEVELDB_SELECTOR) {
+            return DatabaseBackend::LevelDB;
         }
-        return true;
-    }
+        throw std::runtime_error("Unrecognized database selector: " + selectedDatabaseStr);
+    };
+    static DatabaseBackend selectedDatabase = selectorFunc();
+    return selectedDatabase;
+}
 
-    template<typename V> bool GetValue(V& value) {
-        leveldb::Slice slValue = piter->value();
-        try {
-            CDataStream ssValue{MakeByteSpan(slValue), SER_DISK, CLIENT_VERSION};
-            ssValue.Xor(dbwrapper_private::GetObfuscateKey(parent));
-            ssValue >> value;
-        } catch (const std::exception&) {
-            return false;
-        }
-        return true;
-    }
-
-    unsigned int GetValueSize() {
-        return piter->value().size();
-    }
-
+class InternalDBFactories {
+    static std::unique_ptr<IDB> MakeDBImpl(DatabaseBackend tp, const fs::path& path, size_t nCacheSize, bool fMemory, bool fWipe);
+    static std::unique_ptr<IDBBatch> MakeDBBatchImpl(DatabaseBackend tp, CDBWrapper& parent);
+    static std::unique_ptr<IDBIterator> MakeDBIteratorImpl(DatabaseBackend tp, CDBWrapper& parent);
+    friend CDBWrapper;
+    friend CDBBatch;
+    friend CDBIterator;
 };
 
 class CDBWrapper
 {
     friend const std::vector<unsigned char>& dbwrapper_private::GetObfuscateKey(const CDBWrapper &w);
 private:
-    //! custom environment this database is using (may be nullptr in case of default environment)
-    leveldb::Env* penv;
-
-    //! database options used
-    leveldb::Options options;
-
-    //! options used when reading from the database
-    leveldb::ReadOptions readoptions;
-
-    //! options used when iterating over values of the database
-    leveldb::ReadOptions iteroptions;
-
-    //! options used when writing to the database
-    leveldb::WriteOptions writeoptions;
-
-    //! options used when sync writing to the database
-    leveldb::WriteOptions syncoptions;
-
-    //! the database itself
-    leveldb::DB* pdb;
-
-    //! the name of this database
-    std::string m_name;
+    std::unique_ptr<IDB> impl;
 
     //! a key used for optional XOR-obfuscation of the database
     std::vector<unsigned char> obfuscate_key;
@@ -222,7 +88,7 @@ public:
      *                        with a zero'd byte array.
      */
     CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory = false, bool fWipe = false, bool obfuscate = false);
-    ~CDBWrapper();
+    virtual ~CDBWrapper();
 
     CDBWrapper(const CDBWrapper&) = delete;
     CDBWrapper& operator=(const CDBWrapper&) = delete;
@@ -233,18 +99,14 @@ public:
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        leveldb::Slice slKey((const char*)ssKey.data(), ssKey.size());
 
-        std::string strValue;
-        leveldb::Status status = pdb->Get(readoptions, slKey, &strValue);
-        if (!status.ok()) {
-            if (status.IsNotFound())
-                return false;
-            LogPrintf("LevelDB read failure: %s\n", status.ToString());
-            dbwrapper_private::HandleError(status);
+        std::optional<CowBytes> result = impl->Read(IDB::Index::DB_MAIN_INDEX, DBByteSpan(ssKey.data(), ssKey.size()));
+        if (!result) {
+            return false;
         }
+
         try {
-            CDataStream ssValue{MakeByteSpan(strValue), SER_DISK, CLIENT_VERSION};
+            CDataStream ssValue{result->GetSpan(), SER_DISK, CLIENT_VERSION};
             ssValue.Xor(obfuscate_key);
             ssValue >> value;
         } catch (const std::exception&) {
@@ -256,9 +118,16 @@ public:
     template <typename K, typename V>
     bool Write(const K& key, const V& value, bool fSync = false)
     {
-        CDBBatch batch(*this);
-        batch.Write(key, value);
-        return WriteBatch(batch, fSync);
+        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
+        ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
+        ssKey << key;
+
+        CDataStream ssValue(SER_DISK, CLIENT_VERSION);
+        ssValue.reserve(DBWRAPPER_PREALLOC_VALUE_SIZE);
+        ssValue << value;
+        ssValue.Xor(obfuscate_key);
+
+        return impl->Write(IDB::Index::DB_MAIN_INDEX, DBByteSpan(ssKey.data(), ssKey.size()), DBByteSpan(ssValue.data(), ssValue.size()), fSync);
     }
 
     template <typename K>
@@ -267,41 +136,32 @@ public:
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        leveldb::Slice slKey((const char*)ssKey.data(), ssKey.size());
-
-        std::string strValue;
-        leveldb::Status status = pdb->Get(readoptions, slKey, &strValue);
-        if (!status.ok()) {
-            if (status.IsNotFound())
-                return false;
-            LogPrintf("LevelDB read failure: %s\n", status.ToString());
-            dbwrapper_private::HandleError(status);
-        }
-        return true;
+        return impl->Exists(IDB::Index::DB_MAIN_INDEX, Span(ssKey.data(), ssKey.size()));
     }
 
     template <typename K>
     bool Erase(const K& key, bool fSync = false)
     {
-        CDBBatch batch(*this);
-        batch.Erase(key);
-        return WriteBatch(batch, fSync);
+        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
+        ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
+        ssKey << key;
+
+        return impl->Erase(IDB::Index::DB_MAIN_INDEX, DBByteSpan(ssKey.data(), ssKey.size()), fSync);
     }
 
-    bool WriteBatch(CDBBatch& batch, bool fSync = false);
+    bool WriteBatch(CDBBatch &batch, bool fSync = false);
 
     // Get an estimate of LevelDB memory usage (in bytes).
     size_t DynamicMemoryUsage() const;
 
-    CDBIterator *NewIterator()
-    {
-        return new CDBIterator(*this, pdb->NewIterator(iteroptions));
-    }
+    CDBIterator* NewIterator();
 
     /**
      * Return true if the database managed by this class contains no entries.
      */
-    bool IsEmpty();
+    bool IsEmpty() {
+        return impl->IsEmpty();
+    }
 
     template<typename K>
     size_t EstimateSize(const K& key_begin, const K& key_end) const
@@ -311,29 +171,116 @@ public:
         ssKey2.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey1 << key_begin;
         ssKey2 << key_end;
-        leveldb::Slice slKey1((const char*)ssKey1.data(), ssKey1.size());
-        leveldb::Slice slKey2((const char*)ssKey2.data(), ssKey2.size());
-        uint64_t size = 0;
-        leveldb::Range range(slKey1, slKey2);
-        pdb->GetApproximateSizes(&range, 1, &size);
-        return size;
+        return impl->EstimateSize(DBByteSpan(ssKey1.data(), ssKey1.size()), DBByteSpan(ssKey2.data(), ssKey2.size()));
     }
 
+    IDB* GetRawDB();
+};
+
+///** Batch of changes queued to be written to a CDBWrapper */
+class CDBBatch
+{
+    CDBWrapper &parent;
+
+    CDataStream ssKey;
+    CDataStream ssValue;
+
+    std::unique_ptr<IDBBatch> batch_impl;
+
+public:
     /**
-     * Compact a certain range of keys in the database.
-     */
-    template<typename K>
-    void CompactRange(const K& key_begin, const K& key_end) const
+         * @param[in] _parent   CDBWrapper that this batch is to be submitted to
+         */
+    explicit CDBBatch(CDBWrapper &_parent);
+
+    void Clear();
+
+    template <typename K, typename V>
+    void Write(const K& key, const V& value)
     {
-        CDataStream ssKey1(SER_DISK, CLIENT_VERSION), ssKey2(SER_DISK, CLIENT_VERSION);
-        ssKey1.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
-        ssKey2.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
-        ssKey1 << key_begin;
-        ssKey2 << key_end;
-        leveldb::Slice slKey1((const char*)ssKey1.data(), ssKey1.size());
-        leveldb::Slice slKey2((const char*)ssKey2.data(), ssKey2.size());
-        pdb->CompactRange(&slKey1, &slKey2);
+        ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
+        ssKey << key;
+
+        ssValue.reserve(DBWRAPPER_PREALLOC_VALUE_SIZE);
+        ssValue << value;
+        ssValue.Xor(dbwrapper_private::GetObfuscateKey(parent));
+
+        batch_impl->Write(DBByteSpan(ssKey.data(), ssKey.size()), DBByteSpan(ssValue.data(), ssValue.size()));
+
+        ssKey.clear();
+        ssValue.clear();
     }
+
+    template <typename K>
+    void Erase(const K& key)
+    {
+        ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
+        ssKey << key;
+        leveldb::Slice slKey((const char*)ssKey.data(), ssKey.size());
+
+        batch_impl->Erase(DBByteSpan(ssKey.data(), ssKey.size()));
+
+        ssKey.clear();
+    }
+
+    size_t SizeEstimate() const;
+
+    bool FlushToParent(bool fSync);
+};
+
+class CDBIterator
+{
+private:
+    CDBWrapper &parent;
+    std::unique_ptr<IDBIterator> piter;
+
+public:
+
+    /**
+         * @param[in] _parent          Parent CDBWrapper instance.
+         */
+    explicit CDBIterator(CDBWrapper &_parent) :
+        parent(_parent), piter(InternalDBFactories::MakeDBIteratorImpl(GetSelectedDBType(), parent)) { };
+    ~CDBIterator();
+
+    bool Valid() const;
+
+    void SeekToFirst();
+
+    template<typename K> void Seek(const K& key) {
+        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
+        ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
+        ssKey << key;
+        leveldb::Slice slKey((const char*)ssKey.data(), ssKey.size());
+        piter->Seek(DBByteSpan(ssKey.data(), ssKey.size()));
+    }
+
+    void Next();
+
+    template<typename K> bool GetKey(K& key) {
+        std::optional<CowBytes> slKey = piter->GetKey();
+        try {
+            CDataStream ssKey{slKey->GetSpan(), SER_DISK, CLIENT_VERSION};
+            ssKey >> key;
+        } catch (const std::exception&) {
+            return false;
+        }
+        return true;
+    }
+
+    template<typename V> bool GetValue(V& value) {
+        std::optional<CowBytes> slValue = piter->GetValue();
+        try {
+            CDataStream ssValue{slValue->GetSpan(), SER_DISK, CLIENT_VERSION};
+            ssValue.Xor(dbwrapper_private::GetObfuscateKey(parent));
+            ssValue >> value;
+        } catch (const std::exception&) {
+            return false;
+        }
+        return true;
+    }
+
+    uint32_t GetValueSize();
 };
 
 #endif // BITCOIN_DBWRAPPER_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -412,6 +412,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-datadir=<dir>", "Specify data directory", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-dbbatchsize", strprintf("Maximum database write batch size in bytes (default: %u)", nDefaultDbBatchSize), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
     argsman.AddArg("-dbcache=<n>", strprintf("Maximum database cache size <n> MiB (%d to %d, default: %d). In addition, unused mempool memory is shared for this cache (see -maxmempool).", nMinDbCache, nMaxDbCache, nDefaultDbCache), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-dbbackend=<name>", strprintf("The database backend to be used (default: %s)", LEVELDB_SELECTOR), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-includeconf=<file>", "Specify additional configuration file, relative to the -datadir path (only useable from configuration file, not command line)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-loadblock=<file>", "Imports blocks from external file on startup", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-maxmempool=<n>", strprintf("Keep the transaction memory pool below <n> megabytes (default: %u)", DEFAULT_MAX_MEMPOOL_SIZE), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);

--- a/test/lint/lint-locale-dependence.py
+++ b/test/lint/lint-locale-dependence.py
@@ -44,7 +44,7 @@ from subprocess import check_output, CalledProcessError
 
 
 KNOWN_VIOLATIONS = [
-    "src/dbwrapper.cpp:.*vsnprintf",
+    "src/db/leveldbimpl.cpp:.*vsnprintf",
     "src/test/dbwrapper_tests.cpp:.*snprintf",
     "src/test/fuzz/locale.cpp:.*setlocale",
     "src/test/fuzz/string.cpp:.*strtol",

--- a/test/lint/run-lint-format-strings.py
+++ b/test/lint/run-lint-format-strings.py
@@ -13,7 +13,7 @@ import re
 import sys
 
 FALSE_POSITIVES = [
-    ("src/dbwrapper.cpp", "vsnprintf(p, limit - p, format, backup_ap)"),
+    ("src/db/leveldbimpl.cpp", "vsnprintf(p, limit - p, format, backup_ap)"),
     ("src/index/base.cpp", "FatalError(const char* fmt, const Args&... args)"),
     ("src/netbase.cpp", "LogConnectFailure(bool manual_connection, const char* fmt, const Args&... args)"),
     ("src/clientversion.cpp", "strprintf(_(COPYRIGHT_HOLDERS).translated, COPYRIGHT_HOLDERS_SUBSTITUTION)"),


### PR DESCRIPTION
This PR separates the storage abstraction layer (e.g., leveldb layer) from the bitcoin core application layer. This has many benefits:

- Easier testing for the bitcoin core application layer without requiring an open database
- Easier replacement for the storage library in case it's decided to do it in the future with a simple implementation of an interface
- Ensure that any other future implementations can live to the same standard we have now by testing different implementations the same way
- Better interface description to understand the expectations from the implementations of the interface
- Much easier bench-marking separate from serialization

This change has caused zero modification to the bitcoin core application source code, as I deliberately maintained everything from the outside. This change is a drop-in replacement to everything that uses leveldb.

Things I failed to do without breaking backwards compatibility, so I skipped:
- Use DBIndex to decide the prefix of the storage. The problem here is that some key/value database systems provide other mechanisms for separating between different database "tables", so to say. In our case, we use a `char` as a prefix. For example, lmdb provides an integer index. The problem here is that when keys are submitted as a Span, prepending a prefix is a relatively expensive operation as it requires copying the whole key. I don't see how we can do this without that. This is a conflict between the serialization and the storage layer that I couldn't resolve.

Things I'd love to achieve in the next PR(s):
- ~Create an in-memory database that can easily replace leveldb and assist in tests~ (Given that tests use in-memory db as was pointed out in the comments, we may or may not do this)
- Move the block and block-undo storage behind this interface and use DBIndex as a way to tell the implementation how to store the data (in files or in leveldb)
