### PR TITLE
Rework logging timer

### DIFF
--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -216,7 +216,7 @@ std::optional<bilingual_str> LoadAddrman(const NetGroupManager& netgroupman, con
 
 void DumpAnchors(const fs::path& anchors_db_path, const std::vector<CAddress>& anchors)
 {
-    LOG_TIME_SECONDS(strprintf("Flush %d outbound block-relay-only peer addresses to anchors.dat", anchors.size()));
+    LOG_TIME(strprintf("Flush %d outbound block-relay-only peer addresses to anchors.dat", anchors.size()));
     SerializeFileDB("anchors", anchors_db_path, anchors, CLIENT_VERSION | ADDRV2_FORMAT);
 }
 

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -981,7 +981,7 @@ int AddrManImpl::CheckAddrman() const
 {
     AssertLockHeld(cs);
 
-    LOG_TIME_MILLIS_WITH_CATEGORY_MSG_ONCE(
+    LOG_TIME_WITH_CATEGORY_MSG_ONCE(
         strprintf("new %i, tried %i, total %u", nNew, nTried, vRandom.size()), BCLog::ADDRMAN);
 
     std::unordered_set<int> setTried;

--- a/src/logging/timer.h
+++ b/src/logging/timer.h
@@ -28,14 +28,14 @@ public:
         std::string prefix,
         std::string end_msg,
         BCLog::LogFlags log_category = BCLog::LogFlags::ALL,
-        bool msg_on_completion = true) :
-            m_prefix(std::move(prefix)),
-            m_title(std::move(end_msg)),
-            m_log_category(log_category),
-            m_message_on_completion(msg_on_completion)
+        bool msg_on_completion = true)
+        : m_prefix(std::move(prefix)),
+          m_title(std::move(end_msg)),
+          m_log_category(log_category),
+          m_message_on_completion(msg_on_completion)
     {
         this->Log(strprintf("%s started", m_title));
-        m_start_t = GetTime<std::chrono::microseconds>();
+        m_start_t = std::chrono::steady_clock::now();
     }
 
     ~Timer()
@@ -60,8 +60,8 @@ public:
 
     std::string LogMsg(const std::string& msg)
     {
-        const auto end_time = GetTime<std::chrono::microseconds>() - m_start_t;
-        if (m_start_t.count() <= 0) {
+        const auto end_time{std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - m_start_t)};
+        if (m_start_t == decltype(m_start_t){}) {
             return strprintf("%s: %s", m_prefix, msg);
         }
 
@@ -77,7 +77,7 @@ public:
     }
 
 private:
-    std::chrono::microseconds m_start_t{};
+    std::chrono::steady_clock::time_point m_start_t{};
 
     //! Log prefix; usually the name of the function this was created in.
     const std::string m_prefix;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2615,7 +2615,7 @@ UniValue CreateUTXOSnapshot(
         tip = CHECK_NONFATAL(chainstate.m_blockman.LookupBlockIndex(maybe_stats->hashBlock));
     }
 
-    LOG_TIME_SECONDS(strprintf("writing UTXO snapshot at height %s (%s) to file %s (via %s)",
+    LOG_TIME(strprintf("writing UTXO snapshot at height %s (%s) to file %s (via %s)",
         tip->nHeight, tip->GetBlockHash().ToString(),
         fs::PathToString(path), fs::PathToString(temppath)));
 

--- a/src/sync.h
+++ b/src/sync.h
@@ -159,7 +159,7 @@ private:
         EnterCritical(pszName, pszFile, nLine, Base::mutex());
 #ifdef DEBUG_LOCKCONTENTION
         if (Base::try_lock()) return;
-        LOG_TIME_MICROS_WITH_CATEGORY(strprintf("lock contention %s, %s:%d", pszName, pszFile, nLine), BCLog::LOCK);
+        LOG_TIME_WITH_CATEGORY(strprintf("lock contention %s, %s:%d", pszName, pszFile, nLine), BCLog::LOCK);
 #endif
         Base::lock();
     }

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -75,20 +75,9 @@ struct LogSetup : public BasicTestingSetup {
 
 BOOST_AUTO_TEST_CASE(logging_timer)
 {
-    SetMockTime(1);
     auto micro_timer = BCLog::Timer<std::chrono::microseconds>("tests", "end_msg");
-    SetMockTime(2);
-    BOOST_CHECK_EQUAL(micro_timer.LogMsg("test micros"), "tests: test micros (1000000μs)");
-
-    SetMockTime(1);
-    auto ms_timer = BCLog::Timer<std::chrono::milliseconds>("tests", "end_msg");
-    SetMockTime(2);
-    BOOST_CHECK_EQUAL(ms_timer.LogMsg("test ms"), "tests: test ms (1000.00ms)");
-
-    SetMockTime(1);
-    auto sec_timer = BCLog::Timer<std::chrono::seconds>("tests", "end_msg");
-    SetMockTime(2);
-    BOOST_CHECK_EQUAL(sec_timer.LogMsg("test secs"), "tests: test secs (1.00s)");
+    const std::string_view result_prefix{"tests: msg ("};
+    BOOST_CHECK_EQUAL(micro_timer.LogMsg("msg").substr(0, result_prefix.size()), result_prefix);
 }
 
 BOOST_FIXTURE_TEST_CASE(logging_LogPrintf_, LogSetup)

--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -75,9 +75,9 @@ struct LogSetup : public BasicTestingSetup {
 
 BOOST_AUTO_TEST_CASE(logging_timer)
 {
-    auto micro_timer = BCLog::Timer<std::chrono::microseconds>("tests", "end_msg");
-    const std::string_view result_prefix{"tests: msg ("};
-    BOOST_CHECK_EQUAL(micro_timer.LogMsg("msg").substr(0, result_prefix.size()), result_prefix);
+    BCLog::Timer timer{"topic", "end_msg"};
+    const std::string_view result_prefix{"topic: msg ("};
+    BOOST_CHECK_EQUAL(timer.LogMsg("msg").substr(0, result_prefix.size()), result_prefix);
 }
 
 BOOST_FIXTURE_TEST_CASE(logging_LogPrintf_, LogSetup)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2391,11 +2391,11 @@ bool Chainstate::FlushStateToDisk(
             }
 
             if (nManualPruneHeight > 0) {
-                LOG_TIME_MILLIS_WITH_CATEGORY("find files to prune (manual)", BCLog::BENCH);
+                LOG_TIME_WITH_CATEGORY("find files to prune (manual)", BCLog::BENCH);
 
                 m_blockman.FindFilesToPruneManual(setFilesToPrune, std::min(last_prune, nManualPruneHeight), m_chain.Height());
             } else {
-                LOG_TIME_MILLIS_WITH_CATEGORY("find files to prune", BCLog::BENCH);
+                LOG_TIME_WITH_CATEGORY("find files to prune", BCLog::BENCH);
 
                 m_blockman.FindFilesToPrune(setFilesToPrune, m_chainman.GetParams().PruneAfterHeight(), m_chain.Height(), last_prune, IsInitialBlockDownload());
                 m_blockman.m_check_for_pruning = false;
@@ -2433,7 +2433,7 @@ bool Chainstate::FlushStateToDisk(
                 return AbortNode(state, "Disk space is too low!", _("Disk space is too low!"));
             }
             {
-                LOG_TIME_MILLIS_WITH_CATEGORY("write block and undo data to disk", BCLog::BENCH);
+                LOG_TIME_WITH_CATEGORY("write block and undo data to disk", BCLog::BENCH);
 
                 // First make sure all block and undo data is flushed to disk.
                 m_blockman.FlushBlockFile();
@@ -2441,7 +2441,7 @@ bool Chainstate::FlushStateToDisk(
 
             // Then update all block file information (which may refer to block and undo files).
             {
-                LOG_TIME_MILLIS_WITH_CATEGORY("write block index to disk", BCLog::BENCH);
+                LOG_TIME_WITH_CATEGORY("write block index to disk", BCLog::BENCH);
 
                 if (!m_blockman.WriteBlockIndexDB()) {
                     return AbortNode(state, "Failed to write to block index database");
@@ -2449,7 +2449,7 @@ bool Chainstate::FlushStateToDisk(
             }
             // Finally remove any pruned files
             if (fFlushForPrune) {
-                LOG_TIME_MILLIS_WITH_CATEGORY("unlink pruned files", BCLog::BENCH);
+                LOG_TIME_WITH_CATEGORY("unlink pruned files", BCLog::BENCH);
 
                 UnlinkPrunedFiles(setFilesToPrune);
             }
@@ -2457,7 +2457,7 @@ bool Chainstate::FlushStateToDisk(
         }
         // Flush best chain related state. This can only be done if the blocks / block index write was also done.
         if (fDoFullFlush && !CoinsTip().GetBestBlock().IsNull()) {
-            LOG_TIME_MILLIS_WITH_CATEGORY(strprintf("write coins cache to disk (%d coins, %.2fkB)",
+            LOG_TIME_WITH_CATEGORY(strprintf("write coins cache to disk (%d coins, %.2fkB)",
                 coins_count, coins_mem_usage / 1000), BCLog::BENCH);
 
             // Typical Coin structures on disk are around 48 bytes in size.
@@ -4995,7 +4995,7 @@ bool ChainstateManager::ActivateSnapshot(
 
 static void FlushSnapshotToDisk(CCoinsViewCache& coins_cache, bool snapshot_loaded)
 {
-    LOG_TIME_MILLIS_WITH_CATEGORY_MSG_ONCE(
+    LOG_TIME_WITH_CATEGORY_MSG_ONCE(
         strprintf("%s (%.2f MB)",
                   snapshot_loaded ? "saving snapshot chainstate" : "flushing coins cache",
                   coins_cache.DynamicMemoryUsage() / (1000 * 1000)),


### PR DESCRIPTION
The logging timer has many issues:

* The underlying clock is mockable, meaning that benchmarks are useless when mocktime was set at the beginning or end of the benchmark.
* The underlying clock is not monotonic, meaning that benchmarks are useless when the system time was changed during the benchmark.
* The precision is set at compile time, meaning that benchmarks are useless when the precision isn't fine enough to cover the duration. Also, if the precision is too fine, benchmarks will be confusing and pretend a precision that doesn't exist. I think at best a relative precision of 1% can be assumed. There is one argument *for* a fixed precision, as it makes debug log parsers slightly easier.

Fix all issues in this patch.