### PR TITLE
bench: Make WalletLoading benchmark run faster

### DIFF
--- a/src/bench/wallet_loading.cpp
+++ b/src/bench/wallet_loading.cpp
@@ -68,7 +68,7 @@ static void WalletLoading(benchmark::Bench& bench, bool legacy_wallet)
     // reload the wallet for the actual benchmark
     BenchUnloadWallet(std::move(wallet));
 
-    bench.minEpochIterations(10).run([&] {
+    bench.run([&] {
         wallet = BenchLoadWallet(context, options);
 
         // Cleanup

--- a/src/bench/wallet_loading.cpp
+++ b/src/bench/wallet_loading.cpp
@@ -69,7 +69,7 @@ static void WalletLoading(benchmark::Bench& bench, bool legacy_wallet)
     // reload the wallet for the actual benchmark
     BenchUnloadWallet(std::move(wallet));
 
-    bench.run([&] {
+    bench.epochs(5).run([&] {
         wallet = BenchLoadWallet(context, options);
 
         // Cleanup

--- a/src/bench/wallet_loading.cpp
+++ b/src/bench/wallet_loading.cpp
@@ -122,8 +122,12 @@ static void WalletLoading(benchmark::Bench& bench, bool legacy_wallet)
     });
 }
 
+#ifdef USE_BDB
 static void WalletLoadingLegacy(benchmark::Bench& bench) { WalletLoading(bench, /*legacy_wallet=*/true); }
-static void WalletLoadingDescriptors(benchmark::Bench& bench) { WalletLoading(bench, /*legacy_wallet=*/false); }
-
 BENCHMARK(WalletLoadingLegacy);
+#endif
+
+#ifdef USE_SQLITE
+static void WalletLoadingDescriptors(benchmark::Bench& bench) { WalletLoading(bench, /*legacy_wallet=*/false); }
 BENCHMARK(WalletLoadingDescriptors);
+#endif

--- a/src/bench/wallet_loading.cpp
+++ b/src/bench/wallet_loading.cpp
@@ -49,6 +49,7 @@ static void BenchUnloadWallet(std::shared_ptr<CWallet>&& wallet)
 static void WalletLoading(benchmark::Bench& bench, bool legacy_wallet)
 {
     const auto test_setup = MakeNoLogFileContext<TestingSetup>();
+    test_setup->m_args.ForceSetArg("-unsafesqlitesync", "1");
 
     WalletContext context;
     context.args = &test_setup->m_args;

--- a/src/bench/wallet_loading.cpp
+++ b/src/bench/wallet_loading.cpp
@@ -76,7 +76,7 @@ static void WalletLoading(benchmark::Bench& bench, bool legacy_wallet)
     auto wallet = BenchLoadWallet(context, options);
 
     // Generate a bunch of transactions and addresses to put into the wallet
-    for (int i = 0; i < 5000; ++i) {
+    for (int i = 0; i < 1000; ++i) {
         AddTx(*wallet);
     }
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1203,7 +1203,7 @@ std::unique_ptr<WalletDatabase> CreateMockWalletDatabase(DatabaseOptions& option
 
     if (format == DatabaseFormat::SQLITE) {
 #ifdef USE_SQLITE
-        return std::make_unique<SQLiteDatabase>("", "", options, true);
+        return std::make_unique<SQLiteDatabase>(":memory:", "", options, true);
 #endif
         assert(false);
     }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1187,13 +1187,36 @@ std::unique_ptr<WalletDatabase> CreateDummyWalletDatabase()
 }
 
 /** Return object for accessing temporary in-memory database. */
+std::unique_ptr<WalletDatabase> CreateMockWalletDatabase(DatabaseOptions& options)
+{
+
+    std::optional<DatabaseFormat> format;
+    if (options.require_format) format = options.require_format;
+    if (!format) {
+#ifdef USE_BDB
+        format = DatabaseFormat::BERKELEY;
+#endif
+#ifdef USE_SQLITE
+        format = DatabaseFormat::SQLITE;
+#endif
+    }
+
+    if (format == DatabaseFormat::SQLITE) {
+#ifdef USE_SQLITE
+        return std::make_unique<SQLiteDatabase>("", "", options, true);
+#endif
+        assert(false);
+    }
+
+#ifdef USE_BDB
+    return std::make_unique<BerkeleyDatabase>(std::make_shared<BerkeleyEnvironment>(), "", options);
+#endif
+    assert(false);
+}
+
 std::unique_ptr<WalletDatabase> CreateMockWalletDatabase()
 {
     DatabaseOptions options;
-#ifdef USE_SQLITE
-    return std::make_unique<SQLiteDatabase>("", "", options, true);
-#elif USE_BDB
-    return std::make_unique<BerkeleyDatabase>(std::make_shared<BerkeleyEnvironment>(), "", options);
-#endif
+    return CreateMockWalletDatabase(options);
 }
 } // namespace wallet

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -301,6 +301,7 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, st
 std::unique_ptr<WalletDatabase> CreateDummyWalletDatabase();
 
 /** Return object for accessing temporary in-memory database. */
+std::unique_ptr<WalletDatabase> CreateMockWalletDatabase(DatabaseOptions& options);
 std::unique_ptr<WalletDatabase> CreateMockWalletDatabase();
 } // namespace wallet
 


### PR DESCRIPTION
`minEpochIterations` is probably unnecessary to set, so removing it makes the runtime much faster.