### PR TITLE
mempool: use mapNextTx.lower_bound in removeRecursive

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -604,11 +604,9 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReaso
             // be sure to remove any children that are in the pool. This can
             // happen during chain re-orgs if origTx isn't re-accepted into
             // the mempool for any reason.
-            for (unsigned int i = 0; i < origTx.vout.size(); i++) {
-                auto it = mapNextTx.find(COutPoint(origTx.GetHash(), i));
-                if (it == mapNextTx.end())
-                    continue;
-                txiter nextit = mapTx.find(it->second->GetHash());
+            auto iter = mapNextTx.lower_bound(COutPoint(origTx.GetHash(), 0));
+            for (; iter != mapNextTx.end() && iter->first->hash == origTx.GetHash(); ++iter) {
+                txiter nextit = mapTx.find(iter->second->GetHash());
                 assert(nextit != mapTx.end());
                 txToRemove.insert(nextit);
             }


### PR DESCRIPTION
This is a minor optimization where mapNextTx can instead use lower_bound instead of calling find. I think lower_bound and increment should be more efficient compared to N find calls, plus the loop will exit early if there are no more entries in the map for the prevout hash which wasn't the case previously.