### PR TITLE
test: compare `/mempool/contents` response with `getrawmempool` RPC

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -125,6 +125,7 @@ Refer to the `getmempoolinfo` RPC help for details.
 
 Returns the transactions in the mempool.
 Only supports JSON as output format.
+Refer to the `getrawmempool` RPC help for details.
 
 Risks
 -------------

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -326,6 +326,10 @@ class RESTTest (BitcoinTestFramework):
 
         # Check that there are our submitted transactions in the TX memory pool
         json_obj = self.test_rest_request("/mempool/contents")
+        raw_mempool_verbose = self.nodes[0].getrawmempool(verbose=True)
+
+        assert_equal(json_obj, raw_mempool_verbose)
+
         for i, tx in enumerate(txs):
             assert tx in json_obj
             assert_equal(json_obj[tx]['spentby'], txs[i + 1:i + 2])


### PR DESCRIPTION
This PR is similar to #24797, it compares `/mempool/contents` REST response with `getrawmempool` RPC (verbose=True) since they use the same `MempoolToJSON` function.

Also, adds a reference to `getrawmempool` RPC help to get details about the fields from `/mempool/contents`.