### PR TITLE
test: Remove previous release check in feature_taproot.py

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -111,7 +111,6 @@ BASE_SCRIPTS = [
     'p2p_tx_download.py',
     'mempool_updatefromblock.py',
     'wallet_dump.py --legacy-wallet',
-    'feature_taproot.py --previous_release',
     'feature_taproot.py',
     'rpc_signer.py',
     'wallet_signer.py --descriptors',


### PR DESCRIPTION
Now that the commit (7c08d81e119570792648fe95bbacddbb1d5f9ae2) which changes taproot to be enforced for all blocks is sufficiently buried by other commits, and thus less likely to be reverted,  it seems a good time to remove no longer needed test code.

The `feature_taproot` functional test is cleaned up to no longer run against a previous release. Since previous releases are static and impossible to change, it is sufficient to run the test once against the release. Now that this is done, the check can be removed without decreasing test coverage.