### PR TITLE
mempool: use epochs in CalculateDescendants

### DIFF
--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -239,8 +239,9 @@ int BlockAssembler::UpdatePackagesForAdded(const CTxMemPool::setEntries& already
 
     int nDescendantsUpdated = 0;
     for (CTxMemPool::txiter it : alreadyAdded) {
+        CTxMemPool::setEntries iterSet{it};
         CTxMemPool::setEntries descendants;
-        m_mempool.CalculateDescendants(it, descendants);
+        m_mempool.CalculateDescendants(iterSet, descendants);
         // Insert all descendants (not yet in block) into the modified set
         for (CTxMemPool::txiter desc : descendants) {
             if (alreadyAdded.count(desc)) {

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -69,9 +69,7 @@ std::optional<std::string> GetEntriesForConflicts(const CTransaction& tx,
         }
     }
     // Calculate the set of all transactions that would have to be evicted.
-    for (CTxMemPool::txiter it : iters_conflicting) {
-        pool.CalculateDescendants(it, all_conflicts);
-    }
+    pool.CalculateDescendants(iters_conflicting, all_conflicts);
     return std::nullopt;
 }
 

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -527,8 +527,9 @@ static RPCHelpMan getmempooldescendants()
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not in mempool");
     }
 
+    CTxMemPool::setEntries iterSet{it};
     CTxMemPool::setEntries setDescendants;
-    mempool.CalculateDescendants(it, setDescendants);
+    mempool.CalculateDescendants(iterSet, setDescendants);
     // CTxMemPool::CalculateDescendants will include the given tx
     setDescendants.erase(it);
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -690,10 +690,10 @@ public:
                             uint64_t limitDescendantSize,
                             std::string &errString) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
-    /** Populate setDescendants with all in-mempool descendants of hash.
+    /** Populate setDescendants with all in-mempool descendants of iterSet.
      *  Assumes that setDescendants includes all in-mempool descendants of anything
      *  already in it.  */
-    void CalculateDescendants(txiter it, setEntries& setDescendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void CalculateDescendants(const setEntries& iterSet, setEntries& setDescendants) const EXCLUSIVE_LOCKS_REQUIRED(cs) LOCKS_EXCLUDED(m_epoch);
 
     /** The minimum fee to get into the mempool, which may itself not be enough
       *  for larger-sized transactions.


### PR DESCRIPTION
This change allows epochs to be used in CalculateDescendants, which makes the descendant traversal quicker. CalculateDescendants now takes a setEntries parameter so that callers no longer need to call CalculateDescendants in a loop.

The function is basically the same except:
- the single-entry set case is quicker since setDescendants isn't queried
- the looping calls where setDescendants is used across iterations is removed in favor of just a single call to CalculateDescendants with the set and using an epoch instead of set lookups