### PR TITLE
readme: Remove the word 'experimental' from description of Bitcoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Further information about Bitcoin Core is available in the [doc folder](/doc).
 What is Bitcoin?
 ----------------
 
-Bitcoin is an experimental digital currency that enables instant payments to
+Bitcoin is a digital currency that enables instant payments to
 anyone, anywhere in the world. Bitcoin uses peer-to-peer technology to operate
 with no central authority: managing transactions and issuing money are carried
 out collectively by the network. Bitcoin Core is the name of open source


### PR DESCRIPTION
I don't believe the word 'experimental' applies to Bitcoin anymore.

There are hundreds of companies (and a few governments!) that use/hold or contribute to Bitcoin in some way or another, millions of people who hold Bitcoin as a store of value and/or use it as a medium of exchange, the Bitcoin network has been running continuously since its inception more than 13 years ago, and hundreds of projects exist that have gone on to develop other assets that take the methods first implemented in Bitcoin and attempt to copy them or alter them in some way.

Bitcoin is many things but it no longer seems experimental.

I saw [the conclusion](https://github.com/bitcoin/bitcoin/pull/24431#issuecomment-1063327063) of #24431 but I still decided to keep the issue open because it does not seem to me that just saying Bitcoin is a digital currency without the 'experimental' descriptor implies that the Bitcoin Core developers (or Bitcoin developers more generally) would be liable if there were to be some catastrophic bug (waiving any liability is already taken care of by the MIT License).