### PR TITLE
rpc: Add sqlite format option for dumptxoutset

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1339,6 +1339,11 @@ if test "$enable_fuzz_binary" = "yes"; then
   CHECK_RUNTIME_LIB
 fi
 
+dnl Check for sqlite3. We need to check if it's available regardless of whether wallet is enabled or not.
+if test "$use_sqlite" != "no"; then
+  PKG_CHECK_MODULES([SQLITE], [sqlite3 >= 3.7.17], [have_sqlite=yes], [have_sqlite=no])
+fi
+
 if test "$enable_wallet" != "no"; then
     dnl Check for libdb_cxx only if wallet enabled
     if test "$use_bdb" != "no"; then
@@ -1348,10 +1353,7 @@ if test "$enable_wallet" != "no"; then
       fi
     fi
 
-    dnl Check for sqlite3
-    if test "$use_sqlite" != "no"; then
-      PKG_CHECK_MODULES([SQLITE], [sqlite3 >= 3.7.17], [have_sqlite=yes], [have_sqlite=no])
-    fi
+    dnl Check if wallet should be built with sqlite support
     AC_MSG_CHECKING([whether to build wallet with support for sqlite])
     if test "$use_sqlite" = "no"; then
       use_sqlite=no
@@ -1375,6 +1377,19 @@ if test "$enable_wallet" != "no"; then
         fi
         enable_wallet=no
     fi
+elif test "$use_sqlite" == "yes"; then
+  dnl Check if we should build with sqlite for functionality independent of wallet
+  AC_MSG_CHECKING([whether to build with sqlite support without wallet])
+  if test "$have_sqlite" = "no"; then
+    AC_MSG_ERROR([sqlite support requested but cannot be built. Use --without-sqlite])
+    use_sqlite=no
+  else
+    AC_DEFINE([USE_SQLITE],[1],[Define if sqlite support should be compiled in])
+    use_sqlite=yes
+  fi
+else
+  dnl Wallet is disabled and we don't implicitly want to build with sqlite in this case, so disable it
+  use_sqlite=no
 fi
 
 if test "$use_usdt" != "no"; then
@@ -1999,9 +2014,9 @@ echo "  with experimental syscall sandbox support = $use_syscall_sandbox"
 echo "  with libs       = $build_bitcoin_libs"
 echo "  with wallet     = $enable_wallet"
 if test "$enable_wallet" != "no"; then
-    echo "    with sqlite   = $use_sqlite"
     echo "    with bdb      = $use_bdb"
 fi
+echo "  with sqlite     = $use_sqlite"
 echo "  with gui / qt   = $bitcoin_enable_qt"
 if test $bitcoin_enable_qt != "no"; then
     echo "    with qr       = $use_qr"

--- a/doc/release-notes-24952.md
+++ b/doc/release-notes-24952.md
@@ -1,0 +1,7 @@
+Updated RPCs
+------------
+
+- The `dumptxoutset` RPC method now accepts an optional `format` parameter for the output file type.
+  Possible values are "compact" (the default), or "sqlite" for a SQLite DB file with human-readable
+  data in a `utxos` and `metadata` table. This new parameter requires compiling with the wallet or
+  configuring with SQLite support. (#24952)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -410,6 +410,9 @@ libbitcoin_node_a_SOURCES += wallet/init.cpp
 endif
 if !ENABLE_WALLET
 libbitcoin_node_a_SOURCES += dummywallet.cpp
+if USE_SQLITE
+libbitcoin_node_a_LIBADD = $(SQLITE_LIBS)
+endif
 endif
 
 if ENABLE_ZMQ

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -48,11 +48,18 @@ UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex
 /** Used by getblockstats to get feerates at different percentiles by weight  */
 void CalculatePercentilesByWeight(CAmount result[NUM_GETBLOCKSTATS_PERCENTILES], std::vector<std::pair<CAmount, int64_t>>& scores, int64_t total_weight);
 
+/** File format type for CreateUTXOSnapshot() */
+enum class UTXOSnapshotFormat {
+    COMPACT,
+    SQLITE,
+};
+
 /**
  * Helper to create UTXO snapshots given a chainstate and a file handle.
  * @return a UniValue map containing metadata about the snapshot.
  */
 UniValue CreateUTXOSnapshot(
+    const UTXOSnapshotFormat format,
     node::NodeContext& node,
     CChainState& chainstate,
     CAutoFile& afile,

--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -35,7 +35,7 @@ CreateAndActivateUTXOSnapshot(node::NodeContext& node, const fs::path root, F ma
     CAutoFile auto_outfile{outfile, SER_DISK, CLIENT_VERSION};
 
     UniValue result = CreateUTXOSnapshot(
-        node, node.chainman->ActiveChainstate(), auto_outfile, snapshot_path, snapshot_path);
+        UTXOSnapshotFormat::COMPACT, node, node.chainman->ActiveChainstate(), auto_outfile, snapshot_path, snapshot_path);
     BOOST_TEST_MESSAGE(
         "Wrote UTXO snapshot to " << fs::PathToString(snapshot_path.make_preferred()) << ": " << result.write());
 


### PR DESCRIPTION
This allows RPC users of the `dumptxoutset` command to output to a SQLite DB format with human-readable fields.
This approach allows for trivial export to JSON and CSV by using `sqlite3` (detailed in #24628).

There is a new optional 'format' parameter for `dumptxoutset` that can take on the values of either 'compact' or 'sqlite'
with 'compact' as the default. This allows for backward compatibility.

Closes #24628