### PR TITLE
guix: Improve error message about missed macOS SDK

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -132,7 +132,7 @@ for host in $HOSTS; do
                 echo "Found macOS SDK at '${OSX_SDK}', using..."
                 break
             else
-                echo "macOS SDK does not exist at '${OSX_SDK}', please place the extracted, untarred SDK there to perform darwin builds, exiting..."
+                echo "macOS SDK does not exist at '${OSX_SDK}', please place the extracted, untarred SDK there to perform darwin builds, or define SDK_PATH environment variable. Exiting..."
                 exit 1
             fi
             ;;


### PR DESCRIPTION
The error message now mentions another option for users to specify the path to the macOS SDK.