### PR TITLE
Update bitcoin.conf

### DIFF
--- a/share/examples/bitcoin.conf
+++ b/share/examples/bitcoin.conf
@@ -156,6 +156,9 @@
 # Maintain coinstats index used by the gettxoutsetinfo RPC (default: 0).
 #coinstatsindex=1
 
+# Maintain the transaction index, which is useful for exploration and development.
+#txindex=1
+
 # Enable pruning to reduce storage requirements by deleting old blocks.
 # This mode is incompatible with -txindex and -coinstatsindex.
 # 0 = default (no pruning).

--- a/share/examples/bitcoin.conf
+++ b/share/examples/bitcoin.conf
@@ -156,7 +156,8 @@
 # Maintain coinstats index used by the gettxoutsetinfo RPC (default: 0).
 #coinstatsindex=1
 
-# Maintain the transaction index, which is useful for exploration and development.
+# Maintains an index of all transactions that have ever happened, which you can query using the remote procedure 
+# call (RPC) method `getrawtransaction` or the RESTful API call `get-tx`.
 #txindex=1
 
 # Enable pruning to reduce storage requirements by deleting old blocks.


### PR DESCRIPTION
Add txindex to miscellaneous config options.

As a developer migrating from Ethereum to BTC development, it's incredibly useful to see this option in the default config rather than discovering the option later and having to reindex, reboot development stack, etc.