### PR TITLE
bench: remove from available_coins with reference, vout size

### DIFF
--- a/src/bench/mempool_stress.cpp
+++ b/src/bench/mempool_stress.cpp
@@ -51,7 +51,7 @@ static std::vector<CTransactionRef> CreateOrderedCoins(FastRandomContext& det_ra
         size_t n_ancestors = det_rand.randrange(10)+1;
         for (size_t ancestor = 0; ancestor < n_ancestors && !available_coins.empty(); ++ancestor){
             size_t idx = det_rand.randrange(available_coins.size());
-            Available coin = available_coins[idx];
+            Available& coin = available_coins[idx];
             uint256 hash = coin.ref->GetHash();
             // biased towards taking min_ancestors parents, but maybe more
             size_t n_to_take = det_rand.randrange(2) == 0 ?
@@ -63,7 +63,7 @@ static std::vector<CTransactionRef> CreateOrderedCoins(FastRandomContext& det_ra
                 tx.vin.back().scriptSig = CScript() << coin.tx_count;
                 tx.vin.back().scriptWitness.stack.push_back(CScriptNum(coin.tx_count).getvch());
             }
-            if (coin.vin_left == coin.ref->vin.size()) {
+            if (coin.vin_left == coin.ref->vout.size()) {
                 coin = available_coins.back();
                 available_coins.pop_back();
             }


### PR DESCRIPTION
In the current mempool benchmarks, the coins were not being deleted from `available_coins` since `Available` rather than `Available&` was used. Also the lack of the reference meant that `coin.vin_left++` only incremented the copy's variable rather than the one in the vector. The removal condition previously compared the coin's `vin.size()` to `vin_left`, when it should have been using `vout.size()`. I changed the `MempoolCheck` bench to instead use `min_ancestors` of 1 rather than 5 as otherwise an underflow could occur when calling `coin.ref->vout.size() - coin.vin_left`. This previously did not occur since `vin_left` was always 0 since a copy of the coin was used. Using 1 vs 5 shouldn't give too much of a difference since the test can still generate more than 1 (or 5) ancestors.