### PR TITLE
netgroup: Follow-up for #22910

### DIFF
--- a/src/netgroup.cpp
+++ b/src/netgroup.cpp
@@ -71,7 +71,7 @@ std::vector<unsigned char> NetGroupManager::GetGroup(const CNetAddr& address) co
     // ...for the last byte, push nBits and for the rest of the byte push 1's
     if (nBits > 0) {
         assert(num_bytes < addr_bytes.size());
-        vchRet.push_back(addr_bytes[num_bytes] | ((1 << (8 - nBits)) - 1));
+        vchRet.push_back(addr_bytes[num_bytes + nStartByte] | ((1 << (8 - nBits)) - 1));
     }
 
     return vchRet;


### PR DESCRIPTION
This addresses my review [comments](https://github.com/bitcoin/bitcoin/pull/22910#discussion_r856095896) I left on #22910.

This has no effect on the current logic as `nStartByte` is only used for internal addresses which only ever add 10 whole bytes to the returned group. However to avoid future bugs, I think we should use `nStartByte` as offset for the last byte as well, in case we ever add a new address type that makes makes use of `nStartByte` and adds fractional bytes to the group.