### PR TITLE
PT-BR tray menu translation fix

### DIFF
--- a/src/qt/locale/bitcoin_pt_BR.ts
+++ b/src/qt/locale/bitcoin_pt_BR.ts
@@ -1182,7 +1182,7 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     </message>
     <message>
         <source>S&amp;how</source>
-        <translation type="unfinished">S&amp;como</translation>
+        <translation type="unfinished">Mo&amp;strar</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>


### PR DESCRIPTION

The option  to show/hide the main window sis translated incorrectly for brazilian portuguese
Hide = Esconder is corrent
Show = Scomo is not even a word

The corect should be

Show = Mostrar, which is opposite for Esconder

This is caused because of the ampersand and automatic translator "S&how" got translated as "S&como" because "how"was translated to "como"