### PR TITLE
test, contrib, refactor: use `with` when opening a file

### DIFF
--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -320,15 +320,13 @@ def get_most_recent_git_change_year(filename):
 ################################################################################
 
 def read_file_lines(filename):
-    f = open(filename, 'r', encoding="utf8")
-    file_lines = f.readlines()
-    f.close()
+    with open(filename, 'r', encoding="utf8") as f:
+        file_lines = f.readlines()
     return file_lines
 
 def write_file_lines(filename, file_lines):
-    f = open(filename, 'w', encoding="utf8")
-    f.write(''.join(file_lines))
-    f.close()
+    with open(filename, 'w', encoding="utf8") as f:
+        f.write(''.join(file_lines))
 
 ################################################################################
 # update header years execution

--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -34,12 +34,12 @@ def get_blk_dt(blk_hdr):
 # When getting the list of block hashes, undo any byte reversals.
 def get_block_hashes(settings):
     blkindex = []
-    f = open(settings['hashlist'], "r", encoding="utf8")
-    for line in f:
-        line = line.rstrip()
-        if settings['rev_hash_bytes'] == 'true':
-            line = bytes.fromhex(line)[::-1].hex()
-        blkindex.append(line)
+    with open(settings['hashlist'], "r", encoding="utf8") as f:
+        for line in f:
+            line = line.rstrip()
+            if settings['rev_hash_bytes'] == 'true':
+                line = bytes.fromhex(line)[::-1].hex()
+            blkindex.append(line)
 
     print("Read " + str(len(blkindex)) + " hashes")
 
@@ -249,19 +249,18 @@ if __name__ == '__main__':
         print("Usage: linearize-data.py CONFIG-FILE")
         sys.exit(1)
 
-    f = open(sys.argv[1], encoding="utf8")
-    for line in f:
-        # skip comment lines
-        m = re.search(r'^\s*#', line)
-        if m:
-            continue
+    with open(sys.argv[1], encoding="utf8") as f:
+        for line in f:
+            # skip comment lines
+            m = re.search(r'^\s*#', line)
+            if m:
+                continue
 
-        # parse key=value lines
-        m = re.search(r'^(\w+)\s*=\s*(\S.*)$', line)
-        if m is None:
-            continue
-        settings[m.group(1)] = m.group(2)
-    f.close()
+            # parse key=value lines
+            m = re.search(r'^(\w+)\s*=\s*(\S.*)$', line)
+            if m is None:
+                continue
+            settings[m.group(1)] = m.group(2)
 
     # Force hash byte format setting to be lowercase to make comparisons easier.
     # Also place upfront in case any settings need to know about it.

--- a/contrib/linearize/linearize-hashes.py
+++ b/contrib/linearize/linearize-hashes.py
@@ -98,19 +98,18 @@ if __name__ == '__main__':
         print("Usage: linearize-hashes.py CONFIG-FILE")
         sys.exit(1)
 
-    f = open(sys.argv[1], encoding="utf8")
-    for line in f:
-        # skip comment lines
-        m = re.search(r'^\s*#', line)
-        if m:
-            continue
+    with open(sys.argv[1], encoding="utf8") as f:
+        for line in f:
+            # skip comment lines
+            m = re.search(r'^\s*#', line)
+            if m:
+                continue
 
-        # parse key=value lines
-        m = re.search(r'^(\w+)\s*=\s*(\S.*)$', line)
-        if m is None:
-            continue
-        settings[m.group(1)] = m.group(2)
-    f.close()
+            # parse key=value lines
+            m = re.search(r'^(\w+)\s*=\s*(\S.*)$', line)
+            if m is None:
+                continue
+            settings[m.group(1)] = m.group(2)
 
     if 'host' not in settings:
         settings['host'] = '127.0.0.1'

--- a/contrib/verify-commits/verify-commits.py
+++ b/contrib/verify-commits/verify-commits.py
@@ -82,11 +82,16 @@ def main():
     # get directory of this program and read data files
     dirname = os.path.dirname(os.path.abspath(__file__))
     print("Using verify-commits data from " + dirname)
-    verified_root = open(dirname + "/trusted-git-root", "r", encoding="utf8").read().splitlines()[0]
-    verified_sha512_root = open(dirname + "/trusted-sha512-root-commit", "r", encoding="utf8").read().splitlines()[0]
-    revsig_allowed = open(dirname + "/allow-revsig-commits", "r", encoding="utf-8").read().splitlines()
-    unclean_merge_allowed = open(dirname + "/allow-unclean-merge-commits", "r", encoding="utf-8").read().splitlines()
-    incorrect_sha512_allowed = open(dirname + "/allow-incorrect-sha512-commits", "r", encoding="utf-8").read().splitlines()
+    with open(dirname + "/trusted-git-root", "r", encoding="utf8") as f:
+        verified_root = f.read().splitlines()[0]
+    with open(dirname + "/trusted-sha512-root-commit", "r", encoding="utf8") as f:
+        verified_sha512_root = f.read().splitlines()[0]
+    with open(dirname + "/allow-revsig-commits", "r", encoding="utf8") as f:
+        revsig_allowed = f.read().splitlines()
+    with open(dirname + "/allow-unclean-merge-commit", "r", encoding="utf8") as f:
+        unclean_merge_allowed = f.read().splitlines()
+    with open(dirname + "/allow-incorrect-sha512-commits", "r", encoding="utf8") as f:
+        incorrect_sha512_allowed = f.read().splitlines()
 
     # Set commit and branch and set variables
     current_commit = args.commit

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -247,7 +247,8 @@ class ConfArgsTest(BitcoinTestFramework):
         conf_file = os.path.join(default_data_dir, "bitcoin.conf")
 
         # datadir needs to be set before [chain] section
-        conf_file_contents = open(conf_file, encoding='utf8').read()
+        with open(conf_file, encoding='utf8') as f:
+            conf_file_contents = f.read()
         with open(conf_file, 'w', encoding='utf8') as f:
             f.write(f"datadir={new_data_dir}\n")
             f.write(conf_file_contents)

--- a/test/functional/feature_versionbits_warning.py
+++ b/test/functional/feature_versionbits_warning.py
@@ -58,7 +58,8 @@ class VersionBitsWarningTest(BitcoinTestFramework):
 
     def versionbits_in_alert_file(self):
         """Test that the versionbits warning has been written to the alert file."""
-        alert_text = open(self.alert_filename, 'r', encoding='utf8').read()
+        with open(self.alert_filename, 'r', encoding='utf8') as f:
+            alert_text = f.read()
         return VB_PATTERN.search(alert_text) is not None
 
     def run_test(self):

--- a/test/util/test_runner.py
+++ b/test/util/test_runner.py
@@ -22,7 +22,8 @@ import sys
 def main():
     config = configparser.ConfigParser()
     config.optionxform = str
-    config.read_file(open(os.path.join(os.path.dirname(__file__), "../config.ini"), encoding="utf8"))
+    with open(os.path.join(os.path.dirname(__file__), "../config.ini"), encoding="utf8") as f:
+        config.read_file(f)
     env_conf = dict(config.items('environment'))
 
     parser = argparse.ArgumentParser(description=__doc__)
@@ -43,7 +44,8 @@ def main():
 def bctester(testDir, input_basename, buildenv):
     """ Loads and parses the input file, runs all tests and reports results"""
     input_filename = os.path.join(testDir, input_basename)
-    raw_data = open(input_filename, encoding="utf8").read()
+    with open(input_filename, encoding="utf8") as f:
+        raw_data = f.read()
     input_data = json.loads(raw_data)
 
     failed_testcases = []
@@ -80,7 +82,8 @@ def bctest(testDir, testObj, buildenv):
     inputData = None
     if "input" in testObj:
         filename = os.path.join(testDir, testObj["input"])
-        inputData = open(filename, encoding="utf8").read()
+        with open(filename, encoding="utf8") as f:
+            inputData = f.read()
         stdinCfg = subprocess.PIPE
 
     # Read the expected output data (if there is any)
@@ -91,7 +94,8 @@ def bctest(testDir, testObj, buildenv):
         outputFn = testObj['output_cmp']
         outputType = os.path.splitext(outputFn)[1][1:]  # output type from file extension (determines how to compare)
         try:
-            outputData = open(os.path.join(testDir, outputFn), encoding="utf8").read()
+            with open(os.path.join(testDir, outputFn), encoding="utf8") as f:
+                outputData = f.read()
         except:
             logging.error("Output file " + outputFn + " cannot be opened")
             raise


### PR DESCRIPTION
When manipulating a file in Python without using `with()`, you have to close the file manually, so this PR does it in `get_block_hashes` (`contrib/linearize/linearize-data.py`).   

Edit: this PR does it for all occurances that previously weren't using `with`.