### PR TITLE
build: Build `libbitcoinconsensus` from its own convenience library

### DIFF
--- a/build_msvc/libbitcoinconsensus/libbitcoinconsensus.vcxproj
+++ b/build_msvc/libbitcoinconsensus/libbitcoinconsensus.vcxproj
@@ -11,10 +11,7 @@
     <ClCompile Include="..\..\src\arith_uint256.cpp" />
     <ClCompile Include="..\..\src\consensus\merkle.cpp" />
     <ClCompile Include="..\..\src\consensus\tx_check.cpp" />
-    <ClCompile Include="..\..\src\crypto\aes.cpp" />
-    <ClCompile Include="..\..\src\crypto\chacha20.cpp" />
     <ClCompile Include="..\..\src\crypto\hmac_sha256.cpp" />
-    <ClCompile Include="..\..\src\crypto\hmac_sha512.cpp" />
     <ClCompile Include="..\..\src\crypto\ripemd160.cpp" />
     <ClCompile Include="..\..\src\crypto\sha1.cpp" />
     <ClCompile Include="..\..\src\crypto\sha256.cpp" />
@@ -28,6 +25,7 @@
     <ClCompile Include="..\..\src\script\interpreter.cpp" />
     <ClCompile Include="..\..\src\script\script.cpp" />
     <ClCompile Include="..\..\src\script\script_error.cpp" />
+    <ClCompile Include="..\..\src\script\transaction_unserialize.cpp" />
     <ClCompile Include="..\..\src\uint256.cpp" />
     <ClCompile Include="..\..\src\util\strencodings.cpp" />
   </ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -585,6 +585,8 @@ libbitcoin_consensus_a_SOURCES = \
   script/script.h \
   script/script_error.cpp \
   script/script_error.h \
+  script/transaction_unserialize.cpp \
+  script/transaction_unserialize.h \
   serialize.h \
   span.h \
   tinyformat.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -939,12 +939,50 @@ endif # BUILD_BITCOIN_KERNEL_LIB
 if BUILD_BITCOIN_LIBS
 lib_LTLIBRARIES += $(LIBBITCOINCONSENSUS)
 
+noinst_LTLIBRARIES += libscriptvalidation.la
+libscriptvalidation_la_SOURCES =
+libscriptvalidation_la_SOURCES += crypto/hmac_sha512.cpp
+libscriptvalidation_la_SOURCES += crypto/hmac_sha512.h
+libscriptvalidation_la_SOURCES += crypto/ripemd160.cpp
+libscriptvalidation_la_SOURCES += crypto/ripemd160.h
+libscriptvalidation_la_SOURCES += crypto/sha1.cpp
+libscriptvalidation_la_SOURCES += crypto/sha1.h
+libscriptvalidation_la_SOURCES += crypto/sha256.cpp
+libscriptvalidation_la_SOURCES += crypto/sha256.h
+libscriptvalidation_la_SOURCES += crypto/sha256_arm_shani.cpp
+libscriptvalidation_la_SOURCES += crypto/sha256_avx2.cpp
+libscriptvalidation_la_SOURCES += crypto/sha256_sse4.cpp
+libscriptvalidation_la_SOURCES += crypto/sha256_sse41.cpp
+libscriptvalidation_la_SOURCES += crypto/sha256_x86_shani.cpp
+libscriptvalidation_la_SOURCES += crypto/sha512.cpp
+libscriptvalidation_la_SOURCES += crypto/sha512.h
+libscriptvalidation_la_SOURCES += hash.cpp
+libscriptvalidation_la_SOURCES += hash.h
+libscriptvalidation_la_SOURCES += primitives/transaction.cpp
+libscriptvalidation_la_SOURCES += primitives/transaction.h
+libscriptvalidation_la_SOURCES += pubkey.cpp
+libscriptvalidation_la_SOURCES += pubkey.h
+libscriptvalidation_la_SOURCES += script/interpreter.cpp
+libscriptvalidation_la_SOURCES += script/interpreter.h
+libscriptvalidation_la_SOURCES += script/script.cpp
+libscriptvalidation_la_SOURCES += script/script.h
+libscriptvalidation_la_SOURCES += script/transaction_unserialize.cpp
+libscriptvalidation_la_SOURCES += script/transaction_unserialize.h
+libscriptvalidation_la_SOURCES += uint256.cpp
+libscriptvalidation_la_SOURCES += uint256.h
+libscriptvalidation_la_SOURCES += util/strencodings.cpp
+libscriptvalidation_la_SOURCES += util/strencodings.h
+libscriptvalidation_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL
+libscriptvalidation_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+libscriptvalidation_la_LIBADD = $(LIBSECP256K1)
+libscriptvalidation_la_LDFLAGS = $(AM_LDFLAGS) -static
+
 include_HEADERS = script/bitcoinconsensus.h
-libbitcoinconsensus_la_SOURCES = support/cleanse.cpp $(crypto_libbitcoin_crypto_base_la_SOURCES) $(libbitcoin_consensus_a_SOURCES)
+libbitcoinconsensus_la_SOURCES = script/bitcoinconsensus.cpp
 
 libbitcoinconsensus_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS)
-libbitcoinconsensus_la_LIBADD = $(LIBSECP256K1)
-libbitcoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL
+libbitcoinconsensus_la_LIBADD = libscriptvalidation.la
+libbitcoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -DBUILD_BITCOIN_INTERNAL
 libbitcoinconsensus_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 
 endif

--- a/src/script/transaction_unserialize.cpp
+++ b/src/script/transaction_unserialize.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <script/transaction_unserialize.h>
+
+#include <span.h>
+#include <version.h>
+
+#include <cstddef>
+#include <cstring>
+#include <ios>
+#include <string>
+
+namespace {
+
+/** A class that deserializes a single CTransaction one time. */
+class TxInputStream
+{
+public:
+    TxInputStream(int nVersionIn, const unsigned char* txTo, size_t txToLen)
+        : m_version(nVersionIn),
+          m_data(txTo),
+          m_remaining(txToLen)
+    {
+    }
+
+    void read(Span<std::byte> dst)
+    {
+        if (dst.size() > m_remaining) {
+            throw std::ios_base::failure(std::string(__func__) + ": end of data");
+        }
+
+        if (dst.data() == nullptr) {
+            throw std::ios_base::failure(std::string(__func__) + ": bad destination buffer");
+        }
+
+        if (m_data == nullptr) {
+            throw std::ios_base::failure(std::string(__func__) + ": bad source buffer");
+        }
+
+        memcpy(dst.data(), m_data, dst.size());
+        m_remaining -= dst.size();
+        m_data += dst.size();
+    }
+
+    template <typename T>
+    TxInputStream& operator>>(T&& obj)
+    {
+        ::Unserialize(*this, obj);
+        return *this;
+    }
+
+    int GetVersion() const { return m_version; }
+
+private:
+    const int m_version;
+    const unsigned char* m_data;
+    size_t m_remaining;
+};
+} // namespace
+
+CTransaction bitcoinconsensus::UnserializeTx(const unsigned char* txTo, unsigned int txToLen)
+{
+    TxInputStream stream{PROTOCOL_VERSION, txTo, txToLen};
+    return {deserialize, stream};
+}
+
+size_t bitcoinconsensus::TxSize(const CTransaction& tx)
+{
+    return GetSerializeSize(tx, PROTOCOL_VERSION);
+}

--- a/src/script/transaction_unserialize.h
+++ b/src/script/transaction_unserialize.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SCRIPT_TRANSACTION_UNSERIALIZE_H
+#define BITCOIN_SCRIPT_TRANSACTION_UNSERIALIZE_H
+
+#include <primitives/transaction.h>
+
+#include <cstddef>
+
+namespace bitcoinconsensus {
+CTransaction UnserializeTx(const unsigned char* txTo, unsigned int txToLen);
+size_t TxSize(const CTransaction& tx);
+} // namespace bitcoinconsensus
+
+#endif // BITCOIN_SCRIPT_TRANSACTION_UNSERIALIZE_H


### PR DESCRIPTION
This PR has the following 4 benefits:

## First benefit

This PR prunes all of [unnecessary](https://github.com/bitcoin/bitcoin/pull/25020#issuecomment-1142151675) symbols being exported from `libbitcoinconsensus.so`:
```
$ objdump -T bitcoin-c28bb15a117e-x86_64-linux-gnu/bitcoin-c28bb15a117e/lib/libbitcoinconsensus.so.0 | grep -v UND

bitcoin-c28bb15a117e-x86_64-linux-gnu/bitcoin-c28bb15a117e/lib/libbitcoinconsensus.so.0:     file format elf64-x86-64

DYNAMIC SYMBOL TABLE:
0000000000003000 g    DF .init	0000000000000000  Base        _init
0000000000045494 g    DF .fini	0000000000000000  Base        _fini
0000000000004de0 g    DF .text	0000000000000037  Base        bitcoinconsensus_version
0000000000005230 g    DF .text	0000000000000049  Base        bitcoinconsensus_verify_script_with_amount
0000000000005280 g    DF .text	000000000000006d  Base        bitcoinconsensus_verify_script

```

For more details regarding this bug please refer to #26698.

## Second benefit

It fixes `libbitcoinconsensus` Windows builds with `DEBUG=1`.

On master (833add0f48b0fad84d7b8cf9373a349e7aef20b4):
```
$ ./autogen.sh
$ ./configure --host=x86_64-w64-mingw32 CPPFLAGS='-D_GLIBCXX_DEBUG' --disable-bench --disable-fuzz-binary --disable-tests --disable-wallet --without-daemon --without-gui --without-utils
$ make clean
$ make
...
  CXXLD    libbitcoinconsensus.la
/usr/bin/x86_64-w64-mingw32-ld: consensus/.libs/libbitcoinconsensus_la-merkle.o:/usr/lib/gcc/x86_64-w64-mingw32/10-posix/include/c++/x86_64-w64-mingw32/bits/gthr-default.h:749: undefined reference to `__imp_pthread_mutex_lock'
/usr/bin/x86_64-w64-mingw32-ld: consensus/.libs/libbitcoinconsensus_la-merkle.o:/usr/lib/gcc/x86_64-w64-mingw32/10-posix/include/c++/x86_64-w64-mingw32/bits/gthr-default.h:779: undefined reference to `__imp_pthread_mutex_unlock'
...
```

With this PR:
```
$ ./autogen.sh
$ ./configure --host=x86_64-w64-mingw32 CPPFLAGS='-D_GLIBCXX_DEBUG' --disable-bench --disable-fuzz-binary --disable-tests --disable-wallet --without-daemon --without-gui --without-utils
$ make clean
$ make
# no errors
```

From `libstdc++` [docs](https://gcc.gnu.org/onlinedocs/libstdc++/manual/debug_mode_using.html):
> Note that this flag [`-D_GLIBCXX_DEBUG`] changes the sizes and behavior of standard class templates such as `std::vector`, and therefore you can only link code compiled with debug mode and code compiled without debug mode if no instantiation of a container is passed between the two translation units.

On the master branch, a linker adds to binaries every specified object file. And it fails, for example, for https://github.com/bitcoin/bitcoin/blob/f58c1f1a446716a245ca204e2ac1a219455f1340/src/util/strencodings.h#L58-L59
when building `libbitcoinconsensus-0.dll` which [in turn](https://www.sourceware.org/autobook/autobook/autobook_137.html)
> effectively consists of two parts; the DLL itself which contains the shared object code, and an import library which consists of the stub functions which are actually linked into the executable, at a rate of one stub per entry point.

## Third benefit

The resulted binaries got smaller because a linker only extracts from a convenience library those object files that are _actually_ referenced in the code being linked (that could be easy to verify by comparing `nm` outputs):

- master (695ca641a4e3ae065121815a968c769198aa73de)
```
$ ls -l bitcoin-695ca641a4e3-x86_64-linux-gnu/bitcoin-695ca641a4e3/lib/libbitcoinconsensus.so.0.0.0 
-rwxr-xr-x 1 hebasto hebasto 1517816 Jun  4 21:52 bitcoin-695ca641a4e3-x86_64-linux-gnu/bitcoin-695ca641a4e3/lib/libbitcoinconsensus.so.0.0.0
```
- this PR (4.3% smaller)
```
$ ls -l bitcoin-c28bb15a117e-x86_64-linux-gnu/bitcoin-c28bb15a117e/lib/libbitcoinconsensus.so.0.0.0 
-rwxr-xr-x 1 hebasto hebasto 1452280 Apr 27 12:59 bitcoin-c28bb15a117e-x86_64-linux-gnu/bitcoin-c28bb15a117e/lib/libbitcoinconsensus.so.0.0.0
```

## Fourth benefit

This solution does not introduce another Libtool hack as a competitive one [does](https://github.com/bitcoin/bitcoin/issues/25008#issuecomment-1113964111).

---

#### Guix builds on `x86_64`:
```
$ find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
6dbc71f90085bb785b88d6e0fabdfb49e4df01dddc7adcf36847eab1c39323c2  guix-build-c28bb15a117e/output/aarch64-linux-gnu/SHA256SUMS.part
7892c618ad9d29f999528451dc894fd8b9647479bd38b7308d7ad4d687734a6b  guix-build-c28bb15a117e/output/aarch64-linux-gnu/bitcoin-c28bb15a117e-aarch64-linux-gnu-debug.tar.gz
f161c35d495c33a558a049899ad3d782bfeb6ff33f2e5d0346b624339c7ed4d5  guix-build-c28bb15a117e/output/aarch64-linux-gnu/bitcoin-c28bb15a117e-aarch64-linux-gnu.tar.gz
5898572c86b5b20e71e007e3b3759883e567df34200775aa7e8baf4787330b14  guix-build-c28bb15a117e/output/arm-linux-gnueabihf/SHA256SUMS.part
94386f5febb0aa9e77e4bdd079cb550cda39c21d27deae64591bfbb3aa879d3d  guix-build-c28bb15a117e/output/arm-linux-gnueabihf/bitcoin-c28bb15a117e-arm-linux-gnueabihf-debug.tar.gz
8cca048298f11ec932e07c7b5e239a0274b8345f5e048c03d22da2de73f2d2ca  guix-build-c28bb15a117e/output/arm-linux-gnueabihf/bitcoin-c28bb15a117e-arm-linux-gnueabihf.tar.gz
9a11382e702e0f0635e17659664c11139015cbac9731c19a522bf893051e5ad9  guix-build-c28bb15a117e/output/arm64-apple-darwin/SHA256SUMS.part
4e7eaa152d8671c40e661f62cee95a2dc4b03102faadf68e4996d4079673e1ae  guix-build-c28bb15a117e/output/arm64-apple-darwin/bitcoin-c28bb15a117e-arm64-apple-darwin-unsigned.dmg
5fa820623ce24c5f866e4a7a585019a32e09aeede58457521d615f719b6c9ac9  guix-build-c28bb15a117e/output/arm64-apple-darwin/bitcoin-c28bb15a117e-arm64-apple-darwin-unsigned.tar.gz
4b1d616e7a100fb225b8fd283ceb6045806ab108783fffcb7a761ccb101f7a7c  guix-build-c28bb15a117e/output/arm64-apple-darwin/bitcoin-c28bb15a117e-arm64-apple-darwin.tar.gz
45eab8b3a4932163c0d3a27b5d1dbf06c3ddbc025409ce12674faddba974bbf0  guix-build-c28bb15a117e/output/dist-archive/bitcoin-c28bb15a117e.tar.gz
87618c7fe2b3c34866bdb32b52486e4a76b960bf3dd8ba4febeb9477ea7e3a55  guix-build-c28bb15a117e/output/powerpc64-linux-gnu/SHA256SUMS.part
60bbc756a733cd8f902652a2201a422236411ef23996972b7d407eb1a4768f2e  guix-build-c28bb15a117e/output/powerpc64-linux-gnu/bitcoin-c28bb15a117e-powerpc64-linux-gnu-debug.tar.gz
643b3d279eb3bc021f1cb4d461ead0a4abb6c366101c0fc41a99b7da6ea21ca1  guix-build-c28bb15a117e/output/powerpc64-linux-gnu/bitcoin-c28bb15a117e-powerpc64-linux-gnu.tar.gz
0a715a8e37a749a627a09f022aad4e1b5bd8c925d24ac714c7c68223b5a1afb4  guix-build-c28bb15a117e/output/powerpc64le-linux-gnu/SHA256SUMS.part
598eedd190b26a32ebe836eb6cb5ebd7b040d5fe9b0d514d62e6397f8ac32973  guix-build-c28bb15a117e/output/powerpc64le-linux-gnu/bitcoin-c28bb15a117e-powerpc64le-linux-gnu-debug.tar.gz
5ca09731ecb34a37166cbaefbcd956eb1eba32255e7113309c720c4fe6afe8c4  guix-build-c28bb15a117e/output/powerpc64le-linux-gnu/bitcoin-c28bb15a117e-powerpc64le-linux-gnu.tar.gz
0b30ecdc2a34605c7f5ca320e02d4acc13cc0a79fb6bf16795550950c45d4205  guix-build-c28bb15a117e/output/riscv64-linux-gnu/SHA256SUMS.part
9a4ef88387e75f8024630f600789b905bb5e0ebca695cf52dd8e43d382eba08c  guix-build-c28bb15a117e/output/riscv64-linux-gnu/bitcoin-c28bb15a117e-riscv64-linux-gnu-debug.tar.gz
d6efeea1aab7ec4d5cf44e2687ba998c3be950d802b8932f807c30c223a8ef06  guix-build-c28bb15a117e/output/riscv64-linux-gnu/bitcoin-c28bb15a117e-riscv64-linux-gnu.tar.gz
30fc887a3507ea8762021b567b4ef4b88a8a247c3cbb5612ee440aee3ecd7806  guix-build-c28bb15a117e/output/x86_64-apple-darwin/SHA256SUMS.part
ce5b00636bbc350c03bdb768bb644bc2acc4443e5b5e21d5ec8382129043e06b  guix-build-c28bb15a117e/output/x86_64-apple-darwin/bitcoin-c28bb15a117e-x86_64-apple-darwin-unsigned.dmg
8d604959ee976ae6c792a8df19fd481f798bfb2290d2bb9b4fd2c383e1980339  guix-build-c28bb15a117e/output/x86_64-apple-darwin/bitcoin-c28bb15a117e-x86_64-apple-darwin-unsigned.tar.gz
029985c80ec64e156612b61b89c8499ecd3f5f81a38660b7636094772a361f2a  guix-build-c28bb15a117e/output/x86_64-apple-darwin/bitcoin-c28bb15a117e-x86_64-apple-darwin.tar.gz
ebf0c0a4de026fffc85bdc203adcddf7dddb3b7e290e49db458e3f5e7100d52f  guix-build-c28bb15a117e/output/x86_64-linux-gnu/SHA256SUMS.part
dec8a0fb339a40b7e3fe05fc95b0c0de368b37f5ee53d76ac3631af7ac386ad4  guix-build-c28bb15a117e/output/x86_64-linux-gnu/bitcoin-c28bb15a117e-x86_64-linux-gnu-debug.tar.gz
77472639784a37b22a97da3893e9288b009770250f2ae773880c8406b9f02464  guix-build-c28bb15a117e/output/x86_64-linux-gnu/bitcoin-c28bb15a117e-x86_64-linux-gnu.tar.gz
37c60fce475b0b788e859926fe51151519feeab0dd16b83361c967c4a229e687  guix-build-c28bb15a117e/output/x86_64-w64-mingw32/SHA256SUMS.part
321051dbdd456ead04a295bcc1545d91ec30a70dbc5b2655dde0c64babfa454b  guix-build-c28bb15a117e/output/x86_64-w64-mingw32/bitcoin-c28bb15a117e-win64-debug.zip
84acb869ce0ce2f53564b617464e9cb5086761c137115d5eb6e8b3e94ce5b808  guix-build-c28bb15a117e/output/x86_64-w64-mingw32/bitcoin-c28bb15a117e-win64-setup-unsigned.exe
86fbf61f2a208510b3fdda92bb0c0d6489605d6ac54e676cd85e8f06f4f90d5a  guix-build-c28bb15a117e/output/x86_64-w64-mingw32/bitcoin-c28bb15a117e-win64-unsigned.tar.gz
4d6f4e9d3ba152033b484e6c0037047264c9d3dacf9a6c874f597c2b94aba8ec  guix-build-c28bb15a117e/output/x86_64-w64-mingw32/bitcoin-c28bb15a117e-win64.zip
```

---

Fixes bitcoin/bitcoin#19772.
Fixes bitcoin/bitcoin#26698.