### PR TITLE
gui: avoid unclean exit due to permissions issues when setting start on system startup

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -613,8 +613,14 @@ bool GetStartOnSystemStartup()
 
 bool SetStartOnSystemStartup(bool fAutoStart)
 {
-    if (!fAutoStart)
-        fs::remove(GetAutostartFilePath());
+    if (!fAutoStart) {
+        try {
+            fs::remove(GetAutostartFilePath());
+        } catch(const fs::filesystem_error& e) {
+            LogPrintf("failed to remove autostart file: %s\n", e.what());
+            return false;
+        }
+    }
     else
     {
         char pszExePath[MAX_PATH+1];
@@ -623,7 +629,12 @@ bool SetStartOnSystemStartup(bool fAutoStart)
             return false;
         pszExePath[r] = '\0';
 
-        fs::create_directories(GetAutostartDir());
+        try {
+            fs::create_directories(GetAutostartDir());
+        } catch(const fs::filesystem_error& e) {
+            LogPrintf("failed to create autostart directory: %s\n", e.what());
+            return false;
+        }
 
         std::ofstream optionFile{GetAutostartFilePath(), std::ios_base::out | std::ios_base::trunc};
         if (!optionFile.good())


### PR DESCRIPTION
Closes #24953

This remedies two cases where the GUI can cause the process to exit in an unclean manner. These two cases are cases where the directory path causing the exception is likely/usually not under the node's data and/or blocks directory and thus could be more likely to lack write permissions.

Instead of abruptly exiting the process, this path instead makes log entries such as:

```
2022-04-27T11:43:03Z failed to create autostart directory: filesystem error: cannot create directories: Permission denied [/tmp/crash/autostart]
```

```
2022-04-27T11:44:05Z failed to remove autostart file: filesystem error: cannot remove: Permission denied [/tmp/crash/autostart/bitcoin.desktop]
```

the command line used to test and create the above log entries (with this patch applied) was:
```
mkdir -p /tmp/btc && mkdir -p /tmp/crash && chmod 0500 /tmp/crash && XDG_CONFIG_HOME=/tmp/crash ./src/qt/bitcoin-qt -debug -datadir=/tmp/btc -connect=0
```

The short/easy process to generate the exception is noted in the original issue.

This PR does not address the other cases where `fs::create_directories` may create an unclean exit due to the reasoning that the other cases are generated by paths under the blocks and/or data directories and those directories need to be writable by the bitcoin process, or lots of things fail. This is a targeted PR to avoid a couple of unique recoverable situations.