### PR TITLE
guix: consolidate kernel headers to 5.15, specify 3.2.0 as minimum supported

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -130,6 +130,7 @@ chain for " target " development."))
       (license (package-license xgcc)))))
 
 (define base-gcc gcc-10)
+(define base-linux-kernel-headers linux-libre-headers-5.15)
 
 ;; Building glibc with stack smashing protector first landed in glibc 2.25, use
 ;; this function to disable for older glibcs
@@ -148,7 +149,7 @@ chain for " target " development."))
 (define* (make-bitcoin-cross-toolchain target
                                        #:key
                                        (base-gcc-for-libc gcc-7)
-                                       (base-kernel-headers linux-libre-headers-4.9)
+                                       (base-kernel-headers base-linux-kernel-headers)
                                        (base-libc (make-glibc-without-ssp glibc-2.24))
                                        (base-gcc (make-gcc-rpath-link base-gcc)))
   "Convenience wrapper around MAKE-CROSS-TOOLCHAIN with default values
@@ -604,7 +605,7 @@ inspecting signatures in Mach-O binaries.")
                  (cond ((string-contains target "riscv64-")
                         (make-bitcoin-cross-toolchain target
                                                       #:base-libc glibc-2.27/bitcoin-patched
-                                                      #:base-kernel-headers linux-libre-headers-4.19))
+                                                      #:base-kernel-headers base-linux-kernel-headers))
                        (else
                         (make-bitcoin-cross-toolchain target)))))
           ((string-contains target "darwin")

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -20,6 +20,7 @@ You can find installation instructions in the `build-*.md` file for your platfor
 | [Boost](../depends/packages/boost.mk) | [link](https://www.boost.org/users/download/) | [1.77.0](https://github.com/bitcoin/bitcoin/pull/24383) | [1.64.0](https://github.com/bitcoin/bitcoin/pull/22320) | No |
 | [libevent](../depends/packages/libevent.mk) | [link](https://github.com/libevent/libevent/releases) | [2.1.12-stable](https://github.com/bitcoin/bitcoin/pull/21991) | [2.1.8](https://github.com/bitcoin/bitcoin/pull/24681) | No |
 | glibc | [link](https://www.gnu.org/software/libc/) | N/A | [2.18](https://github.com/bitcoin/bitcoin/pull/23511) | Yes |
+| Linux Kernel | [link](https://www.kernel.org/) | N/A | 3.2.0 | Yes |
 
 ## Optional
 


### PR DESCRIPTION
Our minimum supported kernel version is currently defined by Guix, as the version passed to the [`--enable-kernel=`](https://www.gnu.org/software/libc/manual/html_node/Configuring-and-compiling.html) option when configuring glibc. That version is [currently set to 3.2.0](https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/base.scm?id=34e9eae68c9583acce5abc4100add3d88932a5ae#n776):
```scheme
            ;; This is the default for most architectures as of GNU libc 2.26,
            ;; but we specify it explicitly for clarity and consistency.  See
            ;; "kernel-features.h" in the GNU libc for details.
            "--enable-kernel=3.2.0"
```
and has been that way since we started using Guix (i.e from Guix 1.3.0, with the release v22.0).

Passing `--enable-kernel` defines `__LINUX_KERNEL_VERSION` inside glibc, which is then used to determine supported features & syscall usage. For example, some defines in `unix/sysv/linux/kernel-features.h`, from glibc version 2.24, where glibcs default supported kernel version was still 2.6.32 (it's more modern as of recent releases):
```cpp
#ifndef __LINUX_KERNEL_VERSION
/* We assume the worst; all kernels should be supported.  */
# define __LINUX_KERNEL_VERSION	0
#endif

/* Support for various CLOEXEC and NONBLOCK flags was added in
   2.6.23.  */
#define __ASSUME_O_CLOEXEC	1

/* prlimit64 is available in 2.6.36.  */
#if __LINUX_KERNEL_VERSION >= 0x020624
# define __ASSUME_PRLIMIT64	1
#endif
```

Note that because we currently specify the `5.15` headers, the exact version being used, i.e 5.15.x, changes when we update our time-machine commit, as Guix updates all it's header packages as new point releases become available. Currently it is [`5.15.28`](https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/linux.scm?id=34e9eae68c9583acce5abc4100add3d88932a5ae#n380). The changelog for the 5.15 headers is available [here](https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.15.36).

Similar to glibc, it may currently be possible to build and run bitcoind against older kernels, however, for the purposes of documenting what we support for our release binaries, I can't see a reason to document anything other than the version that we are targeting when building the glibc used to build the release binaries.

Guix Build (on x86_64):
```bash
22ff2d3a72d337c4eccbfa4c834a67c7c3397f225aedb71a3c636f2708964e93  guix-build-eb02713efc17/output/aarch64-linux-gnu/SHA256SUMS.part
e316b2d0806183e0e51a25722f48af85d145b1581f44f68b925d9f484a5aa0d3  guix-build-eb02713efc17/output/aarch64-linux-gnu/bitcoin-eb02713efc17-aarch64-linux-gnu-debug.tar.gz
da667d935d9331c5cbca2e0e334cd7e56202ee294553459672fa50f13f501c4d  guix-build-eb02713efc17/output/aarch64-linux-gnu/bitcoin-eb02713efc17-aarch64-linux-gnu.tar.gz
f44f2921f3dac2c545806dffb579137fb9eeeee15671395f6a7f817ed6213143  guix-build-eb02713efc17/output/arm-linux-gnueabihf/SHA256SUMS.part
101bab25ab2a6c36729cdf840264a85700cc3cfa23d3900b0bee0ac9ae637e8d  guix-build-eb02713efc17/output/arm-linux-gnueabihf/bitcoin-eb02713efc17-arm-linux-gnueabihf-debug.tar.gz
9f7338ee42234949ef3104c6cb2b8a723d616a46d0047d833062adc92e3b6b72  guix-build-eb02713efc17/output/arm-linux-gnueabihf/bitcoin-eb02713efc17-arm-linux-gnueabihf.tar.gz
5ca08e7b38c4dd4456145602f25b015c164c0cd0317dd2a26855dc0495605418  guix-build-eb02713efc17/output/arm64-apple-darwin/SHA256SUMS.part
186c9e2df4034472107964e835ee7a05777c7a0fa5e0db12b5740f18e732d7d5  guix-build-eb02713efc17/output/arm64-apple-darwin/bitcoin-eb02713efc17-arm64-apple-darwin-unsigned.dmg
4e252c7775662777ddcb0a1b0efac6b6e71c25479d6b44b821199ae00abd18ca  guix-build-eb02713efc17/output/arm64-apple-darwin/bitcoin-eb02713efc17-arm64-apple-darwin-unsigned.tar.gz
4360342994d54839bbf5fb4d86c6c0b0a3cbcef68b0d2c991aab6e81301638e7  guix-build-eb02713efc17/output/arm64-apple-darwin/bitcoin-eb02713efc17-arm64-apple-darwin.tar.gz
f354822050cd625de7445cfa317475cfad90a7e39d135c5b99950ee69969f445  guix-build-eb02713efc17/output/dist-archive/bitcoin-eb02713efc17.tar.gz
aa864574dd692bb40df95e17c08113f5bcd04b7d5997a2f74ca0557cae3edfcd  guix-build-eb02713efc17/output/powerpc64-linux-gnu/SHA256SUMS.part
45df2a4ec5592834fd08d36068cd0968de281870cb9df48cc4783078b85985dd  guix-build-eb02713efc17/output/powerpc64-linux-gnu/bitcoin-eb02713efc17-powerpc64-linux-gnu-debug.tar.gz
2bc1c481635ac073d61f51db425576a42a54b16218a00e5f80579426dbf9677b  guix-build-eb02713efc17/output/powerpc64-linux-gnu/bitcoin-eb02713efc17-powerpc64-linux-gnu.tar.gz
403d7790e611d3e07b25e02549c9f50e51fff2e1a323605db4f9a569712771a7  guix-build-eb02713efc17/output/powerpc64le-linux-gnu/SHA256SUMS.part
db40032c3b25d95012496f1b3fa5df7f207dcbeefa510bd140b96df4dfd84c88  guix-build-eb02713efc17/output/powerpc64le-linux-gnu/bitcoin-eb02713efc17-powerpc64le-linux-gnu-debug.tar.gz
eea8b4ee96dc8a9813b727550bf07202a6f9cba99605247813beb5251c7f2623  guix-build-eb02713efc17/output/powerpc64le-linux-gnu/bitcoin-eb02713efc17-powerpc64le-linux-gnu.tar.gz
7164e539d25c300b993a620caacdcef659bb6a7c4775a873e30ee645c9ceed15  guix-build-eb02713efc17/output/riscv64-linux-gnu/SHA256SUMS.part
3ae271e6fb94e5d4e46a402508a02d659e879d222c6696e57c78530157eb39ae  guix-build-eb02713efc17/output/riscv64-linux-gnu/bitcoin-eb02713efc17-riscv64-linux-gnu-debug.tar.gz
8c37d0b790c28b692804b360605baec4371af4f080c0024ba75f06c0096a4356  guix-build-eb02713efc17/output/riscv64-linux-gnu/bitcoin-eb02713efc17-riscv64-linux-gnu.tar.gz
51bbf04cb32b579ba5609fe3ef24e9901f8d49e3311fe9776ee1fdb644f7e0b1  guix-build-eb02713efc17/output/x86_64-apple-darwin/SHA256SUMS.part
8e81f8badb0cff1aa430a899065cf9744b4b2d45addb8e30606a2f8bf08faa26  guix-build-eb02713efc17/output/x86_64-apple-darwin/bitcoin-eb02713efc17-x86_64-apple-darwin-unsigned.dmg
8b4120b6d83c03dae34b0b5a189522d01c523ab005d816339fdfddf9c412ef15  guix-build-eb02713efc17/output/x86_64-apple-darwin/bitcoin-eb02713efc17-x86_64-apple-darwin-unsigned.tar.gz
26e633faba4f05f51f4e0bffaa2bbbf8c2d5d134d6777c9395bf9b65af6a808c  guix-build-eb02713efc17/output/x86_64-apple-darwin/bitcoin-eb02713efc17-x86_64-apple-darwin.tar.gz
16c96d1f349ca3fbf5ffb8e00d5defe1af5a14abb6f61abdbd367e9a5e99bf33  guix-build-eb02713efc17/output/x86_64-linux-gnu/SHA256SUMS.part
faa203c9c3943c2f30ca3f4f30c3eee52e38ac9a2f15c6303b0c8ff0be146e07  guix-build-eb02713efc17/output/x86_64-linux-gnu/bitcoin-eb02713efc17-x86_64-linux-gnu-debug.tar.gz
b5cf5154ac0e2138a4ccbc7639026d909e606b9f55c5859ae54d941eb950759b  guix-build-eb02713efc17/output/x86_64-linux-gnu/bitcoin-eb02713efc17-x86_64-linux-gnu.tar.gz
bc14a09399ef3a6d9696116ddda6509b6cb1726719dfd462106cb9d2fde32efc  guix-build-eb02713efc17/output/x86_64-w64-mingw32/SHA256SUMS.part
7c0a773f0e892e41fe8f7b299be655e53f110a64bd6e77c2e7a6b4c699605498  guix-build-eb02713efc17/output/x86_64-w64-mingw32/bitcoin-eb02713efc17-win64-debug.zip
27f6a50394c61c0efa2f3afe655a265c64a34249041ef0090f9043cd4cdc8c71  guix-build-eb02713efc17/output/x86_64-w64-mingw32/bitcoin-eb02713efc17-win64-setup-unsigned.exe
dd5bb661a9d99bbc2c2c7256996b26bef116b2e61b7497ada26b3322550d53cb  guix-build-eb02713efc17/output/x86_64-w64-mingw32/bitcoin-eb02713efc17-win64-unsigned.tar.gz
84d5068dd59180498473263d757192a422859c0704a2e45a762d1635e49efb80  guix-build-eb02713efc17/output/x86_64-w64-mingw32/bitcoin-eb02713efc17-win64.zip
```

Guix build (on arm64):
```bash
2bbcf455381d4be6bb402c705dba5655de3e1b62a0ed1dbbfcb573450a63d148  guix-build-eb02713efc17/output/arm-linux-gnueabihf/SHA256SUMS.part
c9d982eb6c9efc752fffb3a1d2b14e8cc4d9e2cf4c03c2f02eb320d04f52a86d  guix-build-eb02713efc17/output/arm-linux-gnueabihf/bitcoin-eb02713efc17-arm-linux-gnueabihf-debug.tar.gz
0c0b3122dcdc051bee1022dc9b0cf7771b7f6b30fa3e7369c97907d8c10d7ea3  guix-build-eb02713efc17/output/arm-linux-gnueabihf/bitcoin-eb02713efc17-arm-linux-gnueabihf.tar.gz
5388f8a7525ed49d11569988e598a0ec68ddcaf9b35cff0c8bcb02187b0fbaad  guix-build-eb02713efc17/output/arm64-apple-darwin/SHA256SUMS.part
16b745e2b2e036d65b549be740116d9b6e819730cc76075f01bdbc4beb166724  guix-build-eb02713efc17/output/arm64-apple-darwin/bitcoin-eb02713efc17-arm64-apple-darwin-unsigned.dmg
18eaede02d12dcbb83003272b5b79a08a10067a326542687ab445bfc623ce9e8  guix-build-eb02713efc17/output/arm64-apple-darwin/bitcoin-eb02713efc17-arm64-apple-darwin-unsigned.tar.gz
5fb73968c7ea50c9642d3cddcd745a512be3043ada314b8a1fc94f179744a1d8  guix-build-eb02713efc17/output/arm64-apple-darwin/bitcoin-eb02713efc17-arm64-apple-darwin.tar.gz
f354822050cd625de7445cfa317475cfad90a7e39d135c5b99950ee69969f445  guix-build-eb02713efc17/output/dist-archive/bitcoin-eb02713efc17.tar.gz
fad672b9e5d372ba5511c14ed48ef77bcf303d475f35680bd4a668fee150225a  guix-build-eb02713efc17/output/powerpc64-linux-gnu/SHA256SUMS.part
246aa854e87675a0b90cc14f7b6affcfefabfc0f79edd3dc96ae6b98010b8b1c  guix-build-eb02713efc17/output/powerpc64-linux-gnu/bitcoin-eb02713efc17-powerpc64-linux-gnu-debug.tar.gz
90e968e0bab84e80a9f2fe9498eea7c59d8908f5a16accd93d7f9318a7098ce0  guix-build-eb02713efc17/output/powerpc64-linux-gnu/bitcoin-eb02713efc17-powerpc64-linux-gnu.tar.gz
65f0c018d882d7fc845a9bb1581824b17e7ecf0df7081ab2538f0e617e120a8b  guix-build-eb02713efc17/output/powerpc64le-linux-gnu/SHA256SUMS.part
0bf7fcd127180e5e04112914747496db535226bf05126690f259fa0cf2a96642  guix-build-eb02713efc17/output/powerpc64le-linux-gnu/bitcoin-eb02713efc17-powerpc64le-linux-gnu-debug.tar.gz
14fc3e17dfa903f83e44f970c8b4e4726e7476c59d0fffdec815a1c80ec1b51a  guix-build-eb02713efc17/output/powerpc64le-linux-gnu/bitcoin-eb02713efc17-powerpc64le-linux-gnu.tar.gz
9018f95b54d0643d734260b6eb69ee5f086c98e62f25dd579675b467a844793d  guix-build-eb02713efc17/output/riscv64-linux-gnu/SHA256SUMS.part
e1f2b3678c22103d7b89cbbeec9b2863c9c6f749ff4cbedd74cb6e62598c0a04  guix-build-eb02713efc17/output/riscv64-linux-gnu/bitcoin-eb02713efc17-riscv64-linux-gnu-debug.tar.gz
bf9fa35119344dfc93048196dd9cd5bb230b0785350ae5150bb4bdb28fd8423d  guix-build-eb02713efc17/output/riscv64-linux-gnu/bitcoin-eb02713efc17-riscv64-linux-gnu.tar.gz
51bbf04cb32b579ba5609fe3ef24e9901f8d49e3311fe9776ee1fdb644f7e0b1  guix-build-eb02713efc17/output/x86_64-apple-darwin/SHA256SUMS.part
8e81f8badb0cff1aa430a899065cf9744b4b2d45addb8e30606a2f8bf08faa26  guix-build-eb02713efc17/output/x86_64-apple-darwin/bitcoin-eb02713efc17-x86_64-apple-darwin-unsigned.dmg
8b4120b6d83c03dae34b0b5a189522d01c523ab005d816339fdfddf9c412ef15  guix-build-eb02713efc17/output/x86_64-apple-darwin/bitcoin-eb02713efc17-x86_64-apple-darwin-unsigned.tar.gz
26e633faba4f05f51f4e0bffaa2bbbf8c2d5d134d6777c9395bf9b65af6a808c  guix-build-eb02713efc17/output/x86_64-apple-darwin/bitcoin-eb02713efc17-x86_64-apple-darwin.tar.gz
6e5828e2efa4e951b147b8de42f79dee1652933e04c50093bd31ee375c0c4ca9  guix-build-eb02713efc17/output/x86_64-linux-gnu/SHA256SUMS.part
3d3af1d078eee6f66aac2af891fd7d7a77abc3d7164a807d0a7cc44f15e52b9d  guix-build-eb02713efc17/output/x86_64-linux-gnu/bitcoin-eb02713efc17-x86_64-linux-gnu-debug.tar.gz
13f452bc65194de16fa91ed87be9790ed0d1a178deefb102fa54d3f9832b8c25  guix-build-eb02713efc17/output/x86_64-linux-gnu/bitcoin-eb02713efc17-x86_64-linux-gnu.tar.gz
1673b5fca6687ea0f196a5f2ce2b79662b3efe01b71f341fc596069a1ade610c  guix-build-eb02713efc17/output/x86_64-w64-mingw32/SHA256SUMS.part
d6228bdfb4fbc7b895ed4f0c30e1343c3392bd6e8e5ed33a973887ba0bb749ba  guix-build-eb02713efc17/output/x86_64-w64-mingw32/bitcoin-eb02713efc17-win64-debug.zip
27f6a50394c61c0efa2f3afe655a265c64a34249041ef0090f9043cd4cdc8c71  guix-build-eb02713efc17/output/x86_64-w64-mingw32/bitcoin-eb02713efc17-win64-setup-unsigned.exe
dd5bb661a9d99bbc2c2c7256996b26bef116b2e61b7497ada26b3322550d53cb  guix-build-eb02713efc17/output/x86_64-w64-mingw32/bitcoin-eb02713efc17-win64-unsigned.tar.gz
50a68d3644dbe5cb5de21993cd0e8992ab9c6aa88c009a75e5d5a55180476ea6  guix-build-eb02713efc17/output/x86_64-w64-mingw32/bitcoin-eb02713efc17-win64.zip

```