### PR TITLE
tests: Do not always create a descriptor wallet in wallet_createwallet

### DIFF
--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -29,7 +29,7 @@ class CreateWalletTest(BitcoinTestFramework):
         self.log.info("Run createwallet with invalid parameters.")
         # Run createwallet with invalid parameters. This must not prevent a new wallet with the same name from being created with the correct parameters.
         assert_raises_rpc_error(-4, "Passphrase provided but private keys are disabled. A passphrase is only used to encrypt private keys, so cannot be used for wallets with private keys disabled.",
-            self.nodes[0].createwallet, wallet_name='w0',  descriptors=True, disable_private_keys=True, passphrase="passphrase")
+            self.nodes[0].createwallet, wallet_name='w0', disable_private_keys=True, passphrase="passphrase")
 
         self.nodes[0].createwallet(wallet_name='w0')
         w0 = node.get_wallet_rpc('w0')


### PR DESCRIPTION
The createwallet test for some invalid parameters incorrectly always creates a descriptor wallet. This is unnecessary and also breaks the test when bdb is not compiled in.

Fixes #25007