### PR TITLE
validation: make CScriptCheck and prevector swap members noexcept

### DIFF
--- a/src/bench/checkqueue.cpp
+++ b/src/bench/checkqueue.cpp
@@ -39,7 +39,10 @@ static void CCheckQueueSpeedPrevectorJob(benchmark::Bench& bench)
         {
             return true;
         }
-        void swap(PrevectorJob& x){p.swap(x.p);};
+        void swap(PrevectorJob& x) noexcept
+        {
+            p.swap(x.p);
+        };
     };
     CCheckQueue<PrevectorJob> queue {QUEUE_BATCH_SIZE};
     // The main thread should be counted to prevent thread oversubscription, and

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -458,7 +458,8 @@ public:
         return *item_ptr(size() - 1);
     }
 
-    void swap(prevector<N, T, Size, Diff>& other) {
+    void swap(prevector<N, T, Size, Diff>& other) noexcept
+    {
         std::swap(_union, other._union);
         std::swap(_size, other._size);
     }

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -42,7 +42,7 @@ struct FakeCheck {
     {
         return true;
     }
-    void swap(FakeCheck& x){};
+    void swap(FakeCheck& x) noexcept {};
 };
 
 struct FakeCheckCheckCompletion {
@@ -52,7 +52,7 @@ struct FakeCheckCheckCompletion {
         n_calls.fetch_add(1, std::memory_order_relaxed);
         return true;
     }
-    void swap(FakeCheckCheckCompletion& x){};
+    void swap(FakeCheckCheckCompletion& x) noexcept {};
 };
 
 struct FailingCheck {
@@ -63,7 +63,7 @@ struct FailingCheck {
     {
         return !fails;
     }
-    void swap(FailingCheck& x)
+    void swap(FailingCheck& x) noexcept
     {
         std::swap(fails, x.fails);
     };
@@ -81,7 +81,10 @@ struct UniqueCheck {
         results.insert(check_id);
         return true;
     }
-    void swap(UniqueCheck& x) { std::swap(x.check_id, check_id); };
+    void swap(UniqueCheck& x) noexcept
+    {
+        std::swap(x.check_id, check_id);
+    };
 };
 
 
@@ -109,7 +112,10 @@ struct MemoryCheck {
     {
         fake_allocated_memory.fetch_sub(b, std::memory_order_relaxed);
     };
-    void swap(MemoryCheck& x) { std::swap(b, x.b); };
+    void swap(MemoryCheck& x) noexcept
+    {
+        std::swap(b, x.b);
+    };
 };
 
 struct FrozenCleanupCheck {
@@ -133,7 +139,10 @@ struct FrozenCleanupCheck {
             cv.wait(l, []{ return nFrozen.load(std::memory_order_relaxed) == 0;});
         }
     }
-    void swap(FrozenCleanupCheck& x){std::swap(should_freeze, x.should_freeze);};
+    void swap(FrozenCleanupCheck& x) noexcept
+    {
+        std::swap(should_freeze, x.should_freeze);
+    };
 };
 
 // Static Allocations

--- a/src/test/fuzz/checkqueue.cpp
+++ b/src/test/fuzz/checkqueue.cpp
@@ -26,7 +26,7 @@ struct DumbCheck {
         return result;
     }
 
-    void swap(DumbCheck& x)
+    void swap(DumbCheck& x) noexcept
     {
     }
 };

--- a/src/test/fuzz/prevector.cpp
+++ b/src/test/fuzz/prevector.cpp
@@ -161,7 +161,7 @@ public:
         pre_vector.shrink_to_fit();
     }
 
-    void swap()
+    void swap() noexcept
     {
         real_vector.swap(real_vector_alt);
         pre_vector.swap(pre_vector_alt);

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -165,7 +165,8 @@ public:
         test();
     }
 
-    void swap() {
+    void swap() noexcept
+    {
         real_vector.swap(real_vector_alt);
         pre_vector.swap(pre_vector_alt);
         test();

--- a/src/validation.h
+++ b/src/validation.h
@@ -328,7 +328,8 @@ public:
 
     bool operator()();
 
-    void swap(CScriptCheck &check) {
+    void swap(CScriptCheck& check) noexcept
+    {
         std::swap(ptxTo, check.ptxTo);
         std::swap(m_tx_out, check.m_tx_out);
         std::swap(nIn, check.nIn);


### PR DESCRIPTION
along with those seen elsewhere in the codebase (prevector and checkqueue units/fuzz/bench).

A swap must not fail; when a class has a swap member function, it should be declared noexcept.
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c84-a-swap-function-must-not-fail
