### PR TITLE
contrib: Check symbols in the `bitcoinconsensus` shared library

### DIFF
--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -176,7 +176,7 @@ def check_version(max_versions, version, arch) -> bool:
 def check_imported_symbols(binary) -> bool:
     ok: bool = True
 
-    for symbol in binary.imported_symbols:
+    for symbol in binary.concrete.imported_symbols:
         if not symbol.imported:
             continue
 
@@ -184,7 +184,7 @@ def check_imported_symbols(binary) -> bool:
 
         if version:
             aux_version = version.symbol_version_auxiliary.name if version.has_auxiliary_version else None
-            if aux_version and not check_version(MAX_VERSIONS, aux_version, binary.header.machine_type):
+            if aux_version and not check_version(MAX_VERSIONS, aux_version, binary.concrete.header.machine_type):
                 print(f'{filename}: symbol {symbol.name} from unsupported version {version}')
                 ok = False
     return ok
@@ -192,11 +192,11 @@ def check_imported_symbols(binary) -> bool:
 def check_exported_symbols(binary) -> bool:
     ok: bool = True
 
-    for symbol in binary.dynamic_symbols:
+    for symbol in binary.concrete.dynamic_symbols:
         if not symbol.exported:
             continue
         name = symbol.name
-        if binary.header.machine_type == lief.ELF.ARCH.RISCV or name in IGNORE_EXPORTS:
+        if binary.concrete.header.machine_type == lief.ELF.ARCH.RISCV or name in IGNORE_EXPORTS:
             continue
         print(f'{filename}: export of symbol {name} not allowed!')
         ok = False
@@ -204,7 +204,7 @@ def check_exported_symbols(binary) -> bool:
 
 def check_ELF_libraries(binary) -> bool:
     ok: bool = True
-    for library in binary.libraries:
+    for library in binary.concrete.libraries:
         if library not in ELF_ALLOWED_LIBRARIES:
             print(f'{filename}: {library} is not in ALLOWED_LIBRARIES!')
             ok = False
@@ -212,7 +212,7 @@ def check_ELF_libraries(binary) -> bool:
 
 def check_MACHO_libraries(binary) -> bool:
     ok: bool = True
-    for dylib in binary.libraries:
+    for dylib in binary.concrete.libraries:
         library = dylib.name.split('/')[-1]
         if library not in MACHO_ALLOWED_LIBRARIES:
             print(f'{filename}: {library} is not in ALLOWED_LIBRARIES!')
@@ -220,32 +220,32 @@ def check_MACHO_libraries(binary) -> bool:
     return ok
 
 def check_MACHO_min_os(binary) -> bool:
-    if binary.build_version.minos == [10,15,0]:
+    if binary.concrete.build_version.minos == [10,15,0]:
         return True
     return False
 
 def check_MACHO_sdk(binary) -> bool:
-    if binary.build_version.sdk == [11, 0, 0]:
+    if binary.concrete.build_version.sdk == [11, 0, 0]:
         return True
     return False
 
 def check_PE_libraries(binary) -> bool:
     ok: bool = True
-    for dylib in binary.libraries:
+    for dylib in binary.concrete.libraries:
         if dylib not in PE_ALLOWED_LIBRARIES:
             print(f'{filename}: {dylib} is not in ALLOWED_LIBRARIES!')
             ok = False
     return ok
 
 def check_PE_subsystem_version(binary) -> bool:
-    major: int = binary.optional_header.major_subsystem_version
-    minor: int = binary.optional_header.minor_subsystem_version
+    major: int = binary.concrete.optional_header.major_subsystem_version
+    minor: int = binary.concrete.optional_header.minor_subsystem_version
     if major == 6 and minor == 1:
         return True
     return False
 
 def check_ELF_interpreter(binary) -> bool:
-    expected_interpreter = ELF_INTERPRETER_NAMES[binary.header.machine_type][binary.abstract.header.endianness]
+    expected_interpreter = ELF_INTERPRETER_NAMES[binary.concrete.header.machine_type][binary.abstract.header.endianness]
 
     return binary.concrete.interpreter == expected_interpreter
 
@@ -272,7 +272,7 @@ if __name__ == '__main__':
     for filename in sys.argv[1:]:
         try:
             binary = lief.parse(filename)
-            etype = binary.format
+            etype = binary.concrete.format
             if etype == lief.EXE_FORMATS.UNKNOWN:
                 print(f'{filename}: unknown executable format')
                 retval = 1

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -198,7 +198,7 @@ def check_exported_symbols(binary) -> bool:
         name = symbol.name
         if binary.header.machine_type == lief.ELF.ARCH.RISCV or name in IGNORE_EXPORTS:
             continue
-        print(f'{binary.name}: export of symbol {name} not allowed!')
+        print(f'{filename}: export of symbol {name} not allowed!')
         ok = False
     return ok
 
@@ -215,7 +215,7 @@ def check_MACHO_libraries(binary) -> bool:
     for dylib in binary.libraries:
         library = dylib.name.split('/')[-1]
         if library not in MACHO_ALLOWED_LIBRARIES:
-            print(f'{library} is not in ALLOWED_LIBRARIES!')
+            print(f'{filename}: {library} is not in ALLOWED_LIBRARIES!')
             ok = False
     return ok
 
@@ -233,7 +233,7 @@ def check_PE_libraries(binary) -> bool:
     ok: bool = True
     for dylib in binary.libraries:
         if dylib not in PE_ALLOWED_LIBRARIES:
-            print(f'{dylib} is not in ALLOWED_LIBRARIES!')
+            print(f'{filename}: {dylib} is not in ALLOWED_LIBRARIES!')
             ok = False
     return ok
 

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -213,9 +213,9 @@ def check_ELF_libraries(binary) -> bool:
 def check_MACHO_libraries(binary) -> bool:
     ok: bool = True
     for dylib in binary.libraries:
-        split = dylib.name.split('/')
-        if split[-1] not in MACHO_ALLOWED_LIBRARIES:
-            print(f'{split[-1]} is not in ALLOWED_LIBRARIES!')
+        library = dylib.name.split('/')[-1]
+        if library not in MACHO_ALLOWED_LIBRARIES:
+            print(f'{library} is not in ALLOWED_LIBRARIES!')
             ok = False
     return ok
 

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -81,11 +81,12 @@ ELF_INTERPRETER_NAMES: Dict[lief.ELF.ARCH, Dict[lief.ENDIANNESS, str]] = {
 
 # Allowed NEEDED libraries
 ELF_ALLOWED_LIBRARIES = {
-# bitcoind and bitcoin-qt
+# libbitcoinconsensus.so.0, bitcoind and bitcoin-qt
 'libgcc_s.so.1', # GCC base support
 'libc.so.6', # C library
-'libpthread.so.0', # threading
 'libm.so.6', # math library
+# bitcoind and bitcoin-qt
+'libpthread.so.0', # threading
 'librt.so.1', # real-time (clock)
 'libatomic.so.1',
 'ld-linux-x86-64.so.2', # 64-bit dynamic linker
@@ -117,7 +118,7 @@ ELF_ALLOWED_LIBRARIES = {
 }
 
 MACHO_ALLOWED_LIBRARIES = {
-# bitcoind and bitcoin-qt
+# libbitcoinconsensus.0.dylib, bitcoind and bitcoin-qt
 'libc++.1.dylib', # C++ Standard Library
 'libSystem.B.dylib', # libc, libm, libpthread, libinfo
 # bitcoin-qt only
@@ -141,14 +142,17 @@ MACHO_ALLOWED_LIBRARIES = {
 }
 
 PE_ALLOWED_LIBRARIES = {
+# libbitcoinconsensus-0.dll, bitcoind.exe and bitcoin-qt.exe
 'ADVAPI32.dll', # security & registry
-'IPHLPAPI.DLL', # IP helper API
 'KERNEL32.dll', # win32 base APIs
 'msvcrt.dll', # C standard library for MSVC
+'libssp-0.dll', # mingw-w64 stack smashing protection
+# bitcoind.exe and bitcoin-qt.exe
+'IPHLPAPI.DLL', # IP helper API
 'SHELL32.dll', # shell API
 'USER32.dll', # user interface
 'WS2_32.dll', # sockets
-# bitcoin-qt only
+# bitcoin-qt.exe only
 'dwmapi.dll', # desktop window manager
 'GDI32.dll', # graphics device interface
 'IMM32.dll', # input method editor
@@ -191,6 +195,8 @@ def check_imported_symbols(binary) -> bool:
 
 def check_exported_symbols(binary) -> bool:
     ok: bool = True
+    if binary.abstract.header.object_type == lief.OBJECT_TYPES.LIBRARY:
+        return ok
 
     for symbol in binary.concrete.dynamic_symbols:
         if not symbol.exported:
@@ -214,6 +220,8 @@ def check_MACHO_libraries(binary) -> bool:
     ok: bool = True
     for dylib in binary.concrete.libraries:
         library = dylib.name.split('/')[-1]
+        if binary.abstract.header.object_type == lief.OBJECT_TYPES.LIBRARY and library == 'libbitcoinconsensus.0.dylib':
+            continue
         if library not in MACHO_ALLOWED_LIBRARIES:
             print(f'{filename}: {library} is not in ALLOWED_LIBRARIES!')
             ok = False
@@ -245,8 +253,9 @@ def check_PE_subsystem_version(binary) -> bool:
     return False
 
 def check_ELF_interpreter(binary) -> bool:
+    if binary.abstract.header.object_type == lief.OBJECT_TYPES.LIBRARY:
+        return True
     expected_interpreter = ELF_INTERPRETER_NAMES[binary.concrete.header.machine_type][binary.abstract.header.endianness]
-
     return binary.concrete.interpreter == expected_interpreter
 
 CHECKS = {
@@ -275,6 +284,12 @@ if __name__ == '__main__':
             etype = binary.concrete.format
             if etype == lief.EXE_FORMATS.UNKNOWN:
                 print(f'{filename}: unknown executable format')
+                retval = 1
+                continue
+
+            obj_type = binary.abstract.header.object_type
+            if obj_type != lief.OBJECT_TYPES.EXECUTABLE and obj_type != lief.OBJECT_TYPES.LIBRARY:
+                print(f'{filename}: unsupported file type')
                 retval = 1
                 continue
 

--- a/contrib/devtools/test-symbol-check.py
+++ b/contrib/devtools/test-symbol-check.py
@@ -117,7 +117,7 @@ class TestSymbolChecks(unittest.TestCase):
         ''')
 
         self.assertEqual(call_symbol_check(cc, source, executable, ['-lexpat', '-Wl,-platform_version','-Wl,macos', '-Wl,11.4', '-Wl,11.4']),
-            (1, 'libexpat.1.dylib is not in ALLOWED_LIBRARIES!\n' +
+            (1, f'{executable}: libexpat.1.dylib is not in ALLOWED_LIBRARIES!\n' +
                 f'{executable}: failed DYNAMIC_LIBRARIES MIN_OS SDK'))
 
         source = 'test2.c'
@@ -166,8 +166,8 @@ class TestSymbolChecks(unittest.TestCase):
         ''')
 
         self.assertEqual(call_symbol_check(cc, source, executable, ['-lpdh', '-Wl,--major-subsystem-version', '-Wl,6', '-Wl,--minor-subsystem-version', '-Wl,1']),
-            (1, 'pdh.dll is not in ALLOWED_LIBRARIES!\n' +
-                 executable + ': failed DYNAMIC_LIBRARIES'))
+            (1, f'{executable}: pdh.dll is not in ALLOWED_LIBRARIES!\n' +
+                f'{executable}: failed DYNAMIC_LIBRARIES'))
 
         source = 'test2.c'
         executable = 'test2.exe'

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -995,9 +995,19 @@ clean-local:
 	## FIXME: How to get the appropriate modulename_CPPFLAGS in here?
 	$(AM_V_GEN) $(WINDRES) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(CPPFLAGS) -DWINDRES_PREPROC -i $< -o $@
 
-check-symbols: $(bin_PROGRAMS)
+if TARGET_LINUX
+  LIBEXT = .so.0
+endif
+if TARGET_DARWIN
+  LIBEXT = .0.dylib
+endif
+if TARGET_WINDOWS
+  LIBEXT = -0.dll
+endif
+
+check-symbols: $(bin_PROGRAMS) $(LIBBITCOINCONSENSUS)
 	@echo "Running symbol and dynamic library checks..."
-	$(AM_V_at) $(PYTHON) $(top_srcdir)/contrib/devtools/symbol-check.py $(bin_PROGRAMS)
+	$(AM_V_at) $(PYTHON) $(top_srcdir)/contrib/devtools/symbol-check.py $(bin_PROGRAMS) $(builddir)/.libs/$$(echo $(LIBBITCOINCONSENSUS) | sed "s/.la//")$(LIBEXT)
 
 check-security: $(bin_PROGRAMS)
 if HARDEN


### PR DESCRIPTION
In the light of a new [shared library](bitcoin/bitcoin#24322) it looks reasonable to start checking shared library symbols.

During testing this PR, it [was pointed](https://github.com/bitcoin/bitcoin/pull/25020#issuecomment-1142151675) that `libbitcoinconsensus.so` has "a ton of unnecessary symbols being exported". Fortunately, it could be fixed in #24994.

Therefore, it makes sense to draft this PR until #24994 is merged.

#### Guix builds on `x86_64`:
```
```