### PR TITLE
test: fix intermittent wallet_encryption failures on win64 task

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -67,6 +67,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
           " src/util/strencodings.cpp"\
           " src/util/syserror.cpp"\
           " src/util/url.cpp"\
+          " src/wallet/rpc/encrypt.cpp"\
           " -p . ${MAKEJOBS} -- -Xiwyu --cxx17ns -Xiwyu --mapping_file=${BASE_BUILD_DIR}/bitcoin-$HOST/contrib/devtools/iwyu/bitcoin.core.imp"
 fi
 

--- a/src/wallet/rpc/encrypt.cpp
+++ b/src/wallet/rpc/encrypt.cpp
@@ -2,10 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <rpc/util.h>
-#include <wallet/rpc/util.h>
 #include <wallet/wallet.h>
 
+#include <rpc/util.h>
+#include <wallet/rpc/util.h>
+
+#include <algorithm>
 
 namespace wallet {
 RPCHelpMan walletpassphrase()
@@ -59,11 +61,9 @@ RPCHelpMan walletpassphrase()
         if (nSleepTime < 0) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Timeout cannot be negative.");
         }
-        // Clamp timeout
-        constexpr int64_t MAX_SLEEP_TIME = 100000000; // larger values trigger a macos/libevent bug?
-        if (nSleepTime > MAX_SLEEP_TIME) {
-            nSleepTime = MAX_SLEEP_TIME;
-        }
+        // Maximum time to keep the decryption key, in seconds (~3 years). Larger values trigger a macOS/libevent bug?
+        constexpr int64_t MAX_SLEEP_TIME{100'000'000};
+        nSleepTime = std::min(nSleepTime, MAX_SLEEP_TIME);
 
         if (strWalletPass.empty()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "passphrase cannot be empty");

--- a/test/functional/wallet_encryption.py
+++ b/test/functional/wallet_encryption.py
@@ -4,13 +4,12 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test Wallet encryption"""
 
+from math import ceil, floor
 import time
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_raises_rpc_error,
-    assert_greater_than,
-    assert_greater_than_or_equal,
 )
 
 
@@ -74,23 +73,25 @@ class WalletEncryptionTest(BitcoinTestFramework):
         # Test timeout bounds
         assert_raises_rpc_error(-8, "Timeout cannot be negative.", self.nodes[0].walletpassphrase, passphrase2, -10)
 
-        self.log.info('Check a timeout less than the limit')
-        MAX_VALUE = 100000000
-        expected_time = int(time.time()) + MAX_VALUE - 600
-        self.nodes[0].walletpassphrase(passphrase2, MAX_VALUE - 600)
-        # give buffer for walletpassphrase, since it iterates over all encrypted keys
-        expected_time_with_buffer = time.time() + MAX_VALUE - 600
-        actual_time = self.nodes[0].getwalletinfo()['unlocked_until']
-        assert_greater_than_or_equal(actual_time, expected_time)
-        assert_greater_than(expected_time_with_buffer, actual_time)
+        # Maximum time to keep the decryption key, in seconds (~3 years); see MAX_SLEEP_TIME
+        timeout_limit = 100_000_000
 
-        self.log.info('Check a timeout greater than the limit')
-        expected_time = int(time.time()) + MAX_VALUE - 1
-        self.nodes[0].walletpassphrase(passphrase2, MAX_VALUE + 1000)
-        expected_time_with_buffer = time.time() + MAX_VALUE
-        actual_time = self.nodes[0].getwalletinfo()['unlocked_until']
-        assert_greater_than_or_equal(actual_time, expected_time)
-        assert_greater_than(expected_time_with_buffer, actual_time)
+        self.log.info("Test walletpassphrase with a timeout less than the limit")
+        timeout = timeout_limit - 600
+        before = floor(time.time()) + timeout
+        self.nodes[0].walletpassphrase(passphrase2, timeout)
+        after = ceil(time.time()) + timeout
+        actual = self.nodes[0].getwalletinfo()['unlocked_until']
+        if not before <= actual <= after:
+            raise AssertionError(f'walletpassphrase "unlocked_until" value of {actual} not in expected range of {before}..{after}')
+
+        self.log.info("Test walletpassphrase with a timeout greater than the limit")
+        before = floor(time.time()) + timeout_limit
+        self.nodes[0].walletpassphrase(passphrase=passphrase2, timeout=timeout_limit + 1000)
+        after = ceil(time.time()) + timeout_limit
+        actual = self.nodes[0].getwalletinfo()['unlocked_until']
+        if not before <= actual <= after:
+            raise AssertionError(f'walletpassphrase "unlocked_until" value of {actual} not in expected range of {before}..{after}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Fix intermittent failures like https://cirrus-ci.com/task/4571677035069440 and https://cirrus-ci.com/task/6566987122868224
- Document and tidy up RPC walletpassphrase MAX_SLEEP_TIME/nSleepTime
- Add test logging and an assertion and use named args 