### PR TITLE
test: Remove boost::split from rpc_tests.cpp

### DIFF
--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -2,24 +2,20 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <rpc/client.h>
-#include <rpc/server.h>
-#include <rpc/util.h>
-
 #include <core_io.h>
 #include <interfaces/chain.h>
 #include <node/context.h>
+#include <rpc/blockchain.h>
+#include <rpc/client.h>
+#include <rpc/server.h>
+#include <rpc/util.h>
 #include <test/util/setup_common.h>
+#include <univalue.h>
 #include <util/time.h>
 
 #include <any>
 
-#include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
-
-#include <univalue.h>
-
-#include <rpc/blockchain.h>
 
 class RPCTestingSetup : public TestingSetup
 {
@@ -29,8 +25,7 @@ public:
 
 UniValue RPCTestingSetup::CallRPC(std::string args)
 {
-    std::vector<std::string> vArgs;
-    boost::split(vArgs, args, boost::is_any_of(" \t"));
+    std::vector<std::string> vArgs{SplitString(args, ' ')};
     std::string strMethod = vArgs[0];
     vArgs.erase(vArgs.begin());
     JSONRPCRequest request;


### PR DESCRIPTION
No need for boost, as there are no tabs.

Can be tested with:

```diff
diff --git a/src/test/rpc_tests.cpp b/src/test/rpc_tests.cpp
index 50b5078110..ad6a888ad0 100644
--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -29,6 +29,7 @@ public:
 
 UniValue RPCTestingSetup::CallRPC(std::string args)
 {
+Assert(args.find('\t')==std::string::npos);
     std::vector<std::string> vArgs;
     boost::split(vArgs, args, boost::is_any_of(" \t"));
     std::string strMethod = vArgs[0];
