### PR TITLE
rpc: Make pruneblockchain fetch old blocks if height is lower than pruned height

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -159,6 +159,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getblockstats", 0, "hash_or_height" },
     { "getblockstats", 1, "stats" },
     { "pruneblockchain", 0, "height" },
+    { "pruneblockchain", 1, "peer_id" },
     { "keypoolrefill", 0, "newsize" },
     { "getrawmempool", 0, "verbose" },
     { "getrawmempool", 1, "mempool_sequence" },


### PR DESCRIPTION
Implements #24286.

This change allows pruned nodes to fetch older blocks from peers when pruning with a height that is lower than the current pruned height.
This makes use of #20295. The peer used to fetch blocks is by default the peerid 0.
I have added a functional test.
