### PR TITLE
test: Remove boost::split from getarg_tests.cpp

### DIFF
--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -13,7 +13,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_FIXTURE_TEST_SUITE(getarg_tests, BasicTestingSetup)
@@ -21,8 +20,9 @@ BOOST_FIXTURE_TEST_SUITE(getarg_tests, BasicTestingSetup)
 void ResetArgs(ArgsManager& local_args, const std::string& strArg)
 {
     std::vector<std::string> vecArg;
-    if (strArg.size())
-        boost::split(vecArg, strArg, IsSpace, boost::token_compress_on);
+    if (strArg.size()) {
+        vecArg = SplitString(strArg, ' ');
+    }
 
     // Insert dummy executable name:
     vecArg.insert(vecArg.begin(), "testbitcoin");


### PR DESCRIPTION
Only single spaces are used, so no need for boost.

Can be tested with:


```diff
diff --git a/src/test/getarg_tests.cpp b/src/test/getarg_tests.cpp
index c877105fe7..a834830490 100644
--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -21,8 +21,11 @@ BOOST_FIXTURE_TEST_SUITE(getarg_tests, BasicTestingSetup)
 void ResetArgs(ArgsManager& local_args, const std::string& strArg)
 {
     std::vector<std::string> vecArg;
-    if (strArg.size())
+    if (strArg.size()) {
         boost::split(vecArg, strArg, IsSpace, boost::token_compress_on);
+        auto vecArg2{SplitString(strArg, ' ')};
+        assert(vecArg2 == vecArg);
+    }
 
     // Insert dummy executable name:
     vecArg.insert(vecArg.begin(), "testbitcoin");
