### PR TITLE
normalize PSBT entry instead of external signer master fingerprint 

### DIFF
--- a/src/external_signer.cpp
+++ b/src/external_signer.cpp
@@ -77,8 +77,11 @@ bool ExternalSigner::SignTransaction(PartiallySignedTransaction& psbtx, std::str
 
     // Check if signer fingerprint matches any input master key fingerprint
     auto matches_signer_fingerprint = [&](const PSBTInput& input) {
+        std::string entry_fingerprint;
         for (const auto& entry : input.hd_keypaths) {
-            if (m_fingerprint == strprintf("%08x", ReadBE32(entry.second.fingerprint))) return true;
+            entry_fingerprint = strprintf("%08x", ReadBE32(entry.second.fingerprint));
+            // check for both upper/lower hex representation match
+            if (m_fingerprint == entry_fingerprint || m_fingerprint == ToUpper(entry_fingerprint)) return true;
         }
         return false;
     };


### PR DESCRIPTION
Some external signers scripts may provide master fingerprint in uppercase format. In that case core will fail with `Signer fingerprint 00000000 does not match any of the inputs` as it only works with lowercase format. Even if the fingerprints match, yet one is lowercase the other uppercase.

Core can instead normalize fingerprint from PSBT and check both upper/lower case hex representation

Very similar to https://github.com/bitcoin/bitcoin/pull/25019 but no changing of fingerprint from external signer.