### PR TITLE
test: add missing stop_node calls to feature_coinstatsindex and feature_prune

### DIFF
--- a/test/functional/feature_coinstatsindex.py
+++ b/test/functional/feature_coinstatsindex.py
@@ -231,11 +231,13 @@ class CoinStatsIndexTest(BitcoinTestFramework):
 
         self.log.info("Test that -reindex-chainstate is disallowed with coinstatsindex")
 
+        self.stop_node(1)
         self.nodes[1].assert_start_raises_init_error(
             expected_msg='Error: -reindex-chainstate option is not compatible with -coinstatsindex. '
             'Please temporarily disable coinstatsindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.',
             extra_args=['-coinstatsindex', '-reindex-chainstate'],
         )
+        self.restart_node(1, extra_args=["-coinstatsindex"])
 
     def _test_use_index_option(self):
         self.log.info("Test use_index option for nodes running the index")

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -125,6 +125,7 @@ class PruneTest(BitcoinTestFramework):
         self.sync_blocks(self.nodes[0:5])
 
     def test_invalid_command_line_options(self):
+        self.stop_node(0)
         self.nodes[0].assert_start_raises_init_error(
             expected_msg='Error: Prune cannot be configured with a negative value.',
             extra_args=['-prune=-1'],

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -545,6 +545,7 @@ class TestNode():
 
         Will throw if bitcoind starts without an error.
         Will throw if an expected_msg is provided and it does not match bitcoind's stdout."""
+        assert not self.running
         with tempfile.NamedTemporaryFile(dir=self.stderr_dir, delete=False) as log_stderr, \
              tempfile.NamedTemporaryFile(dir=self.stdout_dir, delete=False) as log_stdout:
             try:


### PR DESCRIPTION
In #24789, I forgot to stop the node before using `assert_start_raises_init_error` in `feature_coinstatsindex`. This resulted in a bitcoind process that is not being terminated after the test finishes.
`feature_prune` has the same problem and also creates a zombie bitcoind process.

Also adds an assert to `assert_start_raises_init_error` to make sure the node isn't already running to prevent this sort of mistake in the future.