### PR TITLE
build: Create `noinst_LTLIBRARIES` conditionally

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1475,7 +1475,8 @@ if test "$use_natpmp" != "no"; then
   CPPFLAGS="$TEMP_CPPFLAGS"
 fi
 
-if test "$build_bitcoin_wallet$build_bitcoin_cli$build_bitcoin_tx$build_bitcoind$bitcoin_enable_qt$use_tests$use_bench" = "nonononononono"; then
+UPDATE_TARGET_LIST
+if test "$target_list" = "build_bitcoin_libs"; then
   use_boost=no
 else
   use_boost=yes

--- a/configure.ac
+++ b/configure.ac
@@ -1730,7 +1730,10 @@ if test "$build_bitcoin_libs" = "yes"; then
   AC_CONFIG_FILES([libbitcoinconsensus.pc:libbitcoinconsensus.pc.in])
 fi
 
-AM_CONDITIONAL([BUILD_BITCOIN_KERNEL_LIB], [test "$build_experimental_kernel_lib" != "no" && ( test "$build_experimental_kernel_lib" = "yes" || test "$build_bitcoin_chainstate" = "yes" )])
+if test "$build_experimental_kernel_lib" = "auto" && test "$build_bitcoin_chainstate" != "yes"; then
+  build_experimental_kernel_lib="no"
+fi
+AM_CONDITIONAL([BUILD_BITCOIN_KERNEL_LIB], [test "$build_experimental_kernel_lib" = "yes"])
 
 AC_MSG_RESULT($build_bitcoin_libs)
 
@@ -1883,7 +1886,8 @@ else
   AC_MSG_RESULT([no])
 fi
 
-if test "$build_bitcoin_wallet$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_libs$build_bitcoind$bitcoin_enable_qt$enable_fuzz_binary$use_bench$use_tests" = "nonononononononono"; then
+UPDATE_TARGET_LIST
+if test "$target_list" = ""; then
   AC_MSG_ERROR([No targets! Please specify at least one of: --with-utils --with-libs --with-daemon --with-gui --enable-fuzz(-binary) --enable-bench or --enable-tests])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1892,6 +1892,8 @@ if test "$target_list" = ""; then
   AC_MSG_ERROR([No targets! Please specify at least one of: --with-utils --with-libs --with-daemon --with-gui --enable-fuzz(-binary) --enable-bench or --enable-tests])
 fi
 
+AM_CONDITIONAL([BUILD_LIBBITCOINCONSENSUS_ONLY], [test "$target_list" = "build_bitcoin_libs"])
+
 AM_CONDITIONAL([TARGET_DARWIN], [test "$TARGET_OS" = "darwin"])
 AM_CONDITIONAL([BUILD_DARWIN], [test "$BUILD_OS" = "darwin"])
 AM_CONDITIONAL([TARGET_LINUX], [test "$TARGET_OS" = "linux"])

--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,37 @@ dnl Multi Process
 BITCOIN_MP_NODE_NAME=bitcoin-node
 BITCOIN_MP_GUI_NAME=bitcoin-gui
 
+m4_define([UPDATE_TARGET_LIST], [
+  all_targets="\
+    build_bitcoind \
+    build_bitcoin_cli \
+    build_bitcoin_tx \
+    build_bitcoin_util \
+    build_bitcoin_chainstate \
+    build_bitcoin_wallet \
+    bitcoin_enable_qt \
+    use_tests \
+    enable_fuzz_binary \
+    use_bench \
+    build_multiprocess \
+    build_bitcoin_libs \
+    build_experimental_kernel_lib \
+  "
+
+  sep=", "
+  result=""
+  for target in $all_targets; do
+    AS_VAR_COPY([value], [$target])
+    if test "$value" != "no"; then
+      if test "$result" != ""; then
+        result="${result}${sep}"
+      fi
+      result="${result}${target}"
+    fi
+  done
+  target_list="$result"
+])
+
 dnl Unless the user specified ARFLAGS, force it to be cr
 dnl This is also the default as-of libtool 2.4.7
 AC_ARG_VAR([ARFLAGS], [Flags for the archiver, defaults to <cr> if not set])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1064,8 +1064,11 @@ endif
 
 include Makefile.minisketch.include
 
+if !BUILD_LIBBITCOINCONSENSUS_ONLY
 include Makefile.crc32c.include
 include Makefile.leveldb.include
+include Makefile.univalue.include
+endif
 
 include Makefile.test_util.include
 include Makefile.test_fuzz.include
@@ -1083,5 +1086,3 @@ endif
 if ENABLE_QT_TESTS
 include Makefile.qttest.include
 endif
-
-include Makefile.univalue.include


### PR DESCRIPTION
After #24322, libraries, which were promoted from `EXTRA_LIBRARIES` to `noinst_LTLIBRARIES`, are built regardless whether they are actually required as dependencies.

This PR makes build system to create such libraries conditionally.

Some other improvements of `configure.ac` are incorporated in this PR.

A use case example:
- on master (9ba73758c908ce0c49f1bd9727ea496958e24d54)
```
./configure \
  --disable-tests \
  --disable-bench \
  --without-libs \
  --without-daemon \
  --without-gui \
  --disable-fuzz-binary \
  --without-utils \
  --enable-util-util
...
configure: error: No targets! Please specify at least one of: --with-utils --with-libs --with-daemon --with-gui --enable-fuzz(-binary) --enable-bench or --enable-tests
```

- with this PR the `configure` script finishes successfully, and the `bitcoin-util` binary can be built.