### PR TITLE
policy: nVersion=3 and Package RBF

### DIFF
--- a/doc/policy/mempool-replacements.md
+++ b/doc/policy/mempool-replacements.md
@@ -11,7 +11,8 @@ their in-mempool descendants (together, "original transactions") if, in addition
 other consensus and policy rules, each of the following conditions are met:
 
 1. The directly conflicting transactions all signal replaceability explicitly. A transaction is
-   signaling replaceability if any of its inputs have an nSequence number less than (0xffffffff - 1).
+   signaling replaceability if any of its inputs have an nSequence number less than (0xffffffff - 1)
+   or if its nVersion field is set to 3. See [version 3 policies](./version3_transactions.md).
 
    *Rationale*: See [BIP125
    explanation](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki#motivation).

--- a/doc/policy/packages.md
+++ b/doc/policy/packages.md
@@ -48,8 +48,13 @@ The following rules are enforced for all packages:
      heavily connected, i.e. some transaction in the package is the ancestor or descendant of all
      the other transactions.
 
-The following rules are only enforced for packages to be submitted to the mempool (not enforced for
-test accepts):
+* [CPFP Carve Out](./mempool-limits.md#CPFP-Carve-Out) is disabled. (#21800)
+
+   - *Rationale*: This carve out cannot be accurately applied when there are multiple transactions'
+     ancestors and descendants being considered at the same time.
+
+The following rules are only enforced for packages to be submitted to the mempool (not
+enforced for test accepts):
 
 * Packages must be child-with-unconfirmed-parents packages. This also means packages must contain at
   least 2 transactions. (#22674)

--- a/doc/policy/version3_transactions.md
+++ b/doc/policy/version3_transactions.md
@@ -1,0 +1,120 @@
+# Transactions with nVersion 3
+
+A transaction with its `nVersion` field set to 3 ("V3 transactions") is allowed in mempool and
+transaction relay, with additional policies described below.
+
+The goal with V3 is to create a policy that is DoS-resistant and makes fee-bumping more robust by
+avoiding specific RBF pinning attacks. Contracting protocols in which transactions are signed by
+untrusted counterparties before broadcast time, e.g. the Lightning Network (LN), may benefit from
+opting in to these policies.
+
+## V3 Rationale: RBF Pinning Attacks
+
+Since contracting transactions are shared between multiple parties and mempool congestion is
+difficult to predict, [RBF policy](./mempool-replacements.md) restrictions may accidentally allow a
+malicious party to "pin" a transaction, making it impossible or difficult to replace.
+
+### "Rule 3" Pinning
+
+Imagine that counterparties Alice (honest) and Mallory (malicious) have conflicting transactions A
+and B, respectively.  RBF rules require the replacement transaction pay a higher absolute fee than
+the aggregate fees paid by all original transactions. This means Mallory may increase the fees
+required to replace B by:
+
+1. Adding transaction(s) that descend from B and pay a feerate too low to fee-bump B through CPFP.
+   For example, assuming the default descendant size limit is 101KvB and B is 1000vB paying a
+feerate of 2sat/vB, adding a 100KvB, 2sat/vB child increases the cost to replace B by 200Ksat.
+
+2. Adding a high-fee descendant of B that also spends from a large, low-feerate mempool transaction,
+   C. The child may pay a very large fee but not actually be fee-bumping B if its overall ancestor
+feerate is still lower than B's individual feerate. For example, assuming the default ancestor size
+limit is 101KvB, B is 1000vB paying 2sat/vB, and C is 99KvB paying 1sat/vB, adding a 1000vB child of
+B and C increases the cost to replace B by 101Ksat.
+
+### "Rule 5" Pinning
+
+RBF rules requires that no replacement trigger the removal of more than 100 transactions. This
+number includes the descendants of the conflicted mempool transactions. Mallory can make it more
+difficult to replace transactions by attaching lots of descendants to them. For example, if Alice
+wants to replace 4 transactions and each one has 25 or more descendants, the replacement will be
+rejected regardless of its fees.
+
+## Version 3 Rules
+
+All existing standardness rules and policies apply to V3. The following set of additional
+rules apply to V3 transactions:
+
+1. A v3 transaction signals replaceability, even if it does not signal BIP125 replaceability. Other
+   conditions apply, see [RBF rules](./mempool-replacements.md) and [Package RBF
+rules][./packages.md#Package-Replace-By-Fee].
+
+2. Any descendant of an unconfirmed V3 transaction must also be V3.
+
+*Rationale*: Combined with Rule 1, this gives us the property of "inherited signaling" when
+descendants of unconfirmed transactions are created. Additionally, checking whether a transaction
+signals replaceability this way does not require mempool traversal, and does not change based on
+what transactions are mined.
+
+*Note*: A V3 transaction can spend outputs from *confirmed* non-V3 transactions.
+
+*Note*: This rule is enforced during reorgs. Transactions violating this rule are removed from the
+mempool.
+
+3. A V3 transaction's unconfirmed ancestors must all be V3.
+
+*Rationale*: Ensure the ancestor feerate rule does not underestimate a to-be-replaced V3 mempool
+transaction's incentive compatibility. Imagine the original transaction, A, has a child B and
+co-parent C (i.e. B spends from A and C). C also has another child, D. B is one of the original
+transactions and thus its ancestor feerate must be lower than the package's. However, this may be an
+underestimation because D can bump C without B's help. This is resolved if V3 transactions can only
+have V3 ancestors, as then C cannot have another child.
+
+*Note*: This rule is enforced during reorgs. Transactions violating this rule are removed from the
+mempool.
+
+4. A V3 transaction cannot have more than 1 unconfirmed descendant.
+
+Also, [CPFP Carve Out](./mempool-limits.md#CPFP-Carve-Out) does not apply to V3 transactions.
+
+*Rationale*: (upper bound) the larger the descendant limit, the more transactions may need to be
+replaced. This is a problematic pinning attack, i.e., a malicious counterparty prevents the
+transaction from being replaced by adding many descendant transactions that aren't fee-bumping.
+See example #1 in ["Rule 3" Pining](#Rule-3-Pinning) section above.
+
+*Rationale*: (lower bound) at least 1 descendant is required to allow CPFP of the presigned
+transaction. The contract protocol can create presigned transactions paying 0 fees and 1 output for
+attaching a CPFP at broadcast time ("anchor output"). Without package RBF, multiple anchor outputs
+would be required to allow each counterparty to fee-bump any presigned transaction. With package
+RBF, since the presigned transactions can replace each other, 1 anchor output is sufficient.
+
+5. A V3 transaction that has an unconfirmed V3 ancestor cannot be larger than 4000Wu.
+
+*Rationale*: (upper bound) the larger the descendant size limit, the more vbytes may need to be
+replaced. With default limits, if the child is e.g. 100,000vB, that might be an additional
+100,000sats (at 1sat/vbyte) or more, depending on the feerate. Restricting all children to 4000Wu
+(at most 1000vB) bounds the potential fees by at least 1/100.
+
+*Rationale*: (lower bound) the smaller this limit, the fewer UTXOs a child may use to fund this
+fee-bump. For example, only allowing the V3 child to have 2 inputs would require L2 protocols to
+manage a wallet with high-value UTXOs and make batched fee-bumping impossible. However, as the
+fee-bumping child only needs to fund fees (as opposed to payments), just a few UTXOs should suffice.
+
+*Rationale*: With a limit of 4000 weight units, depending on the output types, the child can have
+6-15 UTXOs, which should be enough to fund a fee-bump without requiring a carefully-managed UTXO
+pool. With this descendant limit, the cost to replace a V3 transaction has much lower variance.
+
+*Rationale*: This makes the rule very easily "tacked on" to existing logic for policy and wallets.
+A transaction may be up to 100KvB on its own (`MAX_STANDARD_TX_WEIGHT`) and 101KvB with descendants
+(`DEFAULT_DESCENDANT_SIZE_LIMIT_KVB`). If an existing V3 transaction in the mempool is 100KvB, its
+descendant cannot be more than 1000vB, even if the policy is 10KvB.
+
+6. A V3 transaction cannot have more than 1 unconfirmed ancestor.
+
+*Rationale*: Prevent the child of an unconfirmed V3 transaction from "bringing in" more unconfirmed
+ancestors. See example #2 in ["Rule 3" Pining](#Rule-3-Pinning) section above.
+
+7. An individual V3 transaction is permitted to be below the mempool min relay feerate, assuming it
+   is considered within a [package](./packages.md#Package-Feerate) that meets all feerate requirements.
+
+*Rationale*: This allows for contracting protocols that create presigned transactions
+with 0 fees and bump them at broadcast time.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -237,6 +237,7 @@ BITCOIN_CORE_H = \
   node/validation_cache_args.h \
   noui.h \
   outputtype.h \
+  policy/v3_policy.h \
   policy/feerate.h \
   policy/fees.h \
   policy/fees_args.h \
@@ -438,6 +439,7 @@ libbitcoin_node_a_SOURCES = \
   node/utxo_snapshot.cpp \
   node/validation_cache_args.cpp \
   noui.cpp \
+  policy/v3_policy.cpp \
   policy/fees.cpp \
   policy/fees_args.cpp \
   policy/packages.cpp \
@@ -694,6 +696,7 @@ libbitcoin_common_a_SOURCES = \
   netbase.cpp \
   net_permissions.cpp \
   outputtype.cpp \
+  policy/v3_policy.cpp \
   policy/feerate.cpp \
   policy/policy.cpp \
   protocol.cpp \
@@ -953,6 +956,7 @@ libbitcoinkernel_la_SOURCES = \
   node/blockstorage.cpp \
   node/chainstate.cpp \
   node/utxo_snapshot.cpp \
+  policy/v3_policy.cpp \
   policy/feerate.cpp \
   policy/fees.cpp \
   policy/packages.cpp \

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -131,7 +131,7 @@ bool IsStandard(const CScript& scriptPubKey, const std::optional<unsigned>& max_
 // Changing the default transaction version requires a two step process: first
 // adapting relay policy by bumping TX_MAX_STANDARD_VERSION, and then later
 // allowing the new transaction version in the wallet/RPC.
-static constexpr decltype(CTransaction::nVersion) TX_MAX_STANDARD_VERSION{2};
+static constexpr decltype(CTransaction::nVersion) TX_MAX_STANDARD_VERSION{3};
 
 /**
 * Check for standard transaction types

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -181,3 +181,49 @@ std::optional<std::string> PaysForRBF(CAmount original_fees,
     }
     return std::nullopt;
 }
+
+std::optional<std::string> CheckMinerScores(CAmount replacement_fees,
+                                            int64_t replacement_vsize,
+                                            const CTxMemPool::setEntries& ancestors,
+                                            const CTxMemPool::setEntries& direct_conflicts,
+                                            const CTxMemPool::setEntries& original_transactions)
+{
+        const CFeeRate replacement_individual_feerate(replacement_fees, replacement_vsize);
+        // Ancestor feerate is the total modified fees divided by the total size. To get the
+        // ancestor feerate, add up all the individual modified fees and sizes. Don't try to use the
+        // cached ancestor fees and sizes because entries may have overlapping ancestors.
+        for (CTxMemPool::txiter it : ancestors) {
+            replacement_fees += it->GetModifiedFee();
+            replacement_vsize += it->GetTxSize();
+        }
+        const CFeeRate replacement_ancestor_feerate(replacement_fees, replacement_vsize);
+        // A package/transaction's ancestor feerate is not equivalent to the miner score; it may
+        // overestimate. Some subset of the ancestors could be included by itself if it has other
+        // high-feerate descendants or are themselves higher feerate than this package/transaction.
+        // For now, as a conservative estimate, use the minimum between the transaction's individual
+        // feerate and ancestor feerate.
+        const CFeeRate replacement_miner_score = std::min(replacement_individual_feerate, replacement_ancestor_feerate);
+        for (const auto& entry : direct_conflicts) {
+            const bool conflict_is_v3{entry->GetSharedTx()->nVersion == 3};
+            CFeeRate original_score(entry->GetModifiedFee(), entry->GetTxSize());
+            // If the original transaction is v3, we can calculate the exact miner score and avoid overestimating.
+            if (conflict_is_v3) {
+                original_score = std::min(original_score, CFeeRate(entry->GetModFeesWithAncestors(), entry->GetSizeWithAncestors()));
+            }
+            if (replacement_miner_score < original_score) {
+                return strprintf("replacement miner score lower than %s miner score of direct conflict; %s < %s",
+                                 conflict_is_v3 ? "calculated" : "estimated",
+                                 replacement_miner_score.ToString(),
+                                 original_score.ToString());
+            }
+        }
+        for (const auto& entry : original_transactions) {
+            const CFeeRate original_ancestor_feerate(entry->GetModFeesWithAncestors(), entry->GetSizeWithAncestors());
+            if (replacement_miner_score < original_ancestor_feerate) {
+                return strprintf("replacement miner score lower than ancestor feerate of original tx; %s < %s",
+                                 replacement_miner_score.ToString(),
+                                 original_ancestor_feerate.ToString());
+            }
+        }
+        return std::nullopt;
+}

--- a/src/policy/rbf.h
+++ b/src/policy/rbf.h
@@ -106,4 +106,15 @@ std::optional<std::string> PaysForRBF(CAmount original_fees,
                                       CFeeRate relay_fee,
                                       const uint256& txid);
 
+/** Require that replacement transactions are more incentive compatible to mine than the
+ * transactions they are replacing. Currently, this function requires that min(ancestor feerate,
+ * individual feerate) of the replacement transaction(s) be higher than the individual feerates of
+ * all directly conflicting transactions and the ancestor feerates of all original transactions.
+ * */
+std::optional<std::string> CheckMinerScores(CAmount replacement_fees,
+                                            int64_t replacement_vsize,
+                                            const CTxMemPool::setEntries& ancestors,
+                                            const CTxMemPool::setEntries& direct_conflicts,
+                                            const CTxMemPool::setEntries& original_transactions);
+
 #endif // BITCOIN_POLICY_RBF_H

--- a/src/policy/v3_policy.cpp
+++ b/src/policy/v3_policy.cpp
@@ -1,0 +1,107 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <policy/v3_policy.h>
+
+#include <coins.h>
+#include <consensus/amount.h>
+#include <logging.h>
+#include <tinyformat.h>
+
+#include <numeric>
+#include <vector>
+
+std::optional<std::tuple<uint256, uint256, bool>> CheckV3Inheritance(const Package& package)
+{
+    assert(std::all_of(package.cbegin(), package.cend(), [](const auto& tx){return tx != nullptr;}));
+    // If all transactions are V3, we can stop here.
+    if (std::all_of(package.cbegin(), package.cend(), [](const auto& tx){return tx->nVersion == 3;})) {
+        return std::nullopt;
+    }
+    // If all transactions are non-V3, we can stop here.
+    if (std::all_of(package.cbegin(), package.cend(), [](const auto& tx){return tx->nVersion != 3;})) {
+        return std::nullopt;
+    }
+    // Look for a V3 transaction spending a non-V3 or vice versa.
+    std::unordered_map<uint256, uint256, SaltedTxidHasher> v3_txid_to_wtxid;
+    std::unordered_map<uint256, uint256, SaltedTxidHasher> non_v3_txid_to_wtxid;
+    for (const auto& tx : package) {
+        if (tx->nVersion == 3) {
+            v3_txid_to_wtxid.emplace(tx->GetHash(), tx->GetWitnessHash());
+        } else {
+            non_v3_txid_to_wtxid.emplace(tx->GetHash(), tx->GetWitnessHash());
+        }
+    }
+    for (const auto& tx : package) {
+        if (tx->nVersion == 3) {
+            for (const auto& input : tx->vin) {
+                if (auto it = non_v3_txid_to_wtxid.find(input.prevout.hash); it != non_v3_txid_to_wtxid.end()) {
+                    return std::make_tuple(it->second, tx->GetWitnessHash(), true);
+                }
+            }
+        } else {
+            for (const auto& input : tx->vin) {
+                if (auto it = v3_txid_to_wtxid.find(input.prevout.hash); it != v3_txid_to_wtxid.end()) {
+                    return std::make_tuple(it->second, tx->GetWitnessHash(), false);
+                }
+            }
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> CheckV3Inheritance(const CTransactionRef& ptx,
+                                              const CTxMemPool::setEntries& ancestors)
+{
+    for (const auto& entry : ancestors) {
+        if (ptx->nVersion != 3 && entry->GetTx().nVersion == 3) {
+            return strprintf("tx that spends from %s must be nVersion=3",
+                             entry->GetTx().GetWitnessHash().ToString());
+        } else if (ptx->nVersion == 3 && entry->GetTx().nVersion != 3) {
+            return strprintf("v3 tx cannot spend from %s which is not nVersion=3",
+                             entry->GetTx().GetWitnessHash().ToString());
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> ApplyV3Rules(const CTransactionRef& ptx,
+                                        const CTxMemPool::setEntries& ancestors,
+                                        const std::set<uint256>& direct_conflicts)
+{
+    // These rules only apply to transactions with nVersion=3.
+    if (ptx->nVersion != 3) return std::nullopt;
+
+    if (ancestors.size() + 1 > V3_ANCESTOR_LIMIT) {
+        return strprintf("tx %s would have too many ancestors", ptx->GetWitnessHash().ToString());
+    }
+    if (ancestors.empty()) {
+        return std::nullopt;
+    } else {
+        const auto tx_weight{GetTransactionWeight(*ptx)};
+        // If this transaction spends V3 parents, it cannot be too large.
+        if (tx_weight > V3_CHILD_MAX_WEIGHT) {
+            return strprintf("v3 child tx is too big: %u weight units", tx_weight);
+        }
+        // Any ancestor of a V3 transaction must also be V3.
+        const auto& parent_entry = *ancestors.begin();
+        if (parent_entry->GetTx().nVersion != 3) {
+            return strprintf("v3 tx cannot spend from %s which is not nVersion=3",
+                             parent_entry->GetTx().GetWitnessHash().ToString());
+        }
+        // If there are any ancestors, this is the only child allowed. The parent cannot have any
+        // other descendants.
+        const auto& children = parent_entry->GetMemPoolChildrenConst();
+        // Don't double-count a transaction that is going to be replaced. This logic assumes that
+        // any descendant of the V3 transaction is a direct child, which makes sense because a V3
+        // transaction can only have 1 descendant.
+        const bool child_will_be_replaced = !children.empty() &&
+            std::any_of(children.cbegin(), children.cend(),
+                [&direct_conflicts](const CTxMemPoolEntry& child){return direct_conflicts.count(child.GetTx().GetHash()) > 0;});
+        if (parent_entry->GetCountWithDescendants() + 1 > V3_DESCENDANT_LIMIT && !child_will_be_replaced) {
+            return strprintf("tx %u would exceed descendant count limit", parent_entry->GetTx().GetHash().ToString());
+        }
+    }
+    return std::nullopt;
+}

--- a/src/policy/v3_policy.h
+++ b/src/policy/v3_policy.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POLICY_V3_POLICY_H
+#define BITCOIN_POLICY_V3_POLICY_H
+
+#include <consensus/amount.h>
+#include <policy/packages.h>
+#include <policy/policy.h>
+#include <primitives/transaction.h>
+#include <txmempool.h>
+
+#include <string>
+
+// This module enforces rules for transactions with nVersion=3 ("V3 transactions") which help make
+// RBF abilities more robust.
+
+// V3 only allows 1 parent and 1 child.
+/** Maximum number of transactions including an unconfirmed tx and its descendants. */
+static constexpr unsigned int V3_DESCENDANT_LIMIT{2};
+/** Maximum number of transactions including a V3 tx and all its mempool ancestors. */
+static constexpr unsigned int V3_ANCESTOR_LIMIT{2};
+
+/** Maximum weight of a tx which spends from an unconfirmed V3 transaction. */
+static constexpr int64_t V3_CHILD_MAX_WEIGHT{4000};
+// Since these limits are within the default ancestor/descendant limits, there is no need to
+// additionally check ancestor/descendant limits for V3 transactions.
+static_assert(V3_CHILD_MAX_WEIGHT + MAX_STANDARD_TX_WEIGHT <= DEFAULT_ANCESTOR_SIZE_LIMIT_KVB * WITNESS_SCALE_FACTOR * 1000);
+static_assert(V3_CHILD_MAX_WEIGHT + MAX_STANDARD_TX_WEIGHT <= DEFAULT_DESCENDANT_SIZE_LIMIT_KVB * WITNESS_SCALE_FACTOR * 1000);
+
+/** Any two unconfirmed transactions with a dependency relationship must either both be V3 or both
+ * non-V3. Check this rule for any list of unconfirmed transactions.
+ * @returns a tuple (parent wtxid, child wtxid, bool) where one is V3 but the other is not, if at
+ * least one such pair exists. The bool represents whether the child is v3 or not. There may be
+ * other such pairs that are not returned.
+ * Otherwise std::nullopt.
+ */
+std::optional<std::tuple<uint256, uint256, bool>> CheckV3Inheritance(const Package& package);
+
+/** Every transaction that spends an unconfirmed V3 transaction must also be V3. */
+std::optional<std::string> CheckV3Inheritance(const CTransactionRef& ptx,
+                                              const CTxMemPool::setEntries& ancestors);
+
+/** The following rules apply to V3 transactions:
+ * 1. Tx with all of its ancestors (including non-nVersion=3) must be within V3_ANCESTOR_SIZE_LIMIT_KVB.
+ * 2. Tx with all of its ancestors must be within V3_ANCESTOR_LIMIT.
+ *
+ * If a V3 tx has V3 ancestors,
+ * 1. Each V3 ancestor and its descendants must be within V3_DESCENDANT_LIMIT.
+ * 2. The tx must be within V3_CHILD_MAX_SIZE.
+ *
+ * @returns an error string if any V3 rule was violated, otherwise std::nullopt.
+ */
+std::optional<std::string> ApplyV3Rules(const CTransactionRef& ptx,
+                                        const CTxMemPool::setEntries& ancestors,
+                                        const std::set<uint256>& direct_conflicts);
+
+#endif // BITCOIN_POLICY_V3_POLICY_H

--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -110,6 +110,7 @@ BOOST_FIXTURE_TEST_CASE(rbf_helper_functions, TestChain100Setup)
     CTxMemPool::setEntries set_12_normal{entry1_normal, entry2_normal};
     CTxMemPool::setEntries set_34_cpfp{entry3_low, entry4_high};
     CTxMemPool::setEntries set_56_low{entry5_low, entry6_low_prioritised};
+    CTxMemPool::setEntries set_78_high{entry7_high, entry8_high};
     CTxMemPool::setEntries all_entries{entry1_normal, entry2_normal, entry3_low, entry4_high,
                                        entry5_low, entry6_low_prioritised, entry7_high, entry8_high};
     CTxMemPool::setEntries empty_set;
@@ -227,6 +228,59 @@ BOOST_FIXTURE_TEST_CASE(rbf_helper_functions, TestChain100Setup)
 
     const auto spends_conflicting_confirmed = make_tx({m_coinbase_txns[0], m_coinbase_txns[1]}, {45 * CENT});
     BOOST_CHECK(HasNoNewUnconfirmed(*spends_conflicting_confirmed.get(), pool, {entry1_normal, entry3_low}) == std::nullopt);
+
+    // Tests for CheckMinerScores
+    // Don't allow replacements with a low ancestor feerate.
+    BOOST_CHECK(CheckMinerScores(/*replacement_fees=*/entry1_normal->GetFee(),
+                                 /*replacement_vsize=*/entry1_normal->GetTxSize(),
+                                 /*ancestors=*/{entry5_low},
+                                 /*direct_conflicts=*/{entry1_normal},
+                                 /*original_transactions=*/set_12_normal).has_value());
+
+    BOOST_CHECK(CheckMinerScores(entry3_low->GetFee() + entry4_high->GetFee() + 10000,
+                                 entry3_low->GetTxSize() + entry4_high->GetTxSize(),
+                                 {entry5_low},
+                                 {entry3_low},
+                                 set_34_cpfp).has_value());
+
+    // These tests use modified fees (including prioritisation), not base fees.
+    BOOST_CHECK(CheckMinerScores(entry5_low->GetFee() + entry6_low_prioritised->GetFee() + 1,
+                                 entry5_low->GetTxSize() + entry6_low_prioritised->GetTxSize(),
+                                 {empty_set},
+                                 {entry5_low},
+                                 set_56_low).has_value());
+    BOOST_CHECK(CheckMinerScores(entry5_low->GetModifiedFee() + entry6_low_prioritised->GetModifiedFee() + 1,
+                                 entry5_low->GetTxSize() + entry6_low_prioritised->GetTxSize(),
+                                 {empty_set},
+                                 {entry5_low},
+                                 set_56_low) == std::nullopt);
+
+    // High-feerate ancestors don't help raise the replacement's miner score.
+    BOOST_CHECK(CheckMinerScores(entry1_normal->GetFee() - 1,
+                                 entry1_normal->GetTxSize(),
+                                 empty_set,
+                                 set_12_normal,
+                                 set_12_normal).has_value());
+
+    BOOST_CHECK(CheckMinerScores(entry1_normal->GetFee() - 1,
+                                 entry1_normal->GetTxSize(),
+                                 set_78_high,
+                                 set_12_normal,
+                                 set_12_normal).has_value());
+
+    // Replacement must be higher than the individual feerate of direct conflicts.
+    // Note entry4_high's individual feerate is higher than its ancestor feerate
+    BOOST_CHECK(CheckMinerScores(entry4_high->GetFee() - 1,
+                                 entry4_high->GetTxSize(),
+                                 empty_set,
+                                 {entry4_high},
+                                 {entry4_high}).has_value());
+
+    BOOST_CHECK(CheckMinerScores(entry4_high->GetFee() - 1,
+                                 entry4_high->GetTxSize(),
+                                 empty_set,
+                                 {entry3_low},
+                                 set_34_cpfp) == std::nullopt);
 
 }
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -793,7 +793,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.nVersion = 0;
     CheckIsNotStandard(t, "version");
 
-    t.nVersion = 3;
+    t.nVersion = 4;
     CheckIsNotStandard(t, "version");
 
     // Allowed nVersion
@@ -801,6 +801,9 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     CheckIsStandard(t);
 
     t.nVersion = 2;
+    CheckIsStandard(t);
+
+    t.nVersion = 3;
     CheckIsStandard(t);
 
     // Check dust with odd relay fee to verify rounding:

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -6,6 +6,7 @@
 #include <key_io.h>
 #include <policy/packages.h>
 #include <policy/policy.h>
+#include <policy/rbf.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <test/util/random.h>
@@ -853,5 +854,169 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
         expected_pool_size += 1;
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
     }
+}
+
+BOOST_FIXTURE_TEST_CASE(package_rbf_tests, TestChain100Setup)
+{
+    mineBlocks(5);
+    LOCK(::cs_main);
+    size_t expected_pool_size = m_node.mempool->size();
+    CKey child_key;
+    child_key.MakeNewKey(true);
+    CScript parent_spk = GetScriptForDestination(WitnessV0KeyHash(child_key.GetPubKey()));
+    CKey grandchild_key;
+    grandchild_key.MakeNewKey(true);
+    CScript child_spk = GetScriptForDestination(WitnessV0KeyHash(grandchild_key.GetPubKey()));
+
+    const CAmount coinbase_value{50 * COIN};
+    // Test that de-duplication works and CheckMinerScores is not called when it's just 1 transaction.
+    {
+        // 1 parent paying 0sat, 1 child paying 300sat
+        Package package1;
+        // 1 parent paying 0sat, 1 child paying 500sat
+        Package package2;
+        // Package1 and package2 have the same parent. The children conflict.
+        auto mtx_parent = CreateValidMempoolTransaction(/*input_transaction=*/m_coinbase_txns[0], /*input_vout=*/0,
+                                                        /*input_height=*/0, /*input_signing_key=*/coinbaseKey,
+                                                        /*output_destination=*/parent_spk,
+                                                        /*output_amount=*/coinbase_value, /*submit=*/false, /*version=*/3);
+        CTransactionRef tx_parent = MakeTransactionRef(mtx_parent);
+        package1.push_back(tx_parent);
+        package2.push_back(tx_parent);
+
+        CTransactionRef tx_child_1 = MakeTransactionRef(CreateValidMempoolTransaction(tx_parent, 0, 101, child_key, child_spk, coinbase_value - 300, false, 3));
+        package1.push_back(tx_child_1);
+        CTransactionRef tx_child_2 = MakeTransactionRef(CreateValidMempoolTransaction(tx_parent, 0, 101, child_key, child_spk, coinbase_value - 500, false, 3));
+        package2.push_back(tx_child_2);
+
+        LOCK(m_node.mempool->cs);
+        const auto submit1 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, /*test_accept=*/false);
+        BOOST_CHECK_MESSAGE(submit1.m_state.IsValid(), "Package validation unexpectedly failed" << submit1.m_state.GetRejectReason());
+        auto it_parent_1 = submit1.m_tx_results.find(tx_parent->GetWitnessHash());
+        auto it_child_1 = submit1.m_tx_results.find(tx_child_1->GetWitnessHash());
+        BOOST_CHECK(it_parent_1 != submit1.m_tx_results.end());
+        BOOST_CHECK(it_child_1 != submit1.m_tx_results.end());
+        BOOST_CHECK_EQUAL(it_parent_1->second.m_result_type, MempoolAcceptResult::ResultType::VALID);
+        BOOST_CHECK_EQUAL(it_child_1->second.m_result_type, MempoolAcceptResult::ResultType::VALID);
+        expected_pool_size += 2;
+        BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
+        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_parent->GetHash())));
+        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_child_1->GetHash())));
+        const auto entry_parent = m_node.mempool->GetIter(tx_parent->GetHash()).value();
+        const auto entry_child1 = m_node.mempool->GetIter(tx_child_1->GetHash()).value();
+
+        // Second time around, parent should be deduplicated and child2 considered by itself.
+        // CheckMinerScores would fail if called with child2. child1's ancestor score is used since
+        // it is v3; it would be unfair to compare child1's individual feerate with child2's
+        // ancestor feerate.
+        BOOST_CHECK(!CheckMinerScores(/*replacement_fees=*/500,
+                                      /*replacement_vsize=*/GetVirtualTransactionSize(*tx_child_2),
+                                      /*ancestors=*/{entry_parent},
+                                      /*direct_conflicts=*/{entry_child1},
+                                      /*original_transactions=*/{entry_child1}).has_value());
+        const auto submit2 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package2, /*test_accept=*/false);
+        auto it_parent_2 = submit2.m_tx_results.find(tx_parent->GetWitnessHash());
+        auto it_child_2 = submit2.m_tx_results.find(tx_child_2->GetWitnessHash());
+        BOOST_CHECK(it_parent_2 != submit2.m_tx_results.end());
+        BOOST_CHECK(it_child_2 != submit2.m_tx_results.end());
+        BOOST_CHECK_MESSAGE(submit2.m_state.IsValid(), "Package validation unexpectedly failed" << submit2.m_state.GetRejectReason());
+        BOOST_CHECK_EQUAL(it_parent_2->second.m_result_type, MempoolAcceptResult::ResultType::MEMPOOL_ENTRY);
+        BOOST_CHECK_EQUAL(it_child_2->second.m_result_type, MempoolAcceptResult::ResultType::VALID);
+        BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
+        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_child_2->GetHash())));
+        BOOST_CHECK(!m_node.mempool->exists(GenTxid::Txid(tx_child_1->GetHash())));
+    }
+
+    // Test that V3 is required for package RBF, and not required for regular RBF.
+    {
+        CTransactionRef tx_parent_1 = MakeTransactionRef(CreateValidMempoolTransaction(
+            m_coinbase_txns[1], /*input_vout=*/0, /*input_height=*/0,
+            coinbaseKey, parent_spk, coinbase_value - 200, /*submit=*/false, /*version=*/2));
+        CTransactionRef tx_child_1 = MakeTransactionRef(CreateValidMempoolTransaction(
+            tx_parent_1, /*input_vout=*/0, /*input_height=*/101,
+            child_key, child_spk, coinbase_value - 400, /*submit=*/false, /*version=*/2));
+
+        CTransactionRef tx_parent_2 = MakeTransactionRef(CreateValidMempoolTransaction(
+            m_coinbase_txns[1], /*input_vout=*/0, /*input_height=*/0,
+            coinbaseKey, parent_spk, coinbase_value - 800, /*submit=*/false, /*version=*/2));
+        CTransactionRef tx_child_2 = MakeTransactionRef(CreateValidMempoolTransaction(
+            tx_parent_2, /*input_vout=*/0, /*input_height=*/101,
+            child_key, child_spk, coinbase_value - 800 - 200, /*submit=*/false, /*version=*/2));
+
+        CTransactionRef tx_parent_3 = MakeTransactionRef(CreateValidMempoolTransaction(
+            m_coinbase_txns[1], /*input_vout=*/0, /*input_height=*/0,
+            coinbaseKey, parent_spk, coinbase_value - 200, /*submit=*/false, /*version=*/2));
+        CTransactionRef tx_child_3 = MakeTransactionRef(CreateValidMempoolTransaction(
+            tx_parent_3, /*input_vout=*/0, /*input_height=*/101,
+            child_key, child_spk, coinbase_value - 200 - 1300, /*submit=*/false, /*version=*/2));
+
+        CTransactionRef tx_parent_4 = MakeTransactionRef(CreateValidMempoolTransaction(
+            m_coinbase_txns[1], /*input_vout=*/0, /*input_height=*/0,
+            coinbaseKey, parent_spk, coinbase_value - 200, /*submit=*/false, /*version=*/3));
+        CTransactionRef tx_child_4 = MakeTransactionRef(CreateValidMempoolTransaction(
+            tx_parent_4, /*input_vout=*/0, /*input_height=*/101,
+            child_key, child_spk, coinbase_value - 200 - 1500, /*submit=*/false, /*version=*/3));
+
+        // 1 parent paying 200sat, 1 child paying 200sat. Both v2.
+        Package package1{tx_parent_1, tx_child_1};
+        // 1 parent paying 800sat, 1 child paying 200sat. Both v2.
+        Package package2{tx_parent_2, tx_child_2};
+        // 1 parent paying 200sat, 1 child paying 1300. Both v2.
+        Package package3{tx_parent_3, tx_child_3};
+        // 1 parent paying 200sat, 1 child paying 1300. Same as package3, but v3.
+        Package package4{tx_parent_4, tx_child_4};
+        // In all packages, the parents conflict with each other
+
+        const auto submit1 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package1, false);
+        BOOST_CHECK_MESSAGE(submit1.m_state.IsValid(), "Package validation unexpectedly failed" << submit1.m_state.GetRejectReason());
+        auto it_parent_1 = submit1.m_tx_results.find(tx_parent_1->GetWitnessHash());
+        auto it_child_1 = submit1.m_tx_results.find(tx_child_1->GetWitnessHash());
+        BOOST_CHECK(it_parent_1 != submit1.m_tx_results.end());
+        BOOST_CHECK(it_child_1 != submit1.m_tx_results.end());
+        BOOST_CHECK_EQUAL(it_parent_1->second.m_result_type, MempoolAcceptResult::ResultType::VALID);
+        BOOST_CHECK_EQUAL(it_child_1->second.m_result_type, MempoolAcceptResult::ResultType::VALID);
+        expected_pool_size += 2;
+        BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
+        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_parent_1->GetHash())));
+        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_child_1->GetHash())));
+
+        // These transactions do not need to be V3 to replace their conflicts within
+        // ProcessNewPackage() because the fees used in RBF are their own; no package RBF is
+        // actually happening.
+        const auto submit2 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package2, false);
+        BOOST_CHECK_MESSAGE(submit2.m_state.IsValid(), "Package validation unexpectedly failed" << submit2.m_state.GetRejectReason());
+        auto it_parent_2 = submit2.m_tx_results.find(tx_parent_2->GetWitnessHash());
+        auto it_child_2 = submit2.m_tx_results.find(tx_child_2->GetWitnessHash());
+        BOOST_CHECK(it_parent_2 != submit2.m_tx_results.end());
+        BOOST_CHECK(it_child_2 != submit2.m_tx_results.end());
+        BOOST_CHECK_EQUAL(it_parent_2->second.m_result_type, MempoolAcceptResult::ResultType::VALID);
+        BOOST_CHECK_EQUAL(it_child_2->second.m_result_type, MempoolAcceptResult::ResultType::VALID);
+        BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
+        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_parent_2->GetHash())));
+        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_child_2->GetHash())));
+
+        // Package RBF, in which the replacement transaction's child sponsors the fees to meet RBF
+        // rules, requires the replacement transactions to be V3.
+        const auto submit3 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package3, false);
+        BOOST_CHECK(submit3.m_state.IsInvalid());
+        BOOST_CHECK_EQUAL(submit3.m_state.GetRejectReason(), "transaction failed");
+        BOOST_CHECK(submit3.m_tx_results.at(tx_parent_3->GetWitnessHash()).m_state.IsInvalid());
+        BOOST_CHECK_EQUAL(submit3.m_tx_results.at(tx_parent_3->GetWitnessHash()).m_state.GetResult(), TxValidationResult::TX_MEMPOOL_POLICY);
+        BOOST_CHECK(submit3.m_tx_results.at(tx_child_3->GetWitnessHash()).m_state.IsInvalid());
+        BOOST_CHECK_EQUAL(submit3.m_tx_results.at(tx_child_3->GetWitnessHash()).m_state.GetResult(), TxValidationResult::TX_MISSING_INPUTS);
+
+        const auto submit4 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package4, false);
+        BOOST_CHECK_MESSAGE(submit4.m_state.IsValid(), "Package validation unexpectedly failed" << submit4.m_state.GetRejectReason());
+        auto it_parent_4 = submit4.m_tx_results.find(tx_parent_4->GetWitnessHash());
+        auto it_child_4 = submit4.m_tx_results.find(tx_child_4->GetWitnessHash());
+        BOOST_CHECK(it_parent_4 != submit4.m_tx_results.end());
+        BOOST_CHECK(it_child_4 != submit4.m_tx_results.end());
+        BOOST_CHECK_EQUAL(it_parent_4->second.m_result_type, MempoolAcceptResult::ResultType::VALID);
+        BOOST_CHECK_EQUAL(it_child_4->second.m_result_type, MempoolAcceptResult::ResultType::VALID);
+        BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
+        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_parent_4->GetHash())));
+        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_child_4->GetHash())));
+    }
+
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -4,11 +4,14 @@
 
 #include <consensus/validation.h>
 #include <key_io.h>
+#include <policy/v3_policy.h>
 #include <policy/packages.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
+#include <random.h>
 #include <script/script.h>
 #include <test/util/setup_common.h>
+#include <test/util/txmempool.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
@@ -48,4 +51,154 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChain100Setup)
     BOOST_CHECK_EQUAL(result.m_state.GetRejectReason(), "coinbase");
     BOOST_CHECK(result.m_state.GetResult() == TxValidationResult::TX_CONSENSUS);
 }
+
+// Generate a number of random, nonexistent outpoints.
+static inline std::vector<COutPoint> random_outpoints(size_t num_outpoints) {
+    std::vector<COutPoint> outpoints;
+    outpoints.resize(num_outpoints);
+    for (size_t i{0}; i < num_outpoints; ++i) {
+        outpoints.emplace_back(Txid::FromUint256(GetRandHash()), 0);
+    }
+    return outpoints;
+}
+
+// Creates a placeholder tx (not valid) with 25 outputs. Specify the nVersion and the inputs.
+static inline CTransactionRef make_tx(const std::vector<COutPoint>& inputs, int32_t version)
+{
+    CMutableTransaction mtx = CMutableTransaction{};
+    mtx.nVersion = version;
+    mtx.vin.resize(inputs.size());
+    mtx.vout.resize(25);
+    for (size_t i{0}; i < inputs.size(); ++i) {
+        mtx.vin[i].prevout = inputs[i];
+    }
+    for (auto i{0}; i < 25; ++i) {
+        mtx.vout[i].scriptPubKey = CScript() << OP_TRUE;
+        mtx.vout[i].nValue = 10000;
+    }
+    return MakeTransactionRef(mtx);
+}
+
+BOOST_FIXTURE_TEST_CASE(version3_tests, RegTestingSetup)
+{
+    // Test V3 policy helper functions
+    CTxMemPool& pool = *Assert(m_node.mempool);
+    LOCK2(cs_main, pool.cs);
+    TestMemPoolEntryHelper entry;
+    std::set<uint256> empty_conflicts_set;
+
+    auto mempool_tx_v3 = make_tx(random_outpoints(1), /*version=*/3);
+    pool.addUnchecked(entry.FromTx(mempool_tx_v3));
+    auto mempool_tx_v2 = make_tx(random_outpoints(1), /*version=*/2);
+    pool.addUnchecked(entry.FromTx(mempool_tx_v2));
+    // These two transactions are unrelated, so CheckV3Inheritance should pass.
+    BOOST_CHECK(CheckV3Inheritance({mempool_tx_v2, mempool_tx_v3}) == std::nullopt);
+    // Default values.
+    CTxMemPool::Limits m_limits{};
+
+    // Cannot spend from an unconfirmed v3 transaction unless this tx is also v3.
+    {
+        auto tx_v2_from_v3 = make_tx({COutPoint{mempool_tx_v3->GetHash(), 0}}, /*version=*/2);
+        auto ancestors_v2_from_v3{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v2_from_v3), m_limits)};
+        BOOST_CHECK(CheckV3Inheritance(tx_v2_from_v3, *ancestors_v2_from_v3).has_value());
+        BOOST_CHECK(CheckV3Inheritance({mempool_tx_v3, tx_v2_from_v3}).has_value());
+        auto tx_v2_from_v2_and_v3 = make_tx({COutPoint{mempool_tx_v3->GetHash(), 0}, COutPoint{mempool_tx_v2->GetHash(), 0}}, /*version=*/2);
+        auto ancestors_v2_from_both{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v2_from_v2_and_v3), m_limits)};
+        BOOST_CHECK(CheckV3Inheritance(tx_v2_from_v2_and_v3, *ancestors_v2_from_both).has_value());
+        BOOST_CHECK(CheckV3Inheritance({mempool_tx_v2, mempool_tx_v3, tx_v2_from_v2_and_v3}).value() ==
+                    std::make_tuple(mempool_tx_v3->GetWitnessHash(), tx_v2_from_v2_and_v3->GetWitnessHash(), false));
+    }
+
+    // V3 cannot spend from an unconfirmed non-v3 transaction.
+    {
+        auto tx_v3_from_v2 = make_tx({COutPoint{mempool_tx_v2->GetHash(), 0}}, /*version=*/3);
+        auto ancestors_v3_from_v2{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v3_from_v2), m_limits)};
+        BOOST_CHECK(CheckV3Inheritance(tx_v3_from_v2, *ancestors_v3_from_v2).has_value());
+        BOOST_CHECK(CheckV3Inheritance({mempool_tx_v2, tx_v3_from_v2}).value() ==
+                    std::make_tuple(mempool_tx_v2->GetWitnessHash(), tx_v3_from_v2->GetWitnessHash(), true));
+        auto tx_v3_from_v2_and_v3 = make_tx({COutPoint{mempool_tx_v3->GetHash(), 0}, COutPoint{mempool_tx_v2->GetHash(), 0}}, /*version=*/3);
+        auto ancestors_v3_from_both{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v3_from_v2_and_v3), m_limits)};
+        BOOST_CHECK(CheckV3Inheritance(tx_v3_from_v2_and_v3, *ancestors_v3_from_both).has_value());
+        BOOST_CHECK(CheckV3Inheritance({mempool_tx_v2, mempool_tx_v3, tx_v3_from_v2_and_v3}).value() ==
+                    std::make_tuple(mempool_tx_v2->GetWitnessHash(), tx_v3_from_v2_and_v3->GetWitnessHash(), true));
+    }
+    // V3 from V3 is ok, and non-V3 from non-V3 is ok.
+    {
+        auto tx_v3_from_v3 = make_tx({COutPoint{mempool_tx_v3->GetHash(), 0}}, /*version=*/3);
+        auto ancestors_v3{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v3_from_v3), m_limits)};
+        BOOST_CHECK(CheckV3Inheritance({tx_v3_from_v3, mempool_tx_v3}) == std::nullopt);
+        BOOST_CHECK(CheckV3Inheritance({mempool_tx_v3, tx_v3_from_v3}) == std::nullopt);
+        BOOST_CHECK(CheckV3Inheritance(tx_v3_from_v3, *ancestors_v3) == std::nullopt);
+
+        auto tx_v2_from_v2 = make_tx({COutPoint{mempool_tx_v2->GetHash(), 0}}, /*version=*/2);
+        auto ancestors_v2{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v2_from_v2), m_limits)};
+        BOOST_CHECK(CheckV3Inheritance({tx_v2_from_v2, mempool_tx_v2}) == std::nullopt);
+        BOOST_CHECK(CheckV3Inheritance({mempool_tx_v2, tx_v2_from_v2}) == std::nullopt);
+        BOOST_CHECK(CheckV3Inheritance(tx_v2_from_v2, *ancestors_v2) == std::nullopt);
+    }
+
+    // Tx spending v3 cannot have too many mempool ancestors
+    // Configuration where the tx has multiple direct parents.
+    {
+        std::vector<COutPoint> mempool_outpoints;
+        mempool_outpoints.emplace_back(mempool_tx_v3->GetHash(), 0);
+        mempool_outpoints.resize(2);
+        for (size_t i{0}; i < 2; ++i) {
+            auto mempool_tx = make_tx(random_outpoints(1), /*version=*/2);
+            pool.addUnchecked(entry.FromTx(mempool_tx));
+            mempool_outpoints.emplace_back(mempool_tx->GetHash(), 0);
+        }
+        auto tx_v3_multi_parent = make_tx(mempool_outpoints, /*version=*/3);
+        auto ancestors{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v3_multi_parent), m_limits)};
+        BOOST_CHECK(ApplyV3Rules(tx_v3_multi_parent, *ancestors, empty_conflicts_set).has_value());
+    }
+
+    // Configuration where the tx is in a multi-generation chain.
+    auto last_outpoint{random_outpoints(1)[0]};
+    for (size_t i{0}; i < 2; ++i) {
+        auto mempool_tx = make_tx({last_outpoint}, /*version=*/2);
+        pool.addUnchecked(entry.FromTx(mempool_tx));
+        last_outpoint = COutPoint{mempool_tx->GetHash(), 0};
+    }
+    {
+        auto tx_v3_multi_gen = make_tx({last_outpoint}, /*version=*/3);
+        auto ancestors{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v3_multi_gen), m_limits)};
+        BOOST_CHECK(ApplyV3Rules(tx_v3_multi_gen, *ancestors, empty_conflicts_set).has_value());
+    }
+
+    // Tx spending v3 cannot be too large
+    auto many_inputs{random_outpoints(100)};
+    many_inputs.emplace_back(mempool_tx_v3->GetHash(), 0);
+    {
+        auto tx_v3_child_big = make_tx(many_inputs, /*version=*/3);
+        BOOST_CHECK(GetTransactionWeight(*tx_v3_child_big) > V3_CHILD_MAX_WEIGHT);
+        auto ancestors{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v3_child_big), m_limits)};
+        BOOST_CHECK(ApplyV3Rules(tx_v3_child_big, *ancestors, empty_conflicts_set).has_value());
+    }
+
+    // Parent + child with v3 in the mempool. Child is allowed as long as it is under V3_CHILD_MAX_SIZE.
+    auto tx_mempool_v3_child = make_tx({COutPoint{mempool_tx_v3->GetHash(), 0}}, /*version=*/3);
+    {
+        BOOST_CHECK(GetTransactionWeight(*tx_mempool_v3_child) <= V3_CHILD_MAX_WEIGHT);
+        auto ancestors{pool.CalculateMemPoolAncestors(entry.FromTx(tx_mempool_v3_child), m_limits)};
+        BOOST_CHECK(ApplyV3Rules(tx_mempool_v3_child, *ancestors, empty_conflicts_set) == std::nullopt);
+        pool.addUnchecked(entry.FromTx(tx_mempool_v3_child));
+    }
+
+    // A v3 transaction cannot have more than 1 descendant.
+    {
+        auto tx_v3_child2 = make_tx({COutPoint{mempool_tx_v3->GetHash(), 1}}, /*version=*/3);
+        auto ancestors{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v3_child2), m_limits)};
+        BOOST_CHECK(ApplyV3Rules(tx_v3_child2, *ancestors, empty_conflicts_set).has_value());
+        // If replacing the child, make sure there is no double-counting.
+        BOOST_CHECK(ApplyV3Rules(tx_v3_child2, *ancestors, {tx_mempool_v3_child->GetHash()}) == std::nullopt);
+    }
+
+    {
+        auto tx_v3_grandchild = make_tx({COutPoint{tx_mempool_v3_child->GetHash(), 0}}, /*version=*/3);
+        auto ancestors{pool.CalculateMemPoolAncestors(entry.FromTx(tx_v3_grandchild), m_limits)};
+        BOOST_CHECK(ApplyV3Rules(tx_v3_grandchild, *ancestors, empty_conflicts_set).has_value());
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -345,9 +345,11 @@ std::pair<CMutableTransaction, CAmount> TestChain100Setup::CreateValidTransactio
                                                                                   const std::vector<CKey>& input_signing_keys,
                                                                                   const std::vector<CTxOut>& outputs,
                                                                                   const std::optional<CFeeRate>& feerate,
-                                                                                  const std::optional<uint32_t>& fee_output)
+                                                                                  const std::optional<uint32_t>& fee_output,
+                                                                                  uint32_t version)
 {
     CMutableTransaction mempool_txn;
+    mempool_txn.nVersion = version;
     mempool_txn.vin.reserve(inputs.size());
     mempool_txn.vout.reserve(outputs.size());
 
@@ -409,9 +411,10 @@ CMutableTransaction TestChain100Setup::CreateValidMempoolTransaction(const std::
                                                                      int input_height,
                                                                      const std::vector<CKey>& input_signing_keys,
                                                                      const std::vector<CTxOut>& outputs,
-                                                                     bool submit)
+                                                                     bool submit,
+                                                                     uint32_t version)
 {
-    CMutableTransaction mempool_txn = CreateValidTransaction(input_transactions, inputs, input_height, input_signing_keys, outputs, std::nullopt, std::nullopt).first;
+    CMutableTransaction mempool_txn = CreateValidTransaction(input_transactions, inputs, input_height, input_signing_keys, outputs, std::nullopt, std::nullopt, version).first;
     // If submit=true, add transaction to the mempool.
     if (submit) {
         LOCK(cs_main);
@@ -427,7 +430,8 @@ CMutableTransaction TestChain100Setup::CreateValidMempoolTransaction(CTransactio
                                                                      CKey input_signing_key,
                                                                      CScript output_destination,
                                                                      CAmount output_amount,
-                                                                     bool submit)
+                                                                     bool submit,
+                                                                     uint32_t version)
 {
     COutPoint input{input_transaction->GetHash(), input_vout};
     CTxOut output{output_amount, output_destination};
@@ -436,7 +440,8 @@ CMutableTransaction TestChain100Setup::CreateValidMempoolTransaction(CTransactio
                                          /*input_height=*/input_height,
                                          /*input_signing_keys=*/{input_signing_key},
                                          /*outputs=*/{output},
-                                         /*submit=*/submit);
+                                         /*submit=*/submit,
+                                         /*version=*/version);
 }
 
 std::vector<CTransactionRef> TestChain100Setup::PopulateMempool(FastRandomContext& det_rand, size_t num_transactions, bool submit)

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -143,7 +143,8 @@ struct TestChain100Setup : public TestingSetup {
                                                                    const std::vector<CKey>& input_signing_keys,
                                                                    const std::vector<CTxOut>& outputs,
                                                                    const std::optional<CFeeRate>& feerate,
-                                                                   const std::optional<uint32_t>& fee_output);
+                                                                   const std::optional<uint32_t>& fee_output,
+                                                                   uint32_t version);
     /**
      * Create a transaction and, optionally, submit to the mempool.
      *
@@ -159,7 +160,8 @@ struct TestChain100Setup : public TestingSetup {
                                                       int input_height,
                                                       const std::vector<CKey>& input_signing_keys,
                                                       const std::vector<CTxOut>& outputs,
-                                                      bool submit = true);
+                                                      bool submit = true,
+                                                      uint32_t version = 2);
 
     /**
      * Create a 1-in-1-out transaction and, optionally, submit to the mempool.
@@ -178,7 +180,8 @@ struct TestChain100Setup : public TestingSetup {
                                                       CKey input_signing_key,
                                                       CScript output_destination,
                                                       CAmount output_amount = CAmount(1 * COIN),
-                                                      bool submit = true);
+                                                      bool submit = true,
+                                                      uint32_t version = 2);
 
     /** Create transactions spending from m_coinbase_txns. These transactions will only spend coins
      * that exist in the current chain, but may be premature coinbase spends, have missing

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -29,6 +29,7 @@
 #include <logging/timer.h>
 #include <node/blockstorage.h>
 #include <node/utxo_snapshot.h>
+#include <policy/v3_policy.h>
 #include <policy/policy.h>
 #include <policy/rbf.h>
 #include <policy/settings.h>
@@ -328,11 +329,13 @@ void Chainstate::MaybeUpdateMempoolForReorg(
     m_mempool->UpdateTransactionsFromBlock(vHashUpdate);
 
     // Predicate to use for filtering transactions in removeForReorg.
+    // Checks whether a non-v3 transaction spends v3 and or vice versa.
     // Checks whether the transaction is still final and, if it spends a coinbase output, mature.
     // Also updates valid entries' cached LockPoints if needed.
     // If false, the tx is still valid and its lockpoints are updated.
     // If true, the tx would be invalid in the next block; remove this entry and all of its descendants.
-    const auto filter_final_and_mature = [this](CTxMemPool::txiter it)
+    auto& func = __func__;
+    const auto filter_valid_after_reorg = [&](CTxMemPool::txiter it)
         EXCLUSIVE_LOCKS_REQUIRED(m_mempool->cs, ::cs_main) {
         AssertLockHeld(m_mempool->cs);
         AssertLockHeld(::cs_main);
@@ -372,11 +375,16 @@ void Chainstate::MaybeUpdateMempoolForReorg(
             }
         }
         // Transaction is still valid and cached LockPoints are updated.
+        auto ancestors{m_mempool->AssumeCalculateMemPoolAncestors(func, *it, CTxMemPool::Limits::NoLimits(),
+                                                                  /*fSearchForParents=*/false)};
+        // This check succeeds for any non-V3 transaction
+        if (auto err{ApplyV3Rules(MakeTransactionRef(it->GetTx()), ancestors, {})}) return true;
+        // Also check V3 inheritance rules if this entry is non-V3
+        if (auto err{CheckV3Inheritance(MakeTransactionRef(it->GetTx()), ancestors)}) return true;
         return false;
     };
-
     // We also need to remove any now-immature transactions
-    m_mempool->removeForReorg(m_chain, filter_final_and_mature);
+    m_mempool->removeForReorg(m_chain, filter_valid_after_reorg);
     // Re-limit mempool size, in case we added any transactions
     LimitMempoolSize(*m_mempool, this->CoinsTip());
 }
@@ -760,9 +768,11 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
                 // check all unconfirmed ancestors; otherwise an opt-in ancestor
                 // might be replaced, causing removal of this descendant.
                 //
-                // If replaceability signaling is ignored due to node setting,
-                // replacement is always allowed.
-                if (!m_pool.m_full_rbf && !SignalsOptInRBF(*ptxConflicting)) {
+                // All V3 transactions are considered replaceable.
+                //
+                // Replaceability signaling of the original transactions may be
+                // ignored due to node setting.
+                if (!m_pool.m_full_rbf && !SignalsOptInRBF(*ptxConflicting) && ptxConflicting->nVersion != 3) {
                     return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "txn-mempool-conflict");
                 }
 
@@ -946,6 +956,16 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     }
 
     ws.m_ancestors = *ancestors;
+    if (const auto err_string{CheckV3Inheritance(ws.m_ptx, ws.m_ancestors)}) {
+        if (ws.m_ptx->nVersion == 3) {
+            return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "v3-tx-spends-non-v3", *err_string);
+        } else {
+            return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "non-v3-tx-spends-v3", *err_string);
+        }
+    }
+    if (const auto err_string{ApplyV3Rules(ws.m_ptx, ws.m_ancestors, ws.m_conflicts)}) {
+        return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "v3-tx-nonstandard", *err_string);
+    }
 
     // A transaction that spends outputs that would be replaced by it is invalid. Now
     // that we have the set of all ancestors we can detect this
@@ -1284,6 +1304,21 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
     std::transform(txns.cbegin(), txns.cend(), std::back_inserter(workspaces),
                    [](const auto& tx) { return Workspace(tx); });
     std::map<uint256, MempoolAcceptResult> results;
+
+    if (const auto v3_violation{CheckV3Inheritance(txns)}) {
+        const auto [parent_wtxid, child_wtxid, child_v3] = v3_violation.value();
+        TxValidationState child_state;
+        if (child_v3) {
+            child_state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "v3-tx-spends-non-v3",
+                          strprintf("tx that spends from %s cannot be nVersion=3", parent_wtxid.ToString()));
+        } else {
+            child_state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "non-v3-tx-spends-v3",
+                          strprintf("tx that spends from %s must be nVersion=3", parent_wtxid.ToString()));
+        }
+        package_state.Invalid(PackageValidationResult::PCKG_TX, "transaction failed");
+        results.emplace(child_wtxid, MempoolAcceptResult::Failure(child_state));
+        return PackageMempoolAcceptResult(package_state, std::move(results));
+    }
 
     LOCK(m_pool.cs);
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -473,6 +473,9 @@ public:
          */
         const bool m_package_feerates;
 
+        /** Whether CPFP carveout and RBF carveout are granted. */
+        const bool m_allow_carveouts;
+
         /** Parameters for single transaction mempool validation. */
         static ATMPArgs SingleAccept(const CChainParams& chainparams, int64_t accept_time,
                                      bool bypass_limits, std::vector<COutPoint>& coins_to_uncache,
@@ -485,6 +488,7 @@ public:
                             /* m_allow_replacement */ true,
                             /* m_package_submission */ false,
                             /* m_package_feerates */ false,
+                            /* m_allow_carveouts */ true,
             };
         }
 
@@ -499,6 +503,7 @@ public:
                             /* m_allow_replacement */ false,
                             /* m_package_submission */ false, // not submitting to mempool
                             /* m_package_feerates */ false,
+                            /* m_allow_carveouts */ false,
             };
         }
 
@@ -513,6 +518,7 @@ public:
                             /* m_allow_replacement */ false,
                             /* m_package_submission */ true,
                             /* m_package_feerates */ true,
+                            /* m_allow_carveouts */ false,
             };
         }
 
@@ -526,6 +532,7 @@ public:
                             /* m_allow_replacement */ true,
                             /* m_package_submission */ true, // do not LimitMempoolSize in Finalize()
                             /* m_package_feerates */ false, // only 1 transaction
+                            /* m_allow_carveouts */ false,
             };
         }
 
@@ -539,7 +546,8 @@ public:
                  bool test_accept,
                  bool allow_replacement,
                  bool package_submission,
-                 bool package_feerates)
+                 bool package_feerates,
+                 bool allow_carveouts)
             : m_chainparams{chainparams},
               m_accept_time{accept_time},
               m_bypass_limits{bypass_limits},
@@ -547,7 +555,8 @@ public:
               m_test_accept{test_accept},
               m_allow_replacement{allow_replacement},
               m_package_submission{package_submission},
-              m_package_feerates{package_feerates}
+              m_package_feerates{package_feerates},
+              m_allow_carveouts{allow_carveouts}
         {
         }
     };
@@ -894,7 +903,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     CTxMemPool::Limits maybe_rbf_limits = m_pool.m_limits;
 
     // Calculate in-mempool ancestors, up to a limit.
-    if (ws.m_conflicts.size() == 1) {
+    if (ws.m_conflicts.size() == 1 && args.m_allow_carveouts) {
         // In general, when we receive an RBF transaction with mempool conflicts, we want to know whether we
         // would meet the chain limits after the conflicts have been removed. However, there isn't a practical
         // way to do this short of calculating the ancestor and descendant sets with an overlay cache of
@@ -932,6 +941,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     auto ancestors{m_pool.CalculateMemPoolAncestors(*entry, maybe_rbf_limits)};
     if (!ancestors) {
         // If CalculateMemPoolAncestors fails second time, we want the original error string.
+        const auto error_message{util::ErrorString(ancestors).original};
         // Contracting/payment channels CPFP carve-out:
         // If the new transaction is relatively small (up to 40k weight)
         // and has at most one ancestor (ie ancestor limit of 2, including
@@ -949,8 +959,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
             .descendant_count = maybe_rbf_limits.descendant_count + 1,
             .descendant_size_vbytes = maybe_rbf_limits.descendant_size_vbytes + EXTRA_DESCENDANT_TX_SIZE_LIMIT,
         };
-        const auto error_message{util::ErrorString(ancestors).original};
-        if (ws.m_vsize > EXTRA_DESCENDANT_TX_SIZE_LIMIT) {
+        if (!args.m_allow_carveouts || ws.m_vsize > EXTRA_DESCENDANT_TX_SIZE_LIMIT) {
             return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "too-long-mempool-chain", error_message);
         }
         ancestors = m_pool.CalculateMemPoolAncestors(*entry, cpfp_carve_out_limits);
@@ -1366,11 +1375,8 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
             MempoolAcceptResult::FeeFailure(placeholder_state, CFeeRate(m_total_modified_fees, m_total_vsize), all_package_wtxids)}});
     }
 
-    // Apply package mempool ancestor/descendant limits. Skip if there is only one transaction,
-    // because it's unnecessary. Also, CPFP carve out can increase the limit for individual
-    // transactions, but this exemption is not extended to packages in CheckPackageLimits().
-    std::string err_string;
-    if (txns.size() > 1 && !PackageMempoolChecks(txns, m_total_vsize, package_state)) {
+    // Apply package mempool ancestor/descendant limits.
+    if (!PackageMempoolChecks(txns, m_total_vsize, package_state)) {
         return PackageMempoolAcceptResult(package_state, std::move(results));
     }
 

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -271,7 +271,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
 
         self.log.info('Some nonstandard transactions')
         tx = tx_from_hex(raw_tx_reference)
-        tx.nVersion = 3  # A version currently non-standard
+        tx.nVersion = 4  # A version currently non-standard
         self.check_mempool_result(
             result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'version'}],
             rawtxs=[tx.serialize().hex()],

--- a/test/functional/mempool_accept_v3.py
+++ b/test/functional/mempool_accept_v3.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.messages import (
+    MAX_BIP125_RBF_SEQUENCE,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_greater_than_or_equal,
+    assert_raises_rpc_error,
+)
+from test_framework.wallet import (
+    DEFAULT_FEE,
+    MiniWallet,
+)
+def cleanup(func):
+    def wrapper(self):
+        try:
+            func(self)
+        finally:
+            # Clear mempool
+            self.generate(self.nodes[0], 1)
+            # Reset config options
+            self.restart_node(0)
+    return wrapper
+
+class MempoolAcceptV3(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def check_mempool(self, txids):
+        """Assert exact contents of the node's mempool (by txid)."""
+        mempool_contents = self.nodes[0].getrawmempool()
+        assert_equal(len(txids), len(mempool_contents))
+        assert all([txid in txids for txid in mempool_contents])
+
+    @cleanup
+    def test_v3_acceptance(self):
+        node = self.nodes[0]
+        self.log.info("Test a child of a V3 transaction cannot be more than 1000vB")
+        self.restart_node(0, extra_args=["-datacarriersize=1000"])
+        tx_v3_parent_normal = self.wallet.send_self_transfer(from_node=node, version=3)
+        self.check_mempool([tx_v3_parent_normal["txid"]])
+        tx_v3_child_heavy = self.wallet.create_self_transfer(
+            utxo_to_spend=tx_v3_parent_normal["new_utxo"],
+            target_weight=4004,
+            version=3
+        )
+        assert_greater_than_or_equal(tx_v3_child_heavy["tx"].get_vsize(), 1000)
+        assert_raises_rpc_error(-26, "v3-tx-nonstandard, v3 child tx is too big", node.sendrawtransaction, tx_v3_child_heavy["hex"])
+        self.check_mempool([tx_v3_parent_normal["txid"]])
+        # tx has no descendants
+        assert_equal(node.getmempoolentry(tx_v3_parent_normal["txid"])["descendantcount"], 1)
+
+        self.log.info("Test that, during replacements, only the new transaction counts for V3 descendant limit")
+        tx_v3_child_almost_heavy = self.wallet.send_self_transfer(
+            from_node=node,
+            fee_rate=DEFAULT_FEE,
+            utxo_to_spend=tx_v3_parent_normal["new_utxo"],
+            target_weight=3987,
+            version=3
+        )
+        assert_greater_than_or_equal(1000, tx_v3_child_almost_heavy["tx"].get_vsize())
+        self.check_mempool([tx_v3_parent_normal["txid"], tx_v3_child_almost_heavy["txid"]])
+        assert_equal(node.getmempoolentry(tx_v3_parent_normal["txid"])["descendantcount"], 2)
+        tx_v3_child_almost_heavy_rbf = self.wallet.send_self_transfer(
+            from_node=node,
+            fee_rate=DEFAULT_FEE * 2,
+            utxo_to_spend=tx_v3_parent_normal["new_utxo"],
+            target_weight=3500,
+            version=3
+        )
+        assert_greater_than_or_equal(tx_v3_child_almost_heavy["tx"].get_vsize() + tx_v3_child_almost_heavy_rbf["tx"].get_vsize(), 1000)
+        self.check_mempool([tx_v3_parent_normal["txid"], tx_v3_child_almost_heavy_rbf["txid"]])
+        assert_equal(node.getmempoolentry(tx_v3_parent_normal["txid"])["descendantcount"], 2)
+
+    @cleanup
+    def test_v3_replacement(self):
+        node = self.nodes[0]
+        self.log.info("Test V3 transactions may be replaced by V3 transactions")
+        utxo_v3_bip125 = self.wallet.get_utxo()
+        tx_v3_bip125 = self.wallet.send_self_transfer(
+            from_node=node,
+            fee_rate=DEFAULT_FEE,
+            utxo_to_spend=utxo_v3_bip125,
+            sequence=MAX_BIP125_RBF_SEQUENCE,
+            version=3
+        )
+        self.check_mempool([tx_v3_bip125["txid"]])
+
+        tx_v3_bip125_rbf = self.wallet.send_self_transfer(
+            from_node=node,
+            fee_rate=DEFAULT_FEE * 2,
+            utxo_to_spend=utxo_v3_bip125,
+            version=3
+        )
+        self.check_mempool([tx_v3_bip125_rbf["txid"]])
+
+        self.log.info("Test V3 transactions may be replaced by V2 transactions")
+        tx_v3_bip125_rbf_v2 = self.wallet.send_self_transfer(
+            from_node=node,
+            fee_rate=DEFAULT_FEE * 3,
+            utxo_to_spend=utxo_v3_bip125,
+            version=2
+        )
+        self.check_mempool([tx_v3_bip125_rbf_v2["txid"]])
+
+        self.log.info("Test that replacements cannot cause violation of inherited V3")
+        utxo_v3_parent = self.wallet.get_utxo()
+        tx_v3_parent = self.wallet.send_self_transfer(
+            from_node=node,
+            fee_rate=DEFAULT_FEE,
+            utxo_to_spend=utxo_v3_parent,
+            version=3
+        )
+        tx_v3_child = self.wallet.send_self_transfer(
+            from_node=node,
+            fee_rate=DEFAULT_FEE,
+            utxo_to_spend=tx_v3_parent["new_utxo"],
+            version=3
+        )
+        self.check_mempool([tx_v3_bip125_rbf_v2["txid"], tx_v3_parent["txid"], tx_v3_child["txid"]])
+
+        tx_v3_child_rbf_v2 = self.wallet.create_self_transfer(
+            fee_rate=DEFAULT_FEE * 2,
+            utxo_to_spend=tx_v3_parent["new_utxo"],
+            version=2
+        )
+        assert_raises_rpc_error(-26, "non-v3-tx-spends-v3", node.sendrawtransaction, tx_v3_child_rbf_v2["hex"])
+        self.check_mempool([tx_v3_bip125_rbf_v2["txid"], tx_v3_parent["txid"], tx_v3_child["txid"]])
+
+
+    @cleanup
+    def test_v3_bip125(self):
+        node = self.nodes[0]
+        self.log.info("Test V3 transactions that don't signal BIP125 are replaceable")
+        assert_equal(node.getmempoolinfo()["fullrbf"], False)
+        utxo_v3_no_bip125 = self.wallet.get_utxo()
+        tx_v3_no_bip125 = self.wallet.send_self_transfer(
+            from_node=node,
+            fee_rate=DEFAULT_FEE,
+            utxo_to_spend=utxo_v3_no_bip125,
+            sequence=MAX_BIP125_RBF_SEQUENCE + 1,
+            version=3
+        )
+
+        self.check_mempool([tx_v3_no_bip125["txid"]])
+        assert not node.getmempoolentry(tx_v3_no_bip125["txid"])["bip125-replaceable"]
+        tx_v3_no_bip125_rbf = self.wallet.send_self_transfer(
+            from_node=node,
+            fee_rate=DEFAULT_FEE * 2,
+            utxo_to_spend=utxo_v3_no_bip125,
+            version=3
+        )
+        self.check_mempool([tx_v3_no_bip125_rbf["txid"]])
+
+    @cleanup
+    def test_v3_reorg(self):
+        node = self.nodes[0]
+        self.restart_node(0, extra_args=["-datacarriersize=40000"])
+        self.log.info("Test that, during a reorg, transactions that now violate v3 rules are evicted")
+        tx_v2_block = self.wallet.send_self_transfer(from_node=node, version=2)
+        tx_v3_block = self.wallet.send_self_transfer(from_node=node, version=3)
+        tx_v3_block2 = self.wallet.send_self_transfer(from_node=node, version=3)
+        assert_equal(set(node.getrawmempool()), set([tx_v3_block["txid"], tx_v2_block["txid"], tx_v3_block2["txid"]]))
+
+        block = self.generate(node, 1)
+        assert_equal(node.getrawmempool(), [])
+        tx_v2_from_v3 = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=tx_v3_block["new_utxo"], version=2)
+        tx_v3_from_v2 = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=tx_v2_block["new_utxo"], version=3)
+        tx_v3_child_large = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=tx_v3_block2["new_utxo"], target_weight=5000, version=3)
+        assert_greater_than(node.getmempoolentry(tx_v3_child_large["txid"])["vsize"], 1000)
+        assert_equal(set(node.getrawmempool()), set([tx_v2_from_v3["txid"], tx_v3_from_v2["txid"], tx_v3_child_large["txid"]]))
+        node.invalidateblock(block[0])
+        assert_equal(set(node.getrawmempool()), set([tx_v3_block["txid"], tx_v2_block["txid"], tx_v3_block2["txid"]]))
+        # This is needed because generate() will create the exact same block again.
+        node.reconsiderblock(block[0])
+
+
+    @cleanup
+    def test_nondefault_package_limits(self):
+        """
+        Max standard tx size + V3 rules imply the ancestor/descendant rules (at their default
+        values), but those checks must not be skipped. Ensure both sets of checks are done by
+        changing the ancestor/descendant limit configurations.
+        """
+        node = self.nodes[0]
+        self.log.info("Test that a decreased limitdescendantsize also applies to V3 child")
+        self.restart_node(0, extra_args=["-limitdescendantsize=10", "-datacarriersize=40000"])
+        tx_v3_parent_large1 = self.wallet.send_self_transfer(from_node=node, target_weight=99900, version=3)
+        tx_v3_child_large1 = self.wallet.create_self_transfer(utxo_to_spend=tx_v3_parent_large1["new_utxo"], version=3)
+        # Child is within V3 limits
+        assert_greater_than(1000, tx_v3_child_large1["tx"].get_vsize())
+        assert_raises_rpc_error(-26, "too-long-mempool-chain", node.sendrawtransaction,
+                tx_v3_child_large1["hex"])
+        self.check_mempool([tx_v3_parent_large1["txid"]])
+        assert_equal(node.getmempoolentry(tx_v3_parent_large1["txid"])["descendantcount"], 1)
+        self.generate(node, 1)
+
+        self.log.info("Test that a decreased limitancestorsize also applies to V3 parent")
+        self.restart_node(0, extra_args=["-limitancestorsize=10", "-datacarriersize=40000"])
+        tx_v3_parent_large2 = self.wallet.send_self_transfer(from_node=node, target_weight=99900, version=3)
+        tx_v3_child_large2 = self.wallet.create_self_transfer(utxo_to_spend=tx_v3_parent_large2["new_utxo"], version=3)
+        # Child is within V3 limits
+        assert_greater_than_or_equal(1000, tx_v3_child_large2["tx"].get_vsize())
+        assert_raises_rpc_error(-26, "too-long-mempool-chain", node.sendrawtransaction,
+                tx_v3_child_large2["hex"])
+        self.check_mempool([tx_v3_parent_large2["txid"]])
+
+    @cleanup
+    def test_fee_dependency_replacements(self):
+        """
+        Since v3 introduces the possibility of 0-fee (i.e. below min relay feerate) transactions in
+        the mempool, it's possible for these transactions' sponsors to disappear due to RBF. In
+        those situations, the 0-fee transaction must be evicted along with the replacements.
+        """
+        node = self.nodes[0]
+        self.log.info("Test that below-min-relay-feerate transactions are removed in RBF")
+        tx_0fee_parent = self.wallet.create_self_transfer(fee=0, fee_rate=0, version=3)
+        utxo_confirmed = self.wallet.get_utxo()
+        tx_child_replacee = self.wallet.create_self_transfer_multi(utxos_to_spend=[tx_0fee_parent["new_utxo"], utxo_confirmed], version=3)
+        node.submitpackage([tx_0fee_parent["hex"], tx_child_replacee["hex"]])
+        self.check_mempool([tx_0fee_parent["txid"], tx_child_replacee["txid"]])
+        tx_replacer = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=utxo_confirmed, fee_rate=DEFAULT_FEE * 10)
+        self.check_mempool([tx_replacer["txid"]])
+
+    def run_test(self):
+        self.log.info("Generate blocks to create UTXOs")
+        node = self.nodes[0]
+        self.wallet = MiniWallet(node)
+        self.generate(self.wallet, 110)
+        self.test_v3_acceptance()
+        self.test_v3_replacement()
+        self.test_v3_bip125()
+        self.test_v3_reorg()
+        self.test_nondefault_package_limits()
+        self.test_fee_dependency_replacements()
+
+
+if __name__ == "__main__":
+    MempoolAcceptV3().main()

--- a/test/functional/mempool_package_onemore.py
+++ b/test/functional/mempool_package_onemore.py
@@ -55,14 +55,20 @@ class MempoolPackagesTest(BitcoinTestFramework):
         assert_raises_rpc_error(-26, "too-long-mempool-chain, too many descendants", self.chain_tx, [chain[0], second_chain])
         # ...especially if its > 40k weight
         assert_raises_rpc_error(-26, "too-long-mempool-chain, too many descendants", self.chain_tx, [chain[0]], num_outputs=350)
+        # ...not if it's submitted with other transactions
+        replacable_tx = self.wallet.create_self_transfer_multi(utxos_to_spend=[chain[0]])
+        txns = [replacable_tx["hex"], self.wallet.create_self_transfer_multi(utxos_to_spend=replacable_tx["new_utxos"])["hex"]]
+        assert_equal(self.nodes[0].testmempoolaccept(txns)[0]["reject-reason"], "too-long-mempool-chain")
+        assert_raises_rpc_error(-26, "too-long-mempool-chain", self.nodes[0].submitpackage, txns)
         # But not if it chains directly off the first transaction
-        replacable_tx = self.wallet.send_self_transfer_multi(from_node=self.nodes[0], utxos_to_spend=[chain[0]])['tx']
+        self.nodes[0].sendrawtransaction(replacable_tx["hex"])
         # and the second chain should work just fine
         self.chain_tx([second_chain])
 
         # Make sure we can RBF the chain which used our carve-out rule
-        replacable_tx.vout[0].nValue -= 1000000
-        self.nodes[0].sendrawtransaction(replacable_tx.serialize().hex())
+        replacement_tx = replacable_tx["tx"]
+        replacement_tx.vout[0].nValue -= 1000000
+        self.nodes[0].sendrawtransaction(replacement_tx.serialize().hex())
 
         # Finally, check that we added two transactions
         assert_equal(len(self.nodes[0].getrawmempool()), DEFAULT_ANCESTOR_LIMIT + 3)

--- a/test/functional/mempool_package_rbf.py
+++ b/test/functional/mempool_package_rbf.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from decimal import Decimal
+
+from test_framework.messages import (
+    COIN,
+    MAX_BIP125_RBF_SEQUENCE,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_greater_than_or_equal,
+    assert_raises_rpc_error,
+)
+from test_framework.wallet import (
+    DEFAULT_FEE,
+    MiniWallet,
+)
+
+class PackageRBFTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def assert_mempool_contents(self, expected=None, unexpected=None):
+        """Assert that all transactions in expected are in the mempool,
+        and all transactions in unexpected are not in the mempool.
+        """
+        if not expected:
+            expected = []
+        if not unexpected:
+            unexpected = []
+        assert set(unexpected).isdisjoint(expected)
+        mempool = self.nodes[0].getrawmempool(verbose=False)
+        for tx in expected:
+            assert tx.rehash() in mempool
+        for tx in unexpected:
+            assert tx.rehash() not in mempool
+
+    def create_simple_package(self, parent_coin, parent_fee=0, child_fee=DEFAULT_FEE, heavy_child=False, version=3):
+        """Create a 1 parent 1 child package using the coin passed in as the parent's input. The
+        parent has 1 output, used to fund 1 child transaction.
+        All transactions signal BIP125 replaceability, but nSequence changes based on self.ctr. This
+        prevents identical txids between packages when the parents spend the same coin and have the
+        same fee (i.e. 0sat).
+
+        returns tuple (hex serialized txns, CTransaction objects)
+        """
+        self.ctr += 1
+        # Use fee_rate=0 because create_self_transfer will use the default fee_rate value otherwise.
+        # Passing in fee>0 overrides fee_rate, so this still works for non-zero parent_fee.
+        parent_result = self.wallet.create_self_transfer(
+            fee_rate=0,
+            fee=parent_fee,
+            utxo_to_spend=parent_coin,
+            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+            version=version
+        )
+
+        num_child_outputs = 10 if heavy_child else 1
+        child_result = self.wallet.create_self_transfer_multi(
+            utxos_to_spend=[parent_result["new_utxo"]],
+            num_outputs=num_child_outputs,
+            fee_per_output=int(child_fee * COIN // num_child_outputs),
+            sequence=MAX_BIP125_RBF_SEQUENCE - self.ctr,
+            version=version
+        )
+        package_hex = [parent_result["hex"], child_result["hex"]]
+        package_txns = [parent_result["tx"], child_result["tx"]]
+        return package_hex, package_txns
+
+    def run_test(self):
+        # Counter used to count the number of times we constructed packages. Since we're constructing parent transactions with the same
+        # coins (to create conflicts), and giving them the same fee (i.e. 0, since their respective children are paying), we might
+        # accidentally just create the exact same transaction again. To prevent this, set nSequences to MAX_BIP125_RBF_SEQUENCE - self.ctr.
+        self.ctr = 0
+
+        self.log.info("Generate blocks to create UTXOs")
+        node = self.nodes[0]
+        self.wallet = MiniWallet(node)
+        self.generate(self.wallet, 160)
+        self.coins = self.wallet.get_utxos(mark_as_spent=False)
+        # Mature coinbase transactions
+        self.generate(self.wallet, 100)
+        self.address = self.wallet.get_address()
+
+        self.test_package_rbf_basic()
+        self.test_package_rbf_signaling()
+        self.test_package_rbf_additional_fees()
+        self.test_package_rbf_max_conflicts()
+        self.test_package_rbf_conflicting_conflicts()
+        self.test_package_rbf_partial()
+
+    def test_package_rbf_basic(self):
+        self.log.info("Test that a child can pay to replace its parents' conflicts")
+        node = self.nodes[0]
+        # Reuse the same coins so that the transactions conflict with one another.
+        parent_coin = self.coins.pop()
+        package_hex1, package_txns1 = self.create_simple_package(parent_coin, DEFAULT_FEE, DEFAULT_FEE)
+        package_hex2, package_txns2 = self.create_simple_package(parent_coin, 0, DEFAULT_FEE * 5)
+        node.submitpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=package_txns2)
+
+        submitres = node.submitpackage(package_hex2)
+        submitres["replaced-transactions"] == [tx.rehash() for tx in package_txns1]
+        self.assert_mempool_contents(expected=package_txns2, unexpected=package_txns1)
+        self.generate(node, 1)
+
+    def test_package_rbf_signaling(self):
+        node = self.nodes[0]
+        self.log.info("Test that V3 transactions not signaling BIP125 are replaceable")
+        # Create single transaction that doesn't signal BIP125 but has nVersion=3
+        coin = self.coins.pop()
+
+        tx_v3_no_bip125 = self.wallet.create_self_transfer(
+            fee=DEFAULT_FEE,
+            utxo_to_spend=coin,
+            sequence=MAX_BIP125_RBF_SEQUENCE + 1,
+            version=3
+        )
+        node.sendrawtransaction(tx_v3_no_bip125["hex"])
+        self.assert_mempool_contents(expected=[tx_v3_no_bip125["tx"]])
+
+        self.log.info("Test that non-V3 transactions signaling BIP125 are replaceable")
+        coin = self.coins[0]
+        del self.coins[0]
+        # This transaction signals BIP125 but isn't V3
+        tx_bip125_v2 = self.wallet.create_self_transfer(
+            fee=DEFAULT_FEE,
+            utxo_to_spend=coin,
+            version=2
+        )
+        node.sendrawtransaction(tx_bip125_v2["hex"])
+
+        self.assert_mempool_contents(expected=[tx_bip125_v2["tx"]])
+        assert node.getmempoolentry(tx_bip125_v2["tx"].rehash())["bip125-replaceable"]
+        assert tx_bip125_v2["tx"].nVersion == 2
+        package_hex_v3, package_txns_v3 = self.create_simple_package(coin, parent_fee=0, child_fee=DEFAULT_FEE * 3, version=3)
+        assert all([tx.nVersion == 3 for tx in package_txns_v3])
+        node.submitpackage(package_hex_v3)
+        self.assert_mempool_contents(expected=package_txns_v3, unexpected=[tx_bip125_v2["tx"]])
+        self.generate(node, 1)
+
+    def test_package_rbf_additional_fees(self):
+        self.log.info("Check Package RBF must increase the absolute fee")
+        node = self.nodes[0]
+        coin = self.coins.pop()
+        package_hex1, package_txns1 = self.create_simple_package(coin, parent_fee=DEFAULT_FEE, child_fee=DEFAULT_FEE, heavy_child=True)
+        assert_greater_than_or_equal(1000, package_txns1[-1].get_vsize())
+        node.submitpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1)
+        # Package 2 has a higher feerate but lower absolute fee
+        package_fees1 = DEFAULT_FEE * 2
+        package_hex2, package_txns2 = self.create_simple_package(coin, parent_fee=0, child_fee=package_fees1 - Decimal("0.000000001"))
+        assert_raises_rpc_error(-25, "package RBF failed: insufficient fee", node.submitpackage, package_hex2)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=package_txns2)
+        # Package 3 has a higher feerate and absolute fee
+        package_hex3, package_txns3 = self.create_simple_package(coin, parent_fee=0, child_fee=package_fees1 * 3)
+        node.submitpackage(package_hex3)
+        self.assert_mempool_contents(expected=package_txns3, unexpected=package_txns1 + package_txns2)
+        self.generate(node, 1)
+
+        self.log.info("Check Package RBF must pay for the entire package's bandwidth")
+        coin = self.coins.pop()
+        package_hex1, package_txns1 = self.create_simple_package(coin, parent_fee=DEFAULT_FEE, child_fee=DEFAULT_FEE)
+        package_fees1 = 2 * DEFAULT_FEE
+        node.submitpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=[])
+        package_hex2, package_txns2 = self.create_simple_package(coin, child_fee=package_fees1 + Decimal("0.000000001"))
+        assert_raises_rpc_error(-25, "package RBF failed: insufficient fee", node.submitpackage, package_hex2)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=package_txns2)
+        self.generate(node, 1)
+
+    def test_package_rbf_max_conflicts(self):
+        node = self.nodes[0]
+        self.log.info("Check Package RBF cannot replace more than 100 transactions")
+        num_coins = 5
+        parent_coins = self.coins[:num_coins]
+        del self.coins[:num_coins]
+        # Original transactions: 5 transactions with 24 descendants each.
+        for coin in parent_coins:
+            self.wallet.send_self_transfer_chain(from_node=node, chain_length=25, utxo_to_spend=coin)
+
+        # Replacement package: 1 parent which conflicts with 5 * (1 + 24) = 125 mempool transactions.
+        package_parent = self.wallet.create_self_transfer_multi(utxos_to_spend=parent_coins, version=3)
+        package_child = self.wallet.create_self_transfer(fee_rate=50*DEFAULT_FEE, utxo_to_spend=package_parent["new_utxos"][0], version=3)
+
+        assert_raises_rpc_error(-25, "package RBF failed: too many potential replacements",
+                node.submitpackage, [package_parent["hex"], package_child["hex"]])
+        self.generate(node, 1)
+
+    def test_package_rbf_conflicting_conflicts(self):
+        node = self.nodes[0]
+        self.log.info("Check that different package transactions cannot share the same conflicts")
+        coin = self.coins.pop()
+        package_hex1, package_txns1 = self.create_simple_package(coin, DEFAULT_FEE, DEFAULT_FEE)
+        package_hex2, package_txns2 = self.create_simple_package(coin, Decimal("0.00009"), DEFAULT_FEE * 2)
+        package_hex3, package_txns3 = self.create_simple_package(coin, 0, DEFAULT_FEE * 5)
+        node.submitpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1)
+        # The first two transactions have the same conflicts
+        package_duplicate_conflicts_hex = [package_hex2[0]] + package_hex3
+        # Note that this won't actually go into the RBF logic, because static package checks will
+        # detect that two package transactions conflict with each other. Either way, this must fail.
+        assert_raises_rpc_error(-25, "package topology disallowed", node.submitpackage, package_duplicate_conflicts_hex)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=package_txns2 + package_txns3)
+        # The RBFs should otherwise work.
+        submitres2 = node.submitpackage(package_hex2)
+        submitres2["replaced-transactions"] == [tx.rehash() for tx in package_txns1]
+        self.assert_mempool_contents(expected=package_txns2, unexpected=package_txns1)
+        submitres3 = node.submitpackage(package_hex3)
+        submitres3["replaced-transactions"] == [tx.rehash() for tx in package_txns2]
+        self.assert_mempool_contents(expected=package_txns3, unexpected=package_txns2)
+
+    def test_package_rbf_partial(self):
+        self.log.info("Test that package RBF works when a transaction was already submitted")
+        node = self.nodes[0]
+        coin = self.coins.pop()
+        package_hex1, package_txns1 = self.create_simple_package(coin, DEFAULT_FEE, DEFAULT_FEE)
+        package_hex2, package_txns2 = self.create_simple_package(coin, DEFAULT_FEE * 3, DEFAULT_FEE * 3)
+        node.submitpackage(package_hex1)
+        self.assert_mempool_contents(expected=package_txns1, unexpected=package_txns2)
+        # Submit parent on its own. It should have no trouble replacing the previous
+        # transaction(s) because the fee is tripled.
+        node.sendrawtransaction(package_hex2[0])
+        node.submitpackage(package_hex2)
+        self.assert_mempool_contents(expected=package_txns2, unexpected=package_txns1)
+        self.generate(node, 1)
+
+if __name__ == "__main__":
+    PackageRBFTest().main()

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -290,7 +290,8 @@ class MiniWallet:
         sequence=0,
         fee_per_output=1000,
         target_weight=0,
-        confirmed_only=False
+        confirmed_only=False,
+        version=2
     ):
         """
         Create and return a transaction that spends the given UTXOs and creates a
@@ -314,6 +315,7 @@ class MiniWallet:
         tx.vin = [CTxIn(COutPoint(int(utxo_to_spend['txid'], 16), utxo_to_spend['vout']), nSequence=seq) for utxo_to_spend, seq in zip(utxos_to_spend, sequence)]
         tx.vout = [CTxOut(amount_per_output, bytearray(self._scriptPubKey)) for _ in range(num_outputs)]
         tx.nLockTime = locktime
+        tx.nVersion = version
 
         self.sign_tx(tx)
 
@@ -344,7 +346,8 @@ class MiniWallet:
             locktime=0,
             sequence=0,
             target_weight=0,
-            confirmed_only=False
+            confirmed_only=False,
+            version=2
     ):
         """Create and return a tx with the specified fee. If fee is 0, use fee_rate, where the resulting fee may be exact or at most one satoshi higher than needed."""
         utxo_to_spend = utxo_to_spend or self.get_utxo(confirmed_only=confirmed_only)
@@ -360,7 +363,14 @@ class MiniWallet:
         send_value = utxo_to_spend["value"] - (fee or (fee_rate * vsize / 1000))
 
         # create tx
-        tx = self.create_self_transfer_multi(utxos_to_spend=[utxo_to_spend], locktime=locktime, sequence=sequence, amount_per_output=int(COIN * send_value), target_weight=target_weight)
+        tx = self.create_self_transfer_multi(
+            utxos_to_spend=[utxo_to_spend],
+            locktime=locktime,
+            sequence=sequence,
+            amount_per_output=int(COIN * send_value),
+            target_weight=target_weight,
+            version=version
+        )
         if not target_weight:
             assert_equal(tx["tx"].get_vsize(), vsize)
         tx["new_utxo"] = tx.pop("new_utxos")[0]

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -274,6 +274,7 @@ BASE_SCRIPTS = [
     'mempool_packages.py',
     'mempool_package_onemore.py',
     'mempool_package_limits.py',
+    'mempool_package_rbf.py',
     'feature_versionbits_warning.py',
     'rpc_preciousblock.py',
     'wallet_importprunedfunds.py --legacy-wallet',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -258,6 +258,7 @@ BASE_SCRIPTS = [
     'p2p_invalid_tx.py --v2transport',
     'p2p_v2_transport.py',
     'example_test.py',
+    'mempool_accept_v3.py',
     'wallet_txn_doublespend.py --legacy-wallet',
     'wallet_multisig_descriptor_psbt.py --descriptors',
     'wallet_txn_doublespend.py --descriptors',


### PR DESCRIPTION
**Note: this PR was superseded by #28948 (v3) and #28984 (package RBF). Also, v3 became TRUC and includes other changes, see BIP 431 for more up-to-date documentation.**

See #27463 for overall package relay tracking.

This PR contains 2 projects: v3 policy and package RBF. Mailing list posts: [package RBF 1](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2021-September/019464.html) and [V3 + package RBF 2](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-September/020937.html). It stems from a long discussion about RBF pinning, across a [mailing list thread](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-January/019817.html) and [gist](https://gist.github.com/glozow/25d9662c52453bd08b4b4b1d3783b9ff).

V3 Policy: A set of policy rules applied to transactions with their `nVersion` field set to 3. Namely, it allows users to opt in to more restrictive descendant limits for shared transactions. If adopted by many nodes in the network, V3 mitigates various RBF pinning attacks. See doc/policy/version3_transactions.md for the exact rules and rationale, and [these review club notes](bitcoincore.reviews/25038) for more background and discussion.

Package RBF: In addition to allowing a child to pay for its parents within the package, also allow the child to pay for replacing the parent's conflicts. For example, this allows LN users to replace commitment transactions existing in the mempool, simply by broadcasting their respective commitment transactions with a high-fee child. The commitment transactions can be signed with 0 fees, which means no overpaying.

FAQ: is v3 still helpful even with cluster mempool (#27677) ?

- Rule 3 pinning: This is addressed with v3 but not really with cluster mempool (descendant allowance is still too permissive).
- Package RBF and ACP pinning: This PR allows for package RBF with v3 packages. V3 has an effective "cluster limit" of 2 which makes it very cheap to calculate the mining score of a v3 transaction. With cluster mempool, which also makes it easier to calculate mining score, we could have package RBF for non-v3 transactions.
- Allowing 0fee transactions: This PR allows v3 transactions to be below minimum relay feerate, provided they are CPFP'd. This is because the simplified topology allows us to avoid situations like the ones described in #26933. With cluster mempool, we can allow this for non-v3 transactions.