### PR TITLE
lint: Fix lint-circular-dependencies.py file list

### DIFF
--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -6,7 +6,6 @@
 #
 # Check for circular dependencies
 
-import glob
 import os
 import re
 import subprocess
@@ -32,17 +31,14 @@ CODE_DIR = "src"
 def main():
     circular_dependencies = []
     exit_code = 0
-    os.chdir(
-        CODE_DIR
-    )  # We change dir before globbing since glob.glob's root_dir option is only available in Python 3.10
 
-    # Using glob.glob since subprocess.run's globbing won't work without shell=True
-    files = []
-    for path in ["*", "*/*", "*/*/*"]:
-        for extension in ["h", "cpp"]:
-            files.extend(glob.glob(f"{path}.{extension}"))
+    os.chdir(CODE_DIR)
+    files = subprocess.check_output(
+        ['git', 'ls-files', '--', '*.h', '*.cpp'],
+        universal_newlines=True,
+    ).splitlines()
 
-    command = ["python3", "../contrib/devtools/circular-dependencies.py", *files]
+    command = [sys.executable, "../contrib/devtools/circular-dependencies.py", *files]
     dependencies_output = subprocess.run(
         command,
         stdout=subprocess.PIPE,

--- a/test/lint/lint-format-strings.py
+++ b/test/lint/lint-format-strings.py
@@ -36,7 +36,7 @@ RUN_LINT_FILE = 'test/lint/run-lint-format-strings.py'
 
 def check_doctest():
     command = [
-        'python3',
+        sys.executable,
         '-m',
         'doctest',
         RUN_LINT_FILE,


### PR DESCRIPTION
currently in-tree files like `wallet/test/fuzz/coinselection.cpp` are missed. Also out-of-tree files like `test/data/bip341_wallet_vectors.json.h` or `qt/moc_qvaluecombobox.cpp` are included.

Change the script to only use in-tree files.

Also, change `'python3'` to `sys.executable`.