### PR TITLE
Reject invalid rpcauth formats

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -4,7 +4,6 @@
 
 #include <httprpc.h>
 
-#include <chainparams.h>
 #include <crypto/hmac_sha256.h>
 #include <httpserver.h>
 #include <rpc/protocol.h>
@@ -12,16 +11,15 @@
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/system.h>
-#include <util/translation.h>
 #include <walletinitinterface.h>
 
 #include <algorithm>
 #include <iterator>
 #include <map>
 #include <memory>
-#include <stdio.h>
 #include <set>
 #include <string>
+#include <vector>
 
 #include <boost/algorithm/string.hpp>
 
@@ -254,13 +252,14 @@ static bool InitRPCAuthentication()
         LogPrintf("Config options rpcuser and rpcpassword will soon be deprecated. Locally-run instances may remove rpcuser to use cookie-based auth, or may be replaced with rpcauth. Please see share/rpcauth for rpcauth auth generation.\n");
         strRPCUserColonPass = gArgs.GetArg("-rpcuser", "") + ":" + gArgs.GetArg("-rpcpassword", "");
     }
-    if (gArgs.GetArg("-rpcauth","") != "")
-    {
+    if (gArgs.GetArg("-rpcauth", "") != "") {
         LogPrintf("Using rpcauth authentication.\n");
         for (const std::string& rpcauth : gArgs.GetArgs("-rpcauth")) {
-            std::vector<std::string> fields;
-            boost::split(fields, rpcauth, boost::is_any_of(":$"));
-            if (fields.size() == 3) {
+            std::vector<std::string> fields{SplitString(rpcauth, ':')};
+            const std::vector<std::string> salt_hmac{SplitString(fields.back(), '$')};
+            if (fields.size() == 2 && salt_hmac.size() == 2) {
+                fields.pop_back();
+                fields.insert(fields.end(), salt_hmac.begin(), salt_hmac.end());
                 g_rpcauth.push_back(fields);
             } else {
                 LogPrintf("Invalid -rpcauth argument.\n");

--- a/test/functional/rpc_users.py
+++ b/test/functional/rpc_users.py
@@ -107,6 +107,9 @@ class HTTPBasicsTest(BitcoinTestFramework):
         self.stop_node(0)
         self.nodes[0].assert_start_raises_init_error(expected_msg=init_error, extra_args=['-rpcauth=foo'])
         self.nodes[0].assert_start_raises_init_error(expected_msg=init_error, extra_args=['-rpcauth=foo:bar'])
+        self.nodes[0].assert_start_raises_init_error(expected_msg=init_error, extra_args=['-rpcauth=foo:bar:baz'])
+        self.nodes[0].assert_start_raises_init_error(expected_msg=init_error, extra_args=['-rpcauth=foo$bar:baz'])
+        self.nodes[0].assert_start_raises_init_error(expected_msg=init_error, extra_args=['-rpcauth=foo$bar$baz'])
 
         self.log.info('Check that failure to write cookie file will abort the node gracefully')
         cookie_file = os.path.join(get_datadir_path(self.options.tmpdir, 0), self.chain, '.cookie.tmp')


### PR DESCRIPTION
This was added in commit 438ee59839ad49bf629452279478462c987b7137, but I couldn't determine if it was intentional.

One reason to accept `foo:bar:baz` over `foo:bar$baz` is that `$` may be eaten by the shell. Though, I don't think many users pass `rpcauth` via the shell. Also it should be easy to avoid by passing `'-rpcauth=foo:bar$baz'` or `"-rpcauth=foo:bar\$baz"`.

Can be tested with the added test.