### PR TITLE
build: Fix `libmultiprocess` cross-compiling to Linux hosts

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -175,7 +175,7 @@ $(1)_cmake=env CC="$$($(1)_cc)" \
                CXX="$$($(1)_cxx)" \
                CXXFLAGS="$$($(1)_cppflags) $$($(1)_cxxflags)" \
                LDFLAGS="$$($(1)_ldflags)" \
-             cmake -DCMAKE_INSTALL_PREFIX:PATH="$$($($(1)_type)_prefix)"
+             cmake -DCMAKE_INSTALL_PREFIX:PATH="$$($($(1)_type)_prefix)" $$($(1)_cmake_opts)
 ifeq ($($(1)_type),build)
 $(1)_cmake += -DCMAKE_INSTALL_RPATH:PATH="$$($($(1)_type)_prefix)/lib"
 else

--- a/depends/packages/libmultiprocess.mk
+++ b/depends/packages/libmultiprocess.mk
@@ -4,6 +4,16 @@ $(package)_download_path=$(native_$(package)_download_path)
 $(package)_file_name=$(native_$(package)_file_name)
 $(package)_sha256_hash=$(native_$(package)_sha256_hash)
 $(package)_dependencies=native_$(package) capnp
+ifneq ($(host),$(build))
+$(package)_dependencies += native_capnp
+endif
+
+define $(package)_set_vars :=
+ifneq ($(host),$(build))
+$(package)_cmake_opts := -DCAPNP_EXECUTABLE="$$(native_capnp_prefixbin)/capnp"
+$(package)_cmake_opts += -DCAPNPC_CXX_EXECUTABLE="$$(native_capnp_prefixbin)/capnpc-c++"
+endif
+endef
 
 define $(package)_config_cmds
   $($(package)_cmake) .


### PR DESCRIPTION
To successfully call the [`capnp_generate_cpp()`](https://github.com/chaincodelabs/libmultiprocess/blob/d576d975debdc9090bd2582f83f49c76c0061698/CMakeLists.txt#L45) function, the `libmultiprocess` build system must be provided with paths to the native `capnp` and `capnpc-c++` tools.

This [comment](https://github.com/bitcoin/bitcoin/issues/24387#issuecomment-1054776195) points the same:
> I think `packages/libmultiprocess.mk` probably needs to be passing a `-DCAPNP_EXECUTABLE=.../depends/arm-linux-gnueabihf/native/bin/capnp` argument to cmake. Also the package should have dependencies on both `capnp` and `native_capnp`.

Fixes bitcoin/bitcoin#24387.