### PR TITLE
CValidationInterface: ValidationInterfaceUnregistering, called when being unregistered

### DIFF
--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -139,6 +139,8 @@ void UnregisterSharedValidationInterface(std::shared_ptr<CValidationInterface> c
 
 void UnregisterValidationInterface(CValidationInterface* callbacks)
 {
+    callbacks->ValidationInterfaceUnregistering();
+
     if (g_signals.m_internals) {
         g_signals.m_internals->Unregister(callbacks);
     }
@@ -149,6 +151,9 @@ void UnregisterAllValidationInterfaces()
     if (!g_signals.m_internals) {
         return;
     }
+
+    g_signals.m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.ValidationInterfaceUnregistering(); });
+
     g_signals.m_internals->Clear();
 }
 

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -173,6 +173,13 @@ protected:
      * Notifies listeners that a block which builds directly on our current tip
      * has been received and connected to the headers tree, though not validated yet */
     virtual void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& block) {};
+    /**
+     * Notifies the validation interface that it is being unregistered
+     */
+    virtual void ValidationInterfaceUnregistering() {};
+
+    friend void UnregisterValidationInterface(CValidationInterface*);
+    friend void UnregisterAllValidationInterfaces();
     friend class CMainSignals;
 };
 


### PR DESCRIPTION
Part of https://github.com/bitcoin-core/gui/pull/444 (GUI Network Watch tool)