### PR TITLE
Bugfix: configure: Define defaults for enable_arm_{crc,shani}

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -466,6 +466,8 @@ fi
 dnl Don't allow extended (non-ASCII) symbols in identifiers. This is easier for code review.
 AX_CHECK_COMPILE_FLAG([-fno-extended-identifiers], [CXXFLAGS="$CXXFLAGS -fno-extended-identifiers"], [], [$CXXFLAG_WERROR])
 
+enable_arm_crc=no
+enable_arm_shani=no
 enable_sse42=no
 enable_sse41=no
 enable_avx2=no


### PR DESCRIPTION
Fix for #17398 and #24115

Trivial, mostly for consistency (you'd have to *try* to break this)