### PR TITLE
Guard `#include <config/bitcoin-config.h>`

### DIFF
--- a/src/shutdown.cpp
+++ b/src/shutdown.cpp
@@ -5,12 +5,14 @@
 
 #include <shutdown.h>
 
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
 #include <logging.h>
 #include <node/ui_interface.h>
 #include <util/tokenpipe.h>
 #include <warnings.h>
-
-#include <config/bitcoin-config.h>
 
 #include <assert.h>
 #include <atomic>

--- a/src/util/tokenpipe.cpp
+++ b/src/util/tokenpipe.cpp
@@ -3,7 +3,9 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include <util/tokenpipe.h>
 
+#if defined(HAVE_CONFIG_H)
 #include <config/bitcoin-config.h>
+#endif
 
 #ifndef WIN32
 


### PR DESCRIPTION
A fix for builds when the `HAVE_CONFIG_H` macro is not defined.