### PR TITLE
validationinterface: make MainSignalsInstance() a class, drop unused forward declarations

### DIFF
--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -17,14 +17,14 @@
 #include <utility>
 
 /**
- * MainSignalsInstance manages a list of shared_ptr<CValidationInterface> callbacks.
+ * MainSignalsImpl manages a list of shared_ptr<CValidationInterface> callbacks.
  *
  * A std::unordered_map is used to track what callbacks are currently
  * registered, and a std::list is used to store the callbacks that are
  * currently registered as well as any callbacks that are just unregistered
  * and about to be deleted when they are done executing.
  */
-class MainSignalsInstance
+class MainSignalsImpl
 {
 private:
     Mutex m_mutex;
@@ -42,7 +42,7 @@ public:
     // our own queue here :(
     SingleThreadedSchedulerClient m_schedulerClient;
 
-    explicit MainSignalsInstance(CScheduler& scheduler LIFETIMEBOUND) : m_schedulerClient(scheduler) {}
+    explicit MainSignalsImpl(CScheduler& scheduler LIFETIMEBOUND) : m_schedulerClient(scheduler) {}
 
     void Register(std::shared_ptr<CValidationInterface> callbacks)
     {
@@ -94,7 +94,7 @@ static CMainSignals g_signals;
 void CMainSignals::RegisterBackgroundSignalScheduler(CScheduler& scheduler)
 {
     assert(!m_internals);
-    m_internals = std::make_unique<MainSignalsInstance>(scheduler);
+    m_internals = std::make_unique<MainSignalsImpl>(scheduler);
 }
 
 void CMainSignals::UnregisterBackgroundSignalScheduler()

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -16,14 +16,16 @@
 #include <unordered_map>
 #include <utility>
 
-//! The MainSignalsInstance manages a list of shared_ptr<CValidationInterface>
-//! callbacks.
-//!
-//! A std::unordered_map is used to track what callbacks are currently
-//! registered, and a std::list is to used to store the callbacks that are
-//! currently registered as well as any callbacks that are just unregistered
-//! and about to be deleted when they are done executing.
-struct MainSignalsInstance {
+/**
+ * MainSignalsInstance manages a list of shared_ptr<CValidationInterface> callbacks.
+ *
+ * A std::unordered_map is used to track what callbacks are currently
+ * registered, and a std::list is used to store the callbacks that are
+ * currently registered as well as any callbacks that are just unregistered
+ * and about to be deleted when they are done executing.
+ */
+class MainSignalsInstance
+{
 private:
     Mutex m_mutex;
     //! List entries consist of a callback pointer and reference count. The

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -175,10 +175,10 @@ protected:
     friend class ValidationInterfaceTest;
 };
 
-class MainSignalsInstance;
+class MainSignalsImpl;
 class CMainSignals {
 private:
-    std::unique_ptr<MainSignalsInstance> m_internals;
+    std::unique_ptr<MainSignalsImpl> m_internals;
 
     friend void ::RegisterSharedValidationInterface(std::shared_ptr<CValidationInterface>);
     friend void ::UnregisterValidationInterface(CValidationInterface*);

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -177,7 +177,7 @@ protected:
     friend class ValidationInterfaceTest;
 };
 
-struct MainSignalsInstance;
+class MainSignalsInstance;
 class CMainSignals {
 private:
     std::unique_ptr<MainSignalsInstance> m_internals;

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -17,9 +17,7 @@ class BlockValidationState;
 class CBlock;
 class CBlockIndex;
 struct CBlockLocator;
-class CConnman;
 class CValidationInterface;
-class uint256;
 class CScheduler;
 enum class MemPoolRemovalReason;
 


### PR DESCRIPTION
Make MainSignalsInstance a class, rename it to MainSignalsImpl, use Doxygen documentation for it, and remove no longer used forward declarations in src/validationinterface.h.

----
    
MainSignalsInstance was created in 3a19fed9db5 and originally was a collection of boost::signals methods moved to validationinterface.cpp, in order to no longer need to include boost/signals in validationinterface.h.

MainSignalsInstance then evolved in d6815a23131 to become class-like:
    
- [C.8: Use class rather than struct if any member is non-public](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-class)
    
 - [C.2: Use class if the class has an invariant; use struct if the data members can vary independently](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c2-use-class-if-the-class-has-an-invariant-use-struct-if-the-data-members-can-vary-independently)
   
- A class has the advantage of default private access, as opposed to public for a struct.
