### PR TITLE
tracing: lock contention analysis

### DIFF
--- a/contrib/tracing/lock_contention_analysis.bt
+++ b/contrib/tracing/lock_contention_analysis.bt
@@ -1,0 +1,117 @@
+#!/usr/bin/env bpftrace
+
+/*
+
+  USAGE:
+
+  bpftrace contrib/tracing/lock_contention_analysis.bt
+
+  This script requires a 'bitcoind' binary compiled with eBPF support and the
+  'sync' tracepoints. By default, it's assumed that 'bitcoind' is
+  located in './src/bitcoind'. This can be modified in the script below.
+
+  configure @min_blocked_duration_ns in the BEGIN section
+
+  NOTE: requires bpftrace v0.12.0 or above.
+*/
+
+BEGIN
+{
+    @min_blocked_duration_ns = (uint64)100000;
+
+    @start_ns = nsecs;
+    printf("minimum blocked duration: %lldµs\n\n", @min_blocked_duration_ns / (uint64)1000);
+    printf("timestamp       | Lock                                  | waiting duration  | waiting at                     | blocked by\n");
+    printf("---------------:|:--------------------------------------|------------------:|:-------------------------------|:------------------------------\n");
+}
+
+END
+{
+    printf("\n\nMonitored from %s to %s. top 50 lock contention locations (file, lineNo): µs\n",
+        strftime("%H:%M:%S.%f", @start_ns),
+        strftime("%H:%M:%S.%f", nsecs));
+    print(@locked_at_source_line, 50, 1000);
+
+    clear(@last_to_unlock);
+    clear(@locking_start);
+    clear(@start_ns);
+    clear(@min_blocked_duration_ns);
+    clear(@locked_at_source_line);
+}
+
+
+/* mutex creation
+   Register an entry in @last_to_unlock[$mutexAddr].
+*/
+usdt:./src/bitcoind:sync:mutex_ctor
+{
+    $mutexAddr = uptr(arg0);
+    @last_to_unlock[$mutexAddr] = (0, 0);
+}
+
+
+/* mutex destructor
+   Unregister the mutex (cleans up the map)
+*/
+usdt:./src/bitcoind:sync:mutex_dtor
+{
+    $mutexAddr = uptr(arg0);
+    delete(@last_to_unlock[$mutexAddr]);
+}
+
+
+/* Start of lock
+   remember timestamp when we try to acquire the lock
+*/
+usdt:./src/bitcoind:sync:enter
+{
+    $mutexAddr = uptr(arg0);
+    @locking_start[tid] = nsecs;
+}
+
+
+/* Lock acquired
+   Check how long it took between sync:enter until the lock was actually acquired
+   Log lock contention information when we waited long enough
+*/
+usdt:./src/bitcoind:sync:locked
+{
+    $duration_ns = nsecs - @locking_start[tid];
+    delete(@locking_start[tid]);
+
+    /* Only show when we've been waiting for quite some time */
+    if ($duration_ns > @min_blocked_duration_ns) {
+        $mutexAddr = uptr(arg0);
+        $pszName = str(arg1);
+        $pszFile = str(arg2);
+        $nLine = (int32)arg3;
+        $lastLocker = @last_to_unlock[$mutexAddr];
+
+        printf("%s | %-38s| %15lldµs | %-24s(%4d) | %-24s(%4d)\n",
+            strftime("%H:%M:%S.%f", nsecs),
+            $pszName,
+            $duration_ns / (uint64)1000,
+            $pszFile,
+            $nLine,
+            str($lastLocker.0),
+            $lastLocker.1);
+
+    }
+
+    /* clear mutex map, we don't want any old information */
+    @last_to_unlock[$mutexAddr] = (0, 0);
+    @locked_at_source_line[str(arg2), arg3] += $duration_ns
+}
+
+
+/* Unlocked:
+   Remember who unlocked the mutex, so the next who locks can print the lock contention time
+*/
+usdt:./src/bitcoind:sync:unlock
+{
+    $mutexAddr = uptr(arg0);
+    $pszFile = str(arg1);
+    $nLine = (int32)arg2;
+
+    @last_to_unlock[$mutexAddr] = (arg1, arg2);
+}

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -327,12 +327,16 @@ bool g_debug_lockorder_abort = true;
 #endif /* DEBUG_LOCKORDER */
 
 template <typename PARENT>
-AnnotatedMixin<PARENT>::AnnotatedMixin() = default;
+AnnotatedMixin<PARENT>::AnnotatedMixin()
+{
+    TRACE1(sync, mutex_ctor, this);
+}
 
 template <typename PARENT>
 AnnotatedMixin<PARENT>::~AnnotatedMixin()
 {
     DeleteLock((void*)this);
+    TRACE1(sync, mutex_dtor, this);
 }
 
 template <typename PARENT>

--- a/src/sync.h
+++ b/src/sync.h
@@ -135,9 +135,13 @@ typedef AnnotatedMixin<std::mutex> Mutex;
 template <typename Mutex, typename Base = typename Mutex::UniqueLock>
 class SCOPED_LOCKABLE UniqueLock : public Base
 {
+    const char* m_pszName;
+    const char* m_pszFile;
+    int m_nLine;
+
 private:
-    void Enter(const char* pszName, const char* pszFile, int nLine);
-    bool TryEnter(const char* pszName, const char* pszFile, int nLine);
+    void Enter();
+    bool TryEnter();
 
 public:
     UniqueLock(Mutex& mutexIn, const char* pszName, const char* pszFile, int nLine, bool fTry = false) EXCLUSIVE_LOCK_FUNCTION(mutexIn);

--- a/src/sync.h
+++ b/src/sync.h
@@ -94,31 +94,19 @@ template <typename PARENT>
 class LOCKABLE AnnotatedMixin : public PARENT
 {
 public:
-    ~AnnotatedMixin() {
-        DeleteLock((void*)this);
-    }
+    AnnotatedMixin();
+    ~AnnotatedMixin();
 
-    void lock() EXCLUSIVE_LOCK_FUNCTION()
-    {
-        PARENT::lock();
-    }
-
-    void unlock() UNLOCK_FUNCTION()
-    {
-        PARENT::unlock();
-    }
-
-    bool try_lock() EXCLUSIVE_TRYLOCK_FUNCTION(true)
-    {
-        return PARENT::try_lock();
-    }
+    void lock() EXCLUSIVE_LOCK_FUNCTION();
+    void unlock() UNLOCK_FUNCTION();
+    bool try_lock() EXCLUSIVE_TRYLOCK_FUNCTION(true);
 
     using UniqueLock = std::unique_lock<PARENT>;
 #ifdef __clang__
     //! For negative capabilities in the Clang Thread Safety Analysis.
     //! A negative requirement uses the EXCLUSIVE_LOCKS_REQUIRED attribute, in conjunction
     //! with the ! operator, to indicate that a mutex should not be held.
-    const AnnotatedMixin& operator!() const { return *this; }
+    const AnnotatedMixin& operator!() const;
 #endif // __clang__
 };
 


### PR DESCRIPTION
Currently there is a macro `DEBUG_LOCKCONTENTION` (see `developer-notes.md`) to enable logging of contention. The disadvantage of this method is that `bitcoind` needs to be especially compiled with that enabled, and when enabled this quickly produces huge log files, and has a relatively large overhead. 

This PR introduces some tracepoints and adds a tracing script `lock_contention_analysis.bt` that can be started at any time while `bitcoind` is running. This has low overhead and gives better analysis possibilities.

When the script is attached with `sudo bpftrace contrib/tracing/lock_contention_analysis.bt`, you'll get a markdown formatted output that looks like this:

timestamp       | Lock                                  | waiting duration  | waiting at                     | blocked by
---------------:|:--------------------------------------|------------------:|:-------------------------------|:------------------------------
12:41:05.512089 | m_mutex                               |            4491µs | ./checkqueue.h          ( 175) | ./checkqueue.h          (  78)
12:41:05.861322 | cs_main                               |          535058µs | net_processing.cpp      (1607) | validation.cpp          (2994)
12:41:06.655427 | m_mutex                               |            4012µs | ./checkqueue.h          (  78) | ./checkqueue.h          (  78)
12:41:06.675967 | cs_main                               |          650117µs | net_processing.cpp      (1607) | validation.cpp          (2994)
12:41:06.894090 | m_mutex                               |            2747µs | ./checkqueue.h          (  78) | ./checkqueue.h          (  78)
12:41:06.961872 | cs_main                               |          142277µs | net_processing.cpp      (1607) | validation.cpp          (2994)
12:41:07.363535 | cs_main                               |          395851µs | net_processing.cpp      (1607) | validation.cpp          (2994)
12:41:07.583226 | cs_main                               |           69281µs | net_processing.cpp      (1607) | validation.cpp          (2994)
12:41:07.746665 | cs_main                               |          157604µs | net_processing.cpp      (1607) | validation.cpp          (2335)
12:41:07.958787 | m_mutex                               |            3041µs | ./checkqueue.h          ( 175) | ./checkqueue.h          (  78)
12:41:07.958801 | m_mutex                               |            2970µs | ./checkqueue.h          (  78) | ./checkqueue.h          ( 175)
12:41:07.958842 | m_mutex                               |            2956µs | ./checkqueue.h          (  78) | ./checkqueue.h          ( 175)
12:41:07.958853 | m_mutex                               |            2898µs | ./checkqueue.h          (  78) | ./checkqueue.h          (  78)
12:41:07.958862 | m_mutex                               |            2820µs | ./checkqueue.h          (  78) | ./checkqueue.h          (  78)
12:41:07.959201 | m_mutex                               |            3028µs | ./checkqueue.h          (  78) | ./checkqueue.h          (  78)
12:41:07.959218 | m_mutex                               |            2916µs | ./checkqueue.h          (  78) | ./checkqueue.h          (  78)

When monitoring is stopped (press Ctrl+C), the script prints the source locations where it has waited the longest while the script was running (unfortunately there seems to be no way to format this more nicely):

```
Monitored from 17:12:18.513400 to 17:42:08.565786. top 50 lock contention locations (file, lineNo): µs
[...]
@locked_at_source_line[./net.h, 1233]: 334654
@locked_at_source_line[txmempool.cpp, 823]: 401472
@locked_at_source_line[net_processing.cpp, 4504]: 661670
@locked_at_source_line[net_processing.cpp, 4872]: 668911
@locked_at_source_line[txmempool.cpp, 1096]: 681892
@locked_at_source_line[net_processing.cpp, 4857]: 825963
@locked_at_source_line[net_processing.cpp, 4724]: 826719
@locked_at_source_line[net_processing.cpp, 4677]: 827335
@locked_at_source_line[net_processing.cpp, 4154]: 827972
@locked_at_source_line[net_processing.cpp, 4222]: 828863
@locked_at_source_line[net.cpp, 2329]: 831334
@locked_at_source_line[net_processing.cpp, 4217]: 831451
@locked_at_source_line[net_processing.cpp, 4231]: 839408
@locked_at_source_line[net_processing.cpp, 4198]: 846353
@locked_at_source_line[util/system.cpp, 1035]: 883117
@locked_at_source_line[net.cpp, 1426]: 1398949
@locked_at_source_line[net.cpp, 1422]: 1416004
@locked_at_source_line[net.cpp, 1611]: 1564984
@locked_at_source_line[net_processing.cpp, 4205]: 1668173
@locked_at_source_line[net_processing.cpp, 1334]: 1704239
@locked_at_source_line[validation.cpp, 5173]: 2899013
```

For this to work I had to add traces to `UniqueLock` and `AnnotatedMixin`, and move the implementation into the cpp file (without moving, due to inlining the maximum number of traces of 512 is quickly exhausted)