### PR TITLE
doc: Explain Bitcoin Core instead of Bitcoin in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,14 @@ https://bitcoincore.org
 For an immediately usable, binary version of the Bitcoin Core software, see
 https://bitcoincore.org/en/download/.
 
+What is Bitcoin Core?
+---------------------
+
+Bitcoin Core connects to the Bitcoin peer-to-peer network to download and fully
+validate blocks and transactions. It also includes a wallet and graphical user
+interface, which can be optionally built.
+
 Further information about Bitcoin Core is available in the [doc folder](/doc).
-
-What is Bitcoin?
-----------------
-
-Bitcoin is an experimental digital currency that enables instant payments to
-anyone, anywhere in the world. Bitcoin uses peer-to-peer technology to operate
-with no central authority: managing transactions and issuing money are carried
-out collectively by the network. Bitcoin Core is the name of open source
-software which enables the use of this currency.
-
-For more information read the original Bitcoin whitepaper.
 
 License
 -------


### PR DESCRIPTION
Currently the README doesn't explain what Bitcoin Core is. Fix that.

Further reading / Inspired by:

* https://github.com/bitcoin/bitcoin/pull/25012 
* https://github.com/bitcoin-core/bitcoincore.org/pull/783
* https://github.com/bitcoin-core/bitcoincore.org/pull/784