### PR TITLE
doc: Fix incorrect sendmany RPC doc

### DIFF
--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -314,12 +314,11 @@ RPCHelpMan sendtoaddress()
 RPCHelpMan sendmany()
 {
     return RPCHelpMan{"sendmany",
-                "\nSend multiple times. Amounts are double-precision floating point numbers." +
+        "Send multiple times. Amounts are double-precision floating point numbers." +
         HELP_REQUIRING_PASSPHRASE,
                 {
-                    {"dummy", RPCArg::Type::STR, RPCArg::Optional::NO, "Must be set to \"\" for backwards compatibility.",
+                    {"dummy", RPCArg::Type::STR, RPCArg::Default{"\"\""}, "Must be set to \"\" for backwards compatibility.",
                      RPCArgOptions{
-                         .skip_type_check = true,
                          .oneline_description = "\"\"",
                      }},
                     {"amounts", RPCArg::Type::OBJ_USER_KEYS, RPCArg::Optional::NO, "The addresses and amounts",

--- a/test/functional/rpc_invalid_address_message.py
+++ b/test/functional/rpc_invalid_address_message.py
@@ -95,15 +95,19 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
         self.check_invalid(INVALID_ADDRESS, 'Not a valid Bech32 or Base58 encoding')
         self.check_invalid(INVALID_ADDRESS_2, 'Not a valid Bech32 or Base58 encoding')
 
+        node = self.nodes[0]
+
+        # Missing arg returns the help text
+        assert_raises_rpc_error(-1, "Return information about the given bitcoin address.", node.validateaddress)
+        # Explicit None is not allowed for required parameters
+        assert_raises_rpc_error(-3, "JSON value of type null is not of expected type string", node.validateaddress, None)
+
     def test_getaddressinfo(self):
         node = self.nodes[0]
 
         assert_raises_rpc_error(-5, "Invalid Bech32 address data size", node.getaddressinfo, BECH32_INVALID_SIZE)
-
         assert_raises_rpc_error(-5, "Not a valid Bech32 or Base58 encoding", node.getaddressinfo, BECH32_INVALID_PREFIX)
-
         assert_raises_rpc_error(-5, "Invalid prefix for Base58-encoded address", node.getaddressinfo, BASE58_INVALID_PREFIX)
-
         assert_raises_rpc_error(-5, "Not a valid Bech32 or Base58 encoding", node.getaddressinfo, INVALID_ADDRESS)
 
     def run_test(self):


### PR DESCRIPTION
This enables the skipped type check for `sendmany` and fixes the resulting error.

Also, there is an unrelated test-only commit.