### PR TITLE
test: Unit tests for taproot/tapscript coverage in `interpreter.cpp`

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -126,6 +126,7 @@ BITCOIN_TESTS =\
   test/script_parse_tests.cpp \
   test/script_segwit_tests.cpp \
   test/script_standard_tests.cpp \
+  test/script_tapscript_tests.cpp \
   test/script_tests.cpp \
   test/scriptnum10.h \
   test/scriptnum_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -139,6 +139,7 @@ BITCOIN_TESTS =\
   test/streams_tests.cpp \
   test/sync_tests.cpp \
   test/system_tests.cpp \
+  test/test_util_tests.cpp \
   test/timedata_tests.cpp \
   test/torcontrol_tests.cpp \
   test/transaction_tests.cpp \

--- a/src/Makefile.test_util.include
+++ b/src/Makefile.test_util.include
@@ -9,15 +9,19 @@ EXTRA_LIBRARIES += \
 
 TEST_UTIL_H = \
     test/util/blockfilter.h \
+    test/util/boost_test_boosts.h \
     test/util/chainstate.h \
     test/util/logging.h \
     test/util/mining.h \
     test/util/net.h \
+    test/util/pretty_data.h \
     test/util/script.h \
     test/util/setup_common.h \
     test/util/str.h \
+    test/util/traits.h \
     test/util/transaction_utils.h \
     test/util/validation.h \
+    test/util/vector.h \
     test/util/wallet.h
 
 libtest_util_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(MINIUPNPC_CPPFLAGS) $(NATPMP_CPPFLAGS) $(EVENT_CFLAGS) $(EVENT_PTHREADS_CFLAGS)
@@ -27,6 +31,7 @@ libtest_util_a_SOURCES = \
   test/util/logging.cpp \
   test/util/mining.cpp \
   test/util/net.cpp \
+  test/util/pretty_data.cpp \
   test/util/script.cpp \
   test/util/setup_common.cpp \
   test/util/str.cpp \

--- a/src/test/fuzz/script_assets_test_minimizer.cpp
+++ b/src/test/fuzz/script_assets_test_minimizer.cpp
@@ -9,6 +9,7 @@
 #include <script/interpreter.h>
 #include <serialize.h>
 #include <streams.h>
+#include <test/util/pretty_data.h>
 #include <univalue.h>
 #include <util/strencodings.h>
 #include <util/string.h>
@@ -88,16 +89,6 @@ CScriptWitness ScriptWitnessFromJSON(const UniValue& univalue)
     return scriptwitness;
 }
 
-const std::map<std::string, unsigned int> FLAG_NAMES = {
-    {std::string("P2SH"), (unsigned int)SCRIPT_VERIFY_P2SH},
-    {std::string("DERSIG"), (unsigned int)SCRIPT_VERIFY_DERSIG},
-    {std::string("NULLDUMMY"), (unsigned int)SCRIPT_VERIFY_NULLDUMMY},
-    {std::string("CHECKLOCKTIMEVERIFY"), (unsigned int)SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY},
-    {std::string("CHECKSEQUENCEVERIFY"), (unsigned int)SCRIPT_VERIFY_CHECKSEQUENCEVERIFY},
-    {std::string("WITNESS"), (unsigned int)SCRIPT_VERIFY_WITNESS},
-    {std::string("TAPROOT"), (unsigned int)SCRIPT_VERIFY_TAPROOT},
-};
-
 std::vector<unsigned int> AllFlags()
 {
     std::vector<unsigned int> ret;
@@ -124,22 +115,6 @@ std::vector<unsigned int> AllFlags()
 }
 
 const std::vector<unsigned int> ALL_FLAGS = AllFlags();
-
-unsigned int ParseScriptFlags(const std::string& str)
-{
-    if (str.empty()) return 0;
-
-    unsigned int flags = 0;
-    std::vector<std::string> words = SplitString(str, ',');
-
-    for (const std::string& word : words) {
-        auto it = FLAG_NAMES.find(word);
-        if (it == FLAG_NAMES.end()) throw std::runtime_error("Unknown verification flag " + word);
-        flags |= it->second;
-    }
-
-    return flags;
-}
 
 void Test(const std::string& str)
 {

--- a/src/test/script_tapscript_tests.cpp
+++ b/src/test/script_tapscript_tests.cpp
@@ -1,0 +1,1711 @@
+// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// TODO: Don't know whether Taproot/Tapscript tests should be exercising
+// `libconsensus` the way the tests in `script_tests` do
+
+#include <core_io.h>
+#include <hash.h>
+#include <pubkey.h>
+#include <script/interpreter.h>
+#include <script/script.h>
+#include <script/script_error.h>
+#include <span.h>
+#include <test/util/boost_test_boosts.h>
+#include <test/util/pretty_data.h>
+#include <test/util/setup_common.h>
+#include <test/util/transaction_utils.h>
+#include <test/util/vector.h>
+#include <univalue.h>
+#include <util/strencodings.h>
+
+#include <boost/test/execution_monitor.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <cstddef>
+#include <iomanip>
+#include <iterator>
+#include <limits>
+#include <ostream>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+using namespace std::literals::string_literals;
+using namespace std::literals::string_view_literals;
+using namespace test::util::literals;
+
+namespace {
+
+typedef std::vector<unsigned char> valtype;
+
+/**
+ * Value/Name pair used in data-driven tests
+ */
+template <typename V>
+struct vn_pair {
+    vn_pair(V value, std::string_view name) : m_value(value), m_name(name) {}
+
+    const V m_value;
+    const std::string_view m_name;
+};
+
+/**
+ * Sequence of value/name pairs used in data-driven tests
+ */
+template <typename V>
+using vn_sequence = std::vector<vn_pair<V>>;
+
+/**
+ * Invokes undefined behavior.  See `std::unreachable` in C++23.
+ */
+[[noreturn]] inline void declare_unreachable()
+{
+#ifdef _MSC_VER
+    __assume(false);
+#else
+    // Assume all other compilers than MSVC implement this GCC builtin.
+    __builtin_unreachable();
+#endif
+}
+
+/**
+ * Representation changer to fill an integral type with a known pattern.
+ *
+ * Pattern is successive byte values given a starting point.  Endianness doesn't
+ * matter.
+ */
+union FillWithPattern {
+    uint256 u256{0};
+    uint64_t u64raw[sizeof(uint256) / sizeof(uint64_t)];
+    uint32_t u32[sizeof(uint256) / sizeof(uint32_t)];
+    int32_t i32[sizeof(uint256) / sizeof(int32_t)];
+    uint8_t u8[sizeof(uint256)];
+
+    constexpr FillWithPattern(uint8_t start)
+    {
+        for (auto it = std::begin(u8); it != std::end(u8); ++it) {
+            *it = start++;
+        }
+    }
+
+    uint64_t u64() const
+    {
+        // It is desirable to force high bit off
+        return u64raw[0] & static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+    }
+};
+
+/**
+ * The two possible actions for our mock signature checker
+ */
+enum class CHECKER_VALIDATION { ALWAYS_SUCCEEDS,
+                                ALWAYS_FAILS };
+
+/**
+ * For these tests don't need _real_ signature/pubkey validation.  That is
+ * tested elsewhere.  So we just _mock_ the signature checker and force it
+ * to answer valid/invalid as we wish.
+ */
+class SignatureCheckerMock : public BaseSignatureChecker
+{
+    //! What kind of mock checker is this?
+    CHECKER_VALIDATION m_kind = CHECKER_VALIDATION::ALWAYS_FAILS;
+
+    //! True _iff_ CheckSchnorrSignature was actually called
+    mutable bool m_was_called = false;
+
+public:
+    //! Whether this mock always validates, or always fails, the signature/pubkey check.
+    explicit SignatureCheckerMock(CHECKER_VALIDATION kind) : m_kind(kind) {}
+
+    //! Mocks the actual checking of the validity of the Schnorr signature by always succeeding or always failing
+    bool CheckSchnorrSignature(Span<const unsigned char> sig,
+                               Span<const unsigned char> pubkey,
+                               SigVersion sigversion,
+                               ScriptExecutionData& execdata,
+                               ScriptError* serror = nullptr) const override
+    {
+        m_was_called = true;
+        switch (m_kind) {
+        case CHECKER_VALIDATION::ALWAYS_SUCCEEDS:
+            if (serror) *serror = SCRIPT_ERR_OK;
+            return true;
+
+        case CHECKER_VALIDATION::ALWAYS_FAILS:
+            if (serror) *serror = SCRIPT_ERR_SCHNORR_SIG;
+            return false;
+        }
+        declare_unreachable();
+    }
+
+    bool CheckerWasCalled() const
+    {
+        return m_was_called;
+    }
+};
+
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(script_tapscript_tests, BasicTestingSetup)
+
+/**
+ * Testing EvalScript OP_CHECKSIGADD branch and EvalChecksigTapscript, both in
+ * interpreter.cpp, against the BIP342 "Rules for signature opcodes".
+ */
+BOOST_AUTO_TEST_CASE(eval_checksigadd_basic_checks)
+{
+    const valtype SIG_64BYTES(64, 0); // N.B.: Must be () not {}!
+    const valtype SIG_65BYTES(65, 0);
+    const valtype SIG_EMPTY{};
+
+    const valtype PUBKEY_32BYTES(32, 0);
+    const valtype PUBKEY_15BYTES(15, 0);
+    const valtype PUBKEY_EMPTY{};
+
+    constexpr int64_t TEST_NUM = 10;
+
+    constexpr int64_t START_VALIDATION_WEIGHT{90};
+    constexpr int64_t BIP342_SIGOPS_LIMIT{50};
+    constexpr int64_t END_VALIDATION_WEIGHT{START_VALIDATION_WEIGHT - BIP342_SIGOPS_LIMIT};
+
+    /**
+     * A fluent API for running these tests.
+     *
+     * (Easiest way to understand this class is to look at the actual tests
+     * that follow in this function.)
+     */
+    struct Context {
+        explicit Context(std::string_view descr) : m_test_description(descr)
+        {
+            m_execdata.m_validation_weight_left_init = true;
+            m_execdata.m_validation_weight_left = START_VALIDATION_WEIGHT;
+        }
+
+        std::string m_test_description;
+        SigVersion m_sig_version = SigVersion::TAPSCRIPT;
+        uint32_t m_flags = 0;
+        CScript m_script;
+        ScriptError m_err = SCRIPT_ERR_OK;
+        std::vector<valtype> m_stack;
+        ScriptExecutionData m_execdata;
+        CHECKER_VALIDATION m_kind;
+        bool m_sigchecker_was_called = false;
+        int64_t m_caller_line = 0;
+        bool m_result = false;
+
+        Context& SetVersion(SigVersion v)
+        {
+            m_sig_version = v;
+            return *this;
+        }
+
+        Context& SetChecker(CHECKER_VALIDATION kind)
+        {
+            m_kind = kind;
+            return *this;
+        }
+
+        Context& SetRemainingWeight(int64_t w)
+        {
+            m_execdata.m_validation_weight_left = w;
+            return *this;
+        }
+
+        Context& AddFlags(uint32_t f)
+        {
+            m_flags |= f;
+            return *this;
+        }
+
+        CScript& SetScript()
+        {
+            return m_script;
+        }
+
+        Context& DoTest(int64_t line)
+        {
+            SignatureCheckerMock checker_mock(m_kind);
+            m_caller_line = line;
+            m_result = EvalScript(m_stack, m_script,
+                                  SCRIPT_VERIFY_TAPROOT | m_flags,
+                                  checker_mock,
+                                  m_sig_version,
+                                  m_execdata,
+                                  &m_err);
+            m_sigchecker_was_called = checker_mock.CheckerWasCalled();
+            return *this;
+        }
+
+        Context& CheckCallSucceeded()
+        {
+            BOOST_CHECK_MESSAGE(m_result,
+                                Descr()
+                                    << ": EvalScript succeeded, as expected");
+            BOOST_CHECK_MESSAGE(m_err == SCRIPT_ERR_OK,
+                                Descr()
+                                    << ": Error code expected OK, actual was "
+                                    << ScriptErrorString(m_err));
+            return *this;
+        }
+
+        Context& CheckCallFailed(ScriptError expected)
+        {
+            BOOST_CHECK_MESSAGE(!m_result,
+                                Descr()
+                                    << ": EvalScript failed, as expected");
+            BOOST_CHECK_MESSAGE(m_err == expected,
+                                Descr()
+                                    << ": Error code expected " << ScriptErrorString(expected)
+                                    << ", actual was " << ScriptErrorString(m_err));
+            return *this;
+        }
+
+        Context& CheckSignatureWasValidated()
+        {
+            BOOST_CHECK_MESSAGE(m_sigchecker_was_called,
+                                Descr() << ": CheckSchnorrSignature was called, as expected");
+            return *this;
+        }
+
+        Context& CheckSignatureWasNotValidated()
+        {
+            BOOST_CHECK_MESSAGE(!m_sigchecker_was_called,
+                                Descr() << ": CheckSchnorrSignature was not called, as expected");
+            return *this;
+        }
+
+        Context& CheckRemainingValidationWeight(int64_t expected)
+        {
+            BOOST_CHECK_MESSAGE(m_execdata.m_validation_weight_left == expected,
+                                Descr()
+                                    << ": Remaining validation weight expected "
+                                    << expected << ", actual was "
+                                    << m_execdata.m_validation_weight_left);
+            return *this;
+        }
+
+        Context& CheckStackDepth(std::size_t expected)
+        {
+            BOOST_CHECK_MESSAGE(m_stack.size() == expected,
+                                Descr()
+                                    << ": Stack depth expected " << expected
+                                    << ", actual was " << m_stack.size());
+            return *this;
+        }
+
+        Context& CheckTOS(int64_t expected)
+        {
+            BOOST_CHECK_MESSAGE(!m_stack.empty(),
+                                Descr()
+                                    << ": Stack expected at least one item, actually was empty");
+            const int64_t actual = CScriptNum(m_stack.at(0), false).GetInt64();
+            BOOST_CHECK_MESSAGE(expected == actual,
+                                Descr()
+                                    << ": Top-of-stack expected " << expected
+                                    << ", actual was " << actual);
+            return *this;
+        }
+
+    private:
+        std::string Descr()
+        {
+            std::string descr;
+            descr.reserve(m_test_description.size() + 20);
+            descr += m_test_description;
+            descr += " (@";
+            descr += as_string(m_caller_line);
+            descr += ")";
+            return descr;
+        }
+    };
+
+    {
+        Context ctx("SigVersion must not be BASE");
+        ctx.SetVersion(SigVersion::BASE).SetScript()
+            << SIG_64BYTES << CScriptNum(TEST_NUM) << PUBKEY_32BYTES << OP_CHECKSIGADD;
+        ctx.DoTest(__LINE__)
+            .CheckCallFailed(SCRIPT_ERR_BAD_OPCODE)
+            .CheckStackDepth(3);
+    }
+
+    {
+        Context ctx("SigVersion must not be WITNESS_V0");
+        ctx.SetVersion(SigVersion::WITNESS_V0).SetScript()
+            << SIG_64BYTES << CScriptNum(TEST_NUM) << PUBKEY_32BYTES << OP_CHECKSIGADD;
+        ctx.DoTest(__LINE__)
+            .CheckCallFailed(SCRIPT_ERR_BAD_OPCODE)
+            .CheckStackDepth(3);
+    }
+
+    {
+        Context ctx("Minimum stack height 3 for OP_CHECKSIGADD");
+        ctx.SetScript()
+            << CScriptNum(TEST_NUM) << PUBKEY_32BYTES << OP_CHECKSIGADD;
+        ctx.DoTest(__LINE__)
+            .CheckCallFailed(SCRIPT_ERR_INVALID_STACK_OPERATION)
+            .CheckStackDepth(2);
+    }
+
+    {
+        Context ctx("`n` (2nd arg) size > 4 must fail");
+        // This is probably meant to be a check on the _encoding_ - that it is
+        // minimal, but it can also be a check on the _value_.  BIP342 doesn't
+        // say which.  Could be both...
+        ctx.SetScript()
+            << SIG_EMPTY << CScriptNum(10000000000LL) << PUBKEY_32BYTES << OP_CHECKSIGADD;
+        ctx.DoTest(__LINE__)
+            // (IMO this is an _unsatisfactory_ error code to return for a required
+            // BIP342 check, but see the `catch` clause in `EvalScript`)
+            .CheckCallFailed(SCRIPT_ERR_UNKNOWN_ERROR)
+            .CheckStackDepth(3);
+    }
+
+    {
+        Context ctx("Empty sig + empty pubkey");
+        ctx.SetScript()
+            << SIG_EMPTY << CScriptNum(TEST_NUM) << PUBKEY_EMPTY << OP_CHECKSIGADD;
+        ctx.DoTest(__LINE__)
+            .CheckCallFailed(SCRIPT_ERR_PUBKEYTYPE)
+            .CheckStackDepth(3);
+    }
+
+    {
+        Context ctx("Sig + empty pubkey");
+        ctx.SetScript()
+            << SIG_64BYTES << CScriptNum(TEST_NUM) << PUBKEY_EMPTY << OP_CHECKSIGADD;
+        ctx.DoTest(__LINE__)
+            .CheckCallFailed(SCRIPT_ERR_PUBKEYTYPE)
+            .CheckStackDepth(3);
+    }
+
+    {
+        Context ctx("Insufficient validation weight remaining");
+        ctx.SetRemainingWeight(BIP342_SIGOPS_LIMIT - 1)
+                .SetScript()
+            << SIG_64BYTES << CScriptNum(TEST_NUM) << PUBKEY_32BYTES << OP_CHECKSIGADD;
+        ctx.DoTest(__LINE__)
+            .CheckCallFailed(SCRIPT_ERR_TAPSCRIPT_VALIDATION_WEIGHT)
+            .CheckStackDepth(3);
+    }
+
+    {
+        Context ctx("Empty sig + 32byte pubkey skips validation");
+        ctx.SetChecker(CHECKER_VALIDATION::ALWAYS_SUCCEEDS)
+                .SetScript()
+            << SIG_EMPTY << CScriptNum(TEST_NUM) << PUBKEY_32BYTES << OP_CHECKSIGADD;
+        ctx.DoTest(__LINE__)
+            .CheckCallSucceeded()
+            .CheckSignatureWasNotValidated()
+            .CheckRemainingValidationWeight(START_VALIDATION_WEIGHT)
+            .CheckStackDepth(1)
+            .CheckTOS(TEST_NUM);
+    }
+
+    {
+        Context ctx("Empty sig + non32byte pubkey skips validation");
+        ctx.SetChecker(CHECKER_VALIDATION::ALWAYS_SUCCEEDS)
+                .SetScript()
+            << SIG_EMPTY << CScriptNum(TEST_NUM) << PUBKEY_15BYTES << OP_CHECKSIGADD;
+        ctx.DoTest(__LINE__)
+            .CheckCallSucceeded()
+            .CheckSignatureWasNotValidated()
+            .CheckRemainingValidationWeight(START_VALIDATION_WEIGHT)
+            .CheckStackDepth(1)
+            .CheckTOS(TEST_NUM);
+    }
+
+    {
+        Context ctx("non32byte pubkey ('unknown pubkey type') _with_ discourage flag fails");
+        ctx.SetChecker(CHECKER_VALIDATION::ALWAYS_SUCCEEDS)
+                .AddFlags(SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_PUBKEYTYPE)
+                .SetScript()
+            << SIG_64BYTES << CScriptNum(TEST_NUM) << PUBKEY_15BYTES << OP_CHECKSIGADD;
+        ctx.DoTest(__LINE__)
+            .CheckCallFailed(SCRIPT_ERR_DISCOURAGE_UPGRADABLE_PUBKEYTYPE)
+            .CheckSignatureWasNotValidated()
+            .CheckStackDepth(3);
+    }
+
+    {
+        Context ctx("32byte pubkey + sig with validation failure forced");
+        ctx.SetChecker(CHECKER_VALIDATION::ALWAYS_FAILS)
+                .SetScript()
+            << SIG_64BYTES << CScriptNum(TEST_NUM) << PUBKEY_32BYTES << OP_CHECKSIGADD;
+        ctx.DoTest(__LINE__)
+            .CheckCallFailed(SCRIPT_ERR_SCHNORR_SIG)
+            .CheckSignatureWasValidated()
+            .CheckStackDepth(3);
+    }
+
+    {
+        Context ctx("32byte pubkey + sig with validation success forced");
+        ctx.SetChecker(CHECKER_VALIDATION::ALWAYS_SUCCEEDS)
+                .SetScript()
+            << SIG_64BYTES << CScriptNum(TEST_NUM) << PUBKEY_32BYTES << OP_CHECKSIGADD;
+        ctx.DoTest(__LINE__)
+            .CheckCallSucceeded()
+            .CheckSignatureWasValidated()
+            .CheckRemainingValidationWeight(END_VALIDATION_WEIGHT)
+            .CheckStackDepth(1)
+            .CheckTOS(TEST_NUM + 1);
+    }
+
+    {
+        Context ctx("non32byte pubkey + empty sig with validation success forced");
+        ctx.SetChecker(CHECKER_VALIDATION::ALWAYS_SUCCEEDS)
+                .SetScript()
+            << SIG_EMPTY << CScriptNum(TEST_NUM) << PUBKEY_15BYTES << OP_CHECKSIGADD;
+        ctx.DoTest(__LINE__)
+            .CheckCallSucceeded()
+            .CheckSignatureWasNotValidated()
+            .CheckRemainingValidationWeight(START_VALIDATION_WEIGHT)
+            .CheckStackDepth(1)
+            .CheckTOS(TEST_NUM);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(signature_hash_schnorr_failure_cases)
+{
+    // As defined by BIP-341 Signature Validation Rules
+    // Here we pick an acceptable SigVersion
+    const SigVersion sigversion = SigVersion::TAPROOT;
+
+    CMutableTransaction tx_to_m;
+    tx_to_m.vin.push_back(CTxIn());
+    const uint32_t in_pos{0};
+
+    PrecomputedTransactionData cache;
+    cache.m_bip341_taproot_ready = true;
+    cache.m_spent_outputs_ready = true;
+
+    ScriptExecutionData execdata;
+    execdata.m_annex_init = true;
+    execdata.m_annex_present = false;
+    execdata.m_annex_hash = uint256::ZERO;
+    execdata.m_tapleaf_hash_init = false;
+    execdata.m_codeseparator_pos_init = true;
+
+    uint256 hash_out{0};
+
+    {
+        // Check all invalid hash_type codes rejected
+        const std::set<uint8_t> allowable_hash_types{0x00, 0x01, 0x02, 0x03, 0x81, 0x82, 0x83};
+        for (unsigned ht = 0; ht <= 255; ht++) {
+            const uint8_t hash_type = static_cast<uint8_t>(ht);
+            if (allowable_hash_types.find(hash_type) != allowable_hash_types.end()) continue;
+
+            BOOST_CHECK_MESSAGE(!SignatureHashSchnorr(hash_out, execdata, tx_to_m, in_pos,
+                                                      hash_type, sigversion, cache,
+                                                      MissingDataBehavior::FAIL),
+                                "hash_type = " << Hex(hash_type) << " expected to fail");
+        }
+    }
+
+    {
+        // Check that if hash_type == SIGHASH_SINGLE then missing a "corresponding
+        // output" fails.
+        CMutableTransaction tx_to_m;
+        tx_to_m.vin.push_back(CTxIn());
+        tx_to_m.vin.push_back(CTxIn());
+        tx_to_m.vin.push_back(CTxIn());
+
+        uint8_t in_pos = 1;
+        BOOST_CHECK_MESSAGE(!SignatureHashSchnorr(hash_out, execdata, tx_to_m,
+                                                  in_pos, SIGHASH_SINGLE, sigversion, cache,
+                                                  MissingDataBehavior::FAIL),
+                            "SIGHASH_SINGLE with in_pos(1) > #tx_to==0 is expected to fail");
+
+        tx_to_m.vout.push_back(CTxOut());
+        in_pos = 2;
+        BOOST_CHECK_MESSAGE(!SignatureHashSchnorr(hash_out, execdata, tx_to_m,
+                                                  in_pos, SIGHASH_SINGLE, sigversion, cache,
+                                                  MissingDataBehavior::FAIL),
+                            "SIGHASH_SINGLE with in_pos(2) > #tx_to==1 is expected to fail");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(signature_hash_schnorr_all_success_paths)
+{
+    // Our approach here will be to follow BIP-341's signature algorithm (with
+    // the BIP-342 extension) doing two things at once:
+    //   1) We'll set up the input arguments to `SignatureHashSchnorr` function
+    //      being tested, _and_
+    //   2) we'll _compute the hash of those fields ourselves_ exaxctly as
+    //      it is described in BIP-341 and BIP-342.
+    // Then we can compare the two.  We'll do this in a data-driven way for each
+    // of the different scenarios that the algorithm supports.
+    //
+    // In this way this test achieves 100% _path_ coverage of `SignatureHashSchnorr`
+    // (not just 100% _branch_ coverage).
+    // - Sadly, this isn't shown in the `lcov` reports.  There are still a few
+    //   red `-` marks left.  This is because:
+    //   1. `lcov` wasn't designed to handle death tests.
+    //   2. ??? Some other unknown reasons, possibly due to the instrumentation,
+    //      possibly due to `lcov` limitations.  You can see by the test output
+    //      (`-log_level=all`) or within a debugger that in fact _all_ branches
+    //      are taken when executing all the tests in this file.
+
+    // Here we define, and then generate, all combinations of the alternatives
+    // for the parameters that vary the signature combination algorithm
+
+    const vn_sequence<SigVersion> SigVersion_alternatives{
+        {SigVersion::TAPROOT, "TAPROOT"sv},
+        {SigVersion::TAPSCRIPT, "TAPSCRIPT"sv}};
+
+    const vn_sequence<uint32_t> hash_type_output_alternatives{
+        {SIGHASH_DEFAULT, "SIGHASH_DEFAULT"sv},
+        {SIGHASH_ALL, "SIGHASH_ALL"sv},
+        {SIGHASH_NONE, "SIGHASH_NONE"sv},
+        {SIGHASH_SINGLE, "SIGHASH_SINGLE"sv}};
+
+    const vn_sequence<uint32_t> hash_type_input_alternatives{
+        {0, "N/A"sv},
+        {SIGHASH_ANYONECANPAY, "SIGHASH_ANYONECANPAY"sv}};
+
+    const vn_sequence<uint8_t> annex_alternatives{
+        {0, "no annex"sv},
+        {1, "annex present"sv}};
+
+    const vn_sequence<bool> output_hash_alternatives{
+        {false, "output hash missing"sv},
+        {true, "output hash provided"sv}};
+
+    for (const auto& sigversion_alternative : SigVersion_alternatives)
+        for (const auto& hash_type_output_alternative : hash_type_output_alternatives)
+            for (const auto& hash_type_input_alternative : hash_type_input_alternatives)
+                for (const auto& annex_alternative : annex_alternatives)
+                    for (const auto& output_hash_alternative : output_hash_alternatives) {
+                        // Exclude the invalid combination of SIGHASH_DEFAULT with SIGHASH_ANYONECANPAY
+                        if (hash_type_output_alternative.m_value == SIGHASH_DEFAULT && hash_type_input_alternative.m_value == SIGHASH_ANYONECANPAY) continue;
+
+                        // We're going to want to know which scenario it is if a check actually
+                        // fails ...
+                        std::string scenario_description;
+                        {
+                            std::ostringstream oss;
+                            oss << sigversion_alternative.m_name << ", "
+                                << hash_type_output_alternative.m_name << ", "
+                                << hash_type_input_alternative.m_name << ", "
+                                << annex_alternative.m_name << ", "
+                                << output_hash_alternative.m_name;
+                            scenario_description = oss.str();
+                        }
+
+                        // Set up the scenario we're running now - these 4 variables define the scenario
+                        const SigVersion sigversion{sigversion_alternative.m_value};
+                        const uint8_t hash_type{static_cast<uint8_t>(hash_type_output_alternative.m_value | hash_type_input_alternative.m_value)};
+                        const uint8_t annex_present{annex_alternative.m_value};
+                        const bool have_output_hash{output_hash_alternative.m_value};
+
+                        // Compute some helper values that depend on scenario
+                        const uint8_t ext_flag{sigversion == SigVersion::TAPSCRIPT};
+                        const uint8_t hash_input_type{static_cast<uint8_t>(hash_type & SIGHASH_INPUT_MASK)};
+                        const uint8_t hash_output_type{static_cast<uint8_t>((hash_type == SIGHASH_DEFAULT) ? SIGHASH_ALL : (hash_type & SIGHASH_OUTPUT_MASK))};
+                        const uint8_t spend_type = (ext_flag * 2) + annex_present;
+
+                        // Fixed values (by algorithm)
+                        const uint8_t epoch{0x00};
+                        const uint8_t key_version{0};
+
+                        // Mocked values fixed for purposes of this unit test.  This is a long
+                        // list of crufty things but that's because `SignatureHashSchnorr`, the
+                        // function being tested, takes as arguments not just the transaction
+                        // being signed (plus control data) but also some _precomputed values_
+                        // in two different structs: `PrecomputedTransactionData`, and
+                        // `ScriptExecutionData`.  On the one hand this is nice because a lot
+                        // of complexity of the signature algorithm doesn't have to be duplicated
+                        // here in this test: we can just use mocked values.  On the other hand,
+                        // there's a lot of icky setup to do to get all the values in the right
+                        // places both for our "by the book" implementation and to be set up to
+                        // call `SignatureHashSchnorr`.
+                        //
+                        // Try to make things simpler by at least using the same names for the
+                        // setup variables as for the fields in the parameter structs.
+
+                        const uint32_t in_pos{1};
+                        const int32_t tx_version{FillWithPattern(0x01).i32[0]};
+                        const uint32_t tx_lock_time{FillWithPattern(0x05).u32[0]};
+                        const uint256 prevouts_single_hash{FillWithPattern(0x10).u256};
+                        const uint256 spent_amounts_single_hash{FillWithPattern(0x18).u256};
+                        const uint256 spent_scripts_single_hash{FillWithPattern(0x20).u256};
+                        const uint256 sequences_single_hash{FillWithPattern(0x28).u256};
+                        const uint256 outputs_single_hash{FillWithPattern(0x30).u256};
+                        const uint256 output_hash{FillWithPattern(0x40).u256};
+                        const uint256 annex_hash{FillWithPattern(0x48).u256};
+                        const uint256 tapleaf_hash{FillWithPattern(0x50).u256};
+                        const uint32_t codeseparator_pos{FillWithPattern(0x58).u32[0]};
+                        const COutPoint tx_input_at_pos_prevout{FillWithPattern(0x60).u256,
+                                                                FillWithPattern(0x68).u32[0]};
+                        const uint32_t tx_input_at_pos_nsequence{FillWithPattern(0x70).u32[0]};
+                        CTxOut spent_output_at_pos;
+                        spent_output_at_pos.nValue = FillWithPattern(0x80).u64();
+                        spent_output_at_pos.scriptPubKey /*random script, not even valid*/
+                            << OP_DUP << OP_HASH160 << OP_EQUALVERIFY << OP_CHECKSIG;
+                        CTxOut tx_output_at_pos;
+                        tx_output_at_pos.nValue = FillWithPattern(0x90).u64();
+                        tx_output_at_pos.scriptPubKey /*random script, not even valid*/
+                            << OP_CHECKSIG << OP_EQUALVERIFY << OP_HASH160 << OP_DUP;
+
+                        // Now set up the arguments that are going to be passed to
+                        // `SignatureHashSchnorr`
+
+                        CMutableTransaction tx_to;
+                        tx_to.nVersion = tx_version;
+                        tx_to.nLockTime = tx_lock_time;
+                        for (uint32_t i = 0; i < in_pos + 2; i++) {
+                            tx_to.vin.push_back(CTxIn());
+                            tx_to.vout.push_back(CTxOut());
+                        }
+                        tx_to.vin[in_pos].prevout = tx_input_at_pos_prevout;
+                        tx_to.vin[in_pos].nSequence = tx_input_at_pos_nsequence;
+                        tx_to.vout[in_pos] = tx_output_at_pos;
+
+                        PrecomputedTransactionData cache;
+                        cache.m_bip341_taproot_ready = true;
+                        cache.m_prevouts_single_hash = prevouts_single_hash;
+                        cache.m_spent_amounts_single_hash = spent_amounts_single_hash;
+                        cache.m_spent_scripts_single_hash = spent_scripts_single_hash;
+                        cache.m_sequences_single_hash = sequences_single_hash;
+                        cache.m_spent_outputs_ready = true;
+                        for (uint32_t i = 0; i < in_pos + 2; i++) {
+                            cache.m_spent_outputs.push_back(CTxOut());
+                        }
+                        cache.m_spent_outputs[in_pos] = spent_output_at_pos;
+                        cache.m_outputs_single_hash = outputs_single_hash;
+
+                        ScriptExecutionData execdata;
+                        execdata.m_annex_init = true;
+                        execdata.m_annex_present = !!annex_present;
+                        execdata.m_annex_hash = annex_hash;
+                        execdata.m_output_hash.reset();
+                        if (have_output_hash) {
+                            execdata.m_output_hash = output_hash;
+                        }
+                        if (sigversion == SigVersion::TAPSCRIPT) {
+                            execdata.m_tapleaf_hash_init = true;
+                            execdata.m_tapleaf_hash = tapleaf_hash;
+                            execdata.m_codeseparator_pos_init = true;
+                            execdata.m_codeseparator_pos = codeseparator_pos;
+                        }
+
+                        // Now here is where we take all that data - _not_ the arguments to
+                        // `SignatureHashSchnorr` but all the scenario parameters, the helpers,
+                        // the values fixed by the algorithm, and our mocked values, and actually
+                        // follow the BIP-341/BIP-342 signature calculation algorithm right from
+                        // the spec ...
+
+                        // Start with a tagged hasher with the correct tag
+                        CHashWriter hasher = TaggedHash("TapSighash");
+
+                        // First byte to hash is always the "epoch", 0x00 (BIP-341, footnote 20)
+                        hasher << epoch;
+
+                        // Next: hash_type (1 byte)
+                        hasher << hash_type;
+
+                        // Next: transaction version (4 bytes)
+                        hasher << tx_version;
+
+                        // Next: transaction lock time (4 bytes)
+                        hasher << tx_lock_time;
+
+                        // Next if _not_ SIGHASH_ANYONECANPAY:
+                        // a) SHA256 of the serialization of all input outpoints (32 bytes)
+                        // b) SHA256 of the serialization of all spent output amounts (32 bytes)
+                        // c) SHA256 of the serialization of all spent outputs' _scriptPubKeys_
+                        //    serialized as script (32 bytes)
+                        // d) SHA256 of the serialization of all input `nSequence` (32 bytes)
+                        if (hash_input_type != SIGHASH_ANYONECANPAY) {
+                            hasher << prevouts_single_hash;
+                            hasher << spent_amounts_single_hash;
+                            hasher << spent_scripts_single_hash;
+                            hasher << sequences_single_hash;
+                        }
+
+                        // Next if _not_ SIGHASH_NONE _and not_ SIGHASH_SINGLE:
+                        // SHA256 of the serialization of all outputs in CTxOut format (32 bytes)
+                        if (hash_output_type != SIGHASH_NONE && hash_output_type != SIGHASH_SINGLE) {
+                            hasher << outputs_single_hash;
+                        }
+
+                        // Now, data about input/prevout being spent
+
+                        // The "spend_type" (1 byte) which is a function of ext_flag (above) and
+                        // whether there is an annex present (here: no)
+                        hasher << spend_type;
+
+                        // Here, if we are _not_ SIGHASH_ANYONECANPAY, we just add the index of
+                        // the input in the transaction input vector (4 bytes). There must be a
+                        // input transaction at this index but _in this scenario_ it doesn't have
+                        // to have any data (it is never inspected).  Same for output transactions.
+                        //
+                        // On the other hand, if we _are_ SIGHASH_ANYONECANPAY, then we add the
+                        // `COutPoint` of this input (36 bytes), the value of the previous
+                        // output spent by this input (8 bytes), the `ScriptPubKey` of the
+                        // previous output spent by this input (35 bytes), and the `nSequence`
+                        // of this input.  These values are all precomputed and made available
+                        // to `SignatureHashSchnorr` in the `PrecomputedTransactionData` struct.
+                        if (hash_input_type == SIGHASH_ANYONECANPAY) {
+                            hasher << tx_input_at_pos_prevout;
+                            hasher << spent_output_at_pos.nValue;
+                            hasher << spent_output_at_pos.scriptPubKey;
+                            hasher << tx_input_at_pos_nsequence;
+                        } else {
+                            hasher << in_pos;
+                        }
+
+                        // Now, if there is an "annex", add its hash (32 byte).  This is
+                        // precomputed and we don't actually have to have an actual annex to
+                        // pass in to `SignatureHashSchnorr`, nor do we have to hash it.
+                        if (annex_present) {
+                            hasher << annex_hash;
+                        }
+
+                        // Here, iff the hash type is `SIGHASH_SINGLE`, add the hash of the
+                        // corresponding transaction output (32 bytes).  The wrinkle here is that
+                        // (for some reason) _sometimes_ this hash is precomputed, and _sometimes_
+                        // it is _not_.  So `SignatureHashSchnorr` will either use it if it is
+                        // provided or compute it from the corresponding output itself. (For our
+                        // purposes in this test the output need not be valid - it just must be
+                        // present.)
+                        if (hash_output_type == SIGHASH_SINGLE) {
+                            if (!have_output_hash) {
+                                CHashWriter hasher2(SER_GETHASH, 0);
+                                hasher2 << tx_output_at_pos;
+                                hasher << hasher2.GetSHA256();
+                            } else {
+                                hasher << output_hash;
+                            }
+                        }
+
+                        // This is the TAPSCRIPT extension from BIP-342.  If the version is
+                        // TAPSCRIPT then add the tapleaf hash (32 bytes), the key_version (1
+                        // byte, fixed value of 0x00), and the "opcode position of the last
+                        // executed OP_CODESEPARATOR before the currently executed signature
+                        // opcode" (4 bytes).  The tapleaf hash and the code separator position
+                        // are both precomputed values.
+                        if (sigversion == SigVersion::TAPSCRIPT) {
+                            hasher << tapleaf_hash;
+                            hasher << key_version;
+                            hasher << codeseparator_pos;
+                        }
+
+                        // That's all that goes into the hasher for this signature
+                        const uint256 expected_hash_out = hasher.GetSHA256();
+
+                        // Now, _finally_, we test the actual implemented algorithm under test:
+                        uint256 actual_hash_out{0};
+                        BOOST_TEST(SignatureHashSchnorr(actual_hash_out,
+                                                        execdata, tx_to, in_pos,
+                                                        hash_type, sigversion, cache,
+                                                        MissingDataBehavior::FAIL),
+                                   "Scenario: " << scenario_description);
+                        BOOST_TEST(expected_hash_out == actual_hash_out,
+                                   "Scenario: " << scenario_description
+                                                << " - expected " << expected_hash_out.ToString()
+                                                << " == actual " << actual_hash_out.ToString());
+                    }
+}
+
+namespace {
+
+// Valid Schnoor (pubkey, msg, signature) tuples (copied from `key_tests.cpp`)
+
+struct SchnorrTriplet {
+    SchnorrTriplet(std::string pubkey, std::string sighash, std::string sig)
+        : m_pubkey(ParseHex(pubkey)), m_sighash(uint256(ParseHex(sighash))), m_sig(ParseHex(sig)) {}
+    valtype m_pubkey;
+    uint256 m_sighash;
+    valtype m_sig;
+};
+
+static const std::vector<SchnorrTriplet> SCHNORR_TRIPLETS = {
+    {"F9308A019258C31049344F85F89D5229B531C845836F99B08601F113BCE036F9", "0000000000000000000000000000000000000000000000000000000000000000", "E907831F80848D1069A5371B402410364BDF1C5F8307B0084C55F1CE2DCA821525F66A4A85EA8B71E482A74F382D2CE5EBEEE8FDB2172F477DF4900D310536C0"},
+    {"DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659", "243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89", "6896BD60EEAE296DB48A229FF71DFE071BDE413E6D43F917DC8DCF8C78DE33418906D11AC976ABCCB20B091292BFF4EA897EFCB639EA871CFA95F6DE339E4B0A"},
+    {"DD308AFEC5777E13121FA72B9CC1B7CC0139715309B086C960E18FD969774EB8", "7E2D58D8B3BCDF1ABADEC7829054F90DDA9805AAB56C77333024B9D0A508B75C", "5831AAEED7B44BB74E5EAB94BA9D4294C49BCF2A60728D8B4C200F50DD313C1BAB745879A5AD954A72C45A91C3A51D3C7ADEA98D82F8481E0E1E03674A6F3FB7"},
+    {"25D1DFF95105F5253C4022F628A996AD3A0D95FBF21D468A1B33F8C160D8F517", "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "7EB0509757E246F19449885651611CB965ECC1A187DD51B64FDA1EDC9637D5EC97582B9CB13DB3933705B32BA982AF5AF25FD78881EBB32771FC5922EFC66EA3"},
+    {"D69C3509BB99E412E68B0FE8544E72837DFA30746D8BE2AA65975F29D22DC7B9", "4DF3C3F68FCC83B27E9D42C90431A72499F17875C81A599B566C9889B9696703", "00000000000000000000003B78CE563F89A0ED9414F5AA28AD0D96D6795F9C6376AFB1548AF603B3EB45C9F8207DEE1060CB71C04E80F593060B07D28308D7F4"},
+};
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(internal_test_validate_schnorr_testdata)
+{
+    for (const auto& triplet : SCHNORR_TRIPLETS) {
+        BOOST_TEST(XOnlyPubKey(triplet.m_pubkey).VerifySchnorr(triplet.m_sighash, triplet.m_sig));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(verify_schnorr_signature)
+{
+    // Defeat, for test purposes, the protected access of
+    // `GenericTransactionSignatureChecker::VerifySchnorrSignature`
+    struct UnprotectedTransactionSignatureChecker : public MutableTransactionSignatureChecker {
+        using MutableTransactionSignatureChecker::MutableTransactionSignatureChecker;
+        using MutableTransactionSignatureChecker::VerifySchnorrSignature;
+    };
+    UnprotectedTransactionSignatureChecker sut{nullptr, 0, {}, {}};
+
+    // Positive tests: triplets which verify
+    for (const auto& triplet : SCHNORR_TRIPLETS) {
+        BOOST_TEST(sut.VerifySchnorrSignature(triplet.m_sig,
+                                              XOnlyPubKey{triplet.m_pubkey},
+                                              triplet.m_sighash));
+    }
+
+    // Negative tests: triplets which fail to verify (get these failing triplets
+    // by modifying a valid triplet, one field at a time)
+    auto diddle_front_byte = [](auto v) { v[0]++; return v; };
+    auto& triplet = SCHNORR_TRIPLETS[0];
+    BOOST_TEST(!sut.VerifySchnorrSignature(diddle_front_byte(triplet.m_sig),
+                                           XOnlyPubKey{triplet.m_pubkey},
+                                           triplet.m_sighash));
+    BOOST_TEST(!sut.VerifySchnorrSignature(triplet.m_sig,
+                                           XOnlyPubKey{diddle_front_byte(triplet.m_pubkey)},
+                                           triplet.m_sighash));
+    BOOST_TEST(!sut.VerifySchnorrSignature(triplet.m_sig,
+                                           XOnlyPubKey{triplet.m_pubkey},
+                                           uint256::ONE));
+}
+
+BOOST_AUTO_TEST_CASE(check_schnorr_signature)
+{
+    // Provide, for test purposes, a subclass of `GenericTransactionsSignatureChecker`
+    // that mocks `VerifySchnorrSignature` so we can more easily test
+    // `CheckSchnorrSignature` without going to the trouble of having a valid
+    // transaction (which is unnecessary for this _unit_ test.)
+    struct MockVerifyingTransactionSignatureChecker : public MutableTransactionSignatureChecker {
+        uint256 m_expected_sighash = []() {
+            uint256 h{};
+            // This is the known sighash of the Tx and input data we set up (precomputed)
+            h.SetHex("f614d8ae6dcc49e2ca2ef1c03f93c7326189e5575d446e825e5a2700fb1cb83c");
+            return h;
+        }();
+
+        using MutableTransactionSignatureChecker::MutableTransactionSignatureChecker;
+
+        enum class if_as_expected_return { False,
+                                           True };
+        if_as_expected_return m_iae{if_as_expected_return::True};
+        void SetExpectation(if_as_expected_return iaer) { m_iae = iaer; }
+
+        bool VerifySchnorrSignature(Span<const unsigned char> sig,
+                                    const XOnlyPubKey& pubkey,
+                                    const uint256& sighash) const override
+        {
+            // Following line used only to determine the known canned `expected_sighash` above:
+            // BOOST_TEST_MESSAGE("MockVerifySchnorrSignature: sighash == " << sighash.ToString());
+
+            bool as_expected = sighash == m_expected_sighash;
+            if (m_iae == if_as_expected_return::True)
+                return as_expected;
+            else
+                return !as_expected;
+        };
+    };
+
+    const auto triplet = SCHNORR_TRIPLETS[0];
+    const CMutableTransaction txToIn{};
+    ScriptExecutionData execdata{};
+
+    {
+        // Signature must be 64 or 65 bytes long
+        for (size_t i = 0; i <= 99; i++) {
+            valtype testsig(i, i);
+            if (testsig.size() == 64 || testsig.size() == 65) continue;
+            MockVerifyingTransactionSignatureChecker sut(&txToIn, 0, {}, MissingDataBehavior::FAIL);
+            ScriptError serror{SCRIPT_ERR_OK};
+            BOOST_TEST(!sut.CheckSchnorrSignature(testsig, triplet.m_pubkey, SigVersion::TAPROOT, execdata, &serror));
+            BOOST_TEST(serror == SCRIPT_ERR_SCHNORR_SIG_SIZE);
+        }
+    }
+
+    {
+        // Iff signature is 65 bytes long last byte must **NOT** be SIGHASH_DEFAULT (0x00) per BIP-342
+        {
+            // Negative test: last byte _is_ SIGHASH_DEFAULT
+            valtype testsig(65, 65);
+            testsig.back() = SIGHASH_DEFAULT;
+
+            MockVerifyingTransactionSignatureChecker sut(&txToIn, 0, {}, MissingDataBehavior::FAIL);
+            ScriptError serror{SCRIPT_ERR_OK};
+            BOOST_TEST(!sut.CheckSchnorrSignature(testsig, triplet.m_pubkey, SigVersion::TAPROOT, execdata, &serror));
+            BOOST_TEST(serror == SCRIPT_ERR_SCHNORR_SIG_HASHTYPE);
+        }
+        {
+            // Negative tests: last byte is _not_ SIGHASH_DEFAULT, but we early exit _without changing
+            // serror_ because we don't provide a txDataIn (🡄 this requires knowledge of how
+            // `CheckSchnorrSignature` is written).
+            for (size_t i = 1; i <= 255; i++) {
+                valtype testsig(65, i);
+
+                MockVerifyingTransactionSignatureChecker sut(&txToIn, 0, {}, MissingDataBehavior::FAIL);
+                ScriptError serror{SCRIPT_ERR_OK};
+                BOOST_TEST(!sut.CheckSchnorrSignature(testsig, triplet.m_pubkey, SigVersion::TAPROOT, execdata, &serror));
+                BOOST_TEST(serror == SCRIPT_ERR_OK);
+            }
+        }
+    }
+
+    {
+        // Now check that, given the parameters, if `SignatureHashSchnorr fails there's an error exit.
+        // Otherwise, if it succeeds, it proceeds to call `VerifySchnorrSignature` and depending on
+        // _that_ result `SignatureHashSchnorr` either succeeds or fails.
+        //
+        // We do this using the mocked `VerifySchnorrSignature` so we only need to pass parameters
+        // that work with `SignatureHashSchnorr`, they don't _also_ have to validate with
+        // `VerifySchnorrSignature`.
+
+        const uint32_t in_pos{0};
+        CMutableTransaction txToIn{};
+        txToIn.nVersion = 0;
+        txToIn.nLockTime = 0;
+        txToIn.vin.push_back(CTxIn());
+        txToIn.vin[in_pos].prevout = COutPoint(uint256::ZERO, 0);
+        txToIn.vin[in_pos].nSequence = 0;
+        txToIn.vout.push_back(CTxOut());
+
+        PrecomputedTransactionData txDataIn{};
+        txDataIn.m_bip341_taproot_ready = true;
+        txDataIn.m_prevouts_single_hash = uint256::ZERO;
+        txDataIn.m_spent_amounts_single_hash = uint256::ZERO;
+        txDataIn.m_spent_scripts_single_hash = uint256::ZERO;
+        txDataIn.m_sequences_single_hash = uint256::ZERO;
+        txDataIn.m_spent_outputs_ready = true;
+        txDataIn.m_spent_outputs.push_back(CTxOut());
+        txDataIn.m_spent_outputs[in_pos].nValue = 0;
+        txDataIn.m_spent_outputs[in_pos].scriptPubKey << OP_DUP << OP_CHECKSIG;
+        txDataIn.m_outputs_single_hash = uint256::ZERO;
+
+        ScriptExecutionData execdata{};
+        execdata.m_annex_init = true;
+        execdata.m_annex_present = true;
+        execdata.m_annex_hash = uint256::ZERO;
+        execdata.m_output_hash.reset();
+
+        {
+            // Confirm that we can force `SignatureHashSchnorr` to fail (via an early exit)
+            PrecomputedTransactionData txDataIn{};
+            MockVerifyingTransactionSignatureChecker sut(&txToIn, in_pos, {}, txDataIn, MissingDataBehavior::FAIL);
+            ScriptError serror{SCRIPT_ERR_OK};
+            BOOST_TEST(!sut.CheckSchnorrSignature(triplet.m_sig, triplet.m_pubkey, SigVersion::TAPROOT, execdata, &serror));
+            BOOST_TEST(serror == SCRIPT_ERR_SCHNORR_SIG_HASHTYPE);
+        }
+
+        {
+            // Now `SignatureHashSchnorr` will return true but we'll fail `VerifySchnorrSignature`
+            // and show it returns the correct error.
+            MockVerifyingTransactionSignatureChecker sut(&txToIn, in_pos, {}, txDataIn, MissingDataBehavior::FAIL);
+            sut.SetExpectation(MockVerifyingTransactionSignatureChecker::if_as_expected_return::False);
+            ScriptError serror{SCRIPT_ERR_OK};
+            BOOST_TEST(!sut.CheckSchnorrSignature(triplet.m_sig, triplet.m_pubkey, SigVersion::TAPROOT, execdata, &serror));
+            BOOST_TEST(serror == SCRIPT_ERR_SCHNORR_SIG);
+        }
+
+        {
+            // Finally, same as previous, except we'll force `VerifySchnorrSignature` to succeed and
+            // show now that `CheckSchnorrSignature` finally succeeds.
+            MockVerifyingTransactionSignatureChecker sut(&txToIn, in_pos, {}, txDataIn, MissingDataBehavior::FAIL);
+            sut.SetExpectation(MockVerifyingTransactionSignatureChecker::if_as_expected_return::True);
+            ScriptError serror{SCRIPT_ERR_OK};
+            BOOST_TEST(sut.CheckSchnorrSignature(triplet.m_sig, triplet.m_pubkey, SigVersion::TAPROOT, execdata, &serror));
+            BOOST_TEST(serror == SCRIPT_ERR_OK);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(compute_tapleaf_hash)
+{
+    // Try two examples, reimplementing the BIP-341 specification
+    {
+        uint8_t leaf_version = 0;
+        CScript cs{};
+        auto expected = (TaggedHash("TapLeaf") << leaf_version << CScript()).GetSHA256();
+        auto actual = ComputeTapleafHash(leaf_version, CScript());
+        BOOST_TEST(expected == actual,
+                   "leaf version 0, empty CScript - expected "
+                       << expected.ToString() << " actual " << actual.ToString());
+    }
+
+    {
+        uint8_t leaf_version = 0x4a;
+        CScript cs{};
+        cs << OP_CHECKLOCKTIMEVERIFY << OP_CHECKSIGADD; // just a random CScript
+        auto expected = (TaggedHash("TapLeaf") << leaf_version << cs).GetSHA256();
+        auto actual = ComputeTapleafHash(leaf_version, cs);
+        BOOST_TEST(expected == actual,
+                   "leaf version 0x4A, CScript w/ 2 opcodes - expected "
+                       << expected.ToString() << " actual " << actual.ToString());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(compute_taproot_merkle_root)
+{
+    using namespace test::util::vector_ops;
+
+    // Test by using a small enhancement to a `vector<unsigned char>` that makes
+    // it easy to convert to/from strings so the tests are more easily readable,
+    // and also adds directly the two necessary operations from BIP-340: byte
+    // vector concatenation and byte vector select subrange.
+
+    // Use an arbitrary tapleaf hash throughout
+    const uint256 tapleaf_hash1 = ComputeTapleafHash(0x10, CScript{} << OP_CHECKMULTISIG);
+    const uint256 tapleaf_hash2 = ComputeTapleafHash(0x20, CScript{} << OP_CHECKSEQUENCEVERIFY);
+
+    //                         ".........|.........|.........|..."      33 bytes
+    const auto control_base1 = "[point (#1) - 33 bytes of junk!!>"_bv;
+    const auto control_base2 = "[point (#2) - 33 more bad bytes!>"_bv;
+    assert(control_base1.size() == 33 && control_base2.size() == 33);
+
+    // Nodes `node_low` and `node_high` are constructed to be _forced_ lower/higher
+    // (respectively) than arbitrary hash.  This isn't exactly true, of course:
+    // only the _first byte_ of these nodes are low or high.  If the first byte
+    // of the "arbitrary" hash is `0x00` or `0xff` we've got a problem .. but
+    // this isn't the case for this test data.
+
+    //                                     ".........|.........|.........|.."       32 bytes
+    const auto node_low = []() { auto r  = "(this is node to-be-diddled low)"_bv; r.front() = 0x00; return r; }();
+    const auto node_high = []() { auto r = "(this is nod to-be-diddled high)"_bv; r.front() = 0xFF; return r; }();
+    assert(node_low.size() == 32 && node_high.size() == 32);
+
+    assert(node_low < from_base_blob(tapleaf_hash1) && from_base_blob(tapleaf_hash1) < node_high);
+    assert(node_low < from_base_blob(tapleaf_hash2) && from_base_blob(tapleaf_hash2) < node_high);
+
+    const CHashWriter hw_branch{TaggedHash("TapBranch")};
+
+    {
+        // Control block contains only the initial point, no nodes - always returns
+        // the tapleaf hash, doesn't matter what the control block is
+        uint256 expected1 = tapleaf_hash1;
+        uint256 actual1a = ComputeTaprootMerkleRoot(control_base1, tapleaf_hash1);
+        BOOST_TEST(expected1 == actual1a,
+                   "expected " << HexStr(expected1) << ", actual " << HexStr(actual1a));
+        uint256 actual1b = ComputeTaprootMerkleRoot(control_base2, tapleaf_hash1);
+        BOOST_TEST(expected1 == actual1b,
+                   "expected " << HexStr(expected1) << ", actual " << HexStr(actual1b));
+        uint256 expected2 = tapleaf_hash2;
+        uint256 actual2 = ComputeTaprootMerkleRoot(control_base2, tapleaf_hash2);
+        BOOST_TEST(expected2 == actual2,
+                   "expected " << HexStr(expected2) << ", actual " << HexStr(actual2));
+    }
+
+    {
+        // Control block contains one node - check both lexicographic orders
+
+        {
+            uint256 expected = (CHashWriter{hw_branch} << Span{node_low} << tapleaf_hash1).GetSHA256();
+            uint256 actual = ComputeTaprootMerkleRoot(Span{control_base1 || node_low}, tapleaf_hash1);
+            BOOST_TEST(expected == actual,
+                    "expected " << HexStr(expected) << ", actual " << HexStr(actual));
+        }
+        {
+            uint256 expected = (CHashWriter{hw_branch} << tapleaf_hash1 << Span{node_high}).GetSHA256();
+            uint256 actual = ComputeTaprootMerkleRoot(Span{control_base1 || node_high}, tapleaf_hash1);
+            BOOST_TEST(expected == actual,
+                    "expected " << HexStr(expected) << ", actual " << HexStr(actual));
+        }
+    }
+
+    {
+        // With a control block with more than one node (here: two nodes), each subsequent node
+        // is hashed with the hash of the previous nodes in _lexicographic_ order.
+
+        // Control block is going to be `point1 || node_high || node_{low,high}`
+        uint256 intermediate_k = (CHashWriter{hw_branch} << tapleaf_hash1 << Span{node_high}).GetSHA256();
+
+        // Verify that the intermediate hash is less than `node_high`
+        assert(from_base_blob(intermediate_k) < node_high);
+
+        {
+            // 2nd node lexicographically _less than_ intermediate hash
+            uint256 expected = (CHashWriter{hw_branch} << Span{node_low} << intermediate_k).GetSHA256();
+            uint256 actual = ComputeTaprootMerkleRoot(control_base1 || node_high || node_low, tapleaf_hash1);
+            BOOST_TEST(expected == actual,
+                    "expected " << HexStr(expected) << ", actual " << HexStr(actual));
+        }
+
+        {
+            // 2nd node lexicographically _greater than_ intermediate hash
+            uint256 expected = (CHashWriter{hw_branch} << intermediate_k << Span{node_high}).GetSHA256();
+            uint256 actual = ComputeTaprootMerkleRoot(control_base1 || node_high || node_high, tapleaf_hash1);
+            BOOST_TEST(expected == actual,
+                    "expected " << HexStr(expected) << ", actual " << HexStr(actual));
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(taproot_v1_verify_script)
+{
+    // Testing Taproot code paths in `VerifyWitnessProgram` and
+    // `SigVersion::TAPSCRIPT` code paths in `ExecuteWitnessScript`.
+
+    // Both `VerifyWitnessProgram` and `ExecuteWitnessScript` are `static`
+    // inside of `interpreter.cpp` and thus inaccessible to a unit test.
+    // The way to get to them is indirectly via `VerifyScript`.
+
+    // Tests all success and failure paths mentioned in BIP-341 and
+    // BIP-342.
+
+    // This is a _unit test_ not a _functional test_ and the unit being
+    // tested here does _not_ include actually verifying the signature.
+    // That is tested elsewhere (e.g., by tests `verify_schnorr_signature`
+    // and `check_schnorr_signature` in this file).  _This_ test _mocks_
+    // the Schnorr signature verfication.  Thus the test data need not
+    // actually have valid signatures (and is thus easier to prepare).
+
+    /**
+     * A fluent API for running these tests.  Swiped and adapted from
+     * `script_tests.cpp`.
+     *
+     * (Easiest way to understand this class is to look at the actual tests
+     * that follow in this function.)
+     */
+
+    struct Context {
+        // raw key data from `key_tests.cpp` @305
+        valtype m_sec{ParseHex("0000000000000000000000000000000000000000000000000000000000000003")};
+        valtype m_pub{ParseHex("F9308A019258C31049344F85F89D5229B531C845836F99B08601F113BCE036F9")};
+        valtype m_sig{ParseHex("E907831F80848D1069A5371B402410364BDF1C5F8307B0084C55F1CE2DCA821525F66A4A85EA8B71E482A74F382D2CE5EBEEE8FDB2172F477DF4900D310536C0")};
+
+        CKey m_sec_key;
+        XOnlyPubKey m_pub_key;
+
+    private:
+        void SetupKeys()
+        {
+            BOOST_TEST(m_sec.size() == 32);
+            BOOST_TEST(m_pub.size() == 32);
+            BOOST_TEST(m_sig.size() == 64);
+
+            m_sec_key.Set(m_sec.begin(), m_sec.end(), true /*compressed*/);
+            m_pub_key = XOnlyPubKey(m_sec_key.GetPubKey());
+
+            BOOST_TEST(m_pub_key.IsFullyValid());
+        }
+
+    public:
+        explicit Context(std::string_view descr) : m_test_description(descr)
+        {
+            SetupKeys();
+
+            // For Taproot v1 force SegWit version 1
+            m_scriptPubKey << OP_1;
+        }
+
+        const std::string m_test_description;
+
+        bool m_p2sh_wrapped = false;
+        CScript m_scriptPubKey;
+        unsigned int m_hash_type = SIGHASH_DEFAULT;
+        valtype m_annex;
+        std::vector<valtype> m_initial_witness_stack;
+        valtype m_witness_signature;
+        bool m_witness_init = false;
+        CScriptWitness m_witness;
+        CScript m_tapscript;
+        bool m_control_block_init = false;
+        valtype m_control_block;
+        unsigned int m_leaf_version = 0;
+        unsigned int m_pubkey_parity = 0;
+        valtype m_taproot_internal_key;
+        valtype m_control_block_field;
+        unsigned int m_flags = 0;
+        CHECKER_VALIDATION m_checker_validation = CHECKER_VALIDATION::ALWAYS_FAILS;
+
+        int64_t m_caller_line = 0;
+        bool m_result = false;
+        ScriptError m_serror = SCRIPT_ERR_OK;
+        bool m_checker_was_called = false;
+
+        //
+        // N.B.: Some methods herein temporarily marked [[maybe_unused]]
+        // until the Tapscript tests get written
+        //
+
+        Context& SetValidPublicKey()
+        {
+            m_scriptPubKey << m_pub;
+            return *this;
+        }
+
+        [[maybe_unused]] Context& SetPublicKey(valtype key)
+        {
+            BOOST_TEST(key.size() == 32);
+            m_scriptPubKey << key;
+            return *this;
+        }
+
+        Context& SetNBytePublicKey(size_t n)
+        {
+            valtype pub(n, 0xAB);
+            m_scriptPubKey << pub;
+            return *this;
+        }
+
+        Context& SetSignatureAnnex(const valtype& annex_without_suffix)
+        {
+            m_annex.push_back(0x50); // by definition of annex
+            m_annex.insert(m_annex.end(), annex_without_suffix.begin(), annex_without_suffix.end());
+            return *this;
+        }
+
+        // Used to directly set a witness (presumably, invalid for Taproot key path spending)
+        Context& SetWitness(const std::vector<valtype>& witness)
+        {
+            m_witness_init = true;
+            m_witness.stack = witness;
+            return *this;
+        }
+
+        [[maybe_unused]] Context& PushToWitnessStack(const valtype& v)
+        {
+            m_initial_witness_stack.push_back(v);
+            return *this;
+        }
+
+        Context& SetValidSignatureInWitness(unsigned char hash_type = SIGHASH_DEFAULT)
+        {
+            m_hash_type = hash_type;
+            m_witness_signature = m_sig;
+            if (hash_type) m_witness_signature.push_back(hash_type);
+
+            BOOST_TEST((hash_type ? m_witness_signature.size() == 65 : m_witness_signature.size() == 64));
+            return *this;
+        }
+
+        // Used to directly set the signature in the witness (presumably, invalid for Taproot key path spending)
+        Context& SetSignatureInWitness(const valtype& sig)
+        {
+            m_hash_type = SIGHASH_DEFAULT;
+            m_witness_signature = sig;
+            return *this;
+        }
+
+        [[maybe_unused]] CScript& SetTapscript()
+        {
+            return m_tapscript;
+        }
+
+        [[maybe_unused]] Context& SetTapscriptLeafVersion()
+        {
+            m_leaf_version = 0xC0;
+            return *this;
+        }
+
+        [[maybe_unused]] Context& SetLeafVersion(unsigned int lv, unsigned int pubkey_parity)
+        {
+            BOOST_TEST(lv < 256);
+            BOOST_TEST(pubkey_parity < 2);
+
+            m_leaf_version = lv;
+            m_pubkey_parity = pubkey_parity;
+            return *this;
+        }
+
+        [[maybe_unused]] Context& SetTaprootInternalKey(const valtype& p)
+        {
+            BOOST_TEST(p.size() == 32);
+            m_taproot_internal_key = p;
+            return *this;
+        }
+
+        [[maybe_unused]] Context& AddControlBlockField(const valtype& f)
+        {
+            BOOST_TEST(f.size() = 32);
+            m_control_block_field.insert(m_control_block_field.end(), f.begin(), f.end());
+            return *this;
+        }
+
+        [[maybe_unused]] Context& SetControlBlock(const valtype& cb)
+        {
+            m_control_block_init = true;
+            m_control_block = cb;
+            return *this;
+        }
+
+        // Used to directly set the flags (presumably, not the usual Taproot key path spending flags)
+        Context& SetVerifyFlags(unsigned int flags)
+        {
+            m_flags = flags;
+            return *this;
+        }
+
+        Context& SetSchnorrSignatureValidation(CHECKER_VALIDATION checker_validation)
+        {
+            m_checker_validation = checker_validation;
+            return *this;
+        }
+
+        Context& SetP2SHWrapped()
+        {
+            m_p2sh_wrapped = true;
+            return *this;
+        }
+
+        Context& DoTest(int64_t line)
+        {
+            m_caller_line = line;
+
+            BOOST_TEST_MESSAGE(Descr() << "doing test");
+
+            // Build control block
+            bool have_control_block = m_control_block_init;
+            valtype control_block(m_control_block);
+            if (!have_control_block) {
+                BOOST_TEST_MESSAGE("maybe building control block");
+                if (m_leaf_version) {
+                    BOOST_TEST_MESSAGE("have !=0 leaf version, definitely building control block");
+                    have_control_block = true;
+                    control_block.push_back(static_cast<unsigned char>(m_leaf_version | m_pubkey_parity));
+                    control_block.insert(control_block.end(), m_taproot_internal_key.begin(), m_taproot_internal_key.end());
+                    control_block.insert(control_block.end(), m_control_block_field.begin(), m_control_block_field.end());
+                    BOOST_TEST_MESSAGE("control block size " << control_block.size());
+                }
+            }
+
+            // build the witness if necessary
+            if (!m_witness_init) {
+                if (have_control_block) {
+                    // Taproot script path spend
+                    for (const auto& elem : m_initial_witness_stack)
+                        m_witness.stack.push_back(elem);
+                    m_witness.stack.push_back(valtype(m_tapscript.begin(), m_tapscript.end()));
+                    m_witness.stack.push_back(control_block);
+                } else {
+                    // Taproot key path spend
+                    if (!m_witness_signature.empty()) m_witness.stack.push_back(m_witness_signature);
+                }
+                if (!m_annex.empty()) m_witness.stack.push_back(m_annex);
+            }
+
+            if (!m_flags) {
+                m_flags = SCRIPT_VERIFY_SIGPUSHONLY | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_TAPROOT;
+            }
+
+            SignatureCheckerMock checker_mock(m_checker_validation);
+            CScript script_sig; // must be empty for actual Taproot
+            if (m_p2sh_wrapped) {
+                // But BIP-341 allows all SegWit v1 P2SH-wrapped outputs to pass
+                valtype fake_hash(20, 0x00);
+                script_sig << OP_0 << fake_hash;
+            }
+
+            m_result = VerifyScript(script_sig,
+                                    m_scriptPubKey,
+                                    &m_witness,
+                                    m_flags,
+                                    checker_mock,
+                                    &m_serror);
+
+            m_checker_was_called = checker_mock.CheckerWasCalled();
+
+            return *this;
+        }
+
+        Context& CheckCallSucceeded()
+        {
+            BOOST_CHECK_MESSAGE(m_result,
+                                Descr() << ": VerifyScript succeeded, as expected");
+            BOOST_CHECK_MESSAGE(m_serror == SCRIPT_ERR_OK,
+                                Descr() << ": error code expected OK, actual was "
+                                        << ScriptErrorString(m_serror));
+            return *this;
+        }
+
+        Context& CheckCallFailed(ScriptError expected)
+        {
+            BOOST_CHECK_MESSAGE(!m_result,
+                                Descr() << ": VerifyScript failed, as expected");
+            BOOST_CHECK_MESSAGE(m_serror == expected,
+                                Descr() << ": Error code expected " << ScriptErrorString(expected)
+                                        << ", actual was " << ScriptErrorString(m_serror));
+            return *this;
+        }
+
+        Context& CheckSignatureCheckerWasCalled()
+        {
+            BOOST_CHECK_MESSAGE(m_checker_was_called,
+                                Descr() << ": Schnoor signature checker was called, as expected");
+            return *this;
+        }
+
+        Context& CheckSignatureCheckerWasNotCalled()
+        {
+            BOOST_CHECK_MESSAGE(!m_checker_was_called,
+                                Descr() << ": Schnoor signature checker was not called, as expected");
+            return *this;
+        }
+
+    private:
+        std::string Descr()
+        {
+            std::string descr;
+            descr.reserve(m_test_description.size() + 20);
+            descr += m_test_description;
+            descr += " (@";
+            descr += as_string(m_caller_line);
+            descr += ")";
+            return descr;
+        }
+    };
+
+    {
+        Context ctx("Valid Taproot v1 key path spend, hash_type == default, verifies");
+        ctx.SetValidPublicKey()
+            .SetValidSignatureInWitness(SIGHASH_DEFAULT)
+            .SetSchnorrSignatureValidation(CHECKER_VALIDATION::ALWAYS_SUCCEEDS)
+            .DoTest(__LINE__)
+            .CheckCallSucceeded()
+            .CheckSignatureCheckerWasCalled();
+    }
+
+    {
+        Context ctx("Valid Taproot v1 key path spend, hash_type == default, with annex, verifies");
+        ctx.SetValidPublicKey()
+            .SetValidSignatureInWitness(SIGHASH_DEFAULT)
+            .SetSignatureAnnex({0x01, 0x02, 0x03, 0x04, 0xFC, 0xFD, 0xFE, 0xFF})
+            .SetSchnorrSignatureValidation(CHECKER_VALIDATION::ALWAYS_SUCCEEDS)
+            .DoTest(__LINE__)
+            .CheckCallSucceeded()
+            .CheckSignatureCheckerWasCalled();
+    }
+
+    {
+        // Taproot v1 but witness program (scriptPubKey push) is NOT 32 bytes exactly: anything goes.
+        // Witness programs size ∈ [2,40], per BIP-141
+        {
+            // Verifies even with arbitrary bad signature
+            for (size_t n = 2; n <= 40; ++n){
+                if (n == 32) continue;
+                Context ctx("Taproot v1 with non-32-byte witness program verifies (bad signature)");
+                ctx.SetNBytePublicKey(n)
+                    .SetSignatureInWitness({1, 2, 3, 4, 5})
+                    .SetSchnorrSignatureValidation(CHECKER_VALIDATION::ALWAYS_FAILS)
+                    .DoTest(__LINE__)
+                    .CheckCallSucceeded()
+                    .CheckSignatureCheckerWasNotCalled();
+            }
+        }
+
+        {
+            // Verifies even if witness blows out stack
+            const valtype dummy_stack_element{0x00, 0x01, 0x02, 0x03, 0x04};
+            std::vector<valtype> ginormous_witness(1100, dummy_stack_element);
+            for (size_t n = 2; n <= 40; ++n) {
+                if (n == 32) continue;
+                Context ctx("Taproot v1 with non-32-byte witness program verifies (bad witness stack height)");
+                ctx.SetNBytePublicKey(n)
+                    .SetWitness(ginormous_witness)
+                    .SetSchnorrSignatureValidation(CHECKER_VALIDATION::ALWAYS_FAILS)
+                    .DoTest(__LINE__)
+                    .CheckCallSucceeded()
+                    .CheckSignatureCheckerWasNotCalled();
+            }
+        }
+
+        {
+            // Verifies even if witness stack elements are too big
+            const valtype dummy_stack_element(1000, 0x00);
+            std::vector<valtype> ginormous_witness(1, dummy_stack_element);
+            for (size_t n = 2; n <= 40; ++n) {
+                if (n == 32) continue;
+                Context ctx("Taproot v1 with non-32-byte witness program verifies (bad witness stack element size)");
+                ctx.SetNBytePublicKey(n)
+                    .SetWitness(ginormous_witness)
+                    .SetSchnorrSignatureValidation(CHECKER_VALIDATION::ALWAYS_FAILS)
+                    .DoTest(__LINE__)
+                    .CheckCallSucceeded()
+                    .CheckSignatureCheckerWasNotCalled();
+            }
+        }
+    }
+
+    {
+        Context ctx("Taproot v1 P2SH-wrapped verifies");
+        ctx.SetValidPublicKey()
+            .SetValidSignatureInWitness(SIGHASH_DEFAULT)
+            .SetP2SHWrapped()
+            .SetSchnorrSignatureValidation(CHECKER_VALIDATION::ALWAYS_FAILS)
+            .SetVerifyFlags(SCRIPT_VERIFY_SIGPUSHONLY | SCRIPT_VERIFY_TAPROOT) // can't verify WITNESS here because that implies verify !P2SH
+            .DoTest(__LINE__)
+            .CheckCallSucceeded()
+            .CheckSignatureCheckerWasNotCalled();
+    }
+
+    {
+        Context ctx("Taproot v1 with empty witness stack fails");
+        ctx.SetValidPublicKey()
+            .SetWitness({})
+            .SetSchnorrSignatureValidation(CHECKER_VALIDATION::ALWAYS_FAILS)
+            .DoTest(__LINE__)
+            .CheckCallFailed(SCRIPT_ERR_WITNESS_PROGRAM_WITNESS_EMPTY)
+            .CheckSignatureCheckerWasNotCalled();
+    }
+
+    {
+        Context ctx("Taproot v1 key path spend where signature verification fails");
+        ctx.SetValidPublicKey()
+            .SetValidSignatureInWitness(SIGHASH_DEFAULT)
+            .SetSchnorrSignatureValidation(CHECKER_VALIDATION::ALWAYS_FAILS)
+            .DoTest(__LINE__)
+            .CheckCallFailed(SCRIPT_ERR_SCHNORR_SIG)
+            .CheckSignatureCheckerWasCalled();
+    }
+
+    // BIP-341 calls for checking that the `hash_type` is valid, also that if the
+    // `hash_type == SIGHASH_SINGLE` that there's a corresponding output: these
+    // checks are tested in test `signature_hash_schnorr_failure_cases`.
+
+    // Additional checks for code coverage (white box tests)
+    {
+        Context ctx("Taproot v1 key path spend with empty witness stack but no VERIFY_TAPROOT flag succeeds");
+        ctx.SetValidPublicKey()
+            .SetWitness({})
+            .SetSchnorrSignatureValidation(CHECKER_VALIDATION::ALWAYS_FAILS)
+            .SetVerifyFlags(SCRIPT_VERIFY_SIGPUSHONLY | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS)
+            .DoTest(__LINE__)
+            .CheckCallSucceeded()
+            .CheckSignatureCheckerWasNotCalled();
+    }
+}
+
+///////////////////////////////////////////////
+// 🡆🡆🡆 DEATH TESTS ONLY PAST THIS POINT 🡄🡄🡄
+///////////////////////////////////////////////
+//
+// See `src/test/util/boost_test_boosts.h` for explanation of the
+// `BOOST_CHECK_SIGABRT` macro.  Note that for each such assertion below a
+// message will be issued to the log along the lines of "... Assertion ...
+// failed.".  For these tests that is an _expected_ result.  The tests succeed
+// iff those asserts fail (and print that message, in failing).
+
+#if defined(OK_TO_TEST_ASSERT_FUNCTION)
+
+BOOST_AUTO_TEST_CASE(signature_hash_schnorr_assert_cases)
+{
+    const SigVersion sigversion = SigVersion::TAPROOT;
+    const uint8_t hash_type{SIGHASH_SINGLE};
+
+    // Here we pass the assert
+    CMutableTransaction tx_to_m;
+    tx_to_m.vin.push_back(CTxIn());
+    tx_to_m.vout.push_back(CTxOut());
+    uint32_t in_pos{0};
+
+    PrecomputedTransactionData cache;
+    cache.m_bip341_taproot_ready = true;
+    cache.m_spent_outputs_ready = true;
+    cache.m_spent_outputs.push_back(CTxOut());
+
+    ScriptExecutionData execdata;
+    execdata.m_annex_init = true;
+    execdata.m_annex_present = false;
+    execdata.m_annex_hash = uint256::ZERO;
+
+    uint256 hash_out{0};
+
+    // (Deliberate variable shadowing follows for ease in writing separate tests
+    // with mainly the same setup.)
+    {
+        // Check that an invalid SigVersion asserts.
+        const SigVersion sigversion = SigVersion::BASE;
+        BOOST_CHECK_SIGABRT(!SignatureHashSchnorr(hash_out, execdata, tx_to_m,
+                                                  in_pos, hash_type, sigversion, cache,
+                                                  MissingDataBehavior::FAIL));
+    }
+
+    {
+        // Check that in_pos must be valid w.r.t. #inputs
+        const uint32_t in_pos{2};
+        BOOST_CHECK_SIGABRT(!SignatureHashSchnorr(hash_out, execdata, tx_to_m,
+                                                  in_pos, hash_type, sigversion, cache,
+                                                  MissingDataBehavior::FAIL));
+    }
+
+    {
+        // Check that annex_init must be true
+        ScriptExecutionData execdata;
+        execdata.m_annex_init = false;
+        BOOST_CHECK_SIGABRT(!SignatureHashSchnorr(hash_out, execdata, tx_to_m,
+                                                  in_pos, hash_type, sigversion, cache,
+                                                  MissingDataBehavior::FAIL));
+    }
+
+    {
+        // Check that tapleaf_hash_init and codeseparator_pos_init must be true
+        // if version == TAPSCRIPT
+        const SigVersion sigversion = SigVersion::TAPSCRIPT;
+        ScriptExecutionData execdata;
+        execdata.m_annex_init = true;
+        execdata.m_annex_present = false;
+        execdata.m_annex_hash = uint256::ZERO;
+        execdata.m_tapleaf_hash_init = false;
+        execdata.m_codeseparator_pos_init = true;
+        BOOST_CHECK_SIGABRT(!SignatureHashSchnorr(hash_out, execdata, tx_to_m,
+                                                  in_pos, hash_type, sigversion, cache,
+                                                  MissingDataBehavior::FAIL));
+        execdata.m_tapleaf_hash_init = true;
+        execdata.m_codeseparator_pos_init = false;
+        BOOST_CHECK_SIGABRT(!SignatureHashSchnorr(hash_out, execdata, tx_to_m,
+                                                  in_pos, hash_type, sigversion, cache,
+                                                  MissingDataBehavior::FAIL));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(handle_missing_data)
+{
+    // `HandleMissingData` is a static free function inside of `interpreter.cpp`.
+    // Easiest way to get to it is via `SignatureHashSchnorr<CMutableTransaction>`
+    // which takes an explicit `MissingDataBehavior` value which is what is
+    // needed to exercise `HandleMissingData`.
+
+    // N.B.: This is somewhat fragile.  We are just finding a path through
+    // `SignatureHashSchnorr` that definitely gets to `HandleMissingData`. If
+    // the code in `SignatureHashSchnorr` changes for whatever reason the
+    // setup code below may no longer pick out that path.
+
+    // Here we pick an acceptable SigVersion and hash type
+    const SigVersion sigversion = SigVersion::TAPROOT;
+    const uint8_t hash_type{SIGHASH_DEFAULT};
+
+    // Here we pass the assert
+    CMutableTransaction tx_to_m;
+    tx_to_m.vin.push_back(CTxIn());
+    const CTransaction tx_to(tx_to_m);
+    const uint32_t in_pos{0};
+
+    // Here we take the `then` clause of the `if`
+    PrecomputedTransactionData cache;
+    cache.m_bip341_taproot_ready = false;
+    cache.m_spent_outputs_ready = false;
+
+    uint256 hash_out{0};
+    ScriptExecutionData execdata;
+
+    // `MissingDataBehavior::FAIL` simply returns false
+    BOOST_CHECK(!SignatureHashSchnorr(hash_out, execdata, tx_to, in_pos,
+                                      hash_type, sigversion, cache,
+                                      MissingDataBehavior::FAIL));
+    // Any other value for `MissingDataBehavior` triggers an `assert` function
+    // which (on Linux) signals SIGABRT.
+    BOOST_CHECK_SIGABRT(SignatureHashSchnorr(hash_out, execdata, tx_to, in_pos,
+                                             hash_type, sigversion, cache,
+                                             MissingDataBehavior::ASSERT_FAIL));
+    BOOST_CHECK_SIGABRT(SignatureHashSchnorr(hash_out, execdata, tx_to, in_pos,
+                                             hash_type, sigversion, cache,
+                                             static_cast<MissingDataBehavior>(25)));
+}
+
+#endif
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -15,6 +15,7 @@
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <streams.h>
+#include <test/util/pretty_data.h>
 #include <test/util/setup_common.h>
 #include <test/util/transaction_utils.h>
 #include <util/strencodings.h>
@@ -38,9 +39,6 @@
 
 static const unsigned int gFlags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC;
 
-unsigned int ParseScriptFlags(std::string strFlags);
-std::string FormatScriptFlags(unsigned int flags);
-
 UniValue read_json(const std::string& jsondata)
 {
     UniValue v;
@@ -51,76 +49,6 @@ UniValue read_json(const std::string& jsondata)
         return UniValue(UniValue::VARR);
     }
     return v.get_array();
-}
-
-struct ScriptErrorDesc
-{
-    ScriptError_t err;
-    const char *name;
-};
-
-static ScriptErrorDesc script_errors[]={
-    {SCRIPT_ERR_OK, "OK"},
-    {SCRIPT_ERR_UNKNOWN_ERROR, "UNKNOWN_ERROR"},
-    {SCRIPT_ERR_EVAL_FALSE, "EVAL_FALSE"},
-    {SCRIPT_ERR_OP_RETURN, "OP_RETURN"},
-    {SCRIPT_ERR_SCRIPT_SIZE, "SCRIPT_SIZE"},
-    {SCRIPT_ERR_PUSH_SIZE, "PUSH_SIZE"},
-    {SCRIPT_ERR_OP_COUNT, "OP_COUNT"},
-    {SCRIPT_ERR_STACK_SIZE, "STACK_SIZE"},
-    {SCRIPT_ERR_SIG_COUNT, "SIG_COUNT"},
-    {SCRIPT_ERR_PUBKEY_COUNT, "PUBKEY_COUNT"},
-    {SCRIPT_ERR_VERIFY, "VERIFY"},
-    {SCRIPT_ERR_EQUALVERIFY, "EQUALVERIFY"},
-    {SCRIPT_ERR_CHECKMULTISIGVERIFY, "CHECKMULTISIGVERIFY"},
-    {SCRIPT_ERR_CHECKSIGVERIFY, "CHECKSIGVERIFY"},
-    {SCRIPT_ERR_NUMEQUALVERIFY, "NUMEQUALVERIFY"},
-    {SCRIPT_ERR_BAD_OPCODE, "BAD_OPCODE"},
-    {SCRIPT_ERR_DISABLED_OPCODE, "DISABLED_OPCODE"},
-    {SCRIPT_ERR_INVALID_STACK_OPERATION, "INVALID_STACK_OPERATION"},
-    {SCRIPT_ERR_INVALID_ALTSTACK_OPERATION, "INVALID_ALTSTACK_OPERATION"},
-    {SCRIPT_ERR_UNBALANCED_CONDITIONAL, "UNBALANCED_CONDITIONAL"},
-    {SCRIPT_ERR_NEGATIVE_LOCKTIME, "NEGATIVE_LOCKTIME"},
-    {SCRIPT_ERR_UNSATISFIED_LOCKTIME, "UNSATISFIED_LOCKTIME"},
-    {SCRIPT_ERR_SIG_HASHTYPE, "SIG_HASHTYPE"},
-    {SCRIPT_ERR_SIG_DER, "SIG_DER"},
-    {SCRIPT_ERR_MINIMALDATA, "MINIMALDATA"},
-    {SCRIPT_ERR_SIG_PUSHONLY, "SIG_PUSHONLY"},
-    {SCRIPT_ERR_SIG_HIGH_S, "SIG_HIGH_S"},
-    {SCRIPT_ERR_SIG_NULLDUMMY, "SIG_NULLDUMMY"},
-    {SCRIPT_ERR_PUBKEYTYPE, "PUBKEYTYPE"},
-    {SCRIPT_ERR_CLEANSTACK, "CLEANSTACK"},
-    {SCRIPT_ERR_MINIMALIF, "MINIMALIF"},
-    {SCRIPT_ERR_SIG_NULLFAIL, "NULLFAIL"},
-    {SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS, "DISCOURAGE_UPGRADABLE_NOPS"},
-    {SCRIPT_ERR_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM, "DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM"},
-    {SCRIPT_ERR_WITNESS_PROGRAM_WRONG_LENGTH, "WITNESS_PROGRAM_WRONG_LENGTH"},
-    {SCRIPT_ERR_WITNESS_PROGRAM_WITNESS_EMPTY, "WITNESS_PROGRAM_WITNESS_EMPTY"},
-    {SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH, "WITNESS_PROGRAM_MISMATCH"},
-    {SCRIPT_ERR_WITNESS_MALLEATED, "WITNESS_MALLEATED"},
-    {SCRIPT_ERR_WITNESS_MALLEATED_P2SH, "WITNESS_MALLEATED_P2SH"},
-    {SCRIPT_ERR_WITNESS_UNEXPECTED, "WITNESS_UNEXPECTED"},
-    {SCRIPT_ERR_WITNESS_PUBKEYTYPE, "WITNESS_PUBKEYTYPE"},
-    {SCRIPT_ERR_OP_CODESEPARATOR, "OP_CODESEPARATOR"},
-    {SCRIPT_ERR_SIG_FINDANDDELETE, "SIG_FINDANDDELETE"},
-};
-
-static std::string FormatScriptError(ScriptError_t err)
-{
-    for (const auto& se : script_errors)
-        if (se.err == err)
-            return se.name;
-    BOOST_ERROR("Unknown scripterror enumeration value, update script_errors in script_tests.cpp.");
-    return "";
-}
-
-static ScriptError_t ParseScriptError(const std::string& name)
-{
-    for (const auto& se : script_errors)
-        if (se.name == name)
-            return se.err;
-    BOOST_ERROR("Unknown scripterror \"" << name << "\" in test description");
-    return SCRIPT_ERR_UNKNOWN_ERROR;
 }
 
 BOOST_FIXTURE_TEST_SUITE(script_tests, BasicTestingSetup)

--- a/src/test/test_util_tests.cpp
+++ b/src/test/test_util_tests.cpp
@@ -1,0 +1,308 @@
+// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <span.h>
+#include <test/util/pretty_data.h>
+#include <test/util/setup_common.h>
+#include <test/util/traits.h>
+#include <test/util/vector.h>
+#include <uint256.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <iomanip>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+using namespace std::literals::string_literals;
+using namespace std::literals::string_view_literals;
+using namespace test::util::literals;
+
+BOOST_FIXTURE_TEST_SUITE(test_util_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(as_string_tests)
+{
+    // Some typical values, independent of integral type
+    BOOST_TEST(as_string(0) == "0"s);
+    BOOST_TEST(as_string(1) == "1"s);
+    BOOST_TEST(as_string(-1) == "-1"s);
+    BOOST_TEST(as_string(12) == "12"s);
+    BOOST_TEST(as_string(123) == "123"s);
+    BOOST_TEST(as_string(1234) == "1234"s);
+
+    // Now some larger values
+    BOOST_TEST(as_string(1'000'000'000'000ULL) == "1000000000000"s);
+    BOOST_TEST(as_string(-1'234'567'890'123LL) == "-1234567890123"s);
+}
+
+BOOST_AUTO_TEST_CASE(hex_to_stream)
+{
+    auto ToStream = [](auto v) {
+        std::ostringstream oss;
+        oss << Hex(v);
+        return oss.str();
+    };
+
+    {
+        // integral types
+        BOOST_TEST(ToStream(static_cast<int8_t>(0x75)) == "0x75");
+        BOOST_TEST(ToStream(static_cast<uint8_t>(0x75)) == "0x75");
+        BOOST_TEST(ToStream(0x75) == "0x00000075");
+        BOOST_TEST(ToStream(0x75U) == "0x00000075");
+        BOOST_TEST(ToStream(0x75LL) == "0x0000000000000075");
+        BOOST_TEST(ToStream(0x75ULL) == "0x0000000000000075");
+    }
+
+    {
+        // `uint256` which acts like a container
+        BOOST_TEST(ToStream(uint256::ZERO) == "0x0000000000000000000000000000000000000000000000000000000000000000");
+        BOOST_TEST(ToStream(uint256::ONE) == "0x0000000000000000000000000000000000000000000000000000000000000001");
+        BOOST_TEST(ToStream(uint256S("fedcba9876543210"s)) == "0x000000000000000000000000000000000000000000000000fedcba9876543210");
+        BOOST_TEST(ToStream(uint256S("0123456789abcdef00000000000000000000000000000000fedcba9876543210")) == "0x0123456789abcdef00000000000000000000000000000000fedcba9876543210");
+    }
+
+    {
+        // `uint160` also acts like a container
+
+        // when initialized from a vector it is little-endian; but when written as a hex string it is big-endian
+        std::vector<unsigned char> v160{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+                                        0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8, 0xf7, 0xf6};
+        BOOST_TEST(ToStream(uint160(v160)) == "0xf6f7f8f9fafbfcfdfeff0a090807060504030201");
+    }
+
+    {
+        // Span of unsigned char
+        std::vector<unsigned char> v{0x10, 0x11, 0x12, 0x13, 0x14, 0x15};
+        BOOST_TEST(ToStream(Span(v)) == "0x101112131415");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(string_hex_to_bytes_and_back)
+{
+    using valtype = std::vector<unsigned char>;
+
+    // hex strings to byte vector
+    BOOST_TEST("0A"_hex == valtype(1, 0x0a));
+    BOOST_TEST("0a"_hex == valtype(1, 0x0a));
+    BOOST_TEST("A0"_hex == valtype(1, 0xa0));
+    BOOST_TEST("a0"_hex == valtype(1, 0xa0));
+    BOOST_TEST("aA"_hex == valtype(1, 0xaa));
+    BOOST_TEST("Aa"_hex == valtype(1, 0xaa));
+
+    BOOST_TEST(("12"_hex == valtype{0x12}));
+    BOOST_TEST(("1234"_hex == valtype{0x12, 0x34}));
+    BOOST_TEST(("123456"_hex == valtype{0x12, 0x34, 0x56}));
+
+    // Invalid hex string literals
+    BOOST_CHECK_THROW("1"_hex, std::logic_error);
+    BOOST_CHECK_THROW("123"_hex, std::logic_error);
+    BOOST_CHECK_THROW("1234xyz"_hex, std::logic_error);
+
+    // Binary to hex string
+    BOOST_TEST("12345678abcd"s == HexStr("12345678abcd"_hex));
+    BOOST_TEST(std::string(64, '0') == HexStr(uint256::ZERO));
+    BOOST_TEST((std::string{'0', '1'} + std::string(62, '0') == HexStr(uint256::ONE)));
+}
+
+BOOST_AUTO_TEST_CASE(string_to_bytes)
+{
+    using valtype = std::vector<unsigned char>;
+
+    BOOST_TEST(("Aa"_bv == valtype{'A', 'a'}));
+    BOOST_TEST(("ABCD-0123-xyz"_bv == valtype{'A', 'B', 'C', 'D', '-', '0', '1', '2', '3', '-', 'x', 'y', 'z'}));
+}
+
+BOOST_AUTO_TEST_CASE(HexStr_problem)
+{
+    std::vector<unsigned char> a5(1, 0xa5);
+    auto a5_r = HexStr(Span<unsigned char>(a5));
+    BOOST_TEST(a5_r == "a5"s);
+}
+
+BOOST_AUTO_TEST_CASE(ex_vector_tests)
+{
+    using valtype = std::vector<unsigned char>;
+
+    using namespace test::util::vector_ops;
+
+    {
+        // Conversion via unary `+`
+        std::vector<int> v{10, 20, 30};
+        auto ev = +v;
+        BOOST_TEST(ev == v);
+    }
+
+    {
+        // Subrange operation
+        ex_vector<unsigned char> c1{"ABCDEFGH"_bv};
+
+        BOOST_TEST((c1[{0, 2}] == "AB"_bv));
+        BOOST_TEST((c1[{1, 4}] == "BCD"_bv));
+        BOOST_TEST((c1[{3, 7}] == "DEFG"_bv));
+        BOOST_TEST((c1[{0, 8}] == c1));
+    }
+
+    {
+        // Creating ex_vector from a `uint256`.
+        //
+        // (w.r.t. these tests note there is an endianness issue - HexStr will print little-endian,
+        // as a byte array, NOT big-endian like an integer
+        ex_vector<unsigned char> exv_ZERO = from_base_blob(uint256::ZERO);
+        BOOST_TEST(HexStr(exv_ZERO) == "0000000000000000000000000000000000000000000000000000000000000000");
+        ex_vector<unsigned char> exv_ONE = from_base_blob(uint256::ONE);
+        BOOST_TEST(HexStr(exv_ONE) == "0100000000000000000000000000000000000000000000000000000000000000");
+        ex_vector<unsigned char> exv_other = from_base_blob(uint256S(
+            "0123456789abcdef00000000000000000000000000000000fedcba9876543210"));
+        BOOST_TEST(HexStr(exv_other) == "1032547698badcfe00000000000000000000000000000000efcdab8967452301");
+    }
+
+    {
+        // Concatenating vectors via `operator||` (producing ex_vectors)
+        valtype c0{};
+        valtype c1{"ABCDEFGH"_bv};
+        valtype c2{"1234"_bv};
+
+        BOOST_TEST(((c0 || c0) == c0));
+        BOOST_TEST(((c0 || c1) == c1));
+        BOOST_TEST(((c2 || c0) == c2));
+        BOOST_TEST(((c1 || c2) == "ABCDEFGH1234"_bv));
+        BOOST_TEST(((c2 || c1) == "1234ABCDEFGH"_bv));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(pretty_flags)
+{
+    // A small assortment
+    BOOST_TEST(SCRIPT_VERIFY_P2SH == ParseScriptFlags("P2SH"sv, false));
+    BOOST_TEST(SCRIPT_VERIFY_SIGPUSHONLY == ParseScriptFlags("SIGPUSHONLY"sv, false));
+    BOOST_TEST(SCRIPT_VERIFY_TAPROOT == ParseScriptFlags("TAPROOT"sv, false));
+    BOOST_TEST((SCRIPT_VERIFY_MINIMALIF | SCRIPT_VERIFY_WITNESS) == ParseScriptFlags("MINIMALIF,WITNESS"sv, false));
+    BOOST_TEST((SCRIPT_VERIFY_TAPROOT | SCRIPT_VERIFY_LOW_S | SCRIPT_VERIFY_DERSIG) == ParseScriptFlags("TAPROOT,LOW_S,DERSIG"sv, false));
+    BOOST_TEST(0 == ParseScriptFlags("F00BAR"sv, false));
+    BOOST_TEST(0 == ParseScriptFlags("witness"sv, false));        // case-sensitive
+    BOOST_TEST(0 == ParseScriptFlags("P2SH , WITNESS"sv, false)); // Underlying function "split" doesn't trim
+
+    BOOST_TEST("STRICTENC"sv == FormatScriptFlags(SCRIPT_VERIFY_STRICTENC));
+    BOOST_TEST("WITNESS_PUBKEYTYPE"sv == FormatScriptFlags(SCRIPT_VERIFY_WITNESS_PUBKEYTYPE));
+    BOOST_TEST("CONST_SCRIPTCODE,TAPROOT"sv == FormatScriptFlags(SCRIPT_VERIFY_TAPROOT | SCRIPT_VERIFY_CONST_SCRIPTCODE));
+    BOOST_TEST("CLEANSTACK,NULLDUMMY,NULLFAIL"sv == FormatScriptFlags(SCRIPT_VERIFY_NULLDUMMY | SCRIPT_VERIFY_CLEANSTACK | SCRIPT_VERIFY_NULLFAIL));
+    BOOST_TEST(""sv == FormatScriptFlags(0));
+    BOOST_TEST(""sv == FormatScriptFlags(1U << 30)); // invalid flags just ignored
+    BOOST_TEST("WITNESS"sv == FormatScriptFlags((1U << 30) | SCRIPT_VERIFY_WITNESS));
+
+    // Systematic
+    auto flag_map = MapFlagNames();
+    for (auto [name1, value1] : flag_map) {
+        BOOST_TEST(value1 == ParseScriptFlags(name1));
+        BOOST_TEST(name1 == FormatScriptFlags(value1));
+
+        for (auto [name2, value2] : flag_map) {
+            if (value1 == value2) continue;
+            BOOST_TEST((value1 | value2) == ParseScriptFlags(std::string(name1) + "," + std::string(name2), false));
+            BOOST_TEST(std::string(name1 < name2 ? name1 : name2) + "," + std::string(name1 < name2 ? name2 : name1) == FormatScriptFlags(value1 | value2));
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(pretty_script_errors)
+{
+    // A small assortment
+    BOOST_TEST("OK"sv == FormatScriptError(SCRIPT_ERR_OK, false));
+    BOOST_TEST("UNKNOWN_ERROR"sv == FormatScriptError(SCRIPT_ERR_UNKNOWN_ERROR, false));
+    BOOST_TEST(""sv == FormatScriptError(SCRIPT_ERR_ERROR_COUNT, false));
+
+    BOOST_TEST(SCRIPT_ERR_OK == ParseScriptError("OK"sv, false));
+    BOOST_TEST(SCRIPT_ERR_SCHNORR_SIG_SIZE == ParseScriptError("SCHNORR_SIG_SIZE"sv, false));
+    BOOST_TEST(SCRIPT_ERR_UNKNOWN_ERROR == ParseScriptError("F00Bar"sv, false));
+    BOOST_TEST(SCRIPT_ERR_UNKNOWN_ERROR == ParseScriptError("Schnorr_Sig"sv, false)); // case-sensitive
+    BOOST_TEST(SCRIPT_ERR_UNKNOWN_ERROR == ParseScriptError("MINIMALIF "sv, false));  // doesn't trim arg
+
+    // Systematic
+    for (size_t i = 0; i < SCRIPT_ERR_ERROR_COUNT; ++i) {
+        const auto name = FormatScriptError(static_cast<ScriptError_t>(i));
+        BOOST_TEST(!name.empty());
+        BOOST_TEST(i == ParseScriptError(name));
+    }
+}
+
+#define EVAL(...) []() -> bool { return __VA_ARGS__; }()
+
+BOOST_AUTO_TEST_CASE(is_base_of_trait)
+{
+    class A
+    {
+    };
+    class B : A
+    {
+    };
+    class C : B
+    {
+    };
+    class D
+    {
+    };
+
+    BOOST_TEST(EVAL((std::is_base_of_v<A, A>)));
+    BOOST_TEST(EVAL((std::is_base_of_v<A, B>)));
+    BOOST_TEST(EVAL((std::is_base_of_v<A, C>)));
+    BOOST_TEST(EVAL(!(std::is_base_of_v<A, D>)));
+    BOOST_TEST(EVAL(!(std::is_base_of_v<B, A>)));
+    BOOST_TEST(EVAL(!(std::is_base_of_v<int, int>)));
+}
+
+template <unsigned int UI>
+struct base_template {
+};
+
+BOOST_AUTO_TEST_CASE(is_base_template_of_template_trait)
+{
+    struct d_1010 : public base_template<1010> {
+    };
+    struct d_2022 : public base_template<2022> {
+    };
+
+    BOOST_TEST(EVAL((traits::is_base_of_template_of_uint_v<base_template, d_1010>)));
+    BOOST_TEST(EVAL((traits::is_base_of_template_of_uint_v<base_template, d_2022>)));
+    BOOST_TEST(EVAL(!(traits::is_base_of_template_of_uint_v<base_template, std::ostringstream>)));
+    BOOST_TEST(EVAL(!(traits::is_base_of_template_of_uint_v<base_template, int>)));
+}
+
+template <typename T>
+using copy_assign_t = decltype(std::declval<T&>() = std::declval<const T&>());
+
+template <typename C>
+bool fun(...)
+{
+    return false;
+}
+
+template <typename C, typename = traits::ok_for_range_based_for<C>>
+bool fun(int)
+{
+    return true;
+}
+
+BOOST_AUTO_TEST_CASE(is_detected)
+{
+    struct Meow {
+    };
+    struct Purr {
+        void operator=(const Purr&) = delete;
+    };
+
+    BOOST_TEST(EVAL((traits::is_detected_v<copy_assign_t, Meow>)));
+    BOOST_TEST(EVAL(!(traits::is_detected_v<copy_assign_t, Purr>)));
+}
+
+BOOST_AUTO_TEST_CASE(ok_for_range_based_for)
+{
+    BOOST_TEST(EVAL((fun<std::vector<int>>(5))));
+    BOOST_TEST(EVAL(!(fun<std::allocator<int>>(5))));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/boost_test_boosts.h
+++ b/src/test/util/boost_test_boosts.h
@@ -1,0 +1,93 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_UTIL_BOOST_TEST_BOOSTS_H
+#define BITCOIN_TEST_UTIL_BOOST_TEST_BOOSTS_H
+
+// This file contain macros and other constructs that "boost" the Boost Test
+// Framework - additional capabilities, or existing capabilities made more
+// usable with wrappers
+
+////////////////////////////////////////////////////////////////////////////////
+// Test that an `assert` was triggered
+////////////////////////////////////////////////////////////////////////////////
+//
+// The following macro provides "death" tests: The test succeeds iff it causes
+// a crash.  (The name comes from the popular Googletest unit test framework.)
+//
+// These tests use the Boost Test `execution_monitor` facility to trap signals,
+// specifically: SIGABRT (which is raised by the `assert` statement - iff Linux!).
+// The execution monitor will trap signals and reflect them as exceptions.  (So
+// these aren't really "full" death tests à la Googletest as it is not trapping
+// hard faults like calling through a null pointer.  But we don't actually need
+// that so it's fine.)
+//
+// `assert` statement signals SIGABRT - the macro `BOOST_CHECK_SIGABRT` succeeds
+// iff that SIGABRT is raised. (Could be a false positive if code signals SIGABRT
+// for _some other reason than calling `assert`; also if some _other_
+// `system_error` is caused ...)) (There doesn't appear to be any way to check
+// the actual `assert` message to distinguish between different asserts, and the
+// line number field of the exception is not set either.)
+//
+// Each successful call of the macro will cause a message to be logged, along the
+// lines of "... Assertion ... failed."  This is _expected_ - the message is
+// emitted by `assertion_fail()` (`src/util/check.{h,cpp}`). The test _succeeds_
+// iff the assert is triggered (and thus prints that message, in failing).
+//
+// N.B.: These tests are _only_ run if the OS is _not_ Windows _and_ the Thread
+// Sanitizer is _not_ being used.  So protect all such death tests by checking
+// that `OK_TO_TEST_ASSERT_FUNCTION` is defined:
+//
+//     ```
+//     #if defined(OK_TO_TEST_ASSERT_FUNCITON)
+//     BOOST_AUTO_TEST_CASE(ensure_method_foo_triggers_assert)
+//     { ... }
+//     #endif
+//     ```
+//
+//     N.B.: Apparently doesn't work with MSVC or MINGW.  Looking at Boost's
+//     `execution_monitor.ipp` it seems like it _should_ work: the code there
+//     seems to take the structured exception from the `assert` and change it to
+//     a `boost::execution_exception`.  But, no, apparently it doesn't: the
+//     Bitcoin repository CI pipeline for `win64 [unit tests, no gui tests,
+//     no boost::process, no functional tests]` prints the assert and then
+//     aborts.  Also `win64 [native]`.
+//
+//     N.B.: Doesn't work with the ThreadSanitizer, which doesn't like an unsafe
+//     call inside of the Boost Test signal handler.
+
+#define BOOST_CHECK_SIGABRT(expr)                                                  \
+    {                                                                              \
+        ::boost::execution_monitor exmon;                                          \
+        BOOST_TEST_MESSAGE("!!! This is a 'death test': It is expected that "      \
+                           "'Assertion ... failed' message will follow .. and if " \
+                           "it does the test will _succeed_");                     \
+        BOOST_CHECK_EXCEPTION(                                                     \
+            exmon.vexecute([&]() { (void)(expr); }),                               \
+            boost::execution_exception,                                            \
+            [](boost::execution_exception const& ex) {                             \
+                return ex.code() == boost::execution_exception::system_error;      \
+            });                                                                    \
+    }
+
+// Tests that check whether an `assert` function is hit can only run when _not_
+// under Windows _and not_ under the Thread Sanitizer.
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+#define THREAD_SANITIZER_IN_PLAY 1
+#endif
+#endif
+
+#if defined(_MSC_VER) || defined(__MINGW32__)
+#define OS_IS_WINDOWS 1
+#endif
+
+#if !defined(THREAD_SANITIZER_IN_PLAY) && !defined(OS_IS_WINDOWS)
+#define OK_TO_TEST_ASSERT_FUNCTION 1
+#endif
+
+#undef THREAD_SANITIZER_IN_PLAY
+#undef OS_IS_WINDOWS
+
+#endif // BITCOIN_TEST_UTIL_BOOST_TEST_BOOSTS_H

--- a/src/test/util/pretty_data.cpp
+++ b/src/test/util/pretty_data.cpp
@@ -1,0 +1,178 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <policy/policy.h>
+#include <script/interpreter.h>
+#include <test/util/pretty_data.h>
+#include <util/string.h>
+
+#include <map>
+#include <string>
+#include <string_view>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace std::string_view_literals;
+
+namespace {
+
+const std::map<std::string_view, unsigned int> mapFlagNames = {
+    {"P2SH"sv, (unsigned int)SCRIPT_VERIFY_P2SH},
+    {"STRICTENC"sv, (unsigned int)SCRIPT_VERIFY_STRICTENC},
+    {"DERSIG"sv, (unsigned int)SCRIPT_VERIFY_DERSIG},
+    {"LOW_S"sv, (unsigned int)SCRIPT_VERIFY_LOW_S},
+    {"SIGPUSHONLY"sv, (unsigned int)SCRIPT_VERIFY_SIGPUSHONLY},
+    {"MINIMALDATA"sv, (unsigned int)SCRIPT_VERIFY_MINIMALDATA},
+    {"NULLDUMMY"sv, (unsigned int)SCRIPT_VERIFY_NULLDUMMY},
+    {"DISCOURAGE_UPGRADABLE_NOPS"sv, (unsigned int)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS},
+    {"CLEANSTACK"sv, (unsigned int)SCRIPT_VERIFY_CLEANSTACK},
+    {"MINIMALIF"sv, (unsigned int)SCRIPT_VERIFY_MINIMALIF},
+    {"NULLFAIL"sv, (unsigned int)SCRIPT_VERIFY_NULLFAIL},
+    {"CHECKLOCKTIMEVERIFY"sv, (unsigned int)SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY},
+    {"CHECKSEQUENCEVERIFY"sv, (unsigned int)SCRIPT_VERIFY_CHECKSEQUENCEVERIFY},
+    {"WITNESS"sv, (unsigned int)SCRIPT_VERIFY_WITNESS},
+    {"DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM"sv, (unsigned int)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM},
+    {"WITNESS_PUBKEYTYPE"sv, (unsigned int)SCRIPT_VERIFY_WITNESS_PUBKEYTYPE},
+    {"CONST_SCRIPTCODE"sv, (unsigned int)SCRIPT_VERIFY_CONST_SCRIPTCODE},
+    {"TAPROOT"sv, (unsigned int)SCRIPT_VERIFY_TAPROOT},
+    {"DISCOURAGE_UPGRADABLE_PUBKEYTYPE"sv, (unsigned int)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_PUBKEYTYPE},
+    {"DISCOURAGE_OP_SUCCESS"sv, (unsigned int)SCRIPT_VERIFY_DISCOURAGE_OP_SUCCESS},
+    {"DISCOURAGE_UPGRADABLE_TAPROOT_VERSION"sv, (unsigned int)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_TAPROOT_VERSION},
+};
+
+// Check that all flags in STANDARD_SCRIPT_VERIFY_FLAGS are present in mapFlagNames
+auto DoValidateMapFlagNames = []() {
+    unsigned int standard_flags_missing{STANDARD_SCRIPT_VERIFY_FLAGS};
+    for (const auto& pair : mapFlagNames) {
+        standard_flags_missing &= ~(pair.second);
+    }
+    assert(!standard_flags_missing && "array `mapFlagNames` is missing a script verification flag");
+    return true;
+}();
+
+struct ScriptErrorDesc {
+    ScriptError_t err;
+    const std::string_view name;
+};
+
+const ScriptErrorDesc script_errors[] = {
+    {SCRIPT_ERR_OK, "OK"sv},
+    {SCRIPT_ERR_UNKNOWN_ERROR, "UNKNOWN_ERROR"sv},
+    {SCRIPT_ERR_EVAL_FALSE, "EVAL_FALSE"sv},
+    {SCRIPT_ERR_OP_RETURN, "OP_RETURN"sv},
+    {SCRIPT_ERR_SCRIPT_SIZE, "SCRIPT_SIZE"sv},
+    {SCRIPT_ERR_PUSH_SIZE, "PUSH_SIZE"sv},
+    {SCRIPT_ERR_OP_COUNT, "OP_COUNT"sv},
+    {SCRIPT_ERR_STACK_SIZE, "STACK_SIZE"sv},
+    {SCRIPT_ERR_SIG_COUNT, "SIG_COUNT"sv},
+    {SCRIPT_ERR_PUBKEY_COUNT, "PUBKEY_COUNT"sv},
+    {SCRIPT_ERR_VERIFY, "VERIFY"sv},
+    {SCRIPT_ERR_EQUALVERIFY, "EQUALVERIFY"sv},
+    {SCRIPT_ERR_CHECKMULTISIGVERIFY, "CHECKMULTISIGVERIFY"sv},
+    {SCRIPT_ERR_CHECKSIGVERIFY, "CHECKSIGVERIFY"sv},
+    {SCRIPT_ERR_NUMEQUALVERIFY, "NUMEQUALVERIFY"sv},
+    {SCRIPT_ERR_BAD_OPCODE, "BAD_OPCODE"sv},
+    {SCRIPT_ERR_DISABLED_OPCODE, "DISABLED_OPCODE"sv},
+    {SCRIPT_ERR_INVALID_STACK_OPERATION, "INVALID_STACK_OPERATION"sv},
+    {SCRIPT_ERR_INVALID_ALTSTACK_OPERATION, "INVALID_ALTSTACK_OPERATION"sv},
+    {SCRIPT_ERR_UNBALANCED_CONDITIONAL, "UNBALANCED_CONDITIONAL"sv},
+    {SCRIPT_ERR_NEGATIVE_LOCKTIME, "NEGATIVE_LOCKTIME"sv},
+    {SCRIPT_ERR_UNSATISFIED_LOCKTIME, "UNSATISFIED_LOCKTIME"sv},
+    {SCRIPT_ERR_SIG_HASHTYPE, "SIG_HASHTYPE"sv},
+    {SCRIPT_ERR_SIG_DER, "SIG_DER"sv},
+    {SCRIPT_ERR_MINIMALDATA, "MINIMALDATA"sv},
+    {SCRIPT_ERR_SIG_PUSHONLY, "SIG_PUSHONLY"sv},
+    {SCRIPT_ERR_SIG_HIGH_S, "SIG_HIGH_S"sv},
+    {SCRIPT_ERR_SIG_NULLDUMMY, "SIG_NULLDUMMY"sv},
+    {SCRIPT_ERR_PUBKEYTYPE, "PUBKEYTYPE"sv},
+    {SCRIPT_ERR_CLEANSTACK, "CLEANSTACK"sv},
+    {SCRIPT_ERR_MINIMALIF, "MINIMALIF"sv},
+    {SCRIPT_ERR_SIG_NULLFAIL, "NULLFAIL"sv},
+    {SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS, "DISCOURAGE_UPGRADABLE_NOPS"sv},
+    {SCRIPT_ERR_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM, "DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM"sv},
+    {SCRIPT_ERR_WITNESS_PROGRAM_WRONG_LENGTH, "WITNESS_PROGRAM_WRONG_LENGTH"sv},
+    {SCRIPT_ERR_WITNESS_PROGRAM_WITNESS_EMPTY, "WITNESS_PROGRAM_WITNESS_EMPTY"sv},
+    {SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH, "WITNESS_PROGRAM_MISMATCH"sv},
+    {SCRIPT_ERR_WITNESS_MALLEATED, "WITNESS_MALLEATED"sv},
+    {SCRIPT_ERR_WITNESS_MALLEATED_P2SH, "WITNESS_MALLEATED_P2SH"sv},
+    {SCRIPT_ERR_WITNESS_UNEXPECTED, "WITNESS_UNEXPECTED"sv},
+    {SCRIPT_ERR_WITNESS_PUBKEYTYPE, "WITNESS_PUBKEYTYPE"sv},
+    {SCRIPT_ERR_OP_CODESEPARATOR, "OP_CODESEPARATOR"sv},
+    {SCRIPT_ERR_SIG_FINDANDDELETE, "SIG_FINDANDDELETE"sv},
+    {SCRIPT_ERR_DISCOURAGE_OP_SUCCESS, "DISCOURAGE_OP_SUCCESS"sv},
+    {SCRIPT_ERR_DISCOURAGE_UPGRADABLE_PUBKEYTYPE, "DISCOURAGE_UPGRADABLE_PUBKEYTYPE"sv},
+    {SCRIPT_ERR_DISCOURAGE_UPGRADABLE_TAPROOT_VERSION, "DISCOURAGE_UPGRADABLE_TAPROOT_VERSION"sv},
+    {SCRIPT_ERR_SCHNORR_SIG, "SCHNORR_SIG"sv},
+    {SCRIPT_ERR_SCHNORR_SIG_HASHTYPE, "SCHNORR_SIG_HASHTYPE"sv},
+    {SCRIPT_ERR_SCHNORR_SIG_SIZE, "SCHNORR_SIG_SIZE"sv},
+    {SCRIPT_ERR_TAPROOT_WRONG_CONTROL_SIZE, "TAPROOT_WRONG_CONTROL_SIZE"sv},
+    {SCRIPT_ERR_TAPSCRIPT_CHECKMULTISIG, "TAPSCRIPT_CHECKMULTISIG"sv},
+    {SCRIPT_ERR_TAPSCRIPT_MINIMALIF, "TAPSCRIPT_MINIMALIF"sv},
+    {SCRIPT_ERR_TAPSCRIPT_VALIDATION_WEIGHT, "TAPSCRIPT_VALIDATION_WEIGHT"sv},
+};
+
+// Check that all ERROR CODES in ScriptError_t are present in script_errors array
+auto DoValidateScriptErrorCount = []() {
+    assert(SCRIPT_ERR_ERROR_COUNT == std::size(script_errors));
+    return true;
+}();
+
+} // namespace
+
+const std::map<std::string_view, unsigned int>& MapFlagNames()
+{
+    return mapFlagNames;
+}
+
+unsigned int ParseScriptFlags(std::string_view strFlags, bool issue_boost_error)
+{
+    if (strFlags.empty() || strFlags == "NONE") return 0;
+    unsigned int flags = 0;
+    std::vector<std::string> words = SplitString(strFlags, ',');
+
+    for (const std::string& word : words) {
+        if (auto r = mapFlagNames.find(word); r != mapFlagNames.end()) {
+            flags |= r->second;
+        } else if (issue_boost_error) {
+            BOOST_ERROR("Bad test: unknown verification flag '" << word << "'");
+        }
+    }
+
+    return flags;
+}
+
+std::string FormatScriptFlags(unsigned int flags)
+{
+    if (flags == 0) {
+        return "";
+    }
+    std::string ret;
+    decltype(mapFlagNames)::const_iterator it = mapFlagNames.begin();
+    while (it != mapFlagNames.end()) {
+        if (flags & it->second) {
+            ret += it->first;
+            ret += ",";
+        }
+        it++;
+    }
+    return ret.substr(0, ret.size() - 1);
+}
+
+std::string FormatScriptError(ScriptError_t err, bool issue_boost_error)
+{
+    for (const auto& se : script_errors)
+        if (se.err == err)
+            return std::string(se.name);
+    if (issue_boost_error) BOOST_ERROR("Unknown scripterror enumeration value, update script_errors in script_tests.cpp.");
+    return "";
+}
+
+ScriptError_t ParseScriptError(std::string_view name, bool issue_boost_error)
+{
+    for (const auto& se : script_errors)
+        if (se.name == name)
+            return se.err;
+    if (issue_boost_error) BOOST_ERROR("Unknown scripterror \"" << name << "\" in test description");
+    return SCRIPT_ERR_UNKNOWN_ERROR;
+}

--- a/src/test/util/pretty_data.h
+++ b/src/test/util/pretty_data.h
@@ -15,6 +15,7 @@
 #include <charconv>
 #include <iomanip>
 #include <map>
+#include <optional>
 #include <ostream>
 #include <set>
 #include <string>
@@ -140,7 +141,7 @@ const std::map<std::string_view, unsigned int>& MapFlagNames();
  * Given a comma-separated string of script verification flags (from
  * `script/interpreter.h`) return the flag word (word with the flag bits set)
  */
-unsigned int ParseScriptFlags(std::string_view strFlags, bool issue_boost_error = true);
+std::optional<unsigned int> ParseScriptFlags(std::string_view strFlags);
 
 /**
  * Given a flag word (word with script verification flag bits set) return
@@ -153,7 +154,7 @@ std::string FormatScriptFlags(unsigned int flags);
  *
  * The name is the enum name with the prefix `SCRIPT_ERR_` removed.
  */
-ScriptError_t ParseScriptError(std::string_view err, bool issue_boost_error = true);
+std::optional<ScriptError_t> ParseScriptError(std::string_view err);
 
 /**
  * Given a script error value return its string name.
@@ -162,7 +163,7 @@ ScriptError_t ParseScriptError(std::string_view err, bool issue_boost_error = tr
  * that this is different from `ScriptErrorString` (`script_error.h`) which
  * returns an English phrase describing the error.
  */
-std::string FormatScriptError(ScriptError_t err, bool issue_boost_error = true);
+std::optional<std::string> FormatScriptError(ScriptError_t err);
 
 namespace test::util::literals {
 

--- a/src/test/util/pretty_data.h
+++ b/src/test/util/pretty_data.h
@@ -1,0 +1,203 @@
+// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_UTIL_PRETTY_DATA_H
+#define BITCOIN_TEST_UTIL_PRETTY_DATA_H
+
+#include <script/script_error.h>
+#include <span.h>
+#include <test/util/traits.h>
+#include <uint256.h>
+#include <util/strencodings.h>
+
+#include <array>
+#include <charconv>
+#include <iomanip>
+#include <map>
+#include <ostream>
+#include <set>
+#include <string>
+#include <string_view>
+
+/**
+ * Integer type to string (without locale issues)
+ *
+ * (This seems rather elaborate to avoid locale issues with `std::to_string`.
+ * One can't help but think the C++ committee could have provided a nicer
+ * wrapper for it.)
+ *
+ */
+template <typename I>
+std::string as_string(I i, int base = 10)
+{
+    std::array<char, 24> a{0};
+    if (const auto [ptr, ec] = std::to_chars(a.data(), a.data() + a.size(), i);
+        ec == std::errc()) {
+        return {a.data(), static_cast<std::string::size_type>(ptr - a.data())};
+    }
+    return {}; // EOVERFLOW - should never happen as buffer `a` is large enough
+}
+
+/**
+ * Outputs to a stream as hex - this unspecialized primary template doesn't
+ * implement `operator<<` - it must be specialized for suitable types.
+ *
+ * Convert something to a hex string in a context suitable for output to a stream
+ */
+template <typename US, typename Enable = void>
+struct Hex {
+    explicit Hex(US v) {}
+}; // primary template - but invalid
+
+/**
+ * Outputs to stream as hex - suitable for any integral type
+ */
+template <typename US>
+struct Hex<US, typename std::enable_if_t<std::is_integral_v<US>>> {
+    explicit Hex(US v) : m_value(v) {}
+
+    // Unfortunately, `<<` operators for streams have overloads for `char`,
+    // `signed char`, and `unsigned char` that output as _characters_ not integers.
+    // Must force a widening for those types.
+    using USBase = std::conditional_t<std::is_same_v<char, US>, int,
+                                      std::conditional_t<std::is_same_v<signed char, US>, int,
+                                                         std::conditional_t<std::is_same_v<unsigned char, US>, unsigned int, US>>>;
+
+    const USBase m_value;
+
+    friend std::ostream& operator<<(std::ostream& os, Hex hex)
+    {
+        auto flags = os.flags();
+        os << std::setw(2 + 2 * sizeof(US)) << std::setfill('0')
+           << std::hex << std::showbase << std::nouppercase << std::internal
+           << hex.m_value;
+        os.flags(flags);
+        return os;
+    }
+};
+
+/**
+ * Outputs to stream as hex - suitable for any `base_blob<>` type, e.g., `uint256`
+ */
+template <typename BLOB>
+struct Hex<BLOB, typename std::enable_if_t<traits::is_base_of_template_of_uint_v<base_blob, BLOB>>> {
+    explicit Hex(const BLOB v) : m_value(v) {}
+    const BLOB m_value;
+
+    friend std::ostream& operator<<(std::ostream& os, Hex hex)
+    {
+        os << "0x" << hex.m_value.GetHex();
+        return os;
+    }
+};
+
+/**
+ * Outputs to stream as hex - suitable for any `Span` with an overload of `HexStr`
+ */
+template <>
+struct Hex<Span<unsigned char>, void> {
+    explicit Hex(const Span<unsigned char> v) : m_value(v) {}
+    const Span<const unsigned char> m_value;
+
+    friend std::ostream& operator<<(std::ostream& os, Hex hex)
+    {
+        os << "0x" << HexStr(hex.m_value);
+        return os;
+    }
+};
+
+/**
+ * Conversion to hex string for any "container" supporting `begin()` and `end()`
+ *
+ * (Another overload for functions defined in `src/util/strencodings.h`)
+ */
+template <typename C, typename = traits::ok_for_range_based_for<C>>
+std::string HexStr(C container)
+{
+    constexpr auto to_hexit = [](unsigned char c) -> char {
+        return "0123456789abcdef"[c];
+    };
+
+    std::string r;
+    r.reserve(container.size() * 2);
+    for (unsigned char c : container) {
+        r.push_back(to_hexit(c >> 4 & 0x0F));
+        r.push_back(to_hexit(c & 0x0F));
+    }
+    return r;
+}
+
+/**
+ * Return a map from script verification flag name to its binary value (word with
+ * single bit set).
+ *
+ * The names are the enum name with the prefix `SCRIPT_VERIFY_` removed.
+ */
+const std::map<std::string_view, unsigned int>& MapFlagNames();
+
+/**
+ * Given a comma-separated string of script verification flags (from
+ * `script/interpreter.h`) return the flag word (word with the flag bits set)
+ */
+unsigned int ParseScriptFlags(std::string_view strFlags, bool issue_boost_error = true);
+
+/**
+ * Given a flag word (word with script verification flag bits set) return
+ * a comma-separated string of the flags by name.
+ */
+std::string FormatScriptFlags(unsigned int flags);
+
+/**
+ * Given the name of script err return the error value.
+ *
+ * The name is the enum name with the prefix `SCRIPT_ERR_` removed.
+ */
+ScriptError_t ParseScriptError(std::string_view err, bool issue_boost_error = true);
+
+/**
+ * Given a script error value return its string name.
+ *
+ * The name is the enum name with the prefix `SCRIPT_ERR_` removed.  Note
+ * that this is different from `ScriptErrorString` (`script_error.h`) which
+ * returns an English phrase describing the error.
+ */
+std::string FormatScriptError(ScriptError_t err, bool issue_boost_error = true);
+
+namespace test::util::literals {
+
+/**
+ * User-defined literal for converting script verify flag name to flag word.
+ */
+inline unsigned int operator"" _svf(const char* s, size_t len)
+{
+    std::string_view sv{s, len};
+    if (auto r = MapFlagNames().find(sv); r != MapFlagNames().end()) return r->second;
+    throw std::invalid_argument("invalid script verify flag name");
+}
+
+/**
+ * User-defined literal for converting hex strings to byte vectors.
+ */
+inline std::vector<unsigned char> operator"" _hex(const char* s, size_t len)
+{
+    std::string_view sv{s, len};
+    if (IsHex(sv)) return ParseHex(sv);
+    throw std::invalid_argument("invalid hex literal");
+}
+
+/**
+ * Literal format for a `vector<unsigned char>` initialized from a string literal.
+ *
+ * Characters in the string are used _directly_, not interpreted as hex.
+ */
+inline std::vector<unsigned char> operator"" _bv(const char* s, size_t len)
+{
+    std::string_view sv{s, len};
+    std::vector<unsigned char> r(sv.begin(), sv.end());
+    return r;
+}
+
+} // namespace test::util::literals
+
+#endif // BITCOIN_TEST_UTIL_PRETTY_DATA_H

--- a/src/test/util/traits.h
+++ b/src/test/util/traits.h
@@ -1,0 +1,95 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_UTIL_TRAITS_H
+#define BITCOIN_TEST_UTIL_TRAITS_H
+
+#include <type_traits>
+
+namespace traits {
+
+/**
+ * Determine if a class is a derived class of a template.  This is a specific
+ * trait where the base template class has one type parameter: an unsigned int.
+ * (This fits the case of `base_blob<>`, used for `uint256`);
+ *
+ * This metaprogramming magic adapted from excellent answer here:
+ * https://stackoverflow.com/a/34672753/751579
+ * Adapted by making it applicable to a base template class with one non-type
+ * parameter.
+ */
+template <template <unsigned int> typename base, typename derived>
+struct is_base_of_template_of_uint {
+    template <unsigned int UI>
+    static constexpr std::true_type test(const base<UI>*);
+    static constexpr std::false_type test(...);
+    using type = decltype(test(std::declval<derived*>()));
+};
+
+template <template <unsigned int> typename base, typename derived>
+using is_base_of_template_of_uint_t = typename is_base_of_template_of_uint<base, derived>::type;
+
+template <template <unsigned int> typename base, typename derived>
+inline constexpr bool is_base_of_template_of_uint_v = is_base_of_template_of_uint<base, derived>::type::value;
+
+/**
+ * Trait `is_detected` from `std::experimental` for "library fundamentals TS v2"
+ * See https://en.cppreference.com/w/cpp/experimental/is_detected for specification
+ * and sample implementation, also https://stackoverflow.com/a/41936999/751579
+ *
+ * Namespace `detail_detected` consists of helpers for `is_detected`.
+ */
+
+namespace detail_detected {
+
+template <class Default, class AlwaysVoid,
+          template <class...> class Op, class... Args>
+struct detector {
+    using value_t = std::false_type;
+    using type = Default;
+};
+
+template <class Default, template <class...> class Op, class... Args>
+struct detector<Default, std::void_t<Op<Args...>>, Op, Args...> {
+    using value_t = std::true_type;
+    using type = Op<Args...>;
+};
+
+struct nonesuch {
+    nonesuch() = delete;
+    ~nonesuch() = delete;
+    nonesuch(nonesuch const&) = delete;
+    void operator=(nonesuch const&) = delete;
+};
+
+} // namespace detail_detected
+
+template <template <class...> class Op, class... Args>
+using is_detected = typename detail_detected::detector<detail_detected::nonesuch, void, Op, Args...>::value_t;
+
+template <template <class...> class Op, class... Args>
+constexpr bool is_detected_v = is_detected<Op, Args...>::value;
+
+// And here we have trait predicates that look for `begin()` and `end()`
+template <class T>
+using requires_has_begin = decltype(std::declval<T&>().begin());
+template <class T>
+using requires_has_end = decltype(std::declval<T&>().end());
+
+/**
+ * Trait (approximate) for a type that supports `begin()` and `end()
+ *
+ * (Approximate because it doesn't check return types are valid among other
+ * flaws, e.g., not checking that theres a `begin(C)` or `end(C)` that can be
+ * found via ADL.  But it's sufficient for our purposes here.  Anyway, will be
+ * obsolete with C++20 and ranges.)
+ */
+template <class C>
+using ok_for_range_based_for =
+    std::enable_if_t<std::conjunction_v<is_detected<requires_has_begin, C>,
+                                        is_detected<requires_has_end, C>>>;
+
+} // namespace traits
+
+#endif // BITCOIN_TEST_UTIL_TRAITS_H

--- a/src/test/util/vector.h
+++ b/src/test/util/vector.h
@@ -1,0 +1,87 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_UTIL_VECTOR_H
+#define BITCOIN_TEST_UTIL_VECTOR_H
+
+#include <test/util/traits.h>
+#include <uint256.h>
+
+#include <algorithm>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+/**
+ * A `std::vector` with a few extra operations to make it nice for unit tests,
+ * especially of byte vectors (`vector<unsigned char>`).
+ */
+template <typename E>
+struct ex_vector : public std::vector<E> {
+    using std::vector<E>::vector;
+    using std::vector<E>::operator[];
+
+    explicit ex_vector(const std::vector<E>& other) : std::vector<E>(other)
+    {
+    }
+
+    explicit ex_vector(std::vector<E>&& other) : std::vector<E>(std::move(other))
+    {
+    }
+
+    /**
+     * Return half-open subrange from byte vector, use notation `v[{i,j}]` for
+     * the subrange `[i,j)`.  N.B.: `first`, `one-past-last`, _NOT_ `first` + `length`.
+     *
+     * (Not sure why `operator[]` overloads must be a member function, but that's
+     * the way it is.))
+     */
+    ex_vector operator[](std::tuple<size_t, size_t> range) const
+    {
+        auto [i, j] = range;
+        assert(i <= j && j <= this->size());
+        ex_vector r(j - i, 0);
+        std::copy(this->begin() + i, this->begin() + j, r.begin());
+        return r;
+    }
+};
+
+/**
+ * Make an `ex_vector` from a `uint160` or `uint256`
+ */
+template <unsigned int BITS>
+ex_vector<unsigned char> from_base_blob(const base_blob<BITS>& bb)
+{
+    return ex_vector<unsigned char>(bb.begin(), bb.end());
+}
+
+namespace test::util::vector_ops {
+
+/**
+ * Convert a `std::vector` into an `ex_vector` via unary `+`
+ */
+template <typename E>
+ex_vector<E> operator+(const std::vector<E>& v)
+{
+    return ex_vector<E>(v);
+}
+
+/**
+ * Concatenate two vectors (producing an `ex_vector` for further operations)
+ */
+template <typename E>
+ex_vector<E> operator||(const std::vector<E>& lhs, const std::vector<E>& rhs)
+{
+    ex_vector<E> r;
+    r.resize(lhs.size() + rhs.size());
+    std::copy(lhs.begin(), lhs.end(), r.begin());
+    std::copy(rhs.begin(), rhs.end(), r.begin() + lhs.size());
+    return r;
+}
+
+} // namespace test::util::vector_ops
+
+#endif // BITCOIN_TEST_UTIL_VECTOR_H

--- a/test/lint/lint-includes.py
+++ b/test/lint/lint-includes.py
@@ -31,6 +31,7 @@ EXPECTED_BOOST_INCLUDES = ["boost/algorithm/string/replace.hpp",
                            "boost/signals2/connection.hpp",
                            "boost/signals2/optional_last_value.hpp",
                            "boost/signals2/signal.hpp",
+                           "boost/test/execution_monitor.hpp",
                            "boost/test/included/unit_test.hpp",
                            "boost/test/unit_test.hpp"]
 


### PR DESCRIPTION
[Unit tests are not complete to resolve #23279 - _yet_.  But those additional tests - see this space for future developments! - will not change the code presented here.]

This PR provides unit tests for Taproot functionality in `script/interpreter.cpp`, #23279.

Goal is to show correctness vs specifications in BIPs 341/342, and to improve code coverage in Taproot functionality there.

Intent is to unit test completely without changing `interpreter.cpp` itself to provide visibility into static functions/private methods.  Thus some of the tests must be "indirect", testing the unit-under-test by probing a visible caller.  This makes those specific tests somewhat fragile as they depend on code paths in the caller, which may change in the future.  However, such tests are written so they will fail if the unit-under-test isn't actually called.  This is noted in the code of those specific tests.

No changes to Bitcoin Core are made - just unit tests added.  The Boost Test framework file `boost/test/execution_monitor.hpp` was added to the lint whitelist - this is acceptable because it is a documented public header of the Boost Test framework, which is already part of the project.

- [x] `EvalChecksigTapscript`
- [x] `HandleMissingData`
- [x] `SignatureHashSchnorr` - now with full _path_ coverage
- [x] `GenericTransactionSignatureChecker<T>::VerifySchnorrSignature`
- [x] `GenericTransactionSignatureChecker<T>::CheckSchnorrSignature`
- [x] `ComputeTaprootMerkleRoot`
- [ ] `SigVersion::TAPSCRIPT` code paths in `ExecuteWitnessScript`
- [x] Taproot code paths in `VerifyWitnessProgram`
- [ ] Tapscript code paths in `VerifyWitnessProgram`

**TODO:** Full Tapscript (BIP-342) unit tests yet to be completed.
**TODO:** Does anything need to be done with `libconsensus`? Please advise!

2 commits:

1. Add new utility functions to `src/test/util` that are not only used in these tests but may also be useful for future unit tests.  Also, refactor some existing utility functions from current tests (mainly, `script_tests.cpp`) into `src/test/util` so they can be more widely used too.  All of these new test utility functions have unit tests themselves, in `src/test/test_utils_tests.cpp`.
1. All the tests for Taproot/Tapscript functionality requested by #23279 in a new file `src/test/script_tapscript_tests.cpp`.  Code coverage runs show 100% coverage of lines and near 100% coverage of branches.

**DEATH TRAP AHEAD!:** These unit tests include "death tests" (name comes from Googletest framework): Tests that check that an `assert` actually fails.  These are handled with a Boost `execution_monitor` (mentioned above) _but_ the asserts _still issue messages_ even when correctly trapped by the Boost Test framework.  You'll see the following in the logs:

```
gitpod /workspace/bitcoin/src/test (23279-taproot-unit-tests) $ ./test_bitcoin 
Running 527 test cases...
test_bitcoin: script/interpreter.cpp:1495: bool SignatureHashSchnorr(uint256 &, ScriptExecutionData &, const T &, uint32_t, uint8_t, SigVersion, const PrecomputedTransactionData &, MissingDataBehavior) [T = CMutableTransaction]: Assertion `false' failed.
test_bitcoin: script/interpreter.cpp:1497: bool SignatureHashSchnorr(uint256 &, ScriptExecutionData &, const T &, uint32_t, uint8_t, SigVersion, const PrecomputedTransactionData &, MissingDataBehavior) [T = CMutableTransaction]: Assertion `in_pos < tx_to.vin.size()' failed.
test_bitcoin: script/interpreter.cpp:1528: bool SignatureHashSchnorr(uint256 &, ScriptExecutionData &, const T &, uint32_t, uint8_t, SigVersion, const PrecomputedTransactionData &, MissingDataBehavior) [T = CMutableTransaction]: Assertion `execdata.m_annex_init' failed.
test_bitcoin: script/interpreter.cpp:1556: bool SignatureHashSchnorr(uint256 &, ScriptExecutionData &, const T &, uint32_t, uint8_t, SigVersion, const PrecomputedTransactionData &, MissingDataBehavior) [T = CMutableTransaction]: Assertion `execdata.m_tapleaf_hash_init' failed.
test_bitcoin: script/interpreter.cpp:1559: bool SignatureHashSchnorr(uint256 &, ScriptExecutionData &, const T &, uint32_t, uint8_t, SigVersion, const PrecomputedTransactionData &, MissingDataBehavior) [T = CMutableTransaction]: Assertion `execdata.m_codeseparator_pos_init' failed.
test_bitcoin: script/interpreter.cpp:1469: bool HandleMissingData(MissingDataBehavior): Assertion `!"Missing data"' failed.
test_bitcoin: script/interpreter.cpp:1474: bool HandleMissingData(MissingDataBehavior): Assertion `!"Unknown MissingDataBehavior value"' failed.

*** No errors detected
gitpod /workspace/bitcoin/src/test (23279-taproot-unit-tests) $ 
```

These specific `Assertion ... failed` messages are _expected_.  The tests triggering them properly _pass_ iff the `assert` (and no other) is _triggered_.

-----

Coverage results 2022-06-05 showing Taproot coverage (Tapscript tests not yet complete) when _only running_ `script_tapscript_tests.cpp`:

|  |   |
|--:|:--|
|`EvalChecksigTapscript`|<img alt="EvalChecksigTapscript" align="left" width="550" src="https://user-images.githubusercontent.com/4162948/172067379-4815fd13-1eca-4fdc-afb3-ab321f644ca6.png">|
|`HandleMissingData`|<img alt="HandleMissingData coverage" align="left" width="550" src="https://user-images.githubusercontent.com/4162948/172066800-7ad85065-448c-4300-8f5f-bbdaeb5bc885.png">|
|`SignatureHashSchnorr`|<img alt="SignatureHashSchnorr coverage" align="left" width="550" src="https://user-images.githubusercontent.com/4162948/172067034-c8d65908-bf41-4420-8a5d-5c023f85824a.png">|
|`GenericTransaction-`<br>`SignatureChecker<T>::`<br>`CheckSchnorrSignature`|<img alt="CheckSchnorrSignature" align="left" width="550" src="https://user-images.githubusercontent.com/4162948/172067232-b58ea75a-9df7-4f02-b291-c1adda4792e8.png">|
|`ComputeTaprootMerkleRoot`|<img alt="ComputeTaprootMerkleRoot" align="left" width="550" src="https://user-images.githubusercontent.com/4162948/172067270-d15ac048-6001-4a8f-b0a7-f62b76cf584b.png">|
|`VerifyWitnessProgram`<br>(Taproot only)|<img alt="VerifyWitnessProgram" align="left" width="550" src="https://user-images.githubusercontent.com/4162948/172067308-c23ccaaa-dbee-43ea-b2df-cbee9ba375ed.png">|

