### PR TITLE
Switch scheduler to steady_clock

### DIFF
--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -4,11 +4,11 @@
 
 #include <scheduler.h>
 
-#include <random.h>
+#include <sync.h>
 #include <util/syscall_sandbox.h>
 #include <util/time.h>
 
-#include <assert.h>
+#include <cassert>
 #include <functional>
 #include <utility>
 
@@ -43,7 +43,7 @@ void CScheduler::serviceQueue()
             // the time of the first item on the queue:
 
             while (!shouldStop() && !taskQueue.empty()) {
-                std::chrono::system_clock::time_point timeToWaitFor = taskQueue.begin()->first;
+                std::chrono::steady_clock::time_point timeToWaitFor = taskQueue.begin()->first;
                 if (newTaskScheduled.wait_until(lock, timeToWaitFor) == std::cv_status::timeout) {
                     break; // Exit loop after timeout, it means we reached the time of the event
                 }
@@ -72,7 +72,7 @@ void CScheduler::serviceQueue()
     newTaskScheduled.notify_one();
 }
 
-void CScheduler::schedule(CScheduler::Function f, std::chrono::system_clock::time_point t)
+void CScheduler::schedule(CScheduler::Function f, std::chrono::steady_clock::time_point t)
 {
     {
         LOCK(newTaskMutex);
@@ -89,7 +89,7 @@ void CScheduler::MockForward(std::chrono::seconds delta_seconds)
         LOCK(newTaskMutex);
 
         // use temp_queue to maintain updated schedule
-        std::multimap<std::chrono::system_clock::time_point, Function> temp_queue;
+        std::multimap<std::chrono::steady_clock::time_point, Function> temp_queue;
 
         for (const auto& element : taskQueue) {
             temp_queue.emplace_hint(temp_queue.cend(), element.first - delta_seconds, element.second);
@@ -114,8 +114,8 @@ void CScheduler::scheduleEvery(CScheduler::Function f, std::chrono::milliseconds
     scheduleFromNow([this, f, delta] { Repeat(*this, f, delta); }, delta);
 }
 
-size_t CScheduler::getQueueInfo(std::chrono::system_clock::time_point& first,
-                                std::chrono::system_clock::time_point& last) const
+size_t CScheduler::getQueueInfo(std::chrono::steady_clock::time_point& first,
+                                std::chrono::steady_clock::time_point& last) const
 {
     LOCK(newTaskMutex);
     size_t result = taskQueue.size();
@@ -143,7 +143,7 @@ void SingleThreadedSchedulerClient::MaybeScheduleProcessQueue()
         if (m_are_callbacks_running) return;
         if (m_callbacks_pending.empty()) return;
     }
-    m_scheduler.schedule([this] { this->ProcessQueue(); }, std::chrono::system_clock::now());
+    m_scheduler.schedule([this] { this->ProcessQueue(); }, std::chrono::steady_clock::now());
 }
 
 void SingleThreadedSchedulerClient::ProcessQueue()

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -46,12 +46,12 @@ public:
     typedef std::function<void()> Function;
 
     /** Call func at/after time t */
-    void schedule(Function f, std::chrono::system_clock::time_point t);
+    void schedule(Function f, std::chrono::steady_clock::time_point t);
 
     /** Call f once after the delta has passed */
     void scheduleFromNow(Function f, std::chrono::milliseconds delta)
     {
-        schedule(std::move(f), std::chrono::system_clock::now() + delta);
+        schedule(std::move(f), std::chrono::steady_clock::now() + delta);
     }
 
     /**
@@ -93,8 +93,8 @@ public:
      * Returns number of tasks waiting to be serviced,
      * and first and last task times
      */
-    size_t getQueueInfo(std::chrono::system_clock::time_point& first,
-                        std::chrono::system_clock::time_point& last) const;
+    size_t getQueueInfo(std::chrono::steady_clock::time_point& first,
+                        std::chrono::steady_clock::time_point& last) const;
 
     /** Returns true if there are threads actively running in serviceQueue() */
     bool AreThreadsServicingQueue() const;
@@ -102,7 +102,7 @@ public:
 private:
     mutable Mutex newTaskMutex;
     std::condition_variable newTaskScheduled;
-    std::multimap<std::chrono::system_clock::time_point, Function> taskQueue GUARDED_BY(newTaskMutex);
+    std::multimap<std::chrono::steady_clock::time_point, Function> taskQueue GUARDED_BY(newTaskMutex);
     int nThreadsServicingQueue GUARDED_BY(newTaskMutex){0};
     bool stopRequested GUARDED_BY(newTaskMutex){false};
     bool stopWhenEmpty GUARDED_BY(newTaskMutex){false};


### PR DESCRIPTION
There is already `mockscheduler`, so it seems brittle, confusing and redundant to be able to mock the scheduler by adjusting the system clock.