### PR TITLE
Add mockable clock type

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -44,7 +44,6 @@
 // trivial to get the mocked time from the server, nor is it needed for now, so
 // just use a plain system_clock.
 using CliClock = std::chrono::system_clock;
-using CliSeconds = std::chrono::time_point<CliClock, std::chrono::seconds>;
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 UrlDecodeFn* const URL_DECODE = urlDecode;
@@ -470,7 +469,7 @@ public:
         if (networkinfo["version"].get_int() < 209900) {
             throw std::runtime_error("-netinfo requires bitcoind server to be running v0.21.0 and up");
         }
-        const int64_t time_now{count_seconds(Now<CliSeconds>())};
+        const int64_t time_now{TicksSinceEpoch<std::chrono::seconds>(CliClock::now())};
 
         // Count peer connection totals, and if DetailsRequested(), store peer data in a vector of structs.
         for (const UniValue& peer : batch[ID_PEERINFO]["result"].getValues()) {

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1488,8 +1488,12 @@ BOOST_AUTO_TEST_CASE(util_time_GetTime)
     for (const auto& num_sleep : {0ms, 1ms}) {
         UninterruptibleSleep(num_sleep);
         BOOST_CHECK_EQUAL(111, GetTime()); // Deprecated time getter
+        BOOST_CHECK_EQUAL(111, Now<NodeSeconds>().time_since_epoch().count());
+        BOOST_CHECK_EQUAL(111, TicksSinceEpoch<std::chrono::seconds>(NodeClock::now()));
+        BOOST_CHECK_EQUAL(111, TicksSinceEpoch<SecondsDouble>(Now<NodeSeconds>()));
         BOOST_CHECK_EQUAL(111, GetTime<std::chrono::seconds>().count());
         BOOST_CHECK_EQUAL(111000, GetTime<std::chrono::milliseconds>().count());
+        BOOST_CHECK_EQUAL(111000, TicksSinceEpoch<std::chrono::milliseconds>(NodeClock::now()));
         BOOST_CHECK_EQUAL(111000000, GetTime<std::chrono::microseconds>().count());
     }
 

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -66,20 +66,16 @@ bool ChronoSanityCheck()
     return true;
 }
 
-template <typename T>
-T GetTime()
+NodeClock::time_point NodeClock::now() noexcept
 {
     const std::chrono::seconds mocktime{nMockTime.load(std::memory_order_relaxed)};
     const auto ret{
         mocktime.count() ?
             mocktime :
-            std::chrono::duration_cast<T>(std::chrono::system_clock::now().time_since_epoch())};
+            std::chrono::system_clock::now().time_since_epoch()};
     assert(ret > 0s);
-    return ret;
-}
-template std::chrono::seconds GetTime();
-template std::chrono::milliseconds GetTime();
-template std::chrono::microseconds GetTime();
+    return time_point{ret};
+};
 
 template <typename T>
 static T GetSystemTime()

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -14,6 +14,16 @@
 
 using namespace std::chrono_literals;
 
+/** Mockable clock in the context of tests, otherwise the system clock */
+struct NodeClock : public std::chrono::system_clock {
+    using time_point = std::chrono::time_point<NodeClock>;
+    /** Return current system time or mocked time, if set */
+    static time_point now() noexcept;
+    static std::time_t to_time_t(const time_point&) = delete; // unused
+    static time_point from_time_t(std::time_t) = delete;      // unused
+};
+using NodeSeconds = std::chrono::time_point<NodeClock, std::chrono::seconds>;
+
 using SteadySeconds = std::chrono::time_point<std::chrono::steady_clock, std::chrono::seconds>;
 using SteadyMilliseconds = std::chrono::time_point<std::chrono::steady_clock, std::chrono::milliseconds>;
 using SteadyMicroseconds = std::chrono::time_point<std::chrono::steady_clock, std::chrono::microseconds>;
@@ -30,10 +40,10 @@ void UninterruptibleSleep(const std::chrono::microseconds& n);
  * This helper is used to convert durations/time_points before passing them over an
  * interface that doesn't support std::chrono (e.g. RPC, debug log, or the GUI)
  */
-template <typename Clock>
-constexpr int64_t count_seconds(std::chrono::time_point<Clock, std::chrono::seconds> t)
+template <typename Duration, typename Timepoint>
+constexpr auto TicksSinceEpoch(Timepoint t)
 {
-    return t.time_since_epoch().count();
+    return std::chrono::time_point_cast<Duration>(t).time_since_epoch().count();
 }
 constexpr int64_t count_seconds(std::chrono::seconds t) { return t.count(); }
 constexpr int64_t count_milliseconds(std::chrono::milliseconds t) { return t.count(); }
@@ -48,7 +58,11 @@ inline double CountSecondsDouble(SecondsDouble t) { return t.count(); }
 
 /**
  * DEPRECATED
- * Use either GetTimeSeconds (not mockable) or GetTime<T> (mockable)
+ * Use either ClockType::now() or Now<TimePointType>() if a cast is needed.
+ * ClockType is
+ * - std::chrono::steady_clock for steady time
+ * - std::chrono::system_clock for system time
+ * - NodeClock                 for mockable system time
  */
 int64_t GetTime();
 
@@ -71,9 +85,6 @@ void SetMockTime(std::chrono::seconds mock_time_in);
 /** For testing */
 std::chrono::seconds GetMockTime();
 
-/** Return system time (or mocked time, if set) */
-template <typename T>
-T GetTime();
 /**
  * Return the current time point cast to the given precicion. Only use this
  * when an exact precicion is needed, otherwise use T::clock::now() directly.
@@ -82,6 +93,12 @@ template <typename T>
 T Now()
 {
     return std::chrono::time_point_cast<typename T::duration>(T::clock::now());
+}
+/** DEPRECATED, see GetTime */
+template <typename T>
+T GetTime()
+{
+    return Now<std::chrono::time_point<NodeClock, T>>().time_since_epoch();
 }
 
 /**


### PR DESCRIPTION
This will be used primarily by the addr time refactor (https://github.com/bitcoin/bitcoin/pull/24697) to make addr relay time type safe. However, it can also be used in other places, and can be reviewed independently, so I split it up.