### PR TITLE
Re-enable external signer support for Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1470,6 +1470,11 @@ if test "$use_external_signer" != "no"; then
   dnl Boost 1.73 and older require the following workaround.
   LDFLAGS="$LDFLAGS $PTHREAD_CFLAGS"
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+    #if defined(WIN32) && !defined(__kernel_entry)
+    // A workaround for boost 1.71 incompatibility with mingw-w64 compiler.
+    // For details see https://github.com/bitcoin/bitcoin/pull/22348.
+    #define __kernel_entry
+    #endif
     #define BOOST_PROCESS_USE_STD_FS
     #include <boost/process.hpp>
   ]],[[

--- a/configure.ac
+++ b/configure.ac
@@ -1459,45 +1459,45 @@ if test "$use_boost" = "yes"; then
 fi
 
 if test "$use_external_signer" != "no"; then
-  case $host in
-    *mingw*)
-      dnl Boost Process uses Boost Filesystem when targeting Windows. Also,
-      dnl since Boost 1.71.0, Process does not work with mingw-w64 without
-      dnl workarounds. See 67669ab425b52a2b6be3d2f3b3b7e3939b676a2c.
-      if test "$use_external_signer" = "yes"; then
-        AC_MSG_ERROR([External signing is not supported on Windows])
-      fi
-      use_external_signer="no";
-    ;;
-    *)
-      AC_MSG_CHECKING([whether Boost.Process can be used])
-      TEMP_CXXFLAGS="$CXXFLAGS"
-      dnl Boost 1.78 requires the following workaround.
-      dnl See: https://github.com/boostorg/process/issues/235
-      CXXFLAGS="$CXXFLAGS -Wno-error=narrowing"
-      TEMP_CPPFLAGS="$CPPFLAGS"
-      CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
-      TEMP_LDFLAGS="$LDFLAGS"
-      dnl Boost 1.73 and older require the following workaround.
-      LDFLAGS="$LDFLAGS $PTHREAD_CFLAGS"
-      AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <boost/process.hpp>]])],
-        [have_boost_process="yes"],
-        [have_boost_process="no"])
-      LDFLAGS="$TEMP_LDFLAGS"
-      CPPFLAGS="$TEMP_CPPFLAGS"
-      CXXFLAGS="$TEMP_CXXFLAGS"
-      AC_MSG_RESULT([$have_boost_process])
-      if test "$have_boost_process" = "yes"; then
-        use_external_signer="yes"
-        AC_DEFINE([ENABLE_EXTERNAL_SIGNER], [1], [Define if external signer support is enabled])
-      else
-        if test "$use_external_signer" = "yes"; then
-          AC_MSG_ERROR([External signing is not supported for this Boost version])
-        fi
-        use_external_signer="no";
-      fi
-    ;;
-  esac
+  AC_MSG_CHECKING([whether Boost.Process can be used])
+  TEMP_CXXFLAGS="$CXXFLAGS"
+  dnl Boost 1.78 requires the following workaround.
+  dnl See: https://github.com/boostorg/process/issues/235
+  CXXFLAGS="$CXXFLAGS -Wno-error=narrowing"
+  TEMP_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+  TEMP_LDFLAGS="$LDFLAGS"
+  dnl Boost 1.73 and older require the following workaround.
+  LDFLAGS="$LDFLAGS $PTHREAD_CFLAGS"
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+    #define BOOST_PROCESS_USE_STD_FS
+    #include <boost/process.hpp>
+  ]],[[
+    namespace bp = boost::process;
+    bp::opstream stdin_stream;
+    bp::ipstream stdout_stream;
+    bp::child c("dummy", bp::std_out > stdout_stream, bp::std_err > stdout_stream, bp::std_in < stdin_stream);
+    stdin_stream << std::string{"test"} << std::endl;
+    if (c.running()) c.terminate();
+    c.wait();
+    c.exit_code();
+  ]])],
+    [have_boost_process="yes"],
+    [have_boost_process="no"])
+  LDFLAGS="$TEMP_LDFLAGS"
+  CPPFLAGS="$TEMP_CPPFLAGS"
+  CXXFLAGS="$TEMP_CXXFLAGS"
+  AC_MSG_RESULT([$have_boost_process])
+  if test "$have_boost_process" = "yes"; then
+    use_external_signer="yes"
+    AC_DEFINE([ENABLE_EXTERNAL_SIGNER], [1], [Define if external signer support is enabled])
+    AC_DEFINE([BOOST_PROCESS_USE_STD_FS], [1], [Defined to avoid Boost::Process trying to use Boost Filesystem])
+  else
+    if test "$use_external_signer" = "yes"; then
+      AC_MSG_ERROR([External signing is not supported for this Boost version])
+    fi
+    use_external_signer="no";
+  fi
 fi
 AM_CONDITIONAL([ENABLE_EXTERNAL_SIGNER], [test "$use_external_signer" = "yes"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1470,6 +1470,8 @@ if test "$use_external_signer" != "no"; then
   dnl Boost 1.73 and older require the following workaround.
   LDFLAGS="$LDFLAGS $PTHREAD_CFLAGS"
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+    // A workaround for boost::process not including what it needs
+    #include <algorithm>
     #if defined(WIN32) && !defined(__kernel_entry)
     // A workaround for boost 1.71 incompatibility with mingw-w64 compiler.
     // For details see https://github.com/bitcoin/bitcoin/pull/22348.

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -4,6 +4,11 @@ $(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/$($(
 $(package)_file_name=boost_$(subst .,_,$($(package)_version)).tar.bz2
 $(package)_sha256_hash=fc9f85fc030e233142908241af7a846e60630aa7388de9a5fafb1f3a26840854
 
+define $(package)_preprocess_cmds
+  rm boost/filesystem* -rf &&\
+  sed -i.old 's/\(#include <\)boost\/filesystem[^>]*>/\1filesystem>/; s/boost\(::filesystem\)/std\1/g' `find boost/process -type f`
+endef
+
 define $(package)_stage_cmds
   mkdir -p $($(package)_staging_prefix_dir)/include && \
   cp -r boost $($(package)_staging_prefix_dir)/include

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -6,6 +6,11 @@
 #include <util/system.h>
 
 #ifdef ENABLE_EXTERNAL_SIGNER
+#if defined(WIN32) && !defined(__kernel_entry)
+// A workaround for boost 1.71 incompatibility with mingw-w64 compiler.
+// For details see https://github.com/bitcoin/bitcoin/pull/22348.
+#define __kernel_entry
+#endif
 #if defined(__GNUC__)
 // Boost 1.78 requires the following workaround.
 // See: https://github.com/boostorg/process/issues/235


### PR DESCRIPTION
`configure` check is modified to actually verify Boost::Process works (without needing extra libs), rather than hardcoding it off for Windows unconditionally.

For now, depends does some trivial patching of boost::process to use std::filesystem instead of boost::filesystem, and also deletes boost::filesystem entirely to be sure it doesn't find its way into builds.

Also, `BOOST_PROCESS_USE_STD_FS` is defined since it looks like that's the approach upstream boost is planning on (https://github.com/klemens-morgenstern/boost-process/commit/85cbc29726e4f4169036ab0b9b905f7287950334)