### PR TITLE
util: Move error message formatting of NonFatalCheckError to cpp

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -59,6 +59,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
           " src/threadinterrupt.cpp"\
           " src/util/bip32.cpp"\
           " src/util/bytevectorhash.cpp"\
+          " src/util/check.cpp"\
           " src/util/error.cpp"\
           " src/util/getuniquepath.cpp"\
           " src/util/hasher.cpp"\

--- a/src/util/check.cpp
+++ b/src/util/check.cpp
@@ -4,7 +4,22 @@
 
 #include <util/check.h>
 
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
 #include <tinyformat.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+
+NonFatalCheckError::NonFatalCheckError(const char* msg, const char* file, int line, const char* func)
+    : std::runtime_error{
+          strprintf("Internal bug detected: \"%s\"\n%s:%d (%s)\nPlease report this issue here: %s\n", msg, file, line, func, PACKAGE_BUGREPORT)}
+{
+}
 
 void assertion_fail(const char* file, int line, const char* func, const char* assertion)
 {

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -5,31 +5,23 @@
 #ifndef BITCOIN_UTIL_CHECK_H
 #define BITCOIN_UTIL_CHECK_H
 
-#if defined(HAVE_CONFIG_H)
-#include <config/bitcoin-config.h>
-#endif
-
 #include <attributes.h>
-#include <tinyformat.h>
 
 #include <stdexcept>
+#include <utility>
 
 class NonFatalCheckError : public std::runtime_error
 {
-    using std::runtime_error::runtime_error;
+public:
+    NonFatalCheckError(const char* msg, const char* file, int line, const char* func);
 };
-
-#define format_internal_error(msg, file, line, func, report)                                    \
-    strprintf("Internal bug detected: \"%s\"\n%s:%d (%s)\nPlease report this issue here: %s\n", \
-              msg, file, line, func, report)
 
 /** Helper for CHECK_NONFATAL() */
 template <typename T>
 T&& inline_check_non_fatal(LIFETIMEBOUND T&& val, const char* file, int line, const char* func, const char* assertion)
 {
-    if (!(val)) {
-        throw NonFatalCheckError(
-            format_internal_error(assertion, file, line, func, PACKAGE_BUGREPORT));
+    if (!val) {
+        throw NonFatalCheckError{assertion, file, line, func};
     }
     return std::forward<T>(val);
 }
@@ -88,11 +80,9 @@ T&& inline_assertion_check(LIFETIMEBOUND T&& val, [[maybe_unused]] const char* f
 
 /**
  * NONFATAL_UNREACHABLE() is a macro that is used to mark unreachable code. It throws a NonFatalCheckError.
- * This is used to mark code that is not yet implemented or is not yet reachable.
  */
 #define NONFATAL_UNREACHABLE()                                        \
     throw NonFatalCheckError(                                         \
-        format_internal_error("Unreachable code reached (non-fatal)", \
-                              __FILE__, __LINE__, __func__, PACKAGE_BUGREPORT))
+        "Unreachable code reached (non-fatal)", __FILE__, __LINE__, __func__)
 
 #endif // BITCOIN_UTIL_CHECK_H


### PR DESCRIPTION
This allows to strip down the header file.