### PR TITLE
test: Check msg type in msg capture is followed by zeros

### DIFF
--- a/test/functional/p2p_message_capture.py
+++ b/test/functional/p2p_message_capture.py
@@ -43,12 +43,8 @@ def mini_parser(dat_file):
                 break
             tmp_header = BytesIO(tmp_header_raw)
             tmp_header.read(TIME_SIZE) # skip the timestamp field
-            raw_msgtype = tmp_header.read(MSGTYPE_SIZE)
-            msgtype: bytes = raw_msgtype.split(b'\x00', 1)[0]
-            remainder =  raw_msgtype.split(b'\x00', 1)[1]
-            assert(len(msgtype) > 0)
+            msgtype = tmp_header.read(MSGTYPE_SIZE).rstrip(b'\x00')
             assert(msgtype in MESSAGEMAP)
-            assert(len(remainder) == 0 or not remainder.decode().isprintable())
             length: int = int.from_bytes(tmp_header.read(LENGTH_SIZE), "little")
             data = f_in.read(length)
             assert_equal(len(data), length)


### PR DESCRIPTION
Checking that they are not printable is an odd (and wrong) way to check that all chars are zero.