### PR TITLE
net, refactor: move StartExtraBlockRelayPeers() from header to implementation

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1867,6 +1867,12 @@ void CConnman::SetTryNewOutboundPeer(bool flag)
     LogPrint(BCLog::NET, "net: setting try another outbound peer=%s\n", flag ? "true" : "false");
 }
 
+void CConnman::StartExtraBlockRelayPeers()
+{
+    LogPrint(BCLog::NET, "net: enabling extra block-relay-only peers\n");
+    m_start_extra_block_relay_peers = true;
+}
+
 // Return the number of peers we have over our outbound connection limit
 // Exclude peers that are marked for disconnect, or are going to be
 // disconnected soon (eg ADDR_FETCH and FEELER)

--- a/src/net.h
+++ b/src/net.h
@@ -13,7 +13,6 @@
 #include <crypto/siphash.h>
 #include <hash.h>
 #include <i2p.h>
-#include <logging.h>
 #include <net_permissions.h>
 #include <netaddress.h>
 #include <netbase.h>
@@ -857,10 +856,7 @@ public:
     void SetTryNewOutboundPeer(bool flag);
     bool GetTryNewOutboundPeer() const;
 
-    void StartExtraBlockRelayPeers() {
-        LogPrint(BCLog::NET, "net: enabling extra block-relay-only peers\n");
-        m_start_extra_block_relay_peers = true;
-    }
+    void StartExtraBlockRelayPeers();
 
     // Return the number of outbound peers we have in excess of our target (eg,
     // if we previously called SetTryNewOutboundPeer(true), and have since set


### PR DESCRIPTION
where all the other logging actions in src/net.{h,cpp} are located.

StartExtraBlockRelayPeers() does not appear to be a hotspot that needs to be inlined for performance, as it is called from CheckForStaleTipAndEvictPeers(), called in turn from StartScheduledTasks() with a scheduleEvery delta of 45 seconds, called at the end of AppInitMain() on bitcoind startup.

This allows dropping `#include <logging.h>` from net.h, which can improve compile time/speed. Currently, none of the other includes in net.h use logging.h, except src/sync.h if DEBUG_LOCKCONTENTION is defined.

