### PR TITLE
test: fix DWARF string_view linker error in blockfilter_tests

### DIFF
--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -14,6 +14,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <string_view>
+
 BOOST_AUTO_TEST_SUITE(blockfilter_tests)
 
 BOOST_AUTO_TEST_CASE(gcsfilter_test)
@@ -160,14 +162,14 @@ BOOST_AUTO_TEST_CASE(blockfilters_json_test)
         CTxUndo& tx_undo = block_undo.vtxundo.back();
         const UniValue& prev_scripts = test[pos++].get_array();
         for (unsigned int ii = 0; ii < prev_scripts.size(); ii++) {
-            std::vector<unsigned char> raw_script = ParseHex(prev_scripts[ii].get_str());
+            std::vector<unsigned char> raw_script = ParseHex(std::string_view{prev_scripts[ii].get_str()});
             CTxOut txout(0, CScript(raw_script.begin(), raw_script.end()));
             tx_undo.vprevout.emplace_back(txout, 0, false);
         }
 
         uint256 prev_filter_header_basic;
         BOOST_CHECK(ParseHashStr(test[pos++].get_str(), prev_filter_header_basic));
-        std::vector<unsigned char> filter_basic = ParseHex(test[pos++].get_str());
+        std::vector<unsigned char> filter_basic = ParseHex(std::string_view{test[pos++].get_str()});
         uint256 filter_header_basic;
         BOOST_CHECK(ParseHashStr(test[pos++].get_str(), filter_header_basic));
 


### PR DESCRIPTION
Fix the following build error that I am seeing with Debian testing clang 15:
```
/usr/bin/ld: /usr/bin/ld: DWARF error: invalid or unhandled FORM value: 0x23
test/test_bitcoin-blockfilter_tests.o: in function `blockfilter_tests::blockfilters_json_test::test_method()':
blockfilter_tests.cpp:(.text+0x59d6): undefined reference to `ParseHex(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: blockfilter_tests.cpp:(.text+0x5e54): undefined reference to `ParseHex(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
