### PR TITLE
test: compare `/mempool/info` response with `getmempoolinfo` RPC

### DIFF
--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -330,6 +330,9 @@ class RESTTest (BitcoinTestFramework):
         # the size of the memory pool should be greater than 3x ~100 bytes
         assert_greater_than(json_obj['bytes'], 300)
 
+        mempool_info = self.nodes[0].getmempoolinfo()
+        assert_equal(json_obj, mempool_info)
+
         # Check that there are our submitted transactions in the TX memory pool
         json_obj = self.test_rest_request("/mempool/contents")
         raw_mempool_verbose = self.nodes[0].getrawmempool(verbose=True)


### PR DESCRIPTION
This PRs compares `/mempool/info` REST response with `getmempoolinfo` RPC in `interface_rest.py`.
Similar to #24936 and #24797. 