### PR TITLE
Torcontrol opt check

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1772,7 +1772,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                                     "for the automatically created Tor onion service."),
                                   onion_service_target.ToStringIPPort()));
         }
-        StartTorControl(onion_service_target);
+        bilingual_str error;
+        if (!StartTorControl(onion_service_target, error)) return InitError(error);
     }
 
     if (connOptions.bind_on_any) {

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -132,6 +132,21 @@ std::vector<std::string> GetNetworkNames(bool append_unroutable)
     return names;
 }
 
+NetworkAddrError HasValidHostPort(std::string_view networkAddr)
+{
+    uint16_t port{0};
+    std::string hostname;
+    bool validPort = SplitHostPort(networkAddr, port, hostname);
+
+    NetworkAddrError res = NetworkAddrError::OK;
+    if (!validPort || port == 0)
+        res = NetworkAddrError::NO_PORT;
+    if (hostname.empty() || hostname.find(' ') != std::string::npos)
+        res = (res == NetworkAddrError::NO_PORT) ? NetworkAddrError::NO_HOSTPORT
+            : NetworkAddrError::NO_HOST;
+    return res;
+}
+
 static bool LookupIntern(const std::string& name, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions, bool fAllowLookup, DNSLookupFn dns_lookup_function)
 {
     vIP.clear();

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <stdint.h>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 
@@ -95,6 +96,15 @@ bool IsProxy(const CNetAddr &addr);
 bool SetNameProxy(const Proxy &addrProxy);
 bool HaveNameProxy();
 bool GetNameProxy(Proxy &nameProxyOut);
+
+enum class NetworkAddrError {
+    OK, //!< No error
+    NO_HOST,
+    NO_PORT,
+    NO_HOSTPORT,
+};
+
+NetworkAddrError HasValidHostPort(std::string_view networkAddr);
 
 using DNSLookupFn = std::function<std::vector<CNetAddr>(const std::string&, bool)>;
 extern DNSLookupFn g_dns_lookup;

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -84,6 +84,43 @@ BOOST_AUTO_TEST_CASE(netbase_properties)
 
 }
 
+bool static TestHasHostPort(const std::string& test, bool hasHost, bool hasPort)
+{
+    NetworkAddrError ret = HasValidHostPort(test);
+    switch (ret) {
+        case NetworkAddrError::OK:
+            return hasHost && hasPort;
+        case NetworkAddrError::NO_HOST:
+            return !hasHost && hasPort;
+        case NetworkAddrError::NO_PORT:
+            return hasHost && !hasPort;
+        case NetworkAddrError::NO_HOSTPORT:
+            return !hasHost && !hasPort;
+        default:
+            return false;
+    }
+}
+
+BOOST_AUTO_TEST_CASE(netbase_hashostport)
+{
+    BOOST_CHECK(TestHasHostPort("1.2.3.4:123", true, true));
+    BOOST_CHECK(TestHasHostPort("[1.2.3.4]:123", true, true));
+    BOOST_CHECK(TestHasHostPort("bitcoincore.org:123", true, true));
+    BOOST_CHECK(TestHasHostPort("[bitcoincore.org]:123", true, true));
+    BOOST_CHECK(TestHasHostPort("[::ffff:127.0.0.1]:1234", true, true));
+    BOOST_CHECK(TestHasHostPort("1.2.3.4", true, false));
+    BOOST_CHECK(TestHasHostPort("bitcoincore.org", true, false));
+    BOOST_CHECK(TestHasHostPort("1.2.3.4:", true, false));
+    BOOST_CHECK(TestHasHostPort("bitcoincore.org:", true, false));
+    BOOST_CHECK(TestHasHostPort(":123", false, true));
+    BOOST_CHECK(TestHasHostPort("1", true, false));
+    BOOST_CHECK(TestHasHostPort("1024", true, false));
+    BOOST_CHECK(TestHasHostPort(":", true, false));
+    BOOST_CHECK(TestHasHostPort("", false, false));
+    BOOST_CHECK(TestHasHostPort(" ", false, false));
+    BOOST_CHECK(TestHasHostPort(" : ", false, false));
+}
+
 bool static TestSplitHost(const std::string& test, const std::string& host, uint16_t port, bool validPort=true)
 {
     std::string hostOut;

--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -21,13 +21,14 @@
 #include <functional>
 #include <string>
 #include <vector>
+#include <util/translation.h>
 
 class CService;
 
 extern const std::string DEFAULT_TOR_CONTROL;
 static const bool DEFAULT_LISTEN_ONION = true;
 
-void StartTorControl(CService onion_service_target);
+bool StartTorControl(CService onion_service_target, bilingual_str& error);
 void InterruptTorControl();
 void StopTorControl();
 


### PR DESCRIPTION
Based on `SplitHostPort` from [#22087](https://github.com/bitcoin/bitcoin/pull/22087)

- Adds new utility for easy sanity check of network addresses
- Checks `-torcontrol` for a valid host:port string
- Adds a return param in `StartTorControl` so that we can stop init and present a message if `torcontrol` input is invalid

Solves #23589