### PR TITLE
GetTimeSeconds() removal followups

### DIFF
--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -257,7 +257,7 @@ BOOST_AUTO_TEST_CASE(versionbits_test)
 /** Check that ComputeBlockVersion will set the appropriate bit correctly */
 static void check_computeblockversion(VersionBitsCache& versionbitscache, const Consensus::Params& params, Consensus::DeploymentPos dep)
 {
-    // Clear the cache everytime
+    // Clear the cache every time
     versionbitscache.Clear();
 
     int64_t bit = params.vDeployments[dep].bit;

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -75,8 +75,8 @@ std::chrono::seconds GetMockTime();
 template <typename T>
 T GetTime();
 /**
- * Return the current time point cast to the given precicion. Only use this
- * when an exact precicion is needed, otherwise use T::clock::now() directly.
+ * Return the current time point cast to the given precision. Only use this
+ * when an exact precision is needed, otherwise use T::clock::now() directly.
  */
 template <typename T>
 T Now()

--- a/test/lint/spelling.ignore-words.txt
+++ b/test/lint/spelling.ignore-words.txt
@@ -11,6 +11,7 @@ inout
 invokable
 keypair
 mor
+nd
 nin
 ser
 unparseable


### PR DESCRIPTION
A few cleanup followups to recently merged #25102 (and #24595).

Edit: dropped commit [Update GetTime() doxygen doc for removed GetTimeSeconds()](https://github.com/bitcoin/bitcoin/pull/25155/commits/1924abea724b7b2b73073736513c633ec45664ac) as it would be fixed in #25101.