### PR TITLE
guix: Simplify code for Linux builds

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -104,7 +104,6 @@ case "$HOST" in
         ;;
     *linux*)
         CROSS_GLIBC="$(store_path "glibc-cross-${HOST}")"
-        CROSS_GLIBC_STATIC="$(store_path "glibc-cross-${HOST}" static)"
         CROSS_KERNEL="$(store_path "linux-libre-headers-cross-${HOST}")"
         CROSS_GCC="$(store_path "gcc-cross-${HOST}")"
         CROSS_GCC_LIB_STORE="$(store_path "gcc-cross-${HOST}" lib)"
@@ -113,7 +112,7 @@ case "$HOST" in
 
         export CROSS_C_INCLUDE_PATH="${CROSS_GCC_LIB}/include:${CROSS_GCC_LIB}/include-fixed:${CROSS_GLIBC}/include:${CROSS_KERNEL}/include"
         export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GCC}/include/c++/${HOST}:${CROSS_GCC}/include/c++/backward:${CROSS_C_INCLUDE_PATH}"
-        export CROSS_LIBRARY_PATH="${CROSS_GCC_LIB_STORE}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib:${CROSS_GLIBC_STATIC}/lib"
+        export CROSS_LIBRARY_PATH="${CROSS_GCC_LIB_STORE}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib"
         ;;
     *)
         exit 1 ;;

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -106,13 +106,10 @@ case "$HOST" in
         CROSS_GLIBC="$(store_path "glibc-cross-${HOST}")"
         CROSS_KERNEL="$(store_path "linux-libre-headers-cross-${HOST}")"
         CROSS_GCC="$(store_path "gcc-cross-${HOST}")"
-        CROSS_GCC_LIB_STORE="$(store_path "gcc-cross-${HOST}" lib)"
-        CROSS_GCC_LIBS=( "${CROSS_GCC_LIB_STORE}/lib/gcc/${HOST}"/* ) # This expands to an array of directories...
-        CROSS_GCC_LIB="${CROSS_GCC_LIBS[0]}" # ...we just want the first one (there should only be one)
 
-        export CROSS_C_INCLUDE_PATH="${CROSS_GCC_LIB}/include:${CROSS_GCC_LIB}/include-fixed:${CROSS_GLIBC}/include:${CROSS_KERNEL}/include"
+        export CROSS_C_INCLUDE_PATH="${CROSS_GLIBC}/include:${CROSS_KERNEL}/include"
         export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GCC}/include/c++/${HOST}:${CROSS_GCC}/include/c++/backward:${CROSS_C_INCLUDE_PATH}"
-        export CROSS_LIBRARY_PATH="${CROSS_GCC_LIB_STORE}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib"
+        export CROSS_LIBRARY_PATH="${CROSS_GLIBC}/lib"
         ;;
     *)
         exit 1 ;;

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -120,8 +120,7 @@ http://www.linuxfromscratch.org/hlfs/view/development/chapter05/gcc-pass1.html"
       (propagated-inputs
        `(("binutils" ,xbinutils)
          ("libc" ,xlibc)
-         ("gcc" ,xgcc)
-         ("gcc-lib" ,xgcc "lib")))
+         ("gcc" ,xgcc)))
       (synopsis (string-append "Complete GCC tool chain for " target))
       (description (string-append "This package provides a complete GCC tool
 chain for " target " development."))

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -120,7 +120,6 @@ http://www.linuxfromscratch.org/hlfs/view/development/chapter05/gcc-pass1.html"
       (propagated-inputs
        `(("binutils" ,xbinutils)
          ("libc" ,xlibc)
-         ("libc:static" ,xlibc "static")
          ("gcc" ,xgcc)
          ("gcc-lib" ,xgcc "lib")))
       (synopsis (string-append "Complete GCC tool chain for " target))

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -604,8 +604,7 @@ inspecting signatures in Mach-O binaries.")
           ((string-contains target "-linux-")
            (list (cond ((string-contains target "riscv64-")
                         (make-bitcoin-cross-toolchain target
-                                                      #:base-libc (make-glibc-without-werror glibc-2.27/bitcoin-patched)
-                                                      #:base-kernel-headers base-linux-kernel-headers))
+                                                      #:base-libc (make-glibc-without-werror glibc-2.27/bitcoin-patched)))
                        (else
                         (make-bitcoin-cross-toolchain target)))))
           ((string-contains target "darwin")


### PR DESCRIPTION
While working on bitcoin/bitcoin#22458 I found that code for Linux builds could be simplified.

#### Guix builds on `x86_64`:
```
$ find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
b8b5d3c516e44f8248a03cee98bf556bd9ec36f8262e15b380a958eca19254c2  guix-build-d9da39fa37ee/output/aarch64-linux-gnu/SHA256SUMS.part
1db5939444af3f9c1f863ac81710b8062535fdb4fc41523ee61f40ba7a571d9c  guix-build-d9da39fa37ee/output/aarch64-linux-gnu/bitcoin-d9da39fa37ee-aarch64-linux-gnu-debug.tar.gz
ceec312f80bb6f42d8bfb28b373661fb7912a7b6ef4d10c151bdbac5d89385e3  guix-build-d9da39fa37ee/output/aarch64-linux-gnu/bitcoin-d9da39fa37ee-aarch64-linux-gnu.tar.gz
c232d9933c5062b0d6d7fa71761cdf872f6c49de0426e229b74a44d61bf9d3dd  guix-build-d9da39fa37ee/output/arm-linux-gnueabihf/SHA256SUMS.part
60c36fcd6fa5e58c243cf1c9dc3be383b5a9ec2bbfe53110133776ee79a7b446  guix-build-d9da39fa37ee/output/arm-linux-gnueabihf/bitcoin-d9da39fa37ee-arm-linux-gnueabihf-debug.tar.gz
e149bd724d9cf18dd0f38d2326c6bee90160cc4006a1ca806834f919029f58e1  guix-build-d9da39fa37ee/output/arm-linux-gnueabihf/bitcoin-d9da39fa37ee-arm-linux-gnueabihf.tar.gz
95e22b4ede04b61f43f54dc2116d1f4ac12534d987148d27bec6d6a631ea889e  guix-build-d9da39fa37ee/output/dist-archive/bitcoin-d9da39fa37ee.tar.gz
ff22ec01ffd21506a8e089664ff55cb76d9fd96301062056c0dcd35c35a428f5  guix-build-d9da39fa37ee/output/powerpc64-linux-gnu/SHA256SUMS.part
462f1f6ed2991cdcf37e8986ca82402506c3daab6af099258a66fc8b345cb0ea  guix-build-d9da39fa37ee/output/powerpc64-linux-gnu/bitcoin-d9da39fa37ee-powerpc64-linux-gnu-debug.tar.gz
7237c94ce85478830e847f12ba8cce575a98abb5e5a2d9e8a389983e2e905dad  guix-build-d9da39fa37ee/output/powerpc64-linux-gnu/bitcoin-d9da39fa37ee-powerpc64-linux-gnu.tar.gz
b52709a327ed5347af61cf8125a0bf3d86b02cb15f653829475be69781308e28  guix-build-d9da39fa37ee/output/powerpc64le-linux-gnu/SHA256SUMS.part
20f60ab1024c160858095cc7f8e0b140dbbfdd1fe365caeeaa255ac40a768452  guix-build-d9da39fa37ee/output/powerpc64le-linux-gnu/bitcoin-d9da39fa37ee-powerpc64le-linux-gnu-debug.tar.gz
a25b7cffe46f7adaba97e3ca891dc0226e47234a02f043929f462ce59cb3f368  guix-build-d9da39fa37ee/output/powerpc64le-linux-gnu/bitcoin-d9da39fa37ee-powerpc64le-linux-gnu.tar.gz
8698461bca56e0420abd78b4d1f32673cebafff4716c93f7b66426937ac384be  guix-build-d9da39fa37ee/output/riscv64-linux-gnu/SHA256SUMS.part
7a2d41c257ef11d859ec9b3bd3166a46ac36c920c12c5f92d6ec57ee0bf1cf90  guix-build-d9da39fa37ee/output/riscv64-linux-gnu/bitcoin-d9da39fa37ee-riscv64-linux-gnu-debug.tar.gz
c95c23e3ba3d8f0361e107cfa3118f4f124c9d89bdf8f1eca5141bc352b9c0af  guix-build-d9da39fa37ee/output/riscv64-linux-gnu/bitcoin-d9da39fa37ee-riscv64-linux-gnu.tar.gz
cebd2596daf488632aee3e5761afbb06eee6f331648719c38251d361261582e3  guix-build-d9da39fa37ee/output/x86_64-linux-gnu/SHA256SUMS.part
63796ad8d6621acc767bf21abcf8668d1e351ee6e95c932a48bb42fa01022e75  guix-build-d9da39fa37ee/output/x86_64-linux-gnu/bitcoin-d9da39fa37ee-x86_64-linux-gnu-debug.tar.gz
645500a034378b6ae64db062acbd1cc7cf61cbf549d09e6b94dcde44584e819b  guix-build-d9da39fa37ee/output/x86_64-linux-gnu/bitcoin-d9da39fa37ee-x86_64-linux-gnu.tar.gz
```