### PR TITLE
refactor: use std:: prefix for std lib funcs

### DIFF
--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -92,7 +92,7 @@ void DeserializeDB(Stream& stream, Data& data, bool fCheckSum = true)
     unsigned char pchMsgTmp[4];
     verifier >> pchMsgTmp;
     // ... verify the network matches ours
-    if (memcmp(pchMsgTmp, Params().MessageStart(), sizeof(pchMsgTmp))) {
+    if (std::memcmp(pchMsgTmp, Params().MessageStart(), sizeof(pchMsgTmp))) {
         throw std::runtime_error{"Invalid network magic number"};
     }
 

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -209,8 +209,8 @@ public:
     friend inline const base_uint operator>>(const base_uint& a, int shift) { return base_uint(a) >>= shift; }
     friend inline const base_uint operator<<(const base_uint& a, int shift) { return base_uint(a) <<= shift; }
     friend inline const base_uint operator*(const base_uint& a, uint32_t b) { return base_uint(a) *= b; }
-    friend inline bool operator==(const base_uint& a, const base_uint& b) { return memcmp(a.pn, b.pn, sizeof(a.pn)) == 0; }
-    friend inline bool operator!=(const base_uint& a, const base_uint& b) { return memcmp(a.pn, b.pn, sizeof(a.pn)) != 0; }
+    friend inline bool operator==(const base_uint& a, const base_uint& b) { return std::memcmp(a.pn, b.pn, sizeof(a.pn)) == 0; }
+    friend inline bool operator!=(const base_uint& a, const base_uint& b) { return std::memcmp(a.pn, b.pn, sizeof(a.pn)) != 0; }
     friend inline bool operator>(const base_uint& a, const base_uint& b) { return a.CompareTo(b) > 0; }
     friend inline bool operator<(const base_uint& a, const base_uint& b) { return a.CompareTo(b) < 0; }
     friend inline bool operator>=(const base_uint& a, const base_uint& b) { return a.CompareTo(b) >= 0; }

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -150,7 +150,7 @@ std::string EncodeBase58Check(Span<const unsigned char> input)
     }
     // re-calculate the checksum, ensure it matches the included 4-byte checksum
     uint256 hash = Hash(Span{vchRet}.first(vchRet.size() - 4));
-    if (memcmp(&hash, &vchRet[vchRet.size() - 4], 4) != 0) {
+    if (std::memcmp(&hash, &vchRet[vchRet.size() - 4], 4) != 0) {
         vchRet.clear();
         return false;
     }

--- a/src/bench/addrman.cpp
+++ b/src/bench/addrman.cpp
@@ -33,10 +33,10 @@ static void CreateAddresses()
 
     auto randAddr = [&rng]() {
         in6_addr addr;
-        memcpy(&addr, rng.randbytes(sizeof(addr)).data(), sizeof(addr));
+        std::memcpy(&addr, rng.randbytes(sizeof(addr)).data(), sizeof(addr));
 
         uint16_t port;
-        memcpy(&port, rng.randbytes(sizeof(port)).data(), sizeof(port));
+        std::memcpy(&port, rng.randbytes(sizeof(port)).data(), sizeof(port));
         if (port == 0) {
             port = 1;
         }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -355,7 +355,7 @@ public:
         CHashWriter h(SER_DISK, 0);
         h << consensus.signet_challenge;
         uint256 hash = h.GetHash();
-        memcpy(pchMessageStart, hash.begin(), 4);
+        std::memcpy(pchMessageStart, hash.begin(), 4);
 
         nDefaultPort = 38333;
         nPruneAfterHeight = 1000;

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -21,7 +21,7 @@ static bool IsToKeyID(const CScript& script, CKeyID &hash)
     if (script.size() == 25 && script[0] == OP_DUP && script[1] == OP_HASH160
                             && script[2] == 20 && script[23] == OP_EQUALVERIFY
                             && script[24] == OP_CHECKSIG) {
-        memcpy(&hash, &script[3], 20);
+        std::memcpy(&hash, &script[3], 20);
         return true;
     }
     return false;
@@ -31,7 +31,7 @@ static bool IsToScriptID(const CScript& script, CScriptID &hash)
 {
     if (script.size() == 23 && script[0] == OP_HASH160 && script[1] == 20
                             && script[22] == OP_EQUAL) {
-        memcpy(&hash, &script[2], 20);
+        std::memcpy(&hash, &script[2], 20);
         return true;
     }
     return false;
@@ -58,20 +58,20 @@ bool CompressScript(const CScript& script, CompressedScript& out)
     if (IsToKeyID(script, keyID)) {
         out.resize(21);
         out[0] = 0x00;
-        memcpy(&out[1], &keyID, 20);
+        std::memcpy(&out[1], &keyID, 20);
         return true;
     }
     CScriptID scriptID;
     if (IsToScriptID(script, scriptID)) {
         out.resize(21);
         out[0] = 0x01;
-        memcpy(&out[1], &scriptID, 20);
+        std::memcpy(&out[1], &scriptID, 20);
         return true;
     }
     CPubKey pubkey;
     if (IsToPubKey(script, pubkey)) {
         out.resize(33);
-        memcpy(&out[1], &pubkey[1], 32);
+        std::memcpy(&out[1], &pubkey[1], 32);
         if (pubkey[0] == 0x02 || pubkey[0] == 0x03) {
             out[0] = pubkey[0];
             return true;
@@ -100,7 +100,7 @@ bool DecompressScript(CScript& script, unsigned int nSize, const CompressedScrip
         script[0] = OP_DUP;
         script[1] = OP_HASH160;
         script[2] = 20;
-        memcpy(&script[3], in.data(), 20);
+        std::memcpy(&script[3], in.data(), 20);
         script[23] = OP_EQUALVERIFY;
         script[24] = OP_CHECKSIG;
         return true;
@@ -108,7 +108,7 @@ bool DecompressScript(CScript& script, unsigned int nSize, const CompressedScrip
         script.resize(23);
         script[0] = OP_HASH160;
         script[1] = 20;
-        memcpy(&script[2], in.data(), 20);
+        std::memcpy(&script[2], in.data(), 20);
         script[22] = OP_EQUAL;
         return true;
     case 0x02:
@@ -116,21 +116,21 @@ bool DecompressScript(CScript& script, unsigned int nSize, const CompressedScrip
         script.resize(35);
         script[0] = 33;
         script[1] = nSize;
-        memcpy(&script[2], in.data(), 32);
+        std::memcpy(&script[2], in.data(), 32);
         script[34] = OP_CHECKSIG;
         return true;
     case 0x04:
     case 0x05:
         unsigned char vch[33] = {};
         vch[0] = nSize - 2;
-        memcpy(&vch[1], in.data(), 32);
+        std::memcpy(&vch[1], in.data(), 32);
         CPubKey pubkey{vch};
         if (!pubkey.Decompress())
             return false;
         assert(pubkey.size() == 65);
         script.resize(67);
         script[0] = 65;
-        memcpy(&script[1], pubkey.begin(), 65);
+        std::memcpy(&script[1], pubkey.begin(), 65);
         script[66] = OP_CHECKSIG;
         return true;
     }

--- a/src/crypto/aes.cpp
+++ b/src/crypto/aes.cpp
@@ -4,7 +4,7 @@
 
 #include <crypto/aes.h>
 
-#include <string.h>
+#include <cstring>
 
 extern "C" {
 #include <crypto/ctaes/ctaes.c>
@@ -17,7 +17,7 @@ AES256Encrypt::AES256Encrypt(const unsigned char key[32])
 
 AES256Encrypt::~AES256Encrypt()
 {
-    memset(&ctx, 0, sizeof(ctx));
+    std::memset(&ctx, 0, sizeof(ctx));
 }
 
 void AES256Encrypt::Encrypt(unsigned char ciphertext[16], const unsigned char plaintext[16]) const
@@ -32,7 +32,7 @@ AES256Decrypt::AES256Decrypt(const unsigned char key[32])
 
 AES256Decrypt::~AES256Decrypt()
 {
-    memset(&ctx, 0, sizeof(ctx));
+    std::memset(&ctx, 0, sizeof(ctx));
 }
 
 void AES256Decrypt::Decrypt(unsigned char plaintext[16], const unsigned char ciphertext[16]) const
@@ -131,7 +131,7 @@ int AES256CBCEncrypt::Encrypt(const unsigned char* data, int size, unsigned char
 
 AES256CBCEncrypt::~AES256CBCEncrypt()
 {
-    memset(iv, 0, sizeof(iv));
+    std::memset(iv, 0, sizeof(iv));
 }
 
 AES256CBCDecrypt::AES256CBCDecrypt(const unsigned char key[AES256_KEYSIZE], const unsigned char ivIn[AES_BLOCKSIZE], bool padIn)
@@ -148,5 +148,5 @@ int AES256CBCDecrypt::Decrypt(const unsigned char* data, int size, unsigned char
 
 AES256CBCDecrypt::~AES256CBCDecrypt()
 {
-    memset(iv, 0, sizeof(iv));
+    std::memset(iv, 0, sizeof(iv));
 }

--- a/src/crypto/aes.cpp
+++ b/src/crypto/aes.cpp
@@ -54,14 +54,14 @@ static int CBCEncrypt(const T& enc, const unsigned char iv[AES_BLOCKSIZE], const
     if (!pad && padsize != 0)
         return 0;
 
-    memcpy(mixed, iv, AES_BLOCKSIZE);
+    std::memcpy(mixed, iv, AES_BLOCKSIZE);
 
     // Write all but the last block
     while (written + AES_BLOCKSIZE <= size) {
         for (int i = 0; i != AES_BLOCKSIZE; i++)
             mixed[i] ^= *data++;
         enc.Encrypt(out + written, mixed);
-        memcpy(mixed, out + written, AES_BLOCKSIZE);
+        std::memcpy(mixed, out + written, AES_BLOCKSIZE);
         written += AES_BLOCKSIZE;
     }
     if (pad) {
@@ -121,7 +121,7 @@ static int CBCDecrypt(const T& dec, const unsigned char iv[AES_BLOCKSIZE], const
 AES256CBCEncrypt::AES256CBCEncrypt(const unsigned char key[AES256_KEYSIZE], const unsigned char ivIn[AES_BLOCKSIZE], bool padIn)
     : enc(key), pad(padIn)
 {
-    memcpy(iv, ivIn, AES_BLOCKSIZE);
+    std::memcpy(iv, ivIn, AES_BLOCKSIZE);
 }
 
 int AES256CBCEncrypt::Encrypt(const unsigned char* data, int size, unsigned char* out) const
@@ -137,7 +137,7 @@ AES256CBCEncrypt::~AES256CBCEncrypt()
 AES256CBCDecrypt::AES256CBCDecrypt(const unsigned char key[AES256_KEYSIZE], const unsigned char ivIn[AES_BLOCKSIZE], bool padIn)
     : dec(key), pad(padIn)
 {
-    memcpy(iv, ivIn, AES_BLOCKSIZE);
+    std::memcpy(iv, ivIn, AES_BLOCKSIZE);
 }
 
 

--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -8,7 +8,7 @@
 #include <crypto/common.h>
 #include <crypto/chacha20.h>
 
-#include <string.h>
+#include <cstring>
 
 constexpr static inline uint32_t rotl32(uint32_t v, int c) { return (v << c) | (v >> (32 - c)); }
 
@@ -53,7 +53,7 @@ void ChaCha20::SetKey(const unsigned char* k, size_t keylen)
 
 ChaCha20::ChaCha20()
 {
-    memset(input, 0, sizeof(input));
+    std::memset(input, 0, sizeof(input));
 }
 
 ChaCha20::ChaCha20(const unsigned char* k, size_t keylen)

--- a/src/crypto/chacha_poly_aead.cpp
+++ b/src/crypto/chacha_poly_aead.cpp
@@ -12,7 +12,7 @@
 #include <support/cleanse.h>
 
 #include <assert.h>
-#include <string.h>
+#include <cstring>
 
 #include <cstdio>
 #include <limits>
@@ -56,7 +56,7 @@ bool ChaCha20Poly1305AEAD::Crypt(uint64_t seqnr_payload, uint64_t seqnr_aad, int
     }
 
     unsigned char expected_tag[POLY1305_TAGLEN], poly_key[POLY1305_KEYLEN];
-    memset(poly_key, 0, sizeof(poly_key));
+    std::memset(poly_key, 0, sizeof(poly_key));
     m_chacha_main.SetIV(seqnr_payload);
 
     // block counter 0 for the poly1305 key

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -10,80 +10,80 @@
 #endif
 
 #include <stdint.h>
-#include <string.h>
+#include <cstring>
 
 #include <compat/endian.h>
 
 uint16_t static inline ReadLE16(const unsigned char* ptr)
 {
     uint16_t x;
-    memcpy((char*)&x, ptr, 2);
+    std::memcpy((char*)&x, ptr, 2);
     return le16toh(x);
 }
 
 uint32_t static inline ReadLE32(const unsigned char* ptr)
 {
     uint32_t x;
-    memcpy((char*)&x, ptr, 4);
+    std::memcpy((char*)&x, ptr, 4);
     return le32toh(x);
 }
 
 uint64_t static inline ReadLE64(const unsigned char* ptr)
 {
     uint64_t x;
-    memcpy((char*)&x, ptr, 8);
+    std::memcpy((char*)&x, ptr, 8);
     return le64toh(x);
 }
 
 void static inline WriteLE16(unsigned char* ptr, uint16_t x)
 {
     uint16_t v = htole16(x);
-    memcpy(ptr, (char*)&v, 2);
+    std::memcpy(ptr, (char*)&v, 2);
 }
 
 void static inline WriteLE32(unsigned char* ptr, uint32_t x)
 {
     uint32_t v = htole32(x);
-    memcpy(ptr, (char*)&v, 4);
+    std::memcpy(ptr, (char*)&v, 4);
 }
 
 void static inline WriteLE64(unsigned char* ptr, uint64_t x)
 {
     uint64_t v = htole64(x);
-    memcpy(ptr, (char*)&v, 8);
+    std::memcpy(ptr, (char*)&v, 8);
 }
 
 uint16_t static inline ReadBE16(const unsigned char* ptr)
 {
     uint16_t x;
-    memcpy((char*)&x, ptr, 2);
+    std::memcpy((char*)&x, ptr, 2);
     return be16toh(x);
 }
 
 uint32_t static inline ReadBE32(const unsigned char* ptr)
 {
     uint32_t x;
-    memcpy((char*)&x, ptr, 4);
+    std::memcpy((char*)&x, ptr, 4);
     return be32toh(x);
 }
 
 uint64_t static inline ReadBE64(const unsigned char* ptr)
 {
     uint64_t x;
-    memcpy((char*)&x, ptr, 8);
+    std::memcpy((char*)&x, ptr, 8);
     return be64toh(x);
 }
 
 void static inline WriteBE32(unsigned char* ptr, uint32_t x)
 {
     uint32_t v = htobe32(x);
-    memcpy(ptr, (char*)&v, 4);
+    std::memcpy(ptr, (char*)&v, 4);
 }
 
 void static inline WriteBE64(unsigned char* ptr, uint64_t x)
 {
     uint64_t v = htobe64(x);
-    memcpy(ptr, (char*)&v, 8);
+    std::memcpy(ptr, (char*)&v, 8);
 }
 
 /** Return the smallest number n such that (x >> n) == 0 (or 64 if the highest bit in x is set. */

--- a/src/crypto/hmac_sha256.cpp
+++ b/src/crypto/hmac_sha256.cpp
@@ -4,17 +4,17 @@
 
 #include <crypto/hmac_sha256.h>
 
-#include <string.h>
+#include <cstring>
 
 CHMAC_SHA256::CHMAC_SHA256(const unsigned char* key, size_t keylen)
 {
     unsigned char rkey[64];
     if (keylen <= 64) {
         memcpy(rkey, key, keylen);
-        memset(rkey + keylen, 0, 64 - keylen);
+        std::memset(rkey + keylen, 0, 64 - keylen);
     } else {
         CSHA256().Write(key, keylen).Finalize(rkey);
-        memset(rkey + 32, 0, 32);
+        std::memset(rkey + 32, 0, 32);
     }
 
     for (int n = 0; n < 64; n++)

--- a/src/crypto/hmac_sha256.cpp
+++ b/src/crypto/hmac_sha256.cpp
@@ -10,7 +10,7 @@ CHMAC_SHA256::CHMAC_SHA256(const unsigned char* key, size_t keylen)
 {
     unsigned char rkey[64];
     if (keylen <= 64) {
-        memcpy(rkey, key, keylen);
+        std::memcpy(rkey, key, keylen);
         std::memset(rkey + keylen, 0, 64 - keylen);
     } else {
         CSHA256().Write(key, keylen).Finalize(rkey);

--- a/src/crypto/hmac_sha512.cpp
+++ b/src/crypto/hmac_sha512.cpp
@@ -4,17 +4,17 @@
 
 #include <crypto/hmac_sha512.h>
 
-#include <string.h>
+#include <cstring>
 
 CHMAC_SHA512::CHMAC_SHA512(const unsigned char* key, size_t keylen)
 {
     unsigned char rkey[128];
     if (keylen <= 128) {
         memcpy(rkey, key, keylen);
-        memset(rkey + keylen, 0, 128 - keylen);
+        std::memset(rkey + keylen, 0, 128 - keylen);
     } else {
         CSHA512().Write(key, keylen).Finalize(rkey);
-        memset(rkey + 64, 0, 64);
+        std::memset(rkey + 64, 0, 64);
     }
 
     for (int n = 0; n < 128; n++)

--- a/src/crypto/hmac_sha512.cpp
+++ b/src/crypto/hmac_sha512.cpp
@@ -10,7 +10,7 @@ CHMAC_SHA512::CHMAC_SHA512(const unsigned char* key, size_t keylen)
 {
     unsigned char rkey[128];
     if (keylen <= 128) {
-        memcpy(rkey, key, keylen);
+        std::memcpy(rkey, key, keylen);
         std::memset(rkey + keylen, 0, 128 - keylen);
     } else {
         CSHA512().Write(key, keylen).Finalize(rkey);

--- a/src/crypto/ripemd160.cpp
+++ b/src/crypto/ripemd160.cpp
@@ -250,7 +250,7 @@ CRIPEMD160& CRIPEMD160::Write(const unsigned char* data, size_t len)
     size_t bufsize = bytes % 64;
     if (bufsize && bufsize + len >= 64) {
         // Fill the buffer, and process it.
-        memcpy(buf + bufsize, data, 64 - bufsize);
+        std::memcpy(buf + bufsize, data, 64 - bufsize);
         bytes += 64 - bufsize;
         data += 64 - bufsize;
         ripemd160::Transform(s, buf);
@@ -264,7 +264,7 @@ CRIPEMD160& CRIPEMD160::Write(const unsigned char* data, size_t len)
     }
     if (end > data) {
         // Fill the buffer with what remains.
-        memcpy(buf + bufsize, data, end - data);
+        std::memcpy(buf + bufsize, data, end - data);
         bytes += end - data;
     }
     return *this;

--- a/src/crypto/sha1.cpp
+++ b/src/crypto/sha1.cpp
@@ -157,7 +157,7 @@ CSHA1& CSHA1::Write(const unsigned char* data, size_t len)
     size_t bufsize = bytes % 64;
     if (bufsize && bufsize + len >= 64) {
         // Fill the buffer, and process it.
-        memcpy(buf + bufsize, data, 64 - bufsize);
+        std::memcpy(buf + bufsize, data, 64 - bufsize);
         bytes += 64 - bufsize;
         data += 64 - bufsize;
         sha1::Transform(s, buf);
@@ -171,7 +171,7 @@ CSHA1& CSHA1::Write(const unsigned char* data, size_t len)
     }
     if (end > data) {
         // Fill the buffer with what remains.
-        memcpy(buf + bufsize, data, end - data);
+        std::memcpy(buf + bufsize, data, end - data);
         bytes += end - data;
     }
     return *this;

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -684,7 +684,7 @@ CSHA256& CSHA256::Write(const unsigned char* data, size_t len)
     size_t bufsize = bytes % 64;
     if (bufsize && bufsize + len >= 64) {
         // Fill the buffer, and process it.
-        memcpy(buf + bufsize, data, 64 - bufsize);
+        std::memcpy(buf + bufsize, data, 64 - bufsize);
         bytes += 64 - bufsize;
         data += 64 - bufsize;
         Transform(s, buf, 1);
@@ -698,7 +698,7 @@ CSHA256& CSHA256::Write(const unsigned char* data, size_t len)
     }
     if (end > data) {
         // Fill the buffer with what remains.
-        memcpy(buf + bufsize, data, end - data);
+        std::memcpy(buf + bufsize, data, end - data);
         bytes += end - data;
     }
     return *this;

--- a/src/crypto/sha512.cpp
+++ b/src/crypto/sha512.cpp
@@ -162,7 +162,7 @@ CSHA512& CSHA512::Write(const unsigned char* data, size_t len)
     size_t bufsize = bytes % 128;
     if (bufsize && bufsize + len >= 128) {
         // Fill the buffer, and process it.
-        memcpy(buf + bufsize, data, 128 - bufsize);
+        std::memcpy(buf + bufsize, data, 128 - bufsize);
         bytes += 128 - bufsize;
         data += 128 - bufsize;
         sha512::Transform(s, buf);
@@ -176,7 +176,7 @@ CSHA512& CSHA512::Write(const unsigned char* data, size_t len)
     }
     if (end > data) {
         // Fill the buffer with what remains.
-        memcpy(buf + bufsize, data, end - data);
+        std::memcpy(buf + bufsize, data, end - data);
         bytes += end - data;
     }
     return *this;

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -55,7 +55,7 @@ public:
                     va_list backup_ap;
                     va_copy(backup_ap, ap);
                     // Do not use vsnprintf elsewhere in bitcoin source code, see above.
-                    p += vsnprintf(p, limit - p, format, backup_ap);
+                    p += std::vsnprintf(p, limit - p, format, backup_ap);
                     va_end(backup_ap);
                 }
 

--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -340,7 +340,7 @@ Binary Session::MyDestination() const
     static constexpr size_t CERT_LEN_POS = 385;
 
     uint16_t cert_len;
-    memcpy(&cert_len, &m_private_key.at(CERT_LEN_POS), sizeof(cert_len));
+    std::memcpy(&cert_len, &m_private_key.at(CERT_LEN_POS), sizeof(cert_len));
     cert_len = be16toh(cert_len);
 
     const size_t dest_len = DEST_LEN_BASE + cert_len;

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -73,7 +73,7 @@ int ec_seckey_import_der(const secp256k1_context* ctx, unsigned char *out32, con
     if (oslen > 32 || end - seckey < oslen) {
         return 0;
     }
-    memcpy(out32 + (32 - oslen), seckey, oslen);
+    std::memcpy(out32 + (32 - oslen), seckey, oslen);
     if (!secp256k1_ec_seckey_verify(ctx, out32)) {
         std::memset(out32, 0, 32);
         return 0;
@@ -115,9 +115,9 @@ int ec_seckey_export_der(const secp256k1_context *ctx, unsigned char *seckey, si
             0x8C,0xD0,0x36,0x41,0x41,0x02,0x01,0x01,0xA1,0x24,0x03,0x22,0x00
         };
         unsigned char *ptr = seckey;
-        memcpy(ptr, begin, sizeof(begin)); ptr += sizeof(begin);
-        memcpy(ptr, key32, 32); ptr += 32;
-        memcpy(ptr, middle, sizeof(middle)); ptr += sizeof(middle);
+        std::memcpy(ptr, begin, sizeof(begin)); ptr += sizeof(begin);
+        std::memcpy(ptr, key32, 32); ptr += 32;
+        std::memcpy(ptr, middle, sizeof(middle)); ptr += sizeof(middle);
         pubkeylen = CPubKey::COMPRESSED_SIZE;
         secp256k1_ec_pubkey_serialize(ctx, ptr, &pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED);
         ptr += pubkeylen;
@@ -141,9 +141,9 @@ int ec_seckey_export_der(const secp256k1_context *ctx, unsigned char *seckey, si
             0x8C,0xD0,0x36,0x41,0x41,0x02,0x01,0x01,0xA1,0x44,0x03,0x42,0x00
         };
         unsigned char *ptr = seckey;
-        memcpy(ptr, begin, sizeof(begin)); ptr += sizeof(begin);
-        memcpy(ptr, key32, 32); ptr += 32;
-        memcpy(ptr, middle, sizeof(middle)); ptr += sizeof(middle);
+        std::memcpy(ptr, begin, sizeof(begin)); ptr += sizeof(begin);
+        std::memcpy(ptr, key32, 32); ptr += 32;
+        std::memcpy(ptr, middle, sizeof(middle)); ptr += sizeof(middle);
         pubkeylen = CPubKey::SIZE;
         secp256k1_ec_pubkey_serialize(ctx, ptr, &pubkeylen, &pubkey, SECP256K1_EC_UNCOMPRESSED);
         ptr += pubkeylen;
@@ -324,8 +324,8 @@ bool CKey::Derive(CKey& keyChild, ChainCode &ccChild, unsigned int nChild, const
         assert(size() == 32);
         BIP32Hash(cc, nChild, 0, begin(), vout.data());
     }
-    memcpy(ccChild.begin(), vout.data()+32, 32);
-    memcpy((unsigned char*)keyChild.begin(), begin(), 32);
+    std::memcpy(ccChild.begin(), vout.data()+32, 32);
+    std::memcpy((unsigned char*)keyChild.begin(), begin(), 32);
     bool ret = secp256k1_ec_seckey_tweak_add(secp256k1_context_sign, (unsigned char*)keyChild.begin(), vout.data());
     keyChild.fCompressed = true;
     keyChild.fValid = ret;
@@ -335,7 +335,7 @@ bool CKey::Derive(CKey& keyChild, ChainCode &ccChild, unsigned int nChild, const
 bool CExtKey::Derive(CExtKey &out, unsigned int _nChild) const {
     out.nDepth = nDepth + 1;
     CKeyID id = key.GetPubKey().GetID();
-    memcpy(out.vchFingerprint, &id, 4);
+    std::memcpy(out.vchFingerprint, &id, 4);
     out.nChild = _nChild;
     return key.Derive(out.key, out.chaincode, _nChild, chaincode);
 }
@@ -346,7 +346,7 @@ void CExtKey::SetSeed(Span<const std::byte> seed)
     std::vector<unsigned char, secure_allocator<unsigned char>> vout(64);
     CHMAC_SHA512{hashkey, sizeof(hashkey)}.Write(UCharCast(seed.data()), seed.size()).Finalize(vout.data());
     key.Set(vout.data(), vout.data() + 32, true);
-    memcpy(chaincode.begin(), vout.data() + 32, 32);
+    std::memcpy(chaincode.begin(), vout.data() + 32, 32);
     nDepth = 0;
     nChild = 0;
     std::memset(vchFingerprint, 0, sizeof(vchFingerprint));
@@ -355,7 +355,7 @@ void CExtKey::SetSeed(Span<const std::byte> seed)
 CExtPubKey CExtKey::Neuter() const {
     CExtPubKey ret;
     ret.nDepth = nDepth;
-    memcpy(ret.vchFingerprint, vchFingerprint, 4);
+    std::memcpy(ret.vchFingerprint, vchFingerprint, 4);
     ret.nChild = nChild;
     ret.pubkey = key.GetPubKey();
     ret.chaincode = chaincode;
@@ -364,19 +364,19 @@ CExtPubKey CExtKey::Neuter() const {
 
 void CExtKey::Encode(unsigned char code[BIP32_EXTKEY_SIZE]) const {
     code[0] = nDepth;
-    memcpy(code+1, vchFingerprint, 4);
+    std::memcpy(code+1, vchFingerprint, 4);
     WriteBE32(code+5, nChild);
-    memcpy(code+9, chaincode.begin(), 32);
+    std::memcpy(code+9, chaincode.begin(), 32);
     code[41] = 0;
     assert(key.size() == 32);
-    memcpy(code+42, key.begin(), 32);
+    std::memcpy(code+42, key.begin(), 32);
 }
 
 void CExtKey::Decode(const unsigned char code[BIP32_EXTKEY_SIZE]) {
     nDepth = code[0];
-    memcpy(vchFingerprint, code+1, 4);
+    std::memcpy(vchFingerprint, code+1, 4);
     nChild = ReadBE32(code+5);
-    memcpy(chaincode.begin(), code+9, 32);
+    std::memcpy(chaincode.begin(), code+9, 32);
     key.Set(code+42, code+BIP32_EXTKEY_SIZE, true);
     if ((nDepth == 0 && (nChild != 0 || ReadLE32(vchFingerprint) != 0)) || code[41] != 0) key = CKey();
 }

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -36,7 +36,7 @@ static secp256k1_context* secp256k1_context_sign = nullptr;
  */
 int ec_seckey_import_der(const secp256k1_context* ctx, unsigned char *out32, const unsigned char *seckey, size_t seckeylen) {
     const unsigned char *end = seckey + seckeylen;
-    memset(out32, 0, 32);
+    std::memset(out32, 0, 32);
     /* sequence header */
     if (end - seckey < 1 || *seckey != 0x30u) {
         return 0;
@@ -75,7 +75,7 @@ int ec_seckey_import_der(const secp256k1_context* ctx, unsigned char *out32, con
     }
     memcpy(out32 + (32 - oslen), seckey, oslen);
     if (!secp256k1_ec_seckey_verify(ctx, out32)) {
-        memset(out32, 0, 32);
+        std::memset(out32, 0, 32);
         return 0;
     }
     return 1;
@@ -349,7 +349,7 @@ void CExtKey::SetSeed(Span<const std::byte> seed)
     memcpy(chaincode.begin(), vout.data() + 32, 32);
     nDepth = 0;
     nChild = 0;
-    memset(vchFingerprint, 0, sizeof(vchFingerprint));
+    std::memset(vchFingerprint, 0, sizeof(vchFingerprint));
 }
 
 CExtPubKey CExtKey::Neuter() const {

--- a/src/key.h
+++ b/src/key.h
@@ -65,7 +65,7 @@ public:
     {
         return a.fCompressed == b.fCompressed &&
             a.size() == b.size() &&
-            memcmp(a.keydata.data(), b.keydata.data(), a.size()) == 0;
+            std::memcmp(a.keydata.data(), b.keydata.data(), a.size()) == 0;
     }
 
     //! Initialize using begin and end iterators to byte data.
@@ -168,7 +168,7 @@ struct CExtKey {
     friend bool operator==(const CExtKey& a, const CExtKey& b)
     {
         return a.nDepth == b.nDepth &&
-            memcmp(a.vchFingerprint, b.vchFingerprint, sizeof(vchFingerprint)) == 0 &&
+            std::memcmp(a.vchFingerprint, b.vchFingerprint, sizeof(vchFingerprint)) == 0 &&
             a.nChild == b.nChild &&
             a.chaincode == b.chaincode &&
             a.key == b.key;

--- a/src/key.h
+++ b/src/key.h
@@ -75,7 +75,7 @@ public:
         if (size_t(pend - pbegin) != keydata.size()) {
             fValid = false;
         } else if (Check(&pbegin[0])) {
-            memcpy(keydata.data(), (unsigned char*)&pbegin[0], keydata.size());
+            std::memcpy(keydata.data(), (unsigned char*)&pbegin[0], keydata.size());
             fValid = true;
             fCompressed = fCompressedIn;
         } else {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -692,7 +692,7 @@ int V1TransportDeserializer::readHeader(Span<const uint8_t> msg_bytes)
     unsigned int nRemaining = CMessageHeader::HEADER_SIZE - nHdrPos;
     unsigned int nCopy = std::min<unsigned int>(nRemaining, msg_bytes.size());
 
-    memcpy(&hdrbuf[nHdrPos], msg_bytes.data(), nCopy);
+    std::memcpy(&hdrbuf[nHdrPos], msg_bytes.data(), nCopy);
     nHdrPos += nCopy;
 
     // if header incomplete, exit
@@ -737,7 +737,7 @@ int V1TransportDeserializer::readData(Span<const uint8_t> msg_bytes)
     }
 
     hasher.Write(msg_bytes.first(nCopy));
-    memcpy(&vRecv[nDataPos], msg_bytes.data(), nCopy);
+    std::memcpy(&vRecv[nDataPos], msg_bytes.data(), nCopy);
     nDataPos += nCopy;
 
     return nCopy;
@@ -794,7 +794,7 @@ void V1TransportSerializer::prepareForTransport(CSerializedNetMsg& msg, std::vec
 
     // create header
     CMessageHeader hdr(Params().MessageStart(), msg.m_type.c_str(), msg.data.size());
-    memcpy(hdr.pchChecksum, hash.begin(), CMessageHeader::CHECKSUM_SIZE);
+    std::memcpy(hdr.pchChecksum, hash.begin(), CMessageHeader::CHECKSUM_SIZE);
 
     // serialize header
     header.reserve(CMessageHeader::HEADER_SIZE);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -709,7 +709,7 @@ int V1TransportDeserializer::readHeader(Span<const uint8_t> msg_bytes)
     }
 
     // Check start string, network magic
-    if (memcmp(hdr.pchMessageStart, m_chain_params.MessageStart(), CMessageHeader::MESSAGE_START_SIZE) != 0) {
+    if (std::memcmp(hdr.pchMessageStart, m_chain_params.MessageStart(), CMessageHeader::MESSAGE_START_SIZE) != 0) {
         LogPrint(BCLog::NET, "Header error: Wrong MessageStart %s received, peer=%d\n", HexStr(hdr.pchMessageStart), m_node_id);
         return -1;
     }
@@ -770,7 +770,7 @@ CNetMessage V1TransportDeserializer::GetMessage(const std::chrono::microseconds 
     RandAddEvent(ReadLE32(hash.begin()));
 
     // Check checksum and header message type string
-    if (memcmp(hash.begin(), hdr.pchChecksum, CMessageHeader::CHECKSUM_SIZE) != 0) {
+    if (std::memcmp(hash.begin(), hdr.pchChecksum, CMessageHeader::CHECKSUM_SIZE) != 0) {
         LogPrint(BCLog::NET, "Header error: Wrong checksum (%s, %u bytes), expected %s was %s, peer=%d\n",
                  SanitizeString(msg.m_type), msg.m_message_size,
                  HexStr(Span{hash}.first(CMessageHeader::CHECKSUM_SIZE)),

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -882,7 +882,7 @@ bool CService::GetSockAddr(struct sockaddr* paddr, socklen_t *addrlen) const
             return false;
         *addrlen = sizeof(struct sockaddr_in);
         struct sockaddr_in *paddrin = (struct sockaddr_in*)paddr;
-        memset(paddrin, 0, *addrlen);
+        std::memset(paddrin, 0, *addrlen);
         if (!GetInAddr(&paddrin->sin_addr))
             return false;
         paddrin->sin_family = AF_INET;
@@ -894,7 +894,7 @@ bool CService::GetSockAddr(struct sockaddr* paddr, socklen_t *addrlen) const
             return false;
         *addrlen = sizeof(struct sockaddr_in6);
         struct sockaddr_in6 *paddrin6 = (struct sockaddr_in6*)paddr;
-        memset(paddrin6, 0, *addrlen);
+        std::memset(paddrin6, 0, *addrlen);
         if (!GetIn6Addr(&paddrin6->sin6_addr))
             return false;
         paddrin6->sin6_scope_id = m_scope_id;
@@ -938,7 +938,7 @@ std::string CService::ToString() const
 CSubNet::CSubNet():
     valid(false)
 {
-    memset(netmask, 0, sizeof(netmask));
+    std::memset(netmask, 0, sizeof(netmask));
 }
 
 CSubNet::CSubNet(const CNetAddr& addr, uint8_t mask) : CSubNet()
@@ -1020,7 +1020,7 @@ CSubNet::CSubNet(const CNetAddr& addr) : CSubNet()
     case NET_IPV6:
         valid = true;
         assert(addr.m_addr.size() <= sizeof(netmask));
-        memset(netmask, 0xFF, addr.m_addr.size());
+        std::memset(netmask, 0xFF, addr.m_addr.size());
         break;
     case NET_ONION:
     case NET_I2P:

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -200,7 +200,7 @@ static void Checksum(Span<const uint8_t> addr_pubkey, uint8_t (&checksum)[CHECKS
 
     hasher.Finalize(checksum_full);
 
-    memcpy(checksum, checksum_full, sizeof(checksum));
+    std::memcpy(checksum, checksum_full, sizeof(checksum));
 }
 
 }; // namespace torv3
@@ -652,7 +652,7 @@ bool CNetAddr::GetInAddr(struct in_addr* pipv4Addr) const
     if (!IsIPv4())
         return false;
     assert(sizeof(*pipv4Addr) == m_addr.size());
-    memcpy(pipv4Addr, m_addr.data(), m_addr.size());
+    std::memcpy(pipv4Addr, m_addr.data(), m_addr.size());
     return true;
 }
 
@@ -672,7 +672,7 @@ bool CNetAddr::GetIn6Addr(struct in6_addr* pipv6Addr) const
         return false;
     }
     assert(sizeof(*pipv6Addr) == m_addr.size());
-    memcpy(pipv6Addr, m_addr.data(), m_addr.size());
+    std::memcpy(pipv6Addr, m_addr.data(), m_addr.size());
     return true;
 }
 
@@ -1003,7 +1003,7 @@ CSubNet::CSubNet(const CNetAddr& addr, const CNetAddr& mask) : CSubNet()
 
     assert(mask.m_addr.size() <= sizeof(netmask));
 
-    memcpy(netmask, mask.m_addr.data(), mask.m_addr.size());
+    std::memcpy(netmask, mask.m_addr.data(), mask.m_addr.size());
 
     network = addr;
 

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -425,7 +425,7 @@ bool CNetAddr::IsLocal() const
 
     // IPv6 loopback (::1/128)
     static const unsigned char pchLocal[16] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1};
-    if (IsIPv6() && memcmp(m_addr.data(), pchLocal, sizeof(pchLocal)) == 0) {
+    if (IsIPv6() && std::memcmp(m_addr.data(), pchLocal, sizeof(pchLocal)) == 0) {
         return true;
     }
 
@@ -446,7 +446,7 @@ bool CNetAddr::IsValid() const
 {
     // unspecified IPv6 address (::/128)
     unsigned char ipNone6[16] = {};
-    if (IsIPv6() && memcmp(m_addr.data(), ipNone6, sizeof(ipNone6)) == 0) {
+    if (IsIPv6() && std::memcmp(m_addr.data(), ipNone6, sizeof(ipNone6)) == 0) {
         return false;
     }
 
@@ -1136,5 +1136,5 @@ bool operator==(const CSubNet& a, const CSubNet& b)
 
 bool operator<(const CSubNet& a, const CSubNet& b)
 {
-    return (a.network < b.network || (a.network == b.network && memcmp(a.netmask, b.netmask, 16) < 0));
+    return (a.network < b.network || (a.network == b.network && std::memcmp(a.netmask, b.netmask, 16) < 0));
 }

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -317,19 +317,19 @@ private:
         switch (m_net) {
         case NET_IPV6:
             assert(m_addr.size() == sizeof(arr));
-            memcpy(arr, m_addr.data(), m_addr.size());
+            std::memcpy(arr, m_addr.data(), m_addr.size());
             return;
         case NET_IPV4:
             prefix_size = sizeof(IPV4_IN_IPV6_PREFIX);
             assert(prefix_size + m_addr.size() == sizeof(arr));
-            memcpy(arr, IPV4_IN_IPV6_PREFIX.data(), prefix_size);
-            memcpy(arr + prefix_size, m_addr.data(), m_addr.size());
+            std::memcpy(arr, IPV4_IN_IPV6_PREFIX.data(), prefix_size);
+            std::memcpy(arr + prefix_size, m_addr.data(), m_addr.size());
             return;
         case NET_INTERNAL:
             prefix_size = sizeof(INTERNAL_IN_IPV6_PREFIX);
             assert(prefix_size + m_addr.size() == sizeof(arr));
-            memcpy(arr, INTERNAL_IN_IPV6_PREFIX.data(), prefix_size);
-            memcpy(arr + prefix_size, m_addr.data(), m_addr.size());
+            std::memcpy(arr, INTERNAL_IN_IPV6_PREFIX.data(), prefix_size);
+            std::memcpy(arr + prefix_size, m_addr.data(), m_addr.size());
             return;
         case NET_ONION:
         case NET_I2P:

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -20,6 +20,7 @@
 
 #include <array>
 #include <cstdint>
+#include <cstring>
 #include <ios>
 #include <string>
 #include <vector>
@@ -438,7 +439,7 @@ private:
             // disk.
             if (HasPrefix(m_addr, INTERNAL_IN_IPV6_PREFIX)) {
                 m_net = NET_INTERNAL;
-                memmove(m_addr.data(), m_addr.data() + INTERNAL_IN_IPV6_PREFIX.size(),
+                std::memmove(m_addr.data(), m_addr.data() + INTERNAL_IN_IPV6_PREFIX.size(),
                         ADDR_INTERNAL_SIZE);
                 m_addr.resize(ADDR_INTERNAL_SIZE);
                 return;

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -341,7 +341,7 @@ private:
         } // no default case, so the compiler can warn about missing cases
 
         // Serialize ONION, I2P and CJDNS as all-zeros.
-        memset(arr, 0x0, V1_SERIALIZATION_SIZE);
+        std::memset(arr, 0x0, V1_SERIALIZATION_SIZE);
     }
 
     /**

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -768,7 +768,7 @@ bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, c
 
         filein >> blk_start >> blk_size;
 
-        if (memcmp(blk_start, message_start, CMessageHeader::MESSAGE_START_SIZE)) {
+        if (std::memcmp(blk_start, message_start, CMessageHeader::MESSAGE_START_SIZE)) {
             return error("%s: Block magic mismatch for %s: %s versus expected %s", __func__, pos.ToString(),
                          HexStr(blk_start),
                          HexStr(message_start));

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -8,7 +8,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <string.h>
+#include <cstring>
 
 #include <algorithm>
 #include <cstddef>
@@ -353,7 +353,7 @@ public:
             change_capacity(new_size + (new_size >> 1));
         }
         T* ptr = item_ptr(p);
-        memmove(ptr + 1, ptr, (size() - p) * sizeof(T));
+        std::memmove(ptr + 1, ptr, (size() - p) * sizeof(T));
         _size++;
         new(static_cast<void*>(ptr)) T(value);
         return iterator(ptr);
@@ -366,7 +366,7 @@ public:
             change_capacity(new_size + (new_size >> 1));
         }
         T* ptr = item_ptr(p);
-        memmove(ptr + count, ptr, (size() - p) * sizeof(T));
+        std::memmove(ptr + count, ptr, (size() - p) * sizeof(T));
         _size += count;
         fill(item_ptr(p), count, value);
     }
@@ -380,7 +380,7 @@ public:
             change_capacity(new_size + (new_size >> 1));
         }
         T* ptr = item_ptr(p);
-        memmove(ptr + count, ptr, (size() - p) * sizeof(T));
+        std::memmove(ptr + count, ptr, (size() - p) * sizeof(T));
         _size += count;
         fill(ptr, first, last);
     }
@@ -414,7 +414,7 @@ public:
         iterator p = first;
         char* endp = (char*)&(*end());
         _size -= last - p;
-        memmove(&(*first), &(*last), endp - ((char*)(&(*last))));
+        std::memmove(&(*first), &(*last), endp - ((char*)(&(*last))));
         return first;
     }
 

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -175,7 +175,7 @@ private:
                 T* indirect = indirect_ptr(0);
                 T* src = indirect;
                 T* dst = direct_ptr(0);
-                memcpy(dst, src, size() * sizeof(T));
+                std::memcpy(dst, src, size() * sizeof(T));
                 free(indirect);
                 _size -= N + 1;
             }
@@ -192,7 +192,7 @@ private:
                 assert(new_indirect);
                 T* src = direct_ptr(0);
                 T* dst = reinterpret_cast<T*>(new_indirect);
-                memcpy(dst, src, size() * sizeof(T));
+                std::memcpy(dst, src, size() * sizeof(T));
                 _union.indirect_contents.indirect = new_indirect;
                 _union.indirect_contents.capacity = new_capacity;
                 _size += N + 1;

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -89,7 +89,7 @@ const static std::vector<std::string> allNetMessageTypesVec(std::begin(allNetMes
 
 CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn, const char* pszCommand, unsigned int nMessageSizeIn)
 {
-    memcpy(pchMessageStart, pchMessageStartIn, MESSAGE_START_SIZE);
+    std::memcpy(pchMessageStart, pchMessageStartIn, MESSAGE_START_SIZE);
 
     // Copy the command name
     size_t i = 0;

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -168,7 +168,7 @@ int ecdsa_signature_parse_der_lax(const secp256k1_context* ctx, secp256k1_ecdsa_
     if (overflow) {
         /* Overwrite the result again with a correctly-parsed but invalid
            signature if parsing failed. */
-        memset(tmpsig, 0, 64);
+        std::memset(tmpsig, 0, 64);
         secp256k1_ecdsa_signature_parse_compact(ctx, sig, tmpsig);
     }
     return 1;

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -147,7 +147,7 @@ int ecdsa_signature_parse_der_lax(const secp256k1_context* ctx, secp256k1_ecdsa_
     if (rlen > 32) {
         overflow = 1;
     } else {
-        memcpy(tmpsig + 32 - rlen, input + rpos, rlen);
+        std::memcpy(tmpsig + 32 - rlen, input + rpos, rlen);
     }
 
     /* Ignore leading zeroes in S */
@@ -159,7 +159,7 @@ int ecdsa_signature_parse_der_lax(const secp256k1_context* ctx, secp256k1_ecdsa_
     if (slen > 32) {
         overflow = 1;
     } else {
-        memcpy(tmpsig + 64 - slen, input + spos, slen);
+        std::memcpy(tmpsig + 64 - slen, input + spos, slen);
     }
 
     if (!overflow) {
@@ -318,7 +318,7 @@ bool CPubKey::Derive(CPubKey& pubkeyChild, ChainCode &ccChild, unsigned int nChi
     assert(size() == COMPRESSED_SIZE);
     unsigned char out[64];
     BIP32Hash(cc, nChild, *begin(), begin()+1, out);
-    memcpy(ccChild.begin(), out+32, 32);
+    std::memcpy(ccChild.begin(), out+32, 32);
     secp256k1_pubkey pubkey;
     assert(secp256k1_context_verify && "secp256k1_context_verify must be initialized to use CPubKey.");
     if (!secp256k1_ec_pubkey_parse(secp256k1_context_verify, &pubkey, vch, size())) {
@@ -336,38 +336,38 @@ bool CPubKey::Derive(CPubKey& pubkeyChild, ChainCode &ccChild, unsigned int nChi
 
 void CExtPubKey::Encode(unsigned char code[BIP32_EXTKEY_SIZE]) const {
     code[0] = nDepth;
-    memcpy(code+1, vchFingerprint, 4);
+    std::memcpy(code+1, vchFingerprint, 4);
     WriteBE32(code+5, nChild);
-    memcpy(code+9, chaincode.begin(), 32);
+    std::memcpy(code+9, chaincode.begin(), 32);
     assert(pubkey.size() == CPubKey::COMPRESSED_SIZE);
-    memcpy(code+41, pubkey.begin(), CPubKey::COMPRESSED_SIZE);
+    std::memcpy(code+41, pubkey.begin(), CPubKey::COMPRESSED_SIZE);
 }
 
 void CExtPubKey::Decode(const unsigned char code[BIP32_EXTKEY_SIZE]) {
     nDepth = code[0];
-    memcpy(vchFingerprint, code+1, 4);
+    std::memcpy(vchFingerprint, code+1, 4);
     nChild = ReadBE32(code+5);
-    memcpy(chaincode.begin(), code+9, 32);
+    std::memcpy(chaincode.begin(), code+9, 32);
     pubkey.Set(code+41, code+BIP32_EXTKEY_SIZE);
     if ((nDepth == 0 && (nChild != 0 || ReadLE32(vchFingerprint) != 0)) || !pubkey.IsFullyValid()) pubkey = CPubKey();
 }
 
 void CExtPubKey::EncodeWithVersion(unsigned char code[BIP32_EXTKEY_WITH_VERSION_SIZE]) const
 {
-    memcpy(code, version, 4);
+    std::memcpy(code, version, 4);
     Encode(&code[4]);
 }
 
 void CExtPubKey::DecodeWithVersion(const unsigned char code[BIP32_EXTKEY_WITH_VERSION_SIZE])
 {
-    memcpy(version, code, 4);
+    std::memcpy(version, code, 4);
     Decode(&code[4]);
 }
 
 bool CExtPubKey::Derive(CExtPubKey &out, unsigned int _nChild) const {
     out.nDepth = nDepth + 1;
     CKeyID id = pubkey.GetID();
-    memcpy(out.vchFingerprint, &id, 4);
+    std::memcpy(out.vchFingerprint, &id, 4);
     out.nChild = _nChild;
     return pubkey.Derive(out.pubkey, out.chaincode, _nChild, chaincode);
 }

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -119,7 +119,7 @@ public:
     friend bool operator==(const CPubKey& a, const CPubKey& b)
     {
         return a.vch[0] == b.vch[0] &&
-               memcmp(a.vch, b.vch, a.size()) == 0;
+               std::memcmp(a.vch, b.vch, a.size()) == 0;
     }
     friend bool operator!=(const CPubKey& a, const CPubKey& b)
     {
@@ -128,12 +128,12 @@ public:
     friend bool operator<(const CPubKey& a, const CPubKey& b)
     {
         return a.vch[0] < b.vch[0] ||
-               (a.vch[0] == b.vch[0] && memcmp(a.vch, b.vch, a.size()) < 0);
+               (a.vch[0] == b.vch[0] && std::memcmp(a.vch, b.vch, a.size()) < 0);
     }
     friend bool operator>(const CPubKey& a, const CPubKey& b)
     {
         return a.vch[0] > b.vch[0] ||
-               (a.vch[0] == b.vch[0] && memcmp(a.vch, b.vch, a.size()) > 0);
+               (a.vch[0] == b.vch[0] && std::memcmp(a.vch, b.vch, a.size()) > 0);
     }
 
     //! Implement serialization, as if this was a byte vector.
@@ -302,7 +302,7 @@ struct CExtPubKey {
     friend bool operator==(const CExtPubKey &a, const CExtPubKey &b)
     {
         return a.nDepth == b.nDepth &&
-            memcmp(a.vchFingerprint, b.vchFingerprint, sizeof(vchFingerprint)) == 0 &&
+            std::memcmp(a.vchFingerprint, b.vchFingerprint, sizeof(vchFingerprint)) == 0 &&
             a.nChild == b.nChild &&
             a.chaincode == b.chaincode &&
             a.pubkey == b.pubkey;

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -90,7 +90,7 @@ public:
     {
         int len = pend == pbegin ? 0 : GetLen(pbegin[0]);
         if (len && len == (pend - pbegin))
-            memcpy(vch, (unsigned char*)&pbegin[0], len);
+            std::memcpy(vch, (unsigned char*)&pbegin[0], len);
         else
             Invalidate();
     }

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -67,6 +67,7 @@
 
 #include <cassert>
 #include <chrono>
+#include <cstdlib>
 #include <exception>
 #include <fstream>
 #include <string>
@@ -574,9 +575,9 @@ bool SetStartOnSystemStartup(bool fAutoStart)
 
 fs::path static GetAutostartDir()
 {
-    char* pszConfigHome = getenv("XDG_CONFIG_HOME");
+    char* pszConfigHome = std::getenv("XDG_CONFIG_HOME");
     if (pszConfigHome) return fs::path(pszConfigHome) / "autostart";
-    char* pszHome = getenv("HOME");
+    char* pszHome = std::getenv("HOME");
     if (pszHome) return fs::path(pszHome) / ".config" / "autostart";
     return fs::path();
 }

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -25,6 +25,7 @@
 #include <QObject>
 #include <QTest>
 
+#include <cstdlib>
 #include <functional>
 
 #if defined(QT_STATICPLUGIN)
@@ -74,7 +75,7 @@ int main(int argc, char* argv[])
     // platform ("xcb", "windows", or "cocoa") so tests can't unintentionally
     // interfere with any background GUIs and don't require extra resources.
     #if defined(WIN32)
-        if (getenv("QT_QPA_PLATFORM") == nullptr) _putenv_s("QT_QPA_PLATFORM", "minimal");
+        if (std::getenv("QT_QPA_PLATFORM") == nullptr) _putenv_s("QT_QPA_PLATFORM", "minimal");
     #else
         setenv("QT_QPA_PLATFORM", "minimal", 0 /* overwrite */);
     #endif

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -422,12 +422,12 @@ public:
             // Finalize the hasher
             hasher.Finalize(buf);
             // Store the last 32 bytes of the hash output as new RNG state.
-            memcpy(m_state, buf + 32, 32);
+            std::memcpy(m_state, buf + 32, 32);
         }
         // If desired, copy (up to) the first 32 bytes of the hash output as output.
         if (num) {
             assert(out != nullptr);
-            memcpy(out, buf, num);
+            std::memcpy(out, buf, num);
         }
         // Best effort cleanup of internal state
         hasher.Reset();
@@ -609,7 +609,7 @@ uint256 FastRandomContext::rand256() noexcept
         FillByteBuffer();
     }
     uint256 ret;
-    memcpy(ret.begin(), bytebuf + 64 - bytebuf_size, 32);
+    std::memcpy(ret.begin(), bytebuf + 64 - bytebuf_size, 32);
     bytebuf_size -= 32;
     return ret;
 }

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -644,7 +644,7 @@ bool Random_SanityCheck()
     int tries = 0;
     /* Loop until all bytes have been overwritten at least once, or max number tries reached */
     do {
-        memset(data, 0, NUM_OS_RANDOM_BYTES);
+        std::memset(data, 0, NUM_OS_RANDOM_BYTES);
         GetOSRand(data);
         for (int x=0; x < NUM_OS_RANDOM_BYTES; ++x) {
             overwritten[x] |= (data[x] != 0);

--- a/src/script/bitcoinconsensus.cpp
+++ b/src/script/bitcoinconsensus.cpp
@@ -36,7 +36,7 @@ public:
             throw std::ios_base::failure(std::string(__func__) + ": bad source buffer");
         }
 
-        memcpy(dst.data(), m_data, dst.size());
+        std::memcpy(dst.data(), m_data, dst.size());
         m_remaining -= dst.size();
         m_data += dst.size();
     }

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1881,7 +1881,7 @@ static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, 
             exec_script = CScript(script_bytes.begin(), script_bytes.end());
             uint256 hash_exec_script;
             CSHA256().Write(exec_script.data(), exec_script.size()).Finalize(hash_exec_script.begin());
-            if (memcmp(hash_exec_script.begin(), program.data(), 32)) {
+            if (std::memcmp(hash_exec_script.begin(), program.data(), 32)) {
                 return set_error(serror, SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH);
             }
             return ExecuteWitnessScript(stack, exec_script, flags, SigVersion::WITNESS_V0, checker, execdata, serror);

--- a/src/script/keyorigin.h
+++ b/src/script/keyorigin.h
@@ -21,7 +21,7 @@ struct KeyOriginInfo
     friend bool operator<(const KeyOriginInfo& a, const KeyOriginInfo& b)
     {
         // Compare the fingerprints lexicographically
-        int fpr_cmp = memcmp(a.fingerprint, b.fingerprint, 4);
+        int fpr_cmp = std::memcmp(a.fingerprint, b.fingerprint, 4);
         if (fpr_cmp < 0) {
             return true;
         } else if (fpr_cmp > 0) {

--- a/src/script/keyorigin.h
+++ b/src/script/keyorigin.h
@@ -41,7 +41,7 @@ struct KeyOriginInfo
 
     void clear()
     {
-        memset(fingerprint, 0, 4);
+        std::memset(fingerprint, 0, 4);
         path.clear();
     }
 };

--- a/src/streams.h
+++ b/src/streams.h
@@ -100,7 +100,7 @@ class CVectorWriter
         assert(nPos <= vchData.size());
         size_t nOverwrite = std::min(src.size(), vchData.size() - nPos);
         if (nOverwrite) {
-            memcpy(vchData.data() + nPos, src.data(), nOverwrite);
+            std::memcpy(vchData.data() + nPos, src.data(), nOverwrite);
         }
         if (nOverwrite < src.size()) {
             vchData.insert(vchData.end(), UCharCast(src.data()) + nOverwrite, UCharCast(src.end()));
@@ -172,7 +172,7 @@ public:
         if (dst.size() > m_data.size()) {
             throw std::ios_base::failure("SpanReader::read(): end of data");
         }
-        memcpy(dst.data(), m_data.data(), dst.size());
+        std::memcpy(dst.data(), m_data.data(), dst.size());
         m_data = m_data.subspan(dst.size());
     }
 };
@@ -286,7 +286,7 @@ public:
         if (!next_read_pos.has_value() || next_read_pos.value() > vch.size()) {
             throw std::ios_base::failure("CDataStream::read(): end of data");
         }
-        memcpy(dst.data(), &vch[m_read_pos], dst.size());
+        std::memcpy(dst.data(), &vch[m_read_pos], dst.size());
         if (next_read_pos.value() == vch.size()) {
             m_read_pos = 0;
             vch.clear();
@@ -678,7 +678,7 @@ public:
                 nNow = vchBuf.size() - pos;
             if (nNow + m_read_pos > nSrcPos)
                 nNow = nSrcPos - m_read_pos;
-            memcpy(dst.data(), &vchBuf[pos], nNow);
+            std::memcpy(dst.data(), &vchBuf[pos], nNow);
             m_read_pos += nNow;
             dst = dst.subspan(nNow);
         }

--- a/src/support/cleanse.cpp
+++ b/src/support/cleanse.cpp
@@ -26,7 +26,7 @@ void memory_cleanse(void *ptr, size_t len)
      *    As best as we can tell, this is sufficient to break any optimisations that
      *    might try to eliminate "superfluous" memsets.
      * This method is used in memzero_explicit() the Linux kernel, too. Its advantage is that it
-     * is pretty efficient because the compiler can still implement the memset() efficiently,
+     * is pretty efficient because the compiler can still implement the std::memset() efficiently,
      * just not remove it entirely. See "Dead Store Elimination (Still) Considered Harmful" by
      * Yang et al. (USENIX Security 2017) for more background.
      */

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -693,14 +693,14 @@ BOOST_AUTO_TEST_CASE(remove_invalid)
     pos = str.find(new2_raw, 0, sizeof(new2_raw));
     BOOST_REQUIRE(pos != std::string::npos);
     BOOST_REQUIRE(pos + sizeof(new2_raw_replacement) <= stream.size());
-    memcpy(stream.data() + pos, new2_raw_replacement, sizeof(new2_raw_replacement));
+    std::memcpy(stream.data() + pos, new2_raw_replacement, sizeof(new2_raw_replacement));
 
     const char tried2_raw[]{8, 8, 8, 8};
     const uint8_t tried2_raw_replacement[]{255, 255, 255, 255}; // 255.255.255.255 is !IsValid()
     pos = str.find(tried2_raw, 0, sizeof(tried2_raw));
     BOOST_REQUIRE(pos != std::string::npos);
     BOOST_REQUIRE(pos + sizeof(tried2_raw_replacement) <= stream.size());
-    memcpy(stream.data() + pos, tried2_raw_replacement, sizeof(tried2_raw_replacement));
+    std::memcpy(stream.data() + pos, tried2_raw_replacement, sizeof(tried2_raw_replacement));
 
     addrman = std::make_unique<AddrMan>(EMPTY_NETGROUPMAN, DETERMINISTIC, GetCheckRatio(m_node));
     stream >> *addrman;

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -142,8 +142,8 @@ BOOST_AUTO_TEST_CASE(bloom_match)
     COutPoint prevOutPoint(uint256S("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0);
     {
         std::vector<unsigned char> data(32 + sizeof(unsigned int));
-        memcpy(data.data(), prevOutPoint.hash.begin(), 32);
-        memcpy(data.data()+32, &prevOutPoint.n, sizeof(unsigned int));
+        std::memcpy(data.data(), prevOutPoint.hash.begin(), 32);
+        std::memcpy(data.data()+32, &prevOutPoint.n, sizeof(unsigned int));
         filter.insert(data);
     }
     BOOST_CHECK_MESSAGE(filter.IsRelevantAndUpdate(tx), "Simple Bloom filter didn't match manually serialized COutPoint");

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(compress_script_to_ckey_id)
     // Check compressed script
     BOOST_CHECK_EQUAL(out.size(), 21U);
     BOOST_CHECK_EQUAL(out[0], 0x00);
-    BOOST_CHECK_EQUAL(memcmp(out.data() + 1, script.data() + 3, 20), 0); // compare the 20 relevant chars of the CKeyId in the script
+    BOOST_CHECK_EQUAL(std::memcmp(out.data() + 1, script.data() + 3, 20), 0); // compare the 20 relevant chars of the CKeyId in the script
 }
 
 BOOST_AUTO_TEST_CASE(compress_script_to_cscript_id)
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(compress_script_to_cscript_id)
     // Check compressed script
     BOOST_CHECK_EQUAL(out.size(), 21U);
     BOOST_CHECK_EQUAL(out[0], 0x01);
-    BOOST_CHECK_EQUAL(memcmp(out.data() + 1, script.data() + 2, 20), 0); // compare the 20 relevant chars of the CScriptId in the script
+    BOOST_CHECK_EQUAL(std::memcmp(out.data() + 1, script.data() + 2, 20), 0); // compare the 20 relevant chars of the CScriptId in the script
 }
 
 BOOST_AUTO_TEST_CASE(compress_script_to_compressed_pubkey_id)
@@ -113,8 +113,8 @@ BOOST_AUTO_TEST_CASE(compress_script_to_compressed_pubkey_id)
 
     // Check compressed script
     BOOST_CHECK_EQUAL(out.size(), 33U);
-    BOOST_CHECK_EQUAL(memcmp(out.data(), script.data() + 1, 1), 0);
-    BOOST_CHECK_EQUAL(memcmp(out.data() + 1, script.data() + 2, 32), 0); // compare the 32 chars of the compressed CPubKey
+    BOOST_CHECK_EQUAL(std::memcmp(out.data(), script.data() + 1, 1), 0);
+    BOOST_CHECK_EQUAL(std::memcmp(out.data() + 1, script.data() + 2, 32), 0); // compare the 32 chars of the compressed CPubKey
 }
 
 BOOST_AUTO_TEST_CASE(compress_script_to_uncompressed_pubkey_id)
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(compress_script_to_uncompressed_pubkey_id)
 
     // Check compressed script
     BOOST_CHECK_EQUAL(out.size(), 33U);
-    BOOST_CHECK_EQUAL(memcmp(out.data() + 1, script.data() + 2, 32), 0); // first 32 chars of CPubKey are copied into out[1:]
+    BOOST_CHECK_EQUAL(std::memcmp(out.data() + 1, script.data() + 2, 32), 0); // first 32 chars of CPubKey are copied into out[1:]
     BOOST_CHECK_EQUAL(out[0], 0x04 | (script[65] & 0x01)); // least significant bit (lsb) of last char of pubkey is mapped into out[0]
 }
 

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -627,13 +627,13 @@ static void TestChaCha20Poly1305AEAD(bool must_succeed, unsigned int expected_aa
 
     // verify ciphertext & mac against the test vector
     BOOST_CHECK_EQUAL(expected_ciphertext_and_mac.size(), ciphertext_buf.size());
-    BOOST_CHECK(memcmp(ciphertext_buf.data(), expected_ciphertext_and_mac.data(), ciphertext_buf.size()) == 0);
+    BOOST_CHECK(std::memcmp(ciphertext_buf.data(), expected_ciphertext_and_mac.data(), ciphertext_buf.size()) == 0);
 
     // manually construct the AAD keystream
     cmp_ctx.SetIV(seqnr_aad);
     cmp_ctx.Seek(0);
     cmp_ctx.Keystream(cmp_ctx_buffer.data(), 64);
-    BOOST_CHECK(memcmp(expected_aad_keystream.data(), cmp_ctx_buffer.data(), expected_aad_keystream.size()) == 0);
+    BOOST_CHECK(std::memcmp(expected_aad_keystream.data(), cmp_ctx_buffer.data(), expected_aad_keystream.size()) == 0);
     // crypt the 3 length bytes and compare the length
     uint32_t len_cmp = 0;
     len_cmp = (ciphertext_buf[0] ^ cmp_ctx_buffer[aad_pos + 0]) |
@@ -651,11 +651,11 @@ static void TestChaCha20Poly1305AEAD(bool must_succeed, unsigned int expected_aa
         BOOST_CHECK(res);
 
         // make sure we repetitive get the same plaintext
-        BOOST_CHECK(memcmp(plaintext_buf.data(), plaintext_buf_new.data(), plaintext_buf.size()) == 0);
+        BOOST_CHECK(std::memcmp(plaintext_buf.data(), plaintext_buf_new.data(), plaintext_buf.size()) == 0);
 
         // compare sequence number 999 against the test vector
         if (seqnr_payload == 999) {
-            BOOST_CHECK(memcmp(ciphertext_buf.data(), expected_ciphertext_and_mac_sequence999.data(), expected_ciphertext_and_mac_sequence999.size()) == 0);
+            BOOST_CHECK(std::memcmp(ciphertext_buf.data(), expected_ciphertext_and_mac_sequence999.data(), expected_ciphertext_and_mac_sequence999.size()) == 0);
         }
         // set nonce and block counter, output the keystream
         cmp_ctx.SetIV(seqnr_aad);
@@ -749,7 +749,7 @@ BOOST_AUTO_TEST_CASE(sha256d64)
             CHash256().Write({in + 64 * j, 64}).Finalize({out1 + 32 * j, 32});
         }
         SHA256D64(out2, in, i);
-        BOOST_CHECK(memcmp(out1, out2, 32 * i) == 0);
+        BOOST_CHECK(std::memcmp(out1, out2, 32 * i) == 0);
     }
 }
 

--- a/src/test/fuzz/asmap.cpp
+++ b/src/test/fuzz/asmap.cpp
@@ -54,7 +54,7 @@ FUZZ_TARGET(asmap)
     } else {
         assert(addr_size == ADDR_IPV4_SIZE);
         in_addr ipv4;
-        memcpy(&ipv4, addr_data, addr_size);
+        std::memcpy(&ipv4, addr_data, addr_size);
         net_addr.SetIP(CNetAddr{ipv4});
     }
     NetGroupManager netgroupman{asmap};

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -516,7 +516,7 @@ CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider) noexcept
     } else if (network == Network::NET_IPV6) {
         if (fuzzed_data_provider.remaining_bytes() >= 16) {
             in6_addr v6_addr = {};
-            memcpy(v6_addr.s6_addr, fuzzed_data_provider.ConsumeBytes<uint8_t>(16).data(), 16);
+            std::memcpy(v6_addr.s6_addr, fuzzed_data_provider.ConsumeBytes<uint8_t>(16).data(), 16);
             net_addr = CNetAddr{v6_addr, fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
         }
     } else if (network == Network::NET_INTERNAL) {

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -770,7 +770,7 @@ CNetAddr UtilBuildAddress(unsigned char p1, unsigned char p2, unsigned char p3, 
 
     struct sockaddr_in sa;
     std::memset(&sa, 0, sizeof(sockaddr_in)); // initialize the memory block
-    memcpy(&(sa.sin_addr), &ip, sizeof(ip));
+    std::memcpy(&(sa.sin_addr), &ip, sizeof(ip));
     return CNetAddr(sa.sin_addr);
 }
 

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -637,7 +637,7 @@ BOOST_AUTO_TEST_CASE(ipv4_peer_with_ipv6_addrMe_test)
 
     // the peer claims to be reaching us via IPv6
     in6_addr ipv6AddrLocal;
-    memset(ipv6AddrLocal.s6_addr, 0, 16);
+    std::memset(ipv6AddrLocal.s6_addr, 0, 16);
     ipv6AddrLocal.s6_addr[0] = 0xcc;
     CAddress addrLocal = CAddress(CService(ipv6AddrLocal, 7777), NODE_NETWORK);
     pnode->SetAddrLocal(addrLocal);
@@ -769,7 +769,7 @@ CNetAddr UtilBuildAddress(unsigned char p1, unsigned char p2, unsigned char p3, 
     unsigned char ip[] = {p1, p2, p3, p4};
 
     struct sockaddr_in sa;
-    memset(&sa, 0, sizeof(sockaddr_in)); // initialize the memory block
+    std::memset(&sa, 0, sizeof(sockaddr_in)); // initialize the memory block
     memcpy(&(sa.sin_addr), &ip, sizeof(ip));
     return CNetAddr(sa.sin_addr);
 }

--- a/src/test/serfloat_tests.cpp
+++ b/src/test/serfloat_tests.cpp
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(double_serfloat_tests) {
                 v &= ~(uint64_t{1} << 63);
                 if (x & 256) v |= (uint64_t{1} << 63);
                 double f;
-                memcpy(&f, &v, 8);
+                std::memcpy(&f, &v, 8);
                 uint64_t v2 = TestDouble(f);
                 if (!std::isnan(f)) BOOST_CHECK_EQUAL(v, v2);
             }

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -26,7 +26,7 @@ public:
     CSerializeMethodsTestSingle() = default;
     CSerializeMethodsTestSingle(int intvalin, bool boolvalin, std::string stringvalin, const uint8_t* charstrvalin, const CTransactionRef& txvalin) : intval(intvalin), boolval(boolvalin), stringval(std::move(stringvalin)), txval(txvalin)
     {
-        memcpy(charstrval, charstrvalin, sizeof(charstrval));
+        std::memcpy(charstrval, charstrvalin, sizeof(charstrval));
     }
 
     SERIALIZE_METHODS(CSerializeMethodsTestSingle, obj)

--- a/src/test/settings_tests.cpp
+++ b/src/test/settings_tests.cpp
@@ -15,6 +15,7 @@
 #include <util/string.h>
 #include <util/system.h>
 
+#include <cstdlib>
 #include <fstream>
 #include <map>
 #include <string>
@@ -184,7 +185,7 @@ BOOST_FIXTURE_TEST_CASE(Merge, MergeTestingSetup)
 {
     CHash256 out_sha;
     FILE* out_file = nullptr;
-    if (const char* out_path = getenv("SETTINGS_MERGE_TEST_OUT")) {
+    if (const char* out_path = std::getenv("SETTINGS_MERGE_TEST_OUT")) {
         out_file = fsbridge::fopen(out_path, "w");
         if (!out_file) throw std::system_error(errno, std::generic_category(), "fopen failed");
     }

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -168,11 +168,11 @@ BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex begin() end() size() GetLow64 G
     TmpL.SetHex(ZeroL.ToString()); BOOST_CHECK(TmpL == uint256());
 
     TmpL.SetHex(R1L.ToString());
-    BOOST_CHECK(memcmp(R1L.begin(), R1Array, 32)==0);
-    BOOST_CHECK(memcmp(TmpL.begin(), R1Array, 32)==0);
-    BOOST_CHECK(memcmp(R2L.begin(), R2Array, 32)==0);
-    BOOST_CHECK(memcmp(ZeroL.begin(), ZeroArray, 32)==0);
-    BOOST_CHECK(memcmp(OneL.begin(), OneArray, 32)==0);
+    BOOST_CHECK(std::memcmp(R1L.begin(), R1Array, 32)==0);
+    BOOST_CHECK(std::memcmp(TmpL.begin(), R1Array, 32)==0);
+    BOOST_CHECK(std::memcmp(R2L.begin(), R2Array, 32)==0);
+    BOOST_CHECK(std::memcmp(ZeroL.begin(), ZeroArray, 32)==0);
+    BOOST_CHECK(std::memcmp(OneL.begin(), OneArray, 32)==0);
     BOOST_CHECK(R1L.size() == sizeof(R1L));
     BOOST_CHECK(sizeof(R1L) == 32);
     BOOST_CHECK(R1L.size() == 32);
@@ -214,11 +214,11 @@ BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex begin() end() size() GetLow64 G
     TmpS.SetHex(ZeroS.ToString()); BOOST_CHECK(TmpS == uint160());
 
     TmpS.SetHex(R1S.ToString());
-    BOOST_CHECK(memcmp(R1S.begin(), R1Array, 20)==0);
-    BOOST_CHECK(memcmp(TmpS.begin(), R1Array, 20)==0);
-    BOOST_CHECK(memcmp(R2S.begin(), R2Array, 20)==0);
-    BOOST_CHECK(memcmp(ZeroS.begin(), ZeroArray, 20)==0);
-    BOOST_CHECK(memcmp(OneS.begin(), OneArray, 20)==0);
+    BOOST_CHECK(std::memcmp(R1S.begin(), R1Array, 20)==0);
+    BOOST_CHECK(std::memcmp(TmpS.begin(), R1Array, 20)==0);
+    BOOST_CHECK(std::memcmp(R2S.begin(), R2Array, 20)==0);
+    BOOST_CHECK(std::memcmp(ZeroS.begin(), ZeroArray, 20)==0);
+    BOOST_CHECK(std::memcmp(OneS.begin(), OneArray, 20)==0);
     BOOST_CHECK(R1S.size() == sizeof(R1S));
     BOOST_CHECK(sizeof(R1S) == 20);
     BOOST_CHECK(R1S.size() == 20);

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -139,13 +139,13 @@ public:
     {
         if (addr != nullptr) {
             // Pretend all connections come from 5.5.5.5:6789
-            memset(addr, 0x00, *addr_len);
+            std::memset(addr, 0x00, *addr_len);
             const socklen_t write_len = static_cast<socklen_t>(sizeof(sockaddr_in));
             if (*addr_len >= write_len) {
                 *addr_len = write_len;
                 sockaddr_in* addr_in = reinterpret_cast<sockaddr_in*>(addr);
                 addr_in->sin_family = AF_INET;
-                memset(&addr_in->sin_addr, 0x05, sizeof(addr_in->sin_addr));
+                std::memset(&addr_in->sin_addr, 0x05, sizeof(addr_in->sin_addr));
                 addr_in->sin_port = htons(6789);
             }
         }

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -25,6 +25,7 @@
 #include <util/vector.h>
 
 #include <array>
+#include <cstdlib>
 #include <fstream>
 #include <limits>
 #include <map>
@@ -1035,7 +1036,7 @@ BOOST_FIXTURE_TEST_CASE(util_ArgsMerge, ArgsMergeTestingSetup)
 {
     CHash256 out_sha;
     FILE* out_file = nullptr;
-    if (const char* out_path = getenv("ARGS_MERGE_TEST_OUT")) {
+    if (const char* out_path = std::getenv("ARGS_MERGE_TEST_OUT")) {
         out_file = fsbridge::fopen(out_path, "w");
         if (!out_file) throw std::system_error(errno, std::generic_category(), "fopen failed");
     }
@@ -1170,7 +1171,7 @@ BOOST_FIXTURE_TEST_CASE(util_ChainMerge, ChainMergeTestingSetup)
 {
     CHash256 out_sha;
     FILE* out_file = nullptr;
-    if (const char* out_path = getenv("CHAIN_MERGE_TEST_OUT")) {
+    if (const char* out_path = std::getenv("CHAIN_MERGE_TEST_OUT")) {
         out_file = fsbridge::fopen(out_path, "w");
         if (!out_file) throw std::system_error(errno, std::generic_category(), "fopen failed");
     }

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -29,7 +29,7 @@ std::string base_blob<BITS>::GetHex() const
 template <unsigned int BITS>
 void base_blob<BITS>::SetHex(const char* psz)
 {
-    memset(m_data, 0, sizeof(m_data));
+    std::memset(m_data, 0, sizeof(m_data));
 
     // skip leading spaces
     while (IsSpace(*psz))

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -13,7 +13,7 @@ template <unsigned int BITS>
 base_blob<BITS>::base_blob(const std::vector<unsigned char>& vch)
 {
     assert(vch.size() == sizeof(m_data));
-    memcpy(m_data, vch.data(), sizeof(m_data));
+    std::memcpy(m_data, vch.data(), sizeof(m_data));
 }
 
 template <unsigned int BITS>

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -43,7 +43,7 @@ public:
         std::memset(m_data, 0, sizeof(m_data));
     }
 
-    inline int Compare(const base_blob& other) const { return memcmp(m_data, other.m_data, sizeof(m_data)); }
+    inline int Compare(const base_blob& other) const { return std::memcmp(m_data, other.m_data, sizeof(m_data)); }
 
     friend inline bool operator==(const base_blob& a, const base_blob& b) { return a.Compare(b) == 0; }
     friend inline bool operator!=(const base_blob& a, const base_blob& b) { return a.Compare(b) != 0; }

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -40,7 +40,7 @@ public:
 
     void SetNull()
     {
-        memset(m_data, 0, sizeof(m_data));
+        std::memset(m_data, 0, sizeof(m_data));
     }
 
     inline int Compare(const base_blob& other) const { return memcmp(m_data, other.m_data, sizeof(m_data)); }

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -68,6 +68,7 @@
 
 #include <univalue.h>
 
+#include <cstdlib>
 #include <fstream>
 #include <map>
 #include <memory>
@@ -864,7 +865,7 @@ fs::path GetDefaultDataDir()
     return GetSpecialFolderPath(CSIDL_APPDATA) / "Bitcoin";
 #else
     fs::path pathRet;
-    char* pszHome = getenv("HOME");
+    char* pszHome = std::getenv("HOME");
     if (pszHome == nullptr || strlen(pszHome) == 0)
         pathRet = fs::path("/");
     else

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3417,7 +3417,7 @@ std::vector<unsigned char> ChainstateManager::GenerateCoinbaseCommitment(CBlock&
         out.scriptPubKey[3] = 0x21;
         out.scriptPubKey[4] = 0xa9;
         out.scriptPubKey[5] = 0xed;
-        memcpy(&out.scriptPubKey[6], witnessroot.begin(), 32);
+        std::memcpy(&out.scriptPubKey[6], witnessroot.begin(), 32);
         commitment = std::vector<unsigned char>(out.scriptPubKey.begin(), out.scriptPubKey.end());
         CMutableTransaction tx(*block.vtx[0]);
         tx.vout.push_back(out);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3537,7 +3537,7 @@ static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& stat
                 return state.Invalid(BlockValidationResult::BLOCK_MUTATED, "bad-witness-nonce-size", strprintf("%s : invalid witness reserved value size", __func__));
             }
             CHash256().Write(hashWitness).Write(block.vtx[0]->vin[0].scriptWitness.stack[0]).Finalize(hashWitness);
-            if (memcmp(hashWitness.begin(), &block.vtx[0]->vout[commitpos].scriptPubKey[6], 32)) {
+            if (std::memcmp(hashWitness.begin(), &block.vtx[0]->vout[commitpos].scriptPubKey[6], 32)) {
                 return state.Invalid(BlockValidationResult::BLOCK_MUTATED, "bad-witness-merkle-match", strprintf("%s : witness merkle commitment mismatch", __func__));
             }
             fHaveWitness = true;
@@ -4282,7 +4282,7 @@ void CChainState::LoadExternalBlockFile(FILE* fileIn, FlatFilePos* dbp)
                 blkdat.FindByte(m_params.MessageStart()[0]);
                 nRewind = blkdat.GetPos() + 1;
                 blkdat >> buf;
-                if (memcmp(buf, m_params.MessageStart(), CMessageHeader::MESSAGE_START_SIZE)) {
+                if (std::memcmp(buf, m_params.MessageStart(), CMessageHeader::MESSAGE_START_SIZE)) {
                     continue;
                 }
                 // read size

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -52,7 +52,7 @@ std::map<std::string, std::weak_ptr<BerkeleyEnvironment>> g_dbenvs GUARDED_BY(cs
 
 bool WalletDatabaseFileId::operator==(const WalletDatabaseFileId& rhs) const
 {
-    return memcmp(value, &rhs.value, sizeof(value)) == 0;
+    return std::memcmp(value, &rhs.value, sizeof(value)) == 0;
 }
 
 /**

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -31,8 +31,8 @@ int CCrypter::BytesToKeySHA512AES(const std::vector<unsigned char>& chSalt, cons
     for(int i = 0; i != count - 1; i++)
         di.Reset().Write(buf, sizeof(buf)).Finalize(buf);
 
-    memcpy(key, buf, WALLET_CRYPTO_KEY_SIZE);
-    memcpy(iv, buf + WALLET_CRYPTO_KEY_SIZE, WALLET_CRYPTO_IV_SIZE);
+    std::memcpy(key, buf, WALLET_CRYPTO_KEY_SIZE);
+    std::memcpy(iv, buf + WALLET_CRYPTO_KEY_SIZE, WALLET_CRYPTO_IV_SIZE);
     memory_cleanse(buf, sizeof(buf));
     return WALLET_CRYPTO_KEY_SIZE;
 }
@@ -62,8 +62,8 @@ bool CCrypter::SetKey(const CKeyingMaterial& chNewKey, const std::vector<unsigne
     if (chNewKey.size() != WALLET_CRYPTO_KEY_SIZE || chNewIV.size() != WALLET_CRYPTO_IV_SIZE)
         return false;
 
-    memcpy(vchKey.data(), chNewKey.data(), chNewKey.size());
-    memcpy(vchIV.data(), chNewIV.data(), chNewIV.size());
+    std::memcpy(vchKey.data(), chNewKey.data(), chNewKey.size());
+    std::memcpy(vchIV.data(), chNewIV.data(), chNewIV.size());
 
     fKeySet = true;
     return true;
@@ -109,7 +109,7 @@ bool EncryptSecret(const CKeyingMaterial& vMasterKey, const CKeyingMaterial &vch
 {
     CCrypter cKeyCrypter;
     std::vector<unsigned char> chIV(WALLET_CRYPTO_IV_SIZE);
-    memcpy(chIV.data(), &nIV, WALLET_CRYPTO_IV_SIZE);
+    std::memcpy(chIV.data(), &nIV, WALLET_CRYPTO_IV_SIZE);
     if(!cKeyCrypter.SetKey(vMasterKey, chIV))
         return false;
     return cKeyCrypter.Encrypt(*((const CKeyingMaterial*)&vchPlaintext), vchCiphertext);
@@ -119,7 +119,7 @@ bool DecryptSecret(const CKeyingMaterial& vMasterKey, const std::vector<unsigned
 {
     CCrypter cKeyCrypter;
     std::vector<unsigned char> chIV(WALLET_CRYPTO_IV_SIZE);
-    memcpy(chIV.data(), &nIV, WALLET_CRYPTO_IV_SIZE);
+    std::memcpy(chIV.data(), &nIV, WALLET_CRYPTO_IV_SIZE);
     if(!cKeyCrypter.SetKey(vMasterKey, chIV))
         return false;
     return cKeyCrypter.Decrypt(vchCiphertext, vchPlaintext);

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -136,7 +136,7 @@ bool IsSQLiteFile(const fs::path& path)
     }
 
     // Check the application id matches our network magic
-    return memcmp(Params().MessageStart(), app_id, 4) == 0;
+    return std::memcmp(Params().MessageStart(), app_id, 4) == 0;
 }
 
 void ReadDatabaseArgs(const ArgsManager& args, DatabaseOptions& options)

--- a/src/wallet/test/wallet_crypto_tests.cpp
+++ b/src/wallet/test/wallet_crypto_tests.cpp
@@ -24,10 +24,10 @@ static void TestPassphraseSingle(const std::vector<unsigned char>& vchSalt, cons
     crypt.SetKeyFromPassphrase(passphrase, vchSalt, rounds, 0);
 
     if(!correctKey.empty())
-        BOOST_CHECK_MESSAGE(memcmp(crypt.vchKey.data(), correctKey.data(), crypt.vchKey.size()) == 0, \
+        BOOST_CHECK_MESSAGE(std::memcmp(crypt.vchKey.data(), correctKey.data(), crypt.vchKey.size()) == 0, \
             HexStr(crypt.vchKey) + std::string(" != ") + HexStr(correctKey));
     if(!correctIV.empty())
-        BOOST_CHECK_MESSAGE(memcmp(crypt.vchIV.data(), correctIV.data(), crypt.vchIV.size()) == 0,
+        BOOST_CHECK_MESSAGE(std::memcmp(crypt.vchIV.data(), correctIV.data(), crypt.vchIV.size()) == 0,
             HexStr(crypt.vchIV) + std::string(" != ") + HexStr(correctIV));
 }
 

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -52,7 +52,7 @@ static int zmq_send_multipart(void *sock, const void* data, size_t size, ...)
         }
 
         void *buf = zmq_msg_data(&msg);
-        memcpy(buf, data, size);
+        std::memcpy(buf, data, size);
 
         data = va_arg(args, const void*);
 


### PR DESCRIPTION
We currently use a mix of `std::mem*(` and `mem*(` throughout the codebase. Consolidate to `std::mem*(`.

Follows up to a comment in #24962:
> Maybe switch to std::memmove, which comes with the documentation:

Also includes a change to `std::vsnprintf` and header changes required to perform compilation.