### PR TITLE
test: add coverage for unknown network in -onlynet

### DIFF
--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -36,6 +36,7 @@ addnode connect to a CJDNS address
 - Test passing invalid -i2psam
 - Test passing -onlynet=onion without -proxy or -onion
 - Test passing -onlynet=onion with -onion=0 and with -noonion
+- Test passing unknown -onlynet
 """
 
 import socket
@@ -348,6 +349,11 @@ class ProxyTest(BitcoinTestFramework):
         for arg in ["-onion=0", "-noonion"]:
             self.nodes[1].extra_args = ["-onlynet=onion", arg]
             self.nodes[1].assert_start_raises_init_error(expected_msg=msg)
+
+        self.log.info("Test passing unknown network to -onlynet raises expected init error")
+        self.nodes[1].extra_args = ["-onlynet=abc"]
+        msg = "Error: Unknown network specified in -onlynet: 'abc'"
+        self.nodes[1].assert_start_raises_init_error(expected_msg=msg)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds test coverage for the following init error by passing an unknown network in -onlynet
https://github.com/bitcoin/bitcoin/blob/0de36941eca1bff91420dd878eb097db2b1a596c/src/init.cpp#L1311

