### PR TITLE
refactor: Improve thread safety analysis by propagating some negative capabilities

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -283,7 +283,7 @@ struct Peer {
     };
 
     /* Initializes a TxRelay struct for this peer. Can be called at most once for a peer. */
-    TxRelay* SetTxRelay()
+    TxRelay* SetTxRelay() EXCLUSIVE_LOCKS_REQUIRED(!m_tx_relay_mutex)
     {
         LOCK(m_tx_relay_mutex);
         Assume(!m_tx_relay);


### PR DESCRIPTION
This PR is a follow-up for bitcoin/bitcoin#22778 and bitcoin/bitcoin#24062, and it seems [required](https://github.com/bitcoin/bitcoin/pull/24931#issuecomment-1132800173) for bitcoin/bitcoin#24931.

See details in the commit messages.