### PR TITLE
doc: remove passing `--disable-external-signer` in OpenBSD build guide

### DIFF
--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,6 +1,6 @@
 # OpenBSD Build Guide
 
-**Updated for OpenBSD [7.0](https://www.openbsd.org/70.html)**
+**Updated for OpenBSD [7.1](https://www.openbsd.org/71.html)**
 
 This guide describes how to build bitcoind, command-line utilities, and GUI on OpenBSD.
 
@@ -78,12 +78,9 @@ export AUTOMAKE_VERSION=1.16
 
 ### 1. Configuration
 
-Note that building with external signer support currently fails on OpenBSD,
-hence you have to explicitly disable it by passing the parameter
-`--disable-external-signer` to the configure script. The feature requires the
-header-only library boost::process, which is available on OpenBSD, but contains
-certain system calls and preprocessor defines like `waitid()` and `WEXITED` that
-are not available.
+Note that external signer support is currently not available on OpenBSD, since
+the used header-only library Boost.Process fails to compile (certain system
+calls and preprocessor defines like `waitid()` and `WEXITED` are missing).
 
 There are many ways to configure Bitcoin Core, here are a few common examples:
 
@@ -91,14 +88,14 @@ There are many ways to configure Bitcoin Core, here are a few common examples:
 This enables the GUI and descriptor wallet support, assuming `sqlite` and `qt5` are installed.
 
 ```bash
-./configure --disable-external-signer MAKE=gmake
+./configure MAKE=gmake
 ```
 
 ##### Descriptor & Legacy Wallet. No GUI:
 This enables support for both wallet types and disables the GUI:
 
 ```bash
-./configure --disable-external-signer --with-gui=no \
+./configure --with-gui=no \
     BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
     BDB_CFLAGS="-I${BDB_PREFIX}/include" \
     MAKE=gmake


### PR DESCRIPTION
Since we have a Boost.Process usage check in the build system (#24254, commit abc057c6030b2a0ddab46835a7801054da677781), passing the option `--disable-external-signer` explicitly is not needed anymore on OpenBSD; the configure script will automatically detect that including `<boost/process.hpp>` leads to a compile error and disable external signer support accordingly:

```
$ ./configure MAKE=gmake
...
checking whether Boost.Process can be used... no
...
Options used to compile and link:
  external signer = no
...

$ ./configure --enable-external-signer MAKE=gmake
...
checking whether Boost.Process can be used... no
configure: error: External signing is not supported for this Boost version
```
The PR basically reverts #22335 but keeps the part mentioning that external signer support is not available on OpenBSD. Also bumps the guide to version 7.1 (released [about a month ago](https://www.openbsd.org/71.html)), where I could verify that the instructions are still accurate.