### PR TITLE
[22.x] qt: Avoid crash on startup if int specified in settings.json

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -588,7 +588,7 @@ bool ArgsManager::IsArgNegated(const std::string& strArg) const
 std::string ArgsManager::GetArg(const std::string& strArg, const std::string& strDefault) const
 {
     const util::SettingsValue value = GetSetting(strArg);
-    return value.isNull() ? strDefault : value.isFalse() ? "0" : value.isTrue() ? "1" : value.get_str();
+    return value.isNull() ? strDefault : value.isFalse() ? "0" : value.isTrue() ? "1" : value.isNum() ? value.getValStr() : value.get_str();
 }
 
 int64_t ArgsManager::GetArg(const std::string& strArg, int64_t nDefault) const


### PR DESCRIPTION
Backport of #24498 to 22.x branch

This was already backported to the 23.x branch in #24511, but vasild discovered the issue can affect 22.x as well https://github.com/bitcoin/bitcoin/pull/15936#issuecomment-1115992866:

> While testing this, 22.x crashes if `settings.json` contains `"prune": 1234` due to #24498 which was fixed in 23.0. So, if this PR is included in 24.x and a user upgrades to 24.x and then downgrades to 22.x his 22.x would crash at startup.

It's not very important to backport this to 22.x because I can work around the issue other ways, but I do see 22.x is listed as an active branch https://github.com/bitcoin/bitcoin/branches, so if there is another 22.x release, it would be nice to have this fix and not have a wonky uncaught univalue exception waiting to be hit
