### PR TITLE
rpc: Filter inputs by type during CoinSelection 

### DIFF
--- a/src/test/fuzz/key.cpp
+++ b/src/test/fuzz/key.cpp
@@ -178,7 +178,7 @@ FUZZ_TARGET_INIT(key, initialize_key)
         assert(v_solutions_ret_tx_multisig[1].size() == 33);
         assert(v_solutions_ret_tx_multisig[2].size() == 1);
 
-        OutputType output_type{};
+        OutputType output_type{OutputType::LEGACY};
         const CTxDestination tx_destination = GetDestinationForKey(pubkey, output_type);
         assert(output_type == OutputType::LEGACY);
         assert(IsValidDestination(tx_destination));

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -38,6 +38,8 @@ public:
     //! If true, the selection process can add extra unselected inputs from the wallet
     //! while requires all selected inputs be used
     bool m_allow_other_inputs = false;
+    //! Filter inputs by type
+    std::optional<unsigned int> m_filter_inputs;
     //! Includes watch only addresses which are solvable
     bool fAllowWatchOnly = false;
     //! Override automatic min/max checks on fee, m_feerate must be set if true

--- a/test/functional/test_framework/address.py
+++ b/test/functional/test_framework/address.py
@@ -158,6 +158,29 @@ def check_script(script):
         return script
     assert False
 
+def is_bech32_address(addr_info):
+    """Check if an address contains a bech32 output."""
+    return addr_info['desc'].startswith('wpkh(')
+
+
+def is_bech32m_address(addr_info):
+    """Check if an address contains a bech32m output."""
+    return addr_info['desc'].startswith('tr(')
+
+
+def is_p2sh_segwit_address(addr_info):
+    """Check if an address contains a P2SH-Segwit output.
+       Note: this function does not actually determine the type
+       of P2SH output, but is sufficient for this test in that
+       we are only generating P2SH-Segwit outputs.
+    """
+    return addr_info['desc'].startswith('sh(wpkh(')
+
+
+def is_legacy_address(addr_info):
+    """Check if an address contains a legacy output."""
+    return addr_info['desc'].startswith('pkh(')
+
 
 class TestFrameworkScript(unittest.TestCase):
     def test_base58encodedecode(self):

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -96,7 +96,6 @@ BASE_SCRIPTS = [
     'mining_getblocktemplate_longpoll.py',
     'feature_maxuploadtarget.py',
     'feature_block.py',
-    'rpc_fundrawtransaction.py --legacy-wallet',
     'rpc_fundrawtransaction.py --descriptors',
     'p2p_compactblocks.py',
     'p2p_compactblocks_blocksonly.py',

--- a/test/functional/wallet_avoid_mixing_output_types.py
+++ b/test/functional/wallet_avoid_mixing_output_types.py
@@ -28,6 +28,7 @@ but still know when to expect mixing due to the wallet being close to empty.
 """
 
 import random
+from test_framework.address import is_bech32_address, is_bech32m_address, is_legacy_address, is_p2sh_segwit_address
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.blocktools import COINBASE_MATURITY
 
@@ -38,33 +39,6 @@ ADDRESS_TYPES = [
     "legacy",
 ]
 
-
-def is_bech32_address(node, addr):
-    """Check if an address contains a bech32 output."""
-    addr_info = node.getaddressinfo(addr)
-    return addr_info['desc'].startswith('wpkh(')
-
-
-def is_bech32m_address(node, addr):
-    """Check if an address contains a bech32m output."""
-    addr_info = node.getaddressinfo(addr)
-    return addr_info['desc'].startswith('tr(')
-
-
-def is_p2sh_segwit_address(node, addr):
-    """Check if an address contains a P2SH-Segwit output.
-       Note: this function does not actually determine the type
-       of P2SH output, but is sufficient for this test in that
-       we are only generating P2SH-Segwit outputs.
-    """
-    addr_info = node.getaddressinfo(addr)
-    return addr_info['desc'].startswith('sh(wpkh(')
-
-
-def is_legacy_address(node, addr):
-    """Check if an address contains a legacy output."""
-    addr_info = node.getaddressinfo(addr)
-    return addr_info['desc'].startswith('pkh(')
 
 
 def is_same_type(node, tx):
@@ -85,13 +59,14 @@ def is_same_type(node, tx):
     has_bech32m = False
 
     for addr in inputs:
-        if is_legacy_address(node, addr):
+        addr_info = node.getaddressinfo(addr)
+        if is_legacy_address(addr_info):
             has_legacy = True
-        if is_p2sh_segwit_address(node, addr):
+        if is_p2sh_segwit_address(addr_info):
             has_p2sh = True
-        if is_bech32_address(node, addr):
+        if is_bech32_address(addr_info):
             has_bech32 = True
-        if is_bech32m_address(node, addr):
+        if is_bech32m_address(addr_info):
             has_bech32m = True
 
     return (sum([has_legacy, has_p2sh, has_bech32, has_bech32m]) == 1)


### PR DESCRIPTION
This PR adds a filter to the CoinControl to select only specific utxos by type. It allows the `fundrawtransaction` and `walletcreatefundedpsbt` rpc calls to filter inputs by type.

Closes #25181.

