### PR TITLE
refactor: Remove defunct attributes.h includes

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -14,7 +14,6 @@
 #ifndef BITCOIN_BASE58_H
 #define BITCOIN_BASE58_H
 
-#include <attributes.h>
 #include <span.h>
 
 #include <string>

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -6,7 +6,6 @@
 #define BITCOIN_CORE_IO_H
 
 #include <consensus/amount.h>
-#include <attributes.h>
 
 #include <string>
 #include <vector>

--- a/src/hash.h
+++ b/src/hash.h
@@ -6,7 +6,6 @@
 #ifndef BITCOIN_HASH_H
 #define BITCOIN_HASH_H
 
-#include <attributes.h>
 #include <crypto/common.h>
 #include <crypto/ripemd160.h>
 #include <crypto/sha256.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -86,7 +86,6 @@
 #include <vector>
 
 #ifndef WIN32
-#include <attributes.h>
 #include <cerrno>
 #include <signal.h>
 #include <sys/stat.h>

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -9,7 +9,6 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <attributes.h>
 #include <compat.h>
 #include <crypto/siphash.h>
 #include <prevector.h>

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_NODE_TRANSACTION_H
 #define BITCOIN_NODE_TRANSACTION_H
 
-#include <attributes.h>
 #include <policy/feerate.h>
 #include <primitives/transaction.h>
 #include <util/error.h>

--- a/src/outputtype.h
+++ b/src/outputtype.h
@@ -6,7 +6,6 @@
 #ifndef BITCOIN_OUTPUTTYPE_H
 #define BITCOIN_OUTPUTTYPE_H
 
-#include <attributes.h>
 #include <script/signingprovider.h>
 #include <script/standard.h>
 

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_PSBT_H
 #define BITCOIN_PSBT_H
 
-#include <attributes.h>
 #include <node/transaction.h>
 #include <policy/feerate.h>
 #include <primitives/transaction.h>

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_SCRIPT_STANDARD_H
 #define BITCOIN_SCRIPT_STANDARD_H
 
+#include <attributes.h>
 #include <pubkey.h>
 #include <script/interpreter.h>
 #include <uint256.h>

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <attributes.h>
 #include <clientversion.h>
 #include <coins.h>
 #include <script/standard.h>

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -6,7 +6,6 @@
 #define BITCOIN_TEST_FUZZ_UTIL_H
 
 #include <arith_uint256.h>
-#include <attributes.h>
 #include <chainparamsbase.h>
 #include <coins.h>
 #include <compat.h>

--- a/src/util/bip32.h
+++ b/src/util/bip32.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_UTIL_BIP32_H
 #define BITCOIN_UTIL_BIP32_H
 
-#include <attributes.h>
 #include <string>
 #include <vector>
 

--- a/src/util/moneystr.h
+++ b/src/util/moneystr.h
@@ -9,7 +9,6 @@
 #ifndef BITCOIN_UTIL_MONEYSTR_H
 #define BITCOIN_UTIL_MONEYSTR_H
 
-#include <attributes.h>
 #include <consensus/amount.h>
 
 #include <optional>

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -9,7 +9,6 @@
 #ifndef BITCOIN_UTIL_STRENCODINGS_H
 #define BITCOIN_UTIL_STRENCODINGS_H
 
-#include <attributes.h>
 #include <span.h>
 #include <util/string.h>
 

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -14,7 +14,6 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <attributes.h>
 #include <compat.h>
 #include <compat/assumptions.h>
 #include <fs.h>

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -5,6 +5,7 @@
 
 #include <validationinterface.h>
 
+#include <attributes.h>
 #include <chain.h>
 #include <consensus/validation.h>
 #include <logging.h>


### PR DESCRIPTION
Since the removal of NODISCARD in 81d5af42f4dba5b68a597536cad7f61894dc22a3,
the only attributes.h def is LIFETIMEBOUND, and it's included in many more
places that it is used.

This removes all includes which do not have an associated use of LIFETIMEBOUND,
and adds it to the following files, due to their use of the same:
* src/validationinterface.h
* src/script/standard.h

See also #20499.