### PR TITLE
test: add coverage for unknown value to -blockfilterindex

### DIFF
--- a/test/functional/p2p_blockfilters.py
+++ b/test/functional/p2p_blockfilters.py
@@ -250,6 +250,11 @@ class CompactFiltersTest(BitcoinTestFramework):
         msg = "Error: Cannot set -peerblockfilters without -blockfilterindex."
         self.nodes[0].assert_start_raises_init_error(expected_msg=msg)
 
+        self.log.info("Test unknown value to -blockfilterindex raises an error")
+        self.nodes[0].extra_args = ["-blockfilterindex=abc"]
+        msg = "Error: Unknown -blockfilterindex value abc."
+        self.nodes[0].assert_start_raises_init_error(expected_msg=msg)
+
         self.log.info("Test -blockfilterindex with -reindex-chainstate raises an error")
         self.nodes[0].assert_start_raises_init_error(
             expected_msg='Error: -reindex-chainstate option is not compatible with -blockfilterindex. '


### PR DESCRIPTION
This PR adds test coverage for the following init error:
https://github.com/bitcoin/bitcoin/blob/44037a29129a830fd9c9580f0818387756cfd7d3/src/init.cpp#L844

Passing an unknown value to -blockfilterindex should throw an error.