### PR TITLE
doc: Fix spelling errors identified by codespell in comments

### DIFF
--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -58,7 +58,7 @@ void benchmark::BenchRunner::RunAll(const Args& args)
     std::smatch baseMatch;
 
     if (args.sanity_check) {
-        std::cout << "Running with --sanity check option, benchmark results will be useless." << std::endl;
+        std::cout << "Running with --sanity-check option, benchmark results will be useless." << std::endl;
     }
 
     std::vector<ankerl::nanobench::Result> benchmarkResults;

--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -182,13 +182,13 @@ void TestAddAddressesToSendBook(interfaces::Node& node)
     search_line->setText("io");
     QCOMPARE(table_view->model()->rowCount(), 2);
 
-    // Check wilcard "?".
+    // Check wildcard "?".
     search_line->setText("io?new");
     QCOMPARE(table_view->model()->rowCount(), 0);
     search_line->setText("io???new");
     QCOMPARE(table_view->model()->rowCount(), 2);
 
-    // Check wilcard "*".
+    // Check wildcard "*".
     search_line->setText("io*new");
     QCOMPARE(table_view->model()->rowCount(), 2);
     search_line->setText("*");

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -257,7 +257,7 @@ BOOST_AUTO_TEST_CASE(versionbits_test)
 /** Check that ComputeBlockVersion will set the appropriate bit correctly */
 static void check_computeblockversion(VersionBitsCache& versionbitscache, const Consensus::Params& params, Consensus::DeploymentPos dep)
 {
-    // Clear the cache everytime
+    // Clear the cache every time
     versionbitscache.Clear();
 
     int64_t bit = params.vDeployments[dep].bit;

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -86,8 +86,8 @@ void SetMockTime(std::chrono::seconds mock_time_in);
 std::chrono::seconds GetMockTime();
 
 /**
- * Return the current time point cast to the given precicion. Only use this
- * when an exact precicion is needed, otherwise use T::clock::now() directly.
+ * Return the current time point cast to the given precision. Only use this
+ * when an exact precision is needed, otherwise use T::clock::now() directly.
  */
 template <typename T>
 T Now()

--- a/test/lint/spelling.ignore-words.txt
+++ b/test/lint/spelling.ignore-words.txt
@@ -11,6 +11,7 @@ inout
 invokable
 keypair
 mor
+nd
 nin
 ser
 unparseable


### PR DESCRIPTION
From the output [here](https://cirrus-ci.com/task/5275612980969472?logs=lint#L849):
```
src/qt/test/addressbooktests.cpp:185: wilcard ==> wildcard
src/qt/test/addressbooktests.cpp:191: wilcard ==> wildcard
src/test/miniscript_tests.cpp:227: nd ==> and, 2nd
src/test/versionbits_tests.cpp:260: everytime ==> every time
src/util/time.h:89: precicion ==> precision
src/util/time.h:90: precicion ==> precision
^ Warning: codespell identified likely spelling errors. Any false positives? Add them to the list of ignored words in test/lint/spelling.ignore-words.txt
```

~~I left the 'nd' in miniscript_tests as-is, as it's valid miniscript,
and I'm wary of whitelisting it.~~