### PR TITLE
scripts and tools: update lint-logs.py to detect LogPrintLevel, mention WalletLogPrintf

### DIFF
--- a/test/lint/lint-logs.py
+++ b/test/lint/lint-logs.py
@@ -16,12 +16,12 @@ from subprocess import check_output
 
 
 def main():
-    logs_list = check_output(["git", "grep", "--extended-regexp", r"LogPrintf?\(", "--", "*.cpp"], universal_newlines=True, encoding="utf8").splitlines()
+    logs_list = check_output(["git", "grep", "--extended-regexp", r"(LogPrintLevel|LogPrintf?)\(", "--", "*.cpp"], universal_newlines=True, encoding="utf8").splitlines()
 
     unterminated_logs = [line for line in logs_list if not re.search(r'(\\n"|/\* Continued \*/)', line)]
 
     if unterminated_logs != []:
-        print("All calls to LogPrintf() and LogPrint() should be terminated with \\n")
+        print("All calls to LogPrintf(), LogPrint(), LogPrintLevel(), and WalletLogPrintf() should be terminated with \"\\n\".")
         print("")
 
         for line in unterminated_logs:


### PR DESCRIPTION
Follow-up to #24464 that added the `LogPrintLevel()` macro. 

- update the `lint-logs.py` script to detect `LogPrintLevel()`
- add `WalletLogPrintf()` (already detected but not mentioned) to the linter suggestion

Example output:
```
$ test/lint/lint-logs.py 
All calls to LogPrintf(), LogPrint(), LogPrintLevel(), and WalletLogPrintf() should be terminated with "\n".

src/addrdb.cpp:147:        LogPrintf("banlist.dat ignored because it can only be read by " PACKAGE_NAME " version 22.x. Remove %s to silence this warning.", fs::quoted(fs::PathToString(m_banlist_dat)));
src/addrman.cpp:388:        LogPrint(BCLog::ADDRMAN, "addrman lost %i new and %i tried addresses due to collisions or invalid addresses", nLostUnk, nLost);
src/banman.cpp:41:        LogPrintf("Recreating the banlist database");
src/banman.cpp:66:    LogPrint(BCLog::NET, "Flushed %d banned node addresses/subnets to disk  %dms", banmap.size(),
src/banman.cpp:194:            LogPrint(BCLog::NET, "Removed banned node address/subnet: %s", sub_net.ToString());
src/net.cpp:2092:                LogPrint(BCLog::NET, "Trying to make an anchor connection to %s", addrConnect.ToString());
src/net.cpp:2408:        LogPrintLevel(BCLog::Level::Error, BCLog::NET, "%s", strError.original);
src/net.cpp:2416:        LogPrintf("%s", strError.original);
src/net.cpp:2432:            LogPrintf("%s", strError.original);
src/net.cpp:2453:        LogPrintLevel(BCLog::Level::Error, BCLog::NET, "%s", strError.original);
src/netbase.cpp:573:                LogPrintf("wait for connect to %s failed: %s",
src/netbase.cpp:578:                LogPrint(BCLog::NET, "connection attempt to %s timed out", addrConnect.ToString());
src/netbase.cpp:590:                LogPrintf("getsockopt() for %s failed: %s", addrConnect.ToString(), NetworkErrorString(WSAGetLastError()));
src/wallet/wallet.cpp:186:    wallet->WalletLogPrintf("Releasing wallet");
src/wallet/wallet.cpp:1809:        WalletLogPrintf("Rescan completed in %15dms", duration_milliseconds.count());
```
