### PR TITLE
test: deploymentinfo.cpp unit tests

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -88,6 +88,7 @@ BITCOIN_TESTS =\
   test/cuckoocache_tests.cpp \
   test/dbwrapper_tests.cpp \
   test/denialofservice_tests.cpp \
+  test/deploymentinfo_tests.cpp \
   test/descriptor_tests.cpp \
   test/flatfile_tests.cpp \
   test/fs_tests.cpp \

--- a/src/test/deploymentinfo_tests.cpp
+++ b/src/test/deploymentinfo_tests.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2011-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <deploymentinfo.h>
+
+#include <test/util/setup_common.h>
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(deploymentinfo_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(name_from_pos)
+{
+    // Check deployment names from Consensus::DeploymentPos
+    BOOST_CHECK(DeploymentName(Consensus::DEPLOYMENT_TESTDUMMY) == VersionBitsDeploymentInfo[Consensus::DEPLOYMENT_TESTDUMMY].name);
+    BOOST_CHECK(DeploymentName(Consensus::DEPLOYMENT_TAPROOT) == VersionBitsDeploymentInfo[Consensus::DEPLOYMENT_TAPROOT].name);
+}
+
+BOOST_AUTO_TEST_CASE(name_from_dep)
+{
+    // Check deployment names from Consensus::BuriedDeployment
+    BOOST_CHECK(DeploymentName(Consensus::DEPLOYMENT_HEIGHTINCB) == "bip34");
+    BOOST_CHECK(DeploymentName(Consensus::DEPLOYMENT_CLTV) == "bip65");
+    BOOST_CHECK(DeploymentName(Consensus::DEPLOYMENT_DERSIG) == "bip66");
+    BOOST_CHECK(DeploymentName(Consensus::DEPLOYMENT_CSV) == "csv");
+    BOOST_CHECK(DeploymentName(Consensus::DEPLOYMENT_SEGWIT) == "segwit");
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This patch implements the unit tests for `deploymentinfo.h` and `deploymentinfo.cpp`. These changes will improve test coverage and run within the unit test suite.

Test coverage:
https://marcofalke.github.io/btc_cov/test_bitcoin.coverage/src/deploymentinfo.h.gcov.html
https://marcofalke.github.io/btc_cov/test_bitcoin.coverage/src/deploymentinfo.cpp.gcov.html

Test execution excerpt:
```cpp
test/deploymentinfo_tests.cpp(10): Entering test suite "deploymentinfo_tests"
test/deploymentinfo_tests.cpp(12): Entering test case "name_from_pos"
test/deploymentinfo_tests.cpp(15): info: check DeploymentName(Consensus::DEPLOYMENT_TESTDUMMY) == VersionBitsDeploymentInfo[Consensus::DEPLOYMENT_TESTDUMMY].name has passed
test/deploymentinfo_tests.cpp(16): info: check DeploymentName(Consensus::DEPLOYMENT_TAPROOT) == VersionBitsDeploymentInfo[Consensus::DEPLOYMENT_TAPROOT].name has passed
test/deploymentinfo_tests.cpp(12): Leaving test case "name_from_pos"; testing time: 7564us
test/deploymentinfo_tests.cpp(19): Entering test case "name_from_dep"
test/deploymentinfo_tests.cpp(22): info: check DeploymentName(Consensus::DEPLOYMENT_HEIGHTINCB) == "bip34" has passed
test/deploymentinfo_tests.cpp(23): info: check DeploymentName(Consensus::DEPLOYMENT_CLTV) == "bip65" has passed
test/deploymentinfo_tests.cpp(24): info: check DeploymentName(Consensus::DEPLOYMENT_DERSIG) == "bip66" has passed
test/deploymentinfo_tests.cpp(25): info: check DeploymentName(Consensus::DEPLOYMENT_CSV) == "csv" has passed
test/deploymentinfo_tests.cpp(26): info: check DeploymentName(Consensus::DEPLOYMENT_SEGWIT) == "segwit" has passed
test/deploymentinfo_tests.cpp(19): Leaving test case "name_from_dep"; testing time: 2011us
test/deploymentinfo_tests.cpp(10): Leaving test suite "deploymentinfo_tests"; testing time: 9707us
```