### PR TITLE
Improve CMedianFilter algorithm

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -45,6 +45,7 @@ bench_bench_bitcoin_SOURCES = \
   bench/rpc_blockchain.cpp \
   bench/rpc_mempool.cpp \
   bench/strencodings.cpp \
+  bench/timedata.cpp \
   bench/util_time.cpp \
   bench/verify_script.cpp
 

--- a/src/bench/timedata.cpp
+++ b/src/bench/timedata.cpp
@@ -18,7 +18,7 @@ static void ComputeMedian256_1000(benchmark::Bench& bench)
     }
 
     bench.run([&rand_num] {
-        CMedianFilter<int> median_filter(256, 15);
+        CMedianFilter<int, 256> median_filter(15);
 
         for (size_t i = 0; i < 1000; ++i) {
             median_filter.input(rand_num[i]);
@@ -38,7 +38,7 @@ static void ComputeMedian20_1000(benchmark::Bench& bench)
     }
 
     bench.run([&rand_num] {
-        CMedianFilter<int> median_filter(20,15);
+        CMedianFilter<int, 20> median_filter(15);
 
         for (size_t i = 0; i < 1000; ++i) {
             median_filter.input(rand_num[i]);
@@ -58,7 +58,7 @@ static void ComputeMedian10_1000(benchmark::Bench& bench)
     }
 
     bench.run([&rand_num] {
-        CMedianFilter<int> median_filter(10, 15);
+        CMedianFilter<int, 10> median_filter(15);
 
         for (size_t i = 0; i < 1000; ++i) {
             median_filter.input(rand_num[i]);

--- a/src/bench/timedata.cpp
+++ b/src/bench/timedata.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2020-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <timedata.h>
+
+#include <bench/bench.h>
+
+// 256 element max
+// 1000 iteration
+static void ComputeMedian256_1000(benchmark::Bench& bench)
+{
+    //Precompute random numbers
+    std::vector<int> rand_num;
+    rand_num.reserve(1000);
+    for (size_t i = 0; i < 1000; ++i) {
+        rand_num.emplace_back(rand());
+    }
+
+    bench.run([&rand_num] {
+        CMedianFilter<int> median_filter(256, 15);
+
+        for (size_t i = 0; i < 1000; ++i) {
+            median_filter.input(rand_num[i]);
+        }
+    });
+}
+
+// 20 element max
+// 1000 iteration
+static void ComputeMedian20_1000(benchmark::Bench& bench)
+{
+    //Precompute random numbers
+    std::vector<int> rand_num;
+    rand_num.reserve(1000);
+    for (size_t i = 0; i < 1000; ++i) {
+        rand_num.emplace_back(rand());
+    }
+
+    bench.run([&rand_num] {
+        CMedianFilter<int> median_filter(20,15);
+
+        for (size_t i = 0; i < 1000; ++i) {
+            median_filter.input(rand_num[i]);
+        }
+    });
+}
+
+// 10 element max
+// 1000 iteration
+static void ComputeMedian10_1000(benchmark::Bench& bench)
+{
+    //Precompute random numbers
+    std::vector<int> rand_num;
+    rand_num.reserve(1000);
+    for (size_t i = 0; i < 1000; ++i) {
+        rand_num.emplace_back(rand());
+    }
+
+    bench.run([&rand_num] {
+        CMedianFilter<int> median_filter(10, 15);
+
+        for (size_t i = 0; i < 1000; ++i) {
+            median_filter.input(rand_num[i]);
+        }
+    });
+}
+
+BENCHMARK(ComputeMedian256_1000);
+BENCHMARK(ComputeMedian20_1000);
+BENCHMARK(ComputeMedian10_1000);
+

--- a/src/test/fuzz/timedata.cpp
+++ b/src/test/fuzz/timedata.cpp
@@ -14,12 +14,11 @@
 FUZZ_TARGET(timedata)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    const unsigned int max_size = fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(0, 1000);
-    // A max_size of 0 implies no limit, so cap the max number of insertions to avoid timeouts
+    constexpr unsigned int max_size = 200;
     auto max_to_insert = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 4000);
     // Divide by 2 to avoid signed integer overflow in .median()
     const int64_t initial_value = fuzzed_data_provider.ConsumeIntegral<int64_t>() / 2;
-    CMedianFilter<int64_t> median_filter{max_size, initial_value};
+    CMedianFilter<int64_t, max_size> median_filter(initial_value);
     while (fuzzed_data_provider.remaining_bytes() > 0 && --max_to_insert >= 0) {
         (void)median_filter.median();
         assert(median_filter.size() > 0);

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -40,7 +40,7 @@ int64_t GetAdjustedTime()
 #define BITCOIN_TIMEDATA_MAX_SAMPLES 200
 
 static std::set<CNetAddr> g_sources;
-static CMedianFilter<int64_t> g_time_offsets{BITCOIN_TIMEDATA_MAX_SAMPLES, 0};
+static CMedianFilter<int64_t, BITCOIN_TIMEDATA_MAX_SAMPLES> g_time_offsets(0);
 static bool g_warning_emitted;
 
 void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
@@ -75,7 +75,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
     //
     if (g_time_offsets.size() >= 5 && g_time_offsets.size() % 2 == 1) {
         int64_t nMedian = g_time_offsets.median();
-        std::vector<int64_t> vSorted = g_time_offsets.sorted();
+        const std::vector<int64_t>& vSorted = g_time_offsets.sorted();
         // Only let other nodes change our time by so much
         int64_t max_adjustment = std::max<int64_t>(0, gArgs.GetIntArg("-maxtimeadjustment", DEFAULT_MAX_TIME_ADJUSTMENT));
         if (nMedian >= -max_adjustment && nMedian <= max_adjustment) {
@@ -115,6 +115,6 @@ void TestOnlyResetTimeData()
     LOCK(g_timeoffset_mutex);
     nTimeOffset = 0;
     g_sources.clear();
-    g_time_offsets = CMedianFilter<int64_t>{BITCOIN_TIMEDATA_MAX_SAMPLES, 0};
+    g_time_offsets = CMedianFilter<int64_t, BITCOIN_TIMEDATA_MAX_SAMPLES>(0);
     g_warning_emitted = false;
 }


### PR DESCRIPTION
1. Add benchmarks for median computation.
2. Improve median computation algorithm
  2.1. Write unit tests to ensure new median computation has the same behavior as the previous implementation
  2.2. Ensure benchmarks are improved

The new median algorithm takes its |max_size| as a template parameter and relies on a ring buffer to keep track of the current values the median needs to be computed on. Instead of sorting the values from scratch on every new insertion, the new algorithm finds where the new value needs to be inserted and where the now outdated value needs to be removed. It then rotates the elements of the vector to perform the sorted insertion.

The test |util_MedianFilter_rand| proves that the new behavior is the same as doing the sorting on every iteration.

