### PR TITLE
rpc: Capture UniValue by ref for rpcdoccheck

### DIFF
--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -583,7 +583,7 @@ UniValue RPCHelpMan::HandleRequest(const JSONRPCRequest& request) const
     }
     const UniValue ret = m_fun(*this, request);
     if (gArgs.GetBoolArg("-rpcdoccheck", DEFAULT_RPC_DOC_CHECK)) {
-        CHECK_NONFATAL(std::any_of(m_results.m_results.begin(), m_results.m_results.end(), [ret](const RPCResult& res) { return res.MatchesType(ret); }));
+        CHECK_NONFATAL(std::any_of(m_results.m_results.begin(), m_results.m_results.end(), [&ret](const RPCResult& res) { return res.MatchesType(ret); }));
     }
     return ret;
 }


### PR DESCRIPTION
Capturing it by reference instead of value should save us from making a copy of a potentially large object. Saw this while having a look at #25229 although I couldn't reproduce an actual leak, so this is not a fix for that issue.