### PR TITLE
script: Disable SC1004 check in `contrib/devtools/gen-bitcoin-conf.sh`

### DIFF
--- a/contrib/devtools/gen-bitcoin-conf.sh
+++ b/contrib/devtools/gen-bitcoin-conf.sh
@@ -49,6 +49,7 @@ EOF
 # parse the output from bitcoind --help
 # adding newlines is a bit funky to ensure portability for BSD
 # see here for more details: https://stackoverflow.com/a/24575385
+# shellcheck disable=SC1004
 ${BITCOIND} --help \
     | sed '1,/Print this help message and exit/d' \
     | sed -E 's/^[[:space:]]{2}\-/#/' \


### PR DESCRIPTION
Otherwise `./test/lint/lint-all.py` gives me error:
```
In contrib/devtools/gen-bitcoin-conf.sh line 58:
    | sed 's,\(^[[:upper:]].*\)\:$,\
                                   ^-- SC1004: This backslash+linefeed is literal. Break outside single quotes if you just want to break the line.

For more information:
  https://www.shellcheck.net/wiki/SC1004 -- This backslash+linefeed is litera...
^---- failure generated from lint-shell.py
```