### PR TITLE
refactor: Add LIFETIMEBOUND / -Wdangling-gsl to Assert()

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -122,6 +122,11 @@ BOOST_AUTO_TEST_CASE(util_check)
 
     // Check nested Asserts
     BOOST_CHECK_EQUAL(Assert((Assert(x).test() ? 3 : 0)), 3);
+
+    // Check -Wdangling-gsl does not trigger when copying the int. (It would
+    // trigger on "const int&")
+    const int nine{*Assert(std::optional<int>{9})};
+    BOOST_CHECK_EQUAL(9, nine);
 }
 
 BOOST_AUTO_TEST_CASE(util_criticalsection)

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -9,6 +9,7 @@
 #include <config/bitcoin-config.h>
 #endif
 
+#include <attributes.h>
 #include <tinyformat.h>
 
 #include <stdexcept>
@@ -24,7 +25,7 @@ class NonFatalCheckError : public std::runtime_error
 
 /** Helper for CHECK_NONFATAL() */
 template <typename T>
-T&& inline_check_non_fatal(T&& val, const char* file, int line, const char* func, const char* assertion)
+T&& inline_check_non_fatal(LIFETIMEBOUND T&& val, const char* file, int line, const char* func, const char* assertion)
 {
     if (!(val)) {
         throw NonFatalCheckError(
@@ -56,7 +57,7 @@ void assertion_fail(const char* file, int line, const char* func, const char* as
 
 /** Helper for Assert()/Assume() */
 template <bool IS_ASSERT, typename T>
-T&& inline_assertion_check(T&& val, [[maybe_unused]] const char* file, [[maybe_unused]] int line, [[maybe_unused]] const char* func, [[maybe_unused]] const char* assertion)
+T&& inline_assertion_check(LIFETIMEBOUND T&& val, [[maybe_unused]] const char* file, [[maybe_unused]] int line, [[maybe_unused]] const char* func, [[maybe_unused]] const char* assertion)
 {
     if constexpr (IS_ASSERT
 #ifdef ABORT_ON_FAILED_ASSUME


### PR DESCRIPTION
Currently compiles clean, but I think it may still be useful.

Can be tested by adding an `&`:

```diff
diff --git a/src/test/util_tests.cpp b/src/test/util_tests.cpp
index 5766fff92d..300c1ec60f 100644
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(util_check)
 
     // Check -Wdangling-gsl does not trigger when copying the int. (It would
     // trigger on "const int&")
-    const int nine{*Assert(std::optional<int>{9})};
+    const int& nine{*Assert(std::optional<int>{9})};
     BOOST_CHECK_EQUAL(9, nine);
 }
 
```

Output:
```
test/util_tests.cpp:128:29: warning: object backing the pointer will be destroyed at the end of the full-expression [-Wdangling-gsl]
    const int& nine{*Assert(std::optional<int>{9})};
                            ^~~~~~~~~~~~~~~~~~~~~
./util/check.h:75:50: note: expanded from macro 'Assert'
#define Assert(val) inline_assertion_check<true>(val, __FILE__, __LINE__, __func__, #val)
                                                 ^~~
1 warning generated.
