### PR TITLE
test: add coverage for non-hex value to -minimumchainwork

### DIFF
--- a/test/functional/feature_minchainwork.py
+++ b/test/functional/feature_minchainwork.py
@@ -106,5 +106,13 @@ class MinimumChainWorkTest(BitcoinTestFramework):
         # not be exercising the logic we want!)
         assert_equal(self.nodes[2].getblockchaininfo()['initialblockdownload'], True)
 
+        self.log.info("Test -minimumchainwork with a non-hex value")
+        self.stop_node(0)
+        self.nodes[0].assert_start_raises_init_error(
+            ["-minimumchainwork=test"],
+            expected_msg='Error: Invalid non-hex (test) minimum chain work value specified',
+        )
+
+
 if __name__ == '__main__':
     MinimumChainWorkTest().main()


### PR DESCRIPTION
This PR adds test coverage for the following init error:
https://github.com/bitcoin/bitcoin/blob/b9ef5a10e2fa4609d048db57b99463305455ebe4/src/init.cpp#L917-L919

Passing a non-hex value to -minimumchainwork should throw an initial error.