### PR TITLE
logging: fix logging empty thread name

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -364,7 +364,8 @@ void BCLog::Logger::LogPrintStr(const std::string& str, const std::string& loggi
     }
 
     if (m_log_threadnames && m_started_new_line) {
-        str_prefixed.insert(0, "[" + util::ThreadGetInternalName() + "] ");
+        const auto threadname = util::ThreadGetInternalName();
+        str_prefixed.insert(0, "[" + (threadname.empty() ? "unknown" : threadname) + "] ");
     }
 
     str_prefixed = LogTimestampStr(str_prefixed);


### PR DESCRIPTION
Currently, `leveldb` background thread does not have a thread name and as a result, an empty thread name is logged. 

This PR fixes this by logging thread name as `"unknown"` if the thread name is empty

On master:
```txt
2022-06-02T14:30:38Z [] [leveldb:debug] Generated table #281@0: 1862 keys, 138303 bytes
```

On this PR:
```txt
2022-06-02T14:30:38Z [unknown] [leveldb:debug] Generated table #281@0: 1862 keys, 138303 bytes
```
