### PR TITLE
test: check pre-segwit peer error in `getblockfrompeer` RPC

### DIFF
--- a/test/functional/rpc_getblockfrompeer.py
+++ b/test/functional/rpc_getblockfrompeer.py
@@ -5,6 +5,11 @@
 """Test the getblockfrompeer RPC."""
 
 from test_framework.authproxy import JSONRPCException
+from test_framework.messages import NODE_WITNESS
+from test_framework.p2p import (
+    P2P_SERVICES,
+    P2PInterface,
+)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -58,6 +63,13 @@ class GetBlockFromPeerTest(BitcoinTestFramework):
         self.log.info("Non-existent peer generates error")
         assert_raises_rpc_error(-1, "Peer does not exist", self.nodes[0].getblockfrompeer, short_tip, peer_0_peer_1_id + 1)
 
+        self.log.info("Fetching from pre-segwit peer generates error")
+        self.nodes[0].add_p2p_connection(P2PInterface(), services=P2P_SERVICES & ~NODE_WITNESS)
+        peers = self.nodes[0].getpeerinfo()
+        assert_equal(len(peers), 2)
+        presegwit_peer_id = peers[1]["id"]
+        assert_raises_rpc_error(-1, "Pre-SegWit peer", self.nodes[0].getblockfrompeer, short_tip, presegwit_peer_id)
+
         self.log.info("Successful fetch")
         result = self.nodes[0].getblockfrompeer(short_tip, peer_0_peer_1_id)
         self.wait_until(lambda: self.check_for_block(short_tip), timeout=1)
@@ -65,6 +77,7 @@ class GetBlockFromPeerTest(BitcoinTestFramework):
 
         self.log.info("Don't fetch blocks we already have")
         assert_raises_rpc_error(-1, "Block already downloaded", self.nodes[0].getblockfrompeer, short_tip, peer_0_peer_1_id)
+
 
 if __name__ == '__main__':
     GetBlockFromPeerTest().main()


### PR DESCRIPTION
This PR adds missing test coverage for the `getblockfrompeer` RPC, in the case that a block is tried to be fetched from a pre-segwit peer (i.e. a peer that doesn't signal the service bit `NODE_WITNESS`):

https://github.com/bitcoin/bitcoin/blob/d4d9daff7ab60a9f0cae0a34f86be0bb497f62f4/src/net_processing.cpp#L1564-L1565