### PR TITLE
rpc: fetch multiple headers in getblockheader()

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -99,6 +99,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getblock", 1, "verbosity" },
     { "getblock", 1, "verbose" },
     { "getblockheader", 1, "verbose" },
+    { "getblockheader", 2, "count" },
     { "getchaintxstats", 0, "nblocks" },
     { "gettransaction", 1, "include_watchonly" },
     { "gettransaction", 2, "verbose" },


### PR DESCRIPTION
**Motivation**: `getblockheader()` has the `count` parameter to fetch more than one header in a single GET via REST.

This patch extends this functionality to `bitcoin-cli` and properly formats output arrays based on
the `verbose` parameter. This is a follow-up to an up-for-grabs issue #23330.

**Implementation**:
I took into account the review comments and previous implementation. The CLI method is used as follows:
```
bitcoin-cli getblockheader <block_hash> <verbose=true> <count=0>
```
* `count` defaults to 0.
> ~~The previous implementation defaulted to 0, but in the REST syntax, this is actually an invalid `count` value. I believe that it makes sense to return a single block header by default.~~
* If `count` is excluded or `count = 0`, the preexisting functionality is used to return the single block header of block <hash> in either hex or JSON format based on `verbose`.
> No regression impact.
* If `0 < count <= 2000`, an array of block headers starting with block <hash> is returned in either hex or JSON format based on `verbose`.
> The previous implementation traversed the `ActiveChain` upwards (towards the genesis block), but again, this differs from the REST functionality that traverses the `ActiveChain` downwards (away from the genesis block), which I replicated instead. If `count` surpasses the number of blocks from the desired <HASH> to the active tip block, then the final block header in the array is simply that of the newest block on the `ActiveChain`.
* If `count < 0` or `count > 2000`, return an `INVALID_PARAMETER` error.
* If `count` is not an integer, report a generic JSON parsing error.

**Changes**:
* The argument has been added to `rpc/client.cpp`.
* The `getblockheader()` help message has been updated accordingly.
* The `getblockheader()` functionality has been expanded, as described above.