### PR TITLE
wallet: re-activate  "AmountWithFeeExceedsBalance" error

### DIFF
--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1160,7 +1160,21 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
     if (!select_coins_res) {
         // 'SelectCoins' either returns a specific error message or, if empty, means a general "Insufficient funds".
         const bilingual_str& err = util::ErrorString(select_coins_res);
-        return util::Error{err.empty() ?_("Insufficient funds") : err};
+        if (!err.empty()) return util::Error{err};
+
+        // Check if we have enough balance but cannot cover the fees
+        CAmount available_balance = preset_inputs.total_amount + available_coins.GetTotalAmount();
+        // Note: Since SFFO reduces existing outputs to cover fees, recipients_sum should already be
+        // strictly less than available_balance when enabled. Still, as a sanity-check, skip when SFFO is enabled.
+        if (available_balance >= recipients_sum && !coin_selection_params.m_subtract_fee_outputs) {
+            CAmount available_effective_balance = preset_inputs.total_amount + *available_coins.GetEffectiveTotalAmount();
+            if (available_effective_balance < selection_target) {
+                return util::Error{_("The total transaction amount exceeds your balance when fees are included")};
+            }
+        }
+
+        // General failure description
+        return util::Error{_("Insufficient funds")};
     }
     const SelectionResult& result = *select_coins_res;
     TRACEPOINT(coin_selection, selected_coins,

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -59,13 +59,13 @@ struct CoinsResult {
     void Add(OutputType type, const COutput& out);
 
     CAmount GetTotalAmount() { return total_amount; }
-    std::optional<CAmount> GetEffectiveTotalAmount() {return total_effective_amount; }
+    std::optional<CAmount> GetEffectiveTotalAmount() { return total_effective_amount; }
 
 private:
     /** Sum of all available coins raw value */
     CAmount total_amount{0};
     /** Sum of all available coins effective value (each output value minus fees required to spend it) */
-    std::optional<CAmount> total_effective_amount{0};
+    std::optional<CAmount> total_effective_amount;
 };
 
 struct CoinFilterParams {

--- a/test/functional/wallet_fundrawtransaction.py
+++ b/test/functional/wallet_fundrawtransaction.py
@@ -152,6 +152,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.test_feerate_rounding()
         self.test_input_confs_control()
         self.test_duplicate_outputs()
+        self.test_cannot_cover_fees()
 
     def test_duplicate_outputs(self):
         self.log.info("Test deserializing and funding a transaction with duplicate outputs")
@@ -1453,7 +1454,8 @@ class RawTransactionsTest(BitcoinTestFramework):
         # To test this does not happen, we subtract 202 sats from the input value. If working correctly, this should
         # fail with insufficient funds rather than bitcoind asserting.
         rawtx = w.createrawtransaction(inputs=[], outputs=[{self.nodes[0].getnewaddress(address_type="bech32"): 1 - 0.00000202}])
-        assert_raises_rpc_error(-4, "Insufficient funds", w.fundrawtransaction, rawtx, fee_rate=1.85)
+        expected_err_msg = "The total transaction amount exceeds your balance when fees are included"
+        assert_raises_rpc_error(-4, expected_err_msg, w.fundrawtransaction, rawtx, fee_rate=1.85)
 
     def test_input_confs_control(self):
         self.nodes[0].createwallet("minconf")
@@ -1515,6 +1517,25 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert txid2 in mempool
 
         wallet.unloadwallet()
+
+    def test_cannot_cover_fees(self):
+        self.log.info("Test tx amount exceeds available balance when fees are included")
+
+        self.nodes[1].createwallet("cannot_cover_fees")
+        wallet = self.nodes[1].get_wallet_rpc("cannot_cover_fees")
+
+        self.nodes[0].sendtoaddress(wallet.getnewaddress(), 0.3)
+        self.generate(self.nodes[0], 1)
+
+        rawtx = wallet.createrawtransaction(inputs=[], outputs=[{self.nodes[0].getnewaddress(): 0.3}])
+        expected_err_msg = "The total transaction amount exceeds your balance when fees are included"
+        assert_raises_rpc_error(-4, expected_err_msg, wallet.fundrawtransaction, rawtx)
+
+        # Test same tx passing when subtracting fee from output
+        wallet.fundrawtransaction(hexstring=rawtx, options={"subtractFeeFromOutputs":[0]})
+
+        wallet.unloadwallet()
+
 
 if __name__ == '__main__':
     RawTransactionsTest(__file__).main()


### PR DESCRIPTION
During a talk with theStack, it was noted that the `AmountWithFeeExceedsBalance` error inside `WalletModel::prepareTransaction` is never thrown.

This is because `createTransaction` does not retrieve the fee when the process fails due to insufficient funds since #20640. The fee return arg is set only at the end of the process, when the transaction is successfully created. Therefore, if the transaction creation fails, the fee is not available inside `WalletModel::prepareTransaction` to trigger the `AmountWithFeeExceedsBalance` error.

This PR re-implements the feature inside `createTransaction` and adds test coverage for it.