### PR TITLE
net: helpfully log in ConnectNode() which peer we are already connected to

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -445,9 +445,8 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
 
         // Look for an existing connection
         CNode* pnode = FindNode(static_cast<CService>(addrConnect));
-        if (pnode)
-        {
-            LogPrintf("Failed to open new connection, already connected\n");
+        if (pnode) {
+            LogPrintLevel(BCLog::NET, BCLog::Level::Info, "Failed to open new connection to %s, already connected (peer=%d)\n", addrConnect.ToString(), pnode->GetId());
             return nullptr;
         }
     }
@@ -473,7 +472,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
             LOCK(m_nodes_mutex);
             CNode* pnode = FindNode(static_cast<CService>(addrConnect));
             if (pnode) {
-                LogPrintf("Failed to open new connection, already connected\n");
+                LogPrintLevel(BCLog::NET, BCLog::Level::Info, "Failed to open new connection to %s, already connected (peer=%d)\n", addrConnect.ToString(), pnode->GetId());
                 return nullptr;
             }
         }


### PR DESCRIPTION
It would be helpful to say which peer we are already connected to, when failing to connect for that reason.
Also update from LogPrintf to LogPrintLevel(BCLog::NET, BCLog::Level::Info).
    
before
```
Failed to open new connection, already connected
```

after
```
[net:info] Failed to open new connection to c6adtamnttsuwqorf4atri67prd7vyq.b32.i2p:0, already connected (peer=5)
```
