### PR TITLE
wallet: Pass through transaction locktime and preset input sequences and scripts to CreateTransaction

### DIFF
--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -39,7 +39,10 @@ std::optional<CTxOut> CCoinControl::GetExternalOutput(const COutPoint& outpoint)
 
 PreselectedInput& CCoinControl::Select(const COutPoint& outpoint)
 {
-    return m_selected[outpoint];
+    auto& input = m_selected[outpoint];
+    input.SetPosition(m_selection_pos);
+    ++m_selection_pos;
+    return input;
 }
 void CCoinControl::UnSelect(const COutPoint& outpoint)
 {
@@ -78,6 +81,12 @@ std::optional<uint32_t> CCoinControl::GetSequence(const COutPoint& outpoint) con
     return it != m_selected.end() ? it->second.GetSequence() : std::nullopt;
 }
 
+std::pair<std::optional<CScript>, std::optional<CScriptWitness>> CCoinControl::GetScripts(const COutPoint& outpoint) const
+{
+    const auto it = m_selected.find(outpoint);
+    return it != m_selected.end() ? m_selected.at(outpoint).GetScripts() : std::make_pair(std::nullopt, std::nullopt);
+}
+
 void PreselectedInput::SetTxOut(const CTxOut& txout)
 {
     m_txout = txout;
@@ -112,5 +121,35 @@ void PreselectedInput::SetSequence(uint32_t sequence)
 std::optional<uint32_t> PreselectedInput::GetSequence() const
 {
     return m_sequence;
+}
+
+void PreselectedInput::SetScriptSig(const CScript& script)
+{
+    m_script_sig = script;
+}
+
+void PreselectedInput::SetScriptWitness(const CScriptWitness& script_wit)
+{
+    m_script_witness = script_wit;
+}
+
+bool PreselectedInput::HasScripts() const
+{
+    return m_script_sig.has_value() || m_script_witness.has_value();
+}
+
+std::pair<std::optional<CScript>, std::optional<CScriptWitness>> PreselectedInput::GetScripts() const
+{
+    return {m_script_sig, m_script_witness};
+}
+
+void PreselectedInput::SetPosition(unsigned int pos)
+{
+    m_pos = pos;
+}
+
+std::optional<unsigned int> PreselectedInput::GetPosition() const
+{
+    return m_pos;
 }
 } // namespace wallet

--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -72,15 +72,10 @@ void CCoinControl::SetInputWeight(const COutPoint& outpoint, int64_t weight)
     m_selected[outpoint].SetInputWeight(weight);
 }
 
-bool CCoinControl::HasInputWeight(const COutPoint& outpoint) const
+std::optional<int64_t> CCoinControl::GetInputWeight(const COutPoint& outpoint) const
 {
     const auto it = m_selected.find(outpoint);
-    return it != m_selected.end() && it->second.HasInputWeight();
-}
-
-int64_t CCoinControl::GetInputWeight(const COutPoint& outpoint) const
-{
-    return m_selected.at(outpoint).GetInputWeight();
+    return it != m_selected.end() ? it->second.GetInputWeight() : std::nullopt;
 }
 
 void PreselectedInput::SetTxOut(const CTxOut& txout)
@@ -104,14 +99,8 @@ void PreselectedInput::SetInputWeight(int64_t weight)
     m_weight = weight;
 }
 
-int64_t PreselectedInput::GetInputWeight() const
+std::optional<int64_t> PreselectedInput::GetInputWeight() const
 {
-    assert(m_weight.has_value());
-    return m_weight.value();
-}
-
-bool PreselectedInput::HasInputWeight() const
-{
-    return m_weight.has_value();
+    return m_weight;
 }
 } // namespace wallet

--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -72,6 +72,12 @@ std::optional<int64_t> CCoinControl::GetInputWeight(const COutPoint& outpoint) c
     return it != m_selected.end() ? it->second.GetInputWeight() : std::nullopt;
 }
 
+std::optional<uint32_t> CCoinControl::GetSequence(const COutPoint& outpoint) const
+{
+    const auto it = m_selected.find(outpoint);
+    return it != m_selected.end() ? it->second.GetSequence() : std::nullopt;
+}
+
 void PreselectedInput::SetTxOut(const CTxOut& txout)
 {
     m_txout = txout;
@@ -96,5 +102,15 @@ void PreselectedInput::SetInputWeight(int64_t weight)
 std::optional<int64_t> PreselectedInput::GetInputWeight() const
 {
     return m_weight;
+}
+
+void PreselectedInput::SetSequence(uint32_t sequence)
+{
+    m_sequence = sequence;
+}
+
+std::optional<uint32_t> PreselectedInput::GetSequence() const
+{
+    return m_sequence;
 }
 } // namespace wallet

--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -41,12 +41,6 @@ PreselectedInput& CCoinControl::Select(const COutPoint& outpoint)
 {
     return m_selected[outpoint];
 }
-
-void CCoinControl::SelectExternal(const COutPoint& outpoint, const CTxOut& txout)
-{
-    m_selected[outpoint].SetTxOut(txout);
-}
-
 void CCoinControl::UnSelect(const COutPoint& outpoint)
 {
     m_selected.erase(outpoint);

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -46,9 +46,7 @@ public:
     /** Set the weight for this input. */
     void SetInputWeight(int64_t weight);
     /** Retrieve the input weight for this input. */
-    int64_t GetInputWeight() const;
-    /** Return whether the input weight is set. */
-    bool HasInputWeight() const;
+    std::optional<int64_t> GetInputWeight() const;
 };
 
 /** Coin Control Features. */
@@ -132,13 +130,9 @@ public:
      */
     void SetInputWeight(const COutPoint& outpoint, int64_t weight);
     /**
-     * Returns true if the input weight is set.
-     */
-    bool HasInputWeight(const COutPoint& outpoint) const;
-    /**
      * Returns the input weight.
      */
-    int64_t GetInputWeight(const COutPoint& outpoint) const;
+    std::optional<int64_t> GetInputWeight(const COutPoint& outpoint) const;
 
 private:
     //! Selected inputs (inputs that will be used, regardless of whether they're optimal or not)

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -91,6 +91,8 @@ public:
     int m_max_depth = DEFAULT_MAX_DEPTH;
     //! SigningProvider that has pubkeys and scripts to do spend size estimation for external inputs
     FlatSigningProvider m_external_provider;
+    //! Locktime
+    std::optional<uint32_t> m_locktime;
 
     CCoinControl();
 

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -109,11 +109,6 @@ public:
      */
     PreselectedInput& Select(const COutPoint& outpoint);
     /**
-     * Lock-in the given output as an external input for spending because it is not in the wallet.
-     * The output will be included in the transaction even if it's not the most optimal choice.
-     */
-    void SelectExternal(const COutPoint& outpoint, const CTxOut& txout);
-    /**
      * Unselects the given output.
      */
     void UnSelect(const COutPoint& outpoint);

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -31,6 +31,8 @@ private:
     std::optional<CTxOut> m_txout;
     //! The input weight for spending this input
     std::optional<int64_t> m_weight;
+    //! The sequence number for this input
+    std::optional<uint32_t> m_sequence;
 
 public:
     /**
@@ -47,6 +49,11 @@ public:
     void SetInputWeight(int64_t weight);
     /** Retrieve the input weight for this input. */
     std::optional<int64_t> GetInputWeight() const;
+
+    /** Set the sequence for this input. */
+    void SetSequence(uint32_t sequence);
+    /** Retrieve the sequence for this input. */
+    std::optional<uint32_t> GetSequence() const;
 };
 
 /** Coin Control Features. */
@@ -128,6 +135,8 @@ public:
      * Returns the input weight.
      */
     std::optional<int64_t> GetInputWeight(const COutPoint& outpoint) const;
+    /** Retrieve the sequence for an input */
+    std::optional<uint32_t> GetSequence(const COutPoint& outpoint) const;
 
 private:
     //! Selected inputs (inputs that will be used, regardless of whether they're optimal or not)

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -24,6 +24,33 @@ const int DEFAULT_MAX_DEPTH = 9999999;
 //! Default for -avoidpartialspends
 static constexpr bool DEFAULT_AVOIDPARTIALSPENDS = false;
 
+class PreselectedInput
+{
+private:
+    //! The previous output being spent by this input
+    std::optional<CTxOut> m_txout;
+    //! The input weight for spending this input
+    std::optional<int64_t> m_weight;
+
+public:
+    /**
+     * Set the previous output for this input.
+     * Only necessary if the input is expected to be an external input.
+     */
+    void SetTxOut(const CTxOut& txout);
+    /** Retrieve the previous output for this input. */
+    CTxOut GetTxOut() const;
+    /** Return whether the previous output is set for this input. */
+    bool HasTxOut() const;
+
+    /** Set the weight for this input. */
+    void SetInputWeight(int64_t weight);
+    /** Retrieve the input weight for this input. */
+    int64_t GetInputWeight() const;
+    /** Return whether the input weight is set. */
+    bool HasInputWeight() const;
+};
+
 /** Coin Control Features. */
 class CCoinControl
 {
@@ -69,11 +96,11 @@ public:
     /**
      * Returns true if the given output is pre-selected.
      */
-    bool IsSelected(const COutPoint& output) const;
+    bool IsSelected(const COutPoint& outpoint) const;
     /**
      * Returns true if the given output is selected as an external input.
      */
-    bool IsExternalSelected(const COutPoint& output) const;
+    bool IsExternalSelected(const COutPoint& outpoint) const;
     /**
      * Returns the external output for the given outpoint if it exists.
      */
@@ -82,7 +109,7 @@ public:
      * Lock-in the given output for spending.
      * The output will be included in the transaction even if it's not the most optimal choice.
      */
-    void Select(const COutPoint& output);
+    PreselectedInput& Select(const COutPoint& outpoint);
     /**
      * Lock-in the given output as an external input for spending because it is not in the wallet.
      * The output will be included in the transaction even if it's not the most optimal choice.
@@ -91,7 +118,7 @@ public:
     /**
      * Unselects the given output.
      */
-    void UnSelect(const COutPoint& output);
+    void UnSelect(const COutPoint& outpoint);
     /**
      * Unselects all outputs.
      */
@@ -115,12 +142,7 @@ public:
 
 private:
     //! Selected inputs (inputs that will be used, regardless of whether they're optimal or not)
-    std::set<COutPoint> m_selected_inputs;
-    //! Map of external inputs to include in the transaction
-    //! These are not in the wallet, so we need to track them separately
-    std::map<COutPoint, CTxOut> m_external_txouts;
-    //! Map of COutPoints to the maximum weight for that input
-    std::map<COutPoint, int64_t> m_input_weights;
+    std::map<COutPoint, PreselectedInput> m_selected;
 };
 } // namespace wallet
 

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -33,6 +33,12 @@ private:
     std::optional<int64_t> m_weight;
     //! The sequence number for this input
     std::optional<uint32_t> m_sequence;
+    //! The scriptSig for this input
+    std::optional<CScript> m_script_sig;
+    //! The scriptWitness for this input
+    std::optional<CScriptWitness> m_script_witness;
+    //! The position in the inputs vector for this input
+    std::optional<unsigned int> m_pos;
 
 public:
     /**
@@ -54,6 +60,20 @@ public:
     void SetSequence(uint32_t sequence);
     /** Retrieve the sequence for this input. */
     std::optional<uint32_t> GetSequence() const;
+
+    /** Set the scriptSig for this input. */
+    void SetScriptSig(const CScript& script);
+    /** Set the scriptWitness for this input. */
+    void SetScriptWitness(const CScriptWitness& script_wit);
+    /** Return whether either the scriptSig or scriptWitness are set for this input. */
+    bool HasScripts() const;
+    /** Retrieve both the scriptSig and the scriptWitness. */
+    std::pair<std::optional<CScript>, std::optional<CScriptWitness>> GetScripts() const;
+
+    /** Store the position of this input. */
+    void SetPosition(unsigned int pos);
+    /** Retrieve the position of this input. */
+    std::optional<unsigned int> GetPosition() const;
 };
 
 /** Coin Control Features. */
@@ -141,10 +161,27 @@ public:
     std::optional<int64_t> GetInputWeight(const COutPoint& outpoint) const;
     /** Retrieve the sequence for an input */
     std::optional<uint32_t> GetSequence(const COutPoint& outpoint) const;
+    /** Retrieves the scriptSig and scriptWitness for an input. */
+    std::pair<std::optional<CScript>, std::optional<CScriptWitness>> GetScripts(const COutPoint& outpoint) const;
+
+    bool HasSelectedOrder() const
+    {
+        return m_selection_pos > 0;
+    }
+
+    std::optional<unsigned int> GetSelectionPos(const COutPoint& outpoint) const
+    {
+        const auto it = m_selected.find(outpoint);
+        if (it == m_selected.end()) {
+            return std::nullopt;
+        }
+        return it->second.GetPosition();
+    }
 
 private:
     //! Selected inputs (inputs that will be used, regardless of whether they're optimal or not)
     std::map<COutPoint, PreselectedInput> m_selected;
+    unsigned int m_selection_pos{0};
 };
 } // namespace wallet
 

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -93,6 +93,8 @@ public:
     FlatSigningProvider m_external_provider;
     //! Locktime
     std::optional<uint32_t> m_locktime;
+    //! Version
+    std::optional<uint32_t> m_version;
 
     CCoinControl();
 

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -316,8 +316,7 @@ Result CreateRateBumpTransaction(CWallet& wallet, const uint256& txid, const CCo
     // We cannot source new unconfirmed inputs(bip125 rule 2)
     new_coin_control.m_min_depth = 1;
 
-    constexpr int RANDOM_CHANGE_POSITION = -1;
-    auto res = CreateTransaction(wallet, recipients, RANDOM_CHANGE_POSITION, new_coin_control, false);
+    auto res = CreateTransaction(wallet, recipients, std::nullopt, new_coin_control, false);
     if (!res) {
         errors.push_back(Untranslated("Unable to create transaction.") + Untranslated(" ") + util::ErrorString(res));
         return Result::WALLET_ERROR;

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -203,10 +203,9 @@ Result CreateRateBumpTransaction(CWallet& wallet, const uint256& txid, const CCo
             errors.push_back(Untranslated(strprintf("%s:%u is already spent", txin.prevout.hash.GetHex(), txin.prevout.n)));
             return Result::MISC_ERROR;
         }
-        if (wallet.IsMine(txin.prevout)) {
-            new_coin_control.Select(txin.prevout);
-        } else {
-            new_coin_control.SelectExternal(txin.prevout, coin.out);
+        PreselectedInput& preset_txin = new_coin_control.Select(txin.prevout);
+        if (!wallet.IsMine(txin.prevout)) {
+            preset_txin.SetTxOut(coin.out);
         }
         input_value += coin.out.nValue;
         spent_outputs.push_back(coin.out);

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -281,12 +281,12 @@ public:
         CAmount& fee) override
     {
         LOCK(m_wallet->cs_wallet);
-        auto res = CreateTransaction(*m_wallet, recipients, change_pos,
+        auto res = CreateTransaction(*m_wallet, recipients, change_pos == -1 ? std::nullopt : std::make_optional(change_pos),
                                      coin_control, sign);
         if (!res) return util::Error{util::ErrorString(res)};
         const auto& txr = *res;
         fee = txr.fee;
-        change_pos = txr.change_pos;
+        change_pos = txr.change_pos ? *txr.change_pos : -1;
 
         return txr.tx;
     }

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -155,8 +155,7 @@ UniValue SendMoney(CWallet& wallet, const CCoinControl &coin_control, std::vecto
     std::shuffle(recipients.begin(), recipients.end(), FastRandomContext());
 
     // Send
-    constexpr int RANDOM_CHANGE_POSITION = -1;
-    auto res = CreateTransaction(wallet, recipients, RANDOM_CHANGE_POSITION, coin_control, true);
+    auto res = CreateTransaction(wallet, recipients, std::nullopt, coin_control, true);
     if (!res) {
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, util::ErrorString(res).original);
     }

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -977,6 +977,10 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
     FastRandomContext rng_fast;
     CMutableTransaction txNew; // The resulting transaction that we make
 
+    if (coin_control.m_version) {
+        txNew.nVersion = coin_control.m_version.value();
+    }
+
     CoinSelectionParams coin_selection_params{rng_fast}; // Parameters for coin selection, init with dummy
     coin_selection_params.m_avoid_partial_spends = coin_control.m_avoid_partial_spends;
     coin_selection_params.m_include_unsafe_inputs = coin_control.m_include_unsafe_inputs;
@@ -1348,6 +1352,9 @@ bool FundTransaction(CWallet& wallet, CMutableTransaction& tx, CAmount& nFeeRet,
 
     // Set the user desired locktime
     coinControl.m_locktime = tx.nLockTime;
+
+    // Set the user desired version
+    coinControl.m_version = tx.nVersion;
 
     // Acquire the locks to prevent races to the new locked unspents between the
     // CreateTransaction call and LockCoin calls (when lockUnspents is true).

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1347,15 +1347,15 @@ bool FundTransaction(CWallet& wallet, CMutableTransaction& tx, CAmount& nFeeRet,
 
     for (const CTxIn& txin : tx.vin) {
         const auto& outPoint = txin.prevout;
-        if (wallet.IsMine(outPoint)) {
-            // The input was found in the wallet, so select as internal
-            coinControl.Select(outPoint);
-        } else if (coins[outPoint].out.IsNull()) {
-            error = _("Unable to find UTXO for external input");
-            return false;
-        } else {
+        PreselectedInput& preset_txin = coinControl.Select(outPoint);
+        if (!wallet.IsMine(outPoint)) {
+            if (coins[outPoint].out.IsNull()) {
+                error = _("Unable to find UTXO for external input");
+                return false;
+            }
+
             // The input was not in the wallet, but is in the UTXO set, so select as external
-            coinControl.SelectExternal(outPoint, coins[outPoint].out);
+            preset_txin.SetTxOut(coins[outPoint].out);
         }
     }
 

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1146,6 +1146,25 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
     // Shuffle selected coins and fill in final vin
     std::vector<std::shared_ptr<COutput>> selected_coins = result.GetShuffledInputVector();
 
+    if (coin_control.HasSelected() && coin_control.HasSelectedOrder()) {
+        // When there are preselected inputs, we need to move them to be the first UTXOs
+        // and have them be in the order selected. We can use stable_sort for this, where we
+        // compare with the positions stored in coin_control. The COutputs that have positions
+        // will be placed before those that don't, and those positions will be in order.
+        std::stable_sort(selected_coins.begin(), selected_coins.end(),
+            [&coin_control](const std::shared_ptr<COutput>& a, const std::shared_ptr<COutput>& b) {
+                auto a_pos = coin_control.GetSelectionPos(a->outpoint);
+                auto b_pos = coin_control.GetSelectionPos(b->outpoint);
+                if (a_pos.has_value() && b_pos.has_value()) {
+                    return a_pos.value() < b_pos.value();
+                } else if (a_pos.has_value() && !b_pos.has_value()) {
+                    return true;
+                } else {
+                    return false;
+                }
+            });
+    }
+
     // The sequence number is set to non-maxint so that DiscourageFeeSniping
     // works.
     //
@@ -1162,7 +1181,15 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
             // If an input has a preset sequence, we can't do anti-fee-sniping
             use_anti_fee_sniping = false;
         }
-        txNew.vin.emplace_back(coin->outpoint, CScript(), sequence.value_or(default_sequence));
+        txNew.vin.emplace_back(coin->outpoint, CScript{}, sequence.value_or(default_sequence));
+
+        auto scripts = coin_control.GetScripts(coin->outpoint);
+        if (scripts.first) {
+            txNew.vin.back().scriptSig = *scripts.first;
+        }
+        if (scripts.second) {
+            txNew.vin.back().scriptWitness = *scripts.second;
+        }
     }
     if (coin_control.m_locktime) {
         txNew.nLockTime = coin_control.m_locktime.value();
@@ -1381,6 +1408,8 @@ bool FundTransaction(CWallet& wallet, CMutableTransaction& tx, CAmount& nFeeRet,
             preset_txin.SetTxOut(coins[outPoint].out);
         }
         preset_txin.SetSequence(txin.nSequence);
+        preset_txin.SetScriptSig(txin.scriptSig);
+        preset_txin.SetScriptWitness(txin.scriptWitness);
     }
 
     auto res = CreateTransaction(wallet, vecSend, nChangePosInOut, coinControl, false);

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -1160,6 +1160,11 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
         }
         txNew.vin.emplace_back(coin->outpoint, CScript(), sequence.value_or(default_sequence));
     }
+    if (coin_control.m_locktime) {
+        txNew.nLockTime = coin_control.m_locktime.value();
+        // If we have a locktime set, we can't use anti-fee-sniping
+        use_anti_fee_sniping = false;
+    }
     if (use_anti_fee_sniping) {
         DiscourageFeeSniping(txNew, rng_fast, wallet.chain(), wallet.GetLastBlockHash(), wallet.GetLastBlockHeight());
     }
@@ -1340,6 +1345,9 @@ bool FundTransaction(CWallet& wallet, CMutableTransaction& tx, CAmount& nFeeRet,
         CRecipient recipient = {dest, txOut.nValue, setSubtractFeeFromOutputs.count(idx) == 1};
         vecSend.push_back(recipient);
     }
+
+    // Set the user desired locktime
+    coinControl.m_locktime = tx.nLockTime;
 
     // Acquire the locks to prevent races to the new locked unspents between the
     // CreateTransaction call and LockCoin calls (when lockUnspents is true).

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -207,9 +207,9 @@ struct CreatedTransactionResult
     CTransactionRef tx;
     CAmount fee;
     FeeCalculation fee_calc;
-    int change_pos;
+    std::optional<unsigned int> change_pos;
 
-    CreatedTransactionResult(CTransactionRef _tx, CAmount _fee, int _change_pos, const FeeCalculation& _fee_calc)
+    CreatedTransactionResult(CTransactionRef _tx, CAmount _fee, std::optional<unsigned int> _change_pos, const FeeCalculation& _fee_calc)
         : tx(_tx), fee(_fee), fee_calc(_fee_calc), change_pos(_change_pos) {}
 };
 
@@ -218,7 +218,7 @@ struct CreatedTransactionResult
  * selected by SelectCoins(); Also create the change output, when needed
  * @note passing change_pos as -1 will result in setting a random position
  */
-util::Result<CreatedTransactionResult> CreateTransaction(CWallet& wallet, const std::vector<CRecipient>& vecSend, int change_pos, const CCoinControl& coin_control, bool sign = true);
+util::Result<CreatedTransactionResult> CreateTransaction(CWallet& wallet, const std::vector<CRecipient>& vecSend, std::optional<unsigned int> change_pos, const CCoinControl& coin_control, bool sign = true);
 
 /**
  * Insert additional inputs into the transaction by

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -224,7 +224,7 @@ util::Result<CreatedTransactionResult> CreateTransaction(CWallet& wallet, const 
  * Insert additional inputs into the transaction by
  * calling CreateTransaction();
  */
-bool FundTransaction(CWallet& wallet, CMutableTransaction& tx, CAmount& nFeeRet, int& nChangePosInOut, bilingual_str& error, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, CCoinControl);
+util::Result<CreatedTransactionResult> FundTransaction(CWallet& wallet, const CMutableTransaction& tx, std::optional<unsigned int> change_pos, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, CCoinControl);
 } // namespace wallet
 
 #endif // BITCOIN_WALLET_SPEND_H

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -1282,7 +1282,7 @@ BOOST_AUTO_TEST_CASE(SelectCoins_effective_value_test)
     cc.m_allow_other_inputs = false;
     COutput output = available_coins.All().at(0);
     cc.SetInputWeight(output.outpoint, 148);
-    cc.SelectExternal(output.outpoint, output.txout);
+    cc.Select(output.outpoint).SetTxOut(output.txout);
 
     LOCK(wallet->cs_wallet);
     const auto preset_inputs = *Assert(FetchSelectedInputs(*wallet, cc, cs_params));

--- a/src/wallet/test/fuzz/coincontrol.cpp
+++ b/src/wallet/test/fuzz/coincontrol.cpp
@@ -60,7 +60,7 @@ FUZZ_TARGET(coincontrol, .init = initialize_coincontrol)
             },
             [&] {
                 const CTxOut tx_out{ConsumeMoney(fuzzed_data_provider), ConsumeScript(fuzzed_data_provider)};
-                (void)coin_control.SelectExternal(out_point, tx_out);
+                (void)coin_control.Select(out_point).SetTxOut(tx_out);
             },
             [&] {
                 (void)coin_control.UnSelect(out_point);

--- a/src/wallet/test/fuzz/coincontrol.cpp
+++ b/src/wallet/test/fuzz/coincontrol.cpp
@@ -76,10 +76,7 @@ FUZZ_TARGET(coincontrol, .init = initialize_coincontrol)
                 (void)coin_control.SetInputWeight(out_point, weight);
             },
             [&] {
-                // Condition to avoid the assertion in GetInputWeight
-                if (coin_control.HasInputWeight(out_point)) {
-                    (void)coin_control.GetInputWeight(out_point);
-                }
+                (void)coin_control.GetInputWeight(out_point);
             });
     }
 }

--- a/src/wallet/test/fuzz/notifications.cpp
+++ b/src/wallet/test/fuzz/notifications.cpp
@@ -156,10 +156,9 @@ struct FuzzedWallet {
         coin_control.fOverrideFeeRate = fuzzed_data_provider.ConsumeBool();
         // Add solving data (m_external_provider and SelectExternal)?
 
-        CAmount fee_out;
         int change_position{fuzzed_data_provider.ConsumeIntegralInRange<int>(-1, tx.vout.size() - 1)};
         bilingual_str error;
-        (void)FundTransaction(*wallet, tx, fee_out, change_position, error, /*lockUnspents=*/false, subtract_fee_from_outputs, coin_control);
+        (void)FundTransaction(*wallet, tx, change_position, /*lockUnspents=*/false, subtract_fee_from_outputs, coin_control);
     }
 };
 

--- a/src/wallet/test/spend_tests.cpp
+++ b/src/wallet/test/spend_tests.cpp
@@ -28,13 +28,12 @@ BOOST_FIXTURE_TEST_CASE(SubtractFee, TestChain100Setup)
     // instead of the miner.
     auto check_tx = [&wallet](CAmount leftover_input_amount) {
         CRecipient recipient{PubKeyDestination({}), 50 * COIN - leftover_input_amount, /*subtract_fee=*/true};
-        constexpr int RANDOM_CHANGE_POSITION = -1;
         CCoinControl coin_control;
         coin_control.m_feerate.emplace(10000);
         coin_control.fOverrideFeeRate = true;
         // We need to use a change type with high cost of change so that the leftover amount will be dropped to fee instead of added as a change output
         coin_control.m_change_type = OutputType::LEGACY;
-        auto res = CreateTransaction(*wallet, {recipient}, RANDOM_CHANGE_POSITION, coin_control);
+        auto res = CreateTransaction(*wallet, {recipient}, std::nullopt, coin_control);
         BOOST_CHECK(res);
         const auto& txr = *res;
         BOOST_CHECK_EQUAL(txr.tx->vout.size(), 1);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -558,8 +558,7 @@ public:
         CTransactionRef tx;
         CCoinControl dummy;
         {
-            constexpr int RANDOM_CHANGE_POSITION = -1;
-            auto res = CreateTransaction(*wallet, {recipient}, RANDOM_CHANGE_POSITION, dummy);
+            auto res = CreateTransaction(*wallet, {recipient}, std::nullopt, dummy);
             BOOST_CHECK(res);
             tx = res->tx;
         }


### PR DESCRIPTION
Currently `FundTransaction` handles transaction locktime and preset input data by extracting the selected inputs and change output from `CreateTransaction`'s results. This means that `CreateTransaction` is actually unaware of any user desired locktime or sequence numbers. This can have an effect on whether and how anti-fee-sniping works.

This PR makes `CreateTransaction` aware of the locktime and preset input data by providing them to `CCoinControl`. `CreateTransasction` will then set the sequences, scriptSigs, scriptWItnesses, and locktime as appropriate if they are specified. This allows `FundTransaction` to actually use `CreateTransaction`'s result directly instead of having to extract the parts of it that it wants.

Additionally `FundTransaction` will return a `CreateTransactionResult` as `CreateTransaction` does instead of having several output parameters. Lastly, instead of using `-1` as a magic number for the change output position, the change position is changed to be an optional with no value set indicating no desired change output position (when provided as an input parameter) or no change output present (in the result).