### PR TITLE
build: Remove unused `LIBBITCOIN_KERNEL` variable

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,7 +29,6 @@ LIBBITCOIN_NODE=libbitcoin_node.a
 LIBBITCOIN_COMMON=libbitcoin_common.a
 LIBBITCOIN_CONSENSUS=libbitcoin_consensus.a
 LIBBITCOIN_CLI=libbitcoin_cli.a
-LIBBITCOIN_KERNEL=libbitcoin_kernel.a
 LIBBITCOIN_UTIL=libbitcoin_util.a
 LIBBITCOIN_CRYPTO_BASE=crypto/libbitcoin_crypto_base.la
 LIBBITCOINQT=qt/libbitcoinqt.a


### PR DESCRIPTION
Noticed that while working on moving the build system to CMake. But I [am not the first](https://github.com/bitcoin/bitcoin/pull/24322/files#r860472867) one :)