### PR TITLE
test: implement 'bech32m' mode for `getnewdestination()` helper

### DIFF
--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -43,7 +43,7 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
         if self.is_bdb_compiled():
             self.final = node2.getnewaddress()
         else:
-            self.final = getnewdestination()[2]
+            self.final = getnewdestination('bech32')[2]
 
     def run_test(self):
         node0, node1, node2 = self.nodes
@@ -66,9 +66,7 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
 
         # Test mixed compressed and uncompressed pubkeys
         self.log.info('Mixed compressed and uncompressed multisigs are not allowed')
-        pk0 = getnewdestination()[0].hex()
-        pk1 = getnewdestination()[0].hex()
-        pk2 = getnewdestination()[0].hex()
+        pk0, pk1, pk2 = [getnewdestination('bech32')[0].hex() for _ in range(3)]
 
         # decompress pk2
         pk_obj = ECPubKey()

--- a/test/functional/test_framework/address.py
+++ b/test/functional/test_framework/address.py
@@ -47,8 +47,7 @@ def create_deterministic_address_bcrt1_p2tr_op_true():
     Returns a tuple with the generated address and the internal key.
     """
     internal_key = (1).to_bytes(32, 'big')
-    scriptPubKey = taproot_construct(internal_key, [(None, CScript([OP_TRUE]))]).scriptPubKey
-    address = encode_segwit_address("bcrt", 1, scriptPubKey[2:])
+    address = output_key_to_p2tr(taproot_construct(internal_key, [(None, CScript([OP_TRUE]))]).output_pubkey)
     assert_equal(address, 'bcrt1p9yfmy5h72durp7zrhlw9lf7jpwjgvwdg0jr0lqmmjtgg83266lqsekaqka')
     return (address, internal_key)
 
@@ -140,6 +139,10 @@ def script_to_p2sh_p2wsh(script, main=False):
     script = check_script(script)
     p2shscript = CScript([OP_0, sha256(script)])
     return script_to_p2sh(p2shscript, main)
+
+def output_key_to_p2tr(key, main=False):
+    assert len(key) == 32
+    return program_to_witness(1, key, main)
 
 def check_key(key):
     if (type(key) is str):

--- a/test/functional/test_framework/script_util.py
+++ b/test/functional/test_framework/script_util.py
@@ -105,6 +105,11 @@ def script_to_p2sh_p2wsh_script(script):
     return script_to_p2sh_script(p2shscript)
 
 
+def output_key_to_p2tr_script(key):
+    assert len(key) == 32
+    return program_to_witness_script(1, key)
+
+
 def check_key(key):
     if isinstance(key, str):
         key = bytes.fromhex(key)  # Assuming this is hex string

--- a/test/functional/wallet_taproot.py
+++ b/test/functional/wallet_taproot.py
@@ -7,19 +7,18 @@
 import random
 
 from decimal import Decimal
+from test_framework.address import output_key_to_p2tr
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 from test_framework.descriptors import descsum_create
 from test_framework.script import (
     CScript,
     MAX_PUBKEYS_PER_MULTI_A,
-    OP_1,
     OP_CHECKSIG,
     OP_CHECKSIGADD,
     OP_NUMEQUAL,
     taproot_construct,
 )
-from test_framework.segwit_addr import encode_segwit_address
 
 # xprvs/xpubs, and m/* derived x-only pubkeys (created using independent implementation)
 KEYS = [
@@ -183,10 +182,7 @@ def multi_a(k, hex_keys, sort=False):
 
 def compute_taproot_address(pubkey, scripts):
     """Compute the address for a taproot output with given inner key and scripts."""
-    tap = taproot_construct(pubkey, scripts)
-    assert tap.scriptPubKey[0] == OP_1
-    assert tap.scriptPubKey[1] == 0x20
-    return encode_segwit_address("bcrt", 1, tap.scriptPubKey[2:])
+    return output_key_to_p2tr(taproot_construct(pubkey, scripts).output_pubkey)
 
 class WalletTaprootTest(BitcoinTestFramework):
     """Test generation and spending of P2TR address outputs."""


### PR DESCRIPTION
This PR adds the missing 'bech32m' mode for the `getnewdestination()` helper and sets it as default, i.e. the function returns a tuple (output x-only-pubkey, scriptPubKey, taproot address) now if not specified otherwise. In a preparation commit, the helpers `output_key_to_p2tr{_script}` are introduced. Note that in contrast to all other common script output types, there are usually _two_ keys involved in creating a taproot output (internal key and output key), hence the prefix `output_` is used to clarify that the  output key is expected and the helpers don't do any key tweaking.

Thanks to michaelfolkson (for pointing out this TODO that I forgot about) and sipa (for patiently explaining basic things about BIP341).