### PR TITLE
test: Refactor rpc_fundrawtransaction.py

### DIFF
--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -841,11 +841,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtx = self.nodes[3].createrawtransaction(inputs=[], outputs={self.nodes[3].getnewaddress(): 1})
         result3 = self.nodes[3].fundrawtransaction(rawtx)
         res_dec = self.nodes[0].decoderawtransaction(result3["hex"])
-        changeaddress = ""
-        for out in res_dec['vout']:
-            if out['value'] > 1.0:
-                changeaddress += out['scriptPubKey']['address']
-        assert changeaddress != ""
+        changeaddress = res_dec["vout"][result3["changepos"]]['scriptPubKey']['address']
         nextaddr = self.nodes[3].getnewaddress()
         # Now the change address key should be removed from the keypool.
         assert changeaddress != nextaddr

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -109,7 +109,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.test_weight_calculation()
         self.test_change_position()
         self.test_simple()
-        self.test_simple_two_coins()
         self.test_simple_two_outputs()
         self.test_change()
         self.test_no_change()
@@ -180,17 +179,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
         assert len(dec_tx['vin']) > 0  #test that we have enough inputs
-
-    def test_simple_two_coins(self):
-        self.log.info("Test fundrawtxn with 2 coins")
-        inputs  = [ ]
-        outputs = { self.nodes[0].getnewaddress() : 2.2 }
-        rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
-        dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
-
-        rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
-        dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
-        assert len(dec_tx['vin']) > 0  #test if we have enough inputs
         assert_equal(dec_tx['vin'][0]['scriptSig']['hex'], '')
 
     def test_simple_two_outputs(self):


### PR DESCRIPTION
Made 2 changes to `tests/functional/rpc_fundrawtransaction.py`- 

1. **Remove test_simple_two_coins** - The current test_simple_two_coins and test_simple are identical and redundant. The test_simple_two_coins was changed in #6417  and asserts ensuring the use of two input coins were removed.
2. **Use changepos to get the change output** - In test_address_reuse the code to get the change output assumes that a coin with a value > 2 BTC was used to fund the transaction, and therefore change value will be greater than 1 BTC. This can fail if previous tests add a small coin. fundrawtransaction directly gives the index of change output as changepos, we use this to get the change output more reliably and cleanly.
