### PR TITLE
Add LogPrintLevel to lint-format-strings, drop LogPrint-vs-LogPrintf section in dev notes

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -831,11 +831,6 @@ int GetInt(Tabs tab)
 Strings and formatting
 ------------------------
 
-- Be careful of `LogPrint` versus `LogPrintf`. `LogPrint` takes a `category` argument, `LogPrintf` does not.
-
-  - *Rationale*: Confusion of these can result in runtime exceptions due to
-    formatting mismatch, and it is easy to get wrong because of subtly similar naming.
-
 - Use `std::string`, avoid C string manipulation functions.
 
   - *Rationale*: C++ string handling is marginally safer, less scope for

--- a/test/lint/lint-format-strings.py
+++ b/test/lint/lint-format-strings.py
@@ -22,6 +22,7 @@ FUNCTION_NAMES_AND_NUMBER_OF_LEADING_ARGUMENTS = [
     'LogConnectFailure,1',
     'LogPrint,1',
     'LogPrintf,0',
+    'LogPrintLevel,2',
     'printf,0',
     'snprintf,2',
     'sprintf,1',


### PR DESCRIPTION
added by #7003 in 2015, as that potential issue would now be caught by the `test/lint/lint-format-strings.py` script run by the CI.
