### PR TITLE
test: Fix wait_for_debug_log UnicodeDecodeError

### DIFF
--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -49,33 +49,33 @@ class InitStressTest(BitcoinTestFramework):
             assert_equal(200, node.getblockcount())
 
         lines_to_terminate_after = [
-            'Validating signatures for all blocks',
-            'scheduler thread start',
-            'Starting HTTP server',
-            'Loading P2P addresses',
-            'Loading banlist',
-            'Loading block index',
-            'Switching active chainstate',
-            'Checking all blk files are present',
-            'Loaded best chain:',
-            'init message: Verifying blocks',
-            'init message: Starting network threads',
-            'net thread start',
-            'addcon thread start',
-            'loadblk thread start',
-            'txindex thread start',
-            'block filter index thread start',
-            'coinstatsindex thread start',
-            'msghand thread start',
-            'net thread start',
-            'addcon thread start',
+            b'Validating signatures for all blocks',
+            b'scheduler thread start',
+            b'Starting HTTP server',
+            b'Loading P2P addresses',
+            b'Loading banlist',
+            b'Loading block index',
+            b'Switching active chainstate',
+            b'Checking all blk files are present',
+            b'Loaded best chain:',
+            b'init message: Verifying blocks',
+            b'init message: Starting network threads',
+            b'net thread start',
+            b'addcon thread start',
+            b'loadblk thread start',
+            b'txindex thread start',
+            b'block filter index thread start',
+            b'coinstatsindex thread start',
+            b'msghand thread start',
+            b'net thread start',
+            b'addcon thread start',
         ]
         if self.is_wallet_compiled():
-            lines_to_terminate_after.append('Verifying wallet')
+            lines_to_terminate_after.append(b'Verifying wallet')
 
         for terminate_line in lines_to_terminate_after:
-            self.log.info(f"Starting node and will exit after line '{terminate_line}'")
-            with node.wait_for_debug_log([terminate_line], ignore_case=True):
+            self.log.info(f"Starting node and will exit after line {terminate_line}")
+            with node.wait_for_debug_log([terminate_line]):
                 node.start(extra_args=['-txindex=1', '-blockfilterindex=1', '-coinstatsindex=1'])
             self.log.debug("Terminating node after terminate line was found")
             sigterm_node()

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -423,7 +423,7 @@ class TestNode():
         self._raise_assertion_error('Expected messages "{}" does not partially match log:\n\n{}\n\n'.format(str(expected_msgs), print_log))
 
     @contextlib.contextmanager
-    def wait_for_debug_log(self, expected_msgs, timeout=60, ignore_case=False):
+    def wait_for_debug_log(self, expected_msgs, timeout=60):
         """
         Block until we see a particular debug log message fragment or until we exceed the timeout.
         Return:
@@ -431,18 +431,17 @@ class TestNode():
         """
         time_end = time.time() + timeout * self.timeout_factor
         prev_size = self.debug_log_bytes()
-        re_flags = re.MULTILINE | (re.IGNORECASE if ignore_case else 0)
 
         yield
 
         while True:
             found = True
-            with open(self.debug_log_path, encoding='utf-8') as dl:
+            with open(self.debug_log_path, "rb") as dl:
                 dl.seek(prev_size)
                 log = dl.read()
 
             for expected_msg in expected_msgs:
-                if re.search(re.escape(expected_msg), log, flags=re_flags) is None:
+                if expected_msg not in log:
                     found = False
 
             if found:


### PR DESCRIPTION
Fix the intermittent `UnicodeDecodeError` when the debug log is truncated on an (multi-byte) unicode character by treating everything as bytes.

Also, remove the `ignore_case` option and the`re.search+re.escape` wrap. All of this is unused and doesn't exist on raw byte strings.

Fixes https://github.com/bitcoin/bitcoin/issues/24575