### PR TITLE
wallet: group independent db writes on single batched db transaction

### DIFF
--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -403,9 +403,7 @@ void BerkeleyBatch::Close()
 {
     if (!pdb)
         return;
-    if (activeTxn)
-        activeTxn->abort();
-    activeTxn = nullptr;
+    TxnAbort();
     pdb = nullptr;
 
     if (fFlushOnClose)

--- a/src/wallet/external_signer_scriptpubkeyman.cpp
+++ b/src/wallet/external_signer_scriptpubkeyman.cpp
@@ -33,7 +33,7 @@ bool ExternalSignerScriptPubKeyMan::SetupDescriptor(std::unique_ptr<Descriptor> 
     }
 
     // TopUp
-    TopUp();
+    TopUp(batch);
 
     m_storage.UnsetBlankWalletFlag(batch);
     return true;

--- a/src/wallet/external_signer_scriptpubkeyman.cpp
+++ b/src/wallet/external_signer_scriptpubkeyman.cpp
@@ -14,7 +14,7 @@
 #include <vector>
 
 namespace wallet {
-bool ExternalSignerScriptPubKeyMan::SetupDescriptor(std::unique_ptr<Descriptor> desc)
+bool ExternalSignerScriptPubKeyMan::SetupDescriptor(WalletBatch& batch, std::unique_ptr<Descriptor> desc)
 {
     LOCK(cs_desc_man);
     assert(m_storage.IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
@@ -27,7 +27,6 @@ bool ExternalSignerScriptPubKeyMan::SetupDescriptor(std::unique_ptr<Descriptor> 
     m_wallet_descriptor = w_desc;
 
     // Store the descriptor
-    WalletBatch batch(m_storage.GetDatabase());
     if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
         throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
     }

--- a/src/wallet/external_signer_scriptpubkeyman.h
+++ b/src/wallet/external_signer_scriptpubkeyman.h
@@ -23,7 +23,7 @@ class ExternalSignerScriptPubKeyMan : public DescriptorScriptPubKeyMan
   /** Provide a descriptor at setup time
   * Returns false if already setup or setup fails, true if setup is successful
   */
-  bool SetupDescriptor(std::unique_ptr<Descriptor>desc);
+  bool SetupDescriptor(WalletBatch& batch, std::unique_ptr<Descriptor>desc);
 
   static ExternalSigner GetExternalSigner();
 

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -1561,16 +1561,19 @@ static UniValue ProcessDescriptorImport(CWallet& wallet, const UniValue& data, c
             throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Could not add descriptor '%s'", descriptor));
         }
 
+        // db handler
+        WalletBatch batch(wallet.GetDatabase(), /*fFlushOnClose=*/true, /*initialize=*/false);
+
         // Set descriptor as active if necessary
         if (active) {
             if (!w_desc.descriptor->GetOutputType()) {
                 warnings.push_back("Unknown output type, cannot set descriptor to active.");
             } else {
-                wallet.AddActiveScriptPubKeyMan(spk_manager->GetID(), *w_desc.descriptor->GetOutputType(), internal);
+                wallet.AddActiveScriptPubKeyMan(batch, spk_manager->GetID(), *w_desc.descriptor->GetOutputType(), internal);
             }
         } else {
             if (w_desc.descriptor->GetOutputType()) {
-                wallet.DeactivateScriptPubKeyMan(spk_manager->GetID(), *w_desc.descriptor->GetOutputType(), internal);
+                wallet.DeactivateScriptPubKeyMan(batch, spk_manager->GetID(), *w_desc.descriptor->GetOutputType(), internal);
             }
         }
 

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2646,10 +2646,9 @@ bool DescriptorScriptPubKeyMan::HasWalletDescriptor(const WalletDescriptor& desc
     return m_wallet_descriptor.descriptor != nullptr && desc.descriptor != nullptr && m_wallet_descriptor.descriptor->ToString() == desc.descriptor->ToString();
 }
 
-void DescriptorScriptPubKeyMan::WriteDescriptor()
+void DescriptorScriptPubKeyMan::WriteDescriptor(WalletBatch& batch)
 {
     LOCK(cs_desc_man);
-    WalletBatch batch(m_storage.GetDatabase());
     if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
         throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
     }

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2250,7 +2250,7 @@ bool DescriptorScriptPubKeyMan::AddDescriptorKeyWithDB(WalletBatch& batch, const
     }
 }
 
-bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(const CExtKey& master_key, OutputType addr_type, bool internal)
+bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(WalletBatch& batch, const CExtKey& master_key, OutputType addr_type, bool internal)
 {
     LOCK(cs_desc_man);
     assert(m_storage.IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
@@ -2311,7 +2311,6 @@ bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(const CExtKey& master_
     m_wallet_descriptor = w_desc;
 
     // Store the master private key, and descriptor
-    WalletBatch batch(m_storage.GetDatabase());
     if (!AddDescriptorKeyWithDB(batch, master_key.key, master_key.key.GetPubKey())) {
         throw std::runtime_error(std::string(__func__) + ": writing descriptor master private key failed");
     }

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1070,7 +1070,7 @@ CPubKey LegacyScriptPubKeyMan::GenerateNewKey(WalletBatch &batch, CHDChain& hd_c
 
     // Compressed public keys were introduced in version 0.6.0
     if (fCompressed) {
-        m_storage.SetMinVersion(FEATURE_COMPRPUBKEY);
+        m_storage.SetMinVersion(FEATURE_COMPRPUBKEY, &batch);
     }
 
     CPubKey pubkey = secret.GetPubKey();

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -38,7 +38,7 @@ util::Result<CTxDestination> LegacyScriptPubKeyMan::GetNewDestination(WalletBatc
     if (!GetKeyFromPool(batch, new_key, type)) {
         return util::Error{_("Error: Keypool ran out, please call keypoolrefill first")};
     }
-    LearnRelatedScripts(new_key, type);
+    LearnRelatedScripts(batch, new_key, type);
     return GetDestinationForKey(new_key, type);
 }
 
@@ -1358,7 +1358,7 @@ void LegacyScriptPubKeyMan::KeepDestination(WalletBatch& batch, int64_t nIndex, 
     CPubKey pubkey;
     bool have_pk = GetPubKey(m_index_to_reserved_key.at(nIndex), pubkey);
     assert(have_pk);
-    LearnRelatedScripts(pubkey, type);
+    LearnRelatedScripts(batch, pubkey, type);
     m_index_to_reserved_key.erase(nIndex);
     WalletLogPrintf("keypool keep %d\n", nIndex);
 }
@@ -1449,7 +1449,7 @@ bool LegacyScriptPubKeyMan::ReserveKeyFromKeyPool(WalletBatch& batch, int64_t& n
     return true;
 }
 
-void LegacyScriptPubKeyMan::LearnRelatedScripts(const CPubKey& key, OutputType type)
+void LegacyScriptPubKeyMan::LearnRelatedScripts(WalletBatch& batch, const CPubKey& key, OutputType type)
 {
     assert(type != OutputType::BECH32M);
     if (key.IsCompressed() && (type == OutputType::P2SH_SEGWIT || type == OutputType::BECH32)) {
@@ -1458,14 +1458,14 @@ void LegacyScriptPubKeyMan::LearnRelatedScripts(const CPubKey& key, OutputType t
         // Make sure the resulting program is solvable.
         const auto desc = InferDescriptor(witprog, *this);
         assert(desc && desc->IsSolvable());
-        AddCScript(witprog);
+        AddCScriptWithDB(batch, witprog);
     }
 }
 
-void LegacyScriptPubKeyMan::LearnAllRelatedScripts(const CPubKey& key)
+void LegacyScriptPubKeyMan::LearnAllRelatedScripts(WalletBatch& batch, const CPubKey& key)
 {
     // OutputType::P2SH_SEGWIT always adds all necessary scripts for all types.
-    LearnRelatedScripts(key, OutputType::P2SH_SEGWIT);
+    LearnRelatedScripts(batch, key, OutputType::P2SH_SEGWIT);
 }
 
 std::vector<CKeyPool> LegacyScriptPubKeyMan::MarkReserveKeysAsUsed(WalletBatch& batch, int64_t keypool_id)
@@ -1485,7 +1485,7 @@ std::vector<CKeyPool> LegacyScriptPubKeyMan::MarkReserveKeysAsUsed(WalletBatch& 
         if (batch.ReadPool(index, keypool)) { //TODO: This should be unnecessary
             m_pool_key_to_index.erase(keypool.vchPubKey.GetID());
         }
-        LearnAllRelatedScripts(keypool.vchPubKey);
+        LearnAllRelatedScripts(batch, keypool.vchPubKey);
         batch.ErasePool(index);
         WalletLogPrintf("keypool index %d removed\n", index);
         it = setKeyPool->erase(it);

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -314,7 +314,7 @@ util::Result<CTxDestination> LegacyScriptPubKeyMan::GetReservedDestination(Walle
     return GetDestinationForKey(keypool.vchPubKey, type);
 }
 
-bool LegacyScriptPubKeyMan::TopUpInactiveHDChain(const CKeyID seed_id, int64_t index, bool internal)
+bool LegacyScriptPubKeyMan::TopUpInactiveHDChain(WalletBatch& batch, const CKeyID seed_id, int64_t index, bool internal)
 {
     LOCK(cs_KeyStore);
 
@@ -331,7 +331,7 @@ bool LegacyScriptPubKeyMan::TopUpInactiveHDChain(const CKeyID seed_id, int64_t i
         chain.m_next_external_index = std::max(chain.m_next_external_index, index + 1);
     }
 
-    TopUpChain(chain, 0);
+    TopUpChain(batch, chain, 0);
 
     return true;
 }
@@ -381,7 +381,7 @@ std::vector<WalletDestination> LegacyScriptPubKeyMan::MarkUnusedAddresses(Wallet
                     bool internal = (path[1] & ~BIP32_HARDENED_KEY_LIMIT) != 0;
                     int64_t index = path[2] & ~BIP32_HARDENED_KEY_LIMIT;
 
-                    if (!TopUpInactiveHDChain(meta.hd_seed_id, index, internal)) {
+                    if (!TopUpInactiveHDChain(batch, meta.hd_seed_id, index, internal)) {
                         WalletLogPrintf("%s: Adding inactive seed keys failed\n", __func__);
                     }
                 }
@@ -1270,11 +1270,11 @@ bool LegacyScriptPubKeyMan::TopUp(WalletBatch& batch, unsigned int kpSize)
         return false;
     }
 
-    if (!TopUpChain(m_hd_chain, kpSize)) {
+    if (!TopUpChain(batch, m_hd_chain, kpSize)) {
         return false;
     }
     for (auto& [chain_id, chain] : m_inactive_hd_chains) {
-        if (!TopUpChain(chain, kpSize)) {
+        if (!TopUpChain(batch, chain, kpSize)) {
             return false;
         }
     }
@@ -1282,7 +1282,7 @@ bool LegacyScriptPubKeyMan::TopUp(WalletBatch& batch, unsigned int kpSize)
     return true;
 }
 
-bool LegacyScriptPubKeyMan::TopUpChain(CHDChain& chain, unsigned int kpSize)
+bool LegacyScriptPubKeyMan::TopUpChain(WalletBatch& batch, CHDChain& chain, unsigned int kpSize)
 {
     LOCK(cs_KeyStore);
 
@@ -1314,7 +1314,6 @@ bool LegacyScriptPubKeyMan::TopUpChain(CHDChain& chain, unsigned int kpSize)
         missingInternal = 0;
     }
     bool internal = false;
-    WalletBatch batch(m_storage.GetDatabase());
     for (int64_t i = missingInternal + missingExternal; i--;) {
         if (i < missingInternal) {
             internal = true;

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -172,7 +172,7 @@ protected:
 public:
     explicit ScriptPubKeyMan(WalletStorage& storage) : m_storage(storage) {}
     virtual ~ScriptPubKeyMan() {};
-    virtual util::Result<CTxDestination> GetNewDestination(const OutputType type) { return util::Error{Untranslated("Not supported")}; }
+    virtual util::Result<CTxDestination> GetNewDestination(WalletBatch& batch, const OutputType type) { return util::Error{Untranslated("Not supported")}; }
     virtual isminetype IsMine(const CScript& script) const { return ISMINE_NO; }
 
     //! Check that the given decryption key is valid for this ScriptPubKeyMan, i.e. it decrypts all of the keys handled by it.
@@ -334,7 +334,7 @@ private:
     std::map<int64_t, CKeyID> m_index_to_reserved_key;
 
     //! Fetches a key from the keypool
-    bool GetKeyFromPool(CPubKey &key, const OutputType type);
+    bool GetKeyFromPool(WalletBatch& batch, CPubKey &key, const OutputType type);
 
     /**
      * Reserves a key from the keypool and sets nIndex to its index
@@ -368,7 +368,7 @@ private:
 public:
     LegacyScriptPubKeyMan(WalletStorage& storage, int64_t keypool_size) : ScriptPubKeyMan(storage), m_keypool_size(keypool_size) {}
 
-    util::Result<CTxDestination> GetNewDestination(const OutputType type) override;
+    util::Result<CTxDestination> GetNewDestination(WalletBatch& batch, const OutputType type) override;
     isminetype IsMine(const CScript& script) const override;
 
     bool CheckDecryptionKey(const CKeyingMaterial& master_key, bool accept_no_keys = false) override;
@@ -590,7 +590,7 @@ public:
 
     mutable RecursiveMutex cs_desc_man;
 
-    util::Result<CTxDestination> GetNewDestination(const OutputType type) override;
+    util::Result<CTxDestination> GetNewDestination(WalletBatch& batch, const OutputType type) override;
     isminetype IsMine(const CScript& script) const override;
 
     bool CheckDecryptionKey(const CKeyingMaterial& master_key, bool accept_no_keys = false) override;

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -187,7 +187,7 @@ public:
       * when something from the address pool is removed, excluding GetNewDestination and GetReservedDestination.
       * External wallet code is primarily responsible for topping up prior to fetching new addresses
       */
-    virtual bool TopUp(unsigned int size = 0) { return false; }
+    virtual bool TopUp(WalletBatch& batch, unsigned int size = 0) { return false; }
 
     /** Mark unused addresses as being used
      * Affects all keys up to and including the one determined by provided script.
@@ -196,7 +196,7 @@ public:
      *
      * @return All of the addresses affected
      */
-    virtual std::vector<WalletDestination> MarkUnusedAddresses(const CScript& script) { return {}; }
+    virtual std::vector<WalletDestination> MarkUnusedAddresses(WalletBatch& batch, const CScript& script) { return {}; }
 
     /** Sets up the key generation stuff, i.e. generates new HD seeds and sets them as active.
       * Returns false if already setup or setup fails, true if setup is successful
@@ -378,9 +378,9 @@ public:
     void KeepDestination(WalletBatch& batch, int64_t index, const OutputType& type) override;
     void ReturnDestination(int64_t index, bool internal, const CTxDestination&) override;
 
-    bool TopUp(unsigned int size = 0) override;
+    bool TopUp(WalletBatch& batch, unsigned int size = 0) override;
 
-    std::vector<WalletDestination> MarkUnusedAddresses(const CScript& script) override;
+    std::vector<WalletDestination> MarkUnusedAddresses(WalletBatch& batch, const CScript& script) override;
 
     //! Upgrade stored CKeyMetadata objects to store key origin info as KeyOriginInfo
     void UpgradeKeyMetadata();
@@ -603,9 +603,9 @@ public:
     // and is used to expand the descriptor in GetNewDestination. DescriptorScriptPubKeyMan relies
     // more on ephemeral data than LegacyScriptPubKeyMan. For wallets using unhardened derivation
     // (with or without private keys), the "keypool" is a single xpub.
-    bool TopUp(unsigned int size = 0) override;
+    bool TopUp(WalletBatch& batch, unsigned int size = 0) override;
 
-    std::vector<WalletDestination> MarkUnusedAddresses(const CScript& script) override;
+    std::vector<WalletDestination> MarkUnusedAddresses(WalletBatch& batch, const CScript& script) override;
 
     bool IsHDEnabled() const override;
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -610,7 +610,7 @@ public:
     bool IsHDEnabled() const override;
 
     //! Setup descriptors based on the given CExtkey
-    bool SetupDescriptorGeneration(const CExtKey& master_key, OutputType addr_type, bool internal);
+    bool SetupDescriptorGeneration(WalletBatch& batch, const CExtKey& master_key, OutputType addr_type, bool internal);
 
     /** Provide a descriptor at setup time
     * Returns false if already setup or setup fails, true if setup is successful

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -362,9 +362,9 @@ private:
      *
      * @return true if seed was found and keys were derived. false if unable to derive seeds
      */
-    bool TopUpInactiveHDChain(const CKeyID seed_id, int64_t index, bool internal);
+    bool TopUpInactiveHDChain(WalletBatch& batch, const CKeyID seed_id, int64_t index, bool internal);
 
-    bool TopUpChain(CHDChain& chain, unsigned int size);
+    bool TopUpChain(WalletBatch& batch, CHDChain& chain, unsigned int size);
 public:
     LegacyScriptPubKeyMan(WalletStorage& storage, int64_t keypool_size) : ScriptPubKeyMan(storage), m_keypool_size(keypool_size) {}
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -612,11 +612,6 @@ public:
     //! Setup descriptors based on the given CExtkey
     bool SetupDescriptorGeneration(WalletBatch& batch, const CExtKey& master_key, OutputType addr_type, bool internal);
 
-    /** Provide a descriptor at setup time
-    * Returns false if already setup or setup fails, true if setup is successful
-    */
-    bool SetupDescriptor(std::unique_ptr<Descriptor>desc);
-
     bool HavePrivateKeys() const override;
 
     std::optional<int64_t> GetOldestKeyPoolTime() const override;

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -496,13 +496,13 @@ public:
      * software, as FillableSigningProvider automatically does this implicitly for all
      * keys now.
      */
-    void LearnRelatedScripts(const CPubKey& key, OutputType);
+    void LearnRelatedScripts(WalletBatch& batch, const CPubKey& key, OutputType);
 
     /**
      * Same as LearnRelatedScripts, but when the OutputType is not known (and could
      * be anything).
      */
-    void LearnAllRelatedScripts(const CPubKey& key);
+    void LearnAllRelatedScripts(WalletBatch& batch, const CPubKey& key);
 
     /**
      * Marks all keys in the keypool up to and including the provided key as used.

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -647,7 +647,7 @@ public:
     void UpdateWalletDescriptor(WalletDescriptor& descriptor);
     bool CanUpdateToWalletDescriptor(const WalletDescriptor& descriptor, std::string& error);
     void AddDescriptorKey(const CKey& key, const CPubKey &pubkey);
-    void WriteDescriptor();
+    void WriteDescriptor(WalletBatch& batch);
 
     WalletDescriptor GetWalletDescriptor() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys() const override;

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -511,7 +511,7 @@ public:
      *
      * @return All affected keys
      */
-    std::vector<CKeyPool> MarkReserveKeysAsUsed(int64_t keypool_id) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
+    std::vector<CKeyPool> MarkReserveKeysAsUsed(WalletBatch& batch, int64_t keypool_id) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
     const std::map<CKeyID, int64_t>& GetAllReserveKeys() const { return m_pool_key_to_index; }
 
     std::set<CKeyID> GetKeys() const override;

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -179,8 +179,8 @@ public:
     virtual bool CheckDecryptionKey(const CKeyingMaterial& master_key, bool accept_no_keys = false) { return false; }
     virtual bool Encrypt(const CKeyingMaterial& master_key, WalletBatch* batch) { return false; }
 
-    virtual util::Result<CTxDestination> GetReservedDestination(const OutputType type, bool internal, int64_t& index, CKeyPool& keypool) { return util::Error{Untranslated("Not supported")}; }
-    virtual void KeepDestination(int64_t index, const OutputType& type) {}
+    virtual util::Result<CTxDestination> GetReservedDestination(WalletBatch& batch, const OutputType type, bool internal, int64_t& index, CKeyPool& keypool) { return util::Error{Untranslated("Not supported")}; }
+    virtual void KeepDestination(WalletBatch& batch, int64_t index, const OutputType& type) {}
     virtual void ReturnDestination(int64_t index, bool internal, const CTxDestination& addr) {}
 
     /** Fills internal address pool. Use within ScriptPubKeyMan implementations should be used sparingly and only
@@ -350,7 +350,7 @@ private:
      *     was not found in the wallet, or was misclassified in the internal
      *     or external keypool
      */
-    bool ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool, bool fRequestedInternal);
+    bool ReserveKeyFromKeyPool(WalletBatch& batch, int64_t& nIndex, CKeyPool& keypool, bool fRequestedInternal);
 
     /**
      * Like TopUp() but adds keys for inactive HD chains.
@@ -374,8 +374,8 @@ public:
     bool CheckDecryptionKey(const CKeyingMaterial& master_key, bool accept_no_keys = false) override;
     bool Encrypt(const CKeyingMaterial& master_key, WalletBatch* batch) override;
 
-    util::Result<CTxDestination> GetReservedDestination(const OutputType type, bool internal, int64_t& index, CKeyPool& keypool) override;
-    void KeepDestination(int64_t index, const OutputType& type) override;
+    util::Result<CTxDestination> GetReservedDestination(WalletBatch& batch, const OutputType type, bool internal, int64_t& index, CKeyPool& keypool) override;
+    void KeepDestination(WalletBatch& batch, int64_t index, const OutputType& type) override;
     void ReturnDestination(int64_t index, bool internal, const CTxDestination&) override;
 
     bool TopUp(unsigned int size = 0) override;
@@ -596,7 +596,7 @@ public:
     bool CheckDecryptionKey(const CKeyingMaterial& master_key, bool accept_no_keys = false) override;
     bool Encrypt(const CKeyingMaterial& master_key, WalletBatch* batch) override;
 
-    util::Result<CTxDestination> GetReservedDestination(const OutputType type, bool internal, int64_t& index, CKeyPool& keypool) override;
+    util::Result<CTxDestination> GetReservedDestination(WalletBatch& batch, const OutputType type, bool internal, int64_t& index, CKeyPool& keypool) override;
     void ReturnDestination(int64_t index, bool internal, const CTxDestination& addr) override;
 
     // Tops up the descriptor cache and m_map_script_pub_keys. The cache is stored in the wallet file

--- a/src/wallet/test/walletload_tests.cpp
+++ b/src/wallet/test/walletload_tests.cpp
@@ -90,7 +90,8 @@ BOOST_FIXTURE_TEST_CASE(wallet_load_verif_crypted_key_checksum, TestingSetup)
         BOOST_CHECK(legacy_spkm->SetupGeneration(true));
 
         // Get the first key in the wallet
-        CTxDestination dest = *Assert(legacy_spkm->GetNewDestination(OutputType::LEGACY));
+        WalletBatch batch(wallet->GetDatabase());
+        CTxDestination dest = *Assert(legacy_spkm->GetNewDestination(batch, OutputType::LEGACY));
         CKeyID key_id = GetKeyForDestination(*legacy_spkm, dest);
         BOOST_CHECK(legacy_spkm->GetKey(key_id, first_key));
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3585,6 +3585,7 @@ void CWallet::SetupDescriptorScriptPubKeyMans(const CExtKey& master_key)
 {
     AssertLockHeld(cs_wallet);
 
+    WalletBatch batch(GetDatabase());
     for (bool internal : {false, true}) {
         for (OutputType t : OUTPUT_TYPES) {
             auto spk_manager = std::unique_ptr<DescriptorScriptPubKeyMan>(new DescriptorScriptPubKeyMan(*this, m_keypool_size));
@@ -3596,7 +3597,7 @@ void CWallet::SetupDescriptorScriptPubKeyMans(const CExtKey& master_key)
                     throw std::runtime_error(std::string(__func__) + ": Could not encrypt new descriptors");
                 }
             }
-            spk_manager->SetupDescriptorGeneration(master_key, t, internal);
+            spk_manager->SetupDescriptorGeneration(batch, master_key, t, internal);
             uint256 id = spk_manager->GetID();
             m_spk_managers[id] = std::move(spk_manager);
             AddActiveScriptPubKeyMan(id, t, internal);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1613,7 +1613,7 @@ bool CWallet::LoadWalletFlags(uint64_t flags)
     return true;
 }
 
-void CWallet::InitWalletFlags(uint64_t flags)
+void CWallet::InitWalletFlags(uint64_t flags, WalletBatch& batch)
 {
     LOCK(cs_wallet);
 
@@ -1622,7 +1622,7 @@ void CWallet::InitWalletFlags(uint64_t flags)
     // This should only be used once, when creating a new wallet - so current flags are expected to be blank
     assert(m_wallet_flags == 0);
 
-    if (!WalletBatch(GetDatabase()).WriteWalletFlags(flags)) {
+    if (!batch.WriteWalletFlags(flags)) {
         throw std::runtime_error(std::string(__func__) + ": writing wallet flags failed");
     }
 
@@ -2964,10 +2964,12 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
                      !walletInstance->IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET);
     if (fFirstRun)
     {
-        // ensure this wallet.dat can only be opened by clients supporting HD with chain split and expects no default key
-        walletInstance->SetMinVersion(FEATURE_LATEST);
+        WalletBatch batch(walletInstance->GetDatabase());
 
-        walletInstance->InitWalletFlags(wallet_creation_flags);
+        // ensure this wallet.dat can only be opened by clients supporting HD with chain split and expects no default key
+        walletInstance->SetMinVersion(FEATURE_LATEST, &batch);
+
+        walletInstance->InitWalletFlags(wallet_creation_flags, batch);
 
         // Only create LegacyScriptPubKeyMan when not descriptor wallet
         if (!walletInstance->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1374,7 +1374,7 @@ void CWallet::SyncTransaction(const CTransactionRef& ptx, const SyncTxState& sta
 
 void CWallet::transactionAddedToMempool(const CTransactionRef& tx) {
     LOCK(cs_wallet);
-    WalletBatch batch(GetDatabase(), /*fFlushOnClose=*/false, /*initialize=*/false);
+    WalletBatch batch(GetDatabase(), /*fFlushOnClose=*/false, /*initialize=*/false, /*is_txn=*/true);
     SyncTransaction(tx, TxStateInMempool{}, batch);
 
     auto it = mapWallet.find(tx->GetHash());
@@ -1416,7 +1416,7 @@ void CWallet::transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRe
         // distinguishing between conflicted and unconfirmed transactions are
         // imperfect, and could be improved in general, see
         // https://github.com/bitcoin-core/bitcoin-devwiki/wiki/Wallet-Transaction-Conflict-Tracking
-        WalletBatch batch(GetDatabase(), /*fFlushOnClose=*/false, /*initialize=*/false);
+        WalletBatch batch(GetDatabase(), /*fFlushOnClose=*/false, /*initialize=*/false, /*is_txn=*/true);
         SyncTransaction(tx, TxStateInactive{}, batch);
     }
 }
@@ -1428,7 +1428,7 @@ void CWallet::blockConnected(const interfaces::BlockInfo& block)
 
     m_last_block_processed_height = block.height;
     m_last_block_processed = block.hash;
-    WalletBatch batch(GetDatabase(), /*fFlushOnClose=*/false, /*initialize=*/false);
+    WalletBatch batch(GetDatabase(), /*fFlushOnClose=*/false, /*initialize=*/false, /*is_txn=*/true);
     for (size_t index = 0; index < block.data->vtx.size(); index++) {
         SyncTransaction(block.data->vtx[index], TxStateConfirmed{block.hash, block.height, static_cast<int>(index)}, batch);
         transactionRemovedFromMempool(block.data->vtx[index], MemPoolRemovalReason::BLOCK);
@@ -1446,7 +1446,7 @@ void CWallet::blockDisconnected(const interfaces::BlockInfo& block)
     // future with a stickier abandoned state or even removing abandontransaction call.
     m_last_block_processed_height = block.height - 1;
     m_last_block_processed = *Assert(block.prev_hash);
-    WalletBatch batch(GetDatabase(), /*fFlushOnClose=*/false, /*initialize=*/false);
+    WalletBatch batch(GetDatabase(), /*fFlushOnClose=*/false, /*initialize=*/false, /*is_txn=*/true);
     for (const CTransactionRef& ptx : Assert(block.data)->vtx) {
         SyncTransaction(ptx, TxStateInactive{}, batch);
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3802,7 +3802,7 @@ ScriptPubKeyMan* CWallet::AddWalletDescriptor(WalletDescriptor& desc, const Flat
     }
 
     // Save the descriptor to DB
-    spk_man->WriteDescriptor();
+    spk_man->WriteDescriptor(batch);
 
     return spk_man;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1175,7 +1175,9 @@ bool CWallet::LoadToWallet(const uint256& hash, const UpdateWalletTxFn& fill_wtx
         if (it != mapWallet.end()) {
             CWalletTx& prevtx = it->second;
             if (auto* prev = prevtx.state<TxStateConflicted>()) {
-                MarkConflicted(prev->conflicting_block_hash, prev->conflicting_block_height, wtx.GetHash());
+                // Do not flush the wallet here for performance reasons
+                WalletBatch batch(GetDatabase(), false);
+                MarkConflicted(batch, prev->conflicting_block_hash, prev->conflicting_block_height, wtx.GetHash());
             }
         }
     }
@@ -1187,6 +1189,8 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
     const CTransaction& tx = *ptx;
     {
         AssertLockHeld(cs_wallet);
+        // Do not flush the wallet here for performance reasons
+        WalletBatch batch(GetDatabase(), false /*fFlushOnClose*/);
 
         if (auto* conf = std::get_if<TxStateConfirmed>(&state)) {
             for (const CTxIn& txin : tx.vin) {
@@ -1194,7 +1198,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
                 while (range.first != range.second) {
                     if (range.first->second != tx.GetHash()) {
                         WalletLogPrintf("Transaction %s (in block %s) conflicts with wallet transaction %s (both spend %s:%i)\n", tx.GetHash().ToString(), conf->confirmed_block_hash.ToString(), range.first->second.ToString(), range.first->first.hash.ToString(), range.first->first.n);
-                        MarkConflicted(conf->confirmed_block_hash, conf->confirmed_block_height, range.first->second);
+                        MarkConflicted(batch, conf->confirmed_block_hash, conf->confirmed_block_height, range.first->second);
                     }
                     range.first++;
                 }
@@ -1227,7 +1231,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
                         // (e.g. it wasn't generated on this node or we're restoring from backup)
                         // add it to the address book for proper transaction accounting
                         if (!*dest.internal && !FindAddressBookEntry(dest.dest, /* allow_change= */ false)) {
-                            SetAddressBook(dest.dest, "", AddressPurpose::RECEIVE);
+                            SetAddressBookWithDB(batch, dest.dest, "", AddressPurpose::RECEIVE);
                         }
                     }
                 }
@@ -1236,7 +1240,6 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
             // Block disconnection override an abandoned tx as unconfirmed
             // which means user may have to call abandontransaction again
             TxState tx_state = std::visit([](auto&& s) -> TxState { return s; }, state);
-            WalletBatch batch(GetDatabase(), false /*fFlushOnClose*/);
             CWalletTx* wtx = AddToWallet(batch, MakeTransactionRef(tx), tx_state, /*update_wtx=*/nullptr, rescanning_old_block);
             if (!wtx) {
                 // Can only be nullptr if there was a db write error (missing db, read-only db or a db engine internal writing error).
@@ -1325,7 +1328,7 @@ bool CWallet::AbandonTransaction(const uint256& hashTx)
     return true;
 }
 
-void CWallet::MarkConflicted(const uint256& hashBlock, int conflicting_height, const uint256& hashTx)
+void CWallet::MarkConflicted(WalletBatch& batch, const uint256& hashBlock, int conflicting_height, const uint256& hashTx)
 {
     LOCK(cs_wallet);
 
@@ -1336,9 +1339,6 @@ void CWallet::MarkConflicted(const uint256& hashBlock, int conflicting_height, c
     // case.
     if (conflictconfirms >= 0)
         return;
-
-    // Do not flush the wallet here for performance reasons
-    WalletBatch batch(GetDatabase(), false);
 
     std::set<uint256> todo;
     std::set<uint256> done;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1008,11 +1008,16 @@ bool CWallet::IsSpentKey(const CScript& scriptPubKey) const
     return false;
 }
 
-CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx, bool fFlushOnClose, bool rescanning_old_block)
+CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx, bool rescanning_old_block)
+{
+    WalletBatch batch(GetDatabase(), true);
+    return AddToWallet(batch, tx, state, update_wtx, rescanning_old_block);
+}
+
+CWalletTx* CWallet::AddToWallet(WalletBatch& batch, CTransactionRef tx, const TxState& state,
+                                const UpdateWalletTxFn& update_wtx, bool rescanning_old_block)
 {
     LOCK(cs_wallet);
-
-    WalletBatch batch(GetDatabase(), fFlushOnClose);
 
     uint256 hash = tx->GetHash();
 
@@ -1231,7 +1236,8 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
             // Block disconnection override an abandoned tx as unconfirmed
             // which means user may have to call abandontransaction again
             TxState tx_state = std::visit([](auto&& s) -> TxState { return s; }, state);
-            CWalletTx* wtx = AddToWallet(MakeTransactionRef(tx), tx_state, /*update_wtx=*/nullptr, /*fFlushOnClose=*/false, rescanning_old_block);
+            WalletBatch batch(GetDatabase(), false /*fFlushOnClose*/);
+            CWalletTx* wtx = AddToWallet(batch, MakeTransactionRef(tx), tx_state, /*update_wtx=*/nullptr, rescanning_old_block);
             if (!wtx) {
                 // Can only be nullptr if there was a db write error (missing db, read-only db or a db engine internal writing error).
                 // As we only store arriving transaction in this process, and we don't want an inconsistent state, let's throw an error.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -900,15 +900,11 @@ DBErrors CWallet::ReorderTransactions()
     return DBErrors::LOAD_OK;
 }
 
-int64_t CWallet::IncOrderPosNext(WalletBatch* batch)
+int64_t CWallet::IncOrderPosNext(WalletBatch& batch)
 {
     AssertLockHeld(cs_wallet);
     int64_t nRet = nOrderPosNext++;
-    if (batch) {
-        batch->WriteOrderPosNext(nOrderPosNext);
-    } else {
-        WalletBatch(GetDatabase()).WriteOrderPosNext(nOrderPosNext);
-    }
+    batch.WriteOrderPosNext(nOrderPosNext);
     return nRet;
 }
 
@@ -1035,7 +1031,7 @@ CWalletTx* CWallet::AddToWallet(WalletBatch& batch, CTransactionRef tx, const Tx
     bool fUpdated = update_wtx && update_wtx(wtx, fInsertedNew);
     if (fInsertedNew) {
         wtx.nTimeReceived = GetTime();
-        wtx.nOrderPos = IncOrderPosNext(&batch);
+        wtx.nOrderPos = IncOrderPosNext(batch);
         wtx.m_it_wtxOrdered = wtxOrdered.insert(std::make_pair(wtx.nOrderPos, &wtx));
         wtx.nTimeSmart = ComputeTimeSmart(wtx, rescanning_old_block);
         AddToSpends(wtx, batch);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2496,8 +2496,8 @@ util::Result<CTxDestination> CWallet::GetNewDestination(const OutputType type, c
         return util::Error{strprintf(_("Error: No %s addresses available."), FormatOutputType(type))};
     }
 
-    WalletBatch batch(GetDatabase());
-    auto op_dest = spk_man->GetNewDestination(type);
+    WalletBatch batch(GetDatabase(), /*fFlushOnClose=*/true, /*initialize=*/false);
+    auto op_dest = spk_man->GetNewDestination(batch, type);
     if (op_dest) {
         SetAddressBookWithDB(batch, *op_dest, label, AddressPurpose::RECEIVE);
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1129,7 +1129,7 @@ CWalletTx* CWallet::AddToWallet(WalletBatch& batch, CTransactionRef tx, const Tx
     return &wtx;
 }
 
-bool CWallet::LoadToWallet(const uint256& hash, const UpdateWalletTxFn& fill_wtx)
+bool CWallet::LoadToWallet(WalletBatch& batch, const uint256& hash, const UpdateWalletTxFn& fill_wtx)
 {
     const auto& ins = mapWallet.emplace(std::piecewise_construct, std::forward_as_tuple(hash), std::forward_as_tuple(nullptr, TxStateInactive{}));
     CWalletTx& wtx = ins.first->second;
@@ -1160,8 +1160,6 @@ bool CWallet::LoadToWallet(const uint256& hash, const UpdateWalletTxFn& fill_wtx
     if (/* insertion took place */ ins.second) {
         wtx.m_it_wtxOrdered = wtxOrdered.insert(std::make_pair(wtx.nOrderPos, &wtx));
     }
-    // Do not flush the wallet here for performance reasons
-    WalletBatch batch(GetDatabase(), false);
     AddToSpends(wtx, batch);
     for (const CTxIn& txin : wtx.tx->vin) {
         auto it = mapWallet.find(txin.prevout.hash);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2496,9 +2496,10 @@ util::Result<CTxDestination> CWallet::GetNewDestination(const OutputType type, c
         return util::Error{strprintf(_("Error: No %s addresses available."), FormatOutputType(type))};
     }
 
+    WalletBatch batch(GetDatabase());
     auto op_dest = spk_man->GetNewDestination(type);
     if (op_dest) {
-        SetAddressBook(*op_dest, label, AddressPurpose::RECEIVE);
+        SetAddressBookWithDB(batch, *op_dest, label, AddressPurpose::RECEIVE);
     }
 
     return op_dest;
@@ -3793,7 +3794,7 @@ ScriptPubKeyMan* CWallet::AddWalletDescriptor(WalletDescriptor& desc, const Flat
             for (const auto& script : script_pub_keys) {
                 CTxDestination dest;
                 if (ExtractDestination(script, dest)) {
-                    SetAddressBook(dest, label, AddressPurpose::RECEIVE);
+                    SetAddressBookWithDB(batch, dest, label, AddressPurpose::RECEIVE);
                 }
             }
         }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -320,7 +320,7 @@ private:
      * Should be called with rescanning_old_block set to true, if the transaction is
      * not discovered in real time, but during a rescan of old blocks.
      */
-    bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const SyncTxState& state, bool fUpdate, bool rescanning_old_block) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const SyncTxState& state, WalletBatch& batch, bool fUpdate, bool rescanning_old_block) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /** Mark a transaction (and its in-wallet descendants) as conflicting with a particular block. */
     void MarkConflicted(WalletBatch& batch, const uint256& hashBlock, int conflicting_height, const uint256& hashTx);
@@ -330,7 +330,7 @@ private:
 
     void SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator>) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    void SyncTransaction(const CTransactionRef& tx, const SyncTxState& state, bool update_tx = true, bool rescanning_old_block = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void SyncTransaction(const CTransactionRef& tx, const SyncTxState& state, WalletBatch& batch, bool update_tx = true, bool rescanning_old_block = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /** WalletFlags set on this wallet. */
     std::atomic<uint64_t> m_wallet_flags{0};

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -323,7 +323,7 @@ private:
     bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const SyncTxState& state, bool fUpdate, bool rescanning_old_block) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /** Mark a transaction (and its in-wallet descendants) as conflicting with a particular block. */
-    void MarkConflicted(const uint256& hashBlock, int conflicting_height, const uint256& hashTx);
+    void MarkConflicted(WalletBatch& batch, const uint256& hashBlock, int conflicting_height, const uint256& hashTx);
 
     /** Mark a transaction's inputs dirty, thus forcing the outputs to be recomputed */
     void MarkInputsDirty(const CTransactionRef& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -550,7 +550,11 @@ public:
      * Add the transaction to the wallet, wrapping it up inside a CWalletTx
      * @return the recently added wtx pointer or nullptr if there was a db write error.
      */
-    CWalletTx* AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx=nullptr, bool fFlushOnClose=true, bool rescanning_old_block = false);
+    CWalletTx* AddToWallet(WalletBatch& batch, CTransactionRef tx, const TxState& state,
+                           const UpdateWalletTxFn& update_wtx = nullptr, bool rescanning_old_block = false);
+    // Wrapper for 'AddToWallet' creating the 'WalletBatch' internally and flushing it on close by default
+    CWalletTx* AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx=nullptr, bool rescanning_old_block = false);
+
     bool LoadToWallet(const uint256& hash, const UpdateWalletTxFn& fill_wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void transactionAddedToMempool(const CTransactionRef& tx) override;
     void blockConnected(const interfaces::BlockInfo& block) override;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -555,7 +555,7 @@ public:
     // Wrapper for 'AddToWallet' creating the 'WalletBatch' internally and flushing it on close by default
     CWalletTx* AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx=nullptr, bool rescanning_old_block = false);
 
-    bool LoadToWallet(const uint256& hash, const UpdateWalletTxFn& fill_wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool LoadToWallet(WalletBatch& batch, const uint256& hash, const UpdateWalletTxFn& fill_wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void transactionAddedToMempool(const CTransactionRef& tx) override;
     void blockConnected(const interfaces::BlockInfo& block) override;
     void blockDisconnected(const interfaces::BlockInfo& block) override;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -301,8 +301,8 @@ private:
      */
     typedef std::unordered_multimap<COutPoint, uint256, SaltedOutpointHasher> TxSpends;
     TxSpends mapTxSpends GUARDED_BY(cs_wallet);
-    void AddToSpends(const COutPoint& outpoint, const uint256& wtxid, WalletBatch* batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    void AddToSpends(const CWalletTx& wtx, WalletBatch* batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void AddToSpends(const COutPoint& outpoint, const uint256& wtxid, WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void AddToSpends(const CWalletTx& wtx, WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /**
      * Add a transaction to the wallet, or update it.  confirm.block_* should

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -935,10 +935,11 @@ public:
     void LoadDescriptorScriptPubKeyMan(uint256 id, WalletDescriptor& desc);
 
     //! Adds the active ScriptPubKeyMan for the specified type and internal. Writes it to the wallet file
+    //! @param[in] batch The process db handler reference
     //! @param[in] id The unique id for the ScriptPubKeyMan
     //! @param[in] type The OutputType this ScriptPubKeyMan provides addresses for
     //! @param[in] internal Whether this ScriptPubKeyMan provides change addresses
-    void AddActiveScriptPubKeyMan(uint256 id, OutputType type, bool internal);
+    void AddActiveScriptPubKeyMan(WalletBatch& batch, uint256 id, OutputType type, bool internal);
 
     //! Loads an active ScriptPubKeyMan for the specified type and internal. (used by LoadWallet)
     //! @param[in] id The unique id for the ScriptPubKeyMan
@@ -947,10 +948,11 @@ public:
     void LoadActiveScriptPubKeyMan(uint256 id, OutputType type, bool internal);
 
     //! Remove specified ScriptPubKeyMan from set of active SPK managers. Writes the change to the wallet file.
+    //! @param[in] batch The process db handler reference
     //! @param[in] id The unique id for the ScriptPubKeyMan
     //! @param[in] type The OutputType this ScriptPubKeyMan provides addresses for
     //! @param[in] internal Whether this ScriptPubKeyMan provides change addresses
-    void DeactivateScriptPubKeyMan(uint256 id, OutputType type, bool internal);
+    void DeactivateScriptPubKeyMan(WalletBatch& batch, uint256 id, OutputType type, bool internal);
 
     //! Create new DescriptorScriptPubKeyMans and add them to the wallet
     void SetupDescriptorScriptPubKeyMans(const CExtKey& master_key) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -853,7 +853,7 @@ public:
     /** overwrite all flags by the given uint64_t
        flags must be uninitialised (or 0)
        only known flags may be present */
-    void InitWalletFlags(uint64_t flags);
+    void InitWalletFlags(uint64_t flags, WalletBatch& batch);
     /** Loads the flags into the wallet. (used by LoadWallet) */
     bool LoadWalletFlags(uint64_t flags);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -533,7 +533,7 @@ public:
      * Increment the next transaction order id
      * @return next transaction order id
      */
-    int64_t IncOrderPosNext(WalletBatch *batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    int64_t IncOrderPosNext(WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     DBErrors ReorderTransactions();
 
     void MarkDirty();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -192,11 +192,11 @@ public:
     }
 
     //! Reserve an address
-    util::Result<CTxDestination> GetReservedDestination(bool internal);
+    util::Result<CTxDestination> GetReservedDestination(WalletBatch& batch, bool internal);
     //! Return reserved address
     void ReturnDestination();
     //! Keep the address. Do not return its key to the keypool when this object goes out of scope
-    void KeepDestination();
+    void KeepDestination(WalletBatch& batch);
 };
 
 /**

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -178,8 +178,8 @@ bool WalletBatch::WriteBestBlock(const CBlockLocator& locator)
 
 bool WalletBatch::ReadBestBlock(CBlockLocator& locator)
 {
-    if (m_batch->Read(DBKeys::BESTBLOCK, locator) && !locator.vHave.empty()) return true;
-    return m_batch->Read(DBKeys::BESTBLOCK_NOMERKLE, locator);
+    if (ReadIC(DBKeys::BESTBLOCK, locator) && !locator.vHave.empty()) return true;
+    return ReadIC(DBKeys::BESTBLOCK_NOMERKLE, locator);
 }
 
 bool WalletBatch::WriteOrderPosNext(int64_t nOrderPosNext)
@@ -189,7 +189,7 @@ bool WalletBatch::WriteOrderPosNext(int64_t nOrderPosNext)
 
 bool WalletBatch::ReadPool(int64_t nPool, CKeyPool& keypool)
 {
-    return m_batch->Read(std::make_pair(DBKeys::POOL, nPool), keypool);
+    return ReadIC(std::make_pair(DBKeys::POOL, nPool), keypool);
 }
 
 bool WalletBatch::WritePool(int64_t nPool, const CKeyPool& keypool)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -66,6 +66,19 @@ const std::unordered_set<std::string> LEGACY_TYPES{CRYPTED_KEY, CSCRIPT, DEFAULT
 // WalletBatch
 //
 
+bool WalletBatch::TryInit()
+{
+    if (m_batch) return false;
+    m_batch = m_database.MakeBatch(m_flush_on_close);
+    if (m_is_txn) {
+        if (!TxnBegin()) {
+            LogPrintf("%s: txn begin failed, reverting to synchronized write mode\n", __func__);
+            m_is_txn = false;
+        }
+    }
+    return true;
+}
+
 bool WalletBatch::WriteName(const std::string& strAddress, const std::string& strName)
 {
     return WriteIC(std::make_pair(DBKeys::NAME, strAddress), strName);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -321,7 +321,7 @@ public:
 };
 
 static bool
-ReadKeyValue(CWallet* pwallet, DataStream& ssKey, CDataStream& ssValue,
+ReadKeyValue(CWallet* pwallet, WalletBatch& batch, DataStream& ssKey, CDataStream& ssValue,
              CWalletScanState &wss, std::string& strType, std::string& strErr, const KeyFilterFn& filter_fn = nullptr) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     try {
@@ -397,7 +397,7 @@ ReadKeyValue(CWallet* pwallet, DataStream& ssKey, CDataStream& ssValue,
 
                 return true;
             };
-            if (!pwallet->LoadToWallet(hash, fill_wtx)) {
+            if (!pwallet->LoadToWallet(batch, hash, fill_wtx)) {
                 return false;
             }
         } else if (strType == DBKeys::WATCHS) {
@@ -765,11 +765,11 @@ ReadKeyValue(CWallet* pwallet, DataStream& ssKey, CDataStream& ssValue,
     return true;
 }
 
-bool ReadKeyValue(CWallet* pwallet, DataStream& ssKey, CDataStream& ssValue, std::string& strType, std::string& strErr, const KeyFilterFn& filter_fn)
+bool ReadKeyValue(CWallet* pwallet, WalletBatch& batch, DataStream& ssKey, CDataStream& ssValue, std::string& strType, std::string& strErr, const KeyFilterFn& filter_fn)
 {
     CWalletScanState dummy_wss;
     LOCK(pwallet->cs_wallet);
-    return ReadKeyValue(pwallet, ssKey, ssValue, dummy_wss, strType, strErr, filter_fn);
+    return ReadKeyValue(pwallet, batch, ssKey, ssValue, dummy_wss, strType, strErr, filter_fn);
 }
 
 bool WalletBatch::IsKeyType(const std::string& strType)
@@ -841,7 +841,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
 
             // Try to be tolerant of single corrupt records:
             std::string strType, strErr;
-            if (!ReadKeyValue(pwallet, ssKey, ssValue, wss, strType, strErr))
+            if (!ReadKeyValue(pwallet, *this, ssKey, ssValue, wss, strType, strErr))
             {
                 if (wss.unexpected_legacy_entry) {
                     strErr = strprintf("Error: Unexpected legacy entry found in descriptor wallet %s. ", pwallet->GetName());

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -218,6 +218,14 @@ private:
         return true;
     }
 
+    template <typename K, typename T>
+    bool ReadIC(const K& key, T& value)
+    {
+        TryInit(); // only if on-demand mode is configured
+
+        return m_batch->Read(key, value);
+    }
+
 public:
 
     /**

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -266,13 +266,7 @@ public:
      *  Initialize the wallet batch on-demand.
      *  no-op if batch was already initialized.
      */
-    bool TryInit()
-    {
-        if (m_batch) return false;
-        m_batch = m_database.MakeBatch(m_flush_on_close);
-        if (m_is_txn) assert(TxnBegin());
-        return true;
-    }
+    bool TryInit();
 
     bool WriteName(const std::string& strAddress, const std::string& strName);
     bool EraseName(const std::string& strAddress);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -303,7 +303,7 @@ void MaybeCompactWalletDB(WalletContext& context);
 using KeyFilterFn = std::function<bool(const std::string&)>;
 
 //! Unserialize a given Key-Value pair and load it into the wallet
-bool ReadKeyValue(CWallet* pwallet, DataStream& ssKey, CDataStream& ssValue, std::string& strType, std::string& strErr, const KeyFilterFn& filter_fn = nullptr);
+bool ReadKeyValue(CWallet* pwallet, WalletBatch& batch, DataStream& ssKey, CDataStream& ssValue, std::string& strType, std::string& strErr, const KeyFilterFn& filter_fn = nullptr);
 
 /** Return object for accessing dummy database with no read/write capabilities. */
 std::unique_ptr<WalletDatabase> CreateDummyWalletDatabase();

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -33,8 +33,9 @@ static void WalletCreate(CWallet* wallet_instance, uint64_t wallet_creation_flag
 {
     LOCK(wallet_instance->cs_wallet);
 
-    wallet_instance->SetMinVersion(FEATURE_LATEST);
-    wallet_instance->InitWalletFlags(wallet_creation_flags);
+    WalletBatch batch(wallet_instance->GetDatabase());
+    wallet_instance->SetMinVersion(FEATURE_LATEST, &batch);
+    wallet_instance->InitWalletFlags(wallet_creation_flags, batch);
 
     if (!wallet_instance->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
         auto spk_man = wallet_instance->GetOrCreateLegacyScriptPubKeyMan();


### PR DESCRIPTION
The block connection process, same as many other wallet processes, contains plenty individual db writes.

This PR batches all the db transaction that occurs along each wallet workflow. Dumping all the information to disk at once atomically at the end of the process.

Then, for BDB, fixed places where we are flushing to db directly on individual writes. e.g we do it in the in the chain sync/scan process, when an output that belongs to the wallet is found if the address is not inside the address book. 

Plus, in several places across the wallet flows, we create new `WalletBatch` objects. Which, internally, mean: Increasing the db references number, try to open the db and, for SQLite, setup and bind the statements.
This PR avoids all this overhead by sharing the same db handler instance through each entire workflow.