### PR TITLE
doc: Correct comments re. units of constants

### DIFF
--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -49,7 +49,7 @@ extern std::atomic_bool fReindex;
 /** Pruning-related variables and constants */
 /** True if we're running in -prune mode. */
 extern bool fPruneMode;
-/** Number of MiB of block files that we're trying to stay below. */
+/** Number of bytes of block files that we're trying to stay below. */
 extern uint64_t nPruneTarget;
 
 // Because validation code takes pointers to the map's CBlockIndex objects, if

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -54,7 +54,7 @@ static constexpr uint8_t PSBT_SEPARATOR = 0x00;
 
 // BIP 174 does not specify a maximum file size, but we set a limit anyway
 // to prevent reading a stream indefinitely and running out of memory.
-const std::streamsize MAX_FILE_SIZE_PSBT = 100000000; // 100 MiB
+const std::streamsize MAX_FILE_SIZE_PSBT = 100000000; // 100 MB
 
 // PSBT version number
 static constexpr uint32_t PSBT_HIGHEST_VERSION = 0;


### PR DESCRIPTION
In https://github.com/bitcoin/bitcoin/pull/15848, darosior fixed up a comment which mis-identified the units of a constant.

Another comment misidentified a value as in MiB rather than MB.