### PR TITLE
build: Check usages of #if defined(...)

### DIFF
--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -4,7 +4,7 @@
 
 #include <bench/bench.h>
 #include <key.h>
-#if defined(HAVE_CONSENSUS_LIB)
+#if HAVE_CONSENSUS_LIB
 #include <script/bitcoinconsensus.h>
 #endif
 #include <script/script.h>
@@ -61,7 +61,7 @@ static void VerifyScriptBench(benchmark::Bench& bench)
         assert(err == SCRIPT_ERR_OK);
         assert(success);
 
-#if defined(HAVE_CONSENSUS_LIB)
+#if HAVE_CONSENSUS_LIB
         CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
         stream << txSpend;
         int csuccess = bitcoinconsensus_verify_script_with_amount(

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -10,18 +10,18 @@
 
 #include <compat/cpuid.h>
 
-#if defined(__linux__) && defined(ENABLE_ARM_SHANI) && !defined(BUILD_BITCOIN_INTERNAL)
+#if defined(__linux__) && ENABLE_ARM_SHANI && !defined(BUILD_BITCOIN_INTERNAL)
 #include <sys/auxv.h>
 #include <asm/hwcap.h>
 #endif
 
-#if defined(MAC_OSX) && defined(ENABLE_ARM_SHANI) && !defined(BUILD_BITCOIN_INTERNAL)
+#if defined(MAC_OSX) && ENABLE_ARM_SHANI && !defined(BUILD_BITCOIN_INTERNAL)
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #endif
 
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
-#if defined(USE_ASM)
+#if USE_ASM
 namespace sha256_sse4
 {
 void Transform(uint32_t* s, const unsigned char* chunk, size_t blocks);
@@ -567,7 +567,7 @@ bool SelfTest() {
     return true;
 }
 
-#if defined(USE_ASM) && (defined(__x86_64__) || defined(__amd64__) || defined(__i386__))
+#if USE_ASM && (defined(__x86_64__) || defined(__amd64__) || defined(__i386__))
 /** Check whether the OS has enabled AVX registers. */
 bool AVXEnabled()
 {
@@ -582,7 +582,7 @@ bool AVXEnabled()
 std::string SHA256AutoDetect()
 {
     std::string ret = "standard";
-#if defined(USE_ASM) && defined(HAVE_GETCPUID)
+#if USE_ASM && defined(HAVE_GETCPUID)
     bool have_sse4 = false;
     bool have_xsave = false;
     bool have_avx = false;
@@ -604,7 +604,7 @@ std::string SHA256AutoDetect()
         have_x86_shani = (ebx >> 29) & 1;
     }
 
-#if defined(ENABLE_X86_SHANI) && !defined(BUILD_BITCOIN_INTERNAL)
+#if ENABLE_X86_SHANI && !defined(BUILD_BITCOIN_INTERNAL)
     if (have_x86_shani) {
         Transform = sha256_x86_shani::Transform;
         TransformD64 = TransformD64Wrapper<sha256_x86_shani::Transform>;
@@ -621,13 +621,13 @@ std::string SHA256AutoDetect()
         TransformD64 = TransformD64Wrapper<sha256_sse4::Transform>;
         ret = "sse4(1way)";
 #endif
-#if defined(ENABLE_SSE41) && !defined(BUILD_BITCOIN_INTERNAL)
+#if ENABLE_SSE41 && !defined(BUILD_BITCOIN_INTERNAL)
         TransformD64_4way = sha256d64_sse41::Transform_4way;
         ret += ",sse41(4way)";
 #endif
     }
 
-#if defined(ENABLE_AVX2) && !defined(BUILD_BITCOIN_INTERNAL)
+#if ENABLE_AVX2 && !defined(BUILD_BITCOIN_INTERNAL)
     if (have_avx2 && have_avx && enabled_avx) {
         TransformD64_8way = sha256d64_avx2::Transform_8way;
         ret += ",avx2(8way)";
@@ -635,7 +635,7 @@ std::string SHA256AutoDetect()
 #endif
 #endif // defined(USE_ASM) && defined(HAVE_GETCPUID)
 
-#if defined(ENABLE_ARM_SHANI) && !defined(BUILD_BITCOIN_INTERNAL)
+#if ENABLE_ARM_SHANI && !defined(BUILD_BITCOIN_INTERNAL)
     bool have_arm_shani = false;
 
 #if defined(__linux__)

--- a/src/crypto/sha256_arm_shani.cpp
+++ b/src/crypto/sha256_arm_shani.cpp
@@ -8,7 +8,7 @@
 // Barry O'Rourke for the mbedTLS project.
 // Variant specialized for 64-byte inputs added by Pieter Wuille.
 
-#ifdef ENABLE_ARM_SHANI
+#if ENABLE_ARM_SHANI
 
 #include <array>
 #include <cstdint>

--- a/src/crypto/sha256_avx2.cpp
+++ b/src/crypto/sha256_avx2.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifdef ENABLE_AVX2
+#if ENABLE_AVX2
 
 #include <stdint.h>
 #include <immintrin.h>

--- a/src/crypto/sha256_sse41.cpp
+++ b/src/crypto/sha256_sse41.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifdef ENABLE_SSE41
+#if ENABLE_SSE41
 
 #include <stdint.h>
 #include <immintrin.h>

--- a/src/crypto/sha256_x86_shani.cpp
+++ b/src/crypto/sha256_x86_shani.cpp
@@ -6,7 +6,7 @@
 // Written and placed in public domain by Jeffrey Walton.
 // Based on code from Intel, and by Sean Gulley for the miTLS project.
 
-#ifdef ENABLE_X86_SHANI
+#if ENABLE_X86_SHANI
 
 #include <stdint.h>
 #include <immintrin.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -590,7 +590,7 @@ void SetupServerArgs(ArgsManager& argsman)
     hidden_args.emplace_back("-daemonwait");
 #endif
 
-#if defined(USE_SYSCALL_SANDBOX)
+#if USE_SYSCALL_SANDBOX
     argsman.AddArg("-sandbox=<mode>", "Use the experimental syscall sandbox in the specified mode (-sandbox=log-and-abort or -sandbox=abort). Allow only expected syscalls to be used by bitcoind. Note that this is an experimental new feature that may cause bitcoind to exit or crash unexpectedly: use with caution. In the \"log-and-abort\" mode the invocation of an unexpected syscall results in a debug handler being invoked which will log the incident and terminate the program (without executing the unexpected syscall). In the \"abort\" mode the invocation of an unexpected syscall results in the entire process being killed immediately by the kernel without executing the unexpected syscall.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #endif // USE_SYSCALL_SANDBOX
 
@@ -1041,7 +1041,7 @@ bool AppInitParameterInteraction(const ArgsManager& args, bool use_syscall_sandb
         }
     }
 
-#if defined(USE_SYSCALL_SANDBOX)
+#if USE_SYSCALL_SANDBOX
     if (args.IsArgSet("-sandbox") && !args.IsArgNegated("-sandbox")) {
         const std::string sandbox_arg{args.GetArg("-sandbox", "")};
         bool log_syscall_violation_before_terminating{false};

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -70,7 +70,7 @@ static RPCHelpMan setmocktime()
     };
 }
 
-#if defined(USE_SYSCALL_SANDBOX)
+#if USE_SYSCALL_SANDBOX
 static RPCHelpMan invokedisallowedsyscall()
 {
     return RPCHelpMan{
@@ -430,7 +430,7 @@ void RegisterNodeRPCCommands(CRPCTable& t)
         {"hidden", &echo},
         {"hidden", &echojson},
         {"hidden", &echoipc},
-#if defined(USE_SYSCALL_SANDBOX)
+#if USE_SYSCALL_SANDBOX
         {"hidden", &invokedisallowedsyscall},
 #endif // USE_SYSCALL_SANDBOX
     };

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -20,7 +20,7 @@
 #include <util/strencodings.h>
 #include <util/system.h>
 
-#if defined(HAVE_CONSENSUS_LIB)
+#if HAVE_CONSENSUS_LIB
 #include <script/bitcoinconsensus.h>
 #endif
 
@@ -149,7 +149,7 @@ void DoTest(const CScript& scriptPubKey, const CScript& scriptSig, const CScript
         BOOST_CHECK_MESSAGE(VerifyScript(scriptSig, scriptPubKey, &scriptWitness, combined_flags, MutableTransactionSignatureChecker(&tx, 0, txCredit.vout[0].nValue, MissingDataBehavior::ASSERT_FAIL), &err) == expect, message + strprintf(" (with flags %x)", combined_flags));
     }
 
-#if defined(HAVE_CONSENSUS_LIB)
+#if HAVE_CONSENSUS_LIB
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << tx2;
     uint32_t libconsensus_flags{flags & bitcoinconsensus_SCRIPT_FLAGS_VERIFY_ALL};
@@ -1501,7 +1501,7 @@ static CScriptWitness ScriptWitnessFromJSON(const UniValue& univalue)
     return scriptwitness;
 }
 
-#if defined(HAVE_CONSENSUS_LIB)
+#if HAVE_CONSENSUS_LIB
 
 /* Test simple (successful) usage of bitcoinconsensus_verify_script */
 BOOST_AUTO_TEST_CASE(bitcoinconsensus_verify_script_returns_true)
@@ -1641,7 +1641,7 @@ BOOST_AUTO_TEST_CASE(bitcoinconsensus_verify_script_invalid_flags)
     BOOST_CHECK_EQUAL(err, bitcoinconsensus_ERR_INVALID_FLAGS);
 }
 
-#endif // defined(HAVE_CONSENSUS_LIB)
+#endif // HAVE_CONSENSUS_LIB
 
 static std::vector<unsigned int> AllConsensusFlags()
 {

--- a/src/util/syscall_sandbox.cpp
+++ b/src/util/syscall_sandbox.cpp
@@ -8,7 +8,7 @@
 
 #include <util/syscall_sandbox.h>
 
-#if defined(USE_SYSCALL_SANDBOX)
+#if USE_SYSCALL_SANDBOX
 #include <array>
 #include <cassert>
 #include <cstdint>
@@ -830,11 +830,11 @@ void TestDisallowedSandboxCall()
     std::array<gid_t, 1> groups;
     [[maybe_unused]] int32_t ignored = getgroups(groups.size(), groups.data());
 }
-#endif // defined(USE_SYSCALL_SANDBOX)
+#endif // USE_SYSCALL_SANDBOX
 
 void SetSyscallSandboxPolicy(SyscallSandboxPolicy syscall_policy)
 {
-#if defined(USE_SYSCALL_SANDBOX)
+#if USE_SYSCALL_SANDBOX
     if (!g_syscall_sandbox_enabled) {
         return;
     }
@@ -923,5 +923,5 @@ void SetSyscallSandboxPolicy(SyscallSandboxPolicy syscall_policy)
 
     const std::string thread_name = !util::ThreadGetInternalName().empty() ? util::ThreadGetInternalName() : "*unnamed*";
     LogPrint(BCLog::UTIL, "Syscall filter installed for thread \"%s\"\n", thread_name);
-#endif // defined(USE_SYSCALL_SANDBOX)
+#endif // USE_SYSCALL_SANDBOX
 }

--- a/src/util/syscall_sandbox.h
+++ b/src/util/syscall_sandbox.h
@@ -43,12 +43,12 @@ enum class SyscallSandboxPolicy {
 //! This experimental feature is available under Linux x86_64 only.
 void SetSyscallSandboxPolicy(SyscallSandboxPolicy syscall_policy);
 
-#if defined(USE_SYSCALL_SANDBOX)
+#if USE_SYSCALL_SANDBOX
 //! Setup and enable the experimental syscall sandbox for the running process.
 [[nodiscard]] bool SetupSyscallSandbox(bool log_syscall_violation_before_terminating);
 
 //! Invoke a disallowed syscall. Use for testing purposes.
 void TestDisallowedSandboxCall();
-#endif // defined(USE_SYSCALL_SANDBOX)
+#endif // USE_SYSCALL_SANDBOX
 
 #endif // BITCOIN_UTIL_SYSCALL_SANDBOX_H


### PR DESCRIPTION
I tried to go over #16419.

Based on #16344 I interpreted that the AC_DEFINE like the following: 
```
AC_DEFINE(USE_EXTERNAL_ASM, 1, [Define this symbol if an external (non-inline) assembly implementation is used])
```
Results in value defines which also #16547 suggests.


If I've missunderstood anything or if there is more `#if defined` or `#ifdef` that should be `#if` then please let me know and I will update the pull request.