### PR TITLE
doc: fix typo in kernel/context.h and add `desig` to ignore-words

### DIFF
--- a/src/kernel/context.h
+++ b/src/kernel/context.h
@@ -12,7 +12,7 @@ class ECCVerifyHandle;
 namespace kernel {
 //! Context struct holding the kernel library's logically global state, and
 //! passed to external libbitcoin_kernel functions which need access to this
-//! state. The kernel libary API is a work in progress, so state organization
+//! state. The kernel library API is a work in progress, so state organization
 //! and member list will evolve over time.
 //!
 //! State stored directly in this struct should be simple. More complex state

--- a/test/lint/spelling.ignore-words.txt
+++ b/test/lint/spelling.ignore-words.txt
@@ -3,6 +3,7 @@ ba
 blockin
 cachable
 creat
+desig
 fo
 fpr
 hights


### PR DESCRIPTION
This PR fixes a typo in `kernel/context.h` (libary => library) and add `desig` to ignore-words since it's a valid word, see:
https://github.com/bitcoin/bitcoin/blob/b9416c3847cd347238a9d75d949327f69e187d79/src/net.cpp#L1105-L1117