### PR TITLE
test: Fix port collisions caused by p2p_getaddr_caching.py

### DIFF
--- a/test/functional/p2p_getaddr_caching.py
+++ b/test/functional/p2p_getaddr_caching.py
@@ -14,8 +14,7 @@ from test_framework.p2p import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    PORT_MIN,
-    PORT_RANGE,
+    p2p_port,
 )
 
 # As defined in net_processing.
@@ -44,10 +43,9 @@ class AddrReceiver(P2PInterface):
 class AddrTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        # Start onion ports after p2p and rpc ports.
-        port = PORT_MIN + 2 * PORT_RANGE
-        self.onion_port1 = port
-        self.onion_port2 = port + 1
+        # Use some of the remaining p2p ports for the onion binds.
+        self.onion_port1 = p2p_port(1)
+        self.onion_port2 = p2p_port(2)
         self.extra_args = [
             [f"-bind=127.0.0.1:{self.onion_port1}=onion", f"-bind=127.0.0.1:{self.onion_port2}=onion"],
         ]

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -223,10 +223,10 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
                 # It still needs to exist and be None in order for tests to work however.
                 self.options.descriptors = None
 
+        PortSeed.n = self.options.port_seed
+
     def setup(self):
         """Call this method to start up the test framework object with options set."""
-
-        PortSeed.n = self.options.port_seed
 
         check_json_precision()
 


### PR DESCRIPTION
This PR fixes the issue mentioned [here](https://github.com/bitcoin/bitcoin/pull/25096#discussion_r892558783), to avoid port collisions between nodes spun up by the test framework.