### PR TITLE
guix: re-revert risc-v execstack workaround

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -250,7 +250,7 @@ case "$HOST" in
 esac
 
 case "$HOST" in
-    powerpc64-linux-*|riscv64-linux-*) HOST_LDFLAGS="${HOST_LDFLAGS} -Wl,-z,noexecstack" ;;
+    powerpc64-linux-*) HOST_LDFLAGS="${HOST_LDFLAGS} -Wl,-z,noexecstack" ;;
 esac
 
 # Make $HOST-specific native binaries from depends available in $PATH


### PR DESCRIPTION
Now that we use GCC 10 for release builds, we no-longer need to
pass `-Wl,-z,noexecstack` to get a non-executable stack in RISC-V binaries.

This was originally removed in #21036, but then re-added in #21799, when
we reverted to using GCC 8.

Guix Build (arm64):
```bash
0655a94f88e8e89b1e048ae96e99c7dd45aed32011fe4ed9d03d0d1dfa073650  guix-build-2dcf3e153fbc/output/arm-linux-gnueabihf/SHA256SUMS.part
7c803347073839e2c7d8c1260e691964ab00b149da506edda4dc693df8e7f345  guix-build-2dcf3e153fbc/output/arm-linux-gnueabihf/bitcoin-2dcf3e153fbc-arm-linux-gnueabihf-debug.tar.gz
3b9ce2f349b9a4a463f66c9a2838e8490d4990c5b8dea9ad458b0bafeba8d1ac  guix-build-2dcf3e153fbc/output/arm-linux-gnueabihf/bitcoin-2dcf3e153fbc-arm-linux-gnueabihf.tar.gz
557c01453e3cedf6ef171715a02fe63abd7223f779a8c9b94ddc9ec17a4a45e4  guix-build-2dcf3e153fbc/output/arm64-apple-darwin/SHA256SUMS.part
26fcdbd10ad372ef541f519cc4990bdb5d513b51b05252ce9bde6e84258157b9  guix-build-2dcf3e153fbc/output/arm64-apple-darwin/bitcoin-2dcf3e153fbc-arm64-apple-darwin-unsigned.dmg
b145a9f6716f8e7f8c23d247fa82a02e4e7b76bebb17d55a1190448d0db5ab23  guix-build-2dcf3e153fbc/output/arm64-apple-darwin/bitcoin-2dcf3e153fbc-arm64-apple-darwin-unsigned.tar.gz
f172cd4c799a7ab065a36829fb8d546e83ce6791d9cb326d7cef14ad74d63d7a  guix-build-2dcf3e153fbc/output/arm64-apple-darwin/bitcoin-2dcf3e153fbc-arm64-apple-darwin.tar.gz
9a6c886a0bc81e729e3bb50dd972e10c8d4563bcbd917a9ba9c418a6fbe2de71  guix-build-2dcf3e153fbc/output/dist-archive/bitcoin-2dcf3e153fbc.tar.gz
254a11143d61aeb98749cd405ed307cca77e80198d58b7bb669ef9490cc8eaf6  guix-build-2dcf3e153fbc/output/powerpc64-linux-gnu/SHA256SUMS.part
83d7dc51404e328f6965f4d2da0b76fbe0a712d48465d6713348e0c4eb314a0a  guix-build-2dcf3e153fbc/output/powerpc64-linux-gnu/bitcoin-2dcf3e153fbc-powerpc64-linux-gnu-debug.tar.gz
522b98c63ab76dac6083a17f6b8f8173e9683f7d79e6f46b0a2e56c48e841a02  guix-build-2dcf3e153fbc/output/powerpc64-linux-gnu/bitcoin-2dcf3e153fbc-powerpc64-linux-gnu.tar.gz
96053b629ba60446f499d19400a25913932a02920bad963aaa12f1b6337b9f6e  guix-build-2dcf3e153fbc/output/powerpc64le-linux-gnu/SHA256SUMS.part
147f0b1d07b986879a859e6d6186c339085bcfcac4c5fe30586f94e0ab09ce77  guix-build-2dcf3e153fbc/output/powerpc64le-linux-gnu/bitcoin-2dcf3e153fbc-powerpc64le-linux-gnu-debug.tar.gz
c916680e75fb265e4099244cb876c2535c45981fbba9cfef9ad47c3aa58bc60b  guix-build-2dcf3e153fbc/output/powerpc64le-linux-gnu/bitcoin-2dcf3e153fbc-powerpc64le-linux-gnu.tar.gz
b90329d8531afb450678ec3d0981d3b1542f7b17d2feb0f2630216d0479630ad  guix-build-2dcf3e153fbc/output/riscv64-linux-gnu/SHA256SUMS.part
c77f02947d57ad2b841d594dca55271c9aecc1ef03f55371e0109ccaa5782aba  guix-build-2dcf3e153fbc/output/riscv64-linux-gnu/bitcoin-2dcf3e153fbc-riscv64-linux-gnu-debug.tar.gz
234f54da9df09ef2f330be016d58ab11e81e49644db01b6093050b5fcd5c5c82  guix-build-2dcf3e153fbc/output/riscv64-linux-gnu/bitcoin-2dcf3e153fbc-riscv64-linux-gnu.tar.gz
637f4a77d17493b319fb404e91c949373e0105caff61200f2a62729ca515f6de  guix-build-2dcf3e153fbc/output/x86_64-apple-darwin/SHA256SUMS.part
6cbe6c91e0a35df9f92af461f68f823c7d12c37237c33e0169825ba56eb9a7c3  guix-build-2dcf3e153fbc/output/x86_64-apple-darwin/bitcoin-2dcf3e153fbc-x86_64-apple-darwin-unsigned.dmg
b9b8cc7317e62a34f2286e07f743d4274b7ad00e93653e281257fc3bc068f30c  guix-build-2dcf3e153fbc/output/x86_64-apple-darwin/bitcoin-2dcf3e153fbc-x86_64-apple-darwin-unsigned.tar.gz
b846df40c5a956ca02a017fbd2b97bc39caba876f7b6ad080ba1962b9092cb0d  guix-build-2dcf3e153fbc/output/x86_64-apple-darwin/bitcoin-2dcf3e153fbc-x86_64-apple-darwin.tar.gz
5260fe7678567af5e73d296bfb115e09cc352e039fa6ae41007a6a93a5d1d6fd  guix-build-2dcf3e153fbc/output/x86_64-linux-gnu/SHA256SUMS.part
2ddbf9afe86ff3bcde44a6beb8e1fa2a8b9a35ceae33aa1633878d8c7f611939  guix-build-2dcf3e153fbc/output/x86_64-linux-gnu/bitcoin-2dcf3e153fbc-x86_64-linux-gnu-debug.tar.gz
a21eb3ad0671d3f09ce3b1e5263ba6cd9ea56f2c51d849bc39010b9c2b273ebf  guix-build-2dcf3e153fbc/output/x86_64-linux-gnu/bitcoin-2dcf3e153fbc-x86_64-linux-gnu.tar.gz
0043277076a16b2baf5dc1957c2e176d5c5d95abe693b3d6bd6dec7ccb9f5481  guix-build-2dcf3e153fbc/output/x86_64-w64-mingw32/SHA256SUMS.part
c7271c7ee7361c2f3349a00fd444fcfd42b07dbe77905a5570366312ba413fbc  guix-build-2dcf3e153fbc/output/x86_64-w64-mingw32/bitcoin-2dcf3e153fbc-win64-debug.zip
19197d3abd2f422ad860a888578369da453509be3f8cab04cbf80055263b83c9  guix-build-2dcf3e153fbc/output/x86_64-w64-mingw32/bitcoin-2dcf3e153fbc-win64-setup-unsigned.exe
21bfae266d684e95ebe8bcf40102c3ee8468e3d7364f6d6c5c6dd9dfc06b376a  guix-build-2dcf3e153fbc/output/x86_64-w64-mingw32/bitcoin-2dcf3e153fbc-win64-unsigned.tar.gz
2feb16aab1fb0007670f816b1e25bff031acca01f68e3b5a8b20d13b60542b48  guix-build-2dcf3e153fbc/output/x86_64-w64-mingw32/bitcoin-2dcf3e153fbc-win64.zip
```