### PR TITLE
p2p: always set nTime for self-advertisements

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -250,7 +250,7 @@ std::optional<CAddress> GetLocalAddrForPeer(CNode *pnode)
         if (pnode->IsInboundConn()) {
             // For inbound connections, assume both the address and the port
             // as seen from the peer.
-            addrLocal = CAddress{pnode->GetAddrLocal(), addrLocal.nServices};
+            addrLocal = CAddress{pnode->GetAddrLocal(), addrLocal.nServices, addrLocal.nTime};
         } else {
             // For outbound connections, assume just the address as seen from
             // the peer and leave the port in `addrLocal` as returned by

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -675,10 +675,13 @@ BOOST_AUTO_TEST_CASE(get_local_addr_for_peer_port)
     const uint16_t bind_port = 20001;
     m_node.args->ForceSetArg("-bind", strprintf("3.4.5.6:%u", bind_port));
 
+    const uint32_t current_time = static_cast<uint32_t>(GetAdjustedTime());
+    SetMockTime(current_time);
+
     // Our address:port as seen from the peer, completely different from the above.
     in_addr peer_us_addr;
     peer_us_addr.s_addr = htonl(0x02030405);
-    const CAddress peer_us{CService{peer_us_addr, 20002}, NODE_NETWORK};
+    const CAddress peer_us{CService{peer_us_addr, 20002}, NODE_NETWORK, current_time};
 
     // Create a peer with a routable IPv4 address (outbound).
     in_addr peer_out_in_addr;
@@ -699,7 +702,7 @@ BOOST_AUTO_TEST_CASE(get_local_addr_for_peer_port)
     // Without the fix peer_us:8333 is chosen instead of the proper peer_us:bind_port.
     auto chosen_local_addr = GetLocalAddrForPeer(&peer_out);
     BOOST_REQUIRE(chosen_local_addr);
-    const CService expected{peer_us_addr, bind_port};
+    const CAddress expected{CService{peer_us_addr, bind_port}, NODE_NETWORK, current_time};
     BOOST_CHECK(*chosen_local_addr == expected);
 
     // Create a peer with a routable IPv4 address (inbound).


### PR DESCRIPTION
This logic was recently changed in https://github.com/bitcoin/bitcoin/commit/0cfc0cd32239d3c08d2121e028b297022450b320 to overwrite `addrLocal` with the address they gave us when self-advertising to an inbound peer. But if we don't also change `nTime` again from the default `TIME_INIT`, our peer will not relay our advertised address any further.