### PR TITLE
0.21 Backports

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -535,13 +535,17 @@ AX_CHECK_COMPILE_FLAG([-march=armv8-a+crc+crypto],[[ARM_CRC_CXXFLAGS="-march=arm
 
 TEMP_CXXFLAGS="$CXXFLAGS"
 CXXFLAGS="$CXXFLAGS $ARM_CRC_CXXFLAGS"
-AC_MSG_CHECKING(for ARM CRC32 intrinsics)
+AC_MSG_CHECKING(for AArch64 CRC32 intrinsics)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
     #include <arm_acle.h>
     #include <arm_neon.h>
   ]],[[
+#ifdef __aarch64__
     __crc32cb(0, 0); __crc32ch(0, 0); __crc32cw(0, 0); __crc32cd(0, 0);
     vmull_p64(0, 0);
+#else
+#error "crc32c library does not support hardware acceleration on 32-bit ARM"
+#endif
   ]])],
  [ AC_MSG_RESULT(yes); enable_arm_crc=yes; ],
  [ AC_MSG_RESULT(no)]

--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -16,6 +16,7 @@
 #define NOMINMAX
 #endif
 #include <codecvt>
+#include <limits>
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
There might not be another 0.21.x release, however these are both straight forward changes. If this isn't merged, then the pulls can remain untagged for needing backport.

Backports:
- https://github.com/bitcoin/bitcoin/pull/23045
- https://github.com/bitcoin/bitcoin/pull/23335