### PR TITLE
p2p: Stop treating message size as misbehavior

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3003,9 +3003,8 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             return;
         }
 
-        if (vAddr.size() > MAX_ADDR_TO_SEND)
-        {
-            Misbehaving(*peer, 20, strprintf("%s message size = %u", msg_type, vAddr.size()));
+        if (vAddr.size() > MAX_ADDR_TO_SEND) {
+            LogPrint(BCLog::NET, "Ignoring %s message size = %u from peer=%d\n", msg_type, vAddr.size(), pfrom.GetId());
             return;
         }
 
@@ -3084,9 +3083,8 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
     if (msg_type == NetMsgType::INV) {
         std::vector<CInv> vInv;
         vRecv >> vInv;
-        if (vInv.size() > MAX_INV_SZ)
-        {
-            Misbehaving(*peer, 20, strprintf("inv message size = %u", vInv.size()));
+        if (vInv.size() > MAX_INV_SZ) {
+            LogPrint(BCLog::NET, "Ignoring %s message size = %u from peer=%d\n", msg_type, vInv.size(), pfrom.GetId());
             return;
         }
 
@@ -3152,9 +3150,8 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
     if (msg_type == NetMsgType::GETDATA) {
         std::vector<CInv> vInv;
         vRecv >> vInv;
-        if (vInv.size() > MAX_INV_SZ)
-        {
-            Misbehaving(*peer, 20, strprintf("getdata message size = %u", vInv.size()));
+        if (vInv.size() > MAX_INV_SZ) {
+            LogPrint(BCLog::NET, "Ignoring %s message size = %u from peer=%d\n", msg_type, vInv.size(), pfrom.GetId());
             return;
         }
 
@@ -3877,7 +3874,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         // Bypass the normal CBlock deserialization, as we don't want to risk deserializing 2000 full blocks.
         unsigned int nCount = ReadCompactSize(vRecv);
         if (nCount > MAX_HEADERS_RESULTS) {
-            Misbehaving(*peer, 20, strprintf("headers message size = %u", nCount));
+            LogPrint(BCLog::NET, "Ignoring %s message size = %u from peer=%d\n", msg_type, nCount, pfrom.GetId());
             return;
         }
         headers.resize(nCount);

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -232,7 +232,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
     def test_oversized_msg(self, msg, size):
         msg_type = msg.msgtype.decode('ascii')
         self.log.info("Test {} message of size {} is logged as misbehaving".format(msg_type, size))
-        with self.nodes[0].assert_debug_log(['Misbehaving', '{} message size = {}'.format(msg_type, size)]):
+        with self.nodes[0].assert_debug_log([f"Ignoring {msg_type} message size = {size}"]):
             self.nodes[0].add_p2p_connection(P2PInterface()).send_and_ping(msg)
         self.nodes[0].disconnect_p2ps()
 


### PR DESCRIPTION
Currently this is treated as misbehaviour with a score of 20 (out of 100). Practically, on my node no peer that hit a score of 20 hit the threshold of 100, so it seems fine to skip.

Effectively, large "vector" messages will be dropped, making them a bandwidth DoS if sent repeatedly. However, any peer can do a bandwidth DoS by sending a "vector" messages of smaller size, or messages of type `notfound` (which don't have any misbehaviour score for size), or a large `block` or `tx` message.

This change skips over a `headers`, `getdata`, `inv`, `addr`, and `addrv2` message if it is too large.

For reference, there is no BIP that prescribes behaviour on oversized messages of those types. BIP 155 is the only BIP that mentions a size limit about the message types:

> One message can contain up to 1,000 addresses. Clients SHOULD reject messages with more addresses.
> https://en.bitcoin.it/wiki/BIP_0155#Specification

For reference, `getblocks` and `getheaders` since commit e254ff5d53b79bee29203b965fca572f218bff54 will unconditionally disconnect on size. It will even disconnect noban peers and manual connections, but this seems fine to keep.
