### PR TITLE
build: Fix `capnp` package build for Android

### DIFF
--- a/depends/packages/capnp.mk
+++ b/depends/packages/capnp.mk
@@ -6,8 +6,13 @@ $(package)_file_name=$(native_$(package)_file_name)
 $(package)_sha256_hash=$(native_$(package)_sha256_hash)
 $(package)_dependencies=native_$(package)
 
+define $(package)_set_vars :=
+$(package)_config_opts := --with-external-capnp
+$(package)_config_opts_android := --disable-shared
+endef
+
 define $(package)_config_cmds
-  $($(package)_autoconf) --with-external-capnp
+  $($(package)_autoconf)
 endef
 
 define $(package)_build_cmds

--- a/depends/packages/capnp.mk
+++ b/depends/packages/capnp.mk
@@ -8,6 +8,8 @@ $(package)_dependencies=native_$(package)
 
 define $(package)_set_vars :=
 $(package)_config_opts := --with-external-capnp
+$(package)_config_opts += CAPNP="$$(native_capnp_prefixbin)/capnp"
+$(package)_config_opts += CAPNP_CXX="$$(native_capnp_prefixbin)/capnp-c++"
 $(package)_config_opts_android := --disable-shared
 endef
 


### PR DESCRIPTION
On master (e3c08eb620a2f317fc09fdf20969fa26f02afb91):
```
$ make -C depends capnp MULTIPROCESS=1 HOST=aarch64-linux-android ANDROID_SDK=$ANDROID_HOME ANDROID_NDK=$ANDROID_HOME/ndk/23.2.8568313 ANDROID_API_LEVEL=28 ANDROID_TOOLCHAIN_BIN=$ANDROID_HOME/ndk/23.2.8568313/toolchains/llvm/prebuilt/linux-x86_64/bin
...
ld: error: unable to find library -lkj
...
```

This PR fixes this error, and also improves configuring according to the docs.