### PR TITLE
refactor: add most of src/util to iwyu

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -47,6 +47,18 @@ if [ "${RUN_TIDY}" = "true" ]; then
           " src/rpc/fees.cpp"\
           " src/rpc/signmessage.cpp"\
           " src/test/fuzz/txorphan.cpp"\
+          " src/util/bip32.cpp"\
+          " src/util/bytevectorhash.cpp"\
+          " src/util/error.cpp"\
+          " src/util/getuniquepath.cpp"\
+          " src/util/hasher.cpp"\
+          " src/util/message.cpp"\
+          " src/util/moneystr.cpp"\
+          " src/util/serfloat.cpp"\
+          " src/util/spanparsing.cpp"\
+          " src/util/strencodings.cpp"\
+          " src/util/syserror.cpp"\
+          " src/util/url.cpp"\
           " -p . ${MAKEJOBS} -- -Xiwyu --cxx17ns -Xiwyu --mapping_file=${BASE_BUILD_DIR}/bitcoin-$HOST/contrib/devtools/iwyu/bitcoin.core.imp"
 fi
 

--- a/src/util/asmap.cpp
+++ b/src/util/asmap.cpp
@@ -8,10 +8,13 @@
 #include <crypto/common.h>
 #include <fs.h>
 #include <logging.h>
+#include <serialize.h>
 #include <streams.h>
 
+#include <algorithm>
 #include <cassert>
-#include <map>
+#include <cstdio>
+#include <utility>
 #include <vector>
 
 namespace {

--- a/src/util/bip32.cpp
+++ b/src/util/bip32.cpp
@@ -2,11 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <sstream>
-#include <stdio.h>
 #include <tinyformat.h>
 #include <util/bip32.h>
 #include <util/strencodings.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <sstream>
 
 
 bool ParseHDKeypath(const std::string& keypath_str, std::vector<uint32_t>& keypath)

--- a/src/util/bip32.h
+++ b/src/util/bip32.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_UTIL_BIP32_H
 #define BITCOIN_UTIL_BIP32_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/util/bytevectorhash.cpp
+++ b/src/util/bytevectorhash.cpp
@@ -6,6 +6,8 @@
 #include <random.h>
 #include <util/bytevectorhash.h>
 
+#include <vector>
+
 ByteVectorHash::ByteVectorHash() :
     m_k0(GetRand<uint64_t>()),
     m_k1(GetRand<uint64_t>())

--- a/src/util/bytevectorhash.h
+++ b/src/util/bytevectorhash.h
@@ -5,7 +5,8 @@
 #ifndef BITCOIN_UTIL_BYTEVECTORHASH_H
 #define BITCOIN_UTIL_BYTEVECTORHASH_H
 
-#include <stdint.h>
+#include <cstdint>
+#include <cstddef>
 #include <vector>
 
 /**

--- a/src/util/error.cpp
+++ b/src/util/error.cpp
@@ -5,8 +5,10 @@
 #include <util/error.h>
 
 #include <tinyformat.h>
-#include <util/system.h>
 #include <util/translation.h>
+
+#include <cassert>
+#include <string>
 
 bilingual_str TransactionErrorString(const TransactionError err)
 {

--- a/src/util/hasher.cpp
+++ b/src/util/hasher.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <crypto/siphash.h>
 #include <random.h>
+#include <span.h>
 #include <util/hasher.h>
-
-#include <limits>
 
 SaltedTxidHasher::SaltedTxidHasher() : k0(GetRand<uint64_t>()), k1(GetRand<uint64_t>()) {}
 

--- a/src/util/hasher.h
+++ b/src/util/hasher.h
@@ -5,9 +5,15 @@
 #ifndef BITCOIN_UTIL_HASHER_H
 #define BITCOIN_UTIL_HASHER_H
 
+#include <crypto/common.h>
 #include <crypto/siphash.h>
 #include <primitives/transaction.h>
 #include <uint256.h>
+
+#include <cstdint>
+#include <cstring>
+
+template <typename C> class Span;
 
 class SaltedTxidHasher
 {

--- a/src/util/message.cpp
+++ b/src/util/message.cpp
@@ -3,16 +3,20 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <hash.h>            // For CHashWriter
-#include <key.h>             // For CKey
-#include <key_io.h>          // For DecodeDestination()
-#include <pubkey.h>          // For CPubKey
-#include <script/standard.h> // For CTxDestination, IsValidDestination(), PKHash
-#include <serialize.h>       // For SER_GETHASH
+#include <hash.h>
+#include <key.h>
+#include <key_io.h>
+#include <pubkey.h>
+#include <script/standard.h>
+#include <serialize.h>
+#include <uint256.h>
 #include <util/message.h>
-#include <util/strencodings.h> // For DecodeBase64()
+#include <util/strencodings.h>
 
+#include <cassert>
+#include <optional>
 #include <string>
+#include <variant>
 #include <vector>
 
 /**

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -6,10 +6,11 @@
 #ifndef BITCOIN_UTIL_MESSAGE_H
 #define BITCOIN_UTIL_MESSAGE_H
 
-#include <key.h> // For CKey
 #include <uint256.h>
 
 #include <string>
+
+class CKey;
 
 extern const std::string MESSAGE_MAGIC;
 

--- a/src/util/moneystr.cpp
+++ b/src/util/moneystr.cpp
@@ -10,6 +10,7 @@
 #include <util/strencodings.h>
 #include <util/string.h>
 
+#include <cstdint>
 #include <optional>
 
 std::string FormatMoney(const CAmount n)

--- a/src/util/readwritefile.cpp
+++ b/src/util/readwritefile.cpp
@@ -5,8 +5,9 @@
 
 #include <fs.h>
 
+#include <algorithm>
+#include <cstdio>
 #include <limits>
-#include <stdio.h>
 #include <string>
 #include <utility>
 

--- a/src/util/serfloat.h
+++ b/src/util/serfloat.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_UTIL_SERFLOAT_H
 #define BITCOIN_UTIL_SERFLOAT_H
 
-#include <stdint.h>
+#include <cstdint>
 
 /* Encode a double using the IEEE 754 binary64 format. All NaNs are encoded as x86/ARM's
  * positive quiet NaN with payload 0. */

--- a/src/util/spanparsing.cpp
+++ b/src/util/spanparsing.cpp
@@ -6,8 +6,9 @@
 
 #include <span.h>
 
+#include <algorithm>
+#include <cstddef>
 #include <string>
-#include <vector>
 
 namespace spanparsing {
 

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -3,17 +3,18 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <span.h>
 #include <util/strencodings.h>
-#include <util/string.h>
-
-#include <tinyformat.h>
 
 #include <algorithm>
 #include <array>
-#include <cstdlib>
+#include <cassert>
 #include <cstring>
 #include <limits>
 #include <optional>
+#include <ostream>
+#include <string>
+#include <vector>
 
 static const std::string CHARS_ALPHA_NUM = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -13,11 +13,14 @@
 #include <util/string.h>
 
 #include <charconv>
+#include <cstddef>
 #include <cstdint>
-#include <iterator>
 #include <limits>
 #include <optional>
 #include <string>
+#include <string_view>
+#include <system_error>
+#include <type_traits>
 #include <vector>
 
 /** Used by SanitizeString() */

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -6,6 +6,8 @@
 
 #include <boost/algorithm/string/replace.hpp>
 
+#include <string>
+
 void ReplaceAll(std::string& in_out, std::string_view search, std::string_view substitute)
 {
     boost::replace_all(in_out, search, substitute);

--- a/src/util/syserror.cpp
+++ b/src/util/syserror.cpp
@@ -10,6 +10,7 @@
 #include <util/syserror.h>
 
 #include <cstring>
+#include <string>
 
 std::string SysErrorString(int err)
 {

--- a/src/util/thread.cpp
+++ b/src/util/thread.cpp
@@ -9,6 +9,7 @@
 #include <util/threadnames.h>
 
 #include <exception>
+#include <functional>
 
 void util::TraceThread(const char* thread_name, std::function<void()> thread_func)
 {

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -8,16 +8,19 @@
 #endif
 
 #include <compat.h>
+#include <tinyformat.h>
 #include <util/time.h>
-
 #include <util/check.h>
 
-#include <atomic>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <ctime>
-#include <thread>
 
-#include <tinyformat.h>
+#include <atomic>
+#include <chrono>
+#include <ctime>
+#include <locale>
+#include <thread>
+#include <sstream>
+#include <string>
 
 void UninterruptibleSleep(const std::chrono::microseconds& n) { std::this_thread::sleep_for(n); }
 

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -9,7 +9,7 @@
 #include <compat.h>
 
 #include <chrono>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 using namespace std::chrono_literals;

--- a/src/util/translation.h
+++ b/src/util/translation.h
@@ -6,7 +6,9 @@
 #define BITCOIN_UTIL_TRANSLATION_H
 
 #include <tinyformat.h>
+
 #include <functional>
+#include <string>
 
 /**
  * Bilingual messages:

--- a/src/util/url.cpp
+++ b/src/util/url.cpp
@@ -5,7 +5,8 @@
 #include <util/url.h>
 
 #include <event2/http.h>
-#include <stdlib.h>
+
+#include <cstdlib>
 #include <string>
 
 std::string urlDecode(const std::string &urlEncoded) {

--- a/src/util/vector.h
+++ b/src/util/vector.h
@@ -7,6 +7,7 @@
 
 #include <initializer_list>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 /** Construct a vector with the specified elements.


### PR DESCRIPTION
These files change infrequently, and not much header shuffling is required.

We don't add everything in src/util/ yet, because IWYU makes some
dubious suggestions, which I'm going to follow up with upstream.

Soon we'll swap `src/util/xyz.cpp` for just `src/util/`. 