### PR TITLE
test: Fix out-of-range port collisions

### DIFF
--- a/test/functional/feature_bind_extra.py
+++ b/test/functional/feature_bind_extra.py
@@ -18,11 +18,11 @@ from test_framework.test_framework import (
     SkipTest,
 )
 from test_framework.util import (
-    PORT_MIN,
-    PORT_RANGE,
     assert_equal,
+    p2p_port,
     rpc_port,
 )
+
 
 class BindExtraTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -33,11 +33,6 @@ class BindExtraTest(BitcoinTestFramework):
         self.num_nodes = 2
 
     def setup_network(self):
-        # Override setup_network() because we want to put the result of
-        # p2p_port() in self.extra_args[], before the nodes are started.
-        # p2p_port() is not usable in set_test_params() because PortSeed.n is
-        # not set at that time.
-
         # Due to OS-specific network stats queries, we only run on Linux.
         self.log.info("Checking for Linux")
         if not sys.platform.startswith('linux'):
@@ -45,8 +40,8 @@ class BindExtraTest(BitcoinTestFramework):
 
         loopback_ipv4 = addr_to_hex("127.0.0.1")
 
-        # Start custom ports after p2p and rpc ports.
-        port = PORT_MIN + 2 * PORT_RANGE
+        # Start custom ports by reusing unused p2p ports
+        port = p2p_port(self.num_nodes)
 
         # Array of tuples [command line arguments, expected bind addresses].
         self.expected = []

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -40,18 +40,14 @@ addnode connect to a CJDNS address
 """
 
 import socket
-import os
 
 from test_framework.socks5 import Socks5Configuration, Socks5Command, Socks5Server, AddressType
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
-    PORT_MIN,
-    PORT_RANGE,
     assert_equal,
+    p2p_port,
 )
 from test_framework.netutil import test_ipv6_local
-
-RANGE_BEGIN = PORT_MIN + 2 * PORT_RANGE  # Start after p2p and rpc ports
 
 # Networks returned by RPC getpeerinfo.
 NET_UNROUTABLE = "not_publicly_routable"
@@ -75,19 +71,19 @@ class ProxyTest(BitcoinTestFramework):
         # Create two proxies on different ports
         # ... one unauthenticated
         self.conf1 = Socks5Configuration()
-        self.conf1.addr = ('127.0.0.1', RANGE_BEGIN + (os.getpid() % 1000))
+        self.conf1.addr = ('127.0.0.1', p2p_port(self.num_nodes))
         self.conf1.unauth = True
         self.conf1.auth = False
         # ... one supporting authenticated and unauthenticated (Tor)
         self.conf2 = Socks5Configuration()
-        self.conf2.addr = ('127.0.0.1', RANGE_BEGIN + 1000 + (os.getpid() % 1000))
+        self.conf2.addr = ('127.0.0.1', p2p_port(self.num_nodes + 1))
         self.conf2.unauth = True
         self.conf2.auth = True
         if self.have_ipv6:
             # ... one on IPv6 with similar configuration
             self.conf3 = Socks5Configuration()
             self.conf3.af = socket.AF_INET6
-            self.conf3.addr = ('::1', RANGE_BEGIN + 2000 + (os.getpid() % 1000))
+            self.conf3.addr = ('::1', p2p_port(self.num_nodes + 2))
             self.conf3.unauth = True
             self.conf3.auth = True
         else:

--- a/test/functional/p2p_getaddr_caching.py
+++ b/test/functional/p2p_getaddr_caching.py
@@ -44,8 +44,8 @@ class AddrTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         # Use some of the remaining p2p ports for the onion binds.
-        self.onion_port1 = p2p_port(1)
-        self.onion_port2 = p2p_port(2)
+        self.onion_port1 = p2p_port(self.num_nodes)
+        self.onion_port2 = p2p_port(self.num_nodes + 1)
         self.extra_args = [
             [f"-bind=127.0.0.1:{self.onion_port1}=onion", f"-bind=127.0.0.1:{self.onion_port2}=onion"],
         ]


### PR DESCRIPTION
Otherwise the test will fail if two tests running in parallel use the same port. See https://github.com/bitcoin/bitcoin/pull/25096#discussion_r892558783 and https://github.com/bitcoin/bitcoin/pull/25312