### PR TITLE
scripted-diff: Avoid incompatibility with CMake AUTOUIC feature

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -198,7 +198,7 @@ BITCOIN_CORE_H = \
   node/minisketchwrapper.h \
   node/psbt.h \
   node/transaction.h \
-  node/ui_interface.h \
+  node/interface_ui.h \
   node/utxo_snapshot.h \
   noui.h \
   outputtype.h \
@@ -375,7 +375,7 @@ libbitcoin_node_a_SOURCES = \
   node/minisketchwrapper.cpp \
   node/psbt.cpp \
   node/transaction.cpp \
-  node/ui_interface.cpp \
+  node/interface_ui.cpp \
   noui.cpp \
   policy/fees.cpp \
   policy/packages.cpp \
@@ -877,7 +877,7 @@ libbitcoinkernel_la_SOURCES = \
   logging.cpp \
   node/blockstorage.cpp \
   node/chainstate.cpp \
-  node/ui_interface.cpp \
+  node/interface_ui.cpp \
   policy/feerate.cpp \
   policy/fees.cpp \
   policy/packages.cpp \

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -6,7 +6,7 @@
 #include <banman.h>
 
 #include <netaddress.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <sync.h>
 #include <util/system.h>
 #include <util/time.h>

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -14,7 +14,7 @@
 #include <interfaces/chain.h>
 #include <interfaces/init.h>
 #include <node/context.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <noui.h>
 #include <shutdown.h>
 #include <util/check.h>

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -11,7 +11,7 @@
 #include <chainparamsbase.h>
 #include <compat.h>
 #include <netbase.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <rpc/protocol.h> // For HTTP status codes
 #include <shutdown.h>
 #include <sync.h>

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -5,7 +5,7 @@
 #include <chainparams.h>
 #include <index/base.h>
 #include <node/blockstorage.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <shutdown.h>
 #include <tinyformat.h>
 #include <util/syscall_sandbox.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -40,7 +40,7 @@
 #include <node/chainstate.h>
 #include <node/context.h>
 #include <node/miner.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <policy/feerate.h>
 #include <policy/fees.h>
 #include <policy/policy.h>

--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -9,7 +9,7 @@
 #include <clientversion.h>
 #include <fs.h>
 #include <logging.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <tinyformat.h>
 #include <util/system.h>
 #include <util/time.h>

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -21,7 +21,7 @@
 #include <net_permissions.h>
 #include <netaddress.h>
 #include <netbase.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <protocol.h>
 #include <random.h>
 #include <scheduler.h>

--- a/src/node/interface_ui.cpp
+++ b/src/node/interface_ui.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 
 #include <util/translation.h>
 

--- a/src/node/interface_ui.h
+++ b/src/node/interface_ui.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_NODE_UI_INTERFACE_H
-#define BITCOIN_NODE_UI_INTERFACE_H
+#ifndef BITCOIN_NODE_INTERFACE_UI_H
+#define BITCOIN_NODE_INTERFACE_UI_H
 
 #include <functional>
 #include <memory>
@@ -120,4 +120,4 @@ constexpr auto AbortError = InitError;
 
 extern CClientUIInterface uiInterface;
 
-#endif // BITCOIN_NODE_UI_INTERFACE_H
+#endif // BITCOIN_NODE_INTERFACE_UI_H

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -22,7 +22,7 @@
 #include <node/coin.h>
 #include <node/context.h>
 #include <node/transaction.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <policy/feerate.h>
 #include <policy/fees.h>
 #include <policy/policy.h>

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -6,7 +6,7 @@
 #include <noui.h>
 
 #include <logging.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <util/translation.h>
 
 #include <string>

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -13,7 +13,7 @@
 #include <interfaces/handler.h>
 #include <interfaces/init.h>
 #include <interfaces/node.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <noui.h>
 #include <qt/bitcoingui.h>
 #include <qt/clientmodel.h>

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -35,7 +35,7 @@
 #include <chainparams.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <util/system.h>
 #include <util/translation.h>
 #include <validation.h>

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -15,7 +15,7 @@
 #include <chainparams.h>
 #include <interfaces/node.h>
 #include <key_io.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <policy/policy.h>
 #include <util/system.h>
 #include <wallet/wallet.h>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -21,7 +21,7 @@
 #include <chainparams.h>
 #include <interfaces/node.h>
 #include <key_io.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <policy/fees.h>
 #include <txmempool.h>
 #include <validation.h>

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -17,7 +17,7 @@
 #include <qt/transactiontablemodel.h>
 #include <qt/walletmodel.h>
 
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 
 #include <chrono>
 #include <optional>

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -5,7 +5,7 @@
 #include <qt/walletframe.h>
 
 #include <fs.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <psbt.h>
 #include <qt/guiutil.h>
 #include <qt/overviewpage.h>

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -21,7 +21,7 @@
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <key_io.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <psbt.h>
 #include <util/system.h> // for GetBoolArg
 #include <util/translation.h>

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -19,7 +19,7 @@
 #include <qt/walletmodel.h>
 
 #include <interfaces/node.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <util/strencodings.h>
 
 #include <QAction>

--- a/src/shutdown.cpp
+++ b/src/shutdown.cpp
@@ -10,7 +10,7 @@
 #endif
 
 #include <logging.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <util/tokenpipe.h>
 #include <warnings.h>
 

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -9,7 +9,7 @@
 #include <timedata.h>
 
 #include <netaddress.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <sync.h>
 #include <tinyformat.h>
 #include <util/system.h>

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -22,7 +22,7 @@
 #include <logging.h>
 #include <logging/timer.h>
 #include <node/blockstorage.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <node/utxo_snapshot.h>
 #include <policy/policy.h>
 #include <policy/rbf.h>

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -9,7 +9,7 @@
 #include <interfaces/wallet.h>
 #include <net.h>
 #include <node/context.h>
-#include <node/ui_interface.h>
+#include <node/interface_ui.h>
 #include <outputtype.h>
 #include <univalue.h>
 #include <util/check.h>


### PR DESCRIPTION
Working on [migration](https://github.com/hebasto/bitcoin/pull/3) from Autotools to CMake build system, I found that our current code base needs to be adjusted.

CMake [allows](https://cmake.org/cmake/help/latest/prop_tgt/AUTOUIC.html) to
> handle the Qt `uic` code generator automatically

When using this feature, statements like `#include "ui_<ui_base>.h"` are processed in a special way.

The `node/ui_interface.h` unintentionally breaks this feature. Of course, it is possible to provide a list of source files to be excluded from `AUTOUIC`. But, unfortunately, this approach does not work for the `qt/sendcoinsdialog.cpp` source file, where there are both https://github.com/bitcoin/bitcoin/blob/b71d37da2c8c8d2a9cef020731767a6929db54b4/src/qt/sendcoinsdialog.cpp#L10 and https://github.com/bitcoin/bitcoin/blob/b71d37da2c8c8d2a9cef020731767a6929db54b4/src/qt/sendcoinsdialog.cpp#L24