### PR TITLE
test: Fix previous release binary download script for Apple ARM64

### DIFF
--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -106,7 +106,7 @@ def download_binary(tag, args) -> int:
         bin_path = 'bin/bitcoin-core-{}/test.{}'.format(
             match.group(1), match.group(2))
     platform = args.platform
-    if tag < "v23" and platform in ["x86_64-apple-darwin", "aarch64-apple-darwin"]:
+    if tag < "v23" and platform in ["x86_64-apple-darwin", "arm64-apple-darwin"]:
         platform = "osx64"
     tarball = 'bitcoin-{tag}-{platform}.tar.gz'.format(
         tag=tag[1:], platform=platform)
@@ -214,7 +214,7 @@ def check_host(args) -> int:
             'aarch64-*-linux*': 'aarch64-linux-gnu',
             'x86_64-*-linux*': 'x86_64-linux-gnu',
             'x86_64-apple-darwin*': 'x86_64-apple-darwin',
-            'aarch64-apple-darwin*': 'aarch64-apple-darwin',
+            'aarch64-apple-darwin*': 'arm64-apple-darwin',
         }
         args.platform = ''
         for pattern, target in platforms.items():


### PR DESCRIPTION
The Apple M1 chip binaries at https://bitcoincore.org/bin/bitcoin-core-23.0/ are use `arm64` and not `aarch64` in the file name. This means on my M1 Macbook the v23 binary could not be downloaded: "Binary tag was not found".

This changes the script to map the `aarch64` from the host detection to `arm64`.