### PR TITLE
I2P: add support for transient addresses for outbound connections

### DIFF
--- a/doc/i2p.md
+++ b/doc/i2p.md
@@ -47,9 +47,26 @@ In a typical situation, this suffices:
 bitcoind -i2psam=127.0.0.1:7656
 ```
 
-The first time Bitcoin Core connects to the I2P router, its I2P address (and
-corresponding private key) will be automatically generated and saved in a file
-named `i2p_private_key` in the Bitcoin Core data directory.
+The first time Bitcoin Core connects to the I2P router, if
+`-i2pacceptincoming=1`, then it will automatically generate a persistent I2P
+address and its corresponding private key. The private key will be saved in a
+file named `i2p_private_key` in the Bitcoin Core data directory. The persistent
+I2P address is used for accepting incoming connections and for making outgoing
+connections if `-i2pacceptincoming=1`. If `-i2pacceptincoming=0` then only
+outbound I2P connections are made and a different transient I2P address is used
+for each connection to improve privacy.
+
+## Persistent vs transient I2P addresses
+
+In I2P connections, the connection receiver sees the I2P address of the
+connection initiator. This is unlike the Tor network where the recipient does
+not know who is connecting to them and can't tell if two connections are from
+the same peer or not.
+
+If an I2P node is not accepting incoming connections, then Bitcoin Core uses
+random, one-time, transient I2P addresses for itself for outbound connections
+to make it harder to discriminate, fingerprint or analyze it based on its I2P
+address.
 
 ## Additional configuration options related to I2P
 
@@ -85,7 +102,8 @@ one of the networks has issues.
 
 ## I2P-related information in Bitcoin Core
 
-There are several ways to see your I2P address in Bitcoin Core:
+There are several ways to see your I2P address in Bitcoin Core if accepting
+incoming I2P connections (`-i2pacceptincoming`):
 - in the "Local addresses" output of CLI `-netinfo`
 - in the "localaddresses" output of RPC `getnetworkinfo`
 - in the debug log (grep for `AddLocal`; the I2P address ends in `.b32.i2p`)

--- a/doc/release-notes-25355.md
+++ b/doc/release-notes-25355.md
@@ -1,0 +1,8 @@
+Notable changes
+===============
+
+P2P and network changes
+-----------------------
+
+- With I2P connections, a new, transient address is used for each outbound
+  connection if `-i2pacceptincoming=0`. (#25355)

--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -434,9 +434,9 @@ void Session::Disconnect()
 {
     if (m_control_sock->Get() != INVALID_SOCKET) {
         if (m_session_id.empty()) {
-            Log("Destroying incomplete session");
+            Log("Destroying incomplete SAM session");
         } else {
-            Log("Destroying session %s", m_session_id);
+            Log("Destroying SAM session %s", m_session_id);
         }
     }
     m_control_sock = std::make_unique<Sock>(INVALID_SOCKET);

--- a/src/i2p.h
+++ b/src/i2p.h
@@ -71,6 +71,19 @@ public:
             CThreadInterrupt* interrupt);
 
     /**
+     * Construct a transient session which will generate its own I2P private key
+     * rather than read the one from disk (it will not be saved on disk either and
+     * will be lost once this object is destroyed). This will not initiate any IO,
+     * the session will be lazily created later when first used.
+     * @param[in] control_host Location of the SAM proxy.
+     * @param[in,out] interrupt If this is signaled then all operations are canceled as soon as
+     * possible and executing methods throw an exception. Notice: only a pointer to the
+     * `CThreadInterrupt` object is saved, so it must not be destroyed earlier than this
+     * `Session` object.
+     */
+    Session(const CService& control_host, CThreadInterrupt* interrupt);
+
+    /**
      * Destroy the session, closing the internally used sockets. The sockets that have been
      * returned by `Accept()` or `Connect()` will not be closed, but they will be closed by
      * the SAM proxy because the session is destroyed. So they will return an error next time
@@ -262,6 +275,12 @@ private:
      * SAM session id.
      */
     std::string m_session_id GUARDED_BY(m_mutex);
+
+    /**
+     * Whether this is a transient session (the I2P private key will not be
+     * read or written to disk).
+     */
+    const bool m_transient;
 };
 
 } // namespace sam

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -564,6 +564,7 @@ void CNode::CloseSocketDisconnect()
         LogPrint(BCLog::NET, "disconnecting peer=%d\n", id);
         m_sock.reset();
     }
+    m_i2p_sam_session.reset();
 }
 
 void CConnman::AddWhitelistPermissionFlags(NetPermissionFlags& flags, const CNetAddr &addr) const {
@@ -2702,20 +2703,27 @@ ServiceFlags CConnman::GetLocalServices() const
 
 unsigned int CConnman::GetReceiveFloodSize() const { return nReceiveFloodSize; }
 
-CNode::CNode(NodeId idIn, std::shared_ptr<Sock> sock, const CAddress& addrIn,
-             uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn,
-             const CAddress& addrBindIn, const std::string& addrNameIn,
-             ConnectionType conn_type_in, bool inbound_onion)
+CNode::CNode(NodeId idIn,
+             std::shared_ptr<Sock> sock,
+             const CAddress& addrIn,
+             uint64_t nKeyedNetGroupIn,
+             uint64_t nLocalHostNonceIn,
+             const CAddress& addrBindIn,
+             const std::string& addrNameIn,
+             ConnectionType conn_type_in,
+             bool inbound_onion,
+             std::unique_ptr<i2p::sam::Session>&& i2p_sam_session)
     : m_sock{sock},
       m_connected{GetTime<std::chrono::seconds>()},
-      addr(addrIn),
-      addrBind(addrBindIn),
+      addr{addrIn},
+      addrBind{addrBindIn},
       m_addr_name{addrNameIn.empty() ? addr.ToStringIPPort() : addrNameIn},
-      m_inbound_onion(inbound_onion),
-      nKeyedNetGroup(nKeyedNetGroupIn),
-      id(idIn),
-      nLocalHostNonce(nLocalHostNonceIn),
-      m_conn_type(conn_type_in)
+      m_inbound_onion{inbound_onion},
+      nKeyedNetGroup{nKeyedNetGroupIn},
+      id{idIn},
+      nLocalHostNonce{nLocalHostNonceIn},
+      m_conn_type{conn_type_in},
+      m_i2p_sam_session{std::move(i2p_sam_session)}
 {
     if (inbound_onion) assert(conn_type_in == ConnectionType::INBOUND);
 

--- a/src/net.h
+++ b/src/net.h
@@ -1090,7 +1090,8 @@ private:
 
     /**
      * I2P SAM session.
-     * Used to accept incoming and make outgoing I2P connections.
+     * Used to accept incoming and make outgoing I2P connections from a persistent
+     * address.
      */
     std::unique_ptr<i2p::sam::Session> m_i2p_sam_session;
 

--- a/src/test/i2p_tests.cpp
+++ b/src/test/i2p_tests.cpp
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(unlimited_recv)
     i2p::sam::Session session(gArgs.GetDataDirNet() / "test_i2p_private_key", CService{}, &interrupt);
 
     {
-        ASSERT_DEBUG_LOG("Creating SAM session");
+        ASSERT_DEBUG_LOG("Creating persistent SAM session");
         ASSERT_DEBUG_LOG("too many bytes without a terminator");
 
         i2p::Connection conn;

--- a/test/functional/p2p_i2p_sessions.py
+++ b/test/functional/p2p_i2p_sessions.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022-2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Test whether persistent or transient I2P sessions are being used, based on `-i2pacceptincoming`.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+
+
+class I2PSessions(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        # The test assumes that an I2P SAM proxy is not listening here.
+        self.extra_args = [
+            ["-i2psam=127.0.0.1:60000", "-i2pacceptincoming=1"],
+            ["-i2psam=127.0.0.1:60000", "-i2pacceptincoming=0"],
+        ]
+
+    def run_test(self):
+        addr = "zsxwyo6qcn3chqzwxnseusqgsnuw3maqnztkiypyfxtya4snkoka.b32.i2p"
+
+        self.log.info("Ensure we create a persistent session when -i2pacceptincoming=1")
+        node0 = self.nodes[0]
+        with node0.assert_debug_log(expected_msgs=[f"Creating persistent SAM session"]):
+            node0.addnode(node=addr, command="onetry")
+
+        self.log.info("Ensure we create a transient session when -i2pacceptincoming=0")
+        node1 = self.nodes[1]
+        with node1.assert_debug_log(expected_msgs=[f"Creating transient SAM session"]):
+            node1.addnode(node=addr, command="onetry")
+
+
+if __name__ == '__main__':
+    I2PSessions().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -328,6 +328,7 @@ BASE_SCRIPTS = [
     'feature_blocksdir.py',
     'wallet_startup.py',
     'p2p_i2p_ports.py',
+    'p2p_i2p_sessions.py',
     'feature_config_args.py',
     'feature_presegwit_node_upgrade.py',
     'feature_settings.py',


### PR DESCRIPTION
Add support for generating a transient, one-time I2P address for ourselves when making I2P outbound connection and discard it once the connection is closed.

Background
---
In I2P connections, the host that receives the connection knows the I2P address of the connection initiator. This is unlike the Tor network where the recipient does not know who is connecting to them, not even the initiator's Tor address.

Persistent vs transient I2P addresses
---
Even if an I2P node is not accepting incoming connections, they are known to other nodes by their outgoing I2P address. This creates an opportunity to white-list given nodes or treat them differently based on their I2P address. However, this also creates an opportunity to fingerprint or analyze a given node because it always uses the same I2P address when it connects to other nodes. Thus, if a node is not accepting incoming I2P connections (`-i2pacceptincoming=0`) we will generate a transient (disposable), one-time I2P address for each new outgoing connection. That address is never going to be reused again, not even if reconnecting to the same peer later. If `-i2pacceptincoming=1` is used then we will use the persistent listening address for outgoing connections and will advertise it to the peers we connect to (like before this PR).