### PR TITLE
test: Remove MiniWallet mempool_valid option

### DIFF
--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -684,7 +684,6 @@ class ReplaceByFeeTest(BitcoinTestFramework):
             utxo_to_spend=parent_utxo,
             sequence=SEQUENCE_FINAL,
             fee_rate=Decimal('0.02'),
-            mempool_valid=False,
         )
 
         # Broadcast replacement child tx

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -75,7 +75,7 @@ class MempoolLimitTest(BitcoinTestFramework):
 
         # Deliberately try to create a tx with a fee less than the minimum mempool fee to assert that it does not get added to the mempool
         self.log.info('Create a mempool tx that will not pass mempoolminfee')
-        assert_raises_rpc_error(-26, "mempool min fee not met", miniwallet.send_self_transfer, from_node=node, fee_rate=relayfee, mempool_valid=False)
+        assert_raises_rpc_error(-26, "mempool min fee not met", miniwallet.send_self_transfer, from_node=node, fee_rate=relayfee)
 
 
 if __name__ == '__main__':

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -53,8 +53,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         utxo = wallet.get_utxo(txid=coinbase_txids[0])
         timelock_tx = wallet.create_self_transfer(
             utxo_to_spend=utxo,
-            mempool_valid=False,
-            locktime=self.nodes[0].getblockcount() + 2
+            locktime=self.nodes[0].getblockcount() + 2,
         )['hex']
 
         self.log.info("Check that the time-locked transaction is too immature to spend")

--- a/test/functional/mempool_spend_coinbase.py
+++ b/test/functional/mempool_spend_coinbase.py
@@ -40,7 +40,7 @@ class MempoolSpendCoinbaseTest(BitcoinTestFramework):
         spend_mature_id = wallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo_mature)["txid"]
 
         # other coinbase should be too immature to spend
-        immature_tx = wallet.create_self_transfer(utxo_to_spend=utxo_immature, mempool_valid=False)
+        immature_tx = wallet.create_self_transfer(utxo_to_spend=utxo_immature)
         assert_raises_rpc_error(-26,
                                 "bad-txns-premature-spend-of-coinbase",
                                 lambda: self.nodes[0].sendrawtransaction(immature_tx['hex']))

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -212,7 +212,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
                 assert x not in mempool
 
         # Create a free transaction.  Should be rejected.
-        tx_res = self.wallet.create_self_transfer(from_node=self.nodes[0], fee_rate=0, mempool_valid=False)
+        tx_res = self.wallet.create_self_transfer(from_node=self.nodes[0], fee_rate=0)
         tx_hex = tx_res['hex']
         tx_id = tx_res['txid']
 

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -285,7 +285,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # Test a transaction with a large fee.
         # Fee rate is 0.20000000 BTC/kvB
-        tx = self.wallet.create_self_transfer(mempool_valid=False, from_node=self.nodes[0], fee_rate=Decimal('0.20000000'))
+        tx = self.wallet.create_self_transfer(from_node=self.nodes[0], fee_rate=Decimal("0.20000000"))
         # Thus, testmempoolaccept should reject
         testres = self.nodes[2].testmempoolaccept([tx['hex']])[0]
         assert_equal(testres['allowed'], False)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -563,7 +563,7 @@ def create_lots_of_big_transactions(mini_wallet, node, fee, tx_batch_size, txout
                 from_node=node,
                 utxo_to_spend=None if use_internal_utxos else utxos.pop(),
                 fee_rate=0,
-                mempool_valid=False)['tx']
+        )["tx"]
         tx.vout[0].nValue -= fee_sats
         tx.vout.extend(txouts)
         res = node.testmempoolaccept([tx.serialize().hex()])[0]

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -193,7 +193,7 @@ class MiniWallet:
 
         Returns a tuple (txid, n) referring to the created external utxo outpoint.
         """
-        tx = self.create_self_transfer(from_node=from_node, fee_rate=0, mempool_valid=False)['tx']
+        tx = self.create_self_transfer(from_node=from_node, fee_rate=0)["tx"]
         assert_greater_than_or_equal(tx.vout[0].nValue, amount + fee)
         tx.vout[0].nValue -= (amount + fee)           # change output -> MiniWallet
         tx.vout.append(CTxOut(amount, scriptPubKey))  # arbitrary output -> to be returned
@@ -230,7 +230,7 @@ class MiniWallet:
         # create simple tx template (1 input, 1 output)
         tx = self.create_self_transfer(
             fee_rate=0, from_node=from_node,
-            utxo_to_spend=utxos_to_spend[0], sequence=sequence, mempool_valid=False)['tx']
+            utxo_to_spend=utxos_to_spend[0], sequence=sequence)["tx"]
 
         # duplicate inputs, witnesses and outputs
         tx.vin = [deepcopy(tx.vin[0]) for _ in range(len(utxos_to_spend))]
@@ -248,9 +248,8 @@ class MiniWallet:
             o.nValue = outputs_value_total // num_outputs
         return tx
 
-    def create_self_transfer(self, *, fee_rate=Decimal("0.003"), from_node=None, utxo_to_spend=None, mempool_valid=True, locktime=0, sequence=0):
-        """Create and return a tx with the specified fee_rate. Fee may be exact or at most one satoshi higher than needed.
-           Checking mempool validity via the testmempoolaccept RPC can be skipped by setting mempool_valid to False."""
+    def create_self_transfer(self, *, fee_rate=Decimal("0.003"), from_node=None, utxo_to_spend=None, locktime=0, sequence=0):
+        """Create and return a tx with the specified fee_rate. Fee may be exact or at most one satoshi higher than needed."""
         from_node = from_node or self._test_node
         utxo_to_spend = utxo_to_spend or self.get_utxo()
         if self._priv_key is None:
@@ -277,11 +276,7 @@ class MiniWallet:
             tx.wit.vtxinwit[0].scriptWitness.stack = [CScript([OP_TRUE]), bytes([LEAF_VERSION_TAPSCRIPT]) + self._internal_key]
         tx_hex = tx.serialize().hex()
 
-        if mempool_valid:
-            tx_info = from_node.testmempoolaccept([tx_hex])[0]
-            assert_equal(tx_info['allowed'], True)
-            assert_equal(tx_info['vsize'], vsize)
-            assert_equal(tx_info['fees']['base'], utxo_to_spend['value'] - Decimal(send_value) / COIN)
+        assert_equal(tx.get_vsize(), vsize)
 
         return {'txid': tx.rehash(), 'wtxid': tx.getwtxid(), 'hex': tx_hex, 'tx': tx}
 


### PR DESCRIPTION
It seems an unnecessary burden to force MiniWallet call-sites to figure out for each tx whether it is mempool valid or not. The result will only be used for internal sanity checks. So remove the option:

* Replace the vsize sanity check with a call to `get_vsize()`.
* Drop the fee check. Hopefully any future bug here will be caught by code-review or otherwise.