### PR TITLE
guix: drop `-z,noexecstack` for PPC64

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -249,10 +249,6 @@ case "$HOST" in
     *powerpc64*) HOST_LDFLAGS="${HOST_LDFLAGS} -Wl,--no-tls-get-addr-optimize" ;;
 esac
 
-case "$HOST" in
-    powerpc64-linux-*) HOST_LDFLAGS="${HOST_LDFLAGS} -Wl,-z,noexecstack" ;;
-esac
-
 # Make $HOST-specific native binaries from depends available in $PATH
 export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
 mkdir -p "$DISTSRC"

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -200,6 +200,10 @@ chain for " target " development."))
   (package-with-extra-patches base-nsis
     (search-our-patches "nsis-gcc-10-memmove.patch")))
 
+(define (fix-ppc64-nx-default lief)
+  (package-with-extra-patches lief
+    (search-our-patches "lief-fix-ppc64-nx-default.patch")))
+
 (define-public lief
   (package
    (name "python-lief")
@@ -602,7 +606,7 @@ inspecting signatures in Mach-O binaries.")
         ;; Git
         git
         ;; Tests
-        lief)
+        (fix-ppc64-nx-default lief))
   (let ((target (getenv "HOST")))
     (cond ((string-suffix? "-mingw32" target)
            ;; Windows

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -203,7 +203,7 @@ chain for " target " development."))
 (define-public lief
   (package
    (name "python-lief")
-   (version "0.12.0")
+   (version "0.12.1")
    (source
     (origin
      (method git-fetch)
@@ -213,7 +213,7 @@ chain for " target " development."))
      (file-name (git-file-name name version))
      (sha256
       (base32
-       "026jchj56q25v6gc0754dj9cj5hz5zaza8ij93y5ga94w20kzm9q"))))
+       "1xzbh3bxy4rw1yamnx68da1v5s56ay4g081cyamv67256g0qy2i1"))))
    (build-system python-build-system)
    (arguments
     `(#:phases

--- a/contrib/guix/patches/lief-fix-ppc64-nx-default.patch
+++ b/contrib/guix/patches/lief-fix-ppc64-nx-default.patch
@@ -1,0 +1,29 @@
+Correct default for Binary::has_nx on ppc64
+
+From the Linux kernel source:
+
+    * This is the default if a program doesn't have a PT_GNU_STACK
+    * program header entry. The PPC64 ELF ABI has a non executable stack
+    * stack by default, so in the absence of a PT_GNU_STACK program header
+    * we turn execute permission off.
+
+This patch can be dropped the next time we update LIEF.
+
+diff --git a/src/ELF/Binary.cpp b/src/ELF/Binary.cpp
+index a90be1ab..fd2d9764 100644
+--- a/src/ELF/Binary.cpp
++++ b/src/ELF/Binary.cpp
+@@ -1084,7 +1084,12 @@ bool Binary::has_nx() const {
+                                        return segment->type() == SEGMENT_TYPES::PT_GNU_STACK;
+                                      });
+   if (it_stack == std::end(segments_)) {
+-    return false;
++    if (header().machine_type() == ARCH::EM_PPC64) {
++      // The PPC64 ELF ABI has a non-executable stack by default.
++      return true;
++    } else {
++      return false;
++    }
+   }
+ 
+   return !(*it_stack)->has(ELF_SEGMENT_FLAGS::PF_X);


### PR DESCRIPTION
The PPC64 ELF ABI has a non-executable stack by default, so passing `-Wl,-z,noexecstack` to force the creation of a `GNU_STACK` segment, just so we can assert that it doesn't have the exectable permission, is awkward. Now that LIEF has been fixed upstream, https://github.com/lief-project/LIEF/pull/718, we can temporarily patch our LIEF build to include the (simple) patch, and drop it the next time we update LIEF.

See the relevant Linux kernel [documentation for powerpc](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/powerpc/include/asm/page_64.h#n92) (and discussion in #25313):
```c
/*
 * This is the default if a program doesn't have a PT_GNU_STACK
 * program header entry. The PPC64 ELF ABI has a non executable stack
 * stack by default, so in the absence of a PT_GNU_STACK program header
 * we turn execute permission off.
 */
#define VM_STACK_DEFAULT_FLAGS32	VM_DATA_FLAGS_EXEC
#define VM_STACK_DEFAULT_FLAGS64	VM_DATA_FLAGS_NON_EXEC

#define VM_STACK_DEFAULT_FLAGS \
	(is_32bit_task() ? \
	 VM_STACK_DEFAULT_FLAGS32 : VM_STACK_DEFAULT_FLAGS64)
```

Guix Build (x86_64):
```bash
0df3f7a716b8c58c29990b0fbad17dbddb7a14d8e348bdabec7593771accaa2c  guix-build-5f082ad4e4cc/output/aarch64-linux-gnu/SHA256SUMS.part
f235d9fb0255a0dd3cca7005e4ee09623b01224372585a49be8f94569bd52617  guix-build-5f082ad4e4cc/output/aarch64-linux-gnu/bitcoin-5f082ad4e4cc-aarch64-linux-gnu-debug.tar.gz
8d870b415dcd30abc889c47f5313cb6a30ec7d0a29bab11394a90c612171a09d  guix-build-5f082ad4e4cc/output/aarch64-linux-gnu/bitcoin-5f082ad4e4cc-aarch64-linux-gnu.tar.gz
1f37b3ba87ab9f3aedc8f23251b423b146c1db9cc93d7cbe1ccb22a818cb597f  guix-build-5f082ad4e4cc/output/arm-linux-gnueabihf/SHA256SUMS.part
515e13725241fe889208df0c4a678da83e06dfa77e0b47125b2bfd46cf784b11  guix-build-5f082ad4e4cc/output/arm-linux-gnueabihf/bitcoin-5f082ad4e4cc-arm-linux-gnueabihf-debug.tar.gz
d6051bde21d3b17c44af6925efcb68fcda5e0ae0bc42f167a36bea79205bd0f7  guix-build-5f082ad4e4cc/output/arm-linux-gnueabihf/bitcoin-5f082ad4e4cc-arm-linux-gnueabihf.tar.gz
3c12359285baa0d1696d855d220f235d5db44c1989e3e13d89cb555ca8f2bc01  guix-build-5f082ad4e4cc/output/arm64-apple-darwin/SHA256SUMS.part
74853e41c40a7d12d08c83b8e77d0a007bb19465c1206b7b78d85e5dc4f08df1  guix-build-5f082ad4e4cc/output/arm64-apple-darwin/bitcoin-5f082ad4e4cc-arm64-apple-darwin-unsigned.dmg
570d3f9578715784c729acdaafaf67ebcefbf48c1da3f322813292803f275ccf  guix-build-5f082ad4e4cc/output/arm64-apple-darwin/bitcoin-5f082ad4e4cc-arm64-apple-darwin-unsigned.tar.gz
670e1f4b2825679d8e92b76f0a253dd11a9d8c484bf8a453068e63d99df7e1dd  guix-build-5f082ad4e4cc/output/arm64-apple-darwin/bitcoin-5f082ad4e4cc-arm64-apple-darwin.tar.gz
935deb771d847aab5feda557902225c49b6f2547f271072853f5a94a501885fd  guix-build-5f082ad4e4cc/output/dist-archive/bitcoin-5f082ad4e4cc.tar.gz
dce5d37e13ddc2482333fe5b0f6b3d5f29a2bfc38446088afeb3b2e3345c0753  guix-build-5f082ad4e4cc/output/powerpc64-linux-gnu/SHA256SUMS.part
b65de56a98b6bd9dbdfa7cb4c92517804b936c7ed101475f2764283d1f3c0b6d  guix-build-5f082ad4e4cc/output/powerpc64-linux-gnu/bitcoin-5f082ad4e4cc-powerpc64-linux-gnu-debug.tar.gz
9d3cb775a467df2d653fc1670008bcf344303dd20f740e727c927ec5f9015aa8  guix-build-5f082ad4e4cc/output/powerpc64-linux-gnu/bitcoin-5f082ad4e4cc-powerpc64-linux-gnu.tar.gz
7f6cbaef349ed129a769bdae2adcff7f65d856f52f2caf25f4da44272058fbf0  guix-build-5f082ad4e4cc/output/powerpc64le-linux-gnu/SHA256SUMS.part
56435b4da1e96beefe0e2093f5c1cafac19d911fe3df667b6652e6641786a582  guix-build-5f082ad4e4cc/output/powerpc64le-linux-gnu/bitcoin-5f082ad4e4cc-powerpc64le-linux-gnu-debug.tar.gz
75a43ecdcd374d15543458251e4d7275551e08cff308483d3f54130fa18008a4  guix-build-5f082ad4e4cc/output/powerpc64le-linux-gnu/bitcoin-5f082ad4e4cc-powerpc64le-linux-gnu.tar.gz
a555d0164046d47ec32c5924657c74a3d481165096dd1b74050871e438563442  guix-build-5f082ad4e4cc/output/riscv64-linux-gnu/SHA256SUMS.part
fc4c430f34bea975f14b755574f4507b9972b873056d9cf55a165b1e2902ddae  guix-build-5f082ad4e4cc/output/riscv64-linux-gnu/bitcoin-5f082ad4e4cc-riscv64-linux-gnu-debug.tar.gz
a25a0fe2c5cf08fa8af588fe4e8c74276db5386ab44118ed6226de575b50cacd  guix-build-5f082ad4e4cc/output/riscv64-linux-gnu/bitcoin-5f082ad4e4cc-riscv64-linux-gnu.tar.gz
811fd6d62e02b6a3bf1a0e39d8721034398c1710649f080c81e514eb34e70500  guix-build-5f082ad4e4cc/output/x86_64-apple-darwin/SHA256SUMS.part
1a43bf4e0b56f9e724c45a7f5cc8f1641e038c450a62ab9baa68f6fe2f60da8a  guix-build-5f082ad4e4cc/output/x86_64-apple-darwin/bitcoin-5f082ad4e4cc-x86_64-apple-darwin-unsigned.dmg
8c2508bdf0256177b05fff4cd613b735deaacee844f74ae075dabdc911b35204  guix-build-5f082ad4e4cc/output/x86_64-apple-darwin/bitcoin-5f082ad4e4cc-x86_64-apple-darwin-unsigned.tar.gz
7cb121072661dc224914d6777135d51aa60f16c8dc890f840f81d39cc55ee7ed  guix-build-5f082ad4e4cc/output/x86_64-apple-darwin/bitcoin-5f082ad4e4cc-x86_64-apple-darwin.tar.gz
4ff472b2f9e786e620c449563c33f032795dada20701e9da9126997b2f9605e7  guix-build-5f082ad4e4cc/output/x86_64-linux-gnu/SHA256SUMS.part
1e0e4662a38f5df3027b4c062a18c6255fb59640afc69dd2e23a1dc47f278a74  guix-build-5f082ad4e4cc/output/x86_64-linux-gnu/bitcoin-5f082ad4e4cc-x86_64-linux-gnu-debug.tar.gz
0d02f5689b008818467d5fe14a10503738e0e6c96f34591771cb8fb0f2cd3763  guix-build-5f082ad4e4cc/output/x86_64-linux-gnu/bitcoin-5f082ad4e4cc-x86_64-linux-gnu.tar.gz
bff9e2893998b1880850f0195a8282564c4bf46d2bfaaf3358ddd7f1812370f1  guix-build-5f082ad4e4cc/output/x86_64-w64-mingw32/SHA256SUMS.part
11e0835f989d86c6c39a8dfa60e7129262e098ef80720d0de6acfdcd8995fd92  guix-build-5f082ad4e4cc/output/x86_64-w64-mingw32/bitcoin-5f082ad4e4cc-win64-debug.zip
491038e48288863860a3adf229a138d1b74a24004dcb1e07b28d207f866e7d15  guix-build-5f082ad4e4cc/output/x86_64-w64-mingw32/bitcoin-5f082ad4e4cc-win64-setup-unsigned.exe
5c8cbbd00a0cb5fcb00478bd05cbb7fa38f97126c677538389173cf71f64f647  guix-build-5f082ad4e4cc/output/x86_64-w64-mingw32/bitcoin-5f082ad4e4cc-win64-unsigned.tar.gz
a6ee1e220e8d91192ee6f36ef33a0c5a1348aba2f84fd42d228f04ab927f3feb  guix-build-5f082ad4e4cc/output/x86_64-w64-mingw32/bitcoin-5f082ad4e4cc-win64.zip
```

Guix Build (arm64):
```bash
17ec23ec07289eb00eec401385aca7e194d366f86778bd747ca17ad2bdded16f  guix-build-5f082ad4e4cc/output/arm-linux-gnueabihf/SHA256SUMS.part
34b997bba0ec8c6f66bde5cd8d08cf2fbf6e5cb04d1825a4ef4b850c059841fa  guix-build-5f082ad4e4cc/output/arm-linux-gnueabihf/bitcoin-5f082ad4e4cc-arm-linux-gnueabihf-debug.tar.gz
93666cc53fd3a6cdfe3528f42a8250bc82bd7a1ab5936d99052bef49142e06c9  guix-build-5f082ad4e4cc/output/arm-linux-gnueabihf/bitcoin-5f082ad4e4cc-arm-linux-gnueabihf.tar.gz
c142bd730e1a564f9c0f65818fa3a0e3d20d41a95c419ce52b11ef33420d03ad  guix-build-5f082ad4e4cc/output/arm64-apple-darwin/SHA256SUMS.part
afcf76d9807173a1dceb6c9933997f1cbac76fb9b683b6ad65af93069dbe7344  guix-build-5f082ad4e4cc/output/arm64-apple-darwin/bitcoin-5f082ad4e4cc-arm64-apple-darwin-unsigned.dmg
f1a6f2b8a01543b3f5926e880619c54317fdcb2e93ed860df5e0bb642a8e6d4c  guix-build-5f082ad4e4cc/output/arm64-apple-darwin/bitcoin-5f082ad4e4cc-arm64-apple-darwin-unsigned.tar.gz
e423a0cb964177d6ad97cebd288666460a902d45f51bacba23b019644ddeea18  guix-build-5f082ad4e4cc/output/arm64-apple-darwin/bitcoin-5f082ad4e4cc-arm64-apple-darwin.tar.gz
935deb771d847aab5feda557902225c49b6f2547f271072853f5a94a501885fd  guix-build-5f082ad4e4cc/output/dist-archive/bitcoin-5f082ad4e4cc.tar.gz
e01cf090da155bc7626d221a87a177b2dd1cdb8d9c2954e2423ab0268976e513  guix-build-5f082ad4e4cc/output/powerpc64-linux-gnu/SHA256SUMS.part
08afcfc256bd8f29d1dad90709828ef800b2ea3d22b834dc78af27b5d10d20b5  guix-build-5f082ad4e4cc/output/powerpc64-linux-gnu/bitcoin-5f082ad4e4cc-powerpc64-linux-gnu-debug.tar.gz
cf861876542e8b27e9335ce9432107a402e8cc4b177d2db1649b54d7e269081e  guix-build-5f082ad4e4cc/output/powerpc64-linux-gnu/bitcoin-5f082ad4e4cc-powerpc64-linux-gnu.tar.gz
0840ae94ea6830d842043d4a8ed17893e3f58917113bcf2e2e3ee247bd8db249  guix-build-5f082ad4e4cc/output/powerpc64le-linux-gnu/SHA256SUMS.part
072251112d709f1c2a3b38065f5fb5a435f3cefbc788e46fa1ff9d96d746ea4d  guix-build-5f082ad4e4cc/output/powerpc64le-linux-gnu/bitcoin-5f082ad4e4cc-powerpc64le-linux-gnu-debug.tar.gz
a8507446c9a69a0c7fe1020e30d6f0334d0f6c0c96263298bafd502c2ce2c7c4  guix-build-5f082ad4e4cc/output/powerpc64le-linux-gnu/bitcoin-5f082ad4e4cc-powerpc64le-linux-gnu.tar.gz
d3cf62ebabb062276dd1615774c7ee231b62a92ba1a9515f13c1f0454d84c6e5  guix-build-5f082ad4e4cc/output/riscv64-linux-gnu/SHA256SUMS.part
0b738e9f973d2ed4031fd81465ea65bc9d17e983e48c892ca89582da9d8afcd5  guix-build-5f082ad4e4cc/output/riscv64-linux-gnu/bitcoin-5f082ad4e4cc-riscv64-linux-gnu-debug.tar.gz
28e84d55aa048be871776cd62c7dcbb6286d2f42ac1ce59772ea65217eb86ec2  guix-build-5f082ad4e4cc/output/riscv64-linux-gnu/bitcoin-5f082ad4e4cc-riscv64-linux-gnu.tar.gz
811fd6d62e02b6a3bf1a0e39d8721034398c1710649f080c81e514eb34e70500  guix-build-5f082ad4e4cc/output/x86_64-apple-darwin/SHA256SUMS.part
1a43bf4e0b56f9e724c45a7f5cc8f1641e038c450a62ab9baa68f6fe2f60da8a  guix-build-5f082ad4e4cc/output/x86_64-apple-darwin/bitcoin-5f082ad4e4cc-x86_64-apple-darwin-unsigned.dmg
8c2508bdf0256177b05fff4cd613b735deaacee844f74ae075dabdc911b35204  guix-build-5f082ad4e4cc/output/x86_64-apple-darwin/bitcoin-5f082ad4e4cc-x86_64-apple-darwin-unsigned.tar.gz
7cb121072661dc224914d6777135d51aa60f16c8dc890f840f81d39cc55ee7ed  guix-build-5f082ad4e4cc/output/x86_64-apple-darwin/bitcoin-5f082ad4e4cc-x86_64-apple-darwin.tar.gz
6463d3502cb839e50aaa2063f3ea1e4c874904e4745836411603e4cf0b5da946  guix-build-5f082ad4e4cc/output/x86_64-linux-gnu/SHA256SUMS.part
dae5e82e1a32312fb417aabeef750cb4317a853af142ec0a7125dcb6f66e7930  guix-build-5f082ad4e4cc/output/x86_64-linux-gnu/bitcoin-5f082ad4e4cc-x86_64-linux-gnu-debug.tar.gz
2434199cc24b8b463d3efda8a053d21324c02d1b06afaa3e08af7cdffa7b05d4  guix-build-5f082ad4e4cc/output/x86_64-linux-gnu/bitcoin-5f082ad4e4cc-x86_64-linux-gnu.tar.gz
8195c14785b4f553eb05fb8c25516d1b337b3ca8fc9d7cf6ad6d2bd3bc6d2093  guix-build-5f082ad4e4cc/output/x86_64-w64-mingw32/SHA256SUMS.part
95b674ae6d9ddff652feeb5280e6a600803f78f685cde62f94332876c4039357  guix-build-5f082ad4e4cc/output/x86_64-w64-mingw32/bitcoin-5f082ad4e4cc-win64-debug.zip
491038e48288863860a3adf229a138d1b74a24004dcb1e07b28d207f866e7d15  guix-build-5f082ad4e4cc/output/x86_64-w64-mingw32/bitcoin-5f082ad4e4cc-win64-setup-unsigned.exe
5c8cbbd00a0cb5fcb00478bd05cbb7fa38f97126c677538389173cf71f64f647  guix-build-5f082ad4e4cc/output/x86_64-w64-mingw32/bitcoin-5f082ad4e4cc-win64-unsigned.tar.gz
3e5fbbe50d266e6e03ae0976ccef74cf1024d107629223e655c672e2b8d73187  guix-build-5f082ad4e4cc/output/x86_64-w64-mingw32/bitcoin-5f082ad4e4cc-win64.zip
```