### PR TITLE
test: passing a value below 5 MB to -maxmempool should throw an error

### DIFF
--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -87,6 +87,10 @@ class MempoolLimitTest(BitcoinTestFramework):
         self.log.info('Create a mempool tx that will not pass mempoolminfee')
         assert_raises_rpc_error(-26, "mempool min fee not met", miniwallet.send_self_transfer, from_node=node, fee_rate=relayfee, mempool_valid=False)
 
+        self.log.info('Test passing a value below the minimum (5 MB) to -maxmempool throws an error')
+        self.stop_node(0)
+        self.nodes[0].assert_start_raises_init_error(["-maxmempool=4"], "Error: -maxmempool must be at least 5 MB")
+
 
 if __name__ == '__main__':
     MempoolLimitTest().main()


### PR DESCRIPTION
This PR adds test coverage for the following init error:
https://github.com/bitcoin/bitcoin/blob/5174a139c92c1238f9700d06e362dc628d81a0a9/src/init.cpp#L931-L935

By default, the minimum value is 5 MB. See:
https://github.com/bitcoin/bitcoin/blob/master/doc/reduce-memory.md#memory-pool