### PR TITLE
util, rpc: Add parameter to `deriveaddresses` to display address information

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -82,6 +82,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendmany", 8, "fee_rate"},
     { "sendmany", 9, "verbose" },
     { "deriveaddresses", 1, "range" },
+    { "deriveaddresses", 2, "options" },
     { "scantxoutset", 1, "scanobjects" },
     { "addmultisigaddress", 0, "nrequired" },
     { "addmultisigaddress", 1, "keys" },

--- a/test/functional/rpc_deriveaddresses.py
+++ b/test/functional/rpc_deriveaddresses.py
@@ -25,9 +25,51 @@ class DeriveaddressesTest(BitcoinTestFramework):
         address = "bcrt1qjqmxmkpmxt80xz4y3746zgt0q3u3ferr34acd5"
         assert_equal(self.nodes[0].deriveaddresses(descriptor_pubkey), [address])
 
+        res = self.nodes[0].deriveaddresses(descriptor=descriptor_pubkey, options={"details": True})
+        assert_equal(res[0]['address'], address)
+        assert_equal(res[0]['output_script'], '001490366dd83b32cef30aa48faba1216f047914e463')
+        assert_equal(len(res[0]['public_keys']), 1)
+        assert_equal(res[0]['public_keys'][0], '03e1c5b6e650966971d7e71ef2674f80222752740fc1dfd63bbbd220d2da9bd0fb')
+
+        res = self.nodes[0].deriveaddresses(descriptor=descriptor + "#t6wfjs64", options={"details": True})
+        assert_equal(res[0]['address'], address)
+        assert_equal(res[0]['output_script'], '001490366dd83b32cef30aa48faba1216f047914e463')
+        assert_equal(len(res[0]['public_keys']), 1)
+        assert_equal(res[0]['public_keys'][0], '03e1c5b6e650966971d7e71ef2674f80222752740fc1dfd63bbbd220d2da9bd0fb')
+
         ranged_descriptor = "wpkh(tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK/1/1/*)#kft60nuy"
         assert_equal(self.nodes[0].deriveaddresses(ranged_descriptor, [1, 2]), ["bcrt1qhku5rq7jz8ulufe2y6fkcpnlvpsta7rq4442dy", "bcrt1qpgptk2gvshyl0s9lqshsmx932l9ccsv265tvaq"])
         assert_equal(self.nodes[0].deriveaddresses(ranged_descriptor, 2), [address, "bcrt1qhku5rq7jz8ulufe2y6fkcpnlvpsta7rq4442dy", "bcrt1qpgptk2gvshyl0s9lqshsmx932l9ccsv265tvaq"])
+
+        res = self.nodes[0].deriveaddresses(ranged_descriptor, [1,2], {"details": True})
+        assert_equal(res[0]['index'], 1)
+        assert_equal(res[0]['address'], 'bcrt1qhku5rq7jz8ulufe2y6fkcpnlvpsta7rq4442dy')
+        assert_equal(res[0]['output_script'], '0014bdb94183d211f9fe272a26936c067f6060bef860')
+        assert_equal(len(res[0]['public_keys']), 1)
+        assert_equal(res[0]['public_keys'][0], '030d820fc9e8211c4169be8530efbc632775d8286167afd178caaf1089b77daba7')
+        assert_equal(res[1]['index'], 2)
+        assert_equal(res[1]['address'], 'bcrt1qpgptk2gvshyl0s9lqshsmx932l9ccsv265tvaq')
+        assert_equal(res[1]['output_script'], '00140a02bb290c85c9f7c0bf042f0d98b157cb8c418a')
+        assert_equal(len(res[1]['public_keys']), 1)
+        assert_equal(res[1]['public_keys'][0], '030d01adfad886db234d143b4d5d7f2abec365ae393407cb425e1f39fa3da694c0')
+
+        ranged_descriptor = "wsh(multi(2,tprv8ZgxMBicQKsPePmENhT9N9yiSfTtDoC1f39P7nNmgEyCB6Nm4Qiv1muq4CykB9jtnQg2VitBrWh8PJU8LHzoGMHTrS2VKBSgAz7Ssjf9S3P/86'/1'/0'/0/*,tprv8ZgxMBicQKsPfMzHFsP1xhYbMGowTt7PPwkfsuBDhCN7rSnCTSConREDsnroDrtNtCCxzhGvhLYVCULPDtrzTV7w1wNWMPsBz2tbX3tKFRy/86'/1'/0'/0/*))#kjq88ke0"
+        res = self.nodes[0].deriveaddresses(ranged_descriptor, 0, {"details": True})
+        assert_equal(res[0]['index'], 0)
+        assert_equal(res[0]['address'], 'bcrt1qupzqr3kdgn6zdjkemlfy5kytr42z96wsutjjylvj4qvwm2argvtshnh8gs')
+        assert_equal(res[0]['output_script'], '0020e04401c6cd44f426cad9dfd24a588b1d5422e9d0e2e5227d92a818edaba34317')
+        assert_equal(len(res[0]['public_keys']), 2)
+        assert_equal(res[0]['public_keys'][0], '02557828307dcf41e15753ec4c7e1f7af149dd85f8e2a10b81bc81174f9129997b')
+        assert_equal(res[0]['public_keys'][1], '03f1f8587257e595dd5a1699da22b749cb9bea5f5d0b9bccfb43f119092b1297de')
+
+        ranged_descriptor = "wsh(multi(2,tprv8ZgxMBicQKsPePmENhT9N9yiSfTtDoC1f39P7nNmgEyCB6Nm4Qiv1muq4CykB9jtnQg2VitBrWh8PJU8LHzoGMHTrS2VKBSgAz7Ssjf9S3P/0/*,tpubDBYDcH8P2PedrEN3HxWYJJJMZEdgnrqMsjeKpPNzwe7jmGwk5M3HRdSf5vudAXwrJPfUsfvUPFooKWmz79Lh111U51RNotagXiGNeJe3i6t/1/*))#szn2yxkq"
+        res = self.nodes[0].deriveaddresses(ranged_descriptor, 0, {"details": True})
+        assert_equal(res[0]['index'], 0)
+        assert_equal(res[0]['address'], 'bcrt1qqsat6c82fvdy73rfzye8f7nwxcz3xny7t56azl73g95mt3tmzvgsgyd282')
+        assert_equal(res[0]['output_script'], '0020043abd60ea4b1a4f4469113274fa6e3605134c9e5d35d17fd14169b5c57b1311')
+        assert_equal(len(res[0]['public_keys']), 2)
+        assert_equal(res[0]['public_keys'][0], '0281c133371848d11ac195189bdfd32c1bbf39ebc1ee1b627897afd2ff8770e77b')
+        assert_equal(res[0]['public_keys'][1], '03db7c6fb51e4386137e2a320c25a8681ebdc5130a902c7abb9fb94d7358f9ca70')
 
         assert_raises_rpc_error(-8, "Range should not be specified for an un-ranged descriptor", self.nodes[0].deriveaddresses, descsum_create("wpkh(tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK/1/1/0)"), [0, 2])
 


### PR DESCRIPTION
This PR adds the `details` parameter to `deriveaddresses` RPC. 
With this option enabled, this RPC will return the private and public key and the output script for each address, as seen below.

Motivation: I needed to retrieve the private key from an address generated by a descriptor wallet, but `dumpprivkey` is not available for new wallets. 
This change allows extracting this type of information from an address generated by a descriptor.

If the descriptor contains `xpub` instead of `xpriv`, the `private_key` field will be omitted.
If the descriptor is non-ranged, the `index` field will be omitted.

This PR does not change the current behavior if the new parameter is not used.

Example:
```
$ bitcoin-cli -signet deriveaddresses "tr(tprv8ZgxMBicQKsPfMzHFsP1xhYbMGowTt7PPwkfsuBDhCN7rSnCTSConREDsnroDrtNtCCxzhGvhLYVCULPDtrzTV7w1wNWMPsBz2tbX3tKFRy/86'/1'/0'/0/*)#ndy4d8qe" "[0,2]" true
[
  {
    "index": 0,
    "address": "tb1p840d3777aztc9mpa4yndtk882ja8cpqstq96399gm5atk8ekt2ws3etmlg",
    "output_script": "51203d5ed8fbdee89782ec3da926d5d8e754ba7c0410580ba894a8dd3abb1f365a9d",
    "public_key": "02557828307dcf41e15753ec4c7e1f7af149dd85f8e2a10b81bc81174f9129997b",
    "private_key": "cP7pg6J5tFzAf1SiPVnJs12EPUgaiVh55uNbfaRgkjAr2cEqf1bK"
  },
  {
    "index": 1,
    "address": "tb1psjvm057x7v8rv45apk5jtplw5w49r9l4wn4q6mc3urdv57wg98zqnygxsq",
    "output_script": "51208499b7d3c6f30e36569d0da92587eea3aa5197f574ea0d6f11e0daca79c829c4",
    "public_key": "02c80f11f563cd9cbf5a26f335bb363fddb7155f97c1a3d26e0f2c8132df33b7d9",
    "private_key": "cPCwhcnJqeVEp2APohD11ZXqVhzEnvYmB37JHfif2sAJD5fZygiQ"
  },
  {
    "index": 2,
    "address": "tb1pggz3twdfe25cczrwc7mf3p3qyrp4m8f75t4ug8r0mfw9kaen3m0sfm3t3y",
    "output_script": "5120420515b9a9caa98c086ec7b698862020c35d9d3ea2ebc41c6fda5c5b77338edf",
    "public_key": "03f8441bf1a56ba725ab58084f449ec147c21359aa59441834df5f15097e846b1f",
    "private_key": "cRPpFpwTZ2P4Jz7Rna7A72caVhQEGyco1R8yHY1KV2s1KdrNEdkZ"
  }
]
```