### PR TITLE
[contrib] message-capture-parser: fix out of bounds error for empty vectors

### DIFF
--- a/contrib/message-capture/message-capture-parser.py
+++ b/contrib/message-capture/message-capture-parser.py
@@ -79,7 +79,8 @@ def to_jsonable(obj: Any) -> Any:
             val = getattr(obj, slot, None)
             if slot in HASH_INTS and isinstance(val, int):
                 ret[slot] = ser_uint256(val).hex()
-            elif slot in HASH_INT_VECTORS and isinstance(val[0], int):
+            elif slot in HASH_INT_VECTORS:
+                assert all(isinstance(a, int) for a in val)
                 ret[slot] = [ser_uint256(a).hex() for a in val]
             else:
                 ret[slot] = to_jsonable(val)


### PR DESCRIPTION
The script [message-capture-parser.py](https://github.com/bitcoin/bitcoin/blob/master/contrib/message-capture/message-capture-parser.py) currently throws an "out of bounds" error if a message containing an empty integer vector element is tried to converted to JSON (e.g. by the BIP157 message `cfcheckpt` with empty `FilterHeaders` vector):
```
Traceback (most recent call last):
  File "/home/honey/bitcoin/./contrib/message-capture/message-capture-parser.py", line 217, in <module>
    main()
  File "/home/honey/bitcoin/./contrib/message-capture/message-capture-parser.py", line 202, in main
    process_file(str(capture), messages, "recv" in capture.stem, progress_bar)
  File "/home/honey/bitcoin/./contrib/message-capture/message-capture-parser.py", line 162, in process_file
    msg_dict["body"] = to_jsonable(msg)
  File "/home/honey/bitcoin/./contrib/message-capture/message-capture-parser.py", line 85, in to_jsonable
    elif slot in HASH_INT_VECTORS and isinstance(val[0], int):
IndexError: list index out of range
```

Fix this by using the `all(...)` predicate rather to access the first element `val[0]` (which in the error case doesn't exist).