### PR TITLE
Support ignoring "opt-in" flag for RBF (aka full RBF)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -558,7 +558,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-bytespersigop", strprintf("Equivalent bytes per sigop in transactions for relay and mining (default: %u)", DEFAULT_BYTES_PER_SIGOP), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarrier", strprintf("Relay and mine data carrier transactions (default: %u)", DEFAULT_ACCEPT_DATACARRIER), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarriersize", strprintf("Maximum size of data in data carrier transactions we relay and mine (default: %u)", MAX_OP_RETURN_RELAY), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
-    argsman.AddArg("-mempoolreplacement", strprintf("Enable transaction replacement in the memory pool (default: %u)", DEFAULT_ENABLE_REPLACEMENT), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-mempoolreplacement", strprintf("Enable transaction replacement in the memory pool (\"fee,-optin\" = ignore opt-out flag, default: %u)", DEFAULT_ENABLE_REPLACEMENT), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-minrelaytxfee=<amt>", strprintf("Fees (in %s/kvB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)",
         CURRENCY_UNIT, FormatMoney(DEFAULT_MIN_RELAY_TX_FEE)), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-whitelistforcerelay", strprintf("Add 'forcerelay' permission to whitelisted inbound peers with default permissions. This will relay transactions even if the transactions were already in the mempool. (default: %d)", DEFAULT_WHITELISTFORCERELAY), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
@@ -1044,8 +1044,13 @@ bool AppInitParameterInteraction(const ArgsManager& args, bool use_syscall_sandb
     if ((!gEnableReplacement) && args.IsArgSet("-mempoolreplacement")) {
         // Minimal effort at forwards compatibility
         std::string replacement_opt = args.GetArg("-mempoolreplacement", "");  // default is impossible
-        std::vector<std::string> replacement_modes = SplitString(replacement_opt, ",");
+        std::vector<std::string> replacement_modes = SplitString(replacement_opt, ",+");
         gEnableReplacement = (std::find(replacement_modes.begin(), replacement_modes.end(), "fee") != replacement_modes.end());
+        if (gEnableReplacement) {
+            gReplacementHonourOptOut = (std::find(replacement_modes.begin(), replacement_modes.end(), "-optin") == replacement_modes.end());
+        } else {
+            gReplacementHonourOptOut = true;
+        }
     }
 
 #if defined(USE_SYSCALL_SANDBOX)

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -36,7 +36,6 @@ static constexpr unsigned int DEFAULT_INCREMENTAL_RELAY_FEE{1000};
 /** Default for -bytespersigop */
 static constexpr unsigned int DEFAULT_BYTES_PER_SIGOP{20};
 /** Default for -mempoolreplacement */
-static constexpr bool DEFAULT_ENABLE_REPLACEMENT{true};
 static constexpr bool DEFAULT_REPLACEMENT_HONOUR_OPTOUT{true};
 /** Default for -permitbaremultisig */
 static constexpr bool DEFAULT_PERMIT_BAREMULTISIG{true};

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -37,6 +37,7 @@ static constexpr unsigned int DEFAULT_INCREMENTAL_RELAY_FEE{1000};
 static constexpr unsigned int DEFAULT_BYTES_PER_SIGOP{20};
 /** Default for -mempoolreplacement */
 static constexpr bool DEFAULT_ENABLE_REPLACEMENT{true};
+static constexpr bool DEFAULT_REPLACEMENT_HONOUR_OPTOUT{true};
 /** Default for -permitbaremultisig */
 static constexpr bool DEFAULT_PERMIT_BAREMULTISIG{true};
 /** The maximum number of witness stack items in a standard P2WSH script */

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -35,6 +35,8 @@ static constexpr unsigned int MAX_STANDARD_TX_SIGOPS_COST{MAX_BLOCK_SIGOPS_COST/
 static constexpr unsigned int DEFAULT_INCREMENTAL_RELAY_FEE{1000};
 /** Default for -bytespersigop */
 static constexpr unsigned int DEFAULT_BYTES_PER_SIGOP{20};
+/** Default for -mempoolreplacement */
+static constexpr bool DEFAULT_ENABLE_REPLACEMENT{true};
 /** Default for -permitbaremultisig */
 static constexpr bool DEFAULT_PERMIT_BAREMULTISIG{true};
 /** The maximum number of witness stack items in a standard P2WSH script */

--- a/src/policy/settings.cpp
+++ b/src/policy/settings.cpp
@@ -8,6 +8,7 @@
 #include <policy/feerate.h>
 #include <policy/policy.h>
 
+bool gEnableReplacement = DEFAULT_ENABLE_REPLACEMENT;
 bool fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
 CFeeRate incrementalRelayFee = CFeeRate(DEFAULT_INCREMENTAL_RELAY_FEE);
 CFeeRate dustRelayFee = CFeeRate(DUST_RELAY_TX_FEE);

--- a/src/policy/settings.cpp
+++ b/src/policy/settings.cpp
@@ -9,6 +9,7 @@
 #include <policy/policy.h>
 
 bool gEnableReplacement = DEFAULT_ENABLE_REPLACEMENT;
+bool gReplacementHonourOptOut = DEFAULT_REPLACEMENT_HONOUR_OPTOUT;
 bool fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
 CFeeRate incrementalRelayFee = CFeeRate(DEFAULT_INCREMENTAL_RELAY_FEE);
 CFeeRate dustRelayFee = CFeeRate(DUST_RELAY_TX_FEE);

--- a/src/policy/settings.cpp
+++ b/src/policy/settings.cpp
@@ -8,7 +8,6 @@
 #include <policy/feerate.h>
 #include <policy/policy.h>
 
-bool gEnableReplacement = DEFAULT_ENABLE_REPLACEMENT;
 bool gReplacementHonourOptOut = DEFAULT_REPLACEMENT_HONOUR_OPTOUT;
 bool fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
 CFeeRate incrementalRelayFee = CFeeRate(DEFAULT_INCREMENTAL_RELAY_FEE);

--- a/src/policy/settings.h
+++ b/src/policy/settings.h
@@ -21,7 +21,6 @@ extern CFeeRate dustRelayFee;
 extern CFeeRate minRelayTxFee;
 extern unsigned int nBytesPerSigOp;
 extern bool fIsBareMultisigStd;
-extern bool gEnableReplacement;
 extern bool gReplacementHonourOptOut;
 
 static inline bool IsStandardTx(const CTransaction& tx, std::string& reason)

--- a/src/policy/settings.h
+++ b/src/policy/settings.h
@@ -21,6 +21,7 @@ extern CFeeRate dustRelayFee;
 extern CFeeRate minRelayTxFee;
 extern unsigned int nBytesPerSigOp;
 extern bool fIsBareMultisigStd;
+extern bool gEnableReplacement;
 
 static inline bool IsStandardTx(const CTransaction& tx, std::string& reason)
 {

--- a/src/policy/settings.h
+++ b/src/policy/settings.h
@@ -22,6 +22,7 @@ extern CFeeRate minRelayTxFee;
 extern unsigned int nBytesPerSigOp;
 extern bool fIsBareMultisigStd;
 extern bool gEnableReplacement;
+extern bool gReplacementHonourOptOut;
 
 static inline bool IsStandardTx(const CTransaction& tx, std::string& reason)
 {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -743,8 +743,10 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
                 bool allow_replacement;
                 if (!gEnableReplacement) {
                     allow_replacement = false;
-                } else {
+                } else if (gReplacementHonourOptOut) {
                     allow_replacement = SignalsOptInRBF(*ptxConflicting);
+                } else {
+                    allow_replacement = true;
                 }
                 if (!allow_replacement) {
                     return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "txn-mempool-conflict");

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -740,7 +740,13 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
                 // Applications relying on first-seen mempool behavior should
                 // check all unconfirmed ancestors; otherwise an opt-in ancestor
                 // might be replaced, causing removal of this descendant.
-                if (!SignalsOptInRBF(*ptxConflicting)) {
+                bool allow_replacement;
+                if (!gEnableReplacement) {
+                    allow_replacement = false;
+                } else {
+                    allow_replacement = SignalsOptInRBF(*ptxConflicting);
+                }
+                if (!allow_replacement) {
                     return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "txn-mempool-conflict");
                 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -741,9 +741,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
                 // check all unconfirmed ancestors; otherwise an opt-in ancestor
                 // might be replaced, causing removal of this descendant.
                 bool allow_replacement;
-                if (!gEnableReplacement) {
-                    allow_replacement = false;
-                } else if (gReplacementHonourOptOut) {
+                if (gReplacementHonourOptOut) {
                     allow_replacement = SignalsOptInRBF(*ptxConflicting);
                 } else {
                     allow_replacement = true;

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -32,7 +32,7 @@ from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE
 MAX_REPLACEMENT_LIMIT = 100
 class ReplaceByFeeTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.num_nodes = 2
+        self.num_nodes = 3
         self.extra_args = [
             [
                 "-acceptnonstdtxn=1",
@@ -44,6 +44,10 @@ class ReplaceByFeeTest(BitcoinTestFramework):
             ],
             # second node has default mempool parameters
             [
+            ],
+            [
+                "-acceptnonstdtxn=1",
+                "-mempoolreplacement=0",
             ],
         ]
         self.supports_cli = False
@@ -127,6 +131,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1a.vout = [CTxOut(1 * COIN, DUMMY_P2WPKH_SCRIPT)]
         tx1a_hex = tx1a.serialize().hex()
         tx1a_txid = self.nodes[0].sendrawtransaction(tx1a_hex, 0)
+        assert_equal(tx1a_txid, self.nodes[2].sendrawtransaction(tx1a_hex, 0))
 
         # Should fail because we haven't changed the fee
         tx1b = deepcopy(tx_template)
@@ -135,10 +140,14 @@ class ReplaceByFeeTest(BitcoinTestFramework):
 
         # This will raise an exception due to insufficient fee
         assert_raises_rpc_error(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx1b_hex, 0)
+        # This will raise an exception due to transaction replacement being disabled
+        assert_raises_rpc_error(-26, "txn-mempool-conflict", self.nodes[2].sendrawtransaction, tx1b_hex, 0)
 
         # Extra 0.1 BTC fee
         tx1b.vout[0].nValue -= int(0.1 * COIN)
         tx1b_hex = tx1b.serialize().hex()
+        # Replacement still disabled even with "enough fee"
+        assert_raises_rpc_error(-26, "txn-mempool-conflict", self.nodes[2].sendrawtransaction, tx1b_hex, 0)
         # Works when enabled
         tx1b_txid = self.nodes[0].sendrawtransaction(tx1b_hex, 0)
 
@@ -148,6 +157,11 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         assert tx1b_txid in mempool
 
         assert_equal(tx1b_hex, self.nodes[0].getrawtransaction(tx1b_txid))
+
+        # Third node is running mempoolreplacement=0, will not replace originally-seen txn
+        mempool = self.nodes[2].getrawmempool()
+        assert tx1a_txid in mempool
+        assert tx1b_txid not in mempool
 
     def test_doublespend_chain(self):
         """Doublespend of a long chain"""


### PR DESCRIPTION
Here's full RBF support, as included in Knots since 2016 (not including the service bit), including functional tests.

Two additional commits have been added, which can be squashed, but kept separate for now, for review purposes:
- The first refactors the full RBF test to use a function parameter rather than avoid rearranging the `self.nodes` list. By separating this out, the test changes should be easier to review.
- The second removes never-replace support. I think it's strictly better to support never-replace (as seen, it is trivial), but if reviewers disagree, this can be squashed into the PR to avoid re-supporting it.