### PR TITLE
Detect and ignore transactions that were CPFP'd in the fee estimator

### DIFF
--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -264,6 +264,11 @@ class EstimateFeeTest(BitcoinTestFramework):
             # Broadcast 5 low fee transaction which don't need to
             for _ in range(5):
                 tx = make_tx(self.wallet, utxos.pop(0), low_feerate)
+                self.confutxo.append({
+                    "txid": tx["txid"],
+                    "vout": 0,
+                    "value": Decimal(tx["tx"].vout[0].nValue) / COIN
+                })
                 txs.append(tx)
             batch_send_tx = [node.sendrawtransaction.get_request(tx["hex"]) for tx in txs]
             for n in self.nodes:
@@ -277,11 +282,15 @@ class EstimateFeeTest(BitcoinTestFramework):
             while len(utxos_to_respend) > 0:
                 u = utxos_to_respend.pop(0)
                 tx = make_tx(self.wallet, u, high_feerate)
+                self.confutxo.append({
+                    "txid": tx["txid"],
+                    "vout": 0,
+                    "value": Decimal(tx["tx"].vout[0].nValue) / COIN
+                })
                 node.sendrawtransaction(tx["hex"])
                 txs.append(tx)
             dec_txs = [res["result"] for res in node.batch([node.decoderawtransaction.get_request(tx["hex"]) for tx in txs])]
             self.wallet.scan_txs(dec_txs)
-
 
         # Mine the last replacement txs
         self.sync_mempools(wait=0.1, nodes=[node, miner])


### PR DESCRIPTION
The fee estimator currently considers the fee of a transaction in isolation (and doesn't consider transactions with unconfirmed parents). This could hold well when it was just a few outliers. But as CPFP is becoming common practice whether it is among wallets (#23074 has a few instances) or protocols (for instance the LN with anchor outputs), i'm afraid that if fees rise this can lead to significantly *underestimated* results.
See the first commit's message for details and #23074 for history.

This PR is a much simpler alternative to #23074. The point is to fix the issue before we come up with a reasonable way to track package feerates in the fee estimator.

The functional test is in a separate commit so reviewers can more easily cherry-pick it on master and see the fee estimator would return the wrong estimate.