### PR TITLE
refactor: Extract MIB_BYTES constant for init.cpp

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -463,6 +463,8 @@ if test "$CXXFLAGS_overridden" = "no"; then
                         [AC_LANG_SOURCE([[struct A { virtual void f(); }; struct B : A { void f() final; };]])])
   AX_CHECK_COMPILE_FLAG([-Wunreachable-code-loop-increment], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wunreachable-code-loop-increment"], [], [$CXXFLAG_WERROR])
   AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wimplicit-fallthrough"], [], [$CXXFLAG_WERROR])
+  AX_CHECK_COMPILE_FLAG([-Wsign-compare], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wsign-compare"], [], [$CXXFLAG_WERROR])
+  AX_CHECK_COMPILE_FLAG([-Wsign-conversion], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wsign-conversion"], [], [$CXXFLAG_WERROR])
 
   if test "$suppress_external_warnings" != "no" ; then
     AX_CHECK_COMPILE_FLAG([-Wdocumentation], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wdocumentation"], [], [$CXXFLAG_WERROR])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -143,6 +143,7 @@ BITCOIN_CORE_H = \
   consensus/consensus.h \
   consensus/tx_check.h \
   consensus/tx_verify.h \
+  constants.h \
   core_io.h \
   core_memusage.h \
   cuckoocache.h \

--- a/src/bench/chacha_poly_aead.cpp
+++ b/src/bench/chacha_poly_aead.cpp
@@ -4,6 +4,7 @@
 
 
 #include <bench/bench.h>
+#include <constants.h>
 #include <crypto/chacha_poly_aead.h>
 #include <crypto/poly1305.h> // for the POLY1305_TAGLEN constant
 #include <hash.h>
@@ -14,7 +15,7 @@
 /* Number of bytes to process per iteration */
 static constexpr uint64_t BUFFER_SIZE_TINY = 64;
 static constexpr uint64_t BUFFER_SIZE_SMALL = 256;
-static constexpr uint64_t BUFFER_SIZE_LARGE = 1024 * 1024;
+static constexpr uint64_t BUFFER_SIZE_LARGE{MIB_BYTES};
 
 static const unsigned char k1[32] = {0};
 static const unsigned char k2[32] = {0};

--- a/src/constants.h
+++ b/src/constants.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2011-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CONSTANTS_H
+#define BITCOIN_CONSTANTS_H
+
+#include <cstdint>
+
+/* One gigabyte (GB) in bytes */
+static constexpr uint64_t GB_BYTES{1000000000};
+
+/* One mebibyte (MiB) in bytes */
+static constexpr int32_t MIB_BYTES{1024 * 1024};
+
+// Require that user allocate at least 550 MiB for block & undo files (blk???.dat and rev???.dat)
+// At 1MB per block, 288 blocks = 288MB.
+// Add 15% for Undo data = 331MB
+// Add 20% for Orphan block rate = 397MB
+// We want the low water mark after pruning to be at least 397 MB and since we prune in
+// full block file chunks, we need the high water mark which triggers the prune to be
+// one 128MB block file + added 15% undo data = 147MB greater for a total of 545MB
+// Setting the target to >= 550 MiB will make it likely we can respect the target.
+static constexpr int32_t MIN_MIB_FOR_BLOCK_FILES{550};
+static constexpr int32_t MIN_BYTES_FOR_BLOCK_FILES{MIN_MIB_FOR_BLOCK_FILES * MIB_BYTES};
+
+#endif // BITCOIN_CONSTANTS_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -19,6 +19,7 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <consensus/amount.h>
+#include <constants.h>
 #include <deploymentstatus.h>
 #include <fs.h>
 #include <hash.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -128,8 +128,6 @@ using node::nPruneTarget;
 static const bool DEFAULT_PROXYRANDOMIZE = true;
 static const bool DEFAULT_REST_ENABLE = false;
 
-static constexpr int32_t MIB_BYTES = 1024 * 1024;
-
 #ifdef WIN32
 // Win32 LevelDB doesn't use filedescriptors, and the ones used for
 // accessing block files don't count towards the fd_set size limit
@@ -435,7 +433,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-pid=<file>", strprintf("Specify pid file. Relative paths will be prefixed by a net-specific datadir location. (default: %s)", BITCOIN_PID_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-prune=<n>", strprintf("Reduce storage requirements by enabling pruning (deleting) of old blocks. This allows the pruneblockchain RPC to be called to delete specific blocks and enables automatic pruning of old blocks if a target size in MiB is provided. This mode is incompatible with -txindex. "
             "Warning: Reverting this setting requires re-downloading the entire blockchain. "
-            "(default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, >=%u = automatically prune block files to stay under the specified target size in MiB)", MIN_DISK_SPACE_FOR_BLOCK_FILES / MIB_BYTES), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+            "(default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, >=%u = automatically prune block files to stay under the specified target size in MiB)", MIN_MIB_FOR_BLOCK_FILES), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-reindex", "Rebuild chain state and block index from the blk*.dat files on disk. This will also rebuild active optional indexes.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-reindex-chainstate", "Rebuild chain state from the currently indexed blocks. When in pruning mode or if blocks on disk might be corrupted, use full -reindex instead. Deactivate all optional indexes before running this.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-settings=<file>", strprintf("Specify path to dynamic settings data file. Can be disabled with -nosettings. File is written at runtime and not meant to be edited by users (use %s instead for custom settings). Relative paths will be prefixed by datadir location. (default: %s)", BITCOIN_CONF_FILENAME, BITCOIN_SETTINGS_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -955,8 +953,8 @@ bool AppInitParameterInteraction(const ArgsManager& args, bool use_syscall_sandb
         nPruneTarget = std::numeric_limits<uint64_t>::max();
         fPruneMode = true;
     } else if (nPruneTarget) {
-        if (nPruneTarget < MIN_DISK_SPACE_FOR_BLOCK_FILES) {
-            return InitError(strprintf(_("Prune configured below the minimum of %d MiB.  Please use a higher number."), MIN_DISK_SPACE_FOR_BLOCK_FILES / MIB_BYTES));
+        if (nPruneTarget < MIN_BYTES_FOR_BLOCK_FILES) {
+            return InitError(strprintf(_("Prune configured below the minimum of %d MiB.  Please use a higher number."), MIN_MIB_FOR_BLOCK_FILES));
         }
         fPruneMode = true;
     }

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_QT_GUICONSTANTS_H
 #define BITCOIN_QT_GUICONSTANTS_H
 
+#include <constants.h>
+
 #include <chrono>
 #include <cstdint>
 
@@ -53,8 +55,8 @@ static const int TOOLTIP_WRAP_THRESHOLD = 80;
 #define QAPP_APP_NAME_SIGNET "Bitcoin-Qt-signet"
 #define QAPP_APP_NAME_REGTEST "Bitcoin-Qt-regtest"
 
-/* One gigabyte (GB) in bytes */
-static constexpr uint64_t GB_BYTES{1000000000};
+/* Minimum prune target displayed in GUI. */
+static constexpr uint64_t MIN_PRUNE_TARGET_GB{(MIN_BYTES_FOR_BLOCK_FILES / GB_BYTES) + ((MIN_BYTES_FOR_BLOCK_FILES % GB_BYTES) ? 1 : 0)};
 
 // Default prune target displayed in GUI.
 static constexpr int DEFAULT_PRUNE_TARGET_GB{2};

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -140,7 +140,7 @@ Intro::Intro(QWidget *parent, int64_t blockchain_size_gb, int64_t chain_state_si
     );
     ui->lblExplanation2->setText(ui->lblExplanation2->text().arg(PACKAGE_NAME));
 
-    const int min_prune_target_GB = std::ceil(MIN_DISK_SPACE_FOR_BLOCK_FILES / 1e9);
+    const int min_prune_target_GB = std::ceil(MIN_BYTES_FOR_BLOCK_FILES / 1e9);
     ui->pruneGB->setRange(min_prune_target_GB, std::numeric_limits<int>::max());
     if (gArgs.GetIntArg("-prune", 0) > 1) { // -prune=1 means enabled, above that it's a size in MiB
         ui->prune->setChecked(true);

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -140,8 +140,7 @@ Intro::Intro(QWidget *parent, int64_t blockchain_size_gb, int64_t chain_state_si
     );
     ui->lblExplanation2->setText(ui->lblExplanation2->text().arg(PACKAGE_NAME));
 
-    const int min_prune_target_GB = std::ceil(MIN_BYTES_FOR_BLOCK_FILES / 1e9);
-    ui->pruneGB->setRange(min_prune_target_GB, std::numeric_limits<int>::max());
+    ui->pruneGB->setRange(MIN_PRUNE_TARGET_GB, std::numeric_limits<int>::max());
     if (gArgs.GetIntArg("-prune", 0) > 1) { // -prune=1 means enabled, above that it's a size in MiB
         ui->prune->setChecked(true);
         ui->prune->setEnabled(false);

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -186,8 +186,7 @@ void OptionsDialog::setModel(OptionsModel *_model)
             showRestartWarning(true);
 
         // Prune values are in GB to be consistent with intro.cpp
-        static constexpr uint64_t nMinDiskSpace = (MIN_BYTES_FOR_BLOCK_FILES / GB_BYTES) + (MIN_BYTES_FOR_BLOCK_FILES % GB_BYTES) ? 1 : 0;
-        ui->pruneSize->setRange(nMinDiskSpace, std::numeric_limits<int>::max());
+        ui->pruneSize->setRange(MIN_PRUNE_TARGET_GB, std::numeric_limits<int>::max());
 
         QString strLabel = _model->getOverriddenByCommandLine();
         if (strLabel.isEmpty())

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -186,7 +186,7 @@ void OptionsDialog::setModel(OptionsModel *_model)
             showRestartWarning(true);
 
         // Prune values are in GB to be consistent with intro.cpp
-        static constexpr uint64_t nMinDiskSpace = (MIN_DISK_SPACE_FOR_BLOCK_FILES / GB_BYTES) + (MIN_DISK_SPACE_FOR_BLOCK_FILES % GB_BYTES) ? 1 : 0;
+        static constexpr uint64_t nMinDiskSpace = (MIN_BYTES_FOR_BLOCK_FILES / GB_BYTES) + (MIN_BYTES_FOR_BLOCK_FILES % GB_BYTES) ? 1 : 0;
         ui->pruneSize->setRange(nMinDiskSpace, std::numeric_limits<int>::max());
 
         QString strLabel = _model->getOverriddenByCommandLine();

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -5,13 +5,13 @@
 #ifndef BITCOIN_QT_OPTIONSMODEL_H
 #define BITCOIN_QT_OPTIONSMODEL_H
 
-#include <cstdint>
+#include <constants.h>
 #include <qt/bitcoinunits.h>
-#include <qt/guiconstants.h>
 
 #include <QAbstractListModel>
 
 #include <assert.h>
+#include <cstdint>
 
 struct bilingual_str;
 namespace interfaces {
@@ -24,12 +24,12 @@ static constexpr uint16_t DEFAULT_GUI_PROXY_PORT = 9050;
 /**
  * Convert configured prune target MiB to displayed GB. Round up to avoid underestimating max disk usage.
  */
-static inline int PruneMiBtoGB(int64_t mib) { return (mib * 1024 * 1024 + GB_BYTES - 1) / GB_BYTES; }
+static constexpr int PruneMiBtoGB(int64_t mib) { return (mib * MIB_BYTES + GB_BYTES - 1) / GB_BYTES; }
 
 /**
  * Convert displayed prune target GB to configured MiB. Round down so roundtrip GB -> MiB -> GB conversion is stable.
  */
-static inline int64_t PruneGBtoMiB(int gb) { return gb * GB_BYTES / 1024 / 1024; }
+static constexpr int64_t PruneGBtoMiB(int gb) { return gb * GB_BYTES / MIB_BYTES; }
 
 /** Interface from Qt to configuration data structure for Bitcoin client.
    To Qt, the options are presented as a list with the different options

--- a/src/test/fuzz/spanparsing.cpp
+++ b/src/test/fuzz/spanparsing.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <constants.h>
+
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <util/spanparsing.h>
@@ -10,7 +12,7 @@ FUZZ_TARGET(spanparsing)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const size_t query_size = fuzzed_data_provider.ConsumeIntegral<size_t>();
-    const std::string query = fuzzed_data_provider.ConsumeBytesAsString(std::min<size_t>(query_size, 1024 * 1024));
+    const std::string query{fuzzed_data_provider.ConsumeBytesAsString(std::min<size_t>(query_size, MIB_BYTES))};
     const std::string span_str = fuzzed_data_provider.ConsumeRemainingBytesAsString();
     const Span<const char> const_span{span_str};
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -18,6 +18,7 @@
 #include <consensus/tx_check.h>
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
+#include <constants.h>
 #include <cuckoocache.h>
 #include <flatfile.h>
 #include <fs.h>
@@ -2332,7 +2333,7 @@ CoinsCacheSizeState Chainstate::GetCoinsCacheSizeState(
         max_coins_cache_size_bytes + std::max<int64_t>(int64_t(max_mempool_size_bytes) - nMempoolUsage, 0);
 
     //! No need to periodic flush if at least this much space still available.
-    static constexpr int64_t MAX_BLOCK_COINSDB_USAGE_BYTES = 10 * 1024 * 1024;  // 10MB
+    static constexpr int64_t MAX_BLOCK_COINSDB_USAGE_BYTES{10 * MIB_BYTES};
     int64_t large_threshold =
         std::max((9 * nTotalSpace) / 10, nTotalSpace - MAX_BLOCK_COINSDB_USAGE_BYTES);
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -71,6 +71,9 @@ static const int DEFAULT_STOPATHEIGHT = 0;
 static const unsigned int MIN_BLOCKS_TO_KEEP = 288;
 static const signed int DEFAULT_CHECKBLOCKS = 6;
 static constexpr int DEFAULT_CHECKLEVEL{3};
+
+static constexpr int32_t MIB_BYTES{1024 * 1024};
+
 // Require that user allocate at least 550 MiB for block & undo files (blk???.dat and rev???.dat)
 // At 1MB per block, 288 blocks = 288MB.
 // Add 15% for Undo data = 331MB
@@ -79,7 +82,8 @@ static constexpr int DEFAULT_CHECKLEVEL{3};
 // full block file chunks, we need the high water mark which triggers the prune to be
 // one 128MB block file + added 15% undo data = 147MB greater for a total of 545MB
 // Setting the target to >= 550 MiB will make it likely we can respect the target.
-static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
+static constexpr int32_t MIN_MIB_FOR_BLOCK_FILES{550};
+static constexpr int32_t MIN_BYTES_FOR_BLOCK_FILES{MIN_MIB_FOR_BLOCK_FILES * MIB_BYTES};
 
 /** Current sync state passed to tip changed callbacks. */
 enum class SynchronizationState {

--- a/src/validation.h
+++ b/src/validation.h
@@ -72,19 +72,6 @@ static const unsigned int MIN_BLOCKS_TO_KEEP = 288;
 static const signed int DEFAULT_CHECKBLOCKS = 6;
 static constexpr int DEFAULT_CHECKLEVEL{3};
 
-static constexpr int32_t MIB_BYTES{1024 * 1024};
-
-// Require that user allocate at least 550 MiB for block & undo files (blk???.dat and rev???.dat)
-// At 1MB per block, 288 blocks = 288MB.
-// Add 15% for Undo data = 331MB
-// Add 20% for Orphan block rate = 397MB
-// We want the low water mark after pruning to be at least 397 MB and since we prune in
-// full block file chunks, we need the high water mark which triggers the prune to be
-// one 128MB block file + added 15% undo data = 147MB greater for a total of 545MB
-// Setting the target to >= 550 MiB will make it likely we can respect the target.
-static constexpr int32_t MIN_MIB_FOR_BLOCK_FILES{550};
-static constexpr int32_t MIN_BYTES_FOR_BLOCK_FILES{MIN_MIB_FOR_BLOCK_FILES * MIB_BYTES};
-
 /** Current sync state passed to tip changed callbacks. */
 enum class SynchronizationState {
     INIT_REINDEX,


### PR DESCRIPTION
This is a common concept which is more communicative and explicit if articulated, IMO.

This could be applied elsewhere if there is a better place to reference it in common, but I don't see it. 

Pulled from #25315 to ease review there.