### PR TITLE
guix: use libtool 2.4.7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,7 @@ BITCOIN_MP_NODE_NAME=bitcoin-node
 BITCOIN_MP_GUI_NAME=bitcoin-gui
 
 dnl Unless the user specified ARFLAGS, force it to be cr
+dnl This is also the default as-of libtool 2.4.7
 AC_ARG_VAR([ARFLAGS], [Flags for the archiver, defaults to <cr> if not set])
 if test "${ARFLAGS+set}" != "set"; then
   ARFLAGS="cr"

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -581,7 +581,7 @@ inspecting signatures in Mach-O binaries.")
         xz
         ;; Build tools
         gnu-make
-        libtool
+        libtool-2.4.7
         autoconf-2.71
         automake
         pkg-config


### PR DESCRIPTION
As of version 2.4.7, libtool now respects ARFLAGS, and has changed the default `ARFLAGS` from `cru` to `cr` (which, historically, we have also done, [see configure](https://github.com/bitcoin/bitcoin/blob/d6832217ef45ea0c858e3fcdec5d4fe87097c839/configure.ac#L33)).

This eliminates spammy `ar` output such as:
```bash
  CXXLD    libunivalue.la
/root/.guix-profile/bin/x86_64-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
  AR       libbitcoin_zmq.a
  AR       libbitcoin_consensus.a
  CXXLD    crypto/libbitcoin_crypto_base.la
  CXXLD    crypto/libbitcoin_crypto_sse41.la
/root/.guix-profile/bin/x86_64-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
/root/.guix-profile/bin/x86_64-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
  CXXLD    crypto/libbitcoin_crypto_avx2.la
  CXXLD    crypto/libbitcoin_crypto_x86_shani.la
  CXXLD    leveldb/libleveldb.la
/root/.guix-profile/bin/x86_64-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
  CXXLD    crc32c/libcrc32c.la
/root/.guix-profile/bin/x86_64-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
  CXXLD    leveldb/libmemenv.la
/root/.guix-profile/bin/x86_64-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
/root/.guix-profile/bin/x86_64-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
/root/.guix-profile/bin/x86_64-linux-gnu-ar: `u' modifier ignored since `D' is the default (see `U')
  AR       libbitcoin_cli.a
```

[Libtool 2.4.7 release notes](https://lists.gnu.org/archive/html/autotools-announce/2022-03/msg00000.html):
** New features:

  - Libtool script now supports (configure-time and runtime) ARFLAGS
    variable, which obsoletes AR_FLAGS.  This is due to naming conventions
    among other *FLAGS and to be consistent with Automake's ARFLAGS.

** Important incompatible changes:

  - Libtool changed ARFLAGS/AR_FLAGS default from 'cru' to 'cr'.

Guix Build (x86_64):
```bash
a4da07d0166a7018d1cb7cddd734c9efe062bd28a6349ebdbf427adf353f2acf  guix-build-4a81ef451094/output/aarch64-linux-gnu/SHA256SUMS.part
e2418d772c8f409b9bfde3bcf494f3d320d89970a4305e8799a8f59ecbd66906  guix-build-4a81ef451094/output/aarch64-linux-gnu/bitcoin-4a81ef451094-aarch64-linux-gnu-debug.tar.gz
44a877696205b1d60d07e60d01d5427d9ed7efaf8cf62db719bc057a0df77636  guix-build-4a81ef451094/output/aarch64-linux-gnu/bitcoin-4a81ef451094-aarch64-linux-gnu.tar.gz
b911cae3d8a73eda2f9224a6073e14e26a1aec7f2cb85dc9d949d22ca4e9f4b4  guix-build-4a81ef451094/output/arm-linux-gnueabihf/SHA256SUMS.part
6fa645e1dbaa77fd082b860852b4a32114d317d630e8791dad14d154a203cd40  guix-build-4a81ef451094/output/arm-linux-gnueabihf/bitcoin-4a81ef451094-arm-linux-gnueabihf-debug.tar.gz
3d86f047e5453ee73cd4dab4ac0b3a97928914f7469b9bcc807230b38b471f3f  guix-build-4a81ef451094/output/arm-linux-gnueabihf/bitcoin-4a81ef451094-arm-linux-gnueabihf.tar.gz
1c0dbc156292c3d142e63b29d1fb9c9b6623db5698f59b2bfce96674438780a6  guix-build-4a81ef451094/output/arm64-apple-darwin/SHA256SUMS.part
17f4c3bf0527ec2bde06691c301e8c6c5290178238a21aa10d3672917eccb27d  guix-build-4a81ef451094/output/arm64-apple-darwin/bitcoin-4a81ef451094-arm64-apple-darwin-unsigned.dmg
5ed1de03d5d87249fc8671f5641816513a93784d38873d277bdf49a4b98b9ba3  guix-build-4a81ef451094/output/arm64-apple-darwin/bitcoin-4a81ef451094-arm64-apple-darwin-unsigned.tar.gz
fb18089efdb291714f1359a548a9f101d5fcc9bdc653cd406ab28f7e02713bcd  guix-build-4a81ef451094/output/arm64-apple-darwin/bitcoin-4a81ef451094-arm64-apple-darwin.tar.gz
4f816681c778b8bb9522be31807d1d60c724383cfa4ae820dd829b716d934939  guix-build-4a81ef451094/output/dist-archive/bitcoin-4a81ef451094.tar.gz
3af9f38caf09f4424b7a982b5992407fb4ce5574a0e98af0b0558ec85a12519d  guix-build-4a81ef451094/output/powerpc64-linux-gnu/SHA256SUMS.part
cf88399bc6ea96df3742cb87bfa0629b22b001f49a6ccfb35b66f7dd46a47a94  guix-build-4a81ef451094/output/powerpc64-linux-gnu/bitcoin-4a81ef451094-powerpc64-linux-gnu-debug.tar.gz
93158fd0b9d3c74565917395d0199d2b9f8b1821dd4aa207f804ee93bd0e4a3d  guix-build-4a81ef451094/output/powerpc64-linux-gnu/bitcoin-4a81ef451094-powerpc64-linux-gnu.tar.gz
c970dd4dcbd25f2a94eaf526756fc0c01920452f4e42b4dd51fea8bf04f1c7ca  guix-build-4a81ef451094/output/powerpc64le-linux-gnu/SHA256SUMS.part
80e488a199b91fc2763da94bf5c4024a7173404419f97c68b825dd6c7dccafbc  guix-build-4a81ef451094/output/powerpc64le-linux-gnu/bitcoin-4a81ef451094-powerpc64le-linux-gnu-debug.tar.gz
00159823c8f0daab6c1034c9648742b6569fe07b50091f4850f5b028d9f1dc83  guix-build-4a81ef451094/output/powerpc64le-linux-gnu/bitcoin-4a81ef451094-powerpc64le-linux-gnu.tar.gz
f796cbe82e3d4f8ed90647728ad76afae4691c671f5a79c87f0b7a41d67c0a3e  guix-build-4a81ef451094/output/riscv64-linux-gnu/SHA256SUMS.part
b51be33b674def05b1d8b0b74a2e8c0340fb911859936e3e0024ecac09540270  guix-build-4a81ef451094/output/riscv64-linux-gnu/bitcoin-4a81ef451094-riscv64-linux-gnu-debug.tar.gz
9f0e52c0b0c706359e28a591c6de71502520e6de9941a6cf378c1c83ebd66480  guix-build-4a81ef451094/output/riscv64-linux-gnu/bitcoin-4a81ef451094-riscv64-linux-gnu.tar.gz
e145886b3f06d6a69db1657e19661cfb1c95f9b35aac3d3efd89f89f791fa909  guix-build-4a81ef451094/output/x86_64-apple-darwin/SHA256SUMS.part
7a3512718270cc9be241d1ca0c7f8f37ebeb620e6c5a1a70992aef99bc209854  guix-build-4a81ef451094/output/x86_64-apple-darwin/bitcoin-4a81ef451094-x86_64-apple-darwin-unsigned.dmg
0439552bc901a9fd10251c1e4a2eb685aae7b4edcf8f047a28eba837d8b6c960  guix-build-4a81ef451094/output/x86_64-apple-darwin/bitcoin-4a81ef451094-x86_64-apple-darwin-unsigned.tar.gz
4c1ce8786b3c381250b8071a17bc6d705e3e5e672909ffeacfa2171814dee527  guix-build-4a81ef451094/output/x86_64-apple-darwin/bitcoin-4a81ef451094-x86_64-apple-darwin.tar.gz
9c08271cee5f3bba08866fcc609290dd009b85793460188a4b3c5df5ac83d002  guix-build-4a81ef451094/output/x86_64-linux-gnu/SHA256SUMS.part
04285f7e68bc25834fe7830f15b1fd0102cd1f02f23701a8f423cf0835d1af5f  guix-build-4a81ef451094/output/x86_64-linux-gnu/bitcoin-4a81ef451094-x86_64-linux-gnu-debug.tar.gz
b0e467b2ccb1b391ddb981f1d1b16f0f6de71aa8177f7735a88989fdc4ade449  guix-build-4a81ef451094/output/x86_64-linux-gnu/bitcoin-4a81ef451094-x86_64-linux-gnu.tar.gz
6adb17642959fee8d123482bf0ec5ad0a4f10e63c87bf45447d1e57ab873d2bc  guix-build-4a81ef451094/output/x86_64-w64-mingw32/SHA256SUMS.part
ac1989f332d1bd5d0acabb7ce28236a80fd6a42eac93c7287f890148ef2999bc  guix-build-4a81ef451094/output/x86_64-w64-mingw32/bitcoin-4a81ef451094-win64-debug.zip
31816d2ef52be01a69fd8701e3da61a32dddaccdd1d424de00a412a798d97b87  guix-build-4a81ef451094/output/x86_64-w64-mingw32/bitcoin-4a81ef451094-win64-setup-unsigned.exe
ecc41932934e5e746883648fd4ee5edf4cd5cadd944d799b31e41aad249c8d7d  guix-build-4a81ef451094/output/x86_64-w64-mingw32/bitcoin-4a81ef451094-win64-unsigned.tar.gz
8634ad4feb1118fc89abd96489533c81176b7172750b8f2cf18a3e10377a8d65  guix-build-4a81ef451094/output/x86_64-w64-mingw32/bitcoin-4a81ef451094-win64.zip
```
Guix Build (arm64):
```bash
b70e6fc1be044e347800d7de78a1c950961f5c52abc724fa8c6fe8556b3ef3ca  guix-build-4a81ef451094/output/arm-linux-gnueabihf/SHA256SUMS.part
62e670fcedc2cb746b3c589edfa9a0950097256ef974c58984a9f252c91b802a  guix-build-4a81ef451094/output/arm-linux-gnueabihf/bitcoin-4a81ef451094-arm-linux-gnueabihf-debug.tar.gz
2637e5c31380fbae1ec5efb1792124a0554d49516e1964a609560487ea673ebb  guix-build-4a81ef451094/output/arm-linux-gnueabihf/bitcoin-4a81ef451094-arm-linux-gnueabihf.tar.gz
1554617b965611ea618664652b566f2c5a16c94fa57572ea31b66a40bb845b3c  guix-build-4a81ef451094/output/arm64-apple-darwin/SHA256SUMS.part
a98efc26e78ce749d75fc467822f6e68c6b3b7abc5d24e8edaa40b19c6b40632  guix-build-4a81ef451094/output/arm64-apple-darwin/bitcoin-4a81ef451094-arm64-apple-darwin-unsigned.dmg
ecd9057eaa2c7166b1320bd85555258fd6a49690b29331cdde7b4c9af05acc0d  guix-build-4a81ef451094/output/arm64-apple-darwin/bitcoin-4a81ef451094-arm64-apple-darwin-unsigned.tar.gz
9417c58463488f3eeddcdfc5440d1cb341d6424517e4b69c227f4291853d3fa6  guix-build-4a81ef451094/output/arm64-apple-darwin/bitcoin-4a81ef451094-arm64-apple-darwin.tar.gz
4f816681c778b8bb9522be31807d1d60c724383cfa4ae820dd829b716d934939  guix-build-4a81ef451094/output/dist-archive/bitcoin-4a81ef451094.tar.gz
25cddb3a6a22d1e57cef92d96b106df0fff5d5c3987c3673decad63db834765b  guix-build-4a81ef451094/output/powerpc64-linux-gnu/SHA256SUMS.part
cb99c30a117e650b837e1e5d835be5e51b282158139b8fd591fa4b6f1aa709db  guix-build-4a81ef451094/output/powerpc64-linux-gnu/bitcoin-4a81ef451094-powerpc64-linux-gnu-debug.tar.gz
66a182566f0950f7b0d9de497118ce3635ca5acf78c356a1fea6f815f61ce94b  guix-build-4a81ef451094/output/powerpc64-linux-gnu/bitcoin-4a81ef451094-powerpc64-linux-gnu.tar.gz
d5f65e1d6cb8de238f1c50ec30c0848675274126d197e274d51fed32de3860ad  guix-build-4a81ef451094/output/powerpc64le-linux-gnu/SHA256SUMS.part
4c2fe35cc087d5e268eb2202cc6579442d4c6b9d6d7b61c55753c6600f8070e7  guix-build-4a81ef451094/output/powerpc64le-linux-gnu/bitcoin-4a81ef451094-powerpc64le-linux-gnu-debug.tar.gz
918da28dbd9c2db024a31877c3913e1e717c1099d91cb32798ea4afee6b80b72  guix-build-4a81ef451094/output/powerpc64le-linux-gnu/bitcoin-4a81ef451094-powerpc64le-linux-gnu.tar.gz
ba3c1095676c3f2255a3fb581404887783d234ed44bd89b7fd96016cccadd401  guix-build-4a81ef451094/output/riscv64-linux-gnu/SHA256SUMS.part
9492973869a7f6274ffe20758ef113cc5f11465c08b465aa18d28618cee6d0fb  guix-build-4a81ef451094/output/riscv64-linux-gnu/bitcoin-4a81ef451094-riscv64-linux-gnu-debug.tar.gz
a4a767045b987f87994eb50ab5bc17639707e184a58aa66842d8cb9d7a4dffb4  guix-build-4a81ef451094/output/riscv64-linux-gnu/bitcoin-4a81ef451094-riscv64-linux-gnu.tar.gz
e145886b3f06d6a69db1657e19661cfb1c95f9b35aac3d3efd89f89f791fa909  guix-build-4a81ef451094/output/x86_64-apple-darwin/SHA256SUMS.part
7a3512718270cc9be241d1ca0c7f8f37ebeb620e6c5a1a70992aef99bc209854  guix-build-4a81ef451094/output/x86_64-apple-darwin/bitcoin-4a81ef451094-x86_64-apple-darwin-unsigned.dmg
0439552bc901a9fd10251c1e4a2eb685aae7b4edcf8f047a28eba837d8b6c960  guix-build-4a81ef451094/output/x86_64-apple-darwin/bitcoin-4a81ef451094-x86_64-apple-darwin-unsigned.tar.gz
4c1ce8786b3c381250b8071a17bc6d705e3e5e672909ffeacfa2171814dee527  guix-build-4a81ef451094/output/x86_64-apple-darwin/bitcoin-4a81ef451094-x86_64-apple-darwin.tar.gz
e19a0c510a95662fef30fc3ea1f2496ae8957df1814f237d4a7c1ef40ba47728  guix-build-4a81ef451094/output/x86_64-linux-gnu/SHA256SUMS.part
1712aca301825d985f7f9e333ebdc2ff0b7f385f79fbecc9747c8a183c15fdac  guix-build-4a81ef451094/output/x86_64-linux-gnu/bitcoin-4a81ef451094-x86_64-linux-gnu-debug.tar.gz
b40369ea098a02a1cc4e0f5812e9947608d218542038364fb5ce743d9c9e3686  guix-build-4a81ef451094/output/x86_64-linux-gnu/bitcoin-4a81ef451094-x86_64-linux-gnu.tar.gz
9402b3b6ce1e6642a60e5324ebef565c8c0d4b49085ff6fa2105097f4879f389  guix-build-4a81ef451094/output/x86_64-w64-mingw32/SHA256SUMS.part
0e810115ea0269311a07cf868270094ced40cb10cfb2faa5db0b8ec881bc46f9  guix-build-4a81ef451094/output/x86_64-w64-mingw32/bitcoin-4a81ef451094-win64-debug.zip
31816d2ef52be01a69fd8701e3da61a32dddaccdd1d424de00a412a798d97b87  guix-build-4a81ef451094/output/x86_64-w64-mingw32/bitcoin-4a81ef451094-win64-setup-unsigned.exe
ecc41932934e5e746883648fd4ee5edf4cd5cadd944d799b31e41aad249c8d7d  guix-build-4a81ef451094/output/x86_64-w64-mingw32/bitcoin-4a81ef451094-win64-unsigned.tar.gz
dbf4dca62ad173df82571a996ceeef4fba715d600716062d9f851a71cbdd1c9a  guix-build-4a81ef451094/output/x86_64-w64-mingw32/bitcoin-4a81ef451094-win64.zip
```