### PR TITLE
sync: introduce a thread-safe generic container and use it to remove a bunch of "GlobalMutex"es

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -181,8 +181,7 @@ struct LocalServiceInfo {
     uint16_t nPort;
 };
 
-extern GlobalMutex g_maplocalhost_mutex;
-extern std::map<CNetAddr, LocalServiceInfo> g_my_net_addr GUARDED_BY(g_maplocalhost_mutex);
+extern Synced<std::map<CNetAddr, LocalServiceInfo>> g_my_net_addr;
 
 extern const std::string NET_MESSAGE_TYPE_OTHER;
 using mapMsgTypeSize = std::map</* message type */ std::string, /* total bytes */ uint64_t>;

--- a/src/net.h
+++ b/src/net.h
@@ -182,7 +182,7 @@ struct LocalServiceInfo {
 };
 
 extern GlobalMutex g_maplocalhost_mutex;
-extern std::map<CNetAddr, LocalServiceInfo> mapLocalHost GUARDED_BY(g_maplocalhost_mutex);
+extern std::map<CNetAddr, LocalServiceInfo> g_my_net_addr GUARDED_BY(g_maplocalhost_mutex);
 
 extern const std::string NET_MESSAGE_TYPE_OTHER;
 using mapMsgTypeSize = std::map</* message type */ std::string, /* total bytes */ uint64_t>;

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -690,7 +690,7 @@ static RPCHelpMan getnetworkinfo()
     UniValue localAddresses(UniValue::VARR);
     {
         LOCK(g_maplocalhost_mutex);
-        for (const std::pair<const CNetAddr, LocalServiceInfo> &item : mapLocalHost)
+        for (const std::pair<const CNetAddr, LocalServiceInfo> &item : g_my_net_addr)
         {
             UniValue rec(UniValue::VOBJ);
             rec.pushKV("address", item.first.ToStringAddr());

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -689,13 +689,12 @@ static RPCHelpMan getnetworkinfo()
     }
     UniValue localAddresses(UniValue::VARR);
     {
-        LOCK(g_maplocalhost_mutex);
-        for (const std::pair<const CNetAddr, LocalServiceInfo> &item : g_my_net_addr)
-        {
+        SYNCED_LOCK(g_my_net_addr, p);
+        for (const auto& [addr, service_info] : *p) {
             UniValue rec(UniValue::VOBJ);
-            rec.pushKV("address", item.first.ToStringAddr());
-            rec.pushKV("port", item.second.nPort);
-            rec.pushKV("score", item.second.nScore);
+            rec.pushKV("address", addr.ToStringAddr());
+            rec.pushKV("port", service_info.nPort);
+            rec.pushKV("score", service_info.nScore);
             localAddresses.push_back(rec);
         }
     }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -31,7 +31,7 @@ static std::string rpcWarmupStatus GUARDED_BY(g_rpc_warmup_mutex) = "RPC server 
 static RPCTimerInterface* timerInterface = nullptr;
 /* Map of name to timer. */
 static GlobalMutex g_deadline_timers_mutex;
-static std::map<std::string, std::unique_ptr<RPCTimerBase> > deadlineTimers GUARDED_BY(g_deadline_timers_mutex);
+static std::map<std::string, std::unique_ptr<RPCTimerBase> > g_deadline_timers GUARDED_BY(g_deadline_timers_mutex);
 static bool ExecuteCommand(const CRPCCommand& command, const JSONRPCRequest& request, UniValue& result, bool last_handler);
 
 struct RPCCommandExecutionInfo
@@ -312,7 +312,7 @@ void StopRPC()
     assert(!g_rpc_running);
     std::call_once(g_rpc_stop_flag, []() {
         LogPrint(BCLog::RPC, "Stopping RPC\n");
-        WITH_LOCK(g_deadline_timers_mutex, deadlineTimers.clear());
+        WITH_LOCK(g_deadline_timers_mutex, g_deadline_timers.clear());
         DeleteAuthCookie();
         g_rpcSignals.Stopped();
     });
@@ -590,9 +590,9 @@ void RPCRunLater(const std::string& name, std::function<void()> func, int64_t nS
     if (!timerInterface)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "No timer handler registered for RPC");
     LOCK(g_deadline_timers_mutex);
-    deadlineTimers.erase(name);
+    g_deadline_timers.erase(name);
     LogPrint(BCLog::RPC, "queue run of timer %s in %i seconds (using %s)\n", name, nSeconds, timerInterface->Name());
-    deadlineTimers.emplace(name, std::unique_ptr<RPCTimerBase>(timerInterface->NewTimer(func, nSeconds*1000)));
+    g_deadline_timers.emplace(name, std::unique_ptr<RPCTimerBase>(timerInterface->NewTimer(func, nSeconds*1000)));
 }
 
 bool RPCSerializationWithoutWitness()

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -608,13 +608,13 @@ BOOST_AUTO_TEST_CASE(ipv4_peer_with_ipv6_addrMe_test)
     // !IsRoutable the undefined behavior is easier to trigger deterministically
     in_addr raw_addr;
     raw_addr.s_addr = htonl(0x7f000001);
-    const CNetAddr mapLocalHost_entry = CNetAddr(raw_addr);
+    const CNetAddr g_my_net_addr_entry = CNetAddr(raw_addr);
     {
         LOCK(g_maplocalhost_mutex);
         LocalServiceInfo lsi;
         lsi.nScore = 23;
         lsi.nPort = 42;
-        mapLocalHost[mapLocalHost_entry] = lsi;
+        g_my_net_addr[g_my_net_addr_entry] = lsi;
     }
 
     // create a peer with an IPv4 address
@@ -648,7 +648,7 @@ BOOST_AUTO_TEST_CASE(ipv4_peer_with_ipv6_addrMe_test)
     // Cleanup, so that we don't confuse other tests.
     {
         LOCK(g_maplocalhost_mutex);
-        mapLocalHost.erase(mapLocalHost_entry);
+        g_my_net_addr.erase(g_my_net_addr_entry);
     }
 }
 

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -608,13 +608,13 @@ BOOST_AUTO_TEST_CASE(ipv4_peer_with_ipv6_addrMe_test)
     // !IsRoutable the undefined behavior is easier to trigger deterministically
     in_addr raw_addr;
     raw_addr.s_addr = htonl(0x7f000001);
-    const CNetAddr g_my_net_addr_entry = CNetAddr(raw_addr);
+    const CNetAddr my_net_addr_entry{raw_addr};
     {
-        LOCK(g_maplocalhost_mutex);
         LocalServiceInfo lsi;
         lsi.nScore = 23;
         lsi.nPort = 42;
-        g_my_net_addr[g_my_net_addr_entry] = lsi;
+        SYNCED_LOCK(g_my_net_addr, p);
+        (*p)[my_net_addr_entry] = lsi;
     }
 
     // create a peer with an IPv4 address
@@ -646,10 +646,8 @@ BOOST_AUTO_TEST_CASE(ipv4_peer_with_ipv6_addrMe_test)
     BOOST_CHECK(1);
 
     // Cleanup, so that we don't confuse other tests.
-    {
-        LOCK(g_maplocalhost_mutex);
-        g_my_net_addr.erase(g_my_net_addr_entry);
-    }
+    SYNCED_LOCK(g_my_net_addr, p);
+    p->erase(my_net_addr_entry);
 }
 
 BOOST_AUTO_TEST_CASE(get_local_addr_for_peer_port)


### PR DESCRIPTION
Introduce a generic container that provides a thread-safe access to any object by using a mutex which is acquired every time the object accessed.

For example:

```cpp
Synced<std::unordered_map<int, int>> m{{3, 9}, {4, 16}};

{
    SYNCED_LOCK(m, m_locked);

    // m_locked represents the internal object, i.e. std::unordered_map,
    // while m_locked is in scope the internal mutex is locked.

    auto it = m_locked->find(3);
    if (it != m_locked->end()) {
        std::cout << it->second << std::endl;
    }

    for (auto& [k, v] : *m_locked) {
        std::cout << k << ", " << v << std::endl;
    }
}

WITH_SYNCED_LOCK(m, p, p->emplace(5, 25));
```

Remove the global mutexes `g_maplocalhost_mutex`, `g_deadline_timers_mutex`, `cs_dir_locks`, `g_loading_wallet_mutex`, `g_wallet_release_mutex` and use `Synced<T>` instead.

## Benefits

_copied from a [comment below](https://github.com/bitcoin/bitcoin/pull/25390#issuecomment-1169788319):_

The `Synced<T>` abstraction is similar to what is suggested in [this comment](https://github.com/bitcoin/bitcoin/pull/24931#discussion_r890636987) but it does so in a generic way to avoid code repetition. Its benefit is:

1. It avoids code repetition at the implementation sites. See [PR#26151](https://github.com/bitcoin/bitcoin/pull/26151) for a live example. Namely this:

<details>
<summary>Lots of repetitions (92 lines)</summary>

```cpp
class Foo
{
public:
    void PushBack(x)
    {
        LOCK(m_mutex);
        m_data.push_back(x);
    }

    size_t Size()
    {
        LOCK(m_mutex);
        return m_data.size();
    }

    // maybe also other methods if needed...

    auto Lock()
    {
        return DebugLock<Mutex>{m_mutex, "Foo::m_mutex", __FILE__, __LINE__};
    }

private:
    Mutex m_mutex;
    std::vector<int> m_data;
};

class Bar
{
public:
    void PushBack(x)
    {
        LOCK(m_mutex);
        m_data.push_back(x);
    }

    size_t Size()
    {
        LOCK(m_mutex);
        return m_data.size();
    }

    // maybe also other methods if needed...

    auto Lock()
    {
        return DebugLock<Mutex>{m_mutex, "Bar::m_mutex", __FILE__, __LINE__};
    }

private:
    Mutex m_mutex;
    std::vector<std::string> m_data;
};

class Baz
{
public:
    void Insert(x)
    {
        LOCK(m_mutex);
        m_data.insert(x);
    }

    size_t Size()
    {
        LOCK(m_mutex);
        return m_data.size();
    }

    // maybe also other methods if needed...

    auto Lock()
    {
        return DebugLock<Mutex>{m_mutex, "Baz::m_mutex", __FILE__, __LINE__};
    }

private:
    Mutex m_mutex;
    std::set<std::string> m_data;
};
```
</details>

becomes this:

<details>
<summary>Short (3 lines)</summary>

```cpp
Synced<std::vector<int>> Foo;
Synced<std::vector<std::string>> Bar;
Synced<std::set<std::string>> Baz;
```
</details>

2. The mutex is properly encapsulated. With a global mutex and a global variable annotated with `GUARDED_BY()` it is indeed not possible to add new code that accesses the variable without protection (if using Clang and `-Wthread-safety-analysis` and `-Werror`), but it is possible to abuse the mutex and start using it to protect some more, possibly unrelated stuff (we already have this in the current code).
