### PR TITLE
guix: Use LTO to build releases

### DIFF
--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -47,8 +47,15 @@ MAX_VERSIONS = {
 # Ignore symbols that are exported as part of every executable
 IGNORE_EXPORTS = {
 'environ', '_environ', '__environ', '_fini', '_init', 'stdin',
-'stdout', 'stderr',
+'stdout', 'stderr', 'in6addr_any',
 }
+
+# bitcoin-qt only
+IGNORE_EXPORTS.update({
+'xcb_xkb_id', 'xcb_xfixes_id', 'timezone', '__tzname', 'xcb_shm_id',
+'tzname', 'xcb_xinerama_id', '__timezone', 'xcb_render_id', 'xcb_shape_id',
+'xcb_randr_id', 'xcb_sync_id',
+})
 
 # Expected linker-loader names can be found here:
 # https://sourceware.org/glibc/wiki/ABIList?action=recall&rev=16

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -176,7 +176,9 @@ make -C depends --jobs="$JOBS" HOST="$HOST" \
                                    x86_64_linux_AR=x86_64-linux-gnu-gcc-ar \
                                    x86_64_linux_RANLIB=x86_64-linux-gnu-gcc-ranlib \
                                    x86_64_linux_NM=x86_64-linux-gnu-gcc-nm \
-                                   x86_64_linux_STRIP=x86_64-linux-gnu-strip
+                                   x86_64_linux_STRIP=x86_64-linux-gnu-strip \
+                                   LTO=1 \
+                                   CFLAGS="-flto" CXXFLAGS="-flto" LDFLAGS="-flto"
 
 case "$HOST" in
     *darwin*)


### PR DESCRIPTION
Changes required to use LTO in Guix (release) builds.