### PR TITLE
doc: fix typos

### DIFF
--- a/contrib/devtools/test-symbol-check.py
+++ b/contrib/devtools/test-symbol-check.py
@@ -39,7 +39,7 @@ class TestSymbolChecks(unittest.TestCase):
         cc = determine_wellknown_cmd('CC', 'gcc')
 
         # there's no way to do this test for RISC-V at the moment; we build for
-        # RISC-V in a glibc 2.27 envinonment and we allow all symbols from 2.27.
+        # RISC-V in a glibc 2.27 environment and we allow all symbols from 2.27.
         if 'riscv' in get_machine(cc):
             self.skipTest("test not available for RISC-V")
 

--- a/contrib/seeds/asmap.py
+++ b/contrib/seeds/asmap.py
@@ -168,7 +168,7 @@ class _Instruction(Enum):
     # Not an actual instruction, but a way to encode the empty program that fails. In the
     # encoder, it is used more generally to represent the failure case inside MATCH instructions,
     # which may (if used inside the context of a DEFAULT instruction) actually correspond to
-    # a succesful return. In this usage, they're always converted to an actual MATCH or RETURN
+    # a successful return. In this usage, they're always converted to an actual MATCH or RETURN
     # before the top level is reached (see make_default below).
     END = 4
 


### PR DESCRIPTION
`contrib/devtools/test-symbol-check.py`: envinonment -> environment
`contrib/seeds/asmap.py`: succesful -> successful
