### PR TITLE
wallet: fix warning: "argument name 'feerate' in comment does not match parameter name"

### DIFF
--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -232,14 +232,13 @@ CoinsResult AvailableCoinsListUnspent(const CWallet& wallet, const CCoinControl*
 CAmount GetAvailableBalance(const CWallet& wallet, const CCoinControl* coinControl)
 {
     LOCK(wallet.cs_wallet);
-    return AvailableCoins(wallet,
-                          coinControl,
-                          std::nullopt, /*feerate=*/
-                          1,            /*nMinimumAmount*/
-                          MAX_MONEY,    /*nMaximumAmount*/
-                          MAX_MONEY,    /*nMinimumSumAmount*/
-                          0             /*nMaximumCount*/
-                          ).total_amount;
+    return AvailableCoins(wallet, coinControl,
+            /*feerate=*/ std::nullopt,
+            /*nMinimumAmount=*/ 1,
+            /*nMaximumAmount=*/ MAX_MONEY,
+            /*nMinimumSumAmount=*/ MAX_MONEY,
+            /*nMaximumCount=*/ 0
+    ).total_amount;
 }
 
 const CTxOut& FindNonChangeParentOutput(const CWallet& wallet, const CTransaction& tx, int output)


### PR DESCRIPTION
Should solve the tiny https://github.com/bitcoin/bitcoin/pull/25005#issuecomment-1159403854.

Which merely happens for the extra "=" character after the comma.