### PR TITLE
refactor: Remove space between two greater-than signs

### DIFF
--- a/src/common/bloom.cpp
+++ b/src/common/bloom.cpp
@@ -123,7 +123,7 @@ bool CBloomFilter::IsRelevantAndUpdate(const CTransaction& tx)
                     insert(COutPoint(hash, i));
                 else if ((nFlags & BLOOM_UPDATE_MASK) == BLOOM_UPDATE_P2PUBKEY_ONLY)
                 {
-                    std::vector<std::vector<unsigned char> > vSolutions;
+                    std::vector<std::vector<unsigned char>> vSolutions;
                     TxoutType type = Solver(txout.scriptPubKey, vSolutions);
                     if (type == TxoutType::PUBKEY || type == TxoutType::MULTISIG) {
                         insert(COutPoint(hash, i));

--- a/src/core_memusage.h
+++ b/src/core_memusage.h
@@ -19,7 +19,7 @@ static inline size_t RecursiveDynamicUsage(const COutPoint& out) {
 
 static inline size_t RecursiveDynamicUsage(const CTxIn& in) {
     size_t mem = RecursiveDynamicUsage(in.scriptSig) + RecursiveDynamicUsage(in.prevout) + memusage::DynamicUsage(in.scriptWitness.stack);
-    for (std::vector<std::vector<unsigned char> >::const_iterator it = in.scriptWitness.stack.begin(); it != in.scriptWitness.stack.end(); it++) {
+    for (std::vector<std::vector<unsigned char>>::const_iterator it = in.scriptWitness.stack.begin(); it != in.scriptWitness.stack.end(); it++) {
          mem += memusage::DynamicUsage(*it);
     }
     return mem;

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -317,7 +317,7 @@ static bool HTTPBindAddresses(struct evhttp* http)
     }
 
     // Bind addresses
-    for (std::vector<std::pair<std::string, uint16_t> >::iterator i = endpoints.begin(); i != endpoints.end(); ++i) {
+    for (std::vector<std::pair<std::string, uint16_t>>::iterator i = endpoints.begin(); i != endpoints.end(); ++i) {
         LogPrint(BCLog::HTTP, "Binding RPC on address %s port %i\n", i->first, i->second);
         evhttp_bound_socket *bind_handle = evhttp_bind_socket_with_handle(http, i->first.empty() ? nullptr : i->first.c_str(), i->second);
         if (bind_handle) {

--- a/src/indirectmap.h
+++ b/src/indirectmap.h
@@ -12,7 +12,7 @@ struct DereferencingComparator { bool operator()(const T a, const T b) const { r
 
 /* Map whose keys are pointers, but are compared by their dereferenced values.
  *
- * Differs from a plain std::map<const K*, T, DereferencingComparator<K*> > in
+ * Differs from a plain std::map<const K*, T, DereferencingComparator<K*>> in
  * that methods that take a key for comparison take a K rather than taking a K*
  * (taking a K* would be confusing, since it's the value rather than the address
  * of the object for comparison that matters due to the dereferencing comparator).
@@ -23,7 +23,7 @@ struct DereferencingComparator { bool operator()(const T a, const T b) const { r
 template <class K, class T>
 class indirectmap {
 private:
-    typedef std::map<const K*, T, DereferencingComparator<const K*> > base;
+    typedef std::map<const K*, T, DereferencingComparator<const K*>> base;
     base m;
 public:
     typedef typename base::iterator iterator;

--- a/src/key.h
+++ b/src/key.h
@@ -20,7 +20,7 @@
  * CPrivKey is a serialized private key, with all parameters included
  * (SIZE bytes)
  */
-typedef std::vector<unsigned char, secure_allocator<unsigned char> > CPrivKey;
+typedef std::vector<unsigned char, secure_allocator<unsigned char>> CPrivKey;
 
 /** An encapsulated private key. */
 class CKey
@@ -48,7 +48,7 @@ private:
     bool fCompressed;
 
     //! The actual byte data
-    std::vector<unsigned char, secure_allocator<unsigned char> > keydata;
+    std::vector<unsigned char, secure_allocator<unsigned char>> keydata;
 
     //! Check whether the 32-byte array pointed to by vch is valid keydata.
     bool static Check(const unsigned char* vch);

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -40,7 +40,7 @@ template<typename X> static inline size_t DynamicUsage(X * const &v) { return 0;
 template<typename X> static inline size_t DynamicUsage(const X * const &v) { return 0; }
 
 /** Compute the memory used for dynamically allocated but owned data structures.
- *  For generic data types, this is *not* recursive. DynamicUsage(vector<vector<int> >)
+ *  For generic data types, this is *not* recursive. DynamicUsage(vector<vector<int>>)
  *  will compute the memory used for the vector<int>'s, but not for the ints inside.
  *  This is for efficiency reasons, as these functions are intended to be fast. If
  *  application data structures require more accurate inner accounting, they should
@@ -110,13 +110,13 @@ static inline size_t IncrementalDynamicUsage(const std::set<X, Y>& s)
 template<typename X, typename Y, typename Z>
 static inline size_t DynamicUsage(const std::map<X, Y, Z>& m)
 {
-    return MallocUsage(sizeof(stl_tree_node<std::pair<const X, Y> >)) * m.size();
+    return MallocUsage(sizeof(stl_tree_node<std::pair<const X, Y>>)) * m.size();
 }
 
 template<typename X, typename Y, typename Z>
 static inline size_t IncrementalDynamicUsage(const std::map<X, Y, Z>& m)
 {
-    return MallocUsage(sizeof(stl_tree_node<std::pair<const X, Y> >));
+    return MallocUsage(sizeof(stl_tree_node<std::pair<const X, Y>>));
 }
 
 // indirectmap has underlying map with pointer as key
@@ -124,13 +124,13 @@ static inline size_t IncrementalDynamicUsage(const std::map<X, Y, Z>& m)
 template<typename X, typename Y>
 static inline size_t DynamicUsage(const indirectmap<X, Y>& m)
 {
-    return MallocUsage(sizeof(stl_tree_node<std::pair<const X*, Y> >)) * m.size();
+    return MallocUsage(sizeof(stl_tree_node<std::pair<const X*, Y>>)) * m.size();
 }
 
 template<typename X, typename Y>
 static inline size_t IncrementalDynamicUsage(const indirectmap<X, Y>& m)
 {
-    return MallocUsage(sizeof(stl_tree_node<std::pair<const X*, Y> >));
+    return MallocUsage(sizeof(stl_tree_node<std::pair<const X*, Y>>));
 }
 
 template<typename X>
@@ -164,7 +164,7 @@ static inline size_t DynamicUsage(const std::unordered_set<X, Y>& s)
 template<typename X, typename Y, typename Z>
 static inline size_t DynamicUsage(const std::unordered_map<X, Y, Z>& m)
 {
-    return MallocUsage(sizeof(unordered_node<std::pair<const X, Y> >)) * m.size() + MallocUsage(sizeof(void*) * m.bucket_count());
+    return MallocUsage(sizeof(unordered_node<std::pair<const X, Y>>)) * m.size() + MallocUsage(sizeof(void*) * m.bucket_count());
 }
 
 }

--- a/src/merkleblock.h
+++ b/src/merkleblock.h
@@ -134,7 +134,7 @@ public:
      * Used only when a bloom filter is specified to allow
      * testing the transactions which matched the bloom filter.
      */
-    std::vector<std::pair<unsigned int, uint256> > vMatchedTxn;
+    std::vector<std::pair<unsigned int, uint256>> vMatchedTxn;
 
     /**
      * Create from a CBlock, filtering transactions according to filter

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1061,7 +1061,7 @@ void ProtectEvictionCandidatesByRatio(std::vector<NodeEvictionCandidate>& evicti
     uint64_t naMostConnections;
     unsigned int nMostConnections = 0;
     std::chrono::seconds nMostConnectionsTime{0};
-    std::map<uint64_t, std::vector<NodeEvictionCandidate> > mapNetGroupNodes;
+    std::map<uint64_t, std::vector<NodeEvictionCandidate>> mapNetGroupNodes;
     for (const NodeEvictionCandidate &node : vEvictionCandidates) {
         std::vector<NodeEvictionCandidate> &group = mapNetGroupNodes[node.nKeyedNetGroup];
         group.push_back(node);
@@ -1881,7 +1881,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
         // Only connect out to one peer per network group (/16 for IPv4).
         int nOutboundFullRelay = 0;
         int nOutboundBlockRelay = 0;
-        std::set<std::vector<unsigned char> > setConnected;
+        std::set<std::vector<unsigned char>> setConnected;
 
         {
             LOCK(m_nodes_mutex);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -754,7 +754,7 @@ private:
      */
     void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<const CBlockIndex*>& vBlocks, NodeId& nodeStaller) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-    std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> > mapBlocksInFlight GUARDED_BY(cs_main);
+    std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator>> mapBlocksInFlight GUARDED_BY(cs_main);
 
     /** When our tip was last updated. */
     std::atomic<std::chrono::seconds> m_last_tip_update{0s};
@@ -981,7 +981,7 @@ bool PeerManagerImpl::BlockRequested(NodeId nodeid, const CBlockIndex& block, st
     assert(state != nullptr);
 
     // Short-circuit most stuff in case it is from the same node
-    std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> >::iterator itInFlight = mapBlocksInFlight.find(hash);
+    std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator>>::iterator itInFlight = mapBlocksInFlight.find(hash);
     if (itInFlight != mapBlocksInFlight.end() && itInFlight->second.first == nodeid) {
         if (pit) {
             *pit = &itInFlight->second.second;
@@ -3642,7 +3642,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             nodestate->m_last_block_announcement = GetTime();
         }
 
-        std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> >::iterator blockInFlightIt = mapBlocksInFlight.find(pindex->GetBlockHash());
+        std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator>>::iterator blockInFlightIt = mapBlocksInFlight.find(pindex->GetBlockHash());
         bool fAlreadyInFlight = blockInFlightIt != mapBlocksInFlight.end();
 
         if (pindex->nStatus & BLOCK_HAVE_DATA) // Nothing to do here
@@ -3801,7 +3801,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         {
             LOCK(cs_main);
 
-            std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> >::iterator it = mapBlocksInFlight.find(resp.blockhash);
+            std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator>>::iterator it = mapBlocksInFlight.find(resp.blockhash);
             if (it == mapBlocksInFlight.end() || !it->second.second->partialBlock ||
                     it->second.first != pfrom.GetId()) {
                 LogPrint(BCLog::NET, "Peer %d sent us block transactions for block we weren't expecting\n", pfrom.GetId());

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -107,7 +107,7 @@ private:
     // Mempool counts of outstanding transactions
     // For each bucket X, track the number of transactions in the mempool
     // that are unconfirmed for each possible confirmation value Y
-    std::vector<std::vector<int> > unconfTxs;  //unconfTxs[Y][X]
+    std::vector<std::vector<int>> unconfTxs;  //unconfTxs[Y][X]
     // transactions still unconfirmed after GetMaxConfirms for each bucket
     std::vector<int> oldUnconfTxs;
 

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -69,7 +69,7 @@ bool IsDust(const CTxOut& txout, const CFeeRate& dustRelayFeeIn)
 
 bool IsStandard(const CScript& scriptPubKey, TxoutType& whichType)
 {
-    std::vector<std::vector<unsigned char> > vSolutions;
+    std::vector<std::vector<unsigned char>> vSolutions;
     whichType = Solver(scriptPubKey, vSolutions);
 
     if (whichType == TxoutType::NONSTANDARD) {
@@ -182,7 +182,7 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
     for (unsigned int i = 0; i < tx.vin.size(); i++) {
         const CTxOut& prev = mapInputs.AccessCoin(tx.vin[i].prevout).out;
 
-        std::vector<std::vector<unsigned char> > vSolutions;
+        std::vector<std::vector<unsigned char>> vSolutions;
         TxoutType whichType = Solver(prev.scriptPubKey, vSolutions);
         if (whichType == TxoutType::NONSTANDARD || whichType == TxoutType::WITNESS_UNKNOWN) {
             // WITNESS_UNKNOWN failures are typically also caught with a policy
@@ -191,7 +191,7 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
             // validation.
             return false;
         } else if (whichType == TxoutType::SCRIPTHASH) {
-            std::vector<std::vector<unsigned char> > stack;
+            std::vector<std::vector<unsigned char>> stack;
             // convert the scriptSig into a stack, so we can inspect the redeemScript
             if (!EvalScript(stack, tx.vin[i].scriptSig, SCRIPT_VERIFY_NONE, BaseSignatureChecker(), SigVersion::BASE))
                 return false;
@@ -226,7 +226,7 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 
         bool p2sh = false;
         if (prevScript.IsPayToScriptHash()) {
-            std::vector <std::vector<unsigned char> > stack;
+            std::vector <std::vector<unsigned char>> stack;
             // If the scriptPubKey is P2SH, we try to extract the redeemScript casually by converting the scriptSig
             // into a stack. We do not check IsPushOnly nor compare the hash as these will be done later anyway.
             // If the check fails at this stage, we know that this txid must be a bad one.

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -154,8 +154,8 @@ bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out)
     rv.amount = 0;
 
     QUrlQuery uriQuery(uri);
-    QList<QPair<QString, QString> > items = uriQuery.queryItems();
-    for (QList<QPair<QString, QString> >::iterator i = items.begin(); i != items.end(); i++)
+    QList<QPair<QString, QString>> items = uriQuery.queryItems();
+    for (QList<QPair<QString, QString>>::iterator i = items.begin(); i != items.end(); i++)
     {
         bool fShouldReturnFalse = false;
         if (i->first.startsWith("req-"))

--- a/src/qt/modaloverlay.h
+++ b/src/qt/modaloverlay.h
@@ -47,7 +47,7 @@ private:
     Ui::ModalOverlay *ui;
     int bestHeaderHeight; //best known height (based on the headers)
     QDateTime bestHeaderDate;
-    QVector<QPair<qint64, double> > blockProcessTime;
+    QVector<QPair<qint64, double>> blockProcessTime;
     bool layerIsVisible;
     bool userClosed;
     QPropertyAnimation m_animation;

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -168,7 +168,7 @@ public:
 
 bool RPCConsole::RPCParseCommandLine(interfaces::Node* node, std::string &strResult, const std::string &strCommand, const bool fExecute, std::string * const pstrFilteredOut, const WalletModel* wallet_model)
 {
-    std::vector< std::vector<std::string> > stack;
+    std::vector<std::vector<std::string>> stack;
     stack.push_back(std::vector<std::string>());
 
     enum CmdParseState

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -27,7 +27,7 @@ static std::string rpcWarmupStatus GUARDED_BY(g_rpc_warmup_mutex) = "RPC server 
 static RPCTimerInterface* timerInterface = nullptr;
 /* Map of name to timer. */
 static GlobalMutex g_deadline_timers_mutex;
-static std::map<std::string, std::unique_ptr<RPCTimerBase> > deadlineTimers GUARDED_BY(g_deadline_timers_mutex);
+static std::map<std::string, std::unique_ptr<RPCTimerBase>> deadlineTimers GUARDED_BY(g_deadline_timers_mutex);
 static bool ExecuteCommand(const CRPCCommand& command, const JSONRPCRequest& request, UniValue& result, bool last_handler);
 
 struct RPCCommandExecutionInfo
@@ -80,7 +80,7 @@ std::string CRPCTable::help(const std::string& strCommand, const JSONRPCRequest&
     std::string strRet;
     std::string category;
     std::set<intptr_t> setDone;
-    std::vector<std::pair<std::string, const CRPCCommand*> > vCommands;
+    std::vector<std::pair<std::string, const CRPCCommand*>> vCommands;
 
     for (const auto& entry : mapCommands)
         vCommands.push_back(make_pair(entry.second.front()->category + entry.first, entry.second.front()));

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -403,7 +403,7 @@ static bool EvalChecksig(const valtype& sig, const valtype& pubkey, CScript::con
     assert(false);
 }
 
-bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* serror)
+bool EvalScript(std::vector<std::vector<unsigned char>>& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* serror)
 {
     static const CScriptNum bnZero(0);
     static const CScriptNum bnOne(1);
@@ -1233,7 +1233,7 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
     return set_success(serror);
 }
 
-bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* serror)
+bool EvalScript(std::vector<std::vector<unsigned char>>& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* serror)
 {
     ScriptExecutionData execdata;
     return EvalScript(stack, script, flags, checker, sigversion, execdata, serror);
@@ -1964,7 +1964,7 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
 
     // scriptSig and scriptPubKey must be evaluated sequentially on the same stack
     // rather than being simply concatenated (see CVE-2010-5141)
-    std::vector<std::vector<unsigned char> > stack, stackCopy;
+    std::vector<std::vector<unsigned char>> stack, stackCopy;
     if (!EvalScript(stack, scriptSig, flags, checker, SigVersion::BASE, serror))
         // serror is set
         return false;

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -338,8 +338,8 @@ uint256 ComputeTapleafHash(uint8_t leaf_version, const CScript& script);
  *  Requires control block to have valid length (33 + k*32, with k in {0,1,..,128}). */
 uint256 ComputeTaprootMerkleRoot(Span<const unsigned char> control, const uint256& tapleaf_hash);
 
-bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* error = nullptr);
-bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* error = nullptr);
+bool EvalScript(std::vector<std::vector<unsigned char>>& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* error = nullptr);
+bool EvalScript(std::vector<std::vector<unsigned char>>& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* error = nullptr);
 bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const CScriptWitness* witness, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* serror = nullptr);
 
 size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey, const CScriptWitness* witness, unsigned int flags);

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -563,7 +563,7 @@ struct CScriptWitness
 {
     // Note that this encodes the data elements being pushed, rather than
     // encoding them as a CScript that pushes them.
-    std::vector<std::vector<unsigned char> > stack;
+    std::vector<std::vector<unsigned char>> stack;
 
     // Some compilers complain without a default constructor
     CScriptWitness() { }

--- a/src/support/allocators/secure.h
+++ b/src/support/allocators/secure.h
@@ -56,6 +56,6 @@ struct secure_allocator : public std::allocator<T> {
 };
 
 // This is exactly like std::string, but with a custom allocator.
-typedef std::basic_string<char, std::char_traits<char>, secure_allocator<char> > SecureString;
+typedef std::basic_string<char, std::char_traits<char>, secure_allocator<char>> SecureString;
 
 #endif // BITCOIN_SUPPORT_ALLOCATORS_SECURE_H

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(script_standard_Solver_success)
     }
 
     CScript s;
-    std::vector<std::vector<unsigned char> > solutions;
+    std::vector<std::vector<unsigned char>> solutions;
 
     // TxoutType::PUBKEY
     s.clear();
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(script_standard_Solver_failure)
     pubkey = key.GetPubKey();
 
     CScript s;
-    std::vector<std::vector<unsigned char> > solutions;
+    std::vector<std::vector<unsigned char>> solutions;
 
     // TxoutType::PUBKEY with incorrectly sized pubkey
     s.clear();

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -983,21 +983,21 @@ BOOST_AUTO_TEST_CASE(script_PushData)
     static const unsigned char pushdata4[] = { OP_PUSHDATA4, 1, 0, 0, 0, 0x5a };
 
     ScriptError err;
-    std::vector<std::vector<unsigned char> > directStack;
+    std::vector<std::vector<unsigned char>> directStack;
     BOOST_CHECK(EvalScript(directStack, CScript(direct, direct + sizeof(direct)), SCRIPT_VERIFY_P2SH, BaseSignatureChecker(), SigVersion::BASE, &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
-    std::vector<std::vector<unsigned char> > pushdata1Stack;
+    std::vector<std::vector<unsigned char>> pushdata1Stack;
     BOOST_CHECK(EvalScript(pushdata1Stack, CScript(pushdata1, pushdata1 + sizeof(pushdata1)), SCRIPT_VERIFY_P2SH, BaseSignatureChecker(), SigVersion::BASE, &err));
     BOOST_CHECK(pushdata1Stack == directStack);
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
-    std::vector<std::vector<unsigned char> > pushdata2Stack;
+    std::vector<std::vector<unsigned char>> pushdata2Stack;
     BOOST_CHECK(EvalScript(pushdata2Stack, CScript(pushdata2, pushdata2 + sizeof(pushdata2)), SCRIPT_VERIFY_P2SH, BaseSignatureChecker(), SigVersion::BASE, &err));
     BOOST_CHECK(pushdata2Stack == directStack);
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
-    std::vector<std::vector<unsigned char> > pushdata4Stack;
+    std::vector<std::vector<unsigned char>> pushdata4Stack;
     BOOST_CHECK(EvalScript(pushdata4Stack, CScript(pushdata4, pushdata4 + sizeof(pushdata4)), SCRIPT_VERIFY_P2SH, BaseSignatureChecker(), SigVersion::BASE, &err));
     BOOST_CHECK(pushdata4Stack == directStack);
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -278,9 +278,9 @@ void CCoinsViewDBCursor::Next()
     }
 }
 
-bool CBlockTreeDB::WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<const CBlockIndex*>& blockinfo) {
+bool CBlockTreeDB::WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*>>& fileInfo, int nLastFile, const std::vector<const CBlockIndex*>& blockinfo) {
     CDBBatch batch(*this);
-    for (std::vector<std::pair<int, const CBlockFileInfo*> >::const_iterator it=fileInfo.begin(); it != fileInfo.end(); it++) {
+    for (std::vector<std::pair<int, const CBlockFileInfo*>>::const_iterator it=fileInfo.begin(); it != fileInfo.end(); it++) {
         batch.Write(std::make_pair(DB_BLOCK_FILES, it->first), *it->second);
     }
     batch.Write(DB_LAST_BLOCK, nLastFile);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -79,7 +79,7 @@ class CBlockTreeDB : public CDBWrapper
 public:
     explicit CBlockTreeDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
 
-    bool WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<const CBlockIndex*>& blockinfo);
+    bool WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*>>& fileInfo, int nLastFile, const std::vector<const CBlockIndex*>& blockinfo);
     bool ReadBlockFileInfo(int nFile, CBlockFileInfo &info);
     bool ReadLastBlockFile(int &nFile);
     bool WriteReindexing(bool fReindexing);

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -59,7 +59,7 @@ public:
     }
 };
 
-typedef std::vector<unsigned char, secure_allocator<unsigned char> > CKeyingMaterial;
+typedef std::vector<unsigned char, secure_allocator<unsigned char>> CKeyingMaterial;
 
 namespace wallet_crypto_tests
 {

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -387,10 +387,10 @@ std::map<CTxDestination, CAmount> GetAddressBalances(const CWallet& wallet)
     return balances;
 }
 
-std::set< std::set<CTxDestination> > GetAddressGroupings(const CWallet& wallet)
+std::set< std::set<CTxDestination>> GetAddressGroupings(const CWallet& wallet)
 {
     AssertLockHeld(wallet.cs_wallet);
-    std::set< std::set<CTxDestination> > groupings;
+    std::set< std::set<CTxDestination>> groupings;
     std::set<CTxDestination> grouping;
 
     for (const auto& walletEntry : wallet.mapWallet)
@@ -470,7 +470,7 @@ std::set< std::set<CTxDestination> > GetAddressGroupings(const CWallet& wallet)
             setmap[element] = merged;
     }
 
-    std::set< std::set<CTxDestination> > ret;
+    std::set< std::set<CTxDestination>> ret;
     for (const std::set<CTxDestination>* uniqueGrouping : uniqueGroupings)
     {
         ret.insert(*uniqueGrouping);

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -749,7 +749,7 @@ RPCHelpMan dumpwallet()
     std::set<CScriptID> scripts = spk_man.GetCScripts();
 
     // sort time/key pairs
-    std::vector<std::pair<int64_t, CKeyID> > vKeyBirth;
+    std::vector<std::pair<int64_t, CKeyID>> vKeyBirth;
     for (const auto& entry : mapKeyBirth) {
         vKeyBirth.push_back(std::make_pair(entry.second, entry.first));
     }
@@ -775,7 +775,7 @@ RPCHelpMan dumpwallet()
             file << "# extended private masterkey: " << EncodeExtKey(masterKey) << "\n\n";
         }
     }
-    for (std::vector<std::pair<int64_t, CKeyID> >::const_iterator it = vKeyBirth.begin(); it != vKeyBirth.end(); it++) {
+    for (std::vector<std::pair<int64_t, CKeyID>>::const_iterator it = vKeyBirth.begin(); it != vKeyBirth.end(); it++) {
         const CKeyID &keyid = it->second;
         std::string strTime = FormatISO8601DateTime(it->first);
         std::string strAddr;

--- a/src/wallet/salvage.cpp
+++ b/src/wallet/salvage.cpp
@@ -16,7 +16,7 @@ namespace wallet {
 static const char *HEADER_END = "HEADER=END";
 /* End of key/value data */
 static const char *DATA_END = "DATA=END";
-typedef std::pair<std::vector<unsigned char>, std::vector<unsigned char> > KeyValPair;
+typedef std::pair<std::vector<unsigned char>, std::vector<unsigned char>> KeyValPair;
 
 static bool KeyFilter(const std::string& type)
 {

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -163,7 +163,7 @@ public:
      *                         2014 (removed in commit 93a18a3)
      */
     mapValue_t mapValue;
-    std::vector<std::pair<std::string, std::string> > vOrderForm;
+    std::vector<std::pair<std::string, std::string>> vOrderForm;
     unsigned int fTimeReceivedIsTxTime;
     unsigned int nTimeReceived; //!< time received by this node
     /**


### PR DESCRIPTION
Putting space between greater-than signs is a pre-C++11 thing and
there are already instances of not doing so in the code base so
let's normalize this bit and just remove the extra space.

For example [this](https://github.com/bitcoin/bitcoin/blob/9edc5133d49978db75cf68be1a2046236c007d9f/src/addrman.cpp#L319) already uses `>>` and there are some more examples on the code base.

To me seeing a code still avoids `>>` is a distraction as makes me to recheck whether the code base still supports pre-C++11 which clearly isn't the case here.

I already have seen the notes about refactoring in `developer-notes.md`, `CONTRIBUTING.md` and `stylistic code changes are usually rejected.` and am ready to close this PR immediately and voluntarily as the first unhappy comment, I just thought it is a common distraction for code reading keeping a historical and obsolete thing inconsistently around but if you are happy to keep it this way it's just ok.

Thanks!