### PR TITLE
net: convert standalone IsSelectableSocket() and SetSocketNonBlocking() to Sock methods

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -109,14 +109,6 @@ typedef char* sockopt_arg_type;
 #define USE_POLL
 #endif
 
-bool static inline IsSelectableSocket(const SOCKET& s) {
-#if defined(USE_POLL) || defined(WIN32)
-    return true;
-#else
-    return (s < FD_SETSIZE);
-#endif
-}
-
 // MSG_NOSIGNAL is not available on some platforms, if it doesn't exist define it as 0
 #if !defined(MSG_NOSIGNAL)
 #define MSG_NOSIGNAL 0

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -961,8 +961,7 @@ void CConnman::CreateNodeFromAcceptedSocket(std::unique_ptr<Sock>&& sock,
         return;
     }
 
-    if (!IsSelectableSocket(sock->Get()))
-    {
+    if (!sock->IsSelectable()) {
         LogPrintf("connection from %s dropped: non-selectable socket\n", addr.ToString());
         return;
     }

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -717,21 +717,6 @@ bool LookupSubNet(const std::string& subnet_str, CSubNet& subnet_out)
     return false;
 }
 
-bool SetSocketNonBlocking(const SOCKET& hSocket)
-{
-#ifdef WIN32
-    u_long nOne = 1;
-    if (ioctlsocket(hSocket, FIONBIO, &nOne) == SOCKET_ERROR) {
-#else
-    int fFlags = fcntl(hSocket, F_GETFL, 0);
-    if (fcntl(hSocket, F_SETFL, fFlags | O_NONBLOCK) == SOCKET_ERROR) {
-#endif
-        return false;
-    }
-
-    return true;
-}
-
 void InterruptSocks5(bool interrupt)
 {
     interruptSocks5Recv = interrupt;

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -304,8 +304,7 @@ enum class IntrRecvError {
  *          read.
  *
  * @see This function can be interrupted by calling InterruptSocks5(bool).
- *      Sockets can be made non-blocking with SetSocketNonBlocking(const
- *      SOCKET&).
+ *      Sockets can be made non-blocking with Sock::SetNonBlocking().
  */
 static IntrRecvError InterruptibleRecv(uint8_t* data, size_t len, int timeout, const Sock& sock)
 {
@@ -525,7 +524,7 @@ std::unique_ptr<Sock> CreateSockTCP(const CService& address_family)
     }
 
     // Set the non-blocking option on the socket.
-    if (!SetSocketNonBlocking(sock->Get())) {
+    if (!sock->SetNonBlocking()) {
         LogPrintf("Error setting socket to non-blocking: %s\n", NetworkErrorString(WSAGetLastError()));
         return nullptr;
     }

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -503,7 +503,7 @@ std::unique_ptr<Sock> CreateSockTCP(const CService& address_family)
 
     // Ensure that waiting for I/O on this socket won't result in undefined
     // behavior.
-    if (!IsSelectableSocket(sock->Get())) {
+    if (!sock->IsSelectable()) {
         LogPrintf("Cannot create connection: non-selectable socket created (fd >= FD_SETSIZE ?)\n");
         return nullptr;
     }

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -221,8 +221,6 @@ bool ConnectSocketDirectly(const CService &addrConnect, const Sock& sock, int nT
  */
 bool ConnectThroughProxy(const Proxy& proxy, const std::string& strDest, uint16_t port, const Sock& sock, int nTimeout, bool& outProxyConnectionFailed);
 
-/** Enable non-blocking mode for a socket */
-bool SetSocketNonBlocking(const SOCKET& hSocket);
 void InterruptSocks5(bool interrupt);
 
 /**

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -254,6 +254,19 @@ int FuzzedSock::GetSockName(sockaddr* name, socklen_t* name_len) const
     return 0;
 }
 
+bool FuzzedSock::SetNonBlocking() const
+{
+    constexpr std::array setnonblocking_errnos{
+        EBADF,
+        EPERM,
+    };
+    if (m_fuzzed_data_provider.ConsumeBool()) {
+        SetFuzzedErrNo(m_fuzzed_data_provider, setnonblocking_errnos);
+        return false;
+    }
+    return true;
+}
+
 bool FuzzedSock::IsSelectable() const
 {
     return m_selectable;

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -16,7 +16,7 @@
 #include <memory>
 
 FuzzedSock::FuzzedSock(FuzzedDataProvider& fuzzed_data_provider)
-    : m_fuzzed_data_provider{fuzzed_data_provider}
+    : m_fuzzed_data_provider{fuzzed_data_provider}, m_selectable{fuzzed_data_provider.ConsumeBool()}
 {
     m_socket = fuzzed_data_provider.ConsumeIntegralInRange<SOCKET>(INVALID_SOCKET - 1, INVALID_SOCKET);
 }
@@ -252,6 +252,11 @@ int FuzzedSock::GetSockName(sockaddr* name, socklen_t* name_len) const
     }
     *name_len = m_fuzzed_data_provider.ConsumeData(name, *name_len);
     return 0;
+}
+
+bool FuzzedSock::IsSelectable() const
+{
+    return m_selectable;
 }
 
 bool FuzzedSock::Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred) const

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -48,6 +48,13 @@ class FuzzedSock : public Sock
      */
     mutable std::optional<uint8_t> m_peek_data;
 
+    /**
+     * Whether to pretend that the socket is select(2)-able. This is randomly set in the
+     * constructor. It should remain constant so that repeated calls to `IsSelectable()`
+     * return the same value.
+     */
+    const bool m_selectable;
+
 public:
     explicit FuzzedSock(FuzzedDataProvider& fuzzed_data_provider);
 
@@ -72,6 +79,8 @@ public:
     int SetSockOpt(int level, int opt_name, const void* opt_val, socklen_t opt_len) const override;
 
     int GetSockName(sockaddr* name, socklen_t* name_len) const override;
+
+    bool IsSelectable() const override;
 
     bool Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred = nullptr) const override;
 

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -80,6 +80,8 @@ public:
 
     int GetSockName(sockaddr* name, socklen_t* name_len) const override;
 
+    bool SetNonBlocking() const override;
+
     bool IsSelectable() const override;
 
     bool Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred = nullptr) const override;

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -166,6 +166,8 @@ public:
         return 0;
     }
 
+    bool SetNonBlocking() const override { return true; }
+
     bool IsSelectable() const override { return true; }
 
     bool Wait(std::chrono::milliseconds timeout,

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -166,6 +166,8 @@ public:
         return 0;
     }
 
+    bool IsSelectable() const override { return true; }
+
     bool Wait(std::chrono::milliseconds timeout,
               Event requested,
               Event* occurred = nullptr) const override

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -117,11 +117,12 @@ int Sock::GetSockName(sockaddr* name, socklen_t* name_len) const
     return getsockname(m_socket, name, name_len);
 }
 
-bool IsSelectableSocket(const SOCKET& s) {
+bool Sock::IsSelectable() const
+{
 #if defined(USE_POLL) || defined(WIN32)
     return true;
 #else
-    return (s < FD_SETSIZE);
+    return m_socket < FD_SETSIZE;
 #endif
 }
 
@@ -193,10 +194,10 @@ bool Sock::WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per
     SOCKET socket_max{0};
 
     for (const auto& [sock, events] : events_per_sock) {
-        const auto& s = sock->m_socket;
-        if (!IsSelectableSocket(s)) {
+        if (!sock->IsSelectable()) {
             return false;
         }
+        const auto& s = sock->m_socket;
         if (events.requested & RECV) {
             FD_SET(s, &recv);
         }

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -117,18 +117,22 @@ int Sock::GetSockName(sockaddr* name, socklen_t* name_len) const
     return getsockname(m_socket, name, name_len);
 }
 
-bool SetSocketNonBlocking(const SOCKET& hSocket)
+bool Sock::SetNonBlocking() const
 {
 #ifdef WIN32
-    u_long nOne = 1;
-    if (ioctlsocket(hSocket, FIONBIO, &nOne) == SOCKET_ERROR) {
-#else
-    int fFlags = fcntl(hSocket, F_GETFL, 0);
-    if (fcntl(hSocket, F_SETFL, fFlags | O_NONBLOCK) == SOCKET_ERROR) {
-#endif
+    u_long on{1};
+    if (ioctlsocket(m_socket, FIONBIO, &on) == SOCKET_ERROR) {
         return false;
     }
-
+#else
+    const int flags{fcntl(m_socket, F_GETFL, 0)};
+    if (flags == SOCKET_ERROR) {
+        return false;
+    }
+    if (fcntl(m_socket, F_SETFL, flags | O_NONBLOCK) == SOCKET_ERROR) {
+        return false;
+    }
+#endif
     return true;
 }
 

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -117,6 +117,21 @@ int Sock::GetSockName(sockaddr* name, socklen_t* name_len) const
     return getsockname(m_socket, name, name_len);
 }
 
+bool SetSocketNonBlocking(const SOCKET& hSocket)
+{
+#ifdef WIN32
+    u_long nOne = 1;
+    if (ioctlsocket(hSocket, FIONBIO, &nOne) == SOCKET_ERROR) {
+#else
+    int fFlags = fcntl(hSocket, F_GETFL, 0);
+    if (fcntl(hSocket, F_SETFL, fFlags | O_NONBLOCK) == SOCKET_ERROR) {
+#endif
+        return false;
+    }
+
+    return true;
+}
+
 bool Sock::IsSelectable() const
 {
 #if defined(USE_POLL) || defined(WIN32)

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -117,6 +117,14 @@ int Sock::GetSockName(sockaddr* name, socklen_t* name_len) const
     return getsockname(m_socket, name, name_len);
 }
 
+bool IsSelectableSocket(const SOCKET& s) {
+#if defined(USE_POLL) || defined(WIN32)
+    return true;
+#else
+    return (s < FD_SETSIZE);
+#endif
+}
+
 bool Sock::Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred) const
 {
     // We need a `shared_ptr` owning `this` for `WaitMany()`, but don't want

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -134,6 +134,12 @@ public:
     [[nodiscard]] virtual int GetSockName(sockaddr* name, socklen_t* name_len) const;
 
     /**
+     * Set the non-blocking option on the socket.
+     * @return true if set successfully
+     */
+    [[nodiscard]] virtual bool SetNonBlocking() const;
+
+    /**
      * Check if the underlying socket can be used for `select(2)` (or the `Wait()` method).
      * @return true if selectable
      */
@@ -272,9 +278,6 @@ private:
      */
     void Close();
 };
-
-/** Enable non-blocking mode for a socket */
-bool SetSocketNonBlocking(const SOCKET& hSocket);
 
 /** Return readable error string for a network error code */
 std::string NetworkErrorString(int err);

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -133,6 +133,12 @@ public:
      */
     [[nodiscard]] virtual int GetSockName(sockaddr* name, socklen_t* name_len) const;
 
+    /**
+     * Check if the underlying socket can be used for `select(2)` (or the `Wait()` method).
+     * @return true if selectable
+     */
+    [[nodiscard]] virtual bool IsSelectable() const;
+
     using Event = uint8_t;
 
     /**
@@ -266,8 +272,6 @@ private:
      */
     void Close();
 };
-
-bool IsSelectableSocket(const SOCKET& s);
 
 /** Return readable error string for a network error code */
 std::string NetworkErrorString(int err);

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -273,6 +273,9 @@ private:
     void Close();
 };
 
+/** Enable non-blocking mode for a socket */
+bool SetSocketNonBlocking(const SOCKET& hSocket);
+
 /** Return readable error string for a network error code */
 std::string NetworkErrorString(int err);
 

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -267,6 +267,8 @@ private:
     void Close();
 };
 
+bool IsSelectableSocket(const SOCKET& s);
+
 /** Return readable error string for a network error code */
 std::string NetworkErrorString(int err);
 


### PR DESCRIPTION
_This is a piece of #21878, chopped off to ease review._

* convert standalone `IsSelectableSocket()` to `Sock::IsSelectable()`
* convert standalone `SetSocketNonBlocking()` to `Sock::SetNonBlocking()`

This further encapsulates syscalls inside the `Sock` class and makes the callers mockable.