### PR TITLE
build: globally define NOMINMAX when building with mingw-w64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -710,6 +710,9 @@ case $host in
      fi
 
      CORE_CPPFLAGS="$CORE_CPPFLAGS -D_MT -DWIN32 -D_WINDOWS -D_WIN32_WINNT=0x0601 -D_WIN32_IE=0x0501 -DWIN32_LEAN_AND_MEAN"
+     dnl Prevent the definition of min/max macros.
+     dnl We always want to use the standard library.
+     CORE_CPPFLAGS="$CORE_CPPFLAGS -DNOMINMAX"
 
      dnl libtool insists upon adding -nostdlib and a list of objects/libs to link against.
      dnl That breaks our ability to build dll's with static libgcc/libstdc++/libssp. Override

--- a/src/compat.h
+++ b/src/compat.h
@@ -11,9 +11,6 @@
 #endif
 
 #ifdef WIN32
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #ifdef FD_SETSIZE
 #undef FD_SETSIZE // prevent redefinition compiler warning
 #endif

--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -12,9 +12,6 @@
 #include <sys/utsname.h>
 #include <unistd.h>
 #else
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #include <codecvt>
 #include <limits>
 #include <windows.h>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -24,9 +24,6 @@
 #include <util/time.h>
 
 #ifdef WIN32
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #include <shellapi.h>
 #include <shlobj.h>
 #include <shlwapi.h>

--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -10,9 +10,6 @@
 #endif
 
 #ifdef WIN32
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #include <windows.h>
 #else
 #include <sys/mman.h> // for mmap

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -62,9 +62,6 @@
 #pragma warning(disable:4717)
 #endif
 
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
 #include <codecvt>
 
 #include <io.h> /* for _commit */


### PR DESCRIPTION
Define (and document) `NOMINMAX` once, rather than across multiple
source files.

Defining this prevents the definition of min/max macros when using
mingw-w64, which may conflict with unprefixed std::min/max usage. While
that might not be the case for us, we'd always prefer to use the standard
library in any case.

For example:
https://github.com/mingw-w64/mingw-w64/blob/73cadc06c62c6af5faf76f64ef08e684b48de48c/mingw-w64-headers/include/ntdef.h#L289-L300

Note that we already define NOMINMAX globally when building with MSVC.

Guix Build (arm64):
```bash
d3a3b7045dc1677f6a0a2a73a484f156c81ae764058003d9e870b346912b744a  guix-build-58a9601dffa6/output/arm-linux-gnueabihf/SHA256SUMS.part
3e66540a3f8c8a10864ab2fed69581241fa41af86bbb028e5f7c3dd4ba859c64  guix-build-58a9601dffa6/output/arm-linux-gnueabihf/bitcoin-58a9601dffa6-arm-linux-gnueabihf-debug.tar.gz
78756e20d45e327cfd7f9e65858bf6d3814bcbe08f9f825fd6dfc9dff999ea6d  guix-build-58a9601dffa6/output/arm-linux-gnueabihf/bitcoin-58a9601dffa6-arm-linux-gnueabihf.tar.gz
11073e88d4fd0411c5119a3dca3a90788693fa9aa5134339c84be98ae893cd77  guix-build-58a9601dffa6/output/arm64-apple-darwin/SHA256SUMS.part
deffd5f8c6286be34bc35e71ec70300bacb37e1b1a83e67c0833cb57d7a45529  guix-build-58a9601dffa6/output/arm64-apple-darwin/bitcoin-58a9601dffa6-arm64-apple-darwin-unsigned.dmg
acee7e98c5ec41f67e86c78dc5b45fa8bc82de86a04b8c43dbf9c59e7aff36a9  guix-build-58a9601dffa6/output/arm64-apple-darwin/bitcoin-58a9601dffa6-arm64-apple-darwin-unsigned.tar.gz
83f7cbaf6680fe8981db9260b97ca87d609a76c0857a744c7d406645d2484e1b  guix-build-58a9601dffa6/output/arm64-apple-darwin/bitcoin-58a9601dffa6-arm64-apple-darwin.tar.gz
b8c73b40a5e307e9e7e482ce92164990d442f3f105a5240ec6eb96a775cb35d5  guix-build-58a9601dffa6/output/dist-archive/bitcoin-58a9601dffa6.tar.gz
cc435cd925771af7e261d0121047339ea8fddb0d1548b699c12108a62988cd32  guix-build-58a9601dffa6/output/powerpc64-linux-gnu/SHA256SUMS.part
7a68bd3181a054056b0a5eb6e830b90ac4ba8435114127d5f1720643011aa78f  guix-build-58a9601dffa6/output/powerpc64-linux-gnu/bitcoin-58a9601dffa6-powerpc64-linux-gnu-debug.tar.gz
bc55b95e263c455a964d9463a3ee60dabee1d10cefc6641ed29a3b1b317d61e0  guix-build-58a9601dffa6/output/powerpc64-linux-gnu/bitcoin-58a9601dffa6-powerpc64-linux-gnu.tar.gz
49df78009d80af02262806c6c395e2c884a979b1ea13d01aa27d8188403e29d1  guix-build-58a9601dffa6/output/powerpc64le-linux-gnu/SHA256SUMS.part
29dc7a0e10707b3511fa2afb6977df7ebbb67f796d8be5a042abc14eba764aef  guix-build-58a9601dffa6/output/powerpc64le-linux-gnu/bitcoin-58a9601dffa6-powerpc64le-linux-gnu-debug.tar.gz
51b7f8e1bccff1e2ce1860bbc382eefe648b90cc3374cdfa3a95a7454386e77d  guix-build-58a9601dffa6/output/powerpc64le-linux-gnu/bitcoin-58a9601dffa6-powerpc64le-linux-gnu.tar.gz
e62e46d8cebbbfc0f587e930acb648fcae99cfe8b2f63aeba98e46e3338fe1e3  guix-build-58a9601dffa6/output/riscv64-linux-gnu/SHA256SUMS.part
fa5d0a074ca586583bf08dbf748909b3ff5e0a54a2e5aaa88abec666e17b4e72  guix-build-58a9601dffa6/output/riscv64-linux-gnu/bitcoin-58a9601dffa6-riscv64-linux-gnu-debug.tar.gz
684b2917fd27a41f884bb6870f7fac847d52b6f8b40df5779d1c674409f7cd14  guix-build-58a9601dffa6/output/riscv64-linux-gnu/bitcoin-58a9601dffa6-riscv64-linux-gnu.tar.gz
7d7cfd0212b49eec48c7f8dc0d97add53096685dfd646feac466c27a45d20c97  guix-build-58a9601dffa6/output/x86_64-apple-darwin/SHA256SUMS.part
d70ae6d060b7832f8741dc5d1958cc0d32702605c863254303107246deec0aa6  guix-build-58a9601dffa6/output/x86_64-apple-darwin/bitcoin-58a9601dffa6-x86_64-apple-darwin-unsigned.dmg
930f3ec43896404208ebdb582c9175e3a5a2470d778722e0001addde84dad99a  guix-build-58a9601dffa6/output/x86_64-apple-darwin/bitcoin-58a9601dffa6-x86_64-apple-darwin-unsigned.tar.gz
2d8a9d12aadcf60634db953fcb8bd496a002608e9a64eb7d60bb7ffe1f94489f  guix-build-58a9601dffa6/output/x86_64-apple-darwin/bitcoin-58a9601dffa6-x86_64-apple-darwin.tar.gz
10363729ece6e1c2cbdf435483006191bf17d1def2d318ff8357197d91c06ded  guix-build-58a9601dffa6/output/x86_64-linux-gnu/SHA256SUMS.part
d50ec8e4f72e8b064b196eb0ece212f7b0b126f4b8b644c4451084cbf0416072  guix-build-58a9601dffa6/output/x86_64-linux-gnu/bitcoin-58a9601dffa6-x86_64-linux-gnu-debug.tar.gz
471e12b8715ecff4d99121c4bb3288ef4b005ca468810a714c67ea3e7c6669e9  guix-build-58a9601dffa6/output/x86_64-linux-gnu/bitcoin-58a9601dffa6-x86_64-linux-gnu.tar.gz
d63946401952d131fdf5df9442c52151d86e53f019234b5ad16fdef0d2976356  guix-build-58a9601dffa6/output/x86_64-w64-mingw32/SHA256SUMS.part
5359782e1eb6f449338f18e053ad82f25382d968690208ae5739d9338eb7bdc7  guix-build-58a9601dffa6/output/x86_64-w64-mingw32/bitcoin-58a9601dffa6-win64-debug.zip
0d387d5a4cb1d712556a3fe5b4bd1e928bb5fbbe57a85ee06c746f132a6b1ec5  guix-build-58a9601dffa6/output/x86_64-w64-mingw32/bitcoin-58a9601dffa6-win64-setup-unsigned.exe
dbfd7419d1d764e853a9dc041e276669b488aea4a80e21e4a175b6c3e512e70c  guix-build-58a9601dffa6/output/x86_64-w64-mingw32/bitcoin-58a9601dffa6-win64-unsigned.tar.gz
0ba07504d9d5a12af9144e8b386b2640b48dba067d47c694a44ecffe56b0c0fc  guix-build-58a9601dffa6/output/x86_64-w64-mingw32/bitcoin-58a9601dffa6-win64.zip
```