### PR TITLE
Remove Sock::Release() and CloseSocket()

### DIFF
--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -410,7 +410,7 @@ void Session::Disconnect()
             Log("Destroying session %s", m_session_id);
         }
     }
-    m_control_sock->Reset();
+    m_control_sock = std::make_unique<Sock>(INVALID_SOCKET);
     m_session_id.clear();
 }
 } // namespace sam

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -24,7 +24,7 @@ FuzzedSock::FuzzedSock(FuzzedDataProvider& fuzzed_data_provider)
 FuzzedSock::~FuzzedSock()
 {
     // Sock::~Sock() will be called after FuzzedSock::~FuzzedSock() and it will call
-    // Sock::Reset() (not FuzzedSock::Reset()!) which will call CloseSocket(m_socket).
+    // Sock::Reset() (not FuzzedSock::Reset()!) which will call close(m_socket).
     // Avoid closing an arbitrary file descriptor (m_socket is just a random very high number which
     // theoretically may concide with a real opened file descriptor).
     Reset();

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -24,21 +24,16 @@ FuzzedSock::FuzzedSock(FuzzedDataProvider& fuzzed_data_provider)
 FuzzedSock::~FuzzedSock()
 {
     // Sock::~Sock() will be called after FuzzedSock::~FuzzedSock() and it will call
-    // Sock::Reset() (not FuzzedSock::Reset()!) which will call close(m_socket).
+    // close(m_socket) if m_socket is not INVALID_SOCKET.
     // Avoid closing an arbitrary file descriptor (m_socket is just a random very high number which
     // theoretically may concide with a real opened file descriptor).
-    Reset();
+    m_socket = INVALID_SOCKET;
 }
 
 FuzzedSock& FuzzedSock::operator=(Sock&& other)
 {
     assert(false && "Move of Sock into FuzzedSock not allowed.");
     return *this;
-}
-
-void FuzzedSock::Reset()
-{
-    m_socket = INVALID_SOCKET;
 }
 
 ssize_t FuzzedSock::Send(const void* data, size_t len, int flags) const

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -55,8 +55,6 @@ public:
 
     FuzzedSock& operator=(Sock&& other) override;
 
-    void Reset() override;
-
     ssize_t Send(const void* data, size_t len, int flags) const override;
 
     ssize_t Recv(void* buf, size_t len, int flags) const override;

--- a/src/test/sock_tests.cpp
+++ b/src/test/sock_tests.cpp
@@ -69,14 +69,6 @@ BOOST_AUTO_TEST_CASE(move_assignment)
     BOOST_CHECK(SocketIsClosed(s));
 }
 
-BOOST_AUTO_TEST_CASE(reset)
-{
-    const SOCKET s = CreateSocket();
-    Sock sock(s);
-    sock.Reset();
-    BOOST_CHECK(SocketIsClosed(s));
-}
-
 #ifndef WIN32 // Windows does not have socketpair(2).
 
 static void CreateSocketPair(int s[2])

--- a/src/test/sock_tests.cpp
+++ b/src/test/sock_tests.cpp
@@ -69,16 +69,6 @@ BOOST_AUTO_TEST_CASE(move_assignment)
     BOOST_CHECK(SocketIsClosed(s));
 }
 
-BOOST_AUTO_TEST_CASE(release)
-{
-    SOCKET s = CreateSocket();
-    Sock* sock = new Sock(s);
-    BOOST_CHECK_EQUAL(sock->Release(), s);
-    delete sock;
-    BOOST_CHECK(!SocketIsClosed(s));
-    BOOST_REQUIRE(CloseSocket(s));
-}
-
 BOOST_AUTO_TEST_CASE(reset)
 {
     const SOCKET s = CreateSocket();

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -100,17 +100,12 @@ public:
         m_socket = INVALID_SOCKET - 1;
     }
 
-    ~StaticContentsSock() override { Reset(); }
+    ~StaticContentsSock() override { m_socket = INVALID_SOCKET; }
 
     StaticContentsSock& operator=(Sock&& other) override
     {
         assert(false && "Move of Sock into MockSock not allowed.");
         return *this;
-    }
-
-    void Reset() override
-    {
-        m_socket = INVALID_SOCKET;
     }
 
     ssize_t Send(const void*, size_t len, int) const override { return len; }

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -39,32 +39,17 @@ Sock::Sock(Sock&& other)
     other.m_socket = INVALID_SOCKET;
 }
 
-Sock::~Sock() { Reset(); }
+Sock::~Sock() { Close(); }
 
 Sock& Sock::operator=(Sock&& other)
 {
-    Reset();
+    Close();
     m_socket = other.m_socket;
     other.m_socket = INVALID_SOCKET;
     return *this;
 }
 
 SOCKET Sock::Get() const { return m_socket; }
-
-void Sock::Reset() {
-    if (m_socket == INVALID_SOCKET) {
-        return;
-    }
-#ifdef WIN32
-    int ret = closesocket(m_socket);
-#else
-    int ret = close(m_socket);
-#endif
-    if (ret) {
-        LogPrintf("Error closing socket %d: %s\n", m_socket, NetworkErrorString(WSAGetLastError()));
-    }
-    m_socket = INVALID_SOCKET;
-}
 
 ssize_t Sock::Send(const void* data, size_t len, int flags) const
 {
@@ -370,6 +355,22 @@ bool Sock::IsConnected(std::string& errmsg) const
     default:
         return true;
     }
+}
+
+void Sock::Close()
+{
+    if (m_socket == INVALID_SOCKET) {
+        return;
+    }
+#ifdef WIN32
+    int ret = closesocket(m_socket);
+#else
+    int ret = close(m_socket);
+#endif
+    if (ret) {
+        LogPrintf("Error closing socket %d: %s\n", m_socket, NetworkErrorString(WSAGetLastError()));
+    }
+    m_socket = INVALID_SOCKET;
 }
 
 #ifdef WIN32

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -51,13 +51,6 @@ Sock& Sock::operator=(Sock&& other)
 
 SOCKET Sock::Get() const { return m_socket; }
 
-SOCKET Sock::Release()
-{
-    const SOCKET s = m_socket;
-    m_socket = INVALID_SOCKET;
-    return s;
-}
-
 void Sock::Reset() { CloseSocket(m_socket); }
 
 ssize_t Sock::Send(const void* data, size_t len, int flags) const

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -250,7 +250,4 @@ protected:
 /** Return readable error string for a network error code */
 std::string NetworkErrorString(int err);
 
-/** Close socket and set hSocket to INVALID_SOCKET */
-bool CloseSocket(SOCKET& hSocket);
-
 #endif // BITCOIN_UTIL_SOCK_H

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -69,13 +69,6 @@ public:
     [[nodiscard]] virtual SOCKET Get() const;
 
     /**
-     * Get the value of the contained socket and drop ownership. It will not be closed by the
-     * destructor after this call.
-     * @return socket or INVALID_SOCKET if empty
-     */
-    virtual SOCKET Release();
-
-    /**
      * Close if non-empty.
      */
     virtual void Reset();

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -69,11 +69,6 @@ public:
     [[nodiscard]] virtual SOCKET Get() const;
 
     /**
-     * Close if non-empty.
-     */
-    virtual void Reset();
-
-    /**
      * send(2) wrapper. Equivalent to `send(this->Get(), data, len, flags);`. Code that uses this
      * wrapper can be unit tested if this method is overridden by a mock Sock implementation.
      */
@@ -245,6 +240,12 @@ protected:
      * Contained socket. `INVALID_SOCKET` designates the object is empty.
      */
     SOCKET m_socket;
+
+private:
+    /**
+     * Close `m_socket` if it is not `INVALID_SOCKET`.
+     */
+    void Close();
 };
 
 /** Return readable error string for a network error code */


### PR DESCRIPTION
_This is a piece of #21878, chopped off to ease review._

* `Sock::Release()` is unused, thus remove it
* `CloseSocket()` is only called from `Sock::Reset()`, so move the body of `CloseSocket()` inside `Sock::Reset()` and remove `CloseSocket()` - this helps to hide low level file descriptor sockets inside the `Sock` class.
* Rename `Sock::Reset()` to `Sock::Close()` and make it `private` - to be used only in the destructor and in the `Sock` assignment operator. This simplifies the public API by removing one method from it.