### PR TITLE
refactor: Avoid UniValue copies

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -273,7 +273,7 @@ public:
 
     UniValue ProcessReply(const UniValue& reply) override
     {
-        if (!reply["error"].isNull()) return reply;
+        if (!reply["error"].isNull()) return reply.copy();
         const std::vector<UniValue>& nodes{reply["result"].getValues()};
         if (!nodes.empty() && nodes.at(0)["network"].isNull()) {
             throw std::runtime_error("-addrinfo requires bitcoind server to be running v22.0 and up");
@@ -330,10 +330,10 @@ public:
         // Errors in getnetworkinfo() and getblockchaininfo() are fatal, pass them on;
         // getwalletinfo() and getbalances() are allowed to fail if there is no wallet.
         if (!batch[ID_NETWORKINFO]["error"].isNull()) {
-            return batch[ID_NETWORKINFO];
+            return batch[ID_NETWORKINFO].copy();
         }
         if (!batch[ID_BLOCKCHAININFO]["error"].isNull()) {
-            return batch[ID_BLOCKCHAININFO];
+            return batch[ID_BLOCKCHAININFO].copy();
         }
         result.pushKV("version", batch[ID_NETWORKINFO]["result"]["version"]);
         result.pushKV("blocks", batch[ID_BLOCKCHAININFO]["result"]["blocks"]);
@@ -463,8 +463,8 @@ public:
     UniValue ProcessReply(const UniValue& batch_in) override
     {
         const std::vector<UniValue> batch{JSONRPCProcessBatchReply(batch_in)};
-        if (!batch[ID_PEERINFO]["error"].isNull()) return batch[ID_PEERINFO];
-        if (!batch[ID_NETWORKINFO]["error"].isNull()) return batch[ID_NETWORKINFO];
+        if (!batch[ID_PEERINFO]["error"].isNull()) return batch[ID_PEERINFO].copy();
+        if (!batch[ID_NETWORKINFO]["error"].isNull()) return batch[ID_NETWORKINFO].copy();
 
         const UniValue& networkinfo{batch[ID_NETWORKINFO]["result"]};
         if (networkinfo["version"].getInt<int>() < 209900) {
@@ -710,7 +710,7 @@ public:
 
     UniValue ProcessReply(const UniValue &reply) override
     {
-        return reply.get_obj();
+        return reply.get_obj().copy();
     }
 };
 
@@ -1184,7 +1184,7 @@ static int CommandLineRPC(int argc, char *argv[])
             const UniValue reply = ConnectAndCallRPC(rh.get(), method, args, wallet_name);
 
             // Parse reply
-            UniValue result = find_value(reply, "result");
+            UniValue result { find_value(reply, "result").copy()};
             const UniValue& error = find_value(reply, "error");
             if (error.isNull()) {
                 if (gArgs.GetBoolArg("-getinfo", false)) {

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -577,7 +577,7 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
     if (!registers.count("privatekeys"))
         throw std::runtime_error("privatekeys register variable must be set.");
     FillableSigningProvider tempKeystore;
-    UniValue keysObj = registers["privatekeys"];
+    const UniValue& keysObj{registers["privatekeys"]};
 
     for (unsigned int kidx = 0; kidx < keysObj.size(); kidx++) {
         if (!keysObj[kidx].isStr())
@@ -592,7 +592,7 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
     // Add previous txouts given in the RPC call:
     if (!registers.count("prevtxs"))
         throw std::runtime_error("prevtxs register variable must be set.");
-    UniValue prevtxsObj = registers["prevtxs"];
+    const UniValue& prevtxsObj{registers["prevtxs"]};
     {
         for (unsigned int previdx = 0; previdx < prevtxsObj.size(); previdx++) {
             const UniValue& prevOut = prevtxsObj[previdx];
@@ -642,7 +642,7 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
             // add redeemScript to the tempKeystore so it can be signed:
             if ((scriptPubKey.IsPayToScriptHash() || scriptPubKey.IsPayToWitnessScriptHash()) &&
                 prevOut.exists("redeemScript")) {
-                UniValue v = prevOut["redeemScript"];
+                const UniValue& v{prevOut["redeemScript"]};
                 std::vector<unsigned char> rsData(ParseHexUV(v, "redeemScript"));
                 CScript redeemScript(rsData.begin(), rsData.end());
                 tempKeystore.AddCScript(redeemScript);

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -130,7 +130,7 @@ static void RegisterSetJson(const std::string& key, const std::string& rawJson)
         throw std::runtime_error(strErr);
     }
 
-    registers[key] = val;
+    registers[key] = std::move(val);
 }
 
 static void RegisterSet(const std::string& strInput)

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -139,7 +139,7 @@ public:
             if (value.isNull()) {
                 settings.rw_settings.erase(name);
             } else {
-                settings.rw_settings[name] = value;
+                settings.rw_settings[name] = value.copy();
             }
         });
         gArgs.WriteSettingsFile();
@@ -150,7 +150,7 @@ public:
             if (value.isNull()) {
                 settings.forced_settings.erase(name);
             } else {
-                settings.forced_settings[name] = value;
+                settings.forced_settings[name] = value.copy();
             }
         });
     }
@@ -313,7 +313,7 @@ public:
     {
         JSONRPCRequest req;
         req.context = m_context;
-        req.params = params;
+        req.params = params.copy();
         req.strMethod = command;
         req.URI = uri;
         return ::tableRPC.execute(req);
@@ -755,7 +755,7 @@ public:
         util::SettingsValue result;
         gArgs.LockSettings([&](const util::Settings& settings) {
             if (const util::SettingsValue* value = util::FindKey(settings.rw_settings, name)) {
-                result = *value;
+                result = value->copy();
             }
         });
         return result;
@@ -766,7 +766,7 @@ public:
             if (value.isNull()) {
                 settings.rw_settings.erase(name);
             } else {
-                settings.rw_settings[name] = value;
+                settings.rw_settings[name] = value.copy();
             }
         });
         return !write || gArgs.WriteSettingsFile();

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -240,20 +240,18 @@ bool RPCConsole::RPCParseCommandLine(interfaces::Node* node, std::string &strRes
                             if (curarg.size() && fExecute)
                             {
                                 // if we have a value query, query arrays with index and objects with a string key
-                                UniValue subelement;
                                 if (lastResult.isArray())
                                 {
                                     const auto parsed{ToIntegral<size_t>(curarg)};
                                     if (!parsed) {
                                         throw std::runtime_error("Invalid result query");
                                     }
-                                    subelement = lastResult[parsed.value()];
+                                    lastResult = lastResult[parsed.value()].copy();
                                 }
                                 else if (lastResult.isObject())
-                                    subelement = find_value(lastResult, curarg);
+                                    lastResult = find_value(lastResult, curarg).copy();
                                 else
                                     throw std::runtime_error("Invalid result query"); //no array or object: abort
-                                lastResult = subelement;
                             }
 
                             state = STATE_COMMAND_EXECUTED;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -903,10 +903,10 @@ static bool rest_getutxos(const std::any& context, HTTPRequest* req, const std::
             // include the script in a json output
             UniValue o(UniValue::VOBJ);
             ScriptToUniv(coin.out.scriptPubKey, /*out=*/o, /*include_hex=*/true, /*include_address=*/true);
-            utxo.pushKV("scriptPubKey", o);
-            utxos.push_back(utxo);
+            utxo.pushKV("scriptPubKey", std::move(o));
+            utxos.push_back(std::move(utxo));
         }
-        objGetUTXOResponse.pushKV("utxos", utxos);
+        objGetUTXOResponse.pushKV("utxos", std::move(utxos));
 
         // return json string
         std::string strJSON = objGetUTXOResponse.write() + "\n";

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -191,12 +191,12 @@ UniValue blockToJSON(BlockManager& blockman, const CBlock& block, const CBlockIn
                 const CTxUndo* txundo = (have_undo && i > 0) ? &blockUndo.vtxundo.at(i - 1) : nullptr;
                 UniValue objTx(UniValue::VOBJ);
                 TxToUniv(*tx, /*block_hash=*/uint256(), /*entry=*/objTx, /*include_hex=*/true, RPCSerializationFlags(), txundo, verbosity);
-                txs.push_back(objTx);
+                txs.push_back(std::move(objTx));
             }
             break;
     }
 
-    result.pushKV("tx", txs);
+    result.pushKV("tx", std::move(txs));
 
     return result;
 }
@@ -1005,9 +1005,9 @@ static RPCHelpMan gettxoutsetinfo()
             unspendables.pushKV("bip30", ValueFromAmount(stats.total_unspendables_bip30 - prev_stats.total_unspendables_bip30));
             unspendables.pushKV("scripts", ValueFromAmount(stats.total_unspendables_scripts - prev_stats.total_unspendables_scripts));
             unspendables.pushKV("unclaimed_rewards", ValueFromAmount(stats.total_unspendables_unclaimed_rewards - prev_stats.total_unspendables_unclaimed_rewards));
-            block_info.pushKV("unspendables", unspendables);
+            block_info.pushKV("unspendables", std::move(unspendables));
 
-            ret.pushKV("block_info", block_info);
+            ret.pushKV("block_info", std::move(block_info));
         }
     } else {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Unable to read UTXO set");
@@ -1091,7 +1091,7 @@ static RPCHelpMan gettxout()
     ret.pushKV("value", ValueFromAmount(coin.out.nValue));
     UniValue o(UniValue::VOBJ);
     ScriptToUniv(coin.out.scriptPubKey, /*out=*/o, /*include_hex=*/true, /*include_address=*/true);
-    ret.pushKV("scriptPubKey", o);
+    ret.pushKV("scriptPubKey", std::move(o));
     ret.pushKV("coinbase", (bool)coin.fCoinBase);
 
     return ret;
@@ -1141,7 +1141,7 @@ static void SoftForkDescPushBack(const CBlockIndex* blockindex, UniValue& softfo
     // one below the activation height
     rv.pushKV("active", DeploymentActiveAfter(blockindex, chainman, dep));
     rv.pushKV("height", chainman.GetConsensus().DeploymentHeight(dep));
-    softforks.pushKV(DeploymentName(dep), rv);
+    softforks.pushKV(DeploymentName(dep), std::move(rv));
 }
 
 static void SoftForkDescPushBack(const CBlockIndex* blockindex, UniValue& softforks, const ChainstateManager& chainman, Consensus::DeploymentPos id)
@@ -1194,7 +1194,7 @@ static void SoftForkDescPushBack(const CBlockIndex* blockindex, UniValue& softfo
             statsUV.pushKV("threshold", statsStruct.threshold);
             statsUV.pushKV("possible", statsStruct.possible);
         }
-        bip9.pushKV("statistics", statsUV);
+        bip9.pushKV("statistics", std::move(statsUV));
 
         std::string sig;
         sig.reserve(signals.size());
@@ -1210,9 +1210,9 @@ static void SoftForkDescPushBack(const CBlockIndex* blockindex, UniValue& softfo
         rv.pushKV("height", chainman.m_versionbitscache.StateSinceHeight(blockindex, chainman.GetConsensus(), id));
     }
     rv.pushKV("active", ThresholdState::ACTIVE == next_state);
-    rv.pushKV("bip9", bip9);
+    rv.pushKV("bip9", std::move(bip9));
 
-    softforks.pushKV(DeploymentName(id), rv);
+    softforks.pushKV(DeploymentName(id), std::move(rv));
 }
 
 // used by rest.cpp:rest_chaininfo, so cannot be static
@@ -1472,7 +1472,7 @@ static RPCHelpMan getchaintips()
         }
         obj.pushKV("status", status);
 
-        res.push_back(obj);
+        res.push_back(std::move(obj));
     }
 
     return res;
@@ -1952,7 +1952,7 @@ static RPCHelpMan getblockstats()
     ret_all.pushKV("avgfeerate", total_weight ? (totalfee * WITNESS_SCALE_FACTOR) / total_weight : 0); // Unit: sat/vbyte
     ret_all.pushKV("avgtxsize", (block.vtx.size() > 1) ? total_size / (block.vtx.size() - 1) : 0);
     ret_all.pushKV("blockhash", pindex.GetBlockHash().GetHex());
-    ret_all.pushKV("feerate_percentiles", feerates_res);
+    ret_all.pushKV("feerate_percentiles", std::move(feerates_res));
     ret_all.pushKV("height", (int64_t)pindex.nHeight);
     ret_all.pushKV("ins", inputs);
     ret_all.pushKV("maxfee", maxfee);
@@ -1990,7 +1990,7 @@ static RPCHelpMan getblockstats()
         if (value.isNull()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid selected statistic '%s'", stat));
         }
-        ret.pushKV(stat, value);
+        //ret.pushKV(stat, std::move(value));
     }
     return ret;
 },
@@ -2231,9 +2231,9 @@ static RPCHelpMan scantxoutset()
             unspent.pushKV("coinbase", coin.IsCoinBase());
             unspent.pushKV("height", (int32_t)coin.nHeight);
 
-            unspents.push_back(unspent);
+            unspents.push_back(std::move(unspent));
         }
-        result.pushKV("unspents", unspents);
+        result.pushKV("unspents", std::move(unspents));
         result.pushKV("total_amount", ValueFromAmount(total_in));
     } else {
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid action '%s'", request.params[0].get_str()));
@@ -2344,7 +2344,7 @@ static RPCHelpMan scanblocks()
         BlockFiltersScanReserver reserver;
         if (reserver.reserve()) {
             // no scan in progress
-            return NullUniValue;
+            return UniValue::VNULL;
         }
         ret.pushKV("progress", g_scanfilter_progress.load());
         ret.pushKV("current_height", g_scanfilter_progress_height.load());
@@ -2473,7 +2473,7 @@ static RPCHelpMan scanblocks()
         }
         ret.pushKV("from_height", start_block->nHeight);
         ret.pushKV("to_height", g_scanfilter_progress_height.load());
-        ret.pushKV("relevant_blocks", blocks);
+        ret.pushKV("relevant_blocks", std::move(blocks));
     }
     else {
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid action '%s'", request.params[0].get_str()));

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1810,7 +1810,7 @@ static RPCHelpMan getblockstats()
 
     std::set<std::string> stats;
     if (!request.params[1].isNull()) {
-        const UniValue stats_univalue = request.params[1].get_array();
+        const UniValue& stats_univalue{request.params[1].get_array()};
         for (unsigned int i = 0; i < stats_univalue.size(); i++) {
             const std::string stat = stats_univalue[i].get_str();
             stats.insert(stat);

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -259,7 +259,7 @@ UniValue ParseNonRFCJSONValue(const std::string& strVal)
     if (!jVal.read(std::string("[")+strVal+std::string("]")) ||
         !jVal.isArray() || jVal.size()!=1)
         throw std::runtime_error(std::string("Error parsing JSON: ") + strVal);
-    return jVal[0];
+    return jVal[0].copy();
 }
 
 UniValue RPCConvertValues(const std::string &strMethod, const std::vector<std::string> &strParams)

--- a/src/rpc/fees.cpp
+++ b/src/rpc/fees.cpp
@@ -89,7 +89,7 @@ static RPCHelpMan estimatesmartfee()
                 result.pushKV("feerate", ValueFromAmount(feeRate.GetFeePerK()));
             } else {
                 errors.push_back("Insufficient data or no feerate found");
-                result.pushKV("errors", errors);
+                result.pushKV("errors", std::move(errors));
             }
             result.pushKV("blocks", feeCalc.returnedTarget);
             return result;
@@ -197,18 +197,18 @@ static RPCHelpMan estimaterawfee()
                     horizon_result.pushKV("feerate", ValueFromAmount(feeRate.GetFeePerK()));
                     horizon_result.pushKV("decay", buckets.decay);
                     horizon_result.pushKV("scale", (int)buckets.scale);
-                    horizon_result.pushKV("pass", passbucket);
+                    horizon_result.pushKV("pass", std::move(passbucket));
                     // buckets.fail.start == -1 indicates that all buckets passed, there is no fail bucket to output
-                    if (buckets.fail.start != -1) horizon_result.pushKV("fail", failbucket);
+                    if (buckets.fail.start != -1) horizon_result.pushKV("fail", std::move(failbucket));
                 } else {
                     // Output only information that is still meaningful in the event of error
                     horizon_result.pushKV("decay", buckets.decay);
                     horizon_result.pushKV("scale", (int)buckets.scale);
-                    horizon_result.pushKV("fail", failbucket);
+                    horizon_result.pushKV("fail", std::move(failbucket));
                     errors.push_back("Insufficient data or no feerate found which meets threshold");
-                    horizon_result.pushKV("errors", errors);
+                    horizon_result.pushKV("errors", std::move(errors));
                 }
-                result.pushKV(StringForFeeEstimateHorizon(horizon), horizon_result);
+                result.pushKV(StringForFeeEstimateHorizon(horizon), std::move(horizon_result));
             }
             return result;
         },

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -142,7 +142,7 @@ static RPCHelpMan testmempoolaccept()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
         {
-            const UniValue raw_transactions = request.params[0].get_array();
+            const UniValue& raw_transactions{request.params[0].get_array()};
             if (raw_transactions.size() < 1 || raw_transactions.size() > MAX_PACKAGE_COUNT) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER,
                                    "Array must contain between 1 and " + ToString(MAX_PACKAGE_COUNT) + " transactions.");
@@ -791,7 +791,7 @@ static RPCHelpMan submitpackage()
             if (!Params().IsMockableChain()) {
                 throw std::runtime_error("submitpackage is for regression testing (-regtest mode) only");
             }
-            const UniValue raw_transactions = request.params[0].get_array();
+            const UniValue& raw_transactions{request.params[0].get_array()};
             if (raw_transactions.size() < 1 || raw_transactions.size() > MAX_PACKAGE_COUNT) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER,
                                    "Array must contain between 1 and " + ToString(MAX_PACKAGE_COUNT) + " transactions.");

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -325,7 +325,7 @@ static RPCHelpMan generateblock()
     const CTxMemPool& mempool = EnsureMemPool(node);
 
     std::vector<CTransactionRef> txs;
-    const auto raw_txs_or_txids = request.params[1].get_array();
+    const auto& raw_txs_or_txids{request.params[1].get_array()};
     for (size_t i = 0; i < raw_txs_or_txids.size(); i++) {
         const auto str(raw_txs_or_txids[i].get_str());
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -596,7 +596,7 @@ static RPCHelpMan getblocktemplate()
     LOCK(cs_main);
 
     std::string strMode = "template";
-    UniValue lpval = NullUniValue;
+    UniValue lpval { UniValue::VNULL};
     std::set<std::string> setClientRules;
     Chainstate& active_chainstate = chainman.ActiveChainstate();
     CChain& active_chain = active_chainstate.m_chain;
@@ -612,7 +612,7 @@ static RPCHelpMan getblocktemplate()
         }
         else
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid mode");
-        lpval = find_value(oparam, "longpollid");
+        lpval = find_value(oparam, "longpollid").copy();
 
         if (strMode == "proposal")
         {
@@ -787,7 +787,7 @@ static RPCHelpMan getblocktemplate()
             if (setTxIndex.count(in.prevout.hash))
                 deps.push_back(setTxIndex[in.prevout.hash]);
         }
-        entry.pushKV("depends", deps);
+        entry.pushKV("depends", std::move(deps));
 
         int index_in_template = i - 1;
         entry.pushKV("fee", pblocktemplate->vTxFees[index_in_template]);
@@ -799,7 +799,7 @@ static RPCHelpMan getblocktemplate()
         entry.pushKV("sigops", nTxSigOps);
         entry.pushKV("weight", GetTransactionWeight(tx));
 
-        transactions.push_back(entry);
+        transactions.push_back(std::move(entry));
     }
 
     UniValue aux(UniValue::VOBJ);
@@ -812,7 +812,7 @@ static RPCHelpMan getblocktemplate()
     aMutable.push_back("prevblock");
 
     UniValue result(UniValue::VOBJ);
-    result.pushKV("capabilities", aCaps);
+    result.pushKV("capabilities", std::move(aCaps));
 
     UniValue aRules(UniValue::VARR);
     aRules.push_back("csv");
@@ -864,18 +864,18 @@ static RPCHelpMan getblocktemplate()
         }
     }
     result.pushKV("version", pblock->nVersion);
-    result.pushKV("rules", aRules);
-    result.pushKV("vbavailable", vbavailable);
+    result.pushKV("rules", std::move(aRules));
+    result.pushKV("vbavailable", std::move(vbavailable));
     result.pushKV("vbrequired", int(0));
 
     result.pushKV("previousblockhash", pblock->hashPrevBlock.GetHex());
-    result.pushKV("transactions", transactions);
-    result.pushKV("coinbaseaux", aux);
+    result.pushKV("transactions", std::move(transactions));
+    result.pushKV("coinbaseaux", std::move(aux));
     result.pushKV("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue);
     result.pushKV("longpollid", active_chain.Tip()->GetBlockHash().GetHex() + ToString(nTransactionsUpdatedLast));
     result.pushKV("target", hashTarget.GetHex());
     result.pushKV("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1);
-    result.pushKV("mutable", aMutable);
+    result.pushKV("mutable", std::move(aMutable));
     result.pushKV("noncerange", "00000000ffffffff");
     int64_t nSigOpLimit = MAX_BLOCK_SIGOPS_COST;
     int64_t nSizeLimit = MAX_BLOCK_SERIALIZED_SIZE;

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -242,7 +242,7 @@ static RPCHelpMan getpeerinfo()
         for (const int height : statestats.vHeightInFlight) {
             heights.push_back(height);
         }
-        obj.pushKV("inflight", heights);
+        obj.pushKV("inflight", std::move(heights));
         obj.pushKV("addr_relay_enabled", statestats.m_addr_relay_enabled);
         obj.pushKV("addr_processed", statestats.m_addr_processed);
         obj.pushKV("addr_rate_limited", statestats.m_addr_rate_limited);
@@ -250,7 +250,7 @@ static RPCHelpMan getpeerinfo()
         for (const auto& permission : NetPermissions::ToStrings(stats.m_permission_flags)) {
             permissions.push_back(permission);
         }
-        obj.pushKV("permissions", permissions);
+        obj.pushKV("permissions", std::move(permissions));
         obj.pushKV("minfeefilter", ValueFromAmount(statestats.m_fee_filter_received));
 
         UniValue sendPerMsgType(UniValue::VOBJ);
@@ -258,17 +258,17 @@ static RPCHelpMan getpeerinfo()
             if (i.second > 0)
                 sendPerMsgType.pushKV(i.first, i.second);
         }
-        obj.pushKV("bytessent_per_msg", sendPerMsgType);
+        obj.pushKV("bytessent_per_msg", std::move(sendPerMsgType));
 
         UniValue recvPerMsgType(UniValue::VOBJ);
         for (const auto& i : stats.mapRecvBytesPerMsgType) {
             if (i.second > 0)
                 recvPerMsgType.pushKV(i.first, i.second);
         }
-        obj.pushKV("bytesrecv_per_msg", recvPerMsgType);
+        obj.pushKV("bytesrecv_per_msg", std::move(recvPerMsgType));
         obj.pushKV("connection_type", ConnectionTypeAsString(stats.m_conn_type));
 
-        ret.push_back(obj);
+        ret.push_back(std::move(obj));
     }
 
     return ret;
@@ -498,10 +498,10 @@ static RPCHelpMan getaddednodeinfo()
             UniValue address(UniValue::VOBJ);
             address.pushKV("address", info.resolvedAddress.ToString());
             address.pushKV("connected", info.fInbound ? "inbound" : "outbound");
-            addresses.push_back(address);
+            addresses.push_back(std::move(address));
         }
-        obj.pushKV("addresses", addresses);
-        ret.push_back(obj);
+        obj.pushKV("addresses", std::move(addresses));
+        ret.push_back(std::move(obj));
     }
 
     return ret;
@@ -553,7 +553,7 @@ static RPCHelpMan getnettotals()
     outboundLimit.pushKV("serve_historical_blocks", !connman.OutboundTargetReached(true));
     outboundLimit.pushKV("bytes_left_in_cycle", connman.GetOutboundTargetBytesLeft());
     outboundLimit.pushKV("time_left_in_cycle", count_seconds(connman.GetMaxOutboundTimeLeftInCycle()));
-    obj.pushKV("uploadtarget", outboundLimit);
+    obj.pushKV("uploadtarget", std::move(outboundLimit));
     return obj;
 },
     };
@@ -573,7 +573,7 @@ static UniValue GetNetworksInfo()
         obj.pushKV("reachable", IsReachable(network));
         obj.pushKV("proxy", proxy.IsValid() ? proxy.proxy.ToStringIPPort() : std::string());
         obj.pushKV("proxy_randomize_credentials", proxy.randomize_credentials);
-        networks.push_back(obj);
+        networks.push_back(std::move(obj));
     }
     return networks;
 }
@@ -667,10 +667,10 @@ static RPCHelpMan getnetworkinfo()
             rec.pushKV("address", item.first.ToString());
             rec.pushKV("port", item.second.nPort);
             rec.pushKV("score", item.second.nScore);
-            localAddresses.push_back(rec);
+            localAddresses.push_back(std::move(rec));
         }
     }
-    obj.pushKV("localaddresses", localAddresses);
+    obj.pushKV("localaddresses", std::move(localAddresses));
     obj.pushKV("warnings",       GetWarnings(false).original);
     return obj;
 },
@@ -805,7 +805,7 @@ static RPCHelpMan listbanned()
         rec.pushKV("ban_duration", (banEntry.nBanUntil - banEntry.nCreateTime));
         rec.pushKV("time_remaining", (banEntry.nBanUntil - current_time));
 
-        bannedAddresses.push_back(rec);
+        bannedAddresses.push_back(std::move(rec));
     }
 
     return bannedAddresses;
@@ -912,7 +912,7 @@ static RPCHelpMan getnodeaddresses()
         obj.pushKV("address", addr.ToStringIP());
         obj.pushKV("port", addr.GetPort());
         obj.pushKV("network", GetNetworkName(addr.GetNetClass()));
-        ret.push_back(obj);
+        ret.push_back(std::move(obj));
     }
     return ret;
 },

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -312,7 +312,7 @@ static RPCHelpMan echo(const std::string& name)
         CHECK_NONFATAL(request.params[9].get_str() != "trigger_internal_bug");
     }
 
-    return request.params;
+    return request.params.copy();
 },
     };
 }

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -208,11 +208,10 @@ static RPCHelpMan getmemoryinfo()
     };
 }
 
-static void EnableOrDisableLogCategories(UniValue cats, bool enable) {
-    cats = cats.get_array();
-    for (unsigned int i = 0; i < cats.size(); ++i) {
-        std::string cat = cats[i].get_str();
-
+static void EnableOrDisableLogCategories(const UniValue& cats, bool enable)
+{
+    for (const auto& cat_json : cats.get_array().getValues()) {
+        const auto& cat{cat_json.get_str()};
         bool success;
         if (enable) {
             success = LogInstance().EnableCategory(cat);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -559,8 +559,7 @@ static RPCHelpMan combinerawtransaction()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-
-    UniValue txs = request.params[0].get_array();
+    const UniValue& txs{request.params[0].get_array()};
     std::vector<CMutableTransaction> txVariants(txs.size());
 
     for (unsigned int idx = 0; idx < txs.size(); idx++) {
@@ -699,7 +698,7 @@ static RPCHelpMan signrawtransactionwithkey()
     FillableSigningProvider keystore;
     const UniValue& keys = request.params[1].get_array();
     for (unsigned int idx = 0; idx < keys.size(); ++idx) {
-        UniValue k = keys[idx];
+        const UniValue& k{keys[idx]};
         CKey key = DecodeSecret(k.get_str());
         if (!key.IsValid()) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key");
@@ -1382,7 +1381,7 @@ static RPCHelpMan combinepsbt()
 {
     // Unserialize the transactions
     std::vector<PartiallySignedTransaction> psbtxs;
-    UniValue txs = request.params[0].get_array();
+    const UniValue& txs{request.params[0].get_array()};
     if (txs.empty()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Parameter 'txs' cannot be empty");
     }
@@ -1604,7 +1603,7 @@ static RPCHelpMan utxoupdatepsbt()
     // Parse descriptors, if any.
     FlatSigningProvider provider;
     if (!request.params[1].isNull()) {
-        auto descs = request.params[1].get_array();
+        const auto& descs{request.params[1].get_array()};
         for (size_t i = 0; i < descs.size(); ++i) {
             EvalDescriptorStringOrObject(descs[i], provider);
         }
@@ -1685,7 +1684,7 @@ static RPCHelpMan joinpsbts()
 {
     // Unserialize the transactions
     std::vector<PartiallySignedTransaction> psbtxs;
-    UniValue txs = request.params[0].get_array();
+    const UniValue& txs{request.params[0].get_array()};
 
     if (txs.size() <= 1) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "At least two PSBTs are required to join PSBTs.");

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -214,8 +214,8 @@ void ParsePrevouts(const UniValue& prevTxsUnival, FillableSigningProvider* keyst
                         {"redeemScript", UniValueType(UniValue::VSTR)},
                         {"witnessScript", UniValueType(UniValue::VSTR)},
                     }, true);
-                UniValue rs = find_value(prevOut, "redeemScript");
-                UniValue ws = find_value(prevOut, "witnessScript");
+                const UniValue& rs{find_value(prevOut, "redeemScript")};
+                const UniValue& ws{find_value(prevOut, "witnessScript")};
                 if (rs.isNull() && ws.isNull()) {
                     throw JSONRPCError(RPC_INVALID_PARAMETER, "Missing redeemScript/witnessScript");
                 }

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -31,11 +31,11 @@ CMutableTransaction ConstructTransaction(const UniValue& inputs_in, const UniVal
     if (inputs_in.isNull()) {
         inputs = UniValue::VARR;
     } else {
-        inputs = inputs_in.get_array();
+        inputs = inputs_in.get_array().copy();
     }
 
     const bool outputs_is_obj = outputs_in.isObject();
-    UniValue outputs = outputs_is_obj ? outputs_in.get_obj() : outputs_in.get_array();
+    UniValue outputs { outputs_is_obj ? outputs_in.get_obj().copy() : outputs_in.get_array().copy()};
 
     CMutableTransaction rawTx;
 

--- a/src/rpc/request.cpp
+++ b/src/rpc/request.cpp
@@ -150,7 +150,7 @@ std::vector<UniValue> JSONRPCProcessBatchReply(const UniValue& in)
         if (id >= num) {
             throw std::runtime_error("Batch member id is larger than batch size");
         }
-        batch[id] = rec;
+        batch[id] = rec.copy();
     }
     return batch;
 }
@@ -163,7 +163,7 @@ void JSONRPCRequest::parse(const UniValue& valRequest)
     const UniValue& request = valRequest.get_obj();
 
     // Parse id now so errors from here on will have the id
-    id = find_value(request, "id");
+    id = find_value(request, "id").copy();
 
     // Parse method
     const UniValue& valMethod{find_value(request, "method")};
@@ -179,9 +179,9 @@ void JSONRPCRequest::parse(const UniValue& valRequest)
         LogPrint(BCLog::RPC, "ThreadRPCServer method=%s user=%s\n", SanitizeString(strMethod), this->authUser);
 
     // Parse params
-    UniValue valParams = find_value(request, "params");
+    const UniValue& valParams { find_value(request, "params")};
     if (valParams.isArray() || valParams.isObject())
-        params = valParams;
+        params = valParams.copy();
     else if (valParams.isNull())
         params = UniValue(UniValue::VARR);
     else

--- a/src/rpc/request.cpp
+++ b/src/rpc/request.cpp
@@ -166,7 +166,7 @@ void JSONRPCRequest::parse(const UniValue& valRequest)
     id = find_value(request, "id");
 
     // Parse method
-    UniValue valMethod = find_value(request, "method");
+    const UniValue& valMethod{find_value(request, "method")};
     if (valMethod.isNull())
         throw JSONRPCError(RPC_INVALID_REQUEST, "Missing method");
     if (!valMethod.isStr())

--- a/src/rpc/txoutproof.cpp
+++ b/src/rpc/txoutproof.cpp
@@ -43,7 +43,7 @@ static RPCHelpMan gettxoutproof()
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
         {
             std::set<uint256> setTxids;
-            UniValue txids = request.params[0].get_array();
+            const UniValue& txids{request.params[0].get_array()};
             if (txids.empty()) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "Parameter 'txids' cannot be empty");
             }

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -17,6 +17,7 @@
 #include <util/translation.h>
 
 #include <tuple>
+#include <type_traits>
 
 const std::string UNIX_EPOCH_TIME = "UNIX epoch time";
 const std::string EXAMPLE_ADDRESS[2] = {"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl", "bc1q02ad21edsxd23d32dfgqqsz4vv4nmtfzuklhy3"};

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -1125,10 +1125,10 @@ std::vector<CScript> EvalDescriptorStringOrObject(const UniValue& scanobject, Fl
     if (scanobject.isStr()) {
         desc_str = scanobject.get_str();
     } else if (scanobject.isObject()) {
-        UniValue desc_uni = find_value(scanobject, "desc");
+        const UniValue& desc_uni{find_value(scanobject, "desc")};
         if (desc_uni.isNull()) throw JSONRPCError(RPC_INVALID_PARAMETER, "Descriptor needs to be provided in scan object");
         desc_str = desc_uni.get_str();
-        UniValue range_uni = find_value(scanobject, "range");
+        const UniValue& range_uni{find_value(scanobject, "range")};
         if (!range_uni.isNull()) {
             range = ParseDescriptorRange(range_uni);
         }

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(setting_args)
 
     auto set_foo = [&](const util::SettingsValue& value) {
       args.LockSettings([&](util::Settings& settings) {
-        settings.rw_settings["foo"] = value;
+        settings.rw_settings["foo"] = value.copy();
       });
     };
 

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -314,20 +314,20 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("setban 127.0.0.0 add")));
     BOOST_CHECK_THROW(r = CallRPC(std::string("setban 127.0.0.0:8334")), std::runtime_error); //portnumber for setban not allowed
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("listbanned")));
-    UniValue ar = r.get_array();
-    UniValue o1 = ar[0].get_obj();
-    UniValue adr = find_value(o1, "address");
+    UniValue ar { r.get_array().copy()};
+    UniValue o1 { ar[0].get_obj().copy()};
+    UniValue adr { find_value(o1, "address").copy()};
     BOOST_CHECK_EQUAL(adr.get_str(), "127.0.0.0/32");
     BOOST_CHECK_NO_THROW(CallRPC(std::string("setban 127.0.0.0 remove")));
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("listbanned")));
-    ar = r.get_array();
+    ar = r.get_array().copy();
     BOOST_CHECK_EQUAL(ar.size(), 0U);
 
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("setban 127.0.0.0/24 add 9907731200 true")));
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("listbanned")));
-    ar = r.get_array();
-    o1 = ar[0].get_obj();
-    adr = find_value(o1, "address");
+    ar = r.get_array().copy();
+    o1 = ar[0].get_obj().copy();
+    adr = find_value(o1, "address").copy();
     int64_t banned_until{find_value(o1, "banned_until").getInt<int64_t>()};
     BOOST_CHECK_EQUAL(adr.get_str(), "127.0.0.0/24");
     BOOST_CHECK_EQUAL(banned_until, 9907731200); // absolute time check
@@ -340,9 +340,9 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
     SetMockTime(now += 2s);
     const int64_t time_remaining_expected{198};
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("listbanned")));
-    ar = r.get_array();
-    o1 = ar[0].get_obj();
-    adr = find_value(o1, "address");
+    ar = r.get_array().copy();
+    o1 = ar[0].get_obj().copy();
+    adr = find_value(o1, "address").copy();
     banned_until = find_value(o1, "banned_until").getInt<int64_t>();
     const int64_t ban_created{find_value(o1, "ban_created").getInt<int64_t>()};
     const int64_t ban_duration{find_value(o1, "ban_duration").getInt<int64_t>()};
@@ -357,7 +357,7 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
 
     BOOST_CHECK_NO_THROW(CallRPC(std::string("setban 127.0.0.0/24 remove")));
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("listbanned")));
-    ar = r.get_array();
+    ar = r.get_array().copy();
     BOOST_CHECK_EQUAL(ar.size(), 0U);
 
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("setban 127.0.0.0/255.255.0.0 add")));
@@ -365,7 +365,7 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
 
     BOOST_CHECK_NO_THROW(CallRPC(std::string("clearbanned")));
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("listbanned")));
-    ar = r.get_array();
+    ar = r.get_array().copy();
     BOOST_CHECK_EQUAL(ar.size(), 0U);
 
 
@@ -374,25 +374,25 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
     //IPv6 tests
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("setban FE80:0000:0000:0000:0202:B3FF:FE1E:8329 add")));
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("listbanned")));
-    ar = r.get_array();
-    o1 = ar[0].get_obj();
-    adr = find_value(o1, "address");
+    ar = r.get_array().copy();
+    o1 = ar[0].get_obj().copy();
+    adr = find_value(o1, "address").copy();
     BOOST_CHECK_EQUAL(adr.get_str(), "fe80::202:b3ff:fe1e:8329/128");
 
     BOOST_CHECK_NO_THROW(CallRPC(std::string("clearbanned")));
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("setban 2001:db8::/ffff:fffc:0:0:0:0:0:0 add")));
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("listbanned")));
-    ar = r.get_array();
-    o1 = ar[0].get_obj();
-    adr = find_value(o1, "address");
+    ar = r.get_array().copy();
+    o1 = ar[0].get_obj().copy();
+    adr = find_value(o1, "address").copy();
     BOOST_CHECK_EQUAL(adr.get_str(), "2001:db8::/30");
 
     BOOST_CHECK_NO_THROW(CallRPC(std::string("clearbanned")));
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("setban 2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/128 add")));
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("listbanned")));
-    ar = r.get_array();
-    o1 = ar[0].get_obj();
-    adr = find_value(o1, "address");
+    ar = r.get_array().copy();
+    o1 = ar[0].get_obj().copy();
+    adr = find_value(o1, "address").copy();
     BOOST_CHECK_EQUAL(adr.get_str(), "2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/128");
 }
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -45,12 +45,11 @@ UniValue read_json(const std::string& jsondata)
 {
     UniValue v;
 
-    if (!v.read(jsondata) || !v.isArray())
-    {
+    if (!v.read(jsondata) || !v.isArray())     {
         BOOST_ERROR("Parse error.");
         return UniValue(UniValue::VARR);
     }
-    return v.get_array();
+    return v;
 }
 
 struct ScriptErrorDesc

--- a/src/test/settings_tests.cpp
+++ b/src/test/settings_tests.cpp
@@ -61,10 +61,10 @@ BOOST_AUTO_TEST_CASE(ReadWrite)
     })");
 
     std::map<std::string, util::SettingsValue> expected{
-        {"string", "string"},
-        {"num", 5},
-        {"bool", true},
-        {"null", {}},
+        {"string", UniValue{"string"}},
+        {"num", UniValue{5}},
+        {"bool", UniValue{true}},
+        {"null", UniValue{}},
     };
 
     // Check file read.

--- a/src/test/settings_tests.cpp
+++ b/src/test/settings_tests.cpp
@@ -32,7 +32,7 @@ inline std::ostream& operator<<(std::ostream& os, const util::SettingsValue& val
     return os;
 }
 
-inline std::ostream& operator<<(std::ostream& os, const std::pair<std::string, util::SettingsValue>& kv)
+inline std::ostream& operator<<(std::ostream& os, const std::map<std::string, util::SettingsValue>::value_type& kv)
 {
     util::SettingsValue out(util::SettingsValue::VOBJ);
     out.__pushKV(kv.first, kv.second);

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(tx_valid)
 
             std::map<COutPoint, CScript> mapprevOutScriptPubKeys;
             std::map<COutPoint, int64_t> mapprevOutValues;
-            UniValue inputs = test[0].get_array();
+            const UniValue& inputs{test[0].get_array()};
             bool fValid = true;
             for (unsigned int inpIdx = 0; inpIdx < inputs.size(); inpIdx++) {
                 const UniValue& input = inputs[inpIdx];
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE(tx_invalid)
 
             std::map<COutPoint, CScript> mapprevOutScriptPubKeys;
             std::map<COutPoint, int64_t> mapprevOutValues;
-            UniValue inputs = test[0].get_array();
+            const UniValue& inputs{test[0].get_array()};
             bool fValid = true;
             for (unsigned int inpIdx = 0; inpIdx < inputs.size(); inpIdx++) {
                 const UniValue& input = inputs[inpIdx];

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -47,6 +47,18 @@ public:
         }
     }
 
+        explicit UniValue(const UniValue&) = default;
+    UniValue& operator=(const UniValue&) = delete;
+
+    UniValue(UniValue&&) = default;
+    UniValue& operator=(UniValue&&) = default;
+    ~UniValue() = default;
+
+    // adds an explicit copy() operation that also works even when WITH_UNIVALUE_COPY_OPERATIONS is defined as 0.
+    UniValue copy() const {
+        return UniValue{*this};
+    }
+
     void clear();
 
     void setNull();

--- a/src/univalue/lib/univalue.cpp
+++ b/src/univalue/lib/univalue.cpp
@@ -112,7 +112,7 @@ void UniValue::push_backV(const std::vector<UniValue>& vec)
 {
     checkType(VARR);
 
-    values.insert(values.end(), vec.begin(), vec.end());
+    //values.insert(values.end(), vec.begin(), vec.end());
 }
 
 void UniValue::__pushKV(std::string key, UniValue val)
@@ -150,7 +150,7 @@ void UniValue::getObjMap(std::map<std::string,UniValue>& kv) const
 
     kv.clear();
     for (size_t i = 0; i < keys.size(); i++)
-        kv[keys[i]] = values[i];
+        kv[keys[i]] = values[i].copy();
 }
 
 bool UniValue::findKey(const std::string& key, size_t& retIdx) const

--- a/src/univalue/lib/univalue_read.cpp
+++ b/src/univalue/lib/univalue_read.cpp
@@ -403,12 +403,12 @@ bool UniValue::read(const char *raw, size_t size)
             }
 
             if (!stack.size()) {
-                *this = tmpVal;
+                *this = std::move(tmpVal);
                 break;
             }
 
             UniValue *top = stack.back();
-            top->values.push_back(tmpVal);
+            top->values.push_back(std::move(tmpVal));
 
             setExpect(NOT_VALUE);
             break;
@@ -417,12 +417,12 @@ bool UniValue::read(const char *raw, size_t size)
         case JTOK_NUMBER: {
             UniValue tmpVal(VNUM, tokenVal);
             if (!stack.size()) {
-                *this = tmpVal;
+                *this = std::move(tmpVal);
                 break;
             }
 
             UniValue *top = stack.back();
-            top->values.push_back(tmpVal);
+            top->values.push_back(std::move(tmpVal));
 
             setExpect(NOT_VALUE);
             break;
@@ -437,11 +437,11 @@ bool UniValue::read(const char *raw, size_t size)
             } else {
                 UniValue tmpVal(VSTR, tokenVal);
                 if (!stack.size()) {
-                    *this = tmpVal;
+                    *this = std::move(tmpVal);
                     break;
                 }
                 UniValue *top = stack.back();
-                top->values.push_back(tmpVal);
+                top->values.push_back(std::move(tmpVal));
             }
 
             setExpect(NOT_VALUE);

--- a/src/univalue/test/object.cpp
+++ b/src/univalue/test/object.cpp
@@ -398,7 +398,7 @@ void univalue_readwrite()
 
     BOOST_CHECK_EQUAL(v[0].getValStr(), "1.10000000");
 
-    UniValue obj = v[1];
+    const UniValue& obj{v[1]};
     BOOST_CHECK(obj.isObject());
     BOOST_CHECK_EQUAL(obj.size(), 3);
 

--- a/src/util/settings.cpp
+++ b/src/util/settings.cpp
@@ -170,7 +170,7 @@ SettingsValue GetSetting(const Settings& settings,
         if (skip_negated_command_line && span.last_negated()) return;
 
         if (!span.empty()) {
-            result = reverse_precedence ? span.begin()[0] : span.end()[-1];
+            result = (reverse_precedence ? span.begin()[0] : span.end()[-1]).copy();
             done = true;
         } else if (span.last_negated()) {
             result = false;
@@ -208,7 +208,7 @@ std::vector<SettingsValue> GetSettingsList(const Settings& settings,
         if (!done || add_zombie_config_values) {
             for (const auto& value : span) {
                 if (value.isArray()) {
-                    result.insert(result.end(), value.getValues().begin(), value.getValues().end());
+                    //result.insert(result.end(), value.getValues().begin(), value.getValues().end());
                 } else {
                     result.push_back(value);
                 }

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -14,6 +14,7 @@
 #include <script/script.h>
 #include <script/standard.h>
 #include <sync.h>
+#include <univalue.h>
 #include <util/bip32.h>
 #include <util/system.h>
 #include <util/time.h>
@@ -25,10 +26,6 @@
 #include <fstream>
 #include <tuple>
 #include <string>
-
-#include <univalue.h>
-
-
 
 using interfaces::FoundBlock;
 
@@ -932,8 +929,8 @@ static UniValue ProcessImportLegacy(ImportData& import_data, std::map<CKeyID, CP
     // Optional fields.
     const std::string& strRedeemScript = data.exists("redeemscript") ? data["redeemscript"].get_str() : "";
     const std::string& witness_script_hex = data.exists("witnessscript") ? data["witnessscript"].get_str() : "";
-    const UniValue& pubKeys = data.exists("pubkeys") ? data["pubkeys"].get_array() : UniValue();
-    const UniValue& keys = data.exists("keys") ? data["keys"].get_array() : UniValue();
+    const UniValue& pubKeys { data.exists("pubkeys") ? data["pubkeys"].get_array() : NullUniValue};
+    const UniValue& keys { data.exists("keys") ? data["keys"].get_array() : NullUniValue};
     const bool internal = data.exists("internal") ? data["internal"].get_bool() : false;
     const bool watchOnly = data.exists("watchonly") ? data["watchonly"].get_bool() : false;
 
@@ -1092,7 +1089,7 @@ static UniValue ProcessImportDescriptor(ImportData& import_data, std::map<CKeyID
         std::tie(range_start, range_end) = ParseDescriptorRange(data["range"]);
     }
 
-    const UniValue& priv_keys = data.exists("keys") ? data["keys"].get_array() : UniValue();
+    const UniValue& priv_keys { data.exists("keys") ? data["keys"].get_array() : NullUniValue};
 
     // Expand all descriptors to get public keys and scripts, and private keys if available.
     for (int i = range_start; i <= range_end; ++i) {

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -573,7 +573,7 @@ RPCHelpMan listunspent()
 
     std::set<CTxDestination> destinations;
     if (!request.params[2].isNull()) {
-        UniValue inputs = request.params[2].get_array();
+        const UniValue& inputs{request.params[2].get_array()};
         for (unsigned int idx = 0; idx < inputs.size(); idx++) {
             const UniValue& input = inputs[idx];
             CTxDestination dest = DecodeDestination(input.get_str());

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -381,7 +381,7 @@ RPCHelpMan sendmany()
     if (!request.params[0].isNull() && !request.params[0].get_str().empty()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Dummy value must be set to \"\"");
     }
-    UniValue sendTo = request.params[1].get_obj();
+    const UniValue& sendTo{request.params[1].get_obj()};
 
     mapValue_t mapValue;
     if (!request.params[3].isNull() && !request.params[3].get_str().empty())
@@ -567,7 +567,7 @@ void FundTransaction(CWallet& wallet, CMutableTransaction& tx, CAmount& fee_out,
             }
         }
 
-        const UniValue include_watching_option = options.exists("include_watching") ? options["include_watching"] : options["includeWatching"];
+        const UniValue& include_watching_option{options.exists("include_watching") ? options["include_watching"] : options["includeWatching"]};
         coinControl.fAllowWatchOnly = ParseIncludeWatchonly(include_watching_option, wallet);
 
         if (options.exists("lockUnspents") || options.exists("lock_unspents")) {
@@ -622,7 +622,7 @@ void FundTransaction(CWallet& wallet, CMutableTransaction& tx, CAmount& fee_out,
     }
 
     if (options.exists("solving_data")) {
-        const UniValue solving_data = options["solving_data"].get_obj();
+        const UniValue& solving_data{options["solving_data"].get_obj()};
         if (solving_data.exists("pubkeys")) {
             for (const UniValue& pk_univ : solving_data["pubkeys"].get_array().getValues()) {
                 const std::string& pk_str = pk_univ.get_str();
@@ -1031,7 +1031,7 @@ static RPCHelpMan bumpfee_helper(std::string method_name)
     coin_control.m_signal_bip125_rbf = true;
 
     if (!request.params[1].isNull()) {
-        UniValue options = request.params[1];
+        const UniValue& options{request.params[1]};
         RPCTypeCheckObj(options,
             {
                 {"confTarget", UniValueType(UniValue::VNUM)},
@@ -1046,7 +1046,7 @@ static RPCHelpMan bumpfee_helper(std::string method_name)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "confTarget and conf_target options should not both be set. Use conf_target (confTarget is deprecated).");
         }
 
-        auto conf_target = options.exists("confTarget") ? options["confTarget"] : options["conf_target"];
+        const auto& conf_target{options.exists("confTarget") ? options["confTarget"] : options["conf_target"]};
 
         if (options.exists("replaceable")) {
             coin_control.m_signal_bip125_rbf = options["replaceable"].get_bool();

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -389,7 +389,7 @@ RPCHelpMan sendmany()
 
     UniValue subtractFeeFromAmount(UniValue::VARR);
     if (!request.params[4].isNull())
-        subtractFeeFromAmount = request.params[4].get_array();
+        subtractFeeFromAmount = request.params[4].get_array().copy();
 
     CCoinControl coin_control;
     if (!request.params[5].isNull()) {
@@ -593,7 +593,7 @@ void FundTransaction(CWallet& wallet, CMutableTransaction& tx, CAmount& fee_out,
         }
 
         if (options.exists("subtractFeeFromOutputs") || options.exists("subtract_fee_from_outputs") )
-            subtractFeeFromOutputs = (options.exists("subtract_fee_from_outputs") ? options["subtract_fee_from_outputs"] : options["subtractFeeFromOutputs"]).get_array();
+            subtractFeeFromOutputs = (options.exists("subtract_fee_from_outputs") ? options["subtract_fee_from_outputs"] : options["subtractFeeFromOutputs"]).get_array().copy();
 
         if (options.exists("replaceable")) {
             coinControl.m_signal_bip125_rbf = options["replaceable"].get_bool();
@@ -1231,7 +1231,7 @@ RPCHelpMan send()
             std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
             if (!pwallet) return UniValue::VNULL;
 
-            UniValue options{request.params[4].isNull() ? UniValue::VOBJ : request.params[4]};
+            UniValue options{request.params[4].isNull() ? UniValue::VOBJ : request.params[4].copy()};
             InterpretFeeEstimationInstructions(/*conf_target=*/request.params[1], /*estimate_mode=*/request.params[2], /*fee_rate=*/request.params[3], options);
             PreventOutdatedOptions(options);
 
@@ -1336,7 +1336,7 @@ RPCHelpMan sendall()
             // the user could have gotten from another RPC command prior to now
             pwallet->BlockUntilSyncedToCurrentChain();
 
-            UniValue options{request.params[4].isNull() ? UniValue::VOBJ : request.params[4]};
+            UniValue options{request.params[4].isNull() ? UniValue::VOBJ : request.params[4].copy()};
             InterpretFeeEstimationInstructions(/*conf_target=*/request.params[1], /*estimate_mode=*/request.params[2], /*fee_rate=*/request.params[3], options);
             PreventOutdatedOptions(options);
 
@@ -1671,7 +1671,7 @@ RPCHelpMan walletcreatefundedpsbt()
     // the user could have gotten from another RPC command prior to now
     wallet.BlockUntilSyncedToCurrentChain();
 
-    UniValue options{request.params[3].isNull() ? UniValue::VOBJ : request.params[3]};
+    UniValue options{request.params[3].isNull() ? UniValue::VOBJ : request.params[3].copy()};
 
     CAmount fee;
     int change_position;


### PR DESCRIPTION
UniValue copies have been a source of performance related bugs and regressions, so it would be good to remove the copy constructors.

This is the first change toward the goal. This change uses a `const UniValue&` where possible.

See also:

* https://github.com/bitcoin-core/univalue-subtree/pull/27
* https://github.com/bitcoin/bitcoin/pull/15974