### PR TITLE
test: Remove from_node from create_self_transfer* MiniWallet helpers

### DIFF
--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -51,7 +51,6 @@ def small_txpuzzle_randfee(
     if total_in <= amount + fee:
         raise RuntimeError(f"Insufficient funds: need {amount + fee}, have {total_in}")
     tx = wallet.create_self_transfer_multi(
-        from_node=from_node,
         utxos_to_spend=utxos_to_spend,
         fee_per_output=0)
     tx.vout[0].nValue = int((total_in - amount - fee) * COIN)

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -473,7 +473,6 @@ class ReplaceByFeeTest(BitcoinTestFramework):
             # Now attempt to submit a tx that double-spends all the root tx inputs, which
             # would invalidate `num_txs_invalidated` transactions.
             double_tx = wallet.create_self_transfer_multi(
-                from_node=normal_node,
                 utxos_to_spend=root_utxos,
                 fee_per_output=10_000_000,  # absurdly high feerate
             )

--- a/test/functional/mempool_unbroadcast.py
+++ b/test/functional/mempool_unbroadcast.py
@@ -40,7 +40,7 @@ class MempoolUnbroadcastTest(BitcoinTestFramework):
             wallet_tx_hsh = node.sendtoaddress(addr, 0.0001)
 
         # generate a txn using sendrawtransaction
-        txFS = self.wallet.create_self_transfer(from_node=node)
+        txFS = self.wallet.create_self_transfer()
         rpc_tx_hsh = node.sendrawtransaction(txFS["hex"])
 
         # check transactions are in unbroadcast using rpc

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -212,7 +212,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
                 assert x not in mempool
 
         # Create a free transaction.  Should be rejected.
-        tx_res = self.wallet.create_self_transfer(from_node=self.nodes[0], fee_rate=0)
+        tx_res = self.wallet.create_self_transfer(fee_rate=0)
         tx_hex = tx_res['hex']
         tx_id = tx_res['txid']
 

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -1998,7 +1998,7 @@ class SegWitTest(BitcoinTestFramework):
             def serialize(self):
                 return serialize_with_bogus_witness(self.tx)
 
-        tx = self.wallet.create_self_transfer(from_node=self.nodes[0])['tx']
+        tx = self.wallet.create_self_transfer()['tx']
         assert_raises_rpc_error(-22, "TX decode failed", self.nodes[0].decoderawtransaction, hexstring=serialize_with_bogus_witness(tx).hex(), iswitness=True)
         with self.nodes[0].assert_debug_log(['Unknown transaction optional data']):
             self.test_node.send_and_ping(msg_bogus_tx(tx))

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -285,7 +285,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # Test a transaction with a large fee.
         # Fee rate is 0.20000000 BTC/kvB
-        tx = self.wallet.create_self_transfer(from_node=self.nodes[0], fee_rate=Decimal("0.20000000"))
+        tx = self.wallet.create_self_transfer(fee_rate=Decimal("0.20000000"))
         # Thus, testmempoolaccept should reject
         testres = self.nodes[2].testmempoolaccept([tx['hex']])[0]
         assert_equal(testres['allowed'], False)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -527,9 +527,8 @@ def create_lots_of_big_transactions(mini_wallet, node, fee, tx_batch_size, txout
     use_internal_utxos = utxos is None
     for _ in range(tx_batch_size):
         tx = mini_wallet.create_self_transfer(
-                from_node=node,
-                utxo_to_spend=None if use_internal_utxos else utxos.pop(),
-                fee_rate=0,
+            utxo_to_spend=None if use_internal_utxos else utxos.pop(),
+            fee_rate=0,
         )["tx"]
         tx.vout[0].nValue -= fee_sats
         tx.vout.extend(txouts)

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -180,10 +180,10 @@ class MiniWallet:
             self._utxos = []
         return utxos
 
-    def send_self_transfer(self, **kwargs):
+    def send_self_transfer(self, *, from_node, **kwargs):
         """Create and send a tx with the specified fee_rate. Fee may be exact or at most one satoshi higher than needed."""
         tx = self.create_self_transfer(**kwargs)
-        self.sendrawtransaction(from_node=kwargs['from_node'], tx_hex=tx['hex'])
+        self.sendrawtransaction(from_node=from_node, tx_hex=tx['hex'])
         return tx
 
     def send_to(self, *, from_node, scriptPubKey, amount, fee=1000):
@@ -198,14 +198,14 @@ class MiniWallet:
 
         Returns a tuple (txid, n) referring to the created external utxo outpoint.
         """
-        tx = self.create_self_transfer(from_node=from_node, fee_rate=0)["tx"]
+        tx = self.create_self_transfer(fee_rate=0)["tx"]
         assert_greater_than_or_equal(tx.vout[0].nValue, amount + fee)
         tx.vout[0].nValue -= (amount + fee)           # change output -> MiniWallet
         tx.vout.append(CTxOut(amount, scriptPubKey))  # arbitrary output -> to be returned
         txid = self.sendrawtransaction(from_node=from_node, tx_hex=tx.serialize().hex())
         return txid, 1
 
-    def send_self_transfer_multi(self, **kwargs):
+    def send_self_transfer_multi(self, *, from_node, **kwargs):
         """
         Create and send a transaction that spends the given UTXOs and creates a
         certain number of outputs with equal amounts.
@@ -217,16 +217,18 @@ class MiniWallet:
             - list of newly created UTXOs, ordered by vout index
         """
         tx = self.create_self_transfer_multi(**kwargs)
-        txid = self.sendrawtransaction(from_node=kwargs['from_node'], tx_hex=tx.serialize().hex())
+        txid = self.sendrawtransaction(from_node=from_node, tx_hex=tx.serialize().hex())
         return {'new_utxos': [self.get_utxo(txid=txid, vout=vout) for vout in range(len(tx.vout))],
                 'txid': txid, 'hex': tx.serialize().hex(), 'tx': tx}
 
     def create_self_transfer_multi(
-            self, *, from_node,
-            utxos_to_spend: Optional[List[dict]] = None,
-            num_outputs=1,
-            sequence=0,
-            fee_per_output=1000):
+        self,
+        *,
+        utxos_to_spend: Optional[List[dict]] = None,
+        num_outputs=1,
+        sequence=0,
+        fee_per_output=1000,
+    ):
         """
         Create and return a transaction that spends the given UTXOs and creates a
         certain number of outputs with equal amounts.
@@ -234,7 +236,7 @@ class MiniWallet:
         utxos_to_spend = utxos_to_spend or [self.get_utxo()]
         # create simple tx template (1 input, 1 output)
         tx = self.create_self_transfer(
-            fee_rate=0, from_node=from_node,
+            fee_rate=0,
             utxo_to_spend=utxos_to_spend[0], sequence=sequence)["tx"]
 
         # duplicate inputs, witnesses and outputs
@@ -253,9 +255,8 @@ class MiniWallet:
             o.nValue = outputs_value_total // num_outputs
         return tx
 
-    def create_self_transfer(self, *, fee_rate=Decimal("0.003"), from_node=None, utxo_to_spend=None, locktime=0, sequence=0):
+    def create_self_transfer(self, *, fee_rate=Decimal("0.003"), utxo_to_spend=None, locktime=0, sequence=0):
         """Create and return a tx with the specified fee_rate. Fee may be exact or at most one satoshi higher than needed."""
-        from_node = from_node or self._test_node
         utxo_to_spend = utxo_to_spend or self.get_utxo()
         if self._mode in (MiniWalletMode.RAW_OP_TRUE, MiniWalletMode.ADDRESS_OP_TRUE):
             vsize = Decimal(104)  # anyone-can-spend


### PR DESCRIPTION
MiniWallet is capable to create a transaction without a node, so don't pass it in where not needed.