### PR TITLE
build: GCC-12 build improvements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1461,6 +1461,11 @@ if test "$use_boost" = "yes"; then
   dnl we don't use multi_index serialization
   BOOST_CPPFLAGS="$BOOST_CPPFLAGS -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION"
 
+  dnl Prevent use of std::unary_function, which was removed in C++17,
+  dnl and will generate warnings with newer compilers.
+  dnl See: https://github.com/boostorg/container_hash/issues/22.
+  BOOST_CPPFLAGS="$BOOST_CPPFLAGS -DBOOST_NO_CXX98_FUNCTION_BASE"
+
   if test "$enable_debug" = "yes" || test "$enable_fuzz" = "yes"; then
     BOOST_CPPFLAGS="$BOOST_CPPFLAGS -DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE"
   fi

--- a/depends/packages/libxkbcommon.mk
+++ b/depends/packages/libxkbcommon.mk
@@ -5,9 +5,14 @@ $(package)_file_name=$(package)-$($(package)_version).tar.xz
 $(package)_sha256_hash=60ddcff932b7fd352752d51a5c4f04f3d0403230a584df9a2e0d5ed87c486c8b
 $(package)_dependencies=libxcb
 
+# This package explicitly enables -Werror=array-bounds, which causes build failures
+# with GCC 12.1+. Work around that by turning errors back into warnings.
+# This workaround would be dropped if the package was updated, as that would require
+# a different build system (Meson)
 define $(package)_set_vars
 $(package)_config_opts = --enable-option-checking --disable-dependency-tracking
 $(package)_config_opts += --disable-static --disable-docs
+$(package)_cflags += -Wno-error=array-bounds
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
2 changes to better support building with GCC 12, which out of the box, is currently broken if you want to build using depends.
Prevent `-Warray-bounds` errors when building libxkbcommon. i.e:
```bash
src/xkbcomp/ast-build.c:82:27: error: array subscript 'ExprDef[0]' is partly outside array bounds of 'unsigned char[32]' [-Werror=array-bounds]
   82 |     expr->expr.value_type = type;
      |     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~
src/xkbcomp/ast-build.c:75:21: note: object of size 32 allocated by 'malloc'
   75 |     ExprDef *expr = malloc(size);
      |                     ^~~~~~~~~~~~
```

It might be the case that these would be fixed by updating the
package, but that would also require installing new build tools (meson),
as well as potentially more dependencies (wayland), and it'd need
testing with Qt. For now, just turn the errors into wanrings.

Define `BOOST_NO_CXX98_FUNCTION_BASE` to prevent GCC warning about the use of `std::unary_function`. i.e:
```bash
/bitcoin/depends/aarch64-unknown-linux-gnu/include/boost/container_hash/hash.hpp:131:33:
warning: 'template<class _Arg, class _Result> struct std::unary_function' is deprecated [-Wdeprecated-declarations]
  131 |         struct hash_base : std::unary_function<T, std::size_t> {};
      |                                 ^~~~~~~~~~~~~~
In file included from /usr/include/c++/12/bits/unique_ptr.h:37,
                 from /usr/include/c++/12/memory:76,
                 from ./init.h:10,
                 from init.cpp:10:
/usr/include/c++/12/bits/stl_function.h:117:12: note: declared here
  117 |     struct unary_function
```

Boost `container_hash` (included via functional -> multi_index) uses
[`std::unary_function`, which was deprecated in C++11](https://en.cppreference.com/w/cpp/utility/functional/unary_function), and "removed" in
C++17. It's use causes warnings with newer compilers, i.e GCC 12.1.

Use the MACRO outlined in https://github.com/boostorg/container_hash/issues/22, and added to Boost Config for GCC 12 in https://github.com/boostorg/config/pull/430, to prevent it's use.

[BOOST_NO_CXX98_FUNCTION_BASE](https://www.boost.org/doc/libs/master/libs/config/doc/html/boost_config/boost_macro_reference.html):
> The standard library no longer supports std::unary_function and std::binary_function.
> They were deprecated in C++11 and is removed from C++14.

Guix Build (x86_64):
```bash

```

Guix Build (arm64):
```bash

```