### PR TITLE
guix: remove explicit glibc stack protector disabling

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -132,25 +132,11 @@ chain for " target " development."))
 (define base-gcc gcc-10)
 (define base-linux-kernel-headers linux-libre-headers-5.15)
 
-;; Building glibc with stack smashing protector first landed in glibc 2.25, use
-;; this function to disable for older glibcs
-;;
-;; From glibc 2.25 changelog:
-;;
-;;   * Most of glibc can now be built with the stack smashing protector enabled.
-;;     It is recommended to build glibc with --enable-stack-protector=strong.
-;;     Implemented by Nick Alcock (Oracle).
-(define (make-glibc-without-ssp xglibc)
-  (package-with-extra-configure-variable
-   (package-with-extra-configure-variable
-    xglibc "libc_cv_ssp" "no")
-   "libc_cv_ssp_strong" "no"))
-
 (define* (make-bitcoin-cross-toolchain target
                                        #:key
                                        (base-gcc-for-libc base-gcc)
                                        (base-kernel-headers base-linux-kernel-headers)
-                                       (base-libc (make-glibc-without-ssp (make-glibc-without-werror glibc-2.24)))
+                                       (base-libc (make-glibc-without-werror glibc-2.24))
                                        (base-gcc (make-gcc-rpath-link base-gcc)))
   "Convenience wrapper around MAKE-CROSS-TOOLCHAIN with default values
 desirable for building Bitcoin Core release binaries."


### PR DESCRIPTION
While glibc 2.25 and newer *can* be built with stack-smashing-protection
enabled, it isn't used by default, and still isn't, as of glibc 2.35,
so I can't see a reason to explicitly disable it.

I'd also like to move in the direction of enabling, by default,
hardening options for the toolchains we build, so removing the explicit
disabling is a step in that direction.

Will be following up with some changes based on this change.

Guix Build (x86_64):
```bash
954b393f5c775919e32b725a45aa93af8a5e75ead348f904304c0367583b41ff  guix-build-4e569c8bd85e/output/aarch64-linux-gnu/SHA256SUMS.part
0ff27062ba2ac4c11a966de2d9aea070f54ab5c255068dd992b19fcb33661ffd  guix-build-4e569c8bd85e/output/aarch64-linux-gnu/bitcoin-4e569c8bd85e-aarch64-linux-gnu-debug.tar.gz
bf48baf97e21467ce439f6e733cf3a20732adee01bb1d98aa9519c2ec54b5f41  guix-build-4e569c8bd85e/output/aarch64-linux-gnu/bitcoin-4e569c8bd85e-aarch64-linux-gnu.tar.gz
041eac2a2e045e2283cc78361adcc2232c5eecc9ad465624499225a4ad44f5fe  guix-build-4e569c8bd85e/output/arm-linux-gnueabihf/SHA256SUMS.part
7a3bbca762f6c3c4fd851fbf74a2f00c21d98c211de5baa06d0ba2fc59505694  guix-build-4e569c8bd85e/output/arm-linux-gnueabihf/bitcoin-4e569c8bd85e-arm-linux-gnueabihf-debug.tar.gz
89e0260075472d10d02de7e3bb382d87f9ffb3d548f533aab0ba7e39f4c796df  guix-build-4e569c8bd85e/output/arm-linux-gnueabihf/bitcoin-4e569c8bd85e-arm-linux-gnueabihf.tar.gz
96f893eefaa9fb5af41f46eece3831a3956a5a9ab1f825e4c17c5675bd020bbe  guix-build-4e569c8bd85e/output/arm64-apple-darwin/SHA256SUMS.part
65865e481d33e1023adef769ca9a38ca8cdf03e8476a61f1724bb1ab0bc54750  guix-build-4e569c8bd85e/output/arm64-apple-darwin/bitcoin-4e569c8bd85e-arm64-apple-darwin-unsigned.dmg
38da0510c34d9c2bff98da60c873593c6a85bc6f73025990daaa8d5b022819c0  guix-build-4e569c8bd85e/output/arm64-apple-darwin/bitcoin-4e569c8bd85e-arm64-apple-darwin-unsigned.tar.gz
a1b5ccda7780df15fda2131d260542e57601fed2c18092edaa3094c23eafd99d  guix-build-4e569c8bd85e/output/arm64-apple-darwin/bitcoin-4e569c8bd85e-arm64-apple-darwin.tar.gz
f1e4fb6d96420865ee1cfdc10960d8b0407ae49d367d5df1901510a8a87a69bf  guix-build-4e569c8bd85e/output/dist-archive/bitcoin-4e569c8bd85e.tar.gz
5cc5e3193435bdd0aafc1a43e1dfc7582e585a27453e92e3383ceb8ba6c162ad  guix-build-4e569c8bd85e/output/powerpc64-linux-gnu/SHA256SUMS.part
56bfeecb15b0c59dcccb31d1d5df978e7bb9c60bc0661638af7b263958cb8d4d  guix-build-4e569c8bd85e/output/powerpc64-linux-gnu/bitcoin-4e569c8bd85e-powerpc64-linux-gnu-debug.tar.gz
46e61a752ba3ac1e553c82f4615854c27b38b9c2e5abd318840d3d5383e1384d  guix-build-4e569c8bd85e/output/powerpc64-linux-gnu/bitcoin-4e569c8bd85e-powerpc64-linux-gnu.tar.gz
52ea9adf7b3a88fa88e89b53852d1d7917af959bee0b67c218959b1123f67c57  guix-build-4e569c8bd85e/output/powerpc64le-linux-gnu/SHA256SUMS.part
2a1a65bd55cc9c83ccbb296e7fe41d5b313466cf8d70ef8aec81aa47e346e422  guix-build-4e569c8bd85e/output/powerpc64le-linux-gnu/bitcoin-4e569c8bd85e-powerpc64le-linux-gnu-debug.tar.gz
b8dbcf97a83a1dd53d23eeafa714e3a3cb8d0b087c060978137e47fdab2b261f  guix-build-4e569c8bd85e/output/powerpc64le-linux-gnu/bitcoin-4e569c8bd85e-powerpc64le-linux-gnu.tar.gz
87e3823e246e139ad14c4d44c8e2ed5e1bebea1a02d3931e66232505a1b35463  guix-build-4e569c8bd85e/output/riscv64-linux-gnu/SHA256SUMS.part
1307b92c608b1001628fda1792fbcb61183286cff707be930bcb1d887f5a4b02  guix-build-4e569c8bd85e/output/riscv64-linux-gnu/bitcoin-4e569c8bd85e-riscv64-linux-gnu-debug.tar.gz
0f660a9165a26f627be913e6bf1bb81cbabebee742031d0a75131a7e380e6c8a  guix-build-4e569c8bd85e/output/riscv64-linux-gnu/bitcoin-4e569c8bd85e-riscv64-linux-gnu.tar.gz
d530151878bdf70c0913a12ba1aa49dad9ba62ac9edd70cda3982fd0fe327e93  guix-build-4e569c8bd85e/output/x86_64-apple-darwin/SHA256SUMS.part
dc3a9ee571854066ea03d60c1f2b8012fdff12ea1e74ab4ce02b1effc6689436  guix-build-4e569c8bd85e/output/x86_64-apple-darwin/bitcoin-4e569c8bd85e-x86_64-apple-darwin-unsigned.dmg
94c0522390e5650d91d63c6afa5bce895a60c17c1365e0d87a898c2868093dc9  guix-build-4e569c8bd85e/output/x86_64-apple-darwin/bitcoin-4e569c8bd85e-x86_64-apple-darwin-unsigned.tar.gz
364d72282e8824d5dffe184fc10bdcbc9cdf96e8c0ac379b8392e1e1992e3307  guix-build-4e569c8bd85e/output/x86_64-apple-darwin/bitcoin-4e569c8bd85e-x86_64-apple-darwin.tar.gz
0d3ce4cbf3444fc9a3c488f12ef7b73d07b85bcf3d4d9500b689d44506a79818  guix-build-4e569c8bd85e/output/x86_64-linux-gnu/SHA256SUMS.part
f584d494db5594ae2bc06e09f8e68c11e446bc82cb8a1dfa6afee5d3a079b5af  guix-build-4e569c8bd85e/output/x86_64-linux-gnu/bitcoin-4e569c8bd85e-x86_64-linux-gnu-debug.tar.gz
ea0e9316dd25ebee9023f3c65cb99fe846de6fe56152d4926005f9da500a502c  guix-build-4e569c8bd85e/output/x86_64-linux-gnu/bitcoin-4e569c8bd85e-x86_64-linux-gnu.tar.gz
a41966b6d13aa1e702cc357bbedfd51bcb431caa39bb904efd9611e3a945bf1c  guix-build-4e569c8bd85e/output/x86_64-w64-mingw32/SHA256SUMS.part
5f150613204341d91a4b755c74120e233567187ba4f9151a12e39e5304efb3a1  guix-build-4e569c8bd85e/output/x86_64-w64-mingw32/bitcoin-4e569c8bd85e-win64-debug.zip
6a94dc9c5dcb2a4448a37573baab50f405e08af0d5a4de8a8046cba5445153e4  guix-build-4e569c8bd85e/output/x86_64-w64-mingw32/bitcoin-4e569c8bd85e-win64-setup-unsigned.exe
31fe85ba31ed84ebbbc4cc42f593e1de1811c1ecc9a0a094d05b0914bd151174  guix-build-4e569c8bd85e/output/x86_64-w64-mingw32/bitcoin-4e569c8bd85e-win64-unsigned.tar.gz
0a6d590c26a47c51192e4003ad97ecd6b7ad91c8f8612ea310fb324bce5dc15a  guix-build-4e569c8bd85e/output/x86_64-w64-mingw32/bitcoin-4e569c8bd85e-win64.zip
```

Guix Build (arm64):
```bash
2ce621cb469772c318a29b21bc4dd546353130a688a5ecb66373256c7be2c37a  guix-build-4e569c8bd85e/output/arm-linux-gnueabihf/SHA256SUMS.part
13abe55069581ca711529d058a8e5de732c6630a94b7e912e9c31f606241c264  guix-build-4e569c8bd85e/output/arm-linux-gnueabihf/bitcoin-4e569c8bd85e-arm-linux-gnueabihf-debug.tar.gz
7a60cd7d9aee30bc8e08cf9d52bd032f82e48214c81130e2f61ca3da71c01477  guix-build-4e569c8bd85e/output/arm-linux-gnueabihf/bitcoin-4e569c8bd85e-arm-linux-gnueabihf.tar.gz
d614a4acfed70f61814a5c26bf51594e0cc666fc3dadc3df805e5cc608835550  guix-build-4e569c8bd85e/output/arm64-apple-darwin/SHA256SUMS.part
c9d5705b947c461ade878d7a0110ae5b34b384991f5bf6e86db0b79f421d4f81  guix-build-4e569c8bd85e/output/arm64-apple-darwin/bitcoin-4e569c8bd85e-arm64-apple-darwin-unsigned.dmg
c1897d204e75b9ef8a58fb3f2c85d9c306b05dbd6c8f74a2b4ccfbd85aed5574  guix-build-4e569c8bd85e/output/arm64-apple-darwin/bitcoin-4e569c8bd85e-arm64-apple-darwin-unsigned.tar.gz
1c9e188d76c18785d4500c1c7ab0e049cf35c878803266580913e8cc4bd01bf6  guix-build-4e569c8bd85e/output/arm64-apple-darwin/bitcoin-4e569c8bd85e-arm64-apple-darwin.tar.gz
f1e4fb6d96420865ee1cfdc10960d8b0407ae49d367d5df1901510a8a87a69bf  guix-build-4e569c8bd85e/output/dist-archive/bitcoin-4e569c8bd85e.tar.gz
f3e7d6b6aca3ca4f150e0e91e9532f4eb21c4f60ab1c21b6ecfaa9c862f9f8a8  guix-build-4e569c8bd85e/output/powerpc64-linux-gnu/SHA256SUMS.part
48e630949976ee298bccf01cfbbb7fea29c9bd0bc658cf0564d4a3e1997556e8  guix-build-4e569c8bd85e/output/powerpc64-linux-gnu/bitcoin-4e569c8bd85e-powerpc64-linux-gnu-debug.tar.gz
9e30c4987f3657ba6499a78c5c578e430c55f71991fc9ad6f3ecf4847ed1814e  guix-build-4e569c8bd85e/output/powerpc64-linux-gnu/bitcoin-4e569c8bd85e-powerpc64-linux-gnu.tar.gz
128ce9194e377b013baceafc4ddba0f70c239e36057c9dc0a9213caa34c5064f  guix-build-4e569c8bd85e/output/powerpc64le-linux-gnu/SHA256SUMS.part
8e4a41c07e9427de4054069c3af668157372cc6cd86d758c0b35b7ed906e5365  guix-build-4e569c8bd85e/output/powerpc64le-linux-gnu/bitcoin-4e569c8bd85e-powerpc64le-linux-gnu-debug.tar.gz
da6924709b35f7fbaf9b7b772e0f14be5b583e9453b0cae58b6a5b1e159580c7  guix-build-4e569c8bd85e/output/powerpc64le-linux-gnu/bitcoin-4e569c8bd85e-powerpc64le-linux-gnu.tar.gz
2415604bf3651ea18dcbb4ec5bf73372bdc19c80aa316b864de20c8a5df4bf34  guix-build-4e569c8bd85e/output/riscv64-linux-gnu/SHA256SUMS.part
8f6ee4b69fb33b40ad505c091684258ded340ab9936b554f8fa4e499d4da1155  guix-build-4e569c8bd85e/output/riscv64-linux-gnu/bitcoin-4e569c8bd85e-riscv64-linux-gnu-debug.tar.gz
0a941d44532287288a9859c35fdaa940c940c1e8f4a17b7994e3796c9a668d57  guix-build-4e569c8bd85e/output/riscv64-linux-gnu/bitcoin-4e569c8bd85e-riscv64-linux-gnu.tar.gz
d530151878bdf70c0913a12ba1aa49dad9ba62ac9edd70cda3982fd0fe327e93  guix-build-4e569c8bd85e/output/x86_64-apple-darwin/SHA256SUMS.part
dc3a9ee571854066ea03d60c1f2b8012fdff12ea1e74ab4ce02b1effc6689436  guix-build-4e569c8bd85e/output/x86_64-apple-darwin/bitcoin-4e569c8bd85e-x86_64-apple-darwin-unsigned.dmg
94c0522390e5650d91d63c6afa5bce895a60c17c1365e0d87a898c2868093dc9  guix-build-4e569c8bd85e/output/x86_64-apple-darwin/bitcoin-4e569c8bd85e-x86_64-apple-darwin-unsigned.tar.gz
364d72282e8824d5dffe184fc10bdcbc9cdf96e8c0ac379b8392e1e1992e3307  guix-build-4e569c8bd85e/output/x86_64-apple-darwin/bitcoin-4e569c8bd85e-x86_64-apple-darwin.tar.gz
047d3eae54136b7f5fb20487fb2c57455dda6bb88594065b71843400fbc41824  guix-build-4e569c8bd85e/output/x86_64-linux-gnu/SHA256SUMS.part
8bfb97bcab8d5e0a86a2a8d20be5215d8bb615a8b6c3ad69e1db5028caf2dd29  guix-build-4e569c8bd85e/output/x86_64-linux-gnu/bitcoin-4e569c8bd85e-x86_64-linux-gnu-debug.tar.gz
4962550d7d113e8544a33e2ffa5a0e77e172984c17bfa461a631bf08dc7cc545  guix-build-4e569c8bd85e/output/x86_64-linux-gnu/bitcoin-4e569c8bd85e-x86_64-linux-gnu.tar.gz
5ad1661c475308c6df102aee51261e36583fe0f5f73713d7f19384b63755a3c5  guix-build-4e569c8bd85e/output/x86_64-w64-mingw32/SHA256SUMS.part
62cf3e15e638f48bd0931a847ba5e5636422fb6bd00da41251c1f636d39c5822  guix-build-4e569c8bd85e/output/x86_64-w64-mingw32/bitcoin-4e569c8bd85e-win64-debug.zip
6a94dc9c5dcb2a4448a37573baab50f405e08af0d5a4de8a8046cba5445153e4  guix-build-4e569c8bd85e/output/x86_64-w64-mingw32/bitcoin-4e569c8bd85e-win64-setup-unsigned.exe
31fe85ba31ed84ebbbc4cc42f593e1de1811c1ecc9a0a094d05b0914bd151174  guix-build-4e569c8bd85e/output/x86_64-w64-mingw32/bitcoin-4e569c8bd85e-win64-unsigned.tar.gz
a3c7db0ca4b557810b5e5f1ec14cecaf47b5bf51631798d8675243bb6ecedf8f  guix-build-4e569c8bd85e/output/x86_64-w64-mingw32/bitcoin-4e569c8bd85e-win64.zip
```