### PR TITLE
refactor: remove unused methods in classes `CDBIterator,CDBWrapper,CCoinsViewDBCursor`

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -142,7 +142,6 @@ public:
 
     virtual bool GetKey(COutPoint &key) const = 0;
     virtual bool GetValue(Coin &coin) const = 0;
-    virtual unsigned int GetValueSize() const = 0;
 
     virtual bool Valid() const = 0;
     virtual void Next() = 0;

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -313,22 +313,6 @@ public:
         pdb->GetApproximateSizes(&range, 1, &size);
         return size;
     }
-
-    /**
-     * Compact a certain range of keys in the database.
-     */
-    template<typename K>
-    void CompactRange(const K& key_begin, const K& key_end) const
-    {
-        CDataStream ssKey1(SER_DISK, CLIENT_VERSION), ssKey2(SER_DISK, CLIENT_VERSION);
-        ssKey1.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
-        ssKey2.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
-        ssKey1 << key_begin;
-        ssKey2 << key_end;
-        leveldb::Slice slKey1((const char*)ssKey1.data(), ssKey1.size());
-        leveldb::Slice slKey2((const char*)ssKey2.data(), ssKey2.size());
-        pdb->CompactRange(&slKey1, &slKey2);
-    }
 };
 
 #endif // BITCOIN_DBWRAPPER_H

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -166,11 +166,6 @@ public:
         }
         return true;
     }
-
-    unsigned int GetValueSize() {
-        return piter->value().size();
-    }
-
 };
 
 class CDBWrapper

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -211,7 +211,6 @@ public:
 
     bool GetKey(COutPoint &key) const override;
     bool GetValue(Coin &coin) const override;
-    unsigned int GetValueSize() const override;
 
     bool Valid() const override;
     void Next() override;
@@ -255,11 +254,6 @@ bool CCoinsViewDBCursor::GetKey(COutPoint &key) const
 bool CCoinsViewDBCursor::GetValue(Coin &coin) const
 {
     return pcursor->GetValue(coin);
-}
-
-unsigned int CCoinsViewDBCursor::GetValueSize() const
-{
-    return pcursor->GetValueSize();
 }
 
 bool CCoinsViewDBCursor::Valid() const


### PR DESCRIPTION
The `GetValueSize` methods haven't been used since the chainstate db cache has been switched from per-tx to per-txout model years ago (PR #10195, commit d342424301013ec47dc146a4beb49d5c9319d80a). The `CompactRange` is unused since the txindex migration code was removed (PR https://github.com/bitcoin/bitcoin/pull/22626, commit https://github.com/bitcoin/bitcoin/commit/fa20f815a9cb438c5ab61e97a453612ddd8b21b5).
