### PR TITLE
test: Return new_utxo from create_self_transfer in MiniWallet

### DIFF
--- a/test/functional/feature_dbcrash.py
+++ b/test/functional/feature_dbcrash.py
@@ -192,14 +192,12 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
                 # Sanity check -- if we chose inputs that are too small, skip
                 continue
 
-            tx = self.wallet.create_self_transfer_multi(
+            self.wallet.send_self_transfer_multi(
                 from_node=node,
                 utxos_to_spend=utxos_to_spend,
                 num_outputs=3,
-                fee_per_output=FEE // 3)
-
-            # Send the transaction to get into the mempool (skip fee-checks to run faster)
-            node.sendrawtransaction(hexstring=tx.serialize().hex(), maxfeerate=0)
+                fee_per_output=FEE // 3,
+            )
             num_transactions += 1
 
     def run_test(self):

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -52,7 +52,8 @@ def small_txpuzzle_randfee(
         raise RuntimeError(f"Insufficient funds: need {amount + fee}, have {total_in}")
     tx = wallet.create_self_transfer_multi(
         utxos_to_spend=utxos_to_spend,
-        fee_per_output=0)
+        fee_per_output=0,
+    )["tx"]
     tx.vout[0].nValue = int((total_in - amount - fee) * COIN)
     tx.vout.append(deepcopy(tx.vout[0]))
     tx.vout[1].nValue = int(amount * COIN)

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -472,11 +472,10 @@ class ReplaceByFeeTest(BitcoinTestFramework):
 
             # Now attempt to submit a tx that double-spends all the root tx inputs, which
             # would invalidate `num_txs_invalidated` transactions.
-            double_tx = wallet.create_self_transfer_multi(
+            tx_hex = wallet.create_self_transfer_multi(
                 utxos_to_spend=root_utxos,
                 fee_per_output=10_000_000,  # absurdly high feerate
-            )
-            tx_hex = double_tx.serialize().hex()
+            )["hex"]
 
             if failure_expected:
                 assert_raises_rpc_error(

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -68,10 +68,8 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         assert_raises_rpc_error(-26, 'non-final', self.nodes[0].sendrawtransaction, timelock_tx)
 
         self.log.info("Create spend_2_1 and spend_3_1")
-        spend_2_utxo = wallet.get_utxo(txid=spend_2['txid'])
-        spend_2_1 = wallet.create_self_transfer(utxo_to_spend=spend_2_utxo)
-        spend_3_utxo = wallet.get_utxo(txid=spend_3['txid'])
-        spend_3_1 = wallet.create_self_transfer(utxo_to_spend=spend_3_utxo)
+        spend_2_1 = wallet.create_self_transfer(utxo_to_spend=spend_2["new_utxo"])
+        spend_3_1 = wallet.create_self_transfer(utxo_to_spend=spend_3["new_utxo"])
 
         self.log.info("Broadcast and mine spend_3_1")
         spend_3_1_id = self.nodes[0].sendrawtransaction(spend_3_1['hex'])

--- a/test/functional/rpc_mempool_info.py
+++ b/test/functional/rpc_mempool_info.py
@@ -4,7 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test RPCs that retrieve information from the mempool."""
 
-from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -19,7 +18,6 @@ class RPCMempoolInfoTest(BitcoinTestFramework):
 
     def run_test(self):
         self.wallet = MiniWallet(self.nodes[0])
-        self.generate(self.wallet, COINBASE_MATURITY + 1)
         self.wallet.rescan_utxos()
         confirmed_utxo = self.wallet.get_utxo()
 

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -101,6 +101,9 @@ class MiniWallet:
             self._address, self._internal_key = create_deterministic_address_bcrt1_p2tr_op_true()
             self._scriptPubKey = bytes.fromhex(self._test_node.validateaddress(self._address)['scriptPubKey'])
 
+    def _create_utxo(self, *, txid, vout, value, height):
+        return {"txid": txid, "vout": vout, "value": value, "height": height}
+
     def get_balance(self):
         return sum(u['value'] for u in self._utxos)
 
@@ -110,13 +113,13 @@ class MiniWallet:
         res = self._test_node.scantxoutset(action="start", scanobjects=[self.get_descriptor()])
         assert_equal(True, res['success'])
         for utxo in res['unspents']:
-            self._utxos.append({'txid': utxo['txid'], 'vout': utxo['vout'], 'value': utxo['amount'], 'height': utxo['height']})
+            self._utxos.append(self._create_utxo(txid=utxo["txid"], vout=utxo["vout"], value=utxo["amount"], height=utxo["height"]))
 
     def scan_tx(self, tx):
         """Scan the tx for self._scriptPubKey outputs and add them to self._utxos"""
         for out in tx['vout']:
             if out['scriptPubKey']['hex'] == self._scriptPubKey.hex():
-                self._utxos.append({'txid': tx['txid'], 'vout': out['n'], 'value': out['value'], 'height': 0})
+                self._utxos.append(self._create_utxo(txid=tx["txid"], vout=out["n"], value=out["value"], height=0))
 
     def sign_tx(self, tx, fixed_length=True):
         """Sign tx that has been created by MiniWallet in P2PK mode"""
@@ -140,7 +143,7 @@ class MiniWallet:
         for b in blocks:
             block_info = self._test_node.getblock(blockhash=b, verbosity=2)
             cb_tx = block_info['tx'][0]
-            self._utxos.append({'txid': cb_tx['txid'], 'vout': 0, 'value': cb_tx['vout'][0]['value'], 'height': block_info['height']})
+            self._utxos.append(self._create_utxo(txid=cb_tx["txid"], vout=0, value=cb_tx["vout"][0]["value"], height=block_info["height"]))
         return blocks
 
     def get_scriptPubKey(self):
@@ -264,12 +267,12 @@ class MiniWallet:
             vsize = Decimal(168)  # P2PK (73 bytes scriptSig + 35 bytes scriptPubKey + 60 bytes other)
         else:
             assert False
-        send_value = int(COIN * (utxo_to_spend['value'] - fee_rate * (vsize / 1000)))
+        send_value = utxo_to_spend["value"] - (fee_rate * vsize / 1000)
         assert send_value > 0
 
         tx = CTransaction()
         tx.vin = [CTxIn(COutPoint(int(utxo_to_spend['txid'], 16), utxo_to_spend['vout']), nSequence=sequence)]
-        tx.vout = [CTxOut(send_value, self._scriptPubKey)]
+        tx.vout = [CTxOut(int(COIN * send_value), self._scriptPubKey)]
         tx.nLockTime = locktime
         if self._mode == MiniWalletMode.RAW_P2PK:
             self.sign_tx(tx)
@@ -283,8 +286,9 @@ class MiniWallet:
         tx_hex = tx.serialize().hex()
 
         assert_equal(tx.get_vsize(), vsize)
+        new_utxo = self._create_utxo(txid=tx.rehash(), vout=0, value=send_value, height=0)
 
-        return {'txid': tx.rehash(), 'wtxid': tx.getwtxid(), 'hex': tx_hex, 'tx': tx}
+        return {"txid": new_utxo["txid"], "wtxid": tx.getwtxid(), "hex": tx_hex, "tx": tx, "new_utxo": new_utxo}
 
     def sendrawtransaction(self, *, from_node, tx_hex, maxfeerate=0, **kwargs):
         txid = from_node.sendrawtransaction(hexstring=tx_hex, maxfeerate=maxfeerate, **kwargs)


### PR DESCRIPTION
I need this for some stuff, but it also makes sense on its own to:

* unify the flow with a private `_create_utxo` helper
* simplify the flow by giving the caller ownership of the utxo right away