### PR TITLE
p2p: Set CNode::m_relays_txs=true when receiving BIP37 filters

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4075,6 +4075,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                 tx_relay->m_relay_txs = true;
             }
             pfrom.m_bloom_filter_loaded = true;
+            pfrom.m_relays_txs = true;
         }
         return;
     }


### PR DESCRIPTION
This line was accidentally removed in https://github.com/bitcoin/bitcoin/pull/22778.

Receiving a `filterload` message implies that we should relay txs to the sender (`CNode::m_relays_txs = true`). `CNode::m_relays_txs` is only used for the inbound eviction logic, so removing the line might have slightly changed the eviction behaviour but nothing else.