### PR TITLE
fuzz: add low-level target for txorphanage

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -46,6 +46,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
           " src/policy/settings.cpp"\
           " src/rpc/fees.cpp"\
           " src/rpc/signmessage.cpp"\
+          " src/test/fuzz/txorphan.cpp"\
           " -p . ${MAKEJOBS} -- -Xiwyu --cxx17ns -Xiwyu --mapping_file=${BASE_BUILD_DIR}/bitcoin-$HOST/contrib/devtools/iwyu/bitcoin.core.imp"
 fi
 

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -325,6 +325,7 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/tx_in.cpp \
  test/fuzz/tx_out.cpp \
  test/fuzz/tx_pool.cpp \
+ test/fuzz/txorphan.cpp \
  test/fuzz/txrequest.cpp \
  test/fuzz/utxo_snapshot.cpp \
  test/fuzz/validation_load_mempool.cpp \

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -1,0 +1,143 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <consensus/amount.h>
+#include <net.h>
+#include <net_processing.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <sync.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/setup_common.h>
+#include <txorphanage.h>
+#include <uint256.h>
+#include <util/check.h>
+#include <util/time.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <set>
+#include <utility>
+#include <vector>
+
+void initialize_orphanage()
+{
+    static const auto testing_setup = MakeNoLogFileContext();
+}
+
+FUZZ_TARGET_INIT(txorphan, initialize_orphanage)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    SetMockTime(ConsumeTime(fuzzed_data_provider));
+
+    TxOrphanage orphanage;
+    std::set<uint256> orphan_work_set;
+    std::vector<COutPoint> outpoints;
+    // initial outpoints used to construct transactions later
+    for (uint8_t i = 0; i < 4; i++) {
+        outpoints.emplace_back(uint256{i}, 0);
+    }
+    // if true, allow duplicate input when constructing tx
+    const bool duplicate_input = fuzzed_data_provider.ConsumeBool();
+
+    LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10 * DEFAULT_MAX_ORPHAN_TRANSACTIONS)
+    {
+        // construct transaction
+        const CTransactionRef tx = [&] {
+            CMutableTransaction tx_mut;
+            const auto num_in = fuzzed_data_provider.ConsumeIntegralInRange<uint32_t>(1, outpoints.size());
+            const auto num_out = fuzzed_data_provider.ConsumeIntegralInRange<uint32_t>(1, outpoints.size());
+            // pick unique outpoints from outpoints as input
+            for (uint32_t i = 0; i < num_in; i++) {
+                auto& prevout = PickValue(fuzzed_data_provider, outpoints);
+                tx_mut.vin.emplace_back(prevout);
+                // pop the picked outpoint if duplicate input is not allowed
+                if (!duplicate_input) {
+                    std::swap(prevout, outpoints.back());
+                    outpoints.pop_back();
+                }
+            }
+            // output amount will not affect txorphanage
+            for (uint32_t i = 0; i < num_out; i++) {
+                tx_mut.vout.emplace_back(CAmount{0}, CScript{});
+            }
+            // restore previously poped outpoints
+            for (auto& in : tx_mut.vin) {
+                outpoints.push_back(in.prevout);
+            }
+            const auto new_tx = MakeTransactionRef(tx_mut);
+            // add newly constructed transaction to outpoints
+            for (uint32_t i = 0; i < num_out; i++) {
+                outpoints.emplace_back(new_tx->GetHash(), i);
+            }
+            return new_tx;
+        }();
+
+        // trigger orphanage functions
+        LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10 * DEFAULT_MAX_ORPHAN_TRANSACTIONS)
+        {
+            NodeId peer_id = fuzzed_data_provider.ConsumeIntegral<NodeId>();
+
+            CallOneOf(
+                fuzzed_data_provider,
+                [&] {
+                    LOCK(g_cs_orphans);
+                    orphanage.AddChildrenToWorkSet(*tx, orphan_work_set);
+                },
+                [&] {
+                    bool have_tx = orphanage.HaveTx(GenTxid::Txid(tx->GetHash())) || orphanage.HaveTx(GenTxid::Wtxid(tx->GetHash()));
+                    {
+                        LOCK(g_cs_orphans);
+                        bool get_tx = orphanage.GetTx(tx->GetHash()).first != nullptr;
+                        Assert(have_tx == get_tx);
+                    }
+                },
+                [&] {
+                    bool have_tx = orphanage.HaveTx(GenTxid::Txid(tx->GetHash())) || orphanage.HaveTx(GenTxid::Wtxid(tx->GetHash()));
+                    // AddTx should return false if tx is too big or already have it
+                    {
+                        LOCK(g_cs_orphans);
+                        Assert(have_tx != orphanage.AddTx(tx, peer_id));
+                    }
+                    have_tx = orphanage.HaveTx(GenTxid::Txid(tx->GetHash())) || orphanage.HaveTx(GenTxid::Wtxid(tx->GetHash()));
+                    // tx should already be added since it will not be too big in the test
+                    // have_tx should be true and AddTx should fail
+                    {
+                        LOCK(g_cs_orphans);
+                        Assert(have_tx && !orphanage.AddTx(tx, peer_id));
+                    }
+                },
+                [&] {
+                    bool have_tx = orphanage.HaveTx(GenTxid::Txid(tx->GetHash())) || orphanage.HaveTx(GenTxid::Wtxid(tx->GetHash()));
+                    // EraseTx should return 0 if m_orphans doesn't have the tx
+                    {
+                        LOCK(g_cs_orphans);
+                        Assert(have_tx == orphanage.EraseTx(tx->GetHash()));
+                    }
+                    have_tx = orphanage.HaveTx(GenTxid::Txid(tx->GetHash())) || orphanage.HaveTx(GenTxid::Wtxid(tx->GetHash()));
+                    // have_tx should be false and EraseTx should fail
+                    {
+                        LOCK(g_cs_orphans);
+                        Assert(!have_tx && !orphanage.EraseTx(tx->GetHash()));
+                    }
+                },
+                [&] {
+                    LOCK(g_cs_orphans);
+                    orphanage.EraseForPeer(peer_id);
+                },
+                [&] {
+                    // test mocktime and expiry
+                    SetMockTime(ConsumeTime(fuzzed_data_provider));
+                    auto size_before = orphanage.Size();
+                    auto limit = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+                    auto n_evicted = WITH_LOCK(g_cs_orphans, return orphanage.LimitOrphans(limit));
+                    Assert(size_before - n_evicted <= limit);
+                    Assert(orphanage.Size() <= limit);
+                });
+        }
+    }
+}


### PR DESCRIPTION
This adds a low-level fuzz target for orphan transaction handling by creating random transactions and calling all functions in `TxOrphanage`.
It cannot simulate real-world `orphan/unorphan` scenarios effectively since it does not maintain any state about the node and the chain. A high-level fuzz target which construct well-designed transaction graphs will be added later.