### PR TITLE
ci: Update Windows task image up to `visualstudio2022`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -180,7 +180,7 @@ task:
     - '%x64_NATIVE_TOOLS%'
     - cd %CIRRUS_WORKING_DIR%
     - ccache --zero-stats --max-size=%CCACHE_SIZE%
-    - python build_msvc\msvc-autogen.py -toolset v143
+    - python build_msvc\msvc-autogen.py
     - msbuild build_msvc\bitcoin.sln -property:CLToolExe=%WRAPPED_CL% -property:Configuration=Release -maxCpuCount -verbosity:minimal -noLogo
     - ccache --show-stats
   unit_tests_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -97,7 +97,7 @@ task:
   name: "Win64 native [vs2022]"
   << : *FILTER_TEMPLATE
   windows_container:
-    cpu: 4
+    cpu: 6
     memory: 8G
     image: cirrusci/windowsservercore:visualstudio2022
   timeout_in: 120m

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -104,7 +104,7 @@ task:
   env:
     PATH: 'C:\jom;C:\Python39;C:\Python39\Scripts;C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin;%PATH%'
     PYTHONUTF8: 1
-    CI_VCPKG_TAG: '2022.04.12'
+    CI_VCPKG_TAG: '2022.06.16.1'
     VCPKG_DOWNLOADS: 'C:\Users\ContainerAdministrator\AppData\Local\vcpkg\downloads'
     VCPKG_DEFAULT_BINARY_CACHE: 'C:\Users\ContainerAdministrator\AppData\Local\vcpkg\archives'
     CCACHE_DIR: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -94,15 +94,15 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_native_tidy.sh"
 
 task:
-  name: "Win64 native [msvc]"
+  name: "Win64 native [vs2022]"
   << : *FILTER_TEMPLATE
   windows_container:
     cpu: 4
     memory: 8G
-    image: cirrusci/windowsservercore:visualstudio2019
+    image: cirrusci/windowsservercore:visualstudio2022
   timeout_in: 120m
   env:
-    PATH: 'C:\jom;C:\Python39;C:\Python39\Scripts;C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin;%PATH%'
+    PATH: 'C:\jom;C:\Python39;C:\Python39\Scripts;C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin;%PATH%'
     PYTHONUTF8: 1
     CI_VCPKG_TAG: '2022.04.12'
     VCPKG_DOWNLOADS: 'C:\Users\ContainerAdministrator\AppData\Local\vcpkg\downloads'
@@ -113,7 +113,7 @@ task:
     QT_LOCAL_PATH: 'C:\qt-everywhere-opensource-src-5.15.3.zip'
     QT_SOURCE_DIR: 'C:\qt-everywhere-src-5.15.3'
     QTBASEDIR: 'C:\Qt_static'
-    x64_NATIVE_TOOLS: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"'
+    x64_NATIVE_TOOLS: '"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"'
     QT_CONFIGURE_COMMAND: '..\configure -release -silent -opensource -confirm-license -opengl desktop -static -static-runtime -mp -qt-zlib -qt-pcre -qt-libpng -nomake examples -nomake tests -nomake tools -no-angle -no-dbus -no-gif -no-gtk -no-ico -no-icu -no-libjpeg -no-libudev -no-sql-sqlite -no-sql-odbc -no-sqlite -no-vulkan -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtconnectivity -skip qtdatavis3d -skip qtdeclarative -skip doc -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtlottie -skip qtmacextras -skip qtmultimedia -skip qtnetworkauth -skip qtpurchasing -skip qtquick3d -skip qtquickcontrols -skip qtquickcontrols2 -skip qtquicktimeline -skip qtremoteobjects -skip qtscript -skip qtscxml -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtsvg -skip qtvirtualkeyboard -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin -skip qtwebsockets -skip qtwebview -skip qtx11extras -skip qtxmlpatterns -no-openssl -no-feature-bearermanagement -no-feature-printdialog -no-feature-printer -no-feature-printpreviewdialog -no-feature-printpreviewwidget -no-feature-sql -no-feature-sqlmodel -no-feature-textbrowser -no-feature-textmarkdownwriter -no-feature-textodfwriter -no-feature-xml'
     IgnoreWarnIntDirInTempDetected: 'true'
   merge_script:
@@ -180,7 +180,7 @@ task:
     - '%x64_NATIVE_TOOLS%'
     - cd %CIRRUS_WORKING_DIR%
     - ccache --zero-stats
-    - python build_msvc\msvc-autogen.py
+    - python build_msvc\msvc-autogen.py -toolset v143
     - msbuild build_msvc\bitcoin.sln -property:CLToolExe=%WRAPPED_CL% -property:Configuration=Release -maxCpuCount -verbosity:minimal -noLogo
     - ccache --show-stats
   unit_tests_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -179,7 +179,7 @@ task:
   build_script:
     - '%x64_NATIVE_TOOLS%'
     - cd %CIRRUS_WORKING_DIR%
-    - ccache --zero-stats
+    - ccache --zero-stats --max-size=%CCACHE_SIZE%
     - python build_msvc\msvc-autogen.py -toolset v143
     - msbuild build_msvc\bitcoin.sln -property:CLToolExe=%WRAPPED_CL% -property:Configuration=Release -maxCpuCount -verbosity:minimal -noLogo
     - ccache --show-stats

--- a/build_msvc/README.md
+++ b/build_msvc/README.md
@@ -3,7 +3,7 @@ Building Bitcoin Core with Visual Studio
 
 Introduction
 ---------------------
-Solution and project files to build Bitcoin Core with `msbuild` or Visual Studio can be found in the `build_msvc` directory. The build has been tested with Visual Studio 2019 (building with earlier versions of Visual Studio should not be expected to work).
+Solution and project files to build Bitcoin Core with `msbuild` or Visual Studio can be found in the `build_msvc` directory. The build has been tested with Visual Studio 2022 and Visual Studio 2019 (building with earlier versions of Visual Studio should not be expected to work).
 
 To build Bitcoin Core from the command-line, it is sufficient to only install the Visual Studio Build Tools component.
 
@@ -30,7 +30,7 @@ To build Bitcoin Core with the GUI, a static build of Qt is required.
 
 1. Download a single ZIP archive of Qt source code from https://download.qt.io/official_releases/qt/ (e.g., [`qt-everywhere-opensource-src-5.15.3.zip`](https://download.qt.io/official_releases/qt/5.15/5.15.3/single/qt-everywhere-opensource-src-5.15.3.zip)), and expand it into a dedicated folder. The following instructions assume that this folder is `C:\dev\qt-source`.
 
-2. Open "x64 Native Tools Command Prompt for VS 2019", and input the following commands:
+2. Open "x64 Native Tools Command Prompt for VS 2022", and input the following commands:
 ```cmd
 cd C:\dev\qt-source
 mkdir build
@@ -47,21 +47,21 @@ To build Bitcoin Core without Qt, unload or disable the `bitcoin-qt`, `libbitcoi
 
 Building
 ---------------------
-1. Use Python to generate `*.vcxproj` from Makefile:
+1. Use Python to generate `*.vcxproj` for the Visual Studio 2022 toolchain from Makefile:
 
-```
-PS >py -3 msvc-autogen.py
+```cmd
+python build_msvc\msvc-autogen.py -toolset v143
 ```
 
 2. An optional step is to adjust the settings in the `build_msvc` directory and the `common.init.vcxproj` file. This project file contains settings that are common to all projects such as the runtime library version and target Windows SDK version. The Qt directories can also be set. To specify a non-default path to a static Qt package directory, use the `QTBASEDIR` environment variable.
 
-3. To build from the command-line with the Visual Studio 2019 toolchain use:
+3. To build from the command-line with the Visual Studio toolchain use:
 
 ```cmd
-msbuild -property:Configuration=Release -maxCpuCount -verbosity:minimal bitcoin.sln
+msbuild build_msvc\bitcoin.sln -property:Configuration=Release -maxCpuCount -verbosity:minimal
 ```
 
-Alternatively, open the `build_msvc/bitcoin.sln` file in Visual Studio 2019.
+Alternatively, open the `build_msvc/bitcoin.sln` file in Visual Studio.
 
 Security
 ---------------------

--- a/build_msvc/README.md
+++ b/build_msvc/README.md
@@ -50,7 +50,7 @@ Building
 1. Use Python to generate `*.vcxproj` for the Visual Studio 2022 toolchain from Makefile:
 
 ```cmd
-python build_msvc\msvc-autogen.py -toolset v143
+python build_msvc\msvc-autogen.py
 ```
 
 2. An optional step is to adjust the settings in the `build_msvc` directory and the `common.init.vcxproj` file. This project file contains settings that are common to all projects such as the runtime library version and target Windows SDK version. The Qt directories can also be set. To specify a non-default path to a static Qt package directory, use the `QTBASEDIR` environment variable.

--- a/build_msvc/msvc-autogen.py
+++ b/build_msvc/msvc-autogen.py
@@ -9,7 +9,7 @@ import argparse
 from shutil import copyfile
 
 SOURCE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
-DEFAULT_PLATFORM_TOOLSET = R'v142'
+DEFAULT_PLATFORM_TOOLSET = R'v143'
 
 libs = [
     'libbitcoin_cli',
@@ -93,7 +93,7 @@ def set_properties(vcxproj_filename, placeholder, content):
 def main():
     parser = argparse.ArgumentParser(description='Bitcoin-core msbuild configuration initialiser.')
     parser.add_argument('-toolset', nargs='?', default=DEFAULT_PLATFORM_TOOLSET,
-        help='Optionally sets the msbuild platform toolset, e.g. v142 for Visual Studio 2019.'
+        help='Optionally sets the msbuild platform toolset, e.g. v142 for Visual Studio 2019, or v143 for Visual Studio 2022.'
          ' default is %s.'%DEFAULT_PLATFORM_TOOLSET)
     args = parser.parse_args()
     set_properties(os.path.join(SOURCE_DIR, '../build_msvc/common.init.vcxproj'), '@TOOLSET@', args.toolset)


### PR DESCRIPTION
Besides upgrading Visual Studio, which seems [inevitable](https://github.com/bitcoin/bitcoin/pull/24531#discussion_r887854193), this PR also:
- bumps vcpkg to the latest version (previous one was in bitcoin/bitcoin#24847)
- fixes cache size limit for `ccache`