### PR TITLE
test: test RBF rule 3

### DIFF
--- a/test/functional/test_framework/script_util.py
+++ b/test/functional/test_framework/script_util.py
@@ -36,6 +36,8 @@ from test_framework.script import (
 # met.
 DUMMY_P2WPKH_SCRIPT = CScript([b'a' * 21])
 DUMMY_2_P2WPKH_SCRIPT = CScript([b'b' * 21])
+DUMMY_P2PKH_SCRIPT = CScript([
+    OP_DUP, OP_HASH160, b'0' * 40, OP_EQUALVERIFY, OP_CHECKSIG])
 
 
 def key_to_p2pk_script(key):


### PR DESCRIPTION
Somewhat surprisingly, [RBF rule 3](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki#implementation-details) (absolute fees of replacement transaction must meet or exceed original) is untested. 

In other words, applying the following patch:

```diff
diff --git a/src/policy/rbf.cpp b/src/policy/rbf.cpp
index e25f5c7c5b..e4f2d9d728 100644
--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -162,14 +162,6 @@ std::optional<std::string> PaysForRBF(CAmount original_fees,
                                       CFeeRate relay_fee,
                                       const uint256& txid)
 {
-    // BIP125 Rule #3: The replacement fees must be greater than or equal to fees of the
-    // transactions it replaces, otherwise the bandwidth used by those conflicting transactions
-    // would not be paid for.
-    if (replacement_fees < original_fees) {
-        return strprintf("rejecting replacement %s, less fees than conflicting txs; %s < %s",
-                         txid.ToString(), FormatMoney(replacement_fees), FormatMoney(original_fees));
-    }
-
     // BIP125 Rule #4: The new transaction must pay for its own bandwidth. Otherwise, we have a DoS
     // vector where attackers can cause a transaction to be replaced (and relayed) repeatedly by
     // increasing the fee by tiny amounts.
```
then recompiling and running the full test suite causes no failures.
 
This is sort of a moot point, because the check following the removed check (rule 4 following rule 3) implicitly requires the absolute fee of the replacement to exceed the original. So effectively, you can't violate rule 3 even if its code is removed.

But still, it seems like we should probably explicitly test for the enforcement of rule 3. This test creates a failure when the above patch is applied.