### PR TITLE
build: remove boost library detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2004,14 +2004,6 @@ CPPFLAGS_TEMP="$CPPFLAGS"
 unset CPPFLAGS
 CPPFLAGS="$CPPFLAGS_TEMP"
 
-LDFLAGS_TEMP="$LDFLAGS"
-unset LDFLAGS
-LDFLAGS="$LDFLAGS_TEMP"
-
-LIBS_TEMP="$LIBS"
-unset LIBS
-LIBS="$LIBS_TEMP"
-
 ac_configure_args="${ac_configure_args} --disable-shared --with-pic --enable-benchmark=no --enable-module-recovery --disable-module-ecdh"
 AC_CONFIG_SUBDIRS([src/secp256k1])
 


### PR DESCRIPTION
We no longer link against any Boost libraries, so don't need to detect them, or set any Boost related LDFLAGS. Removing this from the macro also allows cleaning up some code in our configure.

Guix Build:
```bash
e1ca070d085115767415121f3be8d8fa29547c9df633f9782b168a00753e995a  guix-build-db648e8ccc69/output/aarch64-linux-gnu/SHA256SUMS.part
fb4d229a71d64aef9de4a0301fad3d9ee5937025807a0e101f4cc0e20cf942b2  guix-build-db648e8ccc69/output/aarch64-linux-gnu/bitcoin-db648e8ccc69-aarch64-linux-gnu-debug.tar.gz
5241bb543617df5e64584741b402117a3b9e7015a423507fd6c529ad397b13a5  guix-build-db648e8ccc69/output/aarch64-linux-gnu/bitcoin-db648e8ccc69-aarch64-linux-gnu.tar.gz
eb4ba0914e9a38b3804c062ffd47f4d49dc996ea249c5cdbf64a349f73f59555  guix-build-db648e8ccc69/output/arm-linux-gnueabihf/SHA256SUMS.part
497d1c0d03d52cc6469acf4c61f224e7567c2601b64df3fe5888374e3416d868  guix-build-db648e8ccc69/output/arm-linux-gnueabihf/bitcoin-db648e8ccc69-arm-linux-gnueabihf-debug.tar.gz
86daab76f41581b752a5a786c5be1b094c14b25cdc8f4090f323b914118884ff  guix-build-db648e8ccc69/output/arm-linux-gnueabihf/bitcoin-db648e8ccc69-arm-linux-gnueabihf.tar.gz
e8e2c58948a29b0286d17d7dfb89c81234ab28b98f44c2e1d70034da5ce9b8fc  guix-build-db648e8ccc69/output/arm64-apple-darwin/SHA256SUMS.part
d8f0e791cce42db0741afbb7ec23e251a40ec30f8e1e7fef0d1afc364ce32e9b  guix-build-db648e8ccc69/output/arm64-apple-darwin/bitcoin-db648e8ccc69-arm64-apple-darwin-unsigned.dmg
ee85b5b7942dc3361a3b05a395e271d54215f76fb67fc3c30144b089da374cd7  guix-build-db648e8ccc69/output/arm64-apple-darwin/bitcoin-db648e8ccc69-arm64-apple-darwin-unsigned.tar.gz
72efbe40e3d033165871a8e8b4719c73a085ffc17a3198bf1191e5d22dec8c3a  guix-build-db648e8ccc69/output/arm64-apple-darwin/bitcoin-db648e8ccc69-arm64-apple-darwin.tar.gz
0d86d3a303669235b91b4edbd6a5248dff65e31af3f3830cc8bdc116a2637e64  guix-build-db648e8ccc69/output/dist-archive/bitcoin-db648e8ccc69.tar.gz
0f2371e331d97df50c65714ada6918565d8698637a78c7c97ba254dd5b3cc4b3  guix-build-db648e8ccc69/output/powerpc64-linux-gnu/SHA256SUMS.part
1447777f7adababc6fddad3349ac435744abef35cd30b673c62621718441ca01  guix-build-db648e8ccc69/output/powerpc64-linux-gnu/bitcoin-db648e8ccc69-powerpc64-linux-gnu-debug.tar.gz
3bf1e90df4d7fab18159ffd039dd1fa7e5251b0bdca020afd851fb7cd189cfd2  guix-build-db648e8ccc69/output/powerpc64-linux-gnu/bitcoin-db648e8ccc69-powerpc64-linux-gnu.tar.gz
67ebc32843eb83a08468496c24750ab56bfdb259eb9004732be13427da5dbbc1  guix-build-db648e8ccc69/output/powerpc64le-linux-gnu/SHA256SUMS.part
0da5fad78ab854f62db57a2f44b6ffecbf2b3e9de34b81681c66e28100a209ae  guix-build-db648e8ccc69/output/powerpc64le-linux-gnu/bitcoin-db648e8ccc69-powerpc64le-linux-gnu-debug.tar.gz
e96a41287040d13da4738dde43dd7283356b8af10b535b15b212da702aa7f0af  guix-build-db648e8ccc69/output/powerpc64le-linux-gnu/bitcoin-db648e8ccc69-powerpc64le-linux-gnu.tar.gz
b54a48e03e76672008445a174078e92a149dd9e4ce0c896b013162a6221b3abe  guix-build-db648e8ccc69/output/riscv64-linux-gnu/SHA256SUMS.part
b7fea8fe4c1baecff28c45fa514ec34338a7f0e04a7f58b8cb5493932242c221  guix-build-db648e8ccc69/output/riscv64-linux-gnu/bitcoin-db648e8ccc69-riscv64-linux-gnu-debug.tar.gz
775d406d4a2b1fa1750ae1924cf2f67de7d89dbf0044dc7ab08d3908812fff2e  guix-build-db648e8ccc69/output/riscv64-linux-gnu/bitcoin-db648e8ccc69-riscv64-linux-gnu.tar.gz
a1dcd8c95517e8b98d8584eed00b561582b74a68a1b3d06efd86d5322186b21e  guix-build-db648e8ccc69/output/x86_64-apple-darwin/SHA256SUMS.part
952ea47428b9bcadb809fb02a56347a9f8b29f09eba4edf67a157f7cc4ec9a57  guix-build-db648e8ccc69/output/x86_64-apple-darwin/bitcoin-db648e8ccc69-x86_64-apple-darwin-unsigned.dmg
adb226a702e24962d263edf2e95100508d6728b4dd93a5d6098c37a5721c2bcc  guix-build-db648e8ccc69/output/x86_64-apple-darwin/bitcoin-db648e8ccc69-x86_64-apple-darwin-unsigned.tar.gz
fd389c11cce919c53e4aeccb0e5d1ee1d12b1d9f6987a3317c4b254c3ca03387  guix-build-db648e8ccc69/output/x86_64-apple-darwin/bitcoin-db648e8ccc69-x86_64-apple-darwin.tar.gz
c76314a9194733790533bbfefa7e6a234307aaa252989c2b3fd19191ae286c57  guix-build-db648e8ccc69/output/x86_64-linux-gnu/SHA256SUMS.part
5e2b023b62b77709f30d545705a61826e96ddcfea4c24cde83fe2b98010262e1  guix-build-db648e8ccc69/output/x86_64-linux-gnu/bitcoin-db648e8ccc69-x86_64-linux-gnu-debug.tar.gz
a3e9dcb58aa8554cdeb211461976087b724cd81157517a9f1e00b1a73d74ab9b  guix-build-db648e8ccc69/output/x86_64-linux-gnu/bitcoin-db648e8ccc69-x86_64-linux-gnu.tar.gz
d6733313b8f262b214c28d44d8ee644a2435cb4da90555b30e20dbf3807b6660  guix-build-db648e8ccc69/output/x86_64-w64-mingw32/SHA256SUMS.part
bc4b269f5b89200537d7175492ae31ab87eb4a1da86c1ade968a7bbdc472c5bf  guix-build-db648e8ccc69/output/x86_64-w64-mingw32/bitcoin-db648e8ccc69-win64-debug.zip
ccd83eb4c9ab0df288935ab655cd71b00525b57f82c8b9d7a4d1a08325d26aac  guix-build-db648e8ccc69/output/x86_64-w64-mingw32/bitcoin-db648e8ccc69-win64-setup-unsigned.exe
91ee20dfbaa923066379ea22f3e3a85a52f5b323877b44c19ccec6300d25cd41  guix-build-db648e8ccc69/output/x86_64-w64-mingw32/bitcoin-db648e8ccc69-win64-unsigned.tar.gz
595baf193e0955436c4f2e5047e6842434bb4273b03c9d74e5c90972dde812f4  guix-build-db648e8ccc69/output/x86_64-w64-mingw32/bitcoin-db648e8ccc69-win64.zip
```