### PR TITLE
ci: add unused-using-decls to clang-tidy

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,12 +1,14 @@
 Checks: '
 -*,
 bugprone-argument-comment,
+misc-unused-using-decls,
 modernize-use-default-member-init,
 modernize-use-nullptr,
 readability-redundant-declaration,
 '
 WarningsAsErrors: '
 bugprone-argument-comment,
+misc-unused-using-decls,
 modernize-use-default-member-init,
 modernize-use-nullptr,
 readability-redundant-declaration,

--- a/src/bench/wallet_loading.cpp
+++ b/src/bench/wallet_loading.cpp
@@ -19,8 +19,6 @@
 using wallet::CWallet;
 using wallet::DatabaseFormat;
 using wallet::DatabaseOptions;
-using wallet::ISMINE_SPENDABLE;
-using wallet::MakeWalletDatabase;
 using wallet::TxStateInactive;
 using wallet::WALLET_FLAG_DESCRIPTORS;
 using wallet::WalletContext;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -110,7 +110,6 @@ using node::CacheSizes;
 using node::CalculateCacheSizes;
 using node::ChainstateLoadVerifyError;
 using node::ChainstateLoadingError;
-using node::CleanupBlockRevFiles;
 using node::DEFAULT_PERSIST_MEMPOOL;
 using node::DEFAULT_PRINTPRIORITY;
 using node::DEFAULT_STOPAFTERBLOCKIMPORT;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -77,8 +77,6 @@ Q_DECLARE_METATYPE(CAmount)
 Q_DECLARE_METATYPE(SynchronizationState)
 Q_DECLARE_METATYPE(uint256)
 
-using node::NodeContext;
-
 static void RegisterMetaTypes()
 {
     // Register meta types used for QMetaObject::invokeMethod and Qt::QueuedConnection

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -43,8 +43,6 @@ Q_IMPORT_PLUGIN(QAndroidPlatformIntegrationPlugin)
 #endif
 #endif
 
-using node::NodeContext;
-
 const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
 
 const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS{};

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -25,7 +25,6 @@ using kernel::DumpMempool;
 
 using node::DEFAULT_MAX_RAW_TX_FEE_RATE;
 using node::MempoolPath;
-using node::ShouldPersistMempool;
 using node::NodeContext;
 
 static RPCHelpMan sendrawtransaction()

--- a/src/rpc/output_script.cpp
+++ b/src/rpc/output_script.cpp
@@ -26,11 +26,6 @@
 #include <tuple>
 #include <vector>
 
-namespace node {
-struct NodeContext;
-}
-using node::NodeContext;
-
 static RPCHelpMan validateaddress()
 {
     return RPCHelpMan{

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -46,12 +46,10 @@
 #include <univalue.h>
 
 using node::AnalyzePSBT;
-using node::BroadcastTransaction;
 using node::FindCoins;
 using node::GetTransaction;
 using node::NodeContext;
 using node::PSBTAnalysis;
-using node::ReadBlockFromDisk;
 
 static void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry, CChainState& active_chainstate)
 {

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -13,9 +13,6 @@
 
 #include <chrono>
 
-using kernel::CCoinsStats;
-using kernel::CoinStatsHashType;
-
 BOOST_AUTO_TEST_SUITE(coinstatsindex_tests)
 
 static void IndexWaitSynced(BaseIndex& index)

--- a/src/test/miniscript_tests.cpp
+++ b/src/test/miniscript_tests.cpp
@@ -120,6 +120,8 @@ struct KeyConverter {
 //! Singleton instance of KeyConverter.
 const KeyConverter CONVERTER{};
 
+// https://github.com/llvm/llvm-project/issues/53444
+// NOLINTNEXTLINE(misc-unused-using-decls)
 using miniscript::operator"" _mst;
 
 enum TestMode : int {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -69,7 +69,6 @@ using kernel::ComputeUTXOStats;
 using kernel::LoadMempool;
 
 using fsbridge::FopenFn;
-using node::BLOCKFILE_CHUNK_SIZE;
 using node::BlockManager;
 using node::BlockMap;
 using node::CBlockIndexHeightOnlyComparator;
@@ -77,11 +76,8 @@ using node::CBlockIndexWorkComparator;
 using node::fImporting;
 using node::fPruneMode;
 using node::fReindex;
-using node::nPruneTarget;
-using node::OpenBlockFile;
 using node::ReadBlockFromDisk;
 using node::SnapshotMetadata;
-using node::UNDOFILE_CHUNK_SIZE;
 using node::UndoReadFromDisk;
 using node::UnlinkPrunedFiles;
 


### PR DESCRIPTION
Adds https://clang.llvm.org/extra/clang-tidy/checks/misc/unused-using-decls.html to our clang-tidy.
PR'd after the discussion in #25433 (which it includes).