### PR TITLE
Revert "ci: Increase CPU number for "Win64 native" task"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -97,7 +97,7 @@ task:
   name: "Win64 native [vs2022]"
   << : *FILTER_TEMPLATE
   windows_container:
-    cpu: 6
+    cpu: 4
     memory: 8G
     image: cirrusci/windowsservercore:visualstudio2022
   timeout_in: 120m


### PR DESCRIPTION
This reverts commit 849cf967a3bb69db9431e993e03b6dbb04a99d8b.

It seems this should [improve](https://github.com/bitcoin/bitcoin/pull/25460#discussion_r907268911) the total CI throughput.