### PR TITLE
Guix: enable toolchain hardening by default

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -136,7 +136,7 @@ chain for " target " development."))
                                        #:key
                                        (base-gcc-for-libc base-gcc)
                                        (base-kernel-headers base-linux-kernel-headers)
-                                       (base-libc (make-glibc-without-werror glibc-2.24))
+                                       (base-libc (make-glibc-with-bind-now (make-glibc-without-werror glibc-2.24)))
                                        (base-gcc (make-gcc-rpath-link base-gcc)))
   "Convenience wrapper around MAKE-CROSS-TOOLCHAIN with default values
 desirable for building Bitcoin Core release binaries."
@@ -523,6 +523,9 @@ inspecting signatures in Mach-O binaries.")
 (define (make-glibc-with-stack-protector glibc)
   (package-with-extra-configure-variable glibc "--enable-stack-protector" "all"))
 
+(define (make-glibc-with-bind-now glibc)
+  (package-with-extra-configure-variable glibc "--enable-bind-now" "yes"))
+
 (define-public glibc-2.24
   (package
     (inherit glibc-2.31)
@@ -610,7 +613,8 @@ inspecting signatures in Mach-O binaries.")
           ((string-contains target "-linux-")
            (list (cond ((string-contains target "riscv64-")
                         (make-bitcoin-cross-toolchain target
-                                                      #:base-libc (make-glibc-with-stack-protector (make-glibc-without-werror glibc-2.27/bitcoin-patched))))
+                                                      #:base-libc (make-glibc-with-stack-protector
+                                                        (make-glibc-with-bind-now (make-glibc-without-werror glibc-2.27/bitcoin-patched)))))
                        (else
                         (make-bitcoin-cross-toolchain target)))))
           ((string-contains target "darwin")

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -520,6 +520,9 @@ inspecting signatures in Mach-O binaries.")
 (define (make-glibc-without-werror glibc)
   (package-with-extra-configure-variable glibc "enable_werror" "no"))
 
+(define (make-glibc-with-stack-protector glibc)
+  (package-with-extra-configure-variable glibc "--enable-stack-protector" "all"))
+
 (define-public glibc-2.24
   (package
     (inherit glibc-2.31)
@@ -607,7 +610,7 @@ inspecting signatures in Mach-O binaries.")
           ((string-contains target "-linux-")
            (list (cond ((string-contains target "riscv64-")
                         (make-bitcoin-cross-toolchain target
-                                                      #:base-libc (make-glibc-without-werror glibc-2.27/bitcoin-patched)))
+                                                      #:base-libc (make-glibc-with-stack-protector (make-glibc-without-werror glibc-2.27/bitcoin-patched))))
                        (else
                         (make-bitcoin-cross-toolchain target)))))
           ((string-contains target "darwin")

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -132,12 +132,19 @@ chain for " target " development."))
 (define base-gcc gcc-10)
 (define base-linux-kernel-headers linux-libre-headers-5.15)
 
+;; https://gcc.gnu.org/install/configure.html
+(define (hardened-gcc gcc)
+  (package-with-extra-configure-variable (
+    package-with-extra-configure-variable gcc
+    "--enable-default-ssp" "yes")
+    "--enable-default-pie" "yes"))
+
 (define* (make-bitcoin-cross-toolchain target
                                        #:key
                                        (base-gcc-for-libc base-gcc)
                                        (base-kernel-headers base-linux-kernel-headers)
                                        (base-libc (make-glibc-with-bind-now (make-glibc-without-werror glibc-2.24)))
-                                       (base-gcc (make-gcc-rpath-link base-gcc)))
+                                       (base-gcc (make-gcc-rpath-link (hardened-gcc base-gcc))))
   "Convenience wrapper around MAKE-CROSS-TOOLCHAIN with default values
 desirable for building Bitcoin Core release binaries."
   (make-cross-toolchain target


### PR DESCRIPTION
The GCC (10.3.0) and glibcs (2.24 and 2.27) we build both support configuration option for turning on hardening features by default.

For example, [our GCC provides](https://gcc.gnu.org/install/configure.html) `--enable-default-pie`:
> Turn on -fPIE and -pie by default.

`--enable-default-ssp`:
> Turn on -fstack-protector-strong by default.

and `--enable-cet` options:
> Enable building target run-time libraries with control-flow instrumentation, see -fcf-protection option.

It also provides `--enable-standard-branch-protection`, but we don't do that here, because we don't support building with it yet (#24123).

You could verify the that the on-by-default pie flags are working by Guix building master + this change:
```diff
--- a/configure.ac
+++ b/configure.ac
@@ -971,7 +971,6 @@ if test "$use_hardening" != "no"; then
   AX_CHECK_LINK_FLAG([-Wl,-z,relro], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,-z,relro"], [], [$LDFLAG_WERROR])
   AX_CHECK_LINK_FLAG([-Wl,-z,now], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,-z,now"], [], [$LDFLAG_WERROR])
   AX_CHECK_LINK_FLAG([-Wl,-z,separate-code], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,-z,separate-code"], [], [$LDFLAG_WERROR])
-  AX_CHECK_LINK_FLAG([-fPIE -pie], [PIE_FLAGS="-fPIE"; HARDENED_LDFLAGS="$HARDENED_LDFLAGS -pie"], [], [$CXXFLAG_WERROR])
 ```
and verifying that the `PIE` security checks fail. Then, build this PR branch, + the same change, and checking that they still pass.

A similar thing can be done with the stack-protector, i.e perform a Guix build, and observe the security checks failing after applying this diff to master:
```diff
--- a/configure.ac
+++ b/configure.ac
@@ -936,8 +936,6 @@ dnl -fstack-reuse=none for all gcc builds. (Only gcc understands this flag)
 AX_CHECK_COMPILE_FLAG([-fstack-reuse=none], [HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fstack-reuse=none"])
 if test "$use_hardening" != "no"; then
   use_hardening=yes
-  AX_CHECK_COMPILE_FLAG([-Wstack-protector], [HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -Wstack-protector"])
-  AX_CHECK_COMPILE_FLAG([-fstack-protector-all], [HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fstack-protector-all"])
```

Then check that a build doesn't fail when building this PR + that change. Although it should be noted that the security checks will pass for this + that change, even though the GCC option is for stack-protector-strong, rather than stack-protector-all. This is because our stack protector check is currently just for the presencse of the canary, and not a check that every function is instrumented.

[For glibc](https://www.gnu.org/software/libc/manual/html_node/Configuring-and-compiling.html), we enable `--enable-stack-protector=all` (RISC-V only):
> Compile the C library and all other parts of the glibc package using the GCC -fstack-protector, -fstack-protector-strong or -fstack-protector-all options to detect stack overruns. Only the dynamic linker and a small number of routines called directly from assembler are excluded from this protection.

and `--enable-bind-now`:
> Disable lazy binding for installed shared objects and programs. This provides additional security hardening because it enables full RELRO and a read-only global offset table (GOT), at the cost of slightly increased program load times.

You could check that the stack-protector option is being used for the RISC-V builds, by comparing the contents of a function that comes from glibc, i.e `atexit`, in a build of master:
```bash
riscv64-linux-gnu/src/bitcoind:     file format elf64-littleriscv

00000000007aa078 <atexit>:
  7aa078:	003a5617          	auipc	a2,0x3a5
  7aa07c:	f8863603          	ld	a2,-120(a2) # b4f000 <__dso_handle>
  7aa080:	4581                	li	a1,0
  7aa082:	ff8b3317          	auipc	t1,0xff8b3
  7aa086:	41e30067          	jr	1054(t1) # 5d4a0 <__cxa_atexit@plt>
```

vs this PR:
```bash
riscv64-linux-gnu/src/bitcoind:     file format elf64-littleriscv

00000000007aa078 <atexit>:
  7aa078:	003aa797          	auipc	a5,0x3aa
  7aa07c:	3c87b783          	ld	a5,968(a5) # b54440 <__stack_chk_guard@GLIBC_2.27>
  7aa080:	6398                	ld	a4,0(a5)
  7aa082:	1101                	addi	sp,sp,-32
  7aa084:	ec06                	sd	ra,24(sp)
  7aa086:	e43a                	sd	a4,8(sp)
  7aa088:	6722                	ld	a4,8(sp)
  7aa08a:	639c                	ld	a5,0(a5)
  7aa08c:	00f71d63          	bne	a4,a5,7aa0a6 <atexit+0x2e>
  7aa090:	60e2                	ld	ra,24(sp)
  7aa092:	003a5617          	auipc	a2,0x3a5
  7aa096:	f6e63603          	ld	a2,-146(a2) # b4f000 <__dso_handle>
  7aa09a:	4581                	li	a1,0
  7aa09c:	6105                	addi	sp,sp,32
  7aa09e:	ff8b3317          	auipc	t1,0xff8b3
  7aa0a2:	40230067          	jr	1026(t1) # 5d4a0 <__cxa_atexit@plt>
  7aa0a6:	ff8b3097          	auipc	ra,0xff8b3
  7aa0aa:	2ba080e7          	jalr	698(ra) # 5d360 <__stack_chk_fail@plt>
```

Note that none of the above means we would actually remove the use of hardening flags from our configure.

Guix Build (x86_64):
```bash
8de8ceac0f34729f17c64cd3b788d8e73e8a29cf51ec88ae33e04b1002f07162  guix-build-c99a1ecc52d8/output/aarch64-linux-gnu/SHA256SUMS.part
d638d329d2d23324aa8cb491b5fa9cfc59e7998cc95f6c47540ae34767316764  guix-build-c99a1ecc52d8/output/aarch64-linux-gnu/bitcoin-c99a1ecc52d8-aarch64-linux-gnu-debug.tar.gz
ce57cfd97109e2cebc91936653e291073230e9da1197d60edd6703c2c8e4961a  guix-build-c99a1ecc52d8/output/aarch64-linux-gnu/bitcoin-c99a1ecc52d8-aarch64-linux-gnu.tar.gz
917770f42ca696048c11ce3e7a100b9cc59cbe482878bccf11c1d84e327e61a7  guix-build-c99a1ecc52d8/output/arm-linux-gnueabihf/SHA256SUMS.part
a5e6ea54cb58941b2dceaa036495c65d83e3ae65b806af7124718df428206b38  guix-build-c99a1ecc52d8/output/arm-linux-gnueabihf/bitcoin-c99a1ecc52d8-arm-linux-gnueabihf-debug.tar.gz
c035aa6599aeab74445bcf15966886fafb1e4397d6f4e66e4e5ff05770f3af94  guix-build-c99a1ecc52d8/output/arm-linux-gnueabihf/bitcoin-c99a1ecc52d8-arm-linux-gnueabihf.tar.gz
a48654be85a540b393fefa87f75f10fcb1652cfb824eb5cb32da9aeffdbe9843  guix-build-c99a1ecc52d8/output/arm64-apple-darwin/SHA256SUMS.part
8cf48b00d6cbe7bc203043dde34ca51a82e25bc3b4e91802730209a90637a8ed  guix-build-c99a1ecc52d8/output/arm64-apple-darwin/bitcoin-c99a1ecc52d8-arm64-apple-darwin-unsigned.dmg
6ff1c1f0fbf64303421f71a91c14020554ab96673f2461aae80ef2249a846ebd  guix-build-c99a1ecc52d8/output/arm64-apple-darwin/bitcoin-c99a1ecc52d8-arm64-apple-darwin-unsigned.tar.gz
0df1d3d95759b26a9cc448dba29291c5d940e9faf9a79c7658775285498809eb  guix-build-c99a1ecc52d8/output/arm64-apple-darwin/bitcoin-c99a1ecc52d8-arm64-apple-darwin.tar.gz
3556666828f68205b8b82771a7046e10e10cf31bd894c6ed389bbaa2397b917c  guix-build-c99a1ecc52d8/output/dist-archive/bitcoin-c99a1ecc52d8.tar.gz
970390a724f2b9e40731942a427a5893a489fdac9c970a5a2f52cd684c4e2bcb  guix-build-c99a1ecc52d8/output/powerpc64-linux-gnu/SHA256SUMS.part
c281257c8f9466aca2d68971ff8cd219288f62a601396d4f8f1497a4404fac11  guix-build-c99a1ecc52d8/output/powerpc64-linux-gnu/bitcoin-c99a1ecc52d8-powerpc64-linux-gnu-debug.tar.gz
79e68965a50907f4c3382143f7c58dd71b927f87fe80a62c06b434232d764b93  guix-build-c99a1ecc52d8/output/powerpc64-linux-gnu/bitcoin-c99a1ecc52d8-powerpc64-linux-gnu.tar.gz
b65be16861b1d11225f5497c58adbc585bb1b192096018f006ae11c851235d65  guix-build-c99a1ecc52d8/output/powerpc64le-linux-gnu/SHA256SUMS.part
5edb31e2d6702ab3e24189db1a1151bb40dc009a2d6f196eca19124947400a24  guix-build-c99a1ecc52d8/output/powerpc64le-linux-gnu/bitcoin-c99a1ecc52d8-powerpc64le-linux-gnu-debug.tar.gz
d6e0414082f91a443bcfee9647f8cf9ad09d13fdf6acd6070866505b420db8eb  guix-build-c99a1ecc52d8/output/powerpc64le-linux-gnu/bitcoin-c99a1ecc52d8-powerpc64le-linux-gnu.tar.gz
89edc84604ea960dff7598999cabb14e2dbd7d585021acfd3065e0e8ebb77786  guix-build-c99a1ecc52d8/output/riscv64-linux-gnu/SHA256SUMS.part
091d582c7797792ab62653e61aa2192db768fb624615a2393284d7fad2a643bd  guix-build-c99a1ecc52d8/output/riscv64-linux-gnu/bitcoin-c99a1ecc52d8-riscv64-linux-gnu-debug.tar.gz
fcc20f8f7e2889f544e10d77e714496fd44e3dfdb2d1919b12ec5d41aeb9a8ac  guix-build-c99a1ecc52d8/output/riscv64-linux-gnu/bitcoin-c99a1ecc52d8-riscv64-linux-gnu.tar.gz
4b736dbfca1c0eb37390d791a9cdfe12aa3111f65a0c92775cd68044696f5b17  guix-build-c99a1ecc52d8/output/x86_64-apple-darwin/SHA256SUMS.part
dc51605e5c0f25e25aa1672471c2096e2c95f59d9c7adbee81714ad33da559a0  guix-build-c99a1ecc52d8/output/x86_64-apple-darwin/bitcoin-c99a1ecc52d8-x86_64-apple-darwin-unsigned.dmg
96a7b7b0144049215a4e51a01c4c90dcbf8469590a380fe2b1faca652f80c545  guix-build-c99a1ecc52d8/output/x86_64-apple-darwin/bitcoin-c99a1ecc52d8-x86_64-apple-darwin-unsigned.tar.gz
8d0a9e33e02db7c234d3cff2cf8489a93ae83a0efb9c02dd0a4a43b1615d5f75  guix-build-c99a1ecc52d8/output/x86_64-apple-darwin/bitcoin-c99a1ecc52d8-x86_64-apple-darwin.tar.gz
60e21c7d8eb8422bf3280d63fca7e3983b8d62949b46f582e483bfadf42d9838  guix-build-c99a1ecc52d8/output/x86_64-linux-gnu/SHA256SUMS.part
93cce61cbd237e8d63a7b60fd7c0611834d2587899f241c80ad3e7c31ce9f5c6  guix-build-c99a1ecc52d8/output/x86_64-linux-gnu/bitcoin-c99a1ecc52d8-x86_64-linux-gnu-debug.tar.gz
86e6d35ced80385dbebc9d0b4e443a86d9b5dfecff4928fccb4331fc37b7c8bc  guix-build-c99a1ecc52d8/output/x86_64-linux-gnu/bitcoin-c99a1ecc52d8-x86_64-linux-gnu.tar.gz
cdf1045063b8ad18735d623fa45867a3b6fbcabefac6ef763ad4d04e956ef2b7  guix-build-c99a1ecc52d8/output/x86_64-w64-mingw32/SHA256SUMS.part
e032c517396d818f2a5f7a2f8453966de37a1734f2f2d95ad0e39358647f5068  guix-build-c99a1ecc52d8/output/x86_64-w64-mingw32/bitcoin-c99a1ecc52d8-win64-debug.zip
b09cc098672215e810b4a11df0ebce760f716546d76745367898bb1850a6a8b4  guix-build-c99a1ecc52d8/output/x86_64-w64-mingw32/bitcoin-c99a1ecc52d8-win64-setup-unsigned.exe
a27108b306be7099a426bf2e02009b7271c8c04394bf5c5aa4f592b69be77fb5  guix-build-c99a1ecc52d8/output/x86_64-w64-mingw32/bitcoin-c99a1ecc52d8-win64-unsigned.tar.gz
a682fe68b09de24e1bdef49836d4fc5080e779fac66a73c9dcafb8fc6126af3a  guix-build-c99a1ecc52d8/output/x86_64-w64-mingw32/bitcoin-c99a1ecc52d8-win64.zip
```

Guix Build (arm64):
```bash
917770f42ca696048c11ce3e7a100b9cc59cbe482878bccf11c1d84e327e61a7  guix-build-c99a1ecc52d8/output/arm-linux-gnueabihf/SHA256SUMS.part
a5e6ea54cb58941b2dceaa036495c65d83e3ae65b806af7124718df428206b38  guix-build-c99a1ecc52d8/output/arm-linux-gnueabihf/bitcoin-c99a1ecc52d8-arm-linux-gnueabihf-debug.tar.gz
c035aa6599aeab74445bcf15966886fafb1e4397d6f4e66e4e5ff05770f3af94  guix-build-c99a1ecc52d8/output/arm-linux-gnueabihf/bitcoin-c99a1ecc52d8-arm-linux-gnueabihf.tar.gz
1a306a6dc68183f210aa56c6eb07785654e1c2e21ac9e2bd866d8fdec34a527c  guix-build-c99a1ecc52d8/output/arm64-apple-darwin/SHA256SUMS.part
7da1d43adabf4725b6244df9625b683f47669949ffbcf37184619e431151138f  guix-build-c99a1ecc52d8/output/arm64-apple-darwin/bitcoin-c99a1ecc52d8-arm64-apple-darwin-unsigned.dmg
ac38ae4188927e2e0b0d3bdaae9d314424e4f7e3ab2a90c6cbedc8a985ae237e  guix-build-c99a1ecc52d8/output/arm64-apple-darwin/bitcoin-c99a1ecc52d8-arm64-apple-darwin-unsigned.tar.gz
1b1653f3b3dff1bf5737223a4e5c2b674b700baba4ef594e3c7a040b5e81f3f6  guix-build-c99a1ecc52d8/output/arm64-apple-darwin/bitcoin-c99a1ecc52d8-arm64-apple-darwin.tar.gz
3556666828f68205b8b82771a7046e10e10cf31bd894c6ed389bbaa2397b917c  guix-build-c99a1ecc52d8/output/dist-archive/bitcoin-c99a1ecc52d8.tar.gz
970390a724f2b9e40731942a427a5893a489fdac9c970a5a2f52cd684c4e2bcb  guix-build-c99a1ecc52d8/output/powerpc64-linux-gnu/SHA256SUMS.part
c281257c8f9466aca2d68971ff8cd219288f62a601396d4f8f1497a4404fac11  guix-build-c99a1ecc52d8/output/powerpc64-linux-gnu/bitcoin-c99a1ecc52d8-powerpc64-linux-gnu-debug.tar.gz
79e68965a50907f4c3382143f7c58dd71b927f87fe80a62c06b434232d764b93  guix-build-c99a1ecc52d8/output/powerpc64-linux-gnu/bitcoin-c99a1ecc52d8-powerpc64-linux-gnu.tar.gz
b65be16861b1d11225f5497c58adbc585bb1b192096018f006ae11c851235d65  guix-build-c99a1ecc52d8/output/powerpc64le-linux-gnu/SHA256SUMS.part
5edb31e2d6702ab3e24189db1a1151bb40dc009a2d6f196eca19124947400a24  guix-build-c99a1ecc52d8/output/powerpc64le-linux-gnu/bitcoin-c99a1ecc52d8-powerpc64le-linux-gnu-debug.tar.gz
d6e0414082f91a443bcfee9647f8cf9ad09d13fdf6acd6070866505b420db8eb  guix-build-c99a1ecc52d8/output/powerpc64le-linux-gnu/bitcoin-c99a1ecc52d8-powerpc64le-linux-gnu.tar.gz
89edc84604ea960dff7598999cabb14e2dbd7d585021acfd3065e0e8ebb77786  guix-build-c99a1ecc52d8/output/riscv64-linux-gnu/SHA256SUMS.part
091d582c7797792ab62653e61aa2192db768fb624615a2393284d7fad2a643bd  guix-build-c99a1ecc52d8/output/riscv64-linux-gnu/bitcoin-c99a1ecc52d8-riscv64-linux-gnu-debug.tar.gz
fcc20f8f7e2889f544e10d77e714496fd44e3dfdb2d1919b12ec5d41aeb9a8ac  guix-build-c99a1ecc52d8/output/riscv64-linux-gnu/bitcoin-c99a1ecc52d8-riscv64-linux-gnu.tar.gz
4b736dbfca1c0eb37390d791a9cdfe12aa3111f65a0c92775cd68044696f5b17  guix-build-c99a1ecc52d8/output/x86_64-apple-darwin/SHA256SUMS.part
dc51605e5c0f25e25aa1672471c2096e2c95f59d9c7adbee81714ad33da559a0  guix-build-c99a1ecc52d8/output/x86_64-apple-darwin/bitcoin-c99a1ecc52d8-x86_64-apple-darwin-unsigned.dmg
96a7b7b0144049215a4e51a01c4c90dcbf8469590a380fe2b1faca652f80c545  guix-build-c99a1ecc52d8/output/x86_64-apple-darwin/bitcoin-c99a1ecc52d8-x86_64-apple-darwin-unsigned.tar.gz
8d0a9e33e02db7c234d3cff2cf8489a93ae83a0efb9c02dd0a4a43b1615d5f75  guix-build-c99a1ecc52d8/output/x86_64-apple-darwin/bitcoin-c99a1ecc52d8-x86_64-apple-darwin.tar.gz
60e21c7d8eb8422bf3280d63fca7e3983b8d62949b46f582e483bfadf42d9838  guix-build-c99a1ecc52d8/output/x86_64-linux-gnu/SHA256SUMS.part
93cce61cbd237e8d63a7b60fd7c0611834d2587899f241c80ad3e7c31ce9f5c6  guix-build-c99a1ecc52d8/output/x86_64-linux-gnu/bitcoin-c99a1ecc52d8-x86_64-linux-gnu-debug.tar.gz
86e6d35ced80385dbebc9d0b4e443a86d9b5dfecff4928fccb4331fc37b7c8bc  guix-build-c99a1ecc52d8/output/x86_64-linux-gnu/bitcoin-c99a1ecc52d8-x86_64-linux-gnu.tar.gz
cdf1045063b8ad18735d623fa45867a3b6fbcabefac6ef763ad4d04e956ef2b7  guix-build-c99a1ecc52d8/output/x86_64-w64-mingw32/SHA256SUMS.part
e032c517396d818f2a5f7a2f8453966de37a1734f2f2d95ad0e39358647f5068  guix-build-c99a1ecc52d8/output/x86_64-w64-mingw32/bitcoin-c99a1ecc52d8-win64-debug.zip
b09cc098672215e810b4a11df0ebce760f716546d76745367898bb1850a6a8b4  guix-build-c99a1ecc52d8/output/x86_64-w64-mingw32/bitcoin-c99a1ecc52d8-win64-setup-unsigned.exe
a27108b306be7099a426bf2e02009b7271c8c04394bf5c5aa4f592b69be77fb5  guix-build-c99a1ecc52d8/output/x86_64-w64-mingw32/bitcoin-c99a1ecc52d8-win64-unsigned.tar.gz
a682fe68b09de24e1bdef49836d4fc5080e779fac66a73c9dcafb8fc6126af3a  guix-build-c99a1ecc52d8/output/x86_64-w64-mingw32/bitcoin-c99a1ecc52d8-win64.zip
```