### PR TITLE
util: remove MSVC warning pragmas

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -55,13 +55,6 @@
 
 #else
 
-#ifdef _MSC_VER
-#pragma warning(disable:4786)
-#pragma warning(disable:4804)
-#pragma warning(disable:4805)
-#pragma warning(disable:4717)
-#endif
-
 #include <codecvt>
 
 #include <io.h> /* for _commit */


### PR DESCRIPTION
4786 - I don't think this exists any more?
4805 - Is already defined (globally) there.

Dropped 4717 and 4804, as it seems they are no-longer supressing
anything.

See:
https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warnings-c4000-c5999.