### PR TITLE
test: passing a negative value to `-peertimeout` should throw an error

### DIFF
--- a/test/functional/p2p_timeouts.py
+++ b/test/functional/p2p_timeouts.py
@@ -94,6 +94,11 @@ class TimeoutsTest(BitcoinTestFramework):
             no_version_node.wait_for_disconnect(timeout=1)
             no_send_node.wait_for_disconnect(timeout=1)
 
+        self.stop_nodes(0)
+        self.nodes[0].assert_start_raises_init_error(
+            expected_msg='Error: peertimeout cannot be configured with a negative value.',
+            extra_args=['-peertimeout=-1'],
+        )
 
 if __name__ == '__main__':
     TimeoutsTest().main()


### PR DESCRIPTION
This PR adds test coverage for the following init error:
https://github.com/bitcoin/bitcoin/blob/5bc10b39abbcb77638161902ccd1225139bc7cc0/src/init.cpp#L967-L970