### PR TITLE
test: non-positive integer value to `-peertimeout` should throw an error

### DIFF
--- a/test/functional/p2p_timeouts.py
+++ b/test/functional/p2p_timeouts.py
@@ -94,6 +94,11 @@ class TimeoutsTest(BitcoinTestFramework):
             no_version_node.wait_for_disconnect(timeout=1)
             no_send_node.wait_for_disconnect(timeout=1)
 
+        self.stop_nodes(0)
+        self.nodes[0].assert_start_raises_init_error(
+            expected_msg='Error: peertimeout must be a positive integer.',
+            extra_args=['-peertimeout=0'],
+        )
 
 if __name__ == '__main__':
     TimeoutsTest().main()


### PR DESCRIPTION
This PR adds test coverage for #25506, since #25505 gets closed.