### PR TITLE
psbt: Check Taproot tree depth and leaf versions

### DIFF
--- a/src/psbt.h
+++ b/src/psbt.h
@@ -866,6 +866,12 @@ struct PSBTOutput
                         s_tree >> depth;
                         s_tree >> leaf_ver;
                         s_tree >> script;
+                        if (depth > TAPROOT_CONTROL_MAX_NODE_COUNT) {
+                            throw std::ios_base::failure("Output Taproot tree has as leaf greater than Taproot maximum depth");
+                        }
+                        if ((leaf_ver & ~TAPROOT_LEAF_MASK) != 0) {
+                            throw std::ios_base::failure("Output Taproot tree has a leaf with an invalid leaf version");
+                        }
                         m_tap_tree->Add((int)depth, script, (int)leaf_ver, true /* track */);
                     }
                     if (!m_tap_tree->IsComplete()) {


### PR DESCRIPTION
Since TaprootBuilder has assertions for the depth and leaf versions, the
PSBT decoder should check these values before calling
TaprootBuilder::Add so that the assertions are not triggered on
malformed taproot trees.

Fixes https://github.com/bitcoin/bitcoin/pull/22558#issuecomment-1170935136