### PR TITLE
net, test: Virtualise CConnman and add initial PeerManager unit tests

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -111,6 +111,7 @@ BITCOIN_TESTS =\
   test/net_tests.cpp \
   test/netbase_tests.cpp \
   test/orphanage_tests.cpp \
+  test/peerman_tests.cpp \
   test/pmt_tests.cpp \
   test/policy_fee_tests.cpp \
   test/policyestimator_tests.cpp \

--- a/src/net.h
+++ b/src/net.h
@@ -663,7 +663,64 @@ protected:
     ~NetEventsInterface() = default;
 };
 
-class CConnman
+/** Interface class for interacting with CConnman */
+class ConnectionsInterface
+{
+public:
+    virtual bool ForNode(NodeId id, std::function<bool(CNode* pnode)> func) = 0;
+    using NodeFn = std::function<void(CNode*)>;
+    virtual void ForEachNode(const NodeFn& func) = 0;
+    virtual void ForEachNode(const NodeFn& func) const = 0;
+    virtual void PushMessage(CNode* pnode, CSerializedNetMsg&& msg) = 0;
+    /** Get a unique deterministic randomizer. */
+    virtual CSipHasher GetDeterministicRandomizer(uint64_t id) const = 0;
+    virtual void WakeMessageHandler() = 0;
+    //! check if the outbound target is reached
+    //! if param historicalBlockServingLimit is set true, the function will
+    //! response true if the limit for serving historical blocks has been reached
+    virtual bool OutboundTargetReached(bool historicalBlockServingLimit) const = 0;
+    /**
+     * Return all or many randomly selected addresses, optionally by network.
+     *
+     * @param[in] max_addresses  Maximum number of addresses to return (0 = all).
+     * @param[in] max_pct        Maximum percentage of addresses to return (0 = all).
+     * @param[in] network        Select only addresses of this network (nullopt = all).
+     */
+    virtual std::vector<CAddress> GetAddresses(size_t max_addresses, size_t max_pct, std::optional<Network> network) const = 0;
+    /**
+     * Cache is used to minimize topology leaks, so it should
+     * be used for all non-trusted calls, for example, p2p.
+     * A non-malicious call (from RPC or a peer with addr permission) should
+     * call the function without a parameter to avoid using the cache.
+     */
+    virtual std::vector<CAddress> GetAddresses(CNode& requestor, size_t max_addresses, size_t max_pct) = 0;
+    virtual bool DisconnectNode(const CNetAddr& addr) = 0;
+    virtual unsigned int GetReceiveFloodSize() const = 0;
+    // Return the number of outbound peers we have in excess of our target (eg,
+    // if we previously called SetTryNewOutboundPeer(true), and have since set
+    // to false, we may have extra peers that we wish to disconnect). This may
+    // return a value less than (num_outbound_connections - num_outbound_slots)
+    // in cases where some outbound connections are not yet fully connected, or
+    // not yet fully disconnected.
+    virtual int GetExtraFullOutboundCount() const = 0;
+    // Count the number of block-relay-only peers we have over our limit.
+    virtual int GetExtraBlockRelayCount() const = 0;
+    // This allows temporarily exceeding m_max_outbound_full_relay, with the goal of finding
+    // a peer that is better than all our current peers.
+    virtual void SetTryNewOutboundPeer(bool flag) = 0;
+    virtual bool GetTryNewOutboundPeer() const = 0;
+    virtual bool GetNetworkActive() const = 0;
+    virtual bool GetUseAddrmanOutgoing() const = 0;
+    virtual void StartExtraBlockRelayPeers() = 0;
+    /** Return true if we should disconnect the peer for failing an inactivity check. */
+    virtual bool ShouldRunInactivityChecks(const CNode& node, std::chrono::seconds now) const = 0;
+    virtual bool CheckIncomingNonce(uint64_t nonce) = 0;
+
+protected:
+    ~ConnectionsInterface() = default;
+};
+
+class CConnman : public ConnectionsInterface
 {
 public:
 
@@ -729,7 +786,7 @@ public:
     CConnman(uint64_t seed0, uint64_t seed1, AddrMan& addrman, const NetGroupManager& netgroupman,
              bool network_active = true);
 
-    ~CConnman();
+    virtual ~CConnman();
 
     bool Start(CScheduler& scheduler, const Options& options) EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex, !m_added_nodes_mutex, !m_addr_fetches_mutex, !mutexMsgProc);
 
@@ -742,18 +799,14 @@ public:
     };
 
     void Interrupt() EXCLUSIVE_LOCKS_REQUIRED(!mutexMsgProc);
-    bool GetNetworkActive() const { return fNetworkActive; };
-    bool GetUseAddrmanOutgoing() const { return m_use_addrman_outgoing; };
     void SetNetworkActive(bool active);
     void OpenNetworkConnection(const CAddress& addrConnect, bool fCountFailure, CSemaphoreGrant* grantOutbound, const char* strDest, ConnectionType conn_type);
-    bool CheckIncomingNonce(uint64_t nonce);
 
-    bool ForNode(NodeId id, std::function<bool(CNode* pnode)> func);
 
-    void PushMessage(CNode* pnode, CSerializedNetMsg&& msg) EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex);
-
+    /** Implement ConnectionsInterface */
+    bool ForNode(NodeId id, std::function<bool(CNode* pnode)> func) override;
     using NodeFn = std::function<void(CNode*)>;
-    void ForEachNode(const NodeFn& func)
+    void ForEachNode(const NodeFn& func) override
     {
         LOCK(m_nodes_mutex);
         for (auto&& node : m_nodes) {
@@ -761,8 +814,7 @@ public:
                 func(node);
         }
     };
-
-    void ForEachNode(const NodeFn& func) const
+    void ForEachNode(const NodeFn& func) const override
     {
         LOCK(m_nodes_mutex);
         for (auto&& node : m_nodes) {
@@ -770,41 +822,25 @@ public:
                 func(node);
         }
     };
-
-    // Addrman functions
-    /**
-     * Return all or many randomly selected addresses, optionally by network.
-     *
-     * @param[in] max_addresses  Maximum number of addresses to return (0 = all).
-     * @param[in] max_pct        Maximum percentage of addresses to return (0 = all).
-     * @param[in] network        Select only addresses of this network (nullopt = all).
-     */
-    std::vector<CAddress> GetAddresses(size_t max_addresses, size_t max_pct, std::optional<Network> network) const;
-    /**
-     * Cache is used to minimize topology leaks, so it should
-     * be used for all non-trusted calls, for example, p2p.
-     * A non-malicious call (from RPC or a peer with addr permission) should
-     * call the function without a parameter to avoid using the cache.
-     */
-    std::vector<CAddress> GetAddresses(CNode& requestor, size_t max_addresses, size_t max_pct);
-
-    // This allows temporarily exceeding m_max_outbound_full_relay, with the goal of finding
-    // a peer that is better than all our current peers.
-    void SetTryNewOutboundPeer(bool flag);
-    bool GetTryNewOutboundPeer() const;
-
-    void StartExtraBlockRelayPeers();
-
-    // Return the number of outbound peers we have in excess of our target (eg,
-    // if we previously called SetTryNewOutboundPeer(true), and have since set
-    // to false, we may have extra peers that we wish to disconnect). This may
-    // return a value less than (num_outbound_connections - num_outbound_slots)
-    // in cases where some outbound connections are not yet fully connected, or
-    // not yet fully disconnected.
-    int GetExtraFullOutboundCount() const;
-    // Count the number of block-relay-only peers we have over our limit.
-    int GetExtraBlockRelayCount() const;
-
+    void PushMessage(CNode* pnode, CSerializedNetMsg&& msg) override
+        EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex);
+    CSipHasher GetDeterministicRandomizer(uint64_t id) const override;
+    void WakeMessageHandler() override EXCLUSIVE_LOCKS_REQUIRED(!mutexMsgProc);
+    bool OutboundTargetReached(bool historicalBlockServingLimit) const override
+        EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex);
+    std::vector<CAddress> GetAddresses(size_t max_addresses, size_t max_pct, std::optional<Network> network) const override;
+    std::vector<CAddress> GetAddresses(CNode& requestor, size_t max_addresses, size_t max_pct) override;
+    bool DisconnectNode(const CNetAddr& addr) override;
+    unsigned int GetReceiveFloodSize() const override;
+    int GetExtraFullOutboundCount() const override;
+    int GetExtraBlockRelayCount() const override;
+    void SetTryNewOutboundPeer(bool flag) override;
+    bool GetTryNewOutboundPeer() const override;
+    bool GetNetworkActive() const override { return fNetworkActive; };
+    bool GetUseAddrmanOutgoing() const override { return m_use_addrman_outgoing; };
+    void StartExtraBlockRelayPeers() override;
+    bool ShouldRunInactivityChecks(const CNode& node, std::chrono::seconds now) const override;
+    bool CheckIncomingNonce(uint64_t nonce) override;
     bool AddNode(const std::string& node) EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex);
     bool RemoveAddedNode(const std::string& node) EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex);
     std::vector<AddedNodeInfo> GetAddedNodeInfo() const EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex);
@@ -827,7 +863,6 @@ public:
     void GetNodeStats(std::vector<CNodeStats>& vstats) const;
     bool DisconnectNode(const std::string& node);
     bool DisconnectNode(const CSubNet& subnet);
-    bool DisconnectNode(const CNetAddr& addr);
     bool DisconnectNode(NodeId id);
 
     //! Used to convey which local services we are offering peers during node
@@ -841,11 +876,6 @@ public:
     uint64_t GetMaxOutboundTarget() const EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex);
     std::chrono::seconds GetMaxOutboundTimeframe() const;
 
-    //! check if the outbound target is reached
-    //! if param historicalBlockServingLimit is set true, the function will
-    //! response true if the limit for serving historical blocks has been reached
-    bool OutboundTargetReached(bool historicalBlockServingLimit) const EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex);
-
     //! response the bytes left in the current max outbound cycle
     //! in case of no limit, it will always response 0
     uint64_t GetOutboundTargetBytesLeft() const EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex);
@@ -854,16 +884,6 @@ public:
 
     uint64_t GetTotalBytesRecv() const;
     uint64_t GetTotalBytesSent() const EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex);
-
-    /** Get a unique deterministic randomizer. */
-    CSipHasher GetDeterministicRandomizer(uint64_t id) const;
-
-    unsigned int GetReceiveFloodSize() const;
-
-    void WakeMessageHandler() EXCLUSIVE_LOCKS_REQUIRED(!mutexMsgProc);
-
-    /** Return true if we should disconnect the peer for failing an inactivity check. */
-    bool ShouldRunInactivityChecks(const CNode& node, std::chrono::seconds now) const;
 
 private:
     struct ListenSocket {

--- a/src/net.h
+++ b/src/net.h
@@ -347,6 +347,7 @@ class CNode
 {
     friend class CConnman;
     friend struct ConnmanTestMsg;
+    friend class ConnectionsInterfaceMock;
 
 public:
     const std::unique_ptr<TransportDeserializer> m_deserializer; // Used only by SocketHandler thread
@@ -1187,6 +1188,7 @@ private:
 
     friend struct CConnmanTest;
     friend struct ConnmanTestMsg;
+    friend class ConnectionsInterfaceMock;
 };
 
 /** Dump binary message to file, with timestamp */

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -495,7 +495,7 @@ struct CNodeState {
 class PeerManagerImpl final : public PeerManager
 {
 public:
-    PeerManagerImpl(CConnman& connman, AddrMan& addrman,
+    PeerManagerImpl(ConnectionsInterface& connman, AddrMan& addrman,
                     BanMan* banman, ChainstateManager& chainman,
                     CTxMemPool& pool, bool ignore_incoming_txs);
 
@@ -701,7 +701,7 @@ private:
     void MaybeSendFeefilter(CNode& node, Peer& peer, std::chrono::microseconds current_time) EXCLUSIVE_LOCKS_REQUIRED(g_msgproc_mutex);
 
     const CChainParams& m_chainparams;
-    CConnman& m_connman;
+    ConnectionsInterface& m_connman;
     AddrMan& m_addrman;
     /** Pointer to this node's banman. May be nullptr - check existence before dereferencing. */
     BanMan* const m_banman;
@@ -1763,14 +1763,14 @@ std::optional<std::string> PeerManagerImpl::FetchBlock(NodeId peer_id, const CBl
     return std::nullopt;
 }
 
-std::unique_ptr<PeerManager> PeerManager::make(CConnman& connman, AddrMan& addrman,
+std::unique_ptr<PeerManager> PeerManager::make(ConnectionsInterface& connman, AddrMan& addrman,
                                                BanMan* banman, ChainstateManager& chainman,
                                                CTxMemPool& pool, bool ignore_incoming_txs)
 {
     return std::make_unique<PeerManagerImpl>(connman, addrman, banman, chainman, pool, ignore_incoming_txs);
 }
 
-PeerManagerImpl::PeerManagerImpl(CConnman& connman, AddrMan& addrman,
+PeerManagerImpl::PeerManagerImpl(ConnectionsInterface& connman, AddrMan& addrman,
                                  BanMan* banman, ChainstateManager& chainman,
                                  CTxMemPool& pool, bool ignore_incoming_txs)
     : m_chainparams(chainman.GetParams()),

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -41,7 +41,7 @@ struct CNodeStateStats {
 class PeerManager : public CValidationInterface, public NetEventsInterface
 {
 public:
-    static std::unique_ptr<PeerManager> make(CConnman& connman, AddrMan& addrman,
+    static std::unique_ptr<PeerManager> make(ConnectionsInterface& connman, AddrMan& addrman,
                                              BanMan* banman, ChainstateManager& chainman,
                                              CTxMemPool& pool, bool ignore_incoming_txs);
     virtual ~PeerManager() { }

--- a/src/test/peerman_tests.cpp
+++ b/src/test/peerman_tests.cpp
@@ -13,6 +13,7 @@
 #include <script/signingprovider.h>
 #include <script/standard.h>
 #include <serialize.h>
+#include <span.h>
 #include <test/util/net.h>
 #include <test/util/setup_common.h>
 #include <util/string.h>
@@ -22,6 +23,7 @@
 #include <validation.h>
 
 #include <array>
+#include <optional>
 #include <stdint.h>
 
 #include <boost/test/unit_test.hpp>
@@ -31,6 +33,12 @@ static CService ip(uint32_t i)
     struct in_addr s;
     s.s_addr = i;
     return CService(CNetAddr(s), Params().GetDefaultPort());
+}
+
+static void AdvanceMockTime(int64_t delta)
+{
+    auto time_before{GetMockTime()};
+    SetMockTime(time_before + std::chrono::seconds(delta));
 }
 
 /** Mock the connections interface. */
@@ -63,17 +71,30 @@ public:
 
     void NodeReceiveMsgBytes(CNode& node, Span<const uint8_t> msg_bytes, bool& complete) const;
     bool ReceiveMsgFrom(CNode& node, CSerializedNetMsg& ser_msg) const;
+    void OnPing(CDataStream& data);
 
     virtual ~ConnectionsInterfaceMock() {}
 
     /** Count of number of each message type sent */
     std::map<std::string, uint64_t> m_message_types_sent;
+    /** Most recent ping nonce received. */
+    uint64_t m_ping_nonce{0};
+
 };
 
 void ConnectionsInterfaceMock::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
 {
     BOOST_TEST_MESSAGE(strprintf("sending message %s to peer %d", msg.m_type, pnode->GetId()));
     m_message_types_sent[msg.m_type]++;
+
+    CDataStream data{msg.data, SER_NETWORK, PROTOCOL_VERSION};
+    if (msg.m_type == NetMsgType::PING) OnPing(data);
+}
+
+void ConnectionsInterfaceMock::OnPing(CDataStream& data)
+{
+    data >> m_ping_nonce;
+    BOOST_TEST_MESSAGE(strprintf("received ping. Nonce:%d", m_ping_nonce));
 }
 
 void ConnectionsInterfaceMock::NodeReceiveMsgBytes(CNode& node, Span<const uint8_t> msg_bytes, bool& complete) const
@@ -181,6 +202,104 @@ BOOST_AUTO_TEST_CASE(version_handshake)
     BOOST_CHECK_EQUAL(connman->m_message_types_sent[NetMsgType::SENDCMPCT], 1);
     BOOST_CHECK_EQUAL(connman->m_message_types_sent[NetMsgType::GETHEADERS], 1);
     BOOST_CHECK_EQUAL(connman->m_message_types_sent[NetMsgType::FEEFILTER], 1);
+
+    peerman->FinalizeNode(node);
+}
+
+static void CheckPingTimes(CNode& node, PeerManager& peerman,
+                           std::chrono::microseconds min_ping_time, std::chrono::microseconds last_ping_time, std::chrono::microseconds ping_wait)
+{
+    // Check min and last ping times
+    BOOST_CHECK_EQUAL(node.m_min_ping_time.load().count(), min_ping_time.count());
+    BOOST_CHECK_EQUAL(node.m_last_ping_time.load().count(), last_ping_time.count());
+
+    // Check if and how long current ping has been pending
+    CNodeStateStats stats;
+    peerman.GetNodeStateStats(node.GetId(), stats);
+    BOOST_CHECK_EQUAL(stats.m_ping_wait.count(), ping_wait.count());
+}
+
+static void SendPong(CNode& node, ConnectionsInterfaceMock& connman,
+                     PeerManager& peerman, std::optional<int64_t> nonce = {})
+{
+    const CNetMsgMaker mm{0};
+    CSerializedNetMsg msg_pong = nonce ? mm.Make(NetMsgType::PONG, nonce.value()) : mm.Make(NetMsgType::PONG);
+    SendMessage(connman, peerman, node, msg_pong);
+}
+
+BOOST_AUTO_TEST_CASE(ping)
+{
+    // See PING_INTERVAL in net_processing.cpp
+    constexpr int64_t PING_INTERVAL{2 * 60};
+
+    auto connman = std::make_unique<ConnectionsInterfaceMock>();
+    auto peerman = PeerManager::make(*connman, *m_node.addrman, nullptr,
+                                     *m_node.chainman, *m_node.mempool, false);
+
+    // Mock an outbound peer
+    CNode node{/*id=*/0, /*sock=*/nullptr, CAddress(), /*nKeyedNetGroupIn=*/0, /*nLocalHostNonceIn=*/0, CAddress(),
+               /*addrNameIn=*/"", ConnectionType::OUTBOUND_FULL_RELAY, /*inbound_onion=*/false};
+
+    peerman->InitializeNode(node, /*our_services=*/ServiceFlags(NODE_NETWORK | NODE_WITNESS));
+
+    // Use mock time to control pings from node
+    SetMockTime(GetTime());
+
+    Handshake(*connman, *peerman, node, /*their_services=*/ServiceFlags(NODE_NETWORK | NODE_WITNESS));
+
+    BOOST_TEST_MESSAGE("Advanced mocktime and check that ping is sent after connection is established");
+    AdvanceMockTime(1);
+    BOOST_CHECK_EQUAL(connman->m_message_types_sent[NetMsgType::PING], 1);
+
+    // The ping nonce should be non-zero
+    BOOST_CHECK(connman->m_ping_nonce != 0);
+
+    // No pong response has been received yet, and current ping is outstanding
+    CheckPingTimes(node, *peerman, std::chrono::microseconds::max(), 0us, 1s);
+
+    BOOST_TEST_MESSAGE("Reply without nonce cancels ping");
+    SendPong(node, *connman, *peerman, std::nullopt);
+
+    // Ping metrics have not been updated on the CNode object, and there is no ping outstanding
+    CheckPingTimes(node, *peerman, std::chrono::microseconds::max(), 0us, 0us);
+
+    BOOST_TEST_MESSAGE("Reply without ping");
+    SendPong(node, *connman, *peerman, 0);
+
+    // Ping metrics have not been updated on the CNode object, and there is no ping outstanding
+    CheckPingTimes(node, *peerman, std::chrono::microseconds::max(), 0us, 0us);
+
+    // Wait for next ping
+    AdvanceMockTime(PING_INTERVAL + 1);
+    connman->m_message_types_sent[NetMsgType::PING] = 0;
+    WITH_LOCK(NetEventsInterface::g_msgproc_mutex, peerman->SendMessages(&node));
+    BOOST_CHECK_EQUAL(connman->m_message_types_sent[NetMsgType::PING], 1);
+
+    BOOST_TEST_MESSAGE("Reply with wrong nonce does not cancel ping");
+    SendPong(node, *connman, *peerman, connman->m_ping_nonce + 1);
+    AdvanceMockTime(1);
+
+    // Ping metrics have not been updated on the CNode object, and there is a ping outstanding
+    CheckPingTimes(node, *peerman, std::chrono::microseconds::max(), 0us, 1s);
+
+    BOOST_TEST_MESSAGE("Reply with zero nonce cancels ping");
+    SendPong(node, *connman, *peerman, 0);
+
+    // Ping metrics have not been updated on the CNode object, and there is no ping outstanding
+    CheckPingTimes(node, *peerman, std::chrono::microseconds::max(), 0us, 0us);
+
+    // Wait for next ping
+    AdvanceMockTime(PING_INTERVAL + 1);
+    connman->m_message_types_sent[NetMsgType::PING] = 0;
+    WITH_LOCK(NetEventsInterface::g_msgproc_mutex, peerman->SendMessages(&node));
+    BOOST_CHECK_EQUAL(connman->m_message_types_sent[NetMsgType::PING], 1);
+
+    // Send pong with correct nonce
+    AdvanceMockTime(1);
+    SendPong(node, *connman, *peerman, connman->m_ping_nonce);
+
+    // Ping metrics have been updated on the CNode object, and there is no ping outstanding
+    CheckPingTimes(node, *peerman, 1s, 1s, 0us);
 
     peerman->FinalizeNode(node);
 }

--- a/src/test/peerman_tests.cpp
+++ b/src/test/peerman_tests.cpp
@@ -1,0 +1,188 @@
+// Copyright (c) 2011-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <arith_uint256.h>
+#include <banman.h>
+#include <chainparams.h>
+#include <net.h>
+#include <net_processing.h>
+#include <netmessagemaker.h>
+#include <pubkey.h>
+#include <script/sign.h>
+#include <script/signingprovider.h>
+#include <script/standard.h>
+#include <serialize.h>
+#include <test/util/net.h>
+#include <test/util/setup_common.h>
+#include <util/string.h>
+#include <util/system.h>
+#include <util/time.h>
+#include <timedata.h>
+#include <validation.h>
+
+#include <array>
+#include <stdint.h>
+
+#include <boost/test/unit_test.hpp>
+
+static CService ip(uint32_t i)
+{
+    struct in_addr s;
+    s.s_addr = i;
+    return CService(CNetAddr(s), Params().GetDefaultPort());
+}
+
+/** Mock the connections interface. */
+class ConnectionsInterfaceMock : public ConnectionsInterface
+{
+public:
+    bool ForNode(NodeId id, std::function<bool(CNode* pnode)> func) override { return true; };
+    using NodeFn = std::function<void(CNode*)>;
+    void ForEachNode(const NodeFn& func) override {};
+    void ForEachNode(const NodeFn& func) const override {};
+    void PushMessage(CNode* pnode, CSerializedNetMsg&& msg) override;
+    CSipHasher GetDeterministicRandomizer(uint64_t id) const override { return {0, 0}; };
+    void WakeMessageHandler() override {};
+    bool OutboundTargetReached(bool historicalBlockServingLimit) const override { return true; };
+    std::vector<CAddress> GetAddresses(size_t max_addresses,
+                                       size_t max_pct,
+                                       std::optional<Network> network) const override { return {}; };
+    std::vector<CAddress> GetAddresses(CNode& requestor, size_t max_addresses, size_t max_pct) override { return {}; };
+    bool DisconnectNode(const CNetAddr& addr) override { return true; };
+    unsigned int GetReceiveFloodSize() const override { return 0; };
+    int GetExtraFullOutboundCount() const override { return 0; };
+    int GetExtraBlockRelayCount() const override { return 0; };
+    void SetTryNewOutboundPeer(bool flag) override {};
+    bool GetTryNewOutboundPeer() const override { return true; };
+    bool GetNetworkActive() const override { return true; };
+    bool GetUseAddrmanOutgoing() const override { return true; };
+    void StartExtraBlockRelayPeers() override {};
+    bool ShouldRunInactivityChecks(const CNode& node, std::chrono::seconds now) const override { return true; };
+    bool CheckIncomingNonce(uint64_t nonce) override { return true; };
+
+    void NodeReceiveMsgBytes(CNode& node, Span<const uint8_t> msg_bytes, bool& complete) const;
+    bool ReceiveMsgFrom(CNode& node, CSerializedNetMsg& ser_msg) const;
+
+    virtual ~ConnectionsInterfaceMock() {}
+
+    /** Count of number of each message type sent */
+    std::map<std::string, uint64_t> m_message_types_sent;
+};
+
+void ConnectionsInterfaceMock::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
+{
+    BOOST_TEST_MESSAGE(strprintf("sending message %s to peer %d", msg.m_type, pnode->GetId()));
+    m_message_types_sent[msg.m_type]++;
+}
+
+void ConnectionsInterfaceMock::NodeReceiveMsgBytes(CNode& node, Span<const uint8_t> msg_bytes, bool& complete) const
+{
+    assert(node.ReceiveMsgBytes(msg_bytes, complete));
+    if (complete) {
+        size_t nSizeAdded = 0;
+        auto it(node.vRecvMsg.begin());
+        for (; it != node.vRecvMsg.end(); ++it) {
+            // vRecvMsg contains only completed CNetMessage
+            // the single possible partially deserialized message are held by TransportDeserializer
+            nSizeAdded += it->m_raw_message_size;
+        }
+        {
+            LOCK(node.cs_vProcessMsg);
+            node.vProcessMsg.splice(node.vProcessMsg.end(), node.vRecvMsg, node.vRecvMsg.begin(), it);
+            node.nProcessQueueSize += nSizeAdded;
+        }
+    }
+}
+
+bool ConnectionsInterfaceMock::ReceiveMsgFrom(CNode& node, CSerializedNetMsg& ser_msg) const
+{
+    std::vector<uint8_t> ser_msg_header;
+    node.m_serializer->prepareForTransport(ser_msg, ser_msg_header);
+
+    bool complete;
+    NodeReceiveMsgBytes(node, ser_msg_header, complete);
+    NodeReceiveMsgBytes(node, ser_msg.data, complete);
+    return complete;
+}
+
+BOOST_FIXTURE_TEST_SUITE(peerman_tests, TestingSetup)
+
+static void SendMessage(ConnectionsInterfaceMock& connman, PeerManager& peerman, CNode& node, CSerializedNetMsg& msg)
+{
+    std::atomic<bool> interrupt{false};
+    (void)connman.ReceiveMsgFrom(node, msg);
+    node.fPauseSend = false;
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+    peerman.ProcessMessages(&node, interrupt);
+    peerman.SendMessages(&node);
+}
+
+using HandshakeHookFn = std::function<void(ConnectionsInterfaceMock& connman, PeerManager& peerman, CNode& node)>;
+static void Handshake(
+    ConnectionsInterfaceMock& connman, PeerManager& peerman,
+    CNode& node, ServiceFlags their_services,
+    HandshakeHookFn pre_verack_hook = [](ConnectionsInterfaceMock& connman, PeerManager& peerman, CNode& node) {}) noexcept
+{
+    // Send version message
+    const CNetMsgMaker mm{0};
+    CSerializedNetMsg msg_version{
+        mm.Make(NetMsgType::VERSION,
+                PROTOCOL_VERSION,                              // current p2p version
+                Using<CustomUintFormatter<8>>(their_services), // their service flags
+                GetTime(),                                     // dummy time
+                int64_t{},                                     // ignored service bits
+                CService{},                                    // dummy
+                int64_t{},                                     // ignored service bits
+                CService{},                                    // ignored
+                uint64_t{1},                                   // dummy nonce
+                std::string{},                                 // dummy subver
+                int32_t{},                                     // dummy starting_height
+                true),                                         // fRelay
+    };
+    SendMessage(connman, peerman, node, msg_version);
+    BOOST_CHECK(!node.fDisconnect);
+    BOOST_CHECK_EQUAL(node.nVersion, PROTOCOL_VERSION);
+    BOOST_CHECK_EQUAL(node.GetCommonVersion(), PROTOCOL_VERSION);
+    CNodeStateStats stats;
+    bool ret = peerman.GetNodeStateStats(node.GetId(), stats);
+    BOOST_CHECK_EQUAL(ret, true);
+    BOOST_CHECK_EQUAL(stats.their_services, their_services);
+
+    pre_verack_hook(connman, peerman, node);
+
+    // Send verack message
+    CSerializedNetMsg msg_verack{mm.Make(NetMsgType::VERACK)};
+    SendMessage(connman, peerman, node, msg_verack);
+    BOOST_CHECK_EQUAL(node.fSuccessfullyConnected, true);
+
+    TestOnlyResetTimeData();
+}
+
+BOOST_AUTO_TEST_CASE(version_handshake)
+{
+    auto connman = std::make_unique<ConnectionsInterfaceMock>();
+    auto peerman = PeerManager::make(*connman, *m_node.addrman, nullptr,
+                                     *m_node.chainman, *m_node.mempool, false);
+
+    // Mock an outbound peer
+    CAddress addr1(ip(0xa0b0c001), NODE_NONE);
+    CNode node{/*id=*/0, /*sock=*/nullptr, addr1, /*nKeyedNetGroupIn=*/0, /*nLocalHostNonceIn=*/0, CAddress(),
+               /*addrNameIn=*/"", ConnectionType::OUTBOUND_FULL_RELAY, /*inbound_onion=*/false};
+
+    peerman->InitializeNode(node, /*our_services=*/ServiceFlags(NODE_NETWORK | NODE_WITNESS));
+    Handshake(*connman, *peerman, node, /*their_services=*/ServiceFlags(NODE_NETWORK | NODE_WITNESS));
+
+    BOOST_CHECK_EQUAL(connman->m_message_types_sent[NetMsgType::VERSION], 1);
+    BOOST_CHECK_EQUAL(connman->m_message_types_sent[NetMsgType::WTXIDRELAY], 1);
+    BOOST_CHECK_EQUAL(connman->m_message_types_sent[NetMsgType::SENDADDRV2], 1);
+    BOOST_CHECK_EQUAL(connman->m_message_types_sent[NetMsgType::VERACK], 1);
+    BOOST_CHECK_EQUAL(connman->m_message_types_sent[NetMsgType::GETADDR], 1);
+    BOOST_CHECK_EQUAL(connman->m_message_types_sent[NetMsgType::SENDCMPCT], 1);
+    BOOST_CHECK_EQUAL(connman->m_message_types_sent[NetMsgType::GETHEADERS], 1);
+    BOOST_CHECK_EQUAL(connman->m_message_types_sent[NetMsgType::FEEFILTER], 1);
+
+    peerman->FinalizeNode(node);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR creates an abstract `ConnectionsInterface` class that is used as an interface for interacting with the connection manager. The `PeerManager` is made to hold a reference to a `ConnectionsInterface` instead of `CConnman`, which makes it possible for us to mock the connection manager in the newly introduced `PeerManager` unit tests. Two initial unit tests are added for the version handshake and ping/pong logic.