### PR TITLE
build: Remove outdated libbitcoinkernel comment

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -854,8 +854,7 @@ endif
 
 # TODO: libbitcoinkernel is a work in progress consensus engine library, as more
 #       and more modules are decoupled from the consensus engine, this list will
-#       shrink to only those which are absolutely necessary. For example, things
-#       like index/*.cpp will be removed.
+#       shrink to only those which are absolutely necessary.
 libbitcoinkernel_la_SOURCES = \
   kernel/bitcoinkernel.cpp \
   arith_uint256.cpp \


### PR DESCRIPTION
Looks like this comment is no longer relevant, the last files which matched `index/*.cpp` pattern were removed in https://github.com/bitcoin/bitcoin/commit/f1006875665ffe8ff5da8185effe25b860743b4e