### PR TITLE
tracing: macOS USDT support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ libtool
 src/config/bitcoin-config.h
 src/config/bitcoin-config.h.in
 src/config/stamp-h1
+src/util/probes.h
 src/obj
 share/setup.nsi
 share/qt/Info.plist

--- a/configure.ac
+++ b/configure.ac
@@ -1390,11 +1390,24 @@ if test "$use_usdt" != "no"; then
       [#include <sys/sdt.h>],
       [DTRACE_PROBE("context", "event");]
     )],
-    [AC_MSG_RESULT([yes]); AC_DEFINE([ENABLE_TRACING], [1], [Define to 1 to enable tracepoints for Userspace, Statically Defined Tracing])],
+    [AC_MSG_RESULT([yes]); use_usdt=yes],
     [AC_MSG_RESULT([no]); use_usdt=no;]
   )
+
+  dnl dtrace(1) is needed on darwin to support USDT
+  AC_PATH_PROG([DTRACE], [dtrace])
+  if test "$TARGET_OS" = "darwin" && test -n "$DTRACE"; then
+    use_usdt=yes
+  fi
+else
+  use_usdt=no
+fi
+
+if test x$use_usdt = xyes; then
+  AC_DEFINE([ENABLE_TRACING], [1], [Define to 1 to enable tracepoints for Userspace, Statically Defined Tracing])
 fi
 AM_CONDITIONAL([ENABLE_USDT_TRACEPOINTS], [test "$use_usdt" = "yes"])
+AM_CONDITIONAL([HAVE_DTRACE], [test "$use_usdt" = "yes" && test -n "$DTRACE"])
 
 if test "$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_util$build_bitcoind$bitcoin_enable_qt$use_bench$use_tests" = "nonononononono"; then
   use_upnp=no

--- a/contrib/tracing/README.md
+++ b/contrib/tracing/README.md
@@ -2,8 +2,8 @@ Example scripts for User-space, Statically Defined Tracing (USDT)
 =================================================================
 
 This directory contains scripts showcasing User-space, Statically Defined
-Tracing (USDT) support for Bitcoin Core on Linux using. For more information on
-USDT support in Bitcoin Core see the [USDT documentation].
+Tracing (USDT) support for Bitcoin Core on Linux and macOS. For more
+information on USDT support in Bitcoin Core see the [USDT documentation].
 
 [USDT documentation]: ../../doc/tracing.md
 
@@ -28,6 +28,16 @@ information. For development there exist a [bpftrace Reference Guide], a
 [BCC Reference Guide]: https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md
 [bcc Python Developer Tutorial]: https://github.com/iovisor/bcc/blob/master/docs/tutorial_bcc_python_developer.md
 
+Examples of [dtrace] scripts for macOS, based on the existing bpftrace scripts,
+are also listed.
+
+*Note: On all current macOS versions System Integrity Protection (SIP) is
+enabled by default and prevents most uses of `dtrace`. The usual way to make
+`dtrace` work on macOS is to boot into recovery mode and disable some of the
+SIP protections with `csrutil enable --without dtrace`.*
+
+[dtrace]: https://illumos.org/books/dtrace/
+
 ## Examples
 
 The bpftrace examples contain a relative path to the `bitcoind` binary. By
@@ -39,15 +49,15 @@ example, to point to release builds if needed. See the
 
 [Bitcoin Core USDT documentation]: ../../doc/tracing.md#listing-available-tracepoints
 
-**WARNING: eBPF programs require root privileges to be loaded into a Linux
-kernel VM. This means the bpftrace and BCC examples must be executed with root
-privileges. Make sure to carefully review any scripts that you run with root
-privileges first!**
+**WARNING: eBPF & DTrace programs require root privileges to be loaded into the
+Linux kernel VM and macOS kernel, respectively. This means the bpftrace, BCC
+and dtrace examples must be executed with root privileges. Make sure to
+carefully review any scripts that you run with root privileges first!**
 
-### log_p2p_traffic.bt
+### log_p2p_traffic.{bt,d}
 
-A bpftrace script logging information about inbound and outbound P2P network
-messages. Based on the `net:inbound_message` and `net:outbound_message`
+A `bpftrace`/`dtrace` script logging information about inbound and outbound P2P
+network messages. Based on the `net:inbound_message` and `net:outbound_message`
 tracepoints.
 
 By default, `bpftrace` limits strings to 64 bytes due to the limited stack size
@@ -58,6 +68,9 @@ works fine).
 
 ```
 $ bpftrace contrib/tracing/log_p2p_traffic.bt
+```
+```
+$ dtrace -s contrib/tracing/log_p2p_traffic.d
 ```
 
 Output
@@ -164,11 +177,11 @@ Warning: incomplete message (only 32568 out of 53552 bytes)! inbound msg 'tx' fr
 Possibly lost 2 samples
 ```
 
-### connectblock_benchmark.bt
+### connectblock_benchmark.{bt,d}
 
-A `bpftrace` script to benchmark the `ConnectBlock()` function during, for
-example, a blockchain re-index. Based on the `validation:block_connected` USDT
-tracepoint.
+A `bpftrace`/`dtrace` script to benchmark the `ConnectBlock()` function during,
+for example, a blockchain re-index. Based on the `validation:block_connected`
+USDT tracepoint.
 
 The script takes three positional arguments. The first two arguments, the start,
 and end height indicate between which blocks the benchmark should be run. The
@@ -182,6 +195,9 @@ longer than 25ms to connect.
 
 ```
 $ bpftrace contrib/tracing/connectblock_benchmark.bt 20000 38000 25
+```
+```
+$ dtrace -s contrib/tracing/connectblock_benchmark.d 20000 38000 25
 ```
 
 In a different terminal, starting Bitcoin Core in SigNet mode and with
@@ -252,14 +268,17 @@ Duration (µs)   Mode       Coins Count     Memory Usage    Prune
 81349           ALWAYS     0               1383.49 kB      False
 ```
 
-### log_utxos.bt
+### log_utxos.{bt,d}
 
-A `bpftrace` script to log information about the coins that are added, spent, or
-uncached from the UTXO set. Based on the `utxocache:add`, `utxocache:spend` and
-`utxocache:uncache` tracepoints.
+A `bpftrace`/`dtrace` script to log information about the coins that are added,
+spent, or uncached from the UTXO set. Based on the `utxocache:add`,
+`utxocache:spend` and `utxocache:uncache` tracepoints.
 
 ```bash
 $ bpftrace contrib/tracing/log_utxos.bt
+```
+```bash
+$ dtrace -s contrib/tracing/log_utxos.d
 ```
 
 This should produce an output similar to the following. If you see bpftrace

--- a/contrib/tracing/connectblock_benchmark.d
+++ b/contrib/tracing/connectblock_benchmark.d
@@ -1,0 +1,129 @@
+#!/usr/sbin/dtrace -s
+
+#pragma D option quiet
+
+/*
+    USAGE:
+
+    dtrace -s contrib/tracing/connectblock_benchmark.d <start height> <end height> <logging threshold in ms>
+
+     - <start height> sets the height at which the benchmark should start. Setting
+    the start height to 0 starts the benchmark immediately, even before the
+    first block is connected.
+    - <end height> sets the height after which the benchmark should end. Setting
+        the end height to 0 disables the benchmark.
+    - Threshold <logging threshold in ms>.
+
+    This script requires a 'bitcoind' binary compiled with USDT support and the
+    'validation:block_connected' USDT.
+
+*/
+
+BEGIN
+{
+    blocks = 0;
+    start_height = $1;
+    end_height = $2;
+    logging_threshold_ms = $3;
+
+    if (end_height < start_height) {
+        printf("Error: start height (%d) larger than end height (%d)!\n", start_height, end_height);
+        exit(1);
+    }
+
+    if (end_height > 0) {
+        printf("ConnectBlock benchmark between height %d and %d inclusive\n", start_height, end_height);
+    } else {
+        printf("ConnectBlock logging starting at height %d\n", start_height);
+    }
+
+    if (logging_threshold_ms > 0) {
+        printf("Logging blocks taking longer than %d ms to connect.\n", $3);
+    }
+
+    if (start_height == 0) {
+        start = timestamp;
+    }
+}
+
+/*
+  Attaches to the 'validation:block_connected' USDT and collects stats when the
+  connected block is between the start and end height (or the end height is
+  unset).
+*/
+validation*:::block_connected
+/execname == "bitcoind" && arg1 >= start_height && (arg1 <= end_height || end_height == 0 )/
+{
+    height = arg1;
+    transactions = arg2;
+    inputs = arg3;
+    sigops =  arg4;
+    duration = arg5;
+
+    blocks = blocks + 1;
+    transactions += transactions;
+    inputs += inputs;
+    sigops += sigops;
+
+    @durations = quantize(duration / 1000);
+
+    if (height == start_height && height != 0) {
+        start = timestamp;
+        printf("Starting Connect Block Benchmark between height %d and %d.\n", start_height, end_height);
+    }
+
+    if (end_height > 0 && height >= end_height) {
+        end = timestamp;
+        duration = end - start;
+        printf("\nTook %d ms to connect the blocks between height %d and %d.\n", duration / 1000000, start_height, end_height);
+        exit(0);
+    }
+}
+
+/*
+  Attaches to the 'validation:block_connected' USDT and logs information about
+  blocks where the time it took to connect the block is above the
+  <logging threshold in ms>.
+*/
+validation*:::block_connected
+/execname == "bitcoind" && arg5 / 1000 > logging_threshold_ms /
+{
+    hash = (char *)copyin(arg0, 32);
+    height = arg1;
+    transactions = arg2;
+    inputs = arg3;
+    sigops = arg4;
+    duration = arg5;
+
+    printf("Block %d ", height);
+    /* Prints each byte of the block hash as hex in big-endian (the block-explorer format) */
+    /* Note: Loops are not allowed in DTrace scripts */
+    printf("( %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x )",
+        hash[31], hash[30], hash[29], hash[28], hash[27], hash[26], hash[25], hash[24],
+        hash[23], hash[22], hash[21], hash[20], hash[19], hash[18], hash[17], hash[16],
+        hash[15], hash[14], hash[13], hash[12], hash[11], hash[10], hash[9], hash[8],
+        hash[7], hash[6], hash[5], hash[4], hash[3], hash[2], hash[1], hash[0]);
+    printf(" %4d tx  %5d ins  %5d sigops  took %4d ms\n", transactions, inputs, sigops, duration / 1000);
+}
+
+/*
+  Prints stats about the blocks, transactions, inputs, and sigops processed in
+  the last second (if any).
+*/
+tick-1sec
+{
+    if (blocks > 0) {
+        printf("BENCH %4d blk/s %6d tx/s %7d inputs/s %8d sigops/s (height %d)\n", blocks, transactions, inputs, sigops, height);
+
+        blocks=0;
+        transactions=0;
+        inputs=0;
+        sigops=0;
+    }
+}
+
+END
+{
+    printf("\nHistogram of block connection times in milliseconds (ms).\n");
+    printa(@durations);
+}

--- a/contrib/tracing/log_p2p_traffic.d
+++ b/contrib/tracing/log_p2p_traffic.d
@@ -1,0 +1,39 @@
+#!/usr/sbin/dtrace -s
+
+#pragma D option quiet
+
+/*
+    USAGE:
+
+    dtrace -s contrib/tracing/log_p2p_traffic.d
+
+    This script requires a 'bitcoind' binary compiled with USDT support and the
+    'net' tracepoints.
+*/
+
+BEGIN
+{
+    printf("Logging P2P traffic\n")
+}
+
+net*:::inbound_message
+/execname == "bitcoind"/
+{
+    self->peer_id = arg0;
+    self->peer_addr = copyinstr(arg1);
+    self->peer_type = copyinstr(arg2);
+    self->msg_type = copyinstr(arg3);
+    self->msg_len = arg4;
+    printf("inbound  '%s' msg from peer %d (%s, %s) with %d bytes\n", self->msg_type, self->peer_id, self->peer_type, self->peer_addr, self->msg_len);
+}
+
+net*:::outbound_message
+/execname == "bitcoind"/
+{
+    self->peer_id = arg0;
+    self->peer_addr = copyinstr(arg1);
+    self->peer_type = copyinstr(arg2);
+    self->msg_type = copyinstr(arg3);
+    self->msg_len = arg4;
+    printf("outbound '%s' msg to peer %d (%s, %s) with %d bytes\n", self->msg_type, self->peer_id, self->peer_type, self->peer_addr, self->msg_len);
+}

--- a/contrib/tracing/log_utxos.d
+++ b/contrib/tracing/log_utxos.d
@@ -1,0 +1,45 @@
+#!/usr/sbin/dtrace -s
+
+#pragma D option quiet
+
+/*
+
+   USAGE:
+
+    dtrace -s contrib/tracing/log_utxos.d
+
+    This script requires a 'bitcoind' binary compiled with USDT support and the
+    'utxocache' tracepoints.
+
+*/
+
+BEGIN
+{
+    printf("%-7s %-71s %16s %7s %8s\n",
+          "OP", "Outpoint", "Value", "Height", "Coinbase");
+}
+
+/*
+  Attaches to the 'utxocache:{add, spent, uncache}' tracepoints and prints additions/spents to/from the UTXO set cache
+  and uncache UTXOs from the UTXO set cache.
+*/
+utxocache*:::add, utxocache*:::spent, utxocache*:::uncache
+/execname == "bitcoind"/
+{
+    txid = (char *)copyin(arg0, 32);
+    self->index = arg1;
+    height = arg2;
+    value = arg3;
+    isCoinbase = arg4;
+
+    self->event = probename == "add" ? "Added" : probename == "spent" ? "Spent" : "Uncache";
+
+    printf("%s   ", self->event);
+    printf("%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+        txid[31], txid[30], txid[29], txid[28], txid[27], txid[26], txid[25], txid[24],
+        txid[23], txid[22], txid[21], txid[20], txid[19], txid[18], txid[17], txid[16],
+        txid[15], txid[14], txid[13], txid[12], txid[11], txid[10], txid[9], txid[8],
+        txid[7], txid[6], txid[5], txid[4], txid[3], txid[2], txid[1], txid[0]);
+
+    printf(":%-6d %16ld %7d %s\n", self->index, value, height, (isCoinbase ? "Yes" : "No" ));
+}

--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -6,6 +6,8 @@ These tracepoints make it possible to keep track of custom statistics and
 enable detailed monitoring of otherwise hidden internals. They have
 little to no performance impact when unused.
 
+### eBPF and USDT Overview
+
 ```
 eBPF and USDT Overview
 ======================
@@ -47,11 +49,26 @@ be found in [contrib/tracing].
 
 [bpftrace]: https://github.com/iovisor/bpftrace
 [BPF Compiler Collection (BCC)]: https://github.com/iovisor/bcc
+
+### DTrace and USDT Overview
+[DTrace] supports both static and dynamic instrumentation points called probes.
+Tracepoints are [statically defined probes] that are registered with DTrace
+when the application is executed and replaced by NOPs when not in use.
+
+DTrace operates by activating tracepoints, which fire when your code goes
+through them. You use the D language to specify which tracepoints to activate
+and which actions to execute when a tracepoint fires. Those programs are
+written in a Non-Turing-complete language and run in kernel space. Examples can
+be found in [contrib/tracing].
+
+[DTrace]: https://illumos.org/books/dtrace/
+[statically defined probes]: https://illumos.org/books/dtrace/chp-usdt.html
 [contrib/tracing]: ../contrib/tracing/
 
 ## Tracepoint documentation
 
-The currently available tracepoints are listed here.
+The currently available tracepoints are listed here and also defined at
+[`util/probes.d`].
 
 ### Context `net`
 
@@ -219,8 +236,11 @@ depending on the number of arguments passed to the tracepoint. Up to 12
 arguments can be provided. The `context` and `event` specify the names by which
 the tracepoint is referred to. Please use `snake_case` and try to make sure that
 the tracepoint names make sense even without detailed knowledge of the
-implementation details. Do not forget to update the tracepoint list in this
-document.
+implementation details. Define the new probe for the tracepoint at
+[`util/probes.d`] together with a new provider if needed. Do not forget to update
+the tracepoint list in this document.
+
+
 
 ```c
 #define TRACE(context, event)
@@ -250,6 +270,8 @@ TRACE6(net, inbound_message,
     msg.data.data()
 );
 ```
+
+[`util/probes.d`]: ../src/util/probes.d
 
 ### Guidelines and best practices
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -328,6 +328,21 @@ BITCOIN_CORE_H = \
   zmq/zmqrpc.h \
   zmq/zmqutil.h
 
+if HAVE_DTRACE
+util/probes.h:
+	@$(MKDIR_P) $(builddir)/util
+	$(AM_V_GEN) $(DTRACE) -h -s $(srcdir)/util/probes.d -o "$(abs_top_builddir)/src/util/probes.h"
+
+# util/probes.h is listed in BUILD_SOURCES because
+# it must be created early in the build process.
+BUILT_SOURCES = util/probes.h
+BITCOIN_CORE_H += util/probes.h
+else
+# A rule to make util/probes.h is still needed thus we create an empty file
+util/probes.h:
+	@$(MKDIR_P) $(builddir)/util
+	touch "$(abs_top_builddir)/src/util/probes.h"
+endif # HAVE_DTRACE
 
 obj/build.h: FORCE
 	@$(MKDIR_P) $(builddir)/obj
@@ -979,6 +994,7 @@ CLEANFILES += wallet/*.gcda wallet/*.gcno
 CLEANFILES += wallet/test/*.gcda wallet/test/*.gcno
 CLEANFILES += zmq/*.gcda zmq/*.gcno
 CLEANFILES += obj/build.h
+CLEANFILES += util/probes.h
 
 EXTRA_DIST = $(CTAES_DIST)
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4275,7 +4275,7 @@ bool PeerManagerImpl::ProcessMessages(CNode* pfrom, std::atomic<bool>& interrupt
         pfrom->ConnectionTypeAsString().c_str(),
         msg.m_type.c_str(),
         msg.m_recv.size(),
-        msg.m_recv.data()
+        (unsigned char*)(msg.m_recv.data())
     );
 
     if (gArgs.GetBoolArg("-capturemessages", false)) {

--- a/src/util/probes.d
+++ b/src/util/probes.d
@@ -1,0 +1,40 @@
+/* Copyright (c) 2022 The Bitcoin Core developers
+   Distributed under the MIT software license, see the accompanying
+   file COPYING or http://www.opensource.org/licenses/mit-license.php. */
+
+/*
+
+   This file is part of the more involved process of using USDT probes on macOS
+   as described in the BUILDING CODE CONTAINING USDT PROBES section in the
+   dtrace(1) manpage https://www.unix.com/man-page/mojave/1/dtrace/
+
+   This defines the providers and specifies their probes in order to generate
+   the header file `probes.h` with the necessary tracepoints macros.
+
+   Note: The boolean type is not supported by the D language thus `bool` is
+   replaced by `uint8_t` on probe's signature.
+
+*/
+
+provider net {
+        probe inbound_message(int64_t, char *, char *, char *, int64_t, unsigned char *);
+        probe outbound_message(int64_t, char *, char *, char *, int64_t, unsigned char *);
+};
+
+provider validation {
+        probe block_connected(unsigned char *, int32_t, uint64_t, int32_t, uint64_t, uint64_t);
+};
+
+provider utxocache {
+        probe flush(int64_t, uint32_t, uint64_t, uint64_t, uint8_t);
+        probe add(unsigned char *, uint32_t, uint32_t, int64_t, uint8_t);
+        probe spent(unsigned char *, uint32_t, uint32_t, int64_t, uint8_t);
+        probe uncache(unsigned char *, uint32_t, uint32_t, int64_t, uint8_t);
+};
+
+provider coin_selection {
+        probe selected_coins(char *, char *, int64_t, int64_t, int64_t) ;
+        probe normal_create_tx_internal(char *, uint8_t, int64_t, int32_t);
+        probe attempting_aps_create_tx(char *);
+        probe aps_create_tx_internal(char *, uint8_t, uint8_t, int64_t, int32_t);
+};

--- a/src/util/trace.h
+++ b/src/util/trace.h
@@ -7,6 +7,44 @@
 
 #ifdef ENABLE_TRACING
 
+#ifdef __APPLE__
+
+#include <util/macros.h>
+#include <util/probes.h>
+
+// since the dtrace macros are automatically generated in uppercase, additional
+// macros are needed to translate the lowercase context & event names into the
+// required uppercase CONTEXT_EVENT macros
+#define net_inbound_message NET_INBOUND_MESSAGE
+#define net_outbound_message NET_OUTBOUND_MESSAGE
+#define validation_block_connected VALIDATION_BLOCK_CONNECTED
+#define utxocache_add UTXOCACHE_ADD
+#define utxocache_spent UTXOCACHE_SPENT
+#define utxocache_uncache UTXOCACHE_UNCACHE
+#define utxocache_flush UTXOCACHE_FLUSH
+#define coin_selection_selected_coins COIN_SELECTION_SELECTED_COINS
+#define coin_selection_normal_create_tx_internal COIN_SELECTION_NORMAL_CREATE_TX_INTERNAL
+#define coin_selection_attempting_aps_create_tx COIN_SELECTION_ATTEMPTING_APS_CREATE_TX
+#define coin_selection_aps_create_tx_internal COIN_SELECTION_APS_CREATE_TX_INTERNAL
+
+// The DTRACE_PROBE*(context, event, ...args) macros are not supported on macOS.
+// Instead we are using macros of the format CONTEXT_EVENT(...args).
+#define TRACE(context, event) PASTE2(PASTE2(context, _), event)()
+#define TRACE1(context, event, a) PASTE2(PASTE2(context, _), event)(a)
+#define TRACE2(context, event, a, b) PASTE2(PASTE2(context, _), event)(a, b)
+#define TRACE3(context, event, a, b, c) PASTE2(PASTE2(context, _), event)(a, b, c)
+#define TRACE4(context, event, a, b, c, d) PASTE2(PASTE2(context, _), event)(a, b, c, d)
+#define TRACE5(context, event, a, b, c, d, e) PASTE2(PASTE2(context, _), event)(a, b, c, d, e)
+#define TRACE6(context, event, a, b, c, d, e, f) PASTE2(PASTE2(context, _), event)(a, b, c, d, e, f)
+#define TRACE7(context, event, a, b, c, d, e, f, g) PASTE2(PASTE2(context, _), event)(a, b, c, d, e, f, g)
+#define TRACE8(context, event, a, b, c, d, e, f, g, h) PASTE2(PASTE2(context, _), event)(a, b, c, d, e, f, g, h)
+#define TRACE9(context, event, a, b, c, d, e, f, g, h, i) PASTE2(PASTE2(context, _), event)(a, b, c, d, e, f, g, h, i)
+#define TRACE10(context, event, a, b, c, d, e, f, g, h, i, j) PASTE2(PASTE2(context, _), event)(a, b, c, d, e, f, g, h, i, j)
+#define TRACE11(context, event, a, b, c, d, e, f, g, h, i, j, k) PASTE2(PASTE2(context, _), event)(a, b, c, d, e, f, g, h, i, j, k)
+#define TRACE12(context, event, a, b, c, d, e, f, g, h, i, j, k, l) PASTE2(PASTE2(context, _), event)(a, b, c, d, e, f, g, h, i, j, k, l)
+
+#else
+
 #include <sys/sdt.h>
 
 #define TRACE(context, event) DTRACE_PROBE(context, event)
@@ -22,6 +60,8 @@
 #define TRACE10(context, event, a, b, c, d, e, f, g, h, i, j) DTRACE_PROBE10(context, event, a, b, c, d, e, f, g, h, i, j)
 #define TRACE11(context, event, a, b, c, d, e, f, g, h, i, j, k) DTRACE_PROBE11(context, event, a, b, c, d, e, f, g, h, i, j, k)
 #define TRACE12(context, event, a, b, c, d, e, f, g, h, i, j, k, l) DTRACE_PROBE12(context, event, a, b, c, d, e, f, g, h, i, j, k, l)
+
+#endif // __APPLE__
 
 #else
 
@@ -39,7 +79,7 @@
 #define TRACE11(context, event, a, b, c, d, e, f, g, h, i, j, k)
 #define TRACE12(context, event, a, b, c, d, e, f, g, h, i, j, k, l)
 
-#endif
+#endif // ENABLE_TRACING
 
 
 #endif // BITCOIN_UTIL_TRACE_H


### PR DESCRIPTION
This PR adds macOS support for User-Space, Statically Defined Tracing (USDT) as well as dtrace example scripts based on the existing bpftrace scripts for Linux. This is tested on macOS 10.15. 

## Overview

The current implementation of USDT only supports Linux  as the `DTRACE_PROBE*(context, event, ...args)` macros are not supported on macOS. As initially referenced in https://github.com/bitcoin/bitcoin/pull/22238, the process of using USDT probes on macOS is slightly different and it's described in [the BUILDING CODE CONTAINING USDT PROBES section in the dtrace(1) manpage](https://gist.github.com/fanquake/e56c9866d53b326646d04ab43a8df9e2).

This more involved process includes

1. Creating the providers description file `util/probes.d` which defines the providers and specifies their probes.
2. Use `util/probes.d` to generate the header file `util/probes.h` with the neccesary tracepoints macros which are of the format `CONTEXT_EVENT(...args)`.
3. Add the tracepoints macros to `util/trace.h`.

##  Notes


~Part of the macOS process is to create the providers description in a `.d` file. Therefore, types not supported by the D language (specifically `bool` and `std::byte`) cannot be used as part of the probe's signature. On those occasions, in lack of a better solution, only supported types are used and then a patch is applied at the generated `util/probes.h` file to replace the temporary D-supported types with those that we actually need.~

~You can reproduce the initial header file by running `dtrace -h -s src/util/probes.d -o src/util/probes.h` (compiling with that results to errors because of not matching types) and then apply the [`probes-fix.diff`](https://gist.github.com/kouloumos/df773b1e0896adca827e7960eace1d21) patch with `git apply probes-fix.diff`.~
Edit: `util/probes.h` is now generated during build time after changes (see https://github.com/bitcoin/bitcoin/pull/25541#discussion_r913646086 and https://github.com/bitcoin/bitcoin/pull/25541#discussion_r915192574) that removed the need for the non supported types.

Having the `bitcoind` binary compiled with USDT support, you can then use the dtrace example scripts `connectblock_benchmark.d`, `log_p2p_traffic.d`, `log_utxos.d` (root privileges needed) to test the macOS support. Extra documentation for those can be found at [contrib/tracing](https://github.com/bitcoin/bitcoin/tree/master/contrib/tracing) as they are functionally the same as the existing bpftrace scripts.

### Adding tracepoints to Bitcoin Core (extra steps after this PR)

After this PR when a new tracepoint is added, we will need to

- Define the new probe for the tracepoint at `util/probes.d` together with a new provider if needed.
- Add a new `#define context_event CONTEXT_EVENT`  macro at `util/trace.h`. This might not be final as discussed at https://github.com/bitcoin/bitcoin/pull/25541#discussion_r913611013. 
