### PR TITLE
build: Use Link Time Optimization for Qt code on Linux

### DIFF
--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -9,6 +9,7 @@ define $(package)_set_vars
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
   $(package)_config_opts += --without-xmlwf
   $(package)_config_opts_linux=--with-pic
+  $(package)_cflags += -fno-lto
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -152,6 +152,9 @@ $(package)_config_opts_linux += -fontconfig
 $(package)_config_opts_linux += -no-opengl
 $(package)_config_opts_linux += -no-feature-vulkan
 $(package)_config_opts_linux += -dbus-runtime
+ifneq ($(LTO),)
+$(package)_config_opts_linux += -ltcg
+endif
 $(package)_config_opts_arm_linux += -platform linux-g++ -xplatform bitcoin-linux-g++
 $(package)_config_opts_i686_linux  = -xplatform linux-g++-32
 ifneq (,$(findstring -stdlib=libc++,$($(1)_cxx)))


### PR DESCRIPTION
See: https://www.qt.io/blog/2019/01/02/qt-applications-lto

`bitcon-qt` unstripped size:
| host | master (31c6309cc60ae3fee2d3ecc2aff9576596fb98ac) | this PR, depends built with `LTO=1` |
|---|:-:|:-:|
| x86_64-pc-linux-gnu | 42 MB | 35 MB |
| arm-linux-gnueabihf | 31 MB | 26 MB |
| aarch64-linux-gnu | 41 MB | 32 MB |
| powerpc64-linux-gnu | 51 MB | 41 MB |
| powerpc64le-linux-gnu | 48 MB | 39 MB |
| riscv64-linux-gnu | 35 MB | 29 MB |

Based on the first commit from bitcoin/bitcoin#25391.

Using LTO for macOS and Windows hosts has some issues which could be addressed in follow ups.

x86_64 build:
![image](https://user-images.githubusercontent.com/32963518/179326902-f91853ca-23c1-4c04-9a6d-161b695f27b5.png)
