### PR TITLE
doc: update for NetBSD 9.2, add GUI Build Instructions

### DIFF
--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -1,92 +1,116 @@
-NetBSD Build Guide
-======================
-**Updated for NetBSD [8.0](https://www.netbsd.org/releases/formal-8/NetBSD-8.0.html)**
+# NetBSD Build Guide
 
-This guide describes how to build bitcoind and command-line utilities on NetBSD.
+Updated for NetBSD [9.2](https://netbsd.org/releases/formal-9/NetBSD-9.2.html).
 
-This guide does not contain instructions for building the GUI.
+This guide describes how to build bitcoind, command-line utilities, and GUI on NetBSD.
 
-Preparation
--------------
+## Preparation
 
-You will need the following modules, which can be installed via pkgsrc or pkgin:
+### 1. Install Required Dependencies
+
+Install the required dependencies the usual way you [install software on NetBSD](https://www.netbsd.org/docs/guide/en/chap-boot.html#chap-boot-pkgsrc).
+The example commands below use `pkgin`.
+
+```bash
+pkgin install autoconf automake libtool pkg-config git gmake boost libevent
 
 ```
-autoconf
-automake
-boost
-git
-gmake
-libevent
-libtool
-pkg-config
-python37
 
-git clone https://github.com/bitcoin/bitcoin.git
+NetBSD currently ships with an older version of `gcc` than is needed to build. You should upgrade your `gcc` and then pass this new version to the configure script.
+
+For example, grab `gcc9`:
+```
+pkgin install gcc9
+```
+
+Then, when configuring, pass the following:
+```bash
+./configure
+    ...
+    CC="/usr/pkg/gcc9/bin/gcc" \
+    CXX="/usr/pkg/gcc9/bin/g++" \
+    ...
 ```
 
 See [dependencies.md](dependencies.md) for a complete overview.
 
-### Building Bitcoin Core
+### 2. Clone Bitcoin Repo
 
-**Important**: Use `gmake` (the non-GNU `make` will exit with an error).
+Clone the Bitcoin Core repository to a directory. All build scripts and commands will run from this directory.
 
-#### With descriptor wallet:
+```bash
+git clone https://github.com/bitcoin/bitcoin.git
+```
 
-The descriptor wallet uses `sqlite3`. You can install it using:
+### 3. Install Optional Dependencies
+
+#### Wallet Dependencies
+
+It is not necessary to build wallet functionality to run bitcoind or the GUI.
+
+###### Descriptor Wallet Support
+
+`sqlite3` is required to enable support for [descriptor wallets](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md).
+
 ```bash
 pkgin install sqlite3
 ```
 
+###### Legacy Wallet Support
+
+`db4` is required to enable support for legacy wallets.
+
+```bash
+pkgin install db4
+```
+
+#### GUI Dependencies
+
+Bitcoin Core includes a GUI built with the cross-platform Qt Framework. To compile the GUI, we need to install `qt5`.
+
+```bash
+pkgin install qt5
+```
+
+The GUI can encode addresses in a QR Code. To build in QR support for the GUI, install `qrencode`.
+
+```bash
+pkgin install qrencode
+```
+
+#### Test Suite Dependencies
+
+There is an included test suite that is useful for testing code changes when developing.
+To run the test suite (recommended), you will need to have Python 3 installed:
+
+```bash
+pkgin install python37
+```
+
+### Building Bitcoin Core
+
+**Note**: Use `gmake` (the non-GNU `make` will exit with an error).
+
+
+### 1. Configuration
+
+There are many ways to configure Bitcoin Core. Here is an example that
+explicitly disables the wallet and GUI:
+
 ```bash
 ./autogen.sh
-./configure --with-gui=no --without-bdb \
+./configure --without-wallet --with-gui=no \
     CPPFLAGS="-I/usr/pkg/include" \
-    LDFLAGS="-L/usr/pkg/lib" \
-    BOOST_CPPFLAGS="-I/usr/pkg/include" \
     MAKE=gmake
 ```
 
-#### With legacy wallet:
+For a full list of configuration options, see the output of `./configure --help`
 
-BerkeleyDB is use for legacy wallet functionality.
-
-It is recommended to use Berkeley DB 4.8. You cannot use the BerkeleyDB library
-from ports.
-You can use [the installation script included in contrib/](/contrib/install_db4.sh) like so:
-
-```bash
-./contrib/install_db4.sh `pwd`
-```
-
-from the root of the repository. Then set `BDB_PREFIX` for the next section:
-
-```bash
-export BDB_PREFIX="$PWD/db4"
-```
-
-```bash
-./autogen.sh
-./configure --with-gui=no CPPFLAGS="-I/usr/pkg/include" \
-    LDFLAGS="-L/usr/pkg/lib" \
-    BOOST_CPPFLAGS="-I/usr/pkg/include" \
-    BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
-    BDB_CFLAGS="-I${BDB_PREFIX}/include" \
-    MAKE=gmake
-```
-
-#### Without wallet:
-```bash
-./autogen.sh
-./configure --with-gui=no --disable-wallet \
-    CPPFLAGS="-I/usr/pkg/include" \
-    LDFLAGS="-L/usr/pkg/lib" \
-    BOOST_CPPFLAGS="-I/usr/pkg/include" \
-    MAKE=gmake
-```
+### 2. Compile
 
 Build and run the tests:
+
 ```bash
 gmake # use "-j N" here for N parallel jobs
-gmake check
+gmake check # Run tests if Python 3 is available
 ```


### PR DESCRIPTION
**For reviewer:** as I suppose few have a NetBSD system available, I wrote a [guide](https://gist.github.com/jarolrod/385dc063bb02c90aea0cbe8a147fc418#file-netbsd-vm-setup-guide-md) to setup a VM for testing purposes.

This attempts to update the NetBSD docs so one can successfully build on the latest release. It also adds instructions to build the GUI.

Additionally, it includes a note and an example on how one could update the gcc version bundled with NetBSD 9.2 and prior to be able to actually compile. This note can be updated with the release of NetBSD 10, as it will package an acceptable gcc version.

Master: [render](https://github.com/bitcoin/bitcoin/blob/master/doc/build-netbsd.md)
PR: [render](https://github.com/bitcoin/bitcoin/blob/d3e9a1c71bef1d730b5820f85e9758af54267ac3/doc/build-netbsd.md)

Related to #20610, but reworked.
