### PR TITLE
doc: remove note on arm cross-compilation from build-unix.md

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -288,26 +288,3 @@ This example lists the steps necessary to setup and build a command line only di
     ./src/bitcoind
 
 If you intend to work with legacy Berkeley DB wallets, see [Berkeley DB](#berkeley-db) section.
-
-ARM Cross-compilation
--------------------
-These steps can be performed on, for example, an Ubuntu VM. The depends system
-will also work on other Linux distributions, however the commands for
-installing the toolchain will be different.
-
-Make sure you install the build requirements mentioned above.
-Then, install the toolchain and curl:
-
-    sudo apt-get install g++-arm-linux-gnueabihf curl
-
-To build executables for ARM:
-
-    cd depends
-    make HOST=arm-linux-gnueabihf NO_QT=1
-    cd ..
-    ./autogen.sh
-    CONFIG_SITE=$PWD/depends/arm-linux-gnueabihf/share/config.site ./configure --enable-reduce-exports LDFLAGS=-static-libstdc++
-    make
-
-
-For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.


### PR DESCRIPTION
No reason to have this here with outdated information. We already point users to the depends readme, the doc cross builders should be pointed to, within this doc.

Master: [render](https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md)
PR: [render](https://github.com/jarolrod/bitcoin/blob/f1c16ed733f416a3bea878f1c21621dbd93b267c/doc/build-unix.md)