### PR TITLE
test: Rename inner key to internal key

### DIFF
--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1499,7 +1499,7 @@ class TaprootTest(BitcoinTestFramework):
         # Generate corresponding public x-only pubkeys
         pubs = [compute_xonly_pubkey(prv)[0] for prv in prvs]
         # Generate taproot objects
-        inner_keys = [pubs[i] for i in range(7)]
+        internal_keys = [pubs[i] for i in range(7)]
 
         script_lists = [
             None,
@@ -1510,7 +1510,7 @@ class TaprootTest(BitcoinTestFramework):
             [("0", CScript([pubs[54], OP_CHECKSIG]), 0xc0), [("1", CScript([pubs[55], OP_CHECKSIG]), 0xc0), ("2", CScript([pubs[56], OP_CHECKSIG]), 0xc0)]],
             [("0", CScript([pubs[57], OP_CHECKSIG]), 0xc0), [("1", CScript([pubs[58], OP_CHECKSIG]), 0xc0), ("2", CScript([pubs[59], OP_CHECKSIG]), 0xc0)]],
         ]
-        taps = [taproot_construct(inner_keys[i], script_lists[i]) for i in range(len(inner_keys))]
+        taps = [taproot_construct(internal_keys[i], script_lists[i]) for i in range(len(internal_keys))]
 
         # Require negated taps[0]
         assert taps[0].negflag

--- a/test/functional/wallet_taproot.py
+++ b/test/functional/wallet_taproot.py
@@ -179,7 +179,7 @@ def multi_a(k, hex_keys, sort=False):
     return (None, CScript(ops))
 
 def compute_taproot_address(pubkey, scripts):
-    """Compute the address for a taproot output with given inner key and scripts."""
+    """Compute the address for a taproot output with given internal key and scripts."""
     return output_key_to_p2tr(taproot_construct(pubkey, scripts).output_pubkey)
 
 class WalletTaprootTest(BitcoinTestFramework):


### PR DESCRIPTION
Remove Taproot specific references in functional tests to "inner key" and replace with "internal key" as used in [BIP 341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#script-validation-rules)