### PR TITLE
p2p: Eliminate atomic for m_last_getheaders_timestamp

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -358,7 +358,7 @@ struct Peer {
     std::deque<CInv> m_getdata_requests GUARDED_BY(m_getdata_requests_mutex);
 
     /** Time of the last getheaders message to this peer */
-    std::atomic<NodeClock::time_point> m_last_getheaders_timestamp{NodeSeconds{}};
+    NodeClock::time_point m_last_getheaders_timestamp{};
 
     Peer(NodeId id)
         : m_id{id}
@@ -2276,7 +2276,7 @@ bool PeerManagerImpl::MaybeSendGetHeaders(CNode& pfrom, const CBlockLocator& loc
 
     // Only allow a new getheaders message to go out if we don't have a recent
     // one already in-flight
-    if (current_time - peer.m_last_getheaders_timestamp.load() > HEADERS_RESPONSE_TIME) {
+    if (current_time - peer.m_last_getheaders_timestamp > HEADERS_RESPONSE_TIME) {
         m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::GETHEADERS, locator, uint256()));
         peer.m_last_getheaders_timestamp = current_time;
         return true;
@@ -3974,7 +3974,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
         // Assume that this is in response to any outstanding getheaders
         // request we may have sent, and clear out the time of our last request
-        peer->m_last_getheaders_timestamp.store(NodeSeconds{});
+        peer->m_last_getheaders_timestamp = {};
 
         std::vector<CBlockHeader> headers;
 

--- a/test/functional/feature_minchainwork.py
+++ b/test/functional/feature_minchainwork.py
@@ -82,7 +82,7 @@ class MinimumChainWorkTest(BitcoinTestFramework):
         msg.hashstop = 0
         peer.send_and_ping(msg)
         time.sleep(5)
-        assert ("headers" not in peer.last_message or len(peer.last_message["headers"].headers) == 0)
+        assert "headers" not in peer.last_message or len(peer.last_message["headers"].headers) == 0
 
         self.log.info("Generating one more block")
         self.generate(self.nodes[0], 1)


### PR DESCRIPTION
Eliminate the unnecessary atomic guarding `m_last_getheaders_timestamp`, which is only accessed in a single thread (thanks to MarcoFalke for pointing this out).

Also address a nit that came up in #25454.