### PR TITLE
guix: Make windows cross architecture reproducible

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -147,7 +147,10 @@ desirable for building Bitcoin Core release binaries."
                         base-gcc))
 
 (define (make-gcc-with-pthreads gcc)
-  (package-with-extra-configure-variable gcc "--enable-threads" "posix"))
+  (package-with-extra-configure-variable
+    (package-with-extra-patches gcc
+      (search-our-patches "gcc-10-remap-guix-store.patch"))
+    "--enable-threads" "posix"))
 
 (define (make-mingw-w64-cross-gcc cross-gcc)
   (package-with-extra-patches cross-gcc

--- a/contrib/guix/patches/gcc-10-remap-guix-store.patch
+++ b/contrib/guix/patches/gcc-10-remap-guix-store.patch
@@ -1,0 +1,25 @@
+From aad25427e74f387412e8bc9a9d7bbc6c496c792f Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Wed, 6 Jul 2022 16:49:41 -0400
+Subject: [PATCH] guix: remap guix store paths to /usr
+
+---
+ libgcc/Makefile.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libgcc/Makefile.in b/libgcc/Makefile.in
+index 851e7657d07..476c2becd1c 100644
+--- a/libgcc/Makefile.in
++++ b/libgcc/Makefile.in
+@@ -854,7 +854,7 @@ endif
+ # libgcc_eh.a, only LIB2ADDEH matters.  If we do, only LIB2ADDEHSTATIC and
+ # LIB2ADDEHSHARED matter.  (Usually all three are identical.)
+ 
+-c_flags := -fexceptions
++c_flags := -fexceptions $(shell find /gnu/store -maxdepth 1 -mindepth 1 -type d -exec echo -n " -ffile-prefix-map={}=/usr" \;)
+ 
+ ifeq ($(enable_shared),yes)
+ 
+-- 
+2.37.0
+


### PR DESCRIPTION
The only thing preventing windows from being cross architecture reproducible is a single guix store winpthreads path in the debug symbols. This can be removed by patching libgcc to use `-ffile-prefix-map` so that the debug symbol will be mapped to a fixed `/usr` instead of the guix store path which depends on the building architecture.

x86_64
```
2e585c4a66e930b5e273e89b8aeddc9c3bd1c8375b19d988a6fff64f0d49edfd  guix-build-5bff18bce5d9/output/dist-archive/bitcoin-5bff18bce5d9.tar.gz
b9235dc1a8541e840231cfafd0d971bd5e8a3ea7d5331c4d7af9dbfdabc6905b  guix-build-5bff18bce5d9/output/x86_64-w64-mingw32/SHA256SUMS.part
f82d861de60e22fc7dd731bef60a3e4399b5317eb16e41e92ded171490d1a578  guix-build-5bff18bce5d9/output/x86_64-w64-mingw32/bitcoin-5bff18bce5d9-win64-debug.zip
bfd59561c3cfce91b09d05b17cfc67cd70cb78eea39ea863119870260a8dbdec  guix-build-5bff18bce5d9/output/x86_64-w64-mingw32/bitcoin-5bff18bce5d9-win64-setup-unsigned.exe
3d049d98c6add13b0eb4c7adcf0d3ae59d1eab09799292a2c900de0ad067912a  guix-build-5bff18bce5d9/output/x86_64-w64-mingw32/bitcoin-5bff18bce5d9-win64-unsigned.tar.gz
7af4c34c47f349028ec1f4c2edea547bd9fa30d1c67977d482607a9c6bf2ddee  guix-build-5bff18bce5d9/output/x86_64-w64-mingw32/bitcoin-5bff18bce5d9-win64.zip
```

arm64
```
2e585c4a66e930b5e273e89b8aeddc9c3bd1c8375b19d988a6fff64f0d49edfd  guix-build-5bff18bce5d9/output/dist-archive/bitcoin-5bff18bce5d9.tar.gz
b9235dc1a8541e840231cfafd0d971bd5e8a3ea7d5331c4d7af9dbfdabc6905b  guix-build-5bff18bce5d9/output/x86_64-w64-mingw32/SHA256SUMS.part
f82d861de60e22fc7dd731bef60a3e4399b5317eb16e41e92ded171490d1a578  guix-build-5bff18bce5d9/output/x86_64-w64-mingw32/bitcoin-5bff18bce5d9-win64-debug.zip
bfd59561c3cfce91b09d05b17cfc67cd70cb78eea39ea863119870260a8dbdec  guix-build-5bff18bce5d9/output/x86_64-w64-mingw32/bitcoin-5bff18bce5d9-win64-setup-unsigned.exe
3d049d98c6add13b0eb4c7adcf0d3ae59d1eab09799292a2c900de0ad067912a  guix-build-5bff18bce5d9/output/x86_64-w64-mingw32/bitcoin-5bff18bce5d9-win64-unsigned.tar.gz
7af4c34c47f349028ec1f4c2edea547bd9fa30d1c67977d482607a9c6bf2ddee  guix-build-5bff18bce5d9/output/x86_64-w64-mingw32/bitcoin-5bff18bce5d9-win64.zip
```