### PR TITLE
Fix signed integer oveflow

### DIFF
--- a/src/leveldb/db/write_batch.cc
+++ b/src/leveldb/db/write_batch.cc
@@ -47,7 +47,7 @@ Status WriteBatch::Iterate(Handler* handler) const {
 
   input.remove_prefix(kHeader);
   Slice key, value;
-  int found = 0;
+  uint32_t found = 0;
   while (!input.empty()) {
     found++;
     char tag = input[0];
@@ -79,11 +79,11 @@ Status WriteBatch::Iterate(Handler* handler) const {
   }
 }
 
-int WriteBatchInternal::Count(const WriteBatch* b) {
+uint32_t WriteBatchInternal::Count(const WriteBatch* b) {
   return DecodeFixed32(b->rep_.data() + 8);
 }
 
-void WriteBatchInternal::SetCount(WriteBatch* b, int n) {
+void WriteBatchInternal::SetCount(WriteBatch* b, uint32_t n) {
   EncodeFixed32(&b->rep_[8], n);
 }
 

--- a/src/leveldb/db/write_batch_internal.h
+++ b/src/leveldb/db/write_batch_internal.h
@@ -17,10 +17,10 @@ class MemTable;
 class WriteBatchInternal {
  public:
   // Return the number of entries in the batch.
-  static int Count(const WriteBatch* batch);
+  static uint32_t Count(const WriteBatch* batch);
 
   // Set the count for the number of entries in the batch.
-  static void SetCount(WriteBatch* batch, int n);
+  static void SetCount(WriteBatch* batch, uint32_t n);
 
   // Return the sequence number for the start of this batch.
   static SequenceNumber Sequence(const WriteBatch* batch);


### PR DESCRIPTION
It's Common Vulnerable and Exposure mirror https://github.com/google/leveldb/pull/1040

Ledger by default is safe, but if node is running by `-dbcache=2148` or more it will misbehave.