### PR TITLE
Move DEFAULT_MAX_ORPHAN_TRANSACTIONS to node/txorphanage.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -199,12 +199,13 @@ BITCOIN_CORE_H = \
   node/chainstate.h \
   node/coin.h \
   node/context.h \
+  node/interface_ui.h \
   node/mempool_persist_args.h \
   node/miner.h \
   node/minisketchwrapper.h \
   node/psbt.h \
   node/transaction.h \
-  node/interface_ui.h \
+  node/txorphanage.h \
   node/utxo_snapshot.h \
   noui.h \
   outputtype.h \
@@ -256,7 +257,6 @@ BITCOIN_CORE_H = \
   torcontrol.h \
   txdb.h \
   txmempool.h \
-  node/txorphanage.h \
   txrequest.h \
   undo.h \
   util/asmap.h \
@@ -381,13 +381,14 @@ libbitcoin_node_a_SOURCES = \
   node/connection_types.cpp \
   node/context.cpp \
   node/eviction.cpp \
+  node/interface_ui.cpp \
   node/interfaces.cpp \
   node/mempool_persist_args.cpp \
   node/miner.cpp \
   node/minisketchwrapper.cpp \
   node/psbt.cpp \
   node/transaction.cpp \
-  node/interface_ui.cpp \
+  node/txorphanage.cpp \
   noui.cpp \
   policy/fees.cpp \
   policy/fees_args.cpp \
@@ -415,7 +416,6 @@ libbitcoin_node_a_SOURCES = \
   torcontrol.cpp \
   txdb.cpp \
   txmempool.cpp \
-  node/txorphanage.cpp \
   txrequest.cpp \
   validation.cpp \
   validationinterface.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -256,7 +256,7 @@ BITCOIN_CORE_H = \
   torcontrol.h \
   txdb.h \
   txmempool.h \
-  txorphanage.h \
+  node/txorphanage.h \
   txrequest.h \
   undo.h \
   util/asmap.h \
@@ -415,7 +415,7 @@ libbitcoin_node_a_SOURCES = \
   torcontrol.cpp \
   txdb.cpp \
   txmempool.cpp \
-  txorphanage.cpp \
+  node/txorphanage.cpp \
   txrequest.cpp \
   validation.cpp \
   validationinterface.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -44,6 +44,7 @@
 #include <node/interface_ui.h>
 #include <node/mempool_persist_args.h>
 #include <node/miner.h>
+#include <node/txorphanage.h>
 #include <policy/feerate.h>
 #include <policy/fees.h>
 #include <policy/fees_args.h>
@@ -63,7 +64,6 @@
 #include <torcontrol.h>
 #include <txdb.h>
 #include <txmempool.h>
-#include <node/txorphanage.h>
 #include <util/asmap.h>
 #include <util/check.h>
 #include <util/moneystr.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -63,7 +63,7 @@
 #include <torcontrol.h>
 #include <txdb.h>
 #include <txmempool.h>
-#include <txorphanage.h>
+#include <node/txorphanage.h>
 #include <util/asmap.h>
 #include <util/check.h>
 #include <util/moneystr.h>

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -19,6 +19,7 @@
 #include <netbase.h>
 #include <netmessagemaker.h>
 #include <node/blockstorage.h>
+#include <node/txorphanage.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
 #include <policy/settings.h>
@@ -31,7 +32,6 @@
 #include <sync.h>
 #include <tinyformat.h>
 #include <txmempool.h>
-#include <node/txorphanage.h>
 #include <txrequest.h>
 #include <util/check.h> // For NDEBUG compile time check
 #include <util/strencodings.h>

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -31,7 +31,7 @@
 #include <sync.h>
 #include <tinyformat.h>
 #include <txmempool.h>
-#include <txorphanage.h>
+#include <node/txorphanage.h>
 #include <txrequest.h>
 #include <util/check.h> // For NDEBUG compile time check
 #include <util/strencodings.h>

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -14,8 +14,6 @@ class CChainParams;
 class CTxMemPool;
 class ChainstateManager;
 
-/** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
-static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
 /** Default number of orphan+recently-replaced txn to keep around for block reconstruction */
 static const unsigned int DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN = 100;
 static const bool DEFAULT_PEERBLOOMFILTERS = false;

--- a/src/node/txorphanage.cpp
+++ b/src/node/txorphanage.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <txorphanage.h>
+#include <node/txorphanage.h>
 
 #include <consensus/validation.h>
 #include <logging.h>

--- a/src/node/txorphanage.h
+++ b/src/node/txorphanage.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_TXORPHANAGE_H
-#define BITCOIN_TXORPHANAGE_H
+#ifndef BITCOIN_NODE_TXORPHANAGE_H
+#define BITCOIN_NODE_TXORPHANAGE_H
 
 #include <net.h>
 #include <primitives/block.h>
@@ -89,4 +89,4 @@ protected:
     std::map<uint256, OrphanMap::iterator> m_wtxid_to_orphan_it GUARDED_BY(g_cs_orphans);
 };
 
-#endif // BITCOIN_TXORPHANAGE_H
+#endif // BITCOIN_NODE_TXORPHANAGE_H

--- a/src/node/txorphanage.h
+++ b/src/node/txorphanage.h
@@ -10,6 +10,9 @@
 #include <primitives/transaction.h>
 #include <sync.h>
 
+/** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
+static constexpr unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS{100};
+
 /** Guards orphan transactions and extra txs for compact blocks */
 extern RecursiveMutex g_cs_orphans;
 

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -7,6 +7,7 @@
 #include <consensus/consensus.h>
 #include <net.h>
 #include <net_processing.h>
+#include <node/txorphanage.h>
 #include <protocol.h>
 #include <scheduler.h>
 #include <script/script.h>
@@ -18,7 +19,6 @@
 #include <test/util/net.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
-#include <node/txorphanage.h>
 #include <validationinterface.h>
 #include <version.h>
 

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -18,7 +18,7 @@
 #include <test/util/net.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
-#include <txorphanage.h>
+#include <node/txorphanage.h>
 #include <validationinterface.h>
 #include <version.h>
 

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -13,7 +13,7 @@
 #include <test/util/net.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
-#include <txorphanage.h>
+#include <node/txorphanage.h>
 #include <validation.h>
 #include <validationinterface.h>
 

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -5,6 +5,7 @@
 #include <consensus/consensus.h>
 #include <net.h>
 #include <net_processing.h>
+#include <node/txorphanage.h>
 #include <protocol.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
@@ -13,7 +14,6 @@
 #include <test/util/net.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
-#include <node/txorphanage.h>
 #include <validation.h>
 #include <validationinterface.h>
 

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -4,8 +4,8 @@
 
 #include <consensus/amount.h>
 #include <consensus/validation.h>
-#include <net_processing.h>
 #include <node/eviction.h>
+#include <node/txorphanage.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
@@ -14,7 +14,6 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
-#include <node/txorphanage.h>
 #include <uint256.h>
 #include <util/check.h>
 #include <util/time.h>

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -14,7 +14,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
-#include <txorphanage.h>
+#include <node/txorphanage.h>
 #include <uint256.h>
 #include <util/check.h>
 #include <util/time.h>

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -8,7 +8,7 @@
 #include <script/signingprovider.h>
 #include <script/standard.h>
 #include <test/util/setup_common.h>
-#include <txorphanage.h>
+#include <node/txorphanage.h>
 
 #include <array>
 #include <cstdint>

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -3,12 +3,12 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <arith_uint256.h>
+#include <node/txorphanage.h>
 #include <pubkey.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <script/standard.h>
 #include <test/util/setup_common.h>
-#include <node/txorphanage.h>
 
 #include <array>
 #include <cstdint>


### PR DESCRIPTION
It is not meaninful to run txorphanage without a node (validation, chainstate, mempool, rpc, ...). The module is in the node library and won't be added to the kernel library. Thus, it should be moved to `src/node`.

Also, move `DEFAULT_MAX_ORPHAN_TRANSACTIONS` to `node/txorphanage.h`, as it logically belongs to `TxOrphanage::m_orphans` and not to `PeerManager`.