### PR TITLE
mempool: Add the `bypass_{csv,cltv}` option to `testmempoolaccept`

### DIFF
--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -37,7 +37,7 @@ static void AssembleBlock(benchmark::Bench& bench)
         LOCK(::cs_main);
 
         for (const auto& txr : txs) {
-            const MempoolAcceptResult res = test_setup->m_node.chainman->ProcessTransaction(/*tx=*/txr, /*test_accept=*/false);
+            const MempoolAcceptResult res = test_setup->m_node.chainman->ProcessTransaction(/*tx=*/txr, /*mempool_bypass=*/std::nullopt);
             assert(res.m_result_type == MempoolAcceptResult::ResultType::VALID);
         }
     }

--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -37,7 +37,7 @@ static void AssembleBlock(benchmark::Bench& bench)
         LOCK(::cs_main);
 
         for (const auto& txr : txs) {
-            const MempoolAcceptResult res = test_setup->m_node.chainman->ProcessTransaction(txr);
+            const MempoolAcceptResult res = test_setup->m_node.chainman->ProcessTransaction(/*tx=*/txr, /*test_accept=*/false);
             assert(res.m_result_type == MempoolAcceptResult::ResultType::VALID);
         }
     }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2403,7 +2403,7 @@ void PeerManagerImpl::ProcessOrphanTx(std::set<uint256>& orphan_work_set)
         const auto [porphanTx, from_peer] = m_orphanage.GetTx(orphanHash);
         if (porphanTx == nullptr) continue;
 
-        const MempoolAcceptResult result = m_chainman.ProcessTransaction(porphanTx);
+        const MempoolAcceptResult result = m_chainman.ProcessTransaction(/*tx=*/porphanTx, /*test_accept=*/false);
         const TxValidationState& state = result.m_state;
 
         if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {
@@ -3432,7 +3432,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             return;
         }
 
-        const MempoolAcceptResult result = m_chainman.ProcessTransaction(ptx);
+        const MempoolAcceptResult result = m_chainman.ProcessTransaction(/*tx=*/ptx, /*test_accept=*/false);
         const TxValidationState& state = result.m_state;
 
         if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2403,7 +2403,7 @@ void PeerManagerImpl::ProcessOrphanTx(std::set<uint256>& orphan_work_set)
         const auto [porphanTx, from_peer] = m_orphanage.GetTx(orphanHash);
         if (porphanTx == nullptr) continue;
 
-        const MempoolAcceptResult result = m_chainman.ProcessTransaction(/*tx=*/porphanTx, /*test_accept=*/false);
+        const MempoolAcceptResult result = m_chainman.ProcessTransaction(/*tx=*/porphanTx, /*mempool_bypass=*/std::nullopt);
         const TxValidationState& state = result.m_state;
 
         if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {
@@ -3432,7 +3432,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             return;
         }
 
-        const MempoolAcceptResult result = m_chainman.ProcessTransaction(/*tx=*/ptx, /*test_accept=*/false);
+        const MempoolAcceptResult result = m_chainman.ProcessTransaction(/*tx=*/ptx, /*mempool_bypass=*/std::nullopt);
         const TxValidationState& state = result.m_state;
 
         if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -71,7 +71,9 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
             if (max_tx_fee > 0) {
                 // First, call ATMP with test_accept and check the fee. If ATMP
                 // fails here, return error immediately.
-                const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, /*test_accept=*/true);
+
+                const MemPoolBypass mempool_bypass{/*test_accept=*/true, /*bypass_limits=*/false};
+                const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, mempool_bypass);
                 if (result.m_result_type != MempoolAcceptResult::ResultType::VALID) {
                     return HandleATMPError(result.m_state, err_string);
                 } else if (result.m_base_fees.value() > max_tx_fee) {
@@ -79,7 +81,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
                 }
             }
             // Try to submit the transaction to the mempool.
-            const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, /*test_accept=*/false);
+            const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, /*mempool_bypass=*/std::nullopt);
             if (result.m_result_type != MempoolAcceptResult::ResultType::VALID) {
                 return HandleATMPError(result.m_state, err_string);
             }

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -71,7 +71,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
             if (max_tx_fee > 0) {
                 // First, call ATMP with test_accept and check the fee. If ATMP
                 // fails here, return error immediately.
-                const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, /*test_accept=*/ true);
+                const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, /*test_accept=*/true);
                 if (result.m_result_type != MempoolAcceptResult::ResultType::VALID) {
                     return HandleATMPError(result.m_state, err_string);
                 } else if (result.m_base_fees.value() > max_tx_fee) {
@@ -79,7 +79,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
                 }
             }
             // Try to submit the transaction to the mempool.
-            const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, /*test_accept=*/ false);
+            const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, /*test_accept=*/false);
             if (result.m_result_type != MempoolAcceptResult::ResultType::VALID) {
                 return HandleATMPError(result.m_state, err_string);
             }

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -109,7 +109,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "signrawtransactionwithwallet", 1, "prevtxs" },
     { "sendrawtransaction", 1, "maxfeerate" },
     { "testmempoolaccept", 0, "rawtxs" },
-    { "testmempoolaccept", 1, "maxfeerate" },
+    { "testmempoolaccept", 1, "options" },
     { "submitpackage", 0, "package" },
     { "combinerawtransaction", 0, "txs" },
     { "fundrawtransaction", 1, "options" },

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -164,15 +164,15 @@ static RPCHelpMan testmempoolaccept()
                 }
             }
 
-            std::vector<CTransactionRef> txns;
-            txns.reserve(raw_transactions.size());
+            std::vector<CTransactionRef> package;
+            package.reserve(raw_transactions.size());
             for (const auto& rawtx : raw_transactions.getValues()) {
                 CMutableTransaction mtx;
                 if (!DecodeHexTx(mtx, rawtx.get_str())) {
                     throw JSONRPCError(RPC_DESERIALIZATION_ERROR,
                                        "TX decode failed: " + rawtx.get_str() + " Make sure the tx has at least one input.");
                 }
-                txns.emplace_back(MakeTransactionRef(std::move(mtx)));
+                package.emplace_back(MakeTransactionRef(std::move(mtx)));
             }
 
             NodeContext& node = EnsureAnyNodeContext(request.context);
@@ -181,9 +181,10 @@ static RPCHelpMan testmempoolaccept()
             CChainState& chainstate = chainman.ActiveChainstate();
             const PackageMempoolAcceptResult package_result = [&] {
                 LOCK(::cs_main);
-                if (txns.size() > 1) return ProcessNewPackage(chainstate, mempool, txns, /*test_accept=*/true);
-                return PackageMempoolAcceptResult(txns[0]->GetWitnessHash(),
-                                                  chainman.ProcessTransaction(/*tx=*/txns[0], /*test_accept=*/true));
+                const MemPoolBypass mempool_bypass{/*test_accept=*/true, /*bypass_limits=*/false};
+                if (package.size() > 1) return ProcessNewPackage(/*active_chainstate=*/chainstate, /*pool=*/mempool, package, mempool_bypass);
+                return PackageMempoolAcceptResult(package[0]->GetWitnessHash(),
+                                                  chainman.ProcessTransaction(/*tx=*/package[0], /*test_accept=*/true));
             }();
 
             UniValue rpc_result(UniValue::VARR);
@@ -192,7 +193,7 @@ static RPCHelpMan testmempoolaccept()
             // doesn't make sense to return a validation result for a transaction if its ancestor(s) would
             // not be submitted.
             bool exit_early{false};
-            for (const auto& tx : txns) {
+            for (const auto& tx : package) {
                 UniValue result_inner(UniValue::VOBJ);
                 result_inner.pushKV("txid", tx->GetHash().GetHex());
                 result_inner.pushKV("wtxid", tx->GetWitnessHash().GetHex());
@@ -803,21 +804,21 @@ static RPCHelpMan submitpackage()
                                    "Array must contain between 1 and " + ToString(MAX_PACKAGE_COUNT) + " transactions.");
             }
 
-            std::vector<CTransactionRef> txns;
-            txns.reserve(raw_transactions.size());
+            std::vector<CTransactionRef> package;
+            package.reserve(raw_transactions.size());
             for (const auto& rawtx : raw_transactions.getValues()) {
                 CMutableTransaction mtx;
                 if (!DecodeHexTx(mtx, rawtx.get_str())) {
                     throw JSONRPCError(RPC_DESERIALIZATION_ERROR,
                                        "TX decode failed: " + rawtx.get_str() + " Make sure the tx has at least one input.");
                 }
-                txns.emplace_back(MakeTransactionRef(std::move(mtx)));
+                package.emplace_back(MakeTransactionRef(std::move(mtx)));
             }
 
             NodeContext& node = EnsureAnyNodeContext(request.context);
             CTxMemPool& mempool = EnsureMemPool(node);
             CChainState& chainstate = EnsureChainman(node).ActiveChainstate();
-            const auto package_result = WITH_LOCK(::cs_main, return ProcessNewPackage(chainstate, mempool, txns, /*test_accept=*/ false));
+            const auto package_result = WITH_LOCK(::cs_main, return ProcessNewPackage(/*active_chainstate=*/chainstate, /*pool=*/mempool, package, /*mempool_bypass=*/std::nullopt));
 
             // First catch any errors.
             switch(package_result.m_state.GetResult()) {
@@ -834,7 +835,7 @@ static RPCHelpMan submitpackage()
                 }
                 case PackageValidationResult::PCKG_TX:
                 {
-                    for (const auto& tx : txns) {
+                    for (const auto& tx : package) {
                         auto it = package_result.m_tx_results.find(tx->GetWitnessHash());
                         if (it != package_result.m_tx_results.end() && it->second.m_state.IsInvalid()) {
                             throw JSONRPCTransactionError(TransactionError::MEMPOOL_REJECTED,
@@ -845,7 +846,7 @@ static RPCHelpMan submitpackage()
                     NONFATAL_UNREACHABLE();
                 }
             }
-            for (const auto& tx : txns) {
+            for (const auto& tx : package) {
                 size_t num_submitted{0};
                 std::string err_string;
                 const auto err = BroadcastTransaction(node, tx, err_string, 0, true, true);
@@ -858,7 +859,7 @@ static RPCHelpMan submitpackage()
             UniValue rpc_result{UniValue::VOBJ};
             UniValue tx_result_map{UniValue::VOBJ};
             std::set<uint256> replaced_txids;
-            for (const auto& tx : txns) {
+            for (const auto& tx : package) {
                 auto it = package_result.m_tx_results.find(tx->GetWitnessHash());
                 CHECK_NONFATAL(it != package_result.m_tx_results.end());
                 UniValue result_inner{UniValue::VOBJ};

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -183,7 +183,7 @@ static RPCHelpMan testmempoolaccept()
                 LOCK(::cs_main);
                 if (txns.size() > 1) return ProcessNewPackage(chainstate, mempool, txns, /*test_accept=*/true);
                 return PackageMempoolAcceptResult(txns[0]->GetWitnessHash(),
-                                                  chainman.ProcessTransaction(txns[0], /*test_accept=*/true));
+                                                  chainman.ProcessTransaction(/*tx=*/txns[0], /*test_accept=*/true));
             }();
 
             UniValue rpc_result(UniValue::VARR);

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -103,7 +103,9 @@ static RPCHelpMan testmempoolaccept()
                     "Reject transactions whose fee rate is higher than the specified value, expressed in " + CURRENCY_UNIT + "/kvB\n"},
                     {"bypass_absolute_timelock", RPCArg::Type::BOOL, RPCArg::Default{false}, "Don't enforce nLocktime.\n"},
                     {"bypass_relative_timelock", RPCArg::Type::BOOL, RPCArg::Default{false}, "Don't consensus-enforce BIP68 relative lock-time.\n"},
-                    {"bypass_feerate_accuracy",   RPCArg::Type::BOOL, RPCArg::Default{false}, "Don't enforce mempool minimum feerate.\n"}
+                    {"bypass_feerate_accuracy", RPCArg::Type::BOOL, RPCArg::Default{false}, "Don't enforce mempool minimum feerate.\n"},
+                    {"bypass_cltv", RPCArg::Type::BOOL, RPCArg::Default{false}, "Bypass CLTV execution.\n"},
+                    {"bypass_csv", RPCArg::Type::BOOL, RPCArg::Default{false}, "Bypass CSV execution.\n"}
                 },
                 "\"options\""
             },
@@ -163,7 +165,9 @@ static RPCHelpMan testmempoolaccept()
                         {"maxfeerate", UniValueType()}, // will be checked by AmountFromValue() below
                         {"bypass_absolute_timelock", UniValueType(UniValue::VBOOL)},
                         {"bypass_relative_timelock", UniValueType(UniValue::VBOOL)},
-                        {"bypass_feerate_accuracy", UniValueType(UniValue::VBOOL)}
+                        {"bypass_feerate_accuracy", UniValueType(UniValue::VBOOL)},
+                        {"bypass_cltv", UniValueType(UniValue::VBOOL)},
+                        {"bypass_csv", UniValueType(UniValue::VBOOL)}
                     },
                     true, true);
 
@@ -174,6 +178,8 @@ static RPCHelpMan testmempoolaccept()
                 mempool_bypass.m_bypass_absolute_timelock = options.exists("bypass_absolute_timelock") ? options["bypass_absolute_timelock"].get_bool() : false;
                 mempool_bypass.m_bypass_relative_timelock = options.exists("bypass_relative_timelock") ? options["bypass_relative_timelock"].get_bool() : false;
                 mempool_bypass.m_bypass_feerate_accuracy = options.exists("bypass_feerate_accuracy") ? options["bypass_feerate_accuracy"].get_bool() : false;
+                mempool_bypass.m_bypass_cltv = options.exists("bypass_cltv") ? options["bypass_cltv"].get_bool() : false;
+                mempool_bypass.m_bypass_csv = options.exists("bypass_csv") ? options["bypass_csv"].get_bool() : false;
             }
 
             std::vector<CTransactionRef> package;

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -102,7 +102,8 @@ static RPCHelpMan testmempoolaccept()
                     {"maxfeerate", RPCArg::Type::AMOUNT, RPCArg::Default{FormatMoney(DEFAULT_MAX_RAW_TX_FEE_RATE.GetFeePerK())},
                     "Reject transactions whose fee rate is higher than the specified value, expressed in " + CURRENCY_UNIT + "/kvB\n"},
                     {"bypass_absolute_timelock", RPCArg::Type::BOOL, RPCArg::Default{false}, "Don't enforce nLocktime.\n"},
-                    {"bypass_relative_timelock", RPCArg::Type::BOOL, RPCArg::Default{false}, "Don't consensus-enforce BIP68 relative lock-time.\n"}
+                    {"bypass_relative_timelock", RPCArg::Type::BOOL, RPCArg::Default{false}, "Don't consensus-enforce BIP68 relative lock-time.\n"},
+                    {"bypass_feerate_accuracy",   RPCArg::Type::BOOL, RPCArg::Default{false}, "Don't enforce mempool minimum feerate.\n"}
                 },
                 "\"options\""
             },
@@ -162,6 +163,7 @@ static RPCHelpMan testmempoolaccept()
                         {"maxfeerate", UniValueType()}, // will be checked by AmountFromValue() below
                         {"bypass_absolute_timelock", UniValueType(UniValue::VBOOL)},
                         {"bypass_relative_timelock", UniValueType(UniValue::VBOOL)},
+                        {"bypass_feerate_accuracy", UniValueType(UniValue::VBOOL)}
                     },
                     true, true);
 
@@ -171,6 +173,7 @@ static RPCHelpMan testmempoolaccept()
 
                 mempool_bypass.m_bypass_absolute_timelock = options.exists("bypass_absolute_timelock") ? options["bypass_absolute_timelock"].get_bool() : false;
                 mempool_bypass.m_bypass_relative_timelock = options.exists("bypass_relative_timelock") ? options["bypass_relative_timelock"].get_bool() : false;
+                mempool_bypass.m_bypass_feerate_accuracy = options.exists("bypass_feerate_accuracy") ? options["bypass_feerate_accuracy"].get_bool() : false;
             }
 
             std::vector<CTransactionRef> package;

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -184,7 +184,7 @@ static RPCHelpMan testmempoolaccept()
                 const MemPoolBypass mempool_bypass{/*test_accept=*/true, /*bypass_limits=*/false};
                 if (package.size() > 1) return ProcessNewPackage(/*active_chainstate=*/chainstate, /*pool=*/mempool, package, mempool_bypass);
                 return PackageMempoolAcceptResult(package[0]->GetWitnessHash(),
-                                                  chainman.ProcessTransaction(/*tx=*/package[0], /*test_accept=*/true));
+                                                  chainman.ProcessTransaction(/*tx=*/package[0], mempool_bypass));
             }();
 
             UniValue rpc_result(UniValue::VARR);

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -264,7 +264,8 @@ FUZZ_TARGET_INIT(tx_pool_standard, initialize_tx_pool)
                    it->second.m_result_type == MempoolAcceptResult::ResultType::INVALID);
         }
 
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), bypass_limits, /*test_accept=*/false));
+        const MemPoolBypass mempool_bypass2{/*test_accept=*/false, /*bypass_limits=*/bypass_limits};
+        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(/*active_chainstate=*/chainstate, tx, /*accept_time=*/GetTime(), mempool_bypass2));
         const bool accepted = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
         SyncWithValidationInterfaceQueue();
         UnregisterSharedValidationInterface(txr);
@@ -364,7 +365,8 @@ FUZZ_TARGET_INIT(tx_pool, initialize_tx_pool)
         const auto tx = MakeTransactionRef(mut_tx);
         const bool bypass_limits = fuzzed_data_provider.ConsumeBool();
         ::fRequireStandard = fuzzed_data_provider.ConsumeBool();
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), bypass_limits, /*test_accept=*/false));
+        const MemPoolBypass mempool_bypass{/*test_accept=*/false, /*bypass_limits=*/bypass_limits};
+        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(/*active_chainstate=*/chainstate, tx, /*accept_time=*/GetTime(), mempool_bypass));
         const bool accepted = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
         if (accepted) {
             txids.push_back(tx->GetHash());

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -252,8 +252,9 @@ FUZZ_TARGET_INIT(tx_pool_standard, initialize_tx_pool)
 
         // Make sure ProcessNewPackage on one transaction works.
         // The result is not guaranteed to be the same as what is returned by ATMP.
+        const MemPoolBypass mempool_bypass1{/*test_accept=*/true, /*bypass_limits=*/bypass_limits};
         const auto result_package = WITH_LOCK(::cs_main,
-                                    return ProcessNewPackage(chainstate, tx_pool, {tx}, true));
+                                              return ProcessNewPackage(/*active_chainstate=*/chainstate, /*pool=*/tx_pool, /*package=*/{tx}, mempool_bypass1));
         // If something went wrong due to a package-specific policy, it might not return a
         // validation result for the transaction.
         if (result_package.m_state.GetResult() != PackageValidationResult::PCKG_POLICY) {

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -533,7 +533,7 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
     CTransactionRef ptx_parent2_v1 = MakeTransactionRef(mtx_parent2_v1);
     CTransactionRef ptx_parent2_v2 = MakeTransactionRef(mtx_parent2_v2);
     // Put parent2_v1 in the package, submit parent2_v2 to the mempool.
-    const MempoolAcceptResult parent2_v2_result = m_node.chainman->ProcessTransaction(/*tx=*/ptx_parent2_v2, /*test_accept=*/false);
+    const MempoolAcceptResult parent2_v2_result = m_node.chainman->ProcessTransaction(/*tx=*/ptx_parent2_v2, /*mempool_bypass=*/std::nullopt);
     BOOST_CHECK(parent2_v2_result.m_result_type == MempoolAcceptResult::ResultType::VALID);
     package_mixed.push_back(ptx_parent2_v1);
 

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -87,7 +87,8 @@ BOOST_FIXTURE_TEST_CASE(package_validation_tests, TestChain100Setup)
                                                    /*output_destination=*/child_locking_script,
                                                    /*output_amount=*/CAmount(48 * COIN), /*submit=*/false);
     CTransactionRef tx_child = MakeTransactionRef(mtx_child);
-    const auto result_parent_child = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, {tx_parent, tx_child}, /*test_accept=*/true);
+    const MemPoolBypass mempool_bypass{/*test_accept=*/true, /*bypass_limits=*/false};
+    const auto result_parent_child = ProcessNewPackage(/*active_chainstate=*/m_node.chainman->ActiveChainstate(), /*pool=*/*m_node.mempool, /*package=*/{tx_parent, tx_child}, mempool_bypass);
     BOOST_CHECK_MESSAGE(result_parent_child.m_state.IsValid(),
                         "Package validation unexpectedly failed: " << result_parent_child.m_state.GetRejectReason());
     auto it_parent = result_parent_child.m_tx_results.find(tx_parent->GetWitnessHash());
@@ -105,7 +106,7 @@ BOOST_FIXTURE_TEST_CASE(package_validation_tests, TestChain100Setup)
     // A single, giant transaction submitted through ProcessNewPackage fails on single tx policy.
     CTransactionRef giant_ptx = create_placeholder_tx(999, 999);
     BOOST_CHECK(GetVirtualTransactionSize(*giant_ptx) > MAX_PACKAGE_SIZE * 1000);
-    auto result_single_large = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, {giant_ptx}, /*test_accept=*/true);
+    auto result_single_large = ProcessNewPackage(/*active_chainstate=*/m_node.chainman->ActiveChainstate(), /*pool=*/*m_node.mempool, /*package=*/{giant_ptx}, mempool_bypass);
     BOOST_CHECK(result_single_large.m_state.IsInvalid());
     BOOST_CHECK_EQUAL(result_single_large.m_state.GetResult(), PackageValidationResult::PCKG_TX);
     BOOST_CHECK_EQUAL(result_single_large.m_state.GetRejectReason(), "transaction failed");
@@ -227,8 +228,8 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
                                                  /*output_amount=*/CAmount(49 * COIN), /*submit=*/false);
         package_unrelated.emplace_back(MakeTransactionRef(mtx));
     }
-    auto result_unrelated_submit = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                     package_unrelated, /*test_accept=*/false);
+    auto result_unrelated_submit = ProcessNewPackage(/*active_chainstate=*/m_node.chainman->ActiveChainstate(), /*pool=*/*m_node.mempool,
+                                                     /*package=*/package_unrelated, /*mempool_bypass=*/std::nullopt);
     BOOST_CHECK(result_unrelated_submit.m_state.IsInvalid());
     BOOST_CHECK_EQUAL(result_unrelated_submit.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
     BOOST_CHECK_EQUAL(result_unrelated_submit.m_state.GetRejectReason(), "package-not-child-with-parents");
@@ -269,8 +270,8 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
 
     // 3 Generations is not allowed.
     {
-        auto result_3gen_submit = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                    package_3gen, /*test_accept=*/false);
+        auto result_3gen_submit = ProcessNewPackage(/*active_chainstate=*/m_node.chainman->ActiveChainstate(), /*pool=*/*m_node.mempool,
+                                                    /*package=*/package_3gen, /*mempool_bypass=*/std::nullopt);
         BOOST_CHECK(result_3gen_submit.m_state.IsInvalid());
         BOOST_CHECK_EQUAL(result_3gen_submit.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
         BOOST_CHECK_EQUAL(result_3gen_submit.m_state.GetRejectReason(), "package-not-child-with-parents");
@@ -284,8 +285,8 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
     package_missing_parent.push_back(tx_parent);
     package_missing_parent.push_back(MakeTransactionRef(mtx_child));
     {
-        const auto result_missing_parent = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                             package_missing_parent, /*test_accept=*/false);
+        const auto result_missing_parent = ProcessNewPackage(/*active_chainstate=*/m_node.chainman->ActiveChainstate(), /*pool=*/*m_node.mempool,
+                                                             /*package=*/package_missing_parent, /*mempool_bypass=*/std::nullopt);
         BOOST_CHECK(result_missing_parent.m_state.IsInvalid());
         BOOST_CHECK_EQUAL(result_missing_parent.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
         BOOST_CHECK_EQUAL(result_missing_parent.m_state.GetRejectReason(), "package-not-child-with-unconfirmed-parents");
@@ -296,8 +297,8 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
 
     // Submit package with parent + child.
     {
-        const auto submit_parent_child = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                           package_parent_child, /*test_accept=*/false);
+        const auto submit_parent_child = ProcessNewPackage(/*active_chainstate=*/m_node.chainman->ActiveChainstate(), /*pool=*/*m_node.mempool,
+                                                           /*package=*/package_parent_child, /*mempool_bypass=*/std::nullopt);
         expected_pool_size += 2;
         BOOST_CHECK_MESSAGE(submit_parent_child.m_state.IsValid(),
                             "Package validation unexpectedly failed: " << submit_parent_child.m_state.GetRejectReason());
@@ -319,8 +320,8 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
 
     // Already-in-mempool transactions should be detected and de-duplicated.
     {
-        const auto submit_deduped = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                      package_parent_child, /*test_accept=*/false);
+        const auto submit_deduped = ProcessNewPackage(/*active_chainstate=*/m_node.chainman->ActiveChainstate(), /*pool=*/*m_node.mempool,
+                                                      /*package=*/package_parent_child, /*mempool_bypass=*/std::nullopt);
         BOOST_CHECK_MESSAGE(submit_deduped.m_state.IsValid(),
                             "Package validation unexpectedly failed: " << submit_deduped.m_state.GetRejectReason());
         auto it_parent_deduped = submit_deduped.m_tx_results.find(tx_parent->GetWitnessHash());
@@ -395,8 +396,8 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
     // Try submitting Package1{parent, child1} and Package2{parent, child2} where the children are
     // same-txid-different-witness.
     {
-        const auto submit_witness1 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                       {ptx_parent, ptx_child1}, /*test_accept=*/false);
+        const auto submit_witness1 = ProcessNewPackage(/*active_chainstate=*/m_node.chainman->ActiveChainstate(), /*pool=*/*m_node.mempool,
+                                                       /*package=*/{ptx_parent, ptx_child1}, /*mempool_bypass=*/std::nullopt);
         BOOST_CHECK_MESSAGE(submit_witness1.m_state.IsValid(),
                             "Package validation unexpectedly failed: " << submit_witness1.m_state.GetRejectReason());
         auto it_parent1 = submit_witness1.m_tx_results.find(ptx_parent->GetWitnessHash());
@@ -414,8 +415,8 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
         // Child2 would have been validated individually.
         BOOST_CHECK(submit_witness1.m_package_feerate == std::nullopt);
 
-        const auto submit_witness2 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                       {ptx_parent, ptx_child2}, /*test_accept=*/false);
+        const auto submit_witness2 = ProcessNewPackage(/*active_chainstate=*/m_node.chainman->ActiveChainstate(), /*pool=*/*m_node.mempool,
+                                                       /*package=*/{ptx_parent, ptx_child2}, /*mempool_bypass=*/std::nullopt);
         BOOST_CHECK(submit_witness2.m_package_feerate == std::nullopt);
         BOOST_CHECK_MESSAGE(submit_witness2.m_state.IsValid(),
                             "Package validation unexpectedly failed: " << submit_witness2.m_state.GetRejectReason());
@@ -432,8 +433,8 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
 
         // Deduplication should work when wtxid != txid. Submit package with the already-in-mempool
         // transactions again, which should not fail.
-        const auto submit_segwit_dedup = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                           {ptx_parent, ptx_child1}, /*test_accept=*/false);
+        const auto submit_segwit_dedup = ProcessNewPackage(/*active_chainstate=*/m_node.chainman->ActiveChainstate(), /*pool=*/*m_node.mempool,
+                                                           /*package=*/{ptx_parent, ptx_child1}, /*mempool_bypass=*/std::nullopt);
         BOOST_CHECK_MESSAGE(submit_segwit_dedup.m_state.IsValid(),
                             "Package validation unexpectedly failed: " << submit_segwit_dedup.m_state.GetRejectReason());
         auto it_parent_dup = submit_segwit_dedup.m_tx_results.find(ptx_parent->GetWitnessHash());
@@ -461,8 +462,8 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
 
     // We already submitted child1 above.
     {
-        const auto submit_spend_ignored = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                            {ptx_child2, ptx_grandchild}, /*test_accept=*/false);
+        const auto submit_spend_ignored = ProcessNewPackage(/*active_chainstate=*/m_node.chainman->ActiveChainstate(), /*pool=*/*m_node.mempool,
+                                                            /*package=*/{ptx_child2, ptx_grandchild}, /*mempool_bypass=*/std::nullopt);
         BOOST_CHECK_MESSAGE(submit_spend_ignored.m_state.IsValid(),
                             "Package validation unexpectedly failed: " << submit_spend_ignored.m_state.GetRejectReason());
         auto it_child2_ignored = submit_spend_ignored.m_tx_results.find(ptx_child2->GetWitnessHash());
@@ -566,7 +567,7 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
     // parent3 should be accepted
     // child should be accepted
     {
-        const auto mixed_result = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_mixed, false);
+        const auto mixed_result = ProcessNewPackage(/*active_chainstate=*/m_node.chainman->ActiveChainstate(), /*pool=*/*m_node.mempool, /*package=*/package_mixed, /*mempool_bypass=*/std::nullopt);
         BOOST_CHECK_MESSAGE(mixed_result.m_state.IsValid(), mixed_result.m_state.GetRejectReason());
         auto it_parent1 = mixed_result.m_tx_results.find(ptx_parent1->GetWitnessHash());
         auto it_parent2 = mixed_result.m_tx_results.find(ptx_parent2_v1->GetWitnessHash());
@@ -636,8 +637,8 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
     m_node.mempool->PrioritiseTransaction(tx_parent->GetHash(), -1 * COIN);
     {
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-        const auto submit_cpfp_deprio = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                   package_cpfp, /*test_accept=*/ false);
+        const auto submit_cpfp_deprio = ProcessNewPackage(/*active_chainstate=*/m_node.chainman->ActiveChainstate(), /*pool=*/*m_node.mempool,
+                                                          /*package=*/package_cpfp, /*mempool_bypass=*/std::nullopt);
         BOOST_CHECK_MESSAGE(submit_cpfp_deprio.m_state.IsInvalid(),
                             "Package validation unexpectedly succeeded: " << submit_cpfp_deprio.m_state.GetRejectReason());
         BOOST_CHECK(submit_cpfp_deprio.m_tx_results.empty());
@@ -657,8 +658,8 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
     // enough for the package feerate to meet the threshold.
     {
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-        const auto submit_cpfp = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                   package_cpfp, /*test_accept=*/ false);
+        const auto submit_cpfp = ProcessNewPackage(/*active_chainstate=*/m_node.chainman->ActiveChainstate(), /*pool=*/*m_node.mempool,
+                                                   /*package=*/package_cpfp, /*mempool_bypass=*/std::nullopt);
         expected_pool_size += 2;
         BOOST_CHECK_MESSAGE(submit_cpfp.m_state.IsValid(),
                             "Package validation unexpectedly failed: " << submit_cpfp.m_state.GetRejectReason());
@@ -705,8 +706,8 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
     // Cheap package should fail with package-fee-too-low.
     {
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-        const auto submit_package_too_low = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                   package_still_too_low, /*test_accept=*/false);
+        const auto submit_package_too_low = ProcessNewPackage(/*active_chainstate=*/m_node.chainman->ActiveChainstate(), /*pool=*/*m_node.mempool,
+                                                              /*package=*/package_still_too_low, /*mempool_bypass=*/std::nullopt);
         BOOST_CHECK_MESSAGE(submit_package_too_low.m_state.IsInvalid(), "Package validation unexpectedly succeeded");
         BOOST_CHECK_EQUAL(submit_package_too_low.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
         BOOST_CHECK_EQUAL(submit_package_too_low.m_state.GetRejectReason(), "package-fee-too-low");
@@ -727,8 +728,8 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
     m_node.mempool->PrioritiseTransaction(tx_child_cheap->GetHash(), 1 * COIN);
     // Now that the child's fees have "increased" by 1 BTC, the cheap package should succeed.
     {
-        const auto submit_prioritised_package = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                                  package_still_too_low, /*test_accept=*/false);
+        const auto submit_prioritised_package = ProcessNewPackage(/*active_chainstate=*/m_node.chainman->ActiveChainstate(), /*pool=*/*m_node.mempool,
+                                                                  /*package=*/package_still_too_low, /*mempool_bypass=*/std::nullopt);
         expected_pool_size += 2;
         BOOST_CHECK_MESSAGE(submit_prioritised_package.m_state.IsValid(),
                 "Package validation unexpectedly failed" << submit_prioritised_package.m_state.GetRejectReason());
@@ -764,8 +765,8 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
     // Parent pays 1 BTC and child pays none. The parent should be accepted without the child.
     {
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-        const auto submit_rich_parent = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                          package_rich_parent, /*test_accept=*/false);
+        const auto submit_rich_parent = ProcessNewPackage(/*active_chainstate=*/m_node.chainman->ActiveChainstate(), /*pool=*/*m_node.mempool,
+                                                          /*package=*/package_rich_parent, /*mempool_bypass=*/std::nullopt);
         expected_pool_size += 1;
         BOOST_CHECK_MESSAGE(submit_rich_parent.m_state.IsInvalid(), "Package validation unexpectedly succeeded");
 

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -532,7 +532,7 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
     CTransactionRef ptx_parent2_v1 = MakeTransactionRef(mtx_parent2_v1);
     CTransactionRef ptx_parent2_v2 = MakeTransactionRef(mtx_parent2_v2);
     // Put parent2_v1 in the package, submit parent2_v2 to the mempool.
-    const MempoolAcceptResult parent2_v2_result = m_node.chainman->ProcessTransaction(ptx_parent2_v2);
+    const MempoolAcceptResult parent2_v2_result = m_node.chainman->ProcessTransaction(/*tx=*/ptx_parent2_v2, /*test_accept=*/false);
     BOOST_CHECK(parent2_v2_result.m_result_type == MempoolAcceptResult::ResultType::VALID);
     package_mixed.push_back(ptx_parent2_v1);
 

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -37,7 +37,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChain100Setup)
     LOCK(cs_main);
 
     unsigned int initialPoolSize = m_node.mempool->size();
-    const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(MakeTransactionRef(coinbaseTx));
+    const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(/*tx=*/MakeTransactionRef(coinbaseTx), /*test_accept=*/false);
 
     BOOST_CHECK(result.m_result_type == MempoolAcceptResult::ResultType::INVALID);
 

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -37,7 +37,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChain100Setup)
     LOCK(cs_main);
 
     unsigned int initialPoolSize = m_node.mempool->size();
-    const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(/*tx=*/MakeTransactionRef(coinbaseTx), /*test_accept=*/false);
+    const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(/*tx=*/MakeTransactionRef(coinbaseTx), /*mempool_bypass=*/std::nullopt);
 
     BOOST_CHECK(result.m_result_type == MempoolAcceptResult::ResultType::INVALID);
 

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -36,7 +36,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, Dersig100Setup)
     const auto ToMemPool = [this](const CMutableTransaction& tx) {
         LOCK(cs_main);
 
-        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(MakeTransactionRef(tx));
+        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(/*tx=*/MakeTransactionRef(tx), /*test_accept=*/false);
         return result.m_result_type == MempoolAcceptResult::ResultType::VALID;
     };
 

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -36,7 +36,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, Dersig100Setup)
     const auto ToMemPool = [this](const CMutableTransaction& tx) {
         LOCK(cs_main);
 
-        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(/*tx=*/MakeTransactionRef(tx), /*test_accept=*/false);
+        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(/*tx=*/MakeTransactionRef(tx), /*mempool_bypass=*/std::nullopt);
         return result.m_result_type == MempoolAcceptResult::ResultType::VALID;
     };
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -367,7 +367,7 @@ CMutableTransaction TestChain100Setup::CreateValidMempoolTransaction(CTransactio
     // If submit=true, add transaction to the mempool.
     if (submit) {
         LOCK(cs_main);
-        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(/*tx=*/MakeTransactionRef(mempool_txn), /*test_accept=*/false);
+        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(/*tx=*/MakeTransactionRef(mempool_txn), /*mempool_bypass=*/std::nullopt);
         assert(result.m_result_type == MempoolAcceptResult::ResultType::VALID);
     }
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -367,7 +367,7 @@ CMutableTransaction TestChain100Setup::CreateValidMempoolTransaction(CTransactio
     // If submit=true, add transaction to the mempool.
     if (submit) {
         LOCK(cs_main);
-        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(MakeTransactionRef(mempool_txn));
+        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(/*tx=*/MakeTransactionRef(mempool_txn), /*test_accept=*/false);
         assert(result.m_result_type == MempoolAcceptResult::ResultType::VALID);
     }
 

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE(mempool_locks_reorg)
         {
             LOCK(cs_main);
             for (const auto& tx : txs) {
-                const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(tx);
+                const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(tx, /*test_accept=*/false);
                 BOOST_REQUIRE(result.m_result_type == MempoolAcceptResult::ResultType::VALID);
             }
         }

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE(mempool_locks_reorg)
         {
             LOCK(cs_main);
             for (const auto& tx : txs) {
-                const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(tx, /*test_accept=*/false);
+                const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(tx, /*mempool_bypass=*/std::nullopt);
                 BOOST_REQUIRE(result.m_result_type == MempoolAcceptResult::ResultType::VALID);
             }
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1430,12 +1430,14 @@ MempoolAcceptResult AcceptToMemoryPool(CChainState& active_chainstate, const CTr
     return result;
 }
 
-PackageMempoolAcceptResult ProcessNewPackage(CChainState& active_chainstate, CTxMemPool& pool,
-                                                   const Package& package, bool test_accept)
+PackageMempoolAcceptResult ProcessNewPackage(CChainState& active_chainstate, CTxMemPool& pool, const Package& package,
+                                             const std::optional<MemPoolBypass>& mempool_bypass)
 {
     AssertLockHeld(cs_main);
     assert(!package.empty());
     assert(std::all_of(package.cbegin(), package.cend(), [](const auto& tx){return tx != nullptr;}));
+
+    const bool test_accept = mempool_bypass.has_value() ? mempool_bypass->m_test_accept : false;
 
     std::vector<COutPoint> coins_to_uncache;
     const CChainParams& chainparams = active_chainstate.m_params;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -302,9 +302,9 @@ void CChainState::MaybeUpdateMempoolForReorg(
     auto it = disconnectpool.queuedTx.get<insertion_order>().rbegin();
     while (it != disconnectpool.queuedTx.get<insertion_order>().rend()) {
         // ignore validation errors in resurrected transactions
+        const MemPoolBypass mempool_bypass{/*test_accept=*/false, /*bypass_limits=*/true};
         if (!fAddToMempool || (*it)->IsCoinBase() ||
-            AcceptToMemoryPool(*this, *it, GetTime(),
-                /*bypass_limits=*/true, /*test_accept=*/false).m_result_type !=
+            AcceptToMemoryPool(/*active_chainstate=*/*this, /*tx=*/*it,  /*accept_time=*/GetTime(), /*mempool_bypass=*/mempool_bypass).m_result_type !=
                     MempoolAcceptResult::ResultType::VALID) {
             // If the transaction doesn't make it in to the mempool, remove any
             // transactions that depend on it (which would now be orphans).
@@ -1404,13 +1404,16 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
 } // anon namespace
 
 MempoolAcceptResult AcceptToMemoryPool(CChainState& active_chainstate, const CTransactionRef& tx,
-                                       int64_t accept_time, bool bypass_limits, bool test_accept)
+                                       int64_t accept_time, const std::optional<MemPoolBypass>& mempool_bypass)
     EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
     AssertLockHeld(::cs_main);
     const CChainParams& chainparams{active_chainstate.m_params};
     assert(active_chainstate.GetMempool() != nullptr);
     CTxMemPool& pool{*active_chainstate.GetMempool()};
+
+    const bool bypass_limits = mempool_bypass.has_value() ? mempool_bypass->m_bypass_limits: false;
+    const bool test_accept = mempool_bypass.has_value() ? mempool_bypass->m_test_accept : false;
 
     std::vector<COutPoint> coins_to_uncache;
     auto args = MemPoolAccept::ATMPArgs::SingleAccept(chainparams, accept_time, bypass_limits, coins_to_uncache, test_accept);
@@ -3812,7 +3815,8 @@ MempoolAcceptResult ChainstateManager::ProcessTransaction(const CTransactionRef&
         state.Invalid(TxValidationResult::TX_NO_MEMPOOL, "no-mempool");
         return MempoolAcceptResult::Failure(state);
     }
-    auto result = AcceptToMemoryPool(active_chainstate, tx, GetTime(), /*bypass_limits=*/ false, test_accept);
+    const MemPoolBypass mempool_bypass{/*test_accept=*/test_accept, /*bypass_limits=*/false};
+    auto result = AcceptToMemoryPool(/*active_chainstate=*/active_chainstate, tx, /*accept_time=*/GetTime(), mempool_bypass);
     active_chainstate.GetMempool()->check(active_chainstate.CoinsTip(), active_chainstate.m_chain.Height() + 1);
     return result;
 }
@@ -4679,7 +4683,7 @@ bool LoadMempool(CTxMemPool& pool, CChainState& active_chainstate, FopenFn mocka
             }
             if (nTime > nNow - nExpiryTimeout) {
                 LOCK(cs_main);
-                const auto& accepted = AcceptToMemoryPool(active_chainstate, tx, nTime, /*bypass_limits=*/false, /*test_accept=*/false);
+                const auto& accepted = AcceptToMemoryPool(/*active_chainstate=*/active_chainstate, tx, /*accept_time=*/nTime, /*mempool_bypass=*/std::nullopt);
                 if (accepted.m_result_type == MempoolAcceptResult::ResultType::VALID) {
                     ++count;
                 } else {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -832,7 +832,10 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // No individual transactions are allowed below minRelayTxFee and mempool min fee except from
     // disconnected blocks and transactions in a package. Package transactions will be checked using
     // package feerate later.
-    if (!bypass_limits && !args.m_package_feerates && !CheckFeeRate(ws.m_vsize, ws.m_modified_fees, state)) return false;
+    if (!args.m_mempool_bypass.m_bypass_feerate_accuracy &&
+        !bypass_limits &&
+        !args.m_package_feerates &&
+        !CheckFeeRate(ws.m_vsize, ws.m_modified_fees, state)) return false;
 
     ws.m_iters_conflicting = m_pool.GetIterSet(ws.m_conflicts);
     // Calculate in-mempool ancestors, up to a limit.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3806,7 +3806,7 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
     return true;
 }
 
-MempoolAcceptResult ChainstateManager::ProcessTransaction(const CTransactionRef& tx, bool test_accept)
+MempoolAcceptResult ChainstateManager::ProcessTransaction(const CTransactionRef& tx, const std::optional<MemPoolBypass>& mempool_bypass)
 {
     AssertLockHeld(cs_main);
     CChainState& active_chainstate = ActiveChainstate();
@@ -3815,7 +3815,6 @@ MempoolAcceptResult ChainstateManager::ProcessTransaction(const CTransactionRef&
         state.Invalid(TxValidationResult::TX_NO_MEMPOOL, "no-mempool");
         return MempoolAcceptResult::Failure(state);
     }
-    const MemPoolBypass mempool_bypass{/*test_accept=*/test_accept, /*bypass_limits=*/false};
     auto result = AcceptToMemoryPool(/*active_chainstate=*/active_chainstate, tx, /*accept_time=*/GetTime(), mempool_bypass);
     active_chainstate.GetMempool()->check(active_chainstate.CoinsTip(), active_chainstate.m_chain.Height() + 1);
     return result;

--- a/src/validation.h
+++ b/src/validation.h
@@ -242,10 +242,28 @@ struct MemPoolBypass {
     //! This does not prevent mempool from accepting the transaction.
     bool m_bypass_limits{false};
 
+    //! Don't enforce nLocktime
+    bool m_bypass_absolute_timelock{false};
+
+    //! Don't consensus-enforce BIP68 relative lock-time.
+    bool m_bypass_relative_timelock{false};
+
     MemPoolBypass() {}
 
     MemPoolBypass(bool test_accept, bool bypass_limits) :
         m_test_accept(test_accept), m_bypass_limits(bypass_limits) {}
+
+    bool EnsureFullyValidatedTransaction() const
+    {
+        return !m_bypass_absolute_timelock && !m_bypass_relative_timelock;
+    }
+
+    void AssertTestModeForPartialValidation() const
+    {
+        if(!EnsureFullyValidatedTransaction()) {
+            assert(m_test_accept);
+        }
+    }
 };
 
 /**

--- a/src/validation.h
+++ b/src/validation.h
@@ -251,6 +251,12 @@ struct MemPoolBypass {
     //! Don't enforce the minimum mempool fee rate validation.
     bool m_bypass_feerate_accuracy{false};
 
+    //! Don't enforce CHECKLOCKTIMEVERIFY (BIP65)
+    bool m_bypass_cltv{false};
+
+    //! Don't enforce CHECKSEQUENCEVERIFY (BIP112)
+    bool m_bypass_csv{false};
+
     MemPoolBypass() {}
 
     MemPoolBypass(bool test_accept, bool bypass_limits) :
@@ -258,7 +264,11 @@ struct MemPoolBypass {
 
     bool EnsureFullyValidatedTransaction() const
     {
-        return !m_bypass_absolute_timelock && !m_bypass_relative_timelock && !m_bypass_feerate_accuracy;
+        return !m_bypass_absolute_timelock &&
+               !m_bypass_relative_timelock &&
+               !m_bypass_feerate_accuracy &&
+               !m_bypass_csv &&
+               !m_bypass_cltv;
     }
 
     void AssertTestModeForPartialValidation() const

--- a/src/validation.h
+++ b/src/validation.h
@@ -248,6 +248,9 @@ struct MemPoolBypass {
     //! Don't consensus-enforce BIP68 relative lock-time.
     bool m_bypass_relative_timelock{false};
 
+    //! Don't enforce the minimum mempool fee rate validation.
+    bool m_bypass_feerate_accuracy{false};
+
     MemPoolBypass() {}
 
     MemPoolBypass(bool test_accept, bool bypass_limits) :
@@ -255,7 +258,7 @@ struct MemPoolBypass {
 
     bool EnsureFullyValidatedTransaction() const
     {
-        return !m_bypass_absolute_timelock && !m_bypass_relative_timelock;
+        return !m_bypass_absolute_timelock && !m_bypass_relative_timelock && !m_bypass_feerate_accuracy;
     }
 
     void AssertTestModeForPartialValidation() const

--- a/src/validation.h
+++ b/src/validation.h
@@ -994,9 +994,9 @@ public:
      * Try to add a transaction to the memory pool.
      *
      * @param[in]  tx              The transaction to submit for mempool acceptance.
-     * @param[in]  test_accept     When true, run validation checks but don't submit to mempool.
+     * @param[in]  mempool_bypass     Criteria for bypassing mempool checks
      */
-    [[nodiscard]] MempoolAcceptResult ProcessTransaction(const CTransactionRef& tx, bool test_accept)
+    [[nodiscard]] MempoolAcceptResult ProcessTransaction(const CTransactionRef& tx, const std::optional<MemPoolBypass>& mempool_bypass)
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Load the block tree and coins database from disk, initializing state if we're running with -reindex

--- a/src/validation.h
+++ b/src/validation.h
@@ -266,16 +266,19 @@ MempoolAcceptResult AcceptToMemoryPool(CChainState& active_chainstate, const CTr
     EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /**
-* Validate (and maybe submit) a package to the mempool. See doc/policy/packages.md for full details
-* on package validation rules.
-* @param[in]    test_accept     When true, run validation checks but don't submit to mempool.
-* @returns a PackageMempoolAcceptResult which includes a MempoolAcceptResult for each transaction.
-* If a transaction fails, validation will exit early and some results may be missing. It is also
-* possible for the package to be partially submitted.
-*/
-PackageMempoolAcceptResult ProcessNewPackage(CChainState& active_chainstate, CTxMemPool& pool,
-                                                   const Package& txns, bool test_accept)
-                                                   EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+ * Validate (and maybe submit) a package to the mempool. See doc/policy/packages.md for full details
+ * on package validation rules.
+ * @param[in]  active_chainstate  Reference to the active chainstate.
+ * @param[in]  pool               The mempool.
+ * @param[in]  package               A package of transactions,
+ * @param[in]  mempool_bypass     Criteria for bypassing mempool checks
+ * @returns a PackageMempoolAcceptResult which includes a MempoolAcceptResult for each transaction.
+ * If a transaction fails, validation will exit early and some results may be missing. It is also
+ * possible for the package to be partially submitted.
+ */
+PackageMempoolAcceptResult ProcessNewPackage(CChainState& active_chainstate, CTxMemPool& pool, const Package& package,
+                                             const std::optional<MemPoolBypass>& mempool_bypass)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /* Transaction policy functions */
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -976,7 +976,7 @@ public:
      * @param[in]  tx              The transaction to submit for mempool acceptance.
      * @param[in]  test_accept     When true, run validation checks but don't submit to mempool.
      */
-    [[nodiscard]] MempoolAcceptResult ProcessTransaction(const CTransactionRef& tx, bool test_accept=false)
+    [[nodiscard]] MempoolAcceptResult ProcessTransaction(const CTransactionRef& tx, bool test_accept)
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Load the block tree and coins database from disk, initializing state if we're running with -reindex

--- a/src/validation.h
+++ b/src/validation.h
@@ -231,6 +231,24 @@ struct PackageMempoolAcceptResult
 };
 
 /**
+ * Criteria for bypassing mempool checks.
+ */
+struct MemPoolBypass {
+    //! When true, run validation checks but don't submit to mempool.
+    bool m_test_accept{false};
+
+    //! When true, don't enforce mempool fee and capacity limits.
+    //! This is used to indicate that mempool limiting based on feerate should be bypassed.
+    //! This does not prevent mempool from accepting the transaction.
+    bool m_bypass_limits{false};
+
+    MemPoolBypass() {}
+
+    MemPoolBypass(bool test_accept, bool bypass_limits) :
+        m_test_accept(test_accept), m_bypass_limits(bypass_limits) {}
+};
+
+/**
  * Try to add a transaction to the mempool. This is an internal function and is exposed only for testing.
  * Client code should use ChainstateManager::ProcessTransaction()
  *

--- a/src/validation.h
+++ b/src/validation.h
@@ -256,13 +256,12 @@ struct MemPoolBypass {
  * @param[in]  tx                 The transaction to submit for mempool acceptance.
  * @param[in]  accept_time        The timestamp for adding the transaction to the mempool.
  *                                It is also used to determine when the entry expires.
- * @param[in]  bypass_limits      When true, don't enforce mempool fee and capacity limits.
- * @param[in]  test_accept        When true, run validation checks but don't submit to mempool.
+ * @param[in]  mempool_bypass     Criteria for bypassing mempool checks
  *
  * @returns a MempoolAcceptResult indicating whether the transaction was accepted/rejected with reason.
  */
 MempoolAcceptResult AcceptToMemoryPool(CChainState& active_chainstate, const CTransactionRef& tx,
-                                       int64_t accept_time, bool bypass_limits, bool test_accept)
+                                       int64_t accept_time, const std::optional<MemPoolBypass>& mempool_bypass)
     EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /**

--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -261,9 +261,9 @@ class BIP68Test(BitcoinTestFramework):
                 # sendrawtransaction should fail if the tx is in the mempool
                 assert_raises_rpc_error(-26, NOT_FINAL_ERROR, node.sendrawtransaction, tx.serialize().hex())
 
-                # Should pass with bypass_relative_timelocks=True but not otherwise
+                # Should pass with bypass_relative_timelock=True but not otherwise
                 assert not node.testmempoolaccept([tx.serialize().hex()])[0]["allowed"]
-                assert node.testmempoolaccept(rawtxs=[tx.serialize().hex()], options={"bypass_relative_timelocks":True})[0]["allowed"]
+                assert node.testmempoolaccept(rawtxs=[tx.serialize().hex()], options={"bypass_relative_timelock":True})[0]["allowed"]
             else:
                 # sendrawtransaction should succeed if the tx is not in the mempool
                 node.sendrawtransaction(tx.serialize().hex())
@@ -318,7 +318,7 @@ class BIP68Test(BitcoinTestFramework):
         tx5.vout[0].nValue += int(utxos[0]["amount"]*COIN)
         raw_tx5 = self.nodes[0].signrawtransactionwithwallet(tx5.serialize().hex())["hex"]
 
-        # Should pass with bypass_relative_timelocks=True but not otherwise
+        # Should pass with bypass_relative_timelock=True but not otherwise
         assert not self.nodes[0].testmempoolaccept(rawtxs=[raw_tx5])[0]["allowed"]
         assert self.nodes[0].testmempoolaccept(rawtxs=[raw_tx5], options={"bypass_relative_timelock":True})[0]["allowed"]
 

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -158,15 +158,17 @@ class BIP65Test(BitcoinTestFramework):
             ][i]
             # First we show that this tx is valid except for CLTV by getting it
             # rejected from the mempool for exactly that reason.
-            assert_equal(
-                [{
-                    'txid': spendtx.hash,
-                    'wtxid': spendtx.getwtxid(),
-                    'allowed': False,
-                    'reject-reason': expected_cltv_reject_reason,
-                }],
-                self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], options={"maxfeerate": 0}),
-            )
+            expected_testres = [{
+                'txid': spendtx.hash,
+                'wtxid': spendtx.getwtxid(),
+                'allowed': False,
+                'reject-reason': expected_cltv_reject_reason,
+            }]
+
+            assert_equal(expected_testres, self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], options={"maxfeerate":0}))
+            # It still shouldn't work with bypass_absolute_timelock=True because this is a script error.
+            assert_equal(expected_testres, self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], options={"maxfeerate":0, "bypass_absolute_timelock":True}))
+            assert_equal(expected_testres, self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], options={"maxfeerate":0, "bypass_relative_timelock":True}))
 
             # Now we verify that a block with this transaction is also invalid.
             block.vtx[1] = spendtx

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -165,7 +165,7 @@ class BIP65Test(BitcoinTestFramework):
                     'allowed': False,
                     'reject-reason': expected_cltv_reject_reason,
                 }],
-                self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], maxfeerate=0),
+                self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], options={"maxfeerate": 0}),
             )
 
             # Now we verify that a block with this transaction is also invalid.

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -7,6 +7,8 @@
 Test that the CHECKLOCKTIMEVERIFY soft-fork activates.
 """
 
+from decimal import Decimal
+
 from test_framework.blocktools import (
     create_block,
     create_coinbase,
@@ -169,6 +171,13 @@ class BIP65Test(BitcoinTestFramework):
             # It still shouldn't work with bypass_absolute_timelock=True because this is a script error.
             assert_equal(expected_testres, self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], options={"maxfeerate":0, "bypass_absolute_timelock":True}))
             assert_equal(expected_testres, self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], options={"maxfeerate":0, "bypass_relative_timelock":True}))
+
+            # However with "bypass_cltv" option, the transaction should be allowed
+            assert_equal(
+                self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], options={"bypass_cltv":True}),
+                [{'txid': spendtx.hash, 'wtxid': spendtx.getwtxid(),'allowed': True, 'vsize': spendtx.get_vsize(), 'fees': { 'base': Decimal('0.00031200') }}])
+
+
 
             # Now we verify that a block with this transaction is also invalid.
             block.vtx[1] = spendtx

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -99,6 +99,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
             '-whitelist=noban@127.0.0.1',
             f'-testactivationheight=csv@{CSV_ACTIVATION_HEIGHT}',
             '-par=1',  # Use only one script thread to get the exact reject reason for testing
+            '-acceptnonstdtxn=1',
         ]]
         self.supports_cli = False
 
@@ -410,6 +411,9 @@ class BIP68_112_113Test(BitcoinTestFramework):
         assert not self.nodes[0].testmempoolaccept(rawtxs=[bip112tx_special_v1.serialize().hex()], options={"bypass_relative_timelock":True})[0]["allowed"]
         self.send_blocks([self.create_test_block([bip112tx_special_v1])], success=False,
                          reject_reason='non-mandatory-script-verify-flag (Negative locktime)')
+        assert not self.nodes[0].testmempoolaccept(rawtxs=[bip112tx_special_v1.serialize().hex()])[0]['allowed']
+        # With "bypass_csv" option, the transaction should be allowed
+        assert self.nodes[0].testmempoolaccept(rawtxs=[bip112tx_special_v1.serialize().hex()], options={"bypass_csv":True})[0]['allowed']
 
         assert not self.nodes[0].testmempoolaccept(rawtxs=[bip112tx_emptystack_v1.serialize().hex()], options={"bypass_absolute_timelock":True})[0]["allowed"]
         assert not self.nodes[0].testmempoolaccept(rawtxs=[bip112tx_emptystack_v1.serialize().hex()], options={"bypass_relative_timelock":True})[0]["allowed"]
@@ -432,6 +436,9 @@ class BIP68_112_113Test(BitcoinTestFramework):
             assert not self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()], options={"bypass_relative_timelock":True})[0]["allowed"]
             self.send_blocks([self.create_test_block([tx])], success=False,
                              reject_reason='non-mandatory-script-verify-flag (Locktime requirement not satisfied)')
+            assert not self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()])[0]['allowed']
+            # With "bypass_csv" option, the transaction should be allowed
+            assert self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()], options={"bypass_csv":True})[0]['allowed']
 
         self.log.info("Test version 2 txs")
 
@@ -442,6 +449,9 @@ class BIP68_112_113Test(BitcoinTestFramework):
                          reject_reason='non-mandatory-script-verify-flag (Negative locktime)')
         self.send_blocks([self.create_test_block([bip112tx_emptystack_v2])], success=False,
                          reject_reason='non-mandatory-script-verify-flag (Operation not valid with the current stack size)')
+        assert not self.nodes[0].testmempoolaccept(rawtxs=[bip112tx_special_v2.serialize().hex()])[0]['allowed']
+        # With "bypass_csv" option, the transaction should be allowed
+        assert self.nodes[0].testmempoolaccept(rawtxs=[bip112tx_special_v2.serialize().hex()], options={"bypass_csv":True})[0]['allowed']
 
         # If SEQUENCE_LOCKTIME_DISABLE_FLAG is set in argument to OP_CSV, version 2 txs should pass (all sequence locks are met)
         success_txs = [tx['tx'] for tx in bip112txs_vary_OP_CSV_v2 if tx['sdf']]
@@ -460,6 +470,9 @@ class BIP68_112_113Test(BitcoinTestFramework):
             assert not self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()], options={"bypass_relative_timelock":True})[0]["allowed"]
             self.send_blocks([self.create_test_block([tx])], success=False,
                              reject_reason='non-mandatory-script-verify-flag (Locktime requirement not satisfied)')
+            assert not self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()])[0]['allowed']
+            # With "bypass_csv" option, the transaction should be allowed
+            assert self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()], options={"bypass_csv":True})[0]['allowed']
 
         # If SEQUENCE_LOCKTIME_DISABLE_FLAG is set in nSequence, tx should fail
         fail_txs = [tx['tx'] for tx in bip112txs_vary_nSequence_v2 if tx['sdf']]
@@ -468,6 +481,9 @@ class BIP68_112_113Test(BitcoinTestFramework):
             assert not self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()], options={"bypass_relative_timelock":True})[0]["allowed"]
             self.send_blocks([self.create_test_block([tx])], success=False,
                              reject_reason='non-mandatory-script-verify-flag (Locktime requirement not satisfied)')
+            assert not self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()])[0]['allowed']
+            # With "bypass_csv" option, the transaction should be allowed
+            assert self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()], options={"bypass_csv":True})[0]['allowed']
 
         # If sequencelock types mismatch, tx should fail
         fail_txs = [tx['tx'] for tx in bip112txs_vary_nSequence_v2 if not tx['sdf'] and tx['stf']]
@@ -477,6 +493,9 @@ class BIP68_112_113Test(BitcoinTestFramework):
             assert not self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()], options={"bypass_relative_timelock":True})[0]["allowed"]
             self.send_blocks([self.create_test_block([tx])], success=False,
                              reject_reason='non-mandatory-script-verify-flag (Locktime requirement not satisfied)')
+            assert not self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()])[0]['allowed']
+            # With "bypass_csv" option, the transaction should be allowed
+            assert self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()], options={"bypass_csv":True})[0]['allowed']
 
         # Remaining txs should pass, just test masking works properly
         success_txs = [tx['tx'] for tx in bip112txs_vary_nSequence_v2 if not tx['sdf'] and not tx['stf']]

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -406,8 +406,13 @@ class BIP68_112_113Test(BitcoinTestFramework):
         self.log.info("Test version 1 txs")
 
         # -1 OP_CSV tx and (empty stack) OP_CSV tx should fail
+        assert not self.nodes[0].testmempoolaccept(rawtxs=[bip112tx_special_v1.serialize().hex()], options={"bypass_absolute_timelock":True})[0]["allowed"]
+        assert not self.nodes[0].testmempoolaccept(rawtxs=[bip112tx_special_v1.serialize().hex()], options={"bypass_relative_timelock":True})[0]["allowed"]
         self.send_blocks([self.create_test_block([bip112tx_special_v1])], success=False,
                          reject_reason='non-mandatory-script-verify-flag (Negative locktime)')
+
+        assert not self.nodes[0].testmempoolaccept(rawtxs=[bip112tx_emptystack_v1.serialize().hex()], options={"bypass_absolute_timelock":True})[0]["allowed"]
+        assert not self.nodes[0].testmempoolaccept(rawtxs=[bip112tx_emptystack_v1.serialize().hex()], options={"bypass_relative_timelock":True})[0]["allowed"]
         self.send_blocks([self.create_test_block([bip112tx_emptystack_v1])], success=False,
                          reject_reason='non-mandatory-script-verify-flag (Operation not valid with the current stack size)')
         # If SEQUENCE_LOCKTIME_DISABLE_FLAG is set in argument to OP_CSV, version 1 txs should still pass
@@ -423,12 +428,16 @@ class BIP68_112_113Test(BitcoinTestFramework):
         fail_txs += [tx['tx'] for tx in bip112txs_vary_OP_CSV_v1 if not tx['sdf']]
         fail_txs += [tx['tx'] for tx in bip112txs_vary_OP_CSV_9_v1 if not tx['sdf']]
         for tx in fail_txs:
+            assert not self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()], options={"bypass_absolute_timelock":True})[0]["allowed"]
+            assert not self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()], options={"bypass_relative_timelock":True})[0]["allowed"]
             self.send_blocks([self.create_test_block([tx])], success=False,
                              reject_reason='non-mandatory-script-verify-flag (Locktime requirement not satisfied)')
 
         self.log.info("Test version 2 txs")
 
         # -1 OP_CSV tx and (empty stack) OP_CSV tx should fail
+        assert not self.nodes[0].testmempoolaccept(rawtxs=[bip112tx_special_v2.serialize().hex()], options={"bypass_absolute_timelock":True})[0]["allowed"]
+        assert not self.nodes[0].testmempoolaccept(rawtxs=[bip112tx_special_v2.serialize().hex()], options={"bypass_relative_timelock":True})[0]["allowed"]
         self.send_blocks([self.create_test_block([bip112tx_special_v2])], success=False,
                          reject_reason='non-mandatory-script-verify-flag (Negative locktime)')
         self.send_blocks([self.create_test_block([bip112tx_emptystack_v2])], success=False,
@@ -447,12 +456,16 @@ class BIP68_112_113Test(BitcoinTestFramework):
         fail_txs = all_rlt_txs(bip112txs_vary_nSequence_9_v2)
         fail_txs += [tx['tx'] for tx in bip112txs_vary_OP_CSV_9_v2 if not tx['sdf']]
         for tx in fail_txs:
+            assert not self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()], options={"bypass_absolute_timelock":True})[0]["allowed"]
+            assert not self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()], options={"bypass_relative_timelock":True})[0]["allowed"]
             self.send_blocks([self.create_test_block([tx])], success=False,
                              reject_reason='non-mandatory-script-verify-flag (Locktime requirement not satisfied)')
 
         # If SEQUENCE_LOCKTIME_DISABLE_FLAG is set in nSequence, tx should fail
         fail_txs = [tx['tx'] for tx in bip112txs_vary_nSequence_v2 if tx['sdf']]
         for tx in fail_txs:
+            assert not self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()], options={"bypass_absolute_timelock":True})[0]["allowed"]
+            assert not self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()], options={"bypass_relative_timelock":True})[0]["allowed"]
             self.send_blocks([self.create_test_block([tx])], success=False,
                              reject_reason='non-mandatory-script-verify-flag (Locktime requirement not satisfied)')
 
@@ -460,6 +473,8 @@ class BIP68_112_113Test(BitcoinTestFramework):
         fail_txs = [tx['tx'] for tx in bip112txs_vary_nSequence_v2 if not tx['sdf'] and tx['stf']]
         fail_txs += [tx['tx'] for tx in bip112txs_vary_OP_CSV_v2 if not tx['sdf'] and tx['stf']]
         for tx in fail_txs:
+            assert not self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()], options={"bypass_absolute_timelock":True})[0]["allowed"]
+            assert not self.nodes[0].testmempoolaccept(rawtxs=[tx.serialize().hex()], options={"bypass_relative_timelock":True})[0]["allowed"]
             self.send_blocks([self.create_test_block([tx])], success=False,
                              reject_reason='non-mandatory-script-verify-flag (Locktime requirement not satisfied)')
 

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -122,7 +122,7 @@ class BIP66Test(BitcoinTestFramework):
                 'allowed': False,
                 'reject-reason': 'non-mandatory-script-verify-flag (Non-canonical DER signature)',
             }],
-            self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], maxfeerate=0),
+            self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], options={"maxfeerate": 0}),
         )
 
         # Now we verify that a block with this transaction is also invalid.

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -324,6 +324,13 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
             rawtxs=[tx.serialize().hex()],
         )
 
+        # The same timelocked transaction that failed before must be accepted with the bypass_absolute_timelock option
+        self.check_mempool_result(
+            result_expected=[{'txid': tx.rehash(), 'allowed': True, 'vsize': tx.get_vsize(), 'fees': { 'base': Decimal('0.1') - Decimal('0.05')}}],
+            rawtxs=[tx.serialize().hex()],
+            options={"maxfeerate": 0, "bypass_absolute_timelock":True}
+        )
+
         self.log.info('A transaction that is locked by BIP68 sequence logic')
         tx = tx_from_hex(raw_tx_reference)
         tx.vin[0].nSequence = 2  # We could include it in the second block mined from now, but not the very next one
@@ -333,6 +340,11 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
             options={"maxfeerate": 0},
         )
 
+        self.check_mempool_result(
+            result_expected=[{'txid': tx.rehash(), 'allowed': True, 'vsize': tx.get_vsize(), 'fees': { 'base': Decimal('0.1') - Decimal('0.05')}}],
+            rawtxs=[tx.serialize().hex()],
+            options={"maxfeerate": 0, "bypass_relative_timelock":True}
+        )
 
 if __name__ == '__main__':
     MempoolAcceptanceTest().main()

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -109,7 +109,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         self.check_mempool_result(
             result_expected=[{'txid': tx.rehash(), 'allowed': True, 'vsize': tx.get_vsize(), 'fees': {'base': fee_expected}}],
             rawtxs=[tx.serialize().hex()],
-            maxfeerate=0,
+            options={"maxfeerate": 0},
         )
         node.sendrawtransaction(hexstring=raw_tx_final, maxfeerate=0)
         self.mempool_size += 1
@@ -142,7 +142,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         self.check_mempool_result(
             result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'txn-mempool-conflict'}],
             rawtxs=[tx.serialize().hex()],
-            maxfeerate=0,
+            options={"maxfeerate": 0},
         )
 
         self.log.info('A transaction with missing inputs, that never existed')
@@ -188,7 +188,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         self.check_mempool_result(
             result_expected=[{'txid': tx.rehash(), 'allowed': True, 'vsize': tx.get_vsize(), 'fees': { 'base': Decimal('0.1') - Decimal('0.05')}}],
             rawtxs=[tx.serialize().hex()],
-            maxfeerate=0,
+            options={"maxfeerate": 0},
         )
 
         self.log.info('A transaction with no outputs')
@@ -330,7 +330,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         self.check_mempool_result(
             result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'non-BIP68-final'}],
             rawtxs=[tx.serialize().hex()],
-            maxfeerate=0,
+            options={"maxfeerate": 0},
         )
 
 

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -10,6 +10,7 @@ import time
 from test_framework.messages import (
     COIN,
     MAX_BLOCK_WEIGHT,
+    tx_from_hex
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -219,6 +220,11 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         # This will raise an exception due to min relay fee not being met
         assert_raises_rpc_error(-26, "min relay fee not met", self.nodes[0].sendrawtransaction, tx_hex)
         assert tx_id not in self.nodes[0].getrawmempool()
+
+        # The same transaction previously rejected should be considered valid when testing with "bypass_feerate_accuracy"
+        assert_equal(
+            self.nodes[0].testmempoolaccept(rawtxs=[tx_hex], options={"bypass_feerate_accuracy": True}),
+            [{'txid': tx_res['txid'], 'wtxid': tx_res['wtxid'],'allowed': True, 'vsize': tx_from_hex(tx_hex).get_vsize(), 'fees': { 'base': Decimal('0E-8')}}])
 
         # This is a less than 1000-byte transaction, so just set the fee
         # to be the minimum for a 1000-byte transaction and check that it is

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -273,7 +273,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # Fee rate is 0.00100000 BTC/kvB
         tx = self.wallet.create_self_transfer(fee_rate=Decimal('0.00100000'))
         # Thus, testmempoolaccept should reject
-        testres = self.nodes[2].testmempoolaccept([tx['hex']], 0.00001000)[0]
+        testres = self.nodes[2].testmempoolaccept([tx['hex']], {"maxfeerate": 0.00001000})[0]
         assert_equal(testres['allowed'], False)
         assert_equal(testres['reject-reason'], 'max-fee-exceeded')
         # and sendrawtransaction should throw
@@ -293,7 +293,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # and sendrawtransaction should throw
         assert_raises_rpc_error(-25, fee_exceeds_max, self.nodes[2].sendrawtransaction, tx['hex'])
         # and the following calls should both succeed
-        testres = self.nodes[2].testmempoolaccept(rawtxs=[tx['hex']], maxfeerate='0.20000000')[0]
+        testres = self.nodes[2].testmempoolaccept(rawtxs=[tx['hex']], options={"maxfeerate": 0.20000000})[0]
         assert_equal(testres['allowed'], True)
         self.nodes[2].sendrawtransaction(hexstring=tx['hex'], maxfeerate='0.20000000')
 


### PR DESCRIPTION
This PR adds the the `bypass_csv` and `bypass_cltv` options to `testmempoolaccept` RPC, making it possible to bypass CSV / CLTV execution.

For more context, check https://github.com/bitcoin/bitcoin/pull/25434#pullrequestreview-1020896809.

Since this PR is built on top of https://github.com/bitcoin/bitcoin/pull/25577, https://github.com/bitcoin/bitcoin/pull/25434 and https://github.com/bitcoin/bitcoin/pull/25532, only the last 4 commits are new here.