### PR TITLE
mempool, refactor: add `MemPoolBypass`

### DIFF
--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -37,7 +37,7 @@ static void AssembleBlock(benchmark::Bench& bench)
         LOCK(::cs_main);
 
         for (const auto& txr : txs) {
-            const MempoolAcceptResult res = test_setup->m_node.chainman->ProcessTransaction(/*tx=*/txr, /*test_accept=*/false);
+            const MempoolAcceptResult res = test_setup->m_node.chainman->ProcessTransaction(/*tx=*/txr, /*mempool_bypass=*/std::nullopt);
             assert(res.m_result_type == MempoolAcceptResult::ResultType::VALID);
         }
     }

--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -37,7 +37,7 @@ static void AssembleBlock(benchmark::Bench& bench)
         LOCK(::cs_main);
 
         for (const auto& txr : txs) {
-            const MempoolAcceptResult res = test_setup->m_node.chainman->ProcessTransaction(txr);
+            const MempoolAcceptResult res = test_setup->m_node.chainman->ProcessTransaction(/*tx=*/txr, /*test_accept=*/false);
             assert(res.m_result_type == MempoolAcceptResult::ResultType::VALID);
         }
     }

--- a/src/kernel/mempool_persist.cpp
+++ b/src/kernel/mempool_persist.cpp
@@ -78,7 +78,7 @@ bool LoadMempool(CTxMemPool& pool, const fs::path& load_path, CChainState& activ
             }
             if (nTime > TicksSinceEpoch<std::chrono::seconds>(now - pool.m_expiry)) {
                 LOCK(cs_main);
-                const auto& accepted = AcceptToMemoryPool(active_chainstate, tx, nTime, /*bypass_limits=*/false, /*test_accept=*/false);
+                const auto& accepted = AcceptToMemoryPool(/*active_chainstate=*/active_chainstate, tx, /*accept_time=*/nTime, /*mempool_bypass=*/std::nullopt);
                 if (accepted.m_result_type == MempoolAcceptResult::ResultType::VALID) {
                     ++count;
                 } else {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2537,7 +2537,7 @@ void PeerManagerImpl::ProcessOrphanTx(std::set<uint256>& orphan_work_set)
         const auto [porphanTx, from_peer] = m_orphanage.GetTx(orphanHash);
         if (porphanTx == nullptr) continue;
 
-        const MempoolAcceptResult result = m_chainman.ProcessTransaction(porphanTx);
+        const MempoolAcceptResult result = m_chainman.ProcessTransaction(/*tx=*/porphanTx, /*test_accept=*/false);
         const TxValidationState& state = result.m_state;
 
         if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {
@@ -3561,7 +3561,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             return;
         }
 
-        const MempoolAcceptResult result = m_chainman.ProcessTransaction(ptx);
+        const MempoolAcceptResult result = m_chainman.ProcessTransaction(/*tx=*/ptx, /*test_accept=*/false);
         const TxValidationState& state = result.m_state;
 
         if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2537,7 +2537,7 @@ void PeerManagerImpl::ProcessOrphanTx(std::set<uint256>& orphan_work_set)
         const auto [porphanTx, from_peer] = m_orphanage.GetTx(orphanHash);
         if (porphanTx == nullptr) continue;
 
-        const MempoolAcceptResult result = m_chainman.ProcessTransaction(/*tx=*/porphanTx, /*test_accept=*/false);
+        const MempoolAcceptResult result = m_chainman.ProcessTransaction(/*tx=*/porphanTx, /*mempool_bypass=*/std::nullopt);
         const TxValidationState& state = result.m_state;
 
         if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {
@@ -3561,7 +3561,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             return;
         }
 
-        const MempoolAcceptResult result = m_chainman.ProcessTransaction(/*tx=*/ptx, /*test_accept=*/false);
+        const MempoolAcceptResult result = m_chainman.ProcessTransaction(/*tx=*/ptx, /*mempool_bypass=*/std::nullopt);
         const TxValidationState& state = result.m_state;
 
         if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -71,7 +71,9 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
             if (max_tx_fee > 0) {
                 // First, call ATMP with test_accept and check the fee. If ATMP
                 // fails here, return error immediately.
-                const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, /*test_accept=*/true);
+
+                const MemPoolBypass mempool_bypass{.m_test_accept=true, .m_bypass_limits=false};
+                const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, mempool_bypass);
                 if (result.m_result_type != MempoolAcceptResult::ResultType::VALID) {
                     return HandleATMPError(result.m_state, err_string);
                 } else if (result.m_base_fees.value() > max_tx_fee) {
@@ -79,7 +81,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
                 }
             }
             // Try to submit the transaction to the mempool.
-            const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, /*test_accept=*/false);
+            const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, /*mempool_bypass=*/std::nullopt);
             if (result.m_result_type != MempoolAcceptResult::ResultType::VALID) {
                 return HandleATMPError(result.m_state, err_string);
             }

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -71,7 +71,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
             if (max_tx_fee > 0) {
                 // First, call ATMP with test_accept and check the fee. If ATMP
                 // fails here, return error immediately.
-                const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, /*test_accept=*/ true);
+                const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, /*test_accept=*/true);
                 if (result.m_result_type != MempoolAcceptResult::ResultType::VALID) {
                     return HandleATMPError(result.m_state, err_string);
                 } else if (result.m_base_fees.value() > max_tx_fee) {
@@ -79,7 +79,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
                 }
             }
             // Try to submit the transaction to the mempool.
-            const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, /*test_accept=*/ false);
+            const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, /*test_accept=*/false);
             if (result.m_result_type != MempoolAcceptResult::ResultType::VALID) {
                 return HandleATMPError(result.m_state, err_string);
             }

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -110,6 +110,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendrawtransaction", 1, "maxfeerate" },
     { "testmempoolaccept", 0, "rawtxs" },
     { "testmempoolaccept", 1, "maxfeerate" },
+    { "testmempoolaccept", 1, "options" },
     { "submitpackage", 0, "package" },
     { "combinerawtransaction", 0, "txs" },
     { "fundrawtransaction", 1, "options" },

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -208,7 +208,7 @@ static RPCHelpMan testmempoolaccept()
                 const MemPoolBypass mempool_bypass{.m_test_accept=true, .m_bypass_limits=false};
                 if (package.size() > 1) return ProcessNewPackage(/*active_chainstate=*/chainstate, /*pool=*/mempool, package, mempool_bypass);
                 return PackageMempoolAcceptResult(package[0]->GetWitnessHash(),
-                                                  chainman.ProcessTransaction(/*tx=*/package[0], /*test_accept=*/true));
+                                                  chainman.ProcessTransaction(/*tx=*/package[0], mempool_bypass));
             }();
 
             UniValue rpc_result(UniValue::VARR);

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -207,7 +207,7 @@ static RPCHelpMan testmempoolaccept()
                 LOCK(::cs_main);
                 if (txns.size() > 1) return ProcessNewPackage(chainstate, mempool, txns, /*test_accept=*/true);
                 return PackageMempoolAcceptResult(txns[0]->GetWitnessHash(),
-                                                  chainman.ProcessTransaction(txns[0], /*test_accept=*/true));
+                                                  chainman.ProcessTransaction(/*tx=*/txns[0], /*test_accept=*/true));
             }();
 
             UniValue rpc_result(UniValue::VARR);

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -665,14 +665,23 @@ UniValue RPCHelpMan::GetArgMap() const
     UniValue arr{UniValue::VARR};
     for (int i{0}; i < int(m_args.size()); ++i) {
         const auto& arg = m_args.at(i);
+
+        RPCArg::Type argtype = arg.m_type;
+        size_t arg_num = 0;
+
         std::vector<std::string> arg_names = SplitString(arg.m_names, '|');
         for (const auto& arg_name : arg_names) {
+
+            if (!arg.m_type_per_name.empty()) {
+                argtype = arg.m_type_per_name.at(arg_num++);
+            }
+
             UniValue map{UniValue::VARR};
             map.push_back(m_name);
             map.push_back(i);
             map.push_back(arg_name);
-            map.push_back(arg.m_type == RPCArg::Type::STR ||
-                          arg.m_type == RPCArg::Type::STR_HEX);
+            map.push_back(UniValue(argtype == RPCArg::Type::STR ||
+                          argtype == RPCArg::Type::STR_HEX));
             arr.push_back(map);
         }
     }

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -17,6 +17,7 @@
 #include <univalue.h>
 #include <util/check.h>
 
+#include <algorithm>
 #include <string>
 #include <variant>
 #include <vector>
@@ -171,6 +172,7 @@ struct RPCArg {
     using Fallback = std::variant<Optional, /* hint for default value */ DefaultHint, /* default constant value */ Default>;
     const std::string m_names; //!< The name of the arg (can be empty for inner args, can contain multiple aliases separated by | for named request arguments)
     const Type m_type;
+    const std::vector<Type> m_type_per_name;
     const bool m_hidden;
     const std::vector<RPCArg> m_inner; //!< Only used for arrays or dicts
     const Fallback m_fallback;
@@ -195,6 +197,27 @@ struct RPCArg {
           m_type_str{std::move(type_str)}
     {
         CHECK_NONFATAL(type != Type::ARR && type != Type::OBJ && type != Type::OBJ_USER_KEYS);
+    }
+
+        RPCArg(
+        const std::string name,
+        const std::vector<Type> types,
+        const Fallback fallback,
+        const std::string description,
+        const std::vector<RPCArg> inner,
+        const std::string oneline_description = "",
+        const std::vector<std::string> type_str = {},
+        const bool hidden = false)
+        : m_names{std::move(name)},
+          m_type{types.at(0)},
+          m_type_per_name{std::move(types)},
+          m_hidden{hidden},
+          m_fallback{std::move(fallback)},
+          m_description{std::move(description)},
+          m_oneline_description{std::move(oneline_description)},
+          m_type_str{std::move(type_str)}
+    {
+        CHECK_NONFATAL(m_type_per_name.size() == size_t(std::count(m_names.begin(), m_names.end(), '|')) + 1);
     }
 
     RPCArg(

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -256,7 +256,8 @@ FUZZ_TARGET_INIT(tx_pool_standard, initialize_tx_pool)
                    it->second.m_result_type == MempoolAcceptResult::ResultType::INVALID);
         }
 
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), bypass_limits, /*test_accept=*/false));
+        const MemPoolBypass mempool_bypass2{.m_test_accept=false, .m_bypass_limits=bypass_limits};
+        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(/*active_chainstate=*/chainstate, tx, /*accept_time=*/GetTime(), mempool_bypass2));
         const bool accepted = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
         SyncWithValidationInterfaceQueue();
         UnregisterSharedValidationInterface(txr);
@@ -356,7 +357,8 @@ FUZZ_TARGET_INIT(tx_pool, initialize_tx_pool)
         const auto tx = MakeTransactionRef(mut_tx);
         const bool bypass_limits = fuzzed_data_provider.ConsumeBool();
         ::fRequireStandard = fuzzed_data_provider.ConsumeBool();
-        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(chainstate, tx, GetTime(), bypass_limits, /*test_accept=*/false));
+        const MemPoolBypass mempool_bypass{.m_test_accept=false, .m_bypass_limits=bypass_limits};
+        const auto res = WITH_LOCK(::cs_main, return AcceptToMemoryPool(/*active_chainstate=*/chainstate, tx, /*accept_time=*/GetTime(), mempool_bypass));
         const bool accepted = res.m_result_type == MempoolAcceptResult::ResultType::VALID;
         if (accepted) {
             txids.push_back(tx->GetHash());

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -244,8 +244,9 @@ FUZZ_TARGET_INIT(tx_pool_standard, initialize_tx_pool)
 
         // Make sure ProcessNewPackage on one transaction works.
         // The result is not guaranteed to be the same as what is returned by ATMP.
+        const MemPoolBypass mempool_bypass1{.m_test_accept=true, .m_bypass_limits=bypass_limits};
         const auto result_package = WITH_LOCK(::cs_main,
-                                    return ProcessNewPackage(chainstate, tx_pool, {tx}, true));
+                                              return ProcessNewPackage(/*active_chainstate=*/chainstate, /*pool=*/tx_pool, /*package=*/{tx}, mempool_bypass1));
         // If something went wrong due to a package-specific policy, it might not return a
         // validation result for the transaction.
         if (result_package.m_state.GetResult() != PackageValidationResult::PCKG_POLICY) {

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -533,7 +533,7 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
     CTransactionRef ptx_parent2_v1 = MakeTransactionRef(mtx_parent2_v1);
     CTransactionRef ptx_parent2_v2 = MakeTransactionRef(mtx_parent2_v2);
     // Put parent2_v1 in the package, submit parent2_v2 to the mempool.
-    const MempoolAcceptResult parent2_v2_result = m_node.chainman->ProcessTransaction(/*tx=*/ptx_parent2_v2, /*test_accept=*/false);
+    const MempoolAcceptResult parent2_v2_result = m_node.chainman->ProcessTransaction(/*tx=*/ptx_parent2_v2, /*mempool_bypass=*/std::nullopt);
     BOOST_CHECK(parent2_v2_result.m_result_type == MempoolAcceptResult::ResultType::VALID);
     package_mixed.push_back(ptx_parent2_v1);
 

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -532,7 +532,7 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
     CTransactionRef ptx_parent2_v1 = MakeTransactionRef(mtx_parent2_v1);
     CTransactionRef ptx_parent2_v2 = MakeTransactionRef(mtx_parent2_v2);
     // Put parent2_v1 in the package, submit parent2_v2 to the mempool.
-    const MempoolAcceptResult parent2_v2_result = m_node.chainman->ProcessTransaction(ptx_parent2_v2);
+    const MempoolAcceptResult parent2_v2_result = m_node.chainman->ProcessTransaction(/*tx=*/ptx_parent2_v2, /*test_accept=*/false);
     BOOST_CHECK(parent2_v2_result.m_result_type == MempoolAcceptResult::ResultType::VALID);
     package_mixed.push_back(ptx_parent2_v1);
 

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -37,7 +37,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChain100Setup)
     LOCK(cs_main);
 
     unsigned int initialPoolSize = m_node.mempool->size();
-    const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(MakeTransactionRef(coinbaseTx));
+    const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(/*tx=*/MakeTransactionRef(coinbaseTx), /*test_accept=*/false);
 
     BOOST_CHECK(result.m_result_type == MempoolAcceptResult::ResultType::INVALID);
 

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -37,7 +37,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChain100Setup)
     LOCK(cs_main);
 
     unsigned int initialPoolSize = m_node.mempool->size();
-    const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(/*tx=*/MakeTransactionRef(coinbaseTx), /*test_accept=*/false);
+    const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(/*tx=*/MakeTransactionRef(coinbaseTx), /*mempool_bypass=*/std::nullopt);
 
     BOOST_CHECK(result.m_result_type == MempoolAcceptResult::ResultType::INVALID);
 

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -36,7 +36,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, Dersig100Setup)
     const auto ToMemPool = [this](const CMutableTransaction& tx) {
         LOCK(cs_main);
 
-        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(MakeTransactionRef(tx));
+        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(/*tx=*/MakeTransactionRef(tx), /*test_accept=*/false);
         return result.m_result_type == MempoolAcceptResult::ResultType::VALID;
     };
 

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -36,7 +36,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, Dersig100Setup)
     const auto ToMemPool = [this](const CMutableTransaction& tx) {
         LOCK(cs_main);
 
-        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(/*tx=*/MakeTransactionRef(tx), /*test_accept=*/false);
+        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(/*tx=*/MakeTransactionRef(tx), /*mempool_bypass=*/std::nullopt);
         return result.m_result_type == MempoolAcceptResult::ResultType::VALID;
     };
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -359,7 +359,7 @@ CMutableTransaction TestChain100Setup::CreateValidMempoolTransaction(CTransactio
     // If submit=true, add transaction to the mempool.
     if (submit) {
         LOCK(cs_main);
-        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(MakeTransactionRef(mempool_txn));
+        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(/*tx=*/MakeTransactionRef(mempool_txn), /*test_accept=*/false);
         assert(result.m_result_type == MempoolAcceptResult::ResultType::VALID);
     }
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -359,7 +359,7 @@ CMutableTransaction TestChain100Setup::CreateValidMempoolTransaction(CTransactio
     // If submit=true, add transaction to the mempool.
     if (submit) {
         LOCK(cs_main);
-        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(/*tx=*/MakeTransactionRef(mempool_txn), /*test_accept=*/false);
+        const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(/*tx=*/MakeTransactionRef(mempool_txn), /*mempool_bypass=*/std::nullopt);
         assert(result.m_result_type == MempoolAcceptResult::ResultType::VALID);
     }
 

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE(mempool_locks_reorg)
         {
             LOCK(cs_main);
             for (const auto& tx : txs) {
-                const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(tx);
+                const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(tx, /*test_accept=*/false);
                 BOOST_REQUIRE(result.m_result_type == MempoolAcceptResult::ResultType::VALID);
             }
         }

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE(mempool_locks_reorg)
         {
             LOCK(cs_main);
             for (const auto& tx : txs) {
-                const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(tx, /*test_accept=*/false);
+                const MempoolAcceptResult result = m_node.chainman->ProcessTransaction(tx, /*mempool_bypass=*/std::nullopt);
                 BOOST_REQUIRE(result.m_result_type == MempoolAcceptResult::ResultType::VALID);
             }
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1436,12 +1436,14 @@ MempoolAcceptResult AcceptToMemoryPool(CChainState& active_chainstate, const CTr
     return result;
 }
 
-PackageMempoolAcceptResult ProcessNewPackage(CChainState& active_chainstate, CTxMemPool& pool,
-                                                   const Package& package, bool test_accept)
+PackageMempoolAcceptResult ProcessNewPackage(CChainState& active_chainstate, CTxMemPool& pool, const Package& package,
+                                             const std::optional<MemPoolBypass>& mempool_bypass)
 {
     AssertLockHeld(cs_main);
     assert(!package.empty());
     assert(std::all_of(package.cbegin(), package.cend(), [](const auto& tx){return tx != nullptr;}));
+
+    const bool test_accept = mempool_bypass.has_value() ? mempool_bypass->m_test_accept : false;
 
     std::vector<COutPoint> coins_to_uncache;
     const CChainParams& chainparams = active_chainstate.m_params;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3812,7 +3812,7 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
     return true;
 }
 
-MempoolAcceptResult ChainstateManager::ProcessTransaction(const CTransactionRef& tx, bool test_accept)
+MempoolAcceptResult ChainstateManager::ProcessTransaction(const CTransactionRef& tx, const std::optional<MemPoolBypass>& mempool_bypass)
 {
     AssertLockHeld(cs_main);
     CChainState& active_chainstate = ActiveChainstate();
@@ -3821,7 +3821,6 @@ MempoolAcceptResult ChainstateManager::ProcessTransaction(const CTransactionRef&
         state.Invalid(TxValidationResult::TX_NO_MEMPOOL, "no-mempool");
         return MempoolAcceptResult::Failure(state);
     }
-    const MemPoolBypass mempool_bypass{.m_test_accept=test_accept, .m_bypass_limits=false};
     auto result = AcceptToMemoryPool(/*active_chainstate=*/active_chainstate, tx, /*accept_time=*/GetTime(), mempool_bypass);
     active_chainstate.GetMempool()->check(active_chainstate.CoinsTip(), active_chainstate.m_chain.Height() + 1);
     return result;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -437,7 +437,9 @@ public:
     struct ATMPArgs {
         const CChainParams& m_chainparams;
         const int64_t m_accept_time;
-        const bool m_bypass_limits;
+
+        //! Criteria for bypassing mempool checks.
+        const MemPoolBypass m_mempool_bypass;
         /*
          * Return any outpoints which were not previously present in the coins
          * cache, but were added as a result of validating the tx for mempool
@@ -446,7 +448,6 @@ public:
          * the mempool.
          */
         std::vector<COutPoint>& m_coins_to_uncache;
-        const bool m_test_accept;
         /** Whether we allow transactions to replace mempool transactions by BIP125 rules. If false,
          * any transaction spending the same inputs as a transaction in the mempool is considered
          * a conflict. */
@@ -462,14 +463,13 @@ public:
         const bool m_package_feerates;
 
         /** Parameters for single transaction mempool validation. */
-        static ATMPArgs SingleAccept(const CChainParams& chainparams, int64_t accept_time,
-                                     bool bypass_limits, std::vector<COutPoint>& coins_to_uncache,
-                                     bool test_accept) {
+        static ATMPArgs SingleAccept(const CChainParams& chainparams, const int64_t accept_time,
+                                     const std::optional<MemPoolBypass>& mempool_bypass,
+                                     std::vector<COutPoint>& coins_to_uncache) {
             return ATMPArgs{/* m_chainparams */ chainparams,
                             /* m_accept_time */ accept_time,
-                            /* m_bypass_limits */ bypass_limits,
+                            /* m_mempool_bypass */ mempool_bypass,
                             /* m_coins_to_uncache */ coins_to_uncache,
-                            /* m_test_accept */ test_accept,
                             /* m_allow_bip125_replacement */ true,
                             /* m_package_submission */ false,
                             /* m_package_feerates */ false,
@@ -477,13 +477,13 @@ public:
         }
 
         /** Parameters for test package mempool validation through testmempoolaccept. */
-        static ATMPArgs PackageTestAccept(const CChainParams& chainparams, int64_t accept_time,
+        static ATMPArgs PackageTestAccept(const CChainParams& chainparams, const int64_t accept_time,
                                           std::vector<COutPoint>& coins_to_uncache) {
+            const MemPoolBypass mempool_bypass{/*test_accept=*/true, /*bypass_limits=*/false};
             return ATMPArgs{/* m_chainparams */ chainparams,
                             /* m_accept_time */ accept_time,
-                            /* m_bypass_limits */ false,
+                            /* m_mempool_bypass */ mempool_bypass,
                             /* m_coins_to_uncache */ coins_to_uncache,
-                            /* m_test_accept */ true,
                             /* m_allow_bip125_replacement */ false,
                             /* m_package_submission */ false, // not submitting to mempool
                             /* m_package_feerates */ false,
@@ -495,9 +495,8 @@ public:
                                                 std::vector<COutPoint>& coins_to_uncache) {
             return ATMPArgs{/* m_chainparams */ chainparams,
                             /* m_accept_time */ accept_time,
-                            /* m_bypass_limits */ false,
+                            /* m_mempool_bypass */ std::nullopt,
                             /* m_coins_to_uncache */ coins_to_uncache,
-                            /* m_test_accept */ false,
                             /* m_allow_bip125_replacement */ false,
                             /* m_package_submission */ true,
                             /* m_package_feerates */ true,
@@ -508,9 +507,8 @@ public:
         static ATMPArgs SingleInPackageAccept(const ATMPArgs& package_args) {
             return ATMPArgs{/* m_chainparams */ package_args.m_chainparams,
                             /* m_accept_time */ package_args.m_accept_time,
-                            /* m_bypass_limits */ false,
+                            /* m_mempool_bypass */ package_args.m_mempool_bypass,
                             /* m_coins_to_uncache */ package_args.m_coins_to_uncache,
-                            /* m_test_accept */ package_args.m_test_accept,
                             /* m_allow_bip125_replacement */ true,
                             /* m_package_submission */ false,
                             /* m_package_feerates */ false, // only 1 transaction
@@ -521,18 +519,16 @@ public:
         // Private ctor to avoid exposing details to clients and allowing the possibility of
         // mixing up the order of the arguments. Use static functions above instead.
         ATMPArgs(const CChainParams& chainparams,
-                 int64_t accept_time,
-                 bool bypass_limits,
+                 const int64_t accept_time,
+                 const std::optional<MemPoolBypass>& mempool_bypass,
                  std::vector<COutPoint>& coins_to_uncache,
-                 bool test_accept,
-                 bool allow_bip125_replacement,
-                 bool package_submission,
-                 bool package_feerates)
+                 const bool allow_bip125_replacement,
+                 const bool package_submission,
+                 const bool package_feerates)
             : m_chainparams{chainparams},
               m_accept_time{accept_time},
-              m_bypass_limits{bypass_limits},
+              m_mempool_bypass{mempool_bypass.value_or(MemPoolBypass())},
               m_coins_to_uncache{coins_to_uncache},
-              m_test_accept{test_accept},
               m_allow_bip125_replacement{allow_bip125_replacement},
               m_package_submission{package_submission},
               m_package_feerates{package_feerates}
@@ -682,7 +678,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     // Copy/alias what we need out of args
     const int64_t nAcceptTime = args.m_accept_time;
-    const bool bypass_limits = args.m_bypass_limits;
+    const bool bypass_limits = args.m_mempool_bypass.m_bypass_limits;
     std::vector<COutPoint>& coins_to_uncache = args.m_coins_to_uncache;
 
     // Alias what we need out of ws
@@ -1050,7 +1046,7 @@ bool MemPoolAccept::Finalize(const ATMPArgs& args, Workspace& ws)
     const CTransaction& tx = *ws.m_ptx;
     const uint256& hash = ws.m_hash;
     TxValidationState& state = ws.m_state;
-    const bool bypass_limits = args.m_bypass_limits;
+    const bool bypass_limits = args.m_mempool_bypass.m_bypass_limits;
 
     std::unique_ptr<CTxMemPoolEntry>& entry = ws.m_entry;
 
@@ -1183,7 +1179,7 @@ MempoolAcceptResult MemPoolAccept::AcceptSingleTransaction(const CTransactionRef
     if (!ConsensusScriptChecks(args, ws)) return MempoolAcceptResult::Failure(ws.m_state);
 
     // Tx was accepted, but not added
-    if (args.m_test_accept) {
+    if (args.m_mempool_bypass.m_test_accept) {
         return MempoolAcceptResult::Success(std::move(ws.m_replaced_transactions), ws.m_vsize, ws.m_base_fees);
     }
 
@@ -1256,7 +1252,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
             results.emplace(ws.m_ptx->GetWitnessHash(), MempoolAcceptResult::Failure(ws.m_state));
             return PackageMempoolAcceptResult(package_state, package_feerate, std::move(results));
         }
-        if (args.m_test_accept) {
+        if (args.m_mempool_bypass.m_test_accept) {
             // When test_accept=true, transactions that pass PolicyScriptChecks are valid because there are
             // no further mempool checks (passing PolicyScriptChecks implies passing ConsensusScriptChecks).
             results.emplace(ws.m_ptx->GetWitnessHash(),
@@ -1265,7 +1261,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
         }
     }
 
-    if (args.m_test_accept) return PackageMempoolAcceptResult(package_state, package_feerate, std::move(results));
+    if (args.m_mempool_bypass.m_test_accept) return PackageMempoolAcceptResult(package_state, package_feerate, std::move(results));
 
     if (!SubmitPackage(args, workspaces, package_state, results)) {
         // PackageValidationState filled in by SubmitPackage().
@@ -1418,11 +1414,8 @@ MempoolAcceptResult AcceptToMemoryPool(CChainState& active_chainstate, const CTr
     assert(active_chainstate.GetMempool() != nullptr);
     CTxMemPool& pool{*active_chainstate.GetMempool()};
 
-    const bool bypass_limits = mempool_bypass.has_value() ? mempool_bypass->m_bypass_limits: false;
-    const bool test_accept = mempool_bypass.has_value() ? mempool_bypass->m_test_accept : false;
-
     std::vector<COutPoint> coins_to_uncache;
-    auto args = MemPoolAccept::ATMPArgs::SingleAccept(chainparams, accept_time, bypass_limits, coins_to_uncache, test_accept);
+    auto args = MemPoolAccept::ATMPArgs::SingleAccept(chainparams, accept_time, mempool_bypass, coins_to_uncache);
     const MempoolAcceptResult result = MemPoolAccept(pool, active_chainstate).AcceptSingleTransaction(tx, args);
     if (result.m_result_type != MempoolAcceptResult::ResultType::VALID) {
         // Remove coins that were not present in the coins cache before calling

--- a/src/validation.h
+++ b/src/validation.h
@@ -974,7 +974,7 @@ public:
      * @param[in]  tx              The transaction to submit for mempool acceptance.
      * @param[in]  test_accept     When true, run validation checks but don't submit to mempool.
      */
-    [[nodiscard]] MempoolAcceptResult ProcessTransaction(const CTransactionRef& tx, bool test_accept=false)
+    [[nodiscard]] MempoolAcceptResult ProcessTransaction(const CTransactionRef& tx, bool test_accept)
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Load the block tree and coins database from disk, initializing state if we're running with -reindex

--- a/src/validation.h
+++ b/src/validation.h
@@ -249,13 +249,12 @@ struct MemPoolBypass {
  * @param[in]  tx                 The transaction to submit for mempool acceptance.
  * @param[in]  accept_time        The timestamp for adding the transaction to the mempool.
  *                                It is also used to determine when the entry expires.
- * @param[in]  bypass_limits      When true, don't enforce mempool fee and capacity limits.
- * @param[in]  test_accept        When true, run validation checks but don't submit to mempool.
+ * @param[in]  mempool_bypass     Criteria for bypassing mempool checks
  *
  * @returns a MempoolAcceptResult indicating whether the transaction was accepted/rejected with reason.
  */
 MempoolAcceptResult AcceptToMemoryPool(CChainState& active_chainstate, const CTransactionRef& tx,
-                                       int64_t accept_time, bool bypass_limits, bool test_accept)
+                                       int64_t accept_time, const std::optional<MemPoolBypass>& mempool_bypass)
     EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /**

--- a/src/validation.h
+++ b/src/validation.h
@@ -259,16 +259,19 @@ MempoolAcceptResult AcceptToMemoryPool(CChainState& active_chainstate, const CTr
     EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /**
-* Validate (and maybe submit) a package to the mempool. See doc/policy/packages.md for full details
-* on package validation rules.
-* @param[in]    test_accept     When true, run validation checks but don't submit to mempool.
-* @returns a PackageMempoolAcceptResult which includes a MempoolAcceptResult for each transaction.
-* If a transaction fails, validation will exit early and some results may be missing. It is also
-* possible for the package to be partially submitted.
-*/
-PackageMempoolAcceptResult ProcessNewPackage(CChainState& active_chainstate, CTxMemPool& pool,
-                                                   const Package& txns, bool test_accept)
-                                                   EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+ * Validate (and maybe submit) a package to the mempool. See doc/policy/packages.md for full details
+ * on package validation rules.
+ * @param[in]  active_chainstate  Reference to the active chainstate.
+ * @param[in]  pool               The mempool.
+ * @param[in]  package               A package of transactions,
+ * @param[in]  mempool_bypass     Criteria for bypassing mempool checks
+ * @returns a PackageMempoolAcceptResult which includes a MempoolAcceptResult for each transaction.
+ * If a transaction fails, validation will exit early and some results may be missing. It is also
+ * possible for the package to be partially submitted.
+ */
+PackageMempoolAcceptResult ProcessNewPackage(CChainState& active_chainstate, CTxMemPool& pool, const Package& package,
+                                             const std::optional<MemPoolBypass>& mempool_bypass)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /* Transaction policy functions */
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -229,6 +229,19 @@ struct PackageMempoolAcceptResult
 };
 
 /**
+ * Criteria for bypassing mempool checks.
+ */
+struct MemPoolBypass {
+    //! When true, run validation checks but don't submit to mempool.
+    bool m_test_accept{false};
+
+    //! When true, don't enforce mempool fee and capacity limits.
+    //! This is used to indicate that mempool limiting based on feerate should be bypassed.
+    //! This does not prevent mempool from accepting the transaction.
+    bool m_bypass_limits{false};
+};
+
+/**
  * Try to add a transaction to the mempool. This is an internal function and is exposed only for testing.
  * Client code should use ChainstateManager::ProcessTransaction()
  *

--- a/src/validation.h
+++ b/src/validation.h
@@ -987,9 +987,9 @@ public:
      * Try to add a transaction to the memory pool.
      *
      * @param[in]  tx              The transaction to submit for mempool acceptance.
-     * @param[in]  test_accept     When true, run validation checks but don't submit to mempool.
+     * @param[in]  mempool_bypass     Criteria for bypassing mempool checks
      */
-    [[nodiscard]] MempoolAcceptResult ProcessTransaction(const CTransactionRef& tx, bool test_accept)
+    [[nodiscard]] MempoolAcceptResult ProcessTransaction(const CTransactionRef& tx, const std::optional<MemPoolBypass>& mempool_bypass)
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Load the block tree and coins database from disk, initializing state if we're running with -reindex

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -165,6 +165,17 @@ class BIP65Test(BitcoinTestFramework):
                     'allowed': False,
                     'reject-reason': expected_cltv_reject_reason,
                 }],
+                self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], options={"maxfeerate": 0}),
+            )
+
+            # Test deprecated positional "maxfeerate" argument.
+            assert_equal(
+                [{
+                    'txid': spendtx.hash,
+                    'wtxid': spendtx.getwtxid(),
+                    'allowed': False,
+                    'reject-reason': expected_cltv_reject_reason,
+                }],
                 self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], maxfeerate=0),
             )
 

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -122,6 +122,17 @@ class BIP66Test(BitcoinTestFramework):
                 'allowed': False,
                 'reject-reason': 'non-mandatory-script-verify-flag (Non-canonical DER signature)',
             }],
+            self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], options={"maxfeerate": 0}),
+        )
+
+        # Test deprecated positional "maxfeerate" argument.
+        assert_equal(
+            [{
+                'txid': spendtx.hash,
+                'wtxid': spendtx.getwtxid(),
+                'allowed': False,
+                'reject-reason': 'non-mandatory-script-verify-flag (Non-canonical DER signature)',
+            }],
             self.nodes[0].testmempoolaccept(rawtxs=[spendtx.serialize().hex()], maxfeerate=0),
         )
 

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -273,6 +273,8 @@ class RawTransactionsTest(BitcoinTestFramework):
         # Fee rate is 0.00100000 BTC/kvB
         tx = self.wallet.create_self_transfer(fee_rate=Decimal('0.00100000'))
         # Thus, testmempoolaccept should reject
+        testres = self.nodes[2].testmempoolaccept(rawtxs=[tx['hex']], options={"maxfeerate": 0.00001000})[0]
+        # Test deprecated positional "maxfeerate" argument.
         testres = self.nodes[2].testmempoolaccept([tx['hex']], 0.00001000)[0]
         assert_equal(testres['allowed'], False)
         assert_equal(testres['reject-reason'], 'max-fee-exceeded')
@@ -293,6 +295,8 @@ class RawTransactionsTest(BitcoinTestFramework):
         # and sendrawtransaction should throw
         assert_raises_rpc_error(-25, fee_exceeds_max, self.nodes[2].sendrawtransaction, tx['hex'])
         # and the following calls should both succeed
+        testres = self.nodes[2].testmempoolaccept(rawtxs=[tx['hex']], options={"maxfeerate": 0.20000000})[0]
+        # Test deprecated positional "maxfeerate" argument.
         testres = self.nodes[2].testmempoolaccept(rawtxs=[tx['hex']], maxfeerate='0.20000000')[0]
         assert_equal(testres['allowed'], True)
         self.nodes[2].sendrawtransaction(hexstring=tx['hex'], maxfeerate='0.20000000')


### PR DESCRIPTION
#25434, #25532 and #25570 add some parameters to bypass some mempool checks. The motivations for each parameter can be found in these PRs.

https://github.com/bitcoin/bitcoin/pull/25434#discussion_r916378609 suggested to allocate the existing mempool parameters `bypass_limits` and `test_accept` in the same structure.

This PR makes that change without introducing new behaviors or new assumptions. It is basically a refactor and will be used as basis for the new parameters in the PRs mentioned above.