### PR TITLE
test: refactor: pass absolute fee in `create_lots_of_big_transactions` helper

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -512,16 +512,13 @@ def gen_return_txouts():
 # Create a spend of each passed-in utxo, splicing in "txouts" to each raw
 # transaction to make it large.  See gen_return_txouts() above.
 def create_lots_of_big_transactions(mini_wallet, node, fee, tx_batch_size, txouts, utxos=None):
-    from .messages import COIN
-    fee_sats = int(fee * COIN)
     txids = []
     use_internal_utxos = utxos is None
     for _ in range(tx_batch_size):
         tx = mini_wallet.create_self_transfer(
             utxo_to_spend=None if use_internal_utxos else utxos.pop(),
-            fee_rate=0,
+            fee=fee,
         )["tx"]
-        tx.vout[0].nValue -= fee_sats
         tx.vout.extend(txouts)
         res = node.testmempoolaccept([tx.serialize().hex()])[0]
         assert_equal(res['fees']['base'], fee)


### PR DESCRIPTION
Recently merged PR #25522 (commit 2222842ae73f85494797b14753bc18446e4817a2) enabled specifying an absolute fee for MiniWallet's `create_self_transfer` method. We can use that in the `create_lots_of_big_transactions` helper to avoid deducting the fee manually (with prior conversion from BTC to Satoshis). This helper is used (directly or indirectly) in the tests `feature_maxuploadtarget.py`, `mempool_limit.py`, `mining_prioritisetransaction.py`.