### PR TITLE
bench: add logging benchmarks for LogPrintLevel and LogPrintfCategory

### DIFF
--- a/src/bench/logging.cpp
+++ b/src/bench/logging.cpp
@@ -33,6 +33,16 @@ static void LogPrintfCategoryWithoutThreadNames(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=0"}, [] { LogPrintfCategory(BCLog::NET, "%s\n", "test"); });
 }
+static void LogPrintLevelWithThreadNames(benchmark::Bench& bench)
+{
+    Logging(bench, {"-logthreadnames=1"}, [] {
+        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", "test"); });
+}
+static void LogPrintLevelWithoutThreadNames(benchmark::Bench& bench)
+{
+    Logging(bench, {"-logthreadnames=0"}, [] {
+        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", "test"); });
+}
 static void LoggingYoCategory(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=0", "-debug=net"}, [] { LogPrint(BCLog::NET, "%s\n", "test"); });
@@ -46,6 +56,7 @@ static void LoggingNoFile(benchmark::Bench& bench)
     Logging(bench, {"-nodebuglogfile", "-debug=1"}, [] {
         LogPrintf("%s\n", "test");
         LogPrintfCategory(BCLog::NET, "%s\n", "test");
+        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", "test");
         LogPrint(BCLog::NET, "%s\n", "test");
     });
 }
@@ -54,6 +65,8 @@ BENCHMARK(LoggingYoThreadNames);
 BENCHMARK(LoggingNoThreadNames);
 BENCHMARK(LogPrintfCategoryWithThreadNames);
 BENCHMARK(LogPrintfCategoryWithoutThreadNames);
+BENCHMARK(LogPrintLevelWithThreadNames);
+BENCHMARK(LogPrintLevelWithoutThreadNames);
 BENCHMARK(LoggingYoCategory);
 BENCHMARK(LoggingNoCategory);
 BENCHMARK(LoggingNoFile);

--- a/src/bench/logging.cpp
+++ b/src/bench/logging.cpp
@@ -17,56 +17,62 @@ static void Logging(benchmark::Bench& bench, const std::vector<const char*>& ext
     bench.run([&] { log(); });
 }
 
-static void LogPrintfWithThreadNames(benchmark::Bench& bench)
+static void LogNoDebugLogFile(benchmark::Bench& bench)
 {
-    Logging(bench, {"-logthreadnames=1"}, [] { LogPrintf("%s\n", "test"); });
+    Logging(bench, {"-nodebuglogfile", "-debug=1"}, [] {
+        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", "test");
+        LogPrint(BCLog::NET, "%s\n", "test");
+        LogPrintfCategory(BCLog::NET, "%s\n", "test");
+        LogPrintf("%s\n", "test");
+    });
 }
-static void LogPrintfWithoutThreadNames(benchmark::Bench& bench)
-{
-    Logging(bench, {"-logthreadnames=0"}, [] { LogPrintf("%s\n", "test"); });
-}
-static void LogPrintfCategoryWithThreadNames(benchmark::Bench& bench)
-{
-    Logging(bench, {"-logthreadnames=1"}, [] { LogPrintfCategory(BCLog::NET, "%s\n", "test"); });
-}
-static void LogPrintfCategoryWithoutThreadNames(benchmark::Bench& bench)
-{
-    Logging(bench, {"-logthreadnames=0"}, [] { LogPrintfCategory(BCLog::NET, "%s\n", "test"); });
-}
+
 static void LogPrintLevelWithThreadNames(benchmark::Bench& bench)
 {
-    Logging(bench, {"-logthreadnames=1"}, [] {
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", "test"); });
+    Logging(bench, {"-logthreadnames=1"}, [] { LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", "test"); });
 }
+
 static void LogPrintLevelWithoutThreadNames(benchmark::Bench& bench)
 {
-    Logging(bench, {"-logthreadnames=0"}, [] {
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", "test"); });
+    Logging(bench, {"-logthreadnames=0"}, [] { LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", "test"); });
 }
+
 static void LogPrintWithCategory(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=0", "-debug=net"}, [] { LogPrint(BCLog::NET, "%s\n", "test"); });
 }
+
 static void LogPrintWithoutCategory(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=0", "-debug=0"}, [] { LogPrint(BCLog::NET, "%s\n", "test"); });
 }
-static void LogNoDebugLogFile(benchmark::Bench& bench)
+
+static void LogPrintfCategoryWithThreadNames(benchmark::Bench& bench)
 {
-    Logging(bench, {"-nodebuglogfile", "-debug=1"}, [] {
-        LogPrintf("%s\n", "test");
-        LogPrintfCategory(BCLog::NET, "%s\n", "test");
-        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", "test");
-        LogPrint(BCLog::NET, "%s\n", "test");
-    });
+    Logging(bench, {"-logthreadnames=1"}, [] { LogPrintfCategory(BCLog::NET, "%s\n", "test"); });
 }
 
-BENCHMARK(LogPrintfWithThreadNames);
-BENCHMARK(LogPrintfWithoutThreadNames);
-BENCHMARK(LogPrintfCategoryWithThreadNames);
-BENCHMARK(LogPrintfCategoryWithoutThreadNames);
+static void LogPrintfCategoryWithoutThreadNames(benchmark::Bench& bench)
+{
+    Logging(bench, {"-logthreadnames=0"}, [] { LogPrintfCategory(BCLog::NET, "%s\n", "test"); });
+}
+
+static void LogPrintfWithThreadNames(benchmark::Bench& bench)
+{
+    Logging(bench, {"-logthreadnames=1"}, [] { LogPrintf("%s\n", "test"); });
+}
+
+static void LogPrintfWithoutThreadNames(benchmark::Bench& bench)
+{
+    Logging(bench, {"-logthreadnames=0"}, [] { LogPrintf("%s\n", "test"); });
+}
+
+BENCHMARK(LogNoDebugLogFile);
 BENCHMARK(LogPrintLevelWithThreadNames);
 BENCHMARK(LogPrintLevelWithoutThreadNames);
 BENCHMARK(LogPrintWithCategory);
 BENCHMARK(LogPrintWithoutCategory);
-BENCHMARK(LogNoDebugLogFile);
+BENCHMARK(LogPrintfCategoryWithThreadNames);
+BENCHMARK(LogPrintfCategoryWithoutThreadNames);
+BENCHMARK(LogPrintfWithThreadNames);
+BENCHMARK(LogPrintfWithoutThreadNames);

--- a/src/bench/logging.cpp
+++ b/src/bench/logging.cpp
@@ -17,11 +17,11 @@ static void Logging(benchmark::Bench& bench, const std::vector<const char*>& ext
     bench.run([&] { log(); });
 }
 
-static void LoggingYoThreadNames(benchmark::Bench& bench)
+static void LogPrintfWithThreadNames(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=1"}, [] { LogPrintf("%s\n", "test"); });
 }
-static void LoggingNoThreadNames(benchmark::Bench& bench)
+static void LogPrintfWithoutThreadNames(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=0"}, [] { LogPrintf("%s\n", "test"); });
 }
@@ -43,15 +43,15 @@ static void LogPrintLevelWithoutThreadNames(benchmark::Bench& bench)
     Logging(bench, {"-logthreadnames=0"}, [] {
         LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", "test"); });
 }
-static void LoggingYoCategory(benchmark::Bench& bench)
+static void LogPrintWithCategory(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=0", "-debug=net"}, [] { LogPrint(BCLog::NET, "%s\n", "test"); });
 }
-static void LoggingNoCategory(benchmark::Bench& bench)
+static void LogPrintWithoutCategory(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=0", "-debug=0"}, [] { LogPrint(BCLog::NET, "%s\n", "test"); });
 }
-static void LoggingNoFile(benchmark::Bench& bench)
+static void LogNoDebugLogFile(benchmark::Bench& bench)
 {
     Logging(bench, {"-nodebuglogfile", "-debug=1"}, [] {
         LogPrintf("%s\n", "test");
@@ -61,12 +61,12 @@ static void LoggingNoFile(benchmark::Bench& bench)
     });
 }
 
-BENCHMARK(LoggingYoThreadNames);
-BENCHMARK(LoggingNoThreadNames);
+BENCHMARK(LogPrintfWithThreadNames);
+BENCHMARK(LogPrintfWithoutThreadNames);
 BENCHMARK(LogPrintfCategoryWithThreadNames);
 BENCHMARK(LogPrintfCategoryWithoutThreadNames);
 BENCHMARK(LogPrintLevelWithThreadNames);
 BENCHMARK(LogPrintLevelWithoutThreadNames);
-BENCHMARK(LoggingYoCategory);
-BENCHMARK(LoggingNoCategory);
-BENCHMARK(LoggingNoFile);
+BENCHMARK(LogPrintWithCategory);
+BENCHMARK(LogPrintWithoutCategory);
+BENCHMARK(LogNoDebugLogFile);

--- a/src/bench/logging.cpp
+++ b/src/bench/logging.cpp
@@ -25,6 +25,14 @@ static void LoggingNoThreadNames(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=0"}, [] { LogPrintf("%s\n", "test"); });
 }
+static void LogPrintfCategoryWithThreadNames(benchmark::Bench& bench)
+{
+    Logging(bench, {"-logthreadnames=1"}, [] { LogPrintfCategory(BCLog::NET, "%s\n", "test"); });
+}
+static void LogPrintfCategoryWithoutThreadNames(benchmark::Bench& bench)
+{
+    Logging(bench, {"-logthreadnames=0"}, [] { LogPrintfCategory(BCLog::NET, "%s\n", "test"); });
+}
 static void LoggingYoCategory(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=0", "-debug=net"}, [] { LogPrint(BCLog::NET, "%s\n", "test"); });
@@ -37,12 +45,15 @@ static void LoggingNoFile(benchmark::Bench& bench)
 {
     Logging(bench, {"-nodebuglogfile", "-debug=1"}, [] {
         LogPrintf("%s\n", "test");
+        LogPrintfCategory(BCLog::NET, "%s\n", "test");
         LogPrint(BCLog::NET, "%s\n", "test");
     });
 }
 
 BENCHMARK(LoggingYoThreadNames);
 BENCHMARK(LoggingNoThreadNames);
+BENCHMARK(LogPrintfCategoryWithThreadNames);
+BENCHMARK(LogPrintfCategoryWithoutThreadNames);
 BENCHMARK(LoggingYoCategory);
 BENCHMARK(LoggingNoCategory);
 BENCHMARK(LoggingNoFile);


### PR DESCRIPTION
LogPrintLevel and LogPrintfCategory were recently added to the logging macros in #24464 and #25306, respectively. Our logging is expected to primarily use these methods, so it makes sense to benchmark them.

This pull adds benchmarks for both of them to the logging benchmarks, improves the existing benchmark naming to be clearer and with a more coherent output order, and sorts the benchmark code in that order. 

```
$ NANOBENCH_SUPPRESS_WARNINGS=1 ./src/bench/bench_bitcoin -filter=Log*.*

before

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               75.82 |       13,189,445.28 |    5.3% |      0.01 | `LoggingNoCategory`
|            1,344.86 |          743,571.82 |   19.8% |      0.01 | `LoggingNoFile`
|           15,341.11 |           65,184.34 |   19.6% |      0.01 | `LoggingNoThreadNames`
|           22,790.48 |           43,877.96 |   36.3% |      0.01 | `LoggingYoCategory`
|           22,972.32 |           43,530.65 |    7.4% |      0.01 | `LoggingYoThreadNames`
```

after

```
$ NANOBENCH_SUPPRESS_WARNINGS=1 ./src/bench/bench_bitcoin -filter=Log*.*

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|            2,497.81 |          400,349.92 |   25.1% |      0.01 | `LogNoDebugLogFile`
|           30,758.83 |           32,510.99 |   18.8% |      0.01 | `LogPrintLevelWithThreadNames`
|           25,559.50 |           39,124.40 |    7.1% |      0.01 | `LogPrintLevelWithoutThreadNames`
|           22,128.45 |           45,190.70 |    2.2% |      0.01 | `LogPrintWithCategory`
|           21,888.91 |           45,685.23 |    6.3% |      0.01 | `LogPrintWithoutCategory`
|           28,293.11 |           35,344.29 |    4.9% |      0.01 | `LogPrintfCategoryWithThreadNames`
|           24,329.70 |           41,102.03 |    7.3% |      0.01 | `LogPrintfCategoryWithoutThreadNames`
|           26,814.71 |           37,292.97 |    6.9% |      0.01 | `LogPrintfWithThreadNames`
|           18,139.46 |           55,128.43 |   20.9% |      0.01 | `LogPrintfWithoutThreadNames`
```
