### PR TITLE
test: speedup wallet_coinbase_category.py

### DIFF
--- a/test/functional/wallet_coinbase_category.py
+++ b/test/functional/wallet_coinbase_category.py
@@ -15,6 +15,7 @@ from test_framework.util import (
 class CoinbaseCategoryTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
+        self.setup_clean_chain = True
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()


### PR DESCRIPTION
No need to create a chain (200 extra blocks), nor use the cache, for it.