### PR TITLE
test persistence of non-mempool tx prioritisation

### DIFF
--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -105,6 +105,11 @@ class MempoolPersistTest(BitcoinTestFramework):
         assert_equal(len(self.nodes[0].p2ps), 0)
         self.mini_wallet.send_self_transfer(from_node=self.nodes[0])
 
+        # Test persistence of prioritisation for transactions not in the mempool.
+        # Create a tx and prioritise but don't submit until after the restart.
+        tx_prioritised_not_submitted = self.mini_wallet.create_self_transfer()
+        self.nodes[0].prioritisetransaction(txid=tx_prioritised_not_submitted['txid'], fee_delta=9999)
+
         self.log.debug("Stop-start the nodes. Verify that node0 has the transactions in its mempool and node1 does not. Verify that node2 calculates its balance correctly after loading wallet transactions.")
         self.stop_nodes()
         # Give this node a head-start, so we can be "extra-sure" that it didn't load anything later
@@ -125,6 +130,9 @@ class MempoolPersistTest(BitcoinTestFramework):
 
         self.log.debug('Verify all fields are loaded correctly')
         assert_equal(last_entry, self.nodes[0].getmempoolentry(txid=last_txid))
+        self.nodes[0].sendrawtransaction(tx_prioritised_not_submitted['hex'])
+        entry_prioritised_before_restart = self.nodes[0].getmempoolentry(txid=tx_prioritised_not_submitted['txid'])
+        assert_equal(entry_prioritised_before_restart['fees']['base'] + Decimal('0.00009999'), entry_prioritised_before_restart['fees']['modified'])
 
         # Verify accounting of mempool transactions after restart is correct
         if self.is_sqlite_compiled():
@@ -143,7 +151,7 @@ class MempoolPersistTest(BitcoinTestFramework):
         self.stop_nodes()
         self.start_node(0)
         assert self.nodes[0].getmempoolinfo()["loaded"]
-        assert_equal(len(self.nodes[0].getrawmempool()), 6)
+        assert_equal(len(self.nodes[0].getrawmempool()), 7)
 
         mempooldat0 = os.path.join(self.nodes[0].datadir, self.chain, 'mempool.dat')
         mempooldat1 = os.path.join(self.nodes[1].datadir, self.chain, 'mempool.dat')
@@ -153,12 +161,12 @@ class MempoolPersistTest(BitcoinTestFramework):
         assert os.path.isfile(mempooldat0)
         assert_equal(result0['filename'], mempooldat0)
 
-        self.log.debug("Stop nodes, make node1 use mempool.dat from node0. Verify it has 6 transactions")
+        self.log.debug("Stop nodes, make node1 use mempool.dat from node0. Verify it has 7 transactions")
         os.rename(mempooldat0, mempooldat1)
         self.stop_nodes()
         self.start_node(1, extra_args=["-persistmempool"])
         assert self.nodes[1].getmempoolinfo()["loaded"]
-        assert_equal(len(self.nodes[1].getrawmempool()), 6)
+        assert_equal(len(self.nodes[1].getrawmempool()), 7)
 
         self.log.debug("Prevent bitcoind from writing mempool.dat to disk. Verify that `savemempool` fails")
         # to test the exception we are creating a tmp folder called mempool.dat.new


### PR DESCRIPTION
We persist tx prioritisation/fee deltas in mempool.dat (see `DumpMempool`). It seems we have test coverage for persistence of modified fees of mempool entries (see `vinfo` loop), but not for the prioritisation of transactions not in mempool (see `mapDeltas`).

Relevant: https://github.com/bitcoin/bitcoin/pull/25487#discussion_r917490221