### PR TITLE
refactor: Return BResult from restoreWallet

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -329,7 +329,7 @@ public:
    virtual std::string getWalletDir() = 0;
 
    //! Restore backup wallet
-   virtual std::unique_ptr<Wallet> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, bilingual_str& error, std::vector<bilingual_str>& warnings) = 0;
+   virtual BResult<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings) = 0;
 
    //! Return available wallets in wallet directory.
    virtual std::vector<std::string> listWalletDir() = 0;

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -391,9 +391,10 @@ void RestoreWalletActivity::restore(const fs::path& backup_file, const std::stri
         tr("Restoring Wallet <b>%1</b>…").arg(name.toHtmlEscaped()));
 
     QTimer::singleShot(0, worker(), [this, backup_file, wallet_name] {
-        std::unique_ptr<interfaces::Wallet> wallet = node().walletLoader().restoreWallet(backup_file, wallet_name, m_error_message, m_warning_message);
+        auto wallet{node().walletLoader().restoreWallet(backup_file, wallet_name, m_warning_message)};
 
-        if (wallet) m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet));
+        m_error_message = wallet ? bilingual_str{} : wallet.GetError();
+        if (wallet) m_wallet_model = m_wallet_controller->getOrCreateWallet(wallet.ReleaseObj());
 
         QTimer::singleShot(0, this, &RestoreWalletActivity::finish);
     });

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -6,6 +6,7 @@
 #define BITCOIN_UTIL_RESULT_H
 
 #include <util/translation.h>
+
 #include <variant>
 
 /*
@@ -18,9 +19,9 @@ private:
     std::variant<bilingual_str, T> m_variant;
 
 public:
-    BResult() : m_variant(Untranslated("")) {}
-    BResult(const T& _obj) : m_variant(_obj) {}
-    BResult(const bilingual_str& error) : m_variant(error) {}
+    BResult() : m_variant{Untranslated("")} {}
+    BResult(T obj) : m_variant{std::move(obj)} {}
+    BResult(bilingual_str error) : m_variant{std::move(error)} {}
 
     /* Whether the function succeeded or not */
     bool HasRes() const { return std::holds_alternative<T>(m_variant); }
@@ -29,6 +30,11 @@ public:
     const T& GetObj() const {
         assert(HasRes());
         return std::get<T>(m_variant);
+    }
+    T ReleaseObj()
+    {
+        assert(HasRes());
+        return std::move(std::get<T>(m_variant));
     }
 
     /* In case of failure, the error cause */

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -569,11 +569,13 @@ public:
         options.require_existing = true;
         return MakeWallet(m_context, LoadWallet(m_context, name, true /* load_on_start */, options, status, error, warnings));
     }
-    std::unique_ptr<Wallet> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, bilingual_str& error, std::vector<bilingual_str>& warnings) override
+    BResult<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings) override
     {
         DatabaseStatus status;
-
-        return MakeWallet(m_context, RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, status, error, warnings));
+        bilingual_str error;
+        BResult<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, status, error, warnings))};
+        if (!wallet) return error;
+        return wallet;
     }
     std::string getWalletDir() override
     {


### PR DESCRIPTION
This avoids the `error` in-out param (and if `warnings` is added to `BResult`, it will avoid passing that in-out param as well).

Also, as it is needed for this change, prepare `BResult` for non-copyable types.