### PR TITLE
refactor: replace RecursiveMutex `cs_sendProcessing` with Mutex

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -372,7 +372,7 @@ public:
     std::list<CNetMessage> vProcessMsg GUARDED_BY(cs_vProcessMsg);
     size_t nProcessQueueSize{0};
 
-    RecursiveMutex cs_sendProcessing;
+    Mutex cs_sendProcessing;
 
     uint64_t nRecvBytes GUARDED_BY(cs_vRecv){0};
 


### PR DESCRIPTION
The mutex `cs_sendProcessing` is currently only acquired at one location in the code:

https://github.com/bitcoin/bitcoin/blob/7d258ee8bc3bff439881064dd6234f7b04982783/src/net.cpp#L1998-L2001

apparently with the intention to execute the method for sending messages (`NetEventsInterface::SendMessages(...)`) in serial order, in the case that we ever had more than one message handling thread. With no possibility to re-acquire the mutex in the same thread, there is no reason for it to be a RecursiveMutex, so we can change it to an ordinary Mutex instead.

(An alternative would be to just get rid of the mutex, as it currently doesn't serve any purpose, as long as we only have one message handling thread.)