### PR TITLE
build: Check for std::atomic::exchange rather than std::atomic_exchange

### DIFF
--- a/build-aux/m4/l_atomic.m4
+++ b/build-aux/m4/l_atomic.m4
@@ -18,7 +18,7 @@ m4_define([_CHECK_ATOMIC_testbody], [[
 
   int main() {
     std::atomic<bool> lock{true};
-    std::atomic_exchange(&lock, false);
+    lock.exchange(false);
 
     std::atomic<std::chrono::seconds> t{0s};
     t.store(2s);
@@ -34,6 +34,8 @@ m4_define([_CHECK_ATOMIC_testbody], [[
 AC_DEFUN([CHECK_ATOMIC], [
 
   AC_LANG_PUSH(C++)
+  TEMP_CXXFLAGS="$CXXFLAGS"
+  CXXFLAGS="$CXXFLAGS $PTHREAD_CFLAGS"
 
   AC_MSG_CHECKING([whether std::atomic can be used without link library])
 
@@ -51,5 +53,6 @@ AC_DEFUN([CHECK_ATOMIC], [
         ])
     ])
 
+  CXXFLAGS="$TEMP_CXXFLAGS"
   AC_LANG_POP
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -87,9 +87,6 @@ else
 AX_CXX_COMPILE_STDCXX([20], [noext], [mandatory])
 fi
 
-dnl Check if -latomic is required for <std::atomic>
-CHECK_ATOMIC
-
 dnl check if additional link flags are required for std::filesystem
 CHECK_FILESYSTEM
 
@@ -886,6 +883,9 @@ AC_C_BIGENDIAN
 
 dnl Check for pthread compile/link requirements
 AX_PTHREAD
+
+dnl Check if -latomic is required for <std::atomic>
+CHECK_ATOMIC
 
 dnl The following macro will add the necessary defines to bitcoin-config.h, but
 dnl they also need to be passed down to any subprojects. Pull the results out of


### PR DESCRIPTION
Our usage of std::atomic is with it's own exchange function, not std::atomic_exchange. So we should be looking specifically for that function.

This removes the need for -latomic for riscv builds, which resolves a guix cross architecture reproducibility issue.