### PR TITLE
p2p: Advertise `NODE_FULL_RBF` and connect to 4 outbound full-rbf peers if `-mempoolfullrbf` is set

### DIFF
--- a/doc/reduce-memory.md
+++ b/doc/reduce-memory.md
@@ -26,8 +26,9 @@ The size of some in-memory caches can be reduced. As caches trade off memory usa
 
 - `-maxconnections=<n>` - the maximum number of connections, which defaults to 125. Each active connection takes up some
   memory. This option applies only if inbound connections are enabled; otherwise, the number of connections will not
-  be more than 11. Of the 11 outbound peers, there can be 8 full-relay connections, 2 block-relay-only ones,
-  and occasionally 1 short-lived feeler or extra outbound block-relay-only connection.
+  be more than 11 or 15 if `mempoolfullrbf=1`. Of the 11 outbound peers, there can be 8 full-relay connections, 2 block-relay-only ones,
+  and occasionally 1 short-lived feeler or extra outbound block-relay-only connection. Of the 15 outbound peers, the 4 additional
+  connections are 4 full-rbf peers.
 
 - These limits do not apply to connections added manually with the `-addnode` configuration option or
   the `addnode` RPC, which have a separate limit of 8 connections.

--- a/doc/reduce-traffic.md
+++ b/doc/reduce-traffic.md
@@ -6,7 +6,8 @@ Some node operators need to deal with bandwidth caps imposed by their ISPs.
 By default, Bitcoin Core allows up to 125 connections to different peers, 10 of
 which are outbound. You can therefore, have at most 115 inbound connections.
 Of the 10 outbound peers, there can be 8 full-relay connections and 2
-block-relay-only ones.
+block-relay-only ones. If `-mempoolfullrbf=1`, there is 14 outbound peers,
+of which the additional 4 connections are 4 full-rbf peers.
 
 The default settings can result in relatively significant traffic consumption.
 
@@ -54,3 +55,10 @@ Be reminded of the effects of this setting.
   their transactions.
 - It makes block propagation slower because compact block relay can only be
   used when transaction relay is enabled.
+
+## Turn off full-rbf automatic preferential peering (`-mempoolfullrbf=0`)
+
+Automatic preferential peering with full-rbf peers is currently activated if
+the corresponding setting is turn on. Those 4 full-rbf peers are consuming
+bandwidth to service their block-relay and transaction-relay needs. Note,
+`mempoolfullrbf` is currently turn off by default.

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -375,6 +375,7 @@ private:
     static constexpr uint8_t MAX_DETAIL_LEVEL{4};
     std::array<std::array<uint16_t, NETWORKS.size() + 1>, 3> m_counts{{{}}}; //!< Peer counts by (in/out/total, networks/total)
     uint8_t m_block_relay_peers_count{0};
+    uint8_t m_full_rbf_peers_count{0};
     uint8_t m_manual_peers_count{0};
     int8_t NetworkStringToId(const std::string& str) const
     {
@@ -437,6 +438,7 @@ private:
         if (conn_type == "block-relay-only") return "block";
         if (conn_type == "manual" || conn_type == "feeler") return conn_type;
         if (conn_type == "addr-fetch") return "addr";
+        if (conn_type == "fullrbf") return "full-rbf";
         return "";
     }
 
@@ -485,6 +487,7 @@ public:
             ++m_counts.at(2).at(network_id);                // total by network
             ++m_counts.at(2).at(NETWORKS.size());           // total overall
             if (conn_type == "block-relay-only") ++m_block_relay_peers_count;
+            if (conn_type == "fullrbf") ++m_full_rbf_peers_count;
             if (conn_type == "manual") ++m_manual_peers_count;
             if (DetailsRequested()) {
                 // Push data for this peer to the peers vector.
@@ -583,6 +586,7 @@ public:
             result += strprintf("   %5i", m_counts.at(i).at(NETWORKS.size())); // total peers count
             if (i == 1) { // the outbound row has two extra columns for block relay and manual peer counts
                 result += strprintf("   %5i", m_block_relay_peers_count);
+                if (m_full_rbf_peers_count) result += strprintf("   %5i", m_full_rbf_peers_count);
                 if (m_manual_peers_count) result += strprintf("   %5i", m_manual_peers_count);
             }
         }
@@ -631,11 +635,12 @@ public:
         "           \"in\"  - inbound connections are those initiated by the peer\n"
         "           \"out\" - outbound connections are those initiated by us\n"
         "  type     Type of peer connection\n"
-        "           \"full\"   - full relay, the default\n"
-        "           \"block\"  - block relay; like full relay but does not relay transactions or addresses\n"
-        "           \"manual\" - peer we manually added using RPC addnode or the -addnode/-connect config options\n"
-        "           \"feeler\" - short-lived connection for testing addresses\n"
-        "           \"addr\"   - address fetch; short-lived connection for requesting addresses\n"
+        "           \"full\"    - full relay, the default\n"
+        "           \"block\"   - block relay; like full relay but does not relay transactions or addresses\n"
+        "           \"manual\"  - peer we manually added using RPC addnode or the -addnode/-connect config options\n"
+        "           \"feeler\"  - short-lived connection for testing addresses\n"
+        "           \"addr\"    - address fetch; short-lived connection for requesting addresses\n"
+        "           \"fullrbf\" - full rbf; long-lived connection for full-rbf transaction-relay\n"
         "  net      Network the peer connected through (\"ipv4\", \"ipv6\", \"onion\", \"i2p\", or \"cjdns\")\n"
         "  mping    Minimum observed ping time, in milliseconds (ms)\n"
         "  ping     Last observed ping time, in milliseconds (ms)\n"

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1416,6 +1416,10 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     }
     LogPrintf("* Using %.1f MiB for in-memory UTXO set (plus up to %.1f MiB of unused mempool space)\n", cache_sizes.coins * (1.0 / 1024 / 1024), mempool_opts.max_size_bytes * (1.0 / 1024 / 1024));
 
+    if (mempool_opts.full_rbf) {
+        nLocalServices = ServiceFlags(nLocalServices | NODE_FULL_RBF);
+    }
+
     for (bool fLoaded = false; !fLoaded && !ShutdownRequested();) {
         node.mempool = std::make_unique<CTxMemPool>(mempool_opts);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -564,9 +564,9 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-bytespersigop", strprintf("Equivalent bytes per sigop in transactions for relay and mining (default: %u)", DEFAULT_BYTES_PER_SIGOP), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarrier", strprintf("Relay and mine data carrier transactions (default: %u)", DEFAULT_ACCEPT_DATACARRIER), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarriersize", strprintf("Maximum size of data in data carrier transactions we relay and mine (default: %u)", MAX_OP_RETURN_RELAY), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
-    argsman.AddArg("-mempoolfullrbf", strprintf("Accept transaction replace-by-fee without requiring replaceability signaling (default: %u)", DEFAULT_MEMPOOL_FULL_RBF), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-permitbaremultisig", strprintf("Relay non-P2SH multisig (default: %u)", DEFAULT_PERMIT_BAREMULTISIG), ArgsManager::ALLOW_ANY,
                    OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-mempoolfullrbf", strprintf("Accept transaction replace-by-fee without requiring replaceability signaling (default: %u). This will trigger automatic preferential peering with %u full-rbf peers", DEFAULT_MEMPOOL_FULL_RBF, MAX_FULLRBF_RELAY_CONNECTIONS), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-minrelaytxfee=<amt>", strprintf("Fees (in %s/kvB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)",
         CURRENCY_UNIT, FormatMoney(DEFAULT_MIN_RELAY_TX_FEE)), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-whitelistforcerelay", strprintf("Add 'forcerelay' permission to whitelisted inbound peers with default permissions. This will relay transactions even if the transactions were already in the mempool. (default: %d)", DEFAULT_WHITELISTFORCERELAY), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
@@ -1645,6 +1645,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     connOptions.nMaxConnections = nMaxConnections;
     connOptions.m_max_outbound_full_relay = std::min(MAX_OUTBOUND_FULL_RELAY_CONNECTIONS, connOptions.nMaxConnections);
     connOptions.m_max_outbound_block_relay = std::min(MAX_BLOCK_RELAY_ONLY_CONNECTIONS, connOptions.nMaxConnections-connOptions.m_max_outbound_full_relay);
+    connOptions.m_full_rbf = node.mempool->m_full_rbf;
+    connOptions.m_max_outbound_fullrbf_relay = node.mempool->m_full_rbf ? std::min(MAX_FULLRBF_RELAY_CONNECTIONS, connOptions.nMaxConnections-connOptions.m_max_outbound_full_relay-connOptions.m_max_outbound_block_relay) : 0;
     connOptions.nMaxAddnode = MAX_ADDNODE_CONNECTIONS;
     connOptions.nMaxFeeler = MAX_FEELER_CONNECTIONS;
     connOptions.uiInterface = &uiInterface;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3177,6 +3177,13 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             return;
         }
 
+        if (pfrom.IsFullRBF() && !HasFullRBFServiceFlag(nServices))
+        {
+            LogPrint(BCLog::NET, "peer=%d does not offer fullrbf as expected; disconnecting\n", pfrom.GetId());
+            pfrom.fDisconnect = true;
+            return;
+        }
+
         if (nVersion < MIN_PEER_PROTO_VERSION) {
             // disconnect from peers older than this proto version
             LogPrint(BCLog::NET, "peer=%d using obsolete version %i; disconnecting\n", pfrom.GetId(), nVersion);

--- a/src/node/connection_types.cpp
+++ b/src/node/connection_types.cpp
@@ -20,6 +20,8 @@ std::string ConnectionTypeAsString(ConnectionType conn_type)
         return "block-relay-only";
     case ConnectionType::ADDR_FETCH:
         return "addr-fetch";
+    case ConnectionType::FULL_RBF:
+        return "fullrbf";
     } // no default case, so the compiler can warn about missing cases
 
     assert(false);

--- a/src/node/connection_types.h
+++ b/src/node/connection_types.h
@@ -74,6 +74,12 @@ enum class ConnectionType {
      * AddrMan is empty.
      */
     ADDR_FETCH,
+
+    /**
+     * Full-rbf connections are long-lived connections used to relay transactions
+     * with peers accepting replacement without requiring replaceability signaling.
+     */
+    FULL_RBF,
 };
 
 /** Convert ConnectionType enum to a string value */

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -196,6 +196,7 @@ static std::string serviceFlagToStr(size_t bit)
     case NODE_WITNESS:         return "WITNESS";
     case NODE_COMPACT_FILTERS: return "COMPACT_FILTERS";
     case NODE_NETWORK_LIMITED: return "NETWORK_LIMITED";
+    case NODE_FULL_RBF:        return "FULL_RBF";
     // Not using default, so we get warned when a case is missing
     }
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -293,6 +293,8 @@ enum ServiceFlags : uint64_t {
     // collisions and other cases where nodes may be advertising a service they
     // do not actually support. Other service bits should be allocated via the
     // BIP process.
+
+    NODE_FULL_RBF = (1 << 26),
 };
 
 /**

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -352,6 +352,14 @@ static inline bool MayHaveUsefulAddressDB(ServiceFlags services)
     return (services & NODE_NETWORK) || (services & NODE_NETWORK_LIMITED);
 }
 
+/**
+ * Checks if a peer with the given service flags enables fullrbf.
+ */
+static inline bool HasFullRBFServiceFlag(ServiceFlags services)
+{
+    return (services & NODE_FULL_RBF);
+}
+
 /** A CService with information about it as peer */
 class CAddress : public CService
 {

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -707,6 +707,8 @@ QString ConnectionTypeToQString(ConnectionType conn_type, bool prepend_direction
     case ConnectionType::FEELER: return prefix + QObject::tr("Feeler");
     //: Short-lived peer connection type that solicits known addresses from a peer.
     case ConnectionType::ADDR_FETCH: return prefix + QObject::tr("Address Fetch");
+    //: Peer connection type that is signaling service bit 26 (full-rbf).
+    case ConnectionType::FULL_RBF: return prefix + QObject::tr("Full RBF");
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -514,7 +514,10 @@ RPCConsole::RPCConsole(interfaces::Node& node, const PlatformStyle *_platformSty
         tr("Outbound Feeler: short-lived, for testing addresses"),
         /*: Explanatory text for a short-lived outbound peer connection that is used
             to request addresses from a peer. */
-        tr("Outbound Address Fetch: short-lived, for soliciting addresses")};
+        tr("Outbound Address Fetch: short-lived, for soliciting addresses"),
+        /* Explanartory text for a ling-lived outbound connection that is used
+           to relay transactions to peer accepting replacement without requiring replaceability. */
+        tr("Outbound Full-RBF: long-lived, for connecting with full-rbf peers")};
     const QString list{"<ul><li>" + Join(CONNECTION_TYPE_DOC, QString("</li><li>")) + "</li></ul>"};
     ui->peerConnectionTypeLabel->setToolTip(ui->peerConnectionTypeLabel->toolTip().arg(list));
     const QString hb_list{"<ul><li>\""

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -41,7 +41,8 @@ const std::vector<std::string> CONNECTION_TYPE_DOC{
         "inbound (initiated by the peer)",
         "manual (added via addnode RPC or -addnode/-connect configuration options)",
         "addr-fetch (short-lived automatic connection for soliciting addresses)",
-        "feeler (short-lived automatic connection for testing addresses)"
+        "feeler (short-lived automatic connection for testing addresses)",
+        "fullrbf (long-lived automatic connection for full-rbf peers)"
 };
 
 static RPCHelpMan getconnectioncount()


### PR DESCRIPTION
`mempoolfullrbf` allows a node to accept replace-by-fee transactions without requiring replaceability signaling. While the replacement transaction is locally accepted, it should be rejected by all your opt-in rbf peers, the default behavior. As such, the odds are low the replacement transaction propagates to miners, unless there are full-rbf transaction-relay paths existent between the node and those miners mempools.

This PR aims to improve this issue by enabling the setting of full-rbf transaction-relay link, in both manual and automated fashions. 

The first commit introduces a `NODE_REPLACE_BY_FEE` service flag to advertise support of full-rbf to our peers if [`mempoolfullrbf`](https://github.com/bitcoin/bitcoin/pull/25353) is set to true. From the results of `getpeerinfo` or `getnetworkinfo`, a node operator can find full-rbf peers on the p2p network to which to manually connect to. The service flag bit select is the 26th one to be compatible with previous full-rbf [experiences](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-June/020570.html).

The second commit introduces a `ConnectionType::FULLRBF` if `mempoolfullrbf` is set to true. In `ThreadOpenConnections`, we attempt to keep opened at least 4 outbound full-rbf transaction-relay peer. An outbound full-rbf relay peer is considered as one signaling `NODE_REPLACE_BY_FEE` service flag.

I think if we have concerns on the network-wise resources consumption from those new outbound full-rbf relay peers, we could deduce them `MAX_ADNNODE_CONNECTIONS`. It should be weighted if we have other concerns about the implications on transaction-relay topology robustness or any spying peers flagging themselves as `NODE_REPLACE_BY_FEE` to attract early full-rbf traffic. What else ?

I don't hold to the approach re-using the current automatic connection logic in `ThreadOpenConnections`, if there are others ones I'm interested to consider them. I can split the PR in two, if automatic connection requires more thinking.

TODO:
- add functional tests
- make `MAX_FULLRBF_RELAY_CONNECTIONS` configurable up to `MAX_ADDNODE_CONNECTIONS` ?
- make automatic connection its own boolean setting ?