### PR TITLE
util: Make `BResult` error a generic type instead of only `bilingual_str`

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -329,7 +329,7 @@ public:
    virtual std::string getWalletDir() = 0;
 
    //! Restore backup wallet
-   virtual std::unique_ptr<Wallet> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, bilingual_str& error, std::vector<bilingual_str>& warnings) = 0;
+   virtual BResult<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings) = 0;
 
    //! Return available wallets in wallet directory.
    virtual std::vector<std::string> listWalletDir() = 0;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -139,7 +139,7 @@ public:
     virtual void listLockedCoins(std::vector<COutPoint>& outputs) = 0;
 
     //! Create transaction.
-    virtual BResult<CTransactionRef> createTransaction(const std::vector<wallet::CRecipient>& recipients,
+    virtual SingeErrorResult<CTransactionRef> createTransaction(const std::vector<wallet::CRecipient>& recipients,
         const wallet::CCoinControl& coin_control,
         bool sign,
         int& change_pos,

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -88,7 +88,7 @@ public:
     virtual std::string getWalletName() = 0;
 
     // Get a new address.
-    virtual BResult<CTxDestination> getNewDestination(const OutputType type, const std::string label) = 0;
+    virtual SingeErrorResult<CTxDestination> getNewDestination(const OutputType type, const std::string label) = 0;
 
     //! Get public key.
     virtual bool getPubKey(const CScript& script, const CKeyID& address, CPubKey& pub_key) = 0;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -329,7 +329,7 @@ public:
    virtual std::string getWalletDir() = 0;
 
    //! Restore backup wallet
-   virtual BResult<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings) = 0;
+   virtual SingeErrorResult<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings) = 0;
 
    //! Return available wallets in wallet directory.
    virtual std::vector<std::string> listWalletDir() = 0;

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -391,9 +391,10 @@ void RestoreWalletActivity::restore(const fs::path& backup_file, const std::stri
         tr("Restoring Wallet <b>%1</b>…").arg(name.toHtmlEscaped()));
 
     QTimer::singleShot(0, worker(), [this, backup_file, wallet_name] {
-        std::unique_ptr<interfaces::Wallet> wallet = node().walletLoader().restoreWallet(backup_file, wallet_name, m_error_message, m_warning_message);
+        auto wallet{node().walletLoader().restoreWallet(backup_file, wallet_name, m_warning_message)};
 
-        if (wallet) m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet));
+        m_error_message = wallet ? bilingual_str{} : wallet.GetError();
+        if (wallet) m_wallet_model = m_wallet_controller->getOrCreateWallet(wallet.ReleaseObj());
 
         QTimer::singleShot(0, this, &RestoreWalletActivity::finish);
     });

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -6,6 +6,7 @@
 #define BITCOIN_UTIL_RESULT_H
 
 #include <util/translation.h>
+
 #include <variant>
 
 /*
@@ -18,9 +19,9 @@ private:
     std::variant<bilingual_str, T> m_variant;
 
 public:
-    BResult() : m_variant(Untranslated("")) {}
-    BResult(const T& _obj) : m_variant(_obj) {}
-    BResult(const bilingual_str& error) : m_variant(error) {}
+    BResult() : m_variant{Untranslated("")} {}
+    BResult(T obj) : m_variant{std::move(obj)} {}
+    BResult(bilingual_str error) : m_variant{std::move(error)} {}
 
     /* Whether the function succeeded or not */
     bool HasRes() const { return std::holds_alternative<T>(m_variant); }
@@ -29,6 +30,11 @@ public:
     const T& GetObj() const {
         assert(HasRes());
         return std::get<T>(m_variant);
+    }
+    T ReleaseObj()
+    {
+        assert(HasRes());
+        return std::move(std::get<T>(m_variant));
     }
 
     /* In case of failure, the error cause */

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -46,4 +46,56 @@ public:
     explicit operator bool() const { return HasRes(); }
 };
 
+/**
+ * 'StructuredResult' is a generic class useful for wrapping a return object
+ * (in case of success) or propagating the error cause.
+ *
+ * @tparam S stands for success object.
+ * @tparam E stands for error object.
+ */
+template <class S, class E>
+class StructuredResult
+{
+protected:
+    std::variant<std::monostate, E, S> m_variant;
+
+public:
+    StructuredResult() {}
+    StructuredResult(S obj) : m_variant{std::move(obj)} {}
+    StructuredResult(E error) : m_variant{std::move(error)} {}
+
+    /* Whether the function succeeded or not */
+    bool HasRes() const { return std::holds_alternative<S>(m_variant); }
+
+    /* In case of success, the result object */
+    const S& GetObj() const
+    {
+        assert(HasRes());
+        return std::get<S>(m_variant);
+    }
+    S ReleaseObj()
+    {
+        assert(HasRes());
+        return std::move(std::get<S>(m_variant));
+    }
+
+    /* In case of failure, the error cause */
+    const E& GetError() const
+    {
+        assert(!HasRes());
+        return std::get<E>(m_variant);
+    }
+
+    explicit operator bool() const { return HasRes(); }
+};
+
+template <class T>
+class SingeErrorResult : public StructuredResult<T, bilingual_str>
+{
+public:
+    SingeErrorResult() : StructuredResult<T, bilingual_str>(Untranslated("")) {}
+    SingeErrorResult(bilingual_str error) : StructuredResult<T, bilingual_str>(std::move(error)) {}
+    SingeErrorResult(T obj) : StructuredResult<T, bilingual_str>(std::move(obj)) {}
+};
+
 #endif // BITCOIN_UTIL_RESULT_H

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -9,43 +9,6 @@
 
 #include <variant>
 
-/*
- * 'BResult' is a generic class useful for wrapping a return object
- * (in case of success) or propagating the error cause.
-*/
-template<class T>
-class BResult {
-private:
-    std::variant<bilingual_str, T> m_variant;
-
-public:
-    BResult() : m_variant{Untranslated("")} {}
-    BResult(T obj) : m_variant{std::move(obj)} {}
-    BResult(bilingual_str error) : m_variant{std::move(error)} {}
-
-    /* Whether the function succeeded or not */
-    bool HasRes() const { return std::holds_alternative<T>(m_variant); }
-
-    /* In case of success, the result object */
-    const T& GetObj() const {
-        assert(HasRes());
-        return std::get<T>(m_variant);
-    }
-    T ReleaseObj()
-    {
-        assert(HasRes());
-        return std::move(std::get<T>(m_variant));
-    }
-
-    /* In case of failure, the error cause */
-    const bilingual_str& GetError() const {
-        assert(!HasRes());
-        return std::get<bilingual_str>(m_variant);
-    }
-
-    explicit operator bool() const { return HasRes(); }
-};
-
 /**
  * 'StructuredResult' is a generic class useful for wrapping a return object
  * (in case of success) or propagating the error cause.

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -569,11 +569,13 @@ public:
         options.require_existing = true;
         return MakeWallet(m_context, LoadWallet(m_context, name, true /* load_on_start */, options, status, error, warnings));
     }
-    std::unique_ptr<Wallet> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, bilingual_str& error, std::vector<bilingual_str>& warnings) override
+    BResult<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings) override
     {
         DatabaseStatus status;
-
-        return MakeWallet(m_context, RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, status, error, warnings));
+        bilingual_str error;
+        BResult<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, status, error, warnings))};
+        if (!wallet) return error;
+        return wallet;
     }
     std::string getWalletDir() override
     {

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -569,11 +569,11 @@ public:
         options.require_existing = true;
         return MakeWallet(m_context, LoadWallet(m_context, name, true /* load_on_start */, options, status, error, warnings));
     }
-    BResult<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings) override
+    SingeErrorResult<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings) override
     {
         DatabaseStatus status;
         bilingual_str error;
-        BResult<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, status, error, warnings))};
+        SingeErrorResult<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, status, error, warnings))};
         if (!wallet) return error;
         return wallet;
     }

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -249,7 +249,7 @@ public:
         LOCK(m_wallet->cs_wallet);
         return m_wallet->ListLockedCoins(outputs);
     }
-    BResult<CTransactionRef> createTransaction(const std::vector<CRecipient>& recipients,
+    SingeErrorResult<CTransactionRef> createTransaction(const std::vector<CRecipient>& recipients,
         const CCoinControl& coin_control,
         bool sign,
         int& change_pos,

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -146,7 +146,7 @@ public:
     void abortRescan() override { m_wallet->AbortRescan(); }
     bool backupWallet(const std::string& filename) override { return m_wallet->BackupWallet(filename); }
     std::string getWalletName() override { return m_wallet->GetName(); }
-    BResult<CTxDestination> getNewDestination(const OutputType type, const std::string label) override
+    SingeErrorResult<CTxDestination> getNewDestination(const OutputType type, const std::string label) override
     {
         LOCK(m_wallet->cs_wallet);
         return m_wallet->GetNewDestination(type, label);

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -21,7 +21,7 @@ namespace wallet {
 //! Value for the first BIP 32 hardened derivation. Can be used as a bit mask and as a value. See BIP 32 for more details.
 const uint32_t BIP32_HARDENED_KEY_LIMIT = 0x80000000;
 
-BResult<CTxDestination> LegacyScriptPubKeyMan::GetNewDestination(const OutputType type)
+SingeErrorResult<CTxDestination> LegacyScriptPubKeyMan::GetNewDestination(const OutputType type)
 {
     if (LEGACY_OUTPUT_TYPES.count(type) == 0) {
         return _("Error: Legacy wallets only support the \"legacy\", \"p2sh-segwit\", and \"bech32\" address types");;
@@ -1654,7 +1654,7 @@ std::set<CKeyID> LegacyScriptPubKeyMan::GetKeys() const
     return set_address;
 }
 
-BResult<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination(const OutputType type)
+SingeErrorResult<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination(const OutputType type)
 {
     // Returns true if this descriptor supports getting new addresses. Conditions where we may be unable to fetch them (e.g. locked) are caught later
     if (!CanGetAddresses()) {

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -172,7 +172,7 @@ protected:
 public:
     explicit ScriptPubKeyMan(WalletStorage& storage) : m_storage(storage) {}
     virtual ~ScriptPubKeyMan() {};
-    virtual BResult<CTxDestination> GetNewDestination(const OutputType type) { return Untranslated("Not supported"); }
+    virtual SingeErrorResult<CTxDestination> GetNewDestination(const OutputType type) { return Untranslated("Not supported"); }
     virtual isminetype IsMine(const CScript& script) const { return ISMINE_NO; }
 
     //! Check that the given decryption key is valid for this ScriptPubKeyMan, i.e. it decrypts all of the keys handled by it.
@@ -360,7 +360,7 @@ private:
 public:
     using ScriptPubKeyMan::ScriptPubKeyMan;
 
-    BResult<CTxDestination> GetNewDestination(const OutputType type) override;
+    SingeErrorResult<CTxDestination> GetNewDestination(const OutputType type) override;
     isminetype IsMine(const CScript& script) const override;
 
     bool CheckDecryptionKey(const CKeyingMaterial& master_key, bool accept_no_keys = false) override;
@@ -568,7 +568,7 @@ public:
 
     mutable RecursiveMutex cs_desc_man;
 
-    BResult<CTxDestination> GetNewDestination(const OutputType type) override;
+    SingeErrorResult<CTxDestination> GetNewDestination(const OutputType type) override;
     isminetype IsMine(const CScript& script) const override;
 
     bool CheckDecryptionKey(const CKeyingMaterial& master_key, bool accept_no_keys = false) override;

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -652,7 +652,7 @@ static void DiscourageFeeSniping(CMutableTransaction& tx, FastRandomContext& rng
     }
 }
 
-static BResult<CreatedTransactionResult> CreateTransactionInternal(
+static SingeErrorResult<CreatedTransactionResult> CreateTransactionInternal(
         CWallet& wallet,
         const std::vector<CRecipient>& vecSend,
         int change_pos,
@@ -947,7 +947,7 @@ static BResult<CreatedTransactionResult> CreateTransactionInternal(
     return CreatedTransactionResult(tx, nFeeRet, nChangePosInOut, feeCalc);
 }
 
-BResult<CreatedTransactionResult> CreateTransaction(
+SingeErrorResult<CreatedTransactionResult> CreateTransaction(
         CWallet& wallet,
         const std::vector<CRecipient>& vecSend,
         int change_pos,

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -114,7 +114,7 @@ struct CreatedTransactionResult
  * selected by SelectCoins(); Also create the change output, when needed
  * @note passing change_pos as -1 will result in setting a random position
  */
-BResult<CreatedTransactionResult> CreateTransaction(CWallet& wallet, const std::vector<CRecipient>& vecSend, int change_pos, const CCoinControl& coin_control, bool sign = true);
+SingeErrorResult<CreatedTransactionResult> CreateTransaction(CWallet& wallet, const std::vector<CRecipient>& vecSend, int change_pos, const CCoinControl& coin_control, bool sign = true);
 
 /**
  * Insert additional inputs into the transaction by

--- a/src/wallet/test/fuzz/notifications.cpp
+++ b/src/wallet/test/fuzz/notifications.cpp
@@ -69,7 +69,7 @@ struct FuzzedWallet {
     CScript GetScriptPubKey(FuzzedDataProvider& fuzzed_data_provider)
     {
         auto type{fuzzed_data_provider.PickValueInArray(OUTPUT_TYPES)};
-        BResult<CTxDestination> op_dest;
+        SingeErrorResult<CTxDestination> op_dest;
         if (fuzzed_data_provider.ConsumeBool()) {
             op_dest = wallet->GetNewDestination(type, "");
         } else {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2317,7 +2317,7 @@ bool CWallet::TopUpKeyPool(unsigned int kpSize)
     return res;
 }
 
-BResult<CTxDestination> CWallet::GetNewDestination(const OutputType type, const std::string label)
+SingeErrorResult<CTxDestination> CWallet::GetNewDestination(const OutputType type, const std::string label)
 {
     LOCK(cs_wallet);
     auto spk_man = GetScriptPubKeyMan(type, false /* internal */);
@@ -2334,7 +2334,7 @@ BResult<CTxDestination> CWallet::GetNewDestination(const OutputType type, const 
     return op_dest;
 }
 
-BResult<CTxDestination> CWallet::GetNewChangeDestination(const OutputType type)
+SingeErrorResult<CTxDestination> CWallet::GetNewChangeDestination(const OutputType type)
 {
     LOCK(cs_wallet);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -666,8 +666,8 @@ public:
      */
     void MarkDestinationsDirty(const std::set<CTxDestination>& destinations) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    BResult<CTxDestination> GetNewDestination(const OutputType type, const std::string label);
-    BResult<CTxDestination> GetNewChangeDestination(const OutputType type);
+    SingeErrorResult<CTxDestination> GetNewDestination(const OutputType type, const std::string label);
+    SingeErrorResult<CTxDestination> GetNewChangeDestination(const OutputType type);
 
     isminetype IsMine(const CTxDestination& dest) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     isminetype IsMine(const CScript& script) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);


### PR DESCRIPTION
This PR makes `BResult` error a generic type instead of only `bilingual_str` and changes the class name to `StructuredResult` as `BResut` is not related to the purpose of the class.

The motivation is that some methods, like `src/wallet/wallet.h:{RestoreWallet(...),CreateWallet(...),LoadWallet(...)}` have more output parameters than just `bilingual_str& error` such as `DatabaseStatus& status` and `std::vector<bilingual_str>& warnings`.

With a generic template for error, it will be possible to create a struct that has `bilingual_str& error` and `DatabaseStatus& status`, for example, and use it in `StructuredResult`.

Built on top of #25594