### PR TITLE
wallet, RPC: Default BIP125 signal to -mempoolfullrbf

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -159,7 +159,8 @@ static std::vector<RPCArg> CreateTxDoc()
             },
         },
         {"locktime", RPCArg::Type::NUM, RPCArg::Default{0}, "Raw locktime. Non-0 value also locktime-activates inputs"},
-        {"replaceable", RPCArg::Type::BOOL, RPCArg::Default{false}, "Marks this transaction as BIP125-replaceable.\n"
+        {"replaceable", RPCArg::Type::BOOL, RPCArg::DefaultHint{"Same value as -mempoolfullrbf"},
+                "Marks this transaction as BIP125-replaceable.\n"
                 "Allows this transaction to be replaced by a transaction with higher fees. If provided, it is an error if explicit sequence numbers are incompatible."},
     };
 }
@@ -303,11 +304,9 @@ static RPCHelpMan createrawtransaction()
         UniValue::VBOOL
         }, true
     );
+    const ArgsManager& args{EnsureAnyArgsman(request.context)};
 
-    bool rbf = false;
-    if (!request.params[3].isNull()) {
-        rbf = request.params[3].isTrue();
-    }
+    const bool rbf{request.params[3].isNull() ? args.GetBoolArg("-mempoolfullrbf", DEFAULT_MEMPOOL_FULL_RBF) : request.params[3].getBool()};
     CMutableTransaction rawTx = ConstructTransaction(request.params[0], request.params[1], request.params[2], rbf);
 
     return EncodeHexTx(CTransaction(rawTx));
@@ -1444,11 +1443,9 @@ static RPCHelpMan createpsbt()
         UniValue::VBOOL,
         }, true
     );
+    const ArgsManager& args{EnsureAnyArgsman(request.context)};
 
-    bool rbf = false;
-    if (!request.params[3].isNull()) {
-        rbf = request.params[3].isTrue();
-    }
+    const bool rbf{request.params[3].isNull() ? args.GetBoolArg("-mempoolfullrbf", DEFAULT_MEMPOOL_FULL_RBF) : request.params[3].getBool()};
     CMutableTransaction rawTx = ConstructTransaction(request.params[0], request.params[1], request.params[2], rbf);
 
     // Make a blank psbt

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -77,7 +77,7 @@ void WalletInit::AddWalletOptions(ArgsManager& argsman) const
 #if HAVE_SYSTEM
     argsman.AddArg("-walletnotify=<cmd>", "Execute command when a wallet transaction changes. %s in cmd is replaced by TxID, %w is replaced by wallet name, %b is replaced by the hash of the block including the transaction (set to 'unconfirmed' if the transaction is not included) and %h is replaced by the block height (-1 if not included). %w is not currently implemented on windows. On systems where %w is supported, it should NOT be quoted because this would break shell escaping used to invoke the command.", ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
 #endif
-    argsman.AddArg("-walletrbf", strprintf("Send transactions with full-RBF opt-in enabled (RPC only, default: %u)", DEFAULT_WALLET_RBF), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
+    argsman.AddArg("-walletrbf", "Send transactions with full-RBF opt-in enabled (RPC only, default: Same value as -mempoolfullrbf)", ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
 
 #ifdef USE_BDB
     argsman.AddArg("-dblogsize=<n>", strprintf("Flush wallet database activity from memory to disk log every <n> megabytes (default: %u)", DatabaseOptions().max_log_mb), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2964,7 +2964,7 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
 
     walletInstance->m_confirm_target = args.GetIntArg("-txconfirmtarget", DEFAULT_TX_CONFIRM_TARGET);
     walletInstance->m_spend_zero_conf_change = args.GetBoolArg("-spendzeroconfchange", DEFAULT_SPEND_ZEROCONF_CHANGE);
-    walletInstance->m_signal_rbf = args.GetBoolArg("-walletrbf", DEFAULT_WALLET_RBF);
+    walletInstance->m_signal_rbf = args.GetBoolArg("-walletrbf", args.GetBoolArg("-mempoolfullrbf", DEFAULT_MEMPOOL_FULL_RBF));
 
     walletInstance->WalletLogPrintf("Wallet completed loading in %15dms\n", GetTimeMillis() - nStart);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -98,8 +98,6 @@ static const bool DEFAULT_SPEND_ZEROCONF_CHANGE = true;
 static const bool DEFAULT_WALLET_REJECT_LONG_CHAINS{true};
 //! -txconfirmtarget default
 static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 6;
-//! -walletrbf default
-static const bool DEFAULT_WALLET_RBF = false;
 static const bool DEFAULT_WALLETBROADCAST = true;
 static const bool DEFAULT_DISABLE_WALLET = false;
 static const bool DEFAULT_WALLETCROSSCHAIN = false;
@@ -597,7 +595,7 @@ public:
     /** Allow Coin Selection to pick unconfirmed UTXOs that were sent from our own wallet if it
      * cannot fund the transaction otherwise. */
     bool m_spend_zero_conf_change{DEFAULT_SPEND_ZEROCONF_CHANGE};
-    bool m_signal_rbf{DEFAULT_WALLET_RBF};
+    bool m_signal_rbf{false};
     bool m_allow_fallback_fee{true}; //!< will be false if -fallbackfee=0
     CFeeRate m_min_fee{DEFAULT_TRANSACTION_MINFEE}; //!< Override with -mintxfee
     /**

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -29,8 +29,8 @@ class WalletSendTest(BitcoinTestFramework):
         self.num_nodes = 2
         # whitelist all peers to speed up tx relay / mempool sync
         self.extra_args = [
-            ["-whitelist=127.0.0.1","-walletrbf=1"],
-            ["-whitelist=127.0.0.1","-walletrbf=1"],
+            ["-whitelist=127.0.0.1", "-mempoolfullrbf=1"],  # -mempoolfullrbf=1 implies -walletrbf=1
+            ["-whitelist=127.0.0.1", "-walletrbf=1"],
         ]
         getcontext().prec = 8 # Satoshi precision for Decimal
 


### PR DESCRIPTION
`-mempoolfullrbf` allows valid replacement transactions into the mempool, even if they do not signal for BIP125. If it is set, it would be confusing if the wallet and RPC didn't signal for BIP125 replacement:

* The wallet will refuse to replace non-signalling transactions.
* However, such transactions may be replaced over RPC or P2P.
* Such replacements may not propagate well over the P2P network.

So to prevent those issues in the normal case, adjust the default for `-walletrbf` as well as the RPC raw transactions API.

It is still possible for users to set `-mempoolfullrbf=1 -walletrbf=0`, as well as passing in the `replaceable=False` option to each RPC, if they wish. Or to leave the `-mempoolfullrbf` default value: off.