### PR TITLE
[kernel 3d/n] Misc `ChainstateManager::Options` fixups

### DIFF
--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -78,8 +78,8 @@ int main(int argc, char* argv[])
 
     // SETUP: Chainstate
     const ChainstateManager::Options chainman_opts{
-        chainparams,
-        static_cast<int64_t(*)()>(GetTime),
+        .chainparams = chainparams,
+        .adjusted_time_callback = static_cast<int64_t (*)()>(GetTime),
     };
     ChainstateManager chainman{chainman_opts};
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1440,8 +1440,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         node.mempool = std::make_unique<CTxMemPool>(mempool_opts);
 
         const ChainstateManager::Options chainman_opts{
-            chainparams,
-            GetAdjustedTime,
+            .chainparams = chainparams,
+            .adjusted_time_callback = GetAdjustedTime,
         };
         node.chainman = std::make_unique<ChainstateManager>(chainman_opts);
         ChainstateManager& chainman = *node.chainman;

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -10,6 +10,8 @@
 
 class CChainParams;
 
+namespace kernel {
+
 /**
  * An options struct for `ChainstateManager`, more ergonomically referred to as
  * `ChainstateManager::Options` due to the using-declaration in
@@ -19,5 +21,7 @@ struct ChainstateManagerOpts {
     const CChainParams& chainparams;
     const std::function<int64_t()> adjusted_time_callback{nullptr};
 };
+
+} // namespace kernel
 
 #endif // BITCOIN_KERNEL_CHAINSTATEMANAGER_OPTS_H

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -183,8 +183,8 @@ ChainTestingSetup::ChainTestingSetup(const std::string& chainName, const std::ve
     m_cache_sizes = CalculateCacheSizes(m_args);
 
     const ChainstateManager::Options chainman_opts{
-        chainparams,
-        GetAdjustedTime,
+        .chainparams = chainparams,
+        .adjusted_time_callback = GetAdjustedTime,
     };
     m_node.chainman = std::make_unique<ChainstateManager>(chainman_opts);
     m_node.chainman->m_blockman.m_block_tree_db = std::make_unique<CBlockTreeDB>(m_cache_sizes.block_tree_db, true);

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -24,8 +24,8 @@ BOOST_FIXTURE_TEST_SUITE(validation_chainstate_tests, TestingSetup)
 BOOST_AUTO_TEST_CASE(validation_chainstate_resize_caches)
 {
     const ChainstateManager::Options chainman_opts{
-        Params(),
-        GetAdjustedTime,
+        .chainparams = Params(),
+        .adjusted_time_callback = GetAdjustedTime,
     };
     ChainstateManager manager{chainman_opts};
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -834,7 +834,7 @@ private:
     friend CChainState;
 
 public:
-    using Options = ChainstateManagerOpts;
+    using Options = kernel::ChainstateManagerOpts;
 
     explicit ChainstateManager(const Options& opts)
         : m_chainparams{opts.chainparams},


### PR DESCRIPTION
This is part of the `libbitcoinkernel` project: #24303, https://github.com/bitcoin/bitcoin/projects/18

This PR is **_NOT_** dependent on any other PRs.

-----

Places `ChainstateManager::Options` into the `kernel::` namespace and use designated initializers for construction.