### PR TITLE
rpc: add missing description in gettxout help text

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -617,7 +617,7 @@ const RPCResult getblock_vin{
                 {RPCResult::Type::OBJ, "scriptPubKey", "",
                 {
                     {RPCResult::Type::STR, "asm", "The asm"},
-                    {RPCResult::Type::STR, "hex", "The hex"},
+                    {RPCResult::Type::STR_HEX, "hex", "The hex"},
                     {RPCResult::Type::STR, "address", /*optional=*/true, "The Bitcoin address (only if a well-defined address exists)"},
                     {RPCResult::Type::STR, "type", "The type (one of: " + GetAllOutputTypes() + ")"},
                 }},
@@ -1014,9 +1014,9 @@ static RPCHelpMan gettxout()
                 {RPCResult::Type::NUM, "confirmations", "The number of confirmations"},
                 {RPCResult::Type::STR_AMOUNT, "value", "The transaction value in " + CURRENCY_UNIT},
                 {RPCResult::Type::OBJ, "scriptPubKey", "", {
-                    {RPCResult::Type::STR, "asm", ""},
+                    {RPCResult::Type::STR, "asm", "The asm"},
                     {RPCResult::Type::STR, "desc", "Inferred descriptor for the output"},
-                    {RPCResult::Type::STR_HEX, "hex", ""},
+                    {RPCResult::Type::STR_HEX, "hex", "The hex"},
                     {RPCResult::Type::STR, "type", "The type, eg pubkeyhash"},
                     {RPCResult::Type::STR, "address", /*optional=*/true, "The Bitcoin address (only if a well-defined address exists)"},
                 }},

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -730,7 +730,7 @@ const RPCResult decodepsbt_inputs{
             {RPCResult::Type::OBJ, "final_scriptSig", /*optional=*/true, "",
             {
                 {RPCResult::Type::STR, "asm", "The asm"},
-                {RPCResult::Type::STR, "hex", "The hex"},
+                {RPCResult::Type::STR_HEX, "hex", "The hex"},
             }},
             {RPCResult::Type::ARR, "final_scriptwitness", /*optional=*/true, "",
             {


### PR DESCRIPTION
replaces #25578

Add help text to asm & hex (like everywhere else).
I've also changed two `RPCResult::Type::STR` to `RPCResult::Type::STR_HEX`