### PR TITLE
refactor: univalue test cleanups

### DIFF
--- a/ci/test/wrap-qemu.sh
+++ b/ci/test/wrap-qemu.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-for b_name in {"${BASE_OUTDIR}/bin"/*,src/secp256k1/*tests,src/minisketch/test{,-verify},src/univalue/{no_nul,test_json,unitester,object}}; do
+for b_name in {"${BASE_OUTDIR}/bin"/*,src/secp256k1/*tests,src/minisketch/test{,-verify},src/univalue/{test_json,unitester,object}}; do
     # shellcheck disable=SC2044
     for b in $(find "${BASE_ROOT_DIR}" -executable -type f -name "$(basename "$b_name")"); do
       echo "Wrap $b ..."

--- a/ci/test/wrap-wine.sh
+++ b/ci/test/wrap-wine.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-for b_name in {"${BASE_OUTDIR}/bin"/*,src/secp256k1/*tests,src/minisketch/test{,-verify},src/univalue/{no_nul,test_json,unitester,object}}.exe; do
+for b_name in {"${BASE_OUTDIR}/bin"/*,src/secp256k1/*tests,src/minisketch/test{,-verify},src/univalue/{test_json,unitester,object}}.exe; do
     # shellcheck disable=SC2044
     for b in $(find "${BASE_ROOT_DIR}" -executable -type f -name "$(basename "$b_name")"); do
       if (file "$b" | grep "Windows"); then

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -373,7 +373,7 @@ endif
 	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C secp256k1 check
 
 if ENABLE_TESTS
-UNIVALUE_TESTS = univalue/test/object univalue/test/unitester univalue/test/no_nul
+UNIVALUE_TESTS = univalue/test/object univalue/test/unitester
 noinst_PROGRAMS += $(UNIVALUE_TESTS)
 TESTS += $(UNIVALUE_TESTS)
 
@@ -381,11 +381,6 @@ univalue_test_unitester_SOURCES = $(UNIVALUE_TEST_UNITESTER_INT)
 univalue_test_unitester_LDADD = $(LIBUNIVALUE)
 univalue_test_unitester_CPPFLAGS = -I$(srcdir)/$(UNIVALUE_INCLUDE_DIR_INT) -DJSON_TEST_SRC=\"$(srcdir)/$(UNIVALUE_TEST_DATA_DIR_INT)\"
 univalue_test_unitester_LDFLAGS = -static $(LIBTOOL_APP_LDFLAGS)
-
-univalue_test_no_nul_SOURCES = $(UNIVALUE_TEST_NO_NUL_INT)
-univalue_test_no_nul_LDADD = $(LIBUNIVALUE)
-univalue_test_no_nul_CPPFLAGS = -I$(srcdir)/$(UNIVALUE_INCLUDE_DIR_INT)
-univalue_test_no_nul_LDFLAGS = -static $(LIBTOOL_APP_LDFLAGS)
 
 univalue_test_object_SOURCES = $(UNIVALUE_TEST_OBJECT_INT)
 univalue_test_object_LDADD = $(LIBUNIVALUE)

--- a/src/univalue/sources.mk
+++ b/src/univalue/sources.mk
@@ -25,9 +25,6 @@ UNIVALUE_TEST_UNITESTER_INT += %reldir%/test/unitester.cpp
 UNIVALUE_TEST_JSON_INT =
 UNIVALUE_TEST_JSON_INT += %reldir%/test/test_json.cpp
 
-UNIVALUE_TEST_NO_NUL_INT =
-UNIVALUE_TEST_NO_NUL_INT += %reldir%/test/no_nul.cpp
-
 UNIVALUE_TEST_OBJECT_INT =
 UNIVALUE_TEST_OBJECT_INT += %reldir%/test/object.cpp
 

--- a/src/univalue/sources.mk
+++ b/src/univalue/sources.mk
@@ -1,12 +1,8 @@
-# - All variables are namespaced with UNIVALUE_ to avoid colliding with
-#     downstream makefiles.
 # - All Variables ending in _HEADERS or _SOURCES confuse automake, so the
 #     _INT postfix is applied.
 # - Convenience variables, for example a UNIVALUE_TEST_DIR should not be used
 #     as they interfere with automatic dependency generation
-# - The %reldir% is the relative path from the Makefile.am. This allows
-#   downstreams to use these variables without having to manually account for
-#   the path change.
+# - The %reldir% is the relative path from the Makefile.am.
 
 UNIVALUE_INCLUDE_DIR_INT = %reldir%/include
 

--- a/src/univalue/test/.gitignore
+++ b/src/univalue/test/.gitignore
@@ -2,7 +2,6 @@
 object
 unitester
 test_json
-no_nul
 
 *.trs
 *.log

--- a/src/univalue/test/no_nul.cpp
+++ b/src/univalue/test/no_nul.cpp
@@ -1,8 +1,0 @@
-#include <univalue.h>
-
-int main (int argc, char *argv[])
-{
-    char buf[] = "___[1,2,3]___";
-    UniValue val;
-    return val.read(buf + 3, 7) ? 0 : 1;
-}

--- a/src/univalue/test/object.cpp
+++ b/src/univalue/test/object.cpp
@@ -13,9 +13,6 @@
 #include <string>
 #include <vector>
 
-#define BOOST_FIXTURE_TEST_SUITE(a, b)
-#define BOOST_AUTO_TEST_CASE(funcName) void funcName()
-#define BOOST_AUTO_TEST_SUITE_END()
 #define BOOST_CHECK(expr) assert(expr)
 #define BOOST_CHECK_EQUAL(v1, v2) assert((v1) == (v2))
 #define BOOST_CHECK_THROW(stmt, excMatch) { \
@@ -35,9 +32,7 @@
 	} \
     }
 
-BOOST_FIXTURE_TEST_SUITE(univalue_tests, BasicTestingSetup)
-
-BOOST_AUTO_TEST_CASE(univalue_constructor)
+void univalue_constructor()
 {
     UniValue v1;
     BOOST_CHECK(v1.isNull());
@@ -85,7 +80,7 @@ BOOST_AUTO_TEST_CASE(univalue_constructor)
     BOOST_CHECK_EQUAL(v9.getValStr(), "zappa");
 }
 
-BOOST_AUTO_TEST_CASE(univalue_push_throw)
+void univalue_push_throw()
 {
     UniValue j;
     BOOST_CHECK_THROW(j.push_back(1), std::runtime_error);
@@ -95,7 +90,7 @@ BOOST_AUTO_TEST_CASE(univalue_push_throw)
     BOOST_CHECK_THROW(j.pushKVs({}), std::runtime_error);
 }
 
-BOOST_AUTO_TEST_CASE(univalue_typecheck)
+void univalue_typecheck()
 {
     UniValue v1;
     BOOST_CHECK(v1.setNumStr("1"));
@@ -144,7 +139,7 @@ BOOST_AUTO_TEST_CASE(univalue_typecheck)
     BOOST_CHECK_THROW(vals[1].get_bool(), std::runtime_error);
 }
 
-BOOST_AUTO_TEST_CASE(univalue_set)
+void univalue_set()
 {
     UniValue v(UniValue::VSTR, "foo");
     v.clear();
@@ -203,7 +198,7 @@ BOOST_AUTO_TEST_CASE(univalue_set)
     BOOST_CHECK(v.isNull());
 }
 
-BOOST_AUTO_TEST_CASE(univalue_array)
+void univalue_array()
 {
     UniValue arr(UniValue::VARR);
 
@@ -262,7 +257,7 @@ BOOST_AUTO_TEST_CASE(univalue_array)
     BOOST_CHECK_EQUAL(arr.size(), 0);
 }
 
-BOOST_AUTO_TEST_CASE(univalue_object)
+void univalue_object()
 {
     UniValue obj(UniValue::VOBJ);
     std::string strKey, strVal;
@@ -381,7 +376,7 @@ BOOST_AUTO_TEST_CASE(univalue_object)
 static const char *json1 =
 "[1.10000000,{\"key1\":\"str\\u0000\",\"key2\":800,\"key3\":{\"name\":\"martian http://test.com\"}}]";
 
-BOOST_AUTO_TEST_CASE(univalue_readwrite)
+void univalue_readwrite()
 {
     UniValue v;
     BOOST_CHECK(v.read(json1));
@@ -424,11 +419,10 @@ BOOST_AUTO_TEST_CASE(univalue_readwrite)
     BOOST_CHECK(!v.read("{} 42"));
 }
 
-BOOST_AUTO_TEST_SUITE_END()
-
 int main (int argc, char *argv[])
 {
     univalue_constructor();
+    univalue_push_throw();
     univalue_typecheck();
     univalue_set();
     univalue_array();

--- a/src/univalue/test/unitester.cpp
+++ b/src/univalue/test/unitester.cpp
@@ -149,6 +149,13 @@ void unescape_unicode_test()
     assert(val[0].get_str() == "\xf0\x9d\x85\xa1");
 }
 
+void no_nul_test()
+{
+    char buf[] = "___[1,2,3]___";
+    UniValue val;
+    assert(val.read(buf + 3, 7));
+}
+
 int main (int argc, char *argv[])
 {
     for (const auto& f: filenames) {
@@ -156,6 +163,7 @@ int main (int argc, char *argv[])
     }
 
     unescape_unicode_test();
+    no_nul_test();
 
     return 0;
 }


### PR DESCRIPTION
Remove references to "downstream" from makefiles, as they are now redundant.
Remove `BOOST_TEST` macros in favour of just using functions.
Add missing call to `univalue_push_throw` tests.