### PR TITLE
wallet: Introduce AddressBookManager

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -298,6 +298,7 @@ BITCOIN_CORE_H = \
   validation.h \
   validationinterface.h \
   versionbits.h \
+  wallet/addressbookman.h \
   wallet/bdb.h \
   wallet/coincontrol.h \
   wallet/coinselection.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -444,6 +444,7 @@ endif
 libbitcoin_wallet_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BDB_CPPFLAGS) $(SQLITE_CFLAGS)
 libbitcoin_wallet_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_wallet_a_SOURCES = \
+  wallet/addressbookman.cpp \
   wallet/coincontrol.cpp \
   wallet/context.cpp \
   wallet/crypter.cpp \

--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -119,7 +119,7 @@ void TestAddAddressesToSendBook(interfaces::Node& node)
 
     auto check_addbook_size = [&wallet](int expected_size) {
         LOCK(wallet->cs_wallet);
-        QCOMPARE(static_cast<int>(wallet->m_address_book.size()), expected_size);
+        QCOMPARE(wallet->GetAddrBookSize(), expected_size);
     };
 
     // We should start with the two addresses we added earlier and nothing else.

--- a/src/wallet/addressbookman.cpp
+++ b/src/wallet/addressbookman.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include <wallet/addressbookman.h>
+
+#include <key_io.h>
+#include <logging.h>
+#include <wallet/walletdb.h>
+
+std::optional<CAddressBookData> AddressBookMan::Find(const CTxDestination& dest) const
+{
+    LOCK(cs_addrbook);
+    const auto& address_book_it = m_address_book.find(dest);
+    if (address_book_it == m_address_book.end()) return std::nullopt;
+    return address_book_it->second;
+}
+
+bool AddressBookMan::Has(const CTxDestination& dest, bool allow_change) const
+{
+    const auto& op_entry = Find(dest);
+    if (!op_entry) return false;
+    return op_entry->IsChange() && allow_change;
+}
+
+bool AddressBookMan::Put(wallet::WalletBatch& batch, const CTxDestination& dest, const std::string& label, const std::string& purpose)
+{
+    const std::string& dest_str = EncodeDestination(dest);
+    {
+        LOCK(cs_addrbook);
+        if (!purpose.empty() && !batch.WritePurpose(dest_str, purpose)) {
+            LogPrintf("%s error writing purpose\n", __func__);
+            return false;
+        }
+        if (!batch.WriteName(dest_str, label)) {
+            LogPrintf("%s error writing name\n", __func__);
+            return false;
+        }
+
+        // If db write went well, update memory
+        m_address_book[dest].SetLabel(label);
+        if (!purpose.empty()) /* update purpose only if requested */
+            m_address_book[dest].purpose = purpose;
+    }
+
+    // All good
+    return true;
+}
+
+bool AddressBookMan::Delete(wallet::WalletBatch& batch, const CTxDestination& address)
+{
+    LOCK(cs_addrbook);
+    CAddressBookData* entry = GetEntry(address);
+    if (!entry) return false;
+
+    const std::string& dest = EncodeDestination(address);
+    // Delete destdata tuples associated with address
+    for (const std::pair<const std::string, std::string> &item : entry->destdata) {
+        if (!batch.EraseDestData(dest, item.first)) {
+            LogPrintf("%s error erasing dest data\n", __func__);
+            return false;
+        }
+    }
+
+    if (!batch.ErasePurpose(dest) || !batch.EraseName(dest)) {
+        LogPrintf("%s error erasing purpose/name\n", __func__);
+        return false;
+    }
+
+    // finally, remove it from the map
+    m_address_book.erase(address);
+    return true;
+}
+
+CAddressBookData* AddressBookMan::GetEntry(const CTxDestination& dest)
+{
+    auto address_book_it = m_address_book.find(dest);
+    if (address_book_it == m_address_book.end()) return nullptr;
+    return &address_book_it->second;
+}

--- a/src/wallet/addressbookman.cpp
+++ b/src/wallet/addressbookman.cpp
@@ -72,6 +72,15 @@ bool AddressBookMan::Delete(wallet::WalletBatch& batch, const CTxDestination& ad
     return true;
 }
 
+void AddressBookMan::ForEachAddrBookEntry(const ListAddrBookFunc& func) const
+{
+    LOCK(cs_addrbook);
+    for (const std::pair<const CTxDestination, CAddressBookData>& item : m_address_book) {
+        const auto& entry = item.second;
+        func(item.first, entry.GetLabel(), entry.purpose, entry.IsChange());
+    }
+}
+
 CAddressBookData* AddressBookMan::GetEntry(const CTxDestination& dest)
 {
     auto address_book_it = m_address_book.find(dest);

--- a/src/wallet/addressbookman.cpp
+++ b/src/wallet/addressbookman.cpp
@@ -38,9 +38,10 @@ bool AddressBookMan::Put(wallet::WalletBatch& batch, const CTxDestination& dest,
         }
 
         // If db write went well, update memory
-        m_address_book[dest].SetLabel(label);
-        if (!purpose.empty()) /* update purpose only if requested */
-            m_address_book[dest].purpose = purpose;
+        LoadEntryLabel(dest, label);
+        if (!purpose.empty()) { /* update purpose only if requested */
+            LoadEntryPurpose(dest, purpose);
+        }
     }
 
     // All good
@@ -86,4 +87,28 @@ CAddressBookData* AddressBookMan::GetEntry(const CTxDestination& dest)
     auto address_book_it = m_address_book.find(dest);
     if (address_book_it == m_address_book.end()) return nullptr;
     return &address_book_it->second;
+}
+
+void AddressBookMan::LoadDestData(const CTxDestination& dest, const std::string& key, const std::string& value)
+{
+    LOCK(cs_addrbook);
+    m_address_book[dest].destdata.insert(std::make_pair(key, value));
+}
+
+void AddressBookMan::LoadEntryLabel(const CTxDestination& dest, const std::string& label)
+{
+    LOCK(cs_addrbook);
+    m_address_book[dest].SetLabel(label);
+}
+
+void AddressBookMan::LoadEntryPurpose(const CTxDestination& dest, const std::string& purpose)
+{
+    LOCK(cs_addrbook);
+    m_address_book[dest].purpose = purpose;
+}
+
+int AddressBookMan::GetSize() const
+{
+    LOCK(cs_addrbook);
+    return m_address_book.size();
 }

--- a/src/wallet/addressbookman.h
+++ b/src/wallet/addressbookman.h
@@ -5,6 +5,11 @@
 #ifndef BITCOIN_WALLET_ADDRESSBOOKMAN_H
 #define BITCOIN_WALLET_ADDRESSBOOKMAN_H
 
+#include <script/standard.h>
+#include <sync.h>
+
+#include <map>
+
 /** Address book data */
 class CAddressBookData
 {
@@ -25,6 +30,48 @@ public:
         m_change = false;
         m_label = label;
     }
+};
+
+namespace wallet {
+    class WalletBatch;
+}
+
+class AddressBookMan {
+private:
+    mutable RecursiveMutex cs_addrbook;
+    std::map<CTxDestination, CAddressBookData> m_address_book GUARDED_BY(cs_addrbook);
+
+    // return nullptr if not found
+    CAddressBookData* GetEntry(const CTxDestination&);
+
+public:
+
+    /**
+     * Retrieves the address book entry.
+     * std::nullopt if there is no item for the destination.
+     */
+    std::optional<CAddressBookData> Find(const CTxDestination&) const;
+
+    /**
+     * Returns true if the key exist and 'allow_change' matches the entry.
+     */
+    bool Has(const CTxDestination& dest, bool allow_change = false) const;
+
+    /**
+     *  Store/Update a new entry in the address book map and database.
+     *  Replacing any previously existing value.
+     *
+     *  If 'purpose' is empty, the purpose field will not be updated.
+     *  Note: be REALLY careful with the purpose field.
+     */
+     bool Put(wallet::WalletBatch& batch, const CTxDestination& dest, const std::string& label, const std::string& purpose);
+
+     /**
+      * Removes the entry associated with the specified destination
+      * from the map and database.
+      */
+     bool Delete(wallet::WalletBatch& batch, const CTxDestination& dest);
+
 };
 
 #endif // BITCOIN_WALLET_ADDRESSBOOKMAN_H

--- a/src/wallet/addressbookman.h
+++ b/src/wallet/addressbookman.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_WALLET_ADDRESSBOOKMAN_H
+#define BITCOIN_WALLET_ADDRESSBOOKMAN_H
+
+/** Address book data */
+class CAddressBookData
+{
+private:
+    bool m_change{true};
+    std::string m_label;
+public:
+    std::string purpose;
+
+    CAddressBookData() : purpose("unknown") {}
+
+    typedef std::map<std::string, std::string> StringMap;
+    StringMap destdata;
+
+    bool IsChange() const { return m_change; }
+    const std::string& GetLabel() const { return m_label; }
+    void SetLabel(const std::string& label) {
+        m_change = false;
+        m_label = label;
+    }
+};
+
+#endif // BITCOIN_WALLET_ADDRESSBOOKMAN_H

--- a/src/wallet/addressbookman.h
+++ b/src/wallet/addressbookman.h
@@ -85,6 +85,10 @@ public:
      /** Returns true if the destination was previously marked as 'used' */
      bool IsDestUsed(const CTxDestination& dest) const;
 
+     std::vector<std::string> GetEntriesByDestDataPrefix(const std::string& prefix) const;
+     bool SetEntryDestData(wallet::WalletBatch& batch, const CTxDestination& dest,
+                          const std::string key,  const std::string& id, const std::string& value);
+
      /** Adds a destination data tuple to the store, without saving it to disk */
      void LoadDestData(const CTxDestination& dest, const std::string& key, const std::string& value);
      /** Adds destination label to the store, without saving it to disk */

--- a/src/wallet/addressbookman.h
+++ b/src/wallet/addressbookman.h
@@ -80,6 +80,11 @@ public:
       */
      bool Delete(wallet::WalletBatch& batch, const CTxDestination& dest);
 
+     /** Marks the destination as 'used' */
+     bool SetDestUsed(wallet::WalletBatch& batch, const CTxDestination& dest, bool used);
+     /** Returns true if the destination was previously marked as 'used' */
+     bool IsDestUsed(const CTxDestination& dest) const;
+
      /** Adds a destination data tuple to the store, without saving it to disk */
      void LoadDestData(const CTxDestination& dest, const std::string& key, const std::string& value);
      /** Adds destination label to the store, without saving it to disk */

--- a/src/wallet/addressbookman.h
+++ b/src/wallet/addressbookman.h
@@ -43,7 +43,7 @@ private:
     std::map<CTxDestination, CAddressBookData> m_address_book GUARDED_BY(cs_addrbook);
 
     // return nullptr if not found
-    CAddressBookData* GetEntry(const CTxDestination&);
+    CAddressBookData* GetEntry(const CTxDestination&) EXCLUSIVE_LOCKS_REQUIRED(cs_addrbook);
 
 public:
 
@@ -80,7 +80,14 @@ public:
       */
      bool Delete(wallet::WalletBatch& batch, const CTxDestination& dest);
 
-
+     /** Adds a destination data tuple to the store, without saving it to disk */
+     void LoadDestData(const CTxDestination& dest, const std::string& key, const std::string& value);
+     /** Adds destination label to the store, without saving it to disk */
+     void LoadEntryLabel(const CTxDestination& dest, const std::string& label);
+     /** Adds destination purpose to the store, without saving it to disk */
+     void LoadEntryPurpose(const CTxDestination& dest, const std::string& purpose);
+     /** Return address book size */
+     int GetSize() const;
 };
 
 #endif // BITCOIN_WALLET_ADDRESSBOOKMAN_H

--- a/src/wallet/addressbookman.h
+++ b/src/wallet/addressbookman.h
@@ -8,6 +8,7 @@
 #include <script/standard.h>
 #include <sync.h>
 
+#include <functional>
 #include <map>
 
 /** Address book data */
@@ -58,6 +59,13 @@ public:
     bool Has(const CTxDestination& dest, bool allow_change = false) const;
 
     /**
+     * Walk-through the entries.
+     * Stops when the provided 'ListAddrBookFunc' returns false.
+     */
+    using ListAddrBookFunc = std::function<void(const CTxDestination& dest, const std::string& label, const std::string& purpose, bool is_change)>;
+    void ForEachAddrBookEntry(const ListAddrBookFunc& func) const;
+
+    /**
      *  Store/Update a new entry in the address book map and database.
      *  Replacing any previously existing value.
      *
@@ -71,6 +79,7 @@ public:
       * from the map and database.
       */
      bool Delete(wallet::WalletBatch& batch, const CTxDestination& dest);
+
 
 };
 

--- a/src/wallet/rpc/addresses.cpp
+++ b/src/wallet/rpc/addresses.cpp
@@ -199,7 +199,7 @@ RPCHelpMan listaddressgroupings()
             addressInfo.push_back(EncodeDestination(address));
             addressInfo.push_back(ValueFromAmount(balances[address]));
             {
-                const auto* address_book_entry = pwallet->FindAddressBookEntry(address);
+                const auto& address_book_entry = pwallet->FindAddressBookEntry(address);
                 if (address_book_entry) {
                     addressInfo.push_back(address_book_entry->GetLabel());
                 }
@@ -624,7 +624,7 @@ RPCHelpMan getaddressinfo()
     // stable if we allow multiple labels to be associated with an address in
     // the future.
     UniValue labels(UniValue::VARR);
-    const auto* address_book_entry = pwallet->FindAddressBookEntry(dest);
+    const auto& address_book_entry = pwallet->FindAddressBookEntry(dest);
     if (address_book_entry) {
         labels.push_back(address_book_entry->GetLabel());
     }

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -65,7 +65,7 @@ static bool GetWalletAddressesForKey(const LegacyScriptPubKeyMan* spk_man, const
     CKey key;
     spk_man->GetKey(keyid, key);
     for (const auto& dest : GetAllDestinationsForKey(key.GetPubKey())) {
-        const auto* address_book_entry = wallet.FindAddressBookEntry(dest);
+        const auto& address_book_entry = wallet.FindAddressBookEntry(dest);
         if (address_book_entry) {
             if (!strAddr.empty()) {
                 strAddr += ",";

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -661,7 +661,7 @@ RPCHelpMan listunspent()
         if (fValidAddress) {
             entry.pushKV("address", EncodeDestination(address));
 
-            const auto* address_book_entry = pwallet->FindAddressBookEntry(address);
+            const auto& address_book_entry = pwallet->FindAddressBookEntry(address);
             if (address_book_entry) {
                 entry.pushKV("label", address_book_entry->GetLabel());
             }

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -337,7 +337,7 @@ static void ListTransactions(const CWallet& wallet, const CWalletTx& wtx, int nM
             MaybePushAddress(entry, s.destination);
             entry.pushKV("category", "send");
             entry.pushKV("amount", ValueFromAmount(-s.amount));
-            const auto* address_book_entry = wallet.FindAddressBookEntry(s.destination);
+            const auto& address_book_entry = wallet.FindAddressBookEntry(s.destination);
             if (address_book_entry) {
                 entry.pushKV("label", address_book_entry->GetLabel());
             }
@@ -355,7 +355,7 @@ static void ListTransactions(const CWallet& wallet, const CWalletTx& wtx, int nM
         for (const COutputEntry& r : listReceived)
         {
             std::string label;
-            const auto* address_book_entry = wallet.FindAddressBookEntry(r.destination);
+            const auto& address_book_entry = wallet.FindAddressBookEntry(r.destination);
             if (address_book_entry) {
                 label = address_book_entry->GetLabel();
             }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2237,11 +2237,20 @@ bool CWallet::SetAddressBookWithDB(WalletBatch& batch, const CTxDestination& add
             m_address_book[address].purpose = strPurpose;
         is_mine = IsMine(address) != ISMINE_NO;
     }
+
+    if (!strPurpose.empty() && !batch.WritePurpose(EncodeDestination(address), strPurpose)) {
+        WalletLogPrintf("%s error writing purpose\n", __func__);
+        return false;
+    }
+    if (!batch.WriteName(EncodeDestination(address), strName)) {
+        WalletLogPrintf("%s error writing name\n", __func__);
+        return false;
+    }
+
+    // Only notify if db writes succeeded
     NotifyAddressBookChanged(address, strName, is_mine,
                              strPurpose, (fUpdated ? CT_UPDATED : CT_NEW));
-    if (!strPurpose.empty() && !batch.WritePurpose(EncodeDestination(address), strPurpose))
-        return false;
-    return batch.WriteName(EncodeDestination(address), strName);
+    return true;
 }
 
 bool CWallet::SetAddressBook(const CTxDestination& address, const std::string& strName, const std::string& strPurpose)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2676,6 +2676,16 @@ void CWallet::LoadDestData(const CTxDestination &dest, const std::string &key, c
     m_address_book[dest].destdata.insert(std::make_pair(key, value));
 }
 
+void CWallet::LoadAddrbookEntryLabel(const CTxDestination& dest, const std::string& label)
+{
+    m_address_book[dest].SetLabel(label);
+}
+
+void CWallet::LoadAddrbookEntryPurpose(const CTxDestination& dest, const std::string& purpose)
+{
+    m_address_book[dest].purpose = purpose;
+}
+
 bool CWallet::IsAddressUsed(const CTxDestination& dest) const
 {
     const std::string key{"used"};

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2673,29 +2673,13 @@ bool CWallet::IsAddressUsed(const CTxDestination& dest) const
 std::vector<std::string> CWallet::GetAddressReceiveRequests() const
 {
     const std::string prefix{"rr"};
-    std::vector<std::string> values;
-    for (const auto& address : m_address_book) {
-        for (const auto& data : address.second.destdata) {
-            if (!data.first.compare(0, prefix.size(), prefix)) {
-                values.emplace_back(data.second);
-            }
-        }
-    }
-    return values;
+    return m_address_book_man.GetEntriesByDestDataPrefix(prefix);
 }
 
 bool CWallet::SetAddressReceiveRequest(WalletBatch& batch, const CTxDestination& dest, const std::string& id, const std::string& value)
 {
     const std::string key{"rr" + id}; // "rr" prefix = "receive request" in destdata
-    CAddressBookData& data = m_address_book.at(dest);
-    if (value.empty()) {
-        if (!batch.EraseDestData(EncodeDestination(dest), key)) return false;
-        data.destdata.erase(key);
-    } else {
-        if (!batch.WriteDestData(EncodeDestination(dest), key, value)) return false;
-        data.destdata[key] = value;
-    }
-    return true;
+    return m_address_book_man.SetEntryDestData(batch, dest, key, id, value);
 }
 
 std::unique_ptr<WalletDatabase> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error_string)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2706,6 +2706,11 @@ void CWallet::LoadAddrbookEntryPurpose(const CTxDestination& dest, const std::st
     m_address_book[dest].purpose = purpose;
 }
 
+int CWallet::GetAddrBookSize()
+{
+    return m_address_book.size();
+}
+
 bool CWallet::IsAddressUsed(const CTxDestination& dest) const
 {
     const std::string key{"used"};
@@ -3010,7 +3015,7 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
         walletInstance->SetBroadcastTransactions(args.GetBoolArg("-walletbroadcast", DEFAULT_WALLETBROADCAST));
         walletInstance->WalletLogPrintf("setKeyPool.size() = %u\n",      walletInstance->GetKeyPoolSize());
         walletInstance->WalletLogPrintf("mapWallet.size() = %u\n",       walletInstance->mapWallet.size());
-        walletInstance->WalletLogPrintf("m_address_book.size() = %u\n",  walletInstance->m_address_book.size());
+        walletInstance->WalletLogPrintf("m_address_book.size() = %u\n",  walletInstance->GetAddrBookSize());
     }
 
     return walletInstance;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -233,6 +233,9 @@ private:
     // Local time that the tip block was received. Used to schedule wallet rebroadcasts.
     std::atomic<int64_t> m_best_block_time {0};
 
+    /** Address book storage manager */
+    AddressBookMan m_address_book_man;
+
     /**
      * Used to keep track of spent outpoints, and
      * detect and report conflicts (double-spends or
@@ -377,7 +380,6 @@ public:
     int64_t nOrderPosNext GUARDED_BY(cs_wallet) = 0;
     uint64_t nAccountingEntryNumber = 0;
 
-    std::map<CTxDestination, CAddressBookData> m_address_book GUARDED_BY(cs_wallet);
     const CAddressBookData* FindAddressBookEntry(const CTxDestination&, bool allow_change = false) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /** Set of Coins owned by this wallet that we won't try to spend from. A

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -475,6 +475,10 @@ public:
 
     //! Adds a destination data tuple to the store, without saving it to disk
     void LoadDestData(const CTxDestination& dest, const std::string& key, const std::string& value) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    //! Adds destination label to the store, without saving it to disk
+    void LoadAddrbookEntryLabel(const CTxDestination& dest, const std::string& label) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    //! Adds destination purpose to the store, without saving it to disk
+    void LoadAddrbookEntryPurpose(const CTxDestination& dest, const std::string& purpose) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Holds a timestamp at which point the wallet is scheduled (externally) to be relocked. Caller must arrange for actual relocking to occur via Lock().
     int64_t nRelockTime GUARDED_BY(cs_wallet){0};

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -21,6 +21,7 @@
 #include <util/system.h>
 #include <util/ui_change_type.h>
 #include <validationinterface.h>
+#include <wallet/addressbookman.h>
 #include <wallet/crypter.h>
 #include <wallet/scriptpubkeyman.h>
 #include <wallet/transaction.h>
@@ -194,28 +195,6 @@ public:
     void ReturnDestination();
     //! Keep the address. Do not return it's key to the keypool when this object goes out of scope
     void KeepDestination();
-};
-
-/** Address book data */
-class CAddressBookData
-{
-private:
-    bool m_change{true};
-    std::string m_label;
-public:
-    std::string purpose;
-
-    CAddressBookData() : purpose("unknown") {}
-
-    typedef std::map<std::string, std::string> StringMap;
-    StringMap destdata;
-
-    bool IsChange() const { return m_change; }
-    const std::string& GetLabel() const { return m_label; }
-    void SetLabel(const std::string& label) {
-        m_change = false;
-        m_label = label;
-    }
 };
 
 struct CRecipient

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -380,7 +380,7 @@ public:
     int64_t nOrderPosNext GUARDED_BY(cs_wallet) = 0;
     uint64_t nAccountingEntryNumber = 0;
 
-    const CAddressBookData* FindAddressBookEntry(const CTxDestination&, bool allow_change = false) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    const std::optional<CAddressBookData> FindAddressBookEntry(const CTxDestination&, bool allow_change = false) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /** Set of Coins owned by this wallet that we won't try to spend from. A
      * Coin may be locked if it has already been used to fund a transaction

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -479,6 +479,8 @@ public:
     void LoadAddrbookEntryLabel(const CTxDestination& dest, const std::string& label) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Adds destination purpose to the store, without saving it to disk
     void LoadAddrbookEntryPurpose(const CTxDestination& dest, const std::string& purpose) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    //! Return address book size
+    int GetAddrBookSize() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Holds a timestamp at which point the wallet is scheduled (externally) to be relocked. Caller must arrange for actual relocking to occur via Lock().
     int64_t nRelockTime GUARDED_BY(cs_wallet){0};

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -335,11 +335,13 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             ssKey >> strAddress;
             std::string label;
             ssValue >> label;
-            pwallet->m_address_book[DecodeDestination(strAddress)].SetLabel(label);
+            pwallet->LoadAddrbookEntryLabel(DecodeDestination(strAddress), label);
         } else if (strType == DBKeys::PURPOSE) {
             std::string strAddress;
             ssKey >> strAddress;
-            ssValue >> pwallet->m_address_book[DecodeDestination(strAddress)].purpose;
+            std::string purpose;
+            ssValue >> purpose;
+            pwallet->LoadAddrbookEntryPurpose(DecodeDestination(strAddress), purpose);
         } else if (strType == DBKeys::TX) {
             uint256 hash;
             ssKey >> hash;

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -110,7 +110,7 @@ static void WalletShowInfo(CWallet* wallet_instance)
     tfm::format(std::cout, "HD (hd seed available): %s\n", wallet_instance->IsHDEnabled() ? "yes" : "no");
     tfm::format(std::cout, "Keypool Size: %u\n", wallet_instance->GetKeyPoolSize());
     tfm::format(std::cout, "Transactions: %zu\n", wallet_instance->mapWallet.size());
-    tfm::format(std::cout, "Address Book: %zu\n", wallet_instance->m_address_book.size());
+    tfm::format(std::cout, "Address Book: %zu\n", wallet_instance->GetAddrBookSize());
 }
 
 bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)


### PR DESCRIPTION
Finishing the encapsulation work started in #25337. Please review https://github.com/bitcoin/bitcoin/pull/26836 first.

#### Context

We are currently using the address book for different purposes and features in the wallet such us:

1) Store and retrieve own receive addresses with a label.
2) Store and retrieve external addresses with a label.
3) Store and retrieve payment requests.
4) Mark addresses/destinations as 'used' if they appear on the blockchain (part of the “avoid re-use” feature).
5) Know whether an output is a change or not based on the encoded script.

Some of these points aren’t well known by many because this code has been spread and obfuscated across the wallet’s sources. (and created in a Frankenstein style).

#### PR Goals

Encapsulate the address book functionalities into its own `AddressBookManager` class, so we are able to distinguish properly the address book responsibilities and capabilities.

Be able to decouple the address book dependency on the wallet’s main mutex (up to a certain point, because we are still using the same db connection).

Clean up the wallet sources further.

Be able to unit/fuzz test the address book manager implementation isolated from the wallet flows.

And create a new class that can be easily upgraded/replaced, and even different implementations can be used in parallel in different local wallets, by just providing a different manager instance to the wallet in the constructor.

#### Next steps

After this PR, will be working on improve the ‘change output’ flow which, at least for now, is strictly connected to this process (goal will be to remove the strict dependency).

#### Pending work (still under WIP, almost there)

* [ ] Add manager class description.
* [ ] Clean CAddressBookData.
* [ ] Cover the class with unit tests.
* [ ] Double-check commits order.
* [ ] Add addrbook purposes enum.
* [ ] Make cs_addrbook RecursiveMutex a Mutex?
