### PR TITLE
[kernel 3e/n] Decouple `CDBWrapper` and its kernel users from `ArgsManager`

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -198,6 +198,7 @@ BITCOIN_CORE_H = \
   node/blockstorage.h \
   node/caches.h \
   node/chainstate.h \
+  node/chainstatemanager_args.h \
   node/coin.h \
   node/connection_types.h \
   node/context.h \
@@ -383,6 +384,7 @@ libbitcoin_node_a_SOURCES = \
   node/blockstorage.cpp \
   node/caches.cpp \
   node/chainstate.cpp \
+  node/chainstatemanager_args.cpp \
   node/coin.cpp \
   node/connection_types.cpp \
   node/context.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -178,6 +178,7 @@ BITCOIN_CORE_H = \
   kernel/mempool_limits.h \
   kernel/mempool_options.h \
   kernel/mempool_persist.h \
+  kernel/txdb_options.h \
   kernel/validation_cache_sizes.h \
   key.h \
   key_io.h \
@@ -208,6 +209,7 @@ BITCOIN_CORE_H = \
   node/minisketchwrapper.h \
   node/psbt.h \
   node/transaction.h \
+  node/txdb_args.h \
   node/utxo_snapshot.h \
   node/validation_cache_args.h \
   noui.h \
@@ -393,6 +395,7 @@ libbitcoin_node_a_SOURCES = \
   node/minisketchwrapper.cpp \
   node/psbt.cpp \
   node/transaction.cpp \
+  node/txdb_args.cpp \
   node/validation_cache_args.cpp \
   noui.cpp \
   policy/fees.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -174,6 +174,7 @@ BITCOIN_CORE_H = \
   kernel/checks.h \
   kernel/coinstats.h \
   kernel/context.h \
+  kernel/dbwrapper_options.h \
   kernel/mempool_limits.h \
   kernel/mempool_options.h \
   kernel/mempool_persist.h \

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -80,16 +80,21 @@ int main(int argc, char* argv[])
 
 
     // SETUP: Chainstate
-    const ChainstateManager::Options chainman_opts{
-        .chainparams = chainparams,
-        .adjusted_time_callback = static_cast<int64_t (*)()>(GetTime),
-    };
-    ChainstateManager chainman{chainman_opts};
-
     node::CacheSizes cache_sizes;
     cache_sizes.block_tree_db = 2 << 20;
     cache_sizes.coins_db = 2 << 22;
     cache_sizes.coins = (450 << 20) - (2 << 20) - (2 << 22);
+
+    const ChainstateManager::Options chainman_opts{
+        .chainparams = chainparams,
+        .adjusted_time_callback = static_cast<int64_t (*)()>(GetTime),
+        .block_tree_db_opts = {
+            .cache_size = static_cast<size_t>(cache_sizes.block_tree_db),
+        },
+        .data_dir = abs_datadir,
+    };
+    ChainstateManager chainman{chainman_opts};
+
     node::ChainstateLoadOptions options;
     options.check_interrupt = [] { return false; };
     auto [status, error] = node::LoadChainstate(chainman, cache_sizes, options);

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -96,13 +96,14 @@ int main(int argc, char* argv[])
             .cache_size = static_cast<size_t>(cache_sizes.coins_db),
             .in_memory = false,
             .wipe_existing = false,
-        }
+        },
+        .total_coinstip_cache_bytes = static_cast<size_t>(cache_sizes.coins),
     };
     ChainstateManager chainman{chainman_opts};
 
     node::ChainstateLoadOptions options;
     options.check_interrupt = [] { return false; };
-    auto [status, error] = node::LoadChainstate(chainman, cache_sizes, options);
+    auto [status, error] = node::LoadChainstate(chainman, options);
     if (status != node::ChainstateLoadStatus::SUCCESS) {
         std::cerr << "Failed to load Chain state from your datadir." << std::endl;
         goto epilogue;

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -261,7 +261,6 @@ epilogue:
         for (CChainState* chainstate : chainman.GetAll()) {
             if (chainstate->CanFlushToDisk()) {
                 chainstate->ForceFlushStateToDisk();
-                chainstate->ResetCoinsViews();
             }
         }
     }

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -92,6 +92,11 @@ int main(int argc, char* argv[])
             .cache_size = static_cast<size_t>(cache_sizes.block_tree_db),
         },
         .data_dir = abs_datadir,
+        .coins_view_db_opts = {
+            .cache_size = static_cast<size_t>(cache_sizes.coins_db),
+            .in_memory = false,
+            .wipe_existing = false,
+        }
     };
     ChainstateManager chainman{chainman_opts};
 

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -137,6 +137,7 @@ CDBWrapper::CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory, bo
             .in_memory = fMemory,
             .wipe_existing = fWipe,
             .obfuscate_data = obfuscate,
+            .do_compact = gArgs.GetBoolArg("-forcecompactdb", false),
         }} {}
 
 CDBWrapper::CDBWrapper(const Options& opts)
@@ -172,7 +173,7 @@ CDBWrapper::CDBWrapper(const Options& opts)
     dbwrapper_private::HandleError(status);
     LogPrintf("Opened LevelDB successfully\n");
 
-    if (gArgs.GetBoolArg("-forcecompactdb", false)) {
+    if (opts.do_compact) {
         LogPrintf("Starting database compaction of %s\n", fs::PathToString(opts.db_path));
         pdb->CompactRange(nullptr, nullptr);
         LogPrintf("Finished database compaction of %s\n", fs::PathToString(opts.db_path));

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -128,18 +128,6 @@ static leveldb::Options GetOptions(size_t nCacheSize)
     return options;
 }
 
-// REVIEW-ONLY: This particular constructor will be removed by the end of
-//              the patchset.
-CDBWrapper::CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory, bool fWipe, bool obfuscate)
-    : CDBWrapper{{
-            .db_path = path,
-            .cache_size = nCacheSize,
-            .in_memory = fMemory,
-            .wipe_existing = fWipe,
-            .obfuscate_data = obfuscate,
-            .do_compact = gArgs.GetBoolArg("-forcecompactdb", false),
-        }} {}
-
 CDBWrapper::CDBWrapper(const Options& opts)
     : m_name{[&]() {
         Assert(!opts.db_path.empty());

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_DBWRAPPER_H
 #define BITCOIN_DBWRAPPER_H
 
+#include <kernel/dbwrapper_options.h>
+
 #include <clientversion.h>
 #include <fs.h>
 #include <logging.h>
@@ -220,15 +222,12 @@ private:
     std::vector<unsigned char> CreateObfuscateKey() const;
 
 public:
-    /**
-     * @param[in] path        Location in the filesystem where leveldb data will be stored.
-     * @param[in] nCacheSize  Configures various leveldb cache settings.
-     * @param[in] fMemory     If true, use leveldb's memory environment.
-     * @param[in] fWipe       If true, remove all existing data.
-     * @param[in] obfuscate   If true, store data obfuscated via simple XOR. If false, XOR
-     *                        with a zero'd byte array.
-     */
+    using Options = kernel::DBWrapperOpts;
+
+    // REVIEW-ONLY: This particular constructor will be removed by the end of
+    //              the patchset.
     CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory = false, bool fWipe = false, bool obfuscate = false);
+    CDBWrapper(const Options& opts);
     ~CDBWrapper();
 
     CDBWrapper(const CDBWrapper&) = delete;

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -224,9 +224,6 @@ private:
 public:
     using Options = kernel::DBWrapperOpts;
 
-    // REVIEW-ONLY: This particular constructor will be removed by the end of
-    //              the patchset.
-    CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory = false, bool fWipe = false, bool obfuscate = false);
     CDBWrapper(const Options& opts);
     ~CDBWrapper();
 

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -44,9 +44,16 @@ CBlockLocator GetLocator(interfaces::Chain& chain, const uint256& block_hash)
     return locator;
 }
 
-BaseIndex::DB::DB(const fs::path& path, size_t n_cache_size, bool f_memory, bool f_wipe, bool f_obfuscate) :
-    CDBWrapper(path, n_cache_size, f_memory, f_wipe, f_obfuscate)
-{}
+BaseIndex::DB::DB(const fs::path& path, size_t n_cache_size, bool f_memory, bool f_wipe, bool f_obfuscate)
+    : CDBWrapper{{
+          // TODO: Change this constructor to take CDBWrapper::Options
+          .db_path = path,
+          .cache_size = n_cache_size,
+          .in_memory = f_memory,
+          .wipe_existing = f_wipe,
+          .obfuscate_data = f_obfuscate,
+          .do_compact = gArgs.GetBoolArg("-forcecompactdb", false),
+      }} {}
 
 bool BaseIndex::DB::ReadBestBlock(CBlockLocator& locator) const
 {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1417,6 +1417,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                 .in_memory = false,
                 .wipe_existing = do_reindex || fReindexChainState,
             },
+            .total_coinstip_cache_bytes = static_cast<size_t>(cache_sizes.coins),
         };
         ApplyArgsManOptions(args, chainman_opts);
 
@@ -1446,7 +1447,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         };
         auto [status, error] = catch_exceptions([&] {
             node.chainman = std::make_unique<ChainstateManager>(chainman_opts);
-            return LoadChainstate(*Assert(node.chainman), cache_sizes, options);
+            return LoadChainstate(*Assert(node.chainman), options);
         });
         if (status == node::ChainstateLoadStatus::SUCCESS) {
             ChainstateManager& chainman = *Assert(node.chainman);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -300,7 +300,6 @@ void Shutdown(NodeContext& node)
         for (CChainState* chainstate : node.chainman->GetAll()) {
             if (chainstate->CanFlushToDisk()) {
                 chainstate->ForceFlushStateToDisk();
-                chainstate->ResetCoinsViews();
             }
         }
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1413,6 +1413,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                 .wipe_existing = do_reindex,
             },
             .data_dir = gArgs.GetDataDirNet(),
+            .coins_view_db_opts = {
+                .cache_size = static_cast<size_t>(cache_sizes.coins_db), // FIXME
+                .in_memory = false,
+                .wipe_existing = do_reindex || fReindexChainState,
+            },
         };
         ApplyArgsManOptions(args, chainman_opts);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1498,7 +1498,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // ********************************************************* Step 8: start indexers
     if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
-        if (const auto error{WITH_LOCK(cs_main, return CheckLegacyTxindex(*Assert(chainman.m_blockman.m_block_tree_db)))}) {
+        if (const auto error{WITH_LOCK(cs_main, return CheckLegacyTxindex(chainman.m_blockman.m_block_tree_db))}) {
             return InitError(*error);
         }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -110,6 +110,7 @@
 
 using kernel::DumpMempool;
 using kernel::ValidationCacheSizes;
+using kernel::nDefaultDbBatchSize;
 
 using node::ApplyArgsManOptions;
 using node::CacheSizes;

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -24,6 +24,7 @@ struct ChainstateManagerOpts {
     const std::function<int64_t()> adjusted_time_callback{nullptr};
     BlockTreeDBOpts block_tree_db_opts;
     const fs::path& data_dir;
+    CoinsViewDBOpts coins_view_db_opts;
 };
 
 } // namespace kernel

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_KERNEL_CHAINSTATEMANAGER_OPTS_H
 #define BITCOIN_KERNEL_CHAINSTATEMANAGER_OPTS_H
 
+#include <kernel/txdb_options.h>
+
 #include <cstdint>
 #include <functional>
 
@@ -20,6 +22,7 @@ namespace kernel {
 struct ChainstateManagerOpts {
     const CChainParams& chainparams;
     const std::function<int64_t()> adjusted_time_callback{nullptr};
+    BlockTreeDBOpts block_tree_db_opts;
 };
 
 } // namespace kernel

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -25,6 +25,7 @@ struct ChainstateManagerOpts {
     BlockTreeDBOpts block_tree_db_opts;
     const fs::path& data_dir;
     CoinsViewDBOpts coins_view_db_opts;
+    size_t total_coinstip_cache_bytes;
 };
 
 } // namespace kernel

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -23,6 +23,7 @@ struct ChainstateManagerOpts {
     const CChainParams& chainparams;
     const std::function<int64_t()> adjusted_time_callback{nullptr};
     BlockTreeDBOpts block_tree_db_opts;
+    const fs::path& data_dir;
 };
 
 } // namespace kernel

--- a/src/kernel/dbwrapper_options.h
+++ b/src/kernel/dbwrapper_options.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_KERNEL_DBWRAPPER_OPTIONS_H
+#define BITCOIN_KERNEL_DBWRAPPER_OPTIONS_H
+
+#include <fs.h>
+
+#include <cstddef>
+
+namespace kernel {
+
+struct DBWrapperOpts {
+    //! Location in the filesystem where leveldb data will be stored.
+    fs::path db_path;
+    //! Configures various leveldb cache settings.
+    size_t cache_size;
+    //! If true, use leveldb's memory environment.
+    bool in_memory = false;
+    //! If true, remove all existing data.
+    bool wipe_existing = false;
+    //! If true, store data obfuscated via simple XOR. If false, XOR with a zero'd byte array.
+    bool obfuscate_data = false;
+};
+
+} // namespace kernel
+
+#endif // BITCOIN_KERNEL_DBWRAPPER_OPTIONS_H

--- a/src/kernel/dbwrapper_options.h
+++ b/src/kernel/dbwrapper_options.h
@@ -22,6 +22,7 @@ struct DBWrapperOpts {
     bool wipe_existing = false;
     //! If true, store data obfuscated via simple XOR. If false, XOR with a zero'd byte array.
     bool obfuscate_data = false;
+    bool do_compact = false;
 };
 
 } // namespace kernel

--- a/src/kernel/txdb_options.h
+++ b/src/kernel/txdb_options.h
@@ -39,6 +39,37 @@ struct BlockTreeDBOpts {
     }
 };
 
+//! -dbbatchsize default (bytes)
+static constexpr int64_t nDefaultDbBatchSize{16 << 20};
+
+/**
+ * An options struct for `ChainstateManager`, more ergonomically referred to as
+ * `ChainstateManager::Options` due to the using-declaration in
+ * `ChainstateManager`.
+ */
+struct CoinsViewDBOpts {
+    fs::path db_path;
+    size_t cache_size;
+    bool in_memory = false;
+    bool wipe_existing = false;
+    bool do_compact = false;
+    size_t batch_write_size = nDefaultDbBatchSize;
+    int simulate_write_crash_ratio = 0;
+
+    DBWrapperOpts ToDBWrapperOptions() const
+    {
+        return DBWrapperOpts{
+            .db_path = db_path,
+            .cache_size = cache_size,
+            .in_memory = in_memory,
+            .wipe_existing = wipe_existing,
+            .obfuscate_data = true,
+            .do_compact = do_compact,
+        };
+    }
+};
+
+
 } // namespace kernel
 
 #endif // BITCOIN_KERNEL_TXDB_OPTIONS_H

--- a/src/kernel/txdb_options.h
+++ b/src/kernel/txdb_options.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_KERNEL_TXDB_OPTIONS_H
+#define BITCOIN_KERNEL_TXDB_OPTIONS_H
+
+#include <kernel/dbwrapper_options.h>
+
+#include <cstdint>
+#include <functional>
+
+class CChainParams;
+
+namespace kernel {
+
+/**
+ * An options struct for `CBlockTreeDB`, more ergonomically referred to as
+ * `CBlockTreeDB::Options` due to the using-declaration in
+ * `CBlockTreeDB`.
+ */
+struct BlockTreeDBOpts {
+    fs::path db_path;
+    size_t cache_size;
+    bool in_memory = false;
+    bool wipe_existing = false;
+    bool do_compact = false;
+
+    DBWrapperOpts ToDBWrapperOptions() const
+    {
+        return DBWrapperOpts{
+            .db_path = db_path,
+            .cache_size = cache_size,
+            .in_memory = in_memory,
+            .wipe_existing = wipe_existing,
+            .obfuscate_data = false,
+            .do_compact = do_compact,
+        };
+    }
+};
+
+} // namespace kernel
+
+#endif // BITCOIN_KERNEL_TXDB_OPTIONS_H

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -58,6 +58,9 @@ static FILE* OpenUndoFile(const FlatFilePos& pos, bool fReadOnly = false);
 static FlatFileSeq BlockFileSeq();
 static FlatFileSeq UndoFileSeq();
 
+BlockManager::BlockManager(const CBlockTreeDB::Options& block_tree_db_opts)
+    : m_block_tree_db{new CBlockTreeDB{block_tree_db_opts}} {}
+
 std::vector<CBlockIndex*> BlockManager::GetAllBlockIndices()
 {
     AssertLockHeld(cs_main);

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -140,6 +140,8 @@ private:
     std::unordered_map<std::string, PruneLockInfo> m_prune_locks GUARDED_BY(::cs_main);
 
 public:
+    explicit BlockManager(const CBlockTreeDB::Options& block_tree_db_opts);
+
     BlockMap m_block_index GUARDED_BY(cs_main);
 
     std::vector<CBlockIndex*> GetAllBlockIndices() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -152,7 +152,7 @@ public:
      */
     std::multimap<CBlockIndex*, CBlockIndex*> m_blocks_unlinked;
 
-    std::unique_ptr<CBlockTreeDB> m_block_tree_db GUARDED_BY(::cs_main);
+    CBlockTreeDB m_block_tree_db GUARDED_BY(::cs_main);
 
     bool WriteBlockIndexDB() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool LoadBlockIndexDB(const Consensus::Params& consensus_params) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -35,7 +35,6 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
     LOCK(cs_main);
     chainman.InitializeChainstate(options.mempool);
     chainman.m_total_coinstip_cache = cache_sizes.coins;
-    chainman.m_total_coinsdb_cache = cache_sizes.coins_db;
 
     auto& pblocktree{chainman.m_blockman.m_block_tree_db};
 
@@ -83,11 +82,6 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
     // block tree into BlockIndex()!
 
     for (CChainState* chainstate : chainman.GetAll()) {
-        chainstate->InitCoinsDB(
-            /*cache_size_bytes=*/cache_sizes.coins_db,
-            /*in_memory=*/options.coins_db_in_memory,
-            /*should_wipe=*/options.reindex || options.reindex_chainstate);
-
         if (options.coins_error_cb) {
             chainstate->CoinsErrorCatcher().AddReadErrCallback(options.coins_error_cb);
         }

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -25,8 +25,7 @@
 #include <vector>
 
 namespace node {
-ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,
-                                    const ChainstateLoadOptions& options)
+ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options)
 {
     auto is_coinsview_empty = [&](CChainState* chainstate) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
         return options.reindex || options.reindex_chainstate || chainstate->CoinsTip().GetBestBlock().IsNull();
@@ -34,7 +33,6 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
 
     LOCK(cs_main);
     chainman.InitializeChainstate(options.mempool);
-    chainman.m_total_coinstip_cache = cache_sizes.coins;
 
     auto& pblocktree{chainman.m_blockman.m_block_tree_db};
 
@@ -100,7 +98,7 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
         }
 
         // The on-disk coinsdb is now in a good state, create the cache
-        chainstate->InitCoinsCache(cache_sizes.coins);
+        chainstate->InitCoinsCache(chainman.m_total_coinstip_cache);
         assert(chainstate->CanFlushToDisk());
 
         if (!is_coinsview_empty(chainstate)) {

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -38,10 +38,6 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
     chainman.m_total_coinsdb_cache = cache_sizes.coins_db;
 
     auto& pblocktree{chainman.m_blockman.m_block_tree_db};
-    // new CBlockTreeDB tries to delete the existing file, which
-    // fails if it's still open from the previous loop. Close it first:
-    pblocktree.reset();
-    pblocktree.reset(new CBlockTreeDB(cache_sizes.block_tree_db, options.block_tree_db_in_memory, options.reindex));
 
     if (options.reindex) {
         pblocktree->WriteReindexing(true);

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -40,7 +40,7 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
     auto& pblocktree{chainman.m_blockman.m_block_tree_db};
 
     if (options.reindex) {
-        pblocktree->WriteReindexing(true);
+        pblocktree.WriteReindexing(true);
         //If we're reindexing in prune mode, wipe away unusable block files and all undo data files
         if (options.prune) {
             CleanupBlockRevFiles();

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -20,7 +20,6 @@ struct CacheSizes;
 
 struct ChainstateLoadOptions {
     CTxMemPool* mempool{nullptr};
-    bool block_tree_db_in_memory{false};
     bool coins_db_in_memory{false};
     bool reindex{false};
     bool reindex_chainstate{false};

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -20,7 +20,6 @@ struct CacheSizes;
 
 struct ChainstateLoadOptions {
     CTxMemPool* mempool{nullptr};
-    bool coins_db_in_memory{false};
     bool reindex{false};
     bool reindex_chainstate{false};
     bool prune{false};

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -51,8 +51,7 @@ using ChainstateLoadResult = std::tuple<ChainstateLoadStatus, bilingual_str>;
  *
  *  LoadChainstate returns a (status code, error string) tuple.
  */
-ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,
-                                    const ChainstateLoadOptions& options);
+ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options);
 ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options);
 } // namespace node
 

--- a/src/node/chainstatemanager_args.cpp
+++ b/src/node/chainstatemanager_args.cpp
@@ -15,6 +15,7 @@ namespace node {
 void ApplyArgsManOptions(const ArgsManager& argsman, ChainstateManagerOpts& chainman_opts)
 {
     ApplyArgsManOptions(argsman, chainman_opts.block_tree_db_opts);
+    ApplyArgsManOptions(argsman, chainman_opts.coins_view_db_opts);
 }
 
 } // namespace node

--- a/src/node/chainstatemanager_args.cpp
+++ b/src/node/chainstatemanager_args.cpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/chainstatemanager_args.h>
+
+#include <kernel/chainstatemanager_opts.h>
+
+#include <node/txdb_args.h>
+
+using kernel::ChainstateManagerOpts;
+
+namespace node {
+
+void ApplyArgsManOptions(const ArgsManager& argsman, ChainstateManagerOpts& chainman_opts)
+{
+    ApplyArgsManOptions(argsman, chainman_opts.block_tree_db_opts);
+}
+
+} // namespace node

--- a/src/node/chainstatemanager_args.h
+++ b/src/node/chainstatemanager_args.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_CHAINSTATEMANAGER_ARGS_H
+#define BITCOIN_NODE_CHAINSTATEMANAGER_ARGS_H
+
+class ArgsManager;
+namespace kernel {
+struct ChainstateManagerOpts;
+};
+
+namespace node {
+/**
+ * Overlay the options set in \p argsman on top of corresponding members in \p chainman_opts.
+ */
+void ApplyArgsManOptions(const ArgsManager& argsman, kernel::ChainstateManagerOpts& chainman_opts);
+} // namespace node
+
+
+#endif // BITCOIN_NODE_CHAINSTATEMANAGER_ARGS_H

--- a/src/node/txdb_args.cpp
+++ b/src/node/txdb_args.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/txdb_args.h>
+
+#include <kernel/txdb_options.h>
+
+#include <util/system.h>
+
+namespace node {
+
+void ApplyArgsManOptions(const ArgsManager& argsman, kernel::BlockTreeDBOpts& opts)
+{
+    opts.do_compact = argsman.GetBoolArg("-forcecompactdb", false);
+}
+
+} // namespace node

--- a/src/node/txdb_args.cpp
+++ b/src/node/txdb_args.cpp
@@ -15,4 +15,11 @@ void ApplyArgsManOptions(const ArgsManager& argsman, kernel::BlockTreeDBOpts& op
     opts.do_compact = argsman.GetBoolArg("-forcecompactdb", false);
 }
 
+void ApplyArgsManOptions(const ArgsManager& argsman, kernel::CoinsViewDBOpts& coinsviewdb_opts)
+{
+    coinsviewdb_opts.do_compact = argsman.GetBoolArg("-forcecompactdb", coinsviewdb_opts.do_compact);
+    coinsviewdb_opts.batch_write_size = argsman.GetIntArg("-dbbatchsize", coinsviewdb_opts.batch_write_size);
+    coinsviewdb_opts.simulate_write_crash_ratio = argsman.GetIntArg("-dbcrashratio", coinsviewdb_opts.simulate_write_crash_ratio);
+}
+
 } // namespace node

--- a/src/node/txdb_args.h
+++ b/src/node/txdb_args.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_TXDB_ARGS_H
+#define BITCOIN_NODE_TXDB_ARGS_H
+
+namespace kernel {
+struct BlockTreeDBOpts;
+} //namespace kernel
+
+class ArgsManager;
+
+namespace node {
+
+void ApplyArgsManOptions(const ArgsManager& argsman, kernel::BlockTreeDBOpts& opts);
+
+} // namespace node
+
+#endif // BITCOIN_NODE_TXDB_ARGS_H

--- a/src/node/txdb_args.h
+++ b/src/node/txdb_args.h
@@ -7,6 +7,7 @@
 
 namespace kernel {
 struct BlockTreeDBOpts;
+struct CoinsViewDBOpts;
 } //namespace kernel
 
 class ArgsManager;
@@ -14,6 +15,7 @@ class ArgsManager;
 namespace node {
 
 void ApplyArgsManOptions(const ArgsManager& argsman, kernel::BlockTreeDBOpts& opts);
+void ApplyArgsManOptions(const ArgsManager& argsman, kernel::CoinsViewDBOpts& coinsviewdb_opts);
 
 } // namespace node
 

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <clientversion.h>
 #include <coins.h>
+#include <node/txdb_args.h>
 #include <script/standard.h>
 #include <streams.h>
 #include <test/util/setup_common.h>
@@ -16,6 +17,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
+
+using node::ApplyArgsManOptions;
 
 int ApplyTxInUndo(Coin&& undo, CCoinsViewCache& view, const COutPoint& out);
 void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo &txundo, int nHeight);
@@ -268,7 +271,14 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
     CCoinsViewTest base;
     SimulationTest(&base, false);
 
-    CCoinsViewDB db_base{"test", /*nCacheSize=*/1 << 23, /*fMemory=*/true, /*fWipe=*/false};
+    CCoinsViewDB::Options opts{
+        .db_path = "test",
+        .cache_size = 1 << 23,
+        .in_memory = true,
+        .wipe_existing = false,
+    };
+    ApplyArgsManOptions(m_args, opts);
+    CCoinsViewDB db_base{opts};
     SimulationTest(&db_base, true);
 }
 

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -27,7 +27,13 @@ BOOST_AUTO_TEST_CASE(dbwrapper)
     // Perform tests both obfuscated and non-obfuscated.
     for (const bool obfuscate : {false, true}) {
         fs::path ph = m_args.GetDataDirBase() / (obfuscate ? "dbwrapper_obfuscate_true" : "dbwrapper_obfuscate_false");
-        CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
+        CDBWrapper dbw{{
+            .db_path = ph,
+            .cache_size = (1 << 20),
+            .in_memory = true,
+            .wipe_existing = false,
+            .obfuscate_data = obfuscate,
+        }};
         uint8_t key{'k'};
         uint256 in = InsecureRand256();
         uint256 res;
@@ -46,7 +52,13 @@ BOOST_AUTO_TEST_CASE(dbwrapper_basic_data)
     // Perform tests both obfuscated and non-obfuscated.
     for (bool obfuscate : {false, true}) {
         fs::path ph = m_args.GetDataDirBase() / (obfuscate ? "dbwrapper_1_obfuscate_true" : "dbwrapper_1_obfuscate_false");
-        CDBWrapper dbw(ph, (1 << 20), false, true, obfuscate);
+        CDBWrapper dbw{{
+            .db_path = ph,
+            .cache_size = 1 << 20,
+            .in_memory = false,
+            .wipe_existing = true,
+            .obfuscate_data = obfuscate,
+        }};
 
         uint256 res;
         uint32_t res_uint_32;
@@ -127,7 +139,13 @@ BOOST_AUTO_TEST_CASE(dbwrapper_batch)
     // Perform tests both obfuscated and non-obfuscated.
     for (const bool obfuscate : {false, true}) {
         fs::path ph = m_args.GetDataDirBase() / (obfuscate ? "dbwrapper_batch_obfuscate_true" : "dbwrapper_batch_obfuscate_false");
-        CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
+        CDBWrapper dbw{{
+            .db_path = ph,
+            .cache_size = 1 << 20,
+            .in_memory = true,
+            .wipe_existing = false,
+            .obfuscate_data = obfuscate,
+        }};
 
         uint8_t key{'i'};
         uint256 in = InsecureRand256();
@@ -163,7 +181,13 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
     // Perform tests both obfuscated and non-obfuscated.
     for (const bool obfuscate : {false, true}) {
         fs::path ph = m_args.GetDataDirBase() / (obfuscate ? "dbwrapper_iterator_obfuscate_true" : "dbwrapper_iterator_obfuscate_false");
-        CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
+        CDBWrapper dbw{{
+            .db_path = ph,
+            .cache_size = 1 << 20,
+            .in_memory = true,
+            .wipe_existing = false,
+            .obfuscate_data = obfuscate,
+        }};
 
         // The two keys are intentionally chosen for ordering
         uint8_t key{'j'};
@@ -205,21 +229,33 @@ BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
     fs::path ph = m_args.GetDataDirBase() / "existing_data_no_obfuscate";
     fs::create_directories(ph);
 
-    // Set up a non-obfuscated wrapper to write some initial data.
-    std::unique_ptr<CDBWrapper> dbw = std::make_unique<CDBWrapper>(ph, (1 << 10), false, false, false);
     uint8_t key{'k'};
     uint256 in = InsecureRand256();
-    uint256 res;
 
-    BOOST_CHECK(dbw->Write(key, in));
-    BOOST_CHECK(dbw->Read(key, res));
-    BOOST_CHECK_EQUAL(res.ToString(), in.ToString());
+    {
+        // Set up a non-obfuscated wrapper to write some initial data.
+        CDBWrapper dbw{{
+            .db_path = ph,
+            .cache_size = 1 << 10,
+            .in_memory = false,
+            .wipe_existing = false,
+            .obfuscate_data = false,
+        }};
+        uint256 res;
 
-    // Call the destructor to free leveldb LOCK
-    dbw.reset();
+        BOOST_CHECK(dbw.Write(key, in));
+        BOOST_CHECK(dbw.Read(key, res));
+        BOOST_CHECK_EQUAL(res.ToString(), in.ToString());
+    }
 
     // Now, set up another wrapper that wants to obfuscate the same directory
-    CDBWrapper odbw(ph, (1 << 10), false, false, true);
+    CDBWrapper odbw{{
+        .db_path = ph,
+        .cache_size = 1 << 10,
+        .in_memory = false,
+        .wipe_existing = false,
+        .obfuscate_data = true,
+    }};
 
     // Check that the key/val we wrote with unobfuscated wrapper exists and
     // is readable.
@@ -246,21 +282,33 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
     fs::path ph = m_args.GetDataDirBase() / "existing_data_reindex";
     fs::create_directories(ph);
 
-    // Set up a non-obfuscated wrapper to write some initial data.
-    std::unique_ptr<CDBWrapper> dbw = std::make_unique<CDBWrapper>(ph, (1 << 10), false, false, false);
     uint8_t key{'k'};
     uint256 in = InsecureRand256();
-    uint256 res;
 
-    BOOST_CHECK(dbw->Write(key, in));
-    BOOST_CHECK(dbw->Read(key, res));
-    BOOST_CHECK_EQUAL(res.ToString(), in.ToString());
+    {
+        // Set up a non-obfuscated wrapper to write some initial data.
+        CDBWrapper dbw{{
+            .db_path = ph,
+            .cache_size = 1 << 10,
+            .in_memory = false,
+            .wipe_existing = false,
+            .obfuscate_data = false,
+        }};
+        uint256 res;
 
-    // Call the destructor to free leveldb LOCK
-    dbw.reset();
+        BOOST_CHECK(dbw.Write(key, in));
+        BOOST_CHECK(dbw.Read(key, res));
+        BOOST_CHECK_EQUAL(res.ToString(), in.ToString());
+    }
 
     // Simulate a -reindex by wiping the existing data store
-    CDBWrapper odbw(ph, (1 << 10), false, true, true);
+    CDBWrapper odbw{{
+        .db_path = ph,
+        .cache_size = 1 << 10,
+        .in_memory = false,
+        .wipe_existing = true,
+        .obfuscate_data = true,
+    }};
 
     // Check that the key/val we wrote with unobfuscated wrapper doesn't exist
     uint256 res2;
@@ -279,7 +327,13 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
 BOOST_AUTO_TEST_CASE(iterator_ordering)
 {
     fs::path ph = m_args.GetDataDirBase() / "iterator_ordering";
-    CDBWrapper dbw(ph, (1 << 20), true, false, false);
+    CDBWrapper dbw{{
+        .db_path = ph,
+        .cache_size = 1 << 20,
+        .in_memory = true,
+        .wipe_existing = false,
+        .obfuscate_data = false,
+    }};
     for (int x=0x00; x<256; ++x) {
         uint8_t key = x;
         uint32_t value = x*x;
@@ -359,7 +413,13 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
     char buf[10];
 
     fs::path ph = m_args.GetDataDirBase() / "iterator_string_ordering";
-    CDBWrapper dbw(ph, (1 << 20), true, false, false);
+    CDBWrapper dbw{{
+        .db_path = ph,
+        .cache_size = 1 << 20,
+        .in_memory = true,
+        .wipe_existing = false,
+        .obfuscate_data = false,
+    }};
     for (int x=0x00; x<10; ++x) {
         for (int y = 0; y < 10; y++) {
             snprintf(buf, sizeof(buf), "%d", x);
@@ -405,7 +465,10 @@ BOOST_AUTO_TEST_CASE(unicodepath)
     // the ANSI CreateDirectoryA call and the code page isn't UTF8.
     // It will succeed if created with CreateDirectoryW.
     fs::path ph = m_args.GetDataDirBase() / "test_runner_₿_🏃_20191128_104644";
-    CDBWrapper dbw(ph, (1 << 20));
+    CDBWrapper dbw{{
+        .db_path = ph,
+        .cache_size = 1 << 20,
+    }};
 
     fs::path lockPath = ph / "LOCK";
     BOOST_CHECK(fs::exists(lockPath));

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -52,7 +52,7 @@ FUZZ_TARGET_INIT(utxo_snapshot, initialize_chain)
         } catch (const std::ios_base::failure&) {
             return false;
         }
-        return chainman.ActivateSnapshot(infile, metadata, /*in_memory=*/true);
+        return chainman.ActivateSnapshot(infile, metadata);
     }};
 
     if (fuzzed_data_provider.ConsumeBool()) {

--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -48,7 +48,7 @@ CreateAndActivateUTXOSnapshot(node::NodeContext& node, const fs::path root, F ma
 
     malleation(auto_infile, metadata);
 
-    return node.chainman->ActivateSnapshot(auto_infile, metadata, /*in_memory=*/true);
+    return node.chainman->ActivateSnapshot(auto_infile, metadata);
 }
 
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -24,6 +24,7 @@
 #include <node/context.h>
 #include <node/mempool_args.h>
 #include <node/miner.h>
+#include <node/txdb_args.h>
 #include <node/validation_cache_args.h>
 #include <noui.h>
 #include <policy/fees.h>
@@ -199,6 +200,11 @@ ChainTestingSetup::ChainTestingSetup(const std::string& chainName, const std::ve
             .in_memory = true,
         },
         .data_dir = m_args.GetDataDirNet(),
+        .coins_view_db_opts = {
+            .cache_size = static_cast<size_t>(m_cache_sizes.coins_db),
+            .in_memory = true,
+            .wipe_existing = node::fReindex || m_args.GetBoolArg("-reindex-chainstate", false),
+        },
     };
     ApplyArgsManOptions(m_args, chainman_opts);
 
@@ -235,7 +241,6 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
 
     node::ChainstateLoadOptions options;
     options.mempool = Assert(m_node.mempool.get());
-    options.coins_db_in_memory = true;
     options.reindex = node::fReindex;
     options.reindex_chainstate = m_args.GetBoolArg("-reindex-chainstate", false);
     options.prune = node::fPruneMode;

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -98,8 +98,6 @@ CTxMemPool::Options MemPoolOptionsForTest(const node::NodeContext& node);
  * initialization behaviour.
  */
 struct ChainTestingSetup : public BasicTestingSetup {
-    node::CacheSizes m_cache_sizes{};
-
     explicit ChainTestingSetup(const std::string& chainName = CBaseChainParams::MAIN, const std::vector<const char*>& extra_args = {});
     ~ChainTestingSetup();
 };

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -8,7 +8,6 @@
 #include <chainparamsbase.h>
 #include <fs.h>
 #include <key.h>
-#include <util/system.h>
 #include <node/caches.h>
 #include <node/context.h>
 #include <pubkey.h>
@@ -17,6 +16,7 @@
 #include <txmempool.h>
 #include <util/check.h>
 #include <util/string.h>
+#include <util/system.h>
 #include <util/vector.h>
 
 #include <functional>

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -39,8 +39,6 @@ BOOST_AUTO_TEST_CASE(validation_chainstate_resize_caches)
     };
 
     CChainState& c1 = WITH_LOCK(cs_main, return manager.InitializeChainstate(&mempool));
-    c1.InitCoinsDB(
-        /*cache_size_bytes=*/1 << 23, /*in_memory=*/true, /*should_wipe=*/false);
     WITH_LOCK(::cs_main, c1.InitCoinsCache(1 << 23));
     BOOST_REQUIRE(c1.LoadGenesisBlock()); // Need at least one block loaded to be able to flush caches
 

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -40,8 +40,6 @@ BOOST_AUTO_TEST_CASE(chainstatemanager)
     //
     CChainState& c1 = WITH_LOCK(::cs_main, return manager.InitializeChainstate(&mempool));
     chainstates.push_back(&c1);
-    c1.InitCoinsDB(
-        /*cache_size_bytes=*/1 << 23, /*in_memory=*/true, /*should_wipe=*/false);
     WITH_LOCK(::cs_main, c1.InitCoinsCache(1 << 23));
 
     BOOST_CHECK(!manager.IsSnapshotActive());
@@ -69,8 +67,6 @@ BOOST_AUTO_TEST_CASE(chainstatemanager)
 
     BOOST_CHECK_EQUAL(manager.SnapshotBlockhash().value(), snapshot_blockhash);
 
-    c2.InitCoinsDB(
-        /*cache_size_bytes=*/1 << 23, /*in_memory=*/true, /*should_wipe=*/false);
     WITH_LOCK(::cs_main, c2.InitCoinsCache(1 << 23));
     // Unlike c1, which doesn't have any blocks. Gets us different tip, height.
     c2.LoadGenesisBlock();
@@ -117,8 +113,6 @@ BOOST_AUTO_TEST_CASE(chainstatemanager_rebalance_caches)
     //
     CChainState& c1 = WITH_LOCK(cs_main, return manager.InitializeChainstate(&mempool));
     chainstates.push_back(&c1);
-    c1.InitCoinsDB(
-        /*cache_size_bytes=*/1 << 23, /*in_memory=*/true, /*should_wipe=*/false);
 
     {
         LOCK(::cs_main);
@@ -135,8 +129,6 @@ BOOST_AUTO_TEST_CASE(chainstatemanager_rebalance_caches)
     //
     CChainState& c2 = WITH_LOCK(cs_main, return manager.InitializeChainstate(&mempool, GetRandHash()));
     chainstates.push_back(&c2);
-    c2.InitCoinsDB(
-        /*cache_size_bytes=*/1 << 23, /*in_memory=*/true, /*should_wipe=*/false);
 
     {
         LOCK(::cs_main);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -6,6 +6,7 @@
 #include <txdb.h>
 
 #include <chain.h>
+#include <dbwrapper.h>
 #include <pow.h>
 #include <random.h>
 #include <shutdown.h>
@@ -177,8 +178,8 @@ size_t CCoinsViewDB::EstimateSize() const
     return m_db->EstimateSize(DB_COIN, uint8_t(DB_COIN + 1));
 }
 
-CBlockTreeDB::CBlockTreeDB(size_t nCacheSize, bool fMemory, bool fWipe) : CDBWrapper(gArgs.GetDataDirNet() / "blocks" / "index", nCacheSize, fMemory, fWipe) {
-}
+CBlockTreeDB::CBlockTreeDB(const Options& opts)
+    : CDBWrapper{opts.ToDBWrapperOptions()} {}
 
 bool CBlockTreeDB::ReadBlockFileInfo(int nFile, CBlockFileInfo &info) {
     return Read(std::make_pair(DB_BLOCK_FILES, nFile), info);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -17,6 +17,8 @@
 
 #include <stdint.h>
 
+using kernel::nDefaultDbBatchSize;
+
 static constexpr uint8_t DB_COIN{'C'};
 static constexpr uint8_t DB_BLOCK_FILES{'f'};
 static constexpr uint8_t DB_BLOCK_INDEX{'b'};

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -6,6 +6,8 @@
 #ifndef BITCOIN_TXDB_H
 #define BITCOIN_TXDB_H
 
+#include <kernel/txdb_options.h>
+
 #include <coins.h>
 #include <dbwrapper.h>
 #include <sync.h>
@@ -78,6 +80,8 @@ public:
 class CBlockTreeDB : public CDBWrapper
 {
 public:
+    using Options = kernel::BlockTreeDBOpts;
+
     explicit CBlockTreeDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
 
     bool WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<const CBlockIndex*>& blockinfo);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -53,13 +53,9 @@ public:
     using Options = kernel::CoinsViewDBOpts;
 protected:
     std::unique_ptr<CDBWrapper> m_db;
-    fs::path m_ldb_path;
-    bool m_is_memory;
+    Options m_opts;
 public:
-    /**
-     * @param[in] ldb_path    Location in the filesystem where leveldb data will be stored.
-     */
-    explicit CCoinsViewDB(fs::path ldb_path, size_t nCacheSize, bool fMemory, bool fWipe);
+    explicit CCoinsViewDB(const Options& opts);
 
     bool GetCoin(const COutPoint &outpoint, Coin &coin) const override;
     bool HaveCoin(const COutPoint &outpoint) const override;

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -82,7 +82,7 @@ class CBlockTreeDB : public CDBWrapper
 public:
     using Options = kernel::BlockTreeDBOpts;
 
-    explicit CBlockTreeDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
+    explicit CBlockTreeDB(const Options& opts);
 
     bool WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<const CBlockIndex*>& blockinfo);
     bool ReadBlockFileInfo(int nFile, CBlockFileInfo &info);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -28,8 +28,6 @@ struct bilingual_str;
 
 //! -dbcache default (MiB)
 static const int64_t nDefaultDbCache = 450;
-//! -dbbatchsize default (bytes)
-static const int64_t nDefaultDbBatchSize = 16 << 20;
 //! max. -dbcache (MiB)
 static const int64_t nMaxDbCache = sizeof(void*) > 4 ? 16384 : 1024;
 //! min. -dbcache (MiB)
@@ -51,6 +49,8 @@ extern RecursiveMutex cs_main;
 /** CCoinsView backed by the coin database (chainstate/) */
 class CCoinsViewDB final : public CCoinsView
 {
+public:
+    using Options = kernel::CoinsViewDBOpts;
 protected:
     std::unique_ptr<CDBWrapper> m_db;
     fs::path m_ldb_path;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2377,7 +2377,7 @@ bool CChainState::FlushStateToDisk(
             if (!setFilesToPrune.empty()) {
                 fFlushForPrune = true;
                 if (!m_blockman.m_have_pruned) {
-                    m_blockman.m_block_tree_db->WriteFlag("prunedblockfiles", true);
+                    m_blockman.m_block_tree_db.WriteFlag("prunedblockfiles", true);
                     m_blockman.m_have_pruned = true;
                 }
             }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1502,7 +1502,7 @@ CChainState::CChainState(
     const CCoinsViewDB::Options& opts,
     std::optional<uint256> from_snapshot_blockhash)
     : m_mempool(mempool),
-      m_coins_views{new CoinsViews{[&](CCoinsViewDB::Options opts) { // Make a non-const copy of opts
+      m_coins_views{[&](CCoinsViewDB::Options opts) { // Make a non-const copy of opts
           if (opts.db_path.empty()) {
               std::string ldb_name{"chainstate"};
               if (from_snapshot_blockhash) {
@@ -1511,7 +1511,7 @@ CChainState::CChainState(
               opts.db_path = chainman.m_data_dir / fs::PathFromString(ldb_name);
           }
           return opts;
-      }(opts)}},
+      }(opts)},
       m_blockman(blockman),
       m_params(chainman.GetParams()),
       m_chainman(chainman),
@@ -1520,9 +1520,8 @@ CChainState::CChainState(
 void CChainState::InitCoinsCache(size_t cache_size_bytes)
 {
     AssertLockHeld(::cs_main);
-    assert(m_coins_views != nullptr);
     m_coinstip_cache_size_bytes = cache_size_bytes;
-    m_coins_views->InitCache();
+    m_coins_views.InitCache();
 }
 
 // Note that though this is marked const, we may end up modifying `m_cached_finished_ibd`, which

--- a/src/validation.h
+++ b/src/validation.h
@@ -462,7 +462,7 @@ protected:
     CTxMemPool* m_mempool;
 
     //! Manages the UTXO set, which is a reflection of the contents of `m_chain`.
-    std::unique_ptr<CoinsViews> m_coins_views;
+    CoinsViews m_coins_views;
 
 public:
     //! Reference to a BlockManager instance which itself is shared across all
@@ -494,7 +494,7 @@ public:
     bool CanFlushToDisk() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
     {
         AssertLockHeld(::cs_main);
-        return m_coins_views && m_coins_views->m_cacheview;
+        return static_cast<bool>(m_coins_views.m_cacheview);
     }
 
     //! The current chain of blockheaders we consult and build on.
@@ -524,15 +524,15 @@ public:
     CCoinsViewCache& CoinsTip() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
     {
         AssertLockHeld(::cs_main);
-        assert(m_coins_views->m_cacheview);
-        return *m_coins_views->m_cacheview.get();
+        assert(m_coins_views.m_cacheview);
+        return *m_coins_views.m_cacheview.get();
     }
 
     //! @returns A reference to the on-disk UTXO set database.
     CCoinsViewDB& CoinsDB() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
     {
         AssertLockHeld(::cs_main);
-        return m_coins_views->m_dbview;
+        return m_coins_views.m_dbview;
     }
 
     //! @returns A pointer to the mempool.
@@ -546,11 +546,8 @@ public:
     CCoinsViewErrorCatcher& CoinsErrorCatcher() EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
     {
         AssertLockHeld(::cs_main);
-        return m_coins_views->m_catcherview;
+        return m_coins_views.m_catcherview;
     }
-
-    //! Destructs all objects related to accessing the UTXO set.
-    void ResetCoinsViews() { m_coins_views.reset(); }
 
     //! The cache size of the on-disk coins view.
     size_t m_coinsdb_cache_size_bytes{0};

--- a/src/validation.h
+++ b/src/validation.h
@@ -862,6 +862,7 @@ public:
               }(opts.block_tree_db_opts)
           },
           m_coins_view_db_opts{opts.coins_view_db_opts},
+          m_total_coinstip_cache{static_cast<int64_t>(opts.total_coinstip_cache_bytes)},
           m_total_coinsdb_cache{static_cast<int64_t>(m_coins_view_db_opts.cache_size)} {};
 
     const CChainParams& GetParams() const { return m_chainparams; }

--- a/src/validation.h
+++ b/src/validation.h
@@ -859,11 +859,22 @@ private:
     friend CChainState;
 
 public:
+    const fs::path& m_data_dir;
+
     using Options = kernel::ChainstateManagerOpts;
 
     explicit ChainstateManager(const Options& opts)
         : m_chainparams{opts.chainparams},
-          m_adjusted_time_callback{Assert(opts.adjusted_time_callback)} {};
+          m_adjusted_time_callback{Assert(opts.adjusted_time_callback)},
+          m_data_dir{opts.data_dir},
+          m_blockman{
+              [&data_dir = opts.data_dir](CBlockTreeDB::Options db_opts) {
+                  if (db_opts.db_path.empty()) {
+                      db_opts.db_path = data_dir / "blocks" / "index";
+                  }
+                  return db_opts;
+              }(opts.block_tree_db_opts)
+          } {};
 
     const CChainParams& GetParams() const { return m_chainparams; }
     const Consensus::Params& GetConsensus() const { return m_chainparams.GetConsensus(); }


### PR DESCRIPTION
This is part of the `libbitcoinkernel` project: #24303, https://github.com/bitcoin/bitcoin/projects/18

This PR is **_NOT_** dependent on any other PRs.

-----

This PR introduces `::Options` structs and `ApplyArgsManOptions` functions for `CDBWrapper` and its wrappers and descendants in `libbitcoinkernel`. Namely `CBlockTreeDB` and `CCoinsViewDB`.

`libbitcoinkernel` code can now instantiate these classes by filling in an `::Options` struct without referencing `gArgs`, and non-`libbitcoinkernel` code can use `ApplyArgsManOptions` with a local `ArgsManager`.

The `::Options` struct and `ApplyArgsManOptions` duo has been used in many previous `libbitcoinkernel` `ArgsManager` decoupling PRs. See: https://github.com/bitcoin/bitcoin/projects/18