### PR TITLE
fuzz: Fix assert bug in txorphan target

### DIFF
--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -3,8 +3,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/amount.h>
-#include <net.h>
+#include <consensus/validation.h>
 #include <net_processing.h>
+#include <node/eviction.h>
+#include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <sync.h>
@@ -99,16 +101,20 @@ FUZZ_TARGET_INIT(txorphan, initialize_orphanage)
                 [&] {
                     bool have_tx = orphanage.HaveTx(GenTxid::Txid(tx->GetHash())) || orphanage.HaveTx(GenTxid::Wtxid(tx->GetHash()));
                     // AddTx should return false if tx is too big or already have it
+                    // tx weight is unknown, we only check when tx is already in orphanage
                     {
                         LOCK(g_cs_orphans);
-                        Assert(have_tx != orphanage.AddTx(tx, peer_id));
+                        bool add_tx = orphanage.AddTx(tx, peer_id);
+                        // have_tx == true -> add_tx == false
+                        Assert(!have_tx || !add_tx);
                     }
                     have_tx = orphanage.HaveTx(GenTxid::Txid(tx->GetHash())) || orphanage.HaveTx(GenTxid::Wtxid(tx->GetHash()));
-                    // tx should already be added since it will not be too big in the test
-                    // have_tx should be true and AddTx should fail
                     {
                         LOCK(g_cs_orphans);
-                        Assert(have_tx && !orphanage.AddTx(tx, peer_id));
+                        bool add_tx = orphanage.AddTx(tx, peer_id);
+                        // if have_tx is still false, it must be too big
+                        Assert(!have_tx == GetTransactionWeight(*tx) > MAX_STANDARD_TX_WEIGHT);
+                        Assert(!have_tx || !add_tx);
                     }
                 },
                 [&] {


### PR DESCRIPTION
Fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=48914.

It is possible to construct big tx that got rejected in `AddTx`, so we cannot assume tx will be added successfully. We can only guarantee tx will not be added if orphanage already has it.