### PR TITLE
Replace mempoolfullrbf with more compatible and flexible mempoolreplacement (plus more tests)

### DIFF
--- a/doc/policy/mempool-replacements.md
+++ b/doc/policy/mempool-replacements.md
@@ -15,7 +15,7 @@ other consensus and policy rules, each of the following conditions are met:
 
    *Rationale*: See [BIP125
    explanation](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki#motivation).
-   Use the (`-mempoolfullrbf`) configuration option to allow transaction replacement without enforcement of the
+   Use the (`-mempoolreplacement=fee,-optin`) configuration option to allow transaction replacement without enforcement of the
    opt-in signaling rule.
 
 2. The replacement transaction only include an unconfirmed input if that input was included in

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -86,9 +86,9 @@ Changes to GUI or wallet related settings can be found in the GUI or Wallet sect
 New settings
 ------------
 
-- A new `mempoolfullrbf` option has been added, which enables the mempool to
-  accept transaction replacement without enforcing BIP125 replaceability
-  signaling. (#25353)
+- The `mempoolreplacement` option has been reintroduced to enable the mempool
+  accepting transaction replacement without enforcing BIP125 replaceability
+  signaling (when set to `fee,-optin`). (#25353)
 
 Tools and Utilities
 -------------------

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -557,7 +557,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-bytespersigop", strprintf("Equivalent bytes per sigop in transactions for relay and mining (default: %u)", DEFAULT_BYTES_PER_SIGOP), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarrier", strprintf("Relay and mine data carrier transactions (default: %u)", DEFAULT_ACCEPT_DATACARRIER), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarriersize", strprintf("Maximum size of data in data carrier transactions we relay and mine (default: %u)", MAX_OP_RETURN_RELAY), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
-    argsman.AddArg("-mempoolfullrbf", strprintf("Accept transaction replace-by-fee without requiring replaceability signaling (default: %u)", DEFAULT_MEMPOOL_FULL_RBF), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-mempoolreplacement", strprintf("Set to either \"fee,optin\" to honour RBF opt-out signal, or \"fee,-optin\" to always RBF aka full RBF (default: %s)", DEFAULT_MEMPOOL_FULL_RBF ? "fee,-optin" : "fee,optin"), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-minrelaytxfee=<amt>", strprintf("Fees (in %s/kvB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)",
         CURRENCY_UNIT, FormatMoney(DEFAULT_MIN_RELAY_TX_FEE)), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-whitelistforcerelay", strprintf("Add 'forcerelay' permission to whitelisted inbound peers with default permissions. This will relay transactions even if the transactions were already in the mempool. (default: %d)", DEFAULT_WHITELISTFORCERELAY), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
@@ -1427,7 +1427,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         .estimator = node.fee_estimator.get(),
         .check_ratio = chainparams.DefaultConsistencyChecks() ? 1 : 0,
     };
-    ApplyArgsManOptions(args, mempool_opts);
+    if (!ApplyArgsManOptions(args, mempool_opts)) return false;
     mempool_opts.check_ratio = std::clamp<int>(mempool_opts.check_ratio, 0, 1'000'000);
 
     int64_t descendant_limit_bytes = mempool_opts.limits.descendant_size_vbytes * 40;

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -15,7 +15,7 @@ class CBlockPolicyEstimator;
 static constexpr unsigned int DEFAULT_MAX_MEMPOOL_SIZE_MB{300};
 /** Default for -mempoolexpiry, expiration time for mempool transactions in hours */
 static constexpr unsigned int DEFAULT_MEMPOOL_EXPIRY_HOURS{336};
-/** Default for -mempoolfullrbf, if the transaction replaceability signaling is ignored */
+/** Default for -mempoolreplacement, if the transaction replaceability signaling is ignored */
 static constexpr bool DEFAULT_MEMPOOL_FULL_RBF{false};
 
 namespace kernel {

--- a/src/mempool_args.h
+++ b/src/mempool_args.h
@@ -16,7 +16,7 @@ struct MemPoolOptions;
  * @param[in]  argsman The ArgsManager in which to check set options.
  * @param[in,out] mempool_opts The MemPoolOptions to modify according to \p argsman.
  */
-void ApplyArgsManOptions(const ArgsManager& argsman, kernel::MemPoolOptions& mempool_opts);
+bool ApplyArgsManOptions(const ArgsManager& argsman, kernel::MemPoolOptions& mempool_opts);
 
 
 #endif // BITCOIN_MEMPOOL_ARGS_H

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -663,7 +663,7 @@ UniValue MempoolInfoToJSON(const CTxMemPool& pool)
     ret.pushKV("minrelaytxfee", ValueFromAmount(::minRelayTxFee.GetFeePerK()));
     ret.pushKV("incrementalrelayfee", ValueFromAmount(::incrementalRelayFee.GetFeePerK()));
     ret.pushKV("unbroadcastcount", uint64_t{pool.GetUnbroadcastTxs().size()});
-    ret.pushKV("fullrbf", pool.m_full_rbf);
+    ret.pushKV("replacement_policy", pool.m_full_rbf ? "fee,-optin" : "fee,optin");
     return ret;
 }
 
@@ -685,7 +685,7 @@ static RPCHelpMan getmempoolinfo()
                 {RPCResult::Type::STR_AMOUNT, "minrelaytxfee", "Current minimum relay fee for transactions"},
                 {RPCResult::Type::NUM, "incrementalrelayfee", "minimum fee rate increment for mempool limiting or BIP 125 replacement in " + CURRENCY_UNIT + "/kvB"},
                 {RPCResult::Type::NUM, "unbroadcastcount", "Current number of transactions that haven't passed initial broadcast yet"},
-                {RPCResult::Type::BOOL, "fullrbf", "True if the mempool accepts RBF without replaceability signaling inspection"},
+                {RPCResult::Type::STR, "replacement_policy", "\"fee,-optin\" if the mempool accepts RBF regardless of the opt-out flag, or \"fee,optin\" if the opt-out flag is honoured"},
             }},
         RPCExamples{
             HelpExampleCli("getmempoolinfo", "")

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -704,8 +704,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
     def test_fullrbf(self):
 
         confirmed_utxo = self.make_utxo(self.nodes[0], int(2 * COIN))
-        self.restart_node(0, extra_args=["-mempoolfullrbf=1"])
-        assert self.nodes[0].getmempoolinfo()["fullrbf"]
+        self.restart_node(0, extra_args=["-mempoolreplacement=fee,-optin"])
+        assert_equal(self.nodes[0].getmempoolinfo()["replacement_policy"], 'fee,-optin')
 
         # Create an explicitly opt-out transaction
         optout_tx = self.wallet.send_self_transfer(


### PR DESCRIPTION
Followup to #25353 using traditional `mempoolreplacement` option that is clearer, more compatible (with Core 0.12-0.18 & Knots), and flexible with other policies.

Also runs `test_opt_in` against "full RBF" mode (expectations adjusted).