### PR TITLE
index: Remove unused BlockFilter::Unserialize()

### DIFF
--- a/src/bench/gcs_filter.cpp
+++ b/src/bench/gcs_filter.cpp
@@ -28,7 +28,7 @@ static void GCSBlockFilterGetHash(benchmark::Bench& bench)
     auto elements = GenerateGCSTestElements();
 
     GCSFilter filter({0, 0, BASIC_FILTER_P, BASIC_FILTER_M}, elements);
-    BlockFilter block_filter(BlockFilterType::BASIC, {}, filter.GetEncoded(), /*skip_decode_check=*/false);
+    BlockFilter block_filter(BlockFilterType::BASIC, {}, filter.GetEncoded());
 
     bench.run([&] {
         block_filter.GetHash();
@@ -55,19 +55,7 @@ static void GCSFilterDecode(benchmark::Bench& bench)
     auto encoded = filter.GetEncoded();
 
     bench.run([&] {
-        GCSFilter filter({0, 0, BASIC_FILTER_P, BASIC_FILTER_M}, encoded, /*skip_decode_check=*/false);
-    });
-}
-
-static void GCSFilterDecodeSkipCheck(benchmark::Bench& bench)
-{
-    auto elements = GenerateGCSTestElements();
-
-    GCSFilter filter({0, 0, BASIC_FILTER_P, BASIC_FILTER_M}, elements);
-    auto encoded = filter.GetEncoded();
-
-    bench.run([&] {
-        GCSFilter filter({0, 0, BASIC_FILTER_P, BASIC_FILTER_M}, encoded, /*skip_decode_check=*/true);
+        GCSFilter filter({0, 0, BASIC_FILTER_P, BASIC_FILTER_M}, encoded);
     });
 }
 
@@ -84,5 +72,4 @@ static void GCSFilterMatch(benchmark::Bench& bench)
 BENCHMARK(GCSBlockFilterGetHash);
 BENCHMARK(GCSFilterConstruct);
 BENCHMARK(GCSFilterDecode);
-BENCHMARK(GCSFilterDecodeSkipCheck);
 BENCHMARK(GCSFilterMatch);

--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -47,7 +47,7 @@ GCSFilter::GCSFilter(const Params& params)
     : m_params(params), m_N(0), m_F(0), m_encoded{0}
 {}
 
-GCSFilter::GCSFilter(const Params& params, std::vector<unsigned char> encoded_filter, bool skip_decode_check)
+GCSFilter::GCSFilter(const Params& params, std::vector<unsigned char> encoded_filter)
     : m_params(params), m_encoded(std::move(encoded_filter))
 {
     SpanReader stream{GCS_SER_TYPE, GCS_SER_VERSION, m_encoded};
@@ -58,18 +58,6 @@ GCSFilter::GCSFilter(const Params& params, std::vector<unsigned char> encoded_fi
         throw std::ios_base::failure("N must be <2^32");
     }
     m_F = static_cast<uint64_t>(m_N) * static_cast<uint64_t>(m_params.m_M);
-
-    if (skip_decode_check) return;
-
-    // Verify that the encoded filter contains exactly N elements. If it has too much or too little
-    // data, a std::ios_base::failure exception will be raised.
-    BitStreamReader<SpanReader> bitreader{stream};
-    for (uint64_t i = 0; i < m_N; ++i) {
-        GolombRiceDecode(bitreader, m_params.m_P);
-    }
-    if (!stream.empty()) {
-        throw std::ios_base::failure("encoded_filter contains excess data");
-    }
 }
 
 GCSFilter::GCSFilter(const Params& params, const ElementSet& elements)
@@ -221,14 +209,14 @@ static GCSFilter::ElementSet BasicFilterElements(const CBlock& block,
 }
 
 BlockFilter::BlockFilter(BlockFilterType filter_type, const uint256& block_hash,
-                         std::vector<unsigned char> filter, bool skip_decode_check)
+                         std::vector<unsigned char> filter)
     : m_filter_type(filter_type), m_block_hash(block_hash)
 {
     GCSFilter::Params params;
     if (!BuildParams(params)) {
         throw std::invalid_argument("unknown filter_type");
     }
-    m_filter = GCSFilter(params, std::move(filter), skip_decode_check);
+    m_filter = GCSFilter(params, std::move(filter));
 }
 
 BlockFilter::BlockFilter(BlockFilterType filter_type, const CBlock& block, const CBlockUndo& block_undo)

--- a/src/blockfilter.h
+++ b/src/blockfilter.h
@@ -59,7 +59,7 @@ public:
     explicit GCSFilter(const Params& params = Params());
 
     /** Reconstructs an already-created filter from an encoding. */
-    GCSFilter(const Params& params, std::vector<unsigned char> encoded_filter, bool skip_decode_check);
+    GCSFilter(const Params& params, std::vector<unsigned char> encoded_filter);
 
     /** Builds a new filter from the params and set of elements. */
     GCSFilter(const Params& params, const ElementSet& elements);
@@ -122,7 +122,7 @@ public:
 
     //! Reconstruct a BlockFilter from parts.
     BlockFilter(BlockFilterType filter_type, const uint256& block_hash,
-                std::vector<unsigned char> filter, bool skip_decode_check);
+                std::vector<unsigned char> filter);
 
     //! Construct a new BlockFilter of the specified type from a block.
     BlockFilter(BlockFilterType filter_type, const CBlock& block, const CBlockUndo& block_undo);
@@ -147,24 +147,6 @@ public:
         s << static_cast<uint8_t>(m_filter_type)
           << m_block_hash
           << m_filter.GetEncoded();
-    }
-
-    template <typename Stream>
-    void Unserialize(Stream& s) {
-        std::vector<unsigned char> encoded_filter;
-        uint8_t filter_type;
-
-        s >> filter_type
-          >> m_block_hash
-          >> encoded_filter;
-
-        m_filter_type = static_cast<BlockFilterType>(filter_type);
-
-        GCSFilter::Params params;
-        if (!BuildParams(params)) {
-            throw std::ios_base::failure("unknown filter_type");
-        }
-        m_filter = GCSFilter(params, std::move(encoded_filter), /*skip_decode_check=*/false);
     }
 };
 

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -159,7 +159,7 @@ bool BlockFilterIndex::ReadFilterFromDisk(const FlatFilePos& pos, const uint256&
         uint256 result;
         CHash256().Write(encoded_filter).Finalize(result);
         if (result != hash) return error("Checksum mismatch in filter decode.");
-        filter = BlockFilter(GetFilterType(), block_hash, std::move(encoded_filter), /*skip_decode_check=*/true);
+        filter = BlockFilter(GetFilterType(), block_hash, std::move(encoded_filter));
     }
     catch (const std::exception& e) {
         return error("%s: Failed to deserialize block filter from disk: %s", __func__, e.what());

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -52,6 +52,19 @@ BOOST_AUTO_TEST_CASE(gcsfilter_default_constructor)
     BOOST_CHECK_EQUAL(params.m_M, 1U);
 }
 
+template <typename Stream>
+static BlockFilter UnserializeBlockFilter(Stream& s)
+{
+    std::vector<unsigned char> encoded_filter;
+    uint8_t filter_type_uint8;
+    uint256 block_hash;
+
+    s >> filter_type_uint8 >> block_hash >> encoded_filter;
+
+    const BlockFilterType filter_type = static_cast<BlockFilterType>(filter_type_uint8);
+    return BlockFilter{filter_type, block_hash, std::move(encoded_filter)};
+}
+
 BOOST_AUTO_TEST_CASE(blockfilter_basic_test)
 {
     CScript included_scripts[5], excluded_scripts[4];
@@ -108,11 +121,9 @@ BOOST_AUTO_TEST_CASE(blockfilter_basic_test)
     }
 
     // Test serialization/unserialization.
-    BlockFilter block_filter2;
-
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << block_filter;
-    stream >> block_filter2;
+    BlockFilter block_filter2{UnserializeBlockFilter(stream)};
 
     BOOST_CHECK_EQUAL(block_filter.GetFilterType(), block_filter2.GetFilterType());
     BOOST_CHECK_EQUAL(block_filter.GetBlockHash(), block_filter2.GetBlockHash());

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -112,10 +112,6 @@ void AssertEqualAfterSerializeDeserialize(const T& obj, const int version = INIT
 
 } // namespace
 
-FUZZ_TARGET_DESERIALIZE(block_filter_deserialize, {
-    BlockFilter block_filter;
-    DeserializeFromFuzzingInput(buffer, block_filter);
-})
 FUZZ_TARGET_DESERIALIZE(addr_info_deserialize, {
     AddrInfo addr_info;
     DeserializeFromFuzzingInput(buffer, addr_info);


### PR DESCRIPTION
BlockFilter::Unserialize is only used in the test code. Moving it to
the tests allows for the removal of the optional sanity check in the
GCSFilter and BlockFilter constructor, resulting in simpler code.

This is a follow up to #24832.