### PR TITLE
Fix `-Wparentheses` gcc warning

### DIFF
--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -113,7 +113,7 @@ FUZZ_TARGET_INIT(txorphan, initialize_orphanage)
                         LOCK(g_cs_orphans);
                         bool add_tx = orphanage.AddTx(tx, peer_id);
                         // if have_tx is still false, it must be too big
-                        Assert(!have_tx == GetTransactionWeight(*tx) > MAX_STANDARD_TX_WEIGHT);
+                        Assert(!have_tx == (GetTransactionWeight(*tx) > MAX_STANDARD_TX_WEIGHT));
                         Assert(!have_tx || !add_tx);
                     }
                 },


### PR DESCRIPTION
This PR fixes `-Wparentheses` gcc warning which has been introduced in bitcoin/bitcoin#25624.

On the master branch (6d8707b21d3a5b4abb76b773a69f2bfac22bcd93):
```
$ gcc --version
gcc (Ubuntu 11.2.0-19ubuntu1) 11.2.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ make > /dev/null 
In file included from ./net.h:29,
                 from ./net_processing.h:9,
                 from test/fuzz/txorphan.cpp:7:
test/fuzz/txorphan.cpp: In lambda function:
test/fuzz/txorphan.cpp:116:70: warning: suggest parentheses around comparison in operand of ‘==’ [-Wparentheses]
  116 |                         Assert(!have_tx == GetTransactionWeight(*tx) > MAX_STANDARD_TX_WEIGHT);
      |                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
./util/check.h:74:50: note: in definition of macro ‘Assert’
   74 | #define Assert(val) inline_assertion_check<true>(val, __FILE__, __LINE__, __func__, #val)
      |                                                  ^~~
```