### PR TITLE
depends: compile FastFixedDtoa with -O1 to fix cross-arch reproducibility for arm32

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -21,6 +21,7 @@ $(package)_patches += fix_limits_header.patch
 $(package)_patches += use_android_ndk23.patch
 $(package)_patches += rcc_hardcode_timestamp.patch
 $(package)_patches += duplicate_lcqpafonts.patch
+$(package)_patches += fast_fixed_dtoa_no_optimize.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=5d7869f670a135ad0986e266813b9dd5bbae2b09577338f9cdf8904d4af52db0
@@ -251,6 +252,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/use_android_ndk23.patch && \
   patch -p1 -i $($(package)_patch_dir)/rcc_hardcode_timestamp.patch && \
   patch -p1 -i $($(package)_patch_dir)/duplicate_lcqpafonts.patch && \
+  patch -p1 -i $($(package)_patch_dir)/fast_fixed_dtoa_no_optimize.patch && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f $($(package)_patch_dir)/mac-qmake.conf qtbase/mkspecs/macx-clang-linux/qmake.conf && \

--- a/depends/patches/qt/fast_fixed_dtoa_no_optimize.patch
+++ b/depends/patches/qt/fast_fixed_dtoa_no_optimize.patch
@@ -1,0 +1,20 @@
+Modify the optimisation flags for FastFixedDtoa.
+This fixes a non-determinism issue in the asm produced for
+this function when cross-compiling on x86_64 and aarch64 for
+the arm-linux-gnueabihf HOST.
+
+--- a/qtbase/src/3rdparty/double-conversion/fixed-dtoa.h
++++ b/qtbase/src/3rdparty/double-conversion/fixed-dtoa.h
+@@ -48,9 +48,12 @@ namespace double_conversion {
+ //
+ // This method only works for some parameters. If it can't handle the input it
+ // returns false. The output is null-terminated when the function succeeds.
++#pragma GCC push_options
++#pragma GCC optimize ("-O1")
+ bool FastFixedDtoa(double v, int fractional_count,
+                    Vector<char> buffer, int* length, int* decimal_point);
+ 
++#pragma GCC pop_options
+ }  // namespace double_conversion
+ 
+ #endif  // DOUBLE_CONVERSION_FIXED_DTOA_H_


### PR DESCRIPTION
This fixes a non-determinism issue in the asm produced for
this function when cross-compiling on x86_64 and aarch64 for
the arm-linux-gnueabihf HOST.

Related to #21194. Alternative to #25636. Initial discussion in https://github.com/bitcoin/bitcoin/pull/24615#issuecomment-1080809879.

Guix Build (x86_64):
```bash
28ae0ec2874ead334edd1c5dc509344379d82f7058b649c9076992defd7190d7  guix-build-c32fa85909dd/output/arm-linux-gnueabihf/SHA256SUMS.part
48d34073b029c4f62c8e1bd906533610228d5ca0bb5eefea6010dfa7372ba067  guix-build-c32fa85909dd/output/arm-linux-gnueabihf/bitcoin-c32fa85909dd-arm-linux-gnueabihf-debug.tar.gz
850d6e9859e88bcb93ed586bdb0c0bc95a44249d6a0ec1b1d13125cb9dd56413  guix-build-c32fa85909dd/output/arm-linux-gnueabihf/bitcoin-c32fa85909dd-arm-linux-gnueabihf.tar.gz
b8bb092b1307684ea4b53d810ac110ec14f29eeab8028d924d1cac7418009b14  guix-build-c32fa85909dd/output/dist-archive/bitcoin-c32fa85909dd.tar.gz
```

Guix Build (arm64):
```bash
28ae0ec2874ead334edd1c5dc509344379d82f7058b649c9076992defd7190d7  guix-build-c32fa85909dd/output/arm-linux-gnueabihf/SHA256SUMS.part
48d34073b029c4f62c8e1bd906533610228d5ca0bb5eefea6010dfa7372ba067  guix-build-c32fa85909dd/output/arm-linux-gnueabihf/bitcoin-c32fa85909dd-arm-linux-gnueabihf-debug.tar.gz
850d6e9859e88bcb93ed586bdb0c0bc95a44249d6a0ec1b1d13125cb9dd56413  guix-build-c32fa85909dd/output/arm-linux-gnueabihf/bitcoin-c32fa85909dd-arm-linux-gnueabihf.tar.gz
b8bb092b1307684ea4b53d810ac110ec14f29eeab8028d924d1cac7418009b14  guix-build-c32fa85909dd/output/dist-archive/bitcoin-c32fa85909dd.tar.gz
```