### PR TITLE
refactor: Remove unused includes from dbwrapper.h

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -40,6 +40,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
   export P_CI_DIR="${BASE_BUILD_DIR}/bitcoin-$HOST/"
   CI_EXEC "python3 ${DIR_IWYU}/include-what-you-use/iwyu_tool.py"\
           " src/compat"\
+          " src/dbwrapper.cpp"\
           " src/init"\
           " src/kernel/mempool_persist.cpp"\
           " src/node/chainstate.cpp"\

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -42,6 +42,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
           " src/compat"\
           " src/init"\
           " src/kernel/mempool_persist.cpp"\
+          " src/node/chainstate.cpp"\
           " src/policy/feerate.cpp"\
           " src/policy/packages.cpp"\
           " src/policy/settings.cpp"\

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -8,6 +8,7 @@
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <streams.h>
+#include <util/system.h>
 #include <validation.h>
 
 // These are the two major time-sinks which happen after we have fully received

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -4,15 +4,28 @@
 
 #include <dbwrapper.h>
 
-#include <memory>
+#include <fs.h>
+#include <logging.h>
 #include <random.h>
+#include <tinyformat.h>
+#include <util/strencodings.h>
+#include <util/system.h>
 
+#include <algorithm>
+#include <cassert>
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
 #include <leveldb/cache.h>
+#include <leveldb/db.h>
 #include <leveldb/env.h>
 #include <leveldb/filter_policy.h>
 #include <leveldb/helpers/memenv/memenv.h>
-#include <stdint.h>
-#include <algorithm>
+#include <leveldb/iterator.h>
+#include <leveldb/options.h>
+#include <leveldb/status.h>
+#include <memory>
+#include <optional>
 
 class CBitcoinLevelDBLogger : public leveldb::Logger {
 public:

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -7,14 +7,26 @@
 
 #include <clientversion.h>
 #include <fs.h>
+#include <logging.h>
 #include <serialize.h>
 #include <span.h>
 #include <streams.h>
-#include <util/strencodings.h>
-#include <util/system.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <exception>
 #include <leveldb/db.h>
+#include <leveldb/iterator.h>
+#include <leveldb/options.h>
+#include <leveldb/slice.h>
+#include <leveldb/status.h>
 #include <leveldb/write_batch.h>
+#include <stdexcept>
+#include <string>
+#include <vector>
+namespace leveldb {
+class Env;
+}
 
 static const size_t DBWRAPPER_PREALLOC_KEY_SIZE = 64;
 static const size_t DBWRAPPER_PREALLOC_VALUE_SIZE = 1024;

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -9,6 +9,7 @@
 #include <shutdown.h>
 #include <tinyformat.h>
 #include <util/syscall_sandbox.h>
+#include <util/system.h>
 #include <util/thread.h>
 #include <util/translation.h>
 #include <validation.h> // For g_chainman

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -10,6 +10,7 @@
 #include <serialize.h>
 #include <txdb.h>
 #include <undo.h>
+#include <util/system.h>
 #include <validation.h>
 
 using kernel::CCoinsStats;

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -4,9 +4,22 @@
 
 #include <node/chainstate.h>
 
+#include <chain.h>
+#include <coins.h>
 #include <consensus/params.h>
 #include <node/blockstorage.h>
+#include <sync.h>
+#include <threadsafety.h>
+#include <txdb.h>
+#include <uint256.h>
+#include <util/time.h>
 #include <validation.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <memory>
+#include <vector>
 
 namespace node {
 std::optional<ChainstateLoadingError> LoadChainstate(bool fReset,

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -11,9 +11,6 @@
 
 class ChainstateManager;
 class CTxMemPool;
-namespace Consensus {
-struct Params;
-} // namespace Consensus
 
 namespace node {
 enum class ChainstateLoadingError {

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -19,6 +19,7 @@
 #include <validation.h> // for DEFAULT_SCRIPTCHECK_THREADS and MAX_SCRIPTCHECK_THREADS
 #include <netbase.h>
 #include <txdb.h> // for -dbcache defaults
+#include <util/system.h>
 
 #include <chrono>
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -39,6 +39,7 @@
 #include <univalue.h>
 #include <util/check.h>
 #include <util/strencodings.h>
+#include <util/system.h>
 #include <util/translation.h>
 #include <validation.h>
 #include <validationinterface.h>

--- a/src/rpc/fees.cpp
+++ b/src/rpc/fees.cpp
@@ -6,7 +6,6 @@
 #include <core_io.h>
 #include <policy/feerate.h>
 #include <policy/fees.h>
-#include <policy/policy.h>
 #include <policy/settings.h>
 #include <rpc/protocol.h>
 #include <rpc/request.h>
@@ -16,7 +15,6 @@
 #include <txmempool.h>
 #include <univalue.h>
 #include <util/fees.h>
-#include <util/system.h>
 
 #include <algorithm>
 #include <array>

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -20,6 +20,7 @@
 #include <txmempool.h>
 #include <univalue.h>
 #include <util/moneystr.h>
+#include <util/time.h>
 
 using kernel::DumpMempool;
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -8,6 +8,7 @@
 
 #include <coins.h>
 #include <dbwrapper.h>
+#include <sync.h>
 
 #include <memory>
 #include <optional>


### PR DESCRIPTION
Unused includes are confusing, but also cause unrelated compile errors when the unused includes were to be removed.

Fix that by adding the missing includes where they are needed and then remove them where they are not needed. This is also checked by iwyu.