### PR TITLE
build: remove left-over pkgconfig vars in config.site.in

### DIFF
--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -82,16 +82,6 @@ if test -z "$enable_lto" && test -n "@lto@"; then
   enable_lto=yes
 fi
 
-PKG_CONFIG="$(which pkg-config) --static"
-
-# These two need to remain exported because pkg-config does not see them
-# otherwise. That means they must be unexported at the end of configure.ac to
-# avoid ruining the cache. Sigh.
-export PKG_CONFIG_PATH="${depends_prefix}/share/pkgconfig:${depends_prefix}/lib/pkgconfig"
-if test -z "@allow_host_packages@"; then
-  export PKG_CONFIG_LIBDIR="${depends_prefix}/lib/pkgconfig"
-fi
-
 CPPFLAGS="-I${depends_prefix}/include/ ${CPPFLAGS}"
 LDFLAGS="-L${depends_prefix}/lib ${LDFLAGS}"
 


### PR DESCRIPTION
These were overlooked in ee30bf7c01922938bcf861a57cdf2249edb36256, and they will create problems when updating the secp256k1 subtree, see https://github.com/bitcoin-core/secp256k1/issues/1127.