### PR TITLE
Revert "build: remove some no-longer-needed var unexporting from conf…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1997,6 +1997,14 @@ LIBS_TEMP="$LIBS"
 unset LIBS
 LIBS="$LIBS_TEMP"
 
+PKGCONFIG_PATH_TEMP="$PKG_CONFIG_PATH"
+unset PKG_CONFIG_PATH
+PKG_CONFIG_PATH="$PKGCONFIG_PATH_TEMP"
+
+PKGCONFIG_LIBDIR_TEMP="$PKG_CONFIG_LIBDIR"
+unset PKG_CONFIG_LIBDIR
+PKG_CONFIG_LIBDIR="$PKGCONFIG_LIBDIR_TEMP"
+
 ac_configure_args="${ac_configure_args} --disable-shared --with-pic --enable-benchmark=no --enable-module-recovery --enable-module-schnorrsig"
 AC_CONFIG_SUBDIRS([src/secp256k1])
 


### PR DESCRIPTION
Building with depends implies exporting of the `PKG_CONFIG_PATH` and `PKG_CONFIG_LIBDIR` environment variables: https://github.com/bitcoin/bitcoin/blob/d1e42659bbdd8da170542d8c638242cd94f71a7d/depends/config.site.in#L87-L93

To use `--config-cache` option, as we do in CI, requires that "they must be unexported at the end of `configure.ac`".