### PR TITLE
tracing: do not use `coin` after move in `CCoinsViewCache::AddCoin`

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -99,9 +99,9 @@ void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possi
     TRACE5(utxocache, add,
            outpoint.hash.data(),
            (uint32_t)outpoint.n,
-           (uint32_t)coin.nHeight,
-           (int64_t)coin.out.nValue,
-           (bool)coin.IsCoinBase());
+           (uint32_t)it->second.coin.nHeight,
+           (int64_t)it->second.coin.out.nValue,
+           (bool)it->second.coin.IsCoinBase());
 }
 
 void CCoinsViewCache::EmplaceCoinInternalDANGER(COutPoint&& outpoint, Coin&& coin) {


### PR DESCRIPTION
This is fix for https://github.com/bitcoin/bitcoin/issues/25640.