### PR TITLE
refactor: Add util::Result failure types and ability to merge result values

### DIFF
--- a/ci/test/00_setup_env_native_previous_releases.sh
+++ b/ci/test/00_setup_env_native_previous_releases.sh
@@ -22,7 +22,7 @@ export BITCOIN_CONFIG="\
  -DCMAKE_BUILD_TYPE=Debug \
  -DCMAKE_C_FLAGS='-funsigned-char -Werror' \
  -DCMAKE_C_FLAGS_DEBUG='-g2 -O2' \
- -DCMAKE_CXX_FLAGS='-funsigned-char -Werror' \
+ -DCMAKE_CXX_FLAGS='-funsigned-char -Werror -Wno-error=maybe-uninitialized' \
  -DCMAKE_CXX_FLAGS_DEBUG='-g2 -O2' \
  -DAPPEND_CPPFLAGS='-DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE' \
 "

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -149,11 +149,11 @@ using http_bitcoin::InitHTTPServer;
 using http_bitcoin::InterruptHTTPServer;
 using http_bitcoin::StartHTTPServer;
 using http_bitcoin::StopHTTPServer;
+using kernel::InterruptResult;
 using node::ApplyArgsManOptions;
 using node::BlockManager;
 using node::CalculateCacheSizes;
-using node::ChainstateLoadResult;
-using node::ChainstateLoadStatus;
+using node::ChainstateLoadError;
 using node::DEFAULT_PERSIST_MEMPOOL;
 using node::DEFAULT_PRINT_MODIFIED_FEE;
 using node::DEFAULT_STOPATHEIGHT;
@@ -1317,7 +1317,7 @@ static std::optional<CService> CheckBindingConflicts(const CConnman::Options& co
 
 // A GUI user may opt to retry once with do_reindex set if there is a failure during chainstate initialization.
 // The function therefore has to support re-entry.
-static ChainstateLoadResult InitAndLoadChainstate(
+util::Result<kernel::InterruptResult, ChainstateLoadError> InitAndLoadChainstate(
     NodeContext& node,
     bool do_reindex,
     const bool do_reindex_chainstate,
@@ -1340,7 +1340,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
     Assert(!node.mempool); // Was reset above
     node.mempool = std::make_unique<CTxMemPool>(mempool_opts, mempool_error);
     if (!mempool_error.empty()) {
-        return {ChainstateLoadStatus::FAILURE_FATAL, mempool_error};
+        return {util::Error{mempool_error}, ChainstateLoadError::FAILURE_FATAL};
     }
     auto mining_args{node::ReadMiningArgs(args)};
     Assert(mining_args); // no error can happen, already checked in AppInitParameterInteraction
@@ -1376,12 +1376,12 @@ static ChainstateLoadResult InitAndLoadChainstate(
         node.chainman = std::make_unique<ChainstateManager>(*Assert(node.shutdown_signal), chainman_opts, blockman_opts);
     } catch (dbwrapper_error& e) {
         LogError("%s", e.what());
-        return {ChainstateLoadStatus::FAILURE, _("Error opening block database")};
+        return {util::Error{_("Error opening block database")}, ChainstateLoadError::FAILURE};
     } catch (std::exception& e) {
-        return {ChainstateLoadStatus::FAILURE_FATAL, Untranslated(strprintf("Failed to initialize ChainstateManager: %s", e.what()))};
+        return {util::Error{Untranslated(strprintf("Failed to initialize ChainstateManager: %s", e.what()))}, ChainstateLoadError::FAILURE_FATAL};
     }
     ChainstateManager& chainman = *node.chainman;
-    if (chainman.m_interrupt) return {ChainstateLoadStatus::INTERRUPTED, {}};
+    if (chainman.m_interrupt) return kernel::Interrupted{};
 
     // This is defined and set here instead of inline in validation.h to avoid a hard
     // dependency between validation and index/base, since the latter is not in
@@ -1416,28 +1416,28 @@ static ChainstateLoadResult InitAndLoadChainstate(
             CClientUIInterface::MSG_ERROR);
     };
     uiInterface.InitMessage(_("Loading block index…"));
-    auto catch_exceptions = [](auto&& f) -> ChainstateLoadResult {
+    auto catch_exceptions = [](auto&& f) -> util::Result<InterruptResult, node::ChainstateLoadError> {
         try {
             return f();
         } catch (const std::exception& e) {
             LogError("%s\n", e.what());
-            return std::make_tuple(node::ChainstateLoadStatus::FAILURE, _("Error loading databases"));
+            return {util::Error{_("Error loading databases")}, node::ChainstateLoadError::FAILURE};
         }
     };
-    auto [status, error] = catch_exceptions([&] { return LoadChainstate(chainman, cache_sizes, options); });
-    if (status == node::ChainstateLoadStatus::SUCCESS) {
+    auto result = catch_exceptions([&] { return LoadChainstate(chainman, cache_sizes, options); });
+    if (result && !IsInterrupted(*result)) {
         uiInterface.InitMessage(_("Verifying blocks…"));
         if (chainman.m_blockman.m_have_pruned && options.check_blocks > MIN_BLOCKS_TO_KEEP) {
             LogWarning("pruned datadir may not have more than %d blocks; only checking available blocks\n",
                        MIN_BLOCKS_TO_KEEP);
         }
-        std::tie(status, error) = catch_exceptions([&] { return VerifyLoadedChainstate(chainman, options); });
-        if (status == node::ChainstateLoadStatus::SUCCESS) {
+        result.update(catch_exceptions([&] { return VerifyLoadedChainstate(chainman, options); }));
+        if (result && !IsInterrupted(*result)) {
             LogInfo("Block index and chainstate loaded");
             node.notifications->setChainstateLoaded(true);
         }
     }
-    return {status, error};
+    return result;
 };
 
 bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
@@ -1873,13 +1873,14 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     const bool do_reindex_chainstate{args.GetBoolArg("-reindex-chainstate", false)};
 
     // Chainstate initialization and loading may be retried once with reindexing by GUI users
-    auto [status, error] = InitAndLoadChainstate(
+    auto result = InitAndLoadChainstate(
         node,
         do_reindex,
         do_reindex_chainstate,
         kernel_cache_sizes,
         args);
-    if (status == ChainstateLoadStatus::FAILURE && !do_reindex && !ShutdownRequested(node)) {
+    if (!result && result.error() == ChainstateLoadError::FAILURE && !do_reindex && !ShutdownRequested(node)) {
+        const auto& error = util::ErrorString(result);
         // suggest a reindex
         bool do_retry{HasTestOption(args, "reindex_after_failure_noninteractive_yes") ||
             uiInterface.ThreadSafeQuestion(
@@ -1893,15 +1894,15 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         if (!Assert(node.shutdown_signal)->reset()) {
             LogError("Internal error: failed to reset shutdown signal.\n");
         }
-        std::tie(status, error) = InitAndLoadChainstate(
+        result.update(InitAndLoadChainstate(
             node,
             do_reindex,
             do_reindex_chainstate,
             kernel_cache_sizes,
-            args);
+            args));
     }
-    if (status != ChainstateLoadStatus::SUCCESS && status != ChainstateLoadStatus::INTERRUPTED) {
-        return InitError(error);
+    if (!result) {
+        return InitError(util::ErrorString(result));
     }
 
     // As LoadBlockIndex can take several minutes, it's possible the user

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -148,11 +148,11 @@
 using common::InvalidPortErrMsg;
 using common::ResolveErrMsg;
 
+using kernel::InterruptResult;
 using node::ApplyArgsManOptions;
 using node::BlockManager;
 using node::CalculateCacheSizes;
-using node::ChainstateLoadResult;
-using node::ChainstateLoadStatus;
+using node::ChainstateLoadError;
 using node::DEFAULT_PERSIST_MEMPOOL;
 using node::DEFAULT_PRINT_MODIFIED_FEE;
 using node::DEFAULT_STOPATHEIGHT;
@@ -1371,7 +1371,7 @@ static std::optional<CService> CheckBindingConflicts(const CConnman::Options& co
 
 // A GUI user may opt to retry once with do_reindex set if there is a failure during chainstate initialization.
 // The function therefore has to support re-entry.
-static ChainstateLoadResult InitAndLoadChainstate(
+util::Result<kernel::InterruptResult, ChainstateLoadError> InitAndLoadChainstate(
     NodeContext& node,
     bool do_reindex,
     const bool do_reindex_chainstate,
@@ -1394,7 +1394,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
     Assert(!node.mempool); // Was reset above
     node.mempool = std::make_unique<CTxMemPool>(mempool_opts, mempool_error);
     if (!mempool_error.empty()) {
-        return {ChainstateLoadStatus::FAILURE_FATAL, mempool_error};
+        return {util::Error{mempool_error}, ChainstateLoadError::FAILURE_FATAL};
     }
     auto mining_args{node::ReadMiningArgs(args)};
     Assert(mining_args); // no error can happen, already checked in AppInitParameterInteraction
@@ -1430,12 +1430,12 @@ static ChainstateLoadResult InitAndLoadChainstate(
         node.chainman = std::make_unique<ChainstateManager>(*Assert(node.shutdown_signal), chainman_opts, blockman_opts);
     } catch (dbwrapper_error& e) {
         LogError("%s", e.what());
-        return {ChainstateLoadStatus::FAILURE, _("Error opening block database")};
+        return {util::Error{_("Error opening block database")}, ChainstateLoadError::FAILURE};
     } catch (std::exception& e) {
-        return {ChainstateLoadStatus::FAILURE_FATAL, Untranslated(strprintf("Failed to initialize ChainstateManager: %s", e.what()))};
+        return {util::Error{Untranslated(strprintf("Failed to initialize ChainstateManager: %s", e.what()))}, ChainstateLoadError::FAILURE_FATAL};
     }
     ChainstateManager& chainman = *node.chainman;
-    if (chainman.m_interrupt) return {ChainstateLoadStatus::INTERRUPTED, {}};
+    if (chainman.m_interrupt) return kernel::Interrupted{};
 
     // This is defined and set here instead of inline in validation.h to avoid a hard
     // dependency between validation and index/base, since the latter is not in
@@ -1470,28 +1470,28 @@ static ChainstateLoadResult InitAndLoadChainstate(
             CClientUIInterface::MSG_ERROR);
     };
     uiInterface.InitMessage(_("Loading block index…"));
-    auto catch_exceptions = [](auto&& f) -> ChainstateLoadResult {
+    auto catch_exceptions = [](auto&& f) -> util::Result<InterruptResult, node::ChainstateLoadError> {
         try {
             return f();
         } catch (const std::exception& e) {
             LogError("%s\n", e.what());
-            return std::make_tuple(node::ChainstateLoadStatus::FAILURE, _("Error loading databases"));
+            return {util::Error{_("Error loading databases")}, node::ChainstateLoadError::FAILURE};
         }
     };
-    auto [status, error] = catch_exceptions([&] { return LoadChainstate(chainman, cache_sizes, options); });
-    if (status == node::ChainstateLoadStatus::SUCCESS) {
+    auto result = catch_exceptions([&] { return LoadChainstate(chainman, cache_sizes, options); });
+    if (result && !IsInterrupted(*result)) {
         uiInterface.InitMessage(_("Verifying blocks…"));
         if (chainman.m_blockman.m_have_pruned && options.check_blocks > MIN_BLOCKS_TO_KEEP) {
             LogWarning("pruned datadir may not have more than %d blocks; only checking available blocks\n",
                        MIN_BLOCKS_TO_KEEP);
         }
-        std::tie(status, error) = catch_exceptions([&] { return VerifyLoadedChainstate(chainman, options); });
-        if (status == node::ChainstateLoadStatus::SUCCESS) {
+        result.update(catch_exceptions([&] { return VerifyLoadedChainstate(chainman, options); }));
+        if (result && !IsInterrupted(*result)) {
             LogInfo("Block index and chainstate loaded");
             node.notifications->setChainstateLoaded(true);
         }
     }
-    return {status, error};
+    return result;
 };
 
 bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
@@ -1911,13 +1911,14 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     const bool do_reindex_chainstate{args.GetBoolArg("-reindex-chainstate", false)};
 
     // Chainstate initialization and loading may be retried once with reindexing by GUI users
-    auto [status, error] = InitAndLoadChainstate(
+    auto result = InitAndLoadChainstate(
         node,
         do_reindex,
         do_reindex_chainstate,
         kernel_cache_sizes,
         args);
-    if (status == ChainstateLoadStatus::FAILURE && !do_reindex && !ShutdownRequested(node)) {
+    if (!result && result.error() == ChainstateLoadError::FAILURE && !do_reindex && !ShutdownRequested(node)) {
+        const auto& error = util::ErrorString(result);
         // suggest a reindex
         bool do_retry{HasTestOption(args, "reindex_after_failure_noninteractive_yes") ||
             uiInterface.ThreadSafeQuestion(
@@ -1931,15 +1932,15 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         if (!Assert(node.shutdown_signal)->reset()) {
             LogError("Internal error: failed to reset shutdown signal.\n");
         }
-        std::tie(status, error) = InitAndLoadChainstate(
+        result.update(InitAndLoadChainstate(
             node,
             do_reindex,
             do_reindex_chainstate,
             kernel_cache_sizes,
-            args);
+            args));
     }
-    if (status != ChainstateLoadStatus::SUCCESS && status != ChainstateLoadStatus::INTERRUPTED) {
-        return InitError(error);
+    if (!result) {
+        return InitError(util::ErrorString(result));
     }
 
     // As LoadBlockIndex can take several minutes, it's possible the user

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library(bitcoinkernel
   ../util/fs.cpp
   ../util/fs_helpers.cpp
   ../util/hasher.cpp
+  ../util/messages.cpp
   ../util/moneystr.cpp
   ../util/rbf.cpp
   ../util/signalinterrupt.cpp

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -49,8 +49,8 @@
 #include <span>
 #include <stdexcept>
 #include <string>
-#include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace Consensus {
@@ -1050,14 +1050,14 @@ btck_ChainstateManager* btck_chainstate_manager_create(
         const auto chainstate_load_opts{WITH_LOCK(opts.m_mutex, return opts.m_chainstate_load_options)};
 
         kernel::CacheSizes cache_sizes{DEFAULT_KERNEL_CACHE};
-        auto [status, chainstate_err]{node::LoadChainstate(*chainman, cache_sizes, chainstate_load_opts)};
-        if (status != node::ChainstateLoadStatus::SUCCESS) {
-            LogError("Failed to load chain state from your data directory: %s", chainstate_err.original);
+        auto load_result{node::LoadChainstate(*chainman, cache_sizes, chainstate_load_opts)};
+        if (!load_result || IsInterrupted(*load_result)) {
+            LogError("Failed to load chain state from your data directory: %s", util::ErrorString(load_result).original);
             return nullptr;
         }
-        std::tie(status, chainstate_err) = node::VerifyLoadedChainstate(*chainman, chainstate_load_opts);
-        if (status != node::ChainstateLoadStatus::SUCCESS) {
-            LogError("Failed to verify loaded chain state from your datadir: %s", chainstate_err.original);
+        auto verify_result{node::VerifyLoadedChainstate(*chainman, chainstate_load_opts)};
+        if (!verify_result || IsInterrupted(*verify_result)) {
+            LogError("Failed to verify loaded chain state from your datadir: %s", util::ErrorString(load_result).original);
             return nullptr;
         }
         if (auto result = chainman->ActivateBestChains(); !result) {

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -51,8 +51,8 @@
 #include <span>
 #include <stdexcept>
 #include <string>
-#include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace Consensus {
@@ -1101,14 +1101,14 @@ btck_ChainstateManager* btck_chainstate_manager_create(
         const auto chainstate_load_opts{WITH_LOCK(opts.m_mutex, return opts.m_chainstate_load_options)};
 
         const kernel::CacheSizes cache_sizes{WITH_LOCK(opts.m_mutex, return opts.m_db_cache_bytes)};
-        auto [status, chainstate_err]{node::LoadChainstate(*chainman, cache_sizes, chainstate_load_opts)};
-        if (status != node::ChainstateLoadStatus::SUCCESS) {
-            LogError("Failed to load chain state from your data directory: %s", chainstate_err.original);
+        auto load_result{node::LoadChainstate(*chainman, cache_sizes, chainstate_load_opts)};
+        if (!load_result || IsInterrupted(*load_result)) {
+            LogError("Failed to load chain state from your data directory: %s", util::ErrorString(load_result).original);
             return nullptr;
         }
-        std::tie(status, chainstate_err) = node::VerifyLoadedChainstate(*chainman, chainstate_load_opts);
-        if (status != node::ChainstateLoadStatus::SUCCESS) {
-            LogError("Failed to verify loaded chain state from your datadir: %s", chainstate_err.original);
+        auto verify_result{node::VerifyLoadedChainstate(*chainman, chainstate_load_opts)};
+        if (!verify_result || IsInterrupted(*verify_result)) {
+            LogError("Failed to verify loaded chain state from your datadir: %s", util::ErrorString(load_result).original);
             return nullptr;
         }
         if (auto result = chainman->ActivateBestChains(); !result) {

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -27,35 +27,40 @@
 #include <vector>
 
 using kernel::CacheSizes;
+using kernel::Interrupted;
+using kernel::InterruptResult;
 
 namespace node {
 // Complete initialization of chainstates after the initial call has been made
 // to ChainstateManager::InitializeChainstate().
-static ChainstateLoadResult CompleteChainstateInitialization(
+static util::Result<InterruptResult, ChainstateLoadError> CompleteChainstateInitialization(
     ChainstateManager& chainman,
     const ChainstateLoadOptions& options) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
-    if (chainman.m_interrupt) return {ChainstateLoadStatus::INTERRUPTED, {}};
+    if (chainman.m_interrupt) return Interrupted{};
 
     // LoadBlockIndex will load m_have_pruned if we've ever removed a
     // block file from disk.
     // Note that it also sets m_blockfiles_indexed based on the disk flag!
     if (!chainman.LoadBlockIndex()) {
-        if (chainman.m_interrupt) return {ChainstateLoadStatus::INTERRUPTED, {}};
-        return {ChainstateLoadStatus::FAILURE, _("Error loading block database")};
+        if (chainman.m_interrupt) {
+            return Interrupted{};
+        } else {
+            return {util::Error{_("Error loading block database")}, ChainstateLoadError::FAILURE};
+        }
     }
 
     if (!chainman.BlockIndex().empty() &&
             !chainman.m_blockman.LookupBlockIndex(chainman.GetConsensus().hashGenesisBlock)) {
         // If the loaded chain has a wrong genesis, bail out immediately
         // (we're likely using a testnet datadir, or the other way around).
-        return {ChainstateLoadStatus::FAILURE_INCOMPATIBLE_DB, _("Incorrect or no genesis block found. Wrong datadir for network?")};
+        return {util::Error{_("Incorrect or no genesis block found. Wrong datadir for network?")}, ChainstateLoadError::FAILURE_INCOMPATIBLE_DB};
     }
 
     // Check for changed -prune state.  What we are concerned about is a user who has pruned blocks
     // in the past, but is now trying to run unpruned.
     if (chainman.m_blockman.m_have_pruned && !options.prune) {
-        return {ChainstateLoadStatus::FAILURE, _("You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain")};
+        return {util::Error{_("You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain")}, ChainstateLoadError::FAILURE};
     }
 
     // At this point blocktree args are consistent with what's on disk.
@@ -63,7 +68,7 @@ static ChainstateLoadResult CompleteChainstateInitialization(
     // (otherwise we use the one already on disk).
     // This is called again in ImportBlocks after the reindex completes.
     if (chainman.m_blockman.m_blockfiles_indexed && !chainman.LoadGenesisBlock()) {
-        return {ChainstateLoadStatus::FAILURE, _("Error initializing block database")};
+        return {util::Error{_("Error initializing block database")}, ChainstateLoadError::FAILURE};
     }
 
     auto is_coinsview_empty = [&](Chainstate& chainstate) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
@@ -93,7 +98,7 @@ static ChainstateLoadResult CompleteChainstateInitialization(
                 /*should_wipe=*/options.wipe_chainstate_db);
         } catch (dbwrapper_error& err) {
             LogError("%s\n", err.what());
-            return {ChainstateLoadStatus::FAILURE, _("Error opening coins database")};
+            return {util::Error{_("Error opening coins database")}, ChainstateLoadError::FAILURE};
         }
 
         if (options.coins_error_cb) {
@@ -103,14 +108,15 @@ static ChainstateLoadResult CompleteChainstateInitialization(
         // Refuse to load unsupported database format.
         // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
         if (chainstate->CoinsDB().NeedsUpgrade()) {
-            return {ChainstateLoadStatus::FAILURE_INCOMPATIBLE_DB, _("Unsupported chainstate database format found. "
-                                                                     "Please restart with -reindex-chainstate. This will "
-                                                                     "rebuild the chainstate database.")};
+            return {util::Error{_("Unsupported chainstate database format found. "
+                                         "Please restart with -reindex-chainstate. This will "
+                                         "rebuild the chainstate database.")},
+                                       ChainstateLoadError::FAILURE_INCOMPATIBLE_DB};
         }
 
         // ReplayBlocks is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
         if (!chainstate->ReplayBlocks()) {
-            return {ChainstateLoadStatus::FAILURE, _("Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.")};
+            return {util::Error{_("Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.")}, ChainstateLoadError::FAILURE};
         }
 
         // The on-disk coinsdb is now in a good state, create the cache
@@ -120,7 +126,7 @@ static ChainstateLoadResult CompleteChainstateInitialization(
         if (!is_coinsview_empty(*chainstate)) {
             // LoadChainTip initializes the chain based on CoinsTip()'s best block
             if (!chainstate->LoadChainTip()) {
-                return {ChainstateLoadStatus::FAILURE, _("Error initializing block database")};
+                return {util::Error{_("Error initializing block database")}, ChainstateLoadError::FAILURE};
             }
             assert(chainstate->m_chain.Tip() != nullptr);
         }
@@ -136,8 +142,8 @@ static ChainstateLoadResult CompleteChainstateInitialization(
     const auto& chainstates{chainman.m_chainstates};
     if (std::any_of(chainstates.begin(), chainstates.end(),
                     [](const auto& cs) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return cs->NeedsRedownload(); })) {
-        return {ChainstateLoadStatus::FAILURE, strprintf(_("Witness data for blocks after height %d requires validation. Please restart with -reindex."),
-                                                         chainman.GetConsensus().SegwitHeight)};
+        return {util::Error{strprintf(_("Witness data for blocks after height %d requires validation. Please restart with -reindex."),
+                                      chainman.GetConsensus().SegwitHeight)}, ChainstateLoadError::FAILURE};
     };
 
     // Now that chainstates are loaded and we're able to flush to
@@ -145,12 +151,13 @@ static ChainstateLoadResult CompleteChainstateInitialization(
     // on the condition of each chainstate.
     chainman.MaybeRebalanceCaches();
 
-    return {ChainstateLoadStatus::SUCCESS, {}};
+    return {};
 }
 
-ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,
-                                    const ChainstateLoadOptions& options)
+util::Result<InterruptResult, ChainstateLoadError> LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,
+                                                                  const ChainstateLoadOptions& options)
 {
+    util::Result<InterruptResult, ChainstateLoadError> result;
     if (!chainman.AssumedValidBlock().IsNull()) {
         LogInfo("Assuming ancestors of block %s have valid signatures.", chainman.AssumedValidBlock().GetHex());
     } else {
@@ -183,14 +190,15 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
         validated_cs.SetTargetBlock(nullptr);
         LogInfo("[snapshot] deleting snapshot chainstate due to reindexing");
         if (!chainman.DeleteChainstate(*assumeutxo_cs)) {
-            return {ChainstateLoadStatus::FAILURE_FATAL, Untranslated("Couldn't remove snapshot chainstate.")};
+            result.update({util::Error{Untranslated("Couldn't remove snapshot chainstate.")}, ChainstateLoadError::FAILURE_FATAL});
+            return result;
         }
         assumeutxo_cs = nullptr;
     }
 
-    auto [init_status, init_error] = CompleteChainstateInitialization(chainman, options);
-    if (init_status != ChainstateLoadStatus::SUCCESS) {
-        return {init_status, init_error};
+    result.update(CompleteChainstateInitialization(chainman, options));
+    if (!result || IsInterrupted(*result)) {
+        return result;
     }
 
     // If a snapshot chainstate was fully validated by a background chainstate during
@@ -210,7 +218,8 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
     } else if (snapshot_completion == SnapshotCompletionResult::SUCCESS) {
         LogInfo("[snapshot] cleaning up unneeded background chainstate, then reinitializing");
         if (!chainman.ValidatedSnapshotCleanup(validated_cs, *assumeutxo_cs)) {
-            return {ChainstateLoadStatus::FAILURE_FATAL, Untranslated("Background chainstate cleanup failed unexpectedly.")};
+            result.update({util::Error{Untranslated("Background chainstate cleanup failed unexpectedly.")}, ChainstateLoadError::FAILURE_FATAL});
+            return result;
         }
 
         // Because ValidatedSnapshotCleanup() has torn down chainstates with
@@ -224,20 +233,22 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
         // for the fully validated chainstate.
         chainman.ActiveChainstate().ClearBlockIndexCandidates();
 
-        auto [init_status, init_error] = CompleteChainstateInitialization(chainman, options);
-        if (init_status != ChainstateLoadStatus::SUCCESS) {
-            return {init_status, init_error};
+        auto result{CompleteChainstateInitialization(chainman, options)};
+        if (!result || IsInterrupted(*result)) {
+            return result;
         }
     } else {
-        return {ChainstateLoadStatus::FAILURE_FATAL, _(
+        result.update({util::Error{_(
            "UTXO snapshot failed to validate. "
-           "Restart to resume normal initial block download, or try loading a different snapshot.")};
+           "Restart to resume normal initial block download, or try loading a different snapshot.")},
+           ChainstateLoadError::FAILURE_FATAL});
+        return result;
     }
 
-    return {ChainstateLoadStatus::SUCCESS, {}};
+    return result;
 }
 
-ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options)
+util::Result<InterruptResult, ChainstateLoadError> VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options)
 {
     auto is_coinsview_empty = [&](Chainstate& chainstate) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
         return options.wipe_chainstate_db || chainstate.CoinsTip().GetBestBlock().IsNull();
@@ -245,36 +256,42 @@ ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const C
 
     LOCK(cs_main);
 
+    util::Result<InterruptResult, ChainstateLoadError> result;
     for (auto& chainstate : chainman.m_chainstates) {
         if (!is_coinsview_empty(*chainstate)) {
             const CBlockIndex* tip = chainstate->m_chain.Tip();
             if (tip && tip->nTime > GetTime() + MAX_FUTURE_BLOCK_TIME) {
-                return {ChainstateLoadStatus::FAILURE, _("The block database contains a block which appears to be from the future. "
-                                                         "This may be due to your computer's date and time being set incorrectly. "
-                                                         "Only rebuild the block database if you are sure that your computer's date and time are correct")};
+                result.update({util::Error{_("The block database contains a block which appears to be from the future. "
+                                             "This may be due to your computer's date and time being set incorrectly. "
+                                             "Only rebuild the block database if you are sure that your computer's date and time are correct")},
+                               ChainstateLoadError::FAILURE});
+                return result;
             }
 
-            VerifyDBResult result = CVerifyDB(chainman.GetNotifications()).VerifyDB(
+            VerifyDBResult verify_result = CVerifyDB(chainman.GetNotifications()).VerifyDB(
                 *chainstate, chainman.GetConsensus(), chainstate->CoinsDB(),
                 options.check_level,
                 options.check_blocks);
-            switch (result) {
+            switch (verify_result) {
             case VerifyDBResult::SUCCESS:
             case VerifyDBResult::SKIPPED_MISSING_BLOCKS:
                 break;
             case VerifyDBResult::INTERRUPTED:
-                return {ChainstateLoadStatus::INTERRUPTED, _("Block verification was interrupted")};
+                result.update(Interrupted{});
+                return result;
             case VerifyDBResult::CORRUPTED_BLOCK_DB:
-                return {ChainstateLoadStatus::FAILURE, _("Corrupted block database detected")};
+                result.update({util::Error{_("Corrupted block database detected")}, ChainstateLoadError::FAILURE});
+                return result;
             case VerifyDBResult::SKIPPED_L3_CHECKS:
                 if (options.require_full_verification) {
-                    return {ChainstateLoadStatus::FAILURE_INSUFFICIENT_DBCACHE, _("Insufficient dbcache for block verification")};
+                    result.update({util::Error{_("Insufficient dbcache for block verification")}, ChainstateLoadError::FAILURE_INSUFFICIENT_DBCACHE});
+                    return result;
                 }
                 break;
             } // no default case, so the compiler can warn about missing cases
         }
     }
 
-    return {ChainstateLoadStatus::SUCCESS, {}};
+    return result;
 }
 } // namespace node

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_NODE_CHAINSTATE_H
 #define BITCOIN_NODE_CHAINSTATE_H
 
+#include <kernel/notifications_interface.h>
+#include <util/result.h>
 #include <util/translation.h>
 #include <validation.h>
 
@@ -41,34 +43,16 @@ struct ChainstateLoadOptions {
 //! case, and treat other cases as errors. More complex applications may want to
 //! try reindexing in the generic failure case, and pass an interrupt callback
 //! and exit cleanly in the interrupted case.
-enum class ChainstateLoadStatus {
-    SUCCESS,
+enum class ChainstateLoadError {
     FAILURE, //!< Generic failure which reindexing may fix
     FAILURE_FATAL, //!< Fatal error which should not prompt to reindex
     FAILURE_INCOMPATIBLE_DB,
     FAILURE_INSUFFICIENT_DBCACHE,
-    INTERRUPTED,
 };
 
-//! Chainstate load status code and optional error string.
-using ChainstateLoadResult = std::tuple<ChainstateLoadStatus, bilingual_str>;
-
-/** This sequence can have 4 types of outcomes:
- *
- *  1. Success
- *  2. Shutdown requested
- *    - nothing failed but a shutdown was triggered in the middle of the
- *      sequence
- *  3. Soft failure
- *    - a failure that might be recovered from with a reindex
- *  4. Hard failure
- *    - a failure that definitively cannot be recovered from with a reindex
- *
- *  LoadChainstate returns a (status code, error string) tuple.
- */
-ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const kernel::CacheSizes& cache_sizes,
-                                    const ChainstateLoadOptions& options);
-ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options);
+util::Result<kernel::InterruptResult, ChainstateLoadError> LoadChainstate(ChainstateManager& chainman, const kernel::CacheSizes& cache_sizes,
+                                                                          const ChainstateLoadOptions& options);
+util::Result<kernel::InterruptResult, ChainstateLoadError> VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options);
 } // namespace node
 
 #endif // BITCOIN_NODE_CHAINSTATE_H

--- a/src/test/result_tests.cpp
+++ b/src/test/result_tests.cpp
@@ -182,6 +182,12 @@ void ExpectError(const util::Result<T, F>& result, bilingual_str str, Args&&... 
     BOOST_CHECK_EQUAL(result.error(), expect_error);
 }
 
+BOOST_AUTO_TEST_CASE(check_sizes)
+{
+    static_assert(sizeof(util::Result<int>) == sizeof(void*)*2);
+    static_assert(sizeof(util::Result<void>) == sizeof(void*));
+}
+
 BOOST_AUTO_TEST_CASE(check_returned)
 {
     ExpectResult(VoidSuccessFn(), true, {});

--- a/src/test/result_tests.cpp
+++ b/src/test/result_tests.cpp
@@ -149,6 +149,26 @@ BOOST_AUTO_TEST_CASE(check_returned)
     ExpectError(TruthyFalsyFn(1, false), Untranslated("error value 1."), 1);
 }
 
+BOOST_AUTO_TEST_CASE(check_update)
+{
+    // Test using Update method to change a result value from success -> error,
+    // and error->success.
+    util::Result<int, FnError> result;
+    ExpectSuccess(result, {}, 0);
+    result.update({util::Error{Untranslated("error")}, ERR1});
+    ExpectError(result, Untranslated("error"), ERR1);
+    result.update(2);
+    ExpectSuccess(result, Untranslated(""), 2);
+
+    // Test the same thing but with non-copyable success and error types.
+    util::Result<NoCopy, NoCopy> result2{0};
+    ExpectSuccess(result2, {}, 0);
+    result2.update({util::Error{Untranslated("error")}, 3});
+    ExpectError(result2, Untranslated("error"), 3);
+    result2.update(4);
+    ExpectSuccess(result2, Untranslated(""), 4);
+}
+
 BOOST_AUTO_TEST_CASE(check_dereference_operators)
 {
     util::Result<std::pair<int, std::string>> mutable_result;

--- a/src/test/result_tests.cpp
+++ b/src/test/result_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <util/result.h>
 
 #include <boost/test/unit_test.hpp>
@@ -33,6 +34,34 @@ std::ostream& operator<<(std::ostream& os, const NoCopy& o)
     return os << "NoCopy(" << *o.m_n << ")";
 }
 
+struct NoCopyNoMove {
+    NoCopyNoMove(int n) : m_n{n} {}
+    NoCopyNoMove(const NoCopyNoMove&) = delete;
+    NoCopyNoMove(NoCopyNoMove&&) = delete;
+    int m_n;
+};
+
+bool operator==(const NoCopyNoMove& a, const NoCopyNoMove& b)
+{
+    return a.m_n == b.m_n;
+}
+
+std::ostream& operator<<(std::ostream& os, const NoCopyNoMove& o)
+{
+    os << "NoCopyNoMove(" << o.m_n << ")";
+    return os;
+}
+
+util::Result<void> VoidSuccessFn()
+{
+    return {};
+}
+
+util::Result<void> VoidErrorFn()
+{
+    return util::Error{Untranslated("void error.")};
+}
+
 util::Result<int> IntFn(int i, bool success)
 {
     if (success) return i;
@@ -45,21 +74,46 @@ util::Result<bilingual_str> StrFn(bilingual_str s, bool success)
     return util::Error{Untranslated(strprintf("str %s error.", s.original))};
 }
 
-util::Result<NoCopy> NoCopyFn(int i, bool success)
+util::Result<NoCopy, NoCopy> NoCopyFn(int i, bool success)
 {
     if (success) return {i};
-    return util::Error{Untranslated(strprintf("nocopy %i error.", i))};
+    return {util::Error{Untranslated(strprintf("nocopy %i error.", i))}, i};
 }
 
-template <typename T>
-void ExpectResult(const util::Result<T>& result, bool success, const bilingual_str& str)
+util::Result<NoCopyNoMove, NoCopyNoMove> NoCopyNoMoveFn(int i, bool success)
+{
+    if (success) return {i};
+    return {util::Error{Untranslated(strprintf("nocopynomove %i error.", i))}, i};
+}
+
+enum FnError { ERR1, ERR2 };
+
+util::Result<int, FnError> IntErrorFn(int i, bool success)
+{
+    if (success) return i;
+    return {util::Error{Untranslated(strprintf("int %i error.", i))}, i % 2 ? ERR1 : ERR2};
+}
+
+util::Result<NoCopyNoMove, FnError> EnumErrorFn(FnError ret)
+{
+    return {util::Error{Untranslated("enum error.")}, ret};
+}
+
+util::Result<int, int> TruthyFalsyFn(int i, bool success)
+{
+    if (success) return i;
+    return {util::Error{Untranslated(strprintf("error value %i.", i))}, i};
+}
+
+template <typename T, typename F>
+void ExpectResult(const util::Result<T, F>& result, bool success, const bilingual_str& str)
 {
     BOOST_CHECK_EQUAL(bool(result), success);
     BOOST_CHECK_EQUAL(util::ErrorString(result), str);
 }
 
-template <typename T, typename... Args>
-void ExpectSuccess(const util::Result<T>& result, const bilingual_str& str, Args&&... args)
+template <typename T, typename F, typename... Args>
+void ExpectSuccess(const util::Result<T, F>& result, const bilingual_str& str, Args&&... args)
 {
     ExpectResult(result, true, str);
     BOOST_CHECK_EQUAL(result.has_value(), true);
@@ -68,20 +122,42 @@ void ExpectSuccess(const util::Result<T>& result, const bilingual_str& str, Args
     BOOST_CHECK_EQUAL(&result.value(), &*result);
 }
 
-template <typename T, typename... Args>
-void ExpectFail(const util::Result<T>& result, const bilingual_str& str)
+template <typename T, typename F, typename... Args>
+void ExpectError(const util::Result<T, F>& result, bilingual_str str, Args&&... args)
 {
     ExpectResult(result, false, str);
+    F expect_error{std::forward<Args>(args)...};
+    BOOST_CHECK_EQUAL(result.error(), expect_error);
 }
 
 BOOST_AUTO_TEST_CASE(check_returned)
 {
+    ExpectResult(VoidSuccessFn(), true, {});
+    ExpectResult(VoidErrorFn(), false, Untranslated("void error."));
     ExpectSuccess(IntFn(5, true), {}, 5);
-    ExpectFail(IntFn(5, false), Untranslated("int 5 error."));
+    ExpectResult(IntFn(5, false), false, Untranslated("int 5 error."));
     ExpectSuccess(NoCopyFn(5, true), {}, 5);
-    ExpectFail(NoCopyFn(5, false), Untranslated("nocopy 5 error."));
+    ExpectError(NoCopyFn(5, false), Untranslated("nocopy 5 error."), 5);
+    ExpectSuccess(NoCopyNoMoveFn(5, true), {}, 5);
+    ExpectError(NoCopyNoMoveFn(5, false), Untranslated("nocopynomove 5 error."), 5);
     ExpectSuccess(StrFn(Untranslated("S"), true), {}, Untranslated("S"));
-    ExpectFail(StrFn(Untranslated("S"), false), Untranslated("str S error."));
+    ExpectResult(StrFn(Untranslated("S"), false), false, Untranslated("str S error."));
+    ExpectError(EnumErrorFn(ERR2), Untranslated("enum error."), ERR2);
+    ExpectSuccess(TruthyFalsyFn(0, true), {}, 0);
+    ExpectError(TruthyFalsyFn(0, false), Untranslated("error value 0."), 0);
+    ExpectSuccess(TruthyFalsyFn(1, true), {}, 1);
+    ExpectError(TruthyFalsyFn(1, false), Untranslated("error value 1."), 1);
+}
+
+BOOST_AUTO_TEST_CASE(check_dereference_operators)
+{
+    util::Result<std::pair<int, std::string>> mutable_result;
+    const auto& const_result{mutable_result};
+    mutable_result.value() = {1, "23"};
+    BOOST_CHECK_EQUAL(mutable_result->first, 1);
+    BOOST_CHECK_EQUAL(const_result->second, "23");
+    (*mutable_result).first = 5;
+    BOOST_CHECK_EQUAL((*const_result).first, 5);
 }
 
 BOOST_AUTO_TEST_CASE(check_value_or)
@@ -92,6 +168,20 @@ BOOST_AUTO_TEST_CASE(check_value_or)
     BOOST_CHECK_EQUAL(NoCopyFn(10, false).value_or(20), 20);
     BOOST_CHECK_EQUAL(StrFn(Untranslated("A"), true).value_or(Untranslated("B")), Untranslated("A"));
     BOOST_CHECK_EQUAL(StrFn(Untranslated("A"), false).value_or(Untranslated("B")), Untranslated("B"));
+}
+
+struct Derived : NoCopyNoMove {
+    using NoCopyNoMove::NoCopyNoMove;
+};
+
+util::Result<std::unique_ptr<NoCopyNoMove>> DerivedToBaseFn(util::Result<std::unique_ptr<Derived>> derived)
+{
+    return derived;
+}
+
+BOOST_AUTO_TEST_CASE(derived_to_base)
+{
+    BOOST_CHECK_EQUAL(*Assert(*Assert(DerivedToBaseFn(std::make_unique<Derived>(5)))), 5);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -359,11 +359,11 @@ void ChainTestingSetup::LoadVerifyActivateChainstate()
     options.check_blocks = m_args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS);
     options.check_level = m_args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL);
     options.require_full_verification = m_args.IsArgSet("-checkblocks") || m_args.IsArgSet("-checklevel");
-    auto [status, error] = LoadChainstate(chainman, m_kernel_cache_sizes, options);
-    assert(status == node::ChainstateLoadStatus::SUCCESS);
+    auto load_result{LoadChainstate(chainman, m_kernel_cache_sizes, options)};
+    Assert(load_result);
 
-    std::tie(status, error) = VerifyLoadedChainstate(chainman, options);
-    assert(status == node::ChainstateLoadStatus::SUCCESS);
+    auto verify_result{VerifyLoadedChainstate(chainman, options)};
+    Assert(verify_result);
 
     m_node.notifications->setChainstateLoaded(true);
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -357,11 +357,11 @@ void ChainTestingSetup::LoadVerifyActivateChainstate()
     options.check_blocks = m_args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS);
     options.check_level = m_args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL);
     options.require_full_verification = m_args.IsArgSet("-checkblocks") || m_args.IsArgSet("-checklevel");
-    auto [status, error] = LoadChainstate(chainman, m_kernel_cache_sizes, options);
-    assert(status == node::ChainstateLoadStatus::SUCCESS);
+    auto load_result{LoadChainstate(chainman, m_kernel_cache_sizes, options)};
+    Assert(load_result);
 
-    std::tie(status, error) = VerifyLoadedChainstate(chainman, options);
-    assert(status == node::ChainstateLoadStatus::SUCCESS);
+    auto verify_result{VerifyLoadedChainstate(chainman, options)};
+    Assert(verify_result);
 
     m_node.notifications->setChainstateLoaded(true);
 

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
   fs.cpp
   fs_helpers.cpp
   hasher.cpp
+  messages.cpp
   moneystr.cpp
   rbf.cpp
   readwritefile.cpp

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
   fs.cpp
   fs_helpers.cpp
   hasher.cpp
+  messages.cpp
   moneystr.cpp
   rbf.cpp
   readwritefile.cpp

--- a/src/util/messages.cpp
+++ b/src/util/messages.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit
+
+#include <initializer_list>
+#include <iterator>
+#include <util/messages.h>
+#include <util/translation.h>
+
+namespace util {
+bilingual_str JoinMessages(const Messages& messages)
+{
+    bilingual_str result;
+    for (const auto& messages : {messages.errors, messages.warnings}) {
+        for (const auto& message : messages) {
+            if (!result.empty()) result += Untranslated(" ");
+            result += message;
+        }
+    }
+    return result;
+}
+
+void MoveMessages(Messages& dst, Messages& src)
+{
+    dst.errors.insert(dst.errors.end(), std::make_move_iterator(src.errors.begin()), std::make_move_iterator(src.errors.end()));
+    dst.warnings.insert(dst.warnings.end(), std::make_move_iterator(src.warnings.begin()), std::make_move_iterator(src.warnings.end()));
+    src.errors.clear();
+    src.warnings.clear();
+}
+} // namespace util

--- a/src/util/messages.h
+++ b/src/util/messages.h
@@ -1,0 +1,53 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit
+
+//! @file util/messages.h defines helper function and types that can be used
+//! with the util::Result class to deal with error and warning messages. It
+//! keeps the message representation separate from the implementation of the
+//! Result class, allowing each to be understood and changed more easily.
+
+#ifndef BITCOIN_UTIL_MESSAGES_H
+#define BITCOIN_UTIL_MESSAGES_H
+
+#include <util/translation.h>
+
+#include <string>
+#include <vector>
+
+namespace util {
+//! Default MessagesType for Result class, simple list of errors and warnings.
+struct Messages {
+    std::vector<bilingual_str> errors{};
+    std::vector<bilingual_str> warnings{};
+};
+
+//! Wrapper object to pass an error string to the Result constructor.
+struct Error {
+    bilingual_str message;
+};
+//! Wrapper object to pass a warning string to the Result constructor.
+struct Warning {
+    bilingual_str message;
+};
+
+//! Helper function to join messages in space separated string.
+bilingual_str JoinMessages(const Messages& messages);
+
+//! Helper function to move messages from one instance to another.
+void MoveMessages(Messages& dst, Messages& src);
+
+//! Join error and warning messages in a space separated string. This is
+//! intended for simple applications where there's probably only one error or
+//! warning message to report, but multiple messages should not be lost if they
+//! are present. More complicated applications should use Result::messages_ptr()
+//! method directly.
+template <typename Result>
+bilingual_str ErrorString(const Result& result)
+{
+    const auto* messages{result.messages_ptr()};
+    return messages ? JoinMessages(*messages) : bilingual_str{};
+}
+} // namespace util
+
+#endif // BITCOIN_UTIL_MESSAGES_H

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -65,7 +65,7 @@ namespace util {
 //!    return result;
 //!
 //! It also provides an update() method which is useful for returning early on
-//! failures and for combining results of the same type.
+//! errors and for combining results of the same type.
 //!
 //!    Result<Value> result;
 //!    if (!(DoSomething() >> result)) {

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -8,7 +8,13 @@
 #include <attributes.h>
 #include <util/translation.h>
 
-#include <variant>
+#include <cassert>
+#include <memory>
+#include <new>
+#include <optional>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 namespace util {
 
@@ -16,31 +22,159 @@ struct Error {
     bilingual_str message;
 };
 
-//! The util::Result class provides a standard way for functions to return
-//! either error messages or result values.
+//! The Result<SuccessType, ErrorType, MessagesType> class provides
+//! an efficient way for functions to return structured result information, as
+//! well as descriptive error messages.
 //!
-//! It is intended for high-level functions that need to report error strings to
-//! end users. Lower-level functions that don't need this error-reporting and
-//! that only need error-handling should avoid util::Result and instead use
-//! util::Expected, std::optional, std::variant, or custom structs
-//! and enum types to return function results.
+//! Logically, a result object is equivalent to:
 //!
-//! Usage examples can be found in \example ../test/result_tests.cpp, but in
-//! general code returning `util::Result<T>` values is very similar to code
-//! returning `std::optional<T>` values. Existing functions returning
-//! `std::optional<T>` can be updated to return `util::Result<T>` and return
-//! error strings usually just replacing `return std::nullopt;` with `return
-//! util::Error{error_string};`.
-template <class M>
-class Result
+//!     tuple<variant<SuccessType, ErrorType>, MessagesType>
+//!
+//! But the physical representation is more efficient because it avoids
+//! allocating memory for ErrorType and MessagesType fields unless there is an
+//! error.
+//!
+//! Result<SuccessType> objects support the same operators as
+//! std::optional<SuccessType>, such as !result, *result, result->member, to
+//! make SuccessType values easy to access. They also provide
+//! result.error() and result.messages() methods to
+//! access other parts of the result. A simple usage example is:
+//!
+//!    Result<int> AddNumbers(int a, int b)
+//!    {
+//!        if (b == 0) return util::Error{_("Not adding 0, that's dumb.")};
+//!        return a + b;
+//!    }
+//!
+//!    void TryAddNumbers(int a, int b)
+//!    {
+//!        if (auto result = AddNumbers(a, b)) {
+//!            LogInfo("%i + %i = %i\n", a, b, *result);
+//!        } else {
+//!            LogInfo("Error: %s\n", util::ErrorString(result).translated);
+//!        }
+//!    }
+//!
+//! The `Result` class is superset of `std::expected`, providing additional
+//! features for combining results from different functions and returning error
+//! messages for users instead of just error values for callers.
+template <typename SuccessType = void, typename ErrorType = void, typename MessagesType = bilingual_str>
+class Result;
+
+//! Traits class that can be specialized to control the way result types are
+//! combined and constructed. Specializations provide a construct() method to be
+//! accepted as special arguments to the Result constructor, and a
+//! construct_error bool member indicating whether to construct error values
+//! instead of success values on use.
+template<typename T>
+struct ResultTraits {};
+
+namespace detail {
+//! Substitute for std::monostate that doesn't depend on std::variant.
+struct Monostate{};
+
+//! Container for ErrorType and MessagesType, providing public operator
+//! bool(), error(), messages_ptr(), and messages() methods.
+template <typename ErrorType, typename MessagesType>
+class FailDataHolder
 {
-private:
-    using T = std::conditional_t<std::is_same_v<M, void>, std::monostate, M>;
+protected:
+    struct FailData {
+        std::optional<std::conditional_t<std::is_same_v<ErrorType, void>, Monostate, ErrorType>> error{};
+        MessagesType messages{};
+    };
+    std::unique_ptr<FailData> m_fail_data;
 
-    std::variant<bilingual_str, T> m_variant;
+    // Private accessor, create FailData if it doesn't exist.
+    FailData& fail_data() LIFETIMEBOUND
+    {
+        if (!m_fail_data) m_fail_data = std::make_unique<FailData>();
+        return *m_fail_data;
+    }
 
-    //! Disallow copy constructor, require Result to be moved for efficiency.
-    Result(const Result&) = delete;
+public:
+    // Public accessors.
+    explicit operator bool() const { return !m_fail_data || !m_fail_data->error; }
+    const auto& error() const LIFETIMEBOUND { assert(!*this); return *m_fail_data->error; }
+    auto& error() LIFETIMEBOUND { assert(!*this); return *m_fail_data->error; }
+    const auto* messages_ptr() const LIFETIMEBOUND { return m_fail_data ? &m_fail_data->messages : nullptr; }
+    auto* messages_ptr() LIFETIMEBOUND { return m_fail_data ? &m_fail_data->messages : nullptr; }
+    auto& messages() LIFETIMEBOUND { return fail_data().messages; }
+};
+
+//! Container for SuccessType, providing public accessor methods similar to
+//! std::optional methods to access the success value. There is a specialization
+//! of this class for the void success type.
+template <typename SuccessType, typename ErrorType, typename MessagesType>
+class SuccessHolder : public FailDataHolder<ErrorType, MessagesType>
+{
+protected:
+    //! Success value embedded in an anonymous union so it doesn't need to be
+    //! constructed if the result is holding a error value,
+    union { SuccessType m_success; };
+
+    //! Empty constructor that needs to be declared because the class contains a union.
+    SuccessHolder() {}
+    ~SuccessHolder() { if (*this) m_success.~SuccessType(); }
+
+public:
+    // Public accessors.
+    bool has_value() const { return bool{*this}; }
+    const SuccessType& value() const LIFETIMEBOUND { assert(has_value()); return m_success; }
+    SuccessType& value() LIFETIMEBOUND { assert(has_value()); return m_success; }
+    template <class U>
+    SuccessType value_or(U&& default_value) const&
+    {
+        return has_value() ? value() : std::forward<U>(default_value);
+    }
+    template <class U>
+    SuccessType value_or(U&& default_value) &&
+    {
+        return has_value() ? std::move(value()) : std::forward<U>(default_value);
+    }
+    const SuccessType* operator->() const LIFETIMEBOUND { return &value(); }
+    const SuccessType& operator*() const LIFETIMEBOUND { return value(); }
+    SuccessType* operator->() LIFETIMEBOUND { return &value(); }
+    SuccessType& operator*() LIFETIMEBOUND { return value(); }
+};
+
+//! Specialization of SuccessHolder when SuccessType is void.
+template <typename ErrorType, typename MessagesType>
+class SuccessHolder<void, ErrorType, MessagesType> : public FailDataHolder<ErrorType, MessagesType>
+{
+};
+//! @}
+} // namespace detail
+
+// Result type class, documented at the top of this file.
+template <typename SuccessType_, typename ErrorType_, typename MessagesType_>
+class Result : public detail::SuccessHolder<SuccessType_, ErrorType_, MessagesType_>
+{
+public:
+    using SuccessType = SuccessType_;
+    using ErrorType = ErrorType_;
+    using MessagesType = MessagesType_;
+    static constexpr bool is_result{true};
+
+    //! Construct a Result object setting a success or error value. Initial
+    //! special arguments with ResultTraits::construct methods are processed
+    //! first, and then remaining arguments are passed to the SuccessType
+    //! constructor if this is a successful result or to the FailType
+    //! constructor otherwise.
+    template <typename... Args>
+    Result(Args&&... args)
+    {
+        construct</*Error=*/false>(*this, std::forward<Args>(args)...);
+    }
+
+    //! Move-construct a Result object from another Result object, moving the
+    //! success or error value and messages.
+    template <typename O>
+    requires (std::decay_t<O>::is_result)
+    Result(O&& other)
+    {
+        move(*this, other);
+    }
 
     //! Disallow operator= to avoid confusion in the future when the Result
     //! class gains support for richer error reporting, and callers should have
@@ -49,50 +183,96 @@ private:
     Result& operator=(const Result&) = delete;
     Result& operator=(Result&&) = delete;
 
-    template <typename FT>
-    friend bilingual_str ErrorString(const Result<FT>& result);
+protected:
+    template <typename, typename, typename>
+    friend class Result;
 
-public:
-    Result() : m_variant{std::in_place_index_t<1>{}, std::monostate{}} {}  // constructor for void
-    Result(T obj) : m_variant{std::in_place_index_t<1>{}, std::move(obj)} {}
-    Result(Error error) : m_variant{std::in_place_index_t<0>{}, std::move(error.message)} {}
-    Result(Result&&) = default;
-    ~Result() = default;
+    //! Helper function to construct a new success or error value using the
+    //! arguments provided.
+    template <bool Error, typename Result, typename... Args>
+    static void construct(Result& result, Args&&... args)
+    {
+        if constexpr (Error) {
+            static_assert(sizeof...(args) > 0 || !std::is_scalar_v<ErrorType>,
+                "Refusing to default-construct error value with int, float, enum, or pointer type, please specify an explicit error value.");
+            result.fail_data().error.emplace(std::forward<Args>(args)...);
+        } else if constexpr (std::is_same_v<typename Result::SuccessType, void>) {
+            static_assert(sizeof...(args) == 0, "Error: Arguments cannot be passed to a Result<void> constructor.");
+        } else {
+            new (&result.m_success) typename Result::SuccessType{std::forward<Args>(args)...};
+        }
+    }
 
-    //! std::optional methods, so functions returning optional<T> can change to
-    //! return Result<T> with minimal changes to existing code, and vice versa.
-    bool has_value() const noexcept { return m_variant.index() == 1; }
-    const T& value() const LIFETIMEBOUND
+    //! Overload for construct() for special arguments with
+    //! ResultTraits::construct method defined.
+    template <bool Error, typename Result, typename T, typename... Args>
+    requires requires { ResultTraits<std::decay_t<T>>::construct(std::declval<Result&>(), std::declval<T&&>()); }
+    static void construct(Result& result, T&& arg, Args&&... args)
     {
-        assert(has_value());
-        return std::get<1>(m_variant);
+        using Traits = ResultTraits<std::decay_t<T>>;
+        constexpr bool construct_error{Error || []{
+            if constexpr (requires { Traits::construct_error; }) return Traits::construct_error;
+            return false;
+        }()};
+        Traits::construct(result, std::forward<T>(arg));
+        construct<construct_error>(result, std::forward<Args>(args)...);
     }
-    T& value() LIFETIMEBOUND
+
+    //! Move success, error, and message values from source Result object to
+    //! destination object.
+    //! The source and destination results are not required to have the same
+    //! types, and assigning void source types to non-void destinations type is
+    //! allowed, since no source information is lost. But assigning non-void
+    //! source types to void destination types is not allowed, since this would
+    //! discard source information.
+    template <typename DstResult, typename SrcResult>
+    static void move(DstResult& dst, SrcResult& src)
     {
-        assert(has_value());
-        return std::get<1>(m_variant);
+        // Move messages values first, then move success or error value below.
+        if (src.messages_ptr() && !src.messages_ptr()->empty()) {
+            dst.messages() = std::move(*src.messages_ptr());
+        }
+        // At this point dst has no success or error value set. Can assert
+        // there is no error value.
+        assert(dst);
+        if (src) {
+            // src has a success value, so move it to dst. If the src success
+            // type is void and the dst success type is non-void, just
+            // initialize the dst success value by default initialization.
+            if constexpr (!std::is_same_v<typename SrcResult::SuccessType, void>) {
+               new (&dst.m_success) typename DstResult::SuccessType{std::move(src.m_success)};
+            } else if constexpr (!std::is_same_v<typename DstResult::SuccessType, void>) {
+               new (&dst.m_success) typename DstResult::SuccessType{};
+            }
+        } else {
+            // src has a error value, so move it to dst. If the src error
+            // type is void, just initialize the dst error value by default
+            // initialization.
+            if constexpr (!std::is_same_v<typename SrcResult::ErrorType, void>) {
+                dst.fail_data().error.emplace(std::move(src.error()));
+            } else {
+                dst.fail_data().error.emplace();
+            }
+        }
     }
-    template <class U>
-    T value_or(U&& default_value) const&
-    {
-        return has_value() ? value() : std::forward<U>(default_value);
-    }
-    template <class U>
-    T value_or(U&& default_value) &&
-    {
-        return has_value() ? std::move(value()) : std::forward<U>(default_value);
-    }
-    explicit operator bool() const noexcept { return has_value(); }
-    const T* operator->() const LIFETIMEBOUND { return &value(); }
-    const T& operator*() const LIFETIMEBOUND { return value(); }
-    T* operator->() LIFETIMEBOUND { return &value(); }
-    T& operator*() LIFETIMEBOUND { return value(); }
 };
 
-template <typename T>
-bilingual_str ErrorString(const Result<T>& result)
+//! ResultTraits specialization for Error struct.
+template<>
+struct ResultTraits<Error> {
+    static constexpr bool construct_error{true};
+
+    template<typename ResultType>
+    static void construct(ResultType& dst, Error&& src)
+    {
+       dst.messages() = std::move(src.message);
+    }
+};
+
+template <typename Result>
+bilingual_str ErrorString(const Result& result)
 {
-    return result ? bilingual_str{} : std::get<0>(result.m_variant);
+    return !result && result.messages_ptr() ? *result.messages_ptr() : bilingual_str{};
 }
 } // namespace util
 

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -6,6 +6,7 @@
 #define BITCOIN_UTIL_RESULT_H
 
 #include <attributes.h>
+#include <util/messages.h> // IWYU pragma: export
 #include <util/translation.h>
 
 #include <cassert>
@@ -17,11 +18,6 @@
 #include <vector>
 
 namespace util {
-
-struct Error {
-    bilingual_str message;
-};
-
 //! The Result<SuccessType, ErrorType, MessagesType> class provides
 //! an efficient way for functions to return structured result information, as
 //! well as descriptive error messages.
@@ -58,18 +54,65 @@ struct Error {
 //! The `Result` class is superset of `std::expected`, providing additional
 //! features for combining results from different functions and returning error
 //! messages for users instead of just error values for callers.
-template <typename SuccessType = void, typename ErrorType = void, typename MessagesType = bilingual_str>
+//!
+//! It provides an >> operator to move messages between results without
+//! affecting success and error values.
+//!
+//!    Result<void> result;
+//!    auto r1 = DoSomething() >> result;
+//!    auto r2 = DoSomethingElse() >> result;
+//!    ...
+//!    return result;
+//!
+//! It also provides an update() method which is useful for returning early on
+//! failures and for combining results of the same type.
+//!
+//!    Result<Value> result;
+//!    if (!(DoSomething() >> result)) {
+//!        result.update(Error{_("DoSomething failed.")});
+//!        return result;
+//!    }
+//!    if (!result.update(DoSomethingElse())) {
+//!        result.update(Error{_("DoSomethingElse failed.")});
+//!        return result;
+//!    }
+//!    result.update(...);
+//!    return result;
+//!
+//! Semantically, the update() method merges state from different results,
+//! appending data instead of overwriting it where possible. This can be
+//! controlled by specializing the `ResultTraits` class below, which is used by
+//! the `ResultUpdate()` function.
+template <typename SuccessType = void, typename ErrorType = void, typename MessagesType = Messages>
 class Result;
 
 //! Traits class that can be specialized to control the way result types are
-//! combined and constructed. Specializations provide a construct() method to be
-//! accepted as special arguments to the Result constructor, and a
-//! construct_error bool member indicating whether to construct error values
-//! instead of success values on use.
+//! combined and constructed. Specializations can provide an update() method
+//! merging information from a source object to a destination object. They can
+//! also define an empty() method to avoid updates if a source object contains
+//! no data. They can also define a construct() method to be accepted as
+//! special arguments to the Result constructor, and a construct_error bool
+//! member indicating whether to construct error values instead of success
+//! values on use.
 template<typename T>
 struct ResultTraits {};
 
 namespace detail {
+//! Helper to use ResultTraits and update dst if src is nonempty.
+template<typename T>
+void ResultUpdate(auto&& dst_fn, T& src)
+{
+    using Traits = ResultTraits<T>;
+    if constexpr (requires { Traits::empty; }) {
+        if (Traits::empty(src)) return;
+    }
+    if constexpr (requires { Traits::update; }) {
+        Traits::update(dst_fn(), std::move(src));
+    } else {
+        dst_fn() = std::move(src);
+    }
+}
+
 //! Substitute for std::monostate that doesn't depend on std::variant.
 struct Monostate{};
 
@@ -176,7 +219,10 @@ public:
         move</*DstConstructed=*/false>(*this, other);
     }
 
-    //! Update this result by moving from another result object.
+    //! Update this result by moving from another result object. Existing
+    //! success, error, and messages values are updated using
+    //! ResultTraits::update calls so state can be combined instead of
+    //! overwritten.
     Result& update(Result&& other) LIFETIMEBOUND
     {
         move</*DstConstructed=*/true>(*this, other);
@@ -184,9 +230,7 @@ public:
     }
 
     //! Disallow operator= and require explicit Result::update() calls to avoid
-    //! confusion in the future when the Result class gains support for richer
-    //! error reporting, and callers should have ability to set a new result
-    //! value without clearing existing error messages.
+    //! accidentally clearing messages when combining results.
     Result& operator=(Result&&) = delete;
 
 protected:
@@ -225,7 +269,9 @@ protected:
     }
 
     //! Move success, error, and message values from source Result object to
-    //! destination object.
+    //! destination object. Existing values are updated using
+    //! ResultTraits::update calls so state can be combined instead of
+    //! overwritten.
     //! The source and destination results are not required to have the same
     //! types, and assigning void source types to non-void destinations type is
     //! allowed, since no source information is lost. But assigning non-void
@@ -234,16 +280,27 @@ protected:
     template <bool DstConstructed, typename DstResult, typename SrcResult>
     static void move(DstResult& dst, SrcResult& src)
     {
-        // Move messages values first, then move success or error value below.
-        if (src.messages_ptr() && !src.messages_ptr()->empty()) {
-            dst.messages() = std::move(*src.messages_ptr());
-        }
+        // Use operator>> to move messages values first, then move
+        // success or error value below.
+        src >> dst;
         // If DstConstructed is true, it means dst has either a success value or
-        // a error value set, which needs to be destroyed and replaced. If
+        // a error value set, which needs to be updated or replaced. If
         // DstConstructed is false, then dst is being constructed now and has no
         // values set.
         if constexpr (DstConstructed) {
-            if (dst) {
+            if (dst && src) {
+                // dst and src both hold success values, so update dst from src and return
+                if constexpr (!std::is_same_v<typename DstResult::SuccessType, void>) {
+                    detail::ResultUpdate([&]()->auto& { return *dst; }, *src);
+                }
+                return;
+            } else if (!dst && !src) {
+                // dst and src both hold error values, so update dst from src and return
+                if constexpr (!std::is_same_v<typename DstResult::ErrorType, void>) {
+                    detail::ResultUpdate([&]()->auto& { return dst.error(); }, src.error());
+                }
+                return;
+            } else if (dst) {
                 // dst has a success value, so destroy it before replacing it with src error value
                 if constexpr (!std::is_same_v<typename DstResult::SuccessType, void>) {
                     using DstSuccess = typename DstResult::SuccessType;
@@ -281,6 +338,33 @@ protected:
     }
 };
 
+//! Move information from a source Result object to a destination object. It
+//! only moves InfoType and MessagesType values without affecting SuccessType or
+//! ErrorType values of either Result object.
+template <typename SrcResult, typename DstResult>
+requires (std::decay_t<SrcResult>::is_result)
+decltype(auto) operator>>(SrcResult&& src LIFETIMEBOUND, DstResult&& dst)
+{
+    using SrcType = std::decay_t<SrcResult>;
+    if (src.messages_ptr()) {
+        detail::ResultUpdate([&]()->auto& { return dst.messages(); }, src.messages());
+    }
+    return static_cast<SrcType&&>(src);
+}
+
+//! ResultTraits specialization for Messages struct.
+template<>
+struct ResultTraits<Messages> {
+    static void update(Messages& dst, Messages&& src)
+    {
+        MoveMessages(dst, src);
+    }
+    static bool empty(const Messages& src)
+    {
+        return src.errors.empty() && src.warnings.empty();
+    }
+};
+
 //! ResultTraits specialization for Error struct.
 template<>
 struct ResultTraits<Error> {
@@ -289,15 +373,19 @@ struct ResultTraits<Error> {
     template<typename ResultType>
     static void construct(ResultType& dst, Error&& src)
     {
-       dst.messages() = std::move(src.message);
+       dst.messages().errors.push_back(std::move(src.message));
     }
 };
 
-template <typename Result>
-bilingual_str ErrorString(const Result& result)
-{
-    return !result && result.messages_ptr() ? *result.messages_ptr() : bilingual_str{};
-}
+//! ResultTraits specialization for Warning struct.
+template<>
+struct ResultTraits<Warning> {
+    template<typename ResultType>
+    static void construct(ResultType& dst, Warning&& src)
+    {
+       dst.messages().warnings.push_back(std::move(src.message));
+    }
+};
 } // namespace util
 
 #endif // BITCOIN_UTIL_RESULT_H

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2948,7 +2948,7 @@ util::Result<fs::path> GetWalletPath(const std::string& name)
     // 2. Path to an existing directory.
     // 3. Path to a symlink to a directory.
     // 4. For backwards compatibility, the name of a data file in -walletdir.
-    const fs::path wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), name_path);
+    fs::path wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), name_path);
     fs::file_type path_type = fs::symlink_status(wallet_path).type();
     if (!(path_type == fs::file_type::not_found || path_type == fs::file_type::directory ||
           (path_type == fs::file_type::symlink && fs::is_directory(wallet_path)) ||

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2431,7 +2431,7 @@ util::Result<void> CWallet::RemoveTxs(std::vector<Txid>& txs_to_remove)
     bool was_txn_committed = RunWithinTxn(GetDatabase(), /*process_desc=*/"remove transactions", [&](WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) {
         util::Result<void> result{RemoveTxs(batch, txs_to_remove)};
         if (!result) str_err = util::ErrorString(result);
-        return result.has_value();
+        return bool{result};
     });
     if (!str_err.empty()) return util::Error{str_err};
     if (!was_txn_committed) return util::Error{_("Error starting/committing db txn for wallet transactions removal process")};

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2439,7 +2439,7 @@ util::Result<void> CWallet::RemoveTxs(std::vector<Txid>& txs_to_remove)
     bool was_txn_committed = RunWithinTxn(GetDatabase(), /*process_desc=*/"remove transactions", [&](WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) {
         util::Result<void> result{RemoveTxs(batch, txs_to_remove)};
         if (!result) str_err = util::ErrorString(result);
-        return result.has_value();
+        return bool{result};
     });
     if (!str_err.empty()) return util::Error{str_err};
     if (!was_txn_committed) return util::Error{_("Error starting/committing db txn for wallet transactions removal process")};

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2956,7 +2956,7 @@ util::Result<fs::path> GetWalletPath(const std::string& name)
     // 2. Path to an existing directory.
     // 3. Path to a symlink to a directory.
     // 4. For backwards compatibility, the name of a data file in -walletdir.
-    const fs::path wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), name_path);
+    fs::path wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), name_path);
     fs::file_type path_type = fs::symlink_status(wallet_path).type();
     if (!(path_type == fs::file_type::not_found || path_type == fs::file_type::directory ||
           (path_type == fs::file_type::symlink && fs::is_directory(wallet_path)) ||


### PR DESCRIPTION
Add `util::Result` support for returning more error information and make use of it in [LoadChainstate method](https://github.com/bitcoin/bitcoin/pull/25665/commits/8a4be9e25490388f68404eae45aef1298001abfa) as an initial application. Followup PRs [#25722](https://github.com/bitcoin/bitcoin/pull/25722) and [#29700](https://github.com/bitcoin/bitcoin/pull/29700) use it more broadly to return errors and warnings from wallet and kernel functions as well.

This change adds two major features to the result class:

- For better error handling, adds the ability to return a value on failure, not just a value on success. This is a key missing feature that makes the result class not useful for functions like `LoadChainstate()` which produce different errors that need to be handled differently [^1].

[^1]: Ability to return error values was actually present in the original implementation of [#25218](https://github.com/bitcoin/bitcoin/pull/25218), but unfortunately removed in later iterations. See [design notes](https://github.com/bitcoin-core/bitcoin-devwiki/wiki/util::Result-design-notes).

- For better error reporting, adds the ability to return warning messages and multiple errors, not just a single error string. This provides a way for functions to report errors and warnings in a standard way, and simplifies interfaces:

    ```diff
    -virtual std::unique_ptr<Wallet> loadWallet(const std::string& name, bilingual_str& error, std::vector<bilingual_str>& warnings) = 0;
    +virtual util::Result<std::unique_ptr<Wallet>> loadWallet(const std::string& name) = 0;
    ```

    ```diff
    -std::unique_ptr<WalletDatabase> MakeDatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error);
    +util::Result<std::unique_ptr<WalletDatabase>, DatabaseError> MakeDatabase(const fs::path& path, const DatabaseOptions& options);
   ```

This change also makes some more minor improvements:

- Smaller type size. `util::Result<int>` is 16 bytes, and `util::Result<void>` is 8 bytes. Previously both were 72 bytes.

- Broader type compatibility. Supports noncopyable and nonmovable success and error types.

### Comparison with `std::expected`

Currently, the `util::Result` class is useful for error reporting—returning translated, user-facing error strings—but not as useful for error handling, where callers need structured failure information to decide how to proceed. By contrast, `std::expected` / `util::Expected` (#34005, #34006) is good for error handling but less helpful for reporting. This PR closes the gap between the two classes.

With this PR, `std::expected` remains a good choice for lower-level functions or simple functions that fail in only a few well-defined ways. Meanwhile,

- `Result` becomes a better choice for operations that can fail in many different ways—loading a wallet, connecting a block, etc.—where callers may want complete error traces, not just low-level errors without context or high-level errors without detail. (Followup [#25722](https://github.com/bitcoin/bitcoin/pull/25722) applies this to wallet-loading functions.) 
- `Result` can also be more useful than `expected` when merging status information from multiple calls. (Followup [#29700](https://github.com/bitcoin/bitcoin/pull/29700) uses this to reliably propagate flush and fatal-error status from validation code that can internally trigger flushes or shutdowns.)
- `Result` may also be a better choice than `std::expected` when returning pointer values. (Followup [#26022](https://github.com/bitcoin/bitcoin/pull/26022) adds a `ResultPtr` specialization that avoids double dereferencing.) 
- `Result` can be more efficient than `std::expected` when failures are rare but failure objects are large, since failure values are heap-allocated.

This PR effectively makes `Result` a superset of `expected`, making the representations compatible and allowing them to be used together.