### PR TITLE
build: Do not export `PKG_CONFIG_{PATH|LIBDIR}` variables

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,16 @@ if test "$PKG_CONFIG" = ""; then
   AC_MSG_ERROR([pkg-config not found])
 fi
 
+# When compiling with depends, the `PKG_CONFIG_PATH` and `PKG_CONFIG_LIBDIR` variables,
+# being set in a `config.site` file, are not exported to let the `--config-cache` option
+# work properly.
+if test -n "$PKG_CONFIG_PATH"; then
+  PKG_CONFIG="env PKG_CONFIG_PATH=$PKG_CONFIG_PATH $PKG_CONFIG"
+fi
+if test -n "$PKG_CONFIG_LIBDIR"; then
+  PKG_CONFIG="env PKG_CONFIG_LIBDIR=$PKG_CONFIG_LIBDIR $PKG_CONFIG"
+fi
+
 BITCOIN_DAEMON_NAME=bitcoind
 BITCOIN_GUI_NAME=bitcoin-qt
 BITCOIN_CLI_NAME=bitcoin-cli

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -84,12 +84,9 @@ fi
 
 PKG_CONFIG="$(which pkg-config) --static"
 
-# These two need to remain exported because pkg-config does not see them
-# otherwise. That means they must be unexported at the end of configure.ac to
-# avoid ruining the cache. Sigh.
-export PKG_CONFIG_PATH="${depends_prefix}/share/pkgconfig:${depends_prefix}/lib/pkgconfig"
+PKG_CONFIG_PATH="${depends_prefix}/share/pkgconfig:${depends_prefix}/lib/pkgconfig"
 if test -z "@allow_host_packages@"; then
-  export PKG_CONFIG_LIBDIR="${depends_prefix}/lib/pkgconfig"
+  PKG_CONFIG_LIBDIR="${depends_prefix}/lib/pkgconfig"
 fi
 
 CPPFLAGS="-I${depends_prefix}/include/ ${CPPFLAGS}"


### PR DESCRIPTION
This is an alternative to bitcoin/bitcoin#25660 with no [drawbacks](https://github.com/bitcoin/bitcoin/pull/25660#issuecomment-1191281587).

Guix builds on `x86_64`:
```
8ac4c1164512d8aa1c4c3e379b5e12d7e91f196dc32decea422ab1edcb51461f  guix-build-b9f06bf05b67/output/aarch64-linux-gnu/SHA256SUMS.part
0e91431387030b7d2a6aba9368fab7fcf15931477b17c06350101bcb32a49217  guix-build-b9f06bf05b67/output/aarch64-linux-gnu/bitcoin-b9f06bf05b67-aarch64-linux-gnu-debug.tar.gz
d36ef4c9230d73d73760bf1533535aa8fd325584b11adb9101cff2097f548b88  guix-build-b9f06bf05b67/output/aarch64-linux-gnu/bitcoin-b9f06bf05b67-aarch64-linux-gnu.tar.gz
280d3c31e755b0e8e58cdcf184435fa6b7b69cf3446651ebfe76f9a632827094  guix-build-b9f06bf05b67/output/arm-linux-gnueabihf/SHA256SUMS.part
c6e7869ca390a8693c0d569ec89ffdcb128692e0e7cae89332adc0bd0663d0f3  guix-build-b9f06bf05b67/output/arm-linux-gnueabihf/bitcoin-b9f06bf05b67-arm-linux-gnueabihf-debug.tar.gz
2b0046e12d675c64a157265e16d014bd476be1c6f487f239cbdb151543790eb9  guix-build-b9f06bf05b67/output/arm-linux-gnueabihf/bitcoin-b9f06bf05b67-arm-linux-gnueabihf.tar.gz
92abf22c6c7e6a72d3018a836a2d3e16d2051af14a0c6add749eca268ddad470  guix-build-b9f06bf05b67/output/arm64-apple-darwin/SHA256SUMS.part
4cb47c5b5a302f0156ff0e998d0cb8103418f5e0f85b8d47d395771187cd8fda  guix-build-b9f06bf05b67/output/arm64-apple-darwin/bitcoin-b9f06bf05b67-arm64-apple-darwin-unsigned.dmg
660dab4a573b60a034f06f95a48563e9ea7d96632818140e578cd3ae972eb640  guix-build-b9f06bf05b67/output/arm64-apple-darwin/bitcoin-b9f06bf05b67-arm64-apple-darwin-unsigned.tar.gz
39ac1ecdce5a848aaca91f9f9dcc2a4436c1d257b27608191af45d4d29054990  guix-build-b9f06bf05b67/output/arm64-apple-darwin/bitcoin-b9f06bf05b67-arm64-apple-darwin.tar.gz
5afa45e1c9c2e31d97148e868415f6bbaf51def45aeaa32bb13b8a092284139e  guix-build-b9f06bf05b67/output/dist-archive/bitcoin-b9f06bf05b67.tar.gz
2aff14d389202d87266b93e1c17aa0ebbd9cde787349127f1a891dfddc41b675  guix-build-b9f06bf05b67/output/powerpc64-linux-gnu/SHA256SUMS.part
650c555c9d3d5b2ae18353d621b51cbdfbe5f2ebce31e7add47887adfd9b0283  guix-build-b9f06bf05b67/output/powerpc64-linux-gnu/bitcoin-b9f06bf05b67-powerpc64-linux-gnu-debug.tar.gz
38b33f13f2ac03ea2d864a02d5088b34441567bb6af04df9dc0c3aa4a9068cb2  guix-build-b9f06bf05b67/output/powerpc64-linux-gnu/bitcoin-b9f06bf05b67-powerpc64-linux-gnu.tar.gz
3b435cd35afe0990a6badb3d4f2a5e120c89644b566581db882241e82d5b94ca  guix-build-b9f06bf05b67/output/powerpc64le-linux-gnu/SHA256SUMS.part
3a3259a8c489e522a1763e4178f4d8b6b49cff927d5ebe9918c853f4d04547b7  guix-build-b9f06bf05b67/output/powerpc64le-linux-gnu/bitcoin-b9f06bf05b67-powerpc64le-linux-gnu-debug.tar.gz
006df723180d8260112e26089062f2a1ca4742099bf2d9455acd6be1b5395939  guix-build-b9f06bf05b67/output/powerpc64le-linux-gnu/bitcoin-b9f06bf05b67-powerpc64le-linux-gnu.tar.gz
d13f9c8e9396c46496e06cf6bfbaffae3980e6305024a1e447f73346e66e48a5  guix-build-b9f06bf05b67/output/riscv64-linux-gnu/SHA256SUMS.part
9b18dfafd51a6d249ed74d884c4a8d1b2cf320133cea8008742bc93583cff19e  guix-build-b9f06bf05b67/output/riscv64-linux-gnu/bitcoin-b9f06bf05b67-riscv64-linux-gnu-debug.tar.gz
76d29d553f06c7098c67e8fc95f83c45619860988668567f37946efd63668cef  guix-build-b9f06bf05b67/output/riscv64-linux-gnu/bitcoin-b9f06bf05b67-riscv64-linux-gnu.tar.gz
6661426b6180c8bb908b05f1ea4e8fe81acc02a443784e0ca042feebb1c8770c  guix-build-b9f06bf05b67/output/x86_64-apple-darwin/SHA256SUMS.part
8310942fddcbf991d3162f94b9e0f2f9f413f10089b6ac31d5c3a73039c3e987  guix-build-b9f06bf05b67/output/x86_64-apple-darwin/bitcoin-b9f06bf05b67-x86_64-apple-darwin-unsigned.dmg
cdcbb08d7596a3f9a0b3816b113e7e4afd435fa82ae20d2d6750e30ccb13d820  guix-build-b9f06bf05b67/output/x86_64-apple-darwin/bitcoin-b9f06bf05b67-x86_64-apple-darwin-unsigned.tar.gz
ac02894454dcee5c822304ab83165e500a882f7b5dd4d5f3645ac526652eb707  guix-build-b9f06bf05b67/output/x86_64-apple-darwin/bitcoin-b9f06bf05b67-x86_64-apple-darwin.tar.gz
fa55686ae7c977ee9ec0213cad8f4021e81153a6de60a5b9f74fb840f173fdfa  guix-build-b9f06bf05b67/output/x86_64-linux-gnu/SHA256SUMS.part
cf40ec54ea736876a0fa5060ecad41d9215762b6d9b89fb2716cf073729097b9  guix-build-b9f06bf05b67/output/x86_64-linux-gnu/bitcoin-b9f06bf05b67-x86_64-linux-gnu-debug.tar.gz
4479fe5dc29925d7b51ed20faa44a87b68aa40b1fef979f1061240325892373f  guix-build-b9f06bf05b67/output/x86_64-linux-gnu/bitcoin-b9f06bf05b67-x86_64-linux-gnu.tar.gz
bef988880e6dbb7be90c4b2b56d5d9a68b91dceb64b2fa38e4d67e8c8cc5a78a  guix-build-b9f06bf05b67/output/x86_64-w64-mingw32/SHA256SUMS.part
0040f79968d8ebb507358ee86797880a019f9730b92576af125b778bcf5ee233  guix-build-b9f06bf05b67/output/x86_64-w64-mingw32/bitcoin-b9f06bf05b67-win64-debug.zip
ac63bf2dbf78361133043db7fa24be51c25fc5ddbbe19ea4a1c78e0843054757  guix-build-b9f06bf05b67/output/x86_64-w64-mingw32/bitcoin-b9f06bf05b67-win64-setup-unsigned.exe
0d9e317a95a613eb2e9216c4c9f5b0046ff52e3b11af80b8de9ac89209f33ab7  guix-build-b9f06bf05b67/output/x86_64-w64-mingw32/bitcoin-b9f06bf05b67-win64-unsigned.tar.gz
1a47e56d06207f3c86310c6eaec66f2c7693ca810de27ab2f97e67086239d396  guix-build-b9f06bf05b67/output/x86_64-w64-mingw32/bitcoin-b9f06bf05b67-win64.zip
```