### PR TITLE
net: Add addresses to local addr map even if their network is unreachable

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -293,9 +293,6 @@ bool AddLocal(const CService& addr_, int nScore)
     if (!fDiscover && nScore < LOCAL_MANUAL)
         return false;
 
-    if (!IsReachable(addr))
-        return false;
-
     LogPrintf("AddLocal(%s,%i)\n", addr.ToString(), nScore);
 
     {


### PR DESCRIPTION
Closes #25669 and possibly also addresses #25336

Local addresses specified with `externalip` are currently not added to `mapLocalHost` if their network is set unreachable. This does not seem to be necessary because typically the network is set unreachable if outbound connections via the network are disabled via `onion=0`, `onlynet` etc. On the inbound side this does not necessarily mean there are any restrictions in place. For the use cases that Matt and kroese seem to have there rather seems to be a deliberate choice that a net is not reachable outbound although it is available inbound.

From my understanding `mapLocalHost` is used to prevent the node from connecting to itself and getting a local address to announce to a peer. For the first use case this change may mean that there are some addresses in the map that are never checked because there are no outbound connections on that net. But that doesn't seem to be an issue. For the second use case the upside is that the address actually gets announced to peers. In the case of the open issues mentioned above this does seem to be the intention of the users. On the downside this may also mean that the address is announced even when this particular network is blocked in some way. This seems to have been the original intention by sipa when adding this check but also this was in 2012 and I am sure some of the context was different. In this case it makes more sense to me to assume that the users know what they are doing rather than assuming there is some network issue the user not aware of.

Additionally the change means that these addresses now appear in `getnetworkinfo`.

I have considered and drafted other ways of addressing this issue but this seems to be the most straight forward approach unless I am overlooking something and the downside outlined above is too big of an issue.