### PR TITLE
depends: expat 2.4.8 & fix building with -flto

### DIFF
--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -4,12 +4,15 @@ $(package)_download_path=https://github.com/libexpat/libexpat/releases/download/
 $(package)_file_name=$(package)-$($(package)_version).tar.xz
 $(package)_sha256_hash=f79b8f904b749e3e0d20afeadecf8249c55b2e32d4ebb089ae378df479dcaf25
 
+# -D_DEFAULT_SOURCE defines __USE_MISC, which exposes additional
+# definitions in endian.h, which are required for a working
+# endianess check in configure when building with -flto.
 define $(package)_set_vars
   $(package)_config_opts=--disable-shared --without-docbook --without-tests --without-examples
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
   $(package)_config_opts += --without-xmlwf
   $(package)_config_opts_linux=--with-pic
-  $(package)_cflags += -fno-lto
+  $(package)_cppflags += -D_DEFAULT_SOURCE
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -1,8 +1,8 @@
 package=expat
-$(package)_version=2.4.1
+$(package)_version=2.4.8
 $(package)_download_path=https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$($(package)_version))/
 $(package)_file_name=$(package)-$($(package)_version).tar.xz
-$(package)_sha256_hash=cf032d0dba9b928636548e32b327a2d66b1aab63c4f4a13dd132c2d1d2f2fb6a
+$(package)_sha256_hash=f79b8f904b749e3e0d20afeadecf8249c55b2e32d4ebb089ae378df479dcaf25
 
 define $(package)_set_vars
   $(package)_config_opts=--disable-shared --without-docbook --without-tests --without-examples


### PR DESCRIPTION
Currently, when building the expat package in depends, using `-flto` (`LTO=1`), the configure check can fail, because it cannot determine the system endianess:
```bash
configure:18718: result: unknown
configure:18733: error: unknown endianness
 presetting ac_cv_c_bigendian=no (or yes) will help
```

Fix that by defining `_DEFAULT_SOURCE`, which in turn defines `__USE_MISC` (`features.h`):
```c
#if defined _DEFAULT_SOURCE
# define __USE_MISC	1
#endif
```
which exposes additional definitions in `endian.h`:
```c
#include <features.h>

/* Get the definitions of __*_ENDIAN, __BYTE_ORDER, and __FLOAT_WORD_ORDER.  */
#include <bits/endian.h>

#ifdef __USE_MISC
# define LITTLE_ENDIAN	__LITTLE_ENDIAN
# define BIG_ENDIAN	__BIG_ENDIAN
# define PDP_ENDIAN	__PDP_ENDIAN
# define BYTE_ORDER	__BYTE_ORDER
#endif
```
and gives us a working configure.

You could test building this change with Guix + LTO with [this branch](https://github.com/fanquake/bitcoin/tree/lto_in_guix). Note that that build may fail for other reasons (on x86_64), unrelated to this change.

Some related upstream discussion:
https://bugs.gentoo.org/757681
https://forums.gentoo.org/viewtopic-t-1013786.html