### PR TITLE
crypto: avoid potential buffer overread in `ChaCha20::SetKey`

### DIFF
--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -8,7 +8,8 @@
 #include <crypto/common.h>
 #include <crypto/chacha20.h>
 
-#include <string.h>
+#include <cassert>
+#include <cstring>
 
 constexpr static inline uint32_t rotl32(uint32_t v, int c) { return (v << c) | (v >> (32 - c)); }
 
@@ -25,6 +26,7 @@ static const unsigned char tau[] = "expand 16-byte k";
 
 void ChaCha20::SetKey(const unsigned char* k, size_t keylen)
 {
+    assert(keylen == 16 || keylen == 32);
     const unsigned char *constants;
 
     input[4] = ReadLE32(k + 0);

--- a/src/crypto/chacha20.h
+++ b/src/crypto/chacha20.h
@@ -18,7 +18,7 @@ private:
 public:
     ChaCha20();
     ChaCha20(const unsigned char* key, size_t keylen);
-    void SetKey(const unsigned char* key, size_t keylen); //!< set key with flexible keylength; 256bit recommended */
+    void SetKey(const unsigned char* key, size_t keylen); //!< set key (supported keylengths of 128bit or 256bit); 256bit recommended */
     void SetIV(uint64_t iv); // set the 64bit nonce
     void Seek(uint64_t pos); // set the 64bit block counter
 

--- a/src/test/fuzz/crypto_chacha20.cpp
+++ b/src/test/fuzz/crypto_chacha20.cpp
@@ -16,14 +16,14 @@ FUZZ_TARGET(crypto_chacha20)
 
     ChaCha20 chacha20;
     if (fuzzed_data_provider.ConsumeBool()) {
-        const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(16, 32));
+        const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, fuzzed_data_provider.PickValueInArray({16, 32}));
         chacha20 = ChaCha20{key.data(), key.size()};
     }
     LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000) {
         CallOneOf(
             fuzzed_data_provider,
             [&] {
-                const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(16, 32));
+                const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, fuzzed_data_provider.PickValueInArray({16, 32}));
                 chacha20.SetKey(key.data(), key.size());
             },
             [&] {

--- a/src/test/fuzz/crypto_diff_fuzz_chacha20.cpp
+++ b/src/test/fuzz/crypto_diff_fuzz_chacha20.cpp
@@ -277,7 +277,7 @@ FUZZ_TARGET(crypto_diff_fuzz_chacha20)
     }
 
     if (fuzzed_data_provider.ConsumeBool()) {
-        const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(16, 32));
+        const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, fuzzed_data_provider.PickValueInArray({16, 32}));
         chacha20 = ChaCha20{key.data(), key.size()};
         ECRYPT_keysetup(&ctx, key.data(), key.size() * 8, 0);
         // ECRYPT_keysetup() doesn't set the counter and nonce to 0 while SetKey() does
@@ -289,7 +289,7 @@ FUZZ_TARGET(crypto_diff_fuzz_chacha20)
         CallOneOf(
             fuzzed_data_provider,
             [&] {
-                const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(16, 32));
+                const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, fuzzed_data_provider.PickValueInArray({16, 32}));
                 chacha20.SetKey(key.data(), key.size());
                 ECRYPT_keysetup(&ctx, key.data(), key.size() * 8, 0);
                 // ECRYPT_keysetup() doesn't set the counter and nonce to 0 while SetKey() does


### PR DESCRIPTION
The current interface description of `ChaCha20::SetKey` suggests that literally any key-length is supported (comment `set key with flexible keylength; 256bit recommended`), while passing in a key with a length less than 16 bytes would lead to a buffer overread:

https://github.com/bitcoin/bitcoin/blob/5057adf22fc4c3593e1e633defeda96be508f198/src/crypto/chacha20.cpp#L30-L33

This PR adds an assert to only allowing sizes of 16 or 32 bytes (i.e. 128 and 256 bits, respectively) which seem what was intended originally, looking at the following piece of code:

https://github.com/bitcoin/bitcoin/blob/5057adf22fc4c3593e1e633defeda96be508f198/src/crypto/chacha20.cpp#L34-L39

The fuzz tests are adopted accordingly to pick either 16 or 32 rather than a length in the range of 16 to 32. An alternative would be to just assert for the minimum size of 16 (and a maximum size of 32), if for some reason supporting keys with a length between 17 and 31 bytes is important; I guess it isn't though, it would also be confusing as the extra bytes wouldn't be used.