### PR TITLE
fix comment spellings from the codespell lint

### DIFF
--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -67,7 +67,7 @@ FUZZ_TARGET_INIT(txorphan, initialize_orphanage)
             for (uint32_t i = 0; i < num_out; i++) {
                 tx_mut.vout.emplace_back(CAmount{0}, CScript{});
             }
-            // restore previously poped outpoints
+            // restore previously popped outpoints
             for (auto& in : tx_mut.vin) {
                 outpoints.push_back(in.prevout);
             }

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -779,7 +779,7 @@ BOOST_FIXTURE_TEST_CASE(CreateWallet, TestChain100Setup)
     promise.set_value();
     SyncWithValidationInterfaceQueue();
     // AddToWallet events for block_tx and mempool_tx events are counted a
-    // second time as the notificaiton queue is processed
+    // second time as the notification queue is processed
     BOOST_CHECK_EQUAL(addtx_count, 4);
 
 


### PR DESCRIPTION
test/lint/all-lint.py includes the codespell lint