### PR TITLE
tidy: enable readability-redundant-string-init

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -5,6 +5,7 @@ misc-unused-using-decls,
 modernize-use-default-member-init,
 modernize-use-nullptr,
 readability-redundant-declaration,
+readability-redundant-string-init,
 '
 WarningsAsErrors: '
 bugprone-argument-comment,
@@ -12,4 +13,5 @@ misc-unused-using-decls,
 modernize-use-default-member-init,
 modernize-use-nullptr,
 readability-redundant-declaration,
+readability-redundant-string-init,
 '

--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -148,7 +148,7 @@ bool GCSFilter::MatchAny(const ElementSet& elements) const
 
 const std::string& BlockFilterTypeName(BlockFilterType filter_type)
 {
-    static std::string unknown_retval = "";
+    static std::string unknown_retval;
     auto it = g_filter_types.find(filter_type);
     return it != g_filter_types.end() ? it->second : unknown_retval;
 }

--- a/src/external_signer.cpp
+++ b/src/external_signer.cpp
@@ -49,7 +49,7 @@ bool ExternalSigner::Enumerate(const std::string& command, std::vector<ExternalS
             if (signer.m_fingerprint.compare(fingerprintStr) == 0) duplicate = true;
         }
         if (duplicate) break;
-        std::string name = "";
+        std::string name;
         const UniValue& model_field = find_value(signer, "model");
         if (model_field.isStr() && model_field.getValStr() != "") {
             name += model_field.getValStr();

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -740,7 +740,7 @@ std::string ArgsManager::GetHelpMessage() const
 {
     const bool show_debug = GetBoolArg("-help-debug", false);
 
-    std::string usage = "";
+    std::string usage;
     LOCK(cs_args);
     for (const auto& arg_map : m_available_args) {
         switch(arg_map.first) {

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -140,7 +140,7 @@ RPCHelpMan importprivkey()
         EnsureWalletIsUnlocked(*pwallet);
 
         std::string strSecret = request.params[0].get_str();
-        std::string strLabel = "";
+        std::string strLabel;
         if (!request.params[1].isNull())
             strLabel = request.params[1].get_str();
 

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -241,7 +241,7 @@ static RPCHelpMan loadwallet()
 
 static RPCHelpMan setwalletflag()
 {
-            std::string flags = "";
+            std::string flags;
             for (auto& it : WALLET_FLAG_MAP)
                 if (it.second & MUTABLE_WALLET_FLAGS)
                     flags += (flags == "" ? "" : ", ") + it.first;


### PR DESCRIPTION
Remove unnecessary `std::string` = "" initializations. Enable `readability-redundant-string-init`.

See:
https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-redundant-string-init.html