### PR TITLE
depends: always use correct ar for win qt build

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -177,6 +177,7 @@ $(package)_config_opts_mingw32 += "QMAKE_CFLAGS = '$($(package)_cflags) $($(pack
 $(package)_config_opts_mingw32 += "QMAKE_CXX = '$($(package)_cxx)'"
 $(package)_config_opts_mingw32 += "QMAKE_CXXFLAGS = '$($(package)_cxxflags) $($(package)_cppflags)'"
 $(package)_config_opts_mingw32 += "QMAKE_LFLAGS = '$($(package)_ldflags)'"
+$(package)_config_opts_mingw32 += "QMAKE_LIB = '$($(package)_ar) rc'"
 $(package)_config_opts_mingw32 += -device-option CROSS_COMPILE="$(host)-"
 $(package)_config_opts_mingw32 += -pch
 


### PR DESCRIPTION
If we don't set this explicitly, then qt will still use it's default
windows ar, when building with LTO (when we want it to use gcc-ar).

So set `QMAKE_LIB` which is used for win32, and defaults to `ar rc`, to `our_ar rc`.
This way we always get the correct ar.

Issue can be seen building in Guix with LTO. i.e:
```bash
x86_64-w64-mingw32-ar: .obj/release/hb-blob.o: plugin needed to handle lto object
```

Guix Build (x86_64):
```bash
6c24d8a86c2410d5dbf29e8087c1bcd230aeb3f5c8ba3bf63e4edf07503cd689  guix-build-300918075144/output/aarch64-linux-gnu/SHA256SUMS.part
deb6c99f2efa3b60569fb31fbe543a97071af707f3b6e68825de93e7f1adaab0  guix-build-300918075144/output/aarch64-linux-gnu/bitcoin-300918075144-aarch64-linux-gnu-debug.tar.gz
d3f14344f472d2c0540ac9254935f3008fb6b8286aa6c52045243a42dd05f2e4  guix-build-300918075144/output/aarch64-linux-gnu/bitcoin-300918075144-aarch64-linux-gnu.tar.gz
fe97d5c4eb398c18689e7e68b1d97ab9ccbd12d1f0085eff8bd49de242675963  guix-build-300918075144/output/arm-linux-gnueabihf/SHA256SUMS.part
239dfcaaaee91164c0e6d8835b613af51e43ece4bf7e17236f55c1a4facf8cd7  guix-build-300918075144/output/arm-linux-gnueabihf/bitcoin-300918075144-arm-linux-gnueabihf-debug.tar.gz
29fe2ffb5c85f654cf23efd43035f1db6cff4e532839b50e7610dd588ad6680b  guix-build-300918075144/output/arm-linux-gnueabihf/bitcoin-300918075144-arm-linux-gnueabihf.tar.gz
a100ce07e5566284a1b213174295c49573e8d93bfea86ad35b3b2dcb85d6c263  guix-build-300918075144/output/arm64-apple-darwin/SHA256SUMS.part
593f57ff35de42f262bdae8085afcd49f33e7db350fd0cb0850bc560414a302a  guix-build-300918075144/output/arm64-apple-darwin/bitcoin-300918075144-arm64-apple-darwin-unsigned.dmg
6d5ae0ff77dfb0a7f74621a859c00060cda86c426c604b19269987163b67e413  guix-build-300918075144/output/arm64-apple-darwin/bitcoin-300918075144-arm64-apple-darwin-unsigned.tar.gz
14bc35725df2dbbd1e3447f57d128125cf65a182d4bb081c840947a0af69bce4  guix-build-300918075144/output/arm64-apple-darwin/bitcoin-300918075144-arm64-apple-darwin.tar.gz
29da16189e087c7fc90909d4dfc8002e37ce4ab035d6a94f0d73724d81ce565b  guix-build-300918075144/output/dist-archive/bitcoin-300918075144.tar.gz
fe4a4a3b84f7782c7d65fdc7d4cbdf6fa57a7898d347ad932cbd4b5d3d7712b4  guix-build-300918075144/output/powerpc64-linux-gnu/SHA256SUMS.part
e612386c452d04c7a9c9a624efa00f905928af39694067d903635fc7476d0e2c  guix-build-300918075144/output/powerpc64-linux-gnu/bitcoin-300918075144-powerpc64-linux-gnu-debug.tar.gz
148ff9a17842287e1d541d032bab3c96df98d0c8a2175a132d896e4617799b5b  guix-build-300918075144/output/powerpc64-linux-gnu/bitcoin-300918075144-powerpc64-linux-gnu.tar.gz
d67e6ad7a8ae2c3a0305602aabbed22ccdf07e354fbc1991b99d9ba58f451d1b  guix-build-300918075144/output/powerpc64le-linux-gnu/SHA256SUMS.part
a776fb31b742d391cee1b2401204f41b3e93793cc2b54cdfcfca1f1b24a49051  guix-build-300918075144/output/powerpc64le-linux-gnu/bitcoin-300918075144-powerpc64le-linux-gnu-debug.tar.gz
9bfc9255af051fe3801a556bdeaa940a74399ab7b3b677e5313e5e720a87e9cf  guix-build-300918075144/output/powerpc64le-linux-gnu/bitcoin-300918075144-powerpc64le-linux-gnu.tar.gz
bc74550b70614e7c07500507943f7b7cda7ec0097908e459b84edfcf9c5f2de7  guix-build-300918075144/output/riscv64-linux-gnu/SHA256SUMS.part
00906c4d9ba5aa6f567c8c3cfa0d44749f944a182f531ff6724284dc70157f88  guix-build-300918075144/output/riscv64-linux-gnu/bitcoin-300918075144-riscv64-linux-gnu-debug.tar.gz
9cd40cbaeb3a68faf500410559443376957aafda081e0cdef2a0d17c9b49d933  guix-build-300918075144/output/riscv64-linux-gnu/bitcoin-300918075144-riscv64-linux-gnu.tar.gz
f9bc2d2cf92493af543a9199763ab913d86bf602f3f5123913ad313391527d75  guix-build-300918075144/output/x86_64-apple-darwin/SHA256SUMS.part
ba60756267e7fa7add1bb4375c98a65bd730a72a86646e3ddfb8496c1e1b695a  guix-build-300918075144/output/x86_64-apple-darwin/bitcoin-300918075144-x86_64-apple-darwin-unsigned.dmg
fa44e1d7b861e1f02232ef35e81b28dc78dcf52631944ec38768bc2e08943fa5  guix-build-300918075144/output/x86_64-apple-darwin/bitcoin-300918075144-x86_64-apple-darwin-unsigned.tar.gz
57ddb381261a1c242e683c12db6c2cfc0bb690bef73ad596f6503e07522f90ff  guix-build-300918075144/output/x86_64-apple-darwin/bitcoin-300918075144-x86_64-apple-darwin.tar.gz
95e409a241da708c8eefe87c1ba419258f3e4918a36cddd3bc50dbc754a9958e  guix-build-300918075144/output/x86_64-linux-gnu/SHA256SUMS.part
6b0548280d8558aa68d3a9006beb95a5402e98e64a92a7b211a4341e67b00e85  guix-build-300918075144/output/x86_64-linux-gnu/bitcoin-300918075144-x86_64-linux-gnu-debug.tar.gz
612a684ed3dc374a81806a50946c85c6d043704945596bed7c5f0f7e998ebf10  guix-build-300918075144/output/x86_64-linux-gnu/bitcoin-300918075144-x86_64-linux-gnu.tar.gz
a5adc490213892f93e2ea62af2aac6db26127afc721a44cb787b0207b8c16d07  guix-build-300918075144/output/x86_64-w64-mingw32/SHA256SUMS.part
1c7bf2d489e8d950b22be16506465da70b9402a4e23c770e04a74fb69d05c18c  guix-build-300918075144/output/x86_64-w64-mingw32/bitcoin-300918075144-win64-debug.zip
2a04f07ca0e46a18b68088093eee0bbfbdeb51ec72bb18c2282168d54f748fc4  guix-build-300918075144/output/x86_64-w64-mingw32/bitcoin-300918075144-win64-setup-unsigned.exe
e519347ff375e79d12acd8db87a9b216c5363d4b3cce09d7a8f79b85ba0deb85  guix-build-300918075144/output/x86_64-w64-mingw32/bitcoin-300918075144-win64-unsigned.tar.gz
e49571279f9e5897d5217e5d5fb319467ca213ba7b4e99904e262a1cd1e65df6  guix-build-300918075144/output/x86_64-w64-mingw32/bitcoin-300918075144-win64.zip
```

Guix Build (arm64):
```bash
fe97d5c4eb398c18689e7e68b1d97ab9ccbd12d1f0085eff8bd49de242675963  guix-build-300918075144/output/arm-linux-gnueabihf/SHA256SUMS.part
239dfcaaaee91164c0e6d8835b613af51e43ece4bf7e17236f55c1a4facf8cd7  guix-build-300918075144/output/arm-linux-gnueabihf/bitcoin-300918075144-arm-linux-gnueabihf-debug.tar.gz
29fe2ffb5c85f654cf23efd43035f1db6cff4e532839b50e7610dd588ad6680b  guix-build-300918075144/output/arm-linux-gnueabihf/bitcoin-300918075144-arm-linux-gnueabihf.tar.gz
8ef780a952f6a8352ec897f5446be2c49c2bf06825442dfb38037a2160973ba6  guix-build-300918075144/output/arm64-apple-darwin/SHA256SUMS.part
4c80a8d78c3bfcef0c6368b54f3112746ee8912bbd7efcebe9f7072ad7f47c32  guix-build-300918075144/output/arm64-apple-darwin/bitcoin-300918075144-arm64-apple-darwin-unsigned.dmg
d3aa00742093b62165de0fa74b9c2eef0cc37e245cd1720c82a14db30b05ed40  guix-build-300918075144/output/arm64-apple-darwin/bitcoin-300918075144-arm64-apple-darwin-unsigned.tar.gz
67b56f78a0d410ea346f2aa7432b73d4ab99f8471debd2d8e1459d18fcfdf39f  guix-build-300918075144/output/arm64-apple-darwin/bitcoin-300918075144-arm64-apple-darwin.tar.gz
29da16189e087c7fc90909d4dfc8002e37ce4ab035d6a94f0d73724d81ce565b  guix-build-300918075144/output/dist-archive/bitcoin-300918075144.tar.gz
fe4a4a3b84f7782c7d65fdc7d4cbdf6fa57a7898d347ad932cbd4b5d3d7712b4  guix-build-300918075144/output/powerpc64-linux-gnu/SHA256SUMS.part
e612386c452d04c7a9c9a624efa00f905928af39694067d903635fc7476d0e2c  guix-build-300918075144/output/powerpc64-linux-gnu/bitcoin-300918075144-powerpc64-linux-gnu-debug.tar.gz
148ff9a17842287e1d541d032bab3c96df98d0c8a2175a132d896e4617799b5b  guix-build-300918075144/output/powerpc64-linux-gnu/bitcoin-300918075144-powerpc64-linux-gnu.tar.gz
d67e6ad7a8ae2c3a0305602aabbed22ccdf07e354fbc1991b99d9ba58f451d1b  guix-build-300918075144/output/powerpc64le-linux-gnu/SHA256SUMS.part
a776fb31b742d391cee1b2401204f41b3e93793cc2b54cdfcfca1f1b24a49051  guix-build-300918075144/output/powerpc64le-linux-gnu/bitcoin-300918075144-powerpc64le-linux-gnu-debug.tar.gz
9bfc9255af051fe3801a556bdeaa940a74399ab7b3b677e5313e5e720a87e9cf  guix-build-300918075144/output/powerpc64le-linux-gnu/bitcoin-300918075144-powerpc64le-linux-gnu.tar.gz
bc74550b70614e7c07500507943f7b7cda7ec0097908e459b84edfcf9c5f2de7  guix-build-300918075144/output/riscv64-linux-gnu/SHA256SUMS.part
00906c4d9ba5aa6f567c8c3cfa0d44749f944a182f531ff6724284dc70157f88  guix-build-300918075144/output/riscv64-linux-gnu/bitcoin-300918075144-riscv64-linux-gnu-debug.tar.gz
9cd40cbaeb3a68faf500410559443376957aafda081e0cdef2a0d17c9b49d933  guix-build-300918075144/output/riscv64-linux-gnu/bitcoin-300918075144-riscv64-linux-gnu.tar.gz
f9bc2d2cf92493af543a9199763ab913d86bf602f3f5123913ad313391527d75  guix-build-300918075144/output/x86_64-apple-darwin/SHA256SUMS.part
ba60756267e7fa7add1bb4375c98a65bd730a72a86646e3ddfb8496c1e1b695a  guix-build-300918075144/output/x86_64-apple-darwin/bitcoin-300918075144-x86_64-apple-darwin-unsigned.dmg
fa44e1d7b861e1f02232ef35e81b28dc78dcf52631944ec38768bc2e08943fa5  guix-build-300918075144/output/x86_64-apple-darwin/bitcoin-300918075144-x86_64-apple-darwin-unsigned.tar.gz
57ddb381261a1c242e683c12db6c2cfc0bb690bef73ad596f6503e07522f90ff  guix-build-300918075144/output/x86_64-apple-darwin/bitcoin-300918075144-x86_64-apple-darwin.tar.gz
95e409a241da708c8eefe87c1ba419258f3e4918a36cddd3bc50dbc754a9958e  guix-build-300918075144/output/x86_64-linux-gnu/SHA256SUMS.part
6b0548280d8558aa68d3a9006beb95a5402e98e64a92a7b211a4341e67b00e85  guix-build-300918075144/output/x86_64-linux-gnu/bitcoin-300918075144-x86_64-linux-gnu-debug.tar.gz
612a684ed3dc374a81806a50946c85c6d043704945596bed7c5f0f7e998ebf10  guix-build-300918075144/output/x86_64-linux-gnu/bitcoin-300918075144-x86_64-linux-gnu.tar.gz
a5adc490213892f93e2ea62af2aac6db26127afc721a44cb787b0207b8c16d07  guix-build-300918075144/output/x86_64-w64-mingw32/SHA256SUMS.part
1c7bf2d489e8d950b22be16506465da70b9402a4e23c770e04a74fb69d05c18c  guix-build-300918075144/output/x86_64-w64-mingw32/bitcoin-300918075144-win64-debug.zip
2a04f07ca0e46a18b68088093eee0bbfbdeb51ec72bb18c2282168d54f748fc4  guix-build-300918075144/output/x86_64-w64-mingw32/bitcoin-300918075144-win64-setup-unsigned.exe
e519347ff375e79d12acd8db87a9b216c5363d4b3cce09d7a8f79b85ba0deb85  guix-build-300918075144/output/x86_64-w64-mingw32/bitcoin-300918075144-win64-unsigned.tar.gz
e49571279f9e5897d5217e5d5fb319467ca213ba7b4e99904e262a1cd1e65df6  guix-build-300918075144/output/x86_64-w64-mingw32/bitcoin-300918075144-win64.zip
```