### PR TITLE
script: actually trigger the optimization in BuildScript

### DIFF
--- a/src/script/script.h
+++ b/src/script/script.h
@@ -588,7 +588,6 @@ CScript BuildScript(Ts&&... inputs)
     int cnt{0};
 
     ([&ret, &cnt] (Ts&& input) {
-        cnt++;
         if constexpr (std::is_same_v<std::remove_cv_t<std::remove_reference_t<Ts>>, CScript>) {
             // If it is a CScript, extend ret with it. Move or copy the first element instead.
             if (cnt == 0) {
@@ -600,6 +599,7 @@ CScript BuildScript(Ts&&... inputs)
             // Otherwise invoke CScript::operator<<.
             ret << input;
         }
+        cnt++;
     } (std::forward<Ts>(inputs)), ...);
 
     return ret;


### PR DESCRIPTION
The counter is an optimization over calling `ret.empty()`. It was
suggested that the compiler would realize `cnt` is only `0` on the first
iteration, and not actually emit the check and conditional.

This optimization was actually not triggered at all, since we
incremented `cnt` at the beginning of the first iteration. Fix it by
incrementing at the end instead.

This was reported by Github user "Janus".

Fixes #25682. Note this does *not* change semantics. It only allows the optimization of moving instead of copying on first `CScript` element to actually be reachable.