### PR TITLE
make lint errors failures

### DIFF
--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -5,6 +5,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 export LC_ALL=C
+set -e
 
 GIT_HEAD=$(git rev-parse HEAD)
 if [ -n "$CIRRUS_PR" ]; then


### PR DESCRIPTION
@fanquake [suggested](https://github.com/bitcoin/bitcoin/pull/25701#issuecomment-1195209336) making a lint a failure. I am not sure if we want all lints to be failures, but this PR should accomplish that.