### PR TITLE
crypto: drop 16 byte key support for ChaCha20

### DIFF
--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -8,7 +8,8 @@
 #include <crypto/common.h>
 #include <crypto/chacha20.h>
 
-#include <string.h>
+#include <cassert>
+#include <cstring>
 
 constexpr static inline uint32_t rotl32(uint32_t v, int c) { return (v << c) | (v >> (32 - c)); }
 
@@ -20,31 +21,28 @@ constexpr static inline uint32_t rotl32(uint32_t v, int c) { return (v << c) | (
 
 #define REPEAT10(a) do { {a}; {a}; {a}; {a}; {a}; {a}; {a}; {a}; {a}; {a}; } while(0)
 
-static const unsigned char sigma[] = "expand 32-byte k";
-static const unsigned char tau[] = "expand 16-byte k";
+// sigma (bytestring "expand 32-byte k" as little-endian 32-bit integer chunks)
+#define SIGMA_0 0x61707865
+#define SIGMA_1 0x3320646e
+#define SIGMA_2 0x79622d32
+#define SIGMA_3 0x6b206574
 
 void ChaCha20::SetKey(const unsigned char* k, size_t keylen)
 {
-    const unsigned char *constants;
+    assert(keylen == 32);
 
+    input[0] = SIGMA_0;
+    input[1] = SIGMA_1;
+    input[2] = SIGMA_2;
+    input[3] = SIGMA_3;
     input[4] = ReadLE32(k + 0);
     input[5] = ReadLE32(k + 4);
     input[6] = ReadLE32(k + 8);
     input[7] = ReadLE32(k + 12);
-    if (keylen == 32) { /* recommended */
-        k += 16;
-        constants = sigma;
-    } else { /* keylen == 16 */
-        constants = tau;
-    }
-    input[8] = ReadLE32(k + 0);
-    input[9] = ReadLE32(k + 4);
-    input[10] = ReadLE32(k + 8);
-    input[11] = ReadLE32(k + 12);
-    input[0] = ReadLE32(constants + 0);
-    input[1] = ReadLE32(constants + 4);
-    input[2] = ReadLE32(constants + 8);
-    input[3] = ReadLE32(constants + 12);
+    input[8] = ReadLE32(k + 16);
+    input[9] = ReadLE32(k + 20);
+    input[10] = ReadLE32(k + 24);
+    input[11] = ReadLE32(k + 28);
     input[12] = 0;
     input[13] = 0;
     input[14] = 0;

--- a/src/crypto/chacha20.h
+++ b/src/crypto/chacha20.h
@@ -18,7 +18,7 @@ private:
 public:
     ChaCha20();
     ChaCha20(const unsigned char* key, size_t keylen);
-    void SetKey(const unsigned char* key, size_t keylen); //!< set key with flexible keylength; 256bit recommended */
+    void SetKey(const unsigned char* key, size_t keylen); //!< set the 256bit key */
     void SetIV(uint64_t iv); // set the 64bit nonce
     void Seek(uint64_t pos); // set the 64bit block counter
 

--- a/src/test/fuzz/crypto_chacha20.cpp
+++ b/src/test/fuzz/crypto_chacha20.cpp
@@ -16,14 +16,14 @@ FUZZ_TARGET(crypto_chacha20)
 
     ChaCha20 chacha20;
     if (fuzzed_data_provider.ConsumeBool()) {
-        const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(16, 32));
+        const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, 32);
         chacha20 = ChaCha20{key.data(), key.size()};
     }
     LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10000) {
         CallOneOf(
             fuzzed_data_provider,
             [&] {
-                const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(16, 32));
+                const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, 32);
                 chacha20.SetKey(key.data(), key.size());
             },
             [&] {

--- a/src/test/fuzz/crypto_diff_fuzz_chacha20.cpp
+++ b/src/test/fuzz/crypto_diff_fuzz_chacha20.cpp
@@ -277,7 +277,7 @@ FUZZ_TARGET(crypto_diff_fuzz_chacha20)
     }
 
     if (fuzzed_data_provider.ConsumeBool()) {
-        const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(16, 32));
+        const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, 32);
         chacha20 = ChaCha20{key.data(), key.size()};
         ECRYPT_keysetup(&ctx, key.data(), key.size() * 8, 0);
         // ECRYPT_keysetup() doesn't set the counter and nonce to 0 while SetKey() does
@@ -289,7 +289,7 @@ FUZZ_TARGET(crypto_diff_fuzz_chacha20)
         CallOneOf(
             fuzzed_data_provider,
             [&] {
-                const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(16, 32));
+                const std::vector<unsigned char> key = ConsumeFixedLengthByteVector(fuzzed_data_provider, 32);
                 chacha20.SetKey(key.data(), key.size());
                 ECRYPT_keysetup(&ctx, key.data(), key.size() * 8, 0);
                 // ECRYPT_keysetup() doesn't set the counter and nonce to 0 while SetKey() does


### PR DESCRIPTION
This PR is an alternative to #25698; as suggested in comment https://github.com/bitcoin/bitcoin/pull/25698#issuecomment-1195369032, the support for 16 byte keys for ChaCha20 can likely be dropped in order to simplify the implementation, i.e. only 32 bytes keys are supported then. To keep the diff minimal and to avoid having to change the callers, the length parameter is still kept right now; one option would be to change the parameter to a fixed-size type, e.g. something like `std::array<std::byte, 32>`.