### PR TITLE
tidy: run clang-tidy in quiet mode

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -35,8 +35,9 @@ if [ "$RUN_FUNCTIONAL_TESTS" = "true" ]; then
 fi
 
 if [ "${RUN_TIDY}" = "true" ]; then
+  set -eo pipefail
   export P_CI_DIR="${BASE_BUILD_DIR}/bitcoin-$HOST/src/"
-  CI_EXEC run-clang-tidy "${MAKEJOBS}"
+  ( CI_EXEC run-clang-tidy -quiet "${MAKEJOBS}" ) | grep -C5 "error"
   export P_CI_DIR="${BASE_BUILD_DIR}/bitcoin-$HOST/"
   CI_EXEC "python3 ${DIR_IWYU}/include-what-you-use/iwyu_tool.py"\
           " src/compat"\


### PR DESCRIPTION
This should cut the amount of output by atleast half. 

```bash
/opt/homebrew/opt/llvm/bin/clang-tidy --use-color -p=bitcoin bitcoin/src/wallet/test/fuzz/coinselection.cpp
278 warnings generated.
Suppressed 278 warnings (278 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```
becomes
```bash
/opt/homebrew/opt/llvm/bin/clang-tidy --use-color -p=/bitcoin -quiet bitcoin/src/wallet/test/fuzz/coinselection.cpp
278 warnings generated.
```

See https://clang.llvm.org/extra/clang-tidy/.

>   --quiet
> Run clang-tidy in quiet mode. This suppresses
> printing statistics about ignored warnings and
> warnings treated as errors if the respective
> options are specified.

However the `run-clang-tidy` option is `-quiet`. See https://github.com/llvm/llvm-project/blob/f28c006a5895fc0e329fe15fead81e37457cb1d1/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py#L244.