### PR TITLE
univalue: Avoid std::string copies

### DIFF
--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -20,10 +20,7 @@ public:
     enum VType { VNULL, VOBJ, VARR, VSTR, VNUM, VBOOL, };
 
     UniValue() { typ = VNULL; }
-    UniValue(UniValue::VType initialType, const std::string& initialStr = "") {
-        typ = initialType;
-        val = initialStr;
-    }
+    UniValue(UniValue::VType type, std::string str = {}) : typ{type}, val{std::move(str)} {}
     template <typename Ref, typename T = std::remove_cv_t<std::remove_reference_t<Ref>>,
               std::enable_if_t<std::is_floating_point_v<T> ||                      // setFloat
                                    std::is_same_v<bool, T> ||                      // setBool
@@ -49,12 +46,12 @@ public:
 
     void setNull();
     void setBool(bool val);
-    void setNumStr(const std::string& val);
+    void setNumStr(std::string str);
     void setInt(uint64_t val);
     void setInt(int64_t val);
     void setInt(int val_) { return setInt(int64_t{val_}); }
     void setFloat(double val);
-    void setStr(const std::string& val);
+    void setStr(std::string str);
     void setArray();
     void setObject();
 

--- a/src/univalue/lib/univalue.cpp
+++ b/src/univalue/lib/univalue.cpp
@@ -44,15 +44,15 @@ static bool validNumStr(const std::string& s)
     return (tt == JTOK_NUMBER);
 }
 
-void UniValue::setNumStr(const std::string& val_)
+void UniValue::setNumStr(std::string str)
 {
-    if (!validNumStr(val_)) {
-        throw std::runtime_error{"The string '" + val_ + "' is not a valid JSON number"};
+    if (!validNumStr(str)) {
+        throw std::runtime_error{"The string '" + str + "' is not a valid JSON number"};
     }
 
     clear();
     typ = VNUM;
-    val = val_;
+    val = std::move(str);
 }
 
 void UniValue::setInt(uint64_t val_)
@@ -82,11 +82,11 @@ void UniValue::setFloat(double val_)
     return setNumStr(oss.str());
 }
 
-void UniValue::setStr(const std::string& val_)
+void UniValue::setStr(std::string str)
 {
     clear();
     typ = VSTR;
-    val = val_;
+    val = std::move(str);
 }
 
 void UniValue::setArray()

--- a/src/univalue/test/object.cpp
+++ b/src/univalue/test/object.cpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #define BOOST_CHECK(expr) assert(expr)
@@ -159,6 +160,14 @@ void univalue_set()
     v.setStr("zum");
     BOOST_CHECK(v.isStr());
     BOOST_CHECK_EQUAL(v.getValStr(), "zum");
+
+    {
+        std::string_view sv{"ab\0c", 4};
+        UniValue j{sv};
+        BOOST_CHECK(j.isStr());
+        BOOST_CHECK_EQUAL(j.getValStr(), sv);
+        BOOST_CHECK_EQUAL(j.write(), "\"ab\\u0000c\"");
+    }
 
     v.setFloat(-1.01);
     BOOST_CHECK(v.isNum());


### PR DESCRIPTION
This shouldn't matter too much, unless a really large string is pushed into a json struct, but I think it also clarifies the code.