### PR TITLE
refactor: Use util::Result class for wallet loading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 360  # Use maximum time, see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes.
     steps:
       - name: Determine fetch depth
-        run: echo "FETCH_DEPTH=$((${{ github.event.pull_request.commits }} + 2))" >> "$GITHUB_ENV"
+        run: echo "FETCH_DEPTH=$((${{ github.event.pull_request.commits }} + 1000))" >> "$GITHUB_ENV"
       - &ANNOTATION_PR_NUMBER
         name: Annotate with pull request number
         # This annotation is machine-readable and can be used to assign a check

--- a/ci/test/00_setup_env_native_previous_releases.sh
+++ b/ci/test/00_setup_env_native_previous_releases.sh
@@ -22,7 +22,7 @@ export BITCOIN_CONFIG="\
  -DCMAKE_BUILD_TYPE=Debug \
  -DCMAKE_C_FLAGS='-funsigned-char -Werror' \
  -DCMAKE_C_FLAGS_DEBUG='-g2 -O2' \
- -DCMAKE_CXX_FLAGS='-funsigned-char -Werror' \
+ -DCMAKE_CXX_FLAGS='-funsigned-char -Werror -Wno-error=maybe-uninitialized' \
  -DCMAKE_CXX_FLAGS_DEBUG='-g2 -O2' \
  -DAPPEND_CPPFLAGS='-DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE' \
 "

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -193,7 +193,7 @@ void ReadFromStream(AddrMan& addr, DataStream& ssPeers)
     DeserializeDB(ssPeers, addr, false);
 }
 
-util::Result<std::unique_ptr<AddrMan>> LoadAddrman(const NetGroupManager& netgroupman, const ArgsManager& args)
+util::ResultPtr<std::unique_ptr<AddrMan>> LoadAddrman(const NetGroupManager& netgroupman, const ArgsManager& args)
 {
     auto check_addrman = std::clamp<int32_t>(args.GetIntArg("-checkaddrman", DEFAULT_ADDRMAN_CONSISTENCY_CHECKS), 0, 1000000);
     bool deterministic = HasTestOption(args, "addrman"); // use a deterministic addrman only for tests

--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -49,7 +49,7 @@ public:
 };
 
 /** Returns an error string on failure */
-util::Result<std::unique_ptr<AddrMan>> LoadAddrman(const NetGroupManager& netgroupman, const ArgsManager& args);
+util::ResultPtr<std::unique_ptr<AddrMan>> LoadAddrman(const NetGroupManager& netgroupman, const ArgsManager& args);
 
 /**
  * Dump the anchor IP address database (anchors.dat)

--- a/src/bench/wallet_create.cpp
+++ b/src/bench/wallet_create.cpp
@@ -38,10 +38,6 @@ static void WalletCreate(benchmark::Bench& bench, bool encrypted)
         options.create_passphrase = random.rand256().ToString();
     }
 
-    DatabaseStatus status;
-    bilingual_str error_string;
-    std::vector<bilingual_str> warnings;
-
     const auto wallet_path = test_setup->m_path_root / "test_wallet";
     const auto wallet_name = fs::PathToString(wallet_path);
 
@@ -55,9 +51,9 @@ static void WalletCreate(benchmark::Bench& bench, bool encrypted)
         fs::remove(wallet_path);
     }};
     bench.setup(cleanup).run([&] {
-        wallet = ResultExtract(CreateWallet(context, wallet_name, /*load_on_start=*/std::nullopt, options), &status, &error_string, &warnings);
-        assert(status == DatabaseStatus::SUCCESS);
-        assert(wallet != nullptr);
+        auto result{CreateWallet(context, wallet_name, /*load_on_start=*/std::nullopt, options)};
+        assert(result);
+        wallet = std::move(result).value();
     });
     cleanup();
 }

--- a/src/bench/wallet_create.cpp
+++ b/src/bench/wallet_create.cpp
@@ -8,7 +8,7 @@
 #include <uint256.h>
 #include <util/check.h>
 #include <util/fs.h>
-#include <util/translation.h>
+#include <util/result.h>
 #include <wallet/context.h>
 #include <wallet/db.h>
 #include <wallet/wallet.h>
@@ -18,7 +18,6 @@
 #include <optional>
 #include <string>
 #include <utility>
-#include <vector>
 
 namespace wallet {
 static void WalletCreate(benchmark::Bench& bench, bool encrypted)
@@ -50,13 +49,13 @@ static void WalletCreate(benchmark::Bench& bench, bool encrypted)
     auto cleanup{[&] {
         if (!wallet) return;
         // Release wallet
-        RemoveWallet(context, wallet, /*load_on_start=*/std::nullopt);
+        Assert(RemoveWallet(context, wallet, /*load_on_start=*/std::nullopt));
         WaitForDeleteWallet(std::move(wallet));
         fs::remove(wallet_path / "wallet.dat");
         fs::remove(wallet_path);
     }};
     bench.setup(cleanup).run([&] {
-        wallet = CreateWallet(context, wallet_name, /*load_on_start=*/std::nullopt, options, status, error_string, warnings);
+        wallet = ResultExtract(CreateWallet(context, wallet_name, /*load_on_start=*/std::nullopt, options), &status, &error_string, &warnings);
         assert(status == DatabaseStatus::SUCCESS);
         assert(wallet != nullptr);
     });

--- a/src/bench/wallet_loading.cpp
+++ b/src/bench/wallet_loading.cpp
@@ -10,7 +10,7 @@
 #include <script/script.h>
 #include <test/util/setup_common.h>
 #include <util/check.h>
-#include <util/translation.h>
+#include <util/result.h>
 #include <wallet/context.h>
 #include <wallet/db.h>
 #include <wallet/test/util.h>
@@ -46,13 +46,12 @@ static void WalletLoadingDescriptors(benchmark::Bench& bench)
     // Setup the wallet
     // Loading the wallet will also create it
     uint64_t create_flags = WALLET_FLAG_DESCRIPTORS;
-    DatabaseStatus status;
     DatabaseOptions options;
     options.require_format = DatabaseFormat::SQLITE;
     options.require_create = true;
-    bilingual_str error;
-    auto database = MakeWalletDatabase("", options, status, error);
-    auto wallet = TestCreateWallet(std::move(database), context, create_flags);
+    auto database = MakeWalletDatabase("", options);
+    assert(database);
+    auto wallet = TestCreateWallet(std::move(database.value()), context, create_flags);
 
     // Generate a bunch of transactions and addresses to put into the wallet
     for (int i = 0; i < 1000; ++i) {
@@ -65,10 +64,11 @@ static void WalletLoadingDescriptors(benchmark::Bench& bench)
     bench.epochs(5)
         .setup([&] {
             TestUnloadWallet(std::move(wallet));
-            database = MakeWalletDatabase("", options, status, error);
+            database.update(MakeWalletDatabase("", options));
+            assert(database);
         })
         .run([&] {
-            wallet = TestLoadWallet(std::move(database), context);
+            wallet = TestLoadWallet(std::move(database.value()), context);
         });
 
     // Cleanup

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1658,7 +1658,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         uiInterface.InitMessage(_("Loading P2P addresses…"));
         auto addrman{LoadAddrman(*node.netgroupman, args)};
         if (!addrman) return InitError(util::ErrorString(addrman));
-        node.addrman = std::move(*addrman);
+        node.addrman = std::move(addrman.value());
     }
 
     FastRandomContext rng;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -149,11 +149,11 @@ using http_bitcoin::InitHTTPServer;
 using http_bitcoin::InterruptHTTPServer;
 using http_bitcoin::StartHTTPServer;
 using http_bitcoin::StopHTTPServer;
+using kernel::InterruptResult;
 using node::ApplyArgsManOptions;
 using node::BlockManager;
 using node::CalculateCacheSizes;
-using node::ChainstateLoadResult;
-using node::ChainstateLoadStatus;
+using node::ChainstateLoadError;
 using node::DEFAULT_PERSIST_MEMPOOL;
 using node::DEFAULT_PRINT_MODIFIED_FEE;
 using node::DEFAULT_STOPATHEIGHT;
@@ -1317,7 +1317,7 @@ static std::optional<CService> CheckBindingConflicts(const CConnman::Options& co
 
 // A GUI user may opt to retry once with do_reindex set if there is a failure during chainstate initialization.
 // The function therefore has to support re-entry.
-static ChainstateLoadResult InitAndLoadChainstate(
+util::Result<kernel::InterruptResult, ChainstateLoadError> InitAndLoadChainstate(
     NodeContext& node,
     bool do_reindex,
     const bool do_reindex_chainstate,
@@ -1340,7 +1340,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
     Assert(!node.mempool); // Was reset above
     node.mempool = std::make_unique<CTxMemPool>(mempool_opts, mempool_error);
     if (!mempool_error.empty()) {
-        return {ChainstateLoadStatus::FAILURE_FATAL, mempool_error};
+        return {util::Error{mempool_error}, ChainstateLoadError::FAILURE_FATAL};
     }
     auto mining_args{node::ReadMiningArgs(args)};
     Assert(mining_args); // no error can happen, already checked in AppInitParameterInteraction
@@ -1376,12 +1376,12 @@ static ChainstateLoadResult InitAndLoadChainstate(
         node.chainman = std::make_unique<ChainstateManager>(*Assert(node.shutdown_signal), chainman_opts, blockman_opts);
     } catch (dbwrapper_error& e) {
         LogError("%s", e.what());
-        return {ChainstateLoadStatus::FAILURE, _("Error opening block database")};
+        return {util::Error{_("Error opening block database")}, ChainstateLoadError::FAILURE};
     } catch (std::exception& e) {
-        return {ChainstateLoadStatus::FAILURE_FATAL, Untranslated(strprintf("Failed to initialize ChainstateManager: %s", e.what()))};
+        return {util::Error{Untranslated(strprintf("Failed to initialize ChainstateManager: %s", e.what()))}, ChainstateLoadError::FAILURE_FATAL};
     }
     ChainstateManager& chainman = *node.chainman;
-    if (chainman.m_interrupt) return {ChainstateLoadStatus::INTERRUPTED, {}};
+    if (chainman.m_interrupt) return kernel::Interrupted{};
 
     // This is defined and set here instead of inline in validation.h to avoid a hard
     // dependency between validation and index/base, since the latter is not in
@@ -1416,28 +1416,28 @@ static ChainstateLoadResult InitAndLoadChainstate(
             CClientUIInterface::MSG_ERROR);
     };
     uiInterface.InitMessage(_("Loading block index…"));
-    auto catch_exceptions = [](auto&& f) -> ChainstateLoadResult {
+    auto catch_exceptions = [](auto&& f) -> util::Result<InterruptResult, node::ChainstateLoadError> {
         try {
             return f();
         } catch (const std::exception& e) {
             LogError("%s\n", e.what());
-            return std::make_tuple(node::ChainstateLoadStatus::FAILURE, _("Error loading databases"));
+            return {util::Error{_("Error loading databases")}, node::ChainstateLoadError::FAILURE};
         }
     };
-    auto [status, error] = catch_exceptions([&] { return LoadChainstate(chainman, cache_sizes, options); });
-    if (status == node::ChainstateLoadStatus::SUCCESS) {
+    auto result = catch_exceptions([&] { return LoadChainstate(chainman, cache_sizes, options); });
+    if (result && !IsInterrupted(*result)) {
         uiInterface.InitMessage(_("Verifying blocks…"));
         if (chainman.m_blockman.m_have_pruned && options.check_blocks > MIN_BLOCKS_TO_KEEP) {
             LogWarning("pruned datadir may not have more than %d blocks; only checking available blocks\n",
                        MIN_BLOCKS_TO_KEEP);
         }
-        std::tie(status, error) = catch_exceptions([&] { return VerifyLoadedChainstate(chainman, options); });
-        if (status == node::ChainstateLoadStatus::SUCCESS) {
+        result.update(catch_exceptions([&] { return VerifyLoadedChainstate(chainman, options); }));
+        if (result && !IsInterrupted(*result)) {
             LogInfo("Block index and chainstate loaded");
             node.notifications->setChainstateLoaded(true);
         }
     }
-    return {status, error};
+    return result;
 };
 
 bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
@@ -1873,13 +1873,14 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     const bool do_reindex_chainstate{args.GetBoolArg("-reindex-chainstate", false)};
 
     // Chainstate initialization and loading may be retried once with reindexing by GUI users
-    auto [status, error] = InitAndLoadChainstate(
+    auto result = InitAndLoadChainstate(
         node,
         do_reindex,
         do_reindex_chainstate,
         kernel_cache_sizes,
         args);
-    if (status == ChainstateLoadStatus::FAILURE && !do_reindex && !ShutdownRequested(node)) {
+    if (!result && result.error() == ChainstateLoadError::FAILURE && !do_reindex && !ShutdownRequested(node)) {
+        const auto& error = util::ErrorString(result);
         // suggest a reindex
         bool do_retry{HasTestOption(args, "reindex_after_failure_noninteractive_yes") ||
             uiInterface.ThreadSafeQuestion(
@@ -1893,15 +1894,15 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         if (!Assert(node.shutdown_signal)->reset()) {
             LogError("Internal error: failed to reset shutdown signal.\n");
         }
-        std::tie(status, error) = InitAndLoadChainstate(
+        result.update(InitAndLoadChainstate(
             node,
             do_reindex,
             do_reindex_chainstate,
             kernel_cache_sizes,
-            args);
+            args));
     }
-    if (status != ChainstateLoadStatus::SUCCESS && status != ChainstateLoadStatus::INTERRUPTED) {
-        return InitError(error);
+    if (!result) {
+        return InitError(util::ErrorString(result));
     }
 
     // As LoadBlockIndex can take several minutes, it's possible the user

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -149,11 +149,11 @@ using http_bitcoin::InitHTTPServer;
 using http_bitcoin::InterruptHTTPServer;
 using http_bitcoin::StartHTTPServer;
 using http_bitcoin::StopHTTPServer;
+using kernel::InterruptResult;
 using node::ApplyArgsManOptions;
 using node::BlockManager;
 using node::CalculateCacheSizes;
-using node::ChainstateLoadResult;
-using node::ChainstateLoadStatus;
+using node::ChainstateLoadError;
 using node::DEFAULT_PERSIST_MEMPOOL;
 using node::DEFAULT_PRINT_MODIFIED_FEE;
 using node::DEFAULT_STOPATHEIGHT;
@@ -1327,7 +1327,7 @@ static std::optional<CService> CheckBindingConflicts(const CConnman::Options& co
 
 // A GUI user may opt to retry once with do_reindex set if there is a failure during chainstate initialization.
 // The function therefore has to support re-entry.
-static ChainstateLoadResult InitAndLoadChainstate(
+util::Result<kernel::InterruptResult, ChainstateLoadError> InitAndLoadChainstate(
     NodeContext& node,
     bool do_reindex,
     const bool do_reindex_chainstate,
@@ -1350,7 +1350,7 @@ static ChainstateLoadResult InitAndLoadChainstate(
     Assert(!node.mempool); // Was reset above
     node.mempool = std::make_unique<CTxMemPool>(mempool_opts, mempool_error);
     if (!mempool_error.empty()) {
-        return {ChainstateLoadStatus::FAILURE_FATAL, mempool_error};
+        return {util::Error{mempool_error}, ChainstateLoadError::FAILURE_FATAL};
     }
     auto mining_args{node::ReadMiningArgs(args)};
     Assert(mining_args); // no error can happen, already checked in AppInitParameterInteraction
@@ -1386,12 +1386,12 @@ static ChainstateLoadResult InitAndLoadChainstate(
         node.chainman = std::make_unique<ChainstateManager>(*Assert(node.shutdown_signal), chainman_opts, blockman_opts);
     } catch (dbwrapper_error& e) {
         LogError("%s", e.what());
-        return {ChainstateLoadStatus::FAILURE, _("Error opening block database")};
+        return {util::Error{_("Error opening block database")}, ChainstateLoadError::FAILURE};
     } catch (std::exception& e) {
-        return {ChainstateLoadStatus::FAILURE_FATAL, Untranslated(strprintf("Failed to initialize ChainstateManager: %s", e.what()))};
+        return {util::Error{Untranslated(strprintf("Failed to initialize ChainstateManager: %s", e.what()))}, ChainstateLoadError::FAILURE_FATAL};
     }
     ChainstateManager& chainman = *node.chainman;
-    if (chainman.m_interrupt) return {ChainstateLoadStatus::INTERRUPTED, {}};
+    if (chainman.m_interrupt) return kernel::Interrupted{};
 
     // This is defined and set here instead of inline in validation.h to avoid a hard
     // dependency between validation and index/base, since the latter is not in
@@ -1426,28 +1426,28 @@ static ChainstateLoadResult InitAndLoadChainstate(
             CClientUIInterface::MSG_ERROR);
     };
     uiInterface.InitMessage(_("Loading block index…"));
-    auto catch_exceptions = [](auto&& f) -> ChainstateLoadResult {
+    auto catch_exceptions = [](auto&& f) -> util::Result<InterruptResult, node::ChainstateLoadError> {
         try {
             return f();
         } catch (const std::exception& e) {
             LogError("%s\n", e.what());
-            return std::make_tuple(node::ChainstateLoadStatus::FAILURE, _("Error loading databases"));
+            return {util::Error{_("Error loading databases")}, node::ChainstateLoadError::FAILURE};
         }
     };
-    auto [status, error] = catch_exceptions([&] { return LoadChainstate(chainman, cache_sizes, options); });
-    if (status == node::ChainstateLoadStatus::SUCCESS) {
+    auto result = catch_exceptions([&] { return LoadChainstate(chainman, cache_sizes, options); });
+    if (result && !IsInterrupted(*result)) {
         uiInterface.InitMessage(_("Verifying blocks…"));
         if (chainman.m_blockman.m_have_pruned && options.check_blocks > MIN_BLOCKS_TO_KEEP) {
             LogWarning("pruned datadir may not have more than %d blocks; only checking available blocks\n",
                        MIN_BLOCKS_TO_KEEP);
         }
-        std::tie(status, error) = catch_exceptions([&] { return VerifyLoadedChainstate(chainman, options); });
-        if (status == node::ChainstateLoadStatus::SUCCESS) {
+        result.update(catch_exceptions([&] { return VerifyLoadedChainstate(chainman, options); }));
+        if (result && !IsInterrupted(*result)) {
             LogInfo("Block index and chainstate loaded");
             node.notifications->setChainstateLoaded(true);
         }
     }
-    return {status, error};
+    return result;
 };
 
 bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
@@ -1883,13 +1883,14 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     const bool do_reindex_chainstate{args.GetBoolArg("-reindex-chainstate", false)};
 
     // Chainstate initialization and loading may be retried once with reindexing by GUI users
-    auto [status, error] = InitAndLoadChainstate(
+    auto result = InitAndLoadChainstate(
         node,
         do_reindex,
         do_reindex_chainstate,
         kernel_cache_sizes,
         args);
-    if (status == ChainstateLoadStatus::FAILURE && !do_reindex && !ShutdownRequested(node)) {
+    if (!result && result.error() == ChainstateLoadError::FAILURE && !do_reindex && !ShutdownRequested(node)) {
+        const auto& error = util::ErrorString(result);
         // suggest a reindex
         bool do_retry{HasTestOption(args, "reindex_after_failure_noninteractive_yes") ||
             uiInterface.ThreadSafeQuestion(
@@ -1903,15 +1904,15 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         if (!Assert(node.shutdown_signal)->reset()) {
             LogError("Internal error: failed to reset shutdown signal.\n");
         }
-        std::tie(status, error) = InitAndLoadChainstate(
+        result.update(InitAndLoadChainstate(
             node,
             do_reindex,
             do_reindex_chainstate,
             kernel_cache_sizes,
-            args);
+            args));
     }
-    if (status != ChainstateLoadStatus::SUCCESS && status != ChainstateLoadStatus::INTERRUPTED) {
-        return InitError(error);
+    if (!result) {
+        return InitError(util::ErrorString(result));
     }
 
     // As LoadBlockIndex can take several minutes, it's possible the user

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1712,7 +1712,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         uiInterface.InitMessage(_("Loading P2P addresses…"));
         auto addrman{LoadAddrman(*node.netgroupman, args)};
         if (!addrman) return InitError(util::ErrorString(addrman));
-        node.addrman = std::move(*addrman);
+        node.addrman = std::move(addrman.value());
     }
 
     FastRandomContext rng;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -315,16 +315,16 @@ class WalletLoader : public ChainClient
 {
 public:
     //! Create new wallet.
-    virtual util::Result<std::unique_ptr<Wallet>> createWallet(const std::string& name, const SecureString& passphrase, uint64_t wallet_creation_flags, std::vector<bilingual_str>& warnings) = 0;
+    virtual util::ResultPtr<std::unique_ptr<Wallet>> createWallet(const std::string& name, const SecureString& passphrase, uint64_t wallet_creation_flags, std::vector<bilingual_str>& warnings) = 0;
 
     //! Load existing wallet.
-    virtual util::Result<std::unique_ptr<Wallet>> loadWallet(const std::string& name, std::vector<bilingual_str>& warnings) = 0;
+    virtual util::ResultPtr<std::unique_ptr<Wallet>> loadWallet(const std::string& name, std::vector<bilingual_str>& warnings) = 0;
 
     //! Return default wallet directory.
     virtual std::string getWalletDir() = 0;
 
     //! Restore backup wallet
-    virtual util::Result<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings, bool load_after_restore) = 0;
+    virtual util::ResultPtr<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings, bool load_after_restore) = 0;
 
     //! Migrate a wallet
     virtual util::Result<WalletMigrationResult> migrateWallet(const std::string& name, const SecureString& passphrase) = 0;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -315,16 +315,16 @@ class WalletLoader : public ChainClient
 {
 public:
     //! Create new wallet.
-    virtual util::ResultPtr<std::unique_ptr<Wallet>> createWallet(const std::string& name, const SecureString& passphrase, uint64_t wallet_creation_flags, std::vector<bilingual_str>& warnings) = 0;
+    virtual util::ResultPtr<std::unique_ptr<Wallet>> createWallet(const std::string& name, const SecureString& passphrase, uint64_t wallet_creation_flags) = 0;
 
     //! Load existing wallet.
-    virtual util::ResultPtr<std::unique_ptr<Wallet>> loadWallet(const std::string& name, std::vector<bilingual_str>& warnings) = 0;
+    virtual util::ResultPtr<std::unique_ptr<Wallet>> loadWallet(const std::string& name) = 0;
 
     //! Return default wallet directory.
     virtual std::string getWalletDir() = 0;
 
     //! Restore backup wallet
-    virtual util::ResultPtr<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings, bool load_after_restore) = 0;
+    virtual util::ResultPtr<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, bool load_after_restore) = 0;
 
     //! Migrate a wallet
     virtual util::Result<WalletMigrationResult> migrateWallet(const std::string& name, const SecureString& passphrase) = 0;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -312,16 +312,16 @@ class WalletLoader : public ChainClient
 {
 public:
     //! Create new wallet.
-    virtual util::Result<std::unique_ptr<Wallet>> createWallet(const std::string& name, const SecureString& passphrase, uint64_t wallet_creation_flags, std::vector<bilingual_str>& warnings) = 0;
+    virtual util::ResultPtr<std::unique_ptr<Wallet>> createWallet(const std::string& name, const SecureString& passphrase, uint64_t wallet_creation_flags, std::vector<bilingual_str>& warnings) = 0;
 
     //! Load existing wallet.
-    virtual util::Result<std::unique_ptr<Wallet>> loadWallet(const std::string& name, std::vector<bilingual_str>& warnings) = 0;
+    virtual util::ResultPtr<std::unique_ptr<Wallet>> loadWallet(const std::string& name, std::vector<bilingual_str>& warnings) = 0;
 
     //! Return default wallet directory.
     virtual std::string getWalletDir() = 0;
 
     //! Restore backup wallet
-    virtual util::Result<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings, bool load_after_restore) = 0;
+    virtual util::ResultPtr<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings, bool load_after_restore) = 0;
 
     //! Migrate a wallet
     virtual util::Result<WalletMigrationResult> migrateWallet(const std::string& name, const SecureString& passphrase, bool load_wallet) = 0;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -312,16 +312,16 @@ class WalletLoader : public ChainClient
 {
 public:
     //! Create new wallet.
-    virtual util::ResultPtr<std::unique_ptr<Wallet>> createWallet(const std::string& name, const SecureString& passphrase, uint64_t wallet_creation_flags, std::vector<bilingual_str>& warnings) = 0;
+    virtual util::ResultPtr<std::unique_ptr<Wallet>> createWallet(const std::string& name, const SecureString& passphrase, uint64_t wallet_creation_flags) = 0;
 
     //! Load existing wallet.
-    virtual util::ResultPtr<std::unique_ptr<Wallet>> loadWallet(const std::string& name, std::vector<bilingual_str>& warnings) = 0;
+    virtual util::ResultPtr<std::unique_ptr<Wallet>> loadWallet(const std::string& name) = 0;
 
     //! Return default wallet directory.
     virtual std::string getWalletDir() = 0;
 
     //! Restore backup wallet
-    virtual util::ResultPtr<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings, bool load_after_restore) = 0;
+    virtual util::ResultPtr<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, bool load_after_restore) = 0;
 
     //! Migrate a wallet
     virtual util::Result<WalletMigrationResult> migrateWallet(const std::string& name, const SecureString& passphrase, bool load_wallet) = 0;

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library(bitcoinkernel
   ../util/fs.cpp
   ../util/fs_helpers.cpp
   ../util/hasher.cpp
+  ../util/messages.cpp
   ../util/moneystr.cpp
   ../util/rbf.cpp
   ../util/signalinterrupt.cpp

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -49,8 +49,8 @@
 #include <span>
 #include <stdexcept>
 #include <string>
-#include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace Consensus {
@@ -1050,14 +1050,14 @@ btck_ChainstateManager* btck_chainstate_manager_create(
         const auto chainstate_load_opts{WITH_LOCK(opts.m_mutex, return opts.m_chainstate_load_options)};
 
         kernel::CacheSizes cache_sizes{DEFAULT_KERNEL_CACHE};
-        auto [status, chainstate_err]{node::LoadChainstate(*chainman, cache_sizes, chainstate_load_opts)};
-        if (status != node::ChainstateLoadStatus::SUCCESS) {
-            LogError("Failed to load chain state from your data directory: %s", chainstate_err.original);
+        auto load_result{node::LoadChainstate(*chainman, cache_sizes, chainstate_load_opts)};
+        if (!load_result || IsInterrupted(*load_result)) {
+            LogError("Failed to load chain state from your data directory: %s", util::ErrorString(load_result).original);
             return nullptr;
         }
-        std::tie(status, chainstate_err) = node::VerifyLoadedChainstate(*chainman, chainstate_load_opts);
-        if (status != node::ChainstateLoadStatus::SUCCESS) {
-            LogError("Failed to verify loaded chain state from your datadir: %s", chainstate_err.original);
+        auto verify_result{node::VerifyLoadedChainstate(*chainman, chainstate_load_opts)};
+        if (!verify_result || IsInterrupted(*verify_result)) {
+            LogError("Failed to verify loaded chain state from your datadir: %s", util::ErrorString(load_result).original);
             return nullptr;
         }
         if (auto result = chainman->ActivateBestChains(); !result) {

--- a/src/kernel/bitcoinkernel.cpp
+++ b/src/kernel/bitcoinkernel.cpp
@@ -51,8 +51,8 @@
 #include <span>
 #include <stdexcept>
 #include <string>
-#include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace Consensus {
@@ -1101,14 +1101,14 @@ btck_ChainstateManager* btck_chainstate_manager_create(
         const auto chainstate_load_opts{WITH_LOCK(opts.m_mutex, return opts.m_chainstate_load_options)};
 
         const kernel::CacheSizes cache_sizes{WITH_LOCK(opts.m_mutex, return opts.m_db_cache_bytes)};
-        auto [status, chainstate_err]{node::LoadChainstate(*chainman, cache_sizes, chainstate_load_opts)};
-        if (status != node::ChainstateLoadStatus::SUCCESS) {
-            LogError("Failed to load chain state from your data directory: %s", chainstate_err.original);
+        auto load_result{node::LoadChainstate(*chainman, cache_sizes, chainstate_load_opts)};
+        if (!load_result || IsInterrupted(*load_result)) {
+            LogError("Failed to load chain state from your data directory: %s", util::ErrorString(load_result).original);
             return nullptr;
         }
-        std::tie(status, chainstate_err) = node::VerifyLoadedChainstate(*chainman, chainstate_load_opts);
-        if (status != node::ChainstateLoadStatus::SUCCESS) {
-            LogError("Failed to verify loaded chain state from your datadir: %s", chainstate_err.original);
+        auto verify_result{node::VerifyLoadedChainstate(*chainman, chainstate_load_opts)};
+        if (!verify_result || IsInterrupted(*verify_result)) {
+            LogError("Failed to verify loaded chain state from your datadir: %s", util::ErrorString(load_result).original);
             return nullptr;
         }
         if (auto result = chainman->ActivateBestChains(); !result) {

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -27,35 +27,40 @@
 #include <vector>
 
 using kernel::CacheSizes;
+using kernel::Interrupted;
+using kernel::InterruptResult;
 
 namespace node {
 // Complete initialization of chainstates after the initial call has been made
 // to ChainstateManager::InitializeChainstate().
-static ChainstateLoadResult CompleteChainstateInitialization(
+static util::Result<InterruptResult, ChainstateLoadError> CompleteChainstateInitialization(
     ChainstateManager& chainman,
     const ChainstateLoadOptions& options) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
-    if (chainman.m_interrupt) return {ChainstateLoadStatus::INTERRUPTED, {}};
+    if (chainman.m_interrupt) return Interrupted{};
 
     // LoadBlockIndex will load m_have_pruned if we've ever removed a
     // block file from disk.
     // Note that it also sets m_blockfiles_indexed based on the disk flag!
     if (!chainman.LoadBlockIndex()) {
-        if (chainman.m_interrupt) return {ChainstateLoadStatus::INTERRUPTED, {}};
-        return {ChainstateLoadStatus::FAILURE, _("Error loading block database")};
+        if (chainman.m_interrupt) {
+            return Interrupted{};
+        } else {
+            return {util::Error{_("Error loading block database")}, ChainstateLoadError::FAILURE};
+        }
     }
 
     if (!chainman.BlockIndex().empty() &&
             !chainman.m_blockman.LookupBlockIndex(chainman.GetConsensus().hashGenesisBlock)) {
         // If the loaded chain has a wrong genesis, bail out immediately
         // (we're likely using a testnet datadir, or the other way around).
-        return {ChainstateLoadStatus::FAILURE_INCOMPATIBLE_DB, _("Incorrect or no genesis block found. Wrong datadir for network?")};
+        return {util::Error{_("Incorrect or no genesis block found. Wrong datadir for network?")}, ChainstateLoadError::FAILURE_INCOMPATIBLE_DB};
     }
 
     // Check for changed -prune state.  What we are concerned about is a user who has pruned blocks
     // in the past, but is now trying to run unpruned.
     if (chainman.m_blockman.m_have_pruned && !options.prune) {
-        return {ChainstateLoadStatus::FAILURE, _("You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain")};
+        return {util::Error{_("You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain")}, ChainstateLoadError::FAILURE};
     }
 
     // At this point blocktree args are consistent with what's on disk.
@@ -63,7 +68,7 @@ static ChainstateLoadResult CompleteChainstateInitialization(
     // (otherwise we use the one already on disk).
     // This is called again in ImportBlocks after the reindex completes.
     if (chainman.m_blockman.m_blockfiles_indexed && !chainman.LoadGenesisBlock()) {
-        return {ChainstateLoadStatus::FAILURE, _("Error initializing block database")};
+        return {util::Error{_("Error initializing block database")}, ChainstateLoadError::FAILURE};
     }
 
     auto is_coinsview_empty = [&](Chainstate& chainstate) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
@@ -93,7 +98,7 @@ static ChainstateLoadResult CompleteChainstateInitialization(
                 /*should_wipe=*/options.wipe_chainstate_db);
         } catch (dbwrapper_error& err) {
             LogError("%s\n", err.what());
-            return {ChainstateLoadStatus::FAILURE, _("Error opening coins database")};
+            return {util::Error{_("Error opening coins database")}, ChainstateLoadError::FAILURE};
         }
 
         if (options.coins_error_cb) {
@@ -103,14 +108,15 @@ static ChainstateLoadResult CompleteChainstateInitialization(
         // Refuse to load unsupported database format.
         // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
         if (chainstate->CoinsDB().NeedsUpgrade()) {
-            return {ChainstateLoadStatus::FAILURE_INCOMPATIBLE_DB, _("Unsupported chainstate database format found. "
-                                                                     "Please restart with -reindex-chainstate. This will "
-                                                                     "rebuild the chainstate database.")};
+            return {util::Error{_("Unsupported chainstate database format found. "
+                                         "Please restart with -reindex-chainstate. This will "
+                                         "rebuild the chainstate database.")},
+                                       ChainstateLoadError::FAILURE_INCOMPATIBLE_DB};
         }
 
         // ReplayBlocks is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
         if (!chainstate->ReplayBlocks()) {
-            return {ChainstateLoadStatus::FAILURE, _("Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.")};
+            return {util::Error{_("Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.")}, ChainstateLoadError::FAILURE};
         }
 
         // The on-disk coinsdb is now in a good state, create the cache
@@ -120,7 +126,7 @@ static ChainstateLoadResult CompleteChainstateInitialization(
         if (!is_coinsview_empty(*chainstate)) {
             // LoadChainTip initializes the chain based on CoinsTip()'s best block
             if (!chainstate->LoadChainTip()) {
-                return {ChainstateLoadStatus::FAILURE, _("Error initializing block database")};
+                return {util::Error{_("Error initializing block database")}, ChainstateLoadError::FAILURE};
             }
             assert(chainstate->m_chain.Tip() != nullptr);
         }
@@ -136,8 +142,8 @@ static ChainstateLoadResult CompleteChainstateInitialization(
     const auto& chainstates{chainman.m_chainstates};
     if (std::any_of(chainstates.begin(), chainstates.end(),
                     [](const auto& cs) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return cs->NeedsRedownload(); })) {
-        return {ChainstateLoadStatus::FAILURE, strprintf(_("Witness data for blocks after height %d requires validation. Please restart with -reindex."),
-                                                         chainman.GetConsensus().SegwitHeight)};
+        return {util::Error{strprintf(_("Witness data for blocks after height %d requires validation. Please restart with -reindex."),
+                                      chainman.GetConsensus().SegwitHeight)}, ChainstateLoadError::FAILURE};
     };
 
     // Now that chainstates are loaded and we're able to flush to
@@ -145,12 +151,13 @@ static ChainstateLoadResult CompleteChainstateInitialization(
     // on the condition of each chainstate.
     chainman.MaybeRebalanceCaches();
 
-    return {ChainstateLoadStatus::SUCCESS, {}};
+    return {};
 }
 
-ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,
-                                    const ChainstateLoadOptions& options)
+util::Result<InterruptResult, ChainstateLoadError> LoadChainstate(ChainstateManager& chainman, const CacheSizes& cache_sizes,
+                                                                  const ChainstateLoadOptions& options)
 {
+    util::Result<InterruptResult, ChainstateLoadError> result;
     if (!chainman.AssumedValidBlock().IsNull()) {
         LogInfo("Assuming ancestors of block %s have valid signatures.", chainman.AssumedValidBlock().GetHex());
     } else {
@@ -183,14 +190,15 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
         validated_cs.SetTargetBlock(nullptr);
         LogInfo("[snapshot] deleting snapshot chainstate due to reindexing");
         if (!chainman.DeleteChainstate(*assumeutxo_cs)) {
-            return {ChainstateLoadStatus::FAILURE_FATAL, Untranslated("Couldn't remove snapshot chainstate.")};
+            result.update({util::Error{Untranslated("Couldn't remove snapshot chainstate.")}, ChainstateLoadError::FAILURE_FATAL});
+            return result;
         }
         assumeutxo_cs = nullptr;
     }
 
-    auto [init_status, init_error] = CompleteChainstateInitialization(chainman, options);
-    if (init_status != ChainstateLoadStatus::SUCCESS) {
-        return {init_status, init_error};
+    result.update(CompleteChainstateInitialization(chainman, options));
+    if (!result || IsInterrupted(*result)) {
+        return result;
     }
 
     // If a snapshot chainstate was fully validated by a background chainstate during
@@ -210,7 +218,8 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
     } else if (snapshot_completion == SnapshotCompletionResult::SUCCESS) {
         LogInfo("[snapshot] cleaning up unneeded background chainstate, then reinitializing");
         if (!chainman.ValidatedSnapshotCleanup(validated_cs, *assumeutxo_cs)) {
-            return {ChainstateLoadStatus::FAILURE_FATAL, Untranslated("Background chainstate cleanup failed unexpectedly.")};
+            result.update({util::Error{Untranslated("Background chainstate cleanup failed unexpectedly.")}, ChainstateLoadError::FAILURE_FATAL});
+            return result;
         }
 
         // Because ValidatedSnapshotCleanup() has torn down chainstates with
@@ -224,20 +233,22 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
         // for the fully validated chainstate.
         chainman.ActiveChainstate().ClearBlockIndexCandidates();
 
-        auto [init_status, init_error] = CompleteChainstateInitialization(chainman, options);
-        if (init_status != ChainstateLoadStatus::SUCCESS) {
-            return {init_status, init_error};
+        auto result{CompleteChainstateInitialization(chainman, options)};
+        if (!result || IsInterrupted(*result)) {
+            return result;
         }
     } else {
-        return {ChainstateLoadStatus::FAILURE_FATAL, _(
+        result.update({util::Error{_(
            "UTXO snapshot failed to validate. "
-           "Restart to resume normal initial block download, or try loading a different snapshot.")};
+           "Restart to resume normal initial block download, or try loading a different snapshot.")},
+           ChainstateLoadError::FAILURE_FATAL});
+        return result;
     }
 
-    return {ChainstateLoadStatus::SUCCESS, {}};
+    return result;
 }
 
-ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options)
+util::Result<InterruptResult, ChainstateLoadError> VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options)
 {
     auto is_coinsview_empty = [&](Chainstate& chainstate) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
         return options.wipe_chainstate_db || chainstate.CoinsTip().GetBestBlock().IsNull();
@@ -245,36 +256,42 @@ ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const C
 
     LOCK(cs_main);
 
+    util::Result<InterruptResult, ChainstateLoadError> result;
     for (auto& chainstate : chainman.m_chainstates) {
         if (!is_coinsview_empty(*chainstate)) {
             const CBlockIndex* tip = chainstate->m_chain.Tip();
             if (tip && tip->nTime > GetTime() + MAX_FUTURE_BLOCK_TIME) {
-                return {ChainstateLoadStatus::FAILURE, _("The block database contains a block which appears to be from the future. "
-                                                         "This may be due to your computer's date and time being set incorrectly. "
-                                                         "Only rebuild the block database if you are sure that your computer's date and time are correct")};
+                result.update({util::Error{_("The block database contains a block which appears to be from the future. "
+                                             "This may be due to your computer's date and time being set incorrectly. "
+                                             "Only rebuild the block database if you are sure that your computer's date and time are correct")},
+                               ChainstateLoadError::FAILURE});
+                return result;
             }
 
-            VerifyDBResult result = CVerifyDB(chainman.GetNotifications()).VerifyDB(
+            VerifyDBResult verify_result = CVerifyDB(chainman.GetNotifications()).VerifyDB(
                 *chainstate, chainman.GetConsensus(), chainstate->CoinsDB(),
                 options.check_level,
                 options.check_blocks);
-            switch (result) {
+            switch (verify_result) {
             case VerifyDBResult::SUCCESS:
             case VerifyDBResult::SKIPPED_MISSING_BLOCKS:
                 break;
             case VerifyDBResult::INTERRUPTED:
-                return {ChainstateLoadStatus::INTERRUPTED, _("Block verification was interrupted")};
+                result.update(Interrupted{});
+                return result;
             case VerifyDBResult::CORRUPTED_BLOCK_DB:
-                return {ChainstateLoadStatus::FAILURE, _("Corrupted block database detected")};
+                result.update({util::Error{_("Corrupted block database detected")}, ChainstateLoadError::FAILURE});
+                return result;
             case VerifyDBResult::SKIPPED_L3_CHECKS:
                 if (options.require_full_verification) {
-                    return {ChainstateLoadStatus::FAILURE_INSUFFICIENT_DBCACHE, _("Insufficient dbcache for block verification")};
+                    result.update({util::Error{_("Insufficient dbcache for block verification")}, ChainstateLoadError::FAILURE_INSUFFICIENT_DBCACHE});
+                    return result;
                 }
                 break;
             } // no default case, so the compiler can warn about missing cases
         }
     }
 
-    return {ChainstateLoadStatus::SUCCESS, {}};
+    return result;
 }
 } // namespace node

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_NODE_CHAINSTATE_H
 #define BITCOIN_NODE_CHAINSTATE_H
 
+#include <kernel/notifications_interface.h>
+#include <util/result.h>
 #include <util/translation.h>
 #include <validation.h>
 
@@ -41,34 +43,16 @@ struct ChainstateLoadOptions {
 //! case, and treat other cases as errors. More complex applications may want to
 //! try reindexing in the generic failure case, and pass an interrupt callback
 //! and exit cleanly in the interrupted case.
-enum class ChainstateLoadStatus {
-    SUCCESS,
+enum class ChainstateLoadError {
     FAILURE, //!< Generic failure which reindexing may fix
     FAILURE_FATAL, //!< Fatal error which should not prompt to reindex
     FAILURE_INCOMPATIBLE_DB,
     FAILURE_INSUFFICIENT_DBCACHE,
-    INTERRUPTED,
 };
 
-//! Chainstate load status code and optional error string.
-using ChainstateLoadResult = std::tuple<ChainstateLoadStatus, bilingual_str>;
-
-/** This sequence can have 4 types of outcomes:
- *
- *  1. Success
- *  2. Shutdown requested
- *    - nothing failed but a shutdown was triggered in the middle of the
- *      sequence
- *  3. Soft failure
- *    - a failure that might be recovered from with a reindex
- *  4. Hard failure
- *    - a failure that definitively cannot be recovered from with a reindex
- *
- *  LoadChainstate returns a (status code, error string) tuple.
- */
-ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const kernel::CacheSizes& cache_sizes,
-                                    const ChainstateLoadOptions& options);
-ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options);
+util::Result<kernel::InterruptResult, ChainstateLoadError> LoadChainstate(ChainstateManager& chainman, const kernel::CacheSizes& cache_sizes,
+                                                                          const ChainstateLoadOptions& options);
+util::Result<kernel::InterruptResult, ChainstateLoadError> VerifyLoadedChainstate(ChainstateManager& chainman, const ChainstateLoadOptions& options);
 } // namespace node
 
 #endif // BITCOIN_NODE_CHAINSTATE_H

--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -130,7 +130,7 @@ void TestAddAddressesToSendBook(interfaces::Node& node)
     WalletContext& context = *node.walletLoader().context();
     AddWallet(context, wallet);
     WalletModel walletModel(interfaces::MakeWallet(context, wallet), clientModel, platformStyle.get());
-    RemoveWallet(context, wallet, /* load_on_start= */ std::nullopt);
+    QVERIFY(RemoveWallet(context, wallet, /* load_on_start= */ std::nullopt));
     EditAddressDialog editAddressDialog(EditAddressDialog::NewSendingAddress);
     editAddressDialog.setModel(walletModel.getAddressTableModel());
 

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -238,7 +238,7 @@ public:
         WalletContext& context = *node.walletLoader().context();
         AddWallet(context, wallet);
         walletModel = std::make_unique<WalletModel>(interfaces::MakeWallet(context, wallet), *clientModel, platformStyle);
-        RemoveWallet(context, wallet, /* load_on_start= */ std::nullopt);
+        QVERIFY(RemoveWallet(context, wallet, /* load_on_start= */ std::nullopt));
         sendCoinsDialog.setModel(walletModel.get());
         transactionView.setModel(walletModel.get());
     }

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -267,12 +267,15 @@ void CreateWalletActivity::createWallet()
     }
 
     QTimer::singleShot(500ms, worker(), [this, name, flags] {
-        auto wallet{node().walletLoader().createWallet(name, m_passphrase, flags, m_warning_message)};
-
+        auto wallet{node().walletLoader().createWallet(name, m_passphrase, flags)};
+        m_error_message.clear();
+        m_warning_message.clear();
+        if (wallet.messages_ptr()) {
+            m_error_message = Join(wallet.messages_ptr()->errors, Untranslated(" "));
+            m_warning_message = wallet.messages_ptr()->warnings;
+        }
         if (wallet) {
             m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet.value()));
-        } else {
-            m_error_message = util::ErrorString(wallet);
         }
 
         QTimer::singleShot(500ms, this, &CreateWalletActivity::finish);
@@ -356,12 +359,15 @@ void OpenWalletActivity::open(const std::string& path)
         tr("Opening Wallet <b>%1</b>…").arg(name.toHtmlEscaped()));
 
     QTimer::singleShot(0, worker(), [this, path] {
-        auto wallet{node().walletLoader().loadWallet(path, m_warning_message)};
-
+        auto wallet{node().walletLoader().loadWallet(path)};
+        m_error_message.clear();
+        m_warning_message.clear();
+        if (wallet.messages_ptr()) {
+            m_error_message = Join(wallet.messages_ptr()->errors, Untranslated(" "));
+            m_warning_message = wallet.messages_ptr()->warnings;
+        }
         if (wallet) {
             m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet.value()));
-        } else {
-            m_error_message = util::ErrorString(wallet);
         }
 
         QTimer::singleShot(0, this, &OpenWalletActivity::finish);
@@ -409,12 +415,15 @@ void RestoreWalletActivity::restore(const fs::path& backup_file, const std::stri
         tr("Restoring Wallet <b>%1</b>…").arg(name.toHtmlEscaped()));
 
     QTimer::singleShot(0, worker(), [this, backup_file, wallet_name] {
-        auto wallet{node().walletLoader().restoreWallet(backup_file, wallet_name, m_warning_message, /*load_after_restore=*/true)};
-
+        auto wallet{node().walletLoader().restoreWallet(backup_file, wallet_name, /*load_after_restore=*/true)};
+        m_error_message.clear();
+        m_warning_message.clear();
+        if (wallet.messages_ptr()) {
+            m_error_message = Join(wallet.messages_ptr()->errors, Untranslated(" "));
+            m_warning_message = wallet.messages_ptr()->warnings;
+        }
         if (wallet) {
             m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet.value()));
-        } else {
-            m_error_message = util::ErrorString(wallet);
         }
 
         QTimer::singleShot(0, this, &RestoreWalletActivity::finish);
@@ -515,7 +524,11 @@ void MigrateWalletActivity::restore_and_migrate(const fs::path& path, const std:
         tr("Restoring Wallet <b>%1</b>…").arg(GUIUtil::HtmlEscape(GUIUtil::WalletDisplayName(wallet_name))));
 
     QTimer::singleShot(0, worker(), [this, path, wallet_name] {
-        auto res{node().walletLoader().restoreWallet(path, wallet_name, m_warning_message, /*load_after_restore=*/false)};
+        auto res{node().walletLoader().restoreWallet(path, wallet_name, /*load_after_restore=*/false)};
+        m_warning_message.clear();
+        if (res.messages_ptr()) {
+            m_warning_message = res.messages_ptr()->warnings;
+        }
 
         if (!res) {
             m_error_message = util::ErrorString(res);

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -270,7 +270,7 @@ void CreateWalletActivity::createWallet()
         auto wallet{node().walletLoader().createWallet(name, m_passphrase, flags, m_warning_message)};
 
         if (wallet) {
-            m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(*wallet));
+            m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet.value()));
         } else {
             m_error_message = util::ErrorString(wallet);
         }
@@ -359,7 +359,7 @@ void OpenWalletActivity::open(const std::string& path)
         auto wallet{node().walletLoader().loadWallet(path, m_warning_message)};
 
         if (wallet) {
-            m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(*wallet));
+            m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet.value()));
         } else {
             m_error_message = util::ErrorString(wallet);
         }
@@ -412,7 +412,7 @@ void RestoreWalletActivity::restore(const fs::path& backup_file, const std::stri
         auto wallet{node().walletLoader().restoreWallet(backup_file, wallet_name, m_warning_message, /*load_after_restore=*/true)};
 
         if (wallet) {
-            m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(*wallet));
+            m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet.value()));
         } else {
             m_error_message = util::ErrorString(wallet);
         }

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -268,12 +268,15 @@ void CreateWalletActivity::createWallet()
     }
 
     QTimer::singleShot(500ms, worker(), [this, name, flags] {
-        auto wallet{node().walletLoader().createWallet(name, m_passphrase, flags, m_warning_message)};
-
+        auto wallet{node().walletLoader().createWallet(name, m_passphrase, flags)};
+        m_error_message.clear();
+        m_warning_message.clear();
+        if (wallet.messages_ptr()) {
+            m_error_message = Join(wallet.messages_ptr()->errors, Untranslated(" "));
+            m_warning_message = wallet.messages_ptr()->warnings;
+        }
         if (wallet) {
             m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet.value()));
-        } else {
-            m_error_message = util::ErrorString(wallet);
         }
 
         QTimer::singleShot(500ms, this, &CreateWalletActivity::finish);
@@ -357,12 +360,15 @@ void OpenWalletActivity::open(const std::string& path)
         tr("Opening Wallet <b>%1</b>…").arg(name.toHtmlEscaped()));
 
     QTimer::singleShot(0, worker(), [this, path] {
-        auto wallet{node().walletLoader().loadWallet(path, m_warning_message)};
-
+        auto wallet{node().walletLoader().loadWallet(path)};
+        m_error_message.clear();
+        m_warning_message.clear();
+        if (wallet.messages_ptr()) {
+            m_error_message = Join(wallet.messages_ptr()->errors, Untranslated(" "));
+            m_warning_message = wallet.messages_ptr()->warnings;
+        }
         if (wallet) {
             m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet.value()));
-        } else {
-            m_error_message = util::ErrorString(wallet);
         }
 
         QTimer::singleShot(0, this, &OpenWalletActivity::finish);
@@ -410,12 +416,15 @@ void RestoreWalletActivity::restore(const fs::path& backup_file, const std::stri
         tr("Restoring Wallet <b>%1</b>…").arg(name.toHtmlEscaped()));
 
     QTimer::singleShot(0, worker(), [this, backup_file, wallet_name] {
-        auto wallet{node().walletLoader().restoreWallet(backup_file, wallet_name, m_warning_message, /*load_after_restore=*/true)};
-
+        auto wallet{node().walletLoader().restoreWallet(backup_file, wallet_name, /*load_after_restore=*/true)};
+        m_error_message.clear();
+        m_warning_message.clear();
+        if (wallet.messages_ptr()) {
+            m_error_message = Join(wallet.messages_ptr()->errors, Untranslated(" "));
+            m_warning_message = wallet.messages_ptr()->warnings;
+        }
         if (wallet) {
             m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet.value()));
-        } else {
-            m_error_message = util::ErrorString(wallet);
         }
 
         QTimer::singleShot(0, this, &RestoreWalletActivity::finish);
@@ -525,7 +534,11 @@ void MigrateWalletActivity::restore_and_migrate(const fs::path& path, const std:
         tr("Restoring Wallet <b>%1</b>…").arg(GUIUtil::HtmlEscape(GUIUtil::WalletDisplayName(wallet_name))));
 
     QTimer::singleShot(0, worker(), [this, path, wallet_name] {
-        auto res{node().walletLoader().restoreWallet(path, wallet_name, m_warning_message, /*load_after_restore=*/false)};
+        auto res{node().walletLoader().restoreWallet(path, wallet_name, /*load_after_restore=*/false)};
+        m_warning_message.clear();
+        if (res.messages_ptr()) {
+            m_warning_message = res.messages_ptr()->warnings;
+        }
 
         if (!res) {
             m_error_message = util::ErrorString(res);

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -271,7 +271,7 @@ void CreateWalletActivity::createWallet()
         auto wallet{node().walletLoader().createWallet(name, m_passphrase, flags, m_warning_message)};
 
         if (wallet) {
-            m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(*wallet));
+            m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet.value()));
         } else {
             m_error_message = util::ErrorString(wallet);
         }
@@ -360,7 +360,7 @@ void OpenWalletActivity::open(const std::string& path)
         auto wallet{node().walletLoader().loadWallet(path, m_warning_message)};
 
         if (wallet) {
-            m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(*wallet));
+            m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet.value()));
         } else {
             m_error_message = util::ErrorString(wallet);
         }
@@ -413,7 +413,7 @@ void RestoreWalletActivity::restore(const fs::path& backup_file, const std::stri
         auto wallet{node().walletLoader().restoreWallet(backup_file, wallet_name, m_warning_message, /*load_after_restore=*/true)};
 
         if (wallet) {
-            m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(*wallet));
+            m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet.value()));
         } else {
             m_error_message = util::ErrorString(wallet);
         }

--- a/src/test/result_tests.cpp
+++ b/src/test/result_tests.cpp
@@ -182,6 +182,12 @@ void ExpectError(const util::Result<T, F>& result, bilingual_str str, Args&&... 
     BOOST_CHECK_EQUAL(result.error(), expect_error);
 }
 
+BOOST_AUTO_TEST_CASE(check_sizes)
+{
+    static_assert(sizeof(util::Result<int>) == sizeof(void*)*2);
+    static_assert(sizeof(util::Result<void>) == sizeof(void*));
+}
+
 BOOST_AUTO_TEST_CASE(check_returned)
 {
     ExpectResult(VoidSuccessFn(), true, {});

--- a/src/test/result_tests.cpp
+++ b/src/test/result_tests.cpp
@@ -149,6 +149,26 @@ BOOST_AUTO_TEST_CASE(check_returned)
     ExpectError(TruthyFalsyFn(1, false), Untranslated("error value 1."), 1);
 }
 
+BOOST_AUTO_TEST_CASE(check_update)
+{
+    // Test using Update method to change a result value from success -> error,
+    // and error->success.
+    util::Result<int, FnError> result;
+    ExpectSuccess(result, {}, 0);
+    result.update({util::Error{Untranslated("error")}, ERR1});
+    ExpectError(result, Untranslated("error"), ERR1);
+    result.update(2);
+    ExpectSuccess(result, Untranslated(""), 2);
+
+    // Test the same thing but with non-copyable success and error types.
+    util::Result<NoCopy, NoCopy> result2{0};
+    ExpectSuccess(result2, {}, 0);
+    result2.update({util::Error{Untranslated("error")}, 3});
+    ExpectError(result2, Untranslated("error"), 3);
+    result2.update(4);
+    ExpectSuccess(result2, Untranslated(""), 4);
+}
+
 BOOST_AUTO_TEST_CASE(check_dereference_operators)
 {
     util::Result<std::pair<int, std::string>> mutable_result;

--- a/src/test/result_tests.cpp
+++ b/src/test/result_tests.cpp
@@ -275,7 +275,42 @@ util::Result<std::unique_ptr<NoCopyNoMove>> DerivedToBaseFn(util::Result<std::un
 
 BOOST_AUTO_TEST_CASE(derived_to_base)
 {
+    // Check derived to base conversions work for util::Result
     BOOST_CHECK_EQUAL(*Assert(*Assert(DerivedToBaseFn(std::make_unique<Derived>(5)))), 5);
+
+    // Check conversions work between util::Result and util::ResultPtr
+    util::ResultPtr<std::unique_ptr<Derived>> derived{std::make_unique<Derived>(5)};
+    util::ResultPtr<std::unique_ptr<NoCopyNoMove>> base{DerivedToBaseFn(std::move(derived))};
+    BOOST_CHECK_EQUAL(*Assert(base), 5);
+}
+
+//! For testing ResultPtr, return pointer to a pair of ints, or return pointer to null, or return an error message.
+util::ResultPtr<std::unique_ptr<std::pair<int, int>>> PtrFn(std::optional<std::pair<int, int>> i, bool success)
+{
+    if (success) return i ? std::make_unique<std::pair<int, int>>(*i) : nullptr;
+    return util::Error{Untranslated(strprintf("PtrFn(%s) error.", i ? strprintf("%i, %i", i->first, i->second) : "nullopt"))};
+}
+
+BOOST_AUTO_TEST_CASE(check_ptr)
+{
+    auto result_pair = PtrFn(std::pair{1, 2}, true);
+    ExpectResult(result_pair, true, {});
+    BOOST_CHECK(result_pair);
+    BOOST_CHECK_EQUAL(result_pair->first, 1);
+    BOOST_CHECK_EQUAL(result_pair->second, 2);
+    BOOST_CHECK(*result_pair == std::pair(1,2));
+
+    auto result_null = PtrFn(std::nullopt, true);
+    ExpectResult(result_null, true, {});
+    BOOST_CHECK(!result_null);
+
+    auto result_error_pair = PtrFn(std::pair{1, 2}, false);
+    ExpectResult(result_error_pair, false, Untranslated("PtrFn(1, 2) error."));
+    BOOST_CHECK(!result_error_pair);
+
+    auto result_error_null = PtrFn(std::nullopt, false);
+    ExpectResult(result_error_null, false, Untranslated("PtrFn(nullopt) error."));
+    BOOST_CHECK(!result_error_null);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/result_tests.cpp
+++ b/src/test/result_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/check.h>
 #include <util/result.h>
 
 #include <boost/test/unit_test.hpp>
@@ -33,6 +34,34 @@ std::ostream& operator<<(std::ostream& os, const NoCopy& o)
     return os << "NoCopy(" << *o.m_n << ")";
 }
 
+struct NoCopyNoMove {
+    NoCopyNoMove(int n) : m_n{n} {}
+    NoCopyNoMove(const NoCopyNoMove&) = delete;
+    NoCopyNoMove(NoCopyNoMove&&) = delete;
+    int m_n;
+};
+
+bool operator==(const NoCopyNoMove& a, const NoCopyNoMove& b)
+{
+    return a.m_n == b.m_n;
+}
+
+std::ostream& operator<<(std::ostream& os, const NoCopyNoMove& o)
+{
+    os << "NoCopyNoMove(" << o.m_n << ")";
+    return os;
+}
+
+util::Result<void> VoidSuccessFn()
+{
+    return {};
+}
+
+util::Result<void> VoidErrorFn()
+{
+    return util::Error{Untranslated("void error.")};
+}
+
 util::Result<int> IntFn(int i, bool success)
 {
     if (success) return i;
@@ -45,21 +74,46 @@ util::Result<bilingual_str> StrFn(bilingual_str s, bool success)
     return util::Error{Untranslated(strprintf("str %s error.", s.original))};
 }
 
-util::Result<NoCopy> NoCopyFn(int i, bool success)
+util::Result<NoCopy, NoCopy> NoCopyFn(int i, bool success)
 {
     if (success) return {i};
-    return util::Error{Untranslated(strprintf("nocopy %i error.", i))};
+    return {util::Error{Untranslated(strprintf("nocopy %i error.", i))}, i};
 }
 
-template <typename T>
-void ExpectResult(const util::Result<T>& result, bool success, const bilingual_str& str)
+util::Result<NoCopyNoMove, NoCopyNoMove> NoCopyNoMoveFn(int i, bool success)
+{
+    if (success) return {i};
+    return {util::Error{Untranslated(strprintf("nocopynomove %i error.", i))}, i};
+}
+
+enum FnError { ERR1, ERR2 };
+
+util::Result<int, FnError> IntErrorFn(int i, bool success)
+{
+    if (success) return i;
+    return {util::Error{Untranslated(strprintf("int %i error.", i))}, i % 2 ? ERR1 : ERR2};
+}
+
+util::Result<NoCopyNoMove, FnError> EnumErrorFn(FnError ret)
+{
+    return {util::Error{Untranslated("enum error.")}, ret};
+}
+
+util::Result<int, int> TruthyFalsyFn(int i, bool success)
+{
+    if (success) return i;
+    return {util::Error{Untranslated(strprintf("error value %i.", i))}, i};
+}
+
+template <typename T, typename F>
+void ExpectResult(const util::Result<T, F>& result, bool success, const bilingual_str& str)
 {
     BOOST_CHECK_EQUAL(bool(result), success);
     BOOST_CHECK_EQUAL(util::ErrorString(result), str);
 }
 
-template <typename T, typename... Args>
-void ExpectSuccess(const util::Result<T>& result, const bilingual_str& str, Args&&... args)
+template <typename T, typename F, typename... Args>
+void ExpectSuccess(const util::Result<T, F>& result, const bilingual_str& str, Args&&... args)
 {
     ExpectResult(result, true, str);
     BOOST_CHECK_EQUAL(result.has_value(), true);
@@ -68,20 +122,42 @@ void ExpectSuccess(const util::Result<T>& result, const bilingual_str& str, Args
     BOOST_CHECK_EQUAL(&result.value(), &*result);
 }
 
-template <typename T, typename... Args>
-void ExpectFail(const util::Result<T>& result, const bilingual_str& str)
+template <typename T, typename F, typename... Args>
+void ExpectError(const util::Result<T, F>& result, bilingual_str str, Args&&... args)
 {
     ExpectResult(result, false, str);
+    F expect_error{std::forward<Args>(args)...};
+    BOOST_CHECK_EQUAL(result.error(), expect_error);
 }
 
 BOOST_AUTO_TEST_CASE(check_returned)
 {
+    ExpectResult(VoidSuccessFn(), true, {});
+    ExpectResult(VoidErrorFn(), false, Untranslated("void error."));
     ExpectSuccess(IntFn(5, true), {}, 5);
-    ExpectFail(IntFn(5, false), Untranslated("int 5 error."));
+    ExpectResult(IntFn(5, false), false, Untranslated("int 5 error."));
     ExpectSuccess(NoCopyFn(5, true), {}, 5);
-    ExpectFail(NoCopyFn(5, false), Untranslated("nocopy 5 error."));
+    ExpectError(NoCopyFn(5, false), Untranslated("nocopy 5 error."), 5);
+    ExpectSuccess(NoCopyNoMoveFn(5, true), {}, 5);
+    ExpectError(NoCopyNoMoveFn(5, false), Untranslated("nocopynomove 5 error."), 5);
     ExpectSuccess(StrFn(Untranslated("S"), true), {}, Untranslated("S"));
-    ExpectFail(StrFn(Untranslated("S"), false), Untranslated("str S error."));
+    ExpectResult(StrFn(Untranslated("S"), false), false, Untranslated("str S error."));
+    ExpectError(EnumErrorFn(ERR2), Untranslated("enum error."), ERR2);
+    ExpectSuccess(TruthyFalsyFn(0, true), {}, 0);
+    ExpectError(TruthyFalsyFn(0, false), Untranslated("error value 0."), 0);
+    ExpectSuccess(TruthyFalsyFn(1, true), {}, 1);
+    ExpectError(TruthyFalsyFn(1, false), Untranslated("error value 1."), 1);
+}
+
+BOOST_AUTO_TEST_CASE(check_dereference_operators)
+{
+    util::Result<std::pair<int, std::string>> mutable_result;
+    const auto& const_result{mutable_result};
+    mutable_result.value() = {1, "23"};
+    BOOST_CHECK_EQUAL(mutable_result->first, 1);
+    BOOST_CHECK_EQUAL(const_result->second, "23");
+    (*mutable_result).first = 5;
+    BOOST_CHECK_EQUAL((*const_result).first, 5);
 }
 
 BOOST_AUTO_TEST_CASE(check_value_or)
@@ -92,6 +168,20 @@ BOOST_AUTO_TEST_CASE(check_value_or)
     BOOST_CHECK_EQUAL(NoCopyFn(10, false).value_or(20), 20);
     BOOST_CHECK_EQUAL(StrFn(Untranslated("A"), true).value_or(Untranslated("B")), Untranslated("A"));
     BOOST_CHECK_EQUAL(StrFn(Untranslated("A"), false).value_or(Untranslated("B")), Untranslated("B"));
+}
+
+struct Derived : NoCopyNoMove {
+    using NoCopyNoMove::NoCopyNoMove;
+};
+
+util::Result<std::unique_ptr<NoCopyNoMove>> DerivedToBaseFn(util::Result<std::unique_ptr<Derived>> derived)
+{
+    return derived;
+}
+
+BOOST_AUTO_TEST_CASE(derived_to_base)
+{
+    BOOST_CHECK_EQUAL(*Assert(*Assert(DerivedToBaseFn(std::make_unique<Derived>(5)))), 5);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -359,11 +359,11 @@ void ChainTestingSetup::LoadVerifyActivateChainstate()
     options.check_blocks = m_args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS);
     options.check_level = m_args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL);
     options.require_full_verification = m_args.IsArgSet("-checkblocks") || m_args.IsArgSet("-checklevel");
-    auto [status, error] = LoadChainstate(chainman, m_kernel_cache_sizes, options);
-    assert(status == node::ChainstateLoadStatus::SUCCESS);
+    auto load_result{LoadChainstate(chainman, m_kernel_cache_sizes, options)};
+    Assert(load_result);
 
-    std::tie(status, error) = VerifyLoadedChainstate(chainman, options);
-    assert(status == node::ChainstateLoadStatus::SUCCESS);
+    auto verify_result{VerifyLoadedChainstate(chainman, options)};
+    Assert(verify_result);
 
     m_node.notifications->setChainstateLoaded(true);
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -357,11 +357,11 @@ void ChainTestingSetup::LoadVerifyActivateChainstate()
     options.check_blocks = m_args.GetIntArg("-checkblocks", DEFAULT_CHECKBLOCKS);
     options.check_level = m_args.GetIntArg("-checklevel", DEFAULT_CHECKLEVEL);
     options.require_full_verification = m_args.IsArgSet("-checkblocks") || m_args.IsArgSet("-checklevel");
-    auto [status, error] = LoadChainstate(chainman, m_kernel_cache_sizes, options);
-    assert(status == node::ChainstateLoadStatus::SUCCESS);
+    auto load_result{LoadChainstate(chainman, m_kernel_cache_sizes, options)};
+    Assert(load_result);
 
-    std::tie(status, error) = VerifyLoadedChainstate(chainman, options);
-    assert(status == node::ChainstateLoadStatus::SUCCESS);
+    auto verify_result{VerifyLoadedChainstate(chainman, options)};
+    Assert(verify_result);
 
     m_node.notifications->setChainstateLoaded(true);
 

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(bitcoin_util STATIC EXCLUDE_FROM_ALL
   fs.cpp
   fs_helpers.cpp
   hasher.cpp
+  messages.cpp
   moneystr.cpp
   rbf.cpp
   readwritefile.cpp

--- a/src/util/messages.cpp
+++ b/src/util/messages.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit
+
+#include <initializer_list>
+#include <iterator>
+#include <util/messages.h>
+#include <util/translation.h>
+
+namespace util {
+bilingual_str JoinMessages(const Messages& messages)
+{
+    bilingual_str result;
+    for (const auto& messages : {messages.errors, messages.warnings}) {
+        for (const auto& message : messages) {
+            if (!result.empty()) result += Untranslated(" ");
+            result += message;
+        }
+    }
+    return result;
+}
+
+void MoveMessages(Messages& dst, Messages& src)
+{
+    dst.errors.insert(dst.errors.end(), std::make_move_iterator(src.errors.begin()), std::make_move_iterator(src.errors.end()));
+    dst.warnings.insert(dst.warnings.end(), std::make_move_iterator(src.warnings.begin()), std::make_move_iterator(src.warnings.end()));
+    src.errors.clear();
+    src.warnings.clear();
+}
+} // namespace util

--- a/src/util/messages.h
+++ b/src/util/messages.h
@@ -1,0 +1,53 @@
+// Copyright (c) The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit
+
+//! @file util/messages.h defines helper function and types that can be used
+//! with the util::Result class to deal with error and warning messages. It
+//! keeps the message representation separate from the implementation of the
+//! Result class, allowing each to be understood and changed more easily.
+
+#ifndef BITCOIN_UTIL_MESSAGES_H
+#define BITCOIN_UTIL_MESSAGES_H
+
+#include <util/translation.h>
+
+#include <string>
+#include <vector>
+
+namespace util {
+//! Default MessagesType for Result class, simple list of errors and warnings.
+struct Messages {
+    std::vector<bilingual_str> errors{};
+    std::vector<bilingual_str> warnings{};
+};
+
+//! Wrapper object to pass an error string to the Result constructor.
+struct Error {
+    bilingual_str message;
+};
+//! Wrapper object to pass a warning string to the Result constructor.
+struct Warning {
+    bilingual_str message;
+};
+
+//! Helper function to join messages in space separated string.
+bilingual_str JoinMessages(const Messages& messages);
+
+//! Helper function to move messages from one instance to another.
+void MoveMessages(Messages& dst, Messages& src);
+
+//! Join error and warning messages in a space separated string. This is
+//! intended for simple applications where there's probably only one error or
+//! warning message to report, but multiple messages should not be lost if they
+//! are present. More complicated applications should use Result::messages_ptr()
+//! method directly.
+template <typename Result>
+bilingual_str ErrorString(const Result& result)
+{
+    const auto* messages{result.messages_ptr()};
+    return messages ? JoinMessages(*messages) : bilingual_str{};
+}
+} // namespace util
+
+#endif // BITCOIN_UTIL_MESSAGES_H

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -65,7 +65,7 @@ namespace util {
 //!    return result;
 //!
 //! It also provides an update() method which is useful for returning early on
-//! failures and for combining results of the same type.
+//! errors and for combining results of the same type.
 //!
 //!    Result<Value> result;
 //!    if (!(DoSomething() >> result)) {

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -18,6 +18,11 @@
 #include <vector>
 
 namespace util {
+template <class T, class E>
+class Expected;
+template <class E>
+class Unexpected;
+
 //! The Result<SuccessType, ErrorType, MessagesType> class provides
 //! an efficient way for functions to return structured result information, as
 //! well as descriptive error messages.
@@ -217,6 +222,19 @@ public:
     Result(O&& other)
     {
         move</*DstConstructed=*/false>(*this, other);
+    }
+
+    template<typename E>
+    Result(Unexpected<E>&& e) : Result{Error{}, std::move(e.error())} {}
+
+    template<typename T, typename E>
+    Result(Expected<T, E>&& e)
+    {
+        if (e) {
+            construct<false>(*this, std::move(e.error()));
+        } else {
+            construct<true>(*this, std::move(e.error()));
+        }
     }
 
     //! Update this result by moving from another result object. Existing

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -415,4 +415,35 @@ struct ResultTraits<Warning> {
 };
 } // namespace util
 
+//! Temporary helper used to decompose util::Result into success / failure /
+//! error / warning values.  This is used in upcoming commits to incrementally
+//! port code not using util::Result to start using it, and it is removed after
+//! the last commit when everything is using util::Result.
+//!
+//! First ResultExtract argument is an input result object. Remaining arguments
+//! are output arguments returning the result failure value and error and
+//! warning messages, if any. Return value is the result success value, if the
+//! success type is non-void, or a boolean indicating success / failure if the
+//! success type is void.
+template<typename Result, typename ErrorPtr>
+auto ResultExtract(Result&& result, ErrorPtr error_ptr=nullptr, bilingual_str* error = nullptr, std::vector<bilingual_str>* warnings = nullptr)
+{
+    if constexpr (!std::is_same_v<ErrorPtr, std::nullptr_t>) {
+        if (error_ptr && !result) *error_ptr = result.error();
+        if (error_ptr && result) *error_ptr = typename Result::ErrorType{};
+    }
+    if (error && result.messages_ptr() && !result.messages_ptr()->errors.empty()) {
+        *error = util::ErrorString(result);
+    }
+    if (warnings && result.messages_ptr()) {
+        const auto& w = result.messages_ptr()->warnings;
+        warnings->insert(warnings->end(), w.begin(), w.end());
+    }
+    if constexpr (std::is_same_v<typename Result::SuccessType, void>) {
+        return bool{result};
+    } else {
+        return result ? std::move(result.value()) : typename Result::SuccessType{};
+    }
+}
+
 #endif // BITCOIN_UTIL_RESULT_H

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -8,7 +8,13 @@
 #include <attributes.h>
 #include <util/translation.h>
 
-#include <variant>
+#include <cassert>
+#include <memory>
+#include <new>
+#include <optional>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 namespace util {
 
@@ -16,31 +22,159 @@ struct Error {
     bilingual_str message;
 };
 
-//! The util::Result class provides a standard way for functions to return
-//! either error messages or result values.
+//! The Result<SuccessType, ErrorType, MessagesType> class provides
+//! an efficient way for functions to return structured result information, as
+//! well as descriptive error messages.
 //!
-//! It is intended for high-level functions that need to report error strings to
-//! end users. Lower-level functions that don't need this error-reporting and
-//! that only need error-handling should avoid util::Result and instead use
-//! util::Expected, std::optional, std::variant, or custom structs
-//! and enum types to return function results.
+//! Logically, a result object is equivalent to:
 //!
-//! Usage examples can be found in \example ../test/result_tests.cpp, but in
-//! general code returning `util::Result<T>` values is very similar to code
-//! returning `std::optional<T>` values. Existing functions returning
-//! `std::optional<T>` can be updated to return `util::Result<T>` and return
-//! error strings usually just replacing `return std::nullopt;` with `return
-//! util::Error{error_string};`.
-template <class M>
-class Result
+//!     tuple<variant<SuccessType, ErrorType>, MessagesType>
+//!
+//! But the physical representation is more efficient because it avoids
+//! allocating memory for ErrorType and MessagesType fields unless there is an
+//! error.
+//!
+//! Result<SuccessType> objects support the same operators as
+//! std::optional<SuccessType>, such as !result, *result, result->member, to
+//! make SuccessType values easy to access. They also provide
+//! result.error() and result.messages() methods to
+//! access other parts of the result. A simple usage example is:
+//!
+//!    Result<int> AddNumbers(int a, int b)
+//!    {
+//!        if (b == 0) return util::Error{_("Not adding 0, that's dumb.")};
+//!        return a + b;
+//!    }
+//!
+//!    void TryAddNumbers(int a, int b)
+//!    {
+//!        if (auto result = AddNumbers(a, b)) {
+//!            LogInfo("%i + %i = %i\n", a, b, *result);
+//!        } else {
+//!            LogInfo("Error: %s\n", util::ErrorString(result).translated);
+//!        }
+//!    }
+//!
+//! The `Result` class is superset of `std::expected`, providing additional
+//! features for combining results from different functions and returning error
+//! messages for users instead of just error values for callers.
+template <typename SuccessType = void, typename ErrorType = void, typename MessagesType = bilingual_str>
+class Result;
+
+//! Traits class that can be specialized to control the way result types are
+//! combined and constructed. Specializations provide a construct() method to be
+//! accepted as special arguments to the Result constructor, and a
+//! construct_error bool member indicating whether to construct error values
+//! instead of success values on use.
+template<typename T>
+struct ResultTraits {};
+
+namespace detail {
+//! Substitute for std::monostate that doesn't depend on std::variant.
+struct Monostate{};
+
+//! Container for ErrorType and MessagesType, providing public operator
+//! bool(), error(), messages_ptr(), and messages() methods.
+template <typename ErrorType, typename MessagesType>
+class FailDataHolder
 {
-private:
-    using T = std::conditional_t<std::is_same_v<M, void>, std::monostate, M>;
+protected:
+    struct FailData {
+        std::optional<std::conditional_t<std::is_same_v<ErrorType, void>, Monostate, ErrorType>> error{};
+        MessagesType messages{};
+    };
+    std::unique_ptr<FailData> m_fail_data;
 
-    std::variant<bilingual_str, T> m_variant;
+    // Private accessor, create FailData if it doesn't exist.
+    FailData& fail_data() LIFETIMEBOUND
+    {
+        if (!m_fail_data) m_fail_data = std::make_unique<FailData>();
+        return *m_fail_data;
+    }
 
-    //! Disallow copy constructor, require Result to be moved for efficiency.
-    Result(const Result&) = delete;
+public:
+    // Public accessors.
+    explicit operator bool() const { return !m_fail_data || !m_fail_data->error; }
+    const auto& error() const LIFETIMEBOUND { assert(!*this); return *m_fail_data->error; }
+    auto& error() LIFETIMEBOUND { assert(!*this); return *m_fail_data->error; }
+    const auto* messages_ptr() const LIFETIMEBOUND { return m_fail_data ? &m_fail_data->messages : nullptr; }
+    auto* messages_ptr() LIFETIMEBOUND { return m_fail_data ? &m_fail_data->messages : nullptr; }
+    auto& messages() LIFETIMEBOUND { return fail_data().messages; }
+};
+
+//! Container for SuccessType, providing public accessor methods similar to
+//! std::optional methods to access the success value. There is a specialization
+//! of this class for the void success type.
+template <typename SuccessType, typename ErrorType, typename MessagesType>
+class SuccessHolder : public FailDataHolder<ErrorType, MessagesType>
+{
+protected:
+    //! Success value embedded in an anonymous union so it doesn't need to be
+    //! constructed if the result is holding a error value,
+    union { SuccessType m_success; };
+
+    //! Empty constructor that needs to be declared because the class contains a union.
+    SuccessHolder() {}
+    ~SuccessHolder() { if (*this) m_success.~SuccessType(); }
+
+public:
+    // Public accessors.
+    bool has_value() const { return bool{*this}; }
+    const SuccessType& value() const LIFETIMEBOUND { assert(has_value()); return m_success; }
+    SuccessType& value() LIFETIMEBOUND { assert(has_value()); return m_success; }
+    template <class U>
+    SuccessType value_or(U&& default_value) const&
+    {
+        return has_value() ? value() : std::forward<U>(default_value);
+    }
+    template <class U>
+    SuccessType value_or(U&& default_value) &&
+    {
+        return has_value() ? std::move(value()) : std::forward<U>(default_value);
+    }
+    const SuccessType* operator->() const LIFETIMEBOUND { return &value(); }
+    const SuccessType& operator*() const LIFETIMEBOUND { return value(); }
+    SuccessType* operator->() LIFETIMEBOUND { return &value(); }
+    SuccessType& operator*() LIFETIMEBOUND { return value(); }
+};
+
+//! Specialization of SuccessHolder when SuccessType is void.
+template <typename ErrorType, typename MessagesType>
+class SuccessHolder<void, ErrorType, MessagesType> : public FailDataHolder<ErrorType, MessagesType>
+{
+};
+//! @}
+} // namespace detail
+
+// Result type class, documented at the top of this file.
+template <typename SuccessType_, typename ErrorType_, typename MessagesType_>
+class Result : public detail::SuccessHolder<SuccessType_, ErrorType_, MessagesType_>
+{
+public:
+    using SuccessType = SuccessType_;
+    using ErrorType = ErrorType_;
+    using MessagesType = MessagesType_;
+    static constexpr bool is_result{true};
+
+    //! Construct a Result object setting a success or error value. Initial
+    //! special arguments with ResultTraits::construct methods are processed
+    //! first, and then remaining arguments are passed to the SuccessType
+    //! constructor if this is a successful result or to the FailType
+    //! constructor otherwise.
+    template <typename... Args>
+    Result(Args&&... args)
+    {
+        construct</*Error=*/false>(*this, std::forward<Args>(args)...);
+    }
+
+    //! Move-construct a Result object from another Result object, moving the
+    //! success or error value and messages.
+    template <typename O>
+    requires (std::decay_t<O>::is_result)
+    Result(O&& other)
+    {
+        move(*this, other);
+    }
 
     //! Disallow operator= to avoid confusion in the future when the Result
     //! class gains support for richer error reporting, and callers should have
@@ -49,50 +183,96 @@ private:
     Result& operator=(const Result&) = delete;
     Result& operator=(Result&&) = delete;
 
-    template <typename FT>
-    friend bilingual_str ErrorString(const Result<FT>& result);
+protected:
+    template <typename, typename, typename>
+    friend class Result;
 
-public:
-    Result() : m_variant{std::in_place_index_t<1>{}, std::monostate{}} {}  // constructor for void
-    Result(T obj) : m_variant{std::in_place_index_t<1>{}, std::move(obj)} {}
-    Result(Error error) : m_variant{std::in_place_index_t<0>{}, std::move(error.message)} {}
-    Result(Result&&) = default;
-    ~Result() = default;
+    //! Helper function to construct a new success or error value using the
+    //! arguments provided.
+    template <bool Error, typename Result, typename... Args>
+    static void construct(Result& result, Args&&... args)
+    {
+        if constexpr (Error) {
+            static_assert(sizeof...(args) > 0 || !std::is_scalar_v<ErrorType>,
+                "Refusing to default-construct error value with int, float, enum, or pointer type, please specify an explicit error value.");
+            result.fail_data().error.emplace(std::forward<Args>(args)...);
+        } else if constexpr (std::is_same_v<typename Result::SuccessType, void>) {
+            static_assert(sizeof...(args) == 0, "Error: Arguments cannot be passed to a Result<void> constructor.");
+        } else {
+            new (&result.m_success) typename Result::SuccessType{std::forward<Args>(args)...};
+        }
+    }
 
-    //! std::optional methods, so functions returning optional<T> can change to
-    //! return Result<T> with minimal changes to existing code, and vice versa.
-    bool has_value() const noexcept { return m_variant.index() == 1; }
-    const T& value() const LIFETIMEBOUND
+    //! Overload for construct() for special arguments with
+    //! ResultTraits::construct method defined.
+    template <bool Error, typename Result, typename T, typename... Args>
+    requires requires { ResultTraits<std::decay_t<T>>::construct(std::declval<Result&>(), std::declval<T&&>()); }
+    static void construct(Result& result, T&& arg, Args&&... args)
     {
-        assert(has_value());
-        return std::get<1>(m_variant);
+        using Traits = ResultTraits<std::decay_t<T>>;
+        constexpr bool construct_error{Error || []{
+            if constexpr (requires { Traits::construct_error; }) return Traits::construct_error;
+            return false;
+        }()};
+        Traits::construct(result, std::forward<T>(arg));
+        construct<construct_error>(result, std::forward<Args>(args)...);
     }
-    T& value() LIFETIMEBOUND
+
+    //! Move success, error, and message values from source Result object to
+    //! destination object.
+    //! The source and destination results are not required to have the same
+    //! types, and assigning void source types to non-void destinations type is
+    //! allowed, since no source information is lost. But assigning non-void
+    //! source types to void destination types is not allowed, since this would
+    //! discard source information.
+    template <typename DstResult, typename SrcResult>
+    static void move(DstResult& dst, SrcResult& src)
     {
-        assert(has_value());
-        return std::get<1>(m_variant);
+        // Move messages values first, then move success or error value below.
+        if (src.messages_ptr() && !src.messages_ptr()->empty()) {
+            dst.messages() = std::move(*src.messages_ptr());
+        }
+        // At this point dst has no success or error value set. Can assert
+        // there is no error value.
+        assert(dst);
+        if (src) {
+            // src has a success value, so move it to dst. If the src success
+            // type is void and the dst success type is non-void, just
+            // initialize the dst success value by default initialization.
+            if constexpr (!std::is_same_v<typename SrcResult::SuccessType, void>) {
+               new (&dst.m_success) typename DstResult::SuccessType{std::move(src.m_success)};
+            } else if constexpr (!std::is_same_v<typename DstResult::SuccessType, void>) {
+               new (&dst.m_success) typename DstResult::SuccessType{};
+            }
+        } else {
+            // src has a error value, so move it to dst. If the src error
+            // type is void, just initialize the dst error value by default
+            // initialization.
+            if constexpr (!std::is_same_v<typename SrcResult::ErrorType, void>) {
+                dst.fail_data().error.emplace(std::move(src.error()));
+            } else {
+                dst.fail_data().error.emplace();
+            }
+        }
     }
-    template <class U>
-    T value_or(U&& default_value) const&
-    {
-        return has_value() ? value() : std::forward<U>(default_value);
-    }
-    template <class U>
-    T value_or(U&& default_value) &&
-    {
-        return has_value() ? std::move(value()) : std::forward<U>(default_value);
-    }
-    explicit operator bool() const noexcept { return has_value(); }
-    const T* operator->() const LIFETIMEBOUND { return &value(); }
-    const T& operator*() const LIFETIMEBOUND { return value(); }
-    T* operator->() LIFETIMEBOUND { return &value(); }
-    T& operator*() LIFETIMEBOUND { return value(); }
 };
 
-template <typename T>
-bilingual_str ErrorString(const Result<T>& result)
+//! ResultTraits specialization for Error struct.
+template<>
+struct ResultTraits<Error> {
+    static constexpr bool construct_error{true};
+
+    template<typename ResultType>
+    static void construct(ResultType& dst, Error&& src)
+    {
+       dst.messages() = std::move(src.message);
+    }
+};
+
+template <typename Result>
+bilingual_str ErrorString(const Result& result)
 {
-    return result ? bilingual_str{} : std::get<0>(result.m_variant);
+    return !result && result.messages_ptr() ? *result.messages_ptr() : bilingual_str{};
 }
 } // namespace util
 

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -352,6 +352,33 @@ decltype(auto) operator>>(SrcResult&& src LIFETIMEBOUND, DstResult&& dst)
     return static_cast<SrcType&&>(src);
 }
 
+//! Wrapper around util::Result that is less awkward to use with pointer types.
+//!
+//! It overloads pointer and bool operators so it isn't necessary to dereference
+//! the result object twice to access the result value, so it possible to call
+//! methods with `result->Method()` rather than `(*result)->Method()` and check
+//! whether the pointer is null with `if (result)` rather than `if (result &&
+//! *result)`.
+//!
+//! The `ResultPtr` class just adds syntax sugar to `Result` class. It is still
+//! possible to access the result pointer directly using `ResultPtr` `value()`
+//! and `has_value()` methods.
+template <typename T, typename F = void>
+class ResultPtr : public Result<T, F>
+{
+public:
+    // Inherit Result constructors (excluding copy and move constructors).
+    using Result<T, F>::Result;
+
+    // Inherit Result copy and move constructors.
+    template<typename O>
+    ResultPtr(O&& other) : Result<T, F>{std::forward<O>(other)} {}
+
+    explicit operator bool() const noexcept { return this->has_value() && this->value(); }
+    auto* operator->() const { assert(this->value()); return &*this->value(); }
+    auto& operator*() const { assert(this->value()); return *this->value(); }
+};
+
 //! ResultTraits specialization for Messages struct.
 template<>
 struct ResultTraits<Messages> {

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -6,6 +6,7 @@
 #define BITCOIN_UTIL_RESULT_H
 
 #include <attributes.h>
+#include <util/messages.h> // IWYU pragma: export
 #include <util/translation.h>
 
 #include <cassert>
@@ -17,11 +18,6 @@
 #include <vector>
 
 namespace util {
-
-struct Error {
-    bilingual_str message;
-};
-
 //! The Result<SuccessType, ErrorType, MessagesType> class provides
 //! an efficient way for functions to return structured result information, as
 //! well as descriptive error messages.
@@ -58,18 +54,65 @@ struct Error {
 //! The `Result` class is superset of `std::expected`, providing additional
 //! features for combining results from different functions and returning error
 //! messages for users instead of just error values for callers.
-template <typename SuccessType = void, typename ErrorType = void, typename MessagesType = bilingual_str>
+//!
+//! It provides an >> operator to move messages between results without
+//! affecting success and error values.
+//!
+//!    Result<void> result;
+//!    auto r1 = DoSomething() >> result;
+//!    auto r2 = DoSomethingElse() >> result;
+//!    ...
+//!    return result;
+//!
+//! It also provides an update() method which is useful for returning early on
+//! failures and for combining results of the same type.
+//!
+//!    Result<Value> result;
+//!    if (!(DoSomething() >> result)) {
+//!        result.update(Error{_("DoSomething failed.")});
+//!        return result;
+//!    }
+//!    if (!result.update(DoSomethingElse())) {
+//!        result.update(Error{_("DoSomethingElse failed.")});
+//!        return result;
+//!    }
+//!    result.update(...);
+//!    return result;
+//!
+//! Semantically, the update() method merges state from different results,
+//! appending data instead of overwriting it where possible. This can be
+//! controlled by specializing the `ResultTraits` class below, which is used by
+//! the `ResultUpdate()` function.
+template <typename SuccessType = void, typename ErrorType = void, typename MessagesType = Messages>
 class Result;
 
 //! Traits class that can be specialized to control the way result types are
-//! combined and constructed. Specializations provide a construct() method to be
-//! accepted as special arguments to the Result constructor, and a
-//! construct_error bool member indicating whether to construct error values
-//! instead of success values on use.
+//! combined and constructed. Specializations can provide an update() method
+//! merging information from a source object to a destination object. They can
+//! also define an empty() method to avoid updates if a source object contains
+//! no data. They can also define a construct() method to be accepted as
+//! special arguments to the Result constructor, and a construct_error bool
+//! member indicating whether to construct error values instead of success
+//! values on use.
 template<typename T>
 struct ResultTraits {};
 
 namespace detail {
+//! Helper to use ResultTraits and update dst if src is nonempty.
+template<typename T>
+void ResultUpdate(auto&& dst_fn, T& src)
+{
+    using Traits = ResultTraits<T>;
+    if constexpr (requires { Traits::empty; }) {
+        if (Traits::empty(src)) return;
+    }
+    if constexpr (requires { Traits::update; }) {
+        Traits::update(dst_fn(), std::move(src));
+    } else {
+        dst_fn() = std::move(src);
+    }
+}
+
 //! Substitute for std::monostate that doesn't depend on std::variant.
 struct Monostate{};
 
@@ -176,7 +219,10 @@ public:
         move</*DstConstructed=*/false>(*this, other);
     }
 
-    //! Update this result by moving from another result object.
+    //! Update this result by moving from another result object. Existing
+    //! success, error, and messages values are updated using
+    //! ResultTraits::update calls so state can be combined instead of
+    //! overwritten.
     Result& update(Result&& other) LIFETIMEBOUND
     {
         move</*DstConstructed=*/true>(*this, other);
@@ -184,9 +230,7 @@ public:
     }
 
     //! Disallow operator= and require explicit Result::update() calls to avoid
-    //! confusion in the future when the Result class gains support for richer
-    //! error reporting, and callers should have ability to set a new result
-    //! value without clearing existing error messages.
+    //! accidentally clearing messages when combining results.
     Result& operator=(Result&&) = delete;
 
 protected:
@@ -225,7 +269,9 @@ protected:
     }
 
     //! Move success, error, and message values from source Result object to
-    //! destination object.
+    //! destination object. Existing values are updated using
+    //! ResultTraits::update calls so state can be combined instead of
+    //! overwritten.
     //! The source and destination results are not required to have the same
     //! types, and assigning void source types to non-void destinations type is
     //! allowed, since no source information is lost. But assigning non-void
@@ -234,16 +280,27 @@ protected:
     template <bool DstConstructed, typename DstResult, typename SrcResult>
     static void move(DstResult& dst, SrcResult& src)
     {
-        // Move messages values first, then move success or error value below.
-        if (src.messages_ptr() && !src.messages_ptr()->empty()) {
-            dst.messages() = std::move(*src.messages_ptr());
-        }
+        // Use operator>> to move messages values first, then move
+        // success or error value below.
+        src >> dst;
         // If DstConstructed is true, it means dst has either a success value or
-        // a error value set, which needs to be destroyed and replaced. If
+        // a error value set, which needs to be updated or replaced. If
         // DstConstructed is false, then dst is being constructed now and has no
         // values set.
         if constexpr (DstConstructed) {
-            if (dst) {
+            if (dst && src) {
+                // dst and src both hold success values, so update dst from src and return
+                if constexpr (!std::is_same_v<typename DstResult::SuccessType, void>) {
+                    detail::ResultUpdate([&]()->auto& { return *dst; }, *src);
+                }
+                return;
+            } else if (!dst && !src) {
+                // dst and src both hold error values, so update dst from src and return
+                if constexpr (!std::is_same_v<typename DstResult::ErrorType, void>) {
+                    detail::ResultUpdate([&]()->auto& { return dst.error(); }, src.error());
+                }
+                return;
+            } else if (dst) {
                 // dst has a success value, so destroy it before replacing it with src error value
                 if constexpr (!std::is_same_v<typename DstResult::SuccessType, void>) {
                     using DstSuccess = typename DstResult::SuccessType;
@@ -281,6 +338,33 @@ protected:
     }
 };
 
+//! Move information from a source Result object to a destination object. It
+//! only moves InfoType and MessagesType values without affecting SuccessType or
+//! ErrorType values of either Result object.
+template <typename SrcResult, typename DstResult>
+requires (std::decay_t<SrcResult>::is_result)
+decltype(auto) operator>>(SrcResult&& src LIFETIMEBOUND, DstResult&& dst)
+{
+    using SrcType = std::decay_t<SrcResult>;
+    if (src.messages_ptr()) {
+        detail::ResultUpdate([&]()->auto& { return dst.messages(); }, src.messages());
+    }
+    return static_cast<SrcType&&>(src);
+}
+
+//! ResultTraits specialization for Messages struct.
+template<>
+struct ResultTraits<Messages> {
+    static void update(Messages& dst, Messages&& src)
+    {
+        MoveMessages(dst, src);
+    }
+    static bool empty(const Messages& src)
+    {
+        return src.errors.empty() && src.warnings.empty();
+    }
+};
+
 //! ResultTraits specialization for Error struct.
 template<>
 struct ResultTraits<Error> {
@@ -289,15 +373,19 @@ struct ResultTraits<Error> {
     template<typename ResultType>
     static void construct(ResultType& dst, Error&& src)
     {
-       dst.messages() = std::move(src.message);
+       dst.messages().errors.push_back(std::move(src.message));
     }
 };
 
-template <typename Result>
-bilingual_str ErrorString(const Result& result)
-{
-    return !result && result.messages_ptr() ? *result.messages_ptr() : bilingual_str{};
-}
+//! ResultTraits specialization for Warning struct.
+template<>
+struct ResultTraits<Warning> {
+    template<typename ResultType>
+    static void construct(ResultType& dst, Warning&& src)
+    {
+       dst.messages().warnings.push_back(std::move(src.message));
+    }
+};
 } // namespace util
 
 #endif // BITCOIN_UTIL_RESULT_H

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -433,35 +433,4 @@ struct ResultTraits<Warning> {
 };
 } // namespace util
 
-//! Temporary helper used to decompose util::Result into success / failure /
-//! error / warning values.  This is used in upcoming commits to incrementally
-//! port code not using util::Result to start using it, and it is removed after
-//! the last commit when everything is using util::Result.
-//!
-//! First ResultExtract argument is an input result object. Remaining arguments
-//! are output arguments returning the result failure value and error and
-//! warning messages, if any. Return value is the result success value, if the
-//! success type is non-void, or a boolean indicating success / failure if the
-//! success type is void.
-template<typename Result, typename ErrorPtr>
-auto ResultExtract(Result&& result, ErrorPtr error_ptr=nullptr, bilingual_str* error = nullptr, std::vector<bilingual_str>* warnings = nullptr)
-{
-    if constexpr (!std::is_same_v<ErrorPtr, std::nullptr_t>) {
-        if (error_ptr && !result) *error_ptr = result.error();
-        if (error_ptr && result) *error_ptr = typename Result::ErrorType{};
-    }
-    if (error && result.messages_ptr() && !result.messages_ptr()->errors.empty()) {
-        *error = util::ErrorString(result);
-    }
-    if (warnings && result.messages_ptr()) {
-        const auto& w = result.messages_ptr()->warnings;
-        warnings->insert(warnings->end(), w.begin(), w.end());
-    }
-    if constexpr (std::is_same_v<typename Result::SuccessType, void>) {
-        return bool{result};
-    } else {
-        return result ? std::move(result.value()) : typename Result::SuccessType{};
-    }
-}
-
 #endif // BITCOIN_UTIL_RESULT_H

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -10,6 +10,7 @@
 #include <streams.h>
 #include <support/allocators/secure.h>
 #include <util/fs.h>
+#include <util/result.h>
 
 #include <atomic>
 #include <memory>
@@ -203,7 +204,7 @@ enum class DatabaseStatus {
 std::vector<std::pair<fs::path, std::string>> ListDatabases(const fs::path& path);
 
 void ReadDatabaseArgs(const ArgsManager& args, DatabaseOptions& options);
-std::unique_ptr<WalletDatabase> MakeDatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error);
+util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeDatabase(const fs::path& path, const DatabaseOptions& options);
 
 fs::path BDBDataFile(const fs::path& path);
 fs::path SQLiteDataFile(const fs::path& path);

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -184,8 +184,7 @@ struct DatabaseOptions {
     int64_t max_log_mb = 100;       //!< Max log size to allow before consolidating.
 };
 
-enum class DatabaseStatus {
-    SUCCESS,
+enum class DatabaseError {
     FAILED_BAD_PATH,
     FAILED_BAD_FORMAT,
     FAILED_LEGACY_DISABLED,
@@ -204,7 +203,7 @@ enum class DatabaseStatus {
 std::vector<std::pair<fs::path, std::string>> ListDatabases(const fs::path& path);
 
 void ReadDatabaseArgs(const ArgsManager& args, DatabaseOptions& options);
-util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeDatabase(const fs::path& path, const DatabaseOptions& options);
+util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseError> MakeDatabase(const fs::path& path, const DatabaseOptions& options);
 
 fs::path BDBDataFile(const fs::path& path);
 fs::path SQLiteDataFile(const fs::path& path);

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -10,6 +10,7 @@
 #include <streams.h>
 #include <support/allocators/secure.h>
 #include <util/fs.h>
+#include <util/result.h>
 
 #include <memory>
 #include <optional>
@@ -197,7 +198,7 @@ enum class DatabaseStatus {
 std::vector<std::pair<fs::path, std::string>> ListDatabases(const fs::path& path);
 
 void ReadDatabaseArgs(const ArgsManager& args, DatabaseOptions& options);
-std::unique_ptr<WalletDatabase> MakeDatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error);
+util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeDatabase(const fs::path& path, const DatabaseOptions& options);
 
 fs::path BDBDataFile(const fs::path& path);
 fs::path SQLiteDataFile(const fs::path& path);

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -178,8 +178,7 @@ struct DatabaseOptions {
     bool use_unsafe_sync = false;   //!< Disable file sync for faster performance.
 };
 
-enum class DatabaseStatus {
-    SUCCESS,
+enum class DatabaseError {
     FAILED_BAD_PATH,
     FAILED_BAD_FORMAT,
     FAILED_LEGACY_DISABLED,
@@ -198,7 +197,7 @@ enum class DatabaseStatus {
 std::vector<std::pair<fs::path, std::string>> ListDatabases(const fs::path& path);
 
 void ReadDatabaseArgs(const ArgsManager& args, DatabaseOptions& options);
-util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeDatabase(const fs::path& path, const DatabaseOptions& options);
+util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseError> MakeDatabase(const fs::path& path, const DatabaseOptions& options);
 
 fs::path BDBDataFile(const fs::path& path);
 fs::path SQLiteDataFile(const fs::path& path);

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -196,7 +196,7 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
     ReadDatabaseArgs(args, options);
     options.require_create = true;
     options.require_format = DatabaseFormat::SQLITE;
-    std::unique_ptr<WalletDatabase> database = MakeDatabase(wallet_path, options, status, error);
+    std::unique_ptr<WalletDatabase> database = ResultExtract(MakeDatabase(wallet_path, options), &status, &error);
     if (!database) return false;
 
     // dummy chain interface

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -21,37 +21,36 @@ namespace wallet {
 static const std::string DUMP_MAGIC = "BITCOIN_CORE_WALLET_DUMP";
 uint32_t DUMP_VERSION = 1;
 
-bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& error)
+util::Result<void> DumpWallet(const ArgsManager& args, WalletDatabase& db)
 {
+    util::Result<void> result;
     // Get the dumpfile
     std::string dump_filename = args.GetArg("-dumpfile", "");
     if (dump_filename.empty()) {
-        error = _("No dump file provided. To use dump, -dumpfile=<filename> must be provided.");
-        return false;
+        result.update(util::Error{_("No dump file provided. To use dump, -dumpfile=<filename> must be provided.")});
+        return result;
     }
 
     fs::path path = fs::PathFromString(dump_filename);
     path = fs::absolute(path);
     if (fs::exists(path)) {
-        error = strprintf(_("File %s already exists. If you are sure this is what you want, move it out of the way first."), fs::PathToString(path));
-        return false;
+        result.update(util::Error{strprintf(_("File %s already exists. If you are sure this is what you want, move it out of the way first."), fs::PathToString(path))});
+        return result;
     }
     std::ofstream dump_file;
     dump_file.open(path.std_path());
     if (dump_file.fail()) {
-        error = strprintf(_("Unable to open %s for writing"), fs::PathToString(path));
-        return false;
+        result.update(util::Error{strprintf(_("Unable to open %s for writing"), fs::PathToString(path))});
+        return result;
     }
 
     HashWriter hasher{};
 
     std::unique_ptr<DatabaseBatch> batch = db.MakeBatch();
 
-    bool ret = true;
     std::unique_ptr<DatabaseCursor> cursor = batch->GetNewCursor();
     if (!cursor) {
-        error = _("Error: Couldn't create cursor into database");
-        ret = false;
+        result.update(util::Error{_("Error: Couldn't create cursor into database")});
     }
 
     // Write out a magic string with version
@@ -70,7 +69,7 @@ bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& erro
     dump_file.write(line.data(), line.size());
     hasher << std::span{line};
 
-    if (ret) {
+    if (result) {
 
         // Read the records
         while (true) {
@@ -78,11 +77,10 @@ bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& erro
             DataStream ss_value{};
             DatabaseCursor::Status status = cursor->Next(ss_key, ss_value);
             if (status == DatabaseCursor::Status::DONE) {
-                ret = true;
+                result.update({});
                 break;
             } else if (status == DatabaseCursor::Status::FAIL) {
-                error = _("Error reading next record from wallet database");
-                ret = false;
+                result.update(util::Error{_("Error reading next record from wallet database")});
                 break;
             }
             std::string key_str = HexStr(ss_key);
@@ -96,7 +94,7 @@ bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& erro
     cursor.reset();
     batch.reset();
 
-    if (ret) {
+    if (result) {
         // Write the hash
         tfm::format(dump_file, "checksum,%s\n", HexStr(hasher.GetHash()));
         dump_file.close();
@@ -106,7 +104,7 @@ bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& erro
         fs::remove(path);
     }
 
-    return ret;
+    return result;
 }
 
 // The standard wallet deleter function blocks on the validation interface
@@ -119,25 +117,27 @@ static void WalletToolReleaseWallet(CWallet* wallet)
     delete wallet;
 }
 
-bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::path& wallet_path, bilingual_str& error, std::vector<bilingual_str>& warnings)
+util::Result<void> CreateFromDump(const ArgsManager& args, const std::string& name, const fs::path& wallet_path)
 {
+    util::Result<void> result;
+
     if (name.empty()) {
-        tfm::format(std::cerr, "Wallet name cannot be empty\n");
-        return false;
+        result.update(util::Error{_("Wallet name cannot be empty")});
+        return result;
     }
 
     // Get the dumpfile
     std::string dump_filename = args.GetArg("-dumpfile", "");
     if (dump_filename.empty()) {
-        error = _("No dump file provided. To use createfromdump, -dumpfile=<filename> must be provided.");
-        return false;
+        result.update(util::Error{_("No dump file provided. To use createfromdump, -dumpfile=<filename> must be provided.")});
+        return result;
     }
 
     fs::path dump_path = fs::PathFromString(dump_filename);
     dump_path = fs::absolute(dump_path);
     if (!fs::exists(dump_path)) {
-        error = strprintf(_("Dump file %s does not exist."), fs::PathToString(dump_path));
-        return false;
+        result.update(util::Error{strprintf(_("Dump file %s does not exist."), fs::PathToString(dump_path))});
+        return result;
     }
     std::ifstream dump_file{dump_path.std_path()};
 
@@ -151,21 +151,21 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
     std::string version_value;
     std::getline(dump_file, version_value, '\n');
     if (magic_key != DUMP_MAGIC) {
-        error = strprintf(_("Error: Dumpfile identifier record is incorrect. Got \"%s\", expected \"%s\"."), magic_key, DUMP_MAGIC);
         dump_file.close();
-        return false;
+        result.update(util::Error{strprintf(_("Error: Dumpfile identifier record is incorrect. Got \"%s\", expected \"%s\"."), magic_key, DUMP_MAGIC)});
+        return result;
     }
     // Check the version number (value of first record)
     const auto ver{ToIntegral<uint32_t>(version_value)};
     if (!ver) {
-        error = strprintf(_("Error: Unable to parse version %u as a uint32_t"), version_value);
         dump_file.close();
-        return false;
+        result.update(util::Error{strprintf(_("Error: Unable to parse version %u as a uint32_t"), version_value)});
+        return result;
     }
     if (*ver != DUMP_VERSION) {
-        error = strprintf(_("Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s"), version_value);
         dump_file.close();
-        return false;
+        result.update(util::Error{strprintf(_("Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s"), version_value)});
+        return result;
     }
     std::string magic_hasher_line = strprintf("%s,%s\n", magic_key, version_value);
     hasher << std::span{magic_hasher_line};
@@ -176,32 +176,33 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
     std::string format_value;
     std::getline(dump_file, format_value, '\n');
     if (format_key != "format") {
-        error = strprintf(_("Error: Dumpfile format record is incorrect. Got \"%s\", expected \"format\"."), format_key);
         dump_file.close();
-        return false;
+        result.update(util::Error{strprintf(_("Error: Dumpfile format record is incorrect. Got \"%s\", expected \"format\"."), format_key)});
+        return result;
     }
     // Make sure that the dump was created from a sqlite database only as that is the only
     // type of database that we still support.
     // Other formats such as BDB should not be loaded into a sqlite database since they also
     // use a different type of wallet entirely which is no longer compatible with this software.
     if (format_value != "sqlite") {
-        error = strprintf(_("Error: Dumpfile specifies an unsupported database format (%s). Only sqlite database dumps are supported"), format_value);
-        return false;
+        result.update(util::Error{strprintf(_("Error: Dumpfile specifies an unsupported database format (%s). Only sqlite database dumps are supported"), format_value)});
+        return result;
     }
     std::string format_hasher_line = strprintf("%s,%s\n", format_key, format_value);
     hasher << std::span{format_hasher_line};
 
     DatabaseOptions options;
-    DatabaseStatus status;
     ReadDatabaseArgs(args, options);
     options.require_create = true;
     options.require_format = DatabaseFormat::SQLITE;
-    std::unique_ptr<WalletDatabase> database = ResultExtract(MakeDatabase(wallet_path, options), &status, &error);
-    if (!database) return false;
+    auto database{MakeDatabase(wallet_path, options) >> result};
+    if (!database) {
+        result.update(util::Error{});
+        return result;
+    }
 
     // dummy chain interface
-    bool ret = true;
-    std::shared_ptr<CWallet> wallet(new CWallet(/*chain=*/nullptr, name, std::move(database)), WalletToolReleaseWallet);
+    std::shared_ptr<CWallet> wallet(new CWallet(/*chain=*/nullptr, name, std::move(database.value())), WalletToolReleaseWallet);
     {
         // Get the database handle
         WalletDatabase& db = wallet->GetDatabase();
@@ -218,8 +219,7 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
             if (key == "checksum") {
                 std::vector<unsigned char> parsed_checksum = ParseHex(value);
                 if (parsed_checksum.size() != checksum.size()) {
-                    error = Untranslated("Error: Checksum is not the correct size");
-                    ret = false;
+                    result.update(util::Error{Untranslated("Error: Checksum is not the correct size")});
                     break;
                 }
                 std::copy(parsed_checksum.begin(), parsed_checksum.end(), checksum.begin());
@@ -234,37 +234,32 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
             }
 
             if (!IsHex(key)) {
-                error = strprintf(_("Error: Got key that was not hex: %s"), key);
-                ret = false;
+                result.update(util::Error{strprintf(_("Error: Got key that was not hex: %s"), key)});
                 break;
             }
             if (!IsHex(value)) {
-                error = strprintf(_("Error: Got value that was not hex: %s"), value);
-                ret = false;
+                result.update(util::Error{strprintf(_("Error: Got value that was not hex: %s"), value)});
                 break;
             }
 
             std::vector<unsigned char> k = ParseHex(key);
             std::vector<unsigned char> v = ParseHex(value);
             if (!batch->Write(std::span{k}, std::span{v})) {
-                error = strprintf(_("Error: Unable to write record to new wallet"));
-                ret = false;
+                result.update(util::Error{strprintf(_("Error: Unable to write record to new wallet"))});
                 break;
             }
         }
 
-        if (ret) {
+        if (result) {
             uint256 comp_checksum = hasher.GetHash();
             if (checksum.IsNull()) {
-                error = _("Error: Missing checksum");
-                ret = false;
+                result.update(util::Error{_("Error: Missing checksum")});
             } else if (checksum != comp_checksum) {
-                error = strprintf(_("Error: Dumpfile checksum does not match. Computed %s, expected %s"), HexStr(comp_checksum), HexStr(checksum));
-                ret = false;
+                result.update(util::Error{strprintf(_("Error: Dumpfile checksum does not match. Computed %s, expected %s"), HexStr(comp_checksum), HexStr(checksum))});
             }
         }
 
-        if (ret) {
+        if (result) {
             batch->TxnCommit();
         } else {
             batch->TxnAbort();
@@ -281,12 +276,12 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
     wallet.reset(); // The pointer deleter will close the wallet for us.
 
     // Remove the wallet dir if we have a failure
-    if (!ret) {
+    if (!result) {
         for (const auto& p : paths_to_remove) {
             fs::remove(p);
         }
     }
 
-    return ret;
+    return result;
 }
 } // namespace wallet

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -21,37 +21,36 @@ namespace wallet {
 static const std::string DUMP_MAGIC = "BITCOIN_CORE_WALLET_DUMP";
 uint32_t DUMP_VERSION = 1;
 
-bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& error)
+util::Result<void> DumpWallet(const ArgsManager& args, WalletDatabase& db)
 {
+    util::Result<void> result;
     // Get the dumpfile
     std::string dump_filename = args.GetArg("-dumpfile", "");
     if (dump_filename.empty()) {
-        error = _("No dump file provided. To use dump, -dumpfile=<filename> must be provided.");
-        return false;
+        result.update(util::Error{_("No dump file provided. To use dump, -dumpfile=<filename> must be provided.")});
+        return result;
     }
 
     fs::path path = fs::PathFromString(dump_filename);
     path = fs::absolute(path);
     if (fs::exists(path)) {
-        error = strprintf(_("File %s already exists. If you are sure this is what you want, move it out of the way first."), fs::PathToString(path));
-        return false;
+        result.update(util::Error{strprintf(_("File %s already exists. If you are sure this is what you want, move it out of the way first."), fs::PathToString(path))});
+        return result;
     }
     std::ofstream dump_file;
     dump_file.open(path.std_path());
     if (dump_file.fail()) {
-        error = strprintf(_("Unable to open %s for writing"), fs::PathToString(path));
-        return false;
+        result.update(util::Error{strprintf(_("Unable to open %s for writing"), fs::PathToString(path))});
+        return result;
     }
 
     HashWriter hasher{};
 
     std::unique_ptr<DatabaseBatch> batch = db.MakeBatch();
 
-    bool ret = true;
     std::unique_ptr<DatabaseCursor> cursor = batch->GetNewCursor();
     if (!cursor) {
-        error = _("Error: Couldn't create cursor into database");
-        ret = false;
+        result.update(util::Error{_("Error: Couldn't create cursor into database")});
     }
 
     // Write out a magic string with version
@@ -70,7 +69,7 @@ bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& erro
     dump_file.write(line.data(), line.size());
     hasher << std::span{line};
 
-    if (ret) {
+    if (result) {
 
         // Read the records
         while (true) {
@@ -78,11 +77,10 @@ bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& erro
             DataStream ss_value{};
             DatabaseCursor::Status status = cursor->Next(ss_key, ss_value);
             if (status == DatabaseCursor::Status::DONE) {
-                ret = true;
+                result.update({});
                 break;
             } else if (status == DatabaseCursor::Status::FAIL) {
-                error = _("Error reading next record from wallet database");
-                ret = false;
+                result.update(util::Error{_("Error reading next record from wallet database")});
                 break;
             }
             std::string key_str = HexStr(ss_key);
@@ -96,7 +94,7 @@ bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& erro
     cursor.reset();
     batch.reset();
 
-    if (ret) {
+    if (result) {
         // Write the hash
         tfm::format(dump_file, "checksum,%s\n", HexStr(hasher.GetHash()));
         dump_file.close();
@@ -106,7 +104,7 @@ bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& erro
         fs::remove(path);
     }
 
-    return ret;
+    return result;
 }
 
 // The standard wallet deleter function blocks on the validation interface
@@ -119,25 +117,27 @@ static void WalletToolReleaseWallet(CWallet* wallet)
     delete wallet;
 }
 
-bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::path& wallet_path, bilingual_str& error)
+util::Result<void> CreateFromDump(const ArgsManager& args, const std::string& name, const fs::path& wallet_path)
 {
+    util::Result<void> result;
+
     if (name.empty()) {
-        tfm::format(std::cerr, "Wallet name cannot be empty\n");
-        return false;
+        result.update(util::Error{_("Wallet name cannot be empty")});
+        return result;
     }
 
     // Get the dumpfile
     std::string dump_filename = args.GetArg("-dumpfile", "");
     if (dump_filename.empty()) {
-        error = _("No dump file provided. To use createfromdump, -dumpfile=<filename> must be provided.");
-        return false;
+        result.update(util::Error{_("No dump file provided. To use createfromdump, -dumpfile=<filename> must be provided.")});
+        return result;
     }
 
     fs::path dump_path = fs::PathFromString(dump_filename);
     dump_path = fs::absolute(dump_path);
     if (!fs::exists(dump_path)) {
-        error = strprintf(_("Dump file %s does not exist."), fs::PathToString(dump_path));
-        return false;
+        result.update(util::Error{strprintf(_("Dump file %s does not exist."), fs::PathToString(dump_path))});
+        return result;
     }
     std::ifstream dump_file{dump_path.std_path()};
 
@@ -151,21 +151,21 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
     std::string version_value;
     std::getline(dump_file, version_value, '\n');
     if (magic_key != DUMP_MAGIC) {
-        error = strprintf(_("Error: Dumpfile identifier record is incorrect. Got \"%s\", expected \"%s\"."), magic_key, DUMP_MAGIC);
         dump_file.close();
-        return false;
+        result.update(util::Error{strprintf(_("Error: Dumpfile identifier record is incorrect. Got \"%s\", expected \"%s\"."), magic_key, DUMP_MAGIC)});
+        return result;
     }
     // Check the version number (value of first record)
     const auto ver{ToIntegral<uint32_t>(version_value)};
     if (!ver) {
-        error = strprintf(_("Error: Unable to parse version %u as a uint32_t"), version_value);
         dump_file.close();
-        return false;
+        result.update(util::Error{strprintf(_("Error: Unable to parse version %u as a uint32_t"), version_value)});
+        return result;
     }
     if (*ver != DUMP_VERSION) {
-        error = strprintf(_("Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s"), version_value);
         dump_file.close();
-        return false;
+        result.update(util::Error{strprintf(_("Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s"), version_value)});
+        return result;
     }
     std::string magic_hasher_line = strprintf("%s,%s\n", magic_key, version_value);
     hasher << std::span{magic_hasher_line};
@@ -176,32 +176,33 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
     std::string format_value;
     std::getline(dump_file, format_value, '\n');
     if (format_key != "format") {
-        error = strprintf(_("Error: Dumpfile format record is incorrect. Got \"%s\", expected \"format\"."), format_key);
         dump_file.close();
-        return false;
+        result.update(util::Error{strprintf(_("Error: Dumpfile format record is incorrect. Got \"%s\", expected \"format\"."), format_key)});
+        return result;
     }
     // Make sure that the dump was created from a sqlite database only as that is the only
     // type of database that we still support.
     // Other formats such as BDB should not be loaded into a sqlite database since they also
     // use a different type of wallet entirely which is no longer compatible with this software.
     if (format_value != "sqlite") {
-        error = strprintf(_("Error: Dumpfile specifies an unsupported database format (%s). Only sqlite database dumps are supported"), format_value);
-        return false;
+        result.update(util::Error{strprintf(_("Error: Dumpfile specifies an unsupported database format (%s). Only sqlite database dumps are supported"), format_value)});
+        return result;
     }
     std::string format_hasher_line = strprintf("%s,%s\n", format_key, format_value);
     hasher << std::span{format_hasher_line};
 
     DatabaseOptions options;
-    DatabaseStatus status;
     ReadDatabaseArgs(args, options);
     options.require_create = true;
     options.require_format = DatabaseFormat::SQLITE;
-    std::unique_ptr<WalletDatabase> database = ResultExtract(MakeDatabase(wallet_path, options), &status, &error);
-    if (!database) return false;
+    auto database{MakeDatabase(wallet_path, options) >> result};
+    if (!database) {
+        result.update(util::Error{});
+        return result;
+    }
 
     // dummy chain interface
-    bool ret = true;
-    std::shared_ptr<CWallet> wallet(new CWallet(/*chain=*/nullptr, name, std::move(database)), WalletToolReleaseWallet);
+    std::shared_ptr<CWallet> wallet(new CWallet(/*chain=*/nullptr, name, std::move(database.value())), WalletToolReleaseWallet);
     {
         // Get the database handle
         WalletDatabase& db = wallet->GetDatabase();
@@ -218,8 +219,7 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
             if (key == "checksum") {
                 std::vector<unsigned char> parsed_checksum = ParseHex(value);
                 if (parsed_checksum.size() != checksum.size()) {
-                    error = Untranslated("Error: Checksum is not the correct size");
-                    ret = false;
+                    result.update(util::Error{Untranslated("Error: Checksum is not the correct size")});
                     break;
                 }
                 std::copy(parsed_checksum.begin(), parsed_checksum.end(), checksum.begin());
@@ -234,37 +234,32 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
             }
 
             if (!IsHex(key)) {
-                error = strprintf(_("Error: Got key that was not hex: %s"), key);
-                ret = false;
+                result.update(util::Error{strprintf(_("Error: Got key that was not hex: %s"), key)});
                 break;
             }
             if (!IsHex(value)) {
-                error = strprintf(_("Error: Got value that was not hex: %s"), value);
-                ret = false;
+                result.update(util::Error{strprintf(_("Error: Got value that was not hex: %s"), value)});
                 break;
             }
 
             std::vector<unsigned char> k = ParseHex(key);
             std::vector<unsigned char> v = ParseHex(value);
             if (!batch->Write(std::span{k}, std::span{v})) {
-                error = strprintf(_("Error: Unable to write record to new wallet"));
-                ret = false;
+                result.update(util::Error{strprintf(_("Error: Unable to write record to new wallet"))});
                 break;
             }
         }
 
-        if (ret) {
+        if (result) {
             uint256 comp_checksum = hasher.GetHash();
             if (checksum.IsNull()) {
-                error = _("Error: Missing checksum");
-                ret = false;
+                result.update(util::Error{_("Error: Missing checksum")});
             } else if (checksum != comp_checksum) {
-                error = strprintf(_("Error: Dumpfile checksum does not match. Computed %s, expected %s"), HexStr(comp_checksum), HexStr(checksum));
-                ret = false;
+                result.update(util::Error{strprintf(_("Error: Dumpfile checksum does not match. Computed %s, expected %s"), HexStr(comp_checksum), HexStr(checksum))});
             }
         }
 
-        if (ret) {
+        if (result) {
             batch->TxnCommit();
         } else {
             batch->TxnAbort();
@@ -281,12 +276,12 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
     wallet.reset(); // The pointer deleter will close the wallet for us.
 
     // Remove the wallet dir if we have a failure
-    if (!ret) {
+    if (!result) {
         for (const auto& p : paths_to_remove) {
             fs::remove(p);
         }
     }
 
-    return ret;
+    return result;
 }
 } // namespace wallet

--- a/src/wallet/dump.h
+++ b/src/wallet/dump.h
@@ -6,6 +6,7 @@
 #define BITCOIN_WALLET_DUMP_H
 
 #include <util/fs.h>
+#include <util/result.h>
 
 #include <string>
 #include <vector>
@@ -16,8 +17,8 @@ class ArgsManager;
 namespace wallet {
 class WalletDatabase;
 
-bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& error);
-bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::path& wallet_path, bilingual_str& error, std::vector<bilingual_str>& warnings);
+util::Result<void> DumpWallet(const ArgsManager& args, WalletDatabase& db);
+util::Result<void> CreateFromDump(const ArgsManager& args, const std::string& name, const fs::path& wallet_path);
 } // namespace wallet
 
 #endif // BITCOIN_WALLET_DUMP_H

--- a/src/wallet/dump.h
+++ b/src/wallet/dump.h
@@ -6,6 +6,7 @@
 #define BITCOIN_WALLET_DUMP_H
 
 #include <util/fs.h>
+#include <util/result.h>
 
 #include <string>
 
@@ -15,8 +16,8 @@ class ArgsManager;
 namespace wallet {
 class WalletDatabase;
 
-bool DumpWallet(const ArgsManager& args, WalletDatabase& db, bilingual_str& error);
-bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::path& wallet_path, bilingual_str& error);
+util::Result<void> DumpWallet(const ArgsManager& args, WalletDatabase& db);
+util::Result<void> CreateFromDump(const ArgsManager& args, const std::string& name, const fs::path& wallet_path);
 } // namespace wallet
 
 #endif // BITCOIN_WALLET_DUMP_H

--- a/src/wallet/export.cpp
+++ b/src/wallet/export.cpp
@@ -74,14 +74,15 @@ util::Result<std::string> ExportWatchOnlyWallet(const CWallet& wallet, const fs:
     const uint64_t create_flags = wallet.GetWalletFlags() | WALLET_FLAG_DISABLE_PRIVATE_KEYS;
 
     // Create the temporary watchonly wallet in memory to avoid leaving files on disk
-    std::vector<bilingual_str> warnings;
-    bilingual_str error;
+    std::shared_ptr<CWallet> watchonly_wallet;
+
     WalletContext empty_context;
     empty_context.args = context.args;
-    std::shared_ptr<CWallet> watchonly_wallet = CWallet::CreateNew(empty_context, /*name=*/wallet.GetName() + "_watchonly_temp", MakeInMemoryWalletDatabase(), create_flags, /*born_encrypted=*/false, error, warnings);
-    if (!watchonly_wallet) {
-        return util::Error{strprintf(_("Error: Failed to create new watchonly wallet. %s"), error)};
+    auto watchonly_result{CWallet::CreateNew(empty_context, /*name=*/wallet.GetName() + "_watchonly_temp", MakeInMemoryWalletDatabase(), create_flags, /*born_encrypted=*/false)};
+    if (!watchonly_result) {
+        return util::Error{strprintf(_("Error: Failed to create new watchonly wallet. %s"), util::ErrorString(watchonly_result))};
     }
+    watchonly_wallet = std::move(watchonly_result.value());
 
     {
         LOCK(watchonly_wallet->cs_wallet);

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -559,7 +559,7 @@ public:
     void schedulerMockForward(std::chrono::seconds delta) override { Assert(m_context.scheduler)->MockForward(delta); }
 
     //! WalletLoader methods
-    util::Result<std::unique_ptr<Wallet>> createWallet(const std::string& name, const SecureString& passphrase, uint64_t wallet_creation_flags, std::vector<bilingual_str>& warnings) override
+    util::ResultPtr<std::unique_ptr<Wallet>> createWallet(const std::string& name, const SecureString& passphrase, uint64_t wallet_creation_flags, std::vector<bilingual_str>& warnings) override
     {
         DatabaseOptions options;
         DatabaseStatus status;
@@ -568,36 +568,25 @@ public:
         options.create_flags = wallet_creation_flags;
         options.create_passphrase = passphrase;
         bilingual_str error;
-        std::unique_ptr<Wallet> wallet{MakeWallet(m_context, CreateWallet(m_context, name, /*load_on_start=*/true, options, status, error, warnings))};
-        if (wallet) {
-            return wallet;
-        } else {
-            return util::Error{error};
-        }
+        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, CreateWallet(m_context, name, /*load_on_start=*/true, options, status, error, warnings))};
+        return wallet ? std::move(wallet) : util::Error{error};
     }
-    util::Result<std::unique_ptr<Wallet>> loadWallet(const std::string& name, std::vector<bilingual_str>& warnings) override
+    util::ResultPtr<std::unique_ptr<Wallet>> loadWallet(const std::string& name, std::vector<bilingual_str>& warnings) override
     {
         DatabaseOptions options;
         DatabaseStatus status;
         ReadDatabaseArgs(*m_context.args, options);
         options.require_existing = true;
         bilingual_str error;
-        std::unique_ptr<Wallet> wallet{MakeWallet(m_context, LoadWallet(m_context, name, /*load_on_start=*/true, options, status, error, warnings))};
-        if (wallet) {
-            return wallet;
-        } else {
-            return util::Error{error};
-        }
+        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, LoadWallet(m_context, name, /*load_on_start=*/true, options, status, error, warnings))};
+        return wallet ? std::move(wallet) : util::Error{error};
     }
-    util::Result<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings, bool load_after_restore) override
+    util::ResultPtr<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings, bool load_after_restore) override
     {
         DatabaseStatus status;
         bilingual_str error;
-        std::unique_ptr<Wallet> wallet{MakeWallet(m_context, RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, status, error, warnings, load_after_restore))};
-        if (!error.empty()) {
-            return util::Error{error};
-        }
-        return wallet;
+        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, status, error, warnings, load_after_restore))};
+        return wallet && !error.empty() ? std::move(wallet) : util::Error{error};
     }
     util::Result<WalletMigrationResult> migrateWallet(const std::string& name, const SecureString& passphrase) override
     {

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -490,7 +490,7 @@ public:
     CAmount getDefaultMaxTxFee() override { return m_wallet->m_default_max_tx_fee; }
     void remove() override
     {
-        RemoveWallet(m_context, m_wallet, /*load_on_start=*/false);
+        Assume(RemoveWallet(m_context, m_wallet, /*load_on_start=*/false));
     }
     std::unique_ptr<Handler> handleUnload(UnloadFn fn) override
     {
@@ -568,7 +568,7 @@ public:
         options.create_flags = wallet_creation_flags;
         options.create_passphrase = passphrase;
         bilingual_str error;
-        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, CreateWallet(m_context, name, /*load_on_start=*/true, options, status, error, warnings))};
+        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, ResultExtract(CreateWallet(m_context, name, /*load_on_start=*/true, options), &status, &error, &warnings))};
         return wallet ? std::move(wallet) : util::Error{error};
     }
     util::ResultPtr<std::unique_ptr<Wallet>> loadWallet(const std::string& name, std::vector<bilingual_str>& warnings) override
@@ -578,14 +578,14 @@ public:
         ReadDatabaseArgs(*m_context.args, options);
         options.require_existing = true;
         bilingual_str error;
-        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, LoadWallet(m_context, name, /*load_on_start=*/true, options, status, error, warnings))};
+        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, ResultExtract(LoadWallet(m_context, name, /*load_on_start=*/true, options), &status, &error, &warnings))};
         return wallet ? std::move(wallet) : util::Error{error};
     }
     util::ResultPtr<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings, bool load_after_restore) override
     {
         DatabaseStatus status;
         bilingual_str error;
-        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, status, error, warnings, load_after_restore))};
+        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, ResultExtract(RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, load_after_restore), &status, &error, &warnings))};
         return wallet && !error.empty() ? std::move(wallet) : util::Error{error};
     }
     util::Result<WalletMigrationResult> migrateWallet(const std::string& name, const SecureString& passphrase) override
@@ -611,10 +611,10 @@ public:
         options.require_existing = true;
         DatabaseStatus status;
         bilingual_str error;
-        auto db = MakeWalletDatabase(wallet_name, options, status, error);
+        auto db = ResultExtract(MakeWalletDatabase(wallet_name, options), &status, &error);
         if (!db && status == wallet::DatabaseStatus::FAILED_LEGACY_DISABLED) {
             options.require_format = wallet::DatabaseFormat::BERKELEY_RO;
-            db = MakeWalletDatabase(wallet_name, options, status, error);
+            db = ResultExtract(MakeWalletDatabase(wallet_name, options), &status, &error);
         }
         if (!db) return false;
         return WalletBatch(*db).IsEncrypted();

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -623,7 +623,7 @@ public:
         DatabaseOptions options;
         options.require_existing = true;
         auto db{MakeWalletDatabase(wallet_name, options)};
-        if (!db && db.error() == wallet::DatabaseStatus::FAILED_LEGACY_DISABLED) {
+        if (!db && db.error() == wallet::DatabaseError::FAILED_LEGACY_DISABLED) {
             options.require_format = wallet::DatabaseFormat::BERKELEY_RO;
             db.update(MakeWalletDatabase(wallet_name, options));
         }

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -262,6 +262,7 @@ public:
         bool sign,
         std::optional<unsigned int> change_pos) override
     {
+        util::Result<CTransactionRef> result;
         LOCK(m_wallet->cs_wallet);
         return CreateTransaction(*m_wallet, recipients, change_pos, coin_control, sign);
     }
@@ -559,46 +560,58 @@ public:
     void schedulerMockForward(std::chrono::seconds delta) override { Assert(m_context.scheduler)->MockForward(delta); }
 
     //! WalletLoader methods
-    util::ResultPtr<std::unique_ptr<Wallet>> createWallet(const std::string& name, const SecureString& passphrase, uint64_t wallet_creation_flags, std::vector<bilingual_str>& warnings) override
+    util::ResultPtr<std::unique_ptr<Wallet>> createWallet(const std::string& name, const SecureString& passphrase, uint64_t wallet_creation_flags) override
     {
+        util::ResultPtr<std::unique_ptr<Wallet>> result;
         DatabaseOptions options;
-        DatabaseStatus status;
         ReadDatabaseArgs(*m_context.args, options);
         options.require_create = true;
         options.create_flags = wallet_creation_flags;
         options.create_passphrase = passphrase;
-        bilingual_str error;
-        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, ResultExtract(CreateWallet(m_context, name, /*load_on_start=*/true, options), &status, &error, &warnings))};
-        return wallet ? std::move(wallet) : util::Error{error};
+        if (auto wallet{CreateWallet(m_context, name, true /* load_on_start */, options) >> result}) {
+            result.update(MakeWallet(m_context, wallet.value()));
+        } else {
+            result.update(util::Error{});
+        }
+        return result;
     }
-    util::ResultPtr<std::unique_ptr<Wallet>> loadWallet(const std::string& name, std::vector<bilingual_str>& warnings) override
+    util::ResultPtr<std::unique_ptr<Wallet>> loadWallet(const std::string& name) override
     {
+        util::ResultPtr<std::unique_ptr<Wallet>> result;
         DatabaseOptions options;
-        DatabaseStatus status;
         ReadDatabaseArgs(*m_context.args, options);
         options.require_existing = true;
-        bilingual_str error;
-        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, ResultExtract(LoadWallet(m_context, name, /*load_on_start=*/true, options), &status, &error, &warnings))};
-        return wallet ? std::move(wallet) : util::Error{error};
+        if (auto wallet{LoadWallet(m_context, name, true /* load_on_start */, options) >> result}) {
+            result.update(MakeWallet(m_context, wallet.value()));
+        } else {
+            result.update(util::Error{});
+        }
+        return result;
     }
-    util::ResultPtr<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings, bool load_after_restore) override
+    util::ResultPtr<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, bool load_after_restore) override
     {
-        DatabaseStatus status;
-        bilingual_str error;
-        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, ResultExtract(RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, load_after_restore), &status, &error, &warnings))};
-        return wallet && !error.empty() ? std::move(wallet) : util::Error{error};
+        util::ResultPtr<std::unique_ptr<Wallet>> result;
+        if (auto wallet{RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, load_after_restore) >> result}) {
+            result.update(MakeWallet(m_context, wallet.value()));
+        } else {
+            result.update(util::Error{});
+        }
+        return result;
     }
     util::Result<WalletMigrationResult> migrateWallet(const std::string& name, const SecureString& passphrase) override
     {
-        auto res = wallet::MigrateLegacyToDescriptor(name, passphrase, m_context);
-        if (!res) return util::Error{util::ErrorString(res)};
-        WalletMigrationResult out{
+        util::Result<WalletMigrationResult> result;
+        if (auto res{wallet::MigrateLegacyToDescriptor(name, passphrase, m_context) >> result}) {
+            result.update(WalletMigrationResult{
             .wallet = MakeWallet(m_context, res->wallet),
             .watchonly_wallet_name = res->watchonly_wallet_name,
             .solvables_wallet_name = res->solvables_wallet_name,
             .backup_path = res->backup_path,
-        };
-        return out;
+            });
+        } else {
+            result.update(util::Error{});
+        }
+        return result;
     }
     bool isEncrypted(const std::string& wallet_name) override
     {
@@ -609,12 +622,10 @@ public:
         // Unloaded wallet, read db
         DatabaseOptions options;
         options.require_existing = true;
-        DatabaseStatus status;
-        bilingual_str error;
-        auto db = ResultExtract(MakeWalletDatabase(wallet_name, options), &status, &error);
-        if (!db && status == wallet::DatabaseStatus::FAILED_LEGACY_DISABLED) {
+        auto db{MakeWalletDatabase(wallet_name, options)};
+        if (!db && db.error() == wallet::DatabaseStatus::FAILED_LEGACY_DISABLED) {
             options.require_format = wallet::DatabaseFormat::BERKELEY_RO;
-            db = ResultExtract(MakeWalletDatabase(wallet_name, options), &status, &error);
+            db.update(MakeWalletDatabase(wallet_name, options));
         }
         if (!db) return false;
         return WalletBatch(*db).IsEncrypted();

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -566,7 +566,7 @@ public:
     void schedulerMockForward(std::chrono::seconds delta) override { Assert(m_context.scheduler)->MockForward(delta); }
 
     //! WalletLoader methods
-    util::Result<std::unique_ptr<Wallet>> createWallet(const std::string& name, const SecureString& passphrase, uint64_t wallet_creation_flags, std::vector<bilingual_str>& warnings) override
+    util::ResultPtr<std::unique_ptr<Wallet>> createWallet(const std::string& name, const SecureString& passphrase, uint64_t wallet_creation_flags, std::vector<bilingual_str>& warnings) override
     {
         DatabaseOptions options;
         DatabaseStatus status;
@@ -575,36 +575,25 @@ public:
         options.create_flags = wallet_creation_flags;
         options.create_passphrase = passphrase;
         bilingual_str error;
-        std::unique_ptr<Wallet> wallet{MakeWallet(m_context, CreateWallet(m_context, name, /*load_on_start=*/true, options, status, error, warnings))};
-        if (wallet) {
-            return wallet;
-        } else {
-            return util::Error{error};
-        }
+        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, CreateWallet(m_context, name, /*load_on_start=*/true, options, status, error, warnings))};
+        return wallet ? std::move(wallet) : util::Error{error};
     }
-    util::Result<std::unique_ptr<Wallet>> loadWallet(const std::string& name, std::vector<bilingual_str>& warnings) override
+    util::ResultPtr<std::unique_ptr<Wallet>> loadWallet(const std::string& name, std::vector<bilingual_str>& warnings) override
     {
         DatabaseOptions options;
         DatabaseStatus status;
         ReadDatabaseArgs(*m_context.args, options);
         options.require_existing = true;
         bilingual_str error;
-        std::unique_ptr<Wallet> wallet{MakeWallet(m_context, LoadWallet(m_context, name, /*load_on_start=*/true, options, status, error, warnings))};
-        if (wallet) {
-            return wallet;
-        } else {
-            return util::Error{error};
-        }
+        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, LoadWallet(m_context, name, /*load_on_start=*/true, options, status, error, warnings))};
+        return wallet ? std::move(wallet) : util::Error{error};
     }
-    util::Result<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings, bool load_after_restore) override
+    util::ResultPtr<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings, bool load_after_restore) override
     {
         DatabaseStatus status;
         bilingual_str error;
-        std::unique_ptr<Wallet> wallet{MakeWallet(m_context, RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, status, error, warnings, load_after_restore))};
-        if (!error.empty()) {
-            return util::Error{error};
-        }
-        return wallet;
+        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, status, error, warnings, load_after_restore))};
+        return wallet && !error.empty() ? std::move(wallet) : util::Error{error};
     }
     util::Result<WalletMigrationResult> migrateWallet(const std::string& name, const SecureString& passphrase, bool load_wallet) override
     {

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -263,6 +263,7 @@ public:
         bool sign,
         std::optional<unsigned int> change_pos) override
     {
+        util::Result<CTransactionRef> result;
         LOCK(m_wallet->cs_wallet);
         return CreateTransaction(*m_wallet, recipients, change_pos, coin_control, sign);
     }
@@ -566,46 +567,58 @@ public:
     void schedulerMockForward(std::chrono::seconds delta) override { Assert(m_context.scheduler)->MockForward(delta); }
 
     //! WalletLoader methods
-    util::ResultPtr<std::unique_ptr<Wallet>> createWallet(const std::string& name, const SecureString& passphrase, uint64_t wallet_creation_flags, std::vector<bilingual_str>& warnings) override
+    util::ResultPtr<std::unique_ptr<Wallet>> createWallet(const std::string& name, const SecureString& passphrase, uint64_t wallet_creation_flags) override
     {
+        util::ResultPtr<std::unique_ptr<Wallet>> result;
         DatabaseOptions options;
-        DatabaseStatus status;
         ReadDatabaseArgs(*m_context.args, options);
         options.require_create = true;
         options.create_flags = wallet_creation_flags;
         options.create_passphrase = passphrase;
-        bilingual_str error;
-        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, ResultExtract(CreateWallet(m_context, name, /*load_on_start=*/true, options), &status, &error, &warnings))};
-        return wallet ? std::move(wallet) : util::Error{error};
+        if (auto wallet{CreateWallet(m_context, name, true /* load_on_start */, options) >> result}) {
+            result.update(MakeWallet(m_context, wallet.value()));
+        } else {
+            result.update(util::Error{});
+        }
+        return result;
     }
-    util::ResultPtr<std::unique_ptr<Wallet>> loadWallet(const std::string& name, std::vector<bilingual_str>& warnings) override
+    util::ResultPtr<std::unique_ptr<Wallet>> loadWallet(const std::string& name) override
     {
+        util::ResultPtr<std::unique_ptr<Wallet>> result;
         DatabaseOptions options;
-        DatabaseStatus status;
         ReadDatabaseArgs(*m_context.args, options);
         options.require_existing = true;
-        bilingual_str error;
-        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, ResultExtract(LoadWallet(m_context, name, /*load_on_start=*/true, options), &status, &error, &warnings))};
-        return wallet ? std::move(wallet) : util::Error{error};
+        if (auto wallet{LoadWallet(m_context, name, true /* load_on_start */, options) >> result}) {
+            result.update(MakeWallet(m_context, wallet.value()));
+        } else {
+            result.update(util::Error{});
+        }
+        return result;
     }
-    util::ResultPtr<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings, bool load_after_restore) override
+    util::ResultPtr<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, bool load_after_restore) override
     {
-        DatabaseStatus status;
-        bilingual_str error;
-        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, ResultExtract(RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, load_after_restore), &status, &error, &warnings))};
-        return wallet && !error.empty() ? std::move(wallet) : util::Error{error};
+        util::ResultPtr<std::unique_ptr<Wallet>> result;
+        if (auto wallet{RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, load_after_restore) >> result}) {
+            result.update(MakeWallet(m_context, wallet.value()));
+        } else {
+            result.update(util::Error{});
+        }
+        return result;
     }
     util::Result<WalletMigrationResult> migrateWallet(const std::string& name, const SecureString& passphrase, bool load_wallet) override
     {
-        auto res = wallet::MigrateLegacyToDescriptor(name, passphrase, m_context, load_wallet);
-        if (!res) return util::Error{util::ErrorString(res)};
-        WalletMigrationResult out{
+        util::Result<WalletMigrationResult> result;
+        if (auto res{wallet::MigrateLegacyToDescriptor(name, passphrase, m_context, load_wallet) >> result}) {
+            result.update(WalletMigrationResult{
             .wallet = MakeWallet(m_context, res->wallet),
             .watchonly_wallet_name = res->watchonly_wallet_name,
             .solvables_wallet_name = res->solvables_wallet_name,
             .backup_path = res->backup_path,
-        };
-        return out;
+            });
+        } else {
+            result.update(util::Error{});
+        }
+        return result;
     }
     bool isEncrypted(const std::string& wallet_name) override
     {
@@ -616,12 +629,10 @@ public:
         // Unloaded wallet, read db
         DatabaseOptions options;
         options.require_existing = true;
-        DatabaseStatus status;
-        bilingual_str error;
-        auto db = ResultExtract(MakeWalletDatabase(wallet_name, options), &status, &error);
-        if (!db && status == wallet::DatabaseStatus::FAILED_LEGACY_DISABLED) {
+        auto db{MakeWalletDatabase(wallet_name, options)};
+        if (!db && db.error() == wallet::DatabaseStatus::FAILED_LEGACY_DISABLED) {
             options.require_format = wallet::DatabaseFormat::BERKELEY_RO;
-            db = ResultExtract(MakeWalletDatabase(wallet_name, options), &status, &error);
+            db.update(MakeWalletDatabase(wallet_name, options));
         }
         if (!db) return false;
         return WalletBatch(*db).IsEncrypted();

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -490,7 +490,7 @@ public:
     CAmount getDefaultMaxTxFee() override { return m_wallet->m_default_max_tx_fee; }
     void remove() override
     {
-        RemoveWallet(m_context, m_wallet, /*load_on_start=*/false);
+        Assume(RemoveWallet(m_context, m_wallet, /*load_on_start=*/false));
     }
     std::unique_ptr<Handler> handleUnload(UnloadFn fn) override
     {
@@ -575,7 +575,7 @@ public:
         options.create_flags = wallet_creation_flags;
         options.create_passphrase = passphrase;
         bilingual_str error;
-        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, CreateWallet(m_context, name, /*load_on_start=*/true, options, status, error, warnings))};
+        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, ResultExtract(CreateWallet(m_context, name, /*load_on_start=*/true, options), &status, &error, &warnings))};
         return wallet ? std::move(wallet) : util::Error{error};
     }
     util::ResultPtr<std::unique_ptr<Wallet>> loadWallet(const std::string& name, std::vector<bilingual_str>& warnings) override
@@ -585,14 +585,14 @@ public:
         ReadDatabaseArgs(*m_context.args, options);
         options.require_existing = true;
         bilingual_str error;
-        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, LoadWallet(m_context, name, /*load_on_start=*/true, options, status, error, warnings))};
+        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, ResultExtract(LoadWallet(m_context, name, /*load_on_start=*/true, options), &status, &error, &warnings))};
         return wallet ? std::move(wallet) : util::Error{error};
     }
     util::ResultPtr<std::unique_ptr<Wallet>> restoreWallet(const fs::path& backup_file, const std::string& wallet_name, std::vector<bilingual_str>& warnings, bool load_after_restore) override
     {
         DatabaseStatus status;
         bilingual_str error;
-        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, status, error, warnings, load_after_restore))};
+        util::ResultPtr<std::unique_ptr<Wallet>> wallet{MakeWallet(m_context, ResultExtract(RestoreWallet(m_context, backup_file, wallet_name, /*load_on_start=*/true, load_after_restore), &status, &error, &warnings))};
         return wallet && !error.empty() ? std::move(wallet) : util::Error{error};
     }
     util::Result<WalletMigrationResult> migrateWallet(const std::string& name, const SecureString& passphrase, bool load_wallet) override
@@ -618,10 +618,10 @@ public:
         options.require_existing = true;
         DatabaseStatus status;
         bilingual_str error;
-        auto db = MakeWalletDatabase(wallet_name, options, status, error);
+        auto db = ResultExtract(MakeWalletDatabase(wallet_name, options), &status, &error);
         if (!db && status == wallet::DatabaseStatus::FAILED_LEGACY_DISABLED) {
             options.require_format = wallet::DatabaseFormat::BERKELEY_RO;
-            db = MakeWalletDatabase(wallet_name, options, status, error);
+            db = ResultExtract(MakeWalletDatabase(wallet_name, options), &status, &error);
         }
         if (!db) return false;
         return WalletBatch(*db).IsEncrypted();

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -630,7 +630,7 @@ public:
         DatabaseOptions options;
         options.require_existing = true;
         auto db{MakeWalletDatabase(wallet_name, options)};
-        if (!db && db.error() == wallet::DatabaseStatus::FAILED_LEGACY_DISABLED) {
+        if (!db && db.error() == wallet::DatabaseError::FAILED_LEGACY_DISABLED) {
             options.require_format = wallet::DatabaseFormat::BERKELEY_RO;
             db.update(MakeWalletDatabase(wallet_name, options));
         }

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -65,7 +65,7 @@ bool VerifyWallets(WalletContext& context)
         bilingual_str error_string;
         options.require_existing = true;
         options.verify = false;
-        if (MakeWalletDatabase("", options, status, error_string)) {
+        if (ResultExtract(MakeWalletDatabase("", options), &status, &error_string)) {
             common::SettingsValue wallets(common::SettingsValue::VARR);
             wallets.push_back(""); // Default wallet name is ""
             // Pass write=false because no need to write file and probably
@@ -98,7 +98,7 @@ bool VerifyWallets(WalletContext& context)
         options.require_existing = true;
         options.verify = true;
         bilingual_str error_string;
-        if (!MakeWalletDatabase(wallet_file, options, status, error_string)) {
+        if (!ResultExtract(MakeWalletDatabase(wallet_file, options), &status, &error_string)) {
             if (status == DatabaseStatus::FAILED_NOT_FOUND) {
                 chain.initWarning(Untranslated(strprintf("Skipping -wallet path that doesn't exist. %s", error_string.original)));
             } else if (status == DatabaseStatus::FAILED_LEGACY_DISABLED) {
@@ -137,7 +137,7 @@ bool LoadWallets(WalletContext& context)
             options.verify = false; // No need to verify, assuming verified earlier in VerifyWallets()
             bilingual_str error;
             std::vector<bilingual_str> warnings;
-            std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(name, options, status, error);
+            std::unique_ptr<WalletDatabase> database{ResultExtract(MakeWalletDatabase(name, options), &status, &error)};
             if (!database) {
                 if (status == DatabaseStatus::FAILED_NOT_FOUND) continue;
                 if (status == DatabaseStatus::FAILED_LEGACY_DISABLED) {
@@ -147,7 +147,7 @@ bool LoadWallets(WalletContext& context)
                 }
             }
             chain.initMessage(_("Loading wallet…"));
-            std::shared_ptr<CWallet> pwallet = database ? CWallet::LoadExisting(context, name, std::move(database), error, warnings) : nullptr;
+            std::shared_ptr<CWallet> pwallet{database ? ResultExtract(CWallet::LoadExisting(context, name, std::move(database)), nullptr, &error, &warnings) : nullptr};
             if (!warnings.empty()) chain.initWarning(Join(warnings, Untranslated("\n")));
             if (!pwallet) {
                 chain.initError(error);
@@ -180,7 +180,7 @@ void UnloadWallets(WalletContext& context)
         auto wallet = wallets.back();
         wallets.pop_back();
         std::vector<bilingual_str> warnings;
-        RemoveWallet(context, wallet, /* load_on_start= */ std::nullopt, warnings);
+        ResultExtract(RemoveWallet(context, wallet, /* load_on_start= */ std::nullopt), nullptr, nullptr, &warnings);
         WaitForDeleteWallet(std::move(wallet));
     }
 }

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -97,9 +97,9 @@ bool VerifyWallets(WalletContext& context)
         options.verify = true;
         auto result{MakeWalletDatabase(wallet_file, options)};
         if (!result) {
-            if (result.error() == DatabaseStatus::FAILED_NOT_FOUND) {
+            if (result.error() == DatabaseError::FAILED_NOT_FOUND) {
                 chain.initWarning(Untranslated(strprintf("Skipping -wallet path that doesn't exist. %s", util::ErrorString(result).original)));
-            } else if (result.error() == DatabaseStatus::FAILED_LEGACY_DISABLED) {
+            } else if (result.error() == DatabaseError::FAILED_LEGACY_DISABLED) {
                 // Skipping legacy wallets as they will not be loaded.
                 // This will be properly communicated to the user during the loading process.
                 continue;
@@ -135,8 +135,8 @@ bool LoadWallets(WalletContext& context)
             util::Result<void> result;
             auto database{MakeWalletDatabase(name, options) >> result};
             if (!database) {
-                if (database.error() == DatabaseStatus::FAILED_NOT_FOUND) continue;
-                if (database.error() == DatabaseStatus::FAILED_LEGACY_DISABLED) {
+                if (database.error() == DatabaseError::FAILED_NOT_FOUND) continue;
+                if (database.error() == DatabaseError::FAILED_LEGACY_DISABLED) {
                     // Inform user that legacy wallet is not loaded and suggest upgrade options
                     chain.initWarning(util::ErrorString(result));
                     continue;

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -21,6 +21,7 @@
 
 #include <system_error>
 
+using util::Error;
 using util::Join;
 
 namespace wallet {
@@ -60,12 +61,10 @@ bool VerifyWallets(WalletContext& context)
     // wallets directory, include it in the default list of wallets to load.
     if (!args.IsArgSet("wallet")) {
         DatabaseOptions options;
-        DatabaseStatus status;
         ReadDatabaseArgs(args, options);
-        bilingual_str error_string;
         options.require_existing = true;
         options.verify = false;
-        if (ResultExtract(MakeWalletDatabase("", options), &status, &error_string)) {
+        if (MakeWalletDatabase("", options)) {
             common::SettingsValue wallets(common::SettingsValue::VARR);
             wallets.push_back(""); // Default wallet name is ""
             // Pass write=false because no need to write file and probably
@@ -93,20 +92,19 @@ bool VerifyWallets(WalletContext& context)
         }
 
         DatabaseOptions options;
-        DatabaseStatus status;
         ReadDatabaseArgs(args, options);
         options.require_existing = true;
         options.verify = true;
-        bilingual_str error_string;
-        if (!ResultExtract(MakeWalletDatabase(wallet_file, options), &status, &error_string)) {
-            if (status == DatabaseStatus::FAILED_NOT_FOUND) {
-                chain.initWarning(Untranslated(strprintf("Skipping -wallet path that doesn't exist. %s", error_string.original)));
-            } else if (status == DatabaseStatus::FAILED_LEGACY_DISABLED) {
+        auto result{MakeWalletDatabase(wallet_file, options)};
+        if (!result) {
+            if (result.error() == DatabaseStatus::FAILED_NOT_FOUND) {
+                chain.initWarning(Untranslated(strprintf("Skipping -wallet path that doesn't exist. %s", util::ErrorString(result).original)));
+            } else if (result.error() == DatabaseStatus::FAILED_LEGACY_DISABLED) {
                 // Skipping legacy wallets as they will not be loaded.
                 // This will be properly communicated to the user during the loading process.
                 continue;
             } else {
-                chain.initError(error_string);
+                chain.initError(util::ErrorString(result));
                 return false;
             }
         }
@@ -131,31 +129,30 @@ bool LoadWallets(WalletContext& context)
                 continue;
             }
             DatabaseOptions options;
-            DatabaseStatus status;
             ReadDatabaseArgs(*context.args, options);
             options.require_existing = true;
             options.verify = false; // No need to verify, assuming verified earlier in VerifyWallets()
-            bilingual_str error;
-            std::vector<bilingual_str> warnings;
-            std::unique_ptr<WalletDatabase> database{ResultExtract(MakeWalletDatabase(name, options), &status, &error)};
+            util::Result<void> result;
+            auto database{MakeWalletDatabase(name, options) >> result};
             if (!database) {
-                if (status == DatabaseStatus::FAILED_NOT_FOUND) continue;
-                if (status == DatabaseStatus::FAILED_LEGACY_DISABLED) {
+                if (database.error() == DatabaseStatus::FAILED_NOT_FOUND) continue;
+                if (database.error() == DatabaseStatus::FAILED_LEGACY_DISABLED) {
                     // Inform user that legacy wallet is not loaded and suggest upgrade options
-                    chain.initWarning(error);
+                    chain.initWarning(util::ErrorString(result));
                     continue;
                 }
             }
             chain.initMessage(_("Loading wallet…"));
-            std::shared_ptr<CWallet> pwallet{database ? ResultExtract(CWallet::LoadExisting(context, name, std::move(database)), nullptr, &error, &warnings) : nullptr};
-            if (!warnings.empty()) chain.initWarning(Join(warnings, Untranslated("\n")));
-            if (!pwallet) {
-                chain.initError(error);
+            util::ResultPtr<std::shared_ptr<CWallet>> load{Error{}};
+            if (database) load.update(CWallet::LoadExisting(context, name, std::move(database.value())) >> result);
+            if (result.messages_ptr() && !result.messages_ptr()->warnings.empty()) chain.initWarning(Join(result.messages_ptr()->warnings, Untranslated("\n")));
+            if (!load) {
+                chain.initError(Join(result.messages_ptr()->errors, Untranslated("\n")));
                 return false;
             }
 
-            NotifyWalletLoaded(context, pwallet);
-            AddWallet(context, pwallet);
+            NotifyWalletLoaded(context, load.value());
+            AddWallet(context, load.value());
         }
         return true;
     } catch (const std::runtime_error& e) {
@@ -179,8 +176,8 @@ void UnloadWallets(WalletContext& context)
     while (!wallets.empty()) {
         auto wallet = wallets.back();
         wallets.pop_back();
-        std::vector<bilingual_str> warnings;
-        ResultExtract(RemoveWallet(context, wallet, /* load_on_start= */ std::nullopt), nullptr, nullptr, &warnings);
+        // Note: Warnings returned from RemoveWallet are silently discarded.
+        Assume(RemoveWallet(context, wallet, /* load_on_start= */ std::nullopt));
         WaitForDeleteWallet(std::move(wallet));
     }
 }

--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -792,13 +792,13 @@ std::unique_ptr<DatabaseCursor> BerkeleyROBatch::GetNewPrefixCursor(std::span<co
     return std::make_unique<BerkeleyROCursor>(m_database, prefix);
 }
 
-util::ResultPtr<std::unique_ptr<BerkeleyRODatabase>, DatabaseStatus> MakeBerkeleyRODatabase(const fs::path& path, const DatabaseOptions& options)
+util::ResultPtr<std::unique_ptr<BerkeleyRODatabase>, DatabaseError> MakeBerkeleyRODatabase(const fs::path& path, const DatabaseOptions& options)
 {
     fs::path data_file = BDBDataFile(path);
     try {
         return std::make_unique<BerkeleyRODatabase>(data_file);
     } catch (const std::runtime_error& e) {
-        return {util::Error{Untranslated(e.what())}, DatabaseStatus::FAILED_LOAD};
+        return {util::Error{Untranslated(e.what())}, DatabaseError::FAILED_LOAD};
     }
 }
 } // namespace wallet

--- a/src/wallet/migrate.cpp
+++ b/src/wallet/migrate.cpp
@@ -792,17 +792,13 @@ std::unique_ptr<DatabaseCursor> BerkeleyROBatch::GetNewPrefixCursor(std::span<co
     return std::make_unique<BerkeleyROCursor>(m_database, prefix);
 }
 
-std::unique_ptr<BerkeleyRODatabase> MakeBerkeleyRODatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error)
+util::ResultPtr<std::unique_ptr<BerkeleyRODatabase>, DatabaseStatus> MakeBerkeleyRODatabase(const fs::path& path, const DatabaseOptions& options)
 {
     fs::path data_file = BDBDataFile(path);
     try {
-        std::unique_ptr<BerkeleyRODatabase> db = std::make_unique<BerkeleyRODatabase>(data_file);
-        status = DatabaseStatus::SUCCESS;
-        return db;
+        return std::make_unique<BerkeleyRODatabase>(data_file);
     } catch (const std::runtime_error& e) {
-        error.original = e.what();
-        status = DatabaseStatus::FAILED_LOAD;
-        return nullptr;
+        return {util::Error{Untranslated(e.what())}, DatabaseStatus::FAILED_LOAD};
     }
 }
 } // namespace wallet

--- a/src/wallet/migrate.h
+++ b/src/wallet/migrate.h
@@ -105,7 +105,7 @@ public:
 };
 
 //! Return object giving access to Berkeley Read Only database at specified path.
-util::ResultPtr<std::unique_ptr<BerkeleyRODatabase>, DatabaseStatus> MakeBerkeleyRODatabase(const fs::path& path, const DatabaseOptions& options);
+util::ResultPtr<std::unique_ptr<BerkeleyRODatabase>, DatabaseError> MakeBerkeleyRODatabase(const fs::path& path, const DatabaseOptions& options);
 } // namespace wallet
 
 #endif // BITCOIN_WALLET_MIGRATE_H

--- a/src/wallet/migrate.h
+++ b/src/wallet/migrate.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_WALLET_MIGRATE_H
 #define BITCOIN_WALLET_MIGRATE_H
 
+#include <util/result.h>
 #include <wallet/db.h>
 
 #include <optional>
@@ -104,7 +105,7 @@ public:
 };
 
 //! Return object giving access to Berkeley Read Only database at specified path.
-std::unique_ptr<BerkeleyRODatabase> MakeBerkeleyRODatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error);
+util::ResultPtr<std::unique_ptr<BerkeleyRODatabase>, DatabaseStatus> MakeBerkeleyRODatabase(const fs::path& path, const DatabaseOptions& options);
 } // namespace wallet
 
 #endif // BITCOIN_WALLET_MIGRATE_H

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -644,7 +644,7 @@ RPCMethod restorewallet()
     bilingual_str error;
     std::vector<bilingual_str> warnings;
 
-    const std::shared_ptr<CWallet> wallet = RestoreWallet(context, backup_file, wallet_name, load_on_start, status, error, warnings);
+    const std::shared_ptr<CWallet> wallet{ResultExtract(RestoreWallet(context, backup_file, wallet_name, load_on_start), &status, &error, &warnings)};
 
     HandleWalletError(wallet, status, error);
 

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -640,17 +640,15 @@ RPCMethod restorewallet()
 
     std::optional<bool> load_on_start = request.params[2].isNull() ? std::nullopt : std::optional<bool>(request.params[2].get_bool());
 
-    DatabaseStatus status;
-    bilingual_str error;
-    std::vector<bilingual_str> warnings;
+    auto wallet{RestoreWallet(context, backup_file, wallet_name, load_on_start)};
 
-    const std::shared_ptr<CWallet> wallet{ResultExtract(RestoreWallet(context, backup_file, wallet_name, load_on_start), &status, &error, &warnings)};
-
-    HandleWalletError(wallet, status, error);
+    HandleWalletError(wallet);
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("name", wallet->GetName());
-    PushWarnings(warnings, obj);
+    if (wallet.messages_ptr()) {
+        PushWarnings(wallet.messages_ptr()->warnings, obj);
+    }
 
     return obj;
 

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -637,7 +637,7 @@ RPCMethod restorewallet()
     bilingual_str error;
     std::vector<bilingual_str> warnings;
 
-    const std::shared_ptr<CWallet> wallet = RestoreWallet(context, backup_file, wallet_name, load_on_start, status, error, warnings);
+    const std::shared_ptr<CWallet> wallet{ResultExtract(RestoreWallet(context, backup_file, wallet_name, load_on_start), &status, &error, &warnings)};
 
     HandleWalletError(wallet, status, error);
 

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -633,17 +633,15 @@ RPCMethod restorewallet()
 
     std::optional<bool> load_on_start = request.params[2].isNull() ? std::nullopt : std::optional<bool>(request.params[2].get_bool());
 
-    DatabaseStatus status;
-    bilingual_str error;
-    std::vector<bilingual_str> warnings;
+    auto wallet{RestoreWallet(context, backup_file, wallet_name, load_on_start)};
 
-    const std::shared_ptr<CWallet> wallet{ResultExtract(RestoreWallet(context, backup_file, wallet_name, load_on_start), &status, &error, &warnings)};
-
-    HandleWalletError(wallet, status, error);
+    HandleWalletError(wallet);
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("name", wallet->GetName());
-    PushWarnings(warnings, obj);
+    if (wallet.messages_ptr()) {
+        PushWarnings(wallet.messages_ptr()->warnings, obj);
+    }
 
     return obj;
 

--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -121,29 +121,29 @@ void PushParentDescriptors(const CWallet& wallet, const CScript& script_pubkey, 
     entry.pushKV("parent_descs", std::move(parent_descs));
 }
 
-void HandleWalletError(const util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus>& wallet)
+void HandleWalletError(const util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError>& wallet)
 {
     if (!wallet) {
         // Map bad format to not found, since bad format is returned when the
         // wallet directory exists, but doesn't contain a data file.
         RPCErrorCode code = RPC_WALLET_ERROR;
         switch (wallet.error()) {
-            case DatabaseStatus::FAILED_NOT_FOUND:
-            case DatabaseStatus::FAILED_BAD_FORMAT:
-            case DatabaseStatus::FAILED_LEGACY_DISABLED:
+            case DatabaseError::FAILED_NOT_FOUND:
+            case DatabaseError::FAILED_BAD_FORMAT:
+            case DatabaseError::FAILED_LEGACY_DISABLED:
                 code = RPC_WALLET_NOT_FOUND;
                 break;
-            case DatabaseStatus::FAILED_ALREADY_LOADED:
+            case DatabaseError::FAILED_ALREADY_LOADED:
                 code = RPC_WALLET_ALREADY_LOADED;
                 break;
-            case DatabaseStatus::FAILED_ALREADY_EXISTS:
+            case DatabaseError::FAILED_ALREADY_EXISTS:
                 code = RPC_WALLET_ALREADY_EXISTS;
                 break;
-            case DatabaseStatus::FAILED_NEW_UNNAMED:
-            case DatabaseStatus::FAILED_INVALID_BACKUP_FILE:
+            case DatabaseError::FAILED_NEW_UNNAMED:
+            case DatabaseError::FAILED_INVALID_BACKUP_FILE:
                 code = RPC_INVALID_PARAMETER;
                 break;
-            case DatabaseStatus::FAILED_ENCRYPT:
+            case DatabaseError::FAILED_ENCRYPT:
                 code = RPC_WALLET_ENCRYPTION_FAILED;
                 break;
             default: // RPC_WALLET_ERROR is returned for all other cases.

--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -121,13 +121,13 @@ void PushParentDescriptors(const CWallet& wallet, const CScript& script_pubkey, 
     entry.pushKV("parent_descs", std::move(parent_descs));
 }
 
-void HandleWalletError(const std::shared_ptr<CWallet>& wallet, DatabaseStatus& status, bilingual_str& error)
+void HandleWalletError(const util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus>& wallet)
 {
     if (!wallet) {
         // Map bad format to not found, since bad format is returned when the
         // wallet directory exists, but doesn't contain a data file.
         RPCErrorCode code = RPC_WALLET_ERROR;
-        switch (status) {
+        switch (wallet.error()) {
             case DatabaseStatus::FAILED_NOT_FOUND:
             case DatabaseStatus::FAILED_BAD_FORMAT:
             case DatabaseStatus::FAILED_LEGACY_DISABLED:
@@ -149,7 +149,7 @@ void HandleWalletError(const std::shared_ptr<CWallet>& wallet, DatabaseStatus& s
             default: // RPC_WALLET_ERROR is returned for all other cases.
                 break;
         }
-        throw JSONRPCError(code, error.original);
+        throw JSONRPCError(code, util::ErrorString(wallet).original);
     }
 }
 

--- a/src/wallet/rpc/util.h
+++ b/src/wallet/rpc/util.h
@@ -7,6 +7,7 @@
 
 #include <rpc/util.h>
 #include <script/script.h>
+#include <util/result.h>
 #include <wallet/wallet.h>
 
 #include <any>
@@ -54,7 +55,7 @@ std::string LabelFromValue(const UniValue& value);
 //! Fetch parent descriptors of this scriptPubKey.
 void PushParentDescriptors(const CWallet& wallet, const CScript& script_pubkey, UniValue& entry);
 
-void HandleWalletError(const std::shared_ptr<CWallet>& wallet, DatabaseStatus& status, bilingual_str& error);
+void HandleWalletError(const util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus>& wallet);
 void AppendLastProcessedBlock(UniValue& entry, const CWallet& wallet) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 } //  namespace wallet
 

--- a/src/wallet/rpc/util.h
+++ b/src/wallet/rpc/util.h
@@ -23,7 +23,7 @@ struct bilingual_str;
 
 namespace wallet {
 class LegacyScriptPubKeyMan;
-enum class DatabaseStatus;
+enum class DatabaseError;
 struct WalletContext;
 
 extern const std::string HELP_REQUIRING_PASSPHRASE;
@@ -55,7 +55,7 @@ std::string LabelFromValue(const UniValue& value);
 //! Fetch parent descriptors of this scriptPubKey.
 void PushParentDescriptors(const CWallet& wallet, const CScript& script_pubkey, UniValue& entry);
 
-void HandleWalletError(const util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus>& wallet);
+void HandleWalletError(const util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError>& wallet);
 void AppendLastProcessedBlock(UniValue& entry, const CWallet& wallet) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 } //  namespace wallet
 

--- a/src/wallet/rpc/util.h
+++ b/src/wallet/rpc/util.h
@@ -7,6 +7,7 @@
 
 #include <rpc/util.h>
 #include <script/script.h>
+#include <util/result.h>
 #include <wallet/wallet.h>
 
 #include <any>
@@ -53,7 +54,7 @@ std::string LabelFromValue(const UniValue& value);
 //! Fetch parent descriptors of this scriptPubKey.
 void PushParentDescriptors(const CWallet& wallet, const CScript& script_pubkey, UniValue& entry);
 
-void HandleWalletError(const std::shared_ptr<CWallet>& wallet, DatabaseStatus& status, bilingual_str& error);
+void HandleWalletError(const util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus>& wallet);
 void AppendLastProcessedBlock(UniValue& entry, const CWallet& wallet) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 } //  namespace wallet
 

--- a/src/wallet/rpc/util.h
+++ b/src/wallet/rpc/util.h
@@ -22,7 +22,7 @@ class UniValue;
 struct bilingual_str;
 
 namespace wallet {
-enum class DatabaseStatus;
+enum class DatabaseError;
 struct WalletContext;
 
 extern const std::string HELP_REQUIRING_PASSPHRASE;
@@ -54,7 +54,7 @@ std::string LabelFromValue(const UniValue& value);
 //! Fetch parent descriptors of this scriptPubKey.
 void PushParentDescriptors(const CWallet& wallet, const CScript& script_pubkey, UniValue& entry);
 
-void HandleWalletError(const util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus>& wallet);
+void HandleWalletError(const util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError>& wallet);
 void AppendLastProcessedBlock(UniValue& entry, const CWallet& wallet) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 } //  namespace wallet
 

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -265,7 +265,7 @@ static RPCMethod loadwallet()
         }
     }
 
-    std::shared_ptr<CWallet> const wallet = LoadWallet(context, name, load_on_start, options, status, error, warnings);
+    std::shared_ptr<CWallet> const wallet{ResultExtract(LoadWallet(context, name, load_on_start, options), &status, &error, &warnings)};
 
     HandleWalletError(wallet, status, error);
 
@@ -422,7 +422,7 @@ static RPCMethod createwallet()
     options.create_passphrase = passphrase;
     bilingual_str error;
     std::optional<bool> load_on_start = request.params[6].isNull() ? std::nullopt : std::optional<bool>(request.params[6].get_bool());
-    const std::shared_ptr<CWallet> wallet = CreateWallet(context, request.params[0].get_str(), load_on_start, options, status, error, warnings);
+    const std::shared_ptr<CWallet> wallet{ResultExtract(CreateWallet(context, request.params[0].get_str(), load_on_start, options), &status, &error, &warnings)};
     HandleWalletError(wallet, status, error);
 
     UniValue obj(UniValue::VOBJ);
@@ -474,7 +474,7 @@ static RPCMethod unloadwallet()
         // Note that any attempt to load the same wallet would fail until the wallet
         // is destroyed (see CheckUniqueFileid).
         std::optional<bool> load_on_start{self.MaybeArg<bool>("load_on_startup")};
-        if (!RemoveWallet(context, wallet, load_on_start, warnings)) {
+        if (!ResultExtract(RemoveWallet(context, wallet, load_on_start), nullptr, nullptr, &warnings)) {
             throw JSONRPCError(RPC_MISC_ERROR, "Requested wallet already unloaded");
         }
     }

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -251,11 +251,8 @@ static RPCMethod loadwallet()
     const std::string name(request.params[0].get_str());
 
     DatabaseOptions options;
-    DatabaseStatus status;
     ReadDatabaseArgs(*context.args, options);
     options.require_existing = true;
-    bilingual_str error;
-    std::vector<bilingual_str> warnings;
     std::optional<bool> load_on_start = request.params[1].isNull() ? std::nullopt : std::optional<bool>(request.params[1].get_bool());
 
     {
@@ -265,13 +262,14 @@ static RPCMethod loadwallet()
         }
     }
 
-    std::shared_ptr<CWallet> const wallet{ResultExtract(LoadWallet(context, name, load_on_start, options), &status, &error, &warnings)};
-
-    HandleWalletError(wallet, status, error);
+    auto wallet{LoadWallet(context, name, load_on_start, options)};
+    HandleWalletError(wallet);
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("name", wallet->GetName());
-    PushWarnings(warnings, obj);
+    if (wallet.messages_ptr()) {
+        PushWarnings(wallet.messages_ptr()->warnings, obj);
+    }
 
     return obj;
 },
@@ -390,12 +388,12 @@ static RPCMethod createwallet()
     }
     SecureString passphrase;
     passphrase.reserve(100);
-    std::vector<bilingual_str> warnings;
+    util::Result<void> result;
     if (!request.params[3].isNull()) {
         passphrase = std::string_view{request.params[3].get_str()};
         if (passphrase.empty()) {
             // Empty string means unencrypted
-            warnings.emplace_back(Untranslated("Empty string given as passphrase, wallet will not be encrypted."));
+            result.messages().warnings.push_back(Untranslated("Empty string given as passphrase, wallet will not be encrypted."));
         }
     }
 
@@ -415,19 +413,20 @@ static RPCMethod createwallet()
     }
 
     DatabaseOptions options;
-    DatabaseStatus status;
     ReadDatabaseArgs(*context.args, options);
     options.require_create = true;
     options.create_flags = flags;
     options.create_passphrase = passphrase;
-    bilingual_str error;
     std::optional<bool> load_on_start = request.params[6].isNull() ? std::nullopt : std::optional<bool>(request.params[6].get_bool());
-    const std::shared_ptr<CWallet> wallet{ResultExtract(CreateWallet(context, request.params[0].get_str(), load_on_start, options), &status, &error, &warnings)};
-    HandleWalletError(wallet, status, error);
+    auto wallet{CreateWallet(context, request.params[0].get_str(), load_on_start, options)};
+    HandleWalletError(wallet);
+    wallet >> result;
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("name", wallet->GetName());
-    PushWarnings(warnings, obj);
+    if (result.messages_ptr()) {
+        PushWarnings(result.messages_ptr()->warnings, obj);
+    }
 
     return obj;
 },
@@ -463,7 +462,7 @@ static RPCMethod unloadwallet()
         throw JSONRPCError(RPC_WALLET_NOT_FOUND, "Requested wallet does not exist or is not loaded");
     }
 
-    std::vector<bilingual_str> warnings;
+    util::Result<void> result;
     {
         WalletRescanReserver reserver(*wallet);
         if (!reserver.reserve()) {
@@ -474,17 +473,19 @@ static RPCMethod unloadwallet()
         // Note that any attempt to load the same wallet would fail until the wallet
         // is destroyed (see CheckUniqueFileid).
         std::optional<bool> load_on_start{self.MaybeArg<bool>("load_on_startup")};
-        if (!ResultExtract(RemoveWallet(context, wallet, load_on_start), nullptr, nullptr, &warnings)) {
+        if (!(RemoveWallet(context, wallet, load_on_start) >> result)) {
             throw JSONRPCError(RPC_MISC_ERROR, "Requested wallet already unloaded");
         }
     }
 
     WaitForDeleteWallet(std::move(wallet));
 
-    UniValue result(UniValue::VOBJ);
-    PushWarnings(warnings, result);
+    UniValue ret(UniValue::VOBJ);
+    if (result.messages_ptr()) {
+        PushWarnings(result.messages_ptr()->warnings, ret);
+    }
 
-    return result;
+    return ret;
 },
     };
 }

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -271,7 +271,7 @@ static RPCMethod loadwallet()
         }
     }
 
-    std::shared_ptr<CWallet> const wallet = LoadWallet(context, name, load_on_start, options, status, error, warnings);
+    std::shared_ptr<CWallet> const wallet{ResultExtract(LoadWallet(context, name, load_on_start, options), &status, &error, &warnings)};
 
     HandleWalletError(wallet, status, error);
 
@@ -428,7 +428,7 @@ static RPCMethod createwallet()
     options.create_passphrase = passphrase;
     bilingual_str error;
     std::optional<bool> load_on_start = request.params[6].isNull() ? std::nullopt : std::optional<bool>(request.params[6].get_bool());
-    const std::shared_ptr<CWallet> wallet = CreateWallet(context, request.params[0].get_str(), load_on_start, options, status, error, warnings);
+    const std::shared_ptr<CWallet> wallet{ResultExtract(CreateWallet(context, request.params[0].get_str(), load_on_start, options), &status, &error, &warnings)};
     HandleWalletError(wallet, status, error);
 
     UniValue obj(UniValue::VOBJ);
@@ -480,7 +480,7 @@ static RPCMethod unloadwallet()
         // Note that any attempt to load the same wallet would fail until the wallet
         // is destroyed (see CheckUniqueFileid).
         std::optional<bool> load_on_start{self.MaybeArg<bool>("load_on_startup")};
-        if (!RemoveWallet(context, wallet, load_on_start, warnings)) {
+        if (!ResultExtract(RemoveWallet(context, wallet, load_on_start), nullptr, nullptr, &warnings)) {
             throw JSONRPCError(RPC_MISC_ERROR, "Requested wallet already unloaded");
         }
     }

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -257,11 +257,8 @@ static RPCMethod loadwallet()
     const std::string name(request.params[0].get_str());
 
     DatabaseOptions options;
-    DatabaseStatus status;
     ReadDatabaseArgs(*context.args, options);
     options.require_existing = true;
-    bilingual_str error;
-    std::vector<bilingual_str> warnings;
     std::optional<bool> load_on_start = request.params[1].isNull() ? std::nullopt : std::optional<bool>(request.params[1].get_bool());
 
     {
@@ -271,13 +268,14 @@ static RPCMethod loadwallet()
         }
     }
 
-    std::shared_ptr<CWallet> const wallet{ResultExtract(LoadWallet(context, name, load_on_start, options), &status, &error, &warnings)};
-
-    HandleWalletError(wallet, status, error);
+    auto wallet{LoadWallet(context, name, load_on_start, options)};
+    HandleWalletError(wallet);
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("name", wallet->GetName());
-    PushWarnings(warnings, obj);
+    if (wallet.messages_ptr()) {
+        PushWarnings(wallet.messages_ptr()->warnings, obj);
+    }
 
     return obj;
 },
@@ -396,12 +394,12 @@ static RPCMethod createwallet()
     }
     SecureString passphrase;
     passphrase.reserve(100);
-    std::vector<bilingual_str> warnings;
+    util::Result<void> result;
     if (!request.params[3].isNull()) {
         passphrase = std::string_view{request.params[3].get_str()};
         if (passphrase.empty()) {
             // Empty string means unencrypted
-            warnings.emplace_back(Untranslated("Empty string given as passphrase, wallet will not be encrypted."));
+            result.messages().warnings.push_back(Untranslated("Empty string given as passphrase, wallet will not be encrypted."));
         }
     }
 
@@ -421,19 +419,20 @@ static RPCMethod createwallet()
     }
 
     DatabaseOptions options;
-    DatabaseStatus status;
     ReadDatabaseArgs(*context.args, options);
     options.require_create = true;
     options.create_flags = flags;
     options.create_passphrase = passphrase;
-    bilingual_str error;
     std::optional<bool> load_on_start = request.params[6].isNull() ? std::nullopt : std::optional<bool>(request.params[6].get_bool());
-    const std::shared_ptr<CWallet> wallet{ResultExtract(CreateWallet(context, request.params[0].get_str(), load_on_start, options), &status, &error, &warnings)};
-    HandleWalletError(wallet, status, error);
+    auto wallet{CreateWallet(context, request.params[0].get_str(), load_on_start, options)};
+    HandleWalletError(wallet);
+    wallet >> result;
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("name", wallet->GetName());
-    PushWarnings(warnings, obj);
+    if (result.messages_ptr()) {
+        PushWarnings(result.messages_ptr()->warnings, obj);
+    }
 
     return obj;
 },
@@ -469,7 +468,7 @@ static RPCMethod unloadwallet()
         throw JSONRPCError(RPC_WALLET_NOT_FOUND, "Requested wallet does not exist or is not loaded");
     }
 
-    std::vector<bilingual_str> warnings;
+    util::Result<void> result;
     {
         WalletRescanReserver reserver(*wallet);
         if (!reserver.reserve()) {
@@ -480,17 +479,19 @@ static RPCMethod unloadwallet()
         // Note that any attempt to load the same wallet would fail until the wallet
         // is destroyed (see CheckUniqueFileid).
         std::optional<bool> load_on_start{self.MaybeArg<bool>("load_on_startup")};
-        if (!ResultExtract(RemoveWallet(context, wallet, load_on_start), nullptr, nullptr, &warnings)) {
+        if (!(RemoveWallet(context, wallet, load_on_start) >> result)) {
             throw JSONRPCError(RPC_MISC_ERROR, "Requested wallet already unloaded");
         }
     }
 
     WaitForDeleteWallet(std::move(wallet));
 
-    UniValue result(UniValue::VOBJ);
-    PushWarnings(warnings, result);
+    UniValue ret(UniValue::VOBJ);
+    if (result.messages_ptr()) {
+        PushWarnings(result.messages_ptr()->warnings, ret);
+    }
 
-    return result;
+    return ret;
 },
     };
 }

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -78,21 +78,19 @@ static bool BindBlobToStatement(sqlite3_stmt* stmt,
     return true;
 }
 
-static std::optional<int> ReadPragmaInteger(sqlite3* db, const std::string& key, const std::string& description, bilingual_str& error)
+static util::Result<int> ReadPragmaInteger(sqlite3* db, const std::string& key, const std::string& description)
 {
     std::string stmt_text = strprintf("PRAGMA %s", key);
     sqlite3_stmt* pragma_read_stmt{nullptr};
     int ret = sqlite3_prepare_v2(db, stmt_text.c_str(), -1, &pragma_read_stmt, nullptr);
     if (ret != SQLITE_OK) {
         sqlite3_finalize(pragma_read_stmt);
-        error = Untranslated(strprintf("SQLiteDatabase: Failed to prepare the statement to fetch %s: %s", description, sqlite3_errstr(ret)));
-        return std::nullopt;
+        return {util::Error{Untranslated(strprintf("SQLiteDatabase: Failed to prepare the statement to fetch %s: %s", description, sqlite3_errstr(ret)))}};
     }
     ret = sqlite3_step(pragma_read_stmt);
     if (ret != SQLITE_ROW) {
         sqlite3_finalize(pragma_read_stmt);
-        error = Untranslated(strprintf("SQLiteDatabase: Failed to fetch %s: %s", description, sqlite3_errstr(ret)));
-        return std::nullopt;
+        return {util::Error{Untranslated(strprintf("SQLiteDatabase: Failed to fetch %s: %s", description, sqlite3_errstr(ret)))}};
     }
     int result = sqlite3_column_int(pragma_read_stmt, 0);
     sqlite3_finalize(pragma_read_stmt);
@@ -188,35 +186,42 @@ void SQLiteDatabase::Cleanup() noexcept
     }
 }
 
-bool SQLiteDatabase::Verify(bilingual_str& error)
+util::Result<void> SQLiteDatabase::Verify()
 {
     assert(m_db);
+    util::Result<void> result;
 
     // Check the application ID matches our network magic
-    auto read_result = ReadPragmaInteger(m_db, "application_id", "the application id", error);
-    if (!read_result.has_value()) return false;
-    uint32_t app_id = static_cast<uint32_t>(read_result.value());
+    auto read_app_id{ReadPragmaInteger(m_db, "application_id", "the application id") >> result};
+    if (!read_app_id) {
+        result.update(util::Error{});
+        return result;
+    }
+    uint32_t app_id = static_cast<uint32_t>(*read_app_id);
     uint32_t net_magic = ReadBE32(Params().MessageStart().data());
     if (app_id != net_magic) {
-        error = strprintf(_("SQLiteDatabase: Unexpected application id. Expected %u, got %u"), net_magic, app_id);
-        return false;
+        result.update(util::Error{strprintf(_("SQLiteDatabase: Unexpected application id. Expected %u, got %u"), net_magic, app_id)});
+        return result;
     }
 
     // Check our schema version
-    read_result = ReadPragmaInteger(m_db, "user_version", "sqlite wallet schema version", error);
-    if (!read_result.has_value()) return false;
-    int32_t user_ver = read_result.value();
+    auto read_user_ver{ReadPragmaInteger(m_db, "user_version", "sqlite wallet schema version") >> result};
+    if (!read_user_ver) {
+        result.update(util::Error{});
+        return result;
+    }
+    int32_t user_ver = *read_user_ver;
     if (user_ver != WALLET_SCHEMA_VERSION) {
-        error = strprintf(_("SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported"), user_ver, WALLET_SCHEMA_VERSION);
-        return false;
+        result.update(util::Error{strprintf(_("SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported"), user_ver, WALLET_SCHEMA_VERSION)});
+        return result;
     }
 
     sqlite3_stmt* stmt{nullptr};
     int ret = sqlite3_prepare_v2(m_db, "PRAGMA integrity_check", -1, &stmt, nullptr);
     if (ret != SQLITE_OK) {
         sqlite3_finalize(stmt);
-        error = strprintf(_("SQLiteDatabase: Failed to prepare statement to verify database: %s"), sqlite3_errstr(ret));
-        return false;
+        result.update(util::Error{strprintf(_("SQLiteDatabase: Failed to prepare statement to verify database: %s"), sqlite3_errstr(ret))});
+        return result;
     }
     while (true) {
         ret = sqlite3_step(stmt);
@@ -224,25 +229,25 @@ bool SQLiteDatabase::Verify(bilingual_str& error)
             break;
         }
         if (ret != SQLITE_ROW) {
-            error = strprintf(_("SQLiteDatabase: Failed to execute statement to verify database: %s"), sqlite3_errstr(ret));
+            result.update(util::Error{strprintf(_("SQLiteDatabase: Failed to execute statement to verify database: %s"), sqlite3_errstr(ret))});
             break;
         }
         const char* msg = (const char*)sqlite3_column_text(stmt, 0);
         if (!msg) {
-            error = strprintf(_("SQLiteDatabase: Failed to read database verification error: %s"), sqlite3_errstr(ret));
+            result.update(util::Error{strprintf(_("SQLiteDatabase: Failed to read database verification error: %s"), sqlite3_errstr(ret))});
             break;
         }
         std::string str_msg(msg);
         if (str_msg == "ok") {
             continue;
         }
-        if (error.empty()) {
-            error = _("Failed to verify database") + Untranslated("\n");
+        if (result) {
+            result.update(util::Error{_("Failed to verify database")});
         }
-        error += Untranslated(strprintf("%s\n", str_msg));
+        result.messages().errors.push_back(Untranslated(str_msg));
     }
     sqlite3_finalize(stmt);
-    return error.empty();
+    return result;
 }
 
 void SQLiteDatabase::Open()
@@ -704,22 +709,21 @@ bool SQLiteBatch::TxnAbort()
     return res == SQLITE_OK;
 }
 
-std::unique_ptr<SQLiteDatabase> MakeSQLiteDatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error)
+util::ResultPtr<std::unique_ptr<SQLiteDatabase>, DatabaseStatus> MakeSQLiteDatabase(const fs::path& path, const DatabaseOptions& options)
 {
+    util::ResultPtr<std::unique_ptr<SQLiteDatabase>, DatabaseStatus> result;
     try {
         fs::path data_file = SQLiteDataFile(path);
         auto db = std::make_unique<SQLiteDatabase>(data_file.parent_path(), data_file, options);
-        if (options.verify && !db->Verify(error)) {
-            status = DatabaseStatus::FAILED_VERIFY;
-            return nullptr;
+        if (options.verify && !(db->Verify() >> result)) {
+            result.update({util::Error{}, DatabaseStatus::FAILED_VERIFY});
+        } else {
+            result.update(std::move(db));
         }
-        status = DatabaseStatus::SUCCESS;
-        return db;
     } catch (const std::runtime_error& e) {
-        status = DatabaseStatus::FAILED_LOAD;
-        error = Untranslated(e.what());
-        return nullptr;
+        result.update({util::Error{Untranslated(e.what())}, DatabaseStatus::FAILED_LOAD});
     }
+    return result;
 }
 
 InMemoryWalletDatabase::InMemoryWalletDatabase()

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -709,19 +709,19 @@ bool SQLiteBatch::TxnAbort()
     return res == SQLITE_OK;
 }
 
-util::ResultPtr<std::unique_ptr<SQLiteDatabase>, DatabaseStatus> MakeSQLiteDatabase(const fs::path& path, const DatabaseOptions& options)
+util::ResultPtr<std::unique_ptr<SQLiteDatabase>, DatabaseError> MakeSQLiteDatabase(const fs::path& path, const DatabaseOptions& options)
 {
-    util::ResultPtr<std::unique_ptr<SQLiteDatabase>, DatabaseStatus> result;
+    util::ResultPtr<std::unique_ptr<SQLiteDatabase>, DatabaseError> result;
     try {
         fs::path data_file = SQLiteDataFile(path);
         auto db = std::make_unique<SQLiteDatabase>(data_file.parent_path(), data_file, options);
         if (options.verify && !(db->Verify() >> result)) {
-            result.update({util::Error{}, DatabaseStatus::FAILED_VERIFY});
+            result.update({util::Error{}, DatabaseError::FAILED_VERIFY});
         } else {
             result.update(std::move(db));
         }
     } catch (const std::runtime_error& e) {
-        result.update({util::Error{Untranslated(e.what())}, DatabaseStatus::FAILED_LOAD});
+        result.update({util::Error{Untranslated(e.what())}, DatabaseError::FAILED_LOAD});
     }
     return result;
 }

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -185,7 +185,7 @@ public:
     std::vector<fs::path> Files() override { return {}; }
 };
 
-util::ResultPtr<std::unique_ptr<SQLiteDatabase>, DatabaseStatus> MakeSQLiteDatabase(const fs::path& path, const DatabaseOptions& options);
+util::ResultPtr<std::unique_ptr<SQLiteDatabase>, DatabaseError> MakeSQLiteDatabase(const fs::path& path, const DatabaseOptions& options);
 
 std::unique_ptr<WalletDatabase> MakeInMemoryWalletDatabase();
 

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -6,6 +6,7 @@
 #define BITCOIN_WALLET_SQLITE_H
 
 #include <sync.h>
+#include <util/result.h>
 #include <wallet/db.h>
 
 #include <semaphore>
@@ -139,7 +140,7 @@ public:
     // This ensures that only one batch is modifying the database at a time.
     std::binary_semaphore m_write_semaphore;
 
-    bool Verify(bilingual_str& error);
+    util::Result<void> Verify();
 
     /** Open the database if it is not already opened */
     void Open() override;
@@ -184,7 +185,7 @@ public:
     std::vector<fs::path> Files() override { return {}; }
 };
 
-std::unique_ptr<SQLiteDatabase> MakeSQLiteDatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error);
+util::ResultPtr<std::unique_ptr<SQLiteDatabase>, DatabaseStatus> MakeSQLiteDatabase(const fs::path& path, const DatabaseOptions& options);
 
 std::unique_ptr<WalletDatabase> MakeInMemoryWalletDatabase();
 

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -64,10 +64,8 @@ static std::vector<std::unique_ptr<WalletDatabase>> TestDatabases(const fs::path
 {
     std::vector<std::unique_ptr<WalletDatabase>> dbs;
     DatabaseOptions options;
-    DatabaseStatus status;
-    bilingual_str error;
     // Unable to test BerkeleyRO since we cannot create a new BDB database to open
-    dbs.emplace_back(MakeSQLiteDatabase(path_root / "sqlite", options, status, error));
+    dbs.emplace_back(std::move(MakeSQLiteDatabase(path_root / "sqlite", options).value()));
     dbs.emplace_back(CreateMockableWalletDatabase());
     return dbs;
 }
@@ -227,9 +225,7 @@ BOOST_AUTO_TEST_CASE(txn_close_failure_dangling_txn)
     // Verifies that there is no active dangling, to-be-reversed db txn
     // after the batch object that initiated it is destroyed.
     DatabaseOptions options;
-    DatabaseStatus status;
-    bilingual_str error;
-    std::unique_ptr<SQLiteDatabase> database = MakeSQLiteDatabase(m_path_root / "sqlite", options, status, error);
+    auto database = MakeSQLiteDatabase(m_path_root / "sqlite", options);
 
     std::string key = "key";
     std::string value = "value";
@@ -262,9 +258,7 @@ BOOST_AUTO_TEST_CASE(concurrent_txn_dont_interfere)
     std::string value2 = "value_2";
 
     DatabaseOptions options;
-    DatabaseStatus status;
-    bilingual_str error;
-    const auto& database = MakeSQLiteDatabase(m_path_root / "sqlite", options, status, error);
+    auto database = MakeSQLiteDatabase(m_path_root / "sqlite", options);
 
     std::unique_ptr<DatabaseBatch> handler = Assert(database)->MakeBatch();
 

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -258,7 +258,7 @@ BOOST_AUTO_TEST_CASE(concurrent_txn_dont_interfere)
     std::string value2 = "value_2";
 
     DatabaseOptions options;
-    auto database = MakeSQLiteDatabase(m_path_root / "sqlite", options);
+    const auto& database = MakeSQLiteDatabase(m_path_root / "sqlite", options);
 
     std::unique_ptr<DatabaseBatch> handler = Assert(database)->MakeBatch();
 

--- a/src/wallet/test/fuzz/wallet_bdb_parser.cpp
+++ b/src/wallet/test/fuzz/wallet_bdb_parser.cpp
@@ -49,7 +49,7 @@ FUZZ_TARGET(wallet_bdb_parser, .init = initialize_wallet_bdb_parser)
     }
     g_setup->m_args.ForceSetArg("-dumpfile", fs::PathToString(bdb_ro_dumpfile));
 
-    auto db{MakeBerkeleyRODatabase(wallet_path, options, status, error)};
+    auto db{ResultExtract(MakeBerkeleyRODatabase(wallet_path, options), &status, &error)};
     if (db) {
         assert(DumpWallet(g_setup->m_args, *db, error));
     } else {

--- a/src/wallet/test/fuzz/wallet_bdb_parser.cpp
+++ b/src/wallet/test/fuzz/wallet_bdb_parser.cpp
@@ -51,7 +51,7 @@ FUZZ_TARGET(wallet_bdb_parser, .init = initialize_wallet_bdb_parser)
 
     auto db{ResultExtract(MakeBerkeleyRODatabase(wallet_path, options), &status, &error)};
     if (db) {
-        assert(DumpWallet(g_setup->m_args, *db, error));
+        assert(DumpWallet(g_setup->m_args, *db));
     } else {
         if (error.original.starts_with("AutoFile::ignore: end of file") ||
             error.original.starts_with("AutoFile::read: end of file") ||

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -71,25 +71,21 @@ std::shared_ptr<CWallet> TestCreateWallet(WalletContext& context)
 
 std::shared_ptr<CWallet> TestLoadWallet(std::unique_ptr<WalletDatabase> database, WalletContext& context)
 {
-    bilingual_str error;
-    std::vector<bilingual_str> warnings;
-    auto wallet{ResultExtract(CWallet::LoadExisting(context, "", std::move(database)), nullptr, &error, &warnings)};
-    NotifyWalletLoaded(context, wallet);
+    auto wallet{CWallet::LoadExisting(context, "", std::move(database))};
+    NotifyWalletLoaded(context, wallet.value());
     if (context.chain) {
         wallet->postInitProcess();
     }
-    return wallet;
+    return wallet.value();
 }
 
 std::shared_ptr<CWallet> TestLoadWallet(WalletContext& context)
 {
     DatabaseOptions options;
     options.require_existing = true;
-    DatabaseStatus status;
-    bilingual_str error;
     std::vector<bilingual_str> warnings;
-    auto database{ResultExtract(MakeWalletDatabase("", options), &status, &error)};
-    return TestLoadWallet(std::move(database), context);
+    auto database{MakeWalletDatabase("", options)};
+    return TestLoadWallet(std::move(database.value()), context);
 }
 
 void TestUnloadWallet(std::shared_ptr<CWallet>&& wallet)

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -50,9 +50,7 @@ std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, CChain& cc
 
 std::shared_ptr<CWallet> TestCreateWallet(std::unique_ptr<WalletDatabase> database, WalletContext& context, uint64_t create_flags)
 {
-    bilingual_str _error;
-    std::vector<bilingual_str> _warnings;
-    auto wallet = CWallet::CreateNew(context, "", std::move(database), create_flags, /*born_encrypted=*/false, _error, _warnings);
+    auto wallet = Assert(CWallet::CreateNew(context, "", std::move(database), create_flags, /*born_encrypted=*/false)).value();
     NotifyWalletLoaded(context, wallet);
     if (context.chain) {
         wallet->postInitProcess();
@@ -65,10 +63,8 @@ std::shared_ptr<CWallet> TestCreateWallet(WalletContext& context)
     DatabaseOptions options;
     options.require_create = true;
     options.create_flags = WALLET_FLAG_DESCRIPTORS;
-    DatabaseStatus status;
-    bilingual_str error;
     std::vector<bilingual_str> warnings;
-    auto database = MakeWalletDatabase("", options, status, error);
+    auto database = std::move(Assert(MakeWalletDatabase("", options)).value());
     return TestCreateWallet(std::move(database), context, options.create_flags);
 }
 
@@ -77,7 +73,7 @@ std::shared_ptr<CWallet> TestLoadWallet(std::unique_ptr<WalletDatabase> database
 {
     bilingual_str error;
     std::vector<bilingual_str> warnings;
-    auto wallet = CWallet::LoadExisting(context, "", std::move(database), error, warnings);
+    auto wallet{ResultExtract(CWallet::LoadExisting(context, "", std::move(database)), nullptr, &error, &warnings)};
     NotifyWalletLoaded(context, wallet);
     if (context.chain) {
         wallet->postInitProcess();
@@ -92,7 +88,7 @@ std::shared_ptr<CWallet> TestLoadWallet(WalletContext& context)
     DatabaseStatus status;
     bilingual_str error;
     std::vector<bilingual_str> warnings;
-    auto database = MakeWalletDatabase("", options, status, error);
+    auto database{ResultExtract(MakeWalletDatabase("", options), &status, &error)};
     return TestLoadWallet(std::move(database), context);
 }
 

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -50,9 +50,7 @@ std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, CChain& cc
 
 std::shared_ptr<CWallet> TestCreateWallet(std::unique_ptr<WalletDatabase> database, WalletContext& context, uint64_t create_flags)
 {
-    bilingual_str _error;
-    std::vector<bilingual_str> _warnings;
-    auto wallet = CWallet::CreateNew(context, "", std::move(database), create_flags, /*born_encrypted=*/false, _error, _warnings);
+    auto wallet = Assert(CWallet::CreateNew(context, "", std::move(database), create_flags, /*born_encrypted=*/false)).value();
     NotifyWalletLoaded(context, wallet);
     if (context.chain) {
         wallet->postInitProcess();
@@ -65,9 +63,7 @@ std::shared_ptr<CWallet> TestCreateWallet(WalletContext& context)
     DatabaseOptions options;
     options.require_create = true;
     options.create_flags = WALLET_FLAG_DESCRIPTORS;
-    DatabaseStatus status;
-    bilingual_str error;
-    auto database = MakeWalletDatabase("", options, status, error);
+    auto database = std::move(Assert(MakeWalletDatabase("", options)).value());
     return TestCreateWallet(std::move(database), context, options.create_flags);
 }
 
@@ -76,7 +72,7 @@ std::shared_ptr<CWallet> TestLoadWallet(std::unique_ptr<WalletDatabase> database
 {
     bilingual_str error;
     std::vector<bilingual_str> warnings;
-    auto wallet = CWallet::LoadExisting(context, "", std::move(database), error, warnings);
+    auto wallet{ResultExtract(CWallet::LoadExisting(context, "", std::move(database)), nullptr, &error, &warnings)};
     NotifyWalletLoaded(context, wallet);
     if (context.chain) {
         wallet->postInitProcess();
@@ -90,7 +86,7 @@ std::shared_ptr<CWallet> TestLoadWallet(WalletContext& context)
     options.require_existing = true;
     DatabaseStatus status;
     bilingual_str error;
-    auto database = MakeWalletDatabase("", options, status, error);
+    auto database{ResultExtract(MakeWalletDatabase("", options), &status, &error)};
     return TestLoadWallet(std::move(database), context);
 }
 

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -70,24 +70,20 @@ std::shared_ptr<CWallet> TestCreateWallet(WalletContext& context)
 
 std::shared_ptr<CWallet> TestLoadWallet(std::unique_ptr<WalletDatabase> database, WalletContext& context)
 {
-    bilingual_str error;
-    std::vector<bilingual_str> warnings;
-    auto wallet{ResultExtract(CWallet::LoadExisting(context, "", std::move(database)), nullptr, &error, &warnings)};
-    NotifyWalletLoaded(context, wallet);
+    auto wallet{CWallet::LoadExisting(context, "", std::move(database))};
+    NotifyWalletLoaded(context, wallet.value());
     if (context.chain) {
         wallet->postInitProcess();
     }
-    return wallet;
+    return wallet.value();
 }
 
 std::shared_ptr<CWallet> TestLoadWallet(WalletContext& context)
 {
     DatabaseOptions options;
     options.require_existing = true;
-    DatabaseStatus status;
-    bilingual_str error;
-    auto database{ResultExtract(MakeWalletDatabase("", options), &status, &error)};
-    return TestLoadWallet(std::move(database), context);
+    auto database{MakeWalletDatabase("", options)};
+    return TestLoadWallet(std::move(database.value()), context);
 }
 
 void TestUnloadWallet(std::shared_ptr<CWallet>&& wallet)

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -336,9 +336,9 @@ void TestLoadWallet(const std::string& name, DatabaseFormat format, std::functio
     DatabaseStatus status;
     bilingual_str error;
     std::vector<bilingual_str> warnings;
-    auto database{MakeWalletDatabase(name, options, status, error)};
+    auto database{ResultExtract(MakeWalletDatabase(name, options), &status, &error)};
     auto wallet{std::make_shared<CWallet>(chain.get(), "", std::move(database))};
-    BOOST_CHECK_EQUAL(wallet->PopulateWalletFromDB(error, warnings), DBErrors::LOAD_OK);
+    BOOST_CHECK(wallet->PopulateWalletFromDB());
     WITH_LOCK(wallet->cs_wallet, f(wallet));
 }
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -333,11 +333,8 @@ void TestLoadWallet(const std::string& name, DatabaseFormat format, std::functio
     auto chain{interfaces::MakeChain(node)};
     DatabaseOptions options;
     options.require_format = format;
-    DatabaseStatus status;
-    bilingual_str error;
-    std::vector<bilingual_str> warnings;
-    auto database{ResultExtract(MakeWalletDatabase(name, options), &status, &error)};
-    auto wallet{std::make_shared<CWallet>(chain.get(), "", std::move(database))};
+    auto database{MakeWalletDatabase(name, options)};
+    auto wallet{std::make_shared<CWallet>(chain.get(), "", std::move(database.value()))};
     BOOST_CHECK(wallet->PopulateWalletFromDB());
     WITH_LOCK(wallet->cs_wallet, f(wallet));
 }

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -338,9 +338,9 @@ void TestLoadWallet(const std::string& name, DatabaseFormat format, std::functio
     DatabaseStatus status;
     bilingual_str error;
     std::vector<bilingual_str> warnings;
-    auto database{MakeWalletDatabase(name, options, status, error)};
+    auto database{ResultExtract(MakeWalletDatabase(name, options), &status, &error)};
     auto wallet{std::make_shared<CWallet>(chain.get(), "", std::move(database))};
-    BOOST_CHECK_EQUAL(wallet->PopulateWalletFromDB(error, warnings), DBErrors::LOAD_OK);
+    BOOST_CHECK(wallet->PopulateWalletFromDB());
     WITH_LOCK(wallet->cs_wallet, f(wallet));
 }
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -335,11 +335,8 @@ void TestLoadWallet(const std::string& name, DatabaseFormat format, std::functio
     auto chain{interfaces::MakeChain(node)};
     DatabaseOptions options;
     options.require_format = format;
-    DatabaseStatus status;
-    bilingual_str error;
-    std::vector<bilingual_str> warnings;
-    auto database{ResultExtract(MakeWalletDatabase(name, options), &status, &error)};
-    auto wallet{std::make_shared<CWallet>(chain.get(), "", std::move(database))};
+    auto database{MakeWalletDatabase(name, options)};
+    auto wallet{std::make_shared<CWallet>(chain.get(), "", std::move(database.value()))};
     BOOST_CHECK(wallet->PopulateWalletFromDB());
     WITH_LOCK(wallet->cs_wallet, f(wallet));
 }

--- a/src/wallet/test/walletload_tests.cpp
+++ b/src/wallet/test/walletload_tests.cpp
@@ -46,8 +46,6 @@ public:
 
 BOOST_FIXTURE_TEST_CASE(wallet_load_descriptors, TestingSetup)
 {
-    bilingual_str _error;
-    std::vector<bilingual_str> _warnings;
     std::unique_ptr<WalletDatabase> database = CreateMockableWalletDatabase();
     {
         // Write unknown active descriptor
@@ -61,7 +59,7 @@ BOOST_FIXTURE_TEST_CASE(wallet_load_descriptors, TestingSetup)
     {
         // Now try to load the wallet and verify the error.
         const std::shared_ptr<CWallet> wallet(new CWallet(m_node.chain.get(), "", std::move(database)));
-        BOOST_CHECK_EQUAL(wallet->PopulateWalletFromDB(_error, _warnings), DBErrors::UNKNOWN_DESCRIPTOR);
+        BOOST_CHECK_EQUAL(wallet->PopulateWalletFromDB().error(), DBErrors::UNKNOWN_DESCRIPTOR);
     }
 
     // Test 2
@@ -87,7 +85,7 @@ BOOST_FIXTURE_TEST_CASE(wallet_load_descriptors, TestingSetup)
     {
         // Now try to load the wallet and verify the error.
         const std::shared_ptr<CWallet> wallet(new CWallet(m_node.chain.get(), "", std::move(database)));
-        BOOST_CHECK_EQUAL(wallet->PopulateWalletFromDB(_error, _warnings), DBErrors::CORRUPT);
+        BOOST_CHECK_EQUAL(wallet->PopulateWalletFromDB().error(), DBErrors::CORRUPT);
         BOOST_CHECK(found); // The error must be logged
     }
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -282,9 +282,9 @@ void WaitForDeleteWallet(std::shared_ptr<CWallet>&& wallet)
 }
 
 namespace {
-util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> LoadWalletInternal(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options)
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError> LoadWalletInternal(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options)
 {
-    util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> result;
+    util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError> result;
     try {
         auto database{MakeWalletDatabase(name, options) >> result};
         if (!database) {
@@ -299,7 +299,7 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> LoadWalletInternal(Wal
         if (!wallet) {
             auto& errors{result.messages().errors};
             errors.insert(errors.begin(), Untranslated("Wallet loading failed."));
-            result.update({util::Error{}, DatabaseStatus::FAILED_LOAD});
+            result.update({util::Error{}, DatabaseError::FAILED_LOAD});
             return result;
         }
 
@@ -312,7 +312,7 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> LoadWalletInternal(Wal
 
         result.update(std::move(wallet.value()));
     } catch (const std::runtime_error& e) {
-        result.update({util::Error{Untranslated(e.what())}, DatabaseStatus::FAILED_LOAD});
+        result.update({util::Error{Untranslated(e.what())}, DatabaseError::FAILED_LOAD});
     }
     return result;
 }
@@ -373,23 +373,23 @@ private:
 };
 } // namespace
 
-util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options)
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options)
 {
     auto result = WITH_LOCK(g_loading_wallet_mutex, return g_loading_wallet_set.insert(name));
     if (!result.second) {
-        return {util::Error{Untranslated("Wallet already loading.")}, DatabaseStatus::FAILED_LOAD};
+        return {util::Error{Untranslated("Wallet already loading.")}, DatabaseError::FAILED_LOAD};
     }
     auto wallet{LoadWalletInternal(context, name, load_on_start, options)};
     WITH_LOCK(g_loading_wallet_mutex, g_loading_wallet_set.erase(result.first));
     return wallet;
 }
 
-util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options)
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options)
 {
-    util::Result<std::shared_ptr<CWallet>, DatabaseStatus> result;
+    util::Result<std::shared_ptr<CWallet>, DatabaseError> result;
     // Wallet must have a non-empty name
     if (name.empty()) {
-        result.update({util::Error{Untranslated("Wallet name cannot be empty")}, DatabaseStatus::FAILED_NEW_UNNAMED});
+        result.update({util::Error{Untranslated("Wallet name cannot be empty")}, DatabaseError::FAILED_NEW_UNNAMED});
         return result;
     }
 
@@ -404,13 +404,13 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> CreateWallet(WalletCon
 
     // Private keys must be disabled for an external signer wallet
     if ((wallet_creation_flags & WALLET_FLAG_EXTERNAL_SIGNER) && !(wallet_creation_flags & WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
-        result.update({util::Error{Untranslated("Private keys must be disabled when using an external signer")}, DatabaseStatus::FAILED_CREATE});
+        result.update({util::Error{Untranslated("Private keys must be disabled when using an external signer")}, DatabaseError::FAILED_CREATE});
         return result;
     }
 
     // Do not allow a passphrase when private keys are disabled
     if (born_encrypted && (wallet_creation_flags & WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
-        result.update({util::Error{Untranslated("Passphrase provided but private keys are disabled. A passphrase is only used to encrypt private keys, so cannot be used for wallets with private keys disabled.")}, DatabaseStatus::FAILED_CREATE});
+        result.update({util::Error{Untranslated("Passphrase provided but private keys are disabled. A passphrase is only used to encrypt private keys, so cannot be used for wallets with private keys disabled.")}, DatabaseError::FAILED_CREATE});
         return result;
     }
 
@@ -419,7 +419,7 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> CreateWallet(WalletCon
     if (!database) {
         auto& errors{result.messages().errors};
         errors.insert(errors.begin(), Untranslated("Wallet file verification failed."));
-        result.update({util::Error{}, DatabaseStatus::FAILED_VERIFY});
+        result.update({util::Error{}, DatabaseError::FAILED_VERIFY});
         return result;
     }
 
@@ -427,7 +427,7 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> CreateWallet(WalletCon
     context.chain->initMessage(_("Creating wallet…"));
     auto create{CWallet::CreateNew(context, name, std::move(database.value()), wallet_creation_flags, born_encrypted) >> result};
     if (!create) {
-        result.update({util::Error{Untranslated("Wallet creation failed.")}, DatabaseStatus::FAILED_CREATE});
+        result.update({util::Error{Untranslated("Wallet creation failed.")}, DatabaseError::FAILED_CREATE});
         return result;
     }
     std::shared_ptr<CWallet> wallet = create.value();
@@ -435,7 +435,7 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> CreateWallet(WalletCon
     // Encrypt the wallet
     if (born_encrypted) {
         if (!wallet->EncryptWallet(passphrase)) {
-            result.update({util::Error{Untranslated("Error: Wallet created but failed to encrypt.")}, DatabaseStatus::FAILED_ENCRYPT});
+            result.update({util::Error{Untranslated("Error: Wallet created but failed to encrypt.")}, DatabaseError::FAILED_ENCRYPT});
             return result;
         }
     }
@@ -454,13 +454,13 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> CreateWallet(WalletCon
 
 // Re-creates wallet from the backup file by renaming and moving it into the wallet's directory.
 // If 'load_after_restore=true', the wallet object will be fully initialized and appended to the context.
-util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, bool load_after_restore, bool allow_unnamed)
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, bool load_after_restore, bool allow_unnamed)
 {
-    util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> result;
+    util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError> result;
     // Error if the wallet name is empty and allow_unnamed == false
     // allow_unnamed == true is only used by migration to migrate an unnamed wallet
     if (!allow_unnamed && wallet_name.empty()) {
-        result.update({util::Error{Untranslated("Wallet name cannot be empty")}, DatabaseStatus::FAILED_NEW_UNNAMED});
+        result.update({util::Error{Untranslated("Wallet name cannot be empty")}, DatabaseError::FAILED_NEW_UNNAMED});
         return result;
     }
 
@@ -475,7 +475,7 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> RestoreWallet(WalletCo
 
     try {
         if (!fs::exists(backup_file)) {
-            result.update({util::Error{Untranslated("Backup file does not exist")}, DatabaseStatus::FAILED_INVALID_BACKUP_FILE});
+            result.update({util::Error{Untranslated("Backup file does not exist")}, DatabaseError::FAILED_INVALID_BACKUP_FILE});
             return result;
         }
 
@@ -484,19 +484,19 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> RestoreWallet(WalletCo
         if (fs::exists(wallet_path)) {
             // If this is a file, it is the db and we don't want to overwrite it.
             if (!fs::is_directory(wallet_path)) {
-                result.update({util::Error{Untranslated(strprintf("Failed to restore wallet. Database file exists '%s'.", fs::PathToString(wallet_path)))}, DatabaseStatus::FAILED_ALREADY_EXISTS});
+                result.update({util::Error{Untranslated(strprintf("Failed to restore wallet. Database file exists '%s'.", fs::PathToString(wallet_path)))}, DatabaseError::FAILED_ALREADY_EXISTS});
                 return result;
             }
 
             // Check we are not going to overwrite an existing db file
             if (fs::exists(wallet_file)) {
-                result.update({util::Error{Untranslated(strprintf("Failed to restore wallet. Database file exists in '%s'.", fs::PathToString(wallet_file)))}, DatabaseStatus::FAILED_ALREADY_EXISTS});
+                result.update({util::Error{Untranslated(strprintf("Failed to restore wallet. Database file exists in '%s'.", fs::PathToString(wallet_file)))}, DatabaseError::FAILED_ALREADY_EXISTS});
                 return result;
             }
         } else {
             // The directory doesn't exist, create it
             if (!TryCreateDirectories(wallet_path)) {
-                result.update({util::Error{Untranslated(strprintf("Failed to restore database path '%s'.", fs::PathToString(wallet_path)))}, DatabaseStatus::FAILED_ALREADY_EXISTS});
+                result.update({util::Error{Untranslated(strprintf("Failed to restore database path '%s'.", fs::PathToString(wallet_path)))}, DatabaseError::FAILED_ALREADY_EXISTS});
                 return result;
             }
             created_parent_dir = true;
@@ -510,7 +510,7 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> RestoreWallet(WalletCo
         }
     } catch (const std::exception& e) {
         assert(!result.value());
-        result.update({util::Error{Untranslated(strprintf("Unexpected exception: %s", e.what()))}, DatabaseStatus::FAILED_LOAD});
+        result.update({util::Error{Untranslated(strprintf("Unexpected exception: %s", e.what()))}, DatabaseError::FAILED_LOAD});
         return result;
     }
 
@@ -2961,12 +2961,12 @@ util::Result<fs::path> GetWalletPath(const std::string& name)
     return wallet_path;
 }
 
-util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options)
+util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseError> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options)
 {
-    util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> result;
+    util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseError> result;
     auto wallet_path{GetWalletPath(name) >> result};
     if (!wallet_path) {
-        result.update({util::Error{}, DatabaseStatus::FAILED_BAD_PATH});
+        result.update({util::Error{}, DatabaseError::FAILED_BAD_PATH});
         return result;
     }
     result.update(MakeDatabase(*wallet_path, options));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -89,7 +89,9 @@ using common::AmountHighWarn;
 using common::PSBTError;
 using interfaces::FoundBlock;
 using kernel::ChainstateRole;
+using util::Error;
 using util::ReplaceAll;
+using util::Result;
 using util::ToString;
 
 namespace wallet {
@@ -129,17 +131,18 @@ bool RemoveWalletSetting(interfaces::Chain& chain, const std::string& wallet_nam
     return chain.updateRwSetting("wallet", update_function);
 }
 
-static void UpdateWalletSetting(interfaces::Chain& chain,
-                                const std::string& wallet_name,
-                                std::optional<bool> load_on_startup,
-                                std::vector<bilingual_str>& warnings)
+static util::Result<void> UpdateWalletSetting(interfaces::Chain& chain,
+                                              const std::string& wallet_name,
+                                              std::optional<bool> load_on_startup)
 {
-    if (!load_on_startup) return;
+    util::Result<void> result;
+    if (!load_on_startup) return result;
     if (load_on_startup.value() && !AddWalletSetting(chain, wallet_name)) {
-        warnings.emplace_back(Untranslated("Wallet load on startup setting could not be updated, so wallet may not be loaded next node startup."));
+        result.messages().warnings.push_back(Untranslated("Wallet load on startup setting could not be updated, so wallet may not be loaded next node startup."));
     } else if (!load_on_startup.value() && !RemoveWalletSetting(chain, wallet_name)) {
-        warnings.emplace_back(Untranslated("Wallet load on startup setting could not be updated, so wallet may still be loaded next node startup."));
+        result.messages().warnings.push_back(Untranslated("Wallet load on startup setting could not be updated, so wallet may still be loaded next node startup."));
     }
+    return result;
 }
 
 /**
@@ -168,9 +171,10 @@ bool AddWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet)
     return true;
 }
 
-bool RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet, std::optional<bool> load_on_start, std::vector<bilingual_str>& warnings)
+util::Result<void> RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet, std::optional<bool> load_on_start)
 {
     assert(wallet);
+    util::Result<void> result;
 
     interfaces::Chain& chain = wallet->chain();
     std::string name = wallet->GetName();
@@ -181,22 +185,19 @@ bool RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet
     {
         LOCK(context.wallets_mutex);
         std::vector<std::shared_ptr<CWallet>>::iterator i = std::find(context.wallets.begin(), context.wallets.end(), wallet);
-        if (i == context.wallets.end()) return false;
+        if (i == context.wallets.end()) {
+            result.update(util::Error{});
+            return result;
+        }
         context.wallets.erase(i);
     }
     // Notify unload so that upper layers release the shared pointer.
     wallet->NotifyUnload();
 
     // Write the wallet setting
-    UpdateWalletSetting(chain, name, load_on_start, warnings);
+    UpdateWalletSetting(chain, name, load_on_start) >> result;
 
-    return true;
-}
-
-bool RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet, std::optional<bool> load_on_start)
-{
-    std::vector<bilingual_str> warnings;
-    return RemoveWallet(context, wallet, load_on_start, warnings);
+    return result;
 }
 
 std::vector<std::shared_ptr<CWallet>> GetWallets(WalletContext& context)
@@ -281,36 +282,39 @@ void WaitForDeleteWallet(std::shared_ptr<CWallet>&& wallet)
 }
 
 namespace {
-std::shared_ptr<CWallet> LoadWalletInternal(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings)
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> LoadWalletInternal(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options)
 {
+    util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> result;
     try {
-        std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(name, options, status, error);
+        auto database{MakeWalletDatabase(name, options) >> result};
         if (!database) {
-            error = Untranslated("Wallet file verification failed.") + Untranslated(" ") + error;
-            return nullptr;
+            auto& errors{result.messages().errors};
+            errors.insert(errors.begin(), Untranslated("Wallet file verification failed."));
+            result.update({util::Error{}, database.error()});
+            return result;
         }
 
         context.chain->initMessage(_("Loading wallet…"));
-        std::shared_ptr<CWallet> wallet = CWallet::LoadExisting(context, name, std::move(database), error, warnings);
+        auto wallet{CWallet::LoadExisting(context, name, std::move(database.value())) >> result};
         if (!wallet) {
-            error = Untranslated("Wallet loading failed.") + Untranslated(" ") + error;
-            status = DatabaseStatus::FAILED_LOAD;
-            return nullptr;
+            auto& errors{result.messages().errors};
+            errors.insert(errors.begin(), Untranslated("Wallet loading failed."));
+            result.update({util::Error{}, DatabaseStatus::FAILED_LOAD});
+            return result;
         }
 
-        NotifyWalletLoaded(context, wallet);
-        AddWallet(context, wallet);
+        NotifyWalletLoaded(context, wallet.value());
+        AddWallet(context, wallet.value());
         wallet->postInitProcess();
 
         // Write the wallet setting
-        UpdateWalletSetting(*context.chain, name, load_on_start, warnings);
+        UpdateWalletSetting(*context.chain, name, load_on_start) >> result;
 
-        return wallet;
+        result.update(std::move(wallet.value()));
     } catch (const std::runtime_error& e) {
-        error = Untranslated(e.what());
-        status = DatabaseStatus::FAILED_LOAD;
-        return nullptr;
+        result.update({util::Error{Untranslated(e.what())}, DatabaseStatus::FAILED_LOAD});
     }
+    return result;
 }
 
 class FastWalletRescanFilter
@@ -369,26 +373,24 @@ private:
 };
 } // namespace
 
-std::shared_ptr<CWallet> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings)
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options)
 {
     auto result = WITH_LOCK(g_loading_wallet_mutex, return g_loading_wallet_set.insert(name));
     if (!result.second) {
-        error = Untranslated("Wallet already loading.");
-        status = DatabaseStatus::FAILED_LOAD;
-        return nullptr;
+        return {util::Error{Untranslated("Wallet already loading.")}, DatabaseStatus::FAILED_LOAD};
     }
-    auto wallet = LoadWalletInternal(context, name, load_on_start, options, status, error, warnings);
+    auto wallet{LoadWalletInternal(context, name, load_on_start, options)};
     WITH_LOCK(g_loading_wallet_mutex, g_loading_wallet_set.erase(result.first));
     return wallet;
 }
 
-std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings)
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options)
 {
+    util::Result<std::shared_ptr<CWallet>, DatabaseStatus> result;
     // Wallet must have a non-empty name
     if (name.empty()) {
-        error = Untranslated("Wallet name cannot be empty");
-        status = DatabaseStatus::FAILED_NEW_UNNAMED;
-        return nullptr;
+        result.update({util::Error{Untranslated("Wallet name cannot be empty")}, DatabaseStatus::FAILED_NEW_UNNAMED});
+        return result;
     }
 
     uint64_t wallet_creation_flags = options.create_flags;
@@ -402,41 +404,39 @@ std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string&
 
     // Private keys must be disabled for an external signer wallet
     if ((wallet_creation_flags & WALLET_FLAG_EXTERNAL_SIGNER) && !(wallet_creation_flags & WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
-        error = Untranslated("Private keys must be disabled when using an external signer");
-        status = DatabaseStatus::FAILED_CREATE;
-        return nullptr;
+        result.update({util::Error{Untranslated("Private keys must be disabled when using an external signer")}, DatabaseStatus::FAILED_CREATE});
+        return result;
     }
 
     // Do not allow a passphrase when private keys are disabled
     if (born_encrypted && (wallet_creation_flags & WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
-        error = Untranslated("Passphrase provided but private keys are disabled. A passphrase is only used to encrypt private keys, so cannot be used for wallets with private keys disabled.");
-        status = DatabaseStatus::FAILED_CREATE;
-        return nullptr;
+        result.update({util::Error{Untranslated("Passphrase provided but private keys are disabled. A passphrase is only used to encrypt private keys, so cannot be used for wallets with private keys disabled.")}, DatabaseStatus::FAILED_CREATE});
+        return result;
     }
 
     // Wallet::Verify will check if we're trying to create a wallet with a duplicate name.
-    std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(name, options, status, error);
+    auto database{MakeWalletDatabase(name, options) >> result};
     if (!database) {
-        error = Untranslated("Wallet file verification failed.") + Untranslated(" ") + error;
-        status = DatabaseStatus::FAILED_VERIFY;
-        return nullptr;
+        auto& errors{result.messages().errors};
+        errors.insert(errors.begin(), Untranslated("Wallet file verification failed."));
+        result.update({util::Error{}, DatabaseStatus::FAILED_VERIFY});
+        return result;
     }
 
     // Make the wallet
     context.chain->initMessage(_("Creating wallet…"));
-    std::shared_ptr<CWallet> wallet = CWallet::CreateNew(context, name, std::move(database), wallet_creation_flags, born_encrypted, error, warnings);
-    if (!wallet) {
-        error = Untranslated("Wallet creation failed.") + Untranslated(" ") + error;
-        status = DatabaseStatus::FAILED_CREATE;
-        return nullptr;
+    auto create{CWallet::CreateNew(context, name, std::move(database.value()), wallet_creation_flags, born_encrypted) >> result};
+    if (!create) {
+        result.update({util::Error{Untranslated("Wallet creation failed.")}, DatabaseStatus::FAILED_CREATE});
+        return result;
     }
+    std::shared_ptr<CWallet> wallet = create.value();
 
     // Encrypt the wallet
     if (born_encrypted) {
         if (!wallet->EncryptWallet(passphrase)) {
-            error = Untranslated("Error: Wallet created but failed to encrypt.");
-            status = DatabaseStatus::FAILED_ENCRYPT;
-            return nullptr;
+            result.update({util::Error{Untranslated("Error: Wallet created but failed to encrypt.")}, DatabaseStatus::FAILED_ENCRYPT});
+            return result;
         }
     }
 
@@ -446,22 +446,22 @@ std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string&
     wallet->postInitProcess();
 
     // Write the wallet settings
-    UpdateWalletSetting(*context.chain, name, load_on_start, warnings);
+    UpdateWalletSetting(*context.chain, name, load_on_start) >> result;
 
-    status = DatabaseStatus::SUCCESS;
-    return wallet;
+    result.update(std::move(wallet));
+    return result;
 }
 
 // Re-creates wallet from the backup file by renaming and moving it into the wallet's directory.
 // If 'load_after_restore=true', the wallet object will be fully initialized and appended to the context.
-std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings, bool load_after_restore, bool allow_unnamed)
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, bool load_after_restore, bool allow_unnamed)
 {
+    util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> result;
     // Error if the wallet name is empty and allow_unnamed == false
     // allow_unnamed == true is only used by migration to migrate an unnamed wallet
     if (!allow_unnamed && wallet_name.empty()) {
-        error = Untranslated("Wallet name cannot be empty");
-        status = DatabaseStatus::FAILED_NEW_UNNAMED;
-        return nullptr;
+        result.update({util::Error{Untranslated("Wallet name cannot be empty")}, DatabaseStatus::FAILED_NEW_UNNAMED});
+        return result;
     }
 
     DatabaseOptions options;
@@ -470,15 +470,13 @@ std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& b
 
     const fs::path wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), fs::u8path(wallet_name));
     auto wallet_file = wallet_path / "wallet.dat";
-    std::shared_ptr<CWallet> wallet;
     bool wallet_file_copied = false;
     bool created_parent_dir = false;
 
     try {
         if (!fs::exists(backup_file)) {
-            error = Untranslated("Backup file does not exist");
-            status = DatabaseStatus::FAILED_INVALID_BACKUP_FILE;
-            return nullptr;
+            result.update({util::Error{Untranslated("Backup file does not exist")}, DatabaseStatus::FAILED_INVALID_BACKUP_FILE});
+            return result;
         }
 
         // Wallet directories are allowed to exist, but must not contain a .dat file.
@@ -486,23 +484,20 @@ std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& b
         if (fs::exists(wallet_path)) {
             // If this is a file, it is the db and we don't want to overwrite it.
             if (!fs::is_directory(wallet_path)) {
-                error = Untranslated(strprintf("Failed to restore wallet. Database file exists '%s'.", fs::PathToString(wallet_path)));
-                status = DatabaseStatus::FAILED_ALREADY_EXISTS;
-                return nullptr;
+                result.update({util::Error{Untranslated(strprintf("Failed to restore wallet. Database file exists '%s'.", fs::PathToString(wallet_path)))}, DatabaseStatus::FAILED_ALREADY_EXISTS});
+                return result;
             }
 
             // Check we are not going to overwrite an existing db file
             if (fs::exists(wallet_file)) {
-                error = Untranslated(strprintf("Failed to restore wallet. Database file exists in '%s'.", fs::PathToString(wallet_file)));
-                status = DatabaseStatus::FAILED_ALREADY_EXISTS;
-                return nullptr;
+                result.update({util::Error{Untranslated(strprintf("Failed to restore wallet. Database file exists in '%s'.", fs::PathToString(wallet_file)))}, DatabaseStatus::FAILED_ALREADY_EXISTS});
+                return result;
             }
         } else {
             // The directory doesn't exist, create it
             if (!TryCreateDirectories(wallet_path)) {
-                error = Untranslated(strprintf("Failed to restore database path '%s'.", fs::PathToString(wallet_path)));
-                status = DatabaseStatus::FAILED_ALREADY_EXISTS;
-                return nullptr;
+                result.update({util::Error{Untranslated(strprintf("Failed to restore database path '%s'.", fs::PathToString(wallet_path)))}, DatabaseStatus::FAILED_ALREADY_EXISTS});
+                return result;
             }
             created_parent_dir = true;
         }
@@ -511,16 +506,16 @@ std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& b
         wallet_file_copied = true;
 
         if (load_after_restore) {
-            wallet = LoadWallet(context, wallet_name, load_on_start, options, status, error, warnings);
+            result.update(LoadWallet(context, wallet_name, load_on_start, options));
         }
     } catch (const std::exception& e) {
-        assert(!wallet);
-        if (!error.empty()) error += Untranslated("\n");
-        error += Untranslated(strprintf("Unexpected exception: %s", e.what()));
+        assert(!result.value());
+        result.update({util::Error{Untranslated(strprintf("Unexpected exception: %s", e.what()))}, DatabaseStatus::FAILED_LOAD});
+        return result;
     }
 
     // Remove created wallet path only when loading fails
-    if (load_after_restore && !wallet) {
+    if (load_after_restore && !result) {
         if (wallet_file_copied) fs::remove(wallet_file);
         // Clean up the parent directory if we created it during restoration.
         // As we have created it, it must be empty after deleting the wallet file.
@@ -530,7 +525,7 @@ std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& b
         }
     }
 
-    return wallet;
+    return result;
 }
 
 /** @defgroup mapWallet
@@ -2370,13 +2365,17 @@ void CWallet::CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::ve
     }
 }
 
-DBErrors CWallet::PopulateWalletFromDB(bilingual_str& error, std::vector<bilingual_str>& warnings)
+Result<void, DBErrors> CWallet::PopulateWalletFromDB()
 {
+    Result<void, DBErrors> result;
     LOCK(cs_wallet);
 
     Assert(m_spk_managers.empty());
     Assert(m_wallet_flags == 0);
     DBErrors nLoadWalletRet = WalletBatch(GetDatabase()).LoadWallet(this);
+    if (nLoadWalletRet != DBErrors::LOAD_OK) {
+        result.update({Error{}, nLoadWalletRet});
+    }
 
     if (m_spk_managers.empty()) {
         assert(m_external_spk_managers.empty());
@@ -2388,40 +2387,40 @@ DBErrors CWallet::PopulateWalletFromDB(bilingual_str& error, std::vector<bilingu
     case DBErrors::LOAD_OK:
         break;
     case DBErrors::NONCRITICAL_ERROR:
-        warnings.push_back(strprintf(_("Error reading %s! All keys read correctly, but transaction data"
-                                       " or address metadata may be missing or incorrect."),
+        result.messages().warnings.push_back(strprintf(_("Error reading %s! All keys read correctly, but transaction data"
+                                    " or address metadata may be missing or incorrect."),
             wallet_file));
         break;
     case DBErrors::NEED_RESCAN:
-        warnings.push_back(strprintf(_("Error reading %s! Transaction data may be missing or incorrect."
-                                       " Rescanning wallet."), wallet_file));
+        result.messages().warnings.push_back(strprintf(_("Error reading %s! Transaction data may be missing or incorrect."
+                                    " Rescanning wallet."), wallet_file));
         break;
     case DBErrors::CORRUPT:
-        error = strprintf(_("Error loading %s: Wallet corrupted"), wallet_file);
+        result.messages().errors.push_back(strprintf(_("Error loading %s: Wallet corrupted"), wallet_file));
         break;
     case DBErrors::TOO_NEW:
-        error = strprintf(_("Error loading %s: Wallet requires newer version of %s"), wallet_file, CLIENT_NAME);
+        result.messages().errors.push_back(strprintf(_("Error loading %s: Wallet requires newer version of %s"), wallet_file, CLIENT_NAME));
         break;
     case DBErrors::EXTERNAL_SIGNER_SUPPORT_REQUIRED:
-        error = strprintf(_("Error loading %s: External signer wallet being loaded without external signer support compiled"), wallet_file);
+        result.messages().errors.push_back(strprintf(_("Error loading %s: External signer wallet being loaded without external signer support compiled"), wallet_file));
         break;
     case DBErrors::UNKNOWN_DESCRIPTOR:
-        error = strprintf(_("Unrecognized descriptor found. Loading wallet %s\n\n"
+        result.messages().errors.push_back(strprintf(_("Unrecognized descriptor found. Loading wallet %s\n\n"
                             "The wallet might have been created on a newer version.\n"
-                            "Please try running the latest software version.\n"), wallet_file);
+                            "Please try running the latest software version.\n"), wallet_file));
         break;
     case DBErrors::UNEXPECTED_LEGACY_ENTRY:
-        error = strprintf(_("Unexpected legacy entry in descriptor wallet found. Loading wallet %s\n\n"
-                            "The wallet might have been tampered with or created with malicious intent.\n"), wallet_file);
+        result.messages().errors.push_back(strprintf(_("Unexpected legacy entry in descriptor wallet found. Loading wallet %s\n\n"
+                            "The wallet might have been tampered with or created with malicious intent.\n"), wallet_file));
         break;
     case DBErrors::LEGACY_WALLET:
-        error = strprintf(_("Error loading %s: Wallet is a legacy wallet. Please migrate to a descriptor wallet using the migration tool (migratewallet RPC)."), wallet_file);
+        result.messages().errors.push_back(strprintf(_("Error loading %s: Wallet is a legacy wallet. Please migrate to a descriptor wallet using the migration tool (migratewallet RPC)."), wallet_file));
         break;
     case DBErrors::LOAD_FAIL:
-        error = strprintf(_("Error loading %s"), wallet_file);
+        result.messages().errors.push_back(strprintf(_("Error loading %s"), wallet_file));
         break;
     } // no default case, so the compiler can warn about missing cases
-    return nLoadWalletRet;
+    return result;
 }
 
 util::Result<void> CWallet::RemoveTxs(std::vector<Txid>& txs_to_remove)
@@ -2962,27 +2961,29 @@ util::Result<fs::path> GetWalletPath(const std::string& name)
     return wallet_path;
 }
 
-std::unique_ptr<WalletDatabase> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error_string)
+util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options)
 {
-    const auto& wallet_path = GetWalletPath(name);
+    util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> result;
+    auto wallet_path{GetWalletPath(name) >> result};
     if (!wallet_path) {
-        error_string = util::ErrorString(wallet_path);
-        status = DatabaseStatus::FAILED_BAD_PATH;
-        return nullptr;
+        result.update({util::Error{}, DatabaseStatus::FAILED_BAD_PATH});
+        return result;
     }
-    return ResultExtract(MakeDatabase(*wallet_path, options), &status, &error_string);
+    result.update(MakeDatabase(*wallet_path, options));
+    return result;
 }
 
-bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContext& context, bilingual_str& error, std::vector<bilingual_str>& warnings)
+util::Result<void> CWallet::LoadWalletArgs(const ArgsManager& args)
 {
-    interfaces::Chain* chain = context.chain;
-    const ArgsManager& args = *Assert(context.args);
+    util::Result<void> result;
+    CWallet* wallet = this;
+    interfaces::Chain* chain = m_chain;
 
     if (!args.GetArg("-addresstype", "").empty()) {
         std::optional<OutputType> parsed = ParseOutputType(args.GetArg("-addresstype", ""));
         if (!parsed) {
-            error = strprintf(_("Unknown address type '%s'"), args.GetArg("-addresstype", ""));
-            return false;
+            result.update(Error{strprintf(_("Unknown address type '%s'"), args.GetArg("-addresstype", ""))});
+            return result;
         }
         wallet->m_default_address_type = parsed.value();
     }
@@ -2990,8 +2991,8 @@ bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContex
     if (!args.GetArg("-changetype", "").empty()) {
         std::optional<OutputType> parsed = ParseOutputType(args.GetArg("-changetype", ""));
         if (!parsed) {
-            error = strprintf(_("Unknown change type '%s'"), args.GetArg("-changetype", ""));
-            return false;
+            result.update(Error{strprintf(_("Unknown change type '%s'"), args.GetArg("-changetype", ""))});
+            return result;
         }
         wallet->m_default_change_type = parsed.value();
     }
@@ -2999,10 +3000,10 @@ bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContex
     if (const auto arg{args.GetArg("-mintxfee")}) {
         std::optional<CAmount> min_tx_fee = ParseMoney(*arg);
         if (!min_tx_fee) {
-            error = AmountErrMsg("mintxfee", *arg);
-            return false;
+            result.update(Error{AmountErrMsg("mintxfee", *arg)});
+            return result;
         } else if (min_tx_fee.value() > HIGH_TX_FEE_PER_KB) {
-            warnings.push_back(AmountHighWarn("-mintxfee") + Untranslated(" ") +
+            result.messages().warnings.push_back(AmountHighWarn("-mintxfee") + Untranslated(" ") +
                                _("This is the minimum transaction fee you pay on every transaction."));
         }
 
@@ -3015,23 +3016,23 @@ bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContex
             wallet->m_max_aps_fee = -1;
         } else if (std::optional<CAmount> max_fee = ParseMoney(max_aps_fee)) {
             if (max_fee.value() > HIGH_APS_FEE) {
-                warnings.push_back(AmountHighWarn("-maxapsfee") + Untranslated(" ") +
+                result.messages().warnings.push_back(AmountHighWarn("-maxapsfee") + Untranslated(" ") +
                                   _("This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection."));
             }
             wallet->m_max_aps_fee = max_fee.value();
         } else {
-            error = AmountErrMsg("maxapsfee", max_aps_fee);
-            return false;
+            result.update(Error{AmountErrMsg("maxapsfee", max_aps_fee)});
+            return result;
         }
     }
 
     if (const auto arg{args.GetArg("-fallbackfee")}) {
         std::optional<CAmount> fallback_fee = ParseMoney(*arg);
         if (!fallback_fee) {
-            error = strprintf(_("Invalid amount for %s=<amount>: '%s'"), "-fallbackfee", *arg);
-            return false;
+            result.update(Error{strprintf(_("Invalid amount for %s=<amount>: '%s'"), "-fallbackfee", *arg)});
+            return result;
         } else if (fallback_fee.value() > HIGH_TX_FEE_PER_KB) {
-            warnings.push_back(AmountHighWarn("-fallbackfee") + Untranslated(" ") +
+            result.messages().warnings.push_back(AmountHighWarn("-fallbackfee") + Untranslated(" ") +
                                _("This is the transaction fee you may pay when fee estimates are not available."));
         }
         wallet->m_fallback_fee = CFeeRate{fallback_fee.value()};
@@ -3043,10 +3044,10 @@ bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContex
     if (const auto arg{args.GetArg("-discardfee")}) {
         std::optional<CAmount> discard_fee = ParseMoney(*arg);
         if (!discard_fee) {
-            error = strprintf(_("Invalid amount for %s=<amount>: '%s'"), "-discardfee", *arg);
-            return false;
+            result.update(Error{strprintf(_("Invalid amount for %s=<amount>: '%s'"), "-discardfee", *arg)});
+            return result;
         } else if (discard_fee.value() > HIGH_TX_FEE_PER_KB) {
-            warnings.push_back(AmountHighWarn("-discardfee") + Untranslated(" ") +
+            result.messages().warnings.push_back(AmountHighWarn("-discardfee") + Untranslated(" ") +
                                _("This is the transaction fee you may discard if change is smaller than dust at this level"));
         }
         wallet->m_discard_rate = CFeeRate{discard_fee.value()};
@@ -3055,16 +3056,16 @@ bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContex
     if (const auto arg{args.GetArg("-maxtxfee")}) {
         std::optional<CAmount> max_fee = ParseMoney(*arg);
         if (!max_fee) {
-            error = AmountErrMsg("maxtxfee", *arg);
-            return false;
+            result.update(Error{AmountErrMsg("maxtxfee", *arg)});
+            return result;
         } else if (max_fee.value() > HIGH_MAX_TX_FEE) {
-            warnings.push_back(strprintf(_("%s is set very high! Fees this large could be paid on a single transaction."), "-maxtxfee"));
+            result.messages().warnings.push_back(strprintf(_("%s is set very high! Fees this large could be paid on a single transaction."), "-maxtxfee"));
         }
 
         if (chain && CFeeRate{max_fee.value(), 1000} < chain->relayMinFee()) {
-            error = strprintf(_("Invalid amount for %s=<amount>: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)"),
-                "-maxtxfee", *arg, chain->relayMinFee().ToString());
-            return false;
+            result.update(Error{strprintf(_("Invalid amount for %s=<amount>: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)"),
+                "-maxtxfee", *arg, chain->relayMinFee().ToString())});
+            return result;
         }
 
         wallet->m_default_max_tx_fee = max_fee.value();
@@ -3074,13 +3075,13 @@ bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContex
         if (std::optional<CAmount> consolidate_feerate = ParseMoney(*arg)) {
             wallet->m_consolidate_feerate = CFeeRate(*consolidate_feerate);
         } else {
-            error = AmountErrMsg("consolidatefeerate", *arg);
-            return false;
+            result.update(Error{AmountErrMsg("consolidatefeerate", *arg)});
+            return result;
         }
     }
 
     if (chain && chain->relayMinFee().GetFeePerK() > HIGH_TX_FEE_PER_KB) {
-        warnings.push_back(AmountHighWarn("-minrelaytxfee") + Untranslated(" ") +
+        result.messages().warnings.push_back(AmountHighWarn("-minrelaytxfee") + Untranslated(" ") +
                            _("The wallet will avoid paying less than the minimum relay fee."));
     }
 
@@ -3088,7 +3089,7 @@ bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContex
     wallet->m_spend_zero_conf_change = args.GetBoolArg("-spendzeroconfchange", DEFAULT_SPEND_ZEROCONF_CHANGE);
     wallet->m_signal_rbf = DEFAULT_WALLET_RBF;
     if (auto value{args.GetBoolArg("-walletrbf")}) {
-        warnings.push_back(_("-walletrbf is deprecated and will be fully removed in the next release."));
+        result.messages().warnings.push_back(_("-walletrbf is deprecated and will be fully removed in the next release."));
         wallet->m_signal_rbf = *value;
     }
 
@@ -3096,11 +3097,12 @@ bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContex
     wallet->m_notify_tx_changed_script = args.GetArg("-walletnotify", "");
     wallet->SetBroadcastTransactions(args.GetBoolArg("-walletbroadcast", DEFAULT_WALLETBROADCAST));
 
-    return true;
+    return result;
 }
 
-std::shared_ptr<CWallet> CWallet::CreateNew(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, uint64_t wallet_creation_flags, bool born_encrypted, bilingual_str& error, std::vector<bilingual_str>& warnings)
+util::ResultPtr<std::shared_ptr<CWallet>> CWallet::CreateNew(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, uint64_t wallet_creation_flags, bool born_encrypted)
 {
+    util::ResultPtr<std::shared_ptr<CWallet>> result;
     interfaces::Chain* chain = context.chain;
     const std::string& walletFile = database->Filename();
 
@@ -3109,14 +3111,15 @@ std::shared_ptr<CWallet> CWallet::CreateNew(WalletContext& context, const std::s
     // should be possible to use std::allocate_shared.
     std::shared_ptr<CWallet> walletInstance(new CWallet(chain, name, std::move(database)), FlushAndDeleteWallet);
 
-    if (!LoadWalletArgs(walletInstance, context, error, warnings)) {
-        return nullptr;
+    if (!(walletInstance->LoadWalletArgs(*Assert(context.args)) >> result)) {
+        result.update(Error{});
+        return result;
     }
 
     // Initialize version key.
     if(!WalletBatch(walletInstance->GetDatabase()).WriteVersion(CLIENT_VERSION)) {
-        error = strprintf(_("Error creating %s: Could not write version metadata."), walletFile);
-        return nullptr;
+        result.update(Error{strprintf(_("Error creating %s: Could not write version metadata."), walletFile)});
+        return result;
     }
     {
         LOCK(walletInstance->cs_wallet);
@@ -3146,37 +3149,41 @@ std::shared_ptr<CWallet> CWallet::CreateNew(WalletContext& context, const std::s
     // Try to top up keypool. No-op if the wallet is locked.
     walletInstance->TopUpKeyPool();
 
-    if (chain && !AttachChain(walletInstance, *chain, /*rescan_required=*/false, error, warnings)) {
+    if (chain && !(AttachChain(walletInstance, *chain, /*rescan_required=*/false) >> result)) {
         walletInstance->DisconnectChainNotifications();
-        return nullptr;
+        result.update(Error{});
+        return result;
     }
 
     return walletInstance;
 }
 
-std::shared_ptr<CWallet> CWallet::LoadExisting(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, bilingual_str& error, std::vector<bilingual_str>& warnings)
+util::ResultPtr<std::shared_ptr<CWallet>> CWallet::LoadExisting(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database)
 {
+    util::ResultPtr<std::shared_ptr<CWallet>> result;
     interfaces::Chain* chain = context.chain;
     const std::string& walletFile = database->Filename();
 
     const auto start{SteadyClock::now()};
     std::shared_ptr<CWallet> walletInstance(new CWallet(chain, name, std::move(database)), FlushAndDeleteWallet);
 
-    if (!LoadWalletArgs(walletInstance, context, error, warnings)) {
-        return nullptr;
+    if (!(walletInstance->LoadWalletArgs(*Assert(context.args)) >> result)) {
+        result.update(Error{});
+        return result;
     }
 
     // Load wallet
-    auto nLoadWalletRet = walletInstance->PopulateWalletFromDB(error, warnings);
-    bool rescan_required = nLoadWalletRet == DBErrors::NEED_RESCAN;
-    if (nLoadWalletRet != DBErrors::LOAD_OK && nLoadWalletRet != DBErrors::NONCRITICAL_ERROR && !rescan_required) {
-        return nullptr;
+    auto populate{walletInstance->PopulateWalletFromDB() >> result};
+    bool rescan_required = !populate && populate.error() == DBErrors::NEED_RESCAN;
+    if (!populate && populate.error() != DBErrors::NONCRITICAL_ERROR && !rescan_required) {
+        result.update(Error{});
+        return result;
     }
 
     if (walletInstance->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
         for (auto spk_man : walletInstance->GetActiveScriptPubKeyMans()) {
             if (spk_man->HavePrivateKeys()) {
-                warnings.push_back(strprintf(_("Warning: Private keys detected in wallet {%s} with disabled private keys"), walletFile));
+                result.messages().warnings.push_back(strprintf(_("Warning: Private keys detected in wallet {%s} with disabled private keys"), walletFile));
                 break;
             }
         }
@@ -3187,18 +3194,20 @@ std::shared_ptr<CWallet> CWallet::LoadExisting(WalletContext& context, const std
     // Try to top up keypool. No-op if the wallet is locked.
     walletInstance->TopUpKeyPool();
 
-    if (chain && !AttachChain(walletInstance, *chain, rescan_required, error, warnings)) {
+    if (chain && !(AttachChain(walletInstance, *chain, rescan_required) >> result)) {
         walletInstance->DisconnectChainNotifications();
-        return nullptr;
+        result.update(util::Error{});
+        return result;
     }
 
     WITH_LOCK(walletInstance->cs_wallet, walletInstance->LogStats());
 
-    return walletInstance;
+    result.update(std::move(walletInstance));
+    return result;
 }
 
 
-bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interfaces::Chain& chain, const bool rescan_required, bilingual_str& error, std::vector<bilingual_str>& warnings)
+util::Result<void> CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interfaces::Chain& chain, const bool rescan_required)
 {
     LOCK(walletInstance->cs_wallet);
     // allow setting the chain if it hasn't been set already but prevent changing it
@@ -3213,8 +3222,7 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
             // Wallet is assumed to be from another chain, if genesis block in the active
             // chain differs from the genesis block known to the wallet.
             if (chain.getBlockHash(0) != locator.vHave.back()) {
-                error = Untranslated("Wallet files should not be reused across chains. Restart bitcoind with -walletcrosschain to override.");
-                return false;
+                return {util::Error{Untranslated("Wallet files should not be reused across chains. Restart bitcoind with -walletcrosschain to override.")}};
             }
         }
     }
@@ -3282,15 +3290,14 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
                 // If a block is pruned after this check, we will load the wallet,
                 // but fail the rescan with a generic error.
 
-                error = chain.havePruned() ?
+                return {util::Error{chain.havePruned() ?
                      _("Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of a pruned node)") :
                      strprintf(_(
                         "Error loading wallet. Wallet requires blocks to be downloaded, "
                         "and software does not currently support loading wallets while "
                         "blocks are being downloaded out of order when using assumeutxo "
                         "snapshots. Wallet should be able to load successfully after "
-                        "node sync reaches height %s"), block_height);
-                return false;
+                        "node sync reaches height %s"), block_height)}};
             }
         }
 
@@ -3300,13 +3307,11 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
         {
             WalletRescanReserver reserver(*walletInstance);
             if (!reserver.reserve()) {
-                error = _("Failed to acquire rescan reserver during wallet initialization");
-                return false;
+                return {util::Error{_("Failed to acquire rescan reserver during wallet initialization")}};
             }
             ScanResult scan_res = walletInstance->ScanForWalletTransactions(chain.getBlockHash(rescan_height), rescan_height, /*max_height=*/{}, reserver, /*save_progress=*/true);
             if (ScanResult::SUCCESS != scan_res.status) {
-                error = _("Failed to rescan the wallet during initialization");
-                return false;
+                return {util::Error{_("Failed to rescan the wallet during initialization")}};
             }
             // Set and update the best block record
             // Set last block scanned as the last block processed as it may be different in case of a reorg.
@@ -3315,7 +3320,7 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
         }
     }
 
-    return true;
+    return {};
 }
 
 const CAddressBookData* CWallet::FindAddressBookEntry(const CTxDestination& dest, bool allow_change) const
@@ -3843,15 +3848,16 @@ util::Result<std::reference_wrapper<DescriptorScriptPubKeyMan>> CWallet::AddWall
     return std::reference_wrapper(*spk_man);
 }
 
-bool CWallet::MigrateToSQLite(bilingual_str& error)
+util::Result<void> CWallet::MigrateToSQLite()
 {
     AssertLockHeld(cs_wallet);
+    util::Result<void> result;
 
     WalletLogPrintf("Migrating wallet storage database from BerkeleyDB to SQLite.\n");
 
     if (m_database->Format() == "sqlite") {
-        error = _("Error: This wallet already uses SQLite");
-        return false;
+        result.update(util::Error{_("Error: This wallet already uses SQLite")});
+        return result;
     }
 
     // Get all of the records for DB type migration
@@ -3859,8 +3865,8 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
     std::unique_ptr<DatabaseCursor> cursor = batch->GetNewCursor();
     std::vector<std::pair<SerializeData, SerializeData>> records;
     if (!cursor) {
-        error = _("Error: Unable to begin reading all records in the database");
-        return false;
+        result.update(util::Error{_("Error: Unable to begin reading all records in the database")});
+        return result;
     }
     DatabaseCursor::Status status = DatabaseCursor::Status::FAIL;
     while (true) {
@@ -3877,8 +3883,8 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
     cursor.reset();
     batch.reset();
     if (status != DatabaseCursor::Status::DONE) {
-        error = _("Error: Unable to read all records in the database");
-        return false;
+        result.update(util::Error{_("Error: Unable to read all records in the database")});
+        return result;
     }
 
     // Close this database and delete the file
@@ -3894,11 +3900,10 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
     DatabaseOptions opts;
     opts.require_create = true;
     opts.require_format = DatabaseFormat::SQLITE;
-    DatabaseStatus db_status;
-    std::unique_ptr<WalletDatabase> new_db = ResultExtract(MakeDatabase(wallet_path, opts), &db_status, &error);
+    auto new_db{MakeDatabase(wallet_path, opts) >> result};
     assert(new_db); // This is to prevent doing anything further with this wallet. The original file was deleted, but a backup exists.
     m_database.reset();
-    m_database = std::move(new_db);
+    m_database = std::move(new_db.value());
 
     // Write existing records into the new DB
     batch = m_database->MakeBatch();
@@ -3914,26 +3919,24 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
     }
     bool committed = batch->TxnCommit();
     assert(committed); // This is a critical error, the new db could not be written to. The original db exists as a backup, but we should not continue execution.
-    return true;
+    return result;
 }
 
-std::optional<MigrationData> CWallet::GetDescriptorsForLegacy(bilingual_str& error) const
+util::Result<MigrationData> CWallet::GetDescriptorsForLegacy() const
 {
     AssertLockHeld(cs_wallet);
 
     LegacyDataSPKM* legacy_spkm = GetLegacyDataSPKM();
     if (!Assume(legacy_spkm)) {
         // This shouldn't happen
-        error = Untranslated(STR_INTERNAL_BUG("Error: Legacy wallet data missing"));
-        return std::nullopt;
+        return util::Error{Untranslated(STR_INTERNAL_BUG("Error: Legacy wallet data missing"))};
     }
 
     std::optional<MigrationData> res = legacy_spkm->MigrateToDescriptor();
     if (res == std::nullopt) {
-        error = _("Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet's passphrase if it is encrypted.");
-        return std::nullopt;
+        return {util::Error{_("Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet's passphrase if it is encrypted.")}};
     }
-    return res;
+    return std::move(*res);
 }
 
 util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, MigrationData& data)
@@ -4162,13 +4165,17 @@ static std::string MigrationPrefixName(CWallet& wallet)
     return name.empty() ? "default_wallet" : name;
 }
 
-bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, MigrationResult& res, const bool load_on_startup = true) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+util::Result<void> DoMigration(CWallet& wallet, WalletContext& context, MigrationResult& res, const bool load_on_startup = true) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
     AssertLockHeld(wallet.cs_wallet);
+    util::Result<void> result;
 
     // Get all of the descriptors from the legacy wallet
-    std::optional<MigrationData> data = wallet.GetDescriptorsForLegacy(error);
-    if (data == std::nullopt) return false;
+    auto data{wallet.GetDescriptorsForLegacy() >> result};
+    if (!data) {
+        result.update(util::Error{});
+        return result;
+    }
 
     // Create the watchonly and solvable wallets if necessary
     if (data->watch_descs.size() > 0 || data->solvable_descs.size() > 0) {
@@ -4191,20 +4198,19 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
         if (data->watch_descs.size() > 0) {
             wallet.WalletLogPrintf("Making a new watchonly wallet containing the watched scripts\n");
 
-            DatabaseStatus status;
-            std::vector<bilingual_str> warnings;
             std::string wallet_name = MigrationPrefixName(wallet) + "_watchonly";
-            std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(wallet_name, options, status, error);
+            auto database{MakeWalletDatabase(wallet_name, options) >> result};
             if (!database) {
-                error = strprintf(_("Wallet file creation failed: %s"), error);
-                return false;
+                result.update(util::Error{_("Wallet file creation failed")});
+                return result;
             }
 
-            data->watchonly_wallet = CWallet::CreateNew(empty_context, wallet_name, std::move(database), options.create_flags, /*born_encrypted=*/false, error, warnings);
-            if (!data->watchonly_wallet) {
-                error = _("Error: Failed to create new watchonly wallet");
-                return false;
+            auto watchonly_wallet{CWallet::CreateNew(empty_context, wallet_name, std::move(database.value()), options.create_flags, /*born_encrypted=*/false) >> result};
+            if (!watchonly_wallet) {
+                result.update(util::Error{_("Error: Failed to create new watchonly wallet")});
+                return result;
             }
+            data->watchonly_wallet = std::move(watchonly_wallet.value());
             res.watchonly_wallet = data->watchonly_wallet;
             LOCK(data->watchonly_wallet->cs_wallet);
 
@@ -4225,25 +4231,24 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
             }
 
             // Add the wallet to settings
-            UpdateWalletSetting(*context.chain, wallet_name, load_on_startup, warnings);
+            UpdateWalletSetting(*context.chain, wallet_name, load_on_startup) >> result;
         }
         if (data->solvable_descs.size() > 0) {
             wallet.WalletLogPrintf("Making a new watchonly wallet containing the unwatched solvable scripts\n");
 
-            DatabaseStatus status;
-            std::vector<bilingual_str> warnings;
             std::string wallet_name = MigrationPrefixName(wallet) + "_solvables";
-            std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(wallet_name, options, status, error);
+            auto database{MakeWalletDatabase(wallet_name, options) >> result};
             if (!database) {
-                error = strprintf(_("Wallet file creation failed: %s"), error);
-                return false;
+                result.update(util::Error{_("Wallet file creation failed")});
+                return result;
             }
 
-            data->solvable_wallet = CWallet::CreateNew(empty_context, wallet_name, std::move(database), options.create_flags, /*born_encrypted=*/false, error, warnings);
-            if (!data->solvable_wallet) {
-                error = _("Error: Failed to create new watchonly wallet");
-                return false;
+            auto solvable_wallet{CWallet::CreateNew(empty_context, wallet_name, std::move(database.value()), options.create_flags, /*born_encrypted=*/false) >> result};
+            if (!solvable_wallet) {
+                result.update(util::Error{_("Error: Failed to create new watchonly wallet")});
+                return result;
             }
+            data->solvable_wallet = std::move(solvable_wallet.value());
             res.solvables_wallet = data->solvable_wallet;
             LOCK(data->solvable_wallet->cs_wallet);
 
@@ -4264,30 +4269,29 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
             }
 
             // Add the wallet to settings
-            UpdateWalletSetting(*context.chain, wallet_name, load_on_startup, warnings);
+            UpdateWalletSetting(*context.chain, wallet_name, load_on_startup) >> result;
         }
     }
 
     // Add the descriptors to wallet, remove LegacyScriptPubKeyMan, and cleanup txs and address book data
-    return RunWithinTxn(wallet.GetDatabase(), /*process_desc=*/"apply migration process", [&](WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet){
-        if (auto res_migration = wallet.ApplyMigrationData(batch, *data); !res_migration) {
-            error = util::ErrorString(res_migration);
-            return false;
-        }
-        wallet.WalletLogPrintf("Wallet migration complete.\n");
-        return true;
-    });
+    bool committed{RunWithinTxn(wallet.GetDatabase(), /*process_desc=*/"apply migration process", [&](WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet){
+        result.update(wallet.ApplyMigrationData(batch, *data));
+        if (result) wallet.WalletLogPrintf("Wallet migration complete.\n");
+        return bool{result};
+    })};
+    if (result && !committed) result.update(util::Error{_("Error starting/committing db txn for wallet migration process")});
+    return result;
 }
 
 util::Result<MigrationResult> MigrateLegacyToDescriptor(const std::string& wallet_name, const SecureString& passphrase, WalletContext& context, bool load_wallet)
 {
-    std::vector<bilingual_str> warnings;
-    bilingual_str error;
+    util::Result<MigrationResult> result;
 
     // The only kind of wallets that could be loaded are descriptor ones, which don't need to be migrated.
     if (auto wallet = GetWallet(context, wallet_name)) {
         assert(wallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
-        return util::Error{_("Error: This wallet is already a descriptor wallet")};
+        result.update(util::Error{_("Error: This wallet is already a descriptor wallet")});
+        return result;
     } else {
         // Check if the wallet is BDB
         const auto& wallet_path = GetWalletPath(wallet_name);
@@ -4309,36 +4313,40 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(const std::string& walle
     DatabaseOptions options;
     options.require_existing = true;
     options.require_format = DatabaseFormat::BERKELEY_RO;
-    DatabaseStatus status;
-    std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(wallet_name, options, status, error);
+    auto database{MakeWalletDatabase(wallet_name, options) >> result};
     if (!database) {
-        return util::Error{Untranslated("Wallet file verification failed.") + Untranslated(" ") + error};
+        auto& errors{result.messages().errors};
+        errors.insert(errors.begin(), Untranslated("Wallet file verification failed."));
+        result.update(util::Error{});
+        return result;
     }
 
     // Make the local wallet
-    std::shared_ptr<CWallet> local_wallet = CWallet::LoadExisting(empty_context, wallet_name, std::move(database), error, warnings);
+    auto local_wallet{CWallet::LoadExisting(empty_context, wallet_name, std::move(database.value())) >> result};
     if (!local_wallet) {
-        return util::Error{Untranslated("Wallet loading failed.") + Untranslated(" ") + error};
+        auto& errors{result.messages().errors};
+        errors.insert(errors.begin(), Untranslated("Wallet loading failed."));
+        result.update(util::Error{});
+        return result;
     }
 
-    return MigrateLegacyToDescriptor(std::move(local_wallet), passphrase, context, load_wallet);
+    return MigrateLegacyToDescriptor(std::move(local_wallet.value()), passphrase, context, load_wallet);
 }
 
 util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet> local_wallet, const SecureString& passphrase, WalletContext& context, bool load_wallet)
 {
+    util::Result<MigrationResult> result{util::Error{}};
     MigrationResult res;
-    bilingual_str error;
-    std::vector<bilingual_str> warnings;
 
     DatabaseOptions options;
     options.require_existing = true;
-    DatabaseStatus status;
 
     const std::string wallet_name = local_wallet->GetName();
 
     // Before anything else, check if there is something to migrate.
     if (local_wallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
-        return util::Error{_("Error: This wallet is already a descriptor wallet")};
+        result.update(util::Error{_("Error: This wallet is already a descriptor wallet")});
+        return result;
     }
 
     // Make a backup of the DB in the wallet's directory with a unique filename
@@ -4356,23 +4364,23 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
     fs::path backup_filename = fs::PathFromString(strprintf("%s_%d.legacy.bak", backup_prefix, GetTime()));
     fs::path backup_path = fsbridge::AbsPathJoin(GetWalletDir(), backup_filename);
     if (!local_wallet->BackupWallet(fs::PathToString(backup_path))) {
-        return util::Error{_("Error: Unable to make a backup of your wallet")};
+        result.update(util::Error{_("Error: Unable to make a backup of your wallet")});
+        return result;
     }
     res.backup_path = backup_path;
-
-    bool success = false;
 
     // Unlock the wallet if needed
     if (local_wallet->IsLocked() && !local_wallet->Unlock(passphrase)) {
         if (passphrase.find('\0') == std::string::npos) {
-            return util::Error{Untranslated("Error: Wallet decryption failed, the wallet passphrase was not provided or was incorrect.")};
+            result.update(util::Error{Untranslated("Error: Wallet decryption failed, the wallet passphrase was not provided or was incorrect.")});
         } else {
-            return util::Error{Untranslated("Error: Wallet decryption failed, the wallet passphrase entered was incorrect. "
+            result.update(util::Error{Untranslated("Error: Wallet decryption failed, the wallet passphrase entered was incorrect. "
                                             "The passphrase contains a null character (ie - a zero byte). "
                                             "If this passphrase was set with a version of this software prior to 25.0, "
                                             "please try again with only the characters up to — but not including — "
-                                            "the first null character.")};
+                                            "the first null character.")});
         }
+        return result;
     }
 
     // Indicates whether the current wallet is empty after migration.
@@ -4386,17 +4394,22 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
     {
         LOCK(local_wallet->cs_wallet);
         // First change to using SQLite
-        if (!local_wallet->MigrateToSQLite(error)) return util::Error{error};
+        if (!(local_wallet->MigrateToSQLite() >> result)) {
+            result.update(util::Error{});
+            return result;
+        }
 
         // Do the migration of keys and scripts for non-empty wallets, and cleanup if it fails
         if (HasLegacyRecords(*local_wallet)) {
-            success = DoMigration(*local_wallet, context, error, res, load_wallet);
+            if (DoMigration(*local_wallet, context, res, load_wallet) >> result) {
+                result.update({});
+            }
             // No scripts mean empty wallet after migration
             empty_local_wallet = local_wallet->GetAllScriptPubKeyMans().empty();
         } else {
             // Make sure that descriptors flag is actually set
             local_wallet->SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
-            success = true;
+            result.update({});
         }
     }
 
@@ -4422,7 +4435,7 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
     };
 
 
-    if (success) {
+    if (result) {
         Assume(!res.wallet); // We will set it here.
         // Check if the local wallet is empty after migration
         if (empty_local_wallet) {
@@ -4437,12 +4450,12 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
             /** We only override the load_on_startup setting in case the user explicitly said
              * that he does not want to load the wallet, otherwise keep the old wallet configuration */
         } else {
-            UpdateWalletSetting(*context.chain, wallet_name, /*load_on_startup=*/false, warnings);
+            UpdateWalletSetting(*context.chain, wallet_name, /*load_on_startup=*/false) >> result;
         }
         // Migration successful, if load_wallet is set load all the migrated wallets.
         bool main_wallet_set{false};
         for (std::shared_ptr<CWallet>* wallet_ptr : {&local_wallet, &res.watchonly_wallet, &res.solvables_wallet}) {
-            if (success && *wallet_ptr) {
+            if (result && *wallet_ptr) {
                 std::shared_ptr<CWallet>& wallet = *wallet_ptr;
                 // Track db path
                 track_for_cleanup(*wallet);
@@ -4450,13 +4463,16 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
                 std::string wallet_name = wallet->GetName();
                 wallet.reset();
                 if (load_wallet) {
-                    wallet = LoadWallet(context, wallet_name, /*load_on_start=*/std::nullopt, options, status, error, warnings);
+                    auto loaded{LoadWallet(context, wallet_name, /*load_on_start=*/std::nullopt, options)};
+                    if (loaded) wallet = loaded.value();
                     if (!wallet) {
                         LogError("Failed to load wallet '%s' after migration. Rolling back migration to preserve consistency. "
-                                 "Error cause: %s\n", wallet_name, error.original);
-                        success = false;
+                                 "Error cause: %s\n", wallet_name, ErrorString(loaded).original);
+                        result.update(util::Error{});
+                        loaded >> result;
                         break;
                     }
+                    loaded >> result;
                 }
                 // Set the first wallet as the main one.
                 // The loop order is intentional and must always start with the local wallet.
@@ -4473,7 +4489,7 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
             }
         }
     }
-    if (!success) {
+    if (!result) {
         // Make list of wallets to cleanup
         std::vector<std::shared_ptr<CWallet>> created_wallets;
         if (local_wallet) created_wallets.push_back(std::move(local_wallet));
@@ -4489,9 +4505,9 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
         for (std::shared_ptr<CWallet>& w : created_wallets) {
             if (w->HaveChain()) {
                 // Unloading for wallets that were loaded for normal use
-                if (!RemoveWallet(context, w, /*load_on_start=*/false)) {
-                    error += _("\nUnable to cleanup failed migration");
-                    return util::Error{error};
+                if (!(RemoveWallet(context, w, /*load_on_start=*/false) >> result)) {
+                    result.update(util::Error{_("\nUnable to cleanup failed migration")});
+                    return result;
                 }
                 WaitForDeleteWallet(std::move(w));
             } else {
@@ -4514,18 +4530,18 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
 
         // Restore the backup
         // Convert the backup file to the wallet db file by renaming it and moving it into the wallet's directory.
-        bilingual_str restore_error;
-        const auto& ptr_wallet = RestoreWallet(context, backup_path, wallet_name, /*load_on_start=*/std::nullopt, status, restore_error, warnings, /*load_after_restore=*/false, /*allow_unnamed=*/true);
-        if (!restore_error.empty()) {
-            error += restore_error + _("\nUnable to restore backup of wallet.");
-            return util::Error{error};
+        auto ptr_wallet{RestoreWallet(context, backup_path, wallet_name, /*load_on_start=*/std::nullopt, /*load_after_restore=*/false, /*allow_unnamed=*/true) >> result};
+        if (!ptr_wallet) {
+            result.update(util::Error{_("Unable to restore backup of wallet.")});;
+            return result;
         }
         // Verify that the legacy wallet is not loaded after restoring from the backup.
         assert(!ptr_wallet);
 
-        return util::Error{error};
+        result.update(util::Error{});
     }
-    return res;
+    result.update(std::move(res));
+    return result;
 }
 
 void CWallet::CacheNewScriptPubKeys(const std::set<CScript>& spks, ScriptPubKeyMan* spkm)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2948,7 +2948,7 @@ util::Result<fs::path> GetWalletPath(const std::string& name)
     // 2. Path to an existing directory.
     // 3. Path to a symlink to a directory.
     // 4. For backwards compatibility, the name of a data file in -walletdir.
-    const fs::path wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), name_path);
+    fs::path wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), name_path);
     fs::file_type path_type = fs::symlink_status(wallet_path).type();
     if (!(path_type == fs::file_type::not_found || path_type == fs::file_type::directory ||
           (path_type == fs::file_type::symlink && fs::is_directory(wallet_path)) ||

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2970,7 +2970,7 @@ std::unique_ptr<WalletDatabase> MakeWalletDatabase(const std::string& name, cons
         status = DatabaseStatus::FAILED_BAD_PATH;
         return nullptr;
     }
-    return MakeDatabase(*wallet_path, options, status, error_string);
+    return ResultExtract(MakeDatabase(*wallet_path, options), &status, &error_string);
 }
 
 bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContext& context, bilingual_str& error, std::vector<bilingual_str>& warnings)
@@ -3895,7 +3895,7 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
     opts.require_create = true;
     opts.require_format = DatabaseFormat::SQLITE;
     DatabaseStatus db_status;
-    std::unique_ptr<WalletDatabase> new_db = MakeDatabase(wallet_path, opts, db_status, error);
+    std::unique_ptr<WalletDatabase> new_db = ResultExtract(MakeDatabase(wallet_path, opts), &db_status, &error);
     assert(new_db); // This is to prevent doing anything further with this wallet. The original file was deleted, but a backup exists.
     m_database.reset();
     m_database = std::move(new_db);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2431,7 +2431,7 @@ util::Result<void> CWallet::RemoveTxs(std::vector<Txid>& txs_to_remove)
     bool was_txn_committed = RunWithinTxn(GetDatabase(), /*process_desc=*/"remove transactions", [&](WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) {
         util::Result<void> result{RemoveTxs(batch, txs_to_remove)};
         if (!result) str_err = util::ErrorString(result);
-        return result.has_value();
+        return bool{result};
     });
     if (!str_err.empty()) return util::Error{str_err};
     if (!was_txn_committed) return util::Error{_("Error starting/committing db txn for wallet transactions removal process")};

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2428,7 +2428,7 @@ util::Result<void> CWallet::RemoveTxs(std::vector<Txid>& txs_to_remove)
     bool was_txn_committed = RunWithinTxn(GetDatabase(), /*process_desc=*/"remove transactions", [&](WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) {
         util::Result<void> result{RemoveTxs(batch, txs_to_remove)};
         if (!result) str_err = util::ErrorString(result);
-        return result.has_value();
+        return bool{result};
     });
     if (!str_err.empty()) return util::Error{str_err};
     if (!was_txn_committed) return util::Error{_("Error starting/committing db txn for wallet transactions removal process")};

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2945,7 +2945,7 @@ util::Result<fs::path> GetWalletPath(const std::string& name)
     // 2. Path to an existing directory.
     // 3. Path to a symlink to a directory.
     // 4. For backwards compatibility, the name of a data file in -walletdir.
-    const fs::path wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), name_path);
+    fs::path wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), name_path);
     fs::file_type path_type = fs::symlink_status(wallet_path).type();
     if (!(path_type == fs::file_type::not_found || path_type == fs::file_type::directory ||
           (path_type == fs::file_type::symlink && fs::is_directory(wallet_path)) ||

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -91,7 +91,9 @@ using common::AmountHighWarn;
 using common::PSBTError;
 using interfaces::FoundBlock;
 using kernel::ChainstateRole;
+using util::Error;
 using util::ReplaceAll;
+using util::Result;
 using util::ToString;
 
 namespace wallet {
@@ -131,17 +133,18 @@ bool RemoveWalletSetting(interfaces::Chain& chain, const std::string& wallet_nam
     return chain.updateRwSetting("wallet", update_function);
 }
 
-static void UpdateWalletSetting(interfaces::Chain& chain,
-                                const std::string& wallet_name,
-                                std::optional<bool> load_on_startup,
-                                std::vector<bilingual_str>& warnings)
+static util::Result<void> UpdateWalletSetting(interfaces::Chain& chain,
+                                              const std::string& wallet_name,
+                                              std::optional<bool> load_on_startup)
 {
-    if (!load_on_startup) return;
+    util::Result<void> result;
+    if (!load_on_startup) return result;
     if (load_on_startup.value() && !AddWalletSetting(chain, wallet_name)) {
-        warnings.emplace_back(Untranslated("Wallet load on startup setting could not be updated, so wallet may not be loaded next node startup."));
+        result.messages().warnings.push_back(Untranslated("Wallet load on startup setting could not be updated, so wallet may not be loaded next node startup."));
     } else if (!load_on_startup.value() && !RemoveWalletSetting(chain, wallet_name)) {
-        warnings.emplace_back(Untranslated("Wallet load on startup setting could not be updated, so wallet may still be loaded next node startup."));
+        result.messages().warnings.push_back(Untranslated("Wallet load on startup setting could not be updated, so wallet may still be loaded next node startup."));
     }
+    return result;
 }
 
 /**
@@ -170,9 +173,10 @@ bool AddWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet)
     return true;
 }
 
-bool RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet, std::optional<bool> load_on_start, std::vector<bilingual_str>& warnings)
+util::Result<void> RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet, std::optional<bool> load_on_start)
 {
     assert(wallet);
+    util::Result<void> result;
 
     interfaces::Chain& chain = wallet->chain();
     std::string name = wallet->GetName();
@@ -183,22 +187,19 @@ bool RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet
     {
         LOCK(context.wallets_mutex);
         std::vector<std::shared_ptr<CWallet>>::iterator i = std::find(context.wallets.begin(), context.wallets.end(), wallet);
-        if (i == context.wallets.end()) return false;
+        if (i == context.wallets.end()) {
+            result.update(util::Error{});
+            return result;
+        }
         context.wallets.erase(i);
     }
     // Notify unload so that upper layers release the shared pointer.
     wallet->NotifyUnload();
 
     // Write the wallet setting
-    UpdateWalletSetting(chain, name, load_on_start, warnings);
+    UpdateWalletSetting(chain, name, load_on_start) >> result;
 
-    return true;
-}
-
-bool RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet, std::optional<bool> load_on_start)
-{
-    std::vector<bilingual_str> warnings;
-    return RemoveWallet(context, wallet, load_on_start, warnings);
+    return result;
 }
 
 std::vector<std::shared_ptr<CWallet>> GetWallets(WalletContext& context)
@@ -283,36 +284,39 @@ void WaitForDeleteWallet(std::shared_ptr<CWallet>&& wallet)
 }
 
 namespace {
-std::shared_ptr<CWallet> LoadWalletInternal(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings)
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> LoadWalletInternal(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options)
 {
+    util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> result;
     try {
-        std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(name, options, status, error);
+        auto database{MakeWalletDatabase(name, options) >> result};
         if (!database) {
-            error = Untranslated("Wallet file verification failed.") + Untranslated(" ") + error;
-            return nullptr;
+            auto& errors{result.messages().errors};
+            errors.insert(errors.begin(), Untranslated("Wallet file verification failed."));
+            result.update({util::Error{}, database.error()});
+            return result;
         }
 
         context.chain->initMessage(_("Loading wallet…"));
-        std::shared_ptr<CWallet> wallet = CWallet::LoadExisting(context, name, std::move(database), error, warnings);
+        auto wallet{CWallet::LoadExisting(context, name, std::move(database.value())) >> result};
         if (!wallet) {
-            error = Untranslated("Wallet loading failed.") + Untranslated(" ") + error;
-            status = DatabaseStatus::FAILED_LOAD;
-            return nullptr;
+            auto& errors{result.messages().errors};
+            errors.insert(errors.begin(), Untranslated("Wallet loading failed."));
+            result.update({util::Error{}, DatabaseStatus::FAILED_LOAD});
+            return result;
         }
 
-        NotifyWalletLoaded(context, wallet);
-        AddWallet(context, wallet);
+        NotifyWalletLoaded(context, wallet.value());
+        AddWallet(context, wallet.value());
         wallet->postInitProcess();
 
         // Write the wallet setting
-        UpdateWalletSetting(*context.chain, name, load_on_start, warnings);
+        UpdateWalletSetting(*context.chain, name, load_on_start) >> result;
 
-        return wallet;
+        result.update(std::move(wallet.value()));
     } catch (const std::runtime_error& e) {
-        error = Untranslated(e.what());
-        status = DatabaseStatus::FAILED_LOAD;
-        return nullptr;
+        result.update({util::Error{Untranslated(e.what())}, DatabaseStatus::FAILED_LOAD});
     }
+    return result;
 }
 
 class FastWalletRescanFilter
@@ -371,26 +375,24 @@ private:
 };
 } // namespace
 
-std::shared_ptr<CWallet> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings)
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options)
 {
     auto result = WITH_LOCK(g_loading_wallet_mutex, return g_loading_wallet_set.insert(name));
     if (!result.second) {
-        error = Untranslated("Wallet already loading.");
-        status = DatabaseStatus::FAILED_LOAD;
-        return nullptr;
+        return {util::Error{Untranslated("Wallet already loading.")}, DatabaseStatus::FAILED_LOAD};
     }
-    auto wallet = LoadWalletInternal(context, name, load_on_start, options, status, error, warnings);
+    auto wallet{LoadWalletInternal(context, name, load_on_start, options)};
     WITH_LOCK(g_loading_wallet_mutex, g_loading_wallet_set.erase(result.first));
     return wallet;
 }
 
-std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings)
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options)
 {
+    util::Result<std::shared_ptr<CWallet>, DatabaseStatus> result;
     // Wallet must have a non-empty name
     if (name.empty()) {
-        error = Untranslated("Wallet name cannot be empty");
-        status = DatabaseStatus::FAILED_NEW_UNNAMED;
-        return nullptr;
+        result.update({util::Error{Untranslated("Wallet name cannot be empty")}, DatabaseStatus::FAILED_NEW_UNNAMED});
+        return result;
     }
 
     uint64_t wallet_creation_flags = options.create_flags;
@@ -404,41 +406,39 @@ std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string&
 
     // Private keys must be disabled for an external signer wallet
     if ((wallet_creation_flags & WALLET_FLAG_EXTERNAL_SIGNER) && !(wallet_creation_flags & WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
-        error = Untranslated("Private keys must be disabled when using an external signer");
-        status = DatabaseStatus::FAILED_CREATE;
-        return nullptr;
+        result.update({util::Error{Untranslated("Private keys must be disabled when using an external signer")}, DatabaseStatus::FAILED_CREATE});
+        return result;
     }
 
     // Do not allow a passphrase when private keys are disabled
     if (born_encrypted && (wallet_creation_flags & WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
-        error = Untranslated("Passphrase provided but private keys are disabled. A passphrase is only used to encrypt private keys, so cannot be used for wallets with private keys disabled.");
-        status = DatabaseStatus::FAILED_CREATE;
-        return nullptr;
+        result.update({util::Error{Untranslated("Passphrase provided but private keys are disabled. A passphrase is only used to encrypt private keys, so cannot be used for wallets with private keys disabled.")}, DatabaseStatus::FAILED_CREATE});
+        return result;
     }
 
     // Wallet::Verify will check if we're trying to create a wallet with a duplicate name.
-    std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(name, options, status, error);
+    auto database{MakeWalletDatabase(name, options) >> result};
     if (!database) {
-        error = Untranslated("Wallet file verification failed.") + Untranslated(" ") + error;
-        status = DatabaseStatus::FAILED_VERIFY;
-        return nullptr;
+        auto& errors{result.messages().errors};
+        errors.insert(errors.begin(), Untranslated("Wallet file verification failed."));
+        result.update({util::Error{}, DatabaseStatus::FAILED_VERIFY});
+        return result;
     }
 
     // Make the wallet
     context.chain->initMessage(_("Creating wallet…"));
-    std::shared_ptr<CWallet> wallet = CWallet::CreateNew(context, name, std::move(database), wallet_creation_flags, born_encrypted, error, warnings);
-    if (!wallet) {
-        error = Untranslated("Wallet creation failed.") + Untranslated(" ") + error;
-        status = DatabaseStatus::FAILED_CREATE;
-        return nullptr;
+    auto create{CWallet::CreateNew(context, name, std::move(database.value()), wallet_creation_flags, born_encrypted) >> result};
+    if (!create) {
+        result.update({util::Error{Untranslated("Wallet creation failed.")}, DatabaseStatus::FAILED_CREATE});
+        return result;
     }
+    std::shared_ptr<CWallet> wallet = create.value();
 
     // Encrypt the wallet
     if (born_encrypted) {
         if (!wallet->EncryptWallet(passphrase)) {
-            error = Untranslated("Error: Wallet created but failed to encrypt.");
-            status = DatabaseStatus::FAILED_ENCRYPT;
-            return nullptr;
+            result.update({util::Error{Untranslated("Error: Wallet created but failed to encrypt.")}, DatabaseStatus::FAILED_ENCRYPT});
+            return result;
         }
     }
 
@@ -448,22 +448,22 @@ std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string&
     wallet->postInitProcess();
 
     // Write the wallet settings
-    UpdateWalletSetting(*context.chain, name, load_on_start, warnings);
+    UpdateWalletSetting(*context.chain, name, load_on_start) >> result;
 
-    status = DatabaseStatus::SUCCESS;
-    return wallet;
+    result.update(std::move(wallet));
+    return result;
 }
 
 // Re-creates wallet from the backup file by renaming and moving it into the wallet's directory.
 // If 'load_after_restore=true', the wallet object will be fully initialized and appended to the context.
-std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings, bool load_after_restore, bool allow_unnamed)
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, bool load_after_restore, bool allow_unnamed)
 {
+    util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> result;
     // Error if the wallet name is empty and allow_unnamed == false
     // allow_unnamed == true is only used by migration to migrate an unnamed wallet
     if (!allow_unnamed && wallet_name.empty()) {
-        error = Untranslated("Wallet name cannot be empty");
-        status = DatabaseStatus::FAILED_NEW_UNNAMED;
-        return nullptr;
+        result.update({util::Error{Untranslated("Wallet name cannot be empty")}, DatabaseStatus::FAILED_NEW_UNNAMED});
+        return result;
     }
 
     DatabaseOptions options;
@@ -472,15 +472,13 @@ std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& b
 
     const fs::path wallet_path = fsbridge::AbsPathJoin(GetWalletDir(), fs::u8path(wallet_name));
     auto wallet_file = wallet_path / "wallet.dat";
-    std::shared_ptr<CWallet> wallet;
     bool wallet_file_copied = false;
     bool created_parent_dir = false;
 
     try {
         if (!fs::exists(backup_file)) {
-            error = Untranslated("Backup file does not exist");
-            status = DatabaseStatus::FAILED_INVALID_BACKUP_FILE;
-            return nullptr;
+            result.update({util::Error{Untranslated("Backup file does not exist")}, DatabaseStatus::FAILED_INVALID_BACKUP_FILE});
+            return result;
         }
 
         // Wallet directories are allowed to exist, but must not contain a .dat file.
@@ -488,23 +486,20 @@ std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& b
         if (fs::exists(wallet_path)) {
             // If this is a file, it is the db and we don't want to overwrite it.
             if (!fs::is_directory(wallet_path)) {
-                error = Untranslated(strprintf("Failed to restore wallet. Database file exists '%s'.", fs::PathToString(wallet_path)));
-                status = DatabaseStatus::FAILED_ALREADY_EXISTS;
-                return nullptr;
+                result.update({util::Error{Untranslated(strprintf("Failed to restore wallet. Database file exists '%s'.", fs::PathToString(wallet_path)))}, DatabaseStatus::FAILED_ALREADY_EXISTS});
+                return result;
             }
 
             // Check we are not going to overwrite an existing db file
             if (fs::exists(wallet_file)) {
-                error = Untranslated(strprintf("Failed to restore wallet. Database file exists in '%s'.", fs::PathToString(wallet_file)));
-                status = DatabaseStatus::FAILED_ALREADY_EXISTS;
-                return nullptr;
+                result.update({util::Error{Untranslated(strprintf("Failed to restore wallet. Database file exists in '%s'.", fs::PathToString(wallet_file)))}, DatabaseStatus::FAILED_ALREADY_EXISTS});
+                return result;
             }
         } else {
             // The directory doesn't exist, create it
             if (!TryCreateDirectories(wallet_path)) {
-                error = Untranslated(strprintf("Failed to restore database path '%s'.", fs::PathToString(wallet_path)));
-                status = DatabaseStatus::FAILED_ALREADY_EXISTS;
-                return nullptr;
+                result.update({util::Error{Untranslated(strprintf("Failed to restore database path '%s'.", fs::PathToString(wallet_path)))}, DatabaseStatus::FAILED_ALREADY_EXISTS});
+                return result;
             }
             created_parent_dir = true;
         }
@@ -513,16 +508,16 @@ std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& b
         wallet_file_copied = true;
 
         if (load_after_restore) {
-            wallet = LoadWallet(context, wallet_name, load_on_start, options, status, error, warnings);
+            result.update(LoadWallet(context, wallet_name, load_on_start, options));
         }
     } catch (const std::exception& e) {
-        assert(!wallet);
-        if (!error.empty()) error += Untranslated("\n");
-        error += Untranslated(strprintf("Unexpected exception: %s", e.what()));
+        assert(!result.value());
+        result.update({util::Error{Untranslated(strprintf("Unexpected exception: %s", e.what()))}, DatabaseStatus::FAILED_LOAD});
+        return result;
     }
 
     // Remove created wallet path only when loading fails
-    if (load_after_restore && !wallet) {
+    if (load_after_restore && !result) {
         if (wallet_file_copied) fs::remove(wallet_file);
         // Clean up the parent directory if we created it during restoration.
         // As we have created it, it must be empty after deleting the wallet file.
@@ -532,7 +527,7 @@ std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& b
         }
     }
 
-    return wallet;
+    return result;
 }
 
 /** @defgroup mapWallet
@@ -2378,13 +2373,17 @@ void CWallet::CommitTransaction(
     }
 }
 
-DBErrors CWallet::PopulateWalletFromDB(bilingual_str& error, std::vector<bilingual_str>& warnings)
+Result<void, DBErrors> CWallet::PopulateWalletFromDB()
 {
+    Result<void, DBErrors> result;
     LOCK(cs_wallet);
 
     Assert(m_spk_managers.empty());
     Assert(m_wallet_flags == 0);
     DBErrors nLoadWalletRet = WalletBatch(GetDatabase()).LoadWallet(this);
+    if (nLoadWalletRet != DBErrors::LOAD_OK) {
+        result.update({Error{}, nLoadWalletRet});
+    }
 
     if (m_spk_managers.empty()) {
         assert(m_external_spk_managers.empty());
@@ -2396,40 +2395,40 @@ DBErrors CWallet::PopulateWalletFromDB(bilingual_str& error, std::vector<bilingu
     case DBErrors::LOAD_OK:
         break;
     case DBErrors::NONCRITICAL_ERROR:
-        warnings.push_back(strprintf(_("Error reading %s! All keys read correctly, but transaction data"
-                                       " or address metadata may be missing or incorrect."),
+        result.messages().warnings.push_back(strprintf(_("Error reading %s! All keys read correctly, but transaction data"
+                                    " or address metadata may be missing or incorrect."),
             wallet_file));
         break;
     case DBErrors::NEED_RESCAN:
-        warnings.push_back(strprintf(_("Error reading %s! Transaction data may be missing or incorrect."
-                                       " Rescanning wallet."), wallet_file));
+        result.messages().warnings.push_back(strprintf(_("Error reading %s! Transaction data may be missing or incorrect."
+                                    " Rescanning wallet."), wallet_file));
         break;
     case DBErrors::CORRUPT:
-        error = strprintf(_("Error loading %s: Wallet corrupted"), wallet_file);
+        result.messages().errors.push_back(strprintf(_("Error loading %s: Wallet corrupted"), wallet_file));
         break;
     case DBErrors::TOO_NEW:
-        error = strprintf(_("Error loading %s: Wallet requires newer version of %s"), wallet_file, CLIENT_NAME);
+        result.messages().errors.push_back(strprintf(_("Error loading %s: Wallet requires newer version of %s"), wallet_file, CLIENT_NAME));
         break;
     case DBErrors::EXTERNAL_SIGNER_SUPPORT_REQUIRED:
-        error = strprintf(_("Error loading %s: External signer wallet being loaded without external signer support compiled"), wallet_file);
+        result.messages().errors.push_back(strprintf(_("Error loading %s: External signer wallet being loaded without external signer support compiled"), wallet_file));
         break;
     case DBErrors::UNKNOWN_DESCRIPTOR:
-        error = strprintf(_("Unrecognized descriptor found. Loading wallet %s\n\n"
+        result.messages().errors.push_back(strprintf(_("Unrecognized descriptor found. Loading wallet %s\n\n"
                             "The wallet might have been created on a newer version.\n"
-                            "Please try running the latest software version.\n"), wallet_file);
+                            "Please try running the latest software version.\n"), wallet_file));
         break;
     case DBErrors::UNEXPECTED_LEGACY_ENTRY:
-        error = strprintf(_("Unexpected legacy entry in descriptor wallet found. Loading wallet %s\n\n"
-                            "The wallet might have been tampered with or created with malicious intent.\n"), wallet_file);
+        result.messages().errors.push_back(strprintf(_("Unexpected legacy entry in descriptor wallet found. Loading wallet %s\n\n"
+                            "The wallet might have been tampered with or created with malicious intent.\n"), wallet_file));
         break;
     case DBErrors::LEGACY_WALLET:
-        error = strprintf(_("Error loading %s: Wallet is a legacy wallet. Please migrate to a descriptor wallet using the migration tool (migratewallet RPC)."), wallet_file);
+        result.messages().errors.push_back(strprintf(_("Error loading %s: Wallet is a legacy wallet. Please migrate to a descriptor wallet using the migration tool (migratewallet RPC)."), wallet_file));
         break;
     case DBErrors::LOAD_FAIL:
-        error = strprintf(_("Error loading %s"), wallet_file);
+        result.messages().errors.push_back(strprintf(_("Error loading %s"), wallet_file));
         break;
     } // no default case, so the compiler can warn about missing cases
-    return nLoadWalletRet;
+    return result;
 }
 
 util::Result<void> CWallet::RemoveTxs(std::vector<Txid>& txs_to_remove)
@@ -2970,27 +2969,29 @@ util::Result<fs::path> GetWalletPath(const std::string& name)
     return wallet_path;
 }
 
-std::unique_ptr<WalletDatabase> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error_string)
+util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options)
 {
-    const auto& wallet_path = GetWalletPath(name);
+    util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> result;
+    auto wallet_path{GetWalletPath(name) >> result};
     if (!wallet_path) {
-        error_string = util::ErrorString(wallet_path);
-        status = DatabaseStatus::FAILED_BAD_PATH;
-        return nullptr;
+        result.update({util::Error{}, DatabaseStatus::FAILED_BAD_PATH});
+        return result;
     }
-    return ResultExtract(MakeDatabase(*wallet_path, options), &status, &error_string);
+    result.update(MakeDatabase(*wallet_path, options));
+    return result;
 }
 
-bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContext& context, bilingual_str& error, std::vector<bilingual_str>& warnings)
+util::Result<void> CWallet::LoadWalletArgs(const ArgsManager& args)
 {
-    interfaces::Chain* chain = context.chain;
-    const ArgsManager& args = *Assert(context.args);
+    util::Result<void> result;
+    CWallet* wallet = this;
+    interfaces::Chain* chain = m_chain;
 
     if (!args.GetArg("-addresstype", "").empty()) {
         std::optional<OutputType> parsed = ParseOutputType(args.GetArg("-addresstype", ""));
         if (!parsed) {
-            error = strprintf(_("Unknown address type '%s'"), args.GetArg("-addresstype", ""));
-            return false;
+            result.update(Error{strprintf(_("Unknown address type '%s'"), args.GetArg("-addresstype", ""))});
+            return result;
         }
         wallet->m_default_address_type = parsed.value();
     }
@@ -2998,8 +2999,8 @@ bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContex
     if (!args.GetArg("-changetype", "").empty()) {
         std::optional<OutputType> parsed = ParseOutputType(args.GetArg("-changetype", ""));
         if (!parsed) {
-            error = strprintf(_("Unknown change type '%s'"), args.GetArg("-changetype", ""));
-            return false;
+            result.update(Error{strprintf(_("Unknown change type '%s'"), args.GetArg("-changetype", ""))});
+            return result;
         }
         wallet->m_default_change_type = parsed.value();
     }
@@ -3007,10 +3008,10 @@ bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContex
     if (const auto arg{args.GetArg("-mintxfee")}) {
         std::optional<CAmount> min_tx_fee = ParseMoney(*arg);
         if (!min_tx_fee) {
-            error = AmountErrMsg("mintxfee", *arg);
-            return false;
+            result.update(Error{AmountErrMsg("mintxfee", *arg)});
+            return result;
         } else if (min_tx_fee.value() > HIGH_TX_FEE_PER_KB) {
-            warnings.push_back(AmountHighWarn("-mintxfee") + Untranslated(" ") +
+            result.messages().warnings.push_back(AmountHighWarn("-mintxfee") + Untranslated(" ") +
                                _("This is the minimum transaction fee you pay on every transaction."));
         }
 
@@ -3023,23 +3024,23 @@ bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContex
             wallet->m_max_aps_fee = -1;
         } else if (std::optional<CAmount> max_fee = ParseMoney(max_aps_fee)) {
             if (max_fee.value() > HIGH_APS_FEE) {
-                warnings.push_back(AmountHighWarn("-maxapsfee") + Untranslated(" ") +
+                result.messages().warnings.push_back(AmountHighWarn("-maxapsfee") + Untranslated(" ") +
                                   _("This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection."));
             }
             wallet->m_max_aps_fee = max_fee.value();
         } else {
-            error = AmountErrMsg("maxapsfee", max_aps_fee);
-            return false;
+            result.update(Error{AmountErrMsg("maxapsfee", max_aps_fee)});
+            return result;
         }
     }
 
     if (const auto arg{args.GetArg("-fallbackfee")}) {
         std::optional<CAmount> fallback_fee = ParseMoney(*arg);
         if (!fallback_fee) {
-            error = strprintf(_("Invalid amount for %s=<amount>: '%s'"), "-fallbackfee", *arg);
-            return false;
+            result.update(Error{strprintf(_("Invalid amount for %s=<amount>: '%s'"), "-fallbackfee", *arg)});
+            return result;
         } else if (fallback_fee.value() > HIGH_TX_FEE_PER_KB) {
-            warnings.push_back(AmountHighWarn("-fallbackfee") + Untranslated(" ") +
+            result.messages().warnings.push_back(AmountHighWarn("-fallbackfee") + Untranslated(" ") +
                                _("This is the transaction fee you may pay when fee estimates are not available."));
         }
         wallet->m_fallback_fee = CFeeRate{fallback_fee.value()};
@@ -3051,10 +3052,10 @@ bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContex
     if (const auto arg{args.GetArg("-discardfee")}) {
         std::optional<CAmount> discard_fee = ParseMoney(*arg);
         if (!discard_fee) {
-            error = strprintf(_("Invalid amount for %s=<amount>: '%s'"), "-discardfee", *arg);
-            return false;
+            result.update(Error{strprintf(_("Invalid amount for %s=<amount>: '%s'"), "-discardfee", *arg)});
+            return result;
         } else if (discard_fee.value() > HIGH_TX_FEE_PER_KB) {
-            warnings.push_back(AmountHighWarn("-discardfee") + Untranslated(" ") +
+            result.messages().warnings.push_back(AmountHighWarn("-discardfee") + Untranslated(" ") +
                                _("This is the transaction fee you may discard if change is smaller than dust at this level"));
         }
         wallet->m_discard_rate = CFeeRate{discard_fee.value()};
@@ -3063,16 +3064,16 @@ bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContex
     if (const auto arg{args.GetArg("-maxtxfee")}) {
         std::optional<CAmount> max_fee = ParseMoney(*arg);
         if (!max_fee) {
-            error = AmountErrMsg("maxtxfee", *arg);
-            return false;
+            result.update(Error{AmountErrMsg("maxtxfee", *arg)});
+            return result;
         } else if (max_fee.value() > HIGH_MAX_TX_FEE) {
-            warnings.push_back(strprintf(_("%s is set very high! Fees this large could be paid on a single transaction."), "-maxtxfee"));
+            result.messages().warnings.push_back(strprintf(_("%s is set very high! Fees this large could be paid on a single transaction."), "-maxtxfee"));
         }
 
         if (chain && CFeeRate{max_fee.value(), 1000} < chain->relayMinFee()) {
-            error = strprintf(_("Invalid amount for %s=<amount>: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)"),
-                "-maxtxfee", *arg, chain->relayMinFee().ToString());
-            return false;
+            result.update(Error{strprintf(_("Invalid amount for %s=<amount>: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)"),
+                "-maxtxfee", *arg, chain->relayMinFee().ToString())});
+            return result;
         }
 
         wallet->m_default_max_tx_fee = max_fee.value();
@@ -3082,13 +3083,13 @@ bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContex
         if (std::optional<CAmount> consolidate_feerate = ParseMoney(*arg)) {
             wallet->m_consolidate_feerate = CFeeRate(*consolidate_feerate);
         } else {
-            error = AmountErrMsg("consolidatefeerate", *arg);
-            return false;
+            result.update(Error{AmountErrMsg("consolidatefeerate", *arg)});
+            return result;
         }
     }
 
     if (chain && chain->relayMinFee().GetFeePerK() > HIGH_TX_FEE_PER_KB) {
-        warnings.push_back(AmountHighWarn("-minrelaytxfee") + Untranslated(" ") +
+        result.messages().warnings.push_back(AmountHighWarn("-minrelaytxfee") + Untranslated(" ") +
                            _("The wallet will avoid paying less than the minimum relay fee."));
     }
 
@@ -3096,7 +3097,7 @@ bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContex
     wallet->m_spend_zero_conf_change = args.GetBoolArg("-spendzeroconfchange", DEFAULT_SPEND_ZEROCONF_CHANGE);
     wallet->m_signal_rbf = DEFAULT_WALLET_RBF;
     if (auto value{args.GetBoolArg("-walletrbf")}) {
-        warnings.push_back(_("-walletrbf is deprecated and will be fully removed in the next release."));
+        result.messages().warnings.push_back(_("-walletrbf is deprecated and will be fully removed in the next release."));
         wallet->m_signal_rbf = *value;
     }
 
@@ -3104,11 +3105,12 @@ bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContex
     wallet->m_notify_tx_changed_script = args.GetArg("-walletnotify", "");
     wallet->SetBroadcastTransactions(args.GetBoolArg("-walletbroadcast", DEFAULT_WALLETBROADCAST));
 
-    return true;
+    return result;
 }
 
-std::shared_ptr<CWallet> CWallet::CreateNew(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, uint64_t wallet_creation_flags, bool born_encrypted, bilingual_str& error, std::vector<bilingual_str>& warnings)
+util::ResultPtr<std::shared_ptr<CWallet>> CWallet::CreateNew(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, uint64_t wallet_creation_flags, bool born_encrypted)
 {
+    util::ResultPtr<std::shared_ptr<CWallet>> result;
     interfaces::Chain* chain = context.chain;
     const std::string& walletFile = database->Filename();
 
@@ -3117,14 +3119,15 @@ std::shared_ptr<CWallet> CWallet::CreateNew(WalletContext& context, const std::s
     // should be possible to use std::allocate_shared.
     std::shared_ptr<CWallet> walletInstance(new CWallet(chain, name, std::move(database)), FlushAndDeleteWallet);
 
-    if (!LoadWalletArgs(walletInstance, context, error, warnings)) {
-        return nullptr;
+    if (!(walletInstance->LoadWalletArgs(*Assert(context.args)) >> result)) {
+        result.update(Error{});
+        return result;
     }
 
     // Initialize version key.
     if(!WalletBatch(walletInstance->GetDatabase()).WriteVersion(CLIENT_VERSION)) {
-        error = strprintf(_("Error creating %s: Could not write version metadata."), walletFile);
-        return nullptr;
+        result.update(Error{strprintf(_("Error creating %s: Could not write version metadata."), walletFile)});
+        return result;
     }
     {
         LOCK(walletInstance->cs_wallet);
@@ -3154,37 +3157,41 @@ std::shared_ptr<CWallet> CWallet::CreateNew(WalletContext& context, const std::s
     // Try to top up keypool. No-op if the wallet is locked.
     walletInstance->TopUpKeyPool();
 
-    if (chain && !AttachChain(walletInstance, *chain, /*rescan_required=*/false, error, warnings)) {
+    if (chain && !(AttachChain(walletInstance, *chain, /*rescan_required=*/false) >> result)) {
         walletInstance->DisconnectChainNotifications();
-        return nullptr;
+        result.update(Error{});
+        return result;
     }
 
     return walletInstance;
 }
 
-std::shared_ptr<CWallet> CWallet::LoadExisting(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, bilingual_str& error, std::vector<bilingual_str>& warnings)
+util::ResultPtr<std::shared_ptr<CWallet>> CWallet::LoadExisting(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database)
 {
+    util::ResultPtr<std::shared_ptr<CWallet>> result;
     interfaces::Chain* chain = context.chain;
     const std::string& walletFile = database->Filename();
 
     const auto start{SteadyClock::now()};
     std::shared_ptr<CWallet> walletInstance(new CWallet(chain, name, std::move(database)), FlushAndDeleteWallet);
 
-    if (!LoadWalletArgs(walletInstance, context, error, warnings)) {
-        return nullptr;
+    if (!(walletInstance->LoadWalletArgs(*Assert(context.args)) >> result)) {
+        result.update(Error{});
+        return result;
     }
 
     // Load wallet
-    auto nLoadWalletRet = walletInstance->PopulateWalletFromDB(error, warnings);
-    bool rescan_required = nLoadWalletRet == DBErrors::NEED_RESCAN;
-    if (nLoadWalletRet != DBErrors::LOAD_OK && nLoadWalletRet != DBErrors::NONCRITICAL_ERROR && !rescan_required) {
-        return nullptr;
+    auto populate{walletInstance->PopulateWalletFromDB() >> result};
+    bool rescan_required = !populate && populate.error() == DBErrors::NEED_RESCAN;
+    if (!populate && populate.error() != DBErrors::NONCRITICAL_ERROR && !rescan_required) {
+        result.update(Error{});
+        return result;
     }
 
     if (walletInstance->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
         for (auto spk_man : walletInstance->GetActiveScriptPubKeyMans()) {
             if (spk_man->HavePrivateKeys()) {
-                warnings.push_back(strprintf(_("Warning: Private keys detected in wallet {%s} with disabled private keys"), walletFile));
+                result.messages().warnings.push_back(strprintf(_("Warning: Private keys detected in wallet {%s} with disabled private keys"), walletFile));
                 break;
             }
         }
@@ -3195,18 +3202,20 @@ std::shared_ptr<CWallet> CWallet::LoadExisting(WalletContext& context, const std
     // Try to top up keypool. No-op if the wallet is locked.
     walletInstance->TopUpKeyPool();
 
-    if (chain && !AttachChain(walletInstance, *chain, rescan_required, error, warnings)) {
+    if (chain && !(AttachChain(walletInstance, *chain, rescan_required) >> result)) {
         walletInstance->DisconnectChainNotifications();
-        return nullptr;
+        result.update(util::Error{});
+        return result;
     }
 
     WITH_LOCK(walletInstance->cs_wallet, walletInstance->LogStats());
 
-    return walletInstance;
+    result.update(std::move(walletInstance));
+    return result;
 }
 
 
-bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interfaces::Chain& chain, const bool rescan_required, bilingual_str& error, std::vector<bilingual_str>& warnings)
+util::Result<void> CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interfaces::Chain& chain, const bool rescan_required)
 {
     LOCK(walletInstance->cs_wallet);
     // allow setting the chain if it hasn't been set already but prevent changing it
@@ -3221,8 +3230,7 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
             // Wallet is assumed to be from another chain, if genesis block in the active
             // chain differs from the genesis block known to the wallet.
             if (chain.getBlockHash(0) != locator.vHave.back()) {
-                error = Untranslated("Wallet files should not be reused across chains. Restart bitcoind with -walletcrosschain to override.");
-                return false;
+                return {util::Error{Untranslated("Wallet files should not be reused across chains. Restart bitcoind with -walletcrosschain to override.")}};
             }
         }
     }
@@ -3290,15 +3298,14 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
                 // If a block is pruned after this check, we will load the wallet,
                 // but fail the rescan with a generic error.
 
-                error = chain.havePruned() ?
+                return {util::Error{chain.havePruned() ?
                      _("Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of a pruned node)") :
                      strprintf(_(
                         "Error loading wallet. Wallet requires blocks to be downloaded, "
                         "and software does not currently support loading wallets while "
                         "blocks are being downloaded out of order when using assumeutxo "
                         "snapshots. Wallet should be able to load successfully after "
-                        "node sync reaches height %s"), block_height);
-                return false;
+                        "node sync reaches height %s"), block_height)}};
             }
         }
 
@@ -3308,13 +3315,11 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
         {
             WalletRescanReserver reserver(*walletInstance);
             if (!reserver.reserve()) {
-                error = _("Failed to acquire rescan reserver during wallet initialization");
-                return false;
+                return {util::Error{_("Failed to acquire rescan reserver during wallet initialization")}};
             }
             ScanResult scan_res = walletInstance->ScanForWalletTransactions(chain.getBlockHash(rescan_height), rescan_height, /*max_height=*/{}, reserver, /*save_progress=*/true);
             if (ScanResult::SUCCESS != scan_res.status) {
-                error = _("Failed to rescan the wallet during initialization");
-                return false;
+                return {util::Error{_("Failed to rescan the wallet during initialization")}};
             }
             // Set and update the best block record
             // Set last block scanned as the last block processed as it may be different in case of a reorg.
@@ -3323,7 +3328,7 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
         }
     }
 
-    return true;
+    return {};
 }
 
 const CAddressBookData* CWallet::FindAddressBookEntry(const CTxDestination& dest, bool allow_change) const
@@ -3851,15 +3856,16 @@ util::Result<std::reference_wrapper<DescriptorScriptPubKeyMan>> CWallet::AddWall
     return std::reference_wrapper(*spk_man);
 }
 
-bool CWallet::MigrateToSQLite(bilingual_str& error)
+util::Result<void> CWallet::MigrateToSQLite()
 {
     AssertLockHeld(cs_wallet);
+    util::Result<void> result;
 
     WalletLogPrintf("Migrating wallet storage database from BerkeleyDB to SQLite.\n");
 
     if (m_database->Format() == "sqlite") {
-        error = _("Error: This wallet already uses SQLite");
-        return false;
+        result.update(util::Error{_("Error: This wallet already uses SQLite")});
+        return result;
     }
 
     // Get all of the records for DB type migration
@@ -3867,8 +3873,8 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
     std::unique_ptr<DatabaseCursor> cursor = batch->GetNewCursor();
     std::vector<std::pair<SerializeData, SerializeData>> records;
     if (!cursor) {
-        error = _("Error: Unable to begin reading all records in the database");
-        return false;
+        result.update(util::Error{_("Error: Unable to begin reading all records in the database")});
+        return result;
     }
     DatabaseCursor::Status status = DatabaseCursor::Status::FAIL;
     while (true) {
@@ -3885,8 +3891,8 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
     cursor.reset();
     batch.reset();
     if (status != DatabaseCursor::Status::DONE) {
-        error = _("Error: Unable to read all records in the database");
-        return false;
+        result.update(util::Error{_("Error: Unable to read all records in the database")});
+        return result;
     }
 
     // Close this database and delete the file
@@ -3902,11 +3908,10 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
     DatabaseOptions opts;
     opts.require_create = true;
     opts.require_format = DatabaseFormat::SQLITE;
-    DatabaseStatus db_status;
-    std::unique_ptr<WalletDatabase> new_db = ResultExtract(MakeDatabase(wallet_path, opts), &db_status, &error);
+    auto new_db{MakeDatabase(wallet_path, opts) >> result};
     assert(new_db); // This is to prevent doing anything further with this wallet. The original file was deleted, but a backup exists.
     m_database.reset();
-    m_database = std::move(new_db);
+    m_database = std::move(new_db.value());
 
     // Write existing records into the new DB
     batch = m_database->MakeBatch();
@@ -3922,26 +3927,24 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
     }
     bool committed = batch->TxnCommit();
     assert(committed); // This is a critical error, the new db could not be written to. The original db exists as a backup, but we should not continue execution.
-    return true;
+    return result;
 }
 
-std::optional<MigrationData> CWallet::GetDescriptorsForLegacy(bilingual_str& error) const
+util::Result<MigrationData> CWallet::GetDescriptorsForLegacy() const
 {
     AssertLockHeld(cs_wallet);
 
     LegacyDataSPKM* legacy_spkm = GetLegacyDataSPKM();
     if (!Assume(legacy_spkm)) {
         // This shouldn't happen
-        error = Untranslated(STR_INTERNAL_BUG("Error: Legacy wallet data missing"));
-        return std::nullopt;
+        return util::Error{Untranslated(STR_INTERNAL_BUG("Error: Legacy wallet data missing"))};
     }
 
     std::optional<MigrationData> res = legacy_spkm->MigrateToDescriptor();
     if (res == std::nullopt) {
-        error = _("Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet's passphrase if it is encrypted.");
-        return std::nullopt;
+        return {util::Error{_("Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet's passphrase if it is encrypted.")}};
     }
-    return res;
+    return std::move(*res);
 }
 
 util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, MigrationData& data)
@@ -4167,13 +4170,17 @@ static std::string MigrationPrefixName(CWallet& wallet)
     return name.empty() ? "default_wallet" : name;
 }
 
-bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, MigrationResult& res, const bool load_on_startup = true) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+util::Result<void> DoMigration(CWallet& wallet, WalletContext& context, MigrationResult& res, const bool load_on_startup = true) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
     AssertLockHeld(wallet.cs_wallet);
+    util::Result<void> result;
 
     // Get all of the descriptors from the legacy wallet
-    std::optional<MigrationData> data = wallet.GetDescriptorsForLegacy(error);
-    if (data == std::nullopt) return false;
+    auto data{wallet.GetDescriptorsForLegacy() >> result};
+    if (!data) {
+        result.update(util::Error{});
+        return result;
+    }
 
     // Create the watchonly and solvable wallets if necessary
     if (data->watch_descs.size() > 0 || data->solvable_descs.size() > 0) {
@@ -4196,20 +4203,19 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
         if (data->watch_descs.size() > 0) {
             wallet.WalletLogPrintf("Making a new watchonly wallet containing the watched scripts\n");
 
-            DatabaseStatus status;
-            std::vector<bilingual_str> warnings;
             std::string wallet_name = MigrationPrefixName(wallet) + "_watchonly";
-            std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(wallet_name, options, status, error);
+            auto database{MakeWalletDatabase(wallet_name, options) >> result};
             if (!database) {
-                error = strprintf(_("Wallet file creation failed: %s"), error);
-                return false;
+                result.update(util::Error{_("Wallet file creation failed")});
+                return result;
             }
 
-            data->watchonly_wallet = CWallet::CreateNew(empty_context, wallet_name, std::move(database), options.create_flags, /*born_encrypted=*/false, error, warnings);
-            if (!data->watchonly_wallet) {
-                error = _("Error: Failed to create new watchonly wallet");
-                return false;
+            auto watchonly_wallet{CWallet::CreateNew(empty_context, wallet_name, std::move(database.value()), options.create_flags, /*born_encrypted=*/false) >> result};
+            if (!watchonly_wallet) {
+                result.update(util::Error{_("Error: Failed to create new watchonly wallet")});
+                return result;
             }
+            data->watchonly_wallet = std::move(watchonly_wallet.value());
             res.watchonly_wallet = data->watchonly_wallet;
             LOCK(data->watchonly_wallet->cs_wallet);
 
@@ -4231,25 +4237,24 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
             }
 
             // Add the wallet to settings
-            UpdateWalletSetting(*context.chain, wallet_name, load_on_startup, warnings);
+            UpdateWalletSetting(*context.chain, wallet_name, load_on_startup) >> result;
         }
         if (data->solvable_descs.size() > 0) {
             wallet.WalletLogPrintf("Making a new watchonly wallet containing the unwatched solvable scripts\n");
 
-            DatabaseStatus status;
-            std::vector<bilingual_str> warnings;
             std::string wallet_name = MigrationPrefixName(wallet) + "_solvables";
-            std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(wallet_name, options, status, error);
+            auto database{MakeWalletDatabase(wallet_name, options) >> result};
             if (!database) {
-                error = strprintf(_("Wallet file creation failed: %s"), error);
-                return false;
+                result.update(util::Error{_("Wallet file creation failed")});
+                return result;
             }
 
-            data->solvable_wallet = CWallet::CreateNew(empty_context, wallet_name, std::move(database), options.create_flags, /*born_encrypted=*/false, error, warnings);
-            if (!data->solvable_wallet) {
-                error = _("Error: Failed to create new watchonly wallet");
-                return false;
+            auto solvable_wallet{CWallet::CreateNew(empty_context, wallet_name, std::move(database.value()), options.create_flags, /*born_encrypted=*/false) >> result};
+            if (!solvable_wallet) {
+                result.update(util::Error{_("Error: Failed to create new watchonly wallet")});
+                return result;
             }
+            data->solvable_wallet = std::move(solvable_wallet.value());
             res.solvables_wallet = data->solvable_wallet;
             LOCK(data->solvable_wallet->cs_wallet);
 
@@ -4271,30 +4276,29 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
             }
 
             // Add the wallet to settings
-            UpdateWalletSetting(*context.chain, wallet_name, load_on_startup, warnings);
+            UpdateWalletSetting(*context.chain, wallet_name, load_on_startup) >> result;
         }
     }
 
     // Add the descriptors to the wallet, remove the LegacyDataSPKM, and clean up transactions and address book data
-    return RunWithinTxn(wallet.GetDatabase(), /*process_desc=*/"apply migration process", [&](WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet){
-        if (auto res_migration = wallet.ApplyMigrationData(batch, *data); !res_migration) {
-            error = util::ErrorString(res_migration);
-            return false;
-        }
-        wallet.WalletLogPrintf("Wallet migration complete.\n");
-        return true;
-    });
+    bool committed{RunWithinTxn(wallet.GetDatabase(), /*process_desc=*/"apply migration process", [&](WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet){
+        result.update(wallet.ApplyMigrationData(batch, *data));
+        if (result) wallet.WalletLogPrintf("Wallet migration complete.\n");
+        return bool{result};
+    })};
+    if (result && !committed) result.update(util::Error{_("Error starting/committing db txn for wallet migration process")});
+    return result;
 }
 
 util::Result<MigrationResult> MigrateLegacyToDescriptor(const std::string& wallet_name, const SecureString& passphrase, WalletContext& context, bool load_wallet)
 {
-    std::vector<bilingual_str> warnings;
-    bilingual_str error;
+    util::Result<MigrationResult> result;
 
     // The only kind of wallets that could be loaded are descriptor ones, which don't need to be migrated.
     if (auto wallet = GetWallet(context, wallet_name)) {
         assert(wallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
-        return util::Error{_("Error: This wallet is already a descriptor wallet")};
+        result.update(util::Error{_("Error: This wallet is already a descriptor wallet")});
+        return result;
     } else {
         // Check if the wallet is BDB
         const auto& wallet_path = GetWalletPath(wallet_name);
@@ -4316,36 +4320,40 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(const std::string& walle
     DatabaseOptions options;
     options.require_existing = true;
     options.require_format = DatabaseFormat::BERKELEY_RO;
-    DatabaseStatus status;
-    std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(wallet_name, options, status, error);
+    auto database{MakeWalletDatabase(wallet_name, options) >> result};
     if (!database) {
-        return util::Error{Untranslated("Wallet file verification failed.") + Untranslated(" ") + error};
+        auto& errors{result.messages().errors};
+        errors.insert(errors.begin(), Untranslated("Wallet file verification failed."));
+        result.update(util::Error{});
+        return result;
     }
 
     // Make the local wallet
-    std::shared_ptr<CWallet> local_wallet = CWallet::LoadExisting(empty_context, wallet_name, std::move(database), error, warnings);
+    auto local_wallet{CWallet::LoadExisting(empty_context, wallet_name, std::move(database.value())) >> result};
     if (!local_wallet) {
-        return util::Error{Untranslated("Wallet loading failed.") + Untranslated(" ") + error};
+        auto& errors{result.messages().errors};
+        errors.insert(errors.begin(), Untranslated("Wallet loading failed."));
+        result.update(util::Error{});
+        return result;
     }
 
-    return MigrateLegacyToDescriptor(std::move(local_wallet), passphrase, context, load_wallet);
+    return MigrateLegacyToDescriptor(std::move(local_wallet.value()), passphrase, context, load_wallet);
 }
 
 util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet> local_wallet, const SecureString& passphrase, WalletContext& context, bool load_wallet)
 {
+    util::Result<MigrationResult> result{util::Error{}};
     MigrationResult res;
-    bilingual_str error;
-    std::vector<bilingual_str> warnings;
 
     DatabaseOptions options;
     options.require_existing = true;
-    DatabaseStatus status;
 
     const std::string wallet_name = local_wallet->GetName();
 
     // Before anything else, check if there is something to migrate.
     if (local_wallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
-        return util::Error{_("Error: This wallet is already a descriptor wallet")};
+        result.update(util::Error{_("Error: This wallet is already a descriptor wallet")});
+        return result;
     }
 
     // Make a backup of the DB in the wallet's directory with a unique filename
@@ -4363,23 +4371,23 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
     fs::path backup_filename = fs::PathFromString(strprintf("%s_%d.legacy.bak", backup_prefix, GetTime()));
     fs::path backup_path = fsbridge::AbsPathJoin(GetWalletDir(), backup_filename);
     if (!local_wallet->BackupWallet(fs::PathToString(backup_path))) {
-        return util::Error{_("Error: Unable to make a backup of your wallet")};
+        result.update(util::Error{_("Error: Unable to make a backup of your wallet")});
+        return result;
     }
     res.backup_path = backup_path;
-
-    bool success = false;
 
     // Unlock the wallet if needed
     if (local_wallet->IsLocked() && !local_wallet->Unlock(passphrase)) {
         if (passphrase.find('\0') == std::string::npos) {
-            return util::Error{Untranslated("Error: Wallet decryption failed, the wallet passphrase was not provided or was incorrect.")};
+            result.update(util::Error{Untranslated("Error: Wallet decryption failed, the wallet passphrase was not provided or was incorrect.")});
         } else {
-            return util::Error{Untranslated("Error: Wallet decryption failed, the wallet passphrase entered was incorrect. "
+            result.update(util::Error{Untranslated("Error: Wallet decryption failed, the wallet passphrase entered was incorrect. "
                                             "The passphrase contains a null character (ie - a zero byte). "
                                             "If this passphrase was set with a version of this software prior to 25.0, "
                                             "please try again with only the characters up to — but not including — "
-                                            "the first null character.")};
+                                            "the first null character.")});
         }
+        return result;
     }
 
     // Indicates whether the current wallet is empty after migration.
@@ -4393,17 +4401,22 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
     {
         LOCK(local_wallet->cs_wallet);
         // First change to using SQLite
-        if (!local_wallet->MigrateToSQLite(error)) return util::Error{error};
+        if (!(local_wallet->MigrateToSQLite() >> result)) {
+            result.update(util::Error{});
+            return result;
+        }
 
         // Do the migration of keys and scripts for non-empty wallets, and cleanup if it fails
         if (HasLegacyRecords(*local_wallet)) {
-            success = DoMigration(*local_wallet, context, error, res, load_wallet);
+            if (DoMigration(*local_wallet, context, res, load_wallet) >> result) {
+                result.update({});
+            }
             // No scripts mean empty wallet after migration
             empty_local_wallet = local_wallet->GetAllScriptPubKeyMans().empty();
         } else {
             // Make sure that descriptors flag is actually set
             local_wallet->SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
-            success = true;
+            result.update({});
         }
     }
 
@@ -4429,7 +4442,7 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
     };
 
 
-    if (success) {
+    if (result) {
         Assume(!res.wallet); // We will set it here.
         // Check if the local wallet is empty after migration
         if (empty_local_wallet) {
@@ -4444,12 +4457,12 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
             /** We only override the load_on_startup setting in case the user explicitly said
              * that he does not want to load the wallet, otherwise keep the old wallet configuration */
         } else {
-            UpdateWalletSetting(*context.chain, wallet_name, /*load_on_startup=*/false, warnings);
+            UpdateWalletSetting(*context.chain, wallet_name, /*load_on_startup=*/false) >> result;
         }
         // Migration successful, if load_wallet is set load all the migrated wallets.
         bool main_wallet_set{false};
         for (std::shared_ptr<CWallet>* wallet_ptr : {&local_wallet, &res.watchonly_wallet, &res.solvables_wallet}) {
-            if (success && *wallet_ptr) {
+            if (result && *wallet_ptr) {
                 std::shared_ptr<CWallet>& wallet = *wallet_ptr;
                 // Track db path
                 track_for_cleanup(*wallet);
@@ -4457,13 +4470,16 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
                 std::string wallet_name = wallet->GetName();
                 wallet.reset();
                 if (load_wallet) {
-                    wallet = LoadWallet(context, wallet_name, /*load_on_start=*/std::nullopt, options, status, error, warnings);
+                    auto loaded{LoadWallet(context, wallet_name, /*load_on_start=*/std::nullopt, options)};
+                    if (loaded) wallet = loaded.value();
                     if (!wallet) {
                         LogError("Failed to load wallet '%s' after migration. Rolling back migration to preserve consistency. "
-                                 "Error cause: %s\n", wallet_name, error.original);
-                        success = false;
+                                 "Error cause: %s\n", wallet_name, ErrorString(loaded).original);
+                        result.update(util::Error{});
+                        loaded >> result;
                         break;
                     }
+                    loaded >> result;
                 }
                 // Set the first wallet as the main one.
                 // The loop order is intentional and must always start with the local wallet.
@@ -4480,7 +4496,7 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
             }
         }
     }
-    if (!success) {
+    if (!result) {
         // Make list of wallets to cleanup
         std::vector<std::shared_ptr<CWallet>> created_wallets;
         if (local_wallet) created_wallets.push_back(std::move(local_wallet));
@@ -4496,9 +4512,9 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
         for (std::shared_ptr<CWallet>& w : created_wallets) {
             if (w->HaveChain()) {
                 // Unloading for wallets that were loaded for normal use
-                if (!RemoveWallet(context, w, /*load_on_start=*/false)) {
-                    error += _("\nUnable to cleanup failed migration");
-                    return util::Error{error};
+                if (!(RemoveWallet(context, w, /*load_on_start=*/false) >> result)) {
+                    result.update(util::Error{_("\nUnable to cleanup failed migration")});
+                    return result;
                 }
                 WaitForDeleteWallet(std::move(w));
             } else {
@@ -4521,18 +4537,18 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
 
         // Restore the backup
         // Convert the backup file to the wallet db file by renaming it and moving it into the wallet's directory.
-        bilingual_str restore_error;
-        const auto& ptr_wallet = RestoreWallet(context, backup_path, wallet_name, /*load_on_start=*/std::nullopt, status, restore_error, warnings, /*load_after_restore=*/false, /*allow_unnamed=*/true);
-        if (!restore_error.empty()) {
-            error += restore_error + _("\nUnable to restore backup of wallet.");
-            return util::Error{error};
+        auto ptr_wallet{RestoreWallet(context, backup_path, wallet_name, /*load_on_start=*/std::nullopt, /*load_after_restore=*/false, /*allow_unnamed=*/true) >> result};
+        if (!ptr_wallet) {
+            result.update(util::Error{_("Unable to restore backup of wallet.")});;
+            return result;
         }
         // Verify that the legacy wallet is not loaded after restoring from the backup.
         assert(!ptr_wallet);
 
-        return util::Error{error};
+        result.update(util::Error{});
     }
-    return res;
+    result.update(std::move(res));
+    return result;
 }
 
 void CWallet::CacheNewScriptPubKeys(const std::set<CScript>& spks, ScriptPubKeyMan* spkm)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2978,7 +2978,7 @@ std::unique_ptr<WalletDatabase> MakeWalletDatabase(const std::string& name, cons
         status = DatabaseStatus::FAILED_BAD_PATH;
         return nullptr;
     }
-    return MakeDatabase(*wallet_path, options, status, error_string);
+    return ResultExtract(MakeDatabase(*wallet_path, options), &status, &error_string);
 }
 
 bool CWallet::LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContext& context, bilingual_str& error, std::vector<bilingual_str>& warnings)
@@ -3903,7 +3903,7 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
     opts.require_create = true;
     opts.require_format = DatabaseFormat::SQLITE;
     DatabaseStatus db_status;
-    std::unique_ptr<WalletDatabase> new_db = MakeDatabase(wallet_path, opts, db_status, error);
+    std::unique_ptr<WalletDatabase> new_db = ResultExtract(MakeDatabase(wallet_path, opts), &db_status, &error);
     assert(new_db); // This is to prevent doing anything further with this wallet. The original file was deleted, but a backup exists.
     m_database.reset();
     m_database = std::move(new_db);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -284,9 +284,9 @@ void WaitForDeleteWallet(std::shared_ptr<CWallet>&& wallet)
 }
 
 namespace {
-util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> LoadWalletInternal(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options)
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError> LoadWalletInternal(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options)
 {
-    util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> result;
+    util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError> result;
     try {
         auto database{MakeWalletDatabase(name, options) >> result};
         if (!database) {
@@ -301,7 +301,7 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> LoadWalletInternal(Wal
         if (!wallet) {
             auto& errors{result.messages().errors};
             errors.insert(errors.begin(), Untranslated("Wallet loading failed."));
-            result.update({util::Error{}, DatabaseStatus::FAILED_LOAD});
+            result.update({util::Error{}, DatabaseError::FAILED_LOAD});
             return result;
         }
 
@@ -314,7 +314,7 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> LoadWalletInternal(Wal
 
         result.update(std::move(wallet.value()));
     } catch (const std::runtime_error& e) {
-        result.update({util::Error{Untranslated(e.what())}, DatabaseStatus::FAILED_LOAD});
+        result.update({util::Error{Untranslated(e.what())}, DatabaseError::FAILED_LOAD});
     }
     return result;
 }
@@ -375,23 +375,23 @@ private:
 };
 } // namespace
 
-util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options)
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options)
 {
     auto result = WITH_LOCK(g_loading_wallet_mutex, return g_loading_wallet_set.insert(name));
     if (!result.second) {
-        return {util::Error{Untranslated("Wallet already loading.")}, DatabaseStatus::FAILED_LOAD};
+        return {util::Error{Untranslated("Wallet already loading.")}, DatabaseError::FAILED_LOAD};
     }
     auto wallet{LoadWalletInternal(context, name, load_on_start, options)};
     WITH_LOCK(g_loading_wallet_mutex, g_loading_wallet_set.erase(result.first));
     return wallet;
 }
 
-util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options)
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options)
 {
-    util::Result<std::shared_ptr<CWallet>, DatabaseStatus> result;
+    util::Result<std::shared_ptr<CWallet>, DatabaseError> result;
     // Wallet must have a non-empty name
     if (name.empty()) {
-        result.update({util::Error{Untranslated("Wallet name cannot be empty")}, DatabaseStatus::FAILED_NEW_UNNAMED});
+        result.update({util::Error{Untranslated("Wallet name cannot be empty")}, DatabaseError::FAILED_NEW_UNNAMED});
         return result;
     }
 
@@ -406,13 +406,13 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> CreateWallet(WalletCon
 
     // Private keys must be disabled for an external signer wallet
     if ((wallet_creation_flags & WALLET_FLAG_EXTERNAL_SIGNER) && !(wallet_creation_flags & WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
-        result.update({util::Error{Untranslated("Private keys must be disabled when using an external signer")}, DatabaseStatus::FAILED_CREATE});
+        result.update({util::Error{Untranslated("Private keys must be disabled when using an external signer")}, DatabaseError::FAILED_CREATE});
         return result;
     }
 
     // Do not allow a passphrase when private keys are disabled
     if (born_encrypted && (wallet_creation_flags & WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
-        result.update({util::Error{Untranslated("Passphrase provided but private keys are disabled. A passphrase is only used to encrypt private keys, so cannot be used for wallets with private keys disabled.")}, DatabaseStatus::FAILED_CREATE});
+        result.update({util::Error{Untranslated("Passphrase provided but private keys are disabled. A passphrase is only used to encrypt private keys, so cannot be used for wallets with private keys disabled.")}, DatabaseError::FAILED_CREATE});
         return result;
     }
 
@@ -421,7 +421,7 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> CreateWallet(WalletCon
     if (!database) {
         auto& errors{result.messages().errors};
         errors.insert(errors.begin(), Untranslated("Wallet file verification failed."));
-        result.update({util::Error{}, DatabaseStatus::FAILED_VERIFY});
+        result.update({util::Error{}, DatabaseError::FAILED_VERIFY});
         return result;
     }
 
@@ -429,7 +429,7 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> CreateWallet(WalletCon
     context.chain->initMessage(_("Creating wallet…"));
     auto create{CWallet::CreateNew(context, name, std::move(database.value()), wallet_creation_flags, born_encrypted) >> result};
     if (!create) {
-        result.update({util::Error{Untranslated("Wallet creation failed.")}, DatabaseStatus::FAILED_CREATE});
+        result.update({util::Error{Untranslated("Wallet creation failed.")}, DatabaseError::FAILED_CREATE});
         return result;
     }
     std::shared_ptr<CWallet> wallet = create.value();
@@ -437,7 +437,7 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> CreateWallet(WalletCon
     // Encrypt the wallet
     if (born_encrypted) {
         if (!wallet->EncryptWallet(passphrase)) {
-            result.update({util::Error{Untranslated("Error: Wallet created but failed to encrypt.")}, DatabaseStatus::FAILED_ENCRYPT});
+            result.update({util::Error{Untranslated("Error: Wallet created but failed to encrypt.")}, DatabaseError::FAILED_ENCRYPT});
             return result;
         }
     }
@@ -456,13 +456,13 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> CreateWallet(WalletCon
 
 // Re-creates wallet from the backup file by renaming and moving it into the wallet's directory.
 // If 'load_after_restore=true', the wallet object will be fully initialized and appended to the context.
-util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, bool load_after_restore, bool allow_unnamed)
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, bool load_after_restore, bool allow_unnamed)
 {
-    util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> result;
+    util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError> result;
     // Error if the wallet name is empty and allow_unnamed == false
     // allow_unnamed == true is only used by migration to migrate an unnamed wallet
     if (!allow_unnamed && wallet_name.empty()) {
-        result.update({util::Error{Untranslated("Wallet name cannot be empty")}, DatabaseStatus::FAILED_NEW_UNNAMED});
+        result.update({util::Error{Untranslated("Wallet name cannot be empty")}, DatabaseError::FAILED_NEW_UNNAMED});
         return result;
     }
 
@@ -477,7 +477,7 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> RestoreWallet(WalletCo
 
     try {
         if (!fs::exists(backup_file)) {
-            result.update({util::Error{Untranslated("Backup file does not exist")}, DatabaseStatus::FAILED_INVALID_BACKUP_FILE});
+            result.update({util::Error{Untranslated("Backup file does not exist")}, DatabaseError::FAILED_INVALID_BACKUP_FILE});
             return result;
         }
 
@@ -486,19 +486,19 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> RestoreWallet(WalletCo
         if (fs::exists(wallet_path)) {
             // If this is a file, it is the db and we don't want to overwrite it.
             if (!fs::is_directory(wallet_path)) {
-                result.update({util::Error{Untranslated(strprintf("Failed to restore wallet. Database file exists '%s'.", fs::PathToString(wallet_path)))}, DatabaseStatus::FAILED_ALREADY_EXISTS});
+                result.update({util::Error{Untranslated(strprintf("Failed to restore wallet. Database file exists '%s'.", fs::PathToString(wallet_path)))}, DatabaseError::FAILED_ALREADY_EXISTS});
                 return result;
             }
 
             // Check we are not going to overwrite an existing db file
             if (fs::exists(wallet_file)) {
-                result.update({util::Error{Untranslated(strprintf("Failed to restore wallet. Database file exists in '%s'.", fs::PathToString(wallet_file)))}, DatabaseStatus::FAILED_ALREADY_EXISTS});
+                result.update({util::Error{Untranslated(strprintf("Failed to restore wallet. Database file exists in '%s'.", fs::PathToString(wallet_file)))}, DatabaseError::FAILED_ALREADY_EXISTS});
                 return result;
             }
         } else {
             // The directory doesn't exist, create it
             if (!TryCreateDirectories(wallet_path)) {
-                result.update({util::Error{Untranslated(strprintf("Failed to restore database path '%s'.", fs::PathToString(wallet_path)))}, DatabaseStatus::FAILED_ALREADY_EXISTS});
+                result.update({util::Error{Untranslated(strprintf("Failed to restore database path '%s'.", fs::PathToString(wallet_path)))}, DatabaseError::FAILED_ALREADY_EXISTS});
                 return result;
             }
             created_parent_dir = true;
@@ -512,7 +512,7 @@ util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> RestoreWallet(WalletCo
         }
     } catch (const std::exception& e) {
         assert(!result.value());
-        result.update({util::Error{Untranslated(strprintf("Unexpected exception: %s", e.what()))}, DatabaseStatus::FAILED_LOAD});
+        result.update({util::Error{Untranslated(strprintf("Unexpected exception: %s", e.what()))}, DatabaseError::FAILED_LOAD});
         return result;
     }
 
@@ -2969,12 +2969,12 @@ util::Result<fs::path> GetWalletPath(const std::string& name)
     return wallet_path;
 }
 
-util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options)
+util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseError> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options)
 {
-    util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> result;
+    util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseError> result;
     auto wallet_path{GetWalletPath(name) >> result};
     if (!wallet_path) {
-        result.update({util::Error{}, DatabaseStatus::FAILED_BAD_PATH});
+        result.update({util::Error{}, DatabaseError::FAILED_BAD_PATH});
         return result;
     }
     result.update(MakeDatabase(*wallet_path, options));

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -94,12 +94,12 @@ util::Result<void> RemoveWallet(WalletContext& context, const std::shared_ptr<CW
 std::vector<std::shared_ptr<CWallet>> GetWallets(WalletContext& context);
 std::shared_ptr<CWallet> GetDefaultWallet(WalletContext& context, size_t& count);
 std::shared_ptr<CWallet> GetWallet(WalletContext& context, const std::string& name);
-util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options);
-util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options);
-util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, bool load_after_restore = true, bool allow_unnamed = false);
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options);
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options);
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, bool load_after_restore = true, bool allow_unnamed = false);
 std::unique_ptr<interfaces::Handler> HandleLoadWallet(WalletContext& context, LoadWalletFn load_wallet);
 void NotifyWalletLoaded(WalletContext& context, const std::shared_ptr<CWallet>& wallet);
-util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options);
+util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseError> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options);
 
 //! -fallbackfee default
 static const CAmount DEFAULT_FALLBACK_FEE = 0;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -90,17 +90,16 @@ struct WalletContext;
 void WaitForDeleteWallet(std::shared_ptr<CWallet>&& wallet);
 
 bool AddWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet);
-bool RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet, std::optional<bool> load_on_start, std::vector<bilingual_str>& warnings);
-bool RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet, std::optional<bool> load_on_start);
+util::Result<void> RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet, std::optional<bool> load_on_start);
 std::vector<std::shared_ptr<CWallet>> GetWallets(WalletContext& context);
 std::shared_ptr<CWallet> GetDefaultWallet(WalletContext& context, size_t& count);
 std::shared_ptr<CWallet> GetWallet(WalletContext& context, const std::string& name);
-std::shared_ptr<CWallet> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings);
-std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings);
-std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings, bool load_after_restore = true, bool allow_unnamed = false);
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options);
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options);
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, bool load_after_restore = true, bool allow_unnamed = false);
 std::unique_ptr<interfaces::Handler> HandleLoadWallet(WalletContext& context, LoadWalletFn load_wallet);
 void NotifyWalletLoaded(WalletContext& context, const std::shared_ptr<CWallet>& wallet);
-std::unique_ptr<WalletDatabase> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error);
+util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options);
 
 //! -fallbackfee default
 static const CAmount DEFAULT_FALLBACK_FEE = 0;
@@ -441,7 +440,7 @@ private:
      * block locator and m_last_block_processed, and registering for
      * notifications about new blocks and transactions.
      */
-    static bool AttachChain(const std::shared_ptr<CWallet>& wallet, interfaces::Chain& chain, bool rescan_required, bilingual_str& error, std::vector<bilingual_str>& warnings);
+    static util::Result<void> AttachChain(const std::shared_ptr<CWallet>& wallet, interfaces::Chain& chain, bool rescan_required);
 
     static NodeClock::time_point GetDefaultNextResend();
 
@@ -794,7 +793,7 @@ public:
     bool IsFromMe(const CTransaction& tx) const;
     CAmount GetDebit(const CTransaction& tx) const;
 
-    DBErrors PopulateWalletFromDB(bilingual_str& error, std::vector<bilingual_str>& warnings);
+    util::Result<void, DBErrors> PopulateWalletFromDB();
 
     /** Erases the provided transactions from the wallet. */
     util::Result<void> RemoveTxs(std::vector<Txid>& txs_to_remove) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
@@ -868,13 +867,13 @@ public:
     /** Mark a transaction as replaced by another transaction. */
     bool MarkReplaced(const Txid& originalHash, const Txid& newHash);
 
-    static bool LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContext& context, bilingual_str& error, std::vector<bilingual_str>& warnings);
+    util::Result<void> LoadWalletArgs(const ArgsManager& args);
 
     /* Initializes, creates and returns a new CWallet; returns a null pointer in case of an error */
-    static std::shared_ptr<CWallet> CreateNew(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, uint64_t wallet_creation_flags, bool born_encrypted, bilingual_str& error, std::vector<bilingual_str>& warnings);
+    static util::ResultPtr<std::shared_ptr<CWallet>> CreateNew(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, uint64_t wallet_creation_flags, bool born_encrypted);
 
     /* Initializes, loads, and returns a CWallet from an existing wallet; returns a null pointer in case of an error */
-    static std::shared_ptr<CWallet> LoadExisting(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, bilingual_str& error, std::vector<bilingual_str>& warnings);
+    static util::ResultPtr<std::shared_ptr<CWallet>> LoadExisting(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database);
 
     /**
      * Wallet post-init setup
@@ -1052,10 +1051,10 @@ public:
      * A backup is not created.
      * May crash if something unexpected happens in the filesystem.
      */
-    bool MigrateToSQLite(bilingual_str& error) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    util::Result<void> MigrateToSQLite() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Get all of the descriptors from a legacy wallet
-    std::optional<MigrationData> GetDescriptorsForLegacy(bilingual_str& error) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    util::Result<MigrationData> GetDescriptorsForLegacy() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Adds the ScriptPubKeyMans given in MigrationData to this wallet, removes LegacyScriptPubKeyMan,
     //! and where needed, moves tx and address book entries to watchonly_wallet or solvable_wallet

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -90,17 +90,16 @@ struct WalletContext;
 void WaitForDeleteWallet(std::shared_ptr<CWallet>&& wallet);
 
 bool AddWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet);
-bool RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet, std::optional<bool> load_on_start, std::vector<bilingual_str>& warnings);
-bool RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet, std::optional<bool> load_on_start);
+util::Result<void> RemoveWallet(WalletContext& context, const std::shared_ptr<CWallet>& wallet, std::optional<bool> load_on_start);
 std::vector<std::shared_ptr<CWallet>> GetWallets(WalletContext& context);
 std::shared_ptr<CWallet> GetDefaultWallet(WalletContext& context, size_t& count);
 std::shared_ptr<CWallet> GetWallet(WalletContext& context, const std::string& name);
-std::shared_ptr<CWallet> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings);
-std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings);
-std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings, bool load_after_restore = true, bool allow_unnamed = false);
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options);
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options);
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, bool load_after_restore = true, bool allow_unnamed = false);
 std::unique_ptr<interfaces::Handler> HandleLoadWallet(WalletContext& context, LoadWalletFn load_wallet);
 void NotifyWalletLoaded(WalletContext& context, const std::shared_ptr<CWallet>& wallet);
-std::unique_ptr<WalletDatabase> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error);
+util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options);
 
 //! -fallbackfee default
 inline constexpr CAmount DEFAULT_FALLBACK_FEE = 0;
@@ -441,7 +440,7 @@ private:
      * block locator and m_last_block_processed, and registering for
      * notifications about new blocks and transactions.
      */
-    static bool AttachChain(const std::shared_ptr<CWallet>& wallet, interfaces::Chain& chain, bool rescan_required, bilingual_str& error, std::vector<bilingual_str>& warnings);
+    static util::Result<void> AttachChain(const std::shared_ptr<CWallet>& wallet, interfaces::Chain& chain, bool rescan_required);
 
     static NodeClock::time_point GetDefaultNextResend();
 
@@ -803,7 +802,7 @@ public:
     bool IsFromMe(const CTransaction& tx) const;
     CAmount GetDebit(const CTransaction& tx) const;
 
-    DBErrors PopulateWalletFromDB(bilingual_str& error, std::vector<bilingual_str>& warnings);
+    util::Result<void, DBErrors> PopulateWalletFromDB();
 
     /** Erases the provided transactions from the wallet. */
     util::Result<void> RemoveTxs(std::vector<Txid>& txs_to_remove) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
@@ -877,13 +876,13 @@ public:
     /** Mark a transaction as replaced by another transaction. */
     bool MarkReplaced(const Txid& originalHash, const Txid& newHash);
 
-    static bool LoadWalletArgs(std::shared_ptr<CWallet> wallet, const WalletContext& context, bilingual_str& error, std::vector<bilingual_str>& warnings);
+    util::Result<void> LoadWalletArgs(const ArgsManager& args);
 
     /* Initializes, creates and returns a new CWallet; returns a null pointer in case of an error */
-    static std::shared_ptr<CWallet> CreateNew(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, uint64_t wallet_creation_flags, bool born_encrypted, bilingual_str& error, std::vector<bilingual_str>& warnings);
+    static util::ResultPtr<std::shared_ptr<CWallet>> CreateNew(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, uint64_t wallet_creation_flags, bool born_encrypted);
 
     /* Initializes, loads, and returns a CWallet from an existing wallet; returns a null pointer in case of an error */
-    static std::shared_ptr<CWallet> LoadExisting(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, bilingual_str& error, std::vector<bilingual_str>& warnings);
+    static util::ResultPtr<std::shared_ptr<CWallet>> LoadExisting(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database);
 
     /**
      * Wallet post-init setup
@@ -1061,10 +1060,10 @@ public:
      * A backup is not created.
      * May crash if something unexpected happens in the filesystem.
      */
-    bool MigrateToSQLite(bilingual_str& error) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    util::Result<void> MigrateToSQLite() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Get all of the descriptors from a legacy wallet
-    std::optional<MigrationData> GetDescriptorsForLegacy(bilingual_str& error) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    util::Result<MigrationData> GetDescriptorsForLegacy() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Adds the ScriptPubKeyMans from MigrationData to this wallet, removes the LegacyDataSPKM,
     //! and moves transaction and address book entries to watchonly_wallet or solvable_wallet as needed.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -94,12 +94,12 @@ util::Result<void> RemoveWallet(WalletContext& context, const std::shared_ptr<CW
 std::vector<std::shared_ptr<CWallet>> GetWallets(WalletContext& context);
 std::shared_ptr<CWallet> GetDefaultWallet(WalletContext& context, size_t& count);
 std::shared_ptr<CWallet> GetWallet(WalletContext& context, const std::string& name);
-util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options);
-util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options);
-util::ResultPtr<std::shared_ptr<CWallet>, DatabaseStatus> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, bool load_after_restore = true, bool allow_unnamed = false);
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options);
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options);
+util::ResultPtr<std::shared_ptr<CWallet>, DatabaseError> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, bool load_after_restore = true, bool allow_unnamed = false);
 std::unique_ptr<interfaces::Handler> HandleLoadWallet(WalletContext& context, LoadWalletFn load_wallet);
 void NotifyWalletLoaded(WalletContext& context, const std::shared_ptr<CWallet>& wallet);
-util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options);
+util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseError> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options);
 
 //! -fallbackfee default
 inline constexpr CAmount DEFAULT_FALLBACK_FEE = 0;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1294,15 +1294,13 @@ void WalletBatch::RegisterTxnListener(const DbTxnListener& l)
     m_txn_listeners.emplace_back(l);
 }
 
-std::unique_ptr<WalletDatabase> MakeDatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error)
+util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeDatabase(const fs::path& path, const DatabaseOptions& options)
 {
     bool exists;
     try {
         exists = fs::symlink_status(path).type() != fs::file_type::not_found;
     } catch (const fs::filesystem_error& e) {
-        error = Untranslated(strprintf("Failed to access database path '%s': %s", fs::PathToString(path), e.code().message()));
-        status = DatabaseStatus::FAILED_BAD_PATH;
-        return nullptr;
+        return {util::Error{Untranslated(strprintf("Failed to access database path '%s': %s", fs::PathToString(path), e.code().message()))}, DatabaseStatus::FAILED_BAD_PATH};
     }
 
     std::optional<DatabaseFormat> format;
@@ -1312,42 +1310,30 @@ std::unique_ptr<WalletDatabase> MakeDatabase(const fs::path& path, const Databas
         }
         if (IsSQLiteFile(SQLiteDataFile(path))) {
             if (format) {
-                error = Untranslated(strprintf("Failed to load database path '%s'. Data is in ambiguous format.", fs::PathToString(path)));
-                status = DatabaseStatus::FAILED_BAD_FORMAT;
-                return nullptr;
+                return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Data is in ambiguous format.", fs::PathToString(path)))}, DatabaseStatus::FAILED_BAD_FORMAT};
             }
             format = DatabaseFormat::SQLITE;
         }
     } else if (options.require_existing) {
-        error = Untranslated(strprintf("Failed to load database path '%s'. Path does not exist.", fs::PathToString(path)));
-        status = DatabaseStatus::FAILED_NOT_FOUND;
-        return nullptr;
+        return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Path does not exist.", fs::PathToString(path)))}, DatabaseStatus::FAILED_NOT_FOUND};
     }
 
     if (!format && options.require_existing) {
-        error = Untranslated(strprintf("Failed to load database path '%s'. Data is not in recognized format.", fs::PathToString(path)));
-        status = DatabaseStatus::FAILED_BAD_FORMAT;
-        return nullptr;
+        return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Data is not in recognized format.", fs::PathToString(path)))}, DatabaseStatus::FAILED_BAD_FORMAT};
     }
 
     if (format && options.require_create) {
-        error = Untranslated(strprintf("Failed to create database path '%s'. Database already exists.", fs::PathToString(path)));
-        status = DatabaseStatus::FAILED_ALREADY_EXISTS;
-        return nullptr;
+        return {util::Error{Untranslated(strprintf("Failed to create database path '%s'. Database already exists.", fs::PathToString(path)))}, DatabaseStatus::FAILED_ALREADY_EXISTS};
     }
 
     // BERKELEY_RO can only be opened if require_format was set, which only occurs in migration.
     if (format && format == DatabaseFormat::BERKELEY_RO && (!options.require_format || options.require_format != DatabaseFormat::BERKELEY_RO)) {
-        error = Untranslated(strprintf("Failed to open database path '%s'. The wallet appears to be a Legacy wallet, please use the wallet migration tool (migratewallet RPC or the GUI option).", fs::PathToString(path)));
-        status = DatabaseStatus::FAILED_LEGACY_DISABLED;
-        return nullptr;
+        return {util::Error{Untranslated(strprintf("Failed to open database path '%s'. The wallet appears to be a Legacy wallet, please use the wallet migration tool (migratewallet RPC or the GUI option).", fs::PathToString(path)))}, DatabaseStatus::FAILED_LEGACY_DISABLED};
     }
 
     // A db already exists so format is set, but options also specifies the format, so make sure they agree
     if (format && options.require_format && format != options.require_format) {
-        error = Untranslated(strprintf("Failed to load database path '%s'. Data is not in required format.", fs::PathToString(path)));
-        status = DatabaseStatus::FAILED_BAD_FORMAT;
-        return nullptr;
+        return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Data is not in required format.", fs::PathToString(path)))}, DatabaseStatus::FAILED_BAD_FORMAT};
     }
 
     // Format is not set when a db doesn't already exist, so use the format specified by the options if it is set.
@@ -1358,15 +1344,14 @@ std::unique_ptr<WalletDatabase> MakeDatabase(const fs::path& path, const Databas
     }
 
     if (format == DatabaseFormat::SQLITE) {
-        return ResultExtract(MakeSQLiteDatabase(path, options), &status, &error);
+        return MakeSQLiteDatabase(path, options);
     }
 
     if (format == DatabaseFormat::BERKELEY_RO) {
-        return ResultExtract(MakeBerkeleyRODatabase(path, options), &status, &error);
+        return MakeBerkeleyRODatabase(path, options);
     }
 
-    error = Untranslated(STR_INTERNAL_BUG("Could not determine wallet format"));
-    status = DatabaseStatus::FAILED_BAD_FORMAT;
-    return nullptr;
+    return {util::Error{Untranslated(STR_INTERNAL_BUG("Could not determine wallet format"))},
+            DatabaseStatus::FAILED_BAD_FORMAT};
 }
 } // namespace wallet

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1294,13 +1294,13 @@ void WalletBatch::RegisterTxnListener(const DbTxnListener& l)
     m_txn_listeners.emplace_back(l);
 }
 
-util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeDatabase(const fs::path& path, const DatabaseOptions& options)
+util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseError> MakeDatabase(const fs::path& path, const DatabaseOptions& options)
 {
     bool exists;
     try {
         exists = fs::symlink_status(path).type() != fs::file_type::not_found;
     } catch (const fs::filesystem_error& e) {
-        return {util::Error{Untranslated(strprintf("Failed to access database path '%s': %s", fs::PathToString(path), e.code().message()))}, DatabaseStatus::FAILED_BAD_PATH};
+        return {util::Error{Untranslated(strprintf("Failed to access database path '%s': %s", fs::PathToString(path), e.code().message()))}, DatabaseError::FAILED_BAD_PATH};
     }
 
     std::optional<DatabaseFormat> format;
@@ -1310,30 +1310,30 @@ util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeDatabase(co
         }
         if (IsSQLiteFile(SQLiteDataFile(path))) {
             if (format) {
-                return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Data is in ambiguous format.", fs::PathToString(path)))}, DatabaseStatus::FAILED_BAD_FORMAT};
+                return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Data is in ambiguous format.", fs::PathToString(path)))}, DatabaseError::FAILED_BAD_FORMAT};
             }
             format = DatabaseFormat::SQLITE;
         }
     } else if (options.require_existing) {
-        return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Path does not exist.", fs::PathToString(path)))}, DatabaseStatus::FAILED_NOT_FOUND};
+        return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Path does not exist.", fs::PathToString(path)))}, DatabaseError::FAILED_NOT_FOUND};
     }
 
     if (!format && options.require_existing) {
-        return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Data is not in recognized format.", fs::PathToString(path)))}, DatabaseStatus::FAILED_BAD_FORMAT};
+        return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Data is not in recognized format.", fs::PathToString(path)))}, DatabaseError::FAILED_BAD_FORMAT};
     }
 
     if (format && options.require_create) {
-        return {util::Error{Untranslated(strprintf("Failed to create database path '%s'. Database already exists.", fs::PathToString(path)))}, DatabaseStatus::FAILED_ALREADY_EXISTS};
+        return {util::Error{Untranslated(strprintf("Failed to create database path '%s'. Database already exists.", fs::PathToString(path)))}, DatabaseError::FAILED_ALREADY_EXISTS};
     }
 
     // BERKELEY_RO can only be opened if require_format was set, which only occurs in migration.
     if (format && format == DatabaseFormat::BERKELEY_RO && (!options.require_format || options.require_format != DatabaseFormat::BERKELEY_RO)) {
-        return {util::Error{Untranslated(strprintf("Failed to open database path '%s'. The wallet appears to be a Legacy wallet, please use the wallet migration tool (migratewallet RPC or the GUI option).", fs::PathToString(path)))}, DatabaseStatus::FAILED_LEGACY_DISABLED};
+        return {util::Error{Untranslated(strprintf("Failed to open database path '%s'. The wallet appears to be a Legacy wallet, please use the wallet migration tool (migratewallet RPC or the GUI option).", fs::PathToString(path)))}, DatabaseError::FAILED_LEGACY_DISABLED};
     }
 
     // A db already exists so format is set, but options also specifies the format, so make sure they agree
     if (format && options.require_format && format != options.require_format) {
-        return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Data is not in required format.", fs::PathToString(path)))}, DatabaseStatus::FAILED_BAD_FORMAT};
+        return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Data is not in required format.", fs::PathToString(path)))}, DatabaseError::FAILED_BAD_FORMAT};
     }
 
     // Format is not set when a db doesn't already exist, so use the format specified by the options if it is set.
@@ -1352,6 +1352,6 @@ util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeDatabase(co
     }
 
     return {util::Error{Untranslated(STR_INTERNAL_BUG("Could not determine wallet format"))},
-            DatabaseStatus::FAILED_BAD_FORMAT};
+            DatabaseError::FAILED_BAD_FORMAT};
 }
 } // namespace wallet

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1358,7 +1358,7 @@ std::unique_ptr<WalletDatabase> MakeDatabase(const fs::path& path, const Databas
     }
 
     if (format == DatabaseFormat::SQLITE) {
-        return MakeSQLiteDatabase(path, options, status, error);
+        return ResultExtract(MakeSQLiteDatabase(path, options), &status, &error);
     }
 
     if (format == DatabaseFormat::BERKELEY_RO) {

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1362,7 +1362,7 @@ std::unique_ptr<WalletDatabase> MakeDatabase(const fs::path& path, const Databas
     }
 
     if (format == DatabaseFormat::BERKELEY_RO) {
-        return MakeBerkeleyRODatabase(path, options, status, error);
+        return ResultExtract(MakeBerkeleyRODatabase(path, options), &status, &error);
     }
 
     error = Untranslated(STR_INTERNAL_BUG("Could not determine wallet format"));

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1326,15 +1326,13 @@ void WalletBatch::RegisterTxnListener(const DbTxnListener& l)
     m_txn_listeners.emplace_back(l);
 }
 
-std::unique_ptr<WalletDatabase> MakeDatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error)
+util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeDatabase(const fs::path& path, const DatabaseOptions& options)
 {
     bool exists;
     try {
         exists = fs::symlink_status(path).type() != fs::file_type::not_found;
     } catch (const fs::filesystem_error& e) {
-        error = Untranslated(strprintf("Failed to access database path '%s': %s", fs::PathToString(path), e.code().message()));
-        status = DatabaseStatus::FAILED_BAD_PATH;
-        return nullptr;
+        return {util::Error{Untranslated(strprintf("Failed to access database path '%s': %s", fs::PathToString(path), e.code().message()))}, DatabaseStatus::FAILED_BAD_PATH};
     }
 
     std::optional<DatabaseFormat> format;
@@ -1344,42 +1342,30 @@ std::unique_ptr<WalletDatabase> MakeDatabase(const fs::path& path, const Databas
         }
         if (IsSQLiteFile(SQLiteDataFile(path))) {
             if (format) {
-                error = Untranslated(strprintf("Failed to load database path '%s'. Data is in ambiguous format.", fs::PathToString(path)));
-                status = DatabaseStatus::FAILED_BAD_FORMAT;
-                return nullptr;
+                return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Data is in ambiguous format.", fs::PathToString(path)))}, DatabaseStatus::FAILED_BAD_FORMAT};
             }
             format = DatabaseFormat::SQLITE;
         }
     } else if (options.require_existing) {
-        error = Untranslated(strprintf("Failed to load database path '%s'. Path does not exist.", fs::PathToString(path)));
-        status = DatabaseStatus::FAILED_NOT_FOUND;
-        return nullptr;
+        return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Path does not exist.", fs::PathToString(path)))}, DatabaseStatus::FAILED_NOT_FOUND};
     }
 
     if (!format && options.require_existing) {
-        error = Untranslated(strprintf("Failed to load database path '%s'. Data is not in recognized format.", fs::PathToString(path)));
-        status = DatabaseStatus::FAILED_BAD_FORMAT;
-        return nullptr;
+        return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Data is not in recognized format.", fs::PathToString(path)))}, DatabaseStatus::FAILED_BAD_FORMAT};
     }
 
     if (format && options.require_create) {
-        error = Untranslated(strprintf("Failed to create database path '%s'. Database already exists.", fs::PathToString(path)));
-        status = DatabaseStatus::FAILED_ALREADY_EXISTS;
-        return nullptr;
+        return {util::Error{Untranslated(strprintf("Failed to create database path '%s'. Database already exists.", fs::PathToString(path)))}, DatabaseStatus::FAILED_ALREADY_EXISTS};
     }
 
     // BERKELEY_RO can only be opened if require_format was set, which only occurs in migration.
     if (format && format == DatabaseFormat::BERKELEY_RO && (!options.require_format || options.require_format != DatabaseFormat::BERKELEY_RO)) {
-        error = Untranslated(strprintf("Failed to open database path '%s'. The wallet appears to be a Legacy wallet, please use the wallet migration tool (migratewallet RPC or the GUI option).", fs::PathToString(path)));
-        status = DatabaseStatus::FAILED_LEGACY_DISABLED;
-        return nullptr;
+        return {util::Error{Untranslated(strprintf("Failed to open database path '%s'. The wallet appears to be a Legacy wallet, please use the wallet migration tool (migratewallet RPC or the GUI option).", fs::PathToString(path)))}, DatabaseStatus::FAILED_LEGACY_DISABLED};
     }
 
     // A db already exists so format is set, but options also specifies the format, so make sure they agree
     if (format && options.require_format && format != options.require_format) {
-        error = Untranslated(strprintf("Failed to load database path '%s'. Data is not in required format.", fs::PathToString(path)));
-        status = DatabaseStatus::FAILED_BAD_FORMAT;
-        return nullptr;
+        return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Data is not in required format.", fs::PathToString(path)))}, DatabaseStatus::FAILED_BAD_FORMAT};
     }
 
     // Format is not set when a db doesn't already exist, so use the format specified by the options if it is set.
@@ -1390,15 +1376,14 @@ std::unique_ptr<WalletDatabase> MakeDatabase(const fs::path& path, const Databas
     }
 
     if (format == DatabaseFormat::SQLITE) {
-        return ResultExtract(MakeSQLiteDatabase(path, options), &status, &error);
+        return MakeSQLiteDatabase(path, options);
     }
 
     if (format == DatabaseFormat::BERKELEY_RO) {
-        return ResultExtract(MakeBerkeleyRODatabase(path, options), &status, &error);
+        return MakeBerkeleyRODatabase(path, options);
     }
 
-    error = Untranslated(STR_INTERNAL_BUG("Could not determine wallet format"));
-    status = DatabaseStatus::FAILED_BAD_FORMAT;
-    return nullptr;
+    return {util::Error{Untranslated(STR_INTERNAL_BUG("Could not determine wallet format"))},
+            DatabaseStatus::FAILED_BAD_FORMAT};
 }
 } // namespace wallet

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1390,7 +1390,7 @@ std::unique_ptr<WalletDatabase> MakeDatabase(const fs::path& path, const Databas
     }
 
     if (format == DatabaseFormat::SQLITE) {
-        return MakeSQLiteDatabase(path, options, status, error);
+        return ResultExtract(MakeSQLiteDatabase(path, options), &status, &error);
     }
 
     if (format == DatabaseFormat::BERKELEY_RO) {

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1394,7 +1394,7 @@ std::unique_ptr<WalletDatabase> MakeDatabase(const fs::path& path, const Databas
     }
 
     if (format == DatabaseFormat::BERKELEY_RO) {
-        return MakeBerkeleyRODatabase(path, options, status, error);
+        return ResultExtract(MakeBerkeleyRODatabase(path, options), &status, &error);
     }
 
     error = Untranslated(STR_INTERNAL_BUG("Could not determine wallet format"));

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1326,13 +1326,13 @@ void WalletBatch::RegisterTxnListener(const DbTxnListener& l)
     m_txn_listeners.emplace_back(l);
 }
 
-util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeDatabase(const fs::path& path, const DatabaseOptions& options)
+util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseError> MakeDatabase(const fs::path& path, const DatabaseOptions& options)
 {
     bool exists;
     try {
         exists = fs::symlink_status(path).type() != fs::file_type::not_found;
     } catch (const fs::filesystem_error& e) {
-        return {util::Error{Untranslated(strprintf("Failed to access database path '%s': %s", fs::PathToString(path), e.code().message()))}, DatabaseStatus::FAILED_BAD_PATH};
+        return {util::Error{Untranslated(strprintf("Failed to access database path '%s': %s", fs::PathToString(path), e.code().message()))}, DatabaseError::FAILED_BAD_PATH};
     }
 
     std::optional<DatabaseFormat> format;
@@ -1342,30 +1342,30 @@ util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeDatabase(co
         }
         if (IsSQLiteFile(SQLiteDataFile(path))) {
             if (format) {
-                return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Data is in ambiguous format.", fs::PathToString(path)))}, DatabaseStatus::FAILED_BAD_FORMAT};
+                return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Data is in ambiguous format.", fs::PathToString(path)))}, DatabaseError::FAILED_BAD_FORMAT};
             }
             format = DatabaseFormat::SQLITE;
         }
     } else if (options.require_existing) {
-        return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Path does not exist.", fs::PathToString(path)))}, DatabaseStatus::FAILED_NOT_FOUND};
+        return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Path does not exist.", fs::PathToString(path)))}, DatabaseError::FAILED_NOT_FOUND};
     }
 
     if (!format && options.require_existing) {
-        return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Data is not in recognized format.", fs::PathToString(path)))}, DatabaseStatus::FAILED_BAD_FORMAT};
+        return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Data is not in recognized format.", fs::PathToString(path)))}, DatabaseError::FAILED_BAD_FORMAT};
     }
 
     if (format && options.require_create) {
-        return {util::Error{Untranslated(strprintf("Failed to create database path '%s'. Database already exists.", fs::PathToString(path)))}, DatabaseStatus::FAILED_ALREADY_EXISTS};
+        return {util::Error{Untranslated(strprintf("Failed to create database path '%s'. Database already exists.", fs::PathToString(path)))}, DatabaseError::FAILED_ALREADY_EXISTS};
     }
 
     // BERKELEY_RO can only be opened if require_format was set, which only occurs in migration.
     if (format && format == DatabaseFormat::BERKELEY_RO && (!options.require_format || options.require_format != DatabaseFormat::BERKELEY_RO)) {
-        return {util::Error{Untranslated(strprintf("Failed to open database path '%s'. The wallet appears to be a Legacy wallet, please use the wallet migration tool (migratewallet RPC or the GUI option).", fs::PathToString(path)))}, DatabaseStatus::FAILED_LEGACY_DISABLED};
+        return {util::Error{Untranslated(strprintf("Failed to open database path '%s'. The wallet appears to be a Legacy wallet, please use the wallet migration tool (migratewallet RPC or the GUI option).", fs::PathToString(path)))}, DatabaseError::FAILED_LEGACY_DISABLED};
     }
 
     // A db already exists so format is set, but options also specifies the format, so make sure they agree
     if (format && options.require_format && format != options.require_format) {
-        return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Data is not in required format.", fs::PathToString(path)))}, DatabaseStatus::FAILED_BAD_FORMAT};
+        return {util::Error{Untranslated(strprintf("Failed to load database path '%s'. Data is not in required format.", fs::PathToString(path)))}, DatabaseError::FAILED_BAD_FORMAT};
     }
 
     // Format is not set when a db doesn't already exist, so use the format specified by the options if it is set.
@@ -1384,6 +1384,6 @@ util::ResultPtr<std::unique_ptr<WalletDatabase>, DatabaseStatus> MakeDatabase(co
     }
 
     return {util::Error{Untranslated(STR_INTERNAL_BUG("Could not determine wallet format"))},
-            DatabaseStatus::FAILED_BAD_FORMAT};
+            DatabaseError::FAILED_BAD_FORMAT};
 }
 } // namespace wallet

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -12,6 +12,8 @@
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
 
+using util::Result;
+
 namespace wallet {
 namespace WalletTool {
 
@@ -40,8 +42,6 @@ static void WalletCreate(CWallet* wallet_instance, uint64_t wallet_creation_flag
 
 static std::shared_ptr<CWallet> MakeWallet(const std::string& name, const fs::path& path, DatabaseOptions options)
 {
-    bilingual_str error;
-    std::vector<bilingual_str> warnings;
     auto database{MakeDatabase(path, options)};
     if (!database) {
         tfm::format(std::cerr, "%s\n", util::ErrorString(database).original);
@@ -50,23 +50,23 @@ static std::shared_ptr<CWallet> MakeWallet(const std::string& name, const fs::pa
 
     // dummy chain interface
     std::shared_ptr<CWallet> wallet_instance{new CWallet(/*chain=*/nullptr, name, std::move(database.value())), WalletToolReleaseWallet};
-    DBErrors load_wallet_ret;
+    Result<void, DBErrors> populate;
     try {
-        load_wallet_ret = wallet_instance->PopulateWalletFromDB(error, warnings);
+        populate.update(wallet_instance->PopulateWalletFromDB());
     } catch (const std::runtime_error&) {
         tfm::format(std::cerr, "Error loading %s. Is wallet being used by another process?\n", name);
         return nullptr;
     }
 
-    if (!error.empty()) {
-        tfm::format(std::cerr, "%s", error.original);
+    if (!populate) {
+        tfm::format(std::cerr, "%s", ErrorString(populate).original);
     }
 
-    for (const auto &warning : warnings) {
+    for (const auto &warning : populate.messages().warnings) {
         tfm::format(std::cerr, "%s", warning.original);
     }
 
-    if (load_wallet_ret != DBErrors::LOAD_OK && load_wallet_ret != DBErrors::NONCRITICAL_ERROR && load_wallet_ret != DBErrors::NEED_RESCAN) {
+    if (!populate && populate.error() != DBErrors::NONCRITICAL_ERROR && populate.error() != DBErrors::NEED_RESCAN) {
         return nullptr;
     }
 

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -43,7 +43,7 @@ static std::shared_ptr<CWallet> MakeWallet(const std::string& name, const fs::pa
     DatabaseStatus status;
     bilingual_str error;
     std::vector<bilingual_str> warnings;
-    std::unique_ptr<WalletDatabase> database = MakeDatabase(path, options, status, error);
+    std::unique_ptr<WalletDatabase> database = ResultExtract(MakeDatabase(path, options), &status, &error);
     if (!database) {
         tfm::format(std::cerr, "%s\n", error.original);
         return nullptr;
@@ -147,7 +147,7 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
         }
 
         bilingual_str error;
-        std::unique_ptr<WalletDatabase> database = MakeDatabase(path, options, status, error);
+        std::unique_ptr<WalletDatabase> database = ResultExtract(MakeDatabase(path, options), &status, &error);
         if (!database) {
             tfm::format(std::cerr, "%s\n", error.original);
             return false;

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -153,7 +153,7 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
             return false;
         }
 
-        bool ret = DumpWallet(args, *database, error);
+        bool ret = ResultExtract(DumpWallet(args, *database), nullptr, &error);
         if (!ret && !error.empty()) {
             tfm::format(std::cerr, "%s\n", error.original);
             return ret;
@@ -163,7 +163,7 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
     } else if (command == "createfromdump") {
         bilingual_str error;
         std::vector<bilingual_str> warnings;
-        bool ret = CreateFromDump(args, name, path, error, warnings);
+        bool ret = ResultExtract(CreateFromDump(args, name, path), nullptr, &error, &warnings);
         for (const auto& warning : warnings) {
             tfm::format(std::cout, "%s\n", warning.original);
         }

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -40,17 +40,16 @@ static void WalletCreate(CWallet* wallet_instance, uint64_t wallet_creation_flag
 
 static std::shared_ptr<CWallet> MakeWallet(const std::string& name, const fs::path& path, DatabaseOptions options)
 {
-    DatabaseStatus status;
     bilingual_str error;
     std::vector<bilingual_str> warnings;
-    std::unique_ptr<WalletDatabase> database = ResultExtract(MakeDatabase(path, options), &status, &error);
+    auto database{MakeDatabase(path, options)};
     if (!database) {
-        tfm::format(std::cerr, "%s\n", error.original);
+        tfm::format(std::cerr, "%s\n", util::ErrorString(database).original);
         return nullptr;
     }
 
     // dummy chain interface
-    std::shared_ptr<CWallet> wallet_instance{new CWallet(/*chain=*/nullptr, name, std::move(database)), WalletToolReleaseWallet};
+    std::shared_ptr<CWallet> wallet_instance{new CWallet(/*chain=*/nullptr, name, std::move(database.value())), WalletToolReleaseWallet};
     DBErrors load_wallet_ret;
     try {
         load_wallet_ret = wallet_instance->PopulateWalletFromDB(error, warnings);
@@ -140,37 +139,33 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
         DatabaseOptions options;
         ReadDatabaseArgs(args, options);
         options.require_existing = true;
-        DatabaseStatus status;
-
         if (IsBDBFile(BDBDataFile(path))) {
             options.require_format = DatabaseFormat::BERKELEY_RO;
         }
-
-        bilingual_str error;
-        std::unique_ptr<WalletDatabase> database = ResultExtract(MakeDatabase(path, options), &status, &error);
+        auto database{MakeDatabase(path, options)};
         if (!database) {
-            tfm::format(std::cerr, "%s\n", error.original);
+            tfm::format(std::cerr, "%s\n", util::ErrorString(database).original);
             return false;
         }
 
-        bool ret = ResultExtract(DumpWallet(args, *database), nullptr, &error);
-        if (!ret && !error.empty()) {
-            tfm::format(std::cerr, "%s\n", error.original);
-            return ret;
+        auto ret{DumpWallet(args, *database)};
+        if (!ret) {
+            tfm::format(std::cerr, "%s\n", util::ErrorString(ret).original);
+            return false;
         }
         tfm::format(std::cout, "The dumpfile may contain private keys. To ensure the safety of your Bitcoin, do not share the dumpfile.\n");
-        return ret;
+        return bool{ret};
     } else if (command == "createfromdump") {
-        bilingual_str error;
-        std::vector<bilingual_str> warnings;
-        bool ret = ResultExtract(CreateFromDump(args, name, path), nullptr, &error, &warnings);
-        for (const auto& warning : warnings) {
-            tfm::format(std::cout, "%s\n", warning.original);
+        auto ret{CreateFromDump(args, name, path)};
+        if (ret.messages_ptr()) {
+            for (const auto& warning : ret.messages_ptr()->warnings) {
+                tfm::format(std::cout, "%s\n", warning.original);
+            }
+            for (const auto& error : ret.messages_ptr()->errors) {
+                tfm::format(std::cerr, "%s\n", error.original);
+            }
         }
-        if (!ret && !error.empty()) {
-            tfm::format(std::cerr, "%s\n", error.original);
-        }
-        return ret;
+        return bool{ret};
     } else {
         tfm::format(std::cerr, "Invalid command: %s\n", command);
         return false;

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -153,7 +153,7 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
             return false;
         }
 
-        bool ret = DumpWallet(args, *database, error);
+        bool ret = ResultExtract(DumpWallet(args, *database), nullptr, &error);
         if (!ret && !error.empty()) {
             tfm::format(std::cerr, "%s\n", error.original);
             return ret;
@@ -162,7 +162,11 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
         return ret;
     } else if (command == "createfromdump") {
         bilingual_str error;
-        bool ret = CreateFromDump(args, name, path, error);
+        std::vector<bilingual_str> warnings;
+        bool ret = ResultExtract(CreateFromDump(args, name, path), nullptr, &error, &warnings);
+        for (const auto& warning : warnings) {
+            tfm::format(std::cout, "%s\n", warning.original);
+        }
         if (!ret && !error.empty()) {
             tfm::format(std::cerr, "%s\n", error.original);
         }


### PR DESCRIPTION
<!-- begin based-on -->
**This is based on #25665 + #26022.** The non-base commits are:

- [`8d998440c62` Add temporary ResultExtract helper for porting to util::Result](https://github.com/bitcoin/bitcoin/pull/25722/commits/8d998440c62b6e39c3038009ee05ce020b63b1fc)
- [`ec7c42ab3d0` refactor: Use util::Result class in wallet/sqlite](https://github.com/bitcoin/bitcoin/pull/25722/commits/ec7c42ab3d0d7c86b7c51912fae3f50f0ced3ed0)
- [`e38aad68ca9` refactor: Use util::Result class in wallet/migrate](https://github.com/bitcoin/bitcoin/pull/25722/commits/e38aad68ca95113e0b66ffd44e53c253f62ee577)
- [`4fea959bb76` refactor: Use util::Result class in wallet::MakeDatabase](https://github.com/bitcoin/bitcoin/pull/25722/commits/4fea959bb76f991467170a6d704d0f9faa9925aa)
- [`3d47aba6342` refactor: Use util::Result class in wallet/dump](https://github.com/bitcoin/bitcoin/pull/25722/commits/3d47aba6342be82f1351e2555d02cc2d5bbfa530)
- [`a6a0feca6f7` refactor: Use util::Result class in wallet/wallettool](https://github.com/bitcoin/bitcoin/pull/25722/commits/a6a0feca6f757d1a8c8d0110be5e9a3c7891ea13)
- [`d2ca7d8694c` refactor: Use util::Result class in wallet/wallet](https://github.com/bitcoin/bitcoin/pull/25722/commits/d2ca7d8694cb43ecef72127e7807f063f676cc95)
- [`76d6541f560` refactor: Use util::Result class in wallet/load](https://github.com/bitcoin/bitcoin/pull/25722/commits/76d6541f56080ed302fadeeaee6102f562bacaee)
- [`480a59b0ad0` refactor: Use util::Result class in wallet/rpc](https://github.com/bitcoin/bitcoin/pull/25722/commits/480a59b0ad0c763dde43cb3fcd9432becc82fee1)
- [`dea22903f62` refactor: Use util::Result class in wallet/interfaces](https://github.com/bitcoin/bitcoin/pull/25722/commits/dea22903f624e6b68ab5d712870f038c88d368fd)
- [`6a56e0c7da9` refactor: Use util::Result class in wallet/test](https://github.com/bitcoin/bitcoin/pull/25722/commits/6a56e0c7da996bfc7dea9f121df516d106d12617)
- [`4d7a5352df3` Drop temporary ResultExtract helper for porting to util::Result](https://github.com/bitcoin/bitcoin/pull/25722/commits/4d7a5352df3871cf9435c084615b85b2dff05be8)
- [`109d356f8ff` scripted-diff: replace wallet DatabaseStatus with DatabaseError](https://github.com/bitcoin/bitcoin/pull/25722/commits/109d356f8ffa70218f3965435ab116837f2006eb)<!-- end -->

---

Wallet loading functions up and down the stack have lots of error and warning parameters, and return error information in different ways. This PR makes them uniformly return `util::Result`, without changing behavior.