### PR TITLE
test: Drop unused boost workaround

### DIFF
--- a/src/test/system_tests.cpp
+++ b/src/test/system_tests.cpp
@@ -7,11 +7,6 @@
 #include <univalue.h>
 
 #ifdef ENABLE_EXTERNAL_SIGNER
-#if defined(WIN32) && !defined(__kernel_entry)
-// A workaround for boost 1.71 incompatibility with mingw-w64 compiler.
-// For details see https://github.com/bitcoin/bitcoin/pull/22348.
-#define __kernel_entry
-#endif
 #if defined(__GNUC__)
 // Boost 1.78 requires the following workaround.
 // See: https://github.com/boostorg/process/issues/235


### PR DESCRIPTION
This PR is a follow up of bitcoin/bitcoin#24065 and removes the workaround which has already been removed in other [places](https://github.com/bitcoin/bitcoin/pull/24065/files#diff-19427b0dd1a791adc728c82e88f267751ba4f1c751e19262cac03cccd2822216).

Moreover, this workaround won't be required even if bitcoin/bitcoin#25696 is ever merged.