### PR TITLE
test: negative/unknown `rpcserialversion` should throw an init error

### DIFF
--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -609,6 +609,11 @@ class SegWitTest(BitcoinTestFramework):
                 assert_equal(self.nodes[1].gettransaction(txid, True)["txid"], txid)
                 assert_equal(self.nodes[1].listtransactions("*", 1, 0, True)[0]["txid"], txid)
 
+        self.log.info('Test negative and unknown rpcserialversion throw an init error')
+        self.stop_node(0)
+        self.nodes[0].assert_start_raises_init_error(["-rpcserialversion=-1"], "Error: rpcserialversion must be non-negative.")
+        self.nodes[0].assert_start_raises_init_error(["-rpcserialversion=100"], "Error: Unknown rpcserialversion requested.")
+
     def mine_and_test_listunspent(self, script_list, ismine):
         utxo = find_spendable_utxo(self.nodes[0], 50)
         tx = CTransaction()


### PR DESCRIPTION
This PR adds test coverage for the following init errors:
https://github.com/bitcoin/bitcoin/blob/41205bf442254d17bc7885f3b2693749da714a0e/src/init.cpp#L1025-L1030