### PR TITLE
tidy: enable bugprone-use-after-move

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,6 +1,7 @@
 Checks: '
 -*,
 bugprone-argument-comment,
+bugprone-use-after-move,
 misc-unused-using-decls,
 modernize-use-default-member-init,
 modernize-use-nullptr,
@@ -11,6 +12,7 @@ readability-redundant-string-init,
 '
 WarningsAsErrors: '
 bugprone-argument-comment,
+bugprone-use-after-move,
 misc-unused-using-decls,
 modernize-use-default-member-init,
 modernize-use-nullptr,

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -2510,13 +2510,13 @@ BOOST_AUTO_TEST_CASE(test_tracked_vector)
 
     auto v2 = Vector(std::move(t2));
     BOOST_CHECK_EQUAL(v2.size(), 1U);
-    BOOST_CHECK(v2[0].origin == &t2);
+    BOOST_CHECK(v2[0].origin == &t2); // NOLINT(*-use-after-move)
     BOOST_CHECK_EQUAL(v2[0].copies, 0);
 
     auto v3 = Vector(t1, std::move(t2));
     BOOST_CHECK_EQUAL(v3.size(), 2U);
     BOOST_CHECK(v3[0].origin == &t1);
-    BOOST_CHECK(v3[1].origin == &t2);
+    BOOST_CHECK(v3[1].origin == &t2); // NOLINT(*-use-after-move)
     BOOST_CHECK_EQUAL(v3[0].copies, 1);
     BOOST_CHECK_EQUAL(v3[1].copies, 0);
 
@@ -2524,7 +2524,7 @@ BOOST_AUTO_TEST_CASE(test_tracked_vector)
     BOOST_CHECK_EQUAL(v4.size(), 3U);
     BOOST_CHECK(v4[0].origin == &t1);
     BOOST_CHECK(v4[1].origin == &t2);
-    BOOST_CHECK(v4[2].origin == &t3);
+    BOOST_CHECK(v4[2].origin == &t3); // NOLINT(*-use-after-move)
     BOOST_CHECK_EQUAL(v4[0].copies, 1);
     BOOST_CHECK_EQUAL(v4[1].copies, 1);
     BOOST_CHECK_EQUAL(v4[2].copies, 0);


### PR DESCRIPTION
Would have caught #25640.

Currently `// NOLINT`s around:
```bash
test/util_tests.cpp:2513:34: error: 't2' used after it was moved [bugprone-use-after-move,-warnings-as-errors]
    BOOST_CHECK(v2[0].origin == &t2);
                                 ^
test/util_tests.cpp:2511:15: note: move occurred here
    auto v2 = Vector(std::move(t2));
              ^
test/util_tests.cpp:2519:34: error: 't2' used after it was moved [bugprone-use-after-move,-warnings-as-errors]
    BOOST_CHECK(v3[1].origin == &t2);
                                 ^
test/util_tests.cpp:2516:15: note: move occurred here
    auto v3 = Vector(t1, std::move(t2));
              ^
test/util_tests.cpp:2527:34: error: 't3' used after it was moved [bugprone-use-after-move,-warnings-as-errors]
    BOOST_CHECK(v4[2].origin == &t3);
                                 ^
test/util_tests.cpp:2523:15: note: move occurred here
    auto v4 = Vector(std::move(v3[0]), v3[1], std::move(t3));
```

See: https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/bugprone-use-after-move.html