### PR TITLE
build: Use Link Time Optimization in Qt code for Darwin hosts

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -130,6 +130,9 @@ $(package)_config_opts_darwin += -pch
 $(package)_config_opts_darwin += -no-feature-corewlan
 $(package)_config_opts_darwin += -no-freetype
 $(package)_config_opts_darwin += QMAKE_MACOSX_DEPLOYMENT_TARGET=$(OSX_MIN_VERSION)
+ifneq ($(LTO),)
+$(package)_config_opts_darwin += -ltcg
+endif
 
 ifneq ($(build_os),darwin)
 $(package)_config_opts_darwin += -xplatform macx-clang-linux

--- a/depends/patches/qt/mac-qmake.conf
+++ b/depends/patches/qt/mac-qmake.conf
@@ -18,5 +18,6 @@ QMAKE_MAC_SDK.macosx.PlatformPath = /phony
 !host_build: QMAKE_CXXFLAGS += -target $${MAC_TARGET}
 !host_build: QMAKE_LFLAGS += -target $${MAC_TARGET}
 QMAKE_AR = $${CROSS_COMPILE}ar cq
+QMAKE_AR_LTCG = llvm-ar cqs
 QMAKE_RANLIB=$${CROSS_COMPILE}ranlib
 load(qt_config)


### PR DESCRIPTION
While building the `qt` package in depends succeeds, the following `configure` script fails with:
```
...
LLVM ERROR: Unexistent dir: '/tmp/cc-dea72a.o'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
...
```
when checking for `QMinimalIntegrationPlugin`. 