### PR TITLE
rpc: add a new parameter `desriptor_file` to `importdescriptors` RPC

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -154,6 +154,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "importmulti", 0, "requests" },
     { "importmulti", 1, "options" },
     { "importdescriptors", 0, "requests" },
+    { "importdescriptors", 0, "options" },
     { "listdescriptors", 0, "private" },
     { "listdescriptors", 0, "options" },
     { "verifychain", 0, "checklevel" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -155,6 +155,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "importmulti", 1, "options" },
     { "importdescriptors", 0, "requests" },
     { "listdescriptors", 0, "private" },
+    { "listdescriptors", 0, "options" },
     { "verifychain", 0, "checklevel" },
     { "verifychain", 1, "nblocks" },
     { "getblockstats", 0, "hash_or_height" },

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -665,14 +665,19 @@ UniValue RPCHelpMan::GetArgMap() const
     UniValue arr{UniValue::VARR};
     for (int i{0}; i < int(m_args.size()); ++i) {
         const auto& arg = m_args.at(i);
+        RPCArg::Type argtype = arg.m_type;
+        size_t arg_num = 0;
         std::vector<std::string> arg_names = SplitString(arg.m_names, '|');
         for (const auto& arg_name : arg_names) {
+            if (!arg.m_type_per_name.empty()) {
+                argtype = arg.m_type_per_name.at(arg_num++);
+            }
             UniValue map{UniValue::VARR};
             map.push_back(m_name);
             map.push_back(i);
             map.push_back(arg_name);
-            map.push_back(arg.m_type == RPCArg::Type::STR ||
-                          arg.m_type == RPCArg::Type::STR_HEX);
+            map.push_back(UniValue(argtype == RPCArg::Type::STR ||
+                          argtype == RPCArg::Type::STR_HEX));
             arr.push_back(map);
         }
     }

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -17,6 +17,7 @@
 #include <univalue.h>
 #include <util/check.h>
 
+#include <algorithm>
 #include <string>
 #include <variant>
 #include <vector>
@@ -171,6 +172,7 @@ struct RPCArg {
     using Fallback = std::variant<Optional, /* hint for default value */ DefaultHint, /* default constant value */ Default>;
     const std::string m_names; //!< The name of the arg (can be empty for inner args, can contain multiple aliases separated by | for named request arguments)
     const Type m_type;
+    const std::vector<Type> m_type_per_name;
     const bool m_hidden;
     const std::vector<RPCArg> m_inner; //!< Only used for arrays or dicts
     const Fallback m_fallback;
@@ -195,6 +197,27 @@ struct RPCArg {
           m_type_str{std::move(type_str)}
     {
         CHECK_NONFATAL(type != Type::ARR && type != Type::OBJ && type != Type::OBJ_USER_KEYS);
+    }
+
+    RPCArg(
+        const std::string name,
+        const std::vector<Type> types,
+        const Fallback fallback,
+        const std::string description,
+        const std::vector<RPCArg> inner,
+        const std::string oneline_description = "",
+        const std::vector<std::string> type_str = {},
+        const bool hidden = false)
+        : m_names{std::move(name)},
+          m_type{types.at(0)},
+          m_type_per_name{std::move(types)},
+          m_hidden{hidden},
+          m_fallback{std::move(fallback)},
+          m_description{std::move(description)},
+          m_oneline_description{std::move(oneline_description)},
+          m_type_str{std::move(type_str)}
+    {
+        CHECK_NONFATAL(m_type_per_name.size() == size_t(std::count(m_names.begin(), m_names.end(), '|')) + 1);
     }
 
     RPCArg(

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -15,6 +15,9 @@ variants.
 - `test_address()` is called to call getaddressinfo for an address on node1
   and test the values returned."""
 
+import os
+import json
+
 from test_framework.address import key_to_p2pkh
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
@@ -670,6 +673,20 @@ class ImportDescriptorsTest(BitcoinTestFramework):
                 "internal": True}]
         result = w2.importdescriptors({"requests": desc})
         assert_equal(result[0]['success'], True)
+
+        desc_file = os.path.join(self.nodes[1].datadir, 'desc.json')
+        w2.listdescriptors({'save_to_file': desc_file})
+
+        self.log.info("Descriptors imported from file")
+        self.nodes[1].createwallet(wallet_name="desc_from_file", disable_private_keys=True, blank=True, descriptors=True)
+        desc_from_file_w = self.nodes[1].get_wallet_rpc("desc_from_file")
+
+        result = desc_from_file_w.importdescriptors({"descriptor_file": desc_file})
+        assert_equal(result[0]['success'], True)
+
+        with open(desc_file, encoding="utf8") as json_file:
+            desc = json.load(json_file)
+            assert_equal(desc, desc_from_file_w.listdescriptors()['descriptors'])
 
 if __name__ == '__main__':
     ImportDescriptorsTest().main()

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -663,5 +663,13 @@ class ImportDescriptorsTest(BitcoinTestFramework):
                               success=True,
                               warnings=["Unknown output type, cannot set descriptor to active."])
 
+        self.nodes[1].createwallet(wallet_name="w2", disable_private_keys=True, descriptors=True)
+        w2 = self.nodes[1].get_wallet_rpc("w2")
+        desc = [{"desc": descsum_create("pkh(" + get_generate_key().pubkey + ")"),
+                "timestamp": "now",
+                "internal": True}]
+        result = w2.importdescriptors({"requests": desc})
+        assert_equal(result[0]['success'], True)
+
 if __name__ == '__main__':
     ImportDescriptorsTest().main()

--- a/test/functional/wallet_listdescriptors.py
+++ b/test/functional/wallet_listdescriptors.py
@@ -4,6 +4,9 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the listdescriptors RPC."""
 
+import os
+import json
+
 from test_framework.descriptors import (
     descsum_create
 )
@@ -75,6 +78,15 @@ class ListDescriptorsTest(BitcoinTestFramework):
         assert_equal(expected, wallet.listdescriptors(False))
         assert_equal(wallet.listdescriptors({'private': False}), wallet.listdescriptors())
         assert_equal(wallet.listdescriptors({'private': True}), wallet.listdescriptors(True))
+
+        desc_file = os.path.join(node.datadir, 'desc.json')
+        assert_equal({
+            'wallet_name': 'w2',
+            'descriptor_file': desc_file
+            }, wallet.listdescriptors({'save_to_file': desc_file}))
+
+        with open(desc_file, encoding="utf8") as json_file:
+            assert_equal(expected['descriptors'], json.load(json_file))
 
         self.log.info('Test list private descriptors')
         expected_private = {

--- a/test/functional/wallet_listdescriptors.py
+++ b/test/functional/wallet_listdescriptors.py
@@ -73,6 +73,8 @@ class ListDescriptorsTest(BitcoinTestFramework):
         }
         assert_equal(expected, wallet.listdescriptors())
         assert_equal(expected, wallet.listdescriptors(False))
+        assert_equal(wallet.listdescriptors({'private': False}), wallet.listdescriptors())
+        assert_equal(wallet.listdescriptors({'private': True}), wallet.listdescriptors(True))
 
         self.log.info('Test list private descriptors')
         expected_private = {


### PR DESCRIPTION
This PR adds a new parameter `desriptor_file` to `importdescriptors` RPC, allowing the user to import the descriptors directly from a file.

Only the last two commits are new as this PR is built on top of https://github.com/bitcoin/bitcoin/pull/25747.

With this PR, exporting / importing descriptors and creating watch-only wallet is as simple as:
```
$ bitcoin-cli -rpcwallet="cold_wallet"  listdescriptors "{\"save_to_file\": \"/home/user/Downloads/desc.json\"}"
$ bitcoin-cli -rpcwallet="watch_only_wallet"  importdescriptors "{\"descriptor_file\": \"/home/user/Downloads/desc.json\"}"
```

Without this PR, the user can manually create a file from the `listdescriptors` output or use `jq` to extract the `descriptor` field from `listdescriptors` but the idea here is to make things more automated and standardized.

And this also opens the way to add the functionality of importing descriptors from files in the GUI,

