### PR TITLE
test: Target exact weight in MiniWallet _bulk_tx

### DIFF
--- a/test/functional/mempool_package_limits.py
+++ b/test/functional/mempool_package_limits.py
@@ -35,8 +35,8 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
         self.test_anc_count_limits_2()
         self.test_anc_count_limits_bushy()
 
-        # The node will accept our (nonstandard) extra large OP_RETURN outputs
-        self.restart_node(0, extra_args=["-acceptnonstdtxn=1"])
+        # The node will accept (nonstandard) extra large OP_RETURN outputs
+        self.restart_node(0, extra_args=["-datacarriersize=100000"])
         self.test_anc_size_limits()
         self.test_desc_size_limits()
 


### PR DESCRIPTION
Seems better to target the exact weight than a weight that is up to more than 2000 WU larger.

Also, replace a broad `-acceptnonstdtxn=1` with `-datacarriersize=100000` to document the test assumptions better.