### PR TITLE
guix: pass `--with-newlib` to gcc-sans-libc build

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -78,6 +78,11 @@ http://www.linuxfromscratch.org/hlfs/view/development/chapter05/gcc-pass1.html"
                  (("-rpath=") "-rpath-link="))
                #t))))))))
 
+
+(define (cross-gcc-with-newlib gcc)
+  (package-with-extra-configure-variable gcc
+      "--with-newlib" "yes"))
+
 (define (make-cross-toolchain target
                               base-gcc-for-libc
                               base-kernel-headers
@@ -87,9 +92,9 @@ http://www.linuxfromscratch.org/hlfs/view/development/chapter05/gcc-pass1.html"
   (let* ((xbinutils (cross-binutils target))
          ;; 1. Build a cross-compiling gcc without targeting any libc, derived
          ;; from BASE-GCC-FOR-LIBC
-         (xgcc-sans-libc (cross-gcc target
+         (xgcc-sans-libc (cross-gcc-with-newlib (cross-gcc target
                                     #:xgcc base-gcc-for-libc
-                                    #:xbinutils xbinutils))
+                                    #:xbinutils xbinutils)))
          ;; 2. Build cross-compiled kernel headers with XGCC-SANS-LIBC, derived
          ;; from BASE-KERNEL-HEADERS
          (xkernel (cross-kernel-headers target


### PR DESCRIPTION
When building our initial libc-less gcc, we can pass `--with-newlib`,
which ensures `inhibit_libc` is defined, and better indicates our
intent.

This is somewhat related to, but doesn't solve #22458. 

Co-authored-by: Carl Dong <contact@carldong.me>
Co-authored-by: Hennadii Stepanov <32963518+hebasto@users.noreply.github.com>