### PR TITLE
ThreadOpenConnections bug fix

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1665,7 +1665,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
                 switch (pnode->m_conn_type) {
                     case ConnectionType::INBOUND:
                     case ConnectionType::MANUAL:
-                        break;
+                        continue;
                     case ConnectionType::OUTBOUND_FULL_RELAY:
                     case ConnectionType::BLOCK_RELAY:
                     case ConnectionType::ADDR_FETCH:


### PR DESCRIPTION
Previously would break out of the loop that builds `setConnected` at the first manual/inbound connection. Replacing break with continue considers the rest of the nodes.

...

At least, that's what I think this does... Not sure what's an easy way to test this, and my C++ is definitely Rusty. :)