### PR TITLE
test: add tests for `datacarrier` and `datacarriersize` options

### DIFF
--- a/test/functional/mempool_datacarrier.py
+++ b/test/functional/mempool_datacarrier.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020-2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test datacarrier functionality"""
+from test_framework.messages import (
+    CTxOut,
+    MAX_OP_RETURN_RELAY,
+)
+from test_framework.script import (
+    CScript,
+    OP_RETURN,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_node import TestNode
+from test_framework.util import (
+    assert_raises_rpc_error,
+    random_bytes,
+)
+from test_framework.wallet import MiniWallet
+
+
+class DataCarrierTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 3
+        self.extra_args = [
+            [],
+            ["-datacarrier=0"],
+            ["-datacarrier=1", f"-datacarriersize={MAX_OP_RETURN_RELAY - 1}"]
+        ]
+
+    def test_null_data_transaction(self, node: TestNode, data: bytes, success: bool) -> None:
+        tx = self.wallet.create_self_transfer(fee_rate=0)["tx"]
+        tx.vout.append(CTxOut(nValue=0, scriptPubKey=CScript([OP_RETURN, data])))
+        tx.vout[0].nValue -= tx.get_vsize()  # simply pay 1sat/vbyte fee
+
+        tx_hex = tx.serialize().hex()
+
+        if success:
+            self.wallet.sendrawtransaction(from_node=node, tx_hex=tx_hex)
+            assert tx.rehash() in node.getrawmempool(True), f'{tx_hex} not in mempool'
+        else:
+            assert_raises_rpc_error(-26, "scriptpubkey", self.wallet.sendrawtransaction, from_node=node, tx_hex=tx_hex)
+
+    def run_test(self):
+        self.wallet = MiniWallet(self.nodes[0])
+        self.wallet.rescan_utxos()
+
+        # By default, only 80 bytes are used for data (+1 for OP_RETURN, +2 for the pushdata opcodes).
+        default_size_data = random_bytes(MAX_OP_RETURN_RELAY - 3)
+        too_long_data = random_bytes(MAX_OP_RETURN_RELAY - 2)
+        small_data = random_bytes(MAX_OP_RETURN_RELAY - 4)
+
+        self.log.info("Testing null data transaction with default -datacarrier and -datacarriersize values.")
+        self.test_null_data_transaction(node=self.nodes[0], data=default_size_data, success=True)
+
+        self.log.info("Testing a null data transaction larger than allowed by the default -datacarriersize value.")
+        self.test_null_data_transaction(node=self.nodes[0], data=too_long_data, success=False)
+
+        self.log.info("Testing a null data transaction with -datacarrier=false.")
+        self.test_null_data_transaction(node=self.nodes[1], data=default_size_data, success=False)
+
+        self.log.info("Testing a null data transaction with a size larger than accepted by -datacarriersize.")
+        self.test_null_data_transaction(node=self.nodes[2], data=default_size_data, success=False)
+
+        self.log.info("Testing a null data transaction with a size smaller than accepted by -datacarriersize.")
+        self.test_null_data_transaction(node=self.nodes[2], data=small_data, success=True)
+
+
+if __name__ == '__main__':
+    DataCarrierTest().main()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -68,6 +68,9 @@ WITNESS_SCALE_FACTOR = 4
 DEFAULT_ANCESTOR_LIMIT = 25    # default max number of in-mempool ancestors
 DEFAULT_DESCENDANT_LIMIT = 25  # default max number of in-mempool descendants
 
+# Default setting for -datacarriersize. 80 bytes of data, +1 for OP_RETURN, +2 for the pushdata opcodes.
+MAX_OP_RETURN_RELAY = 83
+
 
 def sha256(s):
     return hashlib.sha256(s).digest()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -320,6 +320,7 @@ BASE_SCRIPTS = [
     'feature_unsupported_utxo_db.py',
     'feature_logging.py',
     'feature_anchors.py',
+    'mempool_datacarrier.py',
     'feature_coinstatsindex.py',
     'wallet_orphanedreward.py',
     'wallet_timelock.py',


### PR DESCRIPTION
As suggested in https://github.com/bitcoin/bitcoin/issues/25787, this PR adds tests for `datacarrier` and `datacarriersize` initialization options.

Close https://github.com/bitcoin/bitcoin/issues/25787.