### PR TITLE
test, tracing: don't rely on `block_connected` USDT event order in tests

### DIFF
--- a/test/functional/interface_usdt_validation.py
+++ b/test/functional/interface_usdt_validation.py
@@ -91,7 +91,7 @@ class ValidationTracepointTest(BitcoinTestFramework):
         # that the handle_* functions succeeded.
         BLOCKS_EXPECTED = 2
         blocks_checked = 0
-        expected_blocks = list()
+        expected_blocks = dict()
 
         self.log.info("hook into the validation:block_connected tracepoint")
         ctx = USDT(pid=self.nodes[0].process.pid)
@@ -104,15 +104,16 @@ class ValidationTracepointTest(BitcoinTestFramework):
             nonlocal expected_blocks, blocks_checked
             event = ctypes.cast(data, ctypes.POINTER(Block)).contents
             self.log.info(f"handle_blockconnected(): {event}")
-            block = expected_blocks.pop(0)
-            assert_equal(block["hash"], bytes(event.hash[::-1]).hex())
+            block_hash = bytes(event.hash[::-1]).hex()
+            block = expected_blocks[block_hash]
+            assert_equal(block["hash"], block_hash)
             assert_equal(block["height"], event.height)
             assert_equal(len(block["tx"]), event.transactions)
             assert_equal(len([tx["vin"] for tx in block["tx"]]), event.inputs)
             assert_equal(0, event.sigops)  # no sigops in coinbase tx
             # only plausibility checks
             assert(event.duration > 0)
-
+            del expected_blocks[block_hash]
             blocks_checked += 1
 
         bpf["block_connected"].open_perf_buffer(
@@ -122,7 +123,7 @@ class ValidationTracepointTest(BitcoinTestFramework):
         block_hashes = self.generatetoaddress(
             self.nodes[0], BLOCKS_EXPECTED, ADDRESS_BCRT1_UNSPENDABLE)
         for block_hash in block_hashes:
-            expected_blocks.append(self.nodes[0].getblock(block_hash, 2))
+            expected_blocks[block_hash] = self.nodes[0].getblock(block_hash, 2)
 
         bpf.perf_buffer_poll(timeout=200)
         bpf.cleanup()


### PR DESCRIPTION
Relying on block_connected event order in the USDT interface tests turned out to be brittle.

Closes https://github.com/bitcoin/bitcoin/issues/25793
Closes https://github.com/bitcoin/bitcoin/issues/25764