### PR TITLE
build: fix cleanup of test logs

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -339,7 +339,7 @@ nodist_test_test_bitcoin_SOURCES = $(GENERATED_TEST_FILES)
 
 $(BITCOIN_TESTS): $(GENERATED_TEST_FILES)
 
-CLEAN_BITCOIN_TEST = test/*.gcda test/*.gcno test/fuzz/*.gcda test/fuzz/*.gcno test/util/*.gcda test/util/*.gcno $(GENERATED_TEST_FILES) $(BITCOIN_TESTS:=.log)
+CLEAN_BITCOIN_TEST = test/*.gcda test/*.gcno test/fuzz/*.gcda test/fuzz/*.gcno test/util/*.gcda test/util/*.gcno $(GENERATED_TEST_FILES) $(addsuffix .log,$(basename $(BITCOIN_TESTS)))
 
 CLEANFILES += $(CLEAN_BITCOIN_TEST)
 


### PR DESCRIPTION
`make clean` currently looks for `test_name.cpp.log`, when it should be `test_name.log`, meaning .log files are left after running `make clean`.

Also fixes #21705. `make distcheck` seems to work fine after the logs files are properly cleaned up:
```bash
./autogen.sh && ./configure && make distcheck -j9
....
make[1]: Leaving directory '/home/ubuntu/bitcoin/bitcoin-23.99.0/_build/sub'
if test -d "bitcoin-23.99.0"; then find "bitcoin-23.99.0" -type d ! -perm -200 -exec chmod u+w {} ';' && rm -rf "bitcoin-23.99.0" || { sleep 5 && rm -rf "bitcoin-23.99.0"; }; else :; fi
=================================================
bitcoin-23.99.0 archives ready for distribution: 
bitcoin-23.99.0.tar.gz
=================================================
```

Probably broken in #19385 / #24715.

Guix Build (x86_64):
```bash
c33306c2ae55bc0e037a1050bd0813fd7654f21fefd0e7df089a541118b629bc  guix-build-5474f5c356c5/output/aarch64-linux-gnu/SHA256SUMS.part
f3cf5b8366e27155f3a369ab0d017074912506c43b4010054a72e5c3ae8cab2c  guix-build-5474f5c356c5/output/aarch64-linux-gnu/bitcoin-5474f5c356c5-aarch64-linux-gnu-debug.tar.gz
48f618300f63533c50c31395959737103bb0279972b989cc5417adbf338a5c9f  guix-build-5474f5c356c5/output/aarch64-linux-gnu/bitcoin-5474f5c356c5-aarch64-linux-gnu.tar.gz
6b3e0ceefc84dfad48aec3a9ea8ae98a427775242370234709605855f593dc88  guix-build-5474f5c356c5/output/arm-linux-gnueabihf/SHA256SUMS.part
36a38f4d0d2d0fee51256ee9c610cde014055cf18b5b852c8b3235ef218b461e  guix-build-5474f5c356c5/output/arm-linux-gnueabihf/bitcoin-5474f5c356c5-arm-linux-gnueabihf-debug.tar.gz
3acb46a786323068fe34eaa8b2f7bff428d35367677e456b78fc00db09da8adf  guix-build-5474f5c356c5/output/arm-linux-gnueabihf/bitcoin-5474f5c356c5-arm-linux-gnueabihf.tar.gz
aaeb126cca3cbbb1d21be2cbb36b3e16a8c110199a5e61172ee55c9c913fb717  guix-build-5474f5c356c5/output/arm64-apple-darwin/SHA256SUMS.part
0135d47c34dfbfbcd68181292fc810a1be4efaa0ff9fab05f9f33415167fc82c  guix-build-5474f5c356c5/output/arm64-apple-darwin/bitcoin-5474f5c356c5-arm64-apple-darwin-unsigned.dmg
261ae9f70238ecbd8fedf9b3e02f34601abe42c4a23b25d0571d04d0881fdaba  guix-build-5474f5c356c5/output/arm64-apple-darwin/bitcoin-5474f5c356c5-arm64-apple-darwin-unsigned.tar.gz
de716e0f425bae38cfda2690e86dbfa6831b6d37dd8a7638ca14334eecbddf99  guix-build-5474f5c356c5/output/arm64-apple-darwin/bitcoin-5474f5c356c5-arm64-apple-darwin.tar.gz
2e2e1d5cd009ec5c69ce22124afe90ff8c15e9cb546df818b2305ff96efa9c81  guix-build-5474f5c356c5/output/dist-archive/bitcoin-5474f5c356c5.tar.gz
85dd41584a2c7715b16508dff0f51bbb20b3891a1901a1781ecc37bc1cfd97c8  guix-build-5474f5c356c5/output/powerpc64-linux-gnu/SHA256SUMS.part
49ae951e9acb34fede0ead4d53679ddc041bfb6d60646efaca2a99cf87972be9  guix-build-5474f5c356c5/output/powerpc64-linux-gnu/bitcoin-5474f5c356c5-powerpc64-linux-gnu-debug.tar.gz
2efcb3fbb6702bff30bbf05d83b9849f390c67a1c363c883d71f365f4bee7ef6  guix-build-5474f5c356c5/output/powerpc64-linux-gnu/bitcoin-5474f5c356c5-powerpc64-linux-gnu.tar.gz
cea9e8e2499932ef6e20bba7a6b3408e2cca6fcd1875c1890293dd745add6942  guix-build-5474f5c356c5/output/powerpc64le-linux-gnu/SHA256SUMS.part
7616659242a1f15b7d6f9f54382dfb52d0bbdca701e1fb3d48fbe7bb590e6213  guix-build-5474f5c356c5/output/powerpc64le-linux-gnu/bitcoin-5474f5c356c5-powerpc64le-linux-gnu-debug.tar.gz
d9d4eeaf6f9d1272000aa598c8461afc330a8e65f263d45b0eab222f8ddfec71  guix-build-5474f5c356c5/output/powerpc64le-linux-gnu/bitcoin-5474f5c356c5-powerpc64le-linux-gnu.tar.gz
f83ee11c35001d34f9fba7d1e9e201a4cc6fa5e44bd51e13dabffcb35324348c  guix-build-5474f5c356c5/output/riscv64-linux-gnu/SHA256SUMS.part
c441e56f23f224122ed064cdb57364fb129f5c9d50c5e8173952ce649b46bdb8  guix-build-5474f5c356c5/output/riscv64-linux-gnu/bitcoin-5474f5c356c5-riscv64-linux-gnu-debug.tar.gz
319db8af21a4d3c7bbdf54c315ad70bacf7fba1f2559408188d90c9ba60ca63c  guix-build-5474f5c356c5/output/riscv64-linux-gnu/bitcoin-5474f5c356c5-riscv64-linux-gnu.tar.gz
9ac536a04d7e500f87b1f7dfb60e1e84cde2c192d3dffb89c308b864e9b9d583  guix-build-5474f5c356c5/output/x86_64-apple-darwin/SHA256SUMS.part
19e70f13fb4bf82375f7ca882a23e831f84729278e643cf5911182bdababa893  guix-build-5474f5c356c5/output/x86_64-apple-darwin/bitcoin-5474f5c356c5-x86_64-apple-darwin-unsigned.dmg
673a20e9457af3d0a89ea6721f84c6136132d3fbe469b7371bf14ce688b567d0  guix-build-5474f5c356c5/output/x86_64-apple-darwin/bitcoin-5474f5c356c5-x86_64-apple-darwin-unsigned.tar.gz
74162d53faffc4372ae4587cde395fe078b5c440c43c5a4ad8b8b890e9546255  guix-build-5474f5c356c5/output/x86_64-apple-darwin/bitcoin-5474f5c356c5-x86_64-apple-darwin.tar.gz
d751d50427d7abcbe9ac1daf087dc3addb7e4e6b90bb4c3ef6c31f8e54cac25e  guix-build-5474f5c356c5/output/x86_64-linux-gnu/SHA256SUMS.part
49951b53172d4fe193d7ffc15b04a4bc058a3209653982b65912f2b221305dd4  guix-build-5474f5c356c5/output/x86_64-linux-gnu/bitcoin-5474f5c356c5-x86_64-linux-gnu-debug.tar.gz
93d4c4b07202a9171a72b6887e3931e53b3a8c22433b26521e2cb2a0c942f52a  guix-build-5474f5c356c5/output/x86_64-linux-gnu/bitcoin-5474f5c356c5-x86_64-linux-gnu.tar.gz
b4b79e3578b6ffbb3075aacff969fb201b386e35a2d9d597047b61ff14bdfbfb  guix-build-5474f5c356c5/output/x86_64-w64-mingw32/SHA256SUMS.part
8260f5c9a38cc577dff2143f00c465d117aa9835b3633365289d6807d7e46e7c  guix-build-5474f5c356c5/output/x86_64-w64-mingw32/bitcoin-5474f5c356c5-win64-debug.zip
b20fbf02ddf617b86e5d5f88346ed97f9d169cd56904684ba3ca5f03ea85f008  guix-build-5474f5c356c5/output/x86_64-w64-mingw32/bitcoin-5474f5c356c5-win64-setup-unsigned.exe
16e9d1b817a832bfb0be2b9065440245a5d04b3aae8e34ff0f43f20c5dd7047f  guix-build-5474f5c356c5/output/x86_64-w64-mingw32/bitcoin-5474f5c356c5-win64-unsigned.tar.gz
da766e257d10cf8890a530babc6100039c69ae7ed8e4f969eb612b4a411dd88f  guix-build-5474f5c356c5/output/x86_64-w64-mingw32/bitcoin-5474f5c356c5-win64.zip
```