### PR TITLE
[23.x] guix: patch NSIS to remove .reloc sections from install stubs

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -201,7 +201,8 @@ chain for " target " development."))
 
 (define (make-nsis-for-gcc-10 base-nsis)
   (package-with-extra-patches base-nsis
-    (search-our-patches "nsis-gcc-10-memmove.patch")))
+    (search-our-patches "nsis-gcc-10-memmove.patch"
+                        "nsis-disable-installer-reloc.patch")))
 
 (define-public lief
   (package

--- a/contrib/guix/patches/nsis-disable-installer-reloc.patch
+++ b/contrib/guix/patches/nsis-disable-installer-reloc.patch
@@ -1,0 +1,30 @@
+Patch NSIS so that it's installer stubs, produced at NSIS build time,
+do not contain .reloc sections, which will exist by default when using
+binutils/ld 2.36+.
+
+This ultimately fixes an issue when running the installer with the
+"Force randomization for images (Mandatory ASLR)" setting active.
+
+This patch has not yet been sent upstream, because it's not clear if this
+is the best fix, for the underlying issue, which seems to be that makensis
+doesn't account for .reloc sections when it builds installers.
+
+The existence of a reloc section shouldn't be a problem, and, if anything,
+is actually a requirement for working ASLR. All other Windows binaries we
+produce contain them, and function correctly when under the same
+"Force randomization for images (Mandatory ASLR)" setting.
+
+See:
+https://github.com/bitcoin/bitcoin/issues/25726
+https://sourceforge.net/p/nsis/bugs/1131/
+
+--- a/SCons/Config/gnu
++++ b/SCons/Config/gnu
+@@ -102,6 +102,7 @@ stub_env.Append(LINKFLAGS = ['-mwindows'])          # build windows executables
+ stub_env.Append(LINKFLAGS = ['$NODEFLIBS_FLAG'])    # no standard libraries
+ stub_env.Append(LINKFLAGS = ['$ALIGN_FLAG'])        # 512 bytes align
+ stub_env.Append(LINKFLAGS = ['$MAP_FLAG'])          # generate map file
++stub_env.Append(LINKFLAGS = ['-Wl,--disable-reloc-section'])
+ 
+ conf = FlagsConfigure(stub_env)
+ conf.CheckCompileFlag('-fno-tree-loop-distribute-patterns')  # GCC 10: Don't generate msvcrt!memmove calls (bug #1248)


### PR DESCRIPTION
Backport of #25788 to the 23.x branch.

Guix Build (x86_64):
```bash
5533c15a0084dfc174b68620a638f5499677be20eafdb1261457f7759298abdc  guix-build-fc77b2a41dd9/output/dist-archive/bitcoin-fc77b2a41dd9.tar.gz
b67742b17aa813350051635f1e0a9b27921deb22c40d89c8d108fd809619826c  guix-build-fc77b2a41dd9/output/x86_64-w64-mingw32/SHA256SUMS.part
34e06ab6fbcce2508095d6899daf9c38b962df1a042d0bedee49169f394d47a5  guix-build-fc77b2a41dd9/output/x86_64-w64-mingw32/bitcoin-fc77b2a41dd9-win64-debug.zip
63e1e7c1aa62577a21606c789bdaf983352c5285eec5722608cf7a3240a25d6a  guix-build-fc77b2a41dd9/output/x86_64-w64-mingw32/bitcoin-fc77b2a41dd9-win64-setup-unsigned.exe
0ae26c5bc2f2aa86c451d3cfa3fbdbd73edab6136fd8d6510cd1c47a833973b7  guix-build-fc77b2a41dd9/output/x86_64-w64-mingw32/bitcoin-fc77b2a41dd9-win64-unsigned.tar.gz
ddb1feb2541d1a4922a62997224e965a3e79c7233c75106eb8c7ad76eff6cf89  guix-build-fc77b2a41dd9/output/x86_64-w64-mingw32/bitcoin-fc77b2a41dd9-win64.zip
```

Guix Build (arm64):
```bash
5533c15a0084dfc174b68620a638f5499677be20eafdb1261457f7759298abdc  guix-build-fc77b2a41dd9/output/dist-archive/bitcoin-fc77b2a41dd9.tar.gz
3c5cb927e397d14f39bed24480b6800d946854c376d35cfb7a9dd635d45a5d6b  guix-build-fc77b2a41dd9/output/x86_64-w64-mingw32/SHA256SUMS.part
b520c2e9f4c29fe711225c737b4c16e2ae933d5954cfb15cec554e1e0b57b061  guix-build-fc77b2a41dd9/output/x86_64-w64-mingw32/bitcoin-fc77b2a41dd9-win64-debug.zip
63e1e7c1aa62577a21606c789bdaf983352c5285eec5722608cf7a3240a25d6a  guix-build-fc77b2a41dd9/output/x86_64-w64-mingw32/bitcoin-fc77b2a41dd9-win64-setup-unsigned.exe
0ae26c5bc2f2aa86c451d3cfa3fbdbd73edab6136fd8d6510cd1c47a833973b7  guix-build-fc77b2a41dd9/output/x86_64-w64-mingw32/bitcoin-fc77b2a41dd9-win64-unsigned.tar.gz
1447a28a582c0e5f2dd03ce22ecf078c6398142b3a2be2de2347a5f095f14d5b  guix-build-fc77b2a41dd9/output/x86_64-w64-mingw32/bitcoin-fc77b2a41dd9-win64.zip
```