### PR TITLE
refactor: Drop `boost/algorithm/string/replace.hpp` dependency

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -249,6 +249,22 @@ BOOST_AUTO_TEST_CASE(util_Join)
     BOOST_CHECK_EQUAL(Join<std::string>({"foo", "bar"}, ", ", op_upper), "FOO, BAR");
 }
 
+BOOST_AUTO_TEST_CASE(util_ReplaceAll)
+{
+    const std::string original("A test \"%s\" string '%s'.");
+    auto test_replaceall = [&original](const std::string& search, const std::string& substitute, const std::string& expected) {
+        auto test = original;
+        ReplaceAll(test, search, substitute);
+        BOOST_CHECK_EQUAL(test, expected);
+    };
+
+    test_replaceall("", "foo", original);
+    test_replaceall(original, "foo", "foo");
+    test_replaceall("%s", "foo", "A test \"foo\" string 'foo'.");
+    test_replaceall("\"", "foo", "A test foo%sfoo string '%s'.");
+    test_replaceall("'", "foo", "A test \"%s\" string foo%sfoo.");
+}
+
 BOOST_AUTO_TEST_CASE(util_TrimString)
 {
     BOOST_CHECK_EQUAL(TrimString(" foo bar "), "foo bar");

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -4,11 +4,12 @@
 
 #include <util/string.h>
 
-#include <boost/algorithm/string/replace.hpp>
-
+#include <regex>
 #include <string>
+#include <utility>
 
-void ReplaceAll(std::string& in_out, std::string_view search, std::string_view substitute)
+void ReplaceAll(std::string& in_out, const std::string& search, const std::string& substitute)
 {
-    boost::replace_all(in_out, search, substitute);
+    if (search.empty()) return;
+    in_out = std::regex_replace(in_out, std::regex(std::move(search)), substitute);
 }

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -17,7 +17,7 @@
 #include <string_view>
 #include <vector>
 
-void ReplaceAll(std::string& in_out, std::string_view search, std::string_view substitute);
+void ReplaceAll(std::string& in_out, const std::string& search, const std::string& substitute);
 
 [[nodiscard]] inline std::vector<std::string> SplitString(std::string_view str, char sep)
 {

--- a/test/lint/lint-includes.py
+++ b/test/lint/lint-includes.py
@@ -21,8 +21,7 @@ EXCLUDED_DIRS = ["src/leveldb/",
                  "src/minisketch/",
                 ]
 
-EXPECTED_BOOST_INCLUDES = ["boost/algorithm/string/replace.hpp",
-                           "boost/date_time/posix_time/posix_time.hpp",
+EXPECTED_BOOST_INCLUDES = ["boost/date_time/posix_time/posix_time.hpp",
                            "boost/multi_index/hashed_index.hpp",
                            "boost/multi_index/ordered_index.hpp",
                            "boost/multi_index/sequenced_index.hpp",


### PR DESCRIPTION
A new implementation of the `ReplaceAll()` seems enough for all of our purposes.