### PR TITLE
fs: work around u8path deprecated-declaration warnings with libc++

### DIFF
--- a/build_msvc/common.init.vcxproj.in
+++ b/build_msvc/common.init.vcxproj.in
@@ -90,7 +90,7 @@
       <AdditionalOptions>/utf-8 /Zc:__cplusplus /std:c++20 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4018;4244;4267;4334;4715;4805;4834</DisableSpecificWarnings>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <PreprocessorDefinitions>_SILENCE_CXX20_U8PATH_DEPRECATION_WARNING;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;ZMQ_STATIC;NOMINMAX;WIN32;HAVE_CONFIG_H;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CONSOLE;_WIN32_WINNT=0x0601;_WIN32_IE=0x0501;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;ZMQ_STATIC;NOMINMAX;WIN32;HAVE_CONFIG_H;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CONSOLE;_WIN32_WINNT=0x0601;_WIN32_IE=0x0501;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\src;..\..\src\minisketch\include;..\..\src\univalue\include;..\..\src\secp256k1\include;..\..\src\leveldb\include;..\..\src\leveldb\helpers\memenv;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/src/fs.h
+++ b/src/fs.h
@@ -69,7 +69,11 @@ public:
 
 static inline path u8path(const std::string& utf8_str)
 {
+#if __cplusplus < 202002L
     return std::filesystem::u8path(utf8_str);
+#else
+    return std::filesystem::path(std::u8string{utf8_str.begin(), utf8_str.end()});
+#endif
 }
 
 // Disallow implicit std::string conversion for absolute to avoid


### PR DESCRIPTION
When building in c++20 mode using libc++, the following warning is emitted:
```bash
./fs.h:72:29: warning: 'u8path<std::string>' is deprecated [-Wdeprecated-declarations]
    return std::filesystem::u8path(utf8_str);
                            ^
/usr/lib/llvm-14/bin/../include/c++/v1/__filesystem/u8path.h:72:27: note: 'u8path<std::string>' has been explicitly marked deprecated here
_LIBCPP_INLINE_VISIBILITY _LIBCPP_DEPRECATED_WITH_CHAR8_T
                          ^
/usr/lib/llvm-14/bin/../include/c++/v1/__config:1042:43: note: expanded from macro '_LIBCPP_DEPRECATED_WITH_CHAR8_T'
                                          ^
/usr/lib/llvm-14/bin/../include/c++/v1/__config:1007:48: note: expanded from macro '_LIBCPP_DEPRECATED'
                                               ^
1 warning generated.
```

as [`u8path<std::string>`](https://en.cppreference.com/w/cpp/filesystem/path/u8path) is deprecated starting with C++20.

Fixes: #24682.