### PR TITLE
build: fix cross-arch macOS M1 build reproducibility

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -131,6 +131,9 @@ $(package)_config_opts_darwin += -no-feature-corewlan
 $(package)_config_opts_darwin += -no-freetype
 $(package)_config_opts_darwin += QMAKE_MACOSX_DEPLOYMENT_TARGET=$(OSX_MIN_VERSION)
 
+# Optimizing using > -O1 causes non-determinism when building across arches.
+$(package)_config_opts_aarch64_darwin += "QMAKE_CFLAGS_OPTIMIZE_FULL = -O1"
+
 ifneq ($(build_os),darwin)
 $(package)_config_opts_darwin += -xplatform macx-clang-linux
 $(package)_config_opts_darwin += -device-option MAC_SDK_PATH=$(OSX_SDK)


### PR DESCRIPTION
Building the macOS M1 bitcoin-qt binary at a optimisation level higher than `-O1` causes reproducibility issues when building on different architectures.

Proposing somewhat of a hammer.

This would fix 1 of the 2 remaining HOSTS in #21194.

Guix Build (x86_64):
```bash
1b58b5109b32dca2509499c93347148e6bab5dca835081f8cbd3123bed72cce1  guix-build-08bd3382777b/output/arm64-apple-darwin/SHA256SUMS.part
0e0d063d3832fad7c5116dabb2ac33c919f40bda04759aad4523c6247295bc9e  guix-build-08bd3382777b/output/arm64-apple-darwin/bitcoin-08bd3382777b-arm64-apple-darwin-unsigned.dmg
1feb301245f2c664edcfd9ac528fe1543fc7b183b3b42637db77d57658bc2b5e  guix-build-08bd3382777b/output/arm64-apple-darwin/bitcoin-08bd3382777b-arm64-apple-darwin-unsigned.tar.gz
641eb100d0a281203f9d6e36e45dc0ffc772c680d6aec462434f106b4c44e295  guix-build-08bd3382777b/output/arm64-apple-darwin/bitcoin-08bd3382777b-arm64-apple-darwin.tar.gz
9d89920626e35939aa6cf506fc85861179f3c0e18d4ef1954750cf81336a851a  guix-build-08bd3382777b/output/dist-archive/bitcoin-08bd3382777b.tar.gz
e7697d30084270d0b5843b3baf0d752e240c2f708f728bc2f6896f153276ca6b  guix-build-08bd3382777b/output/x86_64-apple-darwin/SHA256SUMS.part
dd77acee082dbfd3cdad2c564bbd3bdace8df9bf32f92cf4a2debd5a996ace49  guix-build-08bd3382777b/output/x86_64-apple-darwin/bitcoin-08bd3382777b-x86_64-apple-darwin-unsigned.dmg
85e63fccb7af12468a04a678034c42dcd775d243b2d194a52e1086a6ffbdbe84  guix-build-08bd3382777b/output/x86_64-apple-darwin/bitcoin-08bd3382777b-x86_64-apple-darwin-unsigned.tar.gz
ff2629957608898d76a42025985e3ec4bf5dc8572794e32b4182ba6f8babb828  guix-build-08bd3382777b/output/x86_64-apple-darwin/bitcoin-08bd3382777b-x86_64-apple-darwin.tar.gz
```

Guix Build (arm64):
```bash
1b58b5109b32dca2509499c93347148e6bab5dca835081f8cbd3123bed72cce1  guix-build-08bd3382777b/output/arm64-apple-darwin/SHA256SUMS.part
0e0d063d3832fad7c5116dabb2ac33c919f40bda04759aad4523c6247295bc9e  guix-build-08bd3382777b/output/arm64-apple-darwin/bitcoin-08bd3382777b-arm64-apple-darwin-unsigned.dmg
1feb301245f2c664edcfd9ac528fe1543fc7b183b3b42637db77d57658bc2b5e  guix-build-08bd3382777b/output/arm64-apple-darwin/bitcoin-08bd3382777b-arm64-apple-darwin-unsigned.tar.gz
641eb100d0a281203f9d6e36e45dc0ffc772c680d6aec462434f106b4c44e295  guix-build-08bd3382777b/output/arm64-apple-darwin/bitcoin-08bd3382777b-arm64-apple-darwin.tar.gz
9d89920626e35939aa6cf506fc85861179f3c0e18d4ef1954750cf81336a851a  guix-build-08bd3382777b/output/dist-archive/bitcoin-08bd3382777b.tar.gz
e7697d30084270d0b5843b3baf0d752e240c2f708f728bc2f6896f153276ca6b  guix-build-08bd3382777b/output/x86_64-apple-darwin/SHA256SUMS.part
dd77acee082dbfd3cdad2c564bbd3bdace8df9bf32f92cf4a2debd5a996ace49  guix-build-08bd3382777b/output/x86_64-apple-darwin/bitcoin-08bd3382777b-x86_64-apple-darwin-unsigned.dmg
85e63fccb7af12468a04a678034c42dcd775d243b2d194a52e1086a6ffbdbe84  guix-build-08bd3382777b/output/x86_64-apple-darwin/bitcoin-08bd3382777b-x86_64-apple-darwin-unsigned.tar.gz
ff2629957608898d76a42025985e3ec4bf5dc8572794e32b4182ba6f8babb828  guix-build-08bd3382777b/output/x86_64-apple-darwin/bitcoin-08bd3382777b-x86_64-apple-darwin.tar.gz
```