### PR TITLE
[test] make tx6 child of tx5, not tx3, in rbf_tests

### DIFF
--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -76,7 +76,7 @@ BOOST_FIXTURE_TEST_CASE(rbf_helper_functions, TestChain100Setup)
     // Create a parent tx5 and child tx6 where both have very low fees
     const auto tx5 = make_tx(/*inputs=*/ {m_coinbase_txns[2]}, /*output_values=*/ {1099 * CENT});
     pool.addUnchecked(entry.Fee(low_fee).FromTx(tx5));
-    const auto tx6 = make_tx(/*inputs=*/ {tx3}, /*output_values=*/ {1098 * CENT});
+    const auto tx6 = make_tx(/*inputs=*/ {tx5}, /*output_values=*/ {1098 * CENT});
     pool.addUnchecked(entry.Fee(low_fee).FromTx(tx6));
     // Make tx6's modified fee much higher than its base fee. This should cause it to pass
     // the fee-related checks despite being low-feerate.


### PR DESCRIPTION
A small overlooked oopsie from #25674.
There is no effect on the test results because tx3 and tx5 pay the same fee, but this was the intended configuration, as the comment suggests.