### PR TITLE
build: use package_cc for linux qt build

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -153,6 +153,9 @@ $(package)_config_opts_linux += -fontconfig
 $(package)_config_opts_linux += -no-opengl
 $(package)_config_opts_linux += -no-feature-vulkan
 $(package)_config_opts_linux += -dbus-runtime
+$(package)_config_opts_linux += "QMAKE_COMPILER = '$($(package)_cc)'"
+$(package)_config_opts_linux += "QMAKE_CC = '$($(package)_cc)'"
+$(package)_config_opts_linux += "QMAKE_CXX = '$($(package)_cxx)'"
 ifneq ($(LTO),)
 $(package)_config_opts_linux += -ltcg
 endif
@@ -235,7 +238,9 @@ endef
 #
 # 5. Do similar for the win32-g++ mkspec.
 #
-# 6. In clang.conf, swap out clang & clang++, for our compiler + flags. See #17466.
+# 6. In g++-base.conf, swap out gcc & g++, for our compiler + flags.
+#
+# 7. In clang.conf, swap out clang & clang++, for our compiler + flags. See #17466.
 define $(package)_preprocess_cmds
   cp $($(package)_patch_dir)/qt.pro qt.pro && \
   cp $($(package)_patch_dir)/qttools_src.pro qttools/src/src.pro && \
@@ -259,6 +264,9 @@ define $(package)_preprocess_cmds
   echo "!host_build: QMAKE_CFLAGS     += $($(package)_cflags) $($(package)_cppflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
   echo "!host_build: QMAKE_CXXFLAGS   += $($(package)_cxxflags) $($(package)_cppflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
   echo "!host_build: QMAKE_LFLAGS     += $($(package)_ldflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
+  sed -i.old "s|QMAKE_COMPILER          = gcc|QMAKE_COMPILER          = $($(package)_cc)|" qtbase/mkspecs/common/g++-base.conf && \
+  sed -i.old "s|QMAKE_CC                = \$$$$\$$$${CROSS_COMPILE}gcc|QMAKE_CC                = $($(package)_cc)|" qtbase/mkspecs/common/g++-base.conf && \
+  sed -i.old "s|QMAKE_CXX               = \$$$$\$$$${CROSS_COMPILE}g++|QMAKE_CXX               = $($(package)_cxx)|" qtbase/mkspecs/common/g++-base.conf && \
   sed -i.old "s|QMAKE_CC                = \$$$$\$$$${CROSS_COMPILE}clang|QMAKE_CC                = $($(package)_cc)|" qtbase/mkspecs/common/clang.conf && \
   sed -i.old "s|QMAKE_CXX               = \$$$$\$$$${CROSS_COMPILE}clang++|QMAKE_CXX               = $($(package)_cxx)|" qtbase/mkspecs/common/clang.conf
 endef

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -236,9 +236,6 @@ endef
 # 5. Do similar for the win32-g++ mkspec.
 #
 # 6. In clang.conf, swap out clang & clang++, for our compiler + flags. See #17466.
-#
-# 7. Adjust a regex in toolchain.prf, to accommodate Guix's usage of
-# CROSS_LIBRARY_PATH. See #15277.
 define $(package)_preprocess_cmds
   cp $($(package)_patch_dir)/qt.pro qt.pro && \
   cp $($(package)_patch_dir)/qttools_src.pro qttools/src/src.pro && \


### PR DESCRIPTION
Could be enough to close #22184.

```bash
make -C depends qt CC=gcc-12 CXX=g++-12 -j9 DEBUG=1
...
# qmake build
gmake[1]: Entering directory '/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/qmake'
g++-12 -c -o main.o   -std=c++11 -ffunction-sections -fdata-sections -O2 -g  -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/qmake -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/qmake/library -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/qmake/generators -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/src/3rdparty/tinycbor/src -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/qmake/generators/unix -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/qmake/generators/win32 -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/qmake/generators/mac -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/include -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/include/QtCore -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/include/QtCore/5.15.5 -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/include/QtCore/5.15.5/QtCore -I../src/corelib/global -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/mkspecs/linux-g++ -DQT_VERSION_STR=\"5.15.5\" -DQT_VERSION_MAJOR=5 -DQT_VERSION_MINOR=15 -DQT_VERSION_PATCH=5 -DQT_BUILD_QMAKE -DQT_BOOTSTRAPPED -DPROEVALUATOR_FULL -DQT_NO_FOREACH /home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/qmake/main.cpp
...
# qt configure checks
> g++-12 -c -m64 -pipe -pipe -std=c++17 -O1 -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC -D_LIBCPP_DEBUG=1 -I/home/ubuntu/bitcoin/depends/x86_64-pc-linux-gnu/include -maes -O2 -std=gnu++11 -w -fPIC -DNO_ATTRIBUTE -DQT_COMPILER_SUPPORTS_AESNI -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/config.tests/x86_simd -I. -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/mkspecs/linux-g++-64 -o main.o /home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/config.tests/x86_simd/main.cpp
# qt configuration
Building on: linux-g++ (x86_64, CPU features: mmx sse sse2)
Building for: linux-g++-64 (x86_64, CPU features: mmx sse sse2)
Target compiler: unknown (gcc-12)
Configuration: cross_compile sse2 aesni sse3 ssse3 sse4_1 sse4_2 avx avx2 avx512f avx512bw avx512cd avx512dq avx512er avx512ifma avx512pf avx512vbmi avx512vl enable_new_dtags f16c largefile optimize_debug precompile_header rdrnd rdseed shani x86SimdAlways debug c++11 c++14 c++17 c++1z dbus reduce_exports release_tools static stl
......
# qt build
make[4]: Entering directory '/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-e9a047354b8/qtbase/src/corelib'
g++-12 -c -o qlibraryinfo_final.o   -std=c++11 -ffunction-sections -fdata-sections -O2 -g  -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/qmake -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/qmake/library -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/qmake/generators -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/src/3rdparty/tinycbor/src -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/qmake/generators/unix -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/qmake/generators/win32 -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/qmake/generators/mac -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/include -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/include/QtCore -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/include/QtCore/5.15.5 -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/include/QtCore/5.15.5/QtCore -I../src/corelib/global -I/home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/mkspecs/linux-g++ -DQT_VERSION_STR=\"5.15.5\" -DQT_VERSION_MAJOR=5 -DQT_VERSION_MINOR=15 -DQT_VERSION_PATCH=5 -DQT_BUILD_QMAKE -DQT_BOOTSTRAPPED -DPROEVALUATOR_FULL -DQT_NO_FOREACH /home/ubuntu/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.15.5-59cf8e423fe/qtbase/src/corelib/global/qlibraryinfo.cpp
```

Guix Build (x86_64):
```bash
```

Guix Build (arm64):
```bash
```