### PR TITLE
wallet: consolidate CoinSelectionParams::m_change_target and m_min_change_target

### DIFF
--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -125,8 +125,6 @@ struct CoinSelectionParams {
     CAmount m_min_change_target{0};
     /** Cost of creating the change output. */
     CAmount m_change_fee{0};
-    /** The pre-determined minimum value to target when funding a change output. */
-    CAmount m_change_target{0};
     /** Cost of creating the change output + cost of spending the change output in the future. */
     CAmount m_cost_of_change{0};
     /** The targeted feerate of the transaction being built. */

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -794,7 +794,7 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
             coin_selection_params.m_subtract_fee_outputs = true;
         }
     }
-    coin_selection_params.m_change_target = GenerateChangeTarget(std::floor(recipients_sum / vecSend.size()), rng_fast);
+    coin_selection_params.m_min_change_target = GenerateChangeTarget(std::floor(recipients_sum / vecSend.size()), rng_fast);
 
     // Create change script that will be used if we need change
     CScript scriptChange;


### PR DESCRIPTION
These values are both intended for the same thing. Their divergence seems to be the result of an incomplete rename.