### PR TITLE
refactor: Replace m_params with chainman.GetParams()

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -472,10 +472,6 @@ public:
     //! Chainstate instances.
     node::BlockManager& m_blockman;
 
-    /** Chain parameters for this chainstate */
-    /* TODO: replace with m_chainman.GetParams() */
-    const CChainParams& m_params;
-
     //! The chainstate manager that owns this chainstate. The reference is
     //! necessary so that this instance can check whether it is the active
     //! chainstate within deeply nested method calls.


### PR DESCRIPTION
Fixes a TODO introduced in #24595.
Removes `m_params` from `CChainState` class and replaces it with `m_chainman.GetParams()`.
