### PR TITLE
doc: minor updates to guix README

### DIFF
--- a/contrib/guix/INSTALL.md
+++ b/contrib/guix/INSTALL.md
@@ -72,11 +72,11 @@ writing (July 2021). Guix is expected to be more widely packaged over time. For
 an up-to-date view on Guix's package status/version across distros, please see:
 https://repology.org/project/guix/versions
 
-### Debian 11 (Bullseye)/Ubuntu 21.04 (Hirsute Hippo)
+### Debian / Ubuntu
 
 Guix v1.2.0 is available as a distribution package starting in [Debian
 11](https://packages.debian.org/bullseye/guix) and [Ubuntu
-21.04](https://packages.ubuntu.com/hirsute/guix).
+21.04](https://packages.ubuntu.com/search?keywords=guix).
 
 Note that if you intend on using Guix without using any substitutes (more
 details [here][security-model]), v1.2.0 has a known problem when building GnuTLS

--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -382,7 +382,7 @@ https://ci.guix.gnu.org is automatically used unless the `--no-substitutes` flag
 is supplied. This default list of substitute servers is overridable both on a
 `guix-daemon` level and when you invoke `guix` commands. See examples below for
 the various ways of adding dongcarl's substitute server after having [authorized
-his signing key](#authorize-the-signing-keys).
+his signing key](#step-1-authorize-the-signing-keys).
 
 Change the **default list** of substitute servers by starting `guix-daemon` with
 the `--substitute-urls` option (you will likely need to edit your init script):


### PR DESCRIPTION
Two minor updates to the guix docs:

- `contrib/guix/README.md`: fix broken link
- `contrib/guix/INSTALL.md`: Change Ubuntu version in the section on distribution maintained packages from 21.04 (Hirsute Hippo) to 22.04 (Jammy Jellyfish). The previous link to the Ubuntu Guix package (https://packages.ubuntu.com/hirsute/guix) was for Hirsute. That link is now broken, likely because Hirsute reached EOL in January. I was unable to locate a general page for Ubuntu Guix packages so I replaced the broken link with the search results for all Ubuntu Guix packages. That page currently displays Guix packages for three different versions of Ubuntu. Happy to replace this link if there is a better option.
