### PR TITLE
[BugFix] Make PSBT serializations 174 compliant by excluding empty taptree from serialization

### DIFF
--- a/src/psbt.h
+++ b/src/psbt.h
@@ -866,6 +866,9 @@ struct PSBTOutput
                     std::vector<unsigned char> tree_v;
                     s >> tree_v;
                     SpanReader s_tree(s.GetType(), s.GetVersion(), tree_v);
+                    if (s_tree.empty()) {
+                        throw std::ios_base::failure("Output Taproot tree must not be empty");
+                    }
                     while (!s_tree.empty()) {
                         uint8_t depth;
                         uint8_t leaf_ver;

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1244,17 +1244,21 @@ static RPCHelpMan decodepsbt()
         if (output.m_tap_tree.has_value()) {
             UniValue tree(UniValue::VARR);
             const auto& tuples = output.m_tap_tree->GetTreeTuples();
-            for (const auto& tuple : tuples) {
-                uint8_t depth = std::get<0>(tuple);
-                uint8_t leaf_ver = std::get<1>(tuple);
-                CScript script = std::get<2>(tuple);
-                UniValue elem(UniValue::VOBJ);
-                elem.pushKV("depth", (int)depth);
-                elem.pushKV("leaf_ver", (int)leaf_ver);
-                elem.pushKV("script", HexStr(script));
-                tree.push_back(elem);
+            // do not write an empty tree to be BIP-174 compliant, which
+            // requires one-or-more tuple
+            if (!tuples.empty()) {
+                for (const auto& tuple : tuples) {
+                    uint8_t depth = std::get<0>(tuple);
+                    uint8_t leaf_ver = std::get<1>(tuple);
+                    CScript script = std::get<2>(tuple);
+                    UniValue elem(UniValue::VOBJ);
+                    elem.pushKV("depth", (int)depth);
+                    elem.pushKV("leaf_ver", (int)leaf_ver);
+                    elem.pushKV("script", HexStr(script));
+                    tree.push_back(elem);
+                }
+                out.pushKV("taproot_tree", tree);
             }
-            out.pushKV("taproot_tree", tree);
         }
 
         // Taproot bip32 keypaths


### PR DESCRIPTION
According to BIP-174, the tap_tree field must be:

> One or more tuples representing the depth, leaf version, and script for a leaf in the Taproot tree, allowing the entire tree to be reconstructed. The tuples must be in depth first search order so that the tree is correctly reconstructed. Each tuple is an 8-bit unsigned integer representing the depth in the Taproot tree for this script, an 8-bit unsigned integer representing the leaf version, the length of the script as a compact size unsigned integer, and the script itself.

allowing serializing an empty tap tree tuple breaks the "one or more"ness of the field, so serializations should ignore empty but initialized tap_trees.

see also https://github.com/rust-bitcoin/rust-bitcoin/pull/1194, where this caused downstream issues.
