### PR TITLE
test: speedup wallet tests by whitelisting peers (immediate tx relay)

### DIFF
--- a/test/functional/wallet_abandonconflict.py
+++ b/test/functional/wallet_abandonconflict.py
@@ -24,6 +24,9 @@ class AbandonConflictTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.extra_args = [["-minrelaytxfee=0.00001"], []]
+        # whitelist peers to speed up tx relay / mempool sync
+        for args in self.extra_args:
+            args.append("-whitelist=noban@127.0.0.1")
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -55,6 +55,9 @@ class WalletTest(BitcoinTestFramework):
             ['-limitdescendantcount=3', '-walletrejectlongchains=0'],
             [],
         ]
+        # whitelist peers to speed up tx relay / mempool sync
+        for args in self.extra_args:
+            args.append("-whitelist=noban@127.0.0.1")
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -26,7 +26,7 @@ class WalletTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 4
         self.extra_args = [[
-            "-dustrelayfee=0", "-walletrejectlongchains=0"
+            "-dustrelayfee=0", "-walletrejectlongchains=0", "-whitelist=noban@127.0.0.1"
         ]] * self.num_nodes
         self.setup_clean_chain = True
         self.supports_cli = False

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -53,6 +53,7 @@ class BumpFeeTest(BitcoinTestFramework):
             "-walletrbf={}".format(i),
             "-mintxfee=0.00002",
             "-addresstype=bech32",
+            "-whitelist=noban@127.0.0.1",
         ] for i in range(self.num_nodes)]
 
     def skip_test_if_missing_module(self):

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -26,6 +26,10 @@ class WalletGroupTest(BitcoinTestFramework):
             ["-maxapsfee=0.00002719"],
             ["-maxapsfee=0.00002720"],
         ]
+        # whitelist peers to speed up tx relay / mempool sync
+        for args in self.extra_args:
+            args.append("-whitelist=noban@127.0.0.1")
+
         self.rpc_timeout = 480
 
     def skip_test_if_missing_module(self):

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -20,6 +20,10 @@ class WalletHDTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 2
         self.extra_args = [[], ['-keypool=0']]
+        # whitelist peers to speed up tx relay / mempool sync
+        for args in self.extra_args:
+            args.append("-whitelist=noban@127.0.0.1")
+
         self.supports_cli = False
 
     def skip_test_if_missing_module(self):

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -35,6 +35,9 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         self.extra_args = [["-addresstype=legacy"],
                            ["-addresstype=bech32", "-keypool=5"]
                           ]
+        # whitelist peers to speed up tx relay / mempool sync
+        for args in self.extra_args:
+            args.append("-whitelist=noban@127.0.0.1")
         self.setup_clean_chain = True
         self.wallet_names = []
 

--- a/test/functional/wallet_listreceivedby.py
+++ b/test/functional/wallet_listreceivedby.py
@@ -18,6 +18,8 @@ from test_framework.wallet_util import test_address
 class ReceivedByTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
+        # whitelist peers to speed up tx relay / mempool sync
+        self.extra_args = [["-whitelist=noban@127.0.0.1"]] * self.num_nodes
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -23,6 +23,8 @@ class ListSinceBlockTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 4
         self.setup_clean_chain = True
+        # whitelist peers to speed up tx relay / mempool sync
+        self.extra_args = [["-whitelist=noban@127.0.0.1"]] * self.num_nodes
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()


### PR DESCRIPTION
In the course of testing #25297 by running all wallet-related functional tests (see https://github.com/bitcoin/bitcoin/pull/25297#issuecomment-1203365589), I noticed that the run-time of those tests vary a lot between runs, in fact too much for a useful comparison. This PR fixes this by making the tests both more deterministic and also faster, using the good ol' immediate tx relay trick (parameter `-whitelist=noban@127.0.0.1`).

master branch:
```
wallet_abandonconflict.py --descriptors   | ✓ Passed  | 7 s
wallet_abandonconflict.py --legacy-wallet | ✓ Passed  | 23 s
wallet_balance.py --descriptors           | ✓ Passed  | 17 s
wallet_balance.py --legacy-wallet         | ✓ Passed  | 21 s
wallet_basic.py --descriptors             | ✓ Passed  | 32 s
wallet_basic.py --legacy-wallet           | ✓ Passed  | 56 s
wallet_bumpfee.py --descriptors           | ✓ Passed  | 44 s
wallet_bumpfee.py --legacy-wallet         | ✓ Passed  | 45 s
wallet_groups.py --descriptors            | ✓ Passed  | 89 s
wallet_groups.py --legacy-wallet          | ✓ Passed  | 94 s
wallet_hd.py --descriptors                | ✓ Passed  | 7 s
wallet_hd.py --legacy-wallet              | ✓ Passed  | 13 s
wallet_importdescriptors.py --descriptors | ✓ Passed  | 26 s
wallet_listreceivedby.py --descriptors    | ✓ Passed  | 28 s
wallet_listreceivedby.py --legacy-wallet  | ✓ Passed  | 18 s

ALL                                       | ✓ Passed  | 520 s (accumulated)
Runtime: 526 s
```

PR branch:
```
wallet_abandonconflict.py --descriptors   | ✓ Passed  | 7 s
wallet_abandonconflict.py --legacy-wallet | ✓ Passed  | 11 s
wallet_balance.py --descriptors           | ✓ Passed  | 8 s
wallet_balance.py --legacy-wallet         | ✓ Passed  | 8 s
wallet_basic.py --descriptors             | ✓ Passed  | 29 s
wallet_basic.py --legacy-wallet           | ✓ Passed  | 36 s
wallet_bumpfee.py --descriptors           | ✓ Passed  | 39 s
wallet_bumpfee.py --legacy-wallet         | ✓ Passed  | 32 s
wallet_groups.py --descriptors            | ✓ Passed  | 39 s
wallet_groups.py --legacy-wallet          | ✓ Passed  | 41 s
wallet_hd.py --descriptors                | ✓ Passed  | 8 s
wallet_hd.py --legacy-wallet              | ✓ Passed  | 11 s
wallet_importdescriptors.py --descriptors | ✓ Passed  | 17 s
wallet_listreceivedby.py --descriptors    | ✓ Passed  | 7 s
wallet_listreceivedby.py --legacy-wallet  | ✓ Passed  | 9 s

ALL                                       | ✓ Passed  | 302 s (accumulated)
Runtime: 309 s
```
Note that an alternative approach could be to whitelist peers by default for nodes in the functional test framework and only enable the trickle relay for the few tests where it's really needed.