### PR TITLE
lint: enable E722 do not use bare except

### DIFF
--- a/contrib/devtools/security-check.py
+++ b/contrib/devtools/security-check.py
@@ -34,7 +34,7 @@ def check_ELF_RELRO(binary) -> bool:
         flags = binary.get(lief.ELF.DYNAMIC_TAGS.FLAGS)
         if flags.value & lief.ELF.DYNAMIC_FLAGS.BIND_NOW:
             have_bindnow = True
-    except:
+    except Exception:
         have_bindnow = False
 
     return have_gnu_relro and have_bindnow

--- a/contrib/signet/getcoins.py
+++ b/contrib/signet/getcoins.py
@@ -142,7 +142,7 @@ if args.captcha != '': # Retrieve a captcha
 
 try:
     res = session.post(args.faucet, data=data)
-except:
+except Exception:
     raise SystemExit(f"Unexpected error when contacting faucet: {sys.exc_info()[0]}")
 
 # Display the output as per the returned status code

--- a/test/functional/feature_dbcrash.py
+++ b/test/functional/feature_dbcrash.py
@@ -85,7 +85,7 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
                 self.nodes[node_index].waitforblock(expected_tip)
                 utxo_hash = self.nodes[node_index].gettxoutsetinfo()['hash_serialized_2']
                 return utxo_hash
-            except:
+            except Exception:
                 # An exception here should mean the node is about to crash.
                 # If bitcoind exits, then try again.  wait_for_node_exit()
                 # should raise an exception if bitcoind doesn't exit.

--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -85,7 +85,7 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
         self.connect_nodes(0, 2)
         try:
             self.sync_blocks([self.nodes[0], self.nodes[2]], timeout=5)
-        except:
+        except Exception:
             pass
         # node2 must remain at height 0
         assert_equal(self.nodes[2].getblockheader(self.nodes[2].getbestblockhash())['height'], 0)

--- a/test/functional/rpc_preciousblock.py
+++ b/test/functional/rpc_preciousblock.py
@@ -16,7 +16,7 @@ def unidirectional_node_sync_via_rpc(node_src, node_dest):
         try:
             assert len(node_dest.getblock(blockhash, False)) > 0
             break
-        except:
+        except Exception:
             blocks_to_copy.append(blockhash)
             blockhash = node_src.getblockheader(blockhash, True)['previousblockhash']
     blocks_to_copy.reverse()

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -383,7 +383,7 @@ class P2PInterface(P2PConnection):
                 self.message_count[msgtype] += 1
                 self.last_message[msgtype] = message
                 getattr(self, 'on_' + msgtype)(message)
-            except:
+            except Exception:
                 print("ERROR delivering %s (%s)" % (repr(message), sys.exc_info()[0]))
                 raise
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -547,7 +547,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
                 node.start(extra_args[i], *args, **kwargs)
             for node in self.nodes:
                 node.wait_for_rpc_connection()
-        except:
+        except Exception:
             # If one node failed to start, stop the others
             self.stop_nodes()
             raise

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -805,7 +805,7 @@ class RPCOverloadWrapper():
             int(address ,16)
             is_hex = True
             desc = descsum_create('raw(' + address + ')')
-        except:
+        except Exception:
             desc = descsum_create('addr(' + address + ')')
         reqs = [{
             'desc': desc,

--- a/test/lint/lint-python.py
+++ b/test/lint/lint-python.py
@@ -47,6 +47,7 @@ ENABLED = (
     'E711,'  # comparison to None should be 'if cond is None:'
     'E714,'  # test for object identity should be "is not"
     'E721,'  # do not compare types, use "isinstance()"
+    'E722,'  # do not use bare 'except'
     'E742,'  # do not define classes named "l", "O", or "I"
     'E743,'  # do not define functions named "l", "O", or "I"
     'E901,'  # SyntaxError: invalid syntax

--- a/test/util/test_runner.py
+++ b/test/util/test_runner.py
@@ -54,7 +54,7 @@ def bctester(testDir, input_basename, buildenv):
         try:
             bctest(testDir, testObj, buildenv)
             logging.info("PASSED: " + testObj["description"])
-        except:
+        except Exception:
             logging.info("FAILED: " + testObj["description"])
             failed_testcases.append(testObj["description"])
 
@@ -96,7 +96,7 @@ def bctest(testDir, testObj, buildenv):
         try:
             with open(os.path.join(testDir, outputFn), encoding="utf8") as f:
                 outputData = f.read()
-        except:
+        except Exception:
             logging.error("Output file " + outputFn + " cannot be opened")
             raise
         if not outputData:


### PR DESCRIPTION
Improve test code and enable E722 lint check.

 If you want to catch all exceptions that signal program errors, use except Exception: (bare except is equivalent to except BaseException:).

Reference: https://peps.python.org/pep-0008/#programming-recommendations