### PR TITLE
wallet: remove UNKNOWN type from OUTPUT_TYPES array

### DIFF
--- a/src/outputtype.h
+++ b/src/outputtype.h
@@ -27,7 +27,6 @@ static constexpr auto OUTPUT_TYPES = std::array{
     OutputType::P2SH_SEGWIT,
     OutputType::BECH32,
     OutputType::BECH32M,
-    OutputType::UNKNOWN,
 };
 
 std::optional<OutputType> ParseOutputType(const std::string& str);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3433,7 +3433,6 @@ void CWallet::SetupDescriptorScriptPubKeyMans()
 
         for (bool internal : {false, true}) {
             for (OutputType t : OUTPUT_TYPES) {
-                if (t == OutputType::UNKNOWN) continue;
                 auto spk_manager = std::unique_ptr<DescriptorScriptPubKeyMan>(new DescriptorScriptPubKeyMan(*this));
                 if (IsCrypted()) {
                     if (IsLocked()) {


### PR DESCRIPTION
Fixing https://github.com/bitcoin/bitcoin/pull/25734#discussion_r949502998 ->  https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50329

The `OUTPUT_TYPES` array contain the known active output types only.
And it's solely used to create/walk-through the active spkms.

So, no need to add the `UNKNOWN` type here.