### PR TITLE
depends: Boost 1.80.0

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,8 +1,8 @@
 package=boost
-$(package)_version=1.77.0
+$(package)_version=1.80.0
 $(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/$($(package)_version)/source/
 $(package)_file_name=boost_$(subst .,_,$($(package)_version)).tar.bz2
-$(package)_sha256_hash=fc9f85fc030e233142908241af7a846e60630aa7388de9a5fafb1f3a26840854
+$(package)_sha256_hash=1e19565d82e43bc59209a168f5ac899d3ba471d55c7610c677d4ccf2c9c500c0
 
 define $(package)_stage_cmds
   mkdir -p $($(package)_staging_prefix_dir)/include && \

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -17,7 +17,7 @@ You can find installation instructions in the `build-*.md` file for your platfor
 
 | Dependency | Releases | Version used | Minimum required | Runtime |
 | --- | --- | --- | --- | --- |
-| [Boost](../depends/packages/boost.mk) | [link](https://www.boost.org/users/download/) | [1.77.0](https://github.com/bitcoin/bitcoin/pull/24383) | [1.64.0](https://github.com/bitcoin/bitcoin/pull/22320) | No |
+| [Boost](../depends/packages/boost.mk) | [link](https://www.boost.org/users/download/) | [1.80.0](https://github.com/bitcoin/bitcoin/pull/25873) | [1.64.0](https://github.com/bitcoin/bitcoin/pull/22320) | No |
 | [libevent](../depends/packages/libevent.mk) | [link](https://github.com/libevent/libevent/releases) | [2.1.12-stable](https://github.com/bitcoin/bitcoin/pull/21991) | [2.1.8](https://github.com/bitcoin/bitcoin/pull/24681) | No |
 | glibc | [link](https://www.gnu.org/software/libc/) | N/A | [2.18](https://github.com/bitcoin/bitcoin/pull/23511) | Yes |
 | Linux Kernel | [link](https://www.kernel.org/) | N/A | 3.2.0 | Yes |


### PR DESCRIPTION
Mostly misc bug fixes and improvements, to the continually decreasing parts of Boost that we actually use. See: https://www.boost.org/users/history/version_1_80_0.html.

Includes some boring upstreamed changes, i.e https://github.com/boostorg/multi_index/pull/57, https://github.com/boostorg/signals2/pull/60 that aid #24742. Getting Boost modules to drop their usage of deprecated (redirect) headers means we can prune them from our depends tree.

Also a requirement for #25696.

Guix Build (x86_64):
```bash
e793a5ac9372b8fce6e19916be840eee99735bccdedf44b9bca006fd9ac8c395  guix-build-cc8dff5f8ff8/output/aarch64-linux-gnu/SHA256SUMS.part
001e0382f2b05e12f0ec5eaf09e001e31313ee3ab5367b0ba135ea2d7b863bf6  guix-build-cc8dff5f8ff8/output/aarch64-linux-gnu/bitcoin-cc8dff5f8ff8-aarch64-linux-gnu-debug.tar.gz
a50229534b41eebd6c44001b56eb2be35b50d5f3a3b161a8fa46d7558b79693e  guix-build-cc8dff5f8ff8/output/aarch64-linux-gnu/bitcoin-cc8dff5f8ff8-aarch64-linux-gnu.tar.gz
d54d16ae4d5ef2bb0d0dcebbd6d1ec4b0f0976063bf66222a320e68340f902d5  guix-build-cc8dff5f8ff8/output/arm-linux-gnueabihf/SHA256SUMS.part
04c464043af256ee05d565040df9bb438151d4e041aa46f800fc567eba111c2f  guix-build-cc8dff5f8ff8/output/arm-linux-gnueabihf/bitcoin-cc8dff5f8ff8-arm-linux-gnueabihf-debug.tar.gz
097cd2f633bf6d3b8e922d81ce9f6dfe793589418e394abfa4e183861f5ad236  guix-build-cc8dff5f8ff8/output/arm-linux-gnueabihf/bitcoin-cc8dff5f8ff8-arm-linux-gnueabihf.tar.gz
30c8074725b0701b1a781685f50a23ba038297b2633599f40792157daadc13cb  guix-build-cc8dff5f8ff8/output/arm64-apple-darwin/SHA256SUMS.part
df6036e89c7e8746badcbcf805ec4f84070847833c562bc2185c15904b1b909a  guix-build-cc8dff5f8ff8/output/arm64-apple-darwin/bitcoin-cc8dff5f8ff8-arm64-apple-darwin-unsigned.dmg
8421c957b2b83c4afc3bc7f65f93798755acc99ac5921bd89b367c22c5b064d8  guix-build-cc8dff5f8ff8/output/arm64-apple-darwin/bitcoin-cc8dff5f8ff8-arm64-apple-darwin-unsigned.tar.gz
076e8e185bc01dd43feb3fcbcec04eff5ca435b0fdf47c6f05008feec1cf11ac  guix-build-cc8dff5f8ff8/output/arm64-apple-darwin/bitcoin-cc8dff5f8ff8-arm64-apple-darwin.tar.gz
03de7ffcf8d98c61c3a5b763e9bcc6310c9895950f49768da2eeba4871d8478a  guix-build-cc8dff5f8ff8/output/dist-archive/bitcoin-cc8dff5f8ff8.tar.gz
80ffe674a5fa86cfcf3f47eb8103dbfbc97dd74f793cf785c1347469f19b281f  guix-build-cc8dff5f8ff8/output/powerpc64-linux-gnu/SHA256SUMS.part
8ce2024c3fa65e6cd613ef526f90c5904675012b22eb39ccf94081d91e14340a  guix-build-cc8dff5f8ff8/output/powerpc64-linux-gnu/bitcoin-cc8dff5f8ff8-powerpc64-linux-gnu-debug.tar.gz
89dc31c0306b0f1c79e13e5f705b73233695a802fd4946aac03364c45e7de984  guix-build-cc8dff5f8ff8/output/powerpc64-linux-gnu/bitcoin-cc8dff5f8ff8-powerpc64-linux-gnu.tar.gz
7ed1b82ba3d4c1a8ddc24c6f650aa6b2d1be08580b2ec32cfec0fd682828d797  guix-build-cc8dff5f8ff8/output/powerpc64le-linux-gnu/SHA256SUMS.part
01c7f706b236b342f4e0b5043c5788168806338cdaefd5541b04118665c7e40b  guix-build-cc8dff5f8ff8/output/powerpc64le-linux-gnu/bitcoin-cc8dff5f8ff8-powerpc64le-linux-gnu-debug.tar.gz
01767af5b190d0be4a075a5d038644b7dd0d1fc5f0b69698acaca92bfef960d0  guix-build-cc8dff5f8ff8/output/powerpc64le-linux-gnu/bitcoin-cc8dff5f8ff8-powerpc64le-linux-gnu.tar.gz
414de662e0bb3df6a5c8fc1a3576c90a943998b802d97070e31bde434fc6a7f1  guix-build-cc8dff5f8ff8/output/riscv64-linux-gnu/SHA256SUMS.part
db55ddf8051e6dc80180f3eee12a7370bed1140959c34fb5de8d88f0344b23e2  guix-build-cc8dff5f8ff8/output/riscv64-linux-gnu/bitcoin-cc8dff5f8ff8-riscv64-linux-gnu-debug.tar.gz
bb19f15545d5a52e800ffb7f141915ab7083fb4fab9a80269f6714b28a294502  guix-build-cc8dff5f8ff8/output/riscv64-linux-gnu/bitcoin-cc8dff5f8ff8-riscv64-linux-gnu.tar.gz
d9241782d6e596ae02500ffe062501f80b064357bece5d10f7fd4d218240c3a1  guix-build-cc8dff5f8ff8/output/x86_64-apple-darwin/SHA256SUMS.part
1c3258a573e849a8efe6fce535a4f8737fb3a076ebe74ee29ca1e84a9113d24f  guix-build-cc8dff5f8ff8/output/x86_64-apple-darwin/bitcoin-cc8dff5f8ff8-x86_64-apple-darwin-unsigned.dmg
7e6d562dd636fcacae88bedca45b49a879901c0fc1309ea1812aba59bbbcb5d0  guix-build-cc8dff5f8ff8/output/x86_64-apple-darwin/bitcoin-cc8dff5f8ff8-x86_64-apple-darwin-unsigned.tar.gz
c4bc9c27466504417a4bd581cc024b8c5a370a51c8349c1f067752c98c2c14bc  guix-build-cc8dff5f8ff8/output/x86_64-apple-darwin/bitcoin-cc8dff5f8ff8-x86_64-apple-darwin.tar.gz
59aaf11181373efd2e281004ce968967a26fa95f90c5a25f44cc4c687e9ddb0a  guix-build-cc8dff5f8ff8/output/x86_64-linux-gnu/SHA256SUMS.part
fbcde4bfe21314104c7e6036e1f7f4b3ef0e41a7546fef5d1f2a6456b955778d  guix-build-cc8dff5f8ff8/output/x86_64-linux-gnu/bitcoin-cc8dff5f8ff8-x86_64-linux-gnu-debug.tar.gz
b1302146a0e96f7faa150d764aa0ca92b46e887a886532ee7fc2b2cc63f174c5  guix-build-cc8dff5f8ff8/output/x86_64-linux-gnu/bitcoin-cc8dff5f8ff8-x86_64-linux-gnu.tar.gz
319b52c1a62a9cdad2e3f1fac8dd22458be2a9c1e6a0d60b33cb27272d69e52a  guix-build-cc8dff5f8ff8/output/x86_64-w64-mingw32/SHA256SUMS.part
11300b916588cb060ac06e074b94bc5da852ab36446df903045ad593dce5056b  guix-build-cc8dff5f8ff8/output/x86_64-w64-mingw32/bitcoin-cc8dff5f8ff8-win64-debug.zip
045fcb6ca721bdefb7490b3452f28449cb2b0449721dbbb20c174be76f96e1a3  guix-build-cc8dff5f8ff8/output/x86_64-w64-mingw32/bitcoin-cc8dff5f8ff8-win64-setup-unsigned.exe
38c826537c8054a35103e5ab7ca4f97ca98551f23bcbadb0532f6ca3444e0731  guix-build-cc8dff5f8ff8/output/x86_64-w64-mingw32/bitcoin-cc8dff5f8ff8-win64-unsigned.tar.gz
7c5f75c5a0b9b98540c8c779a6fc6f5e98d7de792d3a218e4ad7a68fa4027385  guix-build-cc8dff5f8ff8/output/x86_64-w64-mingw32/bitcoin-cc8dff5f8ff8-win64.zip
```

Guix Build (arm64):
```bash
d54d16ae4d5ef2bb0d0dcebbd6d1ec4b0f0976063bf66222a320e68340f902d5  guix-build-cc8dff5f8ff8/output/arm-linux-gnueabihf/SHA256SUMS.part
04c464043af256ee05d565040df9bb438151d4e041aa46f800fc567eba111c2f  guix-build-cc8dff5f8ff8/output/arm-linux-gnueabihf/bitcoin-cc8dff5f8ff8-arm-linux-gnueabihf-debug.tar.gz
097cd2f633bf6d3b8e922d81ce9f6dfe793589418e394abfa4e183861f5ad236  guix-build-cc8dff5f8ff8/output/arm-linux-gnueabihf/bitcoin-cc8dff5f8ff8-arm-linux-gnueabihf.tar.gz
30c8074725b0701b1a781685f50a23ba038297b2633599f40792157daadc13cb  guix-build-cc8dff5f8ff8/output/arm64-apple-darwin/SHA256SUMS.part
df6036e89c7e8746badcbcf805ec4f84070847833c562bc2185c15904b1b909a  guix-build-cc8dff5f8ff8/output/arm64-apple-darwin/bitcoin-cc8dff5f8ff8-arm64-apple-darwin-unsigned.dmg
8421c957b2b83c4afc3bc7f65f93798755acc99ac5921bd89b367c22c5b064d8  guix-build-cc8dff5f8ff8/output/arm64-apple-darwin/bitcoin-cc8dff5f8ff8-arm64-apple-darwin-unsigned.tar.gz
076e8e185bc01dd43feb3fcbcec04eff5ca435b0fdf47c6f05008feec1cf11ac  guix-build-cc8dff5f8ff8/output/arm64-apple-darwin/bitcoin-cc8dff5f8ff8-arm64-apple-darwin.tar.gz
03de7ffcf8d98c61c3a5b763e9bcc6310c9895950f49768da2eeba4871d8478a  guix-build-cc8dff5f8ff8/output/dist-archive/bitcoin-cc8dff5f8ff8.tar.gz
80ffe674a5fa86cfcf3f47eb8103dbfbc97dd74f793cf785c1347469f19b281f  guix-build-cc8dff5f8ff8/output/powerpc64-linux-gnu/SHA256SUMS.part
8ce2024c3fa65e6cd613ef526f90c5904675012b22eb39ccf94081d91e14340a  guix-build-cc8dff5f8ff8/output/powerpc64-linux-gnu/bitcoin-cc8dff5f8ff8-powerpc64-linux-gnu-debug.tar.gz
89dc31c0306b0f1c79e13e5f705b73233695a802fd4946aac03364c45e7de984  guix-build-cc8dff5f8ff8/output/powerpc64-linux-gnu/bitcoin-cc8dff5f8ff8-powerpc64-linux-gnu.tar.gz
7ed1b82ba3d4c1a8ddc24c6f650aa6b2d1be08580b2ec32cfec0fd682828d797  guix-build-cc8dff5f8ff8/output/powerpc64le-linux-gnu/SHA256SUMS.part
01c7f706b236b342f4e0b5043c5788168806338cdaefd5541b04118665c7e40b  guix-build-cc8dff5f8ff8/output/powerpc64le-linux-gnu/bitcoin-cc8dff5f8ff8-powerpc64le-linux-gnu-debug.tar.gz
01767af5b190d0be4a075a5d038644b7dd0d1fc5f0b69698acaca92bfef960d0  guix-build-cc8dff5f8ff8/output/powerpc64le-linux-gnu/bitcoin-cc8dff5f8ff8-powerpc64le-linux-gnu.tar.gz
414de662e0bb3df6a5c8fc1a3576c90a943998b802d97070e31bde434fc6a7f1  guix-build-cc8dff5f8ff8/output/riscv64-linux-gnu/SHA256SUMS.part
db55ddf8051e6dc80180f3eee12a7370bed1140959c34fb5de8d88f0344b23e2  guix-build-cc8dff5f8ff8/output/riscv64-linux-gnu/bitcoin-cc8dff5f8ff8-riscv64-linux-gnu-debug.tar.gz
bb19f15545d5a52e800ffb7f141915ab7083fb4fab9a80269f6714b28a294502  guix-build-cc8dff5f8ff8/output/riscv64-linux-gnu/bitcoin-cc8dff5f8ff8-riscv64-linux-gnu.tar.gz
d9241782d6e596ae02500ffe062501f80b064357bece5d10f7fd4d218240c3a1  guix-build-cc8dff5f8ff8/output/x86_64-apple-darwin/SHA256SUMS.part
1c3258a573e849a8efe6fce535a4f8737fb3a076ebe74ee29ca1e84a9113d24f  guix-build-cc8dff5f8ff8/output/x86_64-apple-darwin/bitcoin-cc8dff5f8ff8-x86_64-apple-darwin-unsigned.dmg
7e6d562dd636fcacae88bedca45b49a879901c0fc1309ea1812aba59bbbcb5d0  guix-build-cc8dff5f8ff8/output/x86_64-apple-darwin/bitcoin-cc8dff5f8ff8-x86_64-apple-darwin-unsigned.tar.gz
c4bc9c27466504417a4bd581cc024b8c5a370a51c8349c1f067752c98c2c14bc  guix-build-cc8dff5f8ff8/output/x86_64-apple-darwin/bitcoin-cc8dff5f8ff8-x86_64-apple-darwin.tar.gz
59aaf11181373efd2e281004ce968967a26fa95f90c5a25f44cc4c687e9ddb0a  guix-build-cc8dff5f8ff8/output/x86_64-linux-gnu/SHA256SUMS.part
fbcde4bfe21314104c7e6036e1f7f4b3ef0e41a7546fef5d1f2a6456b955778d  guix-build-cc8dff5f8ff8/output/x86_64-linux-gnu/bitcoin-cc8dff5f8ff8-x86_64-linux-gnu-debug.tar.gz
b1302146a0e96f7faa150d764aa0ca92b46e887a886532ee7fc2b2cc63f174c5  guix-build-cc8dff5f8ff8/output/x86_64-linux-gnu/bitcoin-cc8dff5f8ff8-x86_64-linux-gnu.tar.gz
319b52c1a62a9cdad2e3f1fac8dd22458be2a9c1e6a0d60b33cb27272d69e52a  guix-build-cc8dff5f8ff8/output/x86_64-w64-mingw32/SHA256SUMS.part
11300b916588cb060ac06e074b94bc5da852ab36446df903045ad593dce5056b  guix-build-cc8dff5f8ff8/output/x86_64-w64-mingw32/bitcoin-cc8dff5f8ff8-win64-debug.zip
045fcb6ca721bdefb7490b3452f28449cb2b0449721dbbb20c174be76f96e1a3  guix-build-cc8dff5f8ff8/output/x86_64-w64-mingw32/bitcoin-cc8dff5f8ff8-win64-setup-unsigned.exe
38c826537c8054a35103e5ab7ca4f97ca98551f23bcbadb0532f6ca3444e0731  guix-build-cc8dff5f8ff8/output/x86_64-w64-mingw32/bitcoin-cc8dff5f8ff8-win64-unsigned.tar.gz
7c5f75c5a0b9b98540c8c779a6fc6f5e98d7de792d3a218e4ad7a68fa4027385  guix-build-cc8dff5f8ff8/output/x86_64-w64-mingw32/bitcoin-cc8dff5f8ff8-win64.zip
```