### PR TITLE
tests: Use mocktime for wallet encryption timeout

### DIFF
--- a/test/functional/wallet_encryption.py
+++ b/test/functional/wallet_encryption.py
@@ -9,8 +9,7 @@ import time
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_raises_rpc_error,
-    assert_greater_than,
-    assert_greater_than_or_equal,
+    assert_equal,
 )
 
 
@@ -76,21 +75,18 @@ class WalletEncryptionTest(BitcoinTestFramework):
 
         self.log.info('Check a timeout less than the limit')
         MAX_VALUE = 100000000
-        expected_time = int(time.time()) + MAX_VALUE - 600
+        now = int(time.time())
+        self.nodes[0].setmocktime(now)
+        expected_time = now + MAX_VALUE - 600
         self.nodes[0].walletpassphrase(passphrase2, MAX_VALUE - 600)
-        # give buffer for walletpassphrase, since it iterates over all encrypted keys
-        expected_time_with_buffer = time.time() + MAX_VALUE - 600
         actual_time = self.nodes[0].getwalletinfo()['unlocked_until']
-        assert_greater_than_or_equal(actual_time, expected_time)
-        assert_greater_than(expected_time_with_buffer, actual_time)
+        assert_equal(actual_time, expected_time)
 
         self.log.info('Check a timeout greater than the limit')
-        expected_time = int(time.time()) + MAX_VALUE - 1
+        expected_time = now + MAX_VALUE
         self.nodes[0].walletpassphrase(passphrase2, MAX_VALUE + 1000)
-        expected_time_with_buffer = time.time() + MAX_VALUE
         actual_time = self.nodes[0].getwalletinfo()['unlocked_until']
-        assert_greater_than_or_equal(actual_time, expected_time)
-        assert_greater_than(expected_time_with_buffer, actual_time)
+        assert_equal(actual_time, expected_time)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The intermittent wallet_encryption.py failures are related to differences in time between python and std::chrono. We can avoid this entirely by using mocktime. This also allows us to test for the exact unlocking time rather than that it is greater than expected.

Fixes #25482