### PR TITLE
refactor: use `strprintf` for creating unknown-service-flag string

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -199,12 +199,7 @@ static std::string serviceFlagToStr(size_t bit)
     // Not using default, so we get warned when a case is missing
     }
 
-    std::ostringstream stream;
-    stream.imbue(std::locale::classic());
-    stream << "UNKNOWN[";
-    stream << "2^" << bit;
-    stream << "]";
-    return stream.str();
+    return strprintf("UNKNOWN[2^%u]", bit);
 }
 
 std::vector<std::string> serviceFlagsToStr(uint64_t flags)


### PR DESCRIPTION
No need to use a stringstream here. The trivial change can be verified by running the functional test `rpc_net.py`:
https://github.com/bitcoin/bitcoin/blob/c73c8d53fe27956faacb3e8ca0e94adf071de6ec/test/functional/rpc_net.py#L181-L184
As far as I could tell, this is the only instace left where we used `std::ostringstream` for the creation of simple strings (in `FormatSubVersion` using a stream makes sense since the number of placeholders is not constant).