### PR TITLE
util: remove WSL 1 workaround in fs

### DIFF
--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -60,36 +60,20 @@ FileLock::~FileLock()
     }
 }
 
-static bool IsWSL()
-{
-    struct utsname uname_data;
-    return uname(&uname_data) == 0 && std::string(uname_data.version).find("Microsoft") != std::string::npos;
-}
-
 bool FileLock::TryLock()
 {
     if (fd == -1) {
         return false;
     }
 
-    // Exclusive file locking is broken on WSL using fcntl (issue #18622)
-    // This workaround can be removed once the bug on WSL is fixed
-    static const bool is_wsl = IsWSL();
-    if (is_wsl) {
-        if (flock(fd, LOCK_EX | LOCK_NB) == -1) {
-            reason = GetErrorReason();
-            return false;
-        }
-    } else {
-        struct flock lock;
-        lock.l_type = F_WRLCK;
-        lock.l_whence = SEEK_SET;
-        lock.l_start = 0;
-        lock.l_len = 0;
-        if (fcntl(fd, F_SETLK, &lock) == -1) {
-            reason = GetErrorReason();
-            return false;
-        }
+    struct flock lock;
+    lock.l_type = F_WRLCK;
+    lock.l_whence = SEEK_SET;
+    lock.l_start = 0;
+    lock.l_len = 0;
+    if (fcntl(fd, F_SETLK, &lock) == -1) {
+        reason = GetErrorReason();
+        return false;
     }
 
     return true;


### PR DESCRIPTION
Following discussion, the WSL1 patch will be removed, as WSL1 is no longer being developed by Microsoft. Instead, please upgrade to a mainstream WSL2 version. More information can be found on [the official website](https://docs.microsoft.com/en-us/windows/wsl/).
