### PR TITLE
build: default to DWARF v4 when debugging

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -370,7 +370,7 @@ esac
 if test "$enable_debug" = "yes"; then
   dnl If debugging is enabled, and the user hasn't overridden CXXFLAGS, clear
   dnl them, to prevent autoconfs "-g -O2" being added. Otherwise we'd end up
-  dnl with "-O0 -g3 -g -O2".
+  dnl with "-O0 -g4 -g -O2".
   if test "$CXXFLAGS_overridden" = "no"; then
   CXXFLAGS=""
   fi
@@ -378,10 +378,10 @@ if test "$enable_debug" = "yes"; then
   dnl Disable all optimizations
   AX_CHECK_COMPILE_FLAG([-O0], [DEBUG_CXXFLAGS="$DEBUG_CXXFLAGS -O0"], [], [$CXXFLAG_WERROR])
 
-  dnl Prefer -g3, fall back to -g if that is unavailable.
+  dnl Prefer -g4, fall back to -g if that is unavailable.
   AX_CHECK_COMPILE_FLAG(
-    [-g3],
-    [DEBUG_CXXFLAGS="$DEBUG_CXXFLAGS -g3"],
+    [-g4],
+    [DEBUG_CXXFLAGS="$DEBUG_CXXFLAGS -g4"],
     [AX_CHECK_COMPILE_FLAG([-g], [DEBUG_CXXFLAGS="$DEBUG_CXXFLAGS -g"], [], [$CXXFLAG_WERROR])],
     [$CXXFLAG_WERROR])
 


### PR DESCRIPTION
Modern compilers all default to v4, and more recent ones, i.e Clang 14+
and GCC 11+ default to v5.

[Clang 14](https://releases.llvm.org/14.0.0/tools/clang/docs/ReleaseNotes.html#dwarf-support-in-clang)
> The default DWARF version has increased from DWARFv4 to DWARFv5.

[GCC 11](https://gcc.gnu.org/gcc-11/changes.html):
> For targets that produce DWARF debugging information GCC now defaults to [DWARF version 5](https://dwarfstd.org/doc/DWARF5.pdf).

One noticable difference will be a decent disk space saving when debugging, i.e on master using:

`./autogen.sh && ./configure --enable-debug && make src/bitcoind -j9 && ls -lhS src/`

```bash
total 929M
322M libbitcoin_node.a
176M libbitcoin_wallet.a
144M bitcoind
67M libbitcoin_common.a
44M libbitcoin_util.a
15M libbitcoin_node_a-net_processing.o
14M libbitcoin_node_a-validation.o
```

vs with -g4

```bash
total 800M
270M libbitcoin_node.a
153M libbitcoin_wallet.a
141M bitcoind
58M libbitcoin_common.a
31M libbitcoin_util.a
14M libbitcoin_node_a-net_processing.o
13M libbitcoin_node_a-validation.o
```

Guix Build (arm64):
```bash
0abad61bdf0e757d2f4f6d945da4beb045f90b9e68b1922df3eeb24f15a5b700  guix-build-a311688d84c3/output/arm-linux-gnueabihf/SHA256SUMS.part
e7ce2d49aff36e2834f44bb3b22a7a49075f3758d17a5061ecefb543d6471aa0  guix-build-a311688d84c3/output/arm-linux-gnueabihf/bitcoin-a311688d84c3-arm-linux-gnueabihf-debug.tar.gz
67496cec78dd5cece5aa9595854919dd2c6a1a0285aa11c619126f98f2bc1419  guix-build-a311688d84c3/output/arm-linux-gnueabihf/bitcoin-a311688d84c3-arm-linux-gnueabihf.tar.gz
271296b6f06c874ea7554aacdc647017af0fa0b8dbaa9849329c573fb78f7426  guix-build-a311688d84c3/output/arm64-apple-darwin/SHA256SUMS.part
3bff26302f8a31736d091c3294b578d2609b6bbf1f5b4aabb9f874aec37cb1b6  guix-build-a311688d84c3/output/arm64-apple-darwin/bitcoin-a311688d84c3-arm64-apple-darwin-unsigned.dmg
e68dd5624eb67a0e97ed1ff42765e13358dfd7c83a16d19c481200ebd9b67619  guix-build-a311688d84c3/output/arm64-apple-darwin/bitcoin-a311688d84c3-arm64-apple-darwin-unsigned.tar.gz
79ff48de1bbad90e2b784a62e0aa2a9f0812ac67b7756c4bb5473af6f2165ab2  guix-build-a311688d84c3/output/arm64-apple-darwin/bitcoin-a311688d84c3-arm64-apple-darwin.tar.gz
b0769e1833cd320e6510b0f1d1608668e1905b000c407b371352e58b950fb39a  guix-build-a311688d84c3/output/dist-archive/bitcoin-a311688d84c3.tar.gz
037445d35ccf861c3b05af6620687ac5278356b46e214fe8a68749226078c38d  guix-build-a311688d84c3/output/powerpc64-linux-gnu/SHA256SUMS.part
2b6a751a3c1640945736163c454cff49ce25d65a61ed74b7409c60821ed1426b  guix-build-a311688d84c3/output/powerpc64-linux-gnu/bitcoin-a311688d84c3-powerpc64-linux-gnu-debug.tar.gz
a42c00aab9f9f4e4df9c6c979f05e2a1d7208469a670b6582185aba9813ab9e3  guix-build-a311688d84c3/output/powerpc64-linux-gnu/bitcoin-a311688d84c3-powerpc64-linux-gnu.tar.gz
0f45067b7fc0515f5af33b40ac1779e63ea503c686796f2722630dc63f35474b  guix-build-a311688d84c3/output/powerpc64le-linux-gnu/SHA256SUMS.part
897a4bb8db26a3062c7c91f51a2a5acff69d5e263d1a4c2c30de11bc8d399ede  guix-build-a311688d84c3/output/powerpc64le-linux-gnu/bitcoin-a311688d84c3-powerpc64le-linux-gnu-debug.tar.gz
975cc767bc21e30addb11f6ec9eacb7039494937a366610a5334d291ad0f637e  guix-build-a311688d84c3/output/powerpc64le-linux-gnu/bitcoin-a311688d84c3-powerpc64le-linux-gnu.tar.gz
ea80f4125e084304025613a03db453cef1848935f473e4a211f56e9c15337a11  guix-build-a311688d84c3/output/riscv64-linux-gnu/SHA256SUMS.part
f5ee00f1979617a31eb4417d986578d91dfe9255fa973b5b8641f2325426a913  guix-build-a311688d84c3/output/riscv64-linux-gnu/bitcoin-a311688d84c3-riscv64-linux-gnu-debug.tar.gz
4df25281746ec129a301e1fa806e27216e89dbaae4a67f018194637f75dfa19b  guix-build-a311688d84c3/output/riscv64-linux-gnu/bitcoin-a311688d84c3-riscv64-linux-gnu.tar.gz
aac09474a619f9aa737d6a5804d6eb7a0c18fc1792786e58e64b5b1affe80a7f  guix-build-a311688d84c3/output/x86_64-apple-darwin/SHA256SUMS.part
69a28b242236013f47033ad9410168dc6f98728625f674ea8b76efbb67b97bdc  guix-build-a311688d84c3/output/x86_64-apple-darwin/bitcoin-a311688d84c3-x86_64-apple-darwin-unsigned.dmg
68fda2c3096b9ee70ef25a86da3b8718a7081f02a63902d4092c646fccaf5435  guix-build-a311688d84c3/output/x86_64-apple-darwin/bitcoin-a311688d84c3-x86_64-apple-darwin-unsigned.tar.gz
ffd0f5454539e058500e55e71f35aecb305e65217954428683f2c0a007df2747  guix-build-a311688d84c3/output/x86_64-apple-darwin/bitcoin-a311688d84c3-x86_64-apple-darwin.tar.gz
c08d17d4cd77a5eef268015785383ffdd79cccc20a051885b98ddca6e88c360e  guix-build-a311688d84c3/output/x86_64-linux-gnu/SHA256SUMS.part
a0ceab31ac4255c00c04a9289aa41aff38f03a87d7024076148e8d8ed030589e  guix-build-a311688d84c3/output/x86_64-linux-gnu/bitcoin-a311688d84c3-x86_64-linux-gnu-debug.tar.gz
4af89f9478c8d5b30b2a093ec49aa94e247c74d13607a715bc56b4ee334a7b69  guix-build-a311688d84c3/output/x86_64-linux-gnu/bitcoin-a311688d84c3-x86_64-linux-gnu.tar.gz
800c09c37b8a8332c259e977a4144c71fed8cc02db621d377092ed53f642aac0  guix-build-a311688d84c3/output/x86_64-w64-mingw32/SHA256SUMS.part
951341baa4f0f53e6a2d2ac7d57536c10b5771b7b21b7a9879c05861320eef7a  guix-build-a311688d84c3/output/x86_64-w64-mingw32/bitcoin-a311688d84c3-win64-debug.zip
40dd5ad171727ddbfdd79aacc6542a7202492c7f988c3a0e52e8e1df86e6fed2  guix-build-a311688d84c3/output/x86_64-w64-mingw32/bitcoin-a311688d84c3-win64-setup-unsigned.exe
e5c6b247283ba44a6c4d58e8684ab28e6d6da373bf8ef33a595e480ee6a8dc36  guix-build-a311688d84c3/output/x86_64-w64-mingw32/bitcoin-a311688d84c3-win64-unsigned.tar.gz
249d54d80b35befee2c4c29074804a8cbc32ace3da9ab5775e4f818c56f159f6  guix-build-a311688d84c3/output/x86_64-w64-mingw32/bitcoin-a311688d84c3-win64.zip
```