### PR TITLE
Use static member functions from class instead of instances

### DIFF
--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -241,14 +241,14 @@ uint32_t arith_uint256::GetCompact(bool fNegative) const
 uint256 ArithToUint256(const arith_uint256 &a)
 {
     uint256 b;
-    for(int x=0; x<a.WIDTH; ++x)
+    for (int x = 0; x < arith_uint256::WIDTH; ++x)
         WriteLE32(b.begin() + x*4, a.pn[x]);
     return b;
 }
 arith_uint256 UintToArith256(const uint256 &a)
 {
     arith_uint256 b;
-    for(int x=0; x<b.WIDTH; ++x)
+    for (int x = 0; x < arith_uint256::WIDTH; ++x)
         b.pn[x] = ReadLE32(a.begin() + x*4);
     return b;
 }

--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -8,6 +8,7 @@
 #include <crypto/common.h>
 #include <crypto/chacha20.h>
 
+#include <span.h>
 #include <string.h>
 
 constexpr static inline uint32_t rotl32(uint32_t v, int c) { return (v << c) | (v >> (32 - c)); }

--- a/src/crypto/chacha20.h
+++ b/src/crypto/chacha20.h
@@ -8,6 +8,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include <span.h>
+
+
 /** A class for ChaCha20 256-bit stream cipher developed by Daniel J. Bernstein
     https://cr.yp.to/chacha/chacha-20080128.pdf */
 class ChaCha20
@@ -18,6 +21,7 @@ private:
 public:
     ChaCha20();
     ChaCha20(const unsigned char* key, size_t keylen);
+    ChaCha20(const Span<const unsigned char>& key) : ChaCha20(key.data(), key.size()) {}
     void SetKey(const unsigned char* key, size_t keylen); //!< set key with flexible keylength; 256bit recommended */
     void SetIV(uint64_t iv); // set the 64bit nonce
     void Seek(uint64_t pos); // set the 64bit block counter

--- a/src/crypto/hmac_sha512.h
+++ b/src/crypto/hmac_sha512.h
@@ -6,6 +6,8 @@
 #define BITCOIN_CRYPTO_HMAC_SHA512_H
 
 #include <crypto/sha512.h>
+#include <span.h>
+
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -21,11 +23,13 @@ public:
     static const size_t OUTPUT_SIZE = 64;
 
     CHMAC_SHA512(const unsigned char* key, size_t keylen);
+    CHMAC_SHA512(const Span<const unsigned char>& key) : CHMAC_SHA512(key.data(), key.size()) {}
     CHMAC_SHA512& Write(const unsigned char* data, size_t len)
     {
         inner.Write(data, len);
         return *this;
     }
+    CHMAC_SHA512& Write(const Span<const unsigned char>& k) { return Write(k.data(), k.size()); }
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
 };
 

--- a/src/crypto/muhash.cpp
+++ b/src/crypto/muhash.cpp
@@ -299,7 +299,7 @@ Num3072 MuHash3072::ToNum3072(Span<const unsigned char> in) {
     unsigned char tmp[Num3072::BYTE_SIZE];
 
     uint256 hashed_in{(HashWriter{} << in).GetSHA256()};
-    ChaCha20(hashed_in.data(), hashed_in.size()).Keystream(tmp, Num3072::BYTE_SIZE);
+    ChaCha20(hashed_in.data(), uint256::size()).Keystream(tmp, Num3072::BYTE_SIZE);
     Num3072 out{tmp};
 
     return out;

--- a/src/crypto/muhash.cpp
+++ b/src/crypto/muhash.cpp
@@ -299,7 +299,7 @@ Num3072 MuHash3072::ToNum3072(Span<const unsigned char> in) {
     unsigned char tmp[Num3072::BYTE_SIZE];
 
     uint256 hashed_in{(HashWriter{} << in).GetSHA256()};
-    ChaCha20(hashed_in.data(), uint256::size()).Keystream(tmp, Num3072::BYTE_SIZE);
+    ChaCha20(hashed_in).Keystream(tmp, Num3072::BYTE_SIZE);
     Num3072 out{tmp};
 
     return out;

--- a/src/crypto/ripemd160.h
+++ b/src/crypto/ripemd160.h
@@ -8,6 +8,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include <span.h>
+
+
 /** A hasher class for RIPEMD-160. */
 class CRIPEMD160
 {
@@ -21,6 +24,7 @@ public:
 
     CRIPEMD160();
     CRIPEMD160& Write(const unsigned char* data, size_t len);
+    CRIPEMD160& Write(const Span<const unsigned char>& k) { return Write(k.data(), k.size()); }
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
     CRIPEMD160& Reset();
 };

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -9,6 +9,8 @@
 #include <stdlib.h>
 #include <string>
 
+#include <span.h>
+
 /** A hasher class for SHA-256. */
 class CSHA256
 {
@@ -22,6 +24,7 @@ public:
 
     CSHA256();
     CSHA256& Write(const unsigned char* data, size_t len);
+    CSHA256& Write(const Span<const unsigned char>& k) { return Write(k.data(), k.size()); }
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
     CSHA256& Reset();
 };

--- a/src/crypto/siphash.h
+++ b/src/crypto/siphash.h
@@ -27,6 +27,7 @@ public:
     CSipHasher& Write(uint64_t data);
     /** Hash arbitrary bytes. */
     CSipHasher& Write(const unsigned char* data, size_t size);
+    CSipHasher& Write(const Span<const unsigned char>& k) { return Write(k.data(), k.size()); }
     /** Compute the 64-bit SipHash-2-4 of the data written so far. The object remains untouched. */
     uint64_t Finalize() const;
 };

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -76,7 +76,7 @@ void BIP32Hash(const ChainCode &chainCode, unsigned int nChild, unsigned char he
 {
     unsigned char num[4];
     WriteBE32(num, nChild);
-    CHMAC_SHA512(chainCode.begin(), ChainCode::size()).Write(&header, 1).Write(data, 32).Write(num, 4).Finalize(output);
+    CHMAC_SHA512(chainCode).Write(&header, 1).Write(data, 32).Write(num, 4).Finalize(output);
 }
 
 uint256 SHA256Uint256(const uint256& input)

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -76,7 +76,7 @@ void BIP32Hash(const ChainCode &chainCode, unsigned int nChild, unsigned char he
 {
     unsigned char num[4];
     WriteBE32(num, nChild);
-    CHMAC_SHA512(chainCode.begin(), chainCode.size()).Write(&header, 1).Write(data, 32).Write(num, 4).Finalize(output);
+    CHMAC_SHA512(chainCode.begin(), ChainCode::size()).Write(&header, 1).Write(data, 32).Write(num, 4).Finalize(output);
 }
 
 uint256 SHA256Uint256(const uint256& input)

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -90,14 +90,14 @@ CTxDestination DecodeDestination(const std::string& str, const CChainParams& par
         // Public-key-hash-addresses have version 0 (or 111 testnet).
         // The data vector contains RIPEMD160(SHA256(pubkey)), where pubkey is the serialized public key.
         const std::vector<unsigned char>& pubkey_prefix = params.Base58Prefix(CChainParams::PUBKEY_ADDRESS);
-        if (data.size() == hash.size() + pubkey_prefix.size() && std::equal(pubkey_prefix.begin(), pubkey_prefix.end(), data.begin())) {
+        if (data.size() == uint160::size() + pubkey_prefix.size() && std::equal(pubkey_prefix.begin(), pubkey_prefix.end(), data.begin())) {
             std::copy(data.begin() + pubkey_prefix.size(), data.end(), hash.begin());
             return PKHash(hash);
         }
         // Script-hash-addresses have version 5 (or 196 testnet).
         // The data vector contains RIPEMD160(SHA256(cscript)), where cscript is the serialized redemption script.
         const std::vector<unsigned char>& script_prefix = params.Base58Prefix(CChainParams::SCRIPT_ADDRESS);
-        if (data.size() == hash.size() + script_prefix.size() && std::equal(script_prefix.begin(), script_prefix.end(), data.begin())) {
+        if (data.size() == uint160::size() + script_prefix.size() && std::equal(script_prefix.begin(), script_prefix.end(), data.begin())) {
             std::copy(data.begin() + script_prefix.size(), data.end(), hash.begin());
             return ScriptHash(hash);
         }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -692,7 +692,7 @@ int GuiMain(int argc, char* argv[])
 #if defined(Q_OS_WIN)
             WinShutdownMonitor::registerShutdownBlockReason(QObject::tr("%1 didn't yet exit safely…").arg(PACKAGE_NAME), (HWND)app.getMainWinId());
 #endif
-            app.exec();
+            BitcoinApplication::exec();
             rv = app.getReturnValue();
         } else {
             // A dialog with detailed error will have been shown by InitError()

--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -38,8 +38,7 @@ Notificator::Notificator(const QString &_programName, QSystemTrayIcon *_trayIcon
     ,interface(nullptr)
 #endif
 {
-    if(_trayIcon && _trayIcon->supportsMessages())
-    {
+    if (_trayIcon && QSystemTrayIcon::supportsMessages()) {
         mode = QSystemTray;
     }
 #ifdef USE_DBUS

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -80,9 +80,9 @@ void AppTests::appTests()
     expectCallback("guiTests");
     m_app.baseInitialize();
     m_app.requestInitialize();
-    m_app.exec();
+    BitcoinApplication::exec();
     m_app.requestShutdown();
-    m_app.exec();
+    BitcoinApplication::exec();
 
     // Reset global state to avoid interfering with later tests.
     LogInstance().DisconnectTestLogger();
@@ -114,6 +114,6 @@ AppTests::HandleCallback::~HandleCallback()
     assert(it != callbacks.end());
     callbacks.erase(it);
     if (callbacks.empty()) {
-        m_app_tests.m_app.exit(0);
+        BitcoinApplication::exit(0);
     }
 }

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -82,7 +82,7 @@ int main(int argc, char* argv[])
     // Don't remove this, it's needed to access
     // QApplication:: and QCoreApplication:: in the tests
     BitcoinApplication app;
-    app.setApplicationName("Bitcoin-Qt-test");
+    BitcoinApplication::setApplicationName("Bitcoin-Qt-test");
     app.createNode(*init);
 
     int num_test_failures{0};

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1169,7 +1169,7 @@ static void SoftForkDescPushBack(const CBlockIndex* blockindex, UniValue& softfo
     if (has_signal) {
         UniValue statsUV(UniValue::VOBJ);
         std::vector<bool> signals;
-        BIP9Stats statsStruct = chainman.m_versionbitscache.Statistics(blockindex, chainman.GetConsensus(), id, &signals);
+        BIP9Stats statsStruct = VersionBitsCache::Statistics(blockindex, chainman.GetConsensus(), id, &signals);
         statsUV.pushKV("period", statsStruct.period);
         statsUV.pushKV("elapsed", statsStruct.elapsed);
         statsUV.pushKV("count", statsStruct.count);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -834,7 +834,7 @@ static RPCHelpMan getblocktemplate()
                 break;
             case ThresholdState::LOCKED_IN:
                 // Ensure bit is set in block version
-                pblock->nVersion |= chainman.m_versionbitscache.Mask(consensusParams, pos);
+                pblock->nVersion |= VersionBitsCache::Mask(consensusParams, pos);
                 [[fallthrough]];
             case ThresholdState::STARTED:
             {
@@ -843,7 +843,7 @@ static RPCHelpMan getblocktemplate()
                 if (setClientRules.find(vbinfo.name) == setClientRules.end()) {
                     if (!vbinfo.gbt_force) {
                         // If the client doesn't support this, don't indicate it in the [default] version
-                        pblock->nVersion &= ~chainman.m_versionbitscache.Mask(consensusParams, pos);
+                        pblock->nVersion &= ~VersionBitsCache::Mask(consensusParams, pos);
                     }
                 }
                 break;

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -61,7 +61,7 @@ public:
     ComputeEntrySchnorr(uint256& entry, const uint256 &hash, Span<const unsigned char> sig, const XOnlyPubKey& pubkey) const
     {
         CSHA256 hasher = m_salted_hasher_schnorr;
-        hasher.Write(hash.begin(), 32).Write(pubkey.data(), pubkey.size()).Write(sig.data(), sig.size()).Finalize(entry.begin());
+        hasher.Write(hash.begin(), 32).Write(pubkey.data(), XOnlyPubKey::size()).Write(sig.data(), sig.size()).Finalize(entry.begin());
     }
 
     bool

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -54,14 +54,14 @@ public:
     ComputeEntryECDSA(uint256& entry, const uint256 &hash, const std::vector<unsigned char>& vchSig, const CPubKey& pubkey) const
     {
         CSHA256 hasher = m_salted_hasher_ecdsa;
-        hasher.Write(hash.begin(), 32).Write(pubkey.data(), pubkey.size()).Write(vchSig.data(), vchSig.size()).Finalize(entry.begin());
+        hasher.Write(hash).Write(pubkey).Write(vchSig).Finalize(entry.begin());
     }
 
     void
     ComputeEntrySchnorr(uint256& entry, const uint256 &hash, Span<const unsigned char> sig, const XOnlyPubKey& pubkey) const
     {
         CSHA256 hasher = m_salted_hasher_schnorr;
-        hasher.Write(hash.begin(), 32).Write(pubkey.data(), XOnlyPubKey::size()).Write(sig.data(), sig.size()).Finalize(entry.begin());
+        hasher.Write(hash).Write(pubkey).Write(sig).Finalize(entry.begin());
     }
 
     bool

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -287,7 +287,7 @@ static void check_computeblockversion(VersionBitsCache& versionbitscache, const 
     // Check min_activation_height is on a retarget boundary
     BOOST_REQUIRE_EQUAL(min_activation_height % params.nMinerConfirmationWindow, 0U);
 
-    const uint32_t bitmask{versionbitscache.Mask(params, dep)};
+    const uint32_t bitmask{VersionBitsCache::Mask(params, dep)};
     BOOST_CHECK_EQUAL(bitmask, uint32_t{1} << bit);
 
     // In the first chain, test that the bit is set by CBV until it has failed.
@@ -427,7 +427,7 @@ BOOST_AUTO_TEST_CASE(versionbits_computeblockversion)
             // not take precedence over STARTED/LOCKED_IN. So all softforks on
             // the same bit might overlap, even when non-overlapping start-end
             // times are picked.
-            const uint32_t dep_mask{vbcache.Mask(chainParams->GetConsensus(), dep)};
+            const uint32_t dep_mask{VersionBitsCache::Mask(chainParams->GetConsensus(), dep)};
             BOOST_CHECK(!(chain_all_vbits & dep_mask));
             chain_all_vbits |= dep_mask;
             check_computeblockversion(vbcache, chainParams->GetConsensus(), dep);

--- a/src/txrequest.cpp
+++ b/src/txrequest.cpp
@@ -120,7 +120,7 @@ public:
 
     Priority operator()(const uint256& txhash, NodeId peer, bool preferred) const
     {
-        uint64_t low_bits = CSipHasher(m_k0, m_k1).Write(txhash.begin(), txhash.size()).Write(peer).Finalize() >> 1;
+        uint64_t low_bits = CSipHasher(m_k0, m_k1).Write(txhash.begin(), uint256::size()).Write(peer).Finalize() >> 1;
         return low_bits | uint64_t{preferred} << 63;
     }
 

--- a/src/txrequest.cpp
+++ b/src/txrequest.cpp
@@ -120,7 +120,7 @@ public:
 
     Priority operator()(const uint256& txhash, NodeId peer, bool preferred) const
     {
-        uint64_t low_bits = CSipHasher(m_k0, m_k1).Write(txhash.begin(), uint256::size()).Write(peer).Finalize() >> 1;
+        uint64_t low_bits = CSipHasher(m_k0, m_k1).Write(txhash).Write(peer).Finalize() >> 1;
         return low_bits | uint64_t{preferred} << 63;
     }
 

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -224,7 +224,7 @@ bool CreateFromDump(const ArgsManager& args, const std::string& name, const fs::
 
             if (key == "checksum") {
                 std::vector<unsigned char> parsed_checksum = ParseHex(value);
-                if (parsed_checksum.size() != checksum.size()) {
+                if (parsed_checksum.size() != uint256::size()) {
                     error = Untranslated("Error: Checksum is not the correct size");
                     ret = false;
                     break;

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -537,7 +537,7 @@ RPCHelpMan importwallet()
         CHECK_NONFATAL(pwallet->chain().findBlock(pwallet->GetLastBlockHash(), FoundBlock().time(nTimeBegin)));
 
         int64_t nFilesize = std::max((int64_t)1, (int64_t)file.tellg());
-        file.seekg(0, file.beg);
+        file.seekg(0, std::ifstream::beg);
 
         // Use uiInterface.ShowProgress instead of pwallet.ShowProgress because pwallet.ShowProgress has a cancel button tied to AbortRescan which
         // we don't want for this progress bar showing the import progress. uiInterface.ShowProgress does not have a cancel button.
@@ -893,7 +893,7 @@ static std::string RecurseImportData(const CScript& script, ImportData& import_d
         if (script_ctx == ScriptContext::WITNESS_V0) throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Trying to nest P2WSH inside another P2WSH");
         uint256 fullid(solverdata[0]);
         CScriptID id;
-        CRIPEMD160().Write(fullid.begin(), fullid.size()).Finalize(id.begin());
+        CRIPEMD160().Write(fullid.begin(), uint256::size()).Finalize(id.begin());
         auto subscript = std::move(import_data.witnessscript); // Remove redeemscript from import_data to check for superfluous script later.
         if (!subscript) return "missing witnessscript";
         if (CScriptID(*subscript) != id) return "witnessScript does not match the scriptPubKey or redeemScript";

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -893,7 +893,7 @@ static std::string RecurseImportData(const CScript& script, ImportData& import_d
         if (script_ctx == ScriptContext::WITNESS_V0) throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Trying to nest P2WSH inside another P2WSH");
         uint256 fullid(solverdata[0]);
         CScriptID id;
-        CRIPEMD160().Write(fullid.begin(), uint256::size()).Finalize(id.begin());
+        CRIPEMD160().Write(fullid).Finalize(id.begin());
         auto subscript = std::move(import_data.witnessscript); // Remove redeemscript from import_data to check for superfluous script later.
         if (!subscript) return "missing witnessscript";
         if (CScriptID(*subscript) != id) return "witnessScript does not match the scriptPubKey or redeemScript";


### PR DESCRIPTION
I noticed while reviewing a PR that some static class member functions are accessed by instance instead of class. I believe this makes the code misleading.
This PR enables the clang-tidy check 'readability-static-accessed-through-instance'. 
> Checks for member expressions that access static members through instances, and replaces them with uses of the appropriate qualified-id.

https://clang.llvm.org/extra/clang-tidy/checks/readability/static-accessed-through-instance.html


I used the `-fix` option of clang-tidy to discover and fix these issues.