### PR TITLE
test: add coverage for invalid parameters for `rescanblockchain`

### DIFF
--- a/test/functional/wallet_transactiontime_rescan.py
+++ b/test/functional/wallet_transactiontime_rescan.py
@@ -11,6 +11,7 @@ from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_raises_rpc_error,
     set_node_times,
 )
 
@@ -156,6 +157,12 @@ class TransactionTimeRescanTest(BitcoinTestFramework):
             elif tx['address'] == wo3:
                 assert_equal(tx['blocktime'], cur_time + ten_days + ten_days + ten_days)
                 assert_equal(tx['time'], cur_time + ten_days + ten_days + ten_days)
+
+
+        self.log.info('Test handling of invalid parameters for rescanblockchain')
+        assert_raises_rpc_error(-8, "Invalid start_height", restorewo_wallet.rescanblockchain, -1, 10)
+        assert_raises_rpc_error(-8, "Invalid stop_height", restorewo_wallet.rescanblockchain, 1, -1)
+        assert_raises_rpc_error(-8, "stop_height must be greater than start_height", restorewo_wallet.rescanblockchain, 20, 10)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds test coverage for the following errors:
https://github.com/bitcoin/bitcoin/blob/2bd9aa5a44b88c866c4d98f8a7bf7154049cba31/src/wallet/rpc/transactions.cpp#L880-L894