### PR TITLE
doc: Add my key to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,5 +15,6 @@ The following keys may be used to communicate sensitive information to developer
 |------|-------------|
 | Pieter Wuille | 133E AC17 9436 F14A 5CF1  B794 860F EB80 4E66 9320 |
 | Michael Ford | E777 299F C265 DD04 7930  70EB 944D 35F9 AC3D B76A |
+| Andrew Chow | 1528 1230 0785 C964 44D3  334D 1756 5732 E08E 5E41 |
 
 You can import a key by running the following command with that individual’s fingerprint: `gpg --keyserver hkps://keys.openpgp.org --recv-keys "<fingerprint>"` Ensure that you put quotes around fingerprints containing spaces.


### PR DESCRIPTION
I was recently added to the security list, and I think it would make sense to have more people who are on the list to be publicly listed as security contacts, so adding myself to the doc.