### PR TITLE
test: Fix intermittent issue in p2p_leak.py

### DIFF
--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -138,6 +138,9 @@ class P2PLeakTest(BitcoinTestFramework):
         # Give the node enough time to possibly leak out a message
         time.sleep(PEER_TIMEOUT + 2)
 
+        self.log.info("Connect peer to ensure the net thread runs the disconnect logic at least once")
+        self.nodes[0].add_p2p_connection(P2PInterface())
+
         # Make sure only expected messages came in
         assert not no_version_idle_peer.unexpected_msg
         assert not no_version_idle_peer.got_wtxidrelay
@@ -169,7 +172,7 @@ class P2PLeakTest(BitcoinTestFramework):
 
         self.log.info('Check that old peers are disconnected')
         p2p_old_peer = self.nodes[0].add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
-        with self.nodes[0].assert_debug_log(['peer=4 using obsolete version 31799; disconnecting']):
+        with self.nodes[0].assert_debug_log(["using obsolete version 31799; disconnecting"]):
             p2p_old_peer.send_message(self.create_old_version(31799))
             p2p_old_peer.wait_for_disconnect()
 


### PR DESCRIPTION
Diff to reproduce:

```diff
diff --git a/src/net.cpp b/src/net.cpp
index 865ce2ea97..ccf289d77b 100644
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1150,6 +1150,7 @@ bool CConnman::InactivityCheck(const CNode& node) const
 
     if (last_recv.count() == 0 || last_send.count() == 0) {
         LogPrint(BCLog::NET, "socket no message in first %i seconds, %d %d peer=%d\n", count_seconds(m_peer_connect_timeout), last_recv.count() != 0, last_send.count() != 0, node.GetId());
+        UninterruptibleSleep(6s);
         return true;
     }

```

Example in CI:

```
 node0 2022-08-12T09:51:56.015288Z [net] [net.cpp:1152] [InactivityCheck] [net] socket no message in first 3 seconds, 0 0 peer=0 
 test  2022-08-12T09:51:57.658000Z TestFramework (ERROR): Assertion failed 
                                   Traceback (most recent call last):
                                     File "/tmp/cirrus-ci-build/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/test/functional/test_framework/test_framework.py", line 133, in main
                                       self.run_test()
                                     File "/tmp/cirrus-ci-build/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/test/functional/p2p_leak.py", line 155, in run_test
                                       assert not no_version_idle_peer.is_connected
                                   AssertionError
```

https://cirrus-ci.com/task/5346634421764096?logs=ci#L3683