### PR TITLE
depends: libnatpmp 07004b97cf691774efebe70404cf22201e4d330d

### DIFF
--- a/depends/packages/libnatpmp.mk
+++ b/depends/packages/libnatpmp.mk
@@ -1,8 +1,8 @@
 package=libnatpmp
-$(package)_version=4536032ae32268a45c073a4d5e91bbab4534773a
+$(package)_version=07004b97cf691774efebe70404cf22201e4d330d
 $(package)_download_path=https://github.com/miniupnp/libnatpmp/archive
 $(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=543b460aab26acf91e11d15e17d8798f845304199eea2d76c2f444ec749c5383
+$(package)_sha256_hash=9321953ceb39d07c25463e266e50d0ae7b64676bb3a986d932b18881ed94f1fb
 
 define $(package)_set_vars
   $(package)_build_opts=CC="$($(package)_cc)"

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -35,7 +35,7 @@ You can find installation instructions in the `build-*.md` file for your platfor
 ### Networking
 | Dependency | Releases | Version used | Minimum required | Runtime |
 | --- | --- | --- | --- | --- |
-| [libnatpmp](../depends/packages/libnatpmp.mk) | [link](https://github.com/miniupnp/libnatpmp/) | commit [4536032...](https://github.com/bitcoin/bitcoin/pull/21209) | | No |
+| [libnatpmp](../depends/packages/libnatpmp.mk) | [link](https://github.com/miniupnp/libnatpmp/) | commit [07004b9...](https://github.com/bitcoin/bitcoin/pull/25917) | | No |
 | [MiniUPnPc](../depends/packages/miniupnpc.mk) | [link](https://miniupnp.tuxfamily.org/) | [2.2.2](https://github.com/bitcoin/bitcoin/pull/20421) | 1.9 | No |
 
 ### Notifications


### PR DESCRIPTION
This pulls in two changes I've upstreamed:
Support for pkg-config: https://github.com/miniupnp/libnatpmp/pull/19
Suppressing a deprecation warning: https://github.com/miniupnp/libnatpmp/pull/28

and other upstream bug fixes.

Somewhat related to #22644.

Guix Build (arm64):
```bash
4a4b8e1cb5070482e53b3b869c5f6e19b892619184cf58315a3af368e13a52a2  guix-build-65471008e0a4/output/arm-linux-gnueabihf/SHA256SUMS.part
88b51f0f261f84b58da60a5c8df251b551379b811a255df9982ff496c70fc8b7  guix-build-65471008e0a4/output/arm-linux-gnueabihf/bitcoin-65471008e0a4-arm-linux-gnueabihf-debug.tar.gz
33a564914be6f4134d8e8a5f31a2bb97798a79bae8f75151b35564238d6f288e  guix-build-65471008e0a4/output/arm-linux-gnueabihf/bitcoin-65471008e0a4-arm-linux-gnueabihf.tar.gz
ea429260a2b5ac333f70b2b8b8697a4f76eee79cf6998d18c7de7b60818d8fe5  guix-build-65471008e0a4/output/arm64-apple-darwin/SHA256SUMS.part
304677e040592a0aee947c733657ea6c4dd8613f7c3a9834314a68e5f7a53325  guix-build-65471008e0a4/output/arm64-apple-darwin/bitcoin-65471008e0a4-arm64-apple-darwin-unsigned.dmg
da171a60370ad1da6cfc1566fc4e16d09f6e896002b0ac9758fb4044eb1033c1  guix-build-65471008e0a4/output/arm64-apple-darwin/bitcoin-65471008e0a4-arm64-apple-darwin-unsigned.tar.gz
45c439319a9e2c07de8796dcfd182cdeb5600ad31f8f6b6dc383cc2914f49ab8  guix-build-65471008e0a4/output/arm64-apple-darwin/bitcoin-65471008e0a4-arm64-apple-darwin.tar.gz
120311e7c807b2641b5e7024e1b85fac0800680bccd924016f417b026aa90d25  guix-build-65471008e0a4/output/dist-archive/bitcoin-65471008e0a4.tar.gz
5272264317c93359c158c688cf0d0b6e70a6d9ec4b2e447b9fb9fcaf1950f6bc  guix-build-65471008e0a4/output/powerpc64-linux-gnu/SHA256SUMS.part
98a0d14b8d05974d70f0d5243bfc2fec6aea30b9d8375f950f42a21d5e034065  guix-build-65471008e0a4/output/powerpc64-linux-gnu/bitcoin-65471008e0a4-powerpc64-linux-gnu-debug.tar.gz
8e07410ad2e7e204c5e84a81894c5398b34f36cc9e1ba386bf0963f09755818b  guix-build-65471008e0a4/output/powerpc64-linux-gnu/bitcoin-65471008e0a4-powerpc64-linux-gnu.tar.gz
47ae8b948127f03e43a4c7e83a3611b650e26da50936ea9ce0247e01b29463f3  guix-build-65471008e0a4/output/powerpc64le-linux-gnu/SHA256SUMS.part
04e92527df8c7bb9f78c29b152d920830be0ef26d01e0ee1b32d52bb68fc9717  guix-build-65471008e0a4/output/powerpc64le-linux-gnu/bitcoin-65471008e0a4-powerpc64le-linux-gnu-debug.tar.gz
ddb09291c9e270343b56e66fae33fd792eb2ec7e5a138337ec1608642dd3a983  guix-build-65471008e0a4/output/powerpc64le-linux-gnu/bitcoin-65471008e0a4-powerpc64le-linux-gnu.tar.gz
de3cfcf47abed3d4d3881086eba94ee2c34d9078dc53639cc6321c2bd1041073  guix-build-65471008e0a4/output/riscv64-linux-gnu/SHA256SUMS.part
fecd6a307b66fd54fa5792ce14e1a4d50df5646cdf6cc51d5b355fb1384f5105  guix-build-65471008e0a4/output/riscv64-linux-gnu/bitcoin-65471008e0a4-riscv64-linux-gnu-debug.tar.gz
f2c5a85fb17ad9605809b4ac01eba56cd573744697b9c942d293b42a623a2832  guix-build-65471008e0a4/output/riscv64-linux-gnu/bitcoin-65471008e0a4-riscv64-linux-gnu.tar.gz
4cd0b05e96491d9b0fe7eff78aab885a2f0d62f141950117759fecceaeba5412  guix-build-65471008e0a4/output/x86_64-apple-darwin/SHA256SUMS.part
bae30549d8044e1aa11bae6d57321a7a3a765c8b87ead9cdcc8abf9f22a564a3  guix-build-65471008e0a4/output/x86_64-apple-darwin/bitcoin-65471008e0a4-x86_64-apple-darwin-unsigned.dmg
435187b492d6df77d4fa7cd0f77ad08c587c4bd463295be802b6e222ee92a2fa  guix-build-65471008e0a4/output/x86_64-apple-darwin/bitcoin-65471008e0a4-x86_64-apple-darwin-unsigned.tar.gz
b9cf808ec88368a9b0e1883253a9d8c6f123bf7f61df40e34e5e4b8959846d65  guix-build-65471008e0a4/output/x86_64-apple-darwin/bitcoin-65471008e0a4-x86_64-apple-darwin.tar.gz
b9d9a46f7d3188cd517a180fd24fdb38b8c695175fe9ac75c3b3eb2450d9f5d5  guix-build-65471008e0a4/output/x86_64-linux-gnu/SHA256SUMS.part
fd601d6821fbe5faa1eb44b9f07046187f491a83fbf1e0fd603be212bfea3385  guix-build-65471008e0a4/output/x86_64-linux-gnu/bitcoin-65471008e0a4-x86_64-linux-gnu-debug.tar.gz
98ae9d653a8fdeda055468dbf674ee46b0727e1c5b768b1765fc4451defed36e  guix-build-65471008e0a4/output/x86_64-linux-gnu/bitcoin-65471008e0a4-x86_64-linux-gnu.tar.gz
821de40cbc96c27bb1f0fbcfb46c4e801f202c2dfd7aa9ad88daf6ced2be90e5  guix-build-65471008e0a4/output/x86_64-w64-mingw32/SHA256SUMS.part
0f2425ea0a17c9aa80cf7d2eb316b9ebe76f49de777635ac37f9e6e21bcd650e  guix-build-65471008e0a4/output/x86_64-w64-mingw32/bitcoin-65471008e0a4-win64-debug.zip
046ede05868c153ec1d87b8dad4b6494913ea3e952edee86b068d367c57fa7ec  guix-build-65471008e0a4/output/x86_64-w64-mingw32/bitcoin-65471008e0a4-win64-setup-unsigned.exe
62b6e5ebb085735838ada1f328d6e092d7fb726caad6e049340bfa783897cfa1  guix-build-65471008e0a4/output/x86_64-w64-mingw32/bitcoin-65471008e0a4-win64-unsigned.tar.gz
265f9814a7fa3333395f34a5dceafd11d50d170aa5303386aa6f8244542d070a  guix-build-65471008e0a4/output/x86_64-w64-mingw32/bitcoin-65471008e0a4-win64.zip
```