### PR TITLE
build: use `-mbranch-protection=standard` for aarch64-linux (non-guix)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -962,6 +962,12 @@ if test "$use_hardening" != "no"; then
       ;;
   esac
 
+  case $host in
+    *aarch64-unknown-linux*)
+      AX_CHECK_COMPILE_FLAG([-mbranch-protection=standard], [HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -mbranch-protection=standard"], [], [$CXXFLAG_WERROR])
+      AX_CHECK_LINK_FLAG([-Wl,-z,pac-plt], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,-z,pac-plt"], [], [$LDFLAG_WERROR])
+      ;;
+  esac
 
   dnl When enable_debug is yes, all optimizations are disabled.
   dnl However, FORTIFY_SOURCE requires that there is some level of optimization, otherwise it does nothing and just creates a compiler warning.


### PR DESCRIPTION
For this to be enabled, all libs must be compiled with / instrumented
with this option. This can be the case for some distros, like Fedora.

`-mbranch-protection=x` was added to GCC in GCC 9.x (replacing
`-msign-return-address=x`, and added to LLVM clang in 14.0.0.

`-z,pac-plt` was added to binutils ld in 2.33
> Add -z pac-plt for AArch64 to pick PAC enabled PLTs.

LLVMs ld.lld `--pac-plt` option became `-z,pac-plt` starting with LLVM 10.

Split from #24123, as these changes shouldn't have to wait for us to fully support using this in our Guix env, before we can make a best-effort to turn these flags on for users who are self-compiling.