### PR TITLE
wallet: trigger MaybeResendWalletTxs() every minute

### DIFF
--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -151,7 +151,7 @@ void StartWallets(WalletContext& context, CScheduler& scheduler)
     if (context.args->GetBoolArg("-flushwallet", DEFAULT_FLUSHWALLET)) {
         scheduler.scheduleEvery([&context] { MaybeCompactWalletDB(context); }, std::chrono::milliseconds{500});
     }
-    scheduler.scheduleEvery([&context] { MaybeResendWalletTxs(context); }, std::chrono::milliseconds{1000});
+    scheduler.scheduleEvery([&context] { MaybeResendWalletTxs(context); }, 1min);
 }
 
 void FlushWallets(WalletContext& context)

--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -29,11 +29,11 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         self.log.info("Create a new transaction and wait until it's broadcast")
         txid = node.sendtoaddress(node.getnewaddress(), 1)
 
-        # Wallet rebroadcast is first scheduled 1 sec after startup (see
+        # Wallet rebroadcast is first scheduled 1 min sec after startup (see
         # nNextResend in ResendWalletTransactions()). Tell scheduler to call
         # MaybeResendWalletTxn now to initialize nNextResend before the first
         # setmocktime call below.
-        node.mockscheduler(1)
+        node.mockscheduler(60)
 
         # Can take a few seconds due to transaction trickling
         peer_first.wait_for_broadcast([txid])
@@ -60,7 +60,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         twelve_hrs = 12 * 60 * 60
         two_min = 2 * 60
         node.setmocktime(now + twelve_hrs - two_min)
-        node.mockscheduler(1)  # Tell scheduler to call MaybeResendWalletTxn now
+        node.mockscheduler(60)  # Tell scheduler to call MaybeResendWalletTxn now
         assert_equal(int(txid, 16) in peer_second.get_invs(), False)
 
         self.log.info("Bump time & check that transaction is rebroadcast")
@@ -69,7 +69,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         with node.assert_debug_log(['ResendWalletTransactions: resubmit 1 unconfirmed transactions']):
             node.setmocktime(now + 36 * 60 * 60)
             # Tell scheduler to call MaybeResendWalletTxn now.
-            node.mockscheduler(1)
+            node.mockscheduler(60)
         # Give some time for trickle to occur
         node.setmocktime(now + 36 * 60 * 60 + 600)
         peer_second.wait_for_broadcast([txid])

--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -31,7 +31,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
 
         # Wallet rebroadcast is first scheduled 1 min sec after startup (see
         # nNextResend in ResendWalletTransactions()). Tell scheduler to call
-        # MaybeResendWalletTxn now to initialize nNextResend before the first
+        # MaybeResendWalletTxs now to initialize nNextResend before the first
         # setmocktime call below.
         node.mockscheduler(60)
 
@@ -60,7 +60,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         twelve_hrs = 12 * 60 * 60
         two_min = 2 * 60
         node.setmocktime(now + twelve_hrs - two_min)
-        node.mockscheduler(60)  # Tell scheduler to call MaybeResendWalletTxn now
+        node.mockscheduler(60)  # Tell scheduler to call MaybeResendWalletTxs now
         assert_equal(int(txid, 16) in peer_second.get_invs(), False)
 
         self.log.info("Bump time & check that transaction is rebroadcast")
@@ -68,7 +68,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         # but can range from 12-36. So bump 36 hours to be sure.
         with node.assert_debug_log(['ResendWalletTransactions: resubmit 1 unconfirmed transactions']):
             node.setmocktime(now + 36 * 60 * 60)
-            # Tell scheduler to call MaybeResendWalletTxn now.
+            # Tell scheduler to call MaybeResendWalletTxs now.
             node.mockscheduler(60)
         # Give some time for trickle to occur
         node.setmocktime(now + 36 * 60 * 60 + 600)


### PR DESCRIPTION
ResendWalletTransactions() only executes every [12-36h (24h average)](https://github.com/bitcoin/bitcoin/blob/1420547ec30a24fc82ba3ae5ac18374e8e5af5e5/src/wallet/wallet.cpp#L1947). Triggering it every second is excessive, once per minute should be plenty.

The goal of this PR is to reduce the amount of (unnecessary) schedule executions by ~60x without meaningfully altering transaction rebroadcast logic/assumptions which would require more significant review. 