### PR TITLE
p2p: always provide CNodeStateStats and getpeerinfo/netinfo/gui updates

### DIFF
--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -126,7 +126,7 @@ public:
     virtual size_t getNodeCount(ConnectionDirection flags) = 0;
 
     //! Get stats for connected nodes.
-    using NodesStats = std::vector<std::tuple<CNodeStats, bool, CNodeStateStats>>;
+    using NodesStats = std::vector<std::pair<CNodeStats, CNodeStateStats>>;
     virtual bool getNodesStats(NodesStats& stats) = 0;
 
     //! Get ban map entries.

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -126,8 +126,7 @@ public:
     virtual size_t getNodeCount(ConnectionDirection flags) = 0;
 
     //! Get stats for connected nodes.
-    using NodesStats = std::vector<std::pair<CNodeStats, CNodeStateStats>>;
-    virtual NodesStats getNodesStats() = 0;
+    virtual std::vector<std::pair<CNodeStats, CNodeStateStats>> getNodesStats() = 0;
 
     //! Get ban map entries.
     virtual bool getBanned(banmap_t& banmap) = 0;

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -127,7 +127,7 @@ public:
 
     //! Get stats for connected nodes.
     using NodesStats = std::vector<std::pair<CNodeStats, CNodeStateStats>>;
-    virtual bool getNodesStats(NodesStats& stats) = 0;
+    virtual NodesStats getNodesStats() = 0;
 
     //! Get ban map entries.
     virtual bool getBanned(banmap_t& banmap) = 0;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1559,14 +1559,14 @@ CNodeStateStats PeerManagerImpl::GetNodeStateStats(NodeId nodeid) const
             return stats;
         }
         if (state->pindexBestKnownBlock) {
-            stats.nSyncHeight = state->pindexBestKnownBlock->nHeight;
+            stats.m_sync_height = state->pindexBestKnownBlock->nHeight;
         }
         if (state->pindexLastCommonBlock) {
-            stats.nCommonHeight = state->pindexLastCommonBlock->nHeight;
+            stats.m_common_height = state->pindexLastCommonBlock->nHeight;
         }
         for (const QueuedBlock& queue : state->vBlocksInFlight) {
             if (queue.pindex) {
-                stats.vHeightInFlight.push_back(queue.pindex->nHeight);
+                stats.m_height_in_flight.push_back(queue.pindex->nHeight);
             }
         }
     }
@@ -1575,7 +1575,7 @@ CNodeStateStats PeerManagerImpl::GetNodeStateStats(NodeId nodeid) const
         // Peer is still being set up; return the stats that we do have.
         return stats;
     }
-    stats.their_services = peer->m_their_services;
+    stats.m_services = peer->m_their_services;
     if (peer->m_starting_height != -1) {
         stats.m_starting_height = peer->m_starting_height;
     }
@@ -1597,7 +1597,7 @@ CNodeStateStats PeerManagerImpl::GetNodeStateStats(NodeId nodeid) const
     stats.m_addr_relay_enabled = peer->m_addr_relay_enabled.load();
     {
         LOCK(peer->m_headers_sync_mutex);
-        stats.presync_height = peer->m_headers_sync ? peer->m_headers_sync->GetPresyncHeight() : -1;
+        stats.m_presync_height = peer->m_headers_sync ? peer->m_headers_sync->GetPresyncHeight() : -1;
     }
 
     return stats;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -26,18 +26,18 @@ static const bool DEFAULT_PEERBLOCKFILTERS = false;
 static const int DISCOURAGEMENT_THRESHOLD{100};
 
 struct CNodeStateStats {
-    std::optional<int> nSyncHeight;
-    std::optional<int> nCommonHeight;
+    std::optional<int> m_sync_height;
+    std::optional<int> m_common_height;
     std::optional<int> m_starting_height;
     std::chrono::microseconds m_ping_wait{0us};
-    std::vector<int> vHeightInFlight;
+    std::vector<int> m_height_in_flight;
     std::optional<bool> m_relay_txs{false};
     CAmount m_fee_filter_received{0};
     uint64_t m_addr_processed = 0;
     uint64_t m_addr_rate_limited = 0;
     bool m_addr_relay_enabled{false};
-    std::optional<ServiceFlags> their_services;
-    std::optional<int64_t> presync_height;
+    std::optional<ServiceFlags> m_services;
+    std::optional<int64_t> m_presync_height;
 };
 
 class PeerManager : public CValidationInterface, public NetEventsInterface

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -9,6 +9,8 @@
 #include <net.h>
 #include <validationinterface.h>
 
+#include <optional>
+
 class AddrMan;
 class CChainParams;
 class CTxMemPool;
@@ -24,18 +26,18 @@ static const bool DEFAULT_PEERBLOCKFILTERS = false;
 static const int DISCOURAGEMENT_THRESHOLD{100};
 
 struct CNodeStateStats {
-    int nSyncHeight = -1;
-    int nCommonHeight = -1;
-    int m_starting_height = -1;
-    std::chrono::microseconds m_ping_wait;
+    std::optional<int> nSyncHeight;
+    std::optional<int> nCommonHeight;
+    std::optional<int> m_starting_height;
+    std::chrono::microseconds m_ping_wait{0us};
     std::vector<int> vHeightInFlight;
-    bool m_relay_txs;
-    CAmount m_fee_filter_received;
+    std::optional<bool> m_relay_txs{false};
+    CAmount m_fee_filter_received{0};
     uint64_t m_addr_processed = 0;
     uint64_t m_addr_rate_limited = 0;
     bool m_addr_relay_enabled{false};
-    ServiceFlags their_services;
-    int64_t presync_height{-1};
+    std::optional<ServiceFlags> their_services;
+    std::optional<int64_t> presync_height;
 };
 
 class PeerManager : public CValidationInterface, public NetEventsInterface
@@ -59,7 +61,7 @@ public:
     virtual void StartScheduledTasks(CScheduler& scheduler) = 0;
 
     /** Get statistics from node state */
-    virtual bool GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) const = 0;
+    virtual CNodeStateStats GetNodeStateStats(NodeId nodeid) const = 0;
 
     /** Whether this node ignores txs received over p2p. */
     virtual bool IgnoresIncomingTxs() = 0;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -165,9 +165,9 @@ public:
     {
         return m_context->connman ? m_context->connman->GetNodeCount(flags) : 0;
     }
-    NodesStats getNodesStats() override
+    std::vector<std::pair<CNodeStats, CNodeStateStats>> getNodesStats() override
     {
-        interfaces::Node::NodesStats stats;
+        std::vector<std::pair<CNodeStats, CNodeStateStats>> stats;
         if (!m_context->connman) return stats;
 
         std::vector<CNodeStats> stats_temp;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -165,10 +165,10 @@ public:
     {
         return m_context->connman ? m_context->connman->GetNodeCount(flags) : 0;
     }
-    bool getNodesStats(NodesStats& stats) override
+    NodesStats getNodesStats() override
     {
-        stats.clear();
-        if (!m_context->connman) return false;
+        interfaces::Node::NodesStats stats;
+        if (!m_context->connman) return stats;
 
         std::vector<CNodeStats> stats_temp;
         m_context->connman->GetNodeStats(stats_temp);
@@ -186,7 +186,7 @@ public:
                 }
             }
         }
-        return true;
+        return stats;
     }
     bool getBanned(banmap_t& banmap) override
     {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -168,29 +168,25 @@ public:
     bool getNodesStats(NodesStats& stats) override
     {
         stats.clear();
+        if (!m_context->connman) return false;
 
-        if (m_context->connman) {
-            std::vector<CNodeStats> stats_temp;
-            m_context->connman->GetNodeStats(stats_temp);
+        std::vector<CNodeStats> stats_temp;
+        m_context->connman->GetNodeStats(stats_temp);
 
-            stats.reserve(stats_temp.size());
-            for (auto& node_stats_temp : stats_temp) {
-                stats.emplace_back(std::move(node_stats_temp), false, CNodeStateStats());
-            }
-
+        stats.reserve(stats_temp.size());
+        for (auto& s : stats_temp) {
+            stats.emplace_back(std::move(s), CNodeStateStats());
+        }
+        if (m_context->peerman) {
             // Try to retrieve the CNodeStateStats for each node.
-            if (m_context->peerman) {
-                TRY_LOCK(::cs_main, lockMain);
-                if (lockMain) {
-                    for (auto& node_stats : stats) {
-                        std::get<1>(node_stats) =
-                            m_context->peerman->GetNodeStateStats(std::get<0>(node_stats).nodeid, std::get<2>(node_stats));
-                    }
+            TRY_LOCK(::cs_main, lockMain);
+            if (lockMain) {
+                for (auto& s : stats) {
+                    s.second = m_context->peerman->GetNodeStateStats(s.first.nodeid);
                 }
             }
-            return true;
         }
-        return false;
+        return true;
     }
     bool getBanned(banmap_t& banmap) override
     {

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -748,7 +748,7 @@ QString formatServicesStr(quint64 mask)
     if (strList.size())
         return strList.join(", ");
     else
-        return QObject::tr("None");
+        return QObject::tr("Unknown");
 }
 
 QString formatPingTime(std::chrono::microseconds ping_time)

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -151,8 +151,7 @@ QModelIndex PeerTableModel::index(int row, int column, const QModelIndex& parent
 
 void PeerTableModel::refresh()
 {
-    interfaces::Node::NodesStats nodes_stats;
-    m_node.getNodesStats(nodes_stats);
+    interfaces::Node::NodesStats nodes_stats{m_node.getNodesStats()};
     decltype(m_peers_data) new_peers_data;
     new_peers_data.reserve(nodes_stats.size());
     for (const auto& node_stats : nodes_stats) {

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -156,8 +156,7 @@ void PeerTableModel::refresh()
     decltype(m_peers_data) new_peers_data;
     new_peers_data.reserve(nodes_stats.size());
     for (const auto& node_stats : nodes_stats) {
-        const CNodeCombinedStats stats{std::get<0>(node_stats), std::get<2>(node_stats), std::get<1>(node_stats)};
-        new_peers_data.append(stats);
+        new_peers_data.append(CNodeCombinedStats{node_stats.first, node_stats.second});
     }
 
     // Handle peer addition or removal as suggested in Qt Docs. See:

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -151,7 +151,7 @@ QModelIndex PeerTableModel::index(int row, int column, const QModelIndex& parent
 
 void PeerTableModel::refresh()
 {
-    interfaces::Node::NodesStats nodes_stats{m_node.getNodesStats()};
+    auto nodes_stats{m_node.getNodesStats()};
     decltype(m_peers_data) new_peers_data;
     new_peers_data.reserve(nodes_stats.size());
     for (const auto& node_stats : nodes_stats) {

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -27,7 +27,6 @@ QT_END_NAMESPACE
 struct CNodeCombinedStats {
     CNodeStats nodeStats;
     CNodeStateStats nodeStateStats;
-    bool fNodeStateStatsAvailable;
 };
 Q_DECLARE_METATYPE(CNodeCombinedStats*)
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1193,9 +1193,9 @@ void RPCConsole::updateDetailWidget()
         ui->peerPermissions->setText(permissions.join(" & "));
     }
     ui->peerMappedAS->setText(stats->nodeStats.m_mapped_as != 0 ? QString::number(stats->nodeStats.m_mapped_as) : ts.na);
-    ui->peerServices->setText(stats->nodeStateStats.their_services.has_value() ? GUIUtil::formatServicesStr(stats->nodeStateStats.their_services.value()) : ts.unknown);
-    ui->peerSyncHeight->setText(stats->nodeStateStats.nSyncHeight.has_value() ? QString("%1").arg(stats->nodeStateStats.nSyncHeight.value()) : ts.unknown);
-    ui->peerCommonHeight->setText(stats->nodeStateStats.nCommonHeight.has_value() ? QString("%1").arg(stats->nodeStateStats.nCommonHeight.value()) : ts.unknown);
+    ui->peerServices->setText(stats->nodeStateStats.m_services.has_value() ? GUIUtil::formatServicesStr(stats->nodeStateStats.m_services.value()) : ts.unknown);
+    ui->peerSyncHeight->setText(stats->nodeStateStats.m_sync_height.has_value() ? QString("%1").arg(stats->nodeStateStats.m_sync_height.value()) : ts.unknown);
+    ui->peerCommonHeight->setText(stats->nodeStateStats.m_common_height.has_value() ? QString("%1").arg(stats->nodeStateStats.m_common_height.value()) : ts.unknown);
     ui->peerHeight->setText(stats->nodeStateStats.m_starting_height.has_value() ? QString::number(stats->nodeStateStats.m_starting_height.value()) : ts.unknown);
     ui->peerPingWait->setText(GUIUtil::formatPingTime(stats->nodeStateStats.m_ping_wait));
     ui->peerAddrRelayEnabled->setText(stats->nodeStateStats.m_addr_relay_enabled ? ts.yes : ts.no);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -48,6 +48,7 @@
 #include <QVariant>
 
 #include <chrono>
+#include <optional>
 
 const int CONSOLE_HISTORY = 50;
 const int INITIAL_TRAFFIC_GRAPH_MINS = 30;
@@ -1192,31 +1193,15 @@ void RPCConsole::updateDetailWidget()
         ui->peerPermissions->setText(permissions.join(" & "));
     }
     ui->peerMappedAS->setText(stats->nodeStats.m_mapped_as != 0 ? QString::number(stats->nodeStats.m_mapped_as) : ts.na);
-
-    // This check fails for example if the lock was busy and
-    // nodeStateStats couldn't be fetched.
-    if (stats->fNodeStateStatsAvailable) {
-        ui->peerServices->setText(GUIUtil::formatServicesStr(stats->nodeStateStats.their_services));
-        // Sync height is init to -1
-        if (stats->nodeStateStats.nSyncHeight > -1) {
-            ui->peerSyncHeight->setText(QString("%1").arg(stats->nodeStateStats.nSyncHeight));
-        } else {
-            ui->peerSyncHeight->setText(ts.unknown);
-        }
-        // Common height is init to -1
-        if (stats->nodeStateStats.nCommonHeight > -1) {
-            ui->peerCommonHeight->setText(QString("%1").arg(stats->nodeStateStats.nCommonHeight));
-        } else {
-            ui->peerCommonHeight->setText(ts.unknown);
-        }
-        ui->peerHeight->setText(QString::number(stats->nodeStateStats.m_starting_height));
-        ui->peerPingWait->setText(GUIUtil::formatPingTime(stats->nodeStateStats.m_ping_wait));
-        ui->peerAddrRelayEnabled->setText(stats->nodeStateStats.m_addr_relay_enabled ? ts.yes : ts.no);
-        ui->peerAddrProcessed->setText(QString::number(stats->nodeStateStats.m_addr_processed));
-        ui->peerAddrRateLimited->setText(QString::number(stats->nodeStateStats.m_addr_rate_limited));
-        ui->peerRelayTxes->setText(stats->nodeStateStats.m_relay_txs ? ts.yes : ts.no);
-    }
-
+    ui->peerServices->setText(stats->nodeStateStats.their_services.has_value() ? GUIUtil::formatServicesStr(stats->nodeStateStats.their_services.value()) : ts.unknown);
+    ui->peerSyncHeight->setText(stats->nodeStateStats.nSyncHeight.has_value() ? QString("%1").arg(stats->nodeStateStats.nSyncHeight.value()) : ts.unknown);
+    ui->peerCommonHeight->setText(stats->nodeStateStats.nCommonHeight.has_value() ? QString("%1").arg(stats->nodeStateStats.nCommonHeight.value()) : ts.unknown);
+    ui->peerHeight->setText(stats->nodeStateStats.m_starting_height.has_value() ? QString::number(stats->nodeStateStats.m_starting_height.value()) : ts.unknown);
+    ui->peerPingWait->setText(GUIUtil::formatPingTime(stats->nodeStateStats.m_ping_wait));
+    ui->peerAddrRelayEnabled->setText(stats->nodeStateStats.m_addr_relay_enabled ? ts.yes : ts.no);
+    ui->peerAddrProcessed->setText(QString::number(stats->nodeStateStats.m_addr_processed));
+    ui->peerAddrRateLimited->setText(QString::number(stats->nodeStateStats.m_addr_rate_limited));
+    ui->peerRelayTxes->setText(stats->nodeStateStats.m_relay_txs ? ts.yes : ts.no);
     ui->peersTabRightPanel->show();
 }
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -196,7 +196,7 @@ static RPCHelpMan getpeerinfo()
         if (stats.m_mapped_as != 0) {
             obj.pushKV("mapped_as", uint64_t(stats.m_mapped_as));
         }
-        const ServiceFlags services{statestats.their_services.has_value() ? statestats.their_services.value() : ServiceFlags::NODE_NONE};
+        const ServiceFlags services{statestats.m_services.has_value() ? statestats.m_services.value() : ServiceFlags::NODE_NONE};
         obj.pushKV("services", strprintf("%016x", services));
         obj.pushKV("servicesnames", GetServicesNames(services));
         if (statestats.m_relay_txs.has_value()) {
@@ -228,11 +228,11 @@ static RPCHelpMan getpeerinfo()
         obj.pushKV("bip152_hb_to", stats.m_bip152_highbandwidth_to);
         obj.pushKV("bip152_hb_from", stats.m_bip152_highbandwidth_from);
         if (statestats.m_starting_height.has_value()) obj.pushKV("startingheight", statestats.m_starting_height.value());
-        if (statestats.presync_height.has_value()) obj.pushKV("presynced_headers", statestats.presync_height.value());
-        if (statestats.nSyncHeight.has_value()) obj.pushKV("synced_headers", statestats.nSyncHeight.value());
-        if (statestats.nCommonHeight.has_value()) obj.pushKV("synced_blocks", statestats.nCommonHeight.value());
+        if (statestats.m_presync_height.has_value()) obj.pushKV("presynced_headers", statestats.m_presync_height.value());
+        if (statestats.m_sync_height.has_value()) obj.pushKV("synced_headers", statestats.m_sync_height.value());
+        if (statestats.m_common_height.has_value()) obj.pushKV("synced_blocks", statestats.m_common_height.value());
         UniValue heights(UniValue::VARR);
-        for (const int height : statestats.vHeightInFlight) {
+        for (const int height : statestats.m_height_in_flight) {
             heights.push_back(height);
         }
         obj.pushKV("inflight", heights);

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -48,8 +48,7 @@ void ConnmanTestMsg::Handshake(CNode& node,
     if (node.fDisconnect) return;
     assert(node.nVersion == version);
     assert(node.GetCommonVersion() == std::min(version, PROTOCOL_VERSION));
-    CNodeStateStats statestats;
-    assert(peerman.GetNodeStateStats(node.GetId(), statestats));
+    const CNodeStateStats statestats = peerman.GetNodeStateStats(node.GetId());
     assert(statestats.m_relay_txs == (relay_txs && !node.IsBlockOnlyConn()));
     assert(statestats.their_services == remote_services);
     if (successfully_connected) {

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -50,7 +50,7 @@ void ConnmanTestMsg::Handshake(CNode& node,
     assert(node.GetCommonVersion() == std::min(version, PROTOCOL_VERSION));
     const CNodeStateStats statestats = peerman.GetNodeStateStats(node.GetId());
     assert(statestats.m_relay_txs == (relay_txs && !node.IsBlockOnlyConn()));
-    assert(statestats.their_services == remote_services);
+    assert(statestats.m_services == remote_services);
     if (successfully_connected) {
         CSerializedNetMsg msg_verack{mm.Make(NetMsgType::VERACK)};
         (void)connman.ReceiveMsgFrom(node, msg_verack);


### PR DESCRIPTION
- update CNodeStateStats members to be std::optional or member-initialized with default values

- return CNodeStateStats and NodeStats directly rather than a bool

- make some getpeerinfo and gui peers fields always provided rather than optional: addr_processed, addr_rate_limited, addr_relay_enabled, inflight

- remove NodesStats type which causes more confusion than benefit
