### PR TITLE
doc: add `{import,list}descriptors` to list of descriptor RPCs

### DIFF
--- a/doc/descriptors.md
+++ b/doc/descriptors.md
@@ -11,13 +11,16 @@ Supporting RPCs are:
   addresses.
 - `listunspent` outputs a specialized descriptor for the reported unspent outputs.
 - `getaddressinfo` outputs a descriptor for solvable addresses (since v0.18).
-- `importmulti` takes as input descriptors to import into the wallet
+- `importmulti` takes as input descriptors to import into a legacy wallet
   (since v0.18).
 - `generatetodescriptor` takes as input a descriptor and generates coins to it
   (`regtest` only, since v0.19).
 - `utxoupdatepsbt` takes as input descriptors to add information to the psbt
   (since v0.19).
-- `createmultisig` and `addmultisigaddress` return descriptors as well (since v0.20)
+- `createmultisig` and `addmultisigaddress` return descriptors as well (since v0.20).
+- `importdescriptors` takes as input descriptors to import into a descriptor wallet
+  (since v0.21).
+- `listdescriptors` outputs descriptors imported into a descriptor wallet (since v22).
 
 This document describes the language. For the specifics on usage, see the RPC
 documentation for the functions mentioned above.


### PR DESCRIPTION
This PR adds the missing RPCs `importlistdescriptors` ([since v0.21](https://github.com/bitcoin/bitcoin/blob/1420547ec30a24fc82ba3ae5ac18374e8e5af5e5/doc/release-notes/release-notes-0.21.0.md?plain=1#L405)) and `listdescriptors` ([since v22](https://github.com/bitcoin/bitcoin/blob/1420547ec30a24fc82ba3ae5ac18374e8e5af5e5/doc/release-notes/release-notes-22.0.md?plain=1#L175)) to the list of RPCs supporting descriptors in descriptors.md. Also changes the description of `importmulti` slightly to point out that it only works for legacy wallets.