### PR TITLE
Revert "ci: Integrate ccache into MSVC build"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -107,8 +107,6 @@ task:
     CI_VCPKG_TAG: '2022.06.16.1'
     VCPKG_DOWNLOADS: 'C:\Users\ContainerAdministrator\AppData\Local\vcpkg\downloads'
     VCPKG_DEFAULT_BINARY_CACHE: 'C:\Users\ContainerAdministrator\AppData\Local\vcpkg\archives'
-    CCACHE_DIR: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'
-    WRAPPED_CL: 'C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build\ci\test\wrapped-cl.bat'
     QT_DOWNLOAD_URL: 'https://download.qt.io/official_releases/qt/5.15/5.15.5/single/qt-everywhere-opensource-src-5.15.5.zip'
     QT_LOCAL_PATH: 'C:\qt-everywhere-opensource-src-5.15.5.zip'
     QT_SOURCE_DIR: 'C:\qt-everywhere-src-5.15.5'
@@ -159,13 +157,9 @@ task:
       - msbuild -version
     populate_script:
       - mkdir %VCPKG_DEFAULT_BINARY_CACHE%
-  ccache_cache:
-    folder: '%CCACHE_DIR%'
-  install_tools_script:
-    - choco install --yes --no-progress ccache
+  install_python_script:
     - choco install --yes --no-progress python3 --version=3.9.6
     - pip install zmq
-    - ccache --version
     - python -VV
   install_vcpkg_script:
     - cd ..
@@ -177,12 +171,9 @@ task:
     - .\vcpkg integrate install
     - .\vcpkg version
   build_script:
-    - '%x64_NATIVE_TOOLS%'
     - cd %CIRRUS_WORKING_DIR%
-    - ccache --zero-stats --max-size=%CCACHE_SIZE%
     - python build_msvc\msvc-autogen.py
-    - msbuild build_msvc\bitcoin.sln -property:CLToolExe=%WRAPPED_CL% -property:Configuration=Release -maxCpuCount -verbosity:minimal -noLogo
-    - ccache --show-stats
+    - msbuild build_msvc\bitcoin.sln -property:Configuration=Release -maxCpuCount -verbosity:minimal -noLogo
   unit_tests_script:
     - src\test_bitcoin.exe -l test_suite
     - src\bench_bitcoin.exe > NUL

--- a/ci/test/wrapped-cl.bat
+++ b/ci/test/wrapped-cl.bat
@@ -1,1 +1,0 @@
-ccache cl %*


### PR DESCRIPTION
This PR reverts bitcoin/bitcoin#24540 to fix MSVC CI build which failed recently.

https://community.chocolatey.org/packages/ccache was updated recently:
![image](https://user-images.githubusercontent.com/32963518/186598036-a33de5a2-1429-4e25-a784-8e6f7ac0a0d9.png)
