### PR TITLE
ci: Force `ccache` package version for MSVC build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -162,7 +162,7 @@ task:
   ccache_cache:
     folder: '%CCACHE_DIR%'
   install_tools_script:
-    - choco install --yes --no-progress ccache
+    - choco install --yes --no-progress ccache --version=4.6.1
     - choco install --yes --no-progress python3 --version=3.9.6
     - pip install zmq
     - ccache --version

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -97,8 +97,8 @@ task:
   name: "Win64 native [vs2022]"
   << : *FILTER_TEMPLATE
   windows_container:
-    cpu: 4
-    memory: 8G
+    cpu: 6
+    memory: 12G
     image: cirrusci/windowsservercore:visualstudio2022
   timeout_in: 120m
   env:


### PR DESCRIPTION
The recent update of the `ccache` [package](https://community.chocolatey.org/packages/ccache) from 4.6.1 to [4.6.2](https://ccache.dev/releasenotes.html#_ccache_4_6_2) broke our MSVC CI build.

This PR forces the working version 4.6.1.