### PR TITLE
Update the copyright year range

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (c) 2013-2019 The Bitcoin Core developers
+# Copyright (c) 2013-2022 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 


### PR DESCRIPTION
Changed the year 2019 to 2022 in copyright comments