### PR TITLE
build: include example bitcoin.conf in build outputs under share/examples/ subdirectory

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -367,7 +367,7 @@ mkdir -p "$DISTSRC"
 
         # copy over the example bitcoin.conf file. if contrib/devtools/gen-bitcoin-conf.sh
         # has not been run before buildling, this file will be a stub
-        cp "${DISTSRC}/share/examples/bitcoin.conf" "${DISTNAME}/"
+        cp -r "${DISTSRC}/share/examples" "${DISTNAME}/share/"
 
         cp -r "${DISTSRC}/share/rpcauth" "${DISTNAME}/share/"
 

--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -75,7 +75,8 @@ Section -Main SEC0000
     File @abs_top_builddir@/release/@BITCOIN_GUI_NAME@@EXEEXT@
     File /oname=COPYING.txt @abs_top_srcdir@/COPYING
     File /oname=readme.txt @abs_top_srcdir@/doc/README_windows.txt
-    File @abs_top_srcdir@/share/examples/bitcoin.conf
+    SetOutPath $INSTDIR\share\examples
+    File @abs_top_srcdir@/share/examples/*.*
     SetOutPath $INSTDIR\share\rpcauth
     File @abs_top_srcdir@/share/rpcauth/*.*
     SetOutPath $INSTDIR\daemon
@@ -130,7 +131,6 @@ Section /o -un.Main UNSEC0000
     Delete /REBOOTOK $INSTDIR\@BITCOIN_GUI_NAME@@EXEEXT@
     Delete /REBOOTOK $INSTDIR\COPYING.txt
     Delete /REBOOTOK $INSTDIR\readme.txt
-    Delete /REBOOTOK $INSTDIR\bitcoin.conf
     RMDir /r /REBOOTOK $INSTDIR\share
     RMDir /r /REBOOTOK $INSTDIR\daemon
     DeleteRegValue HKCU "${REGKEY}\Components" Main


### PR DESCRIPTION
Including the config file example in the root of the build output can suggest that editing it will have an effect on the running program.
In fact, it does not - it has to be moved to the datadir to be loaded.
By moving it into share/examples/, its status as an example is clear.
