### PR TITLE
test: add coverage for rpc error when trying to rescan beyond pruned data

### DIFF
--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -143,6 +143,10 @@ class PruneTest(BitcoinTestFramework):
             extra_args=['-prune=550', '-reindex-chainstate'],
         )
 
+    def test_rescan_blockchain(self):
+        self.restart_node(0, ["-prune=550"])
+        assert_raises_rpc_error(-1, "Can't rescan beyond pruned data. Use RPC call getblockchaininfo to determine your pruned height.", self.nodes[0].rescanblockchain)
+
     def test_height_min(self):
         assert os.path.isfile(os.path.join(self.prunedir, "blk00000.dat")), "blk00000.dat is missing, pruning too early"
         self.log.info("Success")
@@ -476,6 +480,9 @@ class PruneTest(BitcoinTestFramework):
         if self.is_wallet_compiled():
             self.log.info("Test wallet re-scan")
             self.wallet_test()
+
+            self.log.info("Test it's not possible to rescan beyond pruned data")
+            self.test_rescan_blockchain()
 
         self.log.info("Test invalid pruning command line options")
         self.test_invalid_command_line_options()


### PR DESCRIPTION
This PR adds test coverage for the following rpc error:
https://github.com/bitcoin/bitcoin/blob/15692e2641592394bdd4da0a7c2d371de8e576dd/src/wallet/rpc/transactions.cpp#L896-L899