### PR TITLE
p2p: make CJDNS fixed seeds usable

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -194,7 +194,7 @@ static std::vector<CAddress> ConvertSeeds(const std::vector<uint8_t> &vSeedsIn)
     while (!s.eof()) {
         CService endpoint;
         s >> endpoint;
-        CAddress addr{endpoint, GetDesirableServiceFlags(NODE_NONE)};
+        CAddress addr{MaybeFlipIPv6toCJDNS(endpoint), GetDesirableServiceFlags(NODE_NONE)};
         addr.nTime = rng.rand_uniform_delay(Now<NodeSeconds>() - one_week, -one_week);
         LogPrint(BCLog::NET, "Added hardcoded seed: %s\n", addr.ToString());
         vSeedsOut.push_back(addr);

--- a/src/net.h
+++ b/src/net.h
@@ -164,6 +164,7 @@ bool SeenLocal(const CService& addr);
 bool IsLocal(const CService& addr);
 bool GetLocal(CService &addr, const CNetAddr *paddrPeer = nullptr);
 CService GetLocalAddress(const CNetAddr& addrPeer);
+CService MaybeFlipIPv6toCJDNS(const CService& service);
 
 
 extern bool fDiscover;

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -945,7 +945,8 @@ static RPCHelpMan addpeeraddress()
     bool success{false};
 
     if (LookupHost(addr_string, net_addr, false)) {
-        CAddress address{{net_addr, port}, ServiceFlags{NODE_NETWORK | NODE_WITNESS}};
+        CService service{net_addr, port};
+        CAddress address{MaybeFlipIPv6toCJDNS(service), ServiceFlags{NODE_NETWORK | NODE_WITNESS}};
         address.nTime = Now<NodeSeconds>();
         // The source address is set equal to the address. This is equivalent to the peer
         // announcing itself.


### PR DESCRIPTION
The CJDNS fixed seeds are currently unusable because in order for them to be interpreted as CJDNS, `MaybeFlipIPv6toCJDNS`  needs to be called (which will change their network to CJDNS if that network is reachable).
Currently, these entries are interpreted as IPv6 addresses that are unroutable and therefore not added to addrman, so bootstrapping a new `onlynet=cjdns` node won't work out of the box.

Fix this, and also add CJDNS support to the debug-only `addpeeraddress` RPC by calling `MaybeFlipIPv6toCJDNS` there as well.