### PR TITLE
build:  Trim `{native_}libmultiprocess` packages in depends 

### DIFF
--- a/depends/packages/libmultiprocess.mk
+++ b/depends/packages/libmultiprocess.mk
@@ -26,3 +26,7 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm -rf bin lib/cmake
+endef

--- a/depends/packages/native_libmultiprocess.mk
+++ b/depends/packages/native_libmultiprocess.mk
@@ -16,3 +16,7 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm -rf lib
+endef


### PR DESCRIPTION
We are interested only in:
- a `mpgen` tool from the `native_libmultiprocess` package and
- a static `libmultiprocess.a` library from the `libmultiprocess` package