### PR TITLE
doc: clarify `blocksdir` setting

### DIFF
--- a/doc/files.md
+++ b/doc/files.md
@@ -45,7 +45,7 @@ Chain option                   | Data directory path
 
 Subdirectory       | File(s)               | Description
 -------------------|-----------------------|------------
-`blocks/`          |                       | Blocks directory; can be specified by `-blocksdir` option (except for `blocks/index/`)
+`blocks/`          |                       | Blocks directory; can be changed by specifying the parent dir with the `-blocksdir` option (except for `blocks/index/`)
 `blocks/index/`    | LevelDB database      | Block index; `-blocksdir` option does not affect this path
 `blocks/`          | `blkNNNNN.dat`<sup>[\[2\]](#note2)</sup> | Actual Bitcoin blocks (in network format, dumped in raw on disk, 128 MiB per file)
 `blocks/`          | `revNNNNN.dat`<sup>[\[2\]](#note2)</sup> | Block undo data (custom format)

--- a/doc/files.md
+++ b/doc/files.md
@@ -45,7 +45,7 @@ Chain option                   | Data directory path
 
 Subdirectory       | File(s)               | Description
 -------------------|-----------------------|------------
-`blocks/`          |                       | Blocks directory; can be changed by specifying the parent dir with the `-blocksdir` option (except for `blocks/index/`)
+`blocks/`          |                       | Blocks directory; can be changed by specifying the parent directory with the `-blocksdir` option (except for `blocks/index/`)
 `blocks/index/`    | LevelDB database      | Block index; `-blocksdir` option does not affect this path
 `blocks/`          | `blkNNNNN.dat`<sup>[\[2\]](#note2)</sup> | Actual Bitcoin blocks (in network format, dumped in raw on disk, 128 MiB per file)
 `blocks/`          | `revNNNNN.dat`<sup>[\[2\]](#note2)</sup> | Block undo data (custom format)


### PR DESCRIPTION
I couldn't figure out why Core was creating a new `blocks\` dir one extra level deep

Its because the `blocksdir=` setting demands the parent folder. Core GUI menu option Help->Command Line Options, explains it properly

This github doc in this PR is ambiguous and should be changed

ref https://github.com/bitcoin/bitcoin/pull/14364