### PR TITLE
doc: Fix `libbitcoin_common` dependencies

### DIFF
--- a/doc/design/libraries.md
+++ b/doc/design/libraries.md
@@ -54,9 +54,6 @@ bitcoin-wallet[bitcoin-wallet]-->libbitcoin_wallet_tool;
 libbitcoin_cli-->libbitcoin_common;
 libbitcoin_cli-->libbitcoin_util;
 
-libbitcoin_common-->libbitcoin_util;
-libbitcoin_common-->libbitcoin_consensus;
-
 libbitcoin_kernel-->libbitcoin_consensus;
 libbitcoin_kernel-->libbitcoin_util;
 


### PR DESCRIPTION
The `libbitcoin_common` library depends on `libunivalue` and `libsecp256k1` libraries only.

Noticed while working on bitcoin/bitcoin#25797.