### PR TITLE
doc: Fix link to MurmurHash3.cpp (moved from Google Code to Github)

### DIFF
--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -16,7 +16,7 @@ inline uint32_t ROTL32(uint32_t x, int8_t r)
 
 unsigned int MurmurHash3(unsigned int nHashSeed, Span<const unsigned char> vDataToHash)
 {
-    // The following is MurmurHash3 (x86_32), see https://code.google.com/p/smhasher/source/browse/trunk/MurmurHash3.cpp
+    // The following is MurmurHash3 (x86_32), see https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp
     uint32_t h1 = nHashSeed;
     const uint32_t c1 = 0xcc9e2d51;
     const uint32_t c2 = 0x1b873593;


### PR DESCRIPTION
Google Code repo doesn't exist anymore