### PR TITLE
p2p: Headers-sync followups

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -165,7 +165,6 @@ const CLogCategoryDesc LogCategories[] =
 #endif
     {BCLog::UTIL, "util"},
     {BCLog::BLOCKSTORE, "blockstorage"},
-    {BCLog::HEADERSSYNC, "headerssync"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };
@@ -264,8 +263,6 @@ std::string LogCategoryToStr(BCLog::LogFlags category)
         return "util";
     case BCLog::LogFlags::BLOCKSTORE:
         return "blockstorage";
-    case BCLog::LogFlags::HEADERSSYNC:
-        return "headerssync";
     case BCLog::LogFlags::ALL:
         return "all";
     }

--- a/src/logging.h
+++ b/src/logging.h
@@ -65,7 +65,6 @@ namespace BCLog {
 #endif
         UTIL        = (1 << 25),
         BLOCKSTORE  = (1 << 26),
-        HEADERSSYNC = (1 << 27),
         ALL         = ~(uint32_t)0,
     };
     enum class Level {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2820,6 +2820,13 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, Peer& peer,
         }
     }
 
+    // If our peer has NetPermissionFlags::NoBan privileges, then bypass our
+    // anti-DoS logic (this saves bandwidth when we connect to a trusted peer
+    // on startup).
+    if (pfrom.HasPermission(NetPermissionFlags::NoBan)) {
+        already_validated_work = true;
+    }
+
     // At this point, the headers connect to something in our block index.
     // Do anti-DoS checks to determine if we should process or store for later
     // processing.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3718,7 +3718,7 @@ void ChainstateManager::ReportHeadersPresync(const arith_uint256& work, int64_t 
     {
         LOCK(cs_main);
         // Don't report headers presync progress if we already have a post-minchainwork header chain.
-        // This means we lose reporting for potentially legimate, but unlikely, deep reorgs, but
+        // This means we lose reporting for potentially legitimate, but unlikely, deep reorgs, but
         // prevent attackers that spam low-work headers from filling our logs.
         if (m_best_header->nChainWork >= UintToArith256(GetConsensus().nMinimumChainWork)) return;
         // Rate limit headers presync updates to 4 per second, as these are not subject to DoS


### PR DESCRIPTION
Remove BCLog::HEADERSSYNC and move all headerssync logging to BCLog::NET.

Bypass headers anti-DoS checks for NoBan peers

Also fix a typo that was introduced in PR25717.