### PR TITLE
CBlockLocator: performance-move-const-arg Clang tidy fixup

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -49,7 +49,7 @@ std::vector<uint256> LocatorEntries(const CBlockIndex* index)
 
 CBlockLocator GetLocator(const CBlockIndex* index)
 {
-    return CBlockLocator{std::move(LocatorEntries(index))};
+    return CBlockLocator{LocatorEntries(index)};
 }
 
 CBlockLocator CChain::GetLocator() const

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -123,7 +123,7 @@ struct CBlockLocator
 
     CBlockLocator() {}
 
-    explicit CBlockLocator(const std::vector<uint256>& vHaveIn) : vHave(vHaveIn) {}
+    explicit CBlockLocator(std::vector<uint256>&& have) : vHave(std::move(have)) {}
 
     SERIALIZE_METHODS(CBlockLocator, obj)
     {


### PR DESCRIPTION
Fix Clang-tidy CI errors on master.  See https://cirrus-ci.com/task/4806752200818688?logs=ci#L4696 for an example.