### PR TITLE
refactor: add LIFETIMEBOUND to blockfilter where needed

### DIFF
--- a/src/blockfilter.h
+++ b/src/blockfilter.h
@@ -11,6 +11,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include <attributes.h>
 #include <primitives/block.h>
 #include <serialize.h>
 #include <uint256.h>
@@ -65,8 +66,8 @@ public:
     GCSFilter(const Params& params, const ElementSet& elements);
 
     uint32_t GetN() const { return m_N; }
-    const Params& GetParams() const { return m_params; }
-    const std::vector<unsigned char>& GetEncoded() const { return m_encoded; }
+    const Params& GetParams() const LIFETIMEBOUND { return m_params; }
+    const std::vector<unsigned char>& GetEncoded() const LIFETIMEBOUND { return m_encoded; }
 
     /**
      * Checks if the element may be in the set. False positives are possible
@@ -128,10 +129,10 @@ public:
     BlockFilter(BlockFilterType filter_type, const CBlock& block, const CBlockUndo& block_undo);
 
     BlockFilterType GetFilterType() const { return m_filter_type; }
-    const uint256& GetBlockHash() const { return m_block_hash; }
-    const GCSFilter& GetFilter() const { return m_filter; }
+    const uint256& GetBlockHash() const LIFETIMEBOUND { return m_block_hash; }
+    const GCSFilter& GetFilter() const LIFETIMEBOUND { return m_filter; }
 
-    const std::vector<unsigned char>& GetEncodedFilter() const
+    const std::vector<unsigned char>& GetEncodedFilter() const LIFETIMEBOUND
     {
         return m_filter.GetEncoded();
     }

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_INDEX_BLOCKFILTERINDEX_H
 #define BITCOIN_INDEX_BLOCKFILTERINDEX_H
 
+#include <attributes.h>
 #include <blockfilter.h>
 #include <chain.h>
 #include <flatfile.h>
@@ -49,9 +50,9 @@ protected:
 
     bool CustomRewind(const interfaces::BlockKey& current_tip, const interfaces::BlockKey& new_tip) override;
 
-    BaseIndex::DB& GetDB() const override { return *m_db; }
+    BaseIndex::DB& GetDB() const LIFETIMEBOUND override { return *m_db; }
 
-    const char* GetName() const override { return m_name.c_str(); }
+    const char* GetName() const LIFETIMEBOUND override { return m_name.c_str(); }
 
 public:
     /** Constructs the index, which becomes available to be queried. */


### PR DESCRIPTION
Noticed from https://github.com/bitcoin/bitcoin/pull/25637#issuecomment-1231860822 that [`BlockFilter::GetFilter()`](https://github.com/bitcoin/bitcoin/blob/01e1627e25bc5477c40f51da03c3c31b609a85c9/src/blockfilter.h#L132) returns a reference to a member variable. Added LIFETIMEBOUND to all blockfilter-related code to ensure that the return values do not have a lifetime that exceeds the lifetime of what it is bound to. See https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#lifetimebound or https://github.com/bitcoin/bitcoin/pull/25060 for a similar example.

I used `grep -E '[a-zA-Z>0-9][&*] ([a-zA-Z]*)\((.*)\)' src/**/blockfilter*` to grep all possible occurrences (not all of them require LIFETIMEBOUND)