### PR TITLE
Optimizations & simplifications following #25717

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -128,12 +128,12 @@ void CBlockIndex::BuildSkip()
         pskip = pprev->GetAncestor(GetSkipHeight(nHeight));
 }
 
-arith_uint256 GetBlockProof(const CBlockIndex& block)
+arith_uint256 GetBitsProof(uint32_t bits)
 {
     arith_uint256 bnTarget;
     bool fNegative;
     bool fOverflow;
-    bnTarget.SetCompact(block.nBits, &fNegative, &fOverflow);
+    bnTarget.SetCompact(bits, &fNegative, &fOverflow);
     if (fNegative || fOverflow || bnTarget == 0)
         return 0;
     // We need to compute 2**256 / (bnTarget+1), but we can't represent 2**256

--- a/src/chain.h
+++ b/src/chain.h
@@ -357,7 +357,15 @@ public:
     const CBlockIndex* GetAncestor(int height) const;
 };
 
-arith_uint256 GetBlockProof(const CBlockIndex& block);
+/** Compute how much work an nBits value corresponds to, based on its nBits value. */
+arith_uint256 GetBitsProof(uint32_t bits);
+
+/** Compute how much work a block index entry corresponds to. */
+inline arith_uint256 GetBlockProof(const CBlockIndex& block) { return GetBitsProof(block.nBits); }
+
+/** Compute how much work a block header corresponds to. */
+inline arith_uint256 GetBlockProof(const CBlockHeader& header) { return GetBitsProof(header.nBits); }
+
 /** Return the time it would take to redo the work difference between from and to, assuming the current hashrate corresponds to the difficulty at tip, in seconds. */
 int64_t GetBlockProofEquivalentTime(const CBlockIndex& to, const CBlockIndex& from, const CBlockIndex& tip, const Consensus::Params&);
 /** Find the forking point between two chain tips. */

--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -65,13 +65,13 @@ void HeadersSyncState::Finalize()
 /** Process the next batch of headers received from our peer.
  *  Validate and store commitments, and compare total chainwork to our target to
  *  see if we can switch to REDOWNLOAD mode.  */
-HeadersSyncState::ProcessingResult HeadersSyncState::ProcessNextHeaders(const
-        std::vector<CBlockHeader>& received_headers, const bool full_headers_message)
+HeadersSyncState::ProcessingResult HeadersSyncState::ProcessNextHeaders(
+        std::vector<CBlockHeader>& headers, const bool full_headers_message)
 {
     ProcessingResult ret;
 
-    Assume(!received_headers.empty());
-    if (received_headers.empty()) return ret;
+    Assume(!headers.empty());
+    if (headers.empty()) return ret;
 
     Assume(m_download_state != State::FINAL);
     if (m_download_state == State::FINAL) return ret;
@@ -80,8 +80,9 @@ HeadersSyncState::ProcessingResult HeadersSyncState::ProcessNextHeaders(const
         // During PRESYNC, we minimally validate block headers and
         // occasionally add commitments to them, until we reach our work
         // threshold (at which point m_download_state is updated to REDOWNLOAD).
-        ret.success = ValidateAndStoreHeadersCommitments(received_headers);
+        ret.success = ValidateAndStoreHeadersCommitments(headers);
         if (ret.success) {
+            headers = {};
             if (full_headers_message || m_download_state == State::REDOWNLOAD) {
                 // A full headers message means the peer may have more to give us;
                 // also if we just switched to REDOWNLOAD then we need to re-request
@@ -101,7 +102,7 @@ HeadersSyncState::ProcessingResult HeadersSyncState::ProcessNextHeaders(const
         // gets big enough (meaning that we've checked enough commitments),
         // we'll return a batch of headers to the caller for processing.
         ret.success = true;
-        for (const auto& hdr : received_headers) {
+        for (const auto& hdr : headers) {
             if (!ValidateAndStoreRedownloadedHeader(hdr)) {
                 // Something went wrong -- the peer gave us an unexpected chain.
                 // We could consider looking at the reason for failure and
@@ -112,8 +113,8 @@ HeadersSyncState::ProcessingResult HeadersSyncState::ProcessNextHeaders(const
         }
 
         if (ret.success) {
-            // Return any headers that are ready for acceptance.
-            ret.pow_validated_headers = PopHeadersReadyForAcceptance();
+            // Return any headers that are ready for acceptance, reusing the headers vector.
+            PopHeadersReadyForAcceptance(headers);
 
             // If we hit our target blockhash, then all remaining headers will be
             // returned and we can clear any leftover internal state.
@@ -277,20 +278,20 @@ bool HeadersSyncState::ValidateAndStoreRedownloadedHeader(const CBlockHeader& he
     return true;
 }
 
-std::vector<CBlockHeader> HeadersSyncState::PopHeadersReadyForAcceptance()
+void HeadersSyncState::PopHeadersReadyForAcceptance(std::vector<CBlockHeader>& headers)
 {
-    std::vector<CBlockHeader> ret;
+    headers.clear();
 
     Assume(m_download_state == State::REDOWNLOAD);
-    if (m_download_state != State::REDOWNLOAD) return ret;
+    if (m_download_state != State::REDOWNLOAD) return;
 
     while (m_redownloaded_headers.size() > REDOWNLOAD_BUFFER_SIZE ||
             (m_redownloaded_headers.size() > 0 && m_process_all_remaining_headers)) {
-        ret.emplace_back(m_redownloaded_headers.front().GetFullHeader(m_redownload_buffer_first_prev_hash));
+        headers.emplace_back(m_redownloaded_headers.front().GetFullHeader(m_redownload_buffer_first_prev_hash));
         m_redownloaded_headers.pop_front();
-        m_redownload_buffer_first_prev_hash = ret.back().GetHash();
+        m_redownload_buffer_first_prev_hash = headers.back().GetHash();
     }
-    return ret;
+    return;
 }
 
 CBlockLocator HeadersSyncState::NextHeadersRequestLocator() const

--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -70,9 +70,6 @@ HeadersSyncState::ProcessingResult HeadersSyncState::ProcessNextHeaders(
 {
     ProcessingResult ret;
 
-    Assume(!headers.empty());
-    if (headers.empty()) return ret;
-
     Assume(m_download_state != State::FINAL);
     if (m_download_state == State::FINAL) return ret;
 
@@ -139,12 +136,10 @@ HeadersSyncState::ProcessingResult HeadersSyncState::ProcessNextHeaders(
 
 bool HeadersSyncState::ValidateAndStoreHeadersCommitments(const std::vector<CBlockHeader>& headers)
 {
-    // The caller should not give us an empty set of headers.
-    Assume(headers.size() > 0);
-    if (headers.size() == 0) return true;
-
     Assume(m_download_state == State::PRESYNC);
     if (m_download_state != State::PRESYNC) return false;
+
+    if (headers.size() == 0) return true;
 
     if (headers[0].hashPrevBlock != m_last_header_received.GetHash()) {
         // Somehow our peer gave us a header that doesn't connect.

--- a/src/headerssync.h
+++ b/src/headerssync.h
@@ -140,20 +140,17 @@ public:
 
     /** Result data structure for ProcessNextHeaders. */
     struct ProcessingResult {
-        std::vector<CBlockHeader> pow_validated_headers;
         bool success{false};
         bool request_more{false};
     };
 
     /** Process a batch of headers, once a sync via this mechanism has started
      *
-     * received_headers: headers that were received over the network for processing.
-     *                   Assumes the caller has already verified the headers
-     *                   are continuous, and has checked that each header
-     *                   satisfies the proof-of-work target included in the
-     *                   header (but not necessarily verified that the
-     *                   proof-of-work target is correct and passes consensus
-     *                   rules).
+     * headers: headers that were received over the network for processing. Assumes the caller has
+     *          already verified the headers are continuous, and has checked that each header
+     *          satisfies the proof-of-work target included in the header (but not necessarily
+     *          verified that the proof-of-work target is correct and passes consensus rules).
+     *          On output, this will be replaced with headers the caller has to process.
      * full_headers_message: true if the message was at max capacity,
      *                       indicating more headers may be available
      * ProcessingResult.pow_validated_headers: will be filled in with any
@@ -165,8 +162,7 @@ public:
      * ProcessingResult.request_more: if true, the caller is suggested to call
      *                       NextHeadersRequestLocator and send a getheaders message using it.
      */
-    ProcessingResult ProcessNextHeaders(const std::vector<CBlockHeader>&
-            received_headers, bool full_headers_message);
+    ProcessingResult ProcessNextHeaders(std::vector<CBlockHeader>& headers, bool full_headers_message);
 
     /** Issue the next GETHEADERS message to our peer.
      *
@@ -198,7 +194,7 @@ private:
     bool ValidateAndStoreRedownloadedHeader(const CBlockHeader& header);
 
     /** Return a set of headers that satisfy our proof-of-work threshold */
-    std::vector<CBlockHeader> PopHeadersReadyForAcceptance();
+    void PopHeadersReadyForAcceptance(std::vector<CBlockHeader>& headers);
 
 private:
     /** NodeId of the peer (used for log messages) **/

--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -29,7 +29,7 @@ std::vector<bool> BytesToBits(const std::vector<unsigned char>& bytes)
 
 CMerkleBlock::CMerkleBlock(const CBlock& block, CBloomFilter* filter, const std::set<uint256>* txids)
 {
-    header = block.GetBlockHeader();
+    header = block;
 
     std::vector<bool> vMatch;
     std::vector<uint256> vHashes;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2514,12 +2514,6 @@ bool PeerManagerImpl::IsContinuationOfLowWorkHeadersSync(Peer& peer, CNode& pfro
             }
         }
 
-        if (result.success) {
-            // We only overwrite the headers passed in if processing was
-            // successful.
-            headers.swap(result.pow_validated_headers);
-        }
-
         return result.success;
     }
     // Either we didn't have a sync in progress, or something went wrong

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4416,7 +4416,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
             // Check work on this block against our anti-dos thresholds.
             const CBlockIndex* prev_block = m_chainman.m_blockman.LookupBlockIndex(pblock->hashPrevBlock);
-            if (prev_block && prev_block->nChainWork + GetBlockProof(pblock->GetBlockHeader()) >= GetAntiDoSWorkThreshold()) {
+            if (prev_block && prev_block->nChainWork + GetBlockProof(*pblock) >= GetAntiDoSWorkThreshold()) {
                 min_pow_checked = true;
             }
         }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2792,7 +2792,7 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, Peer& peer,
     {
         LOCK(cs_main);
         last_received_header = m_chainman.m_blockman.LookupBlockIndex(headers.back().GetHash());
-        if (IsAncestorOfBestHeaderOrTip(last_received_header)) {
+        if (!already_validated_work && IsAncestorOfBestHeaderOrTip(last_received_header)) {
             already_validated_work = true;
         }
     }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2807,13 +2807,13 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, Peer& peer,
     // At this point, the headers connect to something in our block index.
     // Do anti-DoS checks to determine if we should process or store for later
     // processing.
-    if (!already_validated_work && TryLowWorkHeadersSync(peer, pfrom,
-                chain_start_header, headers)) {
-        // If we successfully started a low-work headers sync, then there
-        // should be no headers to process any further.
-        Assume(headers.empty());
-        return;
+    if (!already_validated_work) {
+        already_validated_work = TryLowWorkHeadersSync(peer, pfrom, chain_start_header, headers);
+        have_headers_sync = already_validated_work;
     }
+
+    // If there is nothing left to process, stop.
+    if (headers.empty()) return;
 
     // At this point, we have a set of headers with sufficient work on them
     // which can be processed.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4074,7 +4074,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                 MaybeSendGetHeaders(pfrom, GetLocator(m_chainman.m_best_header), *peer);
             }
             return;
-        } else if (prev_block->nChainWork + CalculateHeadersWork({cmpctblock.header}) < GetAntiDoSWorkThreshold()) {
+        } else if (prev_block->nChainWork + GetBlockProof(cmpctblock.header) < GetAntiDoSWorkThreshold()) {
             // If we get a low-work header in a compact block, we can ignore it.
             LogPrint(BCLog::NET, "Ignoring low-work compact block from peer %d\n", pfrom.GetId());
             return;
@@ -4416,7 +4416,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
             // Check work on this block against our anti-dos thresholds.
             const CBlockIndex* prev_block = m_chainman.m_blockman.LookupBlockIndex(pblock->hashPrevBlock);
-            if (prev_block && prev_block->nChainWork + CalculateHeadersWork({pblock->GetBlockHeader()}) >= GetAntiDoSWorkThreshold()) {
+            if (prev_block && prev_block->nChainWork + GetBlockProof(pblock->GetBlockHeader()) >= GetAntiDoSWorkThreshold()) {
                 min_pow_checked = true;
             }
         }

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -98,18 +98,6 @@ public:
         fChecked = false;
     }
 
-    CBlockHeader GetBlockHeader() const
-    {
-        CBlockHeader block;
-        block.nVersion       = nVersion;
-        block.hashPrevBlock  = hashPrevBlock;
-        block.hashMerkleRoot = hashMerkleRoot;
-        block.nTime          = nTime;
-        block.nBits          = nBits;
-        block.nNonce         = nNonce;
-        return block;
-    }
-
     std::string ToString() const;
 };
 

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -98,7 +98,7 @@ bool BuildChainTestingSetup::BuildChain(const CBlockIndex* pindex,
     chain.resize(length);
     for (auto& block : chain) {
         block = std::make_shared<CBlock>(CreateBlock(pindex, no_txns, coinbase_script_pub_key));
-        CBlockHeader header = block->GetBlockHeader();
+        CBlockHeader header = *block;
 
         BlockValidationState state;
         if (!Assert(m_node.chainman)->ProcessNewBlockHeaders({header}, true, state, &pindex)) {

--- a/src/test/fuzz/block_header.cpp
+++ b/src/test/fuzz/block_header.cpp
@@ -33,10 +33,10 @@ FUZZ_TARGET(block_header)
         mut_block_header.SetNull();
         assert(mut_block_header.IsNull());
         CBlock block{*block_header};
-        assert(block.GetBlockHeader().GetHash() == block_header->GetHash());
+        assert(block.GetHash() == block_header->GetHash());
         (void)block.ToString();
         block.SetNull();
-        assert(block.GetBlockHeader().GetHash() == mut_block_header.GetHash());
+        assert(block.GetHash() == mut_block_header.GetHash());
     }
     {
         std::optional<CBlockLocator> block_locator = ConsumeDeserializable<CBlockLocator>(fuzzed_data_provider);

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -100,7 +100,7 @@ std::shared_ptr<CBlock> MinerTestingSetup::FinalizeBlock(std::shared_ptr<CBlock>
     // submit block header, so that miner can get the block height from the
     // global state and the node has the topology of the chain
     BlockValidationState ignored;
-    BOOST_CHECK(Assert(m_node.chainman)->ProcessNewBlockHeaders({pblock->GetBlockHeader()}, true, ignored));
+    BOOST_CHECK(Assert(m_node.chainman)->ProcessNewBlockHeaders({*pblock}, true, ignored));
 
     return pblock;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3432,19 +3432,16 @@ std::vector<unsigned char> ChainstateManager::GenerateCoinbaseCommitment(CBlock&
     return commitment;
 }
 
-bool HasValidProofOfWork(const std::vector<CBlockHeader>& headers, const Consensus::Params& consensusParams)
+bool HasValidProofOfWork(Span<const CBlockHeader> headers, const Consensus::Params& consensusParams)
 {
-    return std::all_of(headers.cbegin(), headers.cend(),
+    return std::all_of(headers.begin(), headers.end(),
             [&](const auto& header) { return CheckProofOfWork(header.GetHash(), header.nBits, consensusParams);});
 }
 
-arith_uint256 CalculateHeadersWork(const std::vector<CBlockHeader>& headers)
+arith_uint256 CalculateHeadersWork(Span<const CBlockHeader> headers)
 {
     arith_uint256 total_work{0};
-    for (const CBlockHeader& header : headers) {
-        CBlockIndex dummy(header);
-        total_work += GetBlockProof(dummy);
-    }
+    for (const CBlockHeader& header : headers) total_work += GetBlockProof(header);
     return total_work;
 }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -341,10 +341,10 @@ bool TestBlockValidity(BlockValidationState& state,
                        bool fCheckMerkleRoot = true) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** Check with the proof of work on each blockheader matches the value in nBits */
-bool HasValidProofOfWork(const std::vector<CBlockHeader>& headers, const Consensus::Params& consensusParams);
+bool HasValidProofOfWork(Span<const CBlockHeader> headers, const Consensus::Params& consensusParams);
 
 /** Return the sum of the work on a given set of headers */
-arith_uint256 CalculateHeadersWork(const std::vector<CBlockHeader>& headers);
+arith_uint256 CalculateHeadersWork(Span<const CBlockHeader> headers);
 
 /** RAII wrapper for VerifyDB: Verify consistency of the block and coin databases */
 class CVerifyDB {


### PR DESCRIPTION
This contains a list of most-unrelated simplifications and optimizations to the code merged in #25717:
* **Make `ProcessNextHeaders` replace the headers argument**: this allows reusing the same vector storage for input and output headers to `HeadersSync::ProcessNextHeaders`. I find it also natural in the sense that this argument just represents the headers-to-be-processed, both in the caller and the callee, and both before and after the calls.
* **Make `ProcessNextHeaders` support empty headers message**: remove the special case in `ProcessHeadersMessage` dealing with empty headers messages, and instead let `HeadersSync` deal with it correctly.
* **Simplify `TryLowWorkHeadersSync` invocation**: make use of the fact that now `TryLowWorkHeadersSync` is (like `IsContinuationOfLowWorkHeadersSync`) an operation that partially processes headers, it can be invoked in a similar way, bailing out when there is nothing left to do.
* **Avoid an `IsAncestorOfBestHeaderOrTip` call**: just don't call this function when it won't have any effect
* **Compute work from headers without `CBlockIndex`**: avoid the need to construct a `CBlockIndex` object just to compute work for a header, when its `nBits` value suffices for that. Also use some `Span`s where possible.
* **Remove useless `CBlock::GetBlockHeader` (it inherits from it)**: There is no need for a function to convert a `CBlock` to a `CBlockHeader`, as it's a child class of it.

These are not reactions to review feedback, and isn't intended for 24.0.