### PR TITLE
wallet: Filter-out "send" addresses from `listreceivedby*`

### DIFF
--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -137,6 +137,8 @@ static UniValue ListReceived(const CWallet& wallet, const UniValue& params, cons
     const auto& func = [&](const CTxDestination& address, const std::string& label, const std::string& purpose, bool is_change) {
         if (is_change) return; // no change addresses
 
+        if (purpose == "send") return; // no send addresses
+
         auto it = mapTally.find(address);
         if (it == mapTally.end() && !fIncludeEmpty)
             return;

--- a/test/functional/wallet_listreceivedby.py
+++ b/test/functional/wallet_listreceivedby.py
@@ -26,10 +26,17 @@ class ReceivedByTest(BitcoinTestFramework):
         self.skip_if_no_cli()
 
     def run_test(self):
+        self.test_listreceivedbyaddress()
+        self.test_getreceivedby()
+        self.test_receivedbylabel()
+        self.test_coinbase_inclusion()
+
+    def test_listreceivedbyaddress(self):
         # save the number of coinbase reward addresses so far
         num_cb_reward_addresses = len(self.nodes[1].listreceivedbyaddress(minconf=0, include_empty=True, include_watchonly=True))
 
-        self.log.info("listreceivedbyaddress Test")
+        self.log.info("Tests listreceivedbyaddress")
+        self.log.info("- respects minimum confirmations")
 
         # Send from node 0 to 1
         addr = self.nodes[1].getnewaddress()
@@ -37,36 +44,31 @@ class ReceivedByTest(BitcoinTestFramework):
         self.sync_all()
 
         # Check not listed in listreceivedbyaddress because has 0 confirmations
-        assert_array_result(self.nodes[1].listreceivedbyaddress(),
-                            {"address": addr},
-                            {},
-                            True)
+        assert_array_result(self.nodes[1].listreceivedbyaddress(), {"address": addr}, {}, True)
         # Bury Tx under 10 block so it will be returned by listreceivedbyaddress
         self.generate(self.nodes[1], 10)
-        assert_array_result(self.nodes[1].listreceivedbyaddress(),
-                            {"address": addr},
-                            {"address": addr, "label": "", "amount": Decimal("0.1"), "confirmations": 10, "txids": [txid, ]})
+        expected = {"address": addr, "label": "", "amount": Decimal("0.1"), "confirmations": 10, "txids": [txid, ]}
+        assert_array_result(self.nodes[1].listreceivedbyaddress(), {"address": addr}, expected)
         # With min confidence < 10
-        assert_array_result(self.nodes[1].listreceivedbyaddress(5),
-                            {"address": addr},
-                            {"address": addr, "label": "", "amount": Decimal("0.1"), "confirmations": 10, "txids": [txid, ]})
+        assert_array_result(self.nodes[1].listreceivedbyaddress(5), {"address": addr}, expected)
         # With min confidence > 10, should not find Tx
         assert_array_result(self.nodes[1].listreceivedbyaddress(11), {"address": addr}, {}, True)
 
-        # Empty Tx
+        self.log.info("- includes empty addresses")
         empty_addr = self.nodes[1].getnewaddress()
         assert_array_result(self.nodes[1].listreceivedbyaddress(0, True),
                             {"address": empty_addr},
                             {"address": empty_addr, "label": "", "amount": 0, "confirmations": 0, "txids": []})
 
-        # No returned addy should be a change addr
+        self.log.info("- does not return change addresses")
+        # No returned addr should be a change addr
         for node in self.nodes:
             for addr_obj in node.listreceivedbyaddress():
                 assert_equal(node.getaddressinfo(addr_obj["address"])["ischange"], False)
 
+        self.log.info("- respects address filtering")
         # Test Address filtering
         # Only on addr
-        expected = {"address": addr, "label": "", "amount": Decimal("0.1"), "confirmations": 10, "txids": [txid, ]}
         res = self.nodes[1].listreceivedbyaddress(minconf=0, include_empty=True, include_watchonly=True, address_filter=addr)
         assert_array_result(res, {"address": addr}, expected)
         assert_equal(len(res), 1)
@@ -83,7 +85,7 @@ class ReceivedByTest(BitcoinTestFramework):
         txid2 = self.nodes[0].sendtoaddress(other_addr, 0.1)
         self.generate(self.nodes[0], 1)
         # Same test as above should still pass
-        expected = {"address": addr, "label": "", "amount": Decimal("0.1"), "confirmations": 11, "txids": [txid, ]}
+        expected["confirmations"] += 1 # a new block was generated on top
         res = self.nodes[1].listreceivedbyaddress(0, True, True, addr)
         assert_array_result(res, {"address": addr}, expected)
         assert_equal(len(res), 1)
@@ -101,13 +103,15 @@ class ReceivedByTest(BitcoinTestFramework):
         res = self.nodes[1].listreceivedbyaddress(0, True, True, other_addr)
         assert_equal(len(res), 0)
 
-        self.log.info("getreceivedbyaddress Test")
+    def test_getreceivedby(self):
+        self.log.info("Tests getreceivedbyaddress")
 
         # Send from node 0 to 1
         addr = self.nodes[1].getnewaddress()
-        txid = self.nodes[0].sendtoaddress(addr, 0.1)
+        self.nodes[0].sendtoaddress(addr, 0.1)
         self.sync_all()
 
+        self.log.info("- respects minimum confirmations")
         # Check balance is 0 because of 0 confirmations
         balance = self.nodes[1].getreceivedbyaddress(addr)
         assert_equal(balance, Decimal("0.0"))
@@ -121,11 +125,17 @@ class ReceivedByTest(BitcoinTestFramework):
         balance = self.nodes[1].getreceivedbyaddress(addr)
         assert_equal(balance, Decimal("0.1"))
 
+        self.log.info("- does not accept address not found in wallet")
         # Trying to getreceivedby for an address the wallet doesn't own should return an error
         assert_raises_rpc_error(-4, "Address not found in wallet", self.nodes[0].getreceivedbyaddress, addr)
 
-        self.log.info("listreceivedbylabel + getreceivedbylabel Test")
+    def test_receivedbylabel(self):
+        self.log.info("Tests getreceivedbylabel does not accept label not found in wallet")
+        # getreceivedbylabel returns an error if the wallet doesn't own the label
+        assert_raises_rpc_error(-4, "Label not found in wallet", self.nodes[0].getreceivedbylabel, "dummy")
 
+        self.log.info("Tests listreceivedbylabel + getreceivedbylabel")
+        self.log.info("- returns matching balances")
         # set pre-state
         label = ''
         address = self.nodes[1].getnewaddress()
@@ -133,11 +143,8 @@ class ReceivedByTest(BitcoinTestFramework):
         received_by_label_json = [r for r in self.nodes[1].listreceivedbylabel() if r["label"] == label][0]
         balance_by_label = self.nodes[1].getreceivedbylabel(label)
 
-        txid = self.nodes[0].sendtoaddress(addr, 0.1)
+        self.nodes[0].sendtoaddress(address, 0.1)
         self.sync_all()
-
-        # getreceivedbylabel returns an error if the wallet doesn't own the label
-        assert_raises_rpc_error(-4, "Label not found in wallet", self.nodes[0].getreceivedbylabel, "dummy")
 
         # listreceivedbylabel should return received_by_label_json because of 0 confirmations
         assert_array_result(self.nodes[1].listreceivedbylabel(),
@@ -170,8 +177,8 @@ class ReceivedByTest(BitcoinTestFramework):
         balance = self.nodes[1].getreceivedbylabel("mynewlabel")
         assert_equal(balance, Decimal("0.0"))
 
-        self.log.info("Tests for including coinbase outputs")
-
+    def test_coinbase_inclusion(self):
+        self.log.info("Tests for including coinbase outputs for immature coinbase")
         # Generate block reward to address with label
         label = "label"
         address = self.nodes[0].getnewaddress(label)
@@ -180,80 +187,85 @@ class ReceivedByTest(BitcoinTestFramework):
         self.generatetoaddress(self.nodes[0], 1, address)
         hash = self.nodes[0].getbestblockhash()
 
-        self.log.info("getreceivedbyaddress returns nothing with defaults")
+        self.log.info("- getreceivedbyaddress")
+        self.log.info("  - returns nothing with defaults")
         balance = self.nodes[0].getreceivedbyaddress(address)
         assert_equal(balance, 0)
 
-        self.log.info("getreceivedbyaddress returns block reward when including immature coinbase")
+        self.log.info("  - returns block reward when including immature coinbase")
         balance = self.nodes[0].getreceivedbyaddress(address=address, include_immature_coinbase=True)
         assert_equal(balance, reward)
 
-        self.log.info("getreceivedbylabel returns nothing with defaults")
-        balance = self.nodes[0].getreceivedbylabel("label")
+        self.log.info("- getreceivedbylabel")
+        self.log.info("  - returns nothing with defaults")
+        balance = self.nodes[0].getreceivedbylabel(label)
         assert_equal(balance, 0)
 
-        self.log.info("getreceivedbylabel returns block reward when including immature coinbase")
-        balance = self.nodes[0].getreceivedbylabel(label="label", include_immature_coinbase=True)
+        self.log.info("  - returns block reward when including immature coinbase")
+        balance = self.nodes[0].getreceivedbylabel(label=label, include_immature_coinbase=True)
         assert_equal(balance, reward)
 
-        self.log.info("listreceivedbyaddress does not include address with defaults")
+        self.log.info("- listreceivedbyaddress")
+        self.log.info("  - does not include address with defaults")
         assert_array_result(self.nodes[0].listreceivedbyaddress(),
                             {"address": address},
                             {}, True)
 
-        self.log.info("listreceivedbyaddress includes address when including immature coinbase")
+        self.log.info("  - includes address when including immature coinbase")
         assert_array_result(self.nodes[0].listreceivedbyaddress(minconf=1, include_immature_coinbase=True),
                             {"address": address},
                             {"address": address, "amount": reward})
 
-        self.log.info("listreceivedbylabel does not include label with defaults")
+        self.log.info("- listreceivedbylabel")
+        self.log.info("   - does not include label with defaults")
         assert_array_result(self.nodes[0].listreceivedbylabel(),
                             {"label": label},
                             {}, True)
 
-        self.log.info("listreceivedbylabel includes label when including immature coinbase")
+        self.log.info("   - includes label when including immature coinbase")
         assert_array_result(self.nodes[0].listreceivedbylabel(minconf=1, include_immature_coinbase=True),
                             {"label": label},
                             {"label": label, "amount": reward})
 
-        self.log.info("Generate 100 more blocks")
+        self.log.info("Tests for including coinbase outputs for mature coinbase")
         self.generate(self.nodes[0], COINBASE_MATURITY)
+        # Block reward to address with label has now matured
 
-        self.log.info("getreceivedbyaddress returns reward with defaults")
+        self.log.info("- getreceivedbyaddress returns reward with defaults")
         balance = self.nodes[0].getreceivedbyaddress(address)
         assert_equal(balance, reward)
 
-        self.log.info("getreceivedbylabel returns reward with defaults")
-        balance = self.nodes[0].getreceivedbylabel("label")
+        self.log.info("- getreceivedbylabel returns reward with defaults")
+        balance = self.nodes[0].getreceivedbylabel(label)
         assert_equal(balance, reward)
 
-        self.log.info("listreceivedbyaddress includes address with defaults")
+        self.log.info("- listreceivedbyaddress includes address with defaults")
         assert_array_result(self.nodes[0].listreceivedbyaddress(),
                             {"address": address},
                             {"address": address, "amount": reward})
 
-        self.log.info("listreceivedbylabel includes label with defaults")
+        self.log.info("- listreceivedbylabel includes label with defaults")
         assert_array_result(self.nodes[0].listreceivedbylabel(),
                             {"label": label},
                             {"label": label, "amount": reward})
 
-        self.log.info("Invalidate block that paid to address")
+        self.log.info("Tests for including coinbase output from invalidated block when minconf is 0 and including immature coinbase")
         self.nodes[0].invalidateblock(hash)
 
-        self.log.info("getreceivedbyaddress does not include invalidated block when minconf is 0 when including immature coinbase")
+        self.log.info("- getreceivedbyaddress returns nothing")
         balance = self.nodes[0].getreceivedbyaddress(address=address, minconf=0, include_immature_coinbase=True)
         assert_equal(balance, 0)
 
-        self.log.info("getreceivedbylabel does not include invalidated block when minconf is 0 when including immature coinbase")
-        balance = self.nodes[0].getreceivedbylabel(label="label", minconf=0, include_immature_coinbase=True)
+        self.log.info("- getreceivedbylabel returns nothing")
+        balance = self.nodes[0].getreceivedbylabel(label=label, minconf=0, include_immature_coinbase=True)
         assert_equal(balance, 0)
 
-        self.log.info("listreceivedbyaddress does not include invalidated block when minconf is 0 when including immature coinbase")
+        self.log.info("- listreceivedbyaddress does not include address")
         assert_array_result(self.nodes[0].listreceivedbyaddress(minconf=0, include_immature_coinbase=True),
                             {"address": address},
                             {}, True)
 
-        self.log.info("listreceivedbylabel does not include invalidated block when minconf is 0 when including immature coinbase")
+        self.log.info("- listreceivedbylabel does not include address")
         assert_array_result(self.nodes[0].listreceivedbylabel(minconf=0, include_immature_coinbase=True),
                             {"label": label},
                             {}, True)

--- a/test/functional/wallet_listreceivedby.py
+++ b/test/functional/wallet_listreceivedby.py
@@ -27,6 +27,7 @@ class ReceivedByTest(BitcoinTestFramework):
 
     def run_test(self):
         self.test_listreceivedbyaddress()
+        self.test_listreceivedby()
         self.test_getreceivedby()
         self.test_receivedbylabel()
         self.test_coinbase_inclusion()
@@ -102,6 +103,27 @@ class ReceivedByTest(BitcoinTestFramework):
         other_addr = self.nodes[0].getnewaddress()  # note on node[0]! just a random addr
         res = self.nodes[1].listreceivedbyaddress(0, True, True, other_addr)
         assert_equal(len(res), 0)
+
+    def test_listreceivedby(self):
+        self.log.info("Tests listreceivedbyaddress does not return address with 'send' purpose")
+        label = "node0address"
+        address = self.nodes[0].getnewaddress(label)
+        # using setlabel for an address that does not belong to the wallet assigns a "send" purpose to that address
+        self.nodes[1].setlabel(address, label) # address has now assigned a "send" purpose on node1
+        assert_equal(self.nodes[0].getaddressesbylabel(label=label), {address: {'purpose': 'receive'}})
+        assert_equal(self.nodes[1].getaddressesbylabel(label=label), {address: {'purpose': 'send'}})
+
+        txid = self.nodes[0].sendtoaddress(address, 0.1)
+        self.sync_all()
+
+        expected = {"address": address, "label": label, "amount": Decimal("0.1"), "confirmations": 0, "txids": [txid, ]}
+        assert_array_result(self.nodes[0].listreceivedbyaddress(minconf=0, include_empty=True), {"address": address}, expected)
+        assert_array_result(self.nodes[1].listreceivedbyaddress(minconf=0, include_empty=True), {"address": address}, {}, True)
+
+        self.log.info("Tests listreceivedbylabel does not return label of address with 'send' purpose")
+        expected = {"label": label, "amount": Decimal("0.1")}
+        assert_array_result(self.nodes[0].listreceivedbylabel(minconf=0, include_empty=True), {"label": label}, expected)
+        assert_array_result(self.nodes[1].listreceivedbylabel(minconf=0, include_empty=True), {"label": label}, {}, True)
 
     def test_getreceivedby(self):
         self.log.info("Tests getreceivedbyaddress")


### PR DESCRIPTION
`listreceivedbyaddress` & `listreceivedbylabel` RPCs list balances by receiving address and label respectively. That works by creating a tally (`mapTally[address]`) from all the transaction outputs in the wallet and then cross-reference that with the address book in order to calculate which addresses received funds.

If an address is in the address book but not in the tally, it's considered empty (never received funds) and is not returned unless `include_empty=true`. That effectively means that when `include_empty=true` the entire address book is included in the result.

**This creates 2 issues:**

1. As reported in https://github.com/bitcoin/bitcoin/issues/16159, the address book also includes addresses with a "send" purpose which should not be part of the response.
2. As reported in https://github.com/bitcoin/bitcoin/issues/10468, if `include_watchonly=false` [the watchonly addresses are not included in `mapTally`](https://github.com/bitcoin/bitcoin/blob/fa5c224d444802dabec5841009e029b9754c92f1/src/wallet/rpc/transactions.cpp#L120-L122 ) leading to them being considered empty during the subsequent cross-reference with the address book thus becoming part of the result when `include_empty=true`.

This PR fixes https://github.com/bitcoin/bitcoin/issues/16159 by filtering-out "send" addresses, see https://github.com/bitcoin/bitcoin/issues/16159#issuecomment-1234405923 for more details on the issue. I haven't thought of a nice solution to fix (2) yet.

**Edit**: Split `wallet_listreceivedby.py` tests for code maintainability as tests for more than one RPC have been added since the creation of the file. Added test coverage for the introduced change.