### PR TITLE
test, build: Separate `read_json` function into its own module

### DIFF
--- a/src/Makefile.test_util.include
+++ b/src/Makefile.test_util.include
@@ -10,6 +10,7 @@ EXTRA_LIBRARIES += \
 TEST_UTIL_H = \
   test/util/blockfilter.h \
   test/util/chainstate.h \
+  test/util/json.h \
   test/util/logging.h \
   test/util/mining.h \
   test/util/net.h \
@@ -28,6 +29,7 @@ libtest_util_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS)
 libtest_util_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libtest_util_a_SOURCES = \
   test/util/blockfilter.cpp \
+  test/util/json.cpp \
   test/util/logging.cpp \
   test/util/mining.cpp \
   test/util/net.cpp \

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -5,6 +5,7 @@
 #include <test/data/base58_encode_decode.json.h>
 
 #include <base58.h>
+#include <test/util/json.h>
 #include <test/util/setup_common.h>
 #include <util/strencodings.h>
 #include <util/vector.h>
@@ -15,8 +16,6 @@
 #include <string>
 
 using namespace std::literals;
-
-UniValue read_json(const std::string& jsondata);
 
 BOOST_FIXTURE_TEST_SUITE(base58_tests, BasicTestingSetup)
 

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -8,14 +8,13 @@
 #include <key.h>
 #include <key_io.h>
 #include <script/script.h>
+#include <test/util/json.h>
 #include <test/util/setup_common.h>
 #include <util/strencodings.h>
 
 #include <boost/test/unit_test.hpp>
 
 #include <univalue.h>
-
-UniValue read_json(const std::string& jsondata);
 
 BOOST_FIXTURE_TEST_SUITE(key_io_tests, BasicTestingSetup)
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -15,6 +15,7 @@
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <streams.h>
+#include <test/util/json.h>
 #include <test/util/setup_common.h>
 #include <test/util/transaction_utils.h>
 #include <util/strencodings.h>
@@ -40,18 +41,6 @@ static const unsigned int gFlags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC;
 
 unsigned int ParseScriptFlags(std::string strFlags);
 std::string FormatScriptFlags(unsigned int flags);
-
-UniValue read_json(const std::string& jsondata)
-{
-    UniValue v;
-
-    if (!v.read(jsondata) || !v.isArray())
-    {
-        BOOST_ERROR("Parse error.");
-        return UniValue(UniValue::VARR);
-    }
-    return v.get_array();
-}
 
 struct ScriptErrorDesc
 {

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -10,6 +10,7 @@
 #include <serialize.h>
 #include <streams.h>
 #include <test/data/sighash.json.h>
+#include <test/util/json.h>
 #include <test/util/setup_common.h>
 #include <util/strencodings.h>
 #include <util/system.h>
@@ -20,8 +21,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <univalue.h>
-
-UniValue read_json(const std::string& jsondata);
 
 // Old script.cpp SignatureHash function
 uint256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -21,6 +21,7 @@
 #include <script/signingprovider.h>
 #include <script/standard.h>
 #include <streams.h>
+#include <test/util/json.h>
 #include <test/util/script.h>
 #include <test/util/transaction_utils.h>
 #include <util/strencodings.h>
@@ -36,9 +37,6 @@
 #include <univalue.h>
 
 typedef std::vector<unsigned char> valtype;
-
-// In script_tests.cpp
-UniValue read_json(const std::string& jsondata);
 
 static CFeeRate g_dust{DUST_RELAY_TX_FEE};
 static bool g_bare_multi{DEFAULT_PERMIT_BAREMULTISIG};

--- a/src/test/util/json.cpp
+++ b/src/test/util/json.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/util/json.h>
+
+#include <string>
+#include <util/check.h>
+
+#include <univalue.h>
+
+UniValue read_json(const std::string& jsondata)
+{
+    UniValue v;
+    Assert(v.read(jsondata) && v.isArray());
+    return v.get_array();
+}

--- a/src/test/util/json.h
+++ b/src/test/util/json.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_UTIL_JSON_H
+#define BITCOIN_TEST_UTIL_JSON_H
+
+#include <string>
+
+#include <univalue.h>
+
+UniValue read_json(const std::string& jsondata);
+
+#endif // BITCOIN_TEST_UTIL_JSON_H


### PR DESCRIPTION
Currently, 4 source files rely on the definition of the `read_json` function provided in `src/test/script_tests.cpp`.

This PR breaks this entanglement, improves code structure and maintainability.