### PR TITLE
contrib/init: Better systemd integration

### DIFF
--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -18,10 +18,11 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-ExecStart=/usr/bin/bitcoind -daemonwait \
-                            -pid=/run/bitcoind/bitcoind.pid \
+ExecStart=/usr/bin/bitcoind -pid=/run/bitcoind/bitcoind.pid \
                             -conf=/etc/bitcoin/bitcoin.conf \
-                            -datadir=/var/lib/bitcoind
+                            -datadir=/var/lib/bitcoind \
+                            -startupnotify='systemd-notify --ready' \
+                            -shutdownnotify='systemd-notify --stopping'
 
 # Make sure the config directory is readable by the service user
 PermissionsStartOnly=true
@@ -30,8 +31,10 @@ ExecStartPre=/bin/chgrp bitcoin /etc/bitcoin
 # Process management
 ####################
 
-Type=forking
+Type=notify
+NotifyAccess=all
 PIDFile=/run/bitcoind/bitcoind.pid
+
 Restart=on-failure
 TimeoutStartSec=infinity
 TimeoutStopSec=600


### PR DESCRIPTION
```
1. Make logs available to journalctl (systemd's logging system) by not
   specifying -daemonwait, which rightfully has its own set of stdout
   and stderr descriptors (a user invoking with -daemonwait on the
   command line should not see any logs). It makes more sense not to
   daemonize in the systemd context anyway.

2. Make systemd aware of when bitcoind is started and in steady state by
   specifying -startupnotify='systemd-notify --ready' and Type=notify.
   NotifyAccess=all is necessary so that the spawned thread for
   startupnotify is allowed to inform systemd of bitcoind's readiness.

   Note that NotifyAccess=exec won't work because it only allows
   sd_notify readiness signalling from Exec*= declarations in the
   .service file.

Note that we currently don't allow multiple startupnotify commands, but
users can override it in systemd via:

  # systemctl edit bitcoind

By specifying something like:

  [Service]
  ExecStart=/usr/bin/bitcoind -pid=/run/bitcoind/bitcoind.pid \
                              -conf=/etc/bitcoin/bitcoin.conf \
                              -datadir=/var/lib/bitcoind \
                              -startupnotify='systemd-notify --ready; mycommandhere'
```