### PR TITLE
wallet: Guard against undefined behaviour

### DIFF
--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -64,7 +64,7 @@ static void CoinSelection(benchmark::Bench& bench)
 
     const CoinEligibilityFilter filter_standard(1, 6, 0);
     FastRandomContext rand{};
-    const CoinSelectionParams coin_selection_params{
+    CoinSelectionParams coin_selection_params{
         rand,
         /*change_output_size=*/ 34,
         /*change_spend_size=*/ 148,
@@ -75,6 +75,9 @@ static void CoinSelection(benchmark::Bench& bench)
         /*tx_noinputs_size=*/ 0,
         /*avoid_partial=*/ false,
     };
+
+    coin_selection_params.m_cost_of_change = CAmount(1);
+
     bench.run([&] {
         auto result = AttemptSelection(wallet, 1003 * COIN, filter_standard, available_coins, coin_selection_params, /*allow_mixed_output_types=*/true);
         assert(result);
@@ -114,7 +117,7 @@ static void BnBExhaustion(benchmark::Bench& bench)
     bench.run([&] {
         // Benchmark
         CAmount target = make_hard_case(17, utxo_pool);
-        SelectCoinsBnB(utxo_pool, target, 0); // Should exhaust
+        SelectCoinsBnB(utxo_pool, target, 1); // Should exhaust
 
         // Cleanup
         utxo_pool.clear();

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -64,6 +64,12 @@ static const size_t TOTAL_TRIES = 100000;
 
 std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_pool, const CAmount& selection_target, const CAmount& cost_of_change)
 {
+    assert(selection_target > 0);
+    assert(selection_target <= MAX_MONEY);
+
+    assert(cost_of_change > 0);
+    assert(cost_of_change <= MAX_MONEY);
+
     SelectionResult result(selection_target, SelectionAlgorithm::BNB);
     CAmount curr_value = 0;
     std::vector<size_t> curr_selection; // selected utxo indexes

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     expected_result.Clear();
 
     // Cost of change is less than the difference between target value and utxo sum
-    BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 0.9 * CENT, 0));
+    BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 0.9 * CENT, 1));
     expected_result.Clear();
 
     // Select 10 Cent

--- a/src/wallet/test/fuzz/coinselection.cpp
+++ b/src/wallet/test/fuzz/coinselection.cpp
@@ -49,7 +49,7 @@ FUZZ_TARGET(coinselection)
 
     const CFeeRate long_term_fee_rate{ConsumeMoney(fuzzed_data_provider, /*max=*/COIN)};
     const CFeeRate effective_fee_rate{ConsumeMoney(fuzzed_data_provider, /*max=*/COIN)};
-    const CAmount cost_of_change{ConsumeMoney(fuzzed_data_provider, /*max=*/COIN)};
+    const CAmount cost_of_change{fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(1, MAX_MONEY)};
     const CAmount target{fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(1, MAX_MONEY)};
     const bool subtract_fee_outputs{fuzzed_data_provider.ConsumeBool()};
 


### PR DESCRIPTION
This PR adds a few safe guards against undefined or nonsense values.  A `selection_target` of negative or 0 value is undefined and same with `cost_of_change`.  It's safer to prevent undefined values from being evaluated later on in the function body which may result in unexpected behavior.  An exception is raised similar to [here](https://github.com/bitcoin/bitcoin/blob/master/src/wallet/coinselection.cpp#L76) when values are undefined.