### PR TITLE
build: compile depends sqlite with more recommended options

### DIFF
--- a/depends/packages/sqlite.mk
+++ b/depends/packages/sqlite.mk
@@ -11,6 +11,7 @@ $(package)_config_opts_linux=--with-pic
 $(package)_config_opts_freebsd=--with-pic
 $(package)_config_opts_netbsd=--with-pic
 $(package)_config_opts_openbsd=--with-pic
+$(package)_config_opts_debug=--enable-debug
 $(package)_cflags=-DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_OMIT_DEPRECATED
 $(package)_cflags+=-DSQLITE_OMIT_SHARED_CACHE -DSQLITE_OMIT_JSON -DSQLITE_LIKE_DOESNT_MATCH_BLOBS
 $(package)_cflags+=-DSQLITE_OMIT_DECLTYPE -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_OMIT_AUTOINIT

--- a/depends/packages/sqlite.mk
+++ b/depends/packages/sqlite.mk
@@ -6,10 +6,14 @@ $(package)_sha256_hash=5af07de982ba658fd91a03170c945f99c971f6955bc79df3266544373
 
 define $(package)_set_vars
 $(package)_config_opts=--disable-shared --disable-readline --disable-dynamic-extensions --enable-option-checking
+$(package)_config_opts+= --disable-rtree --disable-fts4 --disable-fts5
 $(package)_config_opts_linux=--with-pic
 $(package)_config_opts_freebsd=--with-pic
 $(package)_config_opts_netbsd=--with-pic
 $(package)_config_opts_openbsd=--with-pic
+$(package)_cflags=-DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_OMIT_DEPRECATED
+$(package)_cflags+=-DSQLITE_OMIT_SHARED_CACHE -DSQLITE_OMIT_JSON -DSQLITE_LIKE_DOESNT_MATCH_BLOBS
+$(package)_cflags+=-DSQLITE_OMIT_DECLTYPE -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_OMIT_AUTOINIT
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
https://www.sqlite.org/compile.html

[SQLITE_DQS](https://www.sqlite.org/compile.html#dqs)
> This setting disables the double-quoted string literal misfeature.

[SQLITE_DEFAULT_MEMSTATUS](https://www.sqlite.org/compile.html#default_memstatus)
> This setting causes the sqlite3_status() interfaces that track
> memory usage to be disabled.
> This helps the sqlite3_malloc() routines run much faster, and since
> SQLite uses sqlite3_malloc() internally, this helps to make the
> entire library faster.

[SQLITE_OMIT_DEPRECATED](https://www.sqlite.org/compile.html#omit_deprecated)
> Omitting deprecated interfaces and features will not help SQLite
> to run any faster.
> It will reduce the library footprint, however. And it is the
> right thing to do.

[SQLITE_OMIT_SHARED_CACHE](https://www.sqlite.org/compile.html#omit_shared_cache)
> Omitting the possibility of using shared cache allows many
> conditionals in performance-critical sections of the code to be
> eliminated. This can give a noticeable improvement in performance.

Also: https://www.sqlite.org/sharedcache.html
> Shared-cache mode is an obsolete feature.
> The use of shared-cache mode is discouraged.
> Most use cases for shared-cache are better served by WAL mode.
> Applications that build their own copy of SQLite from source code
> are encouraged to use the -DSQLITE_OMIT_SHARED_CACHE compile-time
> option, as the resulting binary will be both smaller and faster.

[SQLITE_OMIT_JSON](https://www.sqlite.org/compile.html#omit_json)
> Starting with sqlite 3.38.0 the JSON extension became opt-out rather
than opt-in, so we disable it here.

--disable-rtree
> An R-Tree is a special index that is designed for doing range queries.
> R-Trees are most commonly used in geospatial systems...
https://www.sqlite.org/rtree.html

--disable-fts4 --disable-fts5
> FTS5 is an SQLite virtual table module that provides full-text
> search functionality to database applications.

DSQLITE_LIKE_DOESNT_MATCH_BLOBS
> simplifies the implementation of the LIKE optimization and allows
> queries that use the LIKE optimization to run faster.

DSQLITE_OMIT_DECLTYPE
> By omitting the (seldom-needed) ability to return the declared type of
> columns from the result set of query, prepared statements can be made
> to consume less memory.

DSQLITE_OMIT_PROGRESS_CALLBACK
> By omitting this interface, a single conditional is removed from the
> inner loop of the bytecode engine, helping SQL statements to run slightly
> faster.

DSQLITE_OMIT_AUTOINIT
> with the SQLITE_OMIT_AUTOINIT option, the automatic initialization is omitted.
> This helps many API calls to run a little faster
> it also means that the application must call sqlite3_initialize()
manually.

On my Linux box this results in a `libsqlite3.a` that shrinks from ~1.7mb to ~1.3mb.
On macOS, `libsqlite3.a` shrinks from ~2.2mb to ~1.3mb.

Guix Build:
```bash
04626ec7b64086103bfb5537397d7953d0699b31da1b1bc100003c7d30991fdf  guix-build-dee690257c79/output/aarch64-linux-gnu/SHA256SUMS.part
a77c72052266788e890a0d3d89cc6eee9dd72db6a1b6fdc8aab882b35a315284  guix-build-dee690257c79/output/aarch64-linux-gnu/bitcoin-dee690257c79-aarch64-linux-gnu-debug.tar.gz
86d782f185ee0fae8e8733ab8a511de2ca2500f02eb3d4aaa20d65b4434dcd77  guix-build-dee690257c79/output/aarch64-linux-gnu/bitcoin-dee690257c79-aarch64-linux-gnu.tar.gz
d81874ecd378470b01a429f2a4be07fcb4824b56ace146226b77088cc3c41baa  guix-build-dee690257c79/output/arm-linux-gnueabihf/SHA256SUMS.part
8f24076800e5a19ac9005af8c6e4987b32e0a857a83af84931958505228ef58d  guix-build-dee690257c79/output/arm-linux-gnueabihf/bitcoin-dee690257c79-arm-linux-gnueabihf-debug.tar.gz
b913f2b0d8f0e32a176bc0e9330106cf1973afe6e8ee955f3eeb89918ab9d565  guix-build-dee690257c79/output/arm-linux-gnueabihf/bitcoin-dee690257c79-arm-linux-gnueabihf.tar.gz
034b47d8a60a19391e0e18f6fcc8fb3a87be78a9707e3ac3e7ee45eb37687bb7  guix-build-dee690257c79/output/arm64-apple-darwin/SHA256SUMS.part
9efc5c0ceac05f6efce03fcde0cbe8b79bae43fe0d98aecb817908e76f5c39b7  guix-build-dee690257c79/output/arm64-apple-darwin/bitcoin-dee690257c79-arm64-apple-darwin-unsigned.dmg
a549cdcbd311d9b025971b13987290f6cd2b93e16c8389e8a7a2ccd3608326ed  guix-build-dee690257c79/output/arm64-apple-darwin/bitcoin-dee690257c79-arm64-apple-darwin-unsigned.tar.gz
3dd9e26a41596151022aa4288d778dc335a2b38bd391e3f65c0575dd6eb47b54  guix-build-dee690257c79/output/arm64-apple-darwin/bitcoin-dee690257c79-arm64-apple-darwin.tar.gz
a71685a3ff62fbf456fc1d3c0f78ab7ab1d5a4a094c1f43d3829730d65a3ec51  guix-build-dee690257c79/output/dist-archive/bitcoin-dee690257c79.tar.gz
d5c74167b2260b7de72fdbac77eedacbbb929214e279e07f41c3236ea20116b6  guix-build-dee690257c79/output/powerpc64-linux-gnu/SHA256SUMS.part
03c043daa971f70886805c9e4174acd600e5cda03ae0e827043c4df81a6a6426  guix-build-dee690257c79/output/powerpc64-linux-gnu/bitcoin-dee690257c79-powerpc64-linux-gnu-debug.tar.gz
3884423f67d48f671a90169962f9568dcbd8df582cd269df29a4399dc9c70e99  guix-build-dee690257c79/output/powerpc64-linux-gnu/bitcoin-dee690257c79-powerpc64-linux-gnu.tar.gz
cee2847d4feeadebfdf4d37110faafa250824c68cfefc3bfa289ae8b09599a20  guix-build-dee690257c79/output/powerpc64le-linux-gnu/SHA256SUMS.part
ca9f1085184b50e7bd377b68a58afd42ac4055ffe214eede8c6ca7291e00b45a  guix-build-dee690257c79/output/powerpc64le-linux-gnu/bitcoin-dee690257c79-powerpc64le-linux-gnu-debug.tar.gz
b9cadff5b30244f6cb4f277e1ac610841332cb0d732637fe438fd51c88adf5a4  guix-build-dee690257c79/output/powerpc64le-linux-gnu/bitcoin-dee690257c79-powerpc64le-linux-gnu.tar.gz
db6e45d9fc8868e5cb25fa3d0789247db10a6bab2a6f3866a27d641ae00bd03b  guix-build-dee690257c79/output/riscv64-linux-gnu/SHA256SUMS.part
751e90c0aefa249f175c0c1707dc5eee3637e2b9657a9ee1b2068479e9830ff0  guix-build-dee690257c79/output/riscv64-linux-gnu/bitcoin-dee690257c79-riscv64-linux-gnu-debug.tar.gz
8dd87bb24f1fbdba67fb6b72ab5fc93532452eada8c2942463100b8ed8118ae3  guix-build-dee690257c79/output/riscv64-linux-gnu/bitcoin-dee690257c79-riscv64-linux-gnu.tar.gz
b53fe650f431e394a5af6bd809401551e3c36e4f7d90c31f39f51c5fe236efaf  guix-build-dee690257c79/output/x86_64-apple-darwin/SHA256SUMS.part
b35b4ae345a625e42b8315acd9b75bb651f60265f67ec6f7d78a41c8d21c635e  guix-build-dee690257c79/output/x86_64-apple-darwin/bitcoin-dee690257c79-x86_64-apple-darwin-unsigned.dmg
6748e4c64ae069632624cbec20de7f03eca1a7578fcef96607f3e8cb0ac4106e  guix-build-dee690257c79/output/x86_64-apple-darwin/bitcoin-dee690257c79-x86_64-apple-darwin-unsigned.tar.gz
6415cbecfa18002a1e4865b996268558b4f26121118fd73b0ef4ca44967f34c7  guix-build-dee690257c79/output/x86_64-apple-darwin/bitcoin-dee690257c79-x86_64-apple-darwin.tar.gz
f0a8d8837e80e42b5d77c3efc9d746c11ffc9909aece16dcba0a10726e1be7e0  guix-build-dee690257c79/output/x86_64-linux-gnu/SHA256SUMS.part
418f4607159387ee17657120beda1c741fa6060e4457b304b857aa6c33859e6a  guix-build-dee690257c79/output/x86_64-linux-gnu/bitcoin-dee690257c79-x86_64-linux-gnu-debug.tar.gz
d384fe8f2d6515c256a371ad84ae76ac9727ffd49887c0e22bb5ada4cd890092  guix-build-dee690257c79/output/x86_64-linux-gnu/bitcoin-dee690257c79-x86_64-linux-gnu.tar.gz
3f441eb2d68ddd530b32f56a16ff639b27dcc58b5ba395e40f4c2be805f6cd8b  guix-build-dee690257c79/output/x86_64-w64-mingw32/SHA256SUMS.part
d3d22479adc554ced965c4bde79f4c919e6b216acfca598fac4ebfc3b0e2d39d  guix-build-dee690257c79/output/x86_64-w64-mingw32/bitcoin-dee690257c79-win64-debug.zip
89de153f5d839df6cd1266f8b3cb3ad455b2f6c43cee7644889da1e3efc7b2f1  guix-build-dee690257c79/output/x86_64-w64-mingw32/bitcoin-dee690257c79-win64-setup-unsigned.exe
ba30708b9551b3794e4d2726aff27775dd4f1b347ea71b3fe1b00e39e8b7a594  guix-build-dee690257c79/output/x86_64-w64-mingw32/bitcoin-dee690257c79-win64-unsigned.tar.gz
ab6a2b7a3e899fc58030a44b555e449d64aa69b5215d761bc550946b14f93515  guix-build-dee690257c79/output/x86_64-w64-mingw32/bitcoin-dee690257c79-win64.zip
```