### PR TITLE
test: revert #25865 for wallet_groups.py (quick fix)

### DIFF
--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -26,9 +26,6 @@ class WalletGroupTest(BitcoinTestFramework):
             ["-maxapsfee=0.00002719"],
             ["-maxapsfee=0.00002720"],
         ]
-        # whitelist peers to speed up tx relay / mempool sync
-        for args in self.extra_args:
-            args.append("-whitelist=noban@127.0.0.1")
 
         self.rpc_timeout = 480
 


### PR DESCRIPTION
**Edit: root issue fixed in #25990, closing this.**

---

As described in #25940, `test/functional/wallet_groups.py` suddenly started failing intermittently. Even though there are no explanations yet, this seems to be significantly exacerbated or introduced by #25865. This PR patches that by reverting the [change](https://github.com/bitcoin/bitcoin/pull/25865/files#diff-2749503331922c402bb3207619effd4f17a45286f57267b1bc3b48ef0a0ffb14) (only to `wallet_groups.py`) without addressing the root issue, as to quickly unbreak CI which is failing quite often now.

**Should be followed-up with a proper fix since it's not immediately obvious that #25865 should have led to wallet_groups.py failing intermittently.**

I did empirical testing to verify that the test started failing because of #25865 by running wallet_groups.py until it failed, first on commit b21e522ce (the HEAD of #25865) and then on a75b7796b (the HEAD right before #25865). On b21e522ce (i.e. with #25865), it took about ~9.2 runs (n=6) on average before the test failed. On the previous commit a75b7796b (i.e. without #25865), I didn't get a single failure after running the test 100 times.

With this PR, I didn't get a single failure after 240 runs.