### PR TITLE
test: apply fixed feerate to avoid variable dynamic fees in wallet_groups.py

### DIFF
--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -26,9 +26,10 @@ class WalletGroupTest(BitcoinTestFramework):
             ["-maxapsfee=0.00002719"],
             ["-maxapsfee=0.00002720"],
         ]
-        # whitelist peers to speed up tx relay / mempool sync
+
         for args in self.extra_args:
-            args.append("-whitelist=noban@127.0.0.1")
+            args.append("-whitelist=noban@127.0.0.1")   # whitelist peers to speed up tx relay / mempool sync
+            args.append(f"-paytxfee={20 * 1e3 / 1e8}")  # apply feerate of 20 sats/vB across all nodes
 
         self.rpc_timeout = 480
 


### PR DESCRIPTION
Without specifying a feerate, we let the wallet decide on an appropriate feerate, which can be influenced by various factors
such as what's in the mempool. Since wallet_groups.py fails when feerates are unstable, we should use a fixed feerate across all nodes. The assumed feerate was 20 sats/vbyte, so this PR adopts that.

Closes #25940. I'm not 100% sure, but I think the increased tx relay speed introduced by #25865 caused the transactions to more quickly and often enter the other nodes' mempools, affecting their feerate calculation done in [`wallet:GetMinimumFeeRate()`](https://github.com/bitcoin/bitcoin/blob/ea67232cdb80c4bc3f16fcd823f6f811fd8903e1/src/wallet/fees.cpp#L68-L72) and thus deviating slightly from the expected 20 sats/vbyte.

Ran `wallet_groups.py` over 400 times without failure.
