### PR TITLE
[contrib] message-capture-parser: fix AssertionError on parsing `headers` message

### DIFF
--- a/contrib/message-capture/message-capture-parser.py
+++ b/contrib/message-capture/message-capture-parser.py
@@ -79,8 +79,7 @@ def to_jsonable(obj: Any) -> Any:
             val = getattr(obj, slot, None)
             if slot in HASH_INTS and isinstance(val, int):
                 ret[slot] = ser_uint256(val).hex()
-            elif slot in HASH_INT_VECTORS:
-                assert all(isinstance(a, int) for a in val)
+            elif slot in HASH_INT_VECTORS and all(isinstance(a, int) for a in val):
                 ret[slot] = [ser_uint256(a).hex() for a in val]
             else:
                 ret[slot] = to_jsonable(val)


### PR DESCRIPTION
If a test framework message's field name is in the list of `HASH_INT_VECTORS`, we currently assume that it _always_ has to contain a vector of integers and throw otherwise:
https://github.com/bitcoin/bitcoin/blob/0ebd4db32b39cb7c505148f090df4b7ac778c307/contrib/message-capture/message-capture-parser.py#L82-L83
(introduced in PR #25367, commit 42bbbba7c83d1e2baad18b4c6f05bad1358eb117).

However, that assumption is too strict. The (de)serialization field name "headers" is used in two different message types, one for `cfcheckpt` (where it is serialized as an integer vector), and another time for `headers` (where it is serialized as a vector of `CBlockHeader`s). Parsing the latter fails as it is not an integer vector and thus triggers the assert.

Fix this by adding the integer type check as additional condition to the `HASH_INT_VECTORS` check rather than asserting.
Fixes #25954.