### PR TITLE
test: remove Boost Test from libtest_util

### DIFF
--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -7,14 +7,13 @@
 
 #include <clientversion.h>
 #include <fs.h>
+#include <logging.h>
 #include <node/context.h>
 #include <node/utxo_snapshot.h>
 #include <rpc/blockchain.h>
 #include <validation.h>
 
 #include <univalue.h>
-
-#include <boost/test/unit_test.hpp>
 
 const auto NoMalleation = [](AutoFile& file, node::SnapshotMetadata& meta){};
 
@@ -36,8 +35,8 @@ CreateAndActivateUTXOSnapshot(node::NodeContext& node, const fs::path root, F ma
 
     UniValue result = CreateUTXOSnapshot(
         node, node.chainman->ActiveChainstate(), auto_outfile, snapshot_path, snapshot_path);
-    BOOST_TEST_MESSAGE(
-        "Wrote UTXO snapshot to " << fs::PathToString(snapshot_path.make_preferred()) << ": " << result.write());
+    LogPrintf(
+        "Wrote UTXO snapshot to %s: %s", fs::PathToString(snapshot_path.make_preferred()), result.write());
 
     // Read the written snapshot in and then activate it.
     //


### PR DESCRIPTION
Context is the discussion here:
https://github.com/bitcoin/bitcoin/pull/25974/files#r961541457.

Output:
```bash
[test/util/chainstate.h:38] [CreateAndActivateUTXOSnapshot] Wrote UTXO snapshot to /var/folders/sq/z88fhjzj0b19ftsd2_bjrmjm0000gn/T/test_common_Bitcoin Core/8f2783bb3dbf10c669cd892192d70efcca4bab250226856fed7ffecdb378ffc7/test_snapshot.100.dat: {"coins_written":100,"base_hash":"571d80a9967ae599cec0448b0b0ba1cfb606f584d8069bd7166b86854ba7a191","base_height":100,"path":"/var/folders/sq/z88fhjzj0b19ftsd2_bjrmjm0000gn/T/test_common_Bitcoin Core/8f2783bb3dbf10c669cd892192d70efcca4bab250226856fed7ffecdb378ffc7/test_snapshot.100.dat","txoutset_hash":"cd1ba1c3f393058ae743b7c6bdbd00c897744cdcf022c9f2f0f2b4565c08a49c","nchaintx":101}
```