### PR TITLE
fuzz: Avoid timeout in bitdeque fuzz target

### DIFF
--- a/src/test/fuzz/bitdeque.cpp
+++ b/src/test/fuzz/bitdeque.cpp
@@ -2,11 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/bitdeque.h>
-
 #include <random.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/util.h>
+#include <util/bitdeque.h>
 
 #include <deque>
 #include <vector>
@@ -54,7 +53,8 @@ FUZZ_TARGET_INIT(bitdeque, InitRandData)
         --initlen;
     }
 
-    while (provider.remaining_bytes()) {
+    LIMITED_WHILE(provider.remaining_bytes() > 0, 900)
+    {
         {
             assert(deq.size() == bitdeq.size());
             auto it = deq.begin();
@@ -538,5 +538,4 @@ FUZZ_TARGET_INIT(bitdeque, InitRandData)
             }
         );
     }
-
 }

--- a/src/test/fuzz/pow.cpp
+++ b/src/test/fuzz/pow.cpp
@@ -114,7 +114,7 @@ FUZZ_TARGET_INIT(pow_transition, initialize_pow)
         auto current_block{std::make_unique<CBlockIndex>(header)};
         current_block->pprev = blocks.empty() ? nullptr : blocks.back().get();
         current_block->nHeight = height;
-        blocks.emplace_back(std::move(current_block)).get();
+        blocks.emplace_back(std::move(current_block));
     }
     auto last_block{blocks.back().get()};
     unsigned int new_nbits{GetNextWorkRequired(last_block, nullptr, consensus_params)};


### PR DESCRIPTION
I'd guess that any bug should be discoverable within `10` ops. However, `900` seems also better than no limit at all, which causes timeouts such as https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50892