### PR TITLE
guix: consistently use -ffile-prefix-map

### DIFF
--- a/contrib/guix/patches/glibc-2.24-guix-prefix.patch
+++ b/contrib/guix/patches/glibc-2.24-guix-prefix.patch
@@ -15,7 +15,7 @@ when we being using newer versions of glibc.
  CFLAGS-.oS = $(CFLAGS-.o) $(PIC-ccflag)
 +
 +# Map Guix store paths to /usr
-+CFLAGS-.oS += `find /gnu/store -maxdepth 1 -mindepth 1 -type d -exec echo -n " -fdebug-prefix-map={}=/usr" \;`
++CFLAGS-.oS += `find /gnu/store -maxdepth 1 -mindepth 1 -type d -exec echo -n " -ffile-prefix-map={}=/usr" \;`
 +
  CPPFLAGS-.oS = $(CPPFLAGS-.o) -DPIC -DLIBC_NONSHARED=1
  libtype.oS = lib%_nonshared.a

--- a/contrib/guix/patches/glibc-2.27-guix-prefix.patch
+++ b/contrib/guix/patches/glibc-2.27-guix-prefix.patch
@@ -15,7 +15,7 @@ when we being using newer versions of glibc.
  CFLAGS-.o = $(filter %frame-pointer,$(+cflags)) $(pie-default)
 +
 +# Map Guix store paths to /usr
-+CFLAGS-.o += `find /gnu/store -maxdepth 1 -mindepth 1 -type d -exec echo -n " -fdebug-prefix-map={}=/usr" \;`
++CFLAGS-.o += `find /gnu/store -maxdepth 1 -mindepth 1 -type d -exec echo -n " -ffile-prefix-map={}=/usr" \;`
 +
  libtype.o := lib%.a
  object-suffixes += .o


### PR DESCRIPTION
Aside from being the [newer, more comprehensive option](https://reproducible-builds.org/docs/build-path/), it's what we
claim to use in the patch docs, and everywhere else in guix.