### PR TITLE
wallet: fix sendall creates tx that fails tx-size check

### DIFF
--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -1414,6 +1414,11 @@ RPCHelpMan sendall()
                 }
             }
 
+            // If this transaction is too large, e.g. because the wallet has many UTXOs, it will be rejected by the node's mempool.
+            if (tx_size.weight > MAX_STANDARD_TX_WEIGHT) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "Transaction too large.");
+            }
+
             CAmount output_amounts_claimed{0};
             for (const CTxOut& out : rawTx.vout) {
                 output_amounts_claimed += out.nValue;


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/26011

The `sendall` RPC doesn't use `CreateTransactionInternal` as the rest of
the wallet RPCs. [This has already been discussed in the original PR](https://github.com/bitcoin/bitcoin/pull/24118#issuecomment-1029462114). 
By not going through that path, it never checks the transaction's weight 
against the maximum tx weight for transactions we're willing to relay.
https://github.com/bitcoin/bitcoin/blob/447f50e4aed9a8b1d80e1891cda85801aeb80b4e/src/wallet/spend.cpp#L1013-L1018
This PR adds a check for tx-size as well as test coverage for that case.

_Note: It seems that the test takes a bit of time on slower machines, 
I'm not sure if dropping it might be for the better._