### PR TITLE
log: Colorize logs

### DIFF
--- a/src/test/logging_tests.cpp
+++ b/src/test/logging_tests.cpp
@@ -57,6 +57,7 @@ struct LogSetup : public BasicTestingSetup {
 
         LogInstance().SetLogLevel(BCLog::Level::Debug);
         LogInstance().SetCategoryLogLevel({});
+        LogInstance().m_colorman.SetEnableColors(false);
     }
 
     ~LogSetup()

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -625,7 +625,7 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         comp_block = HeaderAndShortIDs()
         comp_block.initialize_from_block(block)
-        with self.nodes[0].assert_debug_log(['[net] Ignoring low-work compact block from peer 0']):
+        with self.nodes[0].assert_debug_log(['Ignoring low-work compact block from peer 0']):
             test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
 
         tips = node.getchaintips()

--- a/test/functional/p2p_headers_sync_with_minchainwork.py
+++ b/test/functional/p2p_headers_sync_with_minchainwork.py
@@ -49,7 +49,7 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
 
     def test_chains_sync_when_long_enough(self):
         self.log.info("Generate blocks on the node with no required chainwork, and verify nodes 1 and 2 have no new headers in their headers tree")
-        with self.nodes[1].assert_debug_log(expected_msgs=["[net] Ignoring low-work chain (height=14)"]), self.nodes[2].assert_debug_log(expected_msgs=["[net] Ignoring low-work chain (height=14)"]), self.nodes[3].assert_debug_log(expected_msgs=["Synchronizing blockheaders, height: 14"]):
+        with self.nodes[1].assert_debug_log(expected_msgs=["Ignoring low-work chain (height=14)"]), self.nodes[2].assert_debug_log(expected_msgs=["Ignoring low-work chain (height=14)"]), self.nodes[3].assert_debug_log(expected_msgs=["Synchronizing blockheaders, height: 14"]):
             self.generate(self.nodes[0], NODE1_BLOCKS_REQUIRED-1, sync_fun=self.no_op)
 
         # Node3 should always allow headers due to noban permissions
@@ -78,7 +78,7 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
             } in chaintips
 
         self.log.info("Generate more blocks to satisfy node1's minchainwork requirement, and verify node2 still has no new headers in headers tree")
-        with self.nodes[2].assert_debug_log(expected_msgs=["[net] Ignoring low-work chain (height=15)"]), self.nodes[3].assert_debug_log(expected_msgs=["Synchronizing blockheaders, height: 15"]):
+        with self.nodes[2].assert_debug_log(expected_msgs=["Ignoring low-work chain (height=15)"]), self.nodes[3].assert_debug_log(expected_msgs=["Synchronizing blockheaders, height: 15"]):
             self.generate(self.nodes[0], NODE1_BLOCKS_REQUIRED - self.nodes[0].getblockcount(), sync_fun=self.no_op)
         self.sync_blocks(self.nodes[0:2]) # node3 will sync headers (noban permissions) but not blocks (due to minchainwork)
 


### PR DESCRIPTION
This PR adds a new class `Color` to `logging.h` which is used to wrap strings easily in ANSI color codes.
I think this makes the logs much easier to read.

I tested this on NixOS with the terminal Kitty and `$TERM` set to `xterm-kitty`.
I don't have a Windows lying around so I have not tested on Windows.

![image](https://user-images.githubusercontent.com/22493292/188748157-b30e14d7-1ff6-4d6f-b6ef-66d2f1abec72.png)
![image](https://user-images.githubusercontent.com/22493292/188748183-92ec3d18-14c0-4243-83b4-0ad8cb5aec89.png)

can also be disabled, like before

![image](https://user-images.githubusercontent.com/22493292/188748223-4a0be848-7986-4e46-949f-47eb88509d6e.png)
