### PR TITLE
More verbose warning for multiple network argument error.

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1264,7 +1264,7 @@ BOOST_FIXTURE_TEST_CASE(util_ChainMerge, ChainMergeTestingSetup)
     // Results file is formatted like:
     //
     //   <input> || <output>
-    BOOST_CHECK_EQUAL(out_sha_hex, "f263493e300023b6509963887444c41386f44b63bc30047eb8402e8c1144854c");
+    BOOST_CHECK_EQUAL(out_sha_hex, "c51699f07a792994a9ac7a57ee97a290d68f3a810ceb920d69fb5a492abe5c38");
 }
 
 BOOST_AUTO_TEST_CASE(util_ReadWriteSettings)

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1072,16 +1072,11 @@ std::string ArgsManager::GetChainName() const
     const bool is_chain_arg_set = IsArgSet("-chain");
 
     if ((int)is_chain_arg_set + (int)fRegTest + (int)fSigNet + (int)fTestNet > 1) {
-        throw std::runtime_error("Invalid combination of -regtest, -signet, -testnet and -chain. Can use at most one.");
+        throw std::runtime_error("Invalid combination of -regtest, -signet, -testnet and -chain. Can use at most one. Please check if chain is specified in config file.");
     }
-    if (fRegTest)
-        return CBaseChainParams::REGTEST;
-    if (fSigNet) {
-        return CBaseChainParams::SIGNET;
-    }
-    if (fTestNet)
-        return CBaseChainParams::TESTNET;
-
+    if (fRegTest) return CBaseChainParams::REGTEST;
+    if (fSigNet) return CBaseChainParams::SIGNET;
+    if (fTestNet) return CBaseChainParams::TESTNET;
     return GetArg("-chain", CBaseChainParams::MAIN);
 }
 


### PR DESCRIPTION
This PR has bitcoin print a more verbose message when a network argument collisions happens. 
I'm new to using the bitcoin software and was reconfiguring an old node. I also have limited experience at coding, this is my first PR on an open-source project, so any feedback on how to improve this process is welcomed.

If a chain argument is in the bitcoin.conf and then a bitcoin command has a network flag or a chain argument, such as : bitcoind -regtest  currently you are presented with the message:
```
"Invalid combination of -regtest, -signet, -testnet and -chain. Can use at most one."
```
As I am a new to this software, with not knowing that the bitcoin.conf was being merge in the command line, I was at a loss until I got guidance in the bitcoin-core-dev irc. 

In this PR, if a user makes this error, they will be notified to check their conf files.

The new error is a bit more verbose for the command bitcoind -regtest if the chain argument is set in the command line.
```
"Invalid combination of -regtest, -signet, -testnet and -chain. Can use at most one. Please check if chain is specified in config file."
```

**In regards to the unit test util_tests/util_ChainMerge:**

I had to write a script to check if the resulting output of master branch was the same output as the test from my branch and then update the hash accordingly. It is a simple compare of two txt files.

You can download the scripts here:
https://github.com/amovfx/btc-argument-collision-warning.git

I understand that your time is valuable and this isn't a significant change but I thought it was something within my ability I could contribute. Thank you for your time. 
Also, thanks to everyone that helped me get to this point to even submit a PR. Jonas at chain code, the blockchains commons project, programming bitcoin by Jimmy Song, Achow101's twitch stream, the many hosts of the bitcoin-pr-review club and the devs in the bitcoin-core-dev and bitcoin stack exchange answering my questions.
