### PR TITLE
contrib: Add script to colorize logs

### DIFF
--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -17,6 +17,23 @@ the script should be called from the git root folder as follows.
 git diff -U0 HEAD~1.. | ./contrib/devtools/clang-format-diff.py -p1 -i -v
 ```
 
+colorize_logging.py
+===================
+
+Colorizes the terminal log output of `bitcoind` or `bitcoin-qt`.
+Colors can be customized by changing the script's color definitions.
+
+Can be used by running the following command:
+
+```
+./src/bitcoind | ./contrib/devtools/colorize_logging.py
+```
+
+```
+./src/qt/bitcoin-qt -printtoconsole | ./contrib/devtools/colorize_logging.py
+```
+
+
 copyright\_header.py
 ====================
 

--- a/contrib/devtools/colorize_logging.py
+++ b/contrib/devtools/colorize_logging.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Colorize log output
+Usage: ./src/bitcoind | ./contrib/devtools/colorize_logging.py
+"""
+import re
+
+COLORS = {
+    "cyan": "\033[36m",
+    "red": "\033[31m",
+    "blue": "\033[34m",
+    "green": "\033[32m",
+    "magenta": "\033[35m"
+}
+
+
+def colorize(text):
+    # Colorize groups of brackets
+    for i, match in enumerate(re.finditer(r"\[.*?\]", text)):
+        text = text.replace(
+            match.group(0),
+            list(COLORS.values())[(i + 1) % len(COLORS)] + match.group(0) + "\033[0m",
+        )
+
+    # Colorize date
+    date = re.search(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", text)
+    if date:
+        text = text.replace(date.group(0), COLORS["cyan"] + date.group(0) + "\033[0m")
+
+    return text
+
+
+if __name__ == "__main__":
+    import sys
+
+    try:
+        for line in sys.stdin:
+            print(colorize(line), end="")
+    except KeyboardInterrupt:
+        print()
+        sys.exit(0)


### PR DESCRIPTION
Proof of concept and an alternative to #26026.
Adds a script to colorize the logs in order to make them more readable. This script removes the burden of maintaining code for colorizing in the actual logger. 

Can be used with `./src/bitcoind | ./contrib/devtools/colorize_logging.py `

![image](https://user-images.githubusercontent.com/22493292/189380332-85469935-77ca-4b95-811f-31544ffc1b9f.png)