### PR TITLE
Revert "guix: Build depends/qt with our platform definition"

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -196,7 +196,6 @@ make -C depends --jobs="$JOBS" HOST="$HOST" \
                                    x86_64_linux_RANLIB=x86_64-linux-gnu-ranlib \
                                    x86_64_linux_NM=x86_64-linux-gnu-nm \
                                    x86_64_linux_STRIP=x86_64-linux-gnu-strip \
-                                   qt_config_opts_x86_64_linux='-platform linux-g++ -xplatform bitcoin-linux-g++' \
                                    FORCE_USE_SYSTEM_CLANG=1
 
 


### PR DESCRIPTION
This PR reverts commit dc4137a60c99979b89f75d2bddba96d043f387b8.

It is no longer required after bitcoin/bitcoin#25838.

Guix build on `x86_64`:
```
2896943c8379f5bfe187666862e0cfcb619bd6c4c98ec6a25cadba1a3e15dad7  guix-build-beb94261ea9d/output/dist-archive/bitcoin-beb94261ea9d.tar.gz
9c829d2c488b07b181fd90590e0ac763761edfa1d231daccd5d25038707f321c  guix-build-beb94261ea9d/output/x86_64-linux-gnu/SHA256SUMS.part
2393a54db15ae372e974f562438c3cd6be3dbde07c3090c1ae884cc6941e7d26  guix-build-beb94261ea9d/output/x86_64-linux-gnu/bitcoin-beb94261ea9d-x86_64-linux-gnu-debug.tar.gz
397f9c023d41a6bf2a8844121badbbd0066e45304e1e085e217e9a0b5d42f088  guix-build-beb94261ea9d/output/x86_64-linux-gnu/bitcoin-beb94261ea9d-x86_64-linux-gnu.tar.gz
```