### PR TITLE
i2p: use the same destination type for transient and persistent addresses

### DIFF
--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -325,6 +325,7 @@ void Session::DestGenerate(const Sock& sock)
     // https://geti2p.net/spec/common-structures#key-certificates
     // "7" or "EdDSA_SHA512_Ed25519" - "Recent Router Identities and Destinations".
     // Use "7" because i2pd <2.24.0 does not recognize the textual form.
+    // If SIGNATURE_TYPE is not specified, then the default one is DSA_SHA1.
     const Reply& reply = SendRequestAndGetReply(sock, "DEST GENERATE SIGNATURE_TYPE=7", false);
 
     m_private_key = DecodeI2PBase64(reply.Get("PRIV"));
@@ -378,7 +379,7 @@ void Session::CreateIfNotCreatedAlready()
         // in the reply in DESTINATION=.
         const Reply& reply = SendRequestAndGetReply(
             *sock,
-            strprintf("SESSION CREATE STYLE=STREAM ID=%s DESTINATION=TRANSIENT", session_id));
+            strprintf("SESSION CREATE STYLE=STREAM ID=%s DESTINATION=TRANSIENT SIGNATURE_TYPE=7", session_id));
 
         m_private_key = DecodeI2PBase64(reply.Get("DESTINATION"));
     } else {


### PR DESCRIPTION
We generate our persistent I2P address with type `EdDSA_SHA512_Ed25519` (`DEST GENERATE SIGNATURE_TYPE=7`).

Use the same type for our transient addresses which are created by the `SESSION CREATE ...` command. If not specified, then the default one is `DSA_SHA1` according to https://geti2p.net/en/docs/api/samv3.

Fixes https://github.com/bitcoin/bitcoin/issues/26062