### PR TITLE
build: Quiet warnings in symlinked headers installed from homebrew

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -746,6 +746,16 @@ case $host in
          dnl It's safe to add these paths even if the functionality is disabled by
          dnl the user (--without-wallet or --without-gui for example).
 
+         dnl Homebrew may create symlinks in /usr/local/include for some packages.
+         dnl Because MacOS's clang internally adds "-I /usr/local/include" to its search
+         dnl paths, this will negate efforts to use -isystem for those packages, as they
+         dnl will be found first in /usr/local. Use the internal "-internal-isystem"
+         dnl option to system-ify all /usr/local/include paths without adding it to the list
+         dnl of search paths in case it's not already there.
+         if test "$suppress_external_warnings" != "no"; then
+           AX_CHECK_PREPROC_FLAG([-Xclang -internal-isystem/usr/local/include], [CORE_CPPFLAGS="$CORE_CPPFLAGS -Xclang -internal-isystem/usr/local/include"], [], [$CXXFLAG_WERROR])
+         fi
+
          if test "$use_bdb" != "no" && $BREW list --versions berkeley-db@4 >/dev/null && test "$BDB_CFLAGS" = "" && test "$BDB_LIBS" = ""; then
            bdb_prefix=$($BREW --prefix berkeley-db@4 2>/dev/null)
            dnl This must precede the call to BITCOIN_FIND_BDB48 below.


### PR DESCRIPTION
From the included comment:

Homebrew may create symlinks in `/usr/local/include` for some packages. Because MacOS's clang internally adds `-I /usr/local/include` to its search paths, this will negate efforts to use `-isystem` for those packages, as they will be found first in `/usr/local`. Use the internal `-internal-isystem` option to system-ify all `/usr/local/include` paths without adding it to the list of search paths in case it's not already there.

This fixes the issue explained here: https://github.com/bitcoin/bitcoin/pull/26056#issuecomment-1243362059

~Also temporarily includes #26056 as a test. I will remove that commit if/when c-i is happy, and fanquake can rebase it post-merge.~
I've removed this commit now that c-i succeeded with it.