### PR TITLE
build: fix depends bdb compilation for BSDs

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -15,6 +15,9 @@ $(package)_config_opts_netbsd=--with-pic
 $(package)_config_opts_openbsd=--with-pic
 $(package)_config_opts_android=--with-pic
 $(package)_cflags+=-Wno-error=implicit-function-declaration -Wno-error=format-security
+$(package)_cppflags_freebsd=-D_XOPEN_SOURCE=600
+$(package)_cppflags_netbsd=-D_XOPEN_SOURCE=600
+$(package)_cppflags_openbsd=-D_XOPEN_SOURCE=600
 $(package)_cppflags_mingw32=-DUNICODE -D_UNICODE
 endef
 


### PR DESCRIPTION
Currently, building bdb for *BSD HOSTs in depends fails with:
```bash
libtool: compile:  clang -m64 -c -I. -I../dist/./.. -I/home/ubuntu/bitcoin/depends/x86_64-unknown-freebsd/include -D_THREAD_SAFE -pipe -std=c11 -O2 -Wno-error=implicit-function-declaration -Wno-error=format-security ../dist/./../mutex/mut_tas.c  -fPIC -DPIC -o mut_tas.o
In file included from ../dist/./../mutex/mut_tas.c:11:
In file included from ./db_int.h:884:
In file included from ../dist/./../dbinc/mutex.h:15:
../dist/./../dbinc/mutex_int.h:932:2: error: unknown type name 'pthread_rwlock_t'
        MUTEX_FIELDS                    /* Opaque thread mutex structures. */
        ^
../dist/./../dbinc/mutex_int.h:65:3: note: expanded from macro 'MUTEX_FIELDS'
                pthread_rwlock_t rwlock;        /* Read/write lock */   \
                ^
1 error generated.
```

Defining `_XOPEN_SOURCE` >=600 fixes access to the missing `pthread_rwlock_t` definitions.

