### PR TITLE
contrib: remove 32bit linux code from release scripts

### DIFF
--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -44,8 +44,6 @@ MAX_VERSIONS = {
 'LIBATOMIC': (1,0),
 'V':         (0,5,0),  # xkb (bitcoin-qt only)
 }
-# See here for a description of _IO_stdin_used:
-# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=634261#109
 
 # Ignore symbols that are exported as part of every executable
 IGNORE_EXPORTS = {

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -35,7 +35,6 @@ import lief #type:ignore
 MAX_VERSIONS = {
 'GCC':       (4,8,0),
 'GLIBC': {
-    lief.ELF.ARCH.i386:   (2,18),
     lief.ELF.ARCH.x86_64: (2,18),
     lief.ELF.ARCH.ARM:    (2,18),
     lief.ELF.ARCH.AARCH64:(2,18),
@@ -57,9 +56,6 @@ IGNORE_EXPORTS = {
 # Expected linker-loader names can be found here:
 # https://sourceware.org/glibc/wiki/ABIList?action=recall&rev=16
 ELF_INTERPRETER_NAMES: Dict[lief.ELF.ARCH, Dict[lief.ENDIANNESS, str]] = {
-    lief.ELF.ARCH.i386:    {
-        lief.ENDIANNESS.LITTLE: "/lib/ld-linux.so.2",
-    },
     lief.ELF.ARCH.x86_64:  {
         lief.ENDIANNESS.LITTLE: "/lib64/ld-linux-x86-64.so.2",
     },


### PR DESCRIPTION
We don't produce 32-bit Linux release binaries.

Guix Build (x86_64 / arm64):
```bash
173c0caab1fc390fa2ccc58b8037e6b0456ac5f814fac84383afd0fcf8207471  guix-build-656f9b0ba233/output/aarch64-linux-gnu/SHA256SUMS.part
6d19c872dcad072de768e24f44ea517d3181783f0157f287b0d756b186264d3b  guix-build-656f9b0ba233/output/aarch64-linux-gnu/bitcoin-656f9b0ba233-aarch64-linux-gnu-debug.tar.gz
bd02655a22ca1e254034e250b5263ae65b5268f84cf3715da97c049c8b52834d  guix-build-656f9b0ba233/output/aarch64-linux-gnu/bitcoin-656f9b0ba233-aarch64-linux-gnu.tar.gz
adaf2e7ea8940716be066fd7669686afc1f6d493738ae257c1963955f41d5d04  guix-build-656f9b0ba233/output/arm-linux-gnueabihf/SHA256SUMS.part
619db8a6ce4740933126e6aa397e982ea9323b6e9641825d32673e009eceed1d  guix-build-656f9b0ba233/output/arm-linux-gnueabihf/bitcoin-656f9b0ba233-arm-linux-gnueabihf-debug.tar.gz
f73e3c1e7051d09b0bdaf8e0c67339b8eef9dec152817e418b878f8165688a42  guix-build-656f9b0ba233/output/arm-linux-gnueabihf/bitcoin-656f9b0ba233-arm-linux-gnueabihf.tar.gz
de7c35702b2e585b479fbbda8e43b611200ad87cd6a67c04786fe44ee5aec9bb  guix-build-656f9b0ba233/output/arm64-apple-darwin/SHA256SUMS.part
53235690d0203b7ea8f53797b7f6c387d35d66ddf0cd9d620260e301e834275f  guix-build-656f9b0ba233/output/arm64-apple-darwin/bitcoin-656f9b0ba233-arm64-apple-darwin-unsigned.dmg
0b2a60d6cbf12e09917e7072fd5dfe343757f6ff77ad53e1b214be019bf60f25  guix-build-656f9b0ba233/output/arm64-apple-darwin/bitcoin-656f9b0ba233-arm64-apple-darwin-unsigned.tar.gz
8240ba04bd9e743684a70fceb8c0e57c295e6bf9b987f9506a013418917d4d48  guix-build-656f9b0ba233/output/arm64-apple-darwin/bitcoin-656f9b0ba233-arm64-apple-darwin.tar.gz
a83c4a6fdb2aa07f21c85ffb6fb58d188e55b6a68ed9431e7562a75168511f70  guix-build-656f9b0ba233/output/dist-archive/bitcoin-656f9b0ba233.tar.gz
f18254bc90cabbf2311d61aa13c2b33cc205bd8c1ec3b488be6579cc7a744d69  guix-build-656f9b0ba233/output/powerpc64-linux-gnu/SHA256SUMS.part
193fdaf1bd85ca69825ad7462dce7bcc874a196913fd4aa9e830d19696fb336d  guix-build-656f9b0ba233/output/powerpc64-linux-gnu/bitcoin-656f9b0ba233-powerpc64-linux-gnu-debug.tar.gz
d12266e5d73ec40c9a356bdf2118b3e186a0675aa66a76097f3170e213a2918d  guix-build-656f9b0ba233/output/powerpc64-linux-gnu/bitcoin-656f9b0ba233-powerpc64-linux-gnu.tar.gz
71e779a3a96959ce3d04de605dbe886741166a56e3599a63867ea6bfd7b2ad2f  guix-build-656f9b0ba233/output/powerpc64le-linux-gnu/SHA256SUMS.part
621b9707a8d7a0806703aadec91d1c8ecf8979d0c8e58f3af67881114386fece  guix-build-656f9b0ba233/output/powerpc64le-linux-gnu/bitcoin-656f9b0ba233-powerpc64le-linux-gnu-debug.tar.gz
957ebd909f209d2308f9e18241354b7c460267e2d9964daad383be94f4470eb6  guix-build-656f9b0ba233/output/powerpc64le-linux-gnu/bitcoin-656f9b0ba233-powerpc64le-linux-gnu.tar.gz
c70dfcc02b3bf11352ae4842dba73748bc59454303506bba046d620a7ff302e2  guix-build-656f9b0ba233/output/riscv64-linux-gnu/SHA256SUMS.part
5c71397b29ea73666a9e8b23c1948dcfb00478a5cd8aa0442d5f8065b1a7bef8  guix-build-656f9b0ba233/output/riscv64-linux-gnu/bitcoin-656f9b0ba233-riscv64-linux-gnu-debug.tar.gz
0d413d7f483872699f878ce8102a9c8e91ee889cb791396e0a750062481e3340  guix-build-656f9b0ba233/output/riscv64-linux-gnu/bitcoin-656f9b0ba233-riscv64-linux-gnu.tar.gz
0a22a1c8ea57b25a2372192279ef2584f8ccf06f219a72436293f52294fa3b9a  guix-build-656f9b0ba233/output/x86_64-apple-darwin/SHA256SUMS.part
be8d4766384eb8d582a58ad0cb8ac04f456afc74f0ada24f04a839fa1c16f8d9  guix-build-656f9b0ba233/output/x86_64-apple-darwin/bitcoin-656f9b0ba233-x86_64-apple-darwin-unsigned.dmg
1e5bd0eeb22dbae7c347e722267f6317a221abb9e610d1208c13d93cbcd6f881  guix-build-656f9b0ba233/output/x86_64-apple-darwin/bitcoin-656f9b0ba233-x86_64-apple-darwin-unsigned.tar.gz
6f0b3986689ad1da6945f2cc9706753204a7bc625fd1a48d3952c2f71a8114be  guix-build-656f9b0ba233/output/x86_64-apple-darwin/bitcoin-656f9b0ba233-x86_64-apple-darwin.tar.gz
bacaff5157ef53cf4e8087b166272f03e16a7b9b8eb2258b0cac8169666f721b  guix-build-656f9b0ba233/output/x86_64-linux-gnu/SHA256SUMS.part
e822e98f8c44e8b7760542780a2e3c7e41f0c245764a5126af235603d455b93c  guix-build-656f9b0ba233/output/x86_64-linux-gnu/bitcoin-656f9b0ba233-x86_64-linux-gnu-debug.tar.gz
270e66fc16dd3e2a825c7b01f51caa242354279be4b65fe6ed0d438405b7dc38  guix-build-656f9b0ba233/output/x86_64-linux-gnu/bitcoin-656f9b0ba233-x86_64-linux-gnu.tar.gz
42b67a4eff63956604f06af5919a45d0c8fd43d4bfa4a0d3b3dda3b2684e8ef0  guix-build-656f9b0ba233/output/x86_64-w64-mingw32/SHA256SUMS.part
04a9d09af75622cadc405ba4d0db251f643fd6d8e5bdffe94a283b53c77d9d83  guix-build-656f9b0ba233/output/x86_64-w64-mingw32/bitcoin-656f9b0ba233-win64-debug.zip
463b2188a1710917e5faba55f2f4bce72ad3188860e3736643f860493b464c27  guix-build-656f9b0ba233/output/x86_64-w64-mingw32/bitcoin-656f9b0ba233-win64-setup-unsigned.exe
d9e27f2d99a83b4d3dc689ec1a69c08d580bb1b77f0f83298fd3586bd61517bb  guix-build-656f9b0ba233/output/x86_64-w64-mingw32/bitcoin-656f9b0ba233-win64-unsigned.tar.gz
51e45cd129d62bc810654b5ca235c7d52d9d5a93bce244c18b1bbe9d70ec61fc  guix-build-656f9b0ba233/output/x86_64-w64-mingw32/bitcoin-656f9b0ba233-win64.zip
```