### PR TITLE
p2p: return `CSubNet` in `LookupSubNet`

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -173,8 +173,7 @@ static bool InitHTTPAllowList()
     rpc_allow_subnets.push_back(CSubNet{LookupHost("127.0.0.1", false).value(), 8});  // always allow IPv4 local subnet
     rpc_allow_subnets.push_back(CSubNet{LookupHost("::1", false).value()});  // always allow IPv6 localhost
     for (const std::string& strAllow : gArgs.GetArgs("-rpcallowip")) {
-        CSubNet subnet;
-        LookupSubNet(strAllow, subnet);
+        const CSubNet subnet{LookupSubNet(strAllow)};
         if (!subnet.IsValid()) {
             uiInterface.ThreadSafeMessageBox(
                 strprintf(Untranslated("Invalid -rpcallowip subnet specification: %s. Valid are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24)."), strAllow),

--- a/src/net_permissions.cpp
+++ b/src/net_permissions.cpp
@@ -111,8 +111,7 @@ bool NetWhitelistPermissions::TryParse(const std::string& str, NetWhitelistPermi
     if (!TryParsePermissionFlags(str, flags, offset, error)) return false;
 
     const std::string net = str.substr(offset);
-    CSubNet subnet;
-    LookupSubNet(net, subnet);
+    const CSubNet subnet{LookupSubNet(net)};
     if (!subnet.IsValid()) {
         error = strprintf(_("Invalid netmask specified in -whitelist: '%s'"), net);
         return false;

--- a/src/net_types.cpp
+++ b/src/net_types.cpp
@@ -63,9 +63,9 @@ void BanMapFromJson(const UniValue& bans_json, banmap_t& bans)
             LogPrintf("Dropping entry with unknown version (%s) from ban list\n", version);
             continue;
         }
-        CSubNet subnet;
         const auto& subnet_str = ban_entry_json[BANMAN_JSON_ADDR_KEY].get_str();
-        if (!LookupSubNet(subnet_str, subnet)) {
+        const CSubNet subnet{LookupSubNet(subnet_str)};
+        if (!subnet.IsValid()) {
             LogPrintf("Dropping entry with unparseable address or subnet (%s) from ban list\n", subnet_str);
             continue;
         }

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -655,10 +655,12 @@ bool ConnectThroughProxy(const Proxy& proxy, const std::string& strDest, uint16_
     return true;
 }
 
-bool LookupSubNet(const std::string& subnet_str, CSubNet& subnet_out)
+CSubNet LookupSubNet(const std::string& subnet_str)
 {
+    CSubNet subnet;
+    assert(!subnet.IsValid());
     if (!ContainsNoNUL(subnet_str)) {
-        return false;
+        return subnet;
     }
 
     const size_t slash_pos{subnet_str.find_last_of('/')};
@@ -671,23 +673,21 @@ bool LookupSubNet(const std::string& subnet_str, CSubNet& subnet_out)
             uint8_t netmask;
             if (ParseUInt8(netmask_str, &netmask)) {
                 // Valid number; assume CIDR variable-length subnet masking.
-                subnet_out = CSubNet{addr.value(), netmask};
-                return subnet_out.IsValid();
+                subnet = CSubNet{addr.value(), netmask};
             } else {
                 // Invalid number; try full netmask syntax. Never allow lookup for netmask.
                 const std::optional<CNetAddr> full_netmask{LookupHost(netmask_str, /*fAllowLookup=*/false)};
                 if (full_netmask.has_value()) {
-                    subnet_out = CSubNet{addr.value(), full_netmask.value()};
-                    return subnet_out.IsValid();
+                    subnet = CSubNet{addr.value(), full_netmask.value()};
                 }
             }
         } else {
             // Single IP subnet (<ipv4>/32 or <ipv6>/128).
-            subnet_out = CSubNet{addr.value()};
-            return subnet_out.IsValid();
+            subnet = CSubNet{addr.value()};
         }
     }
-    return false;
+
+    return subnet;
 }
 
 void InterruptSocks5(bool interrupt)

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -171,11 +171,9 @@ CService LookupNumeric(const std::string& name, uint16_t portDefault = 0, DNSLoo
  * @param[in]  subnet_str  A string representation of a subnet of the form
  *                         `network address [ "/", ( CIDR-style suffix | netmask ) ]`
  *                         e.g. "2001:db8::/32", "192.0.2.0/255.255.255.0" or "8.8.8.8".
- * @param[out] subnet_out  Internal subnet representation, if parsable/resolvable
- *                         from `subnet_str`.
- * @returns whether the operation succeeded or not.
+ * @returns a CSubNet object (that may or may not be valid).
  */
-bool LookupSubNet(const std::string& subnet_str, CSubNet& subnet_out);
+CSubNet LookupSubNet(const std::string& subnet_str);
 
 /**
  * Create a TCP socket in the given address family.

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -719,7 +719,7 @@ static RPCHelpMan setban()
         }
     }
     else
-        LookupSubNet(request.params[0].get_str(), subNet);
+        subNet = LookupSubNet(request.params[0].get_str());
 
     if (! (isSubnet ? subNet.IsValid() : netAddr.IsValid()) )
         throw JSONRPCError(RPC_CLIENT_INVALID_IP_OR_SUBNET, "Error: Invalid IP/Subnet");

--- a/src/test/fuzz/netbase_dns_lookup.cpp
+++ b/src/test/fuzz/netbase_dns_lookup.cpp
@@ -59,9 +59,6 @@ FUZZ_TARGET(netbase_dns_lookup)
         assert(!resolved_service.IsInternal());
     }
     {
-        CSubNet resolved_subnet;
-        if (LookupSubNet(name, resolved_subnet)) {
-            assert(resolved_subnet.IsValid());
-        }
+        (void)LookupSubNet(name);
     }
 }

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -27,13 +27,6 @@ static CNetAddr ResolveIP(const std::string& ip)
     return LookupHost(ip, false).value_or(CNetAddr{});
 }
 
-static CSubNet ResolveSubNet(const std::string& subnet)
-{
-    CSubNet ret;
-    LookupSubNet(subnet, ret);
-    return ret;
-}
-
 static CNetAddr CreateInternal(const std::string& host)
 {
     CNetAddr addr;
@@ -159,49 +152,49 @@ BOOST_AUTO_TEST_CASE(embedded_test)
 BOOST_AUTO_TEST_CASE(subnet_test)
 {
 
-    BOOST_CHECK(ResolveSubNet("1.2.3.0/24") == ResolveSubNet("1.2.3.0/255.255.255.0"));
-    BOOST_CHECK(ResolveSubNet("1.2.3.0/24") != ResolveSubNet("1.2.4.0/255.255.255.0"));
-    BOOST_CHECK(ResolveSubNet("1.2.3.0/24").Match(ResolveIP("1.2.3.4")));
-    BOOST_CHECK(!ResolveSubNet("1.2.2.0/24").Match(ResolveIP("1.2.3.4")));
-    BOOST_CHECK(ResolveSubNet("1.2.3.4").Match(ResolveIP("1.2.3.4")));
-    BOOST_CHECK(ResolveSubNet("1.2.3.4/32").Match(ResolveIP("1.2.3.4")));
-    BOOST_CHECK(!ResolveSubNet("1.2.3.4").Match(ResolveIP("5.6.7.8")));
-    BOOST_CHECK(!ResolveSubNet("1.2.3.4/32").Match(ResolveIP("5.6.7.8")));
-    BOOST_CHECK(ResolveSubNet("::ffff:127.0.0.1").Match(ResolveIP("127.0.0.1")));
-    BOOST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:8").Match(ResolveIP("1:2:3:4:5:6:7:8")));
-    BOOST_CHECK(!ResolveSubNet("1:2:3:4:5:6:7:8").Match(ResolveIP("1:2:3:4:5:6:7:9")));
-    BOOST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:0/112").Match(ResolveIP("1:2:3:4:5:6:7:1234")));
-    BOOST_CHECK(ResolveSubNet("192.168.0.1/24").Match(ResolveIP("192.168.0.2")));
-    BOOST_CHECK(ResolveSubNet("192.168.0.20/29").Match(ResolveIP("192.168.0.18")));
-    BOOST_CHECK(ResolveSubNet("1.2.2.1/24").Match(ResolveIP("1.2.2.4")));
-    BOOST_CHECK(ResolveSubNet("1.2.2.110/31").Match(ResolveIP("1.2.2.111")));
-    BOOST_CHECK(ResolveSubNet("1.2.2.20/26").Match(ResolveIP("1.2.2.63")));
+    BOOST_CHECK(LookupSubNet("1.2.3.0/24") == LookupSubNet("1.2.3.0/255.255.255.0"));
+    BOOST_CHECK(LookupSubNet("1.2.3.0/24") != LookupSubNet("1.2.4.0/255.255.255.0"));
+    BOOST_CHECK(LookupSubNet("1.2.3.0/24").Match(ResolveIP("1.2.3.4")));
+    BOOST_CHECK(!LookupSubNet("1.2.2.0/24").Match(ResolveIP("1.2.3.4")));
+    BOOST_CHECK(LookupSubNet("1.2.3.4").Match(ResolveIP("1.2.3.4")));
+    BOOST_CHECK(LookupSubNet("1.2.3.4/32").Match(ResolveIP("1.2.3.4")));
+    BOOST_CHECK(!LookupSubNet("1.2.3.4").Match(ResolveIP("5.6.7.8")));
+    BOOST_CHECK(!LookupSubNet("1.2.3.4/32").Match(ResolveIP("5.6.7.8")));
+    BOOST_CHECK(LookupSubNet("::ffff:127.0.0.1").Match(ResolveIP("127.0.0.1")));
+    BOOST_CHECK(LookupSubNet("1:2:3:4:5:6:7:8").Match(ResolveIP("1:2:3:4:5:6:7:8")));
+    BOOST_CHECK(!LookupSubNet("1:2:3:4:5:6:7:8").Match(ResolveIP("1:2:3:4:5:6:7:9")));
+    BOOST_CHECK(LookupSubNet("1:2:3:4:5:6:7:0/112").Match(ResolveIP("1:2:3:4:5:6:7:1234")));
+    BOOST_CHECK(LookupSubNet("192.168.0.1/24").Match(ResolveIP("192.168.0.2")));
+    BOOST_CHECK(LookupSubNet("192.168.0.20/29").Match(ResolveIP("192.168.0.18")));
+    BOOST_CHECK(LookupSubNet("1.2.2.1/24").Match(ResolveIP("1.2.2.4")));
+    BOOST_CHECK(LookupSubNet("1.2.2.110/31").Match(ResolveIP("1.2.2.111")));
+    BOOST_CHECK(LookupSubNet("1.2.2.20/26").Match(ResolveIP("1.2.2.63")));
     // All-Matching IPv6 Matches arbitrary IPv6
-    BOOST_CHECK(ResolveSubNet("::/0").Match(ResolveIP("1:2:3:4:5:6:7:1234")));
+    BOOST_CHECK(LookupSubNet("::/0").Match(ResolveIP("1:2:3:4:5:6:7:1234")));
     // But not `::` or `0.0.0.0` because they are considered invalid addresses
-    BOOST_CHECK(!ResolveSubNet("::/0").Match(ResolveIP("::")));
-    BOOST_CHECK(!ResolveSubNet("::/0").Match(ResolveIP("0.0.0.0")));
+    BOOST_CHECK(!LookupSubNet("::/0").Match(ResolveIP("::")));
+    BOOST_CHECK(!LookupSubNet("::/0").Match(ResolveIP("0.0.0.0")));
     // Addresses from one network (IPv4) don't belong to subnets of another network (IPv6)
-    BOOST_CHECK(!ResolveSubNet("::/0").Match(ResolveIP("1.2.3.4")));
+    BOOST_CHECK(!LookupSubNet("::/0").Match(ResolveIP("1.2.3.4")));
     // All-Matching IPv4 does not Match IPv6
-    BOOST_CHECK(!ResolveSubNet("0.0.0.0/0").Match(ResolveIP("1:2:3:4:5:6:7:1234")));
+    BOOST_CHECK(!LookupSubNet("0.0.0.0/0").Match(ResolveIP("1:2:3:4:5:6:7:1234")));
     // Invalid subnets Match nothing (not even invalid addresses)
     BOOST_CHECK(!CSubNet().Match(ResolveIP("1.2.3.4")));
-    BOOST_CHECK(!ResolveSubNet("").Match(ResolveIP("4.5.6.7")));
-    BOOST_CHECK(!ResolveSubNet("bloop").Match(ResolveIP("0.0.0.0")));
-    BOOST_CHECK(!ResolveSubNet("bloop").Match(ResolveIP("hab")));
+    BOOST_CHECK(!LookupSubNet("").Match(ResolveIP("4.5.6.7")));
+    BOOST_CHECK(!LookupSubNet("bloop").Match(ResolveIP("0.0.0.0")));
+    BOOST_CHECK(!LookupSubNet("bloop").Match(ResolveIP("hab")));
     // Check valid/invalid
-    BOOST_CHECK(ResolveSubNet("1.2.3.0/0").IsValid());
-    BOOST_CHECK(!ResolveSubNet("1.2.3.0/-1").IsValid());
-    BOOST_CHECK(ResolveSubNet("1.2.3.0/32").IsValid());
-    BOOST_CHECK(!ResolveSubNet("1.2.3.0/33").IsValid());
-    BOOST_CHECK(!ResolveSubNet("1.2.3.0/300").IsValid());
-    BOOST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:8/0").IsValid());
-    BOOST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:8/33").IsValid());
-    BOOST_CHECK(!ResolveSubNet("1:2:3:4:5:6:7:8/-1").IsValid());
-    BOOST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:8/128").IsValid());
-    BOOST_CHECK(!ResolveSubNet("1:2:3:4:5:6:7:8/129").IsValid());
-    BOOST_CHECK(!ResolveSubNet("fuzzy").IsValid());
+    BOOST_CHECK(LookupSubNet("1.2.3.0/0").IsValid());
+    BOOST_CHECK(!LookupSubNet("1.2.3.0/-1").IsValid());
+    BOOST_CHECK(LookupSubNet("1.2.3.0/32").IsValid());
+    BOOST_CHECK(!LookupSubNet("1.2.3.0/33").IsValid());
+    BOOST_CHECK(!LookupSubNet("1.2.3.0/300").IsValid());
+    BOOST_CHECK(LookupSubNet("1:2:3:4:5:6:7:8/0").IsValid());
+    BOOST_CHECK(LookupSubNet("1:2:3:4:5:6:7:8/33").IsValid());
+    BOOST_CHECK(!LookupSubNet("1:2:3:4:5:6:7:8/-1").IsValid());
+    BOOST_CHECK(LookupSubNet("1:2:3:4:5:6:7:8/128").IsValid());
+    BOOST_CHECK(!LookupSubNet("1:2:3:4:5:6:7:8/129").IsValid());
+    BOOST_CHECK(!LookupSubNet("fuzzy").IsValid());
 
     //CNetAddr constructor test
     BOOST_CHECK(CSubNet(ResolveIP("127.0.0.1")).IsValid());
@@ -247,85 +240,85 @@ BOOST_AUTO_TEST_CASE(subnet_test)
     BOOST_CHECK(!CSubNet(tor_addr, 200).IsValid());
     BOOST_CHECK(!CSubNet(tor_addr, ResolveIP("255.0.0.0")).IsValid());
 
-    subnet = ResolveSubNet("1.2.3.4/255.255.255.255");
+    subnet = LookupSubNet("1.2.3.4/255.255.255.255");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.4/32");
-    subnet = ResolveSubNet("1.2.3.4/255.255.255.254");
+    subnet = LookupSubNet("1.2.3.4/255.255.255.254");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.4/31");
-    subnet = ResolveSubNet("1.2.3.4/255.255.255.252");
+    subnet = LookupSubNet("1.2.3.4/255.255.255.252");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.4/30");
-    subnet = ResolveSubNet("1.2.3.4/255.255.255.248");
+    subnet = LookupSubNet("1.2.3.4/255.255.255.248");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/29");
-    subnet = ResolveSubNet("1.2.3.4/255.255.255.240");
+    subnet = LookupSubNet("1.2.3.4/255.255.255.240");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/28");
-    subnet = ResolveSubNet("1.2.3.4/255.255.255.224");
+    subnet = LookupSubNet("1.2.3.4/255.255.255.224");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/27");
-    subnet = ResolveSubNet("1.2.3.4/255.255.255.192");
+    subnet = LookupSubNet("1.2.3.4/255.255.255.192");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/26");
-    subnet = ResolveSubNet("1.2.3.4/255.255.255.128");
+    subnet = LookupSubNet("1.2.3.4/255.255.255.128");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/25");
-    subnet = ResolveSubNet("1.2.3.4/255.255.255.0");
+    subnet = LookupSubNet("1.2.3.4/255.255.255.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/24");
-    subnet = ResolveSubNet("1.2.3.4/255.255.254.0");
+    subnet = LookupSubNet("1.2.3.4/255.255.254.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.2.0/23");
-    subnet = ResolveSubNet("1.2.3.4/255.255.252.0");
+    subnet = LookupSubNet("1.2.3.4/255.255.252.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/22");
-    subnet = ResolveSubNet("1.2.3.4/255.255.248.0");
+    subnet = LookupSubNet("1.2.3.4/255.255.248.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/21");
-    subnet = ResolveSubNet("1.2.3.4/255.255.240.0");
+    subnet = LookupSubNet("1.2.3.4/255.255.240.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/20");
-    subnet = ResolveSubNet("1.2.3.4/255.255.224.0");
+    subnet = LookupSubNet("1.2.3.4/255.255.224.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/19");
-    subnet = ResolveSubNet("1.2.3.4/255.255.192.0");
+    subnet = LookupSubNet("1.2.3.4/255.255.192.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/18");
-    subnet = ResolveSubNet("1.2.3.4/255.255.128.0");
+    subnet = LookupSubNet("1.2.3.4/255.255.128.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/17");
-    subnet = ResolveSubNet("1.2.3.4/255.255.0.0");
+    subnet = LookupSubNet("1.2.3.4/255.255.0.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/16");
-    subnet = ResolveSubNet("1.2.3.4/255.254.0.0");
+    subnet = LookupSubNet("1.2.3.4/255.254.0.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/15");
-    subnet = ResolveSubNet("1.2.3.4/255.252.0.0");
+    subnet = LookupSubNet("1.2.3.4/255.252.0.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/14");
-    subnet = ResolveSubNet("1.2.3.4/255.248.0.0");
+    subnet = LookupSubNet("1.2.3.4/255.248.0.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/13");
-    subnet = ResolveSubNet("1.2.3.4/255.240.0.0");
+    subnet = LookupSubNet("1.2.3.4/255.240.0.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/12");
-    subnet = ResolveSubNet("1.2.3.4/255.224.0.0");
+    subnet = LookupSubNet("1.2.3.4/255.224.0.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/11");
-    subnet = ResolveSubNet("1.2.3.4/255.192.0.0");
+    subnet = LookupSubNet("1.2.3.4/255.192.0.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/10");
-    subnet = ResolveSubNet("1.2.3.4/255.128.0.0");
+    subnet = LookupSubNet("1.2.3.4/255.128.0.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/9");
-    subnet = ResolveSubNet("1.2.3.4/255.0.0.0");
+    subnet = LookupSubNet("1.2.3.4/255.0.0.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/8");
-    subnet = ResolveSubNet("1.2.3.4/254.0.0.0");
+    subnet = LookupSubNet("1.2.3.4/254.0.0.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/7");
-    subnet = ResolveSubNet("1.2.3.4/252.0.0.0");
+    subnet = LookupSubNet("1.2.3.4/252.0.0.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/6");
-    subnet = ResolveSubNet("1.2.3.4/248.0.0.0");
+    subnet = LookupSubNet("1.2.3.4/248.0.0.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/5");
-    subnet = ResolveSubNet("1.2.3.4/240.0.0.0");
+    subnet = LookupSubNet("1.2.3.4/240.0.0.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/4");
-    subnet = ResolveSubNet("1.2.3.4/224.0.0.0");
+    subnet = LookupSubNet("1.2.3.4/224.0.0.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/3");
-    subnet = ResolveSubNet("1.2.3.4/192.0.0.0");
+    subnet = LookupSubNet("1.2.3.4/192.0.0.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/2");
-    subnet = ResolveSubNet("1.2.3.4/128.0.0.0");
+    subnet = LookupSubNet("1.2.3.4/128.0.0.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/1");
-    subnet = ResolveSubNet("1.2.3.4/0.0.0.0");
+    subnet = LookupSubNet("1.2.3.4/0.0.0.0");
     BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/0");
 
-    subnet = ResolveSubNet("1:2:3:4:5:6:7:8/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
+    subnet = LookupSubNet("1:2:3:4:5:6:7:8/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1:2:3:4:5:6:7:8/128");
-    subnet = ResolveSubNet("1:2:3:4:5:6:7:8/ffff:0000:0000:0000:0000:0000:0000:0000");
+    subnet = LookupSubNet("1:2:3:4:5:6:7:8/ffff:0000:0000:0000:0000:0000:0000:0000");
     BOOST_CHECK_EQUAL(subnet.ToString(), "1::/16");
-    subnet = ResolveSubNet("1:2:3:4:5:6:7:8/0000:0000:0000:0000:0000:0000:0000:0000");
+    subnet = LookupSubNet("1:2:3:4:5:6:7:8/0000:0000:0000:0000:0000:0000:0000:0000");
     BOOST_CHECK_EQUAL(subnet.ToString(), "::/0");
     // Invalid netmasks (with 1-bits after 0-bits)
-    subnet = ResolveSubNet("1.2.3.4/255.255.232.0");
+    subnet = LookupSubNet("1.2.3.4/255.255.232.0");
     BOOST_CHECK(!subnet.IsValid());
-    subnet = ResolveSubNet("1.2.3.4/255.0.255.255");
+    subnet = LookupSubNet("1.2.3.4/255.0.255.255");
     BOOST_CHECK(!subnet.IsValid());
-    subnet = ResolveSubNet("1:2:3:4:5:6:7:8/ffff:ffff:ffff:fffe:ffff:ffff:ffff:ff0f");
+    subnet = LookupSubNet("1:2:3:4:5:6:7:8/ffff:ffff:ffff:fffe:ffff:ffff:ffff:ff0f");
     BOOST_CHECK(!subnet.IsValid());
 }
 
@@ -479,15 +472,15 @@ BOOST_AUTO_TEST_CASE(netbase_dont_resolve_strings_with_embedded_nul_characters)
     BOOST_CHECK(!LookupHost("127.0.0.1\0"s, false).has_value());
     BOOST_CHECK(!LookupHost("127.0.0.1\0example.com"s, false).has_value());
     BOOST_CHECK(!LookupHost("127.0.0.1\0example.com\0"s, false).has_value());
-    CSubNet ret;
-    BOOST_CHECK(LookupSubNet("1.2.3.0/24"s, ret));
-    BOOST_CHECK(!LookupSubNet("1.2.3.0/24\0"s, ret));
-    BOOST_CHECK(!LookupSubNet("1.2.3.0/24\0example.com"s, ret));
-    BOOST_CHECK(!LookupSubNet("1.2.3.0/24\0example.com\0"s, ret));
-    BOOST_CHECK(LookupSubNet("pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion"s, ret));
-    BOOST_CHECK(!LookupSubNet("pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion\0"s, ret));
-    BOOST_CHECK(!LookupSubNet("pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion\0example.com"s, ret));
-    BOOST_CHECK(!LookupSubNet("pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion\0example.com\0"s, ret));
+
+    BOOST_CHECK(LookupSubNet("1.2.3.0/24"s).IsValid());
+    BOOST_CHECK(!LookupSubNet("1.2.3.0/24\0"s).IsValid());
+    BOOST_CHECK(!LookupSubNet("1.2.3.0/24\0example.com"s).IsValid());
+    BOOST_CHECK(!LookupSubNet("1.2.3.0/24\0example.com\0"s).IsValid());
+    BOOST_CHECK(LookupSubNet("pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion"s).IsValid());
+    BOOST_CHECK(!LookupSubNet("pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion\0"s).IsValid());
+    BOOST_CHECK(!LookupSubNet("pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion\0example.com"s).IsValid());
+    BOOST_CHECK(!LookupSubNet("pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion\0example.com\0"s).IsValid());
 }
 
 // Since CNetAddr (un)ser is tested separately in net_tests.cpp here we only


### PR DESCRIPTION
Analyzing the usage of `LookupSubNet`, noticed that most cases uses check if the subnet is valid by calling `subnet.IsValid()`, and the boolean returned by `LookupSubNet` hasn't been used so much, see:
https://github.com/bitcoin/bitcoin/blob/29d540b7ada890dd588c4825d40c27c5e6f20061/src/httpserver.cpp#L172-L174
https://github.com/bitcoin/bitcoin/blob/29d540b7ada890dd588c4825d40c27c5e6f20061/src/net_permissions.cpp#L114-L116

It makes sense to return `CSubNet` instead of `bool`.
