### PR TITLE
sendall: check if the maxtxfee has been exceeded

### DIFF
--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -1402,6 +1402,10 @@ RPCHelpMan sendall()
             const CAmount fee_from_size{fee_rate.GetFee(tx_size.vsize)};
             const CAmount effective_value{total_input_value - fee_from_size};
 
+            if (fee_from_size > pwallet->m_default_max_tx_fee) {
+                throw JSONRPCError(RPC_WALLET_ERROR, TransactionErrorString(TransactionError::MAX_FEE_EXCEEDED).original);
+            }
+
             if (effective_value <= 0) {
                 if (send_max) {
                     throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Total value of UTXO pool too low to pay for transaction, try using lower feerate.");

--- a/test/functional/wallet_sendall.py
+++ b/test/functional/wallet_sendall.py
@@ -264,6 +264,18 @@ class SendallTest(BitcoinTestFramework):
             recipients=[self.remainder_target],
             options={"inputs": [utxo], "send_max": True})
 
+    @cleanup
+    def sendall_fails_on_high_fee(self):
+        self.log.info("Test sendall fails if the transaction fee exceeds the maxtxfee")
+        self.add_utxos([21])
+
+        assert_raises_rpc_error(
+                -4,
+                "Fee exceeds maximum configured by user",
+                self.wallet.sendall,
+                recipients=[self.remainder_target],
+                fee_rate=100000)
+
     def run_test(self):
         self.nodes[0].createwallet("activewallet")
         self.wallet = self.nodes[0].get_wallet_rpc("activewallet")
@@ -311,6 +323,9 @@ class SendallTest(BitcoinTestFramework):
 
         # Sendall fails when using send_max while specifying inputs
         self.sendall_fails_on_specific_inputs_with_send_max()
+
+        # Sendall fails when providing a fee that is too high
+        self.sendall_fails_on_high_fee()
 
 if __name__ == '__main__':
     SendallTest().main()


### PR DESCRIPTION
Previously the `sendall` RPC didn't check whether the fees of the transaction it creates exceed the set `maxtxfee`. This PR adds this check to `sendall` and a test case for it.