### PR TITLE
RPC/Wallet: Access wallets via interfaces::Wallet

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -63,7 +63,7 @@ public:
     virtual bool encryptWallet(const SecureString& wallet_passphrase) = 0;
 
     //! Return whether wallet is encrypted.
-    virtual bool isCrypted() = 0;
+    virtual bool isCrypted() const = 0;
 
     //! Lock wallet.
     virtual bool lock() = 0;
@@ -72,7 +72,7 @@ public:
     virtual bool unlock(const SecureString& wallet_passphrase) = 0;
 
     //! Return whether wallet is locked.
-    virtual bool isLocked() = 0;
+    virtual bool isLocked() const = 0;
 
     //! Change wallet passphrase.
     virtual bool changeWalletPassphrase(const SecureString& old_wallet_passphrase,
@@ -85,7 +85,7 @@ public:
     virtual bool backupWallet(const std::string& filename) = 0;
 
     //! Get wallet name.
-    virtual std::string getWalletName() = 0;
+    virtual std::string getWalletName() const = 0;
 
     // Get a new address.
     virtual util::Result<CTxDestination> getNewDestination(const OutputType type, const std::string& label) = 0;
@@ -97,10 +97,10 @@ public:
     virtual SigningResult signMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) = 0;
 
     //! Return whether wallet has private key.
-    virtual bool isSpendable(const CTxDestination& dest) = 0;
+    virtual bool isSpendable(const CTxDestination& dest) const = 0;
 
     //! Return whether wallet has watch only keys.
-    virtual bool haveWatchOnly() = 0;
+    virtual bool haveWatchOnly() const = 0;
 
     //! Add or update address.
     virtual bool setAddressBook(const CTxDestination& dest, const std::string& name, const std::string& purpose) = 0;
@@ -112,13 +112,13 @@ public:
     virtual bool getAddress(const CTxDestination& dest,
         std::string* name,
         wallet::isminetype* is_mine,
-        std::string* purpose) = 0;
+        std::string* purpose) const = 0;
 
     //! Get wallet address list.
     virtual std::vector<WalletAddress> getAddresses() const = 0;
 
     //! Get receive requests.
-    virtual std::vector<std::string> getAddressReceiveRequests() = 0;
+    virtual std::vector<std::string> getAddressReceiveRequests() const = 0;
 
     //! Save or remove receive request.
     virtual bool setAddressReceiveRequest(const CTxDestination& dest, const std::string& id, const std::string& value) = 0;
@@ -133,10 +133,10 @@ public:
     virtual bool unlockCoin(const COutPoint& output) = 0;
 
     //! Return whether coin is locked.
-    virtual bool isLockedCoin(const COutPoint& output) = 0;
+    virtual bool isLockedCoin(const COutPoint& output) const = 0;
 
     //! List locked coins.
-    virtual void listLockedCoins(std::vector<COutPoint>& outputs) = 0;
+    virtual void listLockedCoins(std::vector<COutPoint>& outputs) const = 0;
 
     //! Create transaction.
     virtual util::Result<CTransactionRef> createTransaction(const std::vector<wallet::CRecipient>& recipients,
@@ -151,13 +151,13 @@ public:
         WalletOrderForm order_form) = 0;
 
     //! Return whether transaction can be abandoned.
-    virtual bool transactionCanBeAbandoned(const uint256& txid) = 0;
+    virtual bool transactionCanBeAbandoned(const uint256& txid) const = 0;
 
     //! Abandon transaction.
     virtual bool abandonTransaction(const uint256& txid) = 0;
 
     //! Return whether transaction can be bumped.
-    virtual bool transactionCanBeBumped(const uint256& txid) = 0;
+    virtual bool transactionCanBeBumped(const uint256& txid) const = 0;
 
     //! Create bump transaction.
     virtual bool createBumpTransaction(const uint256& txid,
@@ -177,26 +177,26 @@ public:
         uint256& bumped_txid) = 0;
 
     //! Get a transaction.
-    virtual CTransactionRef getTx(const uint256& txid) = 0;
+    virtual CTransactionRef getTx(const uint256& txid) const = 0;
 
     //! Get transaction information.
-    virtual WalletTx getWalletTx(const uint256& txid) = 0;
+    virtual WalletTx getWalletTx(const uint256& txid) const = 0;
 
     //! Get list of all wallet transactions.
-    virtual std::set<WalletTx> getWalletTxs() = 0;
+    virtual std::set<WalletTx> getWalletTxs() const = 0;
 
     //! Try to get updated status for a particular transaction, if possible without blocking.
     virtual bool tryGetTxStatus(const uint256& txid,
         WalletTxStatus& tx_status,
         int& num_blocks,
-        int64_t& block_time) = 0;
+        int64_t& block_time) const = 0;
 
     //! Get transaction details.
     virtual WalletTx getWalletTxDetails(const uint256& txid,
         WalletTxStatus& tx_status,
         WalletOrderForm& order_form,
         bool& in_mempool,
-        int& num_blocks) = 0;
+        int& num_blocks) const = 0;
 
     //! Fill PSBT.
     virtual TransactionError fillPSBT(int sighash_type,
@@ -207,78 +207,78 @@ public:
         bool& complete) = 0;
 
     //! Get balances.
-    virtual WalletBalances getBalances() = 0;
+    virtual WalletBalances getBalances() const = 0;
 
     //! Get balances if possible without blocking.
-    virtual bool tryGetBalances(WalletBalances& balances, uint256& block_hash) = 0;
+    virtual bool tryGetBalances(WalletBalances& balances, uint256& block_hash) const = 0;
 
     //! Get balance.
-    virtual CAmount getBalance() = 0;
+    virtual CAmount getBalance() const = 0;
 
     //! Get available balance.
-    virtual CAmount getAvailableBalance(const wallet::CCoinControl& coin_control) = 0;
+    virtual CAmount getAvailableBalance(const wallet::CCoinControl& coin_control) const = 0;
 
     //! Return whether transaction input belongs to wallet.
-    virtual wallet::isminetype txinIsMine(const CTxIn& txin) = 0;
+    virtual wallet::isminetype txinIsMine(const CTxIn& txin) const = 0;
 
     //! Return whether transaction output belongs to wallet.
-    virtual wallet::isminetype txoutIsMine(const CTxOut& txout) = 0;
+    virtual wallet::isminetype txoutIsMine(const CTxOut& txout) const = 0;
 
     //! Return whether a transaction output to a destination belongs to wallet.
-    virtual wallet::isminetype destIsMine(const CTxDestination& dest) = 0;
+    virtual wallet::isminetype destIsMine(const CTxDestination& dest) const = 0;
 
     //! Return debit amount if transaction input belongs to wallet.
-    virtual CAmount getDebit(const CTxIn& txin, wallet::isminefilter filter) = 0;
+    virtual CAmount getDebit(const CTxIn& txin, wallet::isminefilter filter) const = 0;
 
     //! Return credit amount if transaction input belongs to wallet.
-    virtual CAmount getCredit(const CTxOut& txout, wallet::isminefilter filter) = 0;
+    virtual CAmount getCredit(const CTxOut& txout, wallet::isminefilter filter) const = 0;
 
     //! Return AvailableCoins + LockedCoins grouped by wallet address.
     //! (put change in one group with wallet address)
     using CoinsList = std::map<CTxDestination, std::vector<std::tuple<COutPoint, WalletTxOut>>>;
-    virtual CoinsList listCoins() = 0;
+    virtual CoinsList listCoins() const = 0;
 
     //! Return wallet transaction output information.
-    virtual std::vector<WalletTxOut> getCoins(const std::vector<COutPoint>& outputs) = 0;
+    virtual std::vector<WalletTxOut> getCoins(const std::vector<COutPoint>& outputs) const = 0;
 
     //! Get required fee.
-    virtual CAmount getRequiredFee(unsigned int tx_bytes) = 0;
+    virtual CAmount getRequiredFee(unsigned int tx_bytes) const = 0;
 
     //! Get minimum fee.
     virtual CAmount getMinimumFee(unsigned int tx_bytes,
         const wallet::CCoinControl& coin_control,
         int* returned_target,
-        FeeReason* reason) = 0;
+        FeeReason* reason) const = 0;
 
     //! Get tx confirm target.
-    virtual unsigned int getConfirmTarget() = 0;
+    virtual unsigned int getConfirmTarget() const = 0;
 
     // Return whether HD enabled.
-    virtual bool hdEnabled() = 0;
+    virtual bool hdEnabled() const = 0;
 
     // Return whether the wallet is blank.
-    virtual bool canGetAddresses() = 0;
+    virtual bool canGetAddresses() const = 0;
 
     // Return whether private keys enabled.
-    virtual bool privateKeysDisabled() = 0;
+    virtual bool privateKeysDisabled() const = 0;
 
     // Return whether the wallet contains a Taproot scriptPubKeyMan
-    virtual bool taprootEnabled() = 0;
+    virtual bool taprootEnabled() const = 0;
 
     // Return whether wallet uses an external signer.
-    virtual bool hasExternalSigner() = 0;
+    virtual bool hasExternalSigner() const = 0;
 
     // Get default address type.
-    virtual OutputType getDefaultAddressType() = 0;
+    virtual OutputType getDefaultAddressType() const = 0;
 
     //! Get max tx fee.
-    virtual CAmount getDefaultMaxTxFee() = 0;
+    virtual CAmount getDefaultMaxTxFee() const = 0;
 
     // Remove wallet.
     virtual void remove() = 0;
 
     //! Return whether is a legacy wallet
-    virtual bool isLegacy() = 0;
+    virtual bool isLegacy() const = 0;
 
     //! Register handler for unload message.
     using UnloadFn = std::function<void()>;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -224,6 +224,9 @@ public:
     //! Return whether transaction output belongs to wallet.
     virtual wallet::isminetype txoutIsMine(const CTxOut& txout) = 0;
 
+    //! Return whether a transaction output to a destination belongs to wallet.
+    virtual wallet::isminetype destIsMine(const CTxDestination& dest) = 0;
+
     //! Return debit amount if transaction input belongs to wallet.
     virtual CAmount getDebit(const CTxIn& txin, wallet::isminefilter filter) = 0;
 

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -414,6 +414,11 @@ public:
         LOCK(m_wallet->cs_wallet);
         return m_wallet->IsMine(txout);
     }
+    isminetype destIsMine(const CTxDestination& dest) override
+    {
+        LOCK(m_wallet->cs_wallet);
+        return m_wallet->IsMine(dest);
+    }
     CAmount getDebit(const CTxIn& txin, isminefilter filter) override
     {
         LOCK(m_wallet->cs_wallet);

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -136,10 +136,10 @@ public:
     {
         return m_wallet->EncryptWallet(wallet_passphrase);
     }
-    bool isCrypted() override { return m_wallet->IsCrypted(); }
+    bool isCrypted() const override { return m_wallet->IsCrypted(); }
     bool lock() override { return m_wallet->Lock(); }
     bool unlock(const SecureString& wallet_passphrase) override { return m_wallet->Unlock(wallet_passphrase); }
-    bool isLocked() override { return m_wallet->IsLocked(); }
+    bool isLocked() const override { return m_wallet->IsLocked(); }
     bool changeWalletPassphrase(const SecureString& old_wallet_passphrase,
         const SecureString& new_wallet_passphrase) override
     {
@@ -147,7 +147,7 @@ public:
     }
     void abortRescan() override { m_wallet->AbortRescan(); }
     bool backupWallet(const std::string& filename) override { return m_wallet->BackupWallet(filename); }
-    std::string getWalletName() override { return m_wallet->GetName(); }
+    std::string getWalletName() const override { return m_wallet->GetName(); }
     util::Result<CTxDestination> getNewDestination(const OutputType type, const std::string& label) override
     {
         LOCK(m_wallet->cs_wallet);
@@ -165,12 +165,12 @@ public:
     {
         return m_wallet->SignMessage(message, pkhash, str_sig);
     }
-    bool isSpendable(const CTxDestination& dest) override
+    bool isSpendable(const CTxDestination& dest) const override
     {
         LOCK(m_wallet->cs_wallet);
         return m_wallet->IsMine(dest) & ISMINE_SPENDABLE;
     }
-    bool haveWatchOnly() override
+    bool haveWatchOnly() const override
     {
         auto spk_man = m_wallet->GetLegacyScriptPubKeyMan();
         if (spk_man) {
@@ -189,7 +189,7 @@ public:
     bool getAddress(const CTxDestination& dest,
         std::string* name,
         isminetype* is_mine,
-        std::string* purpose) override
+        std::string* purpose) const override
     {
         LOCK(m_wallet->cs_wallet);
         const auto& entry = m_wallet->FindAddressBookEntry(dest, /*allow_change=*/false);
@@ -215,7 +215,7 @@ public:
         });
         return result;
     }
-    std::vector<std::string> getAddressReceiveRequests() override {
+    std::vector<std::string> getAddressReceiveRequests() const override {
         LOCK(m_wallet->cs_wallet);
         return m_wallet->GetAddressReceiveRequests();
     }
@@ -241,12 +241,12 @@ public:
         std::unique_ptr<WalletBatch> batch = std::make_unique<WalletBatch>(m_wallet->GetDatabase());
         return m_wallet->UnlockCoin(output, batch.get());
     }
-    bool isLockedCoin(const COutPoint& output) override
+    bool isLockedCoin(const COutPoint& output) const override
     {
         LOCK(m_wallet->cs_wallet);
         return m_wallet->IsLockedCoin(output);
     }
-    void listLockedCoins(std::vector<COutPoint>& outputs) override
+    void listLockedCoins(std::vector<COutPoint>& outputs) const override
     {
         LOCK(m_wallet->cs_wallet);
         return m_wallet->ListLockedCoins(outputs);
@@ -274,13 +274,13 @@ public:
         LOCK(m_wallet->cs_wallet);
         m_wallet->CommitTransaction(std::move(tx), std::move(value_map), std::move(order_form));
     }
-    bool transactionCanBeAbandoned(const uint256& txid) override { return m_wallet->TransactionCanBeAbandoned(txid); }
+    bool transactionCanBeAbandoned(const uint256& txid) const override { return m_wallet->TransactionCanBeAbandoned(txid); }
     bool abandonTransaction(const uint256& txid) override
     {
         LOCK(m_wallet->cs_wallet);
         return m_wallet->AbandonTransaction(txid);
     }
-    bool transactionCanBeBumped(const uint256& txid) override
+    bool transactionCanBeBumped(const uint256& txid) const override
     {
         return feebumper::TransactionCanBeBumped(*m_wallet.get(), txid);
     }
@@ -302,7 +302,7 @@ public:
         return feebumper::CommitTransaction(*m_wallet.get(), txid, std::move(mtx), errors, bumped_txid) ==
                feebumper::Result::OK;
     }
-    CTransactionRef getTx(const uint256& txid) override
+    CTransactionRef getTx(const uint256& txid) const override
     {
         LOCK(m_wallet->cs_wallet);
         auto mi = m_wallet->mapWallet.find(txid);
@@ -311,7 +311,7 @@ public:
         }
         return {};
     }
-    WalletTx getWalletTx(const uint256& txid) override
+    WalletTx getWalletTx(const uint256& txid) const override
     {
         LOCK(m_wallet->cs_wallet);
         auto mi = m_wallet->mapWallet.find(txid);
@@ -320,7 +320,7 @@ public:
         }
         return {};
     }
-    std::set<WalletTx> getWalletTxs() override
+    std::set<WalletTx> getWalletTxs() const override
     {
         LOCK(m_wallet->cs_wallet);
         std::set<WalletTx> result;
@@ -332,7 +332,7 @@ public:
     bool tryGetTxStatus(const uint256& txid,
         interfaces::WalletTxStatus& tx_status,
         int& num_blocks,
-        int64_t& block_time) override
+        int64_t& block_time) const override
     {
         TRY_LOCK(m_wallet->cs_wallet, locked_wallet);
         if (!locked_wallet) {
@@ -352,7 +352,7 @@ public:
         WalletTxStatus& tx_status,
         WalletOrderForm& order_form,
         bool& in_mempool,
-        int& num_blocks) override
+        int& num_blocks) const override
     {
         LOCK(m_wallet->cs_wallet);
         auto mi = m_wallet->mapWallet.find(txid);
@@ -374,7 +374,7 @@ public:
     {
         return m_wallet->FillPSBT(psbtx, complete, sighash_type, sign, bip32derivs, n_signed);
     }
-    WalletBalances getBalances() override
+    WalletBalances getBalances() const override
     {
         const auto bal = GetBalance(*m_wallet);
         WalletBalances result;
@@ -389,7 +389,7 @@ public:
         }
         return result;
     }
-    bool tryGetBalances(WalletBalances& balances, uint256& block_hash) override
+    bool tryGetBalances(WalletBalances& balances, uint256& block_hash) const override
     {
         TRY_LOCK(m_wallet->cs_wallet, locked_wallet);
         if (!locked_wallet) {
@@ -399,37 +399,37 @@ public:
         balances = getBalances();
         return true;
     }
-    CAmount getBalance() override { return GetBalance(*m_wallet).m_mine_trusted; }
-    CAmount getAvailableBalance(const CCoinControl& coin_control) override
+    CAmount getBalance() const override { return GetBalance(*m_wallet).m_mine_trusted; }
+    CAmount getAvailableBalance(const CCoinControl& coin_control) const override
     {
         return GetAvailableBalance(*m_wallet, &coin_control);
     }
-    isminetype txinIsMine(const CTxIn& txin) override
+    isminetype txinIsMine(const CTxIn& txin) const override
     {
         LOCK(m_wallet->cs_wallet);
         return InputIsMine(*m_wallet, txin);
     }
-    isminetype txoutIsMine(const CTxOut& txout) override
+    isminetype txoutIsMine(const CTxOut& txout) const override
     {
         LOCK(m_wallet->cs_wallet);
         return m_wallet->IsMine(txout);
     }
-    isminetype destIsMine(const CTxDestination& dest) override
+    isminetype destIsMine(const CTxDestination& dest) const override
     {
         LOCK(m_wallet->cs_wallet);
         return m_wallet->IsMine(dest);
     }
-    CAmount getDebit(const CTxIn& txin, isminefilter filter) override
+    CAmount getDebit(const CTxIn& txin, isminefilter filter) const override
     {
         LOCK(m_wallet->cs_wallet);
         return m_wallet->GetDebit(txin, filter);
     }
-    CAmount getCredit(const CTxOut& txout, isminefilter filter) override
+    CAmount getCredit(const CTxOut& txout, isminefilter filter) const override
     {
         LOCK(m_wallet->cs_wallet);
         return OutputGetCredit(*m_wallet, txout, filter);
     }
-    CoinsList listCoins() override
+    CoinsList listCoins() const override
     {
         LOCK(m_wallet->cs_wallet);
         CoinsList result;
@@ -442,7 +442,7 @@ public:
         }
         return result;
     }
-    std::vector<WalletTxOut> getCoins(const std::vector<COutPoint>& outputs) override
+    std::vector<WalletTxOut> getCoins(const std::vector<COutPoint>& outputs) const override
     {
         LOCK(m_wallet->cs_wallet);
         std::vector<WalletTxOut> result;
@@ -459,11 +459,11 @@ public:
         }
         return result;
     }
-    CAmount getRequiredFee(unsigned int tx_bytes) override { return GetRequiredFee(*m_wallet, tx_bytes); }
+    CAmount getRequiredFee(unsigned int tx_bytes) const override { return GetRequiredFee(*m_wallet, tx_bytes); }
     CAmount getMinimumFee(unsigned int tx_bytes,
         const CCoinControl& coin_control,
         int* returned_target,
-        FeeReason* reason) override
+        FeeReason* reason) const override
     {
         FeeCalculation fee_calc;
         CAmount result;
@@ -472,23 +472,23 @@ public:
         if (reason) *reason = fee_calc.reason;
         return result;
     }
-    unsigned int getConfirmTarget() override { return m_wallet->m_confirm_target; }
-    bool hdEnabled() override { return m_wallet->IsHDEnabled(); }
-    bool canGetAddresses() override { return m_wallet->CanGetAddresses(); }
-    bool hasExternalSigner() override { return m_wallet->IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER); }
-    bool privateKeysDisabled() override { return m_wallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS); }
-    bool taprootEnabled() override {
+    unsigned int getConfirmTarget() const override { return m_wallet->m_confirm_target; }
+    bool hdEnabled() const override { return m_wallet->IsHDEnabled(); }
+    bool canGetAddresses() const override { return m_wallet->CanGetAddresses(); }
+    bool hasExternalSigner() const override { return m_wallet->IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER); }
+    bool privateKeysDisabled() const override { return m_wallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS); }
+    bool taprootEnabled() const override {
         if (m_wallet->IsLegacy()) return false;
         auto spk_man = m_wallet->GetScriptPubKeyMan(OutputType::BECH32M, /*internal=*/false);
         return spk_man != nullptr;
     }
-    OutputType getDefaultAddressType() override { return m_wallet->m_default_address_type; }
-    CAmount getDefaultMaxTxFee() override { return m_wallet->m_default_max_tx_fee; }
+    OutputType getDefaultAddressType() const override { return m_wallet->m_default_address_type; }
+    CAmount getDefaultMaxTxFee() const override { return m_wallet->m_default_max_tx_fee; }
     void remove() override
     {
         RemoveWallet(m_context, m_wallet, false /* load_on_start */);
     }
-    bool isLegacy() override { return m_wallet->IsLegacy(); }
+    bool isLegacy() const override { return m_wallet->IsLegacy(); }
     std::unique_ptr<Handler> handleUnload(UnloadFn fn) override
     {
         return MakeHandler(m_wallet->NotifyUnload.connect(fn));

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <core_io.h>
+#include <interfaces/wallet.h>
 #include <key_io.h>
 #include <rpc/util.h>
 #include <util/moneystr.h>
@@ -406,13 +407,11 @@ RPCHelpMan listlockunspent()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    const std::shared_ptr<const CWallet> pwallet = GetWalletForJSONRPCRequest(request);
+    const auto pwallet = GetWalletInterfaceForJSONRPCRequest(request);
     if (!pwallet) return UniValue::VNULL;
 
-    LOCK(pwallet->cs_wallet);
-
     std::vector<COutPoint> vOutpts;
-    pwallet->ListLockedCoins(vOutpts);
+    pwallet->listLockedCoins(vOutpts);
 
     UniValue ret(UniValue::VARR);
 

--- a/src/wallet/rpc/encrypt.cpp
+++ b/src/wallet/rpc/encrypt.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <interfaces/wallet.h>
 #include <rpc/util.h>
 #include <wallet/rpc/util.h>
 #include <wallet/wallet.h>
@@ -119,12 +120,10 @@ RPCHelpMan walletpassphrasechange()
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
+    const auto pwallet = GetWalletInterfaceForJSONRPCRequest(request);
     if (!pwallet) return UniValue::VNULL;
 
-    LOCK(pwallet->cs_wallet);
-
-    if (!pwallet->IsCrypted()) {
+    if (!pwallet->isCrypted()) {
         throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: running with an unencrypted wallet, but walletpassphrasechange was called.");
     }
 
@@ -142,7 +141,7 @@ RPCHelpMan walletpassphrasechange()
         throw JSONRPCError(RPC_INVALID_PARAMETER, "passphrase cannot be empty");
     }
 
-    if (!pwallet->ChangeWalletPassphrase(strOldWalletPass, strNewWalletPass)) {
+    if (!pwallet->changeWalletPassphrase(strOldWalletPass, strNewWalletPass)) {
         throw JSONRPCError(RPC_WALLET_PASSPHRASE_INCORRECT, "Error: The wallet passphrase entered was incorrect.");
     }
 

--- a/src/wallet/rpc/signmessage.cpp
+++ b/src/wallet/rpc/signmessage.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <interfaces/wallet.h>
 #include <key_io.h>
 #include <rpc/util.h>
 #include <util/message.h>
 #include <wallet/rpc/util.h>
-#include <wallet/wallet.h>
 
 #include <univalue.h>
 
@@ -35,10 +35,8 @@ RPCHelpMan signmessage()
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
         {
-            const std::shared_ptr<const CWallet> pwallet = GetWalletForJSONRPCRequest(request);
+            const auto pwallet = GetWalletInterfaceForJSONRPCRequest(request);
             if (!pwallet) return UniValue::VNULL;
-
-            LOCK(pwallet->cs_wallet);
 
             EnsureWalletIsUnlocked(*pwallet);
 
@@ -56,7 +54,7 @@ RPCHelpMan signmessage()
             }
 
             std::string signature;
-            SigningResult err = pwallet->SignMessage(strMessage, *pkhash, signature);
+            SigningResult err = pwallet->signMessage(strMessage, *pkhash, signature);
             if (err == SigningResult::SIGNING_FAILED) {
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, SigningResultString(err));
             } else if (err != SigningResult::OK) {

--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -91,6 +91,13 @@ void EnsureWalletIsUnlocked(const CWallet& wallet)
     }
 }
 
+void EnsureWalletIsUnlocked(const interfaces::Wallet& wallet)
+{
+    if (wallet.isLocked()) {
+        throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");
+    }
+}
+
 WalletContext& EnsureWalletContext(const std::any& context)
 {
     auto wallet_context = util::AnyPtr<WalletContext>(context);

--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -4,6 +4,7 @@
 
 #include <wallet/rpc/util.h>
 
+#include <interfaces/wallet.h>
 #include <rpc/util.h>
 #include <util/translation.h>
 #include <util/url.h>
@@ -74,6 +75,13 @@ std::shared_ptr<CWallet> GetWalletForJSONRPCRequest(const JSONRPCRequest& reques
     }
     throw JSONRPCError(RPC_WALLET_NOT_SPECIFIED,
         "Wallet file not specified (must request wallet RPC through /wallet/<filename> uri-path).");
+}
+
+std::shared_ptr<interfaces::Wallet> GetWalletInterfaceForJSONRPCRequest(const JSONRPCRequest& request)
+{
+    WalletContext& context = EnsureWalletContext(request.context);
+    auto wallet = GetWalletForJSONRPCRequest(request);
+    return MakeWallet(context, wallet);
 }
 
 void EnsureWalletIsUnlocked(const CWallet& wallet)

--- a/src/wallet/rpc/util.h
+++ b/src/wallet/rpc/util.h
@@ -39,6 +39,7 @@ std::shared_ptr<interfaces::Wallet> GetWalletInterfaceForJSONRPCRequest(const JS
 bool GetWalletNameFromJSONRPCRequest(const JSONRPCRequest& request, std::string& wallet_name);
 
 void EnsureWalletIsUnlocked(const CWallet&);
+void EnsureWalletIsUnlocked(const interfaces::Wallet&);
 WalletContext& EnsureWalletContext(const std::any& context);
 LegacyScriptPubKeyMan& EnsureLegacyScriptPubKeyMan(CWallet& wallet, bool also_create = false);
 const LegacyScriptPubKeyMan& EnsureConstLegacyScriptPubKeyMan(const CWallet& wallet);

--- a/src/wallet/rpc/util.h
+++ b/src/wallet/rpc/util.h
@@ -16,6 +16,10 @@ class JSONRPCRequest;
 class UniValue;
 struct bilingual_str;
 
+namespace interfaces {
+class Wallet;
+} // namespace interfaces
+
 namespace wallet {
 class CWallet;
 class LegacyScriptPubKeyMan;
@@ -31,6 +35,7 @@ extern const std::string HELP_REQUIRING_PASSPHRASE;
  * @return nullptr if no wallet should be used, or a pointer to the CWallet
  */
 std::shared_ptr<CWallet> GetWalletForJSONRPCRequest(const JSONRPCRequest& request);
+std::shared_ptr<interfaces::Wallet> GetWalletInterfaceForJSONRPCRequest(const JSONRPCRequest& request);
 bool GetWalletNameFromJSONRPCRequest(const JSONRPCRequest& request, std::string& wallet_name);
 
 void EnsureWalletIsUnlocked(const CWallet&);


### PR DESCRIPTION
This is a minimal "step 1" to migrating wallet RPC methods to access via the abstract interfaces. Only trivial methods are ported at this stage.

Long term goal is to support different actual wallet classes (in particular, core-lighting wallets) which won't have remotely the same internals as Bitcoin Core wallets.