### PR TITLE
build: remove BOOST_CPPFLAGS usage from bitcoin-tx

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -772,7 +772,7 @@ bitcoin_cli_LDADD += $(EVENT_LIBS)
 
 # bitcoin-tx binary #
 bitcoin_tx_SOURCES = bitcoin-tx.cpp
-bitcoin_tx_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS)
+bitcoin_tx_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 bitcoin_tx_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 bitcoin_tx_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(PTHREAD_FLAGS)
 

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -15,7 +15,6 @@
 #include <key_io.h>
 #include <fs.h>
 #include <policy/policy.h>
-#include <policy/rbf.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <script/sign.h>


### PR DESCRIPTION
The only reason `BOOST_CPPFLAGS` was needed here, is because of the `policy/rbf.h` include, which ultimately includes boost multi_index via `txmempool.h`. However this include is unused.