### PR TITLE
build: prune BOOST_CPPFLAGS from libbitcoin_zmq

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -439,7 +439,7 @@ libbitcoin_node_a_SOURCES += dummywallet.cpp
 endif
 
 if ENABLE_ZMQ
-libbitcoin_zmq_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS) $(ZMQ_CFLAGS)
+libbitcoin_zmq_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(ZMQ_CFLAGS)
 libbitcoin_zmq_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_zmq_a_SOURCES = \
   zmq/zmqabstractnotifier.cpp \

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -8,7 +8,7 @@
 
 #include <zmq.h>
 
-#include <validation.h>
+#include <primitives/block.h>
 #include <util/system.h>
 
 CZMQNotificationInterface::CZMQNotificationInterface() : pcontext(nullptr)

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -11,7 +11,6 @@
 #include <rpc/server.h>
 #include <streams.h>
 #include <util/system.h>
-#include <validation.h> // For cs_main
 #include <zmq/zmqutil.h>
 
 #include <zmq.h>


### PR DESCRIPTION
Rather than including `validation.h`, which ultimately means needing boost via `txmempool.h`, include `primitives/block.h` for `CBlock`, and remove `validation.h`, as we can get `cs_main` from `node/blockstorage.h`.