### PR TITLE
doc: clarify that NetPermissionFlags::Implicit is only about whitelists

### DIFF
--- a/src/net_permissions.h
+++ b/src/net_permissions.h
@@ -35,7 +35,8 @@ enum class NetPermissionFlags : uint32_t {
     // unlimited amounts of addrs.
     Addr = (1U << 7),
 
-    // True if the user did not specifically set fine grained permissions
+    // True if the user did not specifically set fine-grained permissions with
+    // the -whitebind or -whitelist configuration options.
     Implicit = (1U << 31),
     All = BloomFilter | ForceRelay | Relay | NoBan | Mempool | Download | Addr,
 };


### PR DESCRIPTION
`NetPermissionFlags::Implicit` applies just to connections from `-whitebind` or `-whitelist`, clarify that in its comment.