### PR TITLE
coin selection: Check whether feerate is higher than long_term_feerate only once

### DIFF
--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -86,6 +86,7 @@ std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_poo
     CAmount curr_waste = 0;
     std::vector<size_t> best_selection;
     CAmount best_waste = MAX_MONEY;
+    bool is_high_feerate = utxo_pool.at(0).fee > utxo_pool.at(0).long_term_fee;
 
     // Depth First search loop for choosing the UTXOs
     for (size_t curr_try = 0, utxo_pool_index = 0; curr_try < TOTAL_TRIES; ++curr_try, ++utxo_pool_index) {
@@ -93,7 +94,7 @@ std::optional<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_poo
         bool backtrack = false;
         if (curr_value + curr_available_value < selection_target || // Cannot possibly reach target with the amount remaining in the curr_available_value.
             curr_value > selection_target + cost_of_change || // Selected value is out of range, go back and try other branch
-            (curr_waste > best_waste && (utxo_pool.at(0).fee - utxo_pool.at(0).long_term_fee) > 0)) { // Don't select things which we know will be more wasteful if the waste is increasing
+            (is_high_feerate && curr_waste > best_waste)) { // Don't select things which we know will be more wasteful if the waste is increasing
             backtrack = true;
         } else if (curr_value >= selection_target) {       // Selected value is within range
             curr_waste += (curr_value - selection_target); // This is the excess value which is added to the waste for the below comparison


### PR DESCRIPTION
This moves code that is loop invariant outside of the loop and thus will cause us to only evaluate the inequality and fee lookups once instead of every time we get to the backtrack check.

I would expect this to slightly improve the performance of the backtrack evaluation in the branch and bound algorithm.