### PR TITLE
Use ReadLE64 in uint256::GetUint64 instead of duplicating logic

### DIFF
--- a/src/uint256.h
+++ b/src/uint256.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_UINT256_H
 #define BITCOIN_UINT256_H
 
+#include <crypto/common.h>
 #include <span.h>
 
 #include <assert.h>
@@ -84,15 +85,7 @@ public:
 
     uint64_t GetUint64(int pos) const
     {
-        const uint8_t* ptr = m_data + pos * 8;
-        return ((uint64_t)ptr[0]) | \
-               ((uint64_t)ptr[1]) << 8 | \
-               ((uint64_t)ptr[2]) << 16 | \
-               ((uint64_t)ptr[3]) << 24 | \
-               ((uint64_t)ptr[4]) << 32 | \
-               ((uint64_t)ptr[5]) << 40 | \
-               ((uint64_t)ptr[6]) << 48 | \
-               ((uint64_t)ptr[7]) << 56;
+        return ReadLE64(m_data + pos * 8);
     }
 
     template<typename Stream>


### PR DESCRIPTION
No need to have a (naive) copy of the `ReadLE64` logic inside `uint256::GetUint64`, when we have an optimized function for exactly that.