### PR TITLE
net: Make AddrFetch connections to fixed seeds

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -648,7 +648,7 @@ Threads
     : Application level message handling (sending and receiving). Almost
     all net_processing and validation logic runs on this thread.
 
-  - [ThreadDNSAddressSeed (`b-dnsseed`)](https://doxygen.bitcoincore.org/class_c_connman.html#aa7c6970ed98a4a7bafbc071d24897d13)
+  - [ThreadAddressSeed (`b-addrseed`)](https://doxygen.bitcoincore.org/class_c_connman.html#aa7c6970ed98a4a7bafbc071d24897d13)
     : Loads addresses of peers from the DNS.
 
   - ThreadMapPort (`b-mapport`)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2182,7 +2182,7 @@ void CConnman::WakeMessageHandler()
     condMsgProc.notify_one();
 }
 
-void CConnman::ThreadDNSAddressSeed()
+void CConnman::ThreadAddressSeed()
 {
     constexpr int TARGET_OUTBOUND_CONNECTIONS = 2;
     int outbound_connection_count = 0;
@@ -3300,7 +3300,7 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
     if (!gArgs.GetBoolArg("-dnsseed", DEFAULT_DNSSEED))
         LogPrintf("DNS seeding disabled\n");
     else
-        threadDNSAddressSeed = std::thread(&util::TraceThread, "dnsseed", [this] { ThreadDNSAddressSeed(); });
+        threadAddressSeed = std::thread(&util::TraceThread, "addrseed", [this] { ThreadAddressSeed(); });
 
     // Initiate manual connections
     threadOpenAddedConnections = std::thread(&util::TraceThread, "addcon", [this] { ThreadOpenAddedConnections(); });
@@ -3389,8 +3389,8 @@ void CConnman::StopThreads()
         threadOpenConnections.join();
     if (threadOpenAddedConnections.joinable())
         threadOpenAddedConnections.join();
-    if (threadDNSAddressSeed.joinable())
-        threadDNSAddressSeed.join();
+    if (threadAddressSeed.joinable())
+        threadAddressSeed.join();
     if (threadSocketHandler.joinable())
         threadSocketHandler.join();
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2184,141 +2184,145 @@ void CConnman::WakeMessageHandler()
 
 void CConnman::ThreadAddressSeed()
 {
-    constexpr int TARGET_OUTBOUND_CONNECTIONS = 2;
-    int outbound_connection_count = 0;
+    if (gArgs.GetBoolArg("-dnsseed", DEFAULT_DNSSEED)) {
+        constexpr int TARGET_OUTBOUND_CONNECTIONS = 2;
+        int outbound_connection_count = 0;
 
-    if (gArgs.IsArgSet("-seednode")) {
-        auto start = NodeClock::now();
-        constexpr std::chrono::seconds SEEDNODE_TIMEOUT = 30s;
-        LogPrintf("-seednode enabled. Trying the provided seeds for %d seconds before defaulting to the dnsseeds.\n", SEEDNODE_TIMEOUT.count());
-        while (!interruptNet) {
-            if (!interruptNet.sleep_for(std::chrono::milliseconds(500)))
-                return;
+        if (gArgs.IsArgSet("-seednode")) {
+            auto start = NodeClock::now();
+            constexpr std::chrono::seconds SEEDNODE_TIMEOUT = 30s;
+            LogPrintf("-seednode enabled. Trying the provided seeds for %d seconds before defaulting to the dnsseeds.\n", SEEDNODE_TIMEOUT.count());
+            while (!interruptNet) {
+                if (!interruptNet.sleep_for(std::chrono::milliseconds(500)))
+                    return;
 
-            // Abort if we have spent enough time without reaching our target.
-            // Giving seed nodes 30 seconds so this does not become a race against fixedseeds (which triggers after 1 min)
-            if (NodeClock::now() > start + SEEDNODE_TIMEOUT) {
-                LogPrintf("Couldn't connect to enough peers via seed nodes. Handing fetch logic to the DNS seeds.\n");
-                break;
-            }
+                // Abort if we have spent enough time without reaching our target.
+                // Giving seed nodes 30 seconds so this does not become a race against fixedseeds (which triggers after 1 min)
+                if (NodeClock::now() > start + SEEDNODE_TIMEOUT) {
+                    LogPrintf("Couldn't connect to enough peers via seed nodes. Handing fetch logic to the DNS seeds.\n");
+                    break;
+                }
 
-            outbound_connection_count = GetFullOutboundConnCount();
-            if (outbound_connection_count >= TARGET_OUTBOUND_CONNECTIONS) {
-                LogPrintf("P2P peers available. Finished fetching data from seed nodes.\n");
-                break;
+                outbound_connection_count = GetFullOutboundConnCount();
+                if (outbound_connection_count >= TARGET_OUTBOUND_CONNECTIONS) {
+                    LogPrintf("P2P peers available. Finished fetching data from seed nodes.\n");
+                    break;
+                }
             }
         }
-    }
 
-    FastRandomContext rng;
-    std::vector<std::string> seeds = m_params.DNSSeeds();
-    std::shuffle(seeds.begin(), seeds.end(), rng);
-    int seeds_right_now = 0; // Number of seeds left before testing if we have enough connections
+        FastRandomContext rng;
+        std::vector<std::string> seeds = m_params.DNSSeeds();
+        std::shuffle(seeds.begin(), seeds.end(), rng);
+        int seeds_right_now = 0; // Number of seeds left before testing if we have enough connections
 
-    if (gArgs.GetBoolArg("-forcednsseed", DEFAULT_FORCEDNSSEED)) {
-        // When -forcednsseed is provided, query all.
-        seeds_right_now = seeds.size();
-    } else if (addrman.Size() == 0) {
-        // If we have no known peers, query all.
-        // This will occur on the first run, or if peers.dat has been
-        // deleted.
-        seeds_right_now = seeds.size();
-    }
+        if (gArgs.GetBoolArg("-forcednsseed", DEFAULT_FORCEDNSSEED)) {
+            // When -forcednsseed is provided, query all.
+            seeds_right_now = seeds.size();
+        } else if (addrman.Size() == 0) {
+            // If we have no known peers, query all.
+            // This will occur on the first run, or if peers.dat has been
+            // deleted.
+            seeds_right_now = seeds.size();
+        }
 
-    // Proceed with dnsseeds if seednodes hasn't reached the target or if forcednsseed is set
-    if (outbound_connection_count < TARGET_OUTBOUND_CONNECTIONS || seeds_right_now) {
-        // goal: only query DNS seed if address need is acute
-        // * If we have a reasonable number of peers in addrman, spend
-        //   some time trying them first. This improves user privacy by
-        //   creating fewer identifying DNS requests, reduces trust by
-        //   giving seeds less influence on the network topology, and
-        //   reduces traffic to the seeds.
-        // * When querying DNS seeds query a few at once, this ensures
-        //   that we don't give DNS seeds the ability to eclipse nodes
-        //   that query them.
-        // * If we continue having problems, eventually query all the
-        //   DNS seeds, and if that fails too, also try the fixed seeds.
-        //   (done in ThreadOpenConnections)
-        int found = 0;
-        const std::chrono::seconds seeds_wait_time = (addrman.Size() >= DNSSEEDS_DELAY_PEER_THRESHOLD ? DNSSEEDS_DELAY_MANY_PEERS : DNSSEEDS_DELAY_FEW_PEERS);
+        // Proceed with dnsseeds if seednodes hasn't reached the target or if forcednsseed is set
+        if (outbound_connection_count < TARGET_OUTBOUND_CONNECTIONS || seeds_right_now) {
+            // goal: only query DNS seed if address need is acute
+            // * If we have a reasonable number of peers in addrman, spend
+            //   some time trying them first. This improves user privacy by
+            //   creating fewer identifying DNS requests, reduces trust by
+            //   giving seeds less influence on the network topology, and
+            //   reduces traffic to the seeds.
+            // * When querying DNS seeds query a few at once, this ensures
+            //   that we don't give DNS seeds the ability to eclipse nodes
+            //   that query them.
+            // * If we continue having problems, eventually query all the
+            //   DNS seeds, and if that fails too, also try the fixed seeds.
+            //   (done in ThreadOpenConnections)
+            int found = 0;
+            const std::chrono::seconds seeds_wait_time = (addrman.Size() >= DNSSEEDS_DELAY_PEER_THRESHOLD ? DNSSEEDS_DELAY_MANY_PEERS : DNSSEEDS_DELAY_FEW_PEERS);
 
-        for (const std::string& seed : seeds) {
-            if (seeds_right_now == 0) {
-                seeds_right_now += DNSSEEDS_TO_QUERY_AT_ONCE;
+            for (const std::string& seed : seeds) {
+                if (seeds_right_now == 0) {
+                    seeds_right_now += DNSSEEDS_TO_QUERY_AT_ONCE;
 
-                if (addrman.Size() > 0) {
-                    LogPrintf("Waiting %d seconds before querying DNS seeds.\n", seeds_wait_time.count());
-                    std::chrono::seconds to_wait = seeds_wait_time;
-                    while (to_wait.count() > 0) {
-                        // if sleeping for the MANY_PEERS interval, wake up
-                        // early to see if we have enough peers and can stop
-                        // this thread entirely freeing up its resources
-                        std::chrono::seconds w = std::min(DNSSEEDS_DELAY_FEW_PEERS, to_wait);
-                        if (!interruptNet.sleep_for(w)) return;
-                        to_wait -= w;
+                    if (addrman.Size() > 0) {
+                        LogPrintf("Waiting %d seconds before querying DNS seeds.\n", seeds_wait_time.count());
+                        std::chrono::seconds to_wait = seeds_wait_time;
+                        while (to_wait.count() > 0) {
+                            // if sleeping for the MANY_PEERS interval, wake up
+                            // early to see if we have enough peers and can stop
+                            // this thread entirely freeing up its resources
+                            std::chrono::seconds w = std::min(DNSSEEDS_DELAY_FEW_PEERS, to_wait);
+                            if (!interruptNet.sleep_for(w)) return;
+                            to_wait -= w;
 
-                        if (GetFullOutboundConnCount() >= TARGET_OUTBOUND_CONNECTIONS) {
-                            if (found > 0) {
-                                LogPrintf("%d addresses found from DNS seeds\n", found);
-                                LogPrintf("P2P peers available. Finished DNS seeding.\n");
-                            } else {
-                                LogPrintf("P2P peers available. Skipped DNS seeding.\n");
+                            if (GetFullOutboundConnCount() >= TARGET_OUTBOUND_CONNECTIONS) {
+                                if (found > 0) {
+                                    LogPrintf("%d addresses found from DNS seeds\n", found);
+                                    LogPrintf("P2P peers available. Finished DNS seeding.\n");
+                                } else {
+                                    LogPrintf("P2P peers available. Skipped DNS seeding.\n");
+                                }
+                                return;
                             }
-                            return;
                         }
                     }
                 }
-            }
 
-            if (interruptNet) return;
+                if (interruptNet) return;
 
-            // hold off on querying seeds if P2P network deactivated
-            if (!fNetworkActive) {
-                LogPrintf("Waiting for network to be reactivated before querying DNS seeds.\n");
-                do {
-                    if (!interruptNet.sleep_for(std::chrono::seconds{1})) return;
-                } while (!fNetworkActive);
-            }
-
-            LogPrintf("Loading addresses from DNS seed %s\n", seed);
-            // If -proxy is in use, we make an ADDR_FETCH connection to the DNS resolved peer address
-            // for the base dns seed domain in chainparams
-            if (HaveNameProxy()) {
-                AddAddrFetch(seed);
-            } else {
-                std::vector<CAddress> vAdd;
-                constexpr ServiceFlags requiredServiceBits{SeedsServiceFlags()};
-                std::string host = strprintf("x%x.%s", requiredServiceBits, seed);
-                CNetAddr resolveSource;
-                if (!resolveSource.SetInternal(host)) {
-                    continue;
+                // hold off on querying seeds if P2P network deactivated
+                if (!fNetworkActive) {
+                    LogPrintf("Waiting for network to be reactivated before querying DNS seeds.\n");
+                    do {
+                        if (!interruptNet.sleep_for(std::chrono::seconds{1})) return;
+                    } while (!fNetworkActive);
                 }
-                // Limit number of IPs learned from a single DNS seed. This limit exists to prevent the results from
-                // one DNS seed from dominating AddrMan. Note that the number of results from a UDP DNS query is
-                // bounded to 33 already, but it is possible for it to use TCP where a larger number of results can be
-                // returned.
-                unsigned int nMaxIPs = 32;
-                const auto addresses{LookupHost(host, nMaxIPs, true)};
-                if (!addresses.empty()) {
-                    for (const CNetAddr& ip : addresses) {
-                        CAddress addr = CAddress(CService(ip, m_params.GetDefaultPort()), requiredServiceBits);
-                        addr.nTime = rng.rand_uniform_delay(Now<NodeSeconds>() - 3 * 24h, -4 * 24h); // use a random age between 3 and 7 days old
-                        vAdd.push_back(addr);
-                        found++;
-                    }
-                    addrman.Add(vAdd, resolveSource);
-                } else {
-                    // If the seed does not support a subdomain with our desired service bits,
-                    // we make an ADDR_FETCH connection to the DNS resolved peer address for the
-                    // base dns seed domain in chainparams
+
+                LogPrintf("Loading addresses from DNS seed %s\n", seed);
+                // If -proxy is in use, we make an ADDR_FETCH connection to the DNS resolved peer address
+                // for the base dns seed domain in chainparams
+                if (HaveNameProxy()) {
                     AddAddrFetch(seed);
+                } else {
+                    std::vector<CAddress> vAdd;
+                    constexpr ServiceFlags requiredServiceBits{SeedsServiceFlags()};
+                    std::string host = strprintf("x%x.%s", requiredServiceBits, seed);
+                    CNetAddr resolveSource;
+                    if (!resolveSource.SetInternal(host)) {
+                        continue;
+                    }
+                    // Limit number of IPs learned from a single DNS seed. This limit exists to prevent the results from
+                    // one DNS seed from dominating AddrMan. Note that the number of results from a UDP DNS query is
+                    // bounded to 33 already, but it is possible for it to use TCP where a larger number of results can be
+                    // returned.
+                    unsigned int nMaxIPs = 32;
+                    const auto addresses{LookupHost(host, nMaxIPs, true)};
+                    if (!addresses.empty()) {
+                        for (const CNetAddr& ip : addresses) {
+                            CAddress addr = CAddress(CService(ip, m_params.GetDefaultPort()), requiredServiceBits);
+                            addr.nTime = rng.rand_uniform_delay(Now<NodeSeconds>() - 3 * 24h, -4 * 24h); // use a random age between 3 and 7 days old
+                            vAdd.push_back(addr);
+                            found++;
+                        }
+                        addrman.Add(vAdd, resolveSource);
+                    } else {
+                        // If the seed does not support a subdomain with our desired service bits,
+                        // we make an ADDR_FETCH connection to the DNS resolved peer address for the
+                        // base dns seed domain in chainparams
+                        AddAddrFetch(seed);
+                    }
                 }
+                --seeds_right_now;
             }
-            --seeds_right_now;
+            LogPrintf("%d addresses found from DNS seeds\n", found);
+        } else {
+            LogPrintf("Skipping DNS seeds. Enough peers have been found\n");
         }
-        LogPrintf("%d addresses found from DNS seeds\n", found);
     } else {
-        LogPrintf("Skipping DNS seeds. Enough peers have been found\n");
+        LogPrintf("DNS seeding disabled\n");
     }
 }
 
@@ -3297,10 +3301,7 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
     // Send and receive from sockets, accept connections
     threadSocketHandler = std::thread(&util::TraceThread, "net", [this] { ThreadSocketHandler(); });
 
-    if (!gArgs.GetBoolArg("-dnsseed", DEFAULT_DNSSEED))
-        LogPrintf("DNS seeding disabled\n");
-    else
-        threadAddressSeed = std::thread(&util::TraceThread, "addrseed", [this] { ThreadAddressSeed(); });
+    threadAddressSeed = std::thread(&util::TraceThread, "addrseed", [this] { ThreadAddressSeed(); });
 
     // Initiate manual connections
     threadOpenAddedConnections = std::thread(&util::TraceThread, "addcon", [this] { ThreadOpenAddedConnections(); });

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2361,6 +2361,28 @@ void CConnman::ProcessFixedSeeds(std::chrono::microseconds start)
                 seed_addrs.erase(std::remove_if(seed_addrs.begin(), seed_addrs.end(),
                                                 [&fixed_seed_networks](const CAddress& addr) { return fixed_seed_networks.count(addr.GetNetwork()) == 0; }),
                                  seed_addrs.end());
+                std::shuffle(seed_addrs.begin(), seed_addrs.end(), FastRandomContext());
+
+
+                // Make AddrFetch connections to fixed seeds first. This reduces the
+                // load on the fixed seeds that would otherwise be serving blocks for
+                // many new peers requiring IBD. Try this with multiple fixed seeds for
+                // a better diversity of received addrs and because some may be offline.
+                LogPrintf("Initiating AddrFetch connections to fixed seeds. This might take up to 2 minutes.\n");
+                for (size_t addr_pos = 0; addr_pos < 10; ++addr_pos) {
+                    if (addr_pos >= seed_addrs.size()) {
+                        break;
+                    }
+                    AddAddrFetch(seed_addrs.at(addr_pos).ToStringAddr());
+                }
+                // Give AddrFetch peers some time to provide us with addresses
+                // before adding the fixed seeds to AddrMan
+                if (!interruptNet.sleep_for(std::chrono::minutes(2))) {
+                    return;
+                }
+                // The fixed seeds queried in the previous steps might have been offline,
+                // failed to send us any addresses or sent us fake ones. Therefore,
+                // we now add all reachable fixed seeds to AddrMan as a fallback.
                 CNetAddr local;
                 local.SetInternal("fixedseeds");
                 addrman.Add(seed_addrs, local);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2182,145 +2182,150 @@ void CConnman::WakeMessageHandler()
     condMsgProc.notify_one();
 }
 
+void CConnman::QueryDNSSeeds()
+{
+    constexpr int TARGET_OUTBOUND_CONNECTIONS = 2;
+    int outbound_connection_count = 0;
+
+    if (gArgs.IsArgSet("-seednode")) {
+        auto start = NodeClock::now();
+        constexpr std::chrono::seconds SEEDNODE_TIMEOUT = 30s;
+        LogPrintf("-seednode enabled. Trying the provided seeds for %d seconds before defaulting to the dnsseeds.\n", SEEDNODE_TIMEOUT.count());
+        while (!interruptNet) {
+            if (!interruptNet.sleep_for(std::chrono::milliseconds(500)))
+                return;
+
+            // Abort if we have spent enough time without reaching our target.
+            // Giving seed nodes 30 seconds so this does not become a race against fixedseeds (which triggers after 1 min)
+            if (NodeClock::now() > start + SEEDNODE_TIMEOUT) {
+                LogPrintf("Couldn't connect to enough peers via seed nodes. Handing fetch logic to the DNS seeds.\n");
+                break;
+            }
+
+            outbound_connection_count = GetFullOutboundConnCount();
+            if (outbound_connection_count >= TARGET_OUTBOUND_CONNECTIONS) {
+                LogPrintf("P2P peers available. Finished fetching data from seed nodes.\n");
+                break;
+            }
+        }
+    }
+
+    FastRandomContext rng;
+    std::vector<std::string> seeds = m_params.DNSSeeds();
+    std::shuffle(seeds.begin(), seeds.end(), rng);
+    int seeds_right_now = 0; // Number of seeds left before testing if we have enough connections
+
+    if (gArgs.GetBoolArg("-forcednsseed", DEFAULT_FORCEDNSSEED)) {
+        // When -forcednsseed is provided, query all.
+        seeds_right_now = seeds.size();
+    } else if (addrman.Size() == 0) {
+        // If we have no known peers, query all.
+        // This will occur on the first run, or if peers.dat has been
+        // deleted.
+        seeds_right_now = seeds.size();
+    }
+
+    // Proceed with dnsseeds if seednodes hasn't reached the target or if forcednsseed is set
+    if (outbound_connection_count < TARGET_OUTBOUND_CONNECTIONS || seeds_right_now) {
+        // goal: only query DNS seed if address need is acute
+        // * If we have a reasonable number of peers in addrman, spend
+        //   some time trying them first. This improves user privacy by
+        //   creating fewer identifying DNS requests, reduces trust by
+        //   giving seeds less influence on the network topology, and
+        //   reduces traffic to the seeds.
+        // * When querying DNS seeds query a few at once, this ensures
+        //   that we don't give DNS seeds the ability to eclipse nodes
+        //   that query them.
+        // * If we continue having problems, eventually query all the
+        //   DNS seeds, and if that fails too, also try the fixed seeds.
+        //   (done in ThreadOpenConnections)
+        int found = 0;
+        const std::chrono::seconds seeds_wait_time = (addrman.Size() >= DNSSEEDS_DELAY_PEER_THRESHOLD ? DNSSEEDS_DELAY_MANY_PEERS : DNSSEEDS_DELAY_FEW_PEERS);
+
+        for (const std::string& seed : seeds) {
+            if (seeds_right_now == 0) {
+                seeds_right_now += DNSSEEDS_TO_QUERY_AT_ONCE;
+
+                if (addrman.Size() > 0) {
+                    LogPrintf("Waiting %d seconds before querying DNS seeds.\n", seeds_wait_time.count());
+                    std::chrono::seconds to_wait = seeds_wait_time;
+                    while (to_wait.count() > 0) {
+                        // if sleeping for the MANY_PEERS interval, wake up
+                        // early to see if we have enough peers and can stop
+                        // this thread entirely freeing up its resources
+                        std::chrono::seconds w = std::min(DNSSEEDS_DELAY_FEW_PEERS, to_wait);
+                        if (!interruptNet.sleep_for(w)) return;
+                        to_wait -= w;
+
+                        if (GetFullOutboundConnCount() >= TARGET_OUTBOUND_CONNECTIONS) {
+                            if (found > 0) {
+                                LogPrintf("%d addresses found from DNS seeds\n", found);
+                                LogPrintf("P2P peers available. Finished DNS seeding.\n");
+                            } else {
+                                LogPrintf("P2P peers available. Skipped DNS seeding.\n");
+                            }
+                            return;
+                        }
+                    }
+                }
+            }
+
+            if (interruptNet) return;
+
+            // hold off on querying seeds if P2P network deactivated
+            if (!fNetworkActive) {
+                LogPrintf("Waiting for network to be reactivated before querying DNS seeds.\n");
+                do {
+                    if (!interruptNet.sleep_for(std::chrono::seconds{1})) return;
+                } while (!fNetworkActive);
+            }
+
+            LogPrintf("Loading addresses from DNS seed %s\n", seed);
+            // If -proxy is in use, we make an ADDR_FETCH connection to the DNS resolved peer address
+            // for the base dns seed domain in chainparams
+            if (HaveNameProxy()) {
+                AddAddrFetch(seed);
+            } else {
+                std::vector<CAddress> vAdd;
+                constexpr ServiceFlags requiredServiceBits{SeedsServiceFlags()};
+                std::string host = strprintf("x%x.%s", requiredServiceBits, seed);
+                CNetAddr resolveSource;
+                if (!resolveSource.SetInternal(host)) {
+                    continue;
+                }
+                // Limit number of IPs learned from a single DNS seed. This limit exists to prevent the results from
+                // one DNS seed from dominating AddrMan. Note that the number of results from a UDP DNS query is
+                // bounded to 33 already, but it is possible for it to use TCP where a larger number of results can be
+                // returned.
+                unsigned int nMaxIPs = 32;
+                const auto addresses{LookupHost(host, nMaxIPs, true)};
+                if (!addresses.empty()) {
+                    for (const CNetAddr& ip : addresses) {
+                        CAddress addr = CAddress(CService(ip, m_params.GetDefaultPort()), requiredServiceBits);
+                        addr.nTime = rng.rand_uniform_delay(Now<NodeSeconds>() - 3 * 24h, -4 * 24h); // use a random age between 3 and 7 days old
+                        vAdd.push_back(addr);
+                        found++;
+                    }
+                    addrman.Add(vAdd, resolveSource);
+                } else {
+                    // If the seed does not support a subdomain with our desired service bits,
+                    // we make an ADDR_FETCH connection to the DNS resolved peer address for the
+                    // base dns seed domain in chainparams
+                    AddAddrFetch(seed);
+                }
+            }
+            --seeds_right_now;
+        }
+        LogPrintf("%d addresses found from DNS seeds\n", found);
+    } else {
+        LogPrintf("Skipping DNS seeds. Enough peers have been found\n");
+    }
+}
+
 void CConnman::ThreadAddressSeed()
 {
     if (gArgs.GetBoolArg("-dnsseed", DEFAULT_DNSSEED)) {
-        constexpr int TARGET_OUTBOUND_CONNECTIONS = 2;
-        int outbound_connection_count = 0;
-
-        if (gArgs.IsArgSet("-seednode")) {
-            auto start = NodeClock::now();
-            constexpr std::chrono::seconds SEEDNODE_TIMEOUT = 30s;
-            LogPrintf("-seednode enabled. Trying the provided seeds for %d seconds before defaulting to the dnsseeds.\n", SEEDNODE_TIMEOUT.count());
-            while (!interruptNet) {
-                if (!interruptNet.sleep_for(std::chrono::milliseconds(500)))
-                    return;
-
-                // Abort if we have spent enough time without reaching our target.
-                // Giving seed nodes 30 seconds so this does not become a race against fixedseeds (which triggers after 1 min)
-                if (NodeClock::now() > start + SEEDNODE_TIMEOUT) {
-                    LogPrintf("Couldn't connect to enough peers via seed nodes. Handing fetch logic to the DNS seeds.\n");
-                    break;
-                }
-
-                outbound_connection_count = GetFullOutboundConnCount();
-                if (outbound_connection_count >= TARGET_OUTBOUND_CONNECTIONS) {
-                    LogPrintf("P2P peers available. Finished fetching data from seed nodes.\n");
-                    break;
-                }
-            }
-        }
-
-        FastRandomContext rng;
-        std::vector<std::string> seeds = m_params.DNSSeeds();
-        std::shuffle(seeds.begin(), seeds.end(), rng);
-        int seeds_right_now = 0; // Number of seeds left before testing if we have enough connections
-
-        if (gArgs.GetBoolArg("-forcednsseed", DEFAULT_FORCEDNSSEED)) {
-            // When -forcednsseed is provided, query all.
-            seeds_right_now = seeds.size();
-        } else if (addrman.Size() == 0) {
-            // If we have no known peers, query all.
-            // This will occur on the first run, or if peers.dat has been
-            // deleted.
-            seeds_right_now = seeds.size();
-        }
-
-        // Proceed with dnsseeds if seednodes hasn't reached the target or if forcednsseed is set
-        if (outbound_connection_count < TARGET_OUTBOUND_CONNECTIONS || seeds_right_now) {
-            // goal: only query DNS seed if address need is acute
-            // * If we have a reasonable number of peers in addrman, spend
-            //   some time trying them first. This improves user privacy by
-            //   creating fewer identifying DNS requests, reduces trust by
-            //   giving seeds less influence on the network topology, and
-            //   reduces traffic to the seeds.
-            // * When querying DNS seeds query a few at once, this ensures
-            //   that we don't give DNS seeds the ability to eclipse nodes
-            //   that query them.
-            // * If we continue having problems, eventually query all the
-            //   DNS seeds, and if that fails too, also try the fixed seeds.
-            //   (done in ThreadOpenConnections)
-            int found = 0;
-            const std::chrono::seconds seeds_wait_time = (addrman.Size() >= DNSSEEDS_DELAY_PEER_THRESHOLD ? DNSSEEDS_DELAY_MANY_PEERS : DNSSEEDS_DELAY_FEW_PEERS);
-
-            for (const std::string& seed : seeds) {
-                if (seeds_right_now == 0) {
-                    seeds_right_now += DNSSEEDS_TO_QUERY_AT_ONCE;
-
-                    if (addrman.Size() > 0) {
-                        LogPrintf("Waiting %d seconds before querying DNS seeds.\n", seeds_wait_time.count());
-                        std::chrono::seconds to_wait = seeds_wait_time;
-                        while (to_wait.count() > 0) {
-                            // if sleeping for the MANY_PEERS interval, wake up
-                            // early to see if we have enough peers and can stop
-                            // this thread entirely freeing up its resources
-                            std::chrono::seconds w = std::min(DNSSEEDS_DELAY_FEW_PEERS, to_wait);
-                            if (!interruptNet.sleep_for(w)) return;
-                            to_wait -= w;
-
-                            if (GetFullOutboundConnCount() >= TARGET_OUTBOUND_CONNECTIONS) {
-                                if (found > 0) {
-                                    LogPrintf("%d addresses found from DNS seeds\n", found);
-                                    LogPrintf("P2P peers available. Finished DNS seeding.\n");
-                                } else {
-                                    LogPrintf("P2P peers available. Skipped DNS seeding.\n");
-                                }
-                                return;
-                            }
-                        }
-                    }
-                }
-
-                if (interruptNet) return;
-
-                // hold off on querying seeds if P2P network deactivated
-                if (!fNetworkActive) {
-                    LogPrintf("Waiting for network to be reactivated before querying DNS seeds.\n");
-                    do {
-                        if (!interruptNet.sleep_for(std::chrono::seconds{1})) return;
-                    } while (!fNetworkActive);
-                }
-
-                LogPrintf("Loading addresses from DNS seed %s\n", seed);
-                // If -proxy is in use, we make an ADDR_FETCH connection to the DNS resolved peer address
-                // for the base dns seed domain in chainparams
-                if (HaveNameProxy()) {
-                    AddAddrFetch(seed);
-                } else {
-                    std::vector<CAddress> vAdd;
-                    constexpr ServiceFlags requiredServiceBits{SeedsServiceFlags()};
-                    std::string host = strprintf("x%x.%s", requiredServiceBits, seed);
-                    CNetAddr resolveSource;
-                    if (!resolveSource.SetInternal(host)) {
-                        continue;
-                    }
-                    // Limit number of IPs learned from a single DNS seed. This limit exists to prevent the results from
-                    // one DNS seed from dominating AddrMan. Note that the number of results from a UDP DNS query is
-                    // bounded to 33 already, but it is possible for it to use TCP where a larger number of results can be
-                    // returned.
-                    unsigned int nMaxIPs = 32;
-                    const auto addresses{LookupHost(host, nMaxIPs, true)};
-                    if (!addresses.empty()) {
-                        for (const CNetAddr& ip : addresses) {
-                            CAddress addr = CAddress(CService(ip, m_params.GetDefaultPort()), requiredServiceBits);
-                            addr.nTime = rng.rand_uniform_delay(Now<NodeSeconds>() - 3 * 24h, -4 * 24h); // use a random age between 3 and 7 days old
-                            vAdd.push_back(addr);
-                            found++;
-                        }
-                        addrman.Add(vAdd, resolveSource);
-                    } else {
-                        // If the seed does not support a subdomain with our desired service bits,
-                        // we make an ADDR_FETCH connection to the DNS resolved peer address for the
-                        // base dns seed domain in chainparams
-                        AddAddrFetch(seed);
-                    }
-                }
-                --seeds_right_now;
-            }
-            LogPrintf("%d addresses found from DNS seeds\n", found);
-        } else {
-            LogPrintf("Skipping DNS seeds. Enough peers have been found\n");
-        }
+        QueryDNSSeeds();
     } else {
         LogPrintf("DNS seeding disabled\n");
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2325,12 +2325,11 @@ void CConnman::QueryDNSSeeds()
 void CConnman::ProcessFixedSeeds(std::chrono::microseconds start)
 {
     const bool dnsseed = gArgs.GetBoolArg("-dnsseed", DEFAULT_DNSSEED);
-    bool add_fixed_seeds = gArgs.GetBoolArg("-fixedseeds", DEFAULT_FIXEDSEEDS);
     const bool use_seednodes{gArgs.IsArgSet("-seednode")};
 
     while (!interruptNet) {
         const std::unordered_set<Network> fixed_seed_networks{GetReachableEmptyNetworks()};
-        if (add_fixed_seeds && !fixed_seed_networks.empty()) {
+        if (!fixed_seed_networks.empty()) {
             // When the node starts with an empty peers.dat, there are a few other sources of peers before
             // we fallback on to fixed seeds: -dnsseed, -seednode, -addnode
             // If none of those are available, we fallback on to fixed seeds immediately, else we allow
@@ -2365,7 +2364,6 @@ void CConnman::ProcessFixedSeeds(std::chrono::microseconds start)
                 CNetAddr local;
                 local.SetInternal("fixedseeds");
                 addrman.Add(seed_addrs, local);
-                add_fixed_seeds = false;
                 LogPrintf("Added %d fixed seeds from reachable networks.\n", seed_addrs.size());
                 return;
             }

--- a/src/net.h
+++ b/src/net.h
@@ -1323,7 +1323,7 @@ private:
     void SocketHandlerListening(const Sock::EventsPerSock& events_per_sock);
 
     void ThreadSocketHandler() EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex, !mutexMsgProc, !m_nodes_mutex, !m_reconnections_mutex);
-    void ThreadDNSAddressSeed() EXCLUSIVE_LOCKS_REQUIRED(!m_addr_fetches_mutex, !m_nodes_mutex);
+    void ThreadAddressSeed() EXCLUSIVE_LOCKS_REQUIRED(!m_addr_fetches_mutex, !m_nodes_mutex);
 
     uint64_t CalculateKeyedNetGroup(const CAddress& ad) const;
 
@@ -1529,7 +1529,7 @@ private:
      */
     std::unique_ptr<i2p::sam::Session> m_i2p_sam_session;
 
-    std::thread threadDNSAddressSeed;
+    std::thread threadAddressSeed;
     std::thread threadSocketHandler;
     std::thread threadOpenAddedConnections;
     std::thread threadOpenConnections;

--- a/src/net.h
+++ b/src/net.h
@@ -1323,8 +1323,9 @@ private:
     void SocketHandlerListening(const Sock::EventsPerSock& events_per_sock);
 
     void ThreadSocketHandler() EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex, !mutexMsgProc, !m_nodes_mutex, !m_reconnections_mutex);
-    void ThreadAddressSeed() EXCLUSIVE_LOCKS_REQUIRED(!m_addr_fetches_mutex, !m_nodes_mutex);
+    void ThreadAddressSeed() EXCLUSIVE_LOCKS_REQUIRED(!m_addr_fetches_mutex, !m_added_nodes_mutex, !m_nodes_mutex);
     void QueryDNSSeeds() EXCLUSIVE_LOCKS_REQUIRED(!m_addr_fetches_mutex, !m_nodes_mutex);
+    void ProcessFixedSeeds(std::chrono::microseconds start) EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex, !m_addr_fetches_mutex);
 
     uint64_t CalculateKeyedNetGroup(const CAddress& ad) const;
 

--- a/src/net.h
+++ b/src/net.h
@@ -1324,6 +1324,7 @@ private:
 
     void ThreadSocketHandler() EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex, !mutexMsgProc, !m_nodes_mutex, !m_reconnections_mutex);
     void ThreadAddressSeed() EXCLUSIVE_LOCKS_REQUIRED(!m_addr_fetches_mutex, !m_nodes_mutex);
+    void QueryDNSSeeds() EXCLUSIVE_LOCKS_REQUIRED(!m_addr_fetches_mutex, !m_nodes_mutex);
 
     uint64_t CalculateKeyedNetGroup(const CAddress& ad) const;
 

--- a/test/functional/p2p_dns_seeds.py
+++ b/test/functional/p2p_dns_seeds.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test ThreadDNSAddressSeed logic for querying DNS seeds."""
+"""Test ThreadAddressSeed logic for querying DNS seeds."""
 
 import itertools
 


### PR DESCRIPTION
This proposes two things:

1. Make AddrFetch connections to fixed seeds instead of just adding them to AddrMan (suggested in https://github.com/bitcoin/bitcoin/pull/25678#issuecomment-1210858925)
When adding fixed seeds, we currently add them to AddrMan and then make regular full outbound connections to them. If many new nodes use the fixed seeds for this, it will result in them getting a lot of peers requiring IBD, which will create a lot of traffic for them. With an AddrFetch connection, we will only use them to get addresses from other peers and disconnect afterwards.
This PR proposes to attempt making AddrFetch connections to 10 peers for better diversity (some may be offline anyway). The fixed seeds will still be added to Addrman as before, but only after a delay of 2 minutes, after which they will hopefully no longer be the only entries in AddrMan.

2. Move the logic of adding fixed seeds out of `ThreadOpenConnections` into `ThreadDNSAddressSeed` (which is being renamed to `ThreadAddressSeed`).
I think this makes sense in general because adding the fixed seeds is in many ways analogous to querying the DNS seeds, and ThreadOpenConnections, which is there to actually open the connections is already quite complex.
Also, it makes the changes from 1) easier if we don't have to worry about interfering with the automatic connection making logic.

One way to test this is to start without `peers.dat` and run with `-nodnsseed -blocksonly -debug=net` and monitor the debug log and `bitcoin-cli -netinfo` behavior.