### PR TITLE
rpc: Allow importmulti watchonly imports with locked wallet

### DIFF
--- a/test/functional/wallet_importmulti.py
+++ b/test/functional/wallet_importmulti.py
@@ -874,6 +874,25 @@ class ImportMultiTest(BitcoinTestFramework):
             addr = wrpc.getnewaddress('', 'bech32')
             assert_equal(addr, addresses[i])
 
+        # Create wallet with passphrase
+        self.log.info('Test watchonly imports on a wallet with a passphrase, without unlocking')
+        self.nodes[1].createwallet(wallet_name='w1', blank=True, passphrase='pass')
+        wrpc = self.nodes[1].get_wallet_rpc('w1')
+        assert_raises_rpc_error(-13, "Please enter the wallet passphrase with walletpassphrase first.",
+                                wrpc.importmulti, [{
+                                    'desc': descsum_create('wpkh(' + pub1 + ')'),
+                                    "timestamp": "now",
+                                }])
+
+        result = wrpc.importmulti(
+            [{
+                'desc': descsum_create('wpkh(' + pub1 + ')'),
+                "timestamp": "now",
+                "watchonly": True,
+            }]
+        )
+        assert result[0]['success']
+
 
 if __name__ == '__main__':
     ImportMultiTest().main()


### PR DESCRIPTION
Allows watch-only imports on locked wallets with `importmulti`.
Also adds a test.

Fixes #17867.