### PR TITLE
wallet, refactor: FundTransaction(): return out-params as `util::Result` structure

### DIFF
--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -717,11 +717,11 @@ void FundTransaction(CWallet& wallet, CMutableTransaction& tx, CAmount& fee_out,
         setSubtractFeeFromOutputs.insert(pos);
     }
 
-    bilingual_str error;
+    auto res = FundTransaction(wallet, tx, change_position, lockUnspents, setSubtractFeeFromOutputs, coinControl);
+    if (!res) throw JSONRPCError(RPC_WALLET_ERROR, util::ErrorString(res).original);
 
-    if (!FundTransaction(wallet, tx, fee_out, change_position, error, lockUnspents, setSubtractFeeFromOutputs, coinControl)) {
-        throw JSONRPCError(RPC_WALLET_ERROR, error.original);
-    }
+    fee_out = res->fee;
+    change_position = res->change_pos;
 }
 
 static void SetOptionsInputWeights(const UniValue& inputs, UniValue& options)

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -195,15 +195,22 @@ util::Result<SelectionResult> SelectCoins(const CWallet& wallet, CoinsResult& av
                                           const CAmount& nTargetValue, const CCoinControl& coin_control,
                                           const CoinSelectionParams& coin_selection_params) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 
-struct CreatedTransactionResult
+struct FundedTransactionResult
 {
-    CTransactionRef tx;
     CAmount fee;
-    FeeCalculation fee_calc;
     int change_pos;
 
+    FundedTransactionResult(CAmount _fee, int _change_pos)
+        : fee(_fee), change_pos(_change_pos) {}
+};
+
+struct CreatedTransactionResult : FundedTransactionResult
+{
+    CTransactionRef tx;
+    FeeCalculation fee_calc;
+
     CreatedTransactionResult(CTransactionRef _tx, CAmount _fee, int _change_pos, const FeeCalculation& _fee_calc)
-        : tx(_tx), fee(_fee), fee_calc(_fee_calc), change_pos(_change_pos) {}
+        : FundedTransactionResult(_fee, _change_pos), tx(_tx), fee_calc(_fee_calc) {}
 };
 
 /**
@@ -217,7 +224,7 @@ util::Result<CreatedTransactionResult> CreateTransaction(CWallet& wallet, const 
  * Insert additional inputs into the transaction by
  * calling CreateTransaction();
  */
-bool FundTransaction(CWallet& wallet, CMutableTransaction& tx, CAmount& nFeeRet, int& nChangePosInOut, bilingual_str& error, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, CCoinControl);
+util::Result<FundedTransactionResult> FundTransaction(CWallet& wallet, CMutableTransaction& tx, int change_pos, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, CCoinControl coinControl);
 } // namespace wallet
 
 #endif // BITCOIN_WALLET_SPEND_H


### PR DESCRIPTION
This PR cleans up the interfaces of the `FundTransaction` functions by returning the out-parameters (fee, change output, error) as `util::Result` with a newly created structure `FundedTransactionResult`. It can be seen as a late follow-up to #20640 which did a similar operation to the `CreateTransaction{Internal}` functions. Note that there are actually two functions `FundTransaction` with the same name:

https://github.com/bitcoin/bitcoin/blob/0b02ce914e8594e8938e527c91c07f57def4e943/src/wallet/spend.h#L160

https://github.com/bitcoin/bitcoin/blob/0b02ce914e8594e8938e527c91c07f57def4e943/src/wallet/rpc/spend.cpp#L489

Only the first returns an error and hence needs to be wrapped into `util::Result`, the other one can directly return the result structure.