### PR TITLE
wallet: Fix nNextResend data race in ResubmitWalletTransactions

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1907,7 +1907,7 @@ std::set<uint256> CWallet::GetTxConflicts(const CWalletTx& wtx) const
 // mempool to relay them. On startup, we will do this for all unconfirmed
 // transactions but will not ask the mempool to relay them. We do this on startup
 // to ensure that our own mempool is aware of our transactions, and to also
-// initialize nNextResend so that the actual rebroadcast is scheduled. There
+// initialize m_next_resend so that the actual rebroadcast is scheduled. There
 // is a privacy side effect here as not broadcasting on startup also means that we won't
 // inform the world of our wallet's state, particularly if the wallet (or node) is not
 // yet synced.
@@ -1941,9 +1941,9 @@ void CWallet::ResubmitWalletTransactions(bool relay, bool force)
 
     // Do this infrequently and randomly to avoid giving away
     // that these are our transactions.
-    if (!force && GetTime() < nNextResend) return;
+    if (!force && GetTime() < m_next_resend) return;
     // resend 12-36 hours from now, ~1 day on average.
-    nNextResend = GetTime() + (12 * 60 * 60) + GetRand(24 * 60 * 60);
+    m_next_resend = GetTime() + (12 * 60 * 60) + GetRand(24 * 60 * 60);
 
     int submitted_tx_count = 0;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -250,7 +250,7 @@ private:
     int nWalletVersion GUARDED_BY(cs_wallet){FEATURE_BASE};
 
     /** The next scheduled rebroadcast of wallet transactions. */
-    int64_t nNextResend = 0;
+    std::atomic<int64_t> m_next_resend{};
     /** Whether this wallet will submit newly created transactions to the node's mempool and
      * prompt rebroadcasts (see ResendWalletTransactions()). */
     bool fBroadcastTransactions = false;


### PR DESCRIPTION
Now that `ResubmitWalletTransactions` is called from more than one thread, it is no longer thread-safe.

Introduced in 5291933fedceb9df16eb9e4627b1d7386b53ba07.