### PR TITLE
test: wait for the expected basic block filter index in `interface_rest`

### DIFF
--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -288,6 +288,10 @@ class RESTTest (BitcoinTestFramework):
 
         # See if we can get 5 headers in one response
         self.generate(self.nodes[1], 5)
+        expected_filter = {
+            'basic block filter index': {'synced': True, 'best_block_height': 208},
+        }
+        self.wait_until(lambda: self.nodes[0].getindexinfo() == expected_filter)
         json_obj = self.test_rest_request(f"/headers/{bb_hash}", query_params={"count": 5})
         assert_equal(len(json_obj), 5)  # now we should have 5 header objects
         json_obj = self.test_rest_request(f"/blockfilterheaders/basic/{bb_hash}", query_params={"count": 5})


### PR DESCRIPTION
Fixes #26098

Wait for the expected 'basic block filter index' to not cause issues when calling `/blockfilterheaders/basic/`, like:
https://github.com/bitcoin/bitcoin/blob/9bd842a5928f160c1bc8fca6ca7d8d43f096fd6a/src/rest.cpp#L423-L424