### PR TITLE
build: define `BOOST_NO_CONFIG`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1479,6 +1479,9 @@ if test "$use_boost" = "yes"; then
     AC_MSG_ERROR([only libbitcoinconsensus can be built without Boost])
   fi
 
+  dnl avoid the use of std::auto_ptr (removed in C++17)
+  BOOST_CPPFLAGS="$BOOST_CPPFLAGS -DBOOST_NO_AUTO_PTR"
+
   dnl avoid the use of std::bind1st (removed in C++17)
   BOOST_CPPFLAGS="$BOOST_CPPFLAGS -DBOOST_NO_CXX98_BINDERS"
 

--- a/configure.ac
+++ b/configure.ac
@@ -1479,6 +1479,9 @@ if test "$use_boost" = "yes"; then
     AC_MSG_ERROR([only libbitcoinconsensus can be built without Boost])
   fi
 
+  dnl avoid the use of std::bind1st (removed in C++17)
+  BOOST_CPPFLAGS="$BOOST_CPPFLAGS -DBOOST_NO_CXX98_BINDERS"
+
   dnl we don't use multi_index serialization
   BOOST_CPPFLAGS="$BOOST_CPPFLAGS -DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION"
 

--- a/configure.ac
+++ b/configure.ac
@@ -1479,6 +1479,9 @@ if test "$use_boost" = "yes"; then
     AC_MSG_ERROR([only libbitcoinconsensus can be built without Boost])
   fi
 
+  dnl Boost says to define BOOST_NO_CONFIG for "for autoconf generated setups"
+  BOOST_CPPFLAGS="$BOOST_CPPFLAGS -DBOOST_NO_CONFIG -DBOOST_NO_USER_CONFIG"
+
   dnl avoid the use of std::auto_ptr (removed in C++17)
   BOOST_CPPFLAGS="$BOOST_CPPFLAGS -DBOOST_NO_AUTO_PTR"
 


### PR DESCRIPTION
Define `BOOST_NO_CONFIG`, which [according to Boost](https://live.boost.org/doc/libs/develop/boost/config/user.hpp) is what we should be doing:
> // define this to disable all config options,
> // excluding the user config.  Use if your
> // setup is fully ISO compliant, and has no
> // useful extensions, or for autoconf generated
> // setups:
> // #define BOOST_NO_CONFIG

Defining `BOOST_NO_CONFIG`, means we need some additional defines to tell Boost to avoid trying to use code that has been removed in C++17. Namely [`std::auto_ptr`](https://en.cppreference.com/w/cpp/memory/auto_ptr) (`BOOST_NO_AUTO_PTR`) and [`std::bind1st`](https://en.cppreference.com/w/cpp/utility/functional/bind12) (`BOOST_NO_CXX98_BINDERS`).

Partially split out of #24742, as this should be ok to do independently. With this change, we'll be able to prune another ~80 Boost headers from our depends bundle.