### PR TITLE
build: remove stdio.h from header checks

### DIFF
--- a/build_msvc/bitcoin_config.h.in
+++ b/build_msvc/bitcoin_config.h.in
@@ -146,9 +146,6 @@
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1
 
-/* Define to 1 if you have the <stdio.h> header file. */
-#define HAVE_STDIO_H 1
-
 /* Define to 1 if you have the <stdlib.h> header file. */
 #define HAVE_STDLIB_H 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -1010,7 +1010,7 @@ if test "$TARGET_OS" = "darwin"; then
   AX_CHECK_LINK_FLAG([-Wl,-bind_at_load], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,-bind_at_load"], [], [$LDFLAG_WERROR])
 fi
 
-AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h stdio.h stdlib.h unistd.h sys/types.h sys/stat.h sys/select.h sys/prctl.h sys/sysctl.h vm/vm_param.h sys/vmmeter.h sys/resources.h])
+AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h stdlib.h unistd.h sys/types.h sys/stat.h sys/select.h sys/prctl.h sys/sysctl.h vm/vm_param.h sys/vmmeter.h sys/resources.h])
 
 AC_CHECK_DECLS([getifaddrs, freeifaddrs],[CHECK_SOCKET],,
     [#include <sys/types.h>

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -27,9 +27,9 @@
 #include <util/system.h>
 #include <util/translation.h>
 
+#include <cstdio>
 #include <functional>
 #include <memory>
-#include <stdio.h>
 
 static bool fCreateBlank;
 static std::map<std::string,UniValue> registers;

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -21,10 +21,10 @@
 #include <util/threadnames.h>
 #include <util/translation.h>
 
+#include <cstdio>
 #include <deque>
 #include <memory>
 #include <optional>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string>
 

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -12,10 +12,10 @@
 #include <tinyformat.h>
 #include <util/system.h>
 
+#include <cstdio>
 #include <functional>
 #include <memory>
 #include <stdexcept>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <string>

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -17,7 +17,7 @@
 #include <util/system.h>
 #include <util/strencodings.h>
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <QCloseEvent>
 #include <QLabel>

--- a/src/streams.h
+++ b/src/streams.h
@@ -13,11 +13,11 @@
 
 #include <algorithm>
 #include <assert.h>
+#include <cstdio>
 #include <ios>
 #include <limits>
 #include <optional>
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 #include <string>
 #include <utility>


### PR DESCRIPTION
We already use a mix of `<cstdio>` and `stdio.h` unconditionally throughout
the codebase.

Us checking this header also duplicates work already done by autotools.
Currently `stdio.h` is checked for 3 times during a ./configure run, after
this change, at least it's only twice.