### PR TITLE
refactor: Guard TxRequestTracker by its own lock instead of cs_main

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1821,10 +1821,7 @@ void PeerManagerImpl::BlockConnected(const std::shared_ptr<const CBlock>& pblock
         }
     }
 
-    for (const auto& ptx : pblock->vtx) {
-        m_txrequest.ForgetTxHash(ptx->GetHash());
-        m_txrequest.ForgetTxHash(ptx->GetWitnessHash());
-    }
+    m_txrequest.ForgetTxs(Span{pblock->vtx});
 }
 
 void PeerManagerImpl::BlockDisconnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex* pindex)

--- a/src/txrequest.h
+++ b/src/txrequest.h
@@ -143,6 +143,7 @@ public:
      * for the same txhash will not trigger new ReceivedInv calls, at least in the short term after this call.
      */
     void ForgetTxHash(const uint256& txhash);
+    void ForgetTxs(Span<const CTransactionRef> txs);
 
     /** Find the txids to request now from peer.
      *


### PR DESCRIPTION
I don't see the need to have the `TxRequestTracker` guarded by `cs_main` which would also be more in line with our developer docs.

From `developer-notes.md`:

```
Re-architecting the core code so there are better-defined interfaces between
the various components is a goal, with any necessary locking done by the
components (e.g. see the self-contained FillableSigningProvider class and its
cs_KeyStore lock for example).
```

This PR gives `TxRequestTracker` its own mutex, thereby removing the need to guard `PeerManagerImpl::m_txrequest` using `cs_main`.
