### PR TITLE
refactor: Move coin_control variable to test setup section

### DIFF
--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -357,6 +357,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
         wallet->SetupDescriptorScriptPubKeyMans();
 
         CoinsResult available_coins;
+        CCoinControl coin_control;
 
         // single coin should be selected when effective fee > long term fee
         coin_selection_params_bnb.m_effective_feerate = CFeeRate(5000);
@@ -368,7 +369,6 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
 
         expected_result.Clear();
         add_coin(10 * CENT, 2, expected_result);
-        CCoinControl coin_control;
         const auto result11 = SelectCoins(*wallet, available_coins, /*pre_set_inputs=*/{}, 10 * CENT, coin_control, coin_selection_params_bnb);
         BOOST_CHECK(EquivalentResult(expected_result, *result11));
         available_coins.Clear();


### PR DESCRIPTION
`coin_control` is used by the subsequent tests, [here](https://github.com/bitcoin/bitcoin/blob/master/src/wallet/test/coinselector_tests.cpp#L381) and [here](https://github.com/bitcoin/bitcoin/blob/master/src/wallet/test/coinselector_tests.cpp#L398) and should be moved to the test setup section.  Removing the [test](https://github.com/bitcoin/bitcoin/blob/master/src/wallet/test/coinselector_tests.cpp#L355:L368) that defines `coin_control` causes the remainder to fail.