### PR TITLE
test: check that `listdescriptors` descriptor strings are sorted

### DIFF
--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -1760,7 +1760,7 @@ RPCHelpMan listdescriptors()
         },
         RPCResult{RPCResult::Type::OBJ, "", "", {
             {RPCResult::Type::STR, "wallet_name", "Name of wallet this operation was performed on"},
-            {RPCResult::Type::ARR, "descriptors", "Array of descriptor objects",
+            {RPCResult::Type::ARR, "descriptors", "Array of descriptor objects (sorted by descriptor string representation)",
             {
                 {RPCResult::Type::OBJ, "", "", {
                     {RPCResult::Type::STR, "desc", "Descriptor string representation"},

--- a/test/functional/wallet_listdescriptors.py
+++ b/test/functional/wallet_listdescriptors.py
@@ -52,6 +52,10 @@ class ListDescriptorsTest(BitcoinTestFramework):
             assert item['range'] == [0, 0]
             assert item['timestamp'] is not None
 
+        self.log.info('Test that descriptor strings are returned in lexicographically sorted order.')
+        descriptor_strings = [descriptor['desc'] for descriptor in result['descriptors']]
+        assert_equal(descriptor_strings, sorted(descriptor_strings))
+
         self.log.info('Test descriptors with hardened derivations are listed in importable form.')
         xprv = 'tprv8ZgxMBicQKsPeuVhWwi6wuMQGfPKi9Li5GtX35jVNknACgqe3CY4g5xgkfDDJcmtF7o1QnxWDRYw4H5P26PXq7sbcUkEqeR4fg3Kxp2tigg'
         xpub_acc = 'tpubDCMVLhErorrAGfApiJSJzEKwqeaf2z3NrkVMxgYQjZLzMjXMBeRw2muGNYbvaekAE8rUFLftyEar4LdrG2wXyyTJQZ26zptmeTEjPTaATts'


### PR DESCRIPTION
This small PR adds a test for the change introduced in PR #25931 ("rpc: sort listdescriptors result", commit 50996241f2b0eefeaab4fcd11b9730fa2dc107ae). The correctness of the test can easily be verified by commenting out the `std::sort` call in the `listdescriptors` RPC implementation:
```diff
diff --git a/src/wallet/rpc/backup.cpp b/src/wallet/rpc/backup.cpp
index 09c74ea2da..3ed1a69b26 100644
--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -1829,9 +1829,11 @@ RPCHelpMan listdescriptors()
         });
     }

+    /*
     std::sort(wallet_descriptors.begin(), wallet_descriptors.end(), [](const auto& a, const auto& b) {
         return a.descriptor < b.descriptor;
     });
+    */

     UniValue descriptors(UniValue::VARR);
     for (const WalletDescInfo& info : wallet_descriptors) {

```
leading to a fail of the functional test `wallet_listdescriptors.py`.