### PR TITLE
rpc: Fix ordering of arguments in listtransactions help message

### DIFF
--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -472,9 +472,9 @@ RPCHelpMan listtransactions()
             "\nList the most recent 10 transactions in the systems\n"
             + HelpExampleCli("listtransactions", "") +
             "\nList transactions 100 to 120\n"
-            + HelpExampleCli("listtransactions", "\"*\" 20 100") +
+            + HelpExampleCli("listtransactions", "\"*\" 100 20") +
             "\nAs a JSON-RPC call\n"
-            + HelpExampleRpc("listtransactions", "\"*\", 20, 100")
+            + HelpExampleRpc("listtransactions", "\"*\", 100, 20")
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {


### PR DESCRIPTION
The help text would say

```
List transactions 100 to 120
> bitcoin-cli listtransactions "*" 20 100
```

which was wrong as the ordering of the arguments is label, count, skip. 

This fixes the help message