### PR TITLE
build: Remove `stdlib.h` from header checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1010,7 +1010,7 @@ if test "$TARGET_OS" = "darwin"; then
   AX_CHECK_LINK_FLAG([-Wl,-bind_at_load], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,-bind_at_load"], [], [$LDFLAG_WERROR])
 fi
 
-AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h stdlib.h unistd.h sys/types.h sys/stat.h sys/select.h sys/prctl.h sys/sysctl.h vm/vm_param.h sys/vmmeter.h sys/resources.h])
+AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h unistd.h sys/types.h sys/stat.h sys/select.h sys/prctl.h sys/sysctl.h vm/vm_param.h sys/vmmeter.h sys/resources.h])
 
 AC_CHECK_DECLS([getifaddrs, freeifaddrs],[CHECK_SOCKET],,
     [#include <sys/types.h>

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -6,7 +6,7 @@
 #ifndef BITCOIN_CONSENSUS_CONSENSUS_H
 #define BITCOIN_CONSENSUS_CONSENSUS_H
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <stdint.h>
 
 /** The maximum allowed size for a serialized block, in bytes (only for buffer size limits) */

--- a/src/crypto/chacha20.h
+++ b/src/crypto/chacha20.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_CHACHA20_H
 #define BITCOIN_CRYPTO_CHACHA20_H
 
+#include <cstdlib>
 #include <stdint.h>
-#include <stdlib.h>
 
 /** A class for ChaCha20 256-bit stream cipher developed by Daniel J. Bernstein
     https://cr.yp.to/chacha/chacha-20080128.pdf */

--- a/src/crypto/hkdf_sha256_32.h
+++ b/src/crypto/hkdf_sha256_32.h
@@ -7,8 +7,8 @@
 
 #include <crypto/hmac_sha256.h>
 
+#include <cstdlib>
 #include <stdint.h>
-#include <stdlib.h>
 
 /** A rfc5869 HKDF implementation with HMAC_SHA256 and fixed key output length of 32 bytes (L=32) */
 class CHKDF_HMAC_SHA256_L32

--- a/src/crypto/hmac_sha256.h
+++ b/src/crypto/hmac_sha256.h
@@ -7,8 +7,8 @@
 
 #include <crypto/sha256.h>
 
+#include <cstdlib>
 #include <stdint.h>
-#include <stdlib.h>
 
 /** A hasher class for HMAC-SHA-256. */
 class CHMAC_SHA256

--- a/src/crypto/hmac_sha512.h
+++ b/src/crypto/hmac_sha512.h
@@ -7,8 +7,8 @@
 
 #include <crypto/sha512.h>
 
+#include <cstdlib>
 #include <stdint.h>
-#include <stdlib.h>
 
 /** A hasher class for HMAC-SHA-512. */
 class CHMAC_SHA512

--- a/src/crypto/poly1305.h
+++ b/src/crypto/poly1305.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_POLY1305_H
 #define BITCOIN_CRYPTO_POLY1305_H
 
+#include <cstdlib>
 #include <stdint.h>
-#include <stdlib.h>
 
 #define POLY1305_KEYLEN 32
 #define POLY1305_TAGLEN 16

--- a/src/crypto/ripemd160.h
+++ b/src/crypto/ripemd160.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_RIPEMD160_H
 #define BITCOIN_CRYPTO_RIPEMD160_H
 
+#include <cstdlib>
 #include <stdint.h>
-#include <stdlib.h>
 
 /** A hasher class for RIPEMD-160. */
 class CRIPEMD160

--- a/src/crypto/sha1.h
+++ b/src/crypto/sha1.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_SHA1_H
 #define BITCOIN_CRYPTO_SHA1_H
 
+#include <cstdlib>
 #include <stdint.h>
-#include <stdlib.h>
 
 /** A hasher class for SHA1. */
 class CSHA1

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_SHA256_H
 #define BITCOIN_CRYPTO_SHA256_H
 
+#include <cstdlib>
 #include <stdint.h>
-#include <stdlib.h>
 #include <string>
 
 /** A hasher class for SHA-256. */

--- a/src/crypto/sha256_sse4.cpp
+++ b/src/crypto/sha256_sse4.cpp
@@ -5,8 +5,8 @@
 // This is a translation to GCC extended asm syntax from YASM code by Intel
 // (available at the bottom of this file).
 
+#include <cstdlib>
 #include <stdint.h>
-#include <stdlib.h>
 
 #if defined(__x86_64__) || defined(__amd64__)
 

--- a/src/crypto/sha3.h
+++ b/src/crypto/sha3.h
@@ -7,8 +7,8 @@
 
 #include <span.h>
 
+#include <cstdlib>
 #include <stdint.h>
-#include <stdlib.h>
 
 //! The Keccak-f[1600] transform.
 void KeccakF(uint64_t (&st)[25]);

--- a/src/crypto/sha512.h
+++ b/src/crypto/sha512.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_SHA512_H
 #define BITCOIN_CRYPTO_SHA512_H
 
+#include <cstdlib>
 #include <stdint.h>
-#include <stdlib.h>
 
 /** A hasher class for SHA-512. */
 class CSHA512

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -22,10 +22,10 @@
 #include <util/translation.h>
 
 #include <cstdio>
+#include <cstdlib>
 #include <deque>
 #include <memory>
 #include <optional>
-#include <stdlib.h>
 #include <string>
 
 #include <sys/types.h>

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -13,10 +13,10 @@
 #include <util/system.h>
 
 #include <cstdio>
+#include <cstdlib>
 #include <functional>
 #include <memory>
 #include <stdexcept>
-#include <stdlib.h>
 #include <string.h>
 #include <string>
 #include <unistd.h>

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -10,10 +10,10 @@
 #include <util/strencodings.h>
 
 #include <cstdint>
+#include <cstdlib>
 #include <exception>
 #include <iostream>
 #include <stdexcept>
-#include <stdlib.h>
 #include <string.h>
 #include <system_error>
 #include <unistd.h>

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -8,9 +8,8 @@
 #include <indirectmap.h>
 #include <prevector.h>
 
-#include <stdlib.h>
-
 #include <cassert>
+#include <cstdlib>
 #include <map>
 #include <memory>
 #include <set>

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -6,7 +6,7 @@
 #define BITCOIN_PREVECTOR_H
 
 #include <assert.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <stdint.h>
 #include <string.h>
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -21,7 +21,7 @@
 #include <util/time.h> // for GetTimeMicros()
 
 #include <cmath>
-#include <stdlib.h>
+#include <cstdlib>
 #include <thread>
 
 #ifndef WIN32

--- a/src/script/miniscript.h
+++ b/src/script/miniscript.h
@@ -13,8 +13,8 @@
 #include <string>
 #include <vector>
 
-#include <stdlib.h>
 #include <assert.h>
+#include <cstdlib>
 
 #include <policy/policy.h>
 #include <primitives/transaction.h>

--- a/src/support/cleanse.h
+++ b/src/support/cleanse.h
@@ -6,7 +6,7 @@
 #ifndef BITCOIN_SUPPORT_CLEANSE_H
 #define BITCOIN_SUPPORT_CLEANSE_H
 
-#include <stdlib.h>
+#include <cstdlib>
 
 /** Secure overwrite a buffer (possibly containing secret data) with zero-bytes. The write
  * operation will not be optimized out by the compiler. */

--- a/src/test/blockchain_tests.cpp
+++ b/src/test/blockchain_tests.cpp
@@ -4,12 +4,12 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <stdlib.h>
-
 #include <chain.h>
 #include <rpc/blockchain.h>
 #include <test/util/setup_common.h>
 #include <util/string.h>
+
+#include <cstdlib>
 
 /* Equality between doubles is imprecise. Comparison should be done
  * with a small threshold of tolerance, rather than exact equality.

--- a/src/test/raii_event_tests.cpp
+++ b/src/test/raii_event_tests.cpp
@@ -4,8 +4,8 @@
 
 #include <event2/event.h>
 
+#include <cstdlib>
 #include <map>
-#include <stdlib.h>
 
 #include <support/events.h>
 


### PR DESCRIPTION
We already use a mix of `<cstlib>` and `stdlib.h` unconditionally throughout
the codebase.

Us checking this header also duplicates work already done by autotools.
Currently stdlib.h is checked for 3 times during a ./configure run, after
this change, at least it's only twice.

Similar to #26150.