### PR TITLE
p2p: ProcessHeadersMessage(): fix received_new_header

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2846,7 +2846,7 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, Peer& peer,
 
     // If we don't have the last header, then this peer will have given us
     // something new (if these headers are valid).
-    bool received_new_header{last_received_header != nullptr};
+    bool received_new_header{last_received_header == nullptr};
 
     // Now process all the headers.
     BlockValidationState state;


### PR DESCRIPTION
Follow-up to #25717. The commit "Utilize anti-DoS headers download strategy" changed how this bool variable is computed, so that its value is now the opposite of what it should be.

Prior to #25717:
```
bool received_new_header{WITH_LOCK(::cs_main, return m_chainman.m_blockman.LookupBlockIndex(headers.back().GetHash()) == nullptr)};
```
After #25717 (simplified):
```
{
    LOCK(cs_main);
    last_received_header = m_chainman.m_blockman.LookupBlockIndex(headers.back().GetHash());
}
bool received_new_header{last_received_header != nullptr};
```