### PR TITLE
build: split ARM crc & crypto extension checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -588,8 +588,8 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 CXXFLAGS="$TEMP_CXXFLAGS"
 
 # ARM
-AX_CHECK_COMPILE_FLAG([-march=armv8-a+crc+crypto], [ARM_CRC_CXXFLAGS="-march=armv8-a+crc+crypto"], [], [$CXXFLAG_WERROR])
-AX_CHECK_COMPILE_FLAG([-march=armv8-a+crc+crypto], [ARM_SHANI_CXXFLAGS="-march=armv8-a+crc+crypto"], [], [$CXXFLAG_WERROR])
+AX_CHECK_COMPILE_FLAG([-march=armv8-a+crc], [ARM_CRC_CXXFLAGS="-march=armv8-a+crc"], [], [$CXXFLAG_WERROR])
+AX_CHECK_COMPILE_FLAG([-march=armv8-a+crypto], [ARM_SHANI_CXXFLAGS="-march=armv8-a+crypto"], [], [$CXXFLAG_WERROR])
 
 TEMP_CXXFLAGS="$CXXFLAGS"
 CXXFLAGS="$ARM_CRC_CXXFLAGS $CXXFLAGS"


### PR DESCRIPTION
We currently perform the same check twice, to put the same set of flags in two different variables. Split the checks so we test for the `crc` and `crypto` extensions independently.

If we don't want to split, we should just delete the second `AX_CHECK_COMPILE_FLAG` check, and set `ARM_CRC_CXXFLAGS` & `ARM_SHANI_CXXFLAGS` at the same time.

Guix Build:
```bash
045392a6a4f538723b7759c67eeafd832735de7294b72b3a7f488d05a13711f7  guix-build-20adaeaef5fa/output/aarch64-linux-gnu/SHA256SUMS.part
054fda86577d757788a1c87508268402535fcbe869240309a2c91997234389cf  guix-build-20adaeaef5fa/output/aarch64-linux-gnu/bitcoin-20adaeaef5fa-aarch64-linux-gnu-debug.tar.gz
92dc2513b2b6d87c0869ae18493fd9d0e2690b5b02bfd4310d54f4d394cfccdf  guix-build-20adaeaef5fa/output/aarch64-linux-gnu/bitcoin-20adaeaef5fa-aarch64-linux-gnu.tar.gz
2515cfc708cc6ce0e650ca00c49de8dad856b54741ddc0c195845fc6ce2d67db  guix-build-20adaeaef5fa/output/arm-linux-gnueabihf/SHA256SUMS.part
fa0a956365e62b484f66dcf9763a02858db5c7e99317861819a54a15589ced80  guix-build-20adaeaef5fa/output/arm-linux-gnueabihf/bitcoin-20adaeaef5fa-arm-linux-gnueabihf-debug.tar.gz
1b3ddf2b1bbdc7632696ca78908e69b4fd156ccf7afa8078b5541d2ac10ab931  guix-build-20adaeaef5fa/output/arm-linux-gnueabihf/bitcoin-20adaeaef5fa-arm-linux-gnueabihf.tar.gz
f87d8e23df60b208a631f6642f6c2cc0fc8e4e5e9563b36d1de9d371f22a69d9  guix-build-20adaeaef5fa/output/arm64-apple-darwin/SHA256SUMS.part
c24ac07bfa935fd40358823d95ef01128a03b80deec6b2cb8bed122994e8adc2  guix-build-20adaeaef5fa/output/arm64-apple-darwin/bitcoin-20adaeaef5fa-arm64-apple-darwin-unsigned.dmg
696660e030accadc27901dfb4e120aa2fefefa8cc2a33ae887e3c98e5d4795f5  guix-build-20adaeaef5fa/output/arm64-apple-darwin/bitcoin-20adaeaef5fa-arm64-apple-darwin-unsigned.tar.gz
30dcd3f543781ac0e07e36336c2901a25a0829e0d1425c25b3c7aba1d0e5420e  guix-build-20adaeaef5fa/output/arm64-apple-darwin/bitcoin-20adaeaef5fa-arm64-apple-darwin.tar.gz
4d63db45f28fcb99aa8f3b30cf06afef80dd308a8d2fdf874752accb3f341258  guix-build-20adaeaef5fa/output/dist-archive/bitcoin-20adaeaef5fa.tar.gz
eb208b98b3118e9f8240aab91c7ecb2f9b778109bc19d81d0ba73b3e35aa1123  guix-build-20adaeaef5fa/output/powerpc64-linux-gnu/SHA256SUMS.part
8b0de7008b1932ed18d3ab71ca309dc4919096e226e0a7197bd192e1ba96da82  guix-build-20adaeaef5fa/output/powerpc64-linux-gnu/bitcoin-20adaeaef5fa-powerpc64-linux-gnu-debug.tar.gz
bcbc269cc4b5883397c516ef3ef6df564f4a81c240d5afcf912a2bf9554ff148  guix-build-20adaeaef5fa/output/powerpc64-linux-gnu/bitcoin-20adaeaef5fa-powerpc64-linux-gnu.tar.gz
e5f7fd823056449a495a68d18fe941b472479bc59d9d4d11a041a4e2cc4044ec  guix-build-20adaeaef5fa/output/powerpc64le-linux-gnu/SHA256SUMS.part
73ee7e786372b32ab840f0c00ca0479ddd022b3d37219cd929cb49f744c174e3  guix-build-20adaeaef5fa/output/powerpc64le-linux-gnu/bitcoin-20adaeaef5fa-powerpc64le-linux-gnu-debug.tar.gz
08f64c9aae4d9beef88d8fbae8ad0152517de74bedc88540775c4f757c8b6b9a  guix-build-20adaeaef5fa/output/powerpc64le-linux-gnu/bitcoin-20adaeaef5fa-powerpc64le-linux-gnu.tar.gz
fe3c28fdb1ee9d5b6ca3ba4510d61c052567edb3b93fdde929ed197072c0fd66  guix-build-20adaeaef5fa/output/riscv64-linux-gnu/SHA256SUMS.part
890d6b96edcc431620eede6239dec51368aff917010e03dabeb29d6a672d7a28  guix-build-20adaeaef5fa/output/riscv64-linux-gnu/bitcoin-20adaeaef5fa-riscv64-linux-gnu-debug.tar.gz
df1fc0c9af4799cfe170444e21965f2a600aa193fdd0da542fedceeb3081b194  guix-build-20adaeaef5fa/output/riscv64-linux-gnu/bitcoin-20adaeaef5fa-riscv64-linux-gnu.tar.gz
f69cae0b2d0eadb336cf314a888b1e0bed241f38954fe58ca9c9c2d00e49b74e  guix-build-20adaeaef5fa/output/x86_64-apple-darwin/SHA256SUMS.part
acc5fa9725bba738d10bb8b1e7df2d8a7b0e648015e1c046f67451d343f68224  guix-build-20adaeaef5fa/output/x86_64-apple-darwin/bitcoin-20adaeaef5fa-x86_64-apple-darwin-unsigned.dmg
7e4d8cb6d74434ba9084f487187c49cd5a4138c9ae03a6c2236cdffadb236bc8  guix-build-20adaeaef5fa/output/x86_64-apple-darwin/bitcoin-20adaeaef5fa-x86_64-apple-darwin-unsigned.tar.gz
8d93add28b20dfb2a556d3867cfbf218db336d7eefee6ab6f76a1bb4dd4ae20b  guix-build-20adaeaef5fa/output/x86_64-apple-darwin/bitcoin-20adaeaef5fa-x86_64-apple-darwin.tar.gz
ba0863eda963db706d2880daa8bc526e6332097010fa7227f513a2d715b6cd6c  guix-build-20adaeaef5fa/output/x86_64-linux-gnu/SHA256SUMS.part
6915794f3cdc8ad9b305b6baa58f89f7493097b88c0af190d52d93457a17e8d8  guix-build-20adaeaef5fa/output/x86_64-linux-gnu/bitcoin-20adaeaef5fa-x86_64-linux-gnu-debug.tar.gz
467b05298058ec507c3b247c423f3ea7e027ecf62e45d7ae4b81160118bc0d02  guix-build-20adaeaef5fa/output/x86_64-linux-gnu/bitcoin-20adaeaef5fa-x86_64-linux-gnu.tar.gz
51a534803deaabcbba27d82359ef46e4d5b9e7b121ab71e1975c2a0d1c4c6f45  guix-build-20adaeaef5fa/output/x86_64-w64-mingw32/SHA256SUMS.part
c9c5496f20bac01ed6439746aff9ca3dd55708718902c898e99f3d5741b167a3  guix-build-20adaeaef5fa/output/x86_64-w64-mingw32/bitcoin-20adaeaef5fa-win64-debug.zip
cfaac54be36789927f83172c0af44c50648f63df7cdc9d81774a170e5ab6e3e5  guix-build-20adaeaef5fa/output/x86_64-w64-mingw32/bitcoin-20adaeaef5fa-win64-setup-unsigned.exe
759b79660c291dcc7da88088de3bb666162fed5c9d94bb24f10cef6e781c565f  guix-build-20adaeaef5fa/output/x86_64-w64-mingw32/bitcoin-20adaeaef5fa-win64-unsigned.tar.gz
f0124333d384ff6962e2131c7b2814bf5c968e77b63ff1b2c7d19cb4c571757c  guix-build-20adaeaef5fa/output/x86_64-w64-mingw32/bitcoin-20adaeaef5fa-win64.zip
```