### PR TITLE
test: silence TSAN false positive in coinstatsindex_initial_sync

### DIFF
--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -76,10 +76,16 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
 
     BOOST_CHECK(block_index != new_block_index);
 
+    // It is not safe to stop and destroy the index until it finishes handling
+    // the last BlockConnected notification. The BlockUntilSyncedToCurrentChain()
+    // call above is sufficient to ensure this, but the
+    // SyncWithValidationInterfaceQueue() call below is also needed to ensure
+    // TSAN always sees the test thread waiting for the notification thread, and
+    // avoid potential false positive reports.
+    SyncWithValidationInterfaceQueue();
+
     // Shutdown sequence (c.f. Shutdown() in init.cpp)
     coin_stats_index.Stop();
-
-    // Rest of shutdown sequence and destructors happen in ~TestingSetup()
 }
 
 // Test shutdown between BlockConnected and ChainStateFlushed notifications,

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -69,11 +69,16 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
         }
     }
 
+    // It is not safe to stop and destroy the index until it finishes handling
+    // the last BlockConnected notification. The BlockUntilSyncedToCurrentChain()
+    // call above is sufficient to ensure this, but the
+    // SyncWithValidationInterfaceQueue() call below is also needed to ensure
+    // TSAN always sees the test thread waiting for the notification thread, and
+    // avoid potential false positive reports.
+    SyncWithValidationInterfaceQueue();
+
     // shutdown sequence (c.f. Shutdown() in init.cpp)
     txindex.Stop();
-
-    // Let scheduler events finish running to avoid accessing any memory related to txindex after it is destructed
-    SyncWithValidationInterfaceQueue();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Silence false positives from TSAN about unsynchronized calls to `BaseIndex::~BaseIndex()` and `BaseIndex::SetBestBlockIndex()`. They are synchronized, but beyond the comprehension of TSAN - by `SyncWithValidationInterfaceQueue()`, called from `BaseIndex::BlockUntilSyncedToCurrentChain()`.

Fixes https://github.com/bitcoin/bitcoin/issues/25365
