### PR TITLE
refactor: Do not discard `try_lock()` return value

### DIFF
--- a/src/sync.h
+++ b/src/sync.h
@@ -165,10 +165,11 @@ private:
     bool TryEnter(const char* pszName, const char* pszFile, int nLine)
     {
         EnterCritical(pszName, pszFile, nLine, Base::mutex(), true);
-        if (!Base::try_lock()) {
-            LeaveCritical();
+        if (Base::try_lock()) {
+            return true;
         }
-        return Base::owns_lock();
+        LeaveCritical();
+        return false;
     }
 
 public:

--- a/src/sync.h
+++ b/src/sync.h
@@ -165,8 +165,7 @@ private:
     bool TryEnter(const char* pszName, const char* pszFile, int nLine)
     {
         EnterCritical(pszName, pszFile, nLine, Base::mutex(), true);
-        Base::try_lock();
-        if (!Base::owns_lock()) {
+        if (!Base::try_lock()) {
             LeaveCritical();
         }
         return Base::owns_lock();


### PR DESCRIPTION
Microsoft's C++ Standard Library uses the `[[nodiscard]]` attribute for `try_lock()`.
See: https://github.com/microsoft/STL/blob/main/stl/inc/mutex

This change allows to drop the current suppression for the warning C4838 and helps to prevent the upcoming warning C4858.
See: https://github.com/microsoft/STL/commit/539c26c923b38cd0b5eba2bb11de4bea9d5c6e43

Fixes bitcoin/bitcoin#26017.

Split from bitcoin/bitcoin#25819.