### PR TITLE
build: Disable noisy `-Wreturn-type` for MinGW-w64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -431,12 +431,6 @@ if test "$enable_werror" = "yes"; then
     AC_MSG_ERROR([enable-werror set but -Werror is not usable])
   fi
   ERROR_CXXFLAGS=$CXXFLAG_WERROR
-
-  dnl -Wreturn-type is broken in GCC for MinGW-w64.
-  dnl https://sourceforge.net/p/mingw-w64/bugs/306/
-  AX_CHECK_COMPILE_FLAG([-Werror=return-type], [], [ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Wno-error=return-type"], [$CXXFLAG_WERROR],
-                        [AC_LANG_SOURCE([[#include <cassert>
-                                          int f(){ assert(false); }]])])
 fi
 
 if test "$CXXFLAGS_overridden" = "no"; then
@@ -477,6 +471,12 @@ if test "$CXXFLAGS_overridden" = "no"; then
     AX_CHECK_COMPILE_FLAG([-Wdeprecated-copy], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-deprecated-copy"], [], [$CXXFLAG_WERROR])
   fi
 fi
+
+dnl -Wreturn-type is broken in GCC for MinGW-w64.
+dnl https://sourceforge.net/p/mingw-w64/bugs/306/
+AX_CHECK_COMPILE_FLAG([-Wreturn-type], [], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-return-type"], [$CXXFLAG_WERROR],
+                      [AC_LANG_SOURCE([[#include <cassert>
+                                        int f(){ assert(false); }]])])
 
 dnl Don't allow extended (non-ASCII) symbols in identifiers. This is easier for code review.
 AX_CHECK_COMPILE_FLAG([-fno-extended-identifiers], [CORE_CXXFLAGS="$CORE_CXXFLAGS -fno-extended-identifiers"], [], [$CXXFLAG_WERROR])


### PR DESCRIPTION
On the master (9fcdb9f3a044330d3d7515fa35709102c98534d2) we have `-Wno-error=return-type` for MinGW-w64, to allow us successfully cross-compile Windows release binaries which also being configured with `--enable-werror`.

Although, even during daily cross-compiling (which is usual for me) such warnings are noisy, distracting and useless, as all of them are false-positive. Disabling them for MinGW-w64 looks safe now because code quality is checked by other compilers, including MSVC. Also, after moving to `std::filesystem`, we have much less Windows-specific code paths.