### PR TITLE
ci: Use git2.34 for lint task

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -8,6 +8,13 @@ export LC_ALL=C
 
 ${CI_RETRY_EXE} apt-get update
 ${CI_RETRY_EXE} apt-get install -y clang-format-9 python3-pip curl git gawk jq
+(
+  # Temporary workaround for https://github.com/bitcoin/bitcoin/pull/26130#issuecomment-1260499544
+  # Can be removed once the underlying image is bumped to something that includes git2.34 or later
+  sed -i -e 's/bionic/jammy/g' /etc/apt/sources.list
+  ${CI_RETRY_EXE} apt-get update
+  ${CI_RETRY_EXE} apt-get install -y --reinstall git
+)
 update-alternatives --install /usr/bin/clang-format      clang-format      "$(which clang-format-9     )" 100
 update-alternatives --install /usr/bin/clang-format-diff clang-format-diff "$(which clang-format-diff-9)" 100
 


### PR DESCRIPTION
Since most maintainers use a recent version of git that uses the `ort` strategy by default (https://git-scm.com/docs/merge-strategies/2.34.0), bump git for the lint taks as well.

Fixes https://github.com/bitcoin/bitcoin/pull/26130#issuecomment-1260499544