### PR TITLE
test: check importing wallets when blocks are pruned throw an error

### DIFF
--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -358,6 +358,8 @@ class PruneTest(BitcoinTestFramework):
         self.restart_node(2, extra_args=["-prune=550"])
         self.log.info("Success")
 
+        assert_raises_rpc_error(-4, "Importing wallets is disabled when blocks are pruned", self.nodes[2].importwallet, "abc")
+
         # check that wallet loads successfully when restarting a pruned node after IBD.
         # this was reported to fail in #7494.
         self.log.info("Syncing node 5 to test wallet")


### PR DESCRIPTION
This PR adds test coverage for the following error:
https://github.com/bitcoin/bitcoin/blob/437b608df289c97fd88f1dd79bdc8359e1b1c5b1/src/wallet/rpc/backup.cpp#L513-L518