### PR TITLE
rest: add verbose and mempool_sequence query params for mempool/contents

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -123,11 +123,15 @@ Returns various information about the transaction mempool.
 Only supports JSON as output format.
 Refer to the `getmempoolinfo` RPC help for details.
 
-`GET /rest/mempool/contents.json`
+`GET /rest/mempool/contents.json?verbose=<true|false>&mempool_sequence=<false|true>`
 
 Returns the transactions in the mempool.
 Only supports JSON as output format.
-Refer to the `getrawmempool` RPC help for details.
+Refer to the `getrawmempool` RPC help for details. Defaults to setting
+`verbose=true` and `mempool_sequence=false`.
+
+*Query parameters for `verbose` and `mempool_sequence` available in 25.0 and up.*
+
 
 Risks
 -------------

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -608,7 +608,20 @@ static bool rest_mempool(const std::any& context, HTTPRequest* req, const std::s
     case RESTResponseFormat::JSON: {
         std::string str_json;
         if (param == "contents") {
-            str_json = MempoolToJSON(*mempool, true).write() + "\n";
+            const std::string raw_verbose{req->GetQueryParameter("verbose").value_or("true")};
+            if (raw_verbose != "true" && raw_verbose != "false") {
+                return RESTERR(req, HTTP_BAD_REQUEST, "The \"verbose\" query parameter must be either \"true\" or \"false\".");
+            }
+            const std::string raw_mempool_sequence{req->GetQueryParameter("mempool_sequence").value_or("false")};
+            if (raw_mempool_sequence != "true" && raw_mempool_sequence != "false") {
+                return RESTERR(req, HTTP_BAD_REQUEST, "The \"mempool_sequence\" query parameter must be either \"true\" or \"false\".");
+            }
+            const bool verbose{raw_verbose == "true"};
+            const bool mempool_sequence{raw_mempool_sequence == "true"};
+            if (verbose && mempool_sequence) {
+                return RESTERR(req, HTTP_BAD_REQUEST, "Verbose results cannot contain mempool sequence values. (hint: set \"verbose=false\")");
+            }
+            str_json = MempoolToJSON(*mempool, verbose, mempool_sequence).write() + "\n";
         } else {
             str_json = MempoolInfoToJSON(*mempool).write() + "\n";
         }

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -348,6 +348,34 @@ class RESTTest (BitcoinTestFramework):
             assert_equal(json_obj[tx]['spentby'], txs[i + 1:i + 2])
             assert_equal(json_obj[tx]['depends'], txs[i - 1:i])
 
+        # Check the mempool response for explicit parameters
+        json_obj = self.test_rest_request("/mempool/contents", query_params={"verbose": "true", "mempool_sequence": "false"})
+        assert_equal(json_obj, raw_mempool_verbose)
+
+        # Check the mempool response for not verbose
+        json_obj = self.test_rest_request("/mempool/contents", query_params={"verbose": "false"})
+        raw_mempool = self.nodes[0].getrawmempool(verbose=False)
+
+        assert_equal(json_obj, raw_mempool)
+
+        # Check the mempool response for sequence
+        json_obj = self.test_rest_request("/mempool/contents", query_params={"verbose": "false", "mempool_sequence": "true"})
+        raw_mempool = self.nodes[0].getrawmempool(verbose=False, mempool_sequence=True)
+
+        assert_equal(json_obj, raw_mempool)
+
+        # Check for error response if verbose=true and mempool_sequence=true
+        resp = self.test_rest_request("/mempool/contents", ret_type=RetType.OBJ, status=400, query_params={"verbose": "true", "mempool_sequence": "true"})
+        assert_equal(resp.read().decode('utf-8').strip(), 'Verbose results cannot contain mempool sequence values. (hint: set "verbose=false")')
+
+        # Check for error response if verbose is not "true" or "false"
+        resp = self.test_rest_request("/mempool/contents", ret_type=RetType.OBJ, status=400, query_params={"verbose": "TRUE"})
+        assert_equal(resp.read().decode('utf-8').strip(), 'The "verbose" query parameter must be either "true" or "false".')
+
+        # Check for error response if mempool_sequence is not "true" or "false"
+        resp = self.test_rest_request("/mempool/contents", ret_type=RetType.OBJ, status=400, query_params={"verbose": "false", "mempool_sequence": "TRUE"})
+        assert_equal(resp.read().decode('utf-8').strip(), 'The "mempool_sequence" query parameter must be either "true" or "false".')
+
         # Now mine the transactions
         newblockhash = self.generate(self.nodes[1], 1)
 


### PR DESCRIPTION
The verbose mempool json response can get very large. This adds an option to return the non-verbose response of just the txids. It is identical to the rpc response so the diff here is minimal. This also adds the mempool_sequence parameter for rpc consistency. Verbose defaults to true to remain backwards compatible.

It uses query parameters to be compatible with the efforts in https://github.com/bitcoin/bitcoin/issues/25752.