### PR TITLE
ci: Bump vcpkg to the latest version `2022.09.27`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -104,7 +104,7 @@ task:
   env:
     PATH: 'C:\jom;C:\Python39;C:\Python39\Scripts;C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin;%PATH%'
     PYTHONUTF8: 1
-    CI_VCPKG_TAG: '2022.06.16.1'
+    CI_VCPKG_TAG: '2022.09.27'
     VCPKG_DOWNLOADS: 'C:\Users\ContainerAdministrator\AppData\Local\vcpkg\downloads'
     VCPKG_DEFAULT_BINARY_CACHE: 'C:\Users\ContainerAdministrator\AppData\Local\vcpkg\archives'
     CCACHE_DIR: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'


### PR DESCRIPTION
Dependency changes in [vcpkg](https://github.com/microsoft/vcpkg) (2022.06.16.1 - [2022.09.27](https://github.com/microsoft/vcpkg/releases/tag/2022.09.27)):
 - boost 1.79.0#0 -> 1.80.0#0
 - sqlite3 3.37.2#1 -> 3.39.2#0
 - zeromq 4.3.4#5 -> 4.3.4#6

The recent update was in bitcoin/bitcoin#25460.