### PR TITLE
contrib: Fix capture_output in getcoins.py

### DIFF
--- a/contrib/signet/getcoins.py
+++ b/contrib/signet/getcoins.py
@@ -129,7 +129,7 @@ if args.captcha != '': # Retrieve a captcha
 
     # Convert SVG image to PPM, and load it
     try:
-        rv = subprocess.run([args.imagemagick, 'svg:-', '-depth', '8', 'ppm:-'], input=res.content, check=True, capture_output=True)
+        rv = subprocess.run([args.imagemagick, 'svg:-', '-depth', '8', 'ppm:-'], input=res.content, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     except FileNotFoundError:
         raise SystemExit(f"The binary {args.imagemagick} could not be found. Please make sure ImageMagick (or a compatible fork) is installed and that the correct path is specified.")
 


### PR DESCRIPTION
Our minimum required Python version 3.6.12 does not support `capture_output` as a subprocess.run argument; this was added in python 3.7.

We can emulate it by setting both stdout and stderr to `subprocess.PIPE`