### PR TITLE
test: Use proper Boost macros instead of assertions

### DIFF
--- a/src/test/banman_tests.cpp
+++ b/src/test/banman_tests.cpp
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(file)
             "  { \"version\": 1, \"ban_created\": 0, \"banned_until\": 778, \"address\": \"1.0.0.0/8\" }"
             "] }",
         };
-        assert(WriteBinaryFile(banlist_path + ".json", entries_write));
+        BOOST_REQUIRE(WriteBinaryFile(banlist_path + ".json", entries_write));
         {
             // The invalid entries will be dropped, but the valid one remains
             ASSERT_DEBUG_LOG("Dropping entry with unparseable address or subnet (aaaaaaaaa) from ban list");
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(file)
             BanMan banman{banlist_path, /*client_interface=*/nullptr, /*default_ban_time=*/0};
             banmap_t entries_read;
             banman.GetBanned(entries_read);
-            assert(entries_read.size() == 1);
+            BOOST_CHECK_EQUAL(entries_read.size(), 1);
         }
     }
 }


### PR DESCRIPTION
On the master branch:
```
$ src/test/test_bitcoin -l test_suite -t banman_tests
Running 1 test case...
...
Test case banman_tests/file did not check any assertions
...
```

This PR suggests to use proper Boost [macros](https://www.boost.org/doc/libs/1_80_0/libs/test/doc/html/boost_test/utf_reference/testing_tool_ref.html).