### PR TITLE
ci: Run `bench_bitcoin.exe --sanity-check` in "Win64 native" task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -183,9 +183,9 @@ task:
     - python build_msvc\msvc-autogen.py
     - msbuild build_msvc\bitcoin.sln -property:CLToolExe=%WRAPPED_CL% -property:Configuration=Release -maxCpuCount -verbosity:minimal -noLogo
     - ccache --show-stats
-  unit_tests_script:
+  check_script:
     - src\test_bitcoin.exe -l test_suite
-    - src\bench_bitcoin.exe > NUL
+    - src\bench_bitcoin.exe --sanity-check > NUL
     - python test\util\test_runner.py
     - python test\util\rpcauth-test.py
   functional_tests_script:


### PR DESCRIPTION
This PR adds [`--sanity-check`](https://github.com/bitcoin/bitcoin/pull/25107) flag to `src\bench_bitcoin.exe` invocation as its results are been discarded.

Also a better name used for the script as it follows GNU's `make check`.