### PR TITLE
ci: Clean up lint task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -67,10 +67,10 @@ compute_credits_template: &CREDITS_TEMPLATE
   use_compute_credits: $CIRRUS_REPO_FULL_NAME == 'bitcoin/bitcoin' && $CIRRUS_PR != ""
 
 task:
-  name: 'lint [bionic]'
+  name: 'lint [jammy]'
   << : *BASE_TEMPLATE
   container:
-    image: ubuntu:bionic  # For python 3.6, oldest supported version according to doc/dependencies.md
+    image: ubuntu:jammy
     cpu: 1
     memory: 1G
   # For faster CI feedback, immediately schedule the linters

--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C
 
 ${CI_RETRY_EXE} apt-get update
-${CI_RETRY_EXE} apt-get install -y clang-format-9 python3-pip curl git gawk jq
+${CI_RETRY_EXE} apt-get install -y python3-pip curl git gawk jq
 (
   # Temporary workaround for https://github.com/bitcoin/bitcoin/pull/26130#issuecomment-1260499544
   # Can be removed once the underlying image is bumped to something that includes git2.34 or later
@@ -15,8 +15,6 @@ ${CI_RETRY_EXE} apt-get install -y clang-format-9 python3-pip curl git gawk jq
   ${CI_RETRY_EXE} apt-get update
   ${CI_RETRY_EXE} apt-get install -y --reinstall git
 )
-update-alternatives --install /usr/bin/clang-format      clang-format      "$(which clang-format-9     )" 100
-update-alternatives --install /usr/bin/clang-format-diff clang-format-diff "$(which clang-format-diff-9)" 100
 
 ${CI_RETRY_EXE} pip3 install codespell==2.2.1
 ${CI_RETRY_EXE} pip3 install flake8==4.0.1

--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -7,14 +7,14 @@
 export LC_ALL=C
 
 ${CI_RETRY_EXE} apt-get update
-${CI_RETRY_EXE} apt-get install -y python3-pip curl git gawk jq
-(
-  # Temporary workaround for https://github.com/bitcoin/bitcoin/pull/26130#issuecomment-1260499544
-  # Can be removed once the underlying image is bumped to something that includes git2.34 or later
-  sed -i -e 's/bionic/jammy/g' /etc/apt/sources.list
-  ${CI_RETRY_EXE} apt-get update
-  ${CI_RETRY_EXE} apt-get install -y --reinstall git
-)
+${CI_RETRY_EXE} apt-get install -y curl git gawk jq software-properties-common
+
+${CI_RETRY_EXE} add-apt-repository --yes ppa:deadsnakes/ppa  # For python3.x
+${CI_RETRY_EXE} apt-get install -y python3.6-venv
+python3.6 -m venv ./lint_env  # Oldest supported version according to doc/dependencies.md
+
+sed -i -e '1 s/^/# shellcheck disable=all\n/' ./lint_env/bin/activate
+source ./lint_env/bin/activate
 
 ${CI_RETRY_EXE} pip3 install codespell==2.2.1
 ${CI_RETRY_EXE} pip3 install flake8==4.0.1


### PR DESCRIPTION
* Remove unused clang-format install
* Remove workaround after bumping to jammy
* Use a PPA to pin the python version instead of having to pick from the limited system-packaged python versions