### PR TITLE
refactor: move *index constants out of validation

### DIFF
--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -12,6 +12,8 @@
 #include <index/base.h>
 #include <util/hasher.h>
 
+static const char* const DEFAULT_BLOCKFILTERINDEX = "0";
+
 /** Interval between compact filter checkpoints. See BIP 157. */
 static constexpr int CFCHECKPT_INTERVAL = 1000;
 

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -14,6 +14,8 @@ namespace kernel {
 struct CCoinsStats;
 }
 
+static constexpr bool DEFAULT_COINSTATSINDEX{false};
+
 /**
  * CoinStatsIndex maintains statistics on the UTXO set.
  */

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -7,6 +7,8 @@
 
 #include <index/base.h>
 
+static constexpr bool DEFAULT_TXINDEX{false};
+
 /**
  * TxIndex is used to look up transactions included in the blockchain by hash.
  * The index is written to a LevelDB database and records the filesystem

--- a/src/node/caches.cpp
+++ b/src/node/caches.cpp
@@ -4,9 +4,9 @@
 
 #include <node/caches.h>
 
+#include <index/txindex.h>
 #include <txdb.h>
 #include <util/system.h>
-#include <validation.h>
 
 namespace node {
 CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes)

--- a/src/validation.h
+++ b/src/validation.h
@@ -65,7 +65,6 @@ static const int MAX_SCRIPTCHECK_THREADS = 15;
 static const int DEFAULT_SCRIPTCHECK_THREADS = 0;
 static const int64_t DEFAULT_MAX_TIP_AGE = 24 * 60 * 60;
 static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
-static constexpr bool DEFAULT_COINSTATSINDEX{false};
 static const char* const DEFAULT_BLOCKFILTERINDEX = "0";
 /** Default for -stopatheight */
 static const int DEFAULT_STOPATHEIGHT = 0;

--- a/src/validation.h
+++ b/src/validation.h
@@ -65,7 +65,6 @@ static const int MAX_SCRIPTCHECK_THREADS = 15;
 static const int DEFAULT_SCRIPTCHECK_THREADS = 0;
 static const int64_t DEFAULT_MAX_TIP_AGE = 24 * 60 * 60;
 static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
-static const char* const DEFAULT_BLOCKFILTERINDEX = "0";
 /** Default for -stopatheight */
 static const int DEFAULT_STOPATHEIGHT = 0;
 /** Block files containing a block-height within MIN_BLOCKS_TO_KEEP of ActiveChain().Tip() will not be pruned. */

--- a/src/validation.h
+++ b/src/validation.h
@@ -65,7 +65,6 @@ static const int MAX_SCRIPTCHECK_THREADS = 15;
 static const int DEFAULT_SCRIPTCHECK_THREADS = 0;
 static const int64_t DEFAULT_MAX_TIP_AGE = 24 * 60 * 60;
 static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
-static const bool DEFAULT_TXINDEX = false;
 static constexpr bool DEFAULT_COINSTATSINDEX{false};
 static const char* const DEFAULT_BLOCKFILTERINDEX = "0";
 /** Default for -stopatheight */


### PR DESCRIPTION
Move `*index` default constants out of `validation.h`.