### PR TITLE
ci: Use same `merge_script` implementation for Windows as for all

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,11 +24,8 @@ filter_template: &FILTER_TEMPLATE
 base_template: &BASE_TEMPLATE
   << : *FILTER_TEMPLATE
   merge_base_script:
-    # Unconditionally install git (used in fingerprint_script) and set the
-    # default git author name (used in verify-commits.py)
+    # Unconditionally install git (used in fingerprint_script).
     - bash -c "$PACKAGE_MANAGER_INSTALL git"
-    - git config --global user.email "ci@ci.ci"
-    - git config --global user.name "ci"
     - if [ "$CIRRUS_PR" = "" ]; then exit 0; fi
     - git fetch $CIRRUS_REPO_CLONE_URL "pull/${CIRRUS_PR}/merge"
     - git checkout FETCH_HEAD  # Use merged changes to detect silent merge conflicts

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -114,14 +114,7 @@ task:
     QT_CONFIGURE_COMMAND: '..\configure -release -silent -opensource -confirm-license -opengl desktop -static -static-runtime -mp -qt-zlib -qt-pcre -qt-libpng -nomake examples -nomake tests -nomake tools -no-angle -no-dbus -no-gif -no-gtk -no-ico -no-icu -no-libjpeg -no-libudev -no-sql-sqlite -no-sql-odbc -no-sqlite -no-vulkan -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtconnectivity -skip qtdatavis3d -skip qtdeclarative -skip doc -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtlottie -skip qtmacextras -skip qtmultimedia -skip qtnetworkauth -skip qtpurchasing -skip qtquick3d -skip qtquickcontrols -skip qtquickcontrols2 -skip qtquicktimeline -skip qtremoteobjects -skip qtscript -skip qtscxml -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtsvg -skip qtvirtualkeyboard -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin -skip qtwebsockets -skip qtwebview -skip qtx11extras -skip qtxmlpatterns -no-openssl -no-feature-bearermanagement -no-feature-printdialog -no-feature-printer -no-feature-printpreviewdialog -no-feature-printpreviewwidget -no-feature-sql -no-feature-sqlmodel -no-feature-textbrowser -no-feature-textmarkdownwriter -no-feature-textodfwriter -no-feature-xml'
     IgnoreWarnIntDirInTempDetected: 'true'
   merge_script:
-    - git config --global user.email "ci@ci.ci"
-    - git config --global user.name "ci"
-    # Windows filesystem loses the executable bit, and all of the executable
-    # files are considered "modified" now. It will break the following `git merge`
-    # command. The next two commands make git ignore this issue.
-    - git config core.filemode false
-    - git reset --hard
-    - PowerShell -NoLogo -Command if ($env:CIRRUS_PR -ne $null) { git fetch $env:CIRRUS_REPO_CLONE_URL $env:CIRRUS_BASE_BRANCH; git merge FETCH_HEAD; }
+    - PowerShell -NoLogo -Command if ($env:CIRRUS_PR -ne $null) { git fetch $env:CIRRUS_REPO_CLONE_URL pull/$env:CIRRUS_PR/merge; git checkout FETCH_HEAD; }
   msvc_qt_built_cache:
     folder: "%QTBASEDIR%"
     reupload_on_changes: false

--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -31,6 +31,8 @@ if [ "$CIRRUS_REPO_FULL_NAME" = "bitcoin/bitcoin" ] && [ "$CIRRUS_PR" = "" ] ; t
     git log HEAD~10 -1 --format='%H' > ./contrib/verify-commits/trusted-sha512-root-commit
     git log HEAD~10 -1 --format='%H' > ./contrib/verify-commits/trusted-git-root
     mapfile -t KEYS < contrib/verify-commits/trusted-keys
+    git config user.email "ci@ci.ci"
+    git config user.name "ci"
     ${CI_RETRY_EXE} gpg --keyserver hkps://keys.openpgp.org --recv-keys "${KEYS[@]}" &&
     ./contrib/verify-commits/verify-commits.py;
 fi


### PR DESCRIPTION
This PR is a continuation of bitcoin/bitcoin#26202 and it suggests the same approach for the "Win64 native" CI task.