### PR TITLE
kernel: remove util/bytevectorhash.cpp

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -927,7 +927,6 @@ libbitcoinkernel_la_SOURCES = \
   txdb.cpp \
   txmempool.cpp \
   uint256.cpp \
-  util/bytevectorhash.cpp \
   util/check.cpp \
   util/getuniquepath.cpp \
   util/hasher.cpp \


### PR DESCRIPTION
This is no-longer used.