### PR TITLE
refactor: Make m_mempool optional in PeerManager

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1569,7 +1569,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     assert(!node.peerman);
     node.peerman = PeerManager::make(*node.connman, *node.addrman, node.banman.get(),
-                                     chainman, *node.mempool, ignores_incoming_txs);
+                                     chainman, node.mempool.get(), ignores_incoming_txs);
     RegisterValidationInterface(node.peerman.get());
 
     // ********************************************************* Step 8: start indexers

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -43,7 +43,7 @@ class PeerManager : public CValidationInterface, public NetEventsInterface
 public:
     static std::unique_ptr<PeerManager> make(CConnman& connman, AddrMan& addrman,
                                              BanMan* banman, ChainstateManager& chainman,
-                                             CTxMemPool& pool, bool ignore_incoming_txs);
+                                             CTxMemPool* pool, bool ignore_incoming_txs);
     virtual ~PeerManager() { }
 
     /**

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
     NodeId id{0};
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman);
     auto peerLogic = PeerManager::make(*connman, *m_node.addrman, nullptr,
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, m_node.mempool.get(), false);
 
     constexpr int max_outbound_full_relay = MAX_OUTBOUND_FULL_RELAY_CONNECTIONS;
     CConnman::Options options;
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(block_relay_only_eviction)
     NodeId id{0};
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman);
     auto peerLogic = PeerManager::make(*connman, *m_node.addrman, nullptr,
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, m_node.mempool.get(), false);
 
     constexpr int max_outbound_block_relay{MAX_BLOCK_RELAY_ONLY_CONNECTIONS};
     constexpr int64_t MINIMUM_CONNECT_TIME{30};
@@ -273,7 +273,7 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     auto banman = std::make_unique<BanMan>(m_args.GetDataDirBase() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman);
     auto peerLogic = PeerManager::make(*connman, *m_node.addrman, banman.get(),
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, m_node.mempool.get(), false);
 
     CNetAddr tor_netaddr;
     BOOST_REQUIRE(
@@ -376,7 +376,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     auto banman = std::make_unique<BanMan>(m_args.GetDataDirBase() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman);
     auto peerLogic = PeerManager::make(*connman, *m_node.addrman, banman.get(),
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, m_node.mempool.get(), false);
 
     banman->ClearBanned();
     int64_t nStartTime = GetTime();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -252,7 +252,7 @@ TestingSetup::TestingSetup(
     m_node.connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman); // Deterministic randomness for tests.
     m_node.peerman = PeerManager::make(*m_node.connman, *m_node.addrman,
                                        m_node.banman.get(), *m_node.chainman,
-                                       *m_node.mempool, false);
+                                       m_node.mempool.get(), false);
     {
         CConnman::Options options;
         options.m_msgproc = m_node.peerman.get();


### PR DESCRIPTION
Make `m_mempool` an optional pointer in PeerManager, instead of a reference.

* This is a prerequisite for the introduction of a `-nomempool` option. (To run a node with just libbitcoinkernel and a minimal P2P stack to receive blocks)
* The mempool is already treated optional in pretty much every other part of the codebase (validation, RPC, ...), so doing it consistently is preferable.
* Removing the requirement of PeerManager to hold a reference to a mempool makes (unit/fuzz) testing easier if there is a test that doesn't need the mempool. Also, it makes the coupling of CTxMemPool and PeerManager a bit more loose.

Picked up from https://github.com/bitcoin/bitcoin/pull/22850
