### PR TITLE
net: Set relay in version msg to peers with relay permission in -blocksonly mode

### DIFF
--- a/test/functional/p2p_blocksonly.py
+++ b/test/functional/p2p_blocksonly.py
@@ -57,6 +57,7 @@ class P2PBlocksOnly(BitcoinTestFramework):
         second_peer = self.nodes[0].add_p2p_connection(P2PInterface())
         peer_1_info = self.nodes[0].getpeerinfo()[0]
         assert_equal(peer_1_info['permissions'], ['relay'])
+        assert_equal(first_peer.relay, 1)
         peer_2_info = self.nodes[0].getpeerinfo()[1]
         assert_equal(peer_2_info['permissions'], ['relay'])
         assert_equal(self.nodes[0].testmempoolaccept([tx_hex])[0]['allowed'], True)

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -446,6 +446,7 @@ class P2PInterface(P2PConnection):
             self.send_message(msg_sendaddrv2())
         self.send_message(msg_verack())
         self.nServices = message.nServices
+        self.relay = message.relay
         self.send_message(msg_getaddr())
 
     # Connection helper methods


### PR DESCRIPTION
Seems odd to set the `relay` permission in -blocksonly mode and also ask the peer not to relay transactions.