### PR TITLE
ci: Remove clang-format from lint task

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C
 
 ${CI_RETRY_EXE} apt-get update
-${CI_RETRY_EXE} apt-get install -y clang-format-9 python3-pip curl git gawk jq
+${CI_RETRY_EXE} apt-get install -y python3-pip curl git gawk jq
 (
   # Temporary workaround for https://github.com/bitcoin/bitcoin/pull/26130#issuecomment-1260499544
   # Can be removed once the underlying image is bumped to something that includes git2.34 or later
@@ -15,8 +15,6 @@ ${CI_RETRY_EXE} apt-get install -y clang-format-9 python3-pip curl git gawk jq
   ${CI_RETRY_EXE} apt-get update
   ${CI_RETRY_EXE} apt-get install -y --reinstall git
 )
-update-alternatives --install /usr/bin/clang-format      clang-format      "$(which clang-format-9     )" 100
-update-alternatives --install /usr/bin/clang-format-diff clang-format-diff "$(which clang-format-diff-9)" 100
 
 ${CI_RETRY_EXE} pip3 install codespell==2.2.1
 ${CI_RETRY_EXE} pip3 install flake8==4.0.1


### PR DESCRIPTION
clang-format could be used in scripted diffs, but remained largely unused.

So remove the install bloat, as it is unlikely to be used in the future.