### PR TITLE
test: Prevent UB in `minisketch_tests.cpp`

### DIFF
--- a/src/test/minisketch_tests.cpp
+++ b/src/test/minisketch_tests.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(minisketch_test)
         Minisketch sketch_c = std::move(sketch_ar);
         sketch_c.Merge(sketch_br);
         auto dec = sketch_c.Decode(errors);
-        BOOST_CHECK(dec.has_value());
+        BOOST_REQUIRE(dec.has_value());
         auto sols = std::move(*dec);
         std::sort(sols.begin(), sols.end());
         for (uint32_t i = 0; i < a_not_b; ++i) BOOST_CHECK_EQUAL(sols[i], start_a + i);


### PR DESCRIPTION
[`std::optional::operator*`](https://en.cppreference.com/w/cpp/utility/optional/operator*), which follows after the changed line, can cause UB.

This PR addresses https://github.com/bitcoin/bitcoin/issues/26262#issuecomment-1268855418 