### PR TITLE
docs: fix m_children to be a member of CTxMemPoolEntry

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -145,7 +145,7 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256>& vHashes
     // Iterate in reverse, so that whenever we are looking at a transaction
     // we are sure that all in-mempool descendants have already been processed.
     // This maximizes the benefit of the descendant cache and guarantees that
-    // CTxMemPool::m_children will be updated, an assumption made in
+    // CTxMemPoolEntry::m_children will be updated, an assumption made in
     // UpdateForDescendants.
     for (const uint256 &hash : reverse_iterate(vHashesToUpdate)) {
         // calculate children from mapNextTx
@@ -154,7 +154,7 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256>& vHashes
             continue;
         }
         auto iter = mapNextTx.lower_bound(COutPoint(hash, 0));
-        // First calculate the children, and update CTxMemPool::m_children to
+        // First calculate the children, and update CTxMemPoolEntry::m_children to
         // include them, and update their CTxMemPoolEntry::m_parents to include this tx.
         // we cache the in-mempool children to avoid duplicate updates
         {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -825,7 +825,7 @@ private:
      *  mempool but may have child transactions in the mempool, eg during a
      *  chain reorg.
      *
-     * @pre CTxMemPool::m_children is correct for the given tx and all
+     * @pre CTxMemPoolEntry::m_children is correct for the given tx and all
      *      descendants.
      * @pre cachedDescendants is an accurate cache where each entry has all
      *      descendants of the corresponding key, including those that should


### PR DESCRIPTION
Small documentation fix to reflect that `m_children` [is a member](https://github.com/bitcoin/bitcoin/blob/73b61717a977fc9d23f1bae3f8620641a9dee1f3/src/txmempool.h#L99) of `CTxMemPoolEntry`, not `CTxMemPool`