### PR TITLE
p2p: Fill reconciliation sets and request reconciliation (Erlay)

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -175,6 +175,8 @@ static constexpr double MAX_ADDR_RATE_PER_SECOND{0.1};
 static constexpr size_t MAX_ADDR_PROCESSING_TOKEN_BUCKET{MAX_ADDR_TO_SEND};
 /** The compactblocks version we support. See BIP 152. */
 static constexpr uint64_t CMPCTBLOCKS_VERSION{2};
+/** Used to determine whether to use low-fanout flooding (or reconciliation) for a tx relay event. */
+static const uint64_t RANDOMIZER_ID_FANOUTTARGET = 0xbac89af818407b6aULL; // SHA256("fanouttarget")[0:8]
 
 // Internal stuff
 namespace {
@@ -3911,6 +3913,9 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                 if (!fAlreadyHave && !m_chainman.IsInitialBlockDownload()) {
                     AddTxAnnouncement(pfrom, gtxid, current_time);
                 }
+                if (m_txreconciliation && gtxid.IsWtxid()) {
+                    m_txreconciliation->TryRemovingFromSet(pfrom.GetId(), gtxid.GetHash());
+                }
             } else {
                 LogPrint(BCLog::NET, "Unknown inv type \"%s\" received from peer=%d\n", inv.ToString(), pfrom.GetId());
             }
@@ -4196,6 +4201,8 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
         m_txrequest.ReceivedResponse(pfrom.GetId(), txid);
         if (tx.HasWitness()) m_txrequest.ReceivedResponse(pfrom.GetId(), wtxid);
+
+        if (m_txreconciliation) m_txreconciliation->TryRemovingFromSet(pfrom.GetId(), wtxid);
 
         // We do the AlreadyHaveTx() check using wtxid, rather than txid - in the
         // absence of witness malleation, this is strictly better, because the
@@ -5752,9 +5759,12 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
         }
 
         if (auto tx_relay = peer->GetTxRelay(); tx_relay != nullptr) {
+                // Lock way before it's used to maintain lock ordering.
+                LOCK2(m_mempool.cs, m_peer_mutex);
                 LOCK(tx_relay->m_tx_inventory_mutex);
                 // Check whether periodic sends should happen
                 bool fSendTrickle = pto->HasPermission(NetPermissionFlags::NoBan);
+                const bool reconciles_txs = m_txreconciliation && m_txreconciliation->IsPeerRegistered(pto->GetId());
                 if (tx_relay->m_next_inv_send_time < current_time) {
                     fSendTrickle = true;
                     if (pto->IsInboundConn()) {
@@ -5814,6 +5824,28 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                     // No reason to drain out at many times the network's capacity,
                     // especially since we have many peers and some will draw much shorter delays.
                     unsigned int nRelayedTransactions = 0;
+
+                    size_t inbounds_nonrcncl_tx_relay = 0, outbounds_nonrcncl_tx_relay = 0;
+                    if (m_txreconciliation) {
+                        for (auto [cur_peer_id, cur_peer] : m_peer_map) {
+                            // Skip the source of the transaction.
+                            if (cur_peer_id == pto->GetId()) continue;
+                            const auto cur_state{State(cur_peer_id)};
+                            if (!cur_state) continue;
+                            if (auto peer_tx_relay = cur_peer->GetTxRelay()) {
+                                LOCK(peer_tx_relay->m_bloom_filter_mutex);
+                                // When we consider to which (and how many) Erlay peers
+                                // we should fanout a tx, we must know to how
+                                // many peers we would certainly announce this tx
+                                // (non-Erlay peers).
+                                if (peer_tx_relay->m_relay_txs && !m_txreconciliation->IsPeerRegistered(cur_peer_id)) {
+                                    inbounds_nonrcncl_tx_relay += cur_state->m_is_inbound;
+                                    outbounds_nonrcncl_tx_relay += !cur_state->m_is_inbound;
+                                }
+                            }
+                        }
+                    }
+
                     LOCK(tx_relay->m_bloom_filter_mutex);
                     size_t broadcast_max{INVENTORY_BROADCAST_TARGET + (tx_relay->m_tx_inventory_to_send.size()/1000)*5};
                     broadcast_max = std::min<size_t>(INVENTORY_BROADCAST_MAX, broadcast_max);
@@ -5841,7 +5873,35 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                         }
                         if (tx_relay->m_bloom_filter && !tx_relay->m_bloom_filter->IsRelevantAndUpdate(*txinfo.tx)) continue;
                         // Send
-                        vInv.push_back(inv);
+                        bool fanout = true;
+                        const auto wtxid = txinfo.tx->GetWitnessHash();
+                        if (reconciles_txs) {
+                            auto txiter = m_mempool.GetIter(txinfo.tx->GetHash());
+                            if (txiter) {
+                                if ((*txiter)->GetCountWithDescendants() > 1) {
+                                    // If a transaction has in-mempool children, always fanout it.
+                                    // Until package relay is implemented, this is needed to avoid
+                                    // breaking parent+child relay expectations in some cases.
+                                    //
+                                    // Potentially reconciling parent+child would mean that for every
+                                    // child we need to to check if any of the parents is currently
+                                    // reconciled so that the child isn't fanouted ahead. But then
+                                    // it gets tricky when reconciliation sets are full: a) the child
+                                    // can't just be added; b) removing parents from reconciliation
+                                    // sets for this one child is not good either.
+                                    fanout = true;
+                                } else {
+                                    auto fanout_randomizer = m_connman.GetDeterministicRandomizer(RANDOMIZER_ID_FANOUTTARGET);
+                                    fanout = m_txreconciliation->ShouldFanoutTo(wtxid, fanout_randomizer, pto->GetId(),
+                                                                                inbounds_nonrcncl_tx_relay, outbounds_nonrcncl_tx_relay);
+                                }
+                            }
+                        }
+
+                        if (fanout || !m_txreconciliation->AddToSet(pto->GetId(), wtxid)) {
+                            vInv.push_back(inv);
+                        }
+
                         nRelayedTransactions++;
                         if (vInv.size() == MAX_INV_SZ) {
                             m_connman.PushMessage(pto, msgMaker.Make(NetMsgType::INV, vInv));
@@ -5851,7 +5911,6 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                     }
 
                     // Ensure we'll respond to GETDATA requests for anything we've just announced
-                    LOCK(m_mempool.cs);
                     tx_relay->m_last_inv_sequence = m_mempool.GetSequence();
                 }
         }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -5535,7 +5535,21 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
 
     PeerRef peer = GetPeerRef(pto->GetId());
     if (!peer) return false;
+
     const Consensus::Params& consensusParams = m_chainparams.GetConsensus();
+
+    const auto current_time{GetTime<std::chrono::microseconds>()};
+
+    // We must look into the reconciliation queue early. Since the queue applies to all peers,
+    // this peer might block other reconciliation if we don't make this call regularly and
+    // unconditionally.
+    // This queue should be queued no matter what's with the peer (e.g. in future a peer
+    // may signal a post-sync IBD after some lag), because otherwise such peer may block the queue
+    // forever.
+    bool reconcile = false;
+    if (m_txreconciliation && !m_chainman.IsInitialBlockDownload()) {
+        reconcile = m_txreconciliation->IsPeerNextToReconcileWith(pto->GetId(), current_time);
+    }
 
     // We must call MaybeDiscourageAndDisconnect first, to ensure that we'll
     // disconnect misbehaving peers even before the version handshake is complete.
@@ -5547,8 +5561,6 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
 
     // If we get here, the outgoing message serialization version is set and can't change.
     const CNetMsgMaker msgMaker(pto->GetCommonVersion());
-
-    const auto current_time{GetTime<std::chrono::microseconds>()};
 
     if (pto->IsAddrFetchConn() && current_time - pto->m_connected > 10 * AVG_ADDRESS_BROADCAST_INTERVAL) {
         LogPrint(BCLog::NET, "addrfetch connection timeout; disconnecting peer=%d\n", pto->GetId());
@@ -5952,6 +5964,19 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
         }
         if (!vInv.empty())
             m_connman.PushMessage(pto, msgMaker.Make(NetMsgType::INV, vInv));
+
+        //
+        // Message: reconciliation request
+        //
+        {
+            if (reconcile) {
+                const auto reconciliation_request_params = m_txreconciliation->InitiateReconciliationRequest(pto->GetId());
+                if (reconciliation_request_params) {
+                    const auto [local_set_size, local_q_formatted] = *reconciliation_request_params;
+                    m_connman.PushMessage(pto, msgMaker.Make(NetMsgType::REQTXRCNCL, local_set_size, local_q_formatted));
+                }
+            }
+        }
 
         // Detect whether we're stalling
         auto stalling_timeout = m_block_stalling_timeout.load();

--- a/src/node/txreconciliation.cpp
+++ b/src/node/txreconciliation.cpp
@@ -134,13 +134,19 @@ public:
         }
     }
 
-    bool IsPeerRegistered(NodeId peer_id) const EXCLUSIVE_LOCKS_REQUIRED(!m_txreconciliation_mutex)
+    bool IsPeerRegistered(NodeId peer_id) const EXCLUSIVE_LOCKS_REQUIRED(m_txreconciliation_mutex)
     {
-        AssertLockNotHeld(m_txreconciliation_mutex);
-        LOCK(m_txreconciliation_mutex);
+        AssertLockHeld(m_txreconciliation_mutex);
         auto recon_state = m_states.find(peer_id);
         return (recon_state != m_states.end() &&
                 std::holds_alternative<TxReconciliationState>(recon_state->second));
+    }
+
+    bool IsPeerRegisteredExternal(NodeId peer_id) const EXCLUSIVE_LOCKS_REQUIRED(!m_txreconciliation_mutex)
+    {
+        AssertLockNotHeld(m_txreconciliation_mutex);
+        LOCK(m_txreconciliation_mutex);
+        return IsPeerRegistered(peer_id);
     }
 };
 
@@ -166,5 +172,5 @@ void TxReconciliationTracker::ForgetPeer(NodeId peer_id)
 
 bool TxReconciliationTracker::IsPeerRegistered(NodeId peer_id) const
 {
-    return m_impl->IsPeerRegistered(peer_id);
+    return m_impl->IsPeerRegisteredExternal(peer_id);
 }

--- a/src/node/txreconciliation.cpp
+++ b/src/node/txreconciliation.cpp
@@ -31,6 +31,29 @@ constexpr size_t OUTBOUND_FANOUT_DESTINATIONS = 1;
  */
 constexpr size_t MAX_SET_SIZE = 3000;
 /**
+ * A floating point coefficient q for estimating reconciliation set difference, and
+ * the value used to convert it to integer for transmission purposes, as specified in BIP-330.
+ */
+constexpr double Q = 0.25;
+constexpr uint16_t Q_PRECISION{(2 << 14) - 1};
+/**
+ * Interval between initiating reconciliations with peers.
+ * This value allows to reconcile ~(7 tx/s * 8s) transactions during normal operation.
+ * More frequent reconciliations would cause significant constant bandwidth overhead
+ * due to reconciliation metadata (sketch sizes etc.), which would nullify the efficiency.
+ * Less frequent reconciliations would introduce high transaction relay latency.
+ */
+constexpr std::chrono::microseconds RECON_REQUEST_INTERVAL{8s};
+
+/**
+ * Represents phase of the current reconciliation round with a peer.
+ */
+enum class Phase {
+    NONE,
+    INIT_REQUESTED,
+};
+
+/**
  * Salt (specified by BIP-330) constructed from contributions from both peers. It is used
  * to compute transaction short IDs, which are then used to construct a sketch representing a set
  * of transactions we want to announce to the peer.
@@ -74,6 +97,17 @@ public:
      */
     std::set<uint256> m_local_set;
 
+    /** Keep track of the reconciliation phase with the peer. */
+    Phase m_phase{Phase::NONE};
+
+    /**
+     * For every outbound peer, we keep track of the last reconciliation finalization,
+     * so that we know whether sufficient time passed to start a next one. This timer
+     * is used in combination with m_queue and m_next_recon_request, so that the
+     * peers are queried periodically and in a fixed order.
+     */
+    std::chrono::microseconds m_last_txrcncl{0};
+
     TxReconciliationState(bool we_initiate, uint64_t k0, uint64_t k1) : m_we_initiate(we_initiate), m_k0(k0), m_k1(k1) {}
 };
 
@@ -108,6 +142,11 @@ private:
      * each given peer at a fixed sufficient interval (same across all peers).
      */
     std::deque<NodeId> m_queue GUARDED_BY(m_txreconciliation_mutex);
+
+    /**
+     * Make reconciliation requests periodically to make reconciliations efficient.
+     */
+    std::chrono::microseconds m_next_request_global GUARDED_BY(m_txreconciliation_mutex){0};
 
 public:
     explicit Impl(uint32_t recon_version) : m_recon_version(recon_version) {}
@@ -194,6 +233,63 @@ public:
         auto& recon_state = std::get<TxReconciliationState>(m_states.find(peer_id)->second);
 
         return recon_state.m_local_set.erase(wtxid_to_remove) > 0;
+    }
+
+    bool IsPeerNextToReconcileWith(NodeId peer_id, std::chrono::microseconds now) EXCLUSIVE_LOCKS_REQUIRED(!m_txreconciliation_mutex)
+    {
+        AssertLockNotHeld(m_txreconciliation_mutex);
+        LOCK(m_txreconciliation_mutex);
+
+        if (!IsPeerRegistered(peer_id)) return false;
+        if (m_queue.empty()) return false;
+
+        const auto& recon_state = std::get<TxReconciliationState>(m_states.find(peer_id)->second);
+
+        if (m_next_request_global <= now && m_queue.front() == peer_id) {
+            Assume(recon_state.m_we_initiate);
+            m_queue.pop_front();
+            m_queue.push_back(peer_id);
+
+            // It is possible that the front-queue peer is not ready for a reconciliation yet:
+            // - either it's own timer has not passed;
+            // - or it's currently in reconciliation.
+            //
+            // In both cases, we should not delay our reconciliations, but these peers should
+            // be moved to the end of the queue to get the next chance.
+            //
+            // Otherwise, we should bump the global timer and allow to proceed for reconciliation.
+            const bool their_delay_is_over = recon_state.m_last_txrcncl + RECON_REQUEST_INTERVAL < now;
+            if (recon_state.m_phase == Phase::NONE && their_delay_is_over) {
+                m_next_request_global = now + std::chrono::seconds(2);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    std::optional<std::pair<uint16_t, uint16_t>> InitiateReconciliationRequest(NodeId peer_id) EXCLUSIVE_LOCKS_REQUIRED(!m_txreconciliation_mutex)
+    {
+        AssertLockNotHeld(m_txreconciliation_mutex);
+        LOCK(m_txreconciliation_mutex);
+        if (!IsPeerRegistered(peer_id)) return std::nullopt;
+
+        auto& recon_state = std::get<TxReconciliationState>(m_states.find(peer_id)->second);
+        if (!recon_state.m_we_initiate) return std::nullopt;
+
+        if (recon_state.m_phase != Phase::NONE) return std::nullopt;
+        recon_state.m_phase = Phase::INIT_REQUESTED;
+
+        size_t local_set_size = recon_state.m_local_set.size();
+
+        LogPrintLevel(BCLog::TXRECONCILIATION, BCLog::Level::Debug, "Initiate reconciliation with peer=%d with the following params: " /* Continued */
+                                                                    "local_set_size=%i\n",
+                      peer_id, local_set_size);
+
+        // In future, Q could be recomputed after every reconciliation based on the
+        // set differences. For now, it provides good enough results without recompute
+        // complexity, but we communicate it here to allow backward compatibility if
+        // the value is changed or made dynamic.
+        return std::make_pair(local_set_size, Q * Q_PRECISION);
     }
 
     void ForgetPeer(NodeId peer_id) EXCLUSIVE_LOCKS_REQUIRED(!m_txreconciliation_mutex)
@@ -343,6 +439,16 @@ bool TxReconciliationTracker::AddToSet(NodeId peer_id, const uint256& wtxid)
 bool TxReconciliationTracker::TryRemovingFromSet(NodeId peer_id, const uint256& wtxid_to_remove)
 {
     return m_impl->TryRemovingFromSet(peer_id, wtxid_to_remove);
+}
+
+bool TxReconciliationTracker::IsPeerNextToReconcileWith(NodeId peer_id, std::chrono::microseconds now)
+{
+    return m_impl->IsPeerNextToReconcileWith(peer_id, now);
+}
+
+std::optional<std::pair<uint16_t, uint16_t>> TxReconciliationTracker::InitiateReconciliationRequest(NodeId peer_id)
+{
+    return m_impl->InitiateReconciliationRequest(peer_id);
 }
 
 void TxReconciliationTracker::ForgetPeer(NodeId peer_id)

--- a/src/node/txreconciliation.cpp
+++ b/src/node/txreconciliation.cpp
@@ -7,7 +7,9 @@
 #include <common/system.h>
 #include <logging.h>
 #include <util/check.h>
+#include <util/hasher.h>
 
+#include <cmath>
 #include <unordered_map>
 #include <variant>
 
@@ -17,6 +19,16 @@ namespace {
 /** Static salt component used to compute short txids for sketch construction, see BIP-330. */
 const std::string RECON_STATIC_SALT = "Tx Relay Salting";
 const HashWriter RECON_SALT_HASHER = TaggedHash(RECON_STATIC_SALT);
+/**
+ * Announce transactions via full wtxid to a limited number of inbound and outbound peers.
+ * Justification for these values are provided here:
+ * https://github.com/naumenkogs/txrelaysim/issues/7#issuecomment-902165806 */
+constexpr double INBOUND_FANOUT_DESTINATIONS_FRACTION = 0.1;
+constexpr size_t OUTBOUND_FANOUT_DESTINATIONS = 1;
+/**
+ * Maximum number of wtxids stored in a peer local set, bounded to protect the memory use of
+ * reconciliation sets and short ids mappings, and CPU used for sketch computation.
+ */
 constexpr size_t MAX_SET_SIZE = 3000;
 /**
  * Salt (specified by BIP-330) constructed from contributions from both peers. It is used
@@ -72,6 +84,11 @@ class TxReconciliationTracker::Impl
 {
 private:
     mutable Mutex m_txreconciliation_mutex;
+
+    /**
+     * ReconciliationTracker-wide randomness to choose fanout targets for a given txid.
+     */
+    const SaltedTxidHasher m_txid_hasher;
 
     // Local protocol version
     uint32_t m_recon_version;
@@ -193,6 +210,104 @@ public:
         LOCK(m_txreconciliation_mutex);
         return IsPeerRegistered(peer_id);
     }
+
+    std::vector<NodeId> GetFanoutTargets(CSipHasher& deterministic_randomizer_with_wtxid,
+                                         bool we_initiate, double limit) const EXCLUSIVE_LOCKS_REQUIRED(m_txreconciliation_mutex)
+    {
+        // The algorithm works as follows. We iterate through the peers (of a given direction)
+        // hashing them with the given wtxid, and sort them by this hash.
+        // We then consider top `limit` peers to be low-fanout flood targets.
+        // The randomness should be seeded with wtxid to return consistent results for every call.
+
+        // To handle fractional values, we add one peer optimistically and then probabilistically
+        // drop it later.
+        double integer_part;
+        double fractional_peer = std::modf(limit, &integer_part);
+        const size_t targets = size_t(integer_part) + 1;
+        const bool drop_peer_if_extra = deterministic_randomizer_with_wtxid.Finalize() > fractional_peer * double(UINT64_MAX);
+
+        std::vector<std::pair<uint64_t, NodeId>> best_peers;
+        for (size_t i = 0; i < targets; ++i) {
+            best_peers.emplace_back(0, 0);
+        }
+
+        auto try_fanout_candidate = [&best_peers, &deterministic_randomizer_with_wtxid, targets](
+                                        const TxReconciliationState& candidate_state, const NodeId& candidate_id) {
+            uint64_t hash_key = deterministic_randomizer_with_wtxid.Write(candidate_state.m_k0).Finalize();
+
+            for (size_t i = 0; i < targets; ++i) {
+                if (hash_key > best_peers[i].first) {
+                    best_peers.insert(best_peers.begin() + i, std::make_pair(hash_key, candidate_id));
+                    break;
+                }
+            }
+        };
+
+        for (auto indexed_state : m_states) {
+            const auto cur_state = std::get_if<TxReconciliationState>(&indexed_state.second);
+            if (cur_state && cur_state->m_we_initiate == we_initiate) {
+                try_fanout_candidate(*cur_state, indexed_state.first);
+            }
+        }
+
+        best_peers.erase(best_peers.begin() + targets, best_peers.end());
+
+        std::vector<NodeId> result;
+        std::for_each(best_peers.begin(), best_peers.end(),
+                      [&result](auto best_peer) {
+                          if (best_peer.first != 0) result.push_back(best_peer.second);
+                      });
+
+        if (result.size() > limit && drop_peer_if_extra) {
+            result.pop_back();
+        }
+
+        return result;
+    }
+
+    bool ShouldFanoutTo(const uint256& wtxid, CSipHasher deterministic_randomizer, NodeId peer_id,
+                        size_t inbounds_nonrcncl_tx_relay, size_t outbounds_nonrcncl_tx_relay)
+                        const EXCLUSIVE_LOCKS_REQUIRED(!m_txreconciliation_mutex)
+    {
+        AssertLockNotHeld(m_txreconciliation_mutex);
+        LOCK(m_txreconciliation_mutex);
+        if (!IsPeerRegistered(peer_id)) return true;
+        // We use the pre-determined randomness to give a consistent result per transaction,
+        // thus making sure that no transaction gets "unlucky" if every per-peer roll fails.
+        deterministic_randomizer.Write(wtxid.GetUint64(0));
+        const auto& recon_state = std::get<TxReconciliationState>(m_states.find(peer_id)->second);
+        // We decide whether a particular peer is a low-fanout flood target differently
+        // based on its connection direction:
+        // - for outbounds we have a fixed number of flood destinations;
+        // - for inbounds we use a fraction of all inbound peers supporting tx relay.
+        //
+        // We first decide how many reconciling peers of a given direction we want to flood to,
+        // and then generate a list of peers of that size for a given transaction. We then see
+        // whether the given peer falls into this list.
+        double destinations;
+        if (recon_state.m_we_initiate) {
+            destinations = OUTBOUND_FANOUT_DESTINATIONS - outbounds_nonrcncl_tx_relay;
+        } else {
+            const size_t inbound_rcncl_peers = std::count_if(m_states.begin(), m_states.end(),
+                                                        [](std::pair<NodeId, std::variant<uint64_t, TxReconciliationState>> indexed_state) {
+                                                            const auto* cur_state = std::get_if<TxReconciliationState>(&indexed_state.second);
+                                                            if (cur_state) return !cur_state->m_we_initiate;
+                                                            return false;
+                                                        });
+
+            // Since we use the fraction for inbound peers, we first need to compute the total
+            // number of inbound targets.
+            const double inbound_targets = (inbounds_nonrcncl_tx_relay + inbound_rcncl_peers) * INBOUND_FANOUT_DESTINATIONS_FRACTION;
+            destinations = inbound_targets - inbounds_nonrcncl_tx_relay;
+        }
+
+        if (destinations < 0.01) {
+            return false;
+        }
+
+        auto fanout_candidates = GetFanoutTargets(deterministic_randomizer, recon_state.m_we_initiate, destinations);
+        return std::count(fanout_candidates.begin(), fanout_candidates.end(), peer_id);
+    }
 };
 
 TxReconciliationTracker::TxReconciliationTracker(uint32_t recon_version) : m_impl{std::make_unique<TxReconciliationTracker::Impl>(recon_version)} {}
@@ -228,4 +343,11 @@ void TxReconciliationTracker::ForgetPeer(NodeId peer_id)
 bool TxReconciliationTracker::IsPeerRegistered(NodeId peer_id) const
 {
     return m_impl->IsPeerRegisteredExternal(peer_id);
+}
+
+bool TxReconciliationTracker::ShouldFanoutTo(const uint256& wtxid, CSipHasher deterministic_randomizer, NodeId peer_id,
+                                             size_t inbounds_nonrcncl_tx_relay, size_t outbounds_nonrcncl_tx_relay) const
+{
+    return m_impl->ShouldFanoutTo(wtxid, deterministic_randomizer, peer_id,
+                                  inbounds_nonrcncl_tx_relay, outbounds_nonrcncl_tx_relay);
 }

--- a/src/node/txreconciliation.h
+++ b/src/node/txreconciliation.h
@@ -91,6 +91,24 @@ public:
     bool TryRemovingFromSet(NodeId peer_id, const uint256& wtxid_to_remove);
 
     /**
+     * Returns whether it's time to initiate reconciliation (Step 2) with a given peer, based on:
+     * - time passed since the last reconciliation;
+     * - reconciliation queue;
+     * - whether previous reconciliations for the given peer were finalized.
+     */
+    bool IsPeerNextToReconcileWith(NodeId peer_id, std::chrono::microseconds now);
+
+    /**
+     * Step 2. Unless the peer hasn't finished a previous reconciliation round, this function will
+     * return the details of our local state, which should be communicated to the peer so that they
+     * better know what we need:
+     * - size of our reconciliation set for the peer
+     * - our q-coefficient with the peer, formatted to be transmitted as integer value
+     * Assumes the peer was previously registered for reconciliations.
+     */
+    std::optional<std::pair<uint16_t, uint16_t>> InitiateReconciliationRequest(NodeId peer_id);
+
+    /**
      * Attempts to forget txreconciliation-related state of the peer (if we previously stored any).
      * After this, we won't be able to reconcile transactions with the peer.
      */

--- a/src/node/txreconciliation.h
+++ b/src/node/txreconciliation.h
@@ -100,6 +100,12 @@ public:
      * Check if a peer is registered to reconcile transactions with us.
      */
     bool IsPeerRegistered(NodeId peer_id) const;
+
+    /**
+     * Returns whether the peer is chosen as a low-fanout destination for a given tx.
+     */
+    bool ShouldFanoutTo(const uint256& wtxid, CSipHasher deterministic_randomizer, NodeId peer_id,
+                        size_t inbounds_nonrcncl_tx_relay, size_t outbounds_nonrcncl_tx_relay) const;
 };
 
 #endif // BITCOIN_NODE_TXRECONCILIATION_H

--- a/src/node/txreconciliation.h
+++ b/src/node/txreconciliation.h
@@ -75,6 +75,22 @@ public:
                                               uint32_t peer_recon_version, uint64_t remote_salt);
 
     /**
+     * Step 1. Add a new transaction we want to announce to the peer to the local reconciliation set
+     * of the peer, so that it will be reconciled later, unless the set limit is reached.
+     * Returns whether it was added.
+     */
+    bool AddToSet(NodeId peer_id, const uint256& wtxid);
+
+    /**
+     * Before Step 2, we might want to remove a wtxid from the reconciliation set, for example if
+     * the peer just announced the transaction to us.
+     * Returns whether the wtxid was removed.
+     *
+     * The caller *must* check that the peer is registered for reconciliations.
+     */
+    bool TryRemovingFromSet(NodeId peer_id, const uint256& wtxid_to_remove);
+
+    /**
      * Attempts to forget txreconciliation-related state of the peer (if we previously stored any).
      * After this, we won't be able to reconcile transactions with the peer.
      */

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -47,6 +47,7 @@ const char* GETCFCHECKPT = "getcfcheckpt";
 const char* CFCHECKPT = "cfcheckpt";
 const char* WTXIDRELAY = "wtxidrelay";
 const char* SENDTXRCNCL = "sendtxrcncl";
+const char* REQTXRCNCL = "reqtxrcncl";
 } // namespace NetMsgType
 
 /** All known message types. Keep this in the same order as the list of
@@ -88,6 +89,7 @@ const static std::vector<std::string> g_all_net_message_types{
     NetMsgType::CFCHECKPT,
     NetMsgType::WTXIDRELAY,
     NetMsgType::SENDTXRCNCL,
+    NetMsgType::REQTXRCNCL,
 };
 
 CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn, const char* pszCommand, unsigned int nMessageSizeIn)

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -265,6 +265,12 @@ extern const char* WTXIDRELAY;
  * txreconciliation, as described by BIP 330.
  */
 extern const char* SENDTXRCNCL;
+/**
+ * Contains a 2-byte local reconciliation set size and 2-byte q-coefficient
+ * sent to initiate a transaction reconciliation round.
+ * Peer should respond with "sketch" message constructed using these arguments.
+ */
+extern const char* REQTXRCNCL;
 }; // namespace NetMsgType
 
 /* Get a vector of all valid message types (see above) */

--- a/test/functional/p2p_reqtxrcncl.py
+++ b/test/functional/p2p_reqtxrcncl.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test REQTXRCNCL message
+"""
+
+import time
+
+from test_framework.p2p import P2PInterface
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+from test_framework.wallet import MiniWallet
+
+class ReqTxrcnclReceiver(P2PInterface):
+    def __init__(self):
+        super().__init__(support_txrcncl = True)
+        self.reqtxrcncl_msg_received = None
+        self.received_inv_items = 0
+
+    def on_inv(self, message):
+        self.received_inv_items += len(message.inv)
+        super().on_inv(message)
+
+    def on_reqtxrcncl(self, message):
+        self.reqtxrcncl_msg_received = message
+
+class ReqTxRcnclTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [['-txreconciliation']]
+
+    def run_test(self):
+        t = int(time.time())
+        self.nodes[0].setmocktime(t)
+        # Check everything about *sending* REQTXRCNCL.
+        self.log.info('REQTXRCNCL sent to an outbound #1')
+        peer = self.nodes[0].add_outbound_p2p_connection(ReqTxrcnclReceiver(), wait_for_verack=True, p2p_idx=0)
+        self.nodes[0].setmocktime(t + 8 + 1)
+        self.wait_until(lambda: peer.reqtxrcncl_msg_received)
+        assert_equal(peer.reqtxrcncl_msg_received.set_size, 0)
+        assert_equal(peer.reqtxrcncl_msg_received.q, int(32767 * 0.25))
+        self.nodes[0].disconnect_p2ps()
+
+        self.log.info('REQTXRCNCL sent to an outbound #1 again, even though we added #2')
+        with self.nodes[0].assert_debug_log(["Register peer=1", "Register peer=2"]):
+            peer1 = self.nodes[0].add_outbound_p2p_connection(ReqTxrcnclReceiver(), wait_for_verack=True, p2p_idx=1)
+            peer2 = self.nodes[0].add_outbound_p2p_connection(ReqTxrcnclReceiver(), wait_for_verack=True, p2p_idx=2)
+        self.nodes[0].setmocktime(t + 16 + 1)
+        self.wait_until(lambda: peer1.reqtxrcncl_msg_received)
+        assert not peer2.reqtxrcncl_msg_received
+        self.log.info('REQTXRCNCL sent to an outbound #2')
+        peer1.reqtxrcncl_msg_received = None
+        # Since there are two peers, it's half the delay.
+        self.nodes[0].setmocktime(t + 20 + 1)
+        self.wait_until(lambda: peer2.reqtxrcncl_msg_received)
+        assert not peer1.reqtxrcncl_msg_received
+        self.nodes[0].disconnect_p2ps()
+
+        self.log.info('Check transactions announced (either low-fanout or reconciliation)')
+        with self.nodes[0].assert_debug_log(["Register peer=3", "Register peer=4"]):
+            peer1 = self.nodes[0].add_outbound_p2p_connection(ReqTxrcnclReceiver(), wait_for_verack=True, p2p_idx=3)
+            peer2 = self.nodes[0].add_outbound_p2p_connection(ReqTxrcnclReceiver(), wait_for_verack=True, p2p_idx=4)
+
+        self.wallet = MiniWallet(self.nodes[0])
+        self.wallet.rescan_utxos()
+        utxos = self.wallet.get_utxos()
+        self.wallet.send_self_transfer_multi(from_node=self.nodes[0], utxos_to_spend=utxos, fee_per_output=1310)
+        self.nodes[0].setmocktime(t + 24 + 1)
+        self.wait_until(lambda: peer1.reqtxrcncl_msg_received)
+        self.nodes[0].setmocktime(t + 28 + 1)
+        self.wait_until(lambda: peer2.reqtxrcncl_msg_received)
+        # Some of the announcements may go into the next reconciliation due to the random delay.
+        # TODO: improve this check once it's possible to finalize this reconciliation
+        #       and receive the next round.
+        assert peer1.reqtxrcncl_msg_received.set_size + peer1.received_inv_items <= len(utxos)
+        assert peer2.reqtxrcncl_msg_received.set_size + peer2.received_inv_items <= len(utxos)
+
+if __name__ == '__main__':
+    ReqTxRcnclTest().main()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1889,6 +1889,27 @@ class msg_sendtxrcncl:
         return "msg_sendtxrcncl(version=%lu, salt=%lu)" %\
             (self.version, self.salt)
 
+class msg_reqtxrcncl:
+    __slots__ = ("set_size", "q")
+    msgtype = b"reqtxrcncl"
+
+    def __init__(self):
+        self.set_size = 0
+        self.q = 0
+
+    def deserialize(self, f):
+        self.set_size = int.from_bytes(f.read(2), 'little')
+        self.q = int.from_bytes(f.read(2), 'little')
+
+    def serialize(self):
+        r = b""
+        r += int.to_bytes(self.set_size, 'little')
+        r += int.to_bytes(self.q, 'little')
+        return r
+
+    def __repr__(self):
+        return f"msg_reqtxrcncl(set_size={self.set_size}, q={self.q})"
+
 class TestFrameworkScript(unittest.TestCase):
     def test_addrv2_encode_decode(self):
         def check_addrv2(ip, net):

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -59,6 +59,7 @@ from test_framework.messages import (
     msg_notfound,
     msg_ping,
     msg_pong,
+    msg_reqtxrcncl,
     msg_sendaddrv2,
     msg_sendcmpct,
     msg_sendheaders,
@@ -130,6 +131,7 @@ MESSAGEMAP = {
     b"notfound": msg_notfound,
     b"ping": msg_ping,
     b"pong": msg_pong,
+    b"reqtxrcncl": msg_reqtxrcncl,
     b"sendaddrv2": msg_sendaddrv2,
     b"sendcmpct": msg_sendcmpct,
     b"sendheaders": msg_sendheaders,
@@ -328,7 +330,7 @@ class P2PInterface(P2PConnection):
 
     Individual testcases should subclass this and override the on_* methods
     if they want to alter message handling behaviour."""
-    def __init__(self, support_addrv2=False, wtxidrelay=True):
+    def __init__(self, support_addrv2=False, wtxidrelay=True, support_txrcncl=False):
         super().__init__()
 
         # Track number of messages of each type received.
@@ -347,6 +349,7 @@ class P2PInterface(P2PConnection):
         self.nServices = 0
 
         self.support_addrv2 = support_addrv2
+        self.support_txrcncl = support_txrcncl
 
         # If the peer supports wtxid-relay
         self.wtxidrelay = wtxidrelay
@@ -453,6 +456,11 @@ class P2PInterface(P2PConnection):
             self.send_message(msg_wtxidrelay())
         if self.support_addrv2:
             self.send_message(msg_sendaddrv2())
+        if self.support_txrcncl:
+            sendtxrcncl_msg = msg_sendtxrcncl()
+            sendtxrcncl_msg.version = 1
+            sendtxrcncl_msg.salt = 2
+            self.send_message(sendtxrcncl_msg)
         self.send_message(msg_verack())
         self.nServices = message.nServices
         self.relay = message.relay

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -356,6 +356,7 @@ BASE_SCRIPTS = [
     'p2p_tx_privacy.py',
     'rpc_scanblocks.py',
     'p2p_sendtxrcncl.py',
+    'p2p_reqtxrcncl.py',
     'rpc_scantxoutset.py',
     'feature_txindex_compatibility.py',
     'feature_unsupported_utxo_db.py',


### PR DESCRIPTION
*See #28765*

First, this PR enables keeping track of per-peer reconciliation sets, containing those transactions which we intend to exchange efficiently. The remaining transactions are announced via flooding, as usual.

Second, this PR enables periodically initiating a reconciliation round via a new p2p message.

Erlay Project Tracking: #28646