### PR TITLE
Temporarily disable -mempoolfullrbf for the main chain

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -564,7 +564,9 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-bytespersigop", strprintf("Equivalent bytes per sigop in transactions for relay and mining (default: %u)", DEFAULT_BYTES_PER_SIGOP), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarrier", strprintf("Relay and mine data carrier transactions (default: %u)", DEFAULT_ACCEPT_DATACARRIER), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarriersize", strprintf("Maximum size of data in data carrier transactions we relay and mine (default: %u)", MAX_OP_RETURN_RELAY), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
-    argsman.AddArg("-mempoolfullrbf", strprintf("Accept transaction replace-by-fee without requiring replaceability signaling (default: %u)", DEFAULT_MEMPOOL_FULL_RBF), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
+    argsman.AddArg("-mempoolfullrbf",
+                   strprintf("Accept transaction replace-by-fee without requiring replaceability signaling (default: %u)", DEFAULT_MEMPOOL_FULL_RBF),
+                   ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-permitbaremultisig", strprintf("Relay non-P2SH multisig (default: %u)", DEFAULT_PERMIT_BAREMULTISIG), ArgsManager::ALLOW_ANY,
                    OptionsCategory::NODE_RELAY);
     argsman.AddArg("-minrelaytxfee=<amt>", strprintf("Fees (in %s/kvB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)",

--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -92,7 +92,12 @@ std::optional<bilingual_str> ApplyArgsManOptions(const ArgsManager& argsman, con
         return strprintf(Untranslated("acceptnonstdtxn is not currently supported for %s chain"), chainparams.NetworkIDString());
     }
 
-    mempool_opts.full_rbf = argsman.GetBoolArg("-mempoolfullrbf", mempool_opts.full_rbf);
+    if (const auto fullrbf{argsman.GetBoolArg("-mempoolfullrbf")}) {
+        if (!chainparams.IsTestChain()) {
+            return strprintf(Untranslated("The mempoolfullrbf setting is currently not supported for the %s chain"), chainparams.NetworkIDString());
+        }
+        mempool_opts.full_rbf = *fullrbf;
+    }
 
     ApplyArgsManOptions(argsman, mempool_opts.limits);
 


### PR DESCRIPTION
The setting was introduced in commit a7f3479ba3fda4c9fb29bd7080165744c02ee921. Despite previous announcements to introduce such a setting to Bitcoin Core, it seems that some services were surprised [1] to find it in the 24.0rc1 release candidate.

Preliminary checks have shown there is no meaningful hashrate of miners that have the setting enabled, which makes it insufficient to rely on at the current time.

My suggestion would be to temporarily disable the setting for the main chain, understanding that it may be re-enabled with a default value of *true* in an upcoming release (for example 25.0 or later). This would make the setting more reliable, since at least a small hashrate is going to take over the default value as-is.

Moreover, services which are currently using heuristics on unsafe transactions (and cover any losses out of their own pockets) may continue to do so at their own risk for a few months. Otherwise, at least one popular services would likely shut down their operation with the release of 24.0, since they deemed the setting too risky even with a default value of *false*.

[1] https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-October/020980.html