### PR TITLE
Enable -Wstring-concatenation and -Wstring-conversion on clang builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -459,6 +459,8 @@ if test "$CXXFLAGS_overridden" = "no"; then
                         [AC_LANG_SOURCE([[struct A { virtual void f(); }; struct B : A { void f() final; };]])])
   AX_CHECK_COMPILE_FLAG([-Wunreachable-code-loop-increment], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wunreachable-code-loop-increment"], [], [$CXXFLAG_WERROR])
   AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wimplicit-fallthrough"], [], [$CXXFLAG_WERROR])
+  AX_CHECK_COMPILE_FLAG([-Wstring-conversion], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wstring-conversion"], [], [$CXXFLAG_WERROR])
+  AX_CHECK_COMPILE_FLAG([-Wstring-concatenation], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wstring-concatenation"], [], [$CXXFLAG_WERROR])
 
   if test "$suppress_external_warnings" != "no" ; then
     AX_CHECK_COMPILE_FLAG([-Wdocumentation], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wdocumentation"], [], [$CXXFLAG_WERROR])

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2216,14 +2216,14 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
         // as the network format matches the format on disk
         std::vector<uint8_t> block_data;
         bool read_succeeded{m_chainman.m_blockman.ReadRawBlockFromDisk(block_data, pindex->GetBlockPos(), m_chainparams.MessageStart())};
-        assert(read_succeeded); // cannot load block from disk
+        Assert(read_succeeded); // cannot load block from disk
         m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::BLOCK, Span{block_data}));
         // Don't set pblock as we've sent the block
     } else {
         // Send block from disk
         std::shared_ptr<CBlock> pblockRead = std::make_shared<CBlock>();
         bool read_succeeded{m_chainman.m_blockman.ReadBlockFromDisk(*pblockRead, *pindex)};
-        assert(read_succeeded); // cannot load block from disk
+        Assert(read_succeeded); // cannot load block from disk
         pblock = pblockRead;
     }
     if (pblock) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2215,17 +2215,15 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
         // Fast-path: in this case it is possible to serve the block directly from disk,
         // as the network format matches the format on disk
         std::vector<uint8_t> block_data;
-        if (!m_chainman.m_blockman.ReadRawBlockFromDisk(block_data, pindex->GetBlockPos(), m_chainparams.MessageStart())) {
-            assert(!"cannot load block from disk");
-        }
+        bool read_succeeded{m_chainman.m_blockman.ReadRawBlockFromDisk(block_data, pindex->GetBlockPos(), m_chainparams.MessageStart())};
+        assert(read_succeeded); // cannot load block from disk
         m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::BLOCK, Span{block_data}));
         // Don't set pblock as we've sent the block
     } else {
         // Send block from disk
         std::shared_ptr<CBlock> pblockRead = std::make_shared<CBlock>();
-        if (!m_chainman.m_blockman.ReadBlockFromDisk(*pblockRead, *pindex)) {
-            assert(!"cannot load block from disk");
-        }
+        bool read_succeeded{m_chainman.m_blockman.ReadBlockFromDisk(*pblockRead, *pindex)};
+        assert(read_succeeded); // cannot load block from disk
         pblock = pblockRead;
     }
     if (pblock) {

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -934,7 +934,7 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                     case OP_ABS:        if (bn < bnZero) bn = -bn; break;
                     case OP_NOT:        bn = (bn == bnZero); break;
                     case OP_0NOTEQUAL:  bn = (bn != bnZero); break;
-                    default:            assert(!"invalid opcode"); break;
+                    default:            assert(false); break; // invalid opcode
                     }
                     popstack(stack);
                     stack.push_back(bn.getvch());
@@ -982,7 +982,7 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                     case OP_GREATERTHANOREQUAL:  bn = (bn1 >= bn2); break;
                     case OP_MIN:                 bn = (bn1 < bn2 ? bn1 : bn2); break;
                     case OP_MAX:                 bn = (bn1 > bn2 ? bn1 : bn2); break;
-                    default:                     assert(!"invalid opcode"); break;
+                    default:                     assert(false); break; // invalid opcode
                     }
                     popstack(stack);
                     popstack(stack);
@@ -1466,12 +1466,12 @@ static bool HandleMissingData(MissingDataBehavior mdb)
 {
     switch (mdb) {
     case MissingDataBehavior::ASSERT_FAIL:
-        assert(!"Missing data");
+        assert(false); // Missing data
         break;
     case MissingDataBehavior::FAIL:
         return false;
     }
-    assert(!"Unknown MissingDataBehavior value");
+    assert(false); // Unknown MissingDataBehavior value
 }
 
 template<typename T>

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -850,8 +850,7 @@ bool BerkeleyBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrit
 {
     if (!pdb)
         return false;
-    if (fReadOnly)
-        assert(!"Write called on database in read-only mode");
+    assert(!fReadOnly); // Write called on database in read-only mode
 
     SafeDbt datKey(key.data(), key.size());
 
@@ -865,8 +864,7 @@ bool BerkeleyBatch::EraseKey(DataStream&& key)
 {
     if (!pdb)
         return false;
-    if (fReadOnly)
-        assert(!"Erase called on database in read-only mode");
+    assert(!fReadOnly); // Erase called on database in read-only mode
 
     SafeDbt datKey(key.data(), key.size());
 

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -850,7 +850,7 @@ bool BerkeleyBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrit
 {
     if (!pdb)
         return false;
-    assert(!fReadOnly); // Write called on database in read-only mode
+    Assert(!fReadOnly); // Write called on database in read-only mode
 
     SafeDbt datKey(key.data(), key.size());
 
@@ -864,7 +864,7 @@ bool BerkeleyBatch::EraseKey(DataStream&& key)
 {
     if (!pdb)
         return false;
-    assert(!fReadOnly); // Erase called on database in read-only mode
+    Assert(!fReadOnly); // Erase called on database in read-only mode
 
     SafeDbt datKey(key.data(), key.size());
 


### PR DESCRIPTION
The only current violations are a few uses of assert(!"descriptive string").

Seems the benefit of ensuring against a code fault outweighs the benefit of possible additional information in these cases.

> [-Wstring-concatenation](https://clang.llvm.org/docs/DiagnosticsReference.html#wstring-concatenation)
> Diagnostic text:
>
> warning: suspicious concatenation of string literals in an array initialization; did you mean to separate the elements with a comma?
>
> [-Wstring-conversion](https://clang.llvm.org/docs/DiagnosticsReference.html#id805)
> Diagnostic text:
>
> warning: implicit conversion turns string literal into bool: A to B

https://clang.llvm.org/docs/DiagnosticsReference.html#wstring-concatenation