### PR TITLE
util: move threadinterrupt into util/

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -56,7 +56,6 @@ if [ "${RUN_TIDY}" = "true" ]; then
           " src/rpc/fees.cpp"\
           " src/rpc/signmessage.cpp"\
           " src/test/fuzz/txorphan.cpp"\
-          " src/threadinterrupt.cpp"\
           " src/util/bip32.cpp"\
           " src/util/bytevectorhash.cpp"\
           " src/util/error.cpp"\
@@ -69,6 +68,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
           " src/util/strencodings.cpp"\
           " src/util/string.cpp"\
           " src/util/syserror.cpp"\
+          " src/util/threadinterrupt.cpp"\
           " src/zmq"\
           " -p . ${MAKEJOBS} -- -Xiwyu --cxx17ns -Xiwyu --mapping_file=${BASE_BUILD_DIR}/bitcoin-$HOST/contrib/devtools/iwyu/bitcoin.core.imp"
 fi

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -258,7 +258,6 @@ BITCOIN_CORE_H = \
   support/events.h \
   support/lockedpool.h \
   sync.h \
-  threadinterrupt.h \
   threadsafety.h \
   timedata.h \
   torcontrol.h \
@@ -297,6 +296,7 @@ BITCOIN_CORE_H = \
   util/syserror.h \
   util/system.h \
   util/thread.h \
+  util/threadinterrupt.h \
   util/threadnames.h \
   util/time.h \
   util/tokenpipe.h \
@@ -686,7 +686,6 @@ libbitcoin_util_a_SOURCES = \
   rpc/request.cpp \
   support/cleanse.cpp \
   sync.cpp \
-  threadinterrupt.cpp \
   util/asmap.cpp \
   util/bip32.cpp \
   util/bytevectorhash.cpp \
@@ -704,6 +703,7 @@ libbitcoin_util_a_SOURCES = \
   util/readwritefile.cpp \
   util/settings.cpp \
   util/thread.cpp \
+  util/threadinterrupt.cpp \
   util/threadnames.cpp \
   util/serfloat.cpp \
   util/spanparsing.cpp \

--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -18,6 +18,7 @@
 #include <util/spanparsing.h>
 #include <util/strencodings.h>
 #include <util/system.h>
+#include <util/threadinterrupt.h>
 
 #include <chrono>
 #include <memory>

--- a/src/i2p.h
+++ b/src/i2p.h
@@ -9,8 +9,8 @@
 #include <fs.h>
 #include <netaddress.h>
 #include <sync.h>
-#include <threadinterrupt.h>
 #include <util/sock.h>
+#include <util/threadinterrupt.h>
 
 #include <memory>
 #include <optional>

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -7,7 +7,7 @@
 
 #include <dbwrapper.h>
 #include <interfaces/chain.h>
-#include <threadinterrupt.h>
+#include <util/threadinterrupt.h>
 #include <validationinterface.h>
 
 #include <string>

--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -13,10 +13,10 @@
 #include <net.h>
 #include <netaddress.h>
 #include <netbase.h>
-#include <threadinterrupt.h>
 #include <util/syscall_sandbox.h>
 #include <util/system.h>
 #include <util/thread.h>
+#include <util/threadinterrupt.h>
 
 #ifdef USE_NATPMP
 #include <compat/compat.h>

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -31,6 +31,7 @@
 #include <util/syscall_sandbox.h>
 #include <util/system.h>
 #include <util/thread.h>
+#include <util/threadinterrupt.h>
 #include <util/trace.h>
 #include <util/translation.h>
 

--- a/src/net.h
+++ b/src/net.h
@@ -24,10 +24,10 @@
 #include <span.h>
 #include <streams.h>
 #include <sync.h>
-#include <threadinterrupt.h>
 #include <uint256.h>
 #include <util/check.h>
 #include <util/sock.h>
+#include <util/threadinterrupt.h>
 
 #include <atomic>
 #include <condition_variable>

--- a/src/test/fuzz/i2p.cpp
+++ b/src/test/fuzz/i2p.cpp
@@ -9,8 +9,8 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
-#include <threadinterrupt.h>
 #include <util/system.h>
+#include <util/threadinterrupt.h>
 
 void initialize_i2p()
 {

--- a/src/test/i2p_tests.cpp
+++ b/src/test/i2p_tests.cpp
@@ -8,8 +8,8 @@
 #include <test/util/logging.h>
 #include <test/util/net.h>
 #include <test/util/setup_common.h>
-#include <threadinterrupt.h>
 #include <util/system.h>
+#include <util/threadinterrupt.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/sock_tests.cpp
+++ b/src/test/sock_tests.cpp
@@ -4,9 +4,9 @@
 
 #include <compat/compat.h>
 #include <test/util/setup_common.h>
-#include <threadinterrupt.h>
 #include <util/sock.h>
 #include <util/system.h>
+#include <util/threadinterrupt.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -4,11 +4,11 @@
 
 #include <compat/compat.h>
 #include <logging.h>
-#include <threadinterrupt.h>
 #include <tinyformat.h>
 #include <util/sock.h>
 #include <util/syserror.h>
 #include <util/system.h>
+#include <util/threadinterrupt.h>
 #include <util/time.h>
 
 #include <memory>

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -6,7 +6,7 @@
 #define BITCOIN_UTIL_SOCK_H
 
 #include <compat/compat.h>
-#include <threadinterrupt.h>
+#include <util/threadinterrupt.h>
 #include <util/time.h>
 
 #include <chrono>

--- a/src/util/threadinterrupt.cpp
+++ b/src/util/threadinterrupt.cpp
@@ -3,7 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <threadinterrupt.h>
+#include <util/threadinterrupt.h>
 
 #include <sync.h>
 

--- a/src/util/threadinterrupt.h
+++ b/src/util/threadinterrupt.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_THREADINTERRUPT_H
-#define BITCOIN_THREADINTERRUPT_H
+#ifndef BITCOIN_UTIL_THREADINTERRUPT_H
+#define BITCOIN_UTIL_THREADINTERRUPT_H
 
 #include <sync.h>
 #include <threadsafety.h>
@@ -33,4 +33,4 @@ private:
     std::atomic<bool> flag;
 };
 
-#endif // BITCOIN_THREADINTERRUPT_H
+#endif // BITCOIN_UTIL_THREADINTERRUPT_H


### PR DESCRIPTION
Alongside thread and threadnames. It's part of libbitcoin_util.