### PR TITLE
build: move util/url to common/url

### DIFF
--- a/build_msvc/bitcoin-cli/bitcoin-cli.vcxproj
+++ b/build_msvc/bitcoin-cli/bitcoin-cli.vcxproj
@@ -15,6 +15,9 @@
     <ProjectReference Include="..\libbitcoin_cli\libbitcoin_cli.vcxproj">
       <Project>{0667528c-d734-4009-adf9-c0d6c4a5a5a6}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\libbitcoin_common\libbitcoin_common.vcxproj">
+      <Project>{7c87e378-df58-482e-aa2f-1bc129bc19ce}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\libbitcoin_crypto\libbitcoin_crypto.vcxproj">
       <Project>{6190199c-6cf4-4dad-bfbd-93fa72a760c1}</Project>
     </ProjectReference>

--- a/build_msvc/libbitcoin_common/libbitcoin_common.vcxproj.in
+++ b/build_msvc/libbitcoin_common/libbitcoin_common.vcxproj.in
@@ -8,6 +8,7 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\src\common\url.cpp" />
 @SOURCE_FILES@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/build_msvc/libbitcoin_util/libbitcoin_util.vcxproj.in
+++ b/build_msvc/libbitcoin_util/libbitcoin_util.vcxproj.in
@@ -8,7 +8,6 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\src\util\url.cpp" />
 @SOURCE_FILES@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -40,6 +40,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
   ( CI_EXEC run-clang-tidy -quiet "${MAKEJOBS}" ) | grep -C5 "error"
   export P_CI_DIR="${BASE_BUILD_DIR}/bitcoin-$HOST/"
   CI_EXEC "python3 ${DIR_IWYU}/include-what-you-use/iwyu_tool.py"\
+          " src/common/url.cpp"\
           " src/compat"\
           " src/dbwrapper.cpp"\
           " src/init"\
@@ -68,7 +69,6 @@ if [ "${RUN_TIDY}" = "true" ]; then
           " src/util/strencodings.cpp"\
           " src/util/string.cpp"\
           " src/util/syserror.cpp"\
-          " src/util/url.cpp"\
           " src/zmq"\
           " -p . ${MAKEJOBS} -- -Xiwyu --cxx17ns -Xiwyu --mapping_file=${BASE_BUILD_DIR}/bitcoin-$HOST/contrib/devtools/iwyu/bitcoin.core.imp"
 fi

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -710,6 +710,7 @@ libbitcoin_util_a_SOURCES = \
   $(BITCOIN_CORE_H)
 
 if USE_LIBEVENT
+libbitcoin_util_a_CPPFLAGS += $(EVENT_CFLAGS)
 libbitcoin_util_a_SOURCES += util/url.cpp
 endif
 #

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -134,6 +134,7 @@ BITCOIN_CORE_H = \
   coins.h \
   common/bloom.h \
   common/run_command.h \
+  common/url.h \
   compat/assumptions.h \
   compat/byteswap.h \
   compat/compat.h \
@@ -303,7 +304,6 @@ BITCOIN_CORE_H = \
   util/translation.h \
   util/types.h \
   util/ui_change_type.h \
-  util/url.h \
   util/vector.h \
   validation.h \
   validationinterface.h \
@@ -662,6 +662,11 @@ libbitcoin_common_a_SOURCES = \
   script/standard.cpp \
   warnings.cpp \
   $(BITCOIN_CORE_H)
+
+if USE_LIBEVENT
+libbitcoin_common_a_CPPFLAGS += $(EVENT_CFLAGS)
+libbitcoin_common_a_SOURCES += common/url.cpp
+endif
 #
 
 # util #
@@ -708,11 +713,6 @@ libbitcoin_util_a_SOURCES = \
   util/time.cpp \
   util/tokenpipe.cpp \
   $(BITCOIN_CORE_H)
-
-if USE_LIBEVENT
-libbitcoin_util_a_CPPFLAGS += $(EVENT_CFLAGS)
-libbitcoin_util_a_SOURCES += util/url.cpp
-endif
 #
 
 # cli #
@@ -776,6 +776,7 @@ endif
 bitcoin_cli_LDADD = \
   $(LIBBITCOIN_CLI) \
   $(LIBUNIVALUE) \
+  $(LIBBITCOIN_COMMON) \
   $(LIBBITCOIN_UTIL) \
   $(LIBBITCOIN_CRYPTO)
 

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -9,6 +9,7 @@
 
 #include <chainparamsbase.h>
 #include <clientversion.h>
+#include <common/url.h>
 #include <compat/compat.h>
 #include <compat/stdin.h>
 #include <policy/feerate.h>
@@ -21,7 +22,6 @@
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <util/translation.h>
-#include <util/url.h>
 
 #include <algorithm>
 #include <chrono>

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -9,6 +9,7 @@
 #include <chainparams.h>
 #include <chainparamsbase.h>
 #include <clientversion.h>
+#include <common/url.h>
 #include <compat/compat.h>
 #include <interfaces/init.h>
 #include <key.h>
@@ -17,7 +18,6 @@
 #include <tinyformat.h>
 #include <util/system.h>
 #include <util/translation.h>
-#include <util/url.h>
 #include <wallet/wallettool.h>
 
 #include <exception>

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -9,6 +9,7 @@
 
 #include <chainparams.h>
 #include <clientversion.h>
+#include <common/url.h>
 #include <compat/compat.h>
 #include <init.h>
 #include <interfaces/chain.h>
@@ -25,7 +26,6 @@
 #include <util/threadnames.h>
 #include <util/tokenpipe.h>
 #include <util/translation.h>
-#include <util/url.h>
 
 #include <any>
 #include <functional>

--- a/src/common/url.cpp
+++ b/src/common/url.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/url.h>
+#include <common/url.h>
 
 #include <event2/http.h>
 

--- a/src/common/url.h
+++ b/src/common/url.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UTIL_URL_H
-#define BITCOIN_UTIL_URL_H
+#ifndef BITCOIN_COMMON_URL_H
+#define BITCOIN_COMMON_URL_H
 
 #include <string>
 
@@ -11,4 +11,4 @@ using UrlDecodeFn = std::string(const std::string& url_encoded);
 UrlDecodeFn urlDecode;
 extern UrlDecodeFn* const URL_DECODE;
 
-#endif // BITCOIN_UTIL_URL_H
+#endif // BITCOIN_COMMON_URL_H

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -4,9 +4,9 @@
 
 #include <qt/bitcoin.h>
 
+#include <common/url.h>
 #include <compat/compat.h>
 #include <util/translation.h>
-#include <util/url.h>
 
 #include <QCoreApplication>
 

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -4,6 +4,7 @@
 
 #include <blockfilter.h>
 #include <clientversion.h>
+#include <common/url.h>
 #include <logging.h>
 #include <netaddress.h>
 #include <netbase.h>
@@ -27,7 +28,6 @@
 #include <util/string.h>
 #include <util/system.h>
 #include <util/translation.h>
-#include <util/url.h>
 #include <version.h>
 
 #include <cstdint>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -9,6 +9,7 @@
 #include <addrman.h>
 #include <banman.h>
 #include <chainparams.h>
+#include <common/url.h>
 #include <consensus/consensus.h>
 #include <consensus/params.h>
 #include <consensus/validation.h>
@@ -46,7 +47,6 @@
 #include <util/threadnames.h>
 #include <util/time.h>
 #include <util/translation.h>
-#include <util/url.h>
 #include <util/vector.h>
 #include <validation.h>
 #include <validationinterface.h>

--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -4,9 +4,9 @@
 
 #include <wallet/rpc/util.h>
 
+#include <common/url.h>
 #include <rpc/util.h>
 #include <util/translation.h>
-#include <util/url.h>
 #include <wallet/context.h>
 #include <wallet/wallet.h>
 


### PR DESCRIPTION
Move `util/url` to `common/url`.

Also add missing `event_*` flags to `libbitcoin_util`. #26293 + the commit dropping boost cppflags from `libbitcoin_util` shows this issue. i.e:
```bash
  CXX      util/libbitcoin_util_a-url.o
util/url.cpp:7:10: fatal error: 'event2/http.h' file not found
#include <event2/http.h>
         ^~~~~~~~~~~~~~~
1 error generated.
```