### PR TITLE
ci: Use all available CPUs for functional tests in "Win64 native" task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -184,7 +184,7 @@ task:
     - netsh int ipv4 set dynamicport tcp start=1025 num=64511
     - netsh int ipv6 set dynamicport tcp start=1025 num=64511
     # Exclude feature_dbcrash for now due to timeout
-    - python test\functional\test_runner.py --nocleanup --ci --quiet --combinedlogslen=4000 --jobs=4 --timeout-factor=8 --extended --exclude feature_dbcrash
+    - python test\functional\test_runner.py --nocleanup --ci --quiet --combinedlogslen=4000 --jobs=6 --timeout-factor=8 --extended --exclude feature_dbcrash
 
 task:
   name: 'ARM [unit tests, no functional tests] [bullseye]'


### PR DESCRIPTION
On the [master](https://cirrus-ci.com/task/5422842484359168) branch:
![Screenshot from 2022-10-12 09-45-58](https://user-images.githubusercontent.com/32963518/195296883-3852ea09-7345-4166-b855-7704dcd87202.png)

This [PR](https://cirrus-ci.com/task/6392972617973760) branch:
![Screenshot from 2022-10-12 11-11-15](https://user-images.githubusercontent.com/32963518/195315902-f667874a-8aeb-4f2f-bdc3-5ba432ae9353.png)


Also consider "CPU Usage" charts provided by CI.

Overlooked in cda62657e95a90a5fd61ba43e2acbd407e3a4135 (bitcoin/bitcoin#25929).