### PR TITLE
ci: Use Multi-ToolTask in "Win64 native" task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -171,7 +171,7 @@ task:
     - cd %CIRRUS_WORKING_DIR%
     - ccache --zero-stats --max-size=%CCACHE_SIZE%
     - python build_msvc\msvc-autogen.py
-    - msbuild build_msvc\bitcoin.sln -property:CLToolExe=%WRAPPED_CL% -property:Configuration=Release -maxCpuCount -verbosity:minimal -noLogo
+    - msbuild build_msvc\bitcoin.sln -property:CLToolExe=%WRAPPED_CL%;UseMultiToolTask=true;Configuration=Release -maxCpuCount -verbosity:minimal -noLogo
     - ccache --show-stats
   check_script:
     - src\test_bitcoin.exe -l test_suite


### PR DESCRIPTION
See https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/.

Build time (`ccache` cache has been _invalidated_ to ensure equal initial conditions):
- on the [master](https://cirrus-ci.com/task/4900469905555456) branch:
![image](https://user-images.githubusercontent.com/32963518/195401896-c714cb08-2a41-4eed-afb1-14992f5a9152.png)

- this [PR](https://cirrus-ci.com/task/5840011785404416) changes:
![image](https://user-images.githubusercontent.com/32963518/195412308-3dd823bb-0ecd-481f-8ab8-05643fd4f7c0.png)

Also consider "CPU Usage" charts provided by CI.