### PR TITLE
refactor: Extract util/exception from util/system

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -61,6 +61,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
           " src/util/bytevectorhash.cpp"\
           " src/util/check.cpp"\
           " src/util/error.cpp"\
+          " src/util/exception.cpp"\
           " src/util/getuniquepath.cpp"\
           " src/util/hasher.cpp"\
           " src/util/message.cpp"\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -274,6 +274,7 @@ BITCOIN_CORE_H = \
   util/check.h \
   util/epochguard.h \
   util/error.h \
+  util/exception.h \
   util/fastrange.h \
   util/fees.h \
   util/getuniquepath.h \
@@ -690,6 +691,7 @@ libbitcoin_util_a_SOURCES = \
   util/bytevectorhash.cpp \
   util/check.cpp \
   util/error.cpp \
+  util/exception.cpp \
   util/fees.cpp \
   util/getuniquepath.cpp \
   util/hasher.cpp \
@@ -940,6 +942,7 @@ libbitcoinkernel_la_SOURCES = \
   txmempool.cpp \
   uint256.cpp \
   util/check.cpp \
+  util/exception.cpp \
   util/getuniquepath.cpp \
   util/hasher.cpp \
   util/moneystr.cpp \

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -19,6 +19,7 @@
 #include <rpc/request.h>
 #include <tinyformat.h>
 #include <univalue.h>
+#include <util/exception.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <util/translation.h>

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -20,6 +20,7 @@
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <univalue.h>
+#include <util/exception.h>
 #include <util/moneystr.h>
 #include <util/rbf.h>
 #include <util/strencodings.h>

--- a/src/bitcoin-util.cpp
+++ b/src/bitcoin-util.cpp
@@ -14,6 +14,7 @@
 #include <compat/compat.h>
 #include <core_io.h>
 #include <streams.h>
+#include <util/exception.h>
 #include <util/system.h>
 #include <util/translation.h>
 #include <version.h>

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -16,6 +16,7 @@
 #include <logging.h>
 #include <pubkey.h>
 #include <tinyformat.h>
+#include <util/exception.h>
 #include <util/system.h>
 #include <util/translation.h>
 #include <wallet/wallettool.h>

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -19,6 +19,7 @@
 #include <noui.h>
 #include <shutdown.h>
 #include <util/check.h>
+#include <util/exception.h>
 #include <util/strencodings.h>
 #include <util/syscall_sandbox.h>
 #include <util/syserror.h>

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -28,6 +28,7 @@
 #include <qt/utilitydialog.h>
 #include <qt/winshutdownmonitor.h>
 #include <uint256.h>
+#include <util/exception.h>
 #include <util/string.h>
 #include <util/system.h>
 #include <util/threadnames.h>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -20,6 +20,7 @@
 #include <protocol.h>
 #include <script/script.h>
 #include <script/standard.h>
+#include <util/exception.h>
 #include <util/system.h>
 #include <util/time.h>
 

--- a/src/qt/initexecutor.cpp
+++ b/src/qt/initexecutor.cpp
@@ -5,6 +5,7 @@
 #include <qt/initexecutor.h>
 
 #include <interfaces/node.h>
+#include <util/exception.h>
 #include <util/system.h>
 #include <util/threadnames.h>
 

--- a/src/util/exception.cpp
+++ b/src/util/exception.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/exception.h>
+
+#include <logging.h>
+#include <tinyformat.h>
+
+#include <iostream>
+#include <typeinfo>
+
+#ifdef WIN32
+#include <compat/compat.h>
+#include <libloaderapi.h>
+#endif // WIN32
+
+static std::string FormatException(const std::exception* pex, std::string_view thread_name)
+{
+#ifdef WIN32
+    char pszModule[MAX_PATH] = "";
+    GetModuleFileNameA(nullptr, pszModule, sizeof(pszModule));
+#else
+    const char* pszModule = "bitcoin";
+#endif
+    if (pex)
+        return strprintf(
+            "EXCEPTION: %s       \n%s       \n%s in %s       \n", typeid(*pex).name(), pex->what(), pszModule, thread_name);
+    else
+        return strprintf(
+            "UNKNOWN EXCEPTION       \n%s in %s       \n", pszModule, thread_name);
+}
+
+void PrintExceptionContinue(const std::exception* pex, std::string_view thread_name)
+{
+    std::string message = FormatException(pex, thread_name);
+    LogPrintf("\n\n************************\n%s\n", message);
+    tfm::format(std::cerr, "\n\n************************\n%s\n", message);
+}

--- a/src/util/exception.h
+++ b/src/util/exception.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_EXCEPTION_H
+#define BITCOIN_UTIL_EXCEPTION_H
+
+#include <exception>
+#include <string>
+
+void PrintExceptionContinue(const std::exception* pex, std::string_view thread_name);
+
+#endif // BITCOIN_UTIL_EXCEPTION_H

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -818,29 +818,6 @@ std::string HelpMessageOpt(const std::string &option, const std::string &message
            std::string("\n\n");
 }
 
-static std::string FormatException(const std::exception* pex, std::string_view thread_name)
-{
-#ifdef WIN32
-    char pszModule[MAX_PATH] = "";
-    GetModuleFileNameA(nullptr, pszModule, sizeof(pszModule));
-#else
-    const char* pszModule = "bitcoin";
-#endif
-    if (pex)
-        return strprintf(
-            "EXCEPTION: %s       \n%s       \n%s in %s       \n", typeid(*pex).name(), pex->what(), pszModule, thread_name);
-    else
-        return strprintf(
-            "UNKNOWN EXCEPTION       \n%s in %s       \n", pszModule, thread_name);
-}
-
-void PrintExceptionContinue(const std::exception* pex, std::string_view thread_name)
-{
-    std::string message = FormatException(pex, thread_name);
-    LogPrintf("\n\n************************\n%s\n", message);
-    tfm::format(std::cerr, "\n\n************************\n%s\n", message);
-}
-
 fs::path GetDefaultDataDir()
 {
     // Windows: C:\Users\Username\AppData\Roaming\Bitcoin

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -24,7 +24,6 @@
 #include <util/time.h>
 
 #include <any>
-#include <exception>
 #include <map>
 #include <optional>
 #include <set>
@@ -50,8 +49,6 @@ bool error(const char* fmt, const Args&... args)
     LogPrintf("ERROR: %s\n", tfm::format(fmt, args...));
     return false;
 }
-
-void PrintExceptionContinue(const std::exception* pex, std::string_view thread_name);
 
 /**
  * Ensure file contents are fully committed to disk, using a platform-specific

--- a/src/util/thread.cpp
+++ b/src/util/thread.cpp
@@ -5,7 +5,7 @@
 #include <util/thread.h>
 
 #include <logging.h>
-#include <util/system.h>
+#include <util/exception.h>
 #include <util/threadnames.h>
 
 #include <exception>


### PR DESCRIPTION
This is the only use of std::exception in util/system, and paves the ways of further splitting that up to remove circular includes and in support of a minimal kernel.

See [overall effort](https://github.com/bitcoin/bitcoin/pull/25152), and [prior conversation re motivation](https://github.com/bitcoin/bitcoin/pull/24455).

Include libloaderapi.h for GetModuleFileNameA as that's the
source noted here: https://docs.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulefilenamea

Recommend using `git diff master --color-moved=dimmed-zebra`