### PR TITLE
refactor: Use type-safe time point for CWallet::m_next_resend

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1916,12 +1916,12 @@ bool CWallet::ShouldResend() const
 
     // Do this infrequently and randomly to avoid giving away
     // that these are our transactions.
-    if (GetTime() < m_next_resend) return false;
+    if (NodeClock::now() < m_next_resend) return false;
 
     return true;
 }
 
-int64_t CWallet::GetDefaultNextResend() { return GetTime() + (12 * 60 * 60) + GetRand(24 * 60 * 60); }
+NodeClock::time_point CWallet::GetDefaultNextResend() { return FastRandomContext{}.rand_uniform_delay(NodeClock::now() + 12h, 24h); }
 
 // Resubmit transactions from the wallet to the mempool, optionally asking the
 // mempool to relay them. On startup, we will do this for all unconfirmed

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -20,6 +20,7 @@
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/system.h>
+#include <util/time.h>
 #include <util/ui_change_type.h>
 #include <validationinterface.h>
 #include <wallet/crypter.h>
@@ -250,7 +251,7 @@ private:
     int nWalletVersion GUARDED_BY(cs_wallet){FEATURE_BASE};
 
     /** The next scheduled rebroadcast of wallet transactions. */
-    int64_t m_next_resend{GetDefaultNextResend()};
+    NodeClock::time_point m_next_resend{GetDefaultNextResend()};
     /** Whether this wallet will submit newly created transactions to the node's mempool and
      * prompt rebroadcasts (see ResendWalletTransactions()). */
     bool fBroadcastTransactions = false;
@@ -348,7 +349,7 @@ private:
      */
     static bool AttachChain(const std::shared_ptr<CWallet>& wallet, interfaces::Chain& chain, const bool rescan_required, bilingual_str& error, std::vector<bilingual_str>& warnings);
 
-    static int64_t GetDefaultNextResend();
+    static NodeClock::time_point GetDefaultNextResend();
 
 public:
     /**


### PR DESCRIPTION
`GetTime` is not type-safe, thus deprecated, see https://github.com/bitcoin/bitcoin/blob/75cbbfa279685f70d9f6fa71432df00862ffa865/src/util/time.h#L62-L70

