### PR TITLE
Enable `mempoolfullrbf=1` by default

### DIFF
--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -21,7 +21,7 @@ static constexpr unsigned int DEFAULT_MAX_MEMPOOL_SIZE_MB{300};
 /** Default for -mempoolexpiry, expiration time for mempool transactions in hours */
 static constexpr unsigned int DEFAULT_MEMPOOL_EXPIRY_HOURS{336};
 /** Default for -mempoolfullrbf, if the transaction replaceability signaling is ignored */
-static constexpr bool DEFAULT_MEMPOOL_FULL_RBF{false};
+static constexpr bool DEFAULT_MEMPOOL_FULL_RBF{true};
 
 namespace kernel {
 /**


### PR DESCRIPTION
This is an alternative to #25600 in the deployment of full-rbf. After listening to feedback, rather to introduce a new service bit and automatic preferential peering to enable full-rbf transaction-relay paths among the interested peers, the default value of `mempoolfullrbf` is switched to 1. This change implies all the Bitcoin Core nodes will accept replacement of opt-out transactions at the next release (at the earliest 25.0). Rather than a gradual construction of full-rbf transaction-relay paths due to node operators activating `mempoolfullrbf`, turning on by default the setting offer more visibility to the zero-conf services node operators.

Mailing list post coming soon to seek what has the preference between this deployment approach and the smoother #25600 approach among the development community and zero-conf services node operators.

(One more approach could be to lock-in `mempoolfullrbf=1` with some flag day activation if one release cycle of time is gauged is not enough or not predictible enough)