### PR TITLE
add lock annotation for FeeFilterRounder::round()

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -1036,6 +1036,7 @@ FeeFilterRounder::FeeFilterRounder(const CFeeRate& minIncrementalFee)
 
 CAmount FeeFilterRounder::round(CAmount currentMinFee)
 {
+    AssertLockNotHeld(m_insecure_rand_mutex);
     std::set<double>::iterator it = m_fee_set.lower_bound(currentMinFee);
     if (it == m_fee_set.end() ||
         (it != m_fee_set.begin() &&

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -302,7 +302,7 @@ public:
     explicit FeeFilterRounder(const CFeeRate& min_incremental_fee);
 
     /** Quantize a minimum fee for privacy purpose before broadcast. */
-    CAmount round(CAmount currentMinFee);
+    CAmount round(CAmount currentMinFee) EXCLUSIVE_LOCKS_REQUIRED(!m_insecure_rand_mutex);
 
 private:
     const std::set<double> m_fee_set;


### PR DESCRIPTION
CI failure from #24407: https://github.com/bitcoin/bitcoin/runs/8876014446

Calling `WITH_LOCK()` on a non-recursive mutex requires not holding it beforehand.