### PR TITLE
test: perturb anchors.dat to test error during initialization

### DIFF
--- a/test/functional/feature_anchors.py
+++ b/test/functional/feature_anchors.py
@@ -63,17 +63,25 @@ class AnchorsTest(BitcoinTestFramework):
         self.log.info("Check the addresses in anchors.dat")
 
         with open(node_anchors_path, "rb") as file_handler:
-            anchors = file_handler.read().hex()
+            anchors = file_handler.read()
 
+        anchors_hex = anchors.hex()
         for port in block_relay_nodes_port:
             ip_port = ip + port
-            assert ip_port in anchors
+            assert ip_port in anchors_hex
         for port in inbound_nodes_port:
             ip_port = ip + port
-            assert ip_port not in anchors
+            assert ip_port not in anchors_hex
 
-        self.log.info("Start node")
-        self.start_node(0)
+        self.log.info("Perturb anchors.dat to test it doesn't throw an error during initialization")
+        with self.nodes[0].assert_debug_log(["0 block-relay-only anchors will be tried for connections."]):
+            with open(node_anchors_path, "wb") as out_file_handler:
+                tweaked_contents = bytearray(anchors)
+                tweaked_contents[20:20] = b'1'
+                out_file_handler.write(bytes(tweaked_contents))
+
+            self.log.info("Start node")
+            self.start_node(0)
 
         self.log.info("When node starts, check if anchors.dat doesn't exist anymore")
         assert not os.path.exists(node_anchors_path)


### PR DESCRIPTION
Got some inspiration from `feature_init`. This PR tests whether perturbing `anchors.dat` doesn't throw any error during initialization.

https://github.com/bitcoin/bitcoin/blob/3f1f5f6f1ec49d0fb2acfddec4021b3582ba0553/src/addrdb.cpp#L223-L235