### PR TITLE
use shared mutex to guard against block files being removed before read

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2136,7 +2136,7 @@ void PeerManagerImpl::ProcessGetBlockData(CNode& pfrom, Peer& peer, const CInv& 
         // Fast-path: in this case it is possible to serve the block directly from disk,
         // as the network format matches the format on disk
         std::vector<uint8_t> block_data;
-        if (!ReadRawBlockFromDisk(block_data, pindex->GetBlockPos(), m_chainparams.MessageStart())) {
+        if (!ReadRawBlockFromDisk(block_data, pindex, m_chainparams.MessageStart())) {
             assert(!"cannot load block from disk");
         }
         m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::BLOCK, Span{block_data}));

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -764,11 +764,11 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
     return true;
 }
 
-bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start)
+bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CBlockIndex* pindex, const CMessageHeader::MessageStartChars& message_start)
 {
-    FlatFilePos hpos = pos;
-    hpos.nPos -= 8; // Seek back 8 bytes for meta header
-    CAutoFile filein(OpenBlockFile(hpos, true), SER_DISK, CLIENT_VERSION);
+    FlatFilePos pos{WITH_LOCK(cs_main, return pindex->GetBlockPos())};
+    pos.nPos -= 8; // Seek back 8 bytes for meta header
+    CAutoFile filein(OpenBlockFile(pos, true), SER_DISK, CLIENT_VERSION);
     if (filein.IsNull()) {
         return error("%s: OpenBlockFile failed for %s", __func__, pos.ToString());
     }

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -211,7 +211,7 @@ void UnlinkPrunedFiles(const std::set<int>& setFilesToPrune);
 /** Functions for disk access for blocks */
 bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams);
 bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
-bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start);
+bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CBlockIndex* pindex, const CMessageHeader::MessageStartChars& message_start);
 
 bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex);
 


### PR DESCRIPTION
Potentially fixed https://github.com/bitcoin/bitcoin/issues/17161. 

It seems there's a race in `ReadBlockFromDisk` and `UndoReadFromDisk` where after the block/undo file position is retrieved the actual block/undo file could be removed during prune. This could just cause the read to fail, or it could prevent the file from being removed if the file is already open depending on the platform (https://en.cppreference.com/w/cpp/io/c/remove). This PR uses a shared mutex to lock the removal of files until any reads are completed. This way it doesn't block `cs_main` while reading so `ReadBlockFromDisk` usage can be moved outside of `cs_main` in some cases like https://github.com/bitcoin/bitcoin/pull/26308.

The first commit also updates the function signature of `ReadRawBlockFromDisk` to take a block index instead of the file position, and then the file position is retrieved while locking `cs_main` inside the function. That way it unifies it with `ReadBlockFromDisk` and can be moved outside `cs_main` scope inside `net_processing` in a follow up PR like https://github.com/bitcoin/bitcoin/pull/26326.

Also see https://github.com/bitcoin/bitcoin/pull/25232.