### PR TITLE
Adjust `.tx/config` for new Transifex CLI

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[bitcoin.qt-translation-024x]
+[o:bitcoin:p:bitcoin:r:qt-translation-024x]
 file_filter = src/qt/locale/bitcoin_<lang>.xlf
 source_file = src/qt/locale/bitcoin_en.xlf
 source_lang = en


### PR DESCRIPTION
The old Transifex Command-Line Tool is considered deprecated (as of January 2022) and will sunset on Nov 30, 2022.

See: https://github.com/transifex/cli/blob/devel/README.md#migrating-from-older-versions-of-the-client

An accompanying PR: https://github.com/bitcoin-core/bitcoin-maintainer-tools/pull/142