### PR TITLE
Make full RBF default, but defer mainnet enablement

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -96,6 +96,9 @@ public:
         consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000003404ba0801921119f903495e");
         consensus.defaultAssumeValid = uint256S("0x00000000000000000009c97098b5295f7e5f183ac811fb5d1534040adb93cabd"); // 751565
 
+        // Defer full RBF activation
+        m_defer_full_rbf =  1682899200; // 1 May 2023 00:00:00 +0000
+
         /**
          * The message start string is designed to be unlikely to occur in normal data.
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
@@ -420,6 +423,10 @@ public:
 
         consensus.nMinimumChainWork = uint256{};
         consensus.defaultAssumeValid = uint256{};
+
+        // Defer full RBF activation
+        // set to past date, so usable with setmocktime
+        m_defer_full_rbf = 1664582400; // 01 Oct 2022 00:00:00 +0000
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -122,6 +122,7 @@ public:
     const MapAssumeutxo& Assumeutxo() const { return m_assumeutxo_data; }
 
     const ChainTxData& TxData() const { return chainTxData; }
+    int64_t DeferFullRBF() const { return m_defer_full_rbf; }
 protected:
     CChainParams() {}
 
@@ -144,6 +145,7 @@ protected:
     CCheckpointData checkpointData;
     MapAssumeutxo m_assumeutxo_data;
     ChainTxData chainTxData;
+    int64_t m_defer_full_rbf{0}; // seconds since unix epoch
 };
 
 /**

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -21,7 +21,7 @@ static constexpr unsigned int DEFAULT_MAX_MEMPOOL_SIZE_MB{300};
 /** Default for -mempoolexpiry, expiration time for mempool transactions in hours */
 static constexpr unsigned int DEFAULT_MEMPOOL_EXPIRY_HOURS{336};
 /** Default for -mempoolfullrbf, if the transaction replaceability signaling is ignored */
-static constexpr bool DEFAULT_MEMPOOL_FULL_RBF{false};
+static constexpr bool DEFAULT_MEMPOOL_FULL_RBF{true};
 
 namespace kernel {
 /**

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -671,6 +671,7 @@ UniValue MempoolInfoToJSON(const CTxMemPool& pool)
     ret.pushKV("incrementalrelayfee", ValueFromAmount(pool.m_incremental_relay_feerate.GetFeePerK()));
     ret.pushKV("unbroadcastcount", uint64_t{pool.GetUnbroadcastTxs().size()});
     ret.pushKV("fullrbf", pool.m_full_rbf);
+    ret.pushKV("defer_fullrbf", Params().DeferFullRBF());
     return ret;
 }
 
@@ -693,6 +694,7 @@ static RPCHelpMan getmempoolinfo()
                 {RPCResult::Type::NUM, "incrementalrelayfee", "minimum fee rate increment for mempool limiting or replacement in " + CURRENCY_UNIT + "/kvB"},
                 {RPCResult::Type::NUM, "unbroadcastcount", "Current number of transactions that haven't passed initial broadcast yet"},
                 {RPCResult::Type::BOOL, "fullrbf", "True if the mempool accepts RBF without replaceability signaling inspection"},
+                {RPCResult::Type::NUM_TIME, "defer_fullrbf", "If non-zero, fullrbf will be considered false until this timestamp is reached, expressed in " + UNIX_EPOCH_TIME},
             }},
         RPCExamples{
             HelpExampleCli("getmempoolinfo", "")

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -726,6 +726,8 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         return state.Invalid(TxValidationResult::TX_CONFLICT, "txn-same-nonwitness-data-in-mempool");
     }
 
+    const bool do_full_rbf = m_pool.m_full_rbf && args.m_chainparams.DeferFullRBF() <= args.m_accept_time;
+
     // Check for conflicts with in-memory transactions
     for (const CTxIn &txin : tx.vin)
     {
@@ -747,7 +749,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
                 //
                 // If replaceability signaling is ignored due to node setting,
                 // replacement is always allowed.
-                if (!m_pool.m_full_rbf && !SignalsOptInRBF(*ptxConflicting)) {
+                if (!do_full_rbf && !SignalsOptInRBF(*ptxConflicting)) {
                     return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "txn-mempool-conflict");
                 }
 

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -26,14 +26,16 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         self.num_nodes = 2
         self.extra_args = [
             [
+                "-mempoolfullrbf=0",
                 "-maxorphantx=1000",
                 "-limitancestorcount=50",
                 "-limitancestorsize=101",
                 "-limitdescendantcount=200",
                 "-limitdescendantsize=101",
             ],
-            # second node has default mempool parameters
+            # second node has default mempool parameters with no fullrbf
             [
+                "-mempoolfullrbf=0",
             ],
         ]
         self.supports_cli = False

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -42,7 +42,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.extra_args = [[
-            '-txindex','-permitbaremultisig=0',
+            '-txindex','-permitbaremultisig=0', '-mempoolfullrbf=0'
         ]] * self.num_nodes
         self.supports_cli = False
 

--- a/test/functional/p2p_permissions.py
+++ b/test/functional/p2p_permissions.py
@@ -100,7 +100,7 @@ class P2PPermissionsTests(BitcoinTestFramework):
         # A test framework p2p connection is needed to send the raw transaction directly. If a full node was used, it could only
         # rebroadcast via the inv-getdata mechanism. However, even for forcerelay connections, a full node would
         # currently not request a txid that is already in the mempool.
-        self.restart_node(1, extra_args=["-whitelist=forcerelay@127.0.0.1"])
+        self.restart_node(1, extra_args=["-whitelist=forcerelay@127.0.0.1", "-mempoolfullrbf=0"])
         p2p_rebroadcast_wallet = self.nodes[1].add_p2p_connection(P2PDataStore())
 
         self.log.debug("Send a tx from the wallet initially")


### PR DESCRIPTION
Enable full RBF on all networks by default, but defer full RBF enablement on mainnet until 1st May 2023. This enables easier testing of the behaviour on test networks and provides time for services relying on RBF being opt-in only to adapt to that policy going away.

Full RBF support can still be entirely disabled for an individual node by setting -mempoolfullrbf=0.