### PR TITLE
[23.x] Revert "build: Use Homebrew's sqlite package if it is available"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -721,10 +721,6 @@ case $host in
            BDB_LIBS="-L$bdb_prefix/lib -ldb_cxx-4.8"
          fi
 
-         if test "$use_sqlite" != "no" && $BREW list --versions sqlite3 >/dev/null; then
-           export PKG_CONFIG_PATH="$($BREW --prefix sqlite3 2>/dev/null)/lib/pkgconfig:$PKG_CONFIG_PATH"
-         fi
-
          if $BREW list --versions qt@5 >/dev/null; then
            export PKG_CONFIG_PATH="$($BREW --prefix qt@5 2>/dev/null)/lib/pkgconfig:$PKG_CONFIG_PATH"
          fi

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -112,15 +112,11 @@ brew install berkeley-db@4
 
 ###### Descriptor Wallet Support
 
-Note: Apple has included a useable `sqlite` package since macOS 10.14.
-You may not need to install this package.
+`sqlite` is required to support for descriptor wallets.
 
-`sqlite` is required to enable support for descriptor wallets.
-Skip if you don't intend to use descriptor wallets.
+macOS ships with a useable `sqlite` package, meaning you don't need to
+install anything.
 
-``` bash
-brew install sqlite
-```
 ---
 
 #### GUI Dependencies


### PR DESCRIPTION
Backport of https://github.com/bitcoin/bitcoin/pull/25985 to the 23.x branch.