### PR TITLE
Guix documentation improvements

### DIFF
--- a/contrib/guix/INSTALL.md
+++ b/contrib/guix/INSTALL.md
@@ -821,3 +821,39 @@ Please see the following links for more details:
 [docker/volumes]: https://docs.docker.com/storage/volumes/
 [docker/bind-mnt]: https://docs.docker.com/storage/bind-mounts/
 [docker/tmpfs]: https://docs.docker.com/storage/tmpfs/
+
+# Purging/Uninstalling Guix
+
+In the extraordinarily rare case where you messed up your Guix installation in
+an irreversible way, you may want to completely purge Guix from your system and
+start over.
+
+1. Uninstall Guix itself according to the way you installed it (e.g. `sudo apt
+   purge guix` for Ubuntu packaging, `sudo make uninstall` for a build from source).
+2. Remove all build users and groups
+
+   You may check for relevant users and groups using:
+
+   ```
+   getent passwd | grep guix
+   getent group | grep guix
+   ```
+
+   Then, you may remove users and groups using:
+
+   ```
+   sudo userdel <user>
+   sudo groupdel <group>
+   ```
+
+3. Remove all possible Guix-related directories
+    - `/var/guix/`
+    - `/var/log/guix/`
+    - `/gnu/`
+    - `/etc/guix/`
+    - `/home/*/.config/guix/`
+    - `/home/*/.cache/guix/`
+    - `/home/*/.guix-profile/`
+    - `/root/.config/guix/`
+    - `/root/.cache/guix/`
+    - `/root/.guix-profile/`

--- a/contrib/guix/INSTALL.md
+++ b/contrib/guix/INSTALL.md
@@ -616,6 +616,8 @@ systemctl enable guix-daemon
 systemctl start guix-daemon
 ```
 
+Remember to set `--no-substitute` in `$libdir/systemd/system/guix-daemon.service` and other customizations if you used them for `guix-daemon-original.service`.
+
 ##### If you installed Guix via the Debian/Ubuntu distribution packages
 
 You will need to create a `guix-daemon-latest` service which points to the new

--- a/contrib/guix/INSTALL.md
+++ b/contrib/guix/INSTALL.md
@@ -338,6 +338,8 @@ packages in Debian at the time of writing.
 |-----------------------|---------------------|
 | guile-gcrypt          | libgcrypt-dev       |
 | guile-git             | libgit2-dev         |
+| guile-gnutls          | (none)              |
+| guile-json            | (none)              |
 | guile-lzlib           | liblz-dev           |
 | guile-ssh             | libssh-dev          |
 | guile-sqlite3         | libsqlite3-dev      |

--- a/contrib/guix/INSTALL.md
+++ b/contrib/guix/INSTALL.md
@@ -384,8 +384,9 @@ cd guix
 ```
 
 You will likely want to build the latest release, however, if the latest release
-when you're reading this is still 1.2.0 then you may want to use 95aca29 instead
-to avoid a problem in the GnuTLS test suite.
+when you're reading this is still 1.3.0 then you may want to use 998eda30 instead
+to avoid the issues described in [#25099](
+https://github.com/bitcoin/bitcoin/pull/25099).
 
 ```
 git branch -a -l 'origin/version-*'  # check for the latest release

--- a/contrib/guix/INSTALL.md
+++ b/contrib/guix/INSTALL.md
@@ -167,6 +167,10 @@ For reference, the graphic below outlines Guix v1.3.0's dependency graph:
 
 ![bootstrap map](https://user-images.githubusercontent.com/6399679/125064185-a9a59880-e0b0-11eb-82c1-9b8e5dc9950d.png)
 
+#### Consider /tmp on tmpfs
+
+If you use an NVME (SSD) drive, you may encounter [cryptic build errors](#coreutils-fail-teststail-2inotify-dir-recreate). Mounting a [tmpfs at /tmp](https://ubuntu.com/blog/data-driven-analysis-tmp-on-tmpfs) should prevent this and may improve performance as a bonus.
+
 #### Guile
 
 ##### Choosing a Guile version and sticking to it
@@ -775,7 +779,7 @@ The inotify-dir-create test fails on "remote" filesystems such as overlayfs
 as non-remote.
 
 A relatively easy workaround to this is to make sure that a somewhat traditional
-filesystem is mounted at `/tmp` (where `guix-daemon` performs its builds). For
+filesystem is mounted at `/tmp` (where `guix-daemon` performs its builds), see [/tmp on tmpfs](#consider-tmp-on-tmpfs). For
 Docker users, this might mean [using a volume][docker/volumes], [binding
 mounting][docker/bind-mnt] from host, or (for those with enough RAM and swap)
 [mounting a tmpfs][docker/tmpfs] using the `--tmpfs` flag.
@@ -783,7 +787,7 @@ mounting][docker/bind-mnt] from host, or (for those with enough RAM and swap)
 Please see the following links for more details:
 
 - An upstream coreutils bug has been filed: [debbugs#47940](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=47940)
-- A Guix bug detailing the underlying problem has been filed: [guix-issues#47935](https://issues.guix.gnu.org/47935)
+- A Guix bug detailing the underlying problem has been filed: [guix-issues#47935](https://issues.guix.gnu.org/47935), [guix-issues#49985](https://issues.guix.gnu.org/49985#5)
 - A commit to skip this test in Guix has been merged into the core-updates branch:
 [savannah/guix@6ba1058](https://git.savannah.gnu.org/cgit/guix.git/commit/?id=6ba1058df0c4ce5611c2367531ae5c3cdc729ab4)
 

--- a/contrib/guix/INSTALL.md
+++ b/contrib/guix/INSTALL.md
@@ -726,6 +726,19 @@ $ bzcat /var/log/guix/drvs/../...-foo-3.6.12.drv.bz2 | less
 times, it may be `/tmp/...drv-1` or `/tmp/...drv-2`. Always consult the build
 failure output for the most accurate, up-to-date information.
 
+### openssl-1.1.1l and openssl-1.1.1n
+
+OpenSSL includes tests that will fail once some certificate has expired. A workaround
+is to change your system clock:
+
+```sh
+sudo timedatectl set-ntp no
+sudo date --set "28 may 2022 15:00:00"
+sudo --login guix build --cores=1 /gnu/store/g9alz81w4q03ncm542487xd001s6akd4-openssl-1.1.1l.drv
+sudo --login guix build --cores=1 /gnu/store/mw6ax0gk33gh082anrdrxp2flrbskxv6-openssl-1.1.1n.drv
+sudo timedatectl set-ntp yes
+```
+
 ### python(-minimal): [Errno 84] Invalid or incomplete multibyte or wide character
 
 This error occurs when your `$TMPDIR` (default: /tmp) exists on a filesystem

--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -430,55 +430,6 @@ used.
 If you start `guix-daemon` using an init script, you can edit said script to
 supply this flag.
 
-
-# Purging/Uninstalling Guix
-
-In the extraordinarily rare case where you messed up your Guix installation in
-an irreversible way, you may want to completely purge Guix from your system and
-start over.
-
-1. Uninstall Guix itself according to the way you installed it (e.g. `sudo apt
-   purge guix` for Ubuntu packaging, `sudo make uninstall` for a build from source).
-2. Remove all build users and groups
-
-   You may check for relevant users and groups using:
-
-   ```
-   getent passwd | grep guix
-   getent group | grep guix
-   ```
-
-   Then, you may remove users and groups using:
-
-   ```
-   sudo userdel <user>
-   sudo groupdel <group>
-   ```
-
-3. Remove all possible Guix-related directories
-    - `/var/guix/`
-    - `/var/log/guix/`
-    - `/gnu/`
-    - `/etc/guix/`
-    - `/home/*/.config/guix/`
-    - `/home/*/.cache/guix/`
-    - `/home/*/.guix-profile/`
-    - `/root/.config/guix/`
-    - `/root/.cache/guix/`
-    - `/root/.guix-profile/`
-
 [b17e]: https://bootstrappable.org/
 [r12e/source-date-epoch]: https://reproducible-builds.org/docs/source-date-epoch/
-
-[guix/install.sh]: https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh
-[guix/bin-install]: https://www.gnu.org/software/guix/manual/en/html_node/Binary-Installation.html
-[guix/env-setup]: https://www.gnu.org/software/guix/manual/en/html_node/Build-Environment-Setup.html
-[guix/substitutes]: https://www.gnu.org/software/guix/manual/en/html_node/Substitutes.html
-[guix/substitute-server-auth]: https://www.gnu.org/software/guix/manual/en/html_node/Substitute-Server-Authorization.html
-[guix/time-machine]: https://guix.gnu.org/manual/en/html_node/Invoking-guix-time_002dmachine.html
-
-[debian/guix-bullseye]: https://packages.debian.org/bullseye/guix
-[ubuntu/guix-hirsute]: https://packages.ubuntu.com/hirsute/guix
-[fanquake/guix-docker]: https://github.com/fanquake/core-review/tree/master/guix
-
 [env-vars-list]: #recognized-environment-variables


### PR DESCRIPTION
I'm manually installing Guix on a fresh Ubuntu machine. Will be pushing more documentation fixes to this PR as I run into things.

1. Bump minimum hash to match time-machine bump in #25099. It's not necessary for the root Guix version to match the time-machine version in our build, because `guix build` will automatically perform an upgrade for the user, but imo it's better to get any build issues (in Guix itself) over with while the user is going though `INSTALL.md`, rather than during their first Guix build (of Bitcoin Core).
2. Recommend mapping a tmpfs to /tmp upfront, rather than in the troubleshooting section
3. Add `guile-gnutls` and `guile-json` to the table of stuff to install (avoids having to find out in the `./configure` phase)
4. Improve systemd doc
5. Workaround OpenSSL v1.1.1l and v1.1.1n test failure (change machine time)
6. Move uninstallation instructions to INSTALL.md, drop unused footnote / links


