### PR TITLE
p2p: Don't require services from `ADDR_FETCH` peers

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -459,10 +459,10 @@ public:
             case ConnectionType::INBOUND:
             case ConnectionType::MANUAL:
             case ConnectionType::FEELER:
+            case ConnectionType::ADDR_FETCH:
                 return false;
             case ConnectionType::OUTBOUND_FULL_RELAY:
             case ConnectionType::BLOCK_RELAY:
-            case ConnectionType::ADDR_FETCH:
                 return true;
         } // no default case, so the compiler can warn about missing cases
 


### PR DESCRIPTION
While testing #20018, I noticed that we sometimes make an AddrFetch connection to a node a DNS seed resolves to (if we have a `-proxy` set), but then disconnect them because we don't like their services. The same could happen for a manually added `-seednode`.
However, we only want addresses from these peers, which are not related to any of the current service flags, so I don't see a point in aborting an AddrFetch attempt due to undesirable services.
