### PR TITLE
Make P2SH redeem script "IF .. PUSH <x> ELSE ... PUSH <y> ENDIF CHECKMULTISIG .. " standard

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -199,7 +199,7 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
             if (stack.empty())
                 return false;
             CScript subscript(stack.back().begin(), stack.back().end());
-            if (subscript.GetSigOpCount(true) > MAX_P2SH_SIGOPS) {
+            if (subscript.GetStandardSigOpCount() > MAX_P2SH_SIGOPS) {
                 return false;
             }
         }

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -195,8 +195,14 @@ unsigned int CScript::GetStandardSigOpCount() const
                 nesting++;
                 break;
             case OP_ELSE:
-                if (nesting==1)
-                    else_n = GetStandardSigOpCount(lastOpcode);
+                if (nesting==1) {
+                    // Avoid considering scripts with multiple OP_ELSE as standard.
+                    // IF ELSE ELSE ENDIF is allowed by Bitcoin script
+                    if (else_n!=MAX_PUBKEYS_PER_MULTISIG)
+                        else_n = MAX_PUBKEYS_PER_MULTISIG;
+                    else
+                        else_n = GetStandardSigOpCount(lastOpcode);
+                }
                 break;
             case OP_ENDIF:
                 if (nesting==1)

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -190,6 +190,8 @@ unsigned int CScript::GetStandardSigOpCount() const
                 break;
             case OP_IF:
             case OP_NOTIF:
+                if (nesting==0)
+                   if_n = else_n = MAX_PUBKEYS_PER_MULTISIG;
                 nesting++;
                 break;
             case OP_ELSE:

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -165,6 +165,7 @@ unsigned int CScript::GetStandardSigOpCount() const
     unsigned int n = 0;
     unsigned int if_n = MAX_PUBKEYS_PER_MULTISIG;
     unsigned int else_n = MAX_PUBKEYS_PER_MULTISIG;
+    unsigned int nesting =0;
     const_iterator pc = begin();
     opcodetype lastOpcode = OP_INVALIDOPCODE;
     while (pc < end())
@@ -180,7 +181,7 @@ unsigned int CScript::GetStandardSigOpCount() const
                 break;
              case OP_CHECKMULTISIG:
              case OP_CHECKMULTISIGVERIFY:
-                if (lastOpcode==OP_ENDIF) {
+                if ((lastOpcode==OP_ENDIF) && (nesting==0)) {
                         n +=std::max(if_n,else_n);
                         if_n = else_n = MAX_PUBKEYS_PER_MULTISIG;
                     }
@@ -189,13 +190,16 @@ unsigned int CScript::GetStandardSigOpCount() const
                 break;
             case OP_IF:
             case OP_NOTIF:
-                if_n = else_n = MAX_PUBKEYS_PER_MULTISIG;
+                nesting++;
                 break;
             case OP_ELSE:
-                else_n = GetStandardSigOpCount(lastOpcode);
+                if (nesting==1)
+                    else_n = GetStandardSigOpCount(lastOpcode);
                 break;
             case OP_ENDIF:
-                if_n = GetStandardSigOpCount(lastOpcode);
+                if (nesting==1)
+                    if_n = GetStandardSigOpCount(lastOpcode);
+                nesting--;
                 break;
             default:
                 break;

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -163,7 +163,7 @@ unsigned int CScript::GetStandardSigOpCount(opcodetype lastOpcode) const {
 unsigned int CScript::GetStandardSigOpCount() const
 {
     unsigned int n = 0;
-    unsigned int if_n = MAX_PUBKEYS_PER_MULTISIG;
+    unsigned int endif_n = MAX_PUBKEYS_PER_MULTISIG;
     unsigned int else_n = MAX_PUBKEYS_PER_MULTISIG;
     unsigned int nesting =0;
     bool  elseFound = false;
@@ -183,8 +183,8 @@ unsigned int CScript::GetStandardSigOpCount() const
              case OP_CHECKMULTISIG:
              case OP_CHECKMULTISIGVERIFY:
                 if ((lastOpcode==OP_ENDIF) && (nesting==0)) {
-                        n +=std::max(if_n,else_n);
-                        if_n = else_n = MAX_PUBKEYS_PER_MULTISIG;
+                        n +=std::max(endif_n,else_n);
+                        endif_n = else_n = MAX_PUBKEYS_PER_MULTISIG;
                         elseFound = false;
                     }
                     else
@@ -193,7 +193,7 @@ unsigned int CScript::GetStandardSigOpCount() const
             case OP_IF:
             case OP_NOTIF:
                 if (nesting==0) {
-                   if_n = else_n = MAX_PUBKEYS_PER_MULTISIG;
+                   endif_n = else_n = MAX_PUBKEYS_PER_MULTISIG;
                    elseFound = false;
                 }
                 nesting++;
@@ -212,7 +212,7 @@ unsigned int CScript::GetStandardSigOpCount() const
                 break;
             case OP_ENDIF:
                 if (nesting==1)
-                    if_n = GetStandardSigOpCount(lastOpcode);
+                    endif_n = GetStandardSigOpCount(lastOpcode);
                 nesting--;
                 break;
             default:

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -524,9 +524,8 @@ public:
      */
     unsigned int GetSigOpCount(bool fAccurate) const;
 
-    unsigned int getAccurateSigOpCount() const;
-    unsigned int getSimpleSigOpCount() const;
-    unsigned int getAccurateSigOpCount(opcodetype lastOpcode) const;
+    unsigned int GetStandardSigOpCount() const;
+    unsigned int GetStandardSigOpCount(opcodetype lastOpcode) const;
 
     /**
      * Accurately count sigOps, including sigOps in

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -524,6 +524,10 @@ public:
      */
     unsigned int GetSigOpCount(bool fAccurate) const;
 
+    unsigned int getAccurateSigOpCount() const;
+    unsigned int getSimpleSigOpCount() const;
+    unsigned int getAccurateSigOpCount(opcodetype lastOpcode) const;
+
     /**
      * Accurately count sigOps, including sigOps in
      * pay-to-script-hash transactions:

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -285,6 +285,36 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         assert(redeemScript.GetStandardSigOpCount()==4+MAX_PUBKEYS_PER_MULTISIG);
     }
 
+    // Invalid script ENDIF and a 7 OP_CHECKMULTISIGVERIFY (revert back to old computations)
+    {
+        CScript redeemScript = CScript() <<
+         OP_ENDIF <<
+         7 <<
+         OP_CHECKMULTISIGVERIFY;
+
+        assert(redeemScript.GetStandardSigOpCount()==7);
+    }
+
+    // Invalid script ENDIF and OP_RETURN OP_CHECKMULTISIGVERIFY (revert back to old computations)
+    {
+        CScript redeemScript = CScript() <<
+         OP_ENDIF <<
+         OP_RETURN <<
+         OP_CHECKMULTISIGVERIFY;
+
+        assert(redeemScript.GetStandardSigOpCount()==MAX_PUBKEYS_PER_MULTISIG);
+    }
+    // Invalid script ENDIF followed by IF/ELSE/ENDIF. Should not use path-related counting.
+    {
+        CScript redeemScript = CScript() <<
+         OP_ENDIF <<
+         OP_NOTIF << 4 <<
+         OP_ELSE  << 1 <<
+         OP_ENDIF << OP_CHECKMULTISIGVERIFY;
+
+        assert(redeemScript.GetStandardSigOpCount()==MAX_PUBKEYS_PER_MULTISIG);
+    }
+
     // Last opcode of ENDIF is not a push
     {
         CScript redeemScript = CScript() <<

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -220,9 +220,9 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
          OP_NOTIF  << 4 <<
          OP_ELSE <<
            OP_IF <<
-             1 << ToByteVector(pubkey) << 1 <<
+             1 <<
            OP_ELSE <<
-             1 << ToByteVector(pubkey) << 1 <<
+             1 <<
            OP_ENDIF  <<
            1 <<
          OP_ENDIF << OP_CHECKMULTISIGVERIFY;

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -230,6 +230,23 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         assert(redeemScript.GetStandardSigOpCount()==4);
 
     }
+    // nested IFs #3
+    {
+        CScript redeemScript = CScript() <<
+         OP_NOTIF  << 1 <<
+         OP_ELSE <<
+           OP_IF <<
+             4 <<
+           OP_ELSE <<
+             5 <<
+           OP_ENDIF  <<
+           2 <<
+         OP_ENDIF << OP_CHECKMULTISIGVERIFY;
+
+        assert(redeemScript.GetStandardSigOpCount()==2);
+
+    }
+
      // Two IFs #1
     {
         CScript redeemScript = CScript() <<

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -246,7 +246,17 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         assert(redeemScript.GetStandardSigOpCount()==2);
 
     }
+    // multiple ELSEs
+    {
+        CScript redeemScript = CScript() <<
+         OP_IF  << 1 <<
+         OP_ELSE << 7 <<
+         OP_ELSE << 1 <<
+         OP_ENDIF << OP_CHECKMULTISIGVERIFY;
 
+        assert(redeemScript.GetStandardSigOpCount()==MAX_PUBKEYS_PER_MULTISIG);
+
+    }
      // Two IFs #1
     {
         CScript redeemScript = CScript() <<


### PR DESCRIPTION
To characterize a transaction as standard or non-standard, Bitcoin Core tries to estimate the number of signature checks a particular script can potentially request. A maximum of 15 signature checks is allowed. The function GetSigopCount() 
 counts the maximum number of signature checks performed by a script.
For each CHECKSIG or CHECKSIGVERIFY found in a script, one is added to the signature check counter. For multisigs, the maximum number of checks depends on the number of signatories. When CHECKMULTISIG is executed, this number is at the top of the stack. However, to avoid executing the script to obtain the top of the stack value, Bitcoin Core performs an estimation based on static analysis of the script, which returns only an upper bound. This is what GetSigOpCount(true) does. However, the static analysis is very rudimentary, and it overestimates the signature checks for certain common scripts.

**How GetSigOpCount() works**

GetSigOpCount() assumes that the number of signers is pushed into the stack immediately before the CHECKMULTISIG opcode. If the previous opcode is not a push opcode, then this function assumes the worst case for each CHECKMULTISIG found, which is 20 signatures (defined by MAX_PUBKEYS_PER_MULTISIG). The problem is that this constant is greater than the maximum number of checks allowed per P2SH redeem script, which means that any P2SH script that uses CHECKMULTISIG must specify the number of signers with a PUSH opcode right before.   

**The bug in the RSK sidechain**

To add a time-locked emergency multisig to RSK powpeg, the RSK community, with the help of RSK core developers, migrated the multisig script that holds the funds of the peg from a traditional P2SH multisig to the following transaction redeem script:

```
OP_NOTIF 
	OP_PUSHNUM_M
	OP_PUSHBYTES_33 pubkey1
	...
	OP_PUSHBYTES_33 pubkeyN
	OP_PUSHNUM_N 
OP_ELSE 
	OP_PUSHBYTES_3 <time-lock-value>
	OP_CSV 
	OP_DROP 
	OP_PUSHNUM_3 
	OP_PUSHBYTES_33 emergencyPubkey1
	…
	OP_PUSHBYTES_33 emergencyPubkey4
	OP_PUSHNUM_4 
OP_ENDIF 
OP_CHECKMULTISIG
```

We see that there are two script paths and, to reduce the script size, a single CHECKMULTISIG is used for the two paths, separating the signer count from the CHECKMULTISIG opcode. This script worked on testnet, because it lacks the standard checks performed in Mainnet. 
The Liquid sidechain uses a very similar script, but using segwit addresses. 

We can see [here](https://github.com/bitcoin/bitcoin/blob/d492dc1cdaabdc52b0766bf4cba4bd73178325d0/src/script/script.cpp#L153) that GetSigOpCount() will find that END_IF is not a push opcode and will assume the number of signature checks is MAX_PUBKEYS_PER_MULTISIG.

**Motivation for Changing Bitcoin's standard rules**

Since having two execution paths for two different multisigs, one of them usually time-locked, is a very common use case, Bitcoin users can benefit from relaxing the standard rule and making two-paths multisigs standard.
The alternate way of having two-paths multisigs is by adding the CHECKMULTISIG at the end of every path. However, this reduces the maximum number of functionaries of the first (non time-locked) multisig, since the sum of both must be below 15.

Another benefit is that this change separates the new GetStandardSigOpCount() function used for standard rules from the old GetSigOpCount() method that is used in consensus code (both with fAccurate==true and fAccurate=false). This is very important because consensus rules should not be mixed with non-consensus rules in a dangerous way, as it is today.

An additional benefit for the RSK community is that if Bitcoin Core implements this improvement, the RSK community avoids preparing and activating a hard-fork to unblock the funds in the peg.

I include additional unit tests to show that:

* Only a single level of nesting is supported. "IF ELSE ENDIF CHECKMULTISIG" is supported but "IF IF ENDIF ENDIF CHECKMULTISIG" is not supported. 
* There must be only two paths (IF ELSE ELSE ELSE ENDIF CHECKMULTISIG" not supported).
* The change does not affect any other script standard rules, apart from the two-paths multisig.
* The change does not modify consensus rules.
