### PR TITLE
[22.x] Revert "build: Use Homebrew's sqlite package if it is available"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -696,10 +696,6 @@ case $host in
            BDB_LIBS="-L$bdb_prefix/lib -ldb_cxx-4.8"
          fi
 
-         if test "x$use_sqlite" != xno && $BREW list --versions sqlite3 >/dev/null; then
-           export PKG_CONFIG_PATH="$($BREW --prefix sqlite3 2>/dev/null)/lib/pkgconfig:$PKG_CONFIG_PATH"
-         fi
-
          if $BREW list --versions qt5 >/dev/null; then
            export PKG_CONFIG_PATH="$($BREW --prefix qt5 2>/dev/null)/lib/pkgconfig:$PKG_CONFIG_PATH"
          fi

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -115,15 +115,11 @@ brew install berkeley-db@4
 
 ###### Descriptor Wallet Support
 
-Note: Apple has included a useable `sqlite` package since macOS 10.14.
-You may not need to install this package.
+`sqlite` is required to support for descriptor wallets.
 
-`sqlite` is required to enable support for descriptor wallets.
-Skip if you don't intend to use descriptor wallets.
+macOS ships with a useable `sqlite` package, meaning you don't need to
+install anything.
 
-``` bash
-brew install sqlite
-```
 ---
 
 #### GUI Dependencies


### PR DESCRIPTION
Backport of https://github.com/bitcoin/bitcoin/pull/25985 to the 22.x branch.