### PR TITLE
guix: bump time-machine to 39dcbc7fa3c02ff5c9682f25e1c29667dbfe7827

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -53,6 +53,7 @@ store_path() {
     grep --extended-regexp "/[^-]{32}-${1}-[^-]+${2:+-${2}}" "${GUIX_ENVIRONMENT}/manifest" \
         | head --lines=1 \
         | sed --expression='s|^[[:space:]]*"||' \
+              --expression='s|)\+||' \
               --expression='s|"[[:space:]]*$||'
 }
 

--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -51,7 +51,7 @@ fi
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://git.savannah.gnu.org/git/guix.git \
-                      --commit=998eda3067c7d21e0d9bb3310d2f5a14b8f1c681 \
+                      --commit=39dcbc7fa3c02ff5c9682f25e1c29667dbfe7827 \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \


### PR DESCRIPTION
When building Guix using `--no-substitutes` this avoids a build failure in OpenSSL v1.1.1p. So far I've not found a workaround, but see Guix issue [58650](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=58650).

The second commit fixes the `store_path` regex to also drop closing brackets.

Alternatively we could bump all the way to the latest Guix master branch commit.

See #26335 for other workarounds you may need when building this version.

Hashes for this PR (without `powerpc64-linux-gnu`, see below):

```
find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum

e7b85edf4a260bb8eca5c766f366b18e46d7842f4c61fe7e5c6373127d965bbb  guix-build-a5cb076e423b/output/aarch64-linux-gnu/SHA256SUMS.part
73cbdb507276cd935966e887efcd85ea358dffd9087b93860335ff228cfa3d7f  guix-build-a5cb076e423b/output/aarch64-linux-gnu/bitcoin-a5cb076e423b-aarch64-linux-gnu-debug.tar.gz
2aa67d7e0aa09865272314359660de0af704df3ba583ba725e398d5982da7ec8  guix-build-a5cb076e423b/output/aarch64-linux-gnu/bitcoin-a5cb076e423b-aarch64-linux-gnu.tar.gz
c3f7ae50bf6e488cf8fc7af1a27cb1c33e5744ef9f1d62e00619eeb49de18113  guix-build-a5cb076e423b/output/arm-linux-gnueabihf/SHA256SUMS.part
2e397378b29a7594313a9a3918f7a4d10783880bd1f6c965e09b0d5a20bafe8d  guix-build-a5cb076e423b/output/arm-linux-gnueabihf/bitcoin-a5cb076e423b-arm-linux-gnueabihf-debug.tar.gz
ea862f5e4474252fc71b743268d00248a444740b1af82906fc49a5bb89304cf5  guix-build-a5cb076e423b/output/arm-linux-gnueabihf/bitcoin-a5cb076e423b-arm-linux-gnueabihf.tar.gz
3bc840cb1ab69808281d4ec8d262fc1ec3e2bf75faca0859af5c25cc1d763dd8  guix-build-a5cb076e423b/output/arm64-apple-darwin/SHA256SUMS.part
434c00d3b28edb5b7907913ecb7929e91aeff71c6f20545da33de41766870849  guix-build-a5cb076e423b/output/arm64-apple-darwin/bitcoin-a5cb076e423b-arm64-apple-darwin-unsigned.dmg
beb7b261dcb43c87c38d4bac32d645d2955c4af8e0d3956dd19e0c46fe58b8dc  guix-build-a5cb076e423b/output/arm64-apple-darwin/bitcoin-a5cb076e423b-arm64-apple-darwin-unsigned.tar.gz
6816c48c46e697a55a3205a402beecd42835aeea6f8ea704ffd977a836974177  guix-build-a5cb076e423b/output/arm64-apple-darwin/bitcoin-a5cb076e423b-arm64-apple-darwin.tar.gz
ddd5679daa5f65adb01e755aab5ce0702dcd8ee1801c74f669ede575c41d14f2  guix-build-a5cb076e423b/output/dist-archive/bitcoin-a5cb076e423b.tar.gz
7a89a53cb3d0d348e8d0fe0e043b0c2b1b8a4f5d13534ac714b84e2cb30131ce  guix-build-a5cb076e423b/output/powerpc64le-linux-gnu/SHA256SUMS.part
586188a79d70e8712ffd4f8e43ceb4420c259a87ebf6415743428be24f5f9d07  guix-build-a5cb076e423b/output/powerpc64le-linux-gnu/bitcoin-a5cb076e423b-powerpc64le-linux-gnu-debug.tar.gz
d26c20454acb97232b6a6d2b04193e6180e4a37c0da06bcde0023cc88525dd73  guix-build-a5cb076e423b/output/powerpc64le-linux-gnu/bitcoin-a5cb076e423b-powerpc64le-linux-gnu.tar.gz
74a2944ebb3a674ef807f3c2832dd5fd597e667103b787e5f71ce06ae5e2989b  guix-build-a5cb076e423b/output/riscv64-linux-gnu/SHA256SUMS.part
7c0e5b777deded533c4b5b46bf653652036c335f4522edb712c556a4f0126b9f  guix-build-a5cb076e423b/output/riscv64-linux-gnu/bitcoin-a5cb076e423b-riscv64-linux-gnu-debug.tar.gz
56ac007f82d8ea0a6e2fc20918f11b3d2ce9b1a1a8586f8f921bec57eb014235  guix-build-a5cb076e423b/output/riscv64-linux-gnu/bitcoin-a5cb076e423b-riscv64-linux-gnu.tar.gz
2aa370b2eaf790a25ad16277bc93735fe98ac4fed3fd6817eb23bcf8d2866d62  guix-build-a5cb076e423b/output/x86_64-apple-darwin/SHA256SUMS.part
3afe392a93188989f771c13fddd178125b815b3fa84ff48614fd30fd2c2d2ee9  guix-build-a5cb076e423b/output/x86_64-apple-darwin/bitcoin-a5cb076e423b-x86_64-apple-darwin-unsigned.dmg
41e8cb5bab761c11c5b47264fa17dc18b71129ac2a6faa4b64835885e1cb3d90  guix-build-a5cb076e423b/output/x86_64-apple-darwin/bitcoin-a5cb076e423b-x86_64-apple-darwin-unsigned.tar.gz
9fab82a1f631209b8ad413ad2c43c570d324eef6c1eb666a15de610843c8928a  guix-build-a5cb076e423b/output/x86_64-apple-darwin/bitcoin-a5cb076e423b-x86_64-apple-darwin.tar.gz
faa87a4292e0e745f1b80832b451e06f4cb8f3f6958253f7834608eaadb8dccc  guix-build-a5cb076e423b/output/x86_64-linux-gnu/SHA256SUMS.part
0bad56945b3d2af88a38d052e9fda8b82766bd3d7f3501aad110ef788abfb86b  guix-build-a5cb076e423b/output/x86_64-linux-gnu/bitcoin-a5cb076e423b-x86_64-linux-gnu-debug.tar.gz
8bb4694765577ce0bd5a64fb670e6081393afe7a130cf69f6302257849a25315  guix-build-a5cb076e423b/output/x86_64-linux-gnu/bitcoin-a5cb076e423b-x86_64-linux-gnu.tar.gz
9bf66ac377602a78672655f4b51a716590e915effab6150a4ed70fb9a7ab1693  guix-build-a5cb076e423b/output/x86_64-w64-mingw32/SHA256SUMS.part
4818acac490b248f4ae0154b562bbc93bef2efd7ae0a2d737bb720692d2fc41e  guix-build-a5cb076e423b/output/x86_64-w64-mingw32/bitcoin-a5cb076e423b-win64-debug.zip
41c90606b61fd18ce7922a3e370fd8ff9cf6b8d45ad334e804b88337d20c73c8  guix-build-a5cb076e423b/output/x86_64-w64-mingw32/bitcoin-a5cb076e423b-win64-setup-unsigned.exe
90c230b090d0e0bbf7e931c8604f2d32ebf93932e7b233a9e809eb88800f1fda  guix-build-a5cb076e423b/output/x86_64-w64-mingw32/bitcoin-a5cb076e423b-win64-unsigned.tar.gz
f69fbb26611b7455b6d09a7374a74bad48f8afeb0865a76b82f777f376b9e982  guix-build-a5cb076e423b/output/x86_64-w64-mingw32/bitcoin-a5cb076e423b-win64.zip
```

I also built v24.0rc2 with the new guix commit (see [branch](https://github.com/Sjors/bitcoin/tree/2022/10/guix-bump-timemachine-v24)) to see if the hashes change; they do (not very surprising). More importantly, the build still works, so in principle this PR can be backported.

(without `powerpc64-linux-gnu`, see below)

```
37cc772dd5f59a5b8e9e3935f44a7ae047129f56f20e7965491c9c34627a538d  guix-build-3eb0068bc299/output/aarch64-linux-gnu/SHA256SUMS.part
72e6b339ffe9c0f25811a0d571dae155de0361aa56b7431513cd68b540349173  guix-build-3eb0068bc299/output/aarch64-linux-gnu/bitcoin-3eb0068bc299-aarch64-linux-gnu-debug.tar.gz
bf93c5fa53a92691a8dddfd49ab6a4e12818e4b9be545b80805764f68b63ccd5  guix-build-3eb0068bc299/output/aarch64-linux-gnu/bitcoin-3eb0068bc299-aarch64-linux-gnu.tar.gz
3f1b6a855192980993a6fe5afc26a4fe61624d54f76534a79f33fb8dc81dff3d  guix-build-3eb0068bc299/output/arm-linux-gnueabihf/SHA256SUMS.part
134f53aa26d6c92c05d8e08fc71eb6efc126084338a3ffcacdc36986dfe18c9b  guix-build-3eb0068bc299/output/arm-linux-gnueabihf/bitcoin-3eb0068bc299-arm-linux-gnueabihf-debug.tar.gz
24f1adb05007e8749368cdcccfe09d8270cccf0bfc1af0cb657cf410dc1489d6  guix-build-3eb0068bc299/output/arm-linux-gnueabihf/bitcoin-3eb0068bc299-arm-linux-gnueabihf.tar.gz
29c0cd4ce1af5db8e1bbde64fdcf3b7356223bd05857027b23eeed63f4c049b2  guix-build-3eb0068bc299/output/arm64-apple-darwin/SHA256SUMS.part
9a8be16a71e06aa486881ae399db3ff25b5c660fbd3a27e8957241f6a135c729  guix-build-3eb0068bc299/output/arm64-apple-darwin/bitcoin-3eb0068bc299-arm64-apple-darwin-unsigned.dmg
62efdd24c9dbefff8a4127ae341bad1c4873e23b1db806d27506ba037f1194d6  guix-build-3eb0068bc299/output/arm64-apple-darwin/bitcoin-3eb0068bc299-arm64-apple-darwin-unsigned.tar.gz
689a80191eecc600d3ba02f6e6100a1b53c2debb6bf411a85afbb6adf6a6f128  guix-build-3eb0068bc299/output/arm64-apple-darwin/bitcoin-3eb0068bc299-arm64-apple-darwin.tar.gz
a05e4427b8c5be809ea1d611b36b330baaba606afb5df292839f273ed0cf7e60  guix-build-3eb0068bc299/output/dist-archive/bitcoin-3eb0068bc299.tar.gz
49d937ab154df39c62a86832720535cccbe74bf05c8947eb9c07092af8949eb3  guix-build-3eb0068bc299/output/powerpc64le-linux-gnu/SHA256SUMS.part
9f24087936128b34950f56c2cac17dfcdfc72d92b086062bd11abfd9135d7536  guix-build-3eb0068bc299/output/powerpc64le-linux-gnu/bitcoin-3eb0068bc299-powerpc64le-linux-gnu-debug.tar.gz
5b913d395bedc0cb3ae599b351940d1e2dd4a0b7acee93c6ddb6db4338b2e1fb  guix-build-3eb0068bc299/output/powerpc64le-linux-gnu/bitcoin-3eb0068bc299-powerpc64le-linux-gnu.tar.gz
0aeb9f4c49ef438bcaa0b2616ec1d248a9c00a81ca6cf1a0d0c2c077865c8b4a  guix-build-3eb0068bc299/output/riscv64-linux-gnu/SHA256SUMS.part
0fa3bd79cdd8d7a71bac1beec72a941a02f0e42de4d118c20370acdcc8df017a  guix-build-3eb0068bc299/output/riscv64-linux-gnu/bitcoin-3eb0068bc299-riscv64-linux-gnu-debug.tar.gz
e3b0e1c40b89fffa628fb86dbd1946bb03ba0a75f6236b3ad2ea79acc0bee17e  guix-build-3eb0068bc299/output/riscv64-linux-gnu/bitcoin-3eb0068bc299-riscv64-linux-gnu.tar.gz
bc64b62e1284c0de371e537b2e988228280f1cb11a1115342ebc111d3b904e24  guix-build-3eb0068bc299/output/x86_64-apple-darwin/SHA256SUMS.part
d7a87d41b6d96d8c7bf4bc4f42cf3cbe8999256e5fda1bcb0e154b2ad3ca514d  guix-build-3eb0068bc299/output/x86_64-apple-darwin/bitcoin-3eb0068bc299-x86_64-apple-darwin-unsigned.dmg
50aeed1df3811ed0e3136a8154f0e122b2a5764ce4cb64198b7a6c26b9b4dc30  guix-build-3eb0068bc299/output/x86_64-apple-darwin/bitcoin-3eb0068bc299-x86_64-apple-darwin-unsigned.tar.gz
7c765a8aa1619c66c21bf7035e8153ba48e2fa37196c1d356cfb46ba5533c54b  guix-build-3eb0068bc299/output/x86_64-apple-darwin/bitcoin-3eb0068bc299-x86_64-apple-darwin.tar.gz
25f9900f83dc633b64cdd65c502adeca6aa81c991ee00b156a20e7bbda0c1aa0  guix-build-3eb0068bc299/output/x86_64-linux-gnu/SHA256SUMS.part
4e94544cd94d6ce16b150741a41c90d51155a2ba033544185d81eb6049bc34d5  guix-build-3eb0068bc299/output/x86_64-linux-gnu/bitcoin-3eb0068bc299-x86_64-linux-gnu-debug.tar.gz
189ecc5ccadc7462666cd19c84a854b56db308cb1a26312436ad98e9ee6e9e9c  guix-build-3eb0068bc299/output/x86_64-linux-gnu/bitcoin-3eb0068bc299-x86_64-linux-gnu.tar.gz
7023ff9a930a649bf3a47ccd84a05fa976c0ece6b0b2f2673e6a21ded6ff8cb5  guix-build-3eb0068bc299/output/x86_64-w64-mingw32/SHA256SUMS.part
8fd95b8accc5736b0d387a6bb66adbbed476f26ba9f1516890a11b459b4537ef  guix-build-3eb0068bc299/output/x86_64-w64-mingw32/bitcoin-3eb0068bc299-win64-debug.zip
978d4a16487c1f040efba502e179f5f7072249c812309a2e35f4f0407271a45b  guix-build-3eb0068bc299/output/x86_64-w64-mingw32/bitcoin-3eb0068bc299-win64-setup-unsigned.exe
5310f21160402ef53997b269100e61be6103819d3718c2ecbdec06bc04d4bc75  guix-build-3eb0068bc299/output/x86_64-w64-mingw32/bitcoin-3eb0068bc299-win64-unsigned.tar.gz
8480993168f59f77b585975561b4493ae32f2864b0414e2b608c3bb5edc220b6  guix-build-3eb0068bc299/output/x86_64-w64-mingw32/bitcoin-3eb0068bc299-win64.zip
```
