### PR TITLE
test: Use consistent assert functions

### DIFF
--- a/test/functional/feature_backwards_compatibility.py
+++ b/test/functional/feature_backwards_compatibility.py
@@ -144,8 +144,8 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
         node_master.createwallet(wallet_name="w2", disable_private_keys=True)
         wallet = node_master.get_wallet_rpc("w2")
         info = wallet.getwalletinfo()
-        assert info['private_keys_enabled'] == False
-        assert info['keypoolsize'] == 0
+        assert_equal(info['private_keys_enabled'], False)
+        assert_equal(info['keypoolsize'], 0)
 
         # w3: blank wallet, created on master: update this
         #     test when default blank wallets can no longer be opened by older versions.
@@ -153,7 +153,7 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
         wallet = node_master.get_wallet_rpc("w3")
         info = wallet.getwalletinfo()
         assert info['private_keys_enabled']
-        assert info['keypoolsize'] == 0
+        assert_equal(info['keypoolsize'], 0)
 
         # Unload wallets and copy to older nodes:
         node_master_wallets_dir = os.path.join(node_master.datadir, "regtest/wallets")
@@ -187,26 +187,26 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
                     wallet = node.get_wallet_rpc(wallet_name)
                     info = wallet.getwalletinfo()
                     if wallet_name == "w1":
-                        assert info['private_keys_enabled'] == True
+                        assert_equal(info['private_keys_enabled'], True)
                         assert info['keypoolsize'] > 0
                         txs = wallet.listtransactions()
                         assert_equal(len(txs), 5)
                         assert_equal(txs[1]["txid"], tx1_id)
                         assert_equal(txs[2]["walletconflicts"], [tx1_id])
                         assert_equal(txs[1]["replaced_by_txid"], tx2_id)
-                        assert not(txs[1]["abandoned"])
+                        assert not txs[1]["abandoned"]
                         assert_equal(txs[1]["confirmations"], -1)
                         assert_equal(txs[2]["blockindex"], 1)
                         assert txs[3]["abandoned"]
                         assert_equal(txs[4]["walletconflicts"], [tx3_id])
                         assert_equal(txs[3]["replaced_by_txid"], tx4_id)
-                        assert not(hasattr(txs[3], "blockindex"))
+                        assert not hasattr(txs[3], "blockindex")
                     elif wallet_name == "w2":
-                        assert(info['private_keys_enabled'] == False)
-                        assert info['keypoolsize'] == 0
+                        assert_equal(info['private_keys_enabled'], False)
+                        assert_equal(info['keypoolsize'], 0)
                     else:
-                        assert(info['private_keys_enabled'] == True)
-                        assert info['keypoolsize'] == 0
+                        assert_equal(info['private_keys_enabled'], True)
+                        assert_equal(info['keypoolsize'], 0)
         else:
             for node in legacy_nodes:
                 # Descriptor wallets appear to be corrupted wallets to old software
@@ -236,7 +236,7 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
             self.restart_node(node_v16.index, extra_args=["-wallet=w2"])
             wallet = node_v16.get_wallet_rpc("w2")
             info = wallet.getwalletinfo()
-            assert info['keypoolsize'] == 1
+            assert_equal(info['keypoolsize'], 1)
 
         # Create upgrade wallet in v0.16
         self.restart_node(node_v16.index, extra_args=["-wallet=u1_v16"])

--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -45,6 +45,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_greater_than_or_equal,
+    assert_not_equal,
     assert_is_hex_string,
     assert_raises_rpc_error,
     try_rpc,
@@ -221,16 +222,16 @@ class SegWitTest(BitcoinTestFramework):
         self.fail_accept(self.nodes[0], "non-mandatory-script-verify-flag (Witness program was passed an empty witness)", p2sh_ids[NODE_0][P2WSH][0], sign=False, redeem_script=witness_script(True, self.pubkey[0]))
 
         self.log.info("Verify block and transaction serialization rpcs return differing serializations depending on rpc serialization flag")
-        assert self.nodes[2].getblock(blockhash, False) != self.nodes[0].getblock(blockhash, False)
-        assert self.nodes[1].getblock(blockhash, False) == self.nodes[2].getblock(blockhash, False)
+        assert_not_equal(self.nodes[2].getblock(blockhash, False), self.nodes[0].getblock(blockhash, False))
+        assert_equal(self.nodes[1].getblock(blockhash, False), self.nodes[2].getblock(blockhash, False))
 
         for tx_id in segwit_tx_list:
             tx = tx_from_hex(self.nodes[2].gettransaction(tx_id)["hex"])
-            assert self.nodes[2].getrawtransaction(tx_id, False, blockhash) != self.nodes[0].getrawtransaction(tx_id, False, blockhash)
-            assert self.nodes[1].getrawtransaction(tx_id, False, blockhash) == self.nodes[2].getrawtransaction(tx_id, False, blockhash)
-            assert self.nodes[0].getrawtransaction(tx_id, False, blockhash) != self.nodes[2].gettransaction(tx_id)["hex"]
-            assert self.nodes[1].getrawtransaction(tx_id, False, blockhash) == self.nodes[2].gettransaction(tx_id)["hex"]
-            assert self.nodes[0].getrawtransaction(tx_id, False, blockhash) == tx.serialize_without_witness().hex()
+            assert_not_equal(self.nodes[2].getrawtransaction(tx_id, False, blockhash), self.nodes[0].getrawtransaction(tx_id, False, blockhash))
+            assert_equal(self.nodes[1].getrawtransaction(tx_id, False, blockhash), self.nodes[2].getrawtransaction(tx_id, False, blockhash))
+            assert_not_equal(self.nodes[0].getrawtransaction(tx_id, False, blockhash), self.nodes[2].gettransaction(tx_id)["hex"])
+            assert_equal(self.nodes[1].getrawtransaction(tx_id, False, blockhash), self.nodes[2].gettransaction(tx_id)["hex"])
+            assert_equal(self.nodes[0].getrawtransaction(tx_id, False, blockhash), tx.serialize_without_witness().hex())
 
         # Coinbase contains the witness commitment nonce, check that RPC shows us
         coinbase_txid = self.nodes[2].getblock(blockhash)['tx'][0]
@@ -256,7 +257,7 @@ class SegWitTest(BitcoinTestFramework):
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
         raw_tx = self.nodes[0].getrawtransaction(txid, True)
         tmpl = self.nodes[0].getblocktemplate({'rules': ['segwit']})
-        assert_greater_than_or_equal(tmpl['sizelimit'], 3999577)  # actual maximum size is lower due to minimum mandatory non-witness data
+        assert_greater_than_or_equal(tmpl['sizelimit'], 3999577) # actual maximum size is lower due to minimum mandatory non-witness data
         assert_equal(tmpl['weightlimit'], 4000000)
         assert_equal(tmpl['sigoplimit'], 80000)
         assert_equal(tmpl['transactions'][0]['txid'], txid)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -51,9 +51,19 @@ def assert_fee_amount(fee, tx_size, feerate_BTC_kvB):
         raise AssertionError("Fee of %s BTC too high! (Should be %s BTC)" % (str(fee), str(target_fee)))
 
 
-def assert_equal(thing1, thing2, *args):
+def assert_equal(thing1, thing2, *args, err_msg=None):
     if thing1 != thing2 or any(thing1 != arg for arg in args):
-        raise AssertionError("not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args))
+        if err_msg is None:
+            err_msg = "not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args)
+        raise AssertionError(err_msg)
+
+
+def assert_not_equal(thing1, thing2, *args, err_msg=None):
+    if thing1 == thing2 or any(thing1 == arg for arg in args):
+        msg = "%s" % " == ".join(str(arg) for arg in (thing1, thing2) + args)
+        if err_msg is not None:
+            msg = err_msg
+        raise AssertionError(msg)
 
 
 def assert_greater_than(thing1, thing2):

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -60,10 +60,9 @@ def assert_equal(thing1, thing2, *args, err_msg=None):
 
 def assert_not_equal(thing1, thing2, *args, err_msg=None):
     if thing1 == thing2 or any(thing1 == arg for arg in args):
-        msg = "%s" % " == ".join(str(arg) for arg in (thing1, thing2) + args)
-        if err_msg is not None:
-            msg = err_msg
-        raise AssertionError(msg)
+        if err_msg is None:
+                err_msg = "%s" % " == ".join(str(arg) for arg in (thing1, thing2) + args)
+        raise AssertionError(err_msg)
 
 
 def assert_greater_than(thing1, thing2):


### PR DESCRIPTION
ref #23119: Updated a subset of the test cases to get approach feedback before making a large amount of changes that may need to change again. 

Approach:

- assert_equal is preferred over assert where possible. 
- A matching assert_not_equal function has been added also. 
- Where assert_equal is not possible, the built-in assert function will be used. 

Rationale:
This has been discussed in a few PRs / Issue.  The most recent consensus is that a [minimal approach](https://github.com/bitcoin/bitcoin/pull/25732) is best. 

