### PR TITLE
doc: Rearrange a few lines in the dependency graph of libraries

### DIFF
--- a/doc/design/libraries.md
+++ b/doc/design/libraries.md
@@ -35,7 +35,7 @@
 
 ```mermaid
 
-%%{ init : { "flowchart" : { "curve" : "linear" }}}%%
+%%{ init : { "flowchart" : { "curve" : "basis" }}}%%
 
 graph TD;
 
@@ -51,18 +51,18 @@ bitcoin-qt[bitcoin-qt]-->libbitcoin_wallet;
 bitcoin-wallet[bitcoin-wallet]-->libbitcoin_wallet;
 bitcoin-wallet[bitcoin-wallet]-->libbitcoin_wallet_tool;
 
-libbitcoin_cli-->libbitcoin_common;
 libbitcoin_cli-->libbitcoin_util;
+libbitcoin_cli-->libbitcoin_common;
 
-libbitcoin_common-->libbitcoin_util;
 libbitcoin_common-->libbitcoin_consensus;
+libbitcoin_common-->libbitcoin_util;
 
 libbitcoin_kernel-->libbitcoin_consensus;
 libbitcoin_kernel-->libbitcoin_util;
 
-libbitcoin_node-->libbitcoin_common;
 libbitcoin_node-->libbitcoin_consensus;
 libbitcoin_node-->libbitcoin_kernel;
+libbitcoin_node-->libbitcoin_common;
 libbitcoin_node-->libbitcoin_util;
 
 libbitcoinqt-->libbitcoin_common;
@@ -71,8 +71,8 @@ libbitcoinqt-->libbitcoin_util;
 libbitcoin_wallet-->libbitcoin_common;
 libbitcoin_wallet-->libbitcoin_util;
 
-libbitcoin_wallet_tool-->libbitcoin_util;
 libbitcoin_wallet_tool-->libbitcoin_wallet;
+libbitcoin_wallet_tool-->libbitcoin_util;
 
 classDef bold stroke-width:2px, font-weight:bold, font-size: smaller;
 class bitcoin-qt,bitcoind,bitcoin-cli,bitcoin-wallet bold


### PR DESCRIPTION
In this PR, I've attempted to improve readability in the [dependency graph of libraries](https://github.com/bitcoin/bitcoin/blob/master/doc/design/libraries.md) by untangling a few crossed lines. I'm not sure if this is that big of an improvement but  wanted to throw it out there.

I used an extremely scientific method of manually counting the number of crossed lines in the original diagram and got 15. This PR reduces that number down to about 10.

I also changed the curve of the lines to "basis" which rounds the edges out. Again, not sure if it really is that much of an improvement, but it seems marginally easier on the eyes.

Here is what the new graph looks like rendered:

![Screenshot from 2022-10-20 22-09-30](https://user-images.githubusercontent.com/1823216/197095545-5fc90cce-a817-4db2-a0f5-1a8a95380b70.png)

The changes can be verified independently with [Mermaid](https://mermaid-js.github.io/mermaid/#/), with the easiest way being the online editor: https://mermaid.live/

I did try moving some more stuff around, particularly the top level of library callers, but was not able to simplify the graph any further.