### PR TITLE
build: remove threadinterrupt from libbitcoinkernel

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -933,7 +933,6 @@ libbitcoinkernel_la_SOURCES = \
   support/cleanse.cpp \
   support/lockedpool.cpp \
   sync.cpp \
-  threadinterrupt.cpp \
   txdb.cpp \
   txmempool.cpp \
   uint256.cpp \


### PR DESCRIPTION
Extracted from #26292.