### PR TITLE
rpc: fix `getblockstats` for genesis block

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -593,12 +593,16 @@ static CBlockUndo GetUndoChecked(BlockManager& blockman, const CBlockIndex* pblo
 {
     AssertLockHeld(::cs_main);
     CBlockUndo blockUndo;
-    if (blockman.IsBlockPruned(pblockindex)) {
-        throw JSONRPCError(RPC_MISC_ERROR, "Undo data not available (pruned data)");
-    }
 
-    if (!UndoReadFromDisk(blockUndo, pblockindex)) {
-        throw JSONRPCError(RPC_MISC_ERROR, "Can't read undo data from disk");
+    // Ignore genesis block
+    if (pblockindex->nHeight > 0) {
+        if (blockman.IsBlockPruned(pblockindex)) {
+            throw JSONRPCError(RPC_MISC_ERROR, "Undo data not available (pruned data)");
+        }
+
+        if (!UndoReadFromDisk(blockUndo, pblockindex)) {
+            throw JSONRPCError(RPC_MISC_ERROR, "Can't read undo data from disk");
+        }
     }
 
     return blockUndo;


### PR DESCRIPTION
For the genesis block there is no undo data available, i.e. we can simply use an empty CBlockUndo instance instead of aborting with an "Can't read undo data from disk" error (-1) in this case.

master branch:
```
$ ./src/bitcoin-cli getblockstats 0
error code: -1
error message:
Can't read undo data from disk
```


PR branch:
```
$ ./src/bitcoin-cli getblockstats 0
{
  "avgfee": 0,
  "avgfeerate": 0,
  "avgtxsize": 0,
  "blockhash": "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
  "feerate_percentiles": [
    0,
    0,
    0,
    0,
    0
  ],
  "height": 0,
  "ins": 0,
  "maxfee": 0,
  "maxfeerate": 0,
  "maxtxsize": 0,
  "medianfee": 0,
  "mediantime": 1231006505,
  "mediantxsize": 0,
  "minfee": 0,
  "minfeerate": 0,
  "mintxsize": 0,
  "outs": 1,
  "subsidy": 5000000000,
  "swtotal_size": 0,
  "swtotal_weight": 0,
  "swtxs": 0,
  "time": 1231006505,
  "total_out": 0,
  "total_size": 0,
  "total_weight": 0,
  "totalfee": 0,
  "txs": 1,
  "utxo_increase": 1,
  "utxo_size_inc": 117
}
```