### PR TITLE
build, msvc: Drop no longer required macro definitions for leveldb

### DIFF
--- a/build_msvc/libleveldb/libleveldb.vcxproj
+++ b/build_msvc/libleveldb/libleveldb.vcxproj
@@ -50,7 +50,7 @@
   </ItemGroup>
   <ItemDefinitionGroup>
      <ClCompile>
-       <PreprocessorDefinitions>HAVE_CRC32C=0;HAVE_SNAPPY=0;__STDC_LIMIT_MACROS;LEVELDB_IS_BIG_ENDIAN=0;_UNICODE;UNICODE;_CRT_NONSTDC_NO_DEPRECATE;LEVELDB_PLATFORM_WINDOWS;LEVELDB_ATOMIC_PRESENT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <PreprocessorDefinitions>HAVE_CRC32C=0;HAVE_SNAPPY=0;LEVELDB_IS_BIG_ENDIAN=0;_UNICODE;UNICODE;_CRT_NONSTDC_NO_DEPRECATE;LEVELDB_PLATFORM_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
        <DisableSpecificWarnings>4244;4267</DisableSpecificWarnings>
        <AdditionalIncludeDirectories>..\..\src\leveldb;..\..\src\leveldb\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
      </ClCompile>


### PR DESCRIPTION
Since levedb v1.21:
- the `__STDC_LIMIT_MACROS` macro definition is unneeded;
  commit: [50fbc87e8c62a816d6afd4740e0652a13ac6dc3e](https://github.com/bitcoin-core/leveldb-subtree/commit/50fbc87e8c62a816d6afd4740e0652a13ac6dc3e)

- the `LEVELDB_ATOMIC_PRESENT` macro is unused;
  commit: [04f39105c5a418905da8b7657ca244d672c99d3b](https://github.com/bitcoin-core/leveldb-subtree/commit/04f39105c5a418905da8b7657ca244d672c99d3b)