### PR TITLE
 test: Fix intermittent issue in p2p_sendtxrcncl.py 

### DIFF
--- a/test/functional/p2p_sendtxrcncl.py
+++ b/test/functional/p2p_sendtxrcncl.py
@@ -168,9 +168,10 @@ class SendTxRcnclTest(BitcoinTestFramework):
         self.log.info('SENDTXRCNCL with initiator=1 and responder=0 from outbound triggers a disconnect')
         sendtxrcncl_wrong_role = create_sendtxrcncl_msg(initiator=True)
         peer = self.nodes[0].add_outbound_p2p_connection(
-            P2PInterface(), wait_for_verack=False, p2p_idx=4, connection_type="outbound-full-relay")
-        peer.send_message(sendtxrcncl_wrong_role)
-        peer.wait_for_disconnect()
+            PeerNoVerack(), wait_for_verack=False, p2p_idx=4, connection_type="outbound-full-relay")
+        with self.nodes[0].assert_debug_log(["txreconciliation protocol violation"]):
+            peer.send_message(sendtxrcncl_wrong_role)
+            peer.wait_for_disconnect()
 
         self.log.info('SENDTXRCNCL not sent if -txreconciliation flag is not set')
         self.restart_node(0, [])

--- a/test/functional/p2p_sendtxrcncl.py
+++ b/test/functional/p2p_sendtxrcncl.py
@@ -132,12 +132,10 @@ class SendTxRcnclTest(BitcoinTestFramework):
         peer.wait_for_disconnect()
 
         self.log.info('sending SENDTXRCNCL after sending VERACK triggers a disconnect')
-        # We use PeerNoVerack even though verack is sent right after, to make sure it was actually
-        # sent before sendtxrcncl is sent.
-        peer = self.nodes[0].add_p2p_connection(PeerNoVerack(), send_version=True, wait_for_verack=False)
-        peer.send_and_ping(msg_verack())
-        peer.send_message(create_sendtxrcncl_msg())
-        peer.wait_for_disconnect()
+        peer = self.nodes[0].add_p2p_connection(P2PInterface())
+        with self.nodes[0].assert_debug_log(["sendtxrcncl received after verack"]):
+            peer.send_message(create_sendtxrcncl_msg())
+            peer.wait_for_disconnect()
 
         self.log.info('SENDTXRCNCL without WTXIDRELAY is ignored (recon state is erased after VERACK)')
         peer = self.nodes[0].add_p2p_connection(PeerNoVerack(wtxidrelay=False), send_version=True, wait_for_verack=False)


### PR DESCRIPTION
Should fix https://github.com/bitcoin/bitcoin/issues/26364

I can't reproduce this, but my guess would be that `PeerNoVerack::on_version`, which sends the `wtxidrelay` message, is executed in the event loop and thus may run after the main thread sending `msg_verack`.

Also, fix another bug.

Finally, add some `assert_debug_log` to ensure the right code branch is executed (and not some random, unrelated disconnect).