### PR TITLE
index: Compare deserialized block hash with the block hash from the blockindex

### DIFF
--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -33,7 +33,7 @@ private:
     FlatFilePos m_next_filter_pos;
     std::unique_ptr<FlatFileSeq> m_filter_fileseq;
 
-    bool ReadFilterFromDisk(const FlatFilePos& pos, const uint256& hash, BlockFilter& filter) const;
+    bool ReadFilterFromDisk(const FlatFilePos& pos, const uint256& hash, const uint256& block_hash, BlockFilter& filter) const;
     size_t WriteFilterToDisk(FlatFilePos& pos, const BlockFilter& filter);
 
     Mutex m_cs_headers_cache;


### PR DESCRIPTION
There is already an integrity check for the blockfilter but there aren't any integrity checks for the block hash that's stored with the blockfilter. We can add this check by comparing the deserialized block hash from the disk with the block hash provided to us by the blockindex.