### PR TITLE
rpc: add missing lock around chainman.ActiveTip()

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -461,7 +461,7 @@ static RPCHelpMan getblockfrompeer()
 
     // Fetching blocks before the node has syncing past their height can prevent block files from
     // being pruned, so we avoid it if the node is in prune mode.
-    if (index->nHeight > chainman.ActiveChain().Tip()->nHeight && node::fPruneMode) {
+    if (node::fPruneMode && index->nHeight > WITH_LOCK(chainman.GetMutex(), return chainman.ActiveTip()->nHeight)) {
         throw JSONRPCError(RPC_MISC_ERROR, "In prune mode, only blocks that the node has already synced previously can be fetched from a peer");
     }
 


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/pull/23927 seems to have missed a lock around `chainman.ActiveChain()`.