### PR TITLE
test: fix intermittent failure in rpc_getblockfrompeer.py

### DIFF
--- a/test/functional/rpc_getblockfrompeer.py
+++ b/test/functional/rpc_getblockfrompeer.py
@@ -100,7 +100,7 @@ class GetBlockFromPeerTest(BitcoinTestFramework):
         # Connect a P2PInterface to the pruning node and have it submit only the header of the
         # block that the pruning node has not seen
         node1_interface = self.nodes[1].add_p2p_connection(P2PInterface())
-        node1_interface.send_message(msg_headers([block]))
+        node1_interface.send_and_ping(msg_headers([block]))
 
         # Get the peer id of the P2PInterface from the pruning node
         node1_peers = self.nodes[1].getpeerinfo()


### PR DESCRIPTION
Fixes an intermittent failure in `rpc_getblockfrompeer.py` observed in https://cirrus-ci.com/task/6610115527704576 by adding a sync to make sure the node has processed the header we sent it before we query it for the corresponding block.

Fixes #26412