### PR TITLE
test: Remove spam from debug log

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -102,6 +102,7 @@ class TestNode():
             "-debug",
             "-debugexclude=libevent",
             "-debugexclude=leveldb",
+            "-debugexclude=rand",
             "-uacomment=testnode%d" % i,
         ]
         if use_valgrind:


### PR DESCRIPTION
Currently, `debug.log` is spammed with messages like this from `random.cpp` when functional tests are run. 

```
2022-10-25T19:24:34.787663Z [scheduler] [random.cpp:519] [SeedPeriodic] [rand] Feeding 36565 bytes of dynamic environment data into RNG
```

These logs are not useful for debugging and decrease the signal-to-noise ratio of the logs, so they should be suppressed by excluding the `rand` category, as the `libevent` and `leveldb` categories currently are.