### PR TITLE
refactor: Silence GCC Wmissing-field-initializers in ChainstateManagerOpts

### DIFF
--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -31,9 +31,9 @@ struct ChainstateManagerOpts {
     std::optional<bool> check_block_index{};
     bool checkpoints_enabled{DEFAULT_CHECKPOINTS_ENABLED};
     //! If set, it will override the minimum work we will assume exists on some valid chain.
-    std::optional<arith_uint256> minimum_chain_work;
+    std::optional<arith_uint256> minimum_chain_work{};
     //! If set, it will override the block hash whose ancestors we will assume to have valid scripts without checking them.
-    std::optional<uint256> assumed_valid_block;
+    std::optional<uint256> assumed_valid_block{};
     //! If the tip is older than this, the node is considered to be in initial block download.
     std::chrono::seconds max_tip_age{DEFAULT_MAX_TIP_AGE};
 };


### PR DESCRIPTION
The `std::optional` fields in the struct that fall back to chain param defaults if not provided should be initialized to `std::nullopt`. This already happens with the current code.

However, for consistency with `check_block_index` and to silence a GCC warning, add the "missing" `{}`.