### PR TITLE
Initialize optional members of ChainstateManagerOpts to nullopt

### DIFF
--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -31,9 +31,9 @@ struct ChainstateManagerOpts {
     std::optional<bool> check_block_index{};
     bool checkpoints_enabled{DEFAULT_CHECKPOINTS_ENABLED};
     //! If set, it will override the minimum work we will assume exists on some valid chain.
-    std::optional<arith_uint256> minimum_chain_work;
+    std::optional<arith_uint256> minimum_chain_work{std::nullopt};
     //! If set, it will override the block hash whose ancestors we will assume to have valid scripts without checking them.
-    std::optional<uint256> assumed_valid_block;
+    std::optional<uint256> assumed_valid_block{std::nullopt};
     //! If the tip is older than this, the node is considered to be in initial block download.
     std::chrono::seconds max_tip_age{DEFAULT_MAX_TIP_AGE};
 };


### PR DESCRIPTION
Silences missing-field-initializers warnings for these.