### PR TITLE
test: fix intermittent failure in feature_index_prune.py

### DIFF
--- a/test/functional/feature_index_prune.py
+++ b/test/functional/feature_index_prune.py
@@ -138,6 +138,7 @@ class FeatureIndexPruneTest(BitcoinTestFramework):
             self.connect_nodes(i, 3)
 
         self.sync_blocks(timeout=300)
+        self.sync_index(height=2500)
 
         for node in self.nodes[:2]:
             with node.assert_debug_log(['limited pruning to height 2489']):


### PR DESCRIPTION
I can't reproduce the error from #26630 locally, but from analying the logs I think the problem is the following:

After calling `sync_blocks`, we didn't check that the indexes have caught up to the tip before performing the manual pruning. This could possibly lead to prune blockers with a lower height than the expected 2489, which do appear in the logs of the failed CI runs, e.g.
 - `2022-10-27T21:14:17.703920Z [C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build\src\validation.cpp:2395] [FlushStateToDisk] [prune] coinstatsindex limited pruning to height 2488` ([Cirrus](https://cirrus-ci.com/task/5443742333665280?logs=functional_tests#L2506))

So, this should be fixed by a call to `sync_index`.
Fixes #26330