### PR TITLE
build: copy config.{guess,sub} post autogen in zmq package

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -20,12 +20,12 @@ endef
 
 define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/remove_libstd_link.patch && \
-  patch -p1 < $($(package)_patch_dir)/netbsd_kevent_void.patch && \
-  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub config
+  patch -p1 < $($(package)_patch_dir)/netbsd_kevent_void.patch
 endef
 
 define $(package)_config_cmds
   ./autogen.sh && \
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub config && \
   $($(package)_autoconf)
 endef
 


### PR DESCRIPTION
Otherwise our config.guess and config.sub will be copied over. This problem has been masked by the fact that modern systems ship with versions that recognise all the triplets we use (namely arm64-apple-darwin). However building on ubuntu 20.04 surfaces the issue.

Fixes #26420.