### PR TITLE
doc: correct deriveaddresses RPC name

### DIFF
--- a/doc/descriptors.md
+++ b/doc/descriptors.md
@@ -266,6 +266,6 @@ ones. For larger numbers of errors, or other types of errors, there is a
 roughly 1 in a trillion chance of not detecting the errors.
 
 All RPCs in Bitcoin Core will include the checksum in their output. Only
-certain RPCs require checksums on input, including `deriveaddress` and
+certain RPCs require checksums on input, including `deriveaddresses` and
 `importmulti`. The checksum for a descriptor without one can be computed
 using the `getdescriptorinfo` RPC.


### PR DESCRIPTION
There never was a `deriveaddress` RPC, from what I can tell. It was always called `deriveaddresses` (plural).
